### PR TITLE
core: Add initial support of `vaccum` op

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -131,7 +131,7 @@ ongoing work to pass the full SQLite TCL test suite.
 | SELECT ... JOIN USING     | ✅ Yes     |                                                                                   |
 | SELECT ... NATURAL JOIN   | ✅ Yes     |                                                                                   |
 | UPDATE                    | ✅ Yes     |                                                                                   |
-| VACUUM                    | 🚧 Partial | VACUUM INTO supported, plain VACUUM not yet                                       |
+| VACUUM                    | 🚧 Partial | VACUUM INTO supported; plain in-place VACUUM is experimental                       |
 | WITH clause               | 🚧 Partial | ❌ No RECURSIVE, no MATERIALIZED, only SELECT supported in CTEs                      |
 | WINDOW functions             | 🚧 Partial | ROW_NUMBER() supported; RANK(), DENSE_RANK(), LAG(), LEAD(), NTILE() not yet     |
 | GENERATED                 | 🚧 Partial      | virtual columns only (no ALTER, partial affinity support)                |

--- a/bindings/javascript/packages/common/types.ts
+++ b/bindings/javascript/packages/common/types.ts
@@ -1,4 +1,4 @@
-export type ExperimentalFeature = 'views' | 'strict' | 'encryption' | 'index_method' | 'autovacuum' | 'triggers' | 'attach' | 'multiprocess_wal';
+export type ExperimentalFeature = 'views' | 'strict' | 'encryption' | 'index_method' | 'autovacuum' | 'vacuum' | 'triggers' | 'attach' | 'multiprocess_wal';
 
 /** Supported encryption ciphers for local database encryption. */
 export type EncryptionCipher = 'aes128gcm' | 'aes256gcm' | 'aegis256' | 'aegis256x2' | 'aegis128l' | 'aegis128x2' | 'aegis128x4'

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -279,6 +279,7 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
                     "encryption" => core_opts.with_encryption(true),
                     "index_method" => core_opts.with_index_method(true),
                     "autovacuum" => core_opts.with_autovacuum(true),
+                    "vacuum" => core_opts.with_vacuum(true),
                     "attach" => core_opts.with_attach(true),
                     "generated_columns" => core_opts.with_generated_columns(true),
                     "multiprocess_wal" => core_opts.with_multiprocess_wal(true),

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -144,6 +144,7 @@ pub struct Builder {
     enable_custom_types: bool,
     enable_index_method: bool,
     enable_materialized_views: bool,
+    enable_vacuum: bool,
     enable_generated_columns: bool,
     enable_multiprocess_wal: bool,
     vfs: Option<String>,
@@ -161,6 +162,7 @@ impl Builder {
             enable_custom_types: false,
             enable_index_method: false,
             enable_materialized_views: false,
+            enable_vacuum: false,
             enable_generated_columns: false,
             enable_multiprocess_wal: false,
             vfs: None,
@@ -214,6 +216,11 @@ impl Builder {
         self
     }
 
+    pub fn experimental_vacuum(mut self, enabled: bool) -> Self {
+        self.enable_vacuum = enabled;
+        self
+    }
+
     pub fn experimental_multiprocess_wal(mut self, enabled: bool) -> Self {
         self.enable_multiprocess_wal = enabled;
         self
@@ -246,6 +253,9 @@ impl Builder {
         }
         if self.enable_materialized_views {
             features.push("views");
+        }
+        if self.enable_vacuum {
+            features.push("vacuum");
         }
         if self.enable_generated_columns {
             features.push("generated_columns");

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -89,6 +89,8 @@ pub struct Opts {
     pub experimental_index_method: bool,
     #[clap(long, help = "Enable experimental autovacuum feature")]
     pub experimental_autovacuum: bool,
+    #[clap(long, help = "Enable experimental vacuum feature")]
+    pub experimental_vacuum: bool,
     #[clap(long, help = "Enable experimental attach feature")]
     pub experimental_attach: bool,
     #[clap(long, help = "Enable experimental generated columns feature")]
@@ -236,6 +238,7 @@ impl Limbo {
             .with_encryption(opts.experimental_encryption)
             .with_index_method(opts.experimental_index_method)
             .with_autovacuum(opts.experimental_autovacuum)
+            .with_vacuum(opts.experimental_vacuum)
             .with_attach(opts.experimental_attach)
             .with_generated_columns(opts.experimental_generated_columns)
             .with_multiprocess_wal(opts.experimental_multiprocess_wal)

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3097,6 +3097,39 @@ impl Connection {
         self.set_tx_state(TransactionState::None);
     }
 
+    /// Roll back transaction state for helpers that start a manual `BEGIN`
+    /// outside the normal Transaction opcode path.
+    ///
+    /// Unlike `rollback_current_txn_state`, this tolerates the attached-only
+    /// case where the connection flipped `auto_commit` off but never opened a
+    /// main-db read transaction.
+    pub(crate) fn rollback_manual_txn_cleanup(
+        &self,
+        pager: &Arc<Pager>,
+        clear_attached_schemas: bool,
+    ) {
+        let main_has_implicit_state = self.get_tx_state() != TransactionState::None
+            || self.get_mv_tx().is_some()
+            || pager.holds_read_lock()
+            || pager.holds_write_lock();
+
+        if main_has_implicit_state {
+            self.rollback_current_txn_state(pager, clear_attached_schemas);
+        } else {
+            if self.next_attached_mv_tx().is_some() {
+                self.rollback_attached_mvcc_txs(clear_attached_schemas);
+            }
+            self.rollback_attached_wal_txns();
+            self.set_tx_state(TransactionState::None);
+            self.auto_commit.store(true, Ordering::SeqCst);
+        }
+
+        self.rollback_temp_schema();
+        self.set_cdc_transaction_id(-1);
+        self.clear_named_savepoints();
+        self.clear_deferred_foreign_key_violations();
+    }
+
     /// Iterate over all attached MVCC transactions, calling `f(db_id, tx_id)` for each.
     pub(crate) fn for_each_attached_mv_tx(&self, mut f: impl FnMut(usize, u64)) {
         let txs = self.attached_mv_txs.read();

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -139,6 +139,18 @@ pub(crate) struct RollbackFrameInfo {
     pub(crate) staged_schema_snapshot: HashMap<usize, Arc<Schema>>,
 }
 
+struct SchemaReparseGuard {
+    connection: Arc<Connection>,
+}
+
+impl Drop for SchemaReparseGuard {
+    fn drop(&mut self) {
+        self.connection
+            .schema_reparse_in_progress
+            .store(false, Ordering::SeqCst);
+    }
+}
+
 /// Database connection handle.
 ///
 /// If you add a setting that affects SQL compilation or execution, call
@@ -247,6 +259,10 @@ pub struct Connection {
     /// Connection-level named savepoint stack used to mirror savepoint state
     /// onto temp/attached databases that start participating after SAVEPOINT.
     pub(crate) named_savepoints: RwLock<Vec<NamedSavepointFrame>>,
+    /// True while this connection is rebuilding its schema from sqlite_schema.
+    /// Internal helper statements used during reload must not recursively
+    /// trigger another schema reparse on the same connection.
+    pub(crate) schema_reparse_in_progress: AtomicBool,
     /// Generation counter bumped whenever any setting that affects PrepareContext
     /// changes. Allows prepared statements to cheaply detect when they need to be
     /// reprepared (single u64 comparison instead of rebuilding the full context).
@@ -316,6 +332,21 @@ impl Drop for Connection {
 }
 
 impl Connection {
+    fn schema_reparse_guard(self: &Arc<Connection>) -> SchemaReparseGuard {
+        let was_reparsing = self.schema_reparse_in_progress.swap(true, Ordering::SeqCst);
+        turso_assert!(
+            !was_reparsing,
+            "schema reparse must not recurse on the same connection"
+        );
+        SchemaReparseGuard {
+            connection: self.clone(),
+        }
+    }
+
+    pub(crate) fn schema_reparse_in_progress(&self) -> bool {
+        self.schema_reparse_in_progress.load(Ordering::Acquire)
+    }
+
     pub(crate) fn empty_temp_schema(&self) -> Arc<Schema> {
         // with_options only fails if built-in type SQL is malformed (programmer bug).
         let mut schema = Schema::with_options(self.db.experimental_custom_types_enabled())
@@ -904,6 +935,8 @@ impl Connection {
     }
 
     pub(crate) fn reparse_schema_with_cookie(self: &Arc<Connection>, cookie: u32) -> Result<()> {
+        let _reparse_guard = self.schema_reparse_guard();
+        self.pager.load().set_schema_cookie(Some(cookie));
         // create fresh schema as some objects can be deleted
         let mut fresh = Schema::with_options(self.experimental_custom_types_enabled())?;
         fresh.generated_columns_enabled = self.db.experimental_generated_columns_enabled();
@@ -1252,7 +1285,7 @@ impl Connection {
         if !has_types_table {
             return Ok(Vec::new());
         }
-        let mut type_stmt = self.prepare(format!(
+        let mut type_stmt = self.prepare_internal(format!(
             "SELECT name, sql FROM {}",
             crate::schema::TURSO_TYPES_TABLE_NAME
         ))?;
@@ -1265,6 +1298,9 @@ impl Connection {
     }
 
     pub fn maybe_update_schema(&self) {
+        if self.schema_reparse_in_progress() {
+            return;
+        }
         let current_schema_version = self.schema.read().schema_version;
         let schema = self.db.schema.lock();
         if matches!(self.get_tx_state(), TransactionState::None)

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -329,6 +329,7 @@ impl Connection {
             .with_views(self.db.experimental_views_enabled())
             .with_custom_types(self.db.experimental_custom_types_enabled())
             .with_index_method(self.db.experimental_index_method_enabled())
+            .with_vacuum(self.db.experimental_vacuum_enabled())
             .with_generated_columns(self.db.experimental_generated_columns_enabled())
     }
 
@@ -1908,6 +1909,14 @@ impl Connection {
         self.db.experimental_attach_enabled()
     }
 
+    pub fn experimental_vacuum_enabled(&self) -> bool {
+        self.db.experimental_vacuum_enabled()
+    }
+
+    pub fn experimental_multiprocess_wal_enabled(&self) -> bool {
+        self.db.experimental_multiprocess_wal_enabled()
+    }
+
     pub fn experimental_generated_columns_enabled(&self) -> bool {
         self.db.experimental_generated_columns_enabled()
     }
@@ -2337,6 +2346,7 @@ impl Connection {
             .with_views(self.db.experimental_views_enabled())
             .with_custom_types(self.db.experimental_custom_types_enabled())
             .with_index_method(self.db.experimental_index_method_enabled())
+            .with_vacuum(self.db.experimental_vacuum_enabled())
             .with_generated_columns(self.db.experimental_generated_columns_enabled());
         // Select the IO layer for the attached database:
         // - :memory: databases always get a fresh MemoryIO

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2626,10 +2626,6 @@ impl Connection {
     pub fn set_reserved_bytes(&self, reserved_bytes: u8) -> Result<()> {
         let pager = self.pager.load();
         pager.set_reserved_space_bytes(reserved_bytes);
-        #[cfg(feature = "checksum")]
-        if reserved_bytes != crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES {
-            pager.reset_checksum_context();
-        }
         Ok(())
     }
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1769,10 +1769,6 @@ impl Connection {
         self.db.experimental_custom_types_enabled()
     }
 
-    pub fn experimental_encryption_enabled(&self) -> bool {
-        self.db.experimental_encryption_enabled()
-    }
-
     pub fn experimental_attach_enabled(&self) -> bool {
         self.db.experimental_attach_enabled()
     }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1769,6 +1769,10 @@ impl Connection {
         self.db.experimental_custom_types_enabled()
     }
 
+    pub fn experimental_encryption_enabled(&self) -> bool {
+        self.db.experimental_encryption_enabled()
+    }
+
     pub fn experimental_attach_enabled(&self) -> bool {
         self.db.experimental_attach_enabled()
     }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2626,6 +2626,10 @@ impl Connection {
     pub fn set_reserved_bytes(&self, reserved_bytes: u8) -> Result<()> {
         let pager = self.pager.load();
         pager.set_reserved_space_bytes(reserved_bytes);
+        #[cfg(feature = "checksum")]
+        if reserved_bytes != crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES {
+            pager.reset_checksum_context();
+        }
         Ok(())
     }
 

--- a/core/error.rs
+++ b/core/error.rs
@@ -144,6 +144,12 @@ pub enum CompletionError {
         expected: usize,
         actual: usize,
     },
+    #[error("WAL frame page mismatch at frame {frame_id}: expected page {expected}, got {actual}")]
+    WalFramePageMismatch {
+        frame_id: u64,
+        expected: usize,
+        actual: u32,
+    },
     #[error("Checksum mismatch on page {page_id}: expected {expected}, got {actual}")]
     ChecksumMismatch {
         page_id: usize,

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -393,6 +393,7 @@ mod tests {
                 enable_encryption: false,
                 enable_index_method: false,
                 enable_autovacuum: false,
+                enable_vacuum: false,
                 enable_attach: false,
                 enable_generated_columns: false,
                 enable_multiprocess_wal: false,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -201,6 +201,7 @@ pub struct DatabaseOpts {
     pub enable_encryption: bool,
     pub enable_index_method: bool,
     pub enable_autovacuum: bool,
+    pub enable_vacuum: bool,
     pub enable_attach: bool,
     pub enable_generated_columns: bool,
     pub enable_multiprocess_wal: bool,
@@ -241,6 +242,11 @@ impl DatabaseOpts {
 
     pub fn with_autovacuum(mut self, enable: bool) -> Self {
         self.enable_autovacuum = enable;
+        self
+    }
+
+    pub fn with_vacuum(mut self, enable: bool) -> Self {
+        self.enable_vacuum = enable;
         self
     }
 
@@ -2372,6 +2378,18 @@ impl Database {
 
     pub fn experimental_custom_types_enabled(&self) -> bool {
         self.opts.enable_custom_types
+    }
+
+    pub fn experimental_encryption_enabled(&self) -> bool {
+        self.opts.enable_encryption
+    }
+
+    pub fn experimental_autovacuum_enabled(&self) -> bool {
+        self.opts.enable_autovacuum
+    }
+
+    pub fn experimental_vacuum_enabled(&self) -> bool {
+        self.opts.enable_vacuum
     }
 
     pub fn experimental_attach_enabled(&self) -> bool {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1716,6 +1716,7 @@ impl Database {
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
             named_savepoints: RwLock::new(Vec::new()),
+            schema_reparse_in_progress: AtomicBool::new(false),
             prepare_context_generation: AtomicU64::new(0),
         });
         self.n_connections

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1720,6 +1720,10 @@ impl Database {
         self.opts.enable_custom_types
     }
 
+    pub fn experimental_encryption_enabled(&self) -> bool {
+        self.opts.enable_encryption
+    }
+
     pub fn experimental_attach_enabled(&self) -> bool {
         self.opts.enable_attach
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -68,6 +68,7 @@ use crate::{
     schema::Trigger,
     stats::refresh_analyze_stats,
     storage::{
+        checksum::CHECKSUM_REQUIRED_RESERVED_BYTES,
         encryption::{AtomicCipherMode, SQLITE_HEADER, TURSO_HEADER_PREFIX},
         journal_mode,
         pager::{self, AutoVacuumMode, HeaderRef, HeaderRefMut},
@@ -1557,10 +1558,16 @@ impl Database {
                 Some(cipher.metadata_size() as u8)
             } else {
                 // For non-encrypted databases, don't set reserved_bytes here.
-                // This allows checksums to be enabled by default.
+                // This allows checksums to be enabled by default (disable_checksums will be false).
                 None
             }
         });
+        let disable_checksums = if let Some(reserved_bytes) = reserved_bytes {
+            // if the required reserved bytes for checksums is not present, disable checksums
+            reserved_bytes != CHECKSUM_REQUIRED_RESERVED_BYTES
+        } else {
+            false
+        };
         // Check if WAL is enabled
         let shared_wal = self.shared_wal.read();
 
@@ -1594,6 +1601,9 @@ impl Database {
         pager.set_page_size(page_size);
         if let Some(reserved_bytes) = reserved_bytes {
             pager.set_reserved_space_bytes(reserved_bytes);
+        }
+        if disable_checksums {
+            pager.reset_checksum_context();
         }
 
         Ok(pager)

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1720,7 +1720,7 @@ impl Database {
         self.opts.enable_custom_types
     }
 
-    pub fn experimental_encryption_enabled(&self) -> bool {
+    pub(crate) fn experimental_encryption_enabled(&self) -> bool {
         self.opts.enable_encryption
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -68,7 +68,6 @@ use crate::{
     schema::Trigger,
     stats::refresh_analyze_stats,
     storage::{
-        checksum::CHECKSUM_REQUIRED_RESERVED_BYTES,
         encryption::{AtomicCipherMode, SQLITE_HEADER, TURSO_HEADER_PREFIX},
         journal_mode,
         pager::{self, AutoVacuumMode, HeaderRef, HeaderRefMut},
@@ -1558,16 +1557,10 @@ impl Database {
                 Some(cipher.metadata_size() as u8)
             } else {
                 // For non-encrypted databases, don't set reserved_bytes here.
-                // This allows checksums to be enabled by default (disable_checksums will be false).
+                // This allows checksums to be enabled by default.
                 None
             }
         });
-        let disable_checksums = if let Some(reserved_bytes) = reserved_bytes {
-            // if the required reserved bytes for checksums is not present, disable checksums
-            reserved_bytes != CHECKSUM_REQUIRED_RESERVED_BYTES
-        } else {
-            false
-        };
         // Check if WAL is enabled
         let shared_wal = self.shared_wal.read();
 
@@ -1601,9 +1594,6 @@ impl Database {
         pager.set_page_size(page_size);
         if let Some(reserved_bytes) = reserved_bytes {
             pager.set_reserved_space_bytes(reserved_bytes);
-        }
-        if disable_checksums {
-            pager.reset_checksum_context();
         }
 
         Ok(pager)

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1720,7 +1720,7 @@ impl Database {
         self.opts.enable_custom_types
     }
 
-    pub(crate) fn experimental_encryption_enabled(&self) -> bool {
+    pub fn experimental_encryption_enabled(&self) -> bool {
         self.opts.enable_encryption
     }
 

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -921,6 +921,34 @@ fn subprocess_database_open_selects_multiprocess_shm_backend() {
 }
 
 #[test]
+fn plain_vacuum_rejects_multiprocess_wal_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("vacuum-multiprocess.db");
+    let db_path_str = db_path.to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+
+    let db = open_multiprocess_db(io, db_path_str).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("create table test(id integer primary key, value text)")
+        .unwrap();
+    conn.execute("insert into test(value) values ('parent')")
+        .unwrap();
+
+    let err = conn
+        .execute("VACUUM")
+        .expect_err("VACUUM should reject on a multiprocess-WAL database");
+    assert!(
+        matches!(err, LimboError::ParseError(ref msg) if msg.contains("experimental multiprocess WAL")),
+        "expected explicit multiprocess VACUUM rejection, got {err:?}"
+    );
+    assert_eq!(
+        count_test_rows(&conn),
+        1,
+        "rejecting VACUUM on a multiprocess-WAL database must not disturb the existing connection"
+    );
+}
+
+#[test]
 fn subprocess_child_close_skips_shutdown_checkpoint_in_multiprocess_wal_mode() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("close-skip-shutdown-checkpoint.db");

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2395,6 +2395,108 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
+    /// Acquire MVCC's stop-the-world gate for VACUUM.
+    ///
+    /// This is the same lock used by MVCC checkpointing. All MVCC transactions
+    /// hold it in read mode for their whole lifetime, so acquiring it in write
+    /// mode proves there are no active MVCC transactions and prevents new ones
+    /// from starting until VACUUM releases it.
+    pub(crate) fn try_begin_vacuum_gate(&self) -> Result<()> {
+        if !self.blocking_checkpoint_lock.write() {
+            return Err(LimboError::Busy);
+        }
+        turso_assert!(
+            self.txs.is_empty(),
+            "MVCC vacuum gate acquired while transactions are still active"
+        );
+        Ok(())
+    }
+
+    /// Release the MVCC stop-the-world gate acquired by `try_begin_vacuum_gate`.
+    pub(crate) fn release_vacuum_gate(&self) {
+        self.blocking_checkpoint_lock.unlock();
+    }
+
+    /// VACUUM copies the physical DB image, so any MVCC logical-log bytes must
+    /// be checkpointed first.
+    pub(crate) fn has_uncheckpointed_log(&self) -> Result<bool> {
+        Ok(self.get_logical_log_file().size()? != 0)
+    }
+
+    /// Rebuild MVCC's physical root-page metadata after in-place VACUUM
+    /// reparses the rewritten B-tree image and stages the committed page-1
+    /// header that now owns the physical schema cookie.
+    ///
+    /// The caller must hold the MVCC vacuum gate and pass both the committed
+    /// page-1 header and the schema parsed from the post-VACUUM physical
+    /// database image.
+    pub(crate) fn reset_after_vacuum(&self, header: DatabaseHeader, schema: &Schema) {
+        turso_assert!(
+            self.txs.is_empty(),
+            "MVCC VACUUM reset requires no active transactions"
+        );
+        // see the test `test_mvcc_plain_vacuum_active_write_tx_returns_busy`
+        self.drop_unused_row_versions();
+        let has_table_versions = self
+            .rows
+            .iter()
+            .any(|entry| !entry.value().read().is_empty());
+        turso_assert!(
+            !has_table_versions,
+            "MVCC VACUUM reset requires checkpointed table versions to be cleared"
+        );
+        let has_index_versions = self.index_rows.iter().any(|index_entry| {
+            index_entry
+                .value()
+                .iter()
+                .any(|entry| !entry.value().read().is_empty())
+        });
+        turso_assert!(
+            !has_index_versions,
+            "MVCC VACUUM reset requires checkpointed index versions to be cleared"
+        );
+        turso_assert!(
+            self.finalized_tx_states.is_empty(),
+            "MVCC VACUUM reset requires finalized transaction cache to be cleared"
+        );
+        let root_pages = schema
+            .tables
+            .values()
+            .filter_map(|table| match table.as_ref() {
+                Table::BTree(btree) => Some(btree.root_page),
+                _ => None,
+            })
+            .chain(
+                schema
+                    .indexes
+                    .values()
+                    .flatten()
+                    .map(|index| index.root_page),
+            )
+            .collect::<Vec<_>>();
+        for &root_page in &root_pages {
+            turso_assert!(
+                root_page > 0,
+                "post-VACUUM B-tree root page must be positive"
+            );
+        }
+        let keys = self
+            .table_id_to_rootpage
+            .iter()
+            .map(|entry| *entry.key())
+            .collect::<Vec<_>>();
+        for key in keys {
+            self.table_id_to_rootpage.remove(&key);
+        }
+        self.table_id_to_last_rowid.write().clear();
+        self.insert_table_id_to_rootpage(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1));
+        for root_page in root_pages {
+            let table_id = MVTableId::from(-root_page);
+            self.insert_table_id_to_rootpage(table_id, Some(root_page as u64));
+        }
+        self.global_header.write().replace(header);
+    }
+
     /// Creates the `__turso_internal_mvcc_meta` table and seeds it with
     /// `persistent_tx_ts_max` (initialized to 0). This table stores the durable replay
     /// boundary: on recovery, only logical-log frames with `commit_ts > persistent_tx_ts_max`

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -75,6 +75,209 @@ impl MvccTestDb {
     }
 }
 
+#[test]
+fn mvcc_active_read_tx_blocks_vacuum_gate() {
+    let db = MvccTestDb::new();
+    let pager = db.conn.pager.load().clone();
+    let tx_id = db.mvcc_store.begin_tx(pager).unwrap();
+
+    assert!(matches!(
+        db.mvcc_store.try_begin_vacuum_gate(),
+        Err(LimboError::Busy)
+    ));
+
+    db.mvcc_store.remove_tx(tx_id);
+    db.mvcc_store.try_begin_vacuum_gate().unwrap();
+    db.mvcc_store.release_vacuum_gate();
+}
+
+#[test]
+fn mvcc_active_write_tx_blocks_vacuum_gate() {
+    let db = MvccTestDb::new();
+    let pager = db.conn.pager.load().clone();
+    let tx_id = db
+        .mvcc_store
+        .begin_exclusive_tx(pager.clone(), None)
+        .unwrap();
+
+    assert!(matches!(
+        db.mvcc_store.try_begin_vacuum_gate(),
+        Err(LimboError::Busy)
+    ));
+
+    db.mvcc_store
+        .rollback_tx(tx_id, pager, &db.conn, crate::MAIN_DB_ID);
+    db.mvcc_store.try_begin_vacuum_gate().unwrap();
+    db.mvcc_store.release_vacuum_gate();
+}
+
+#[test]
+fn mvcc_vacuum_gate_blocks_new_read_and_write_tx() {
+    let db = MvccTestDb::new();
+    let pager = db.conn.pager.load().clone();
+
+    db.mvcc_store.try_begin_vacuum_gate().unwrap();
+
+    assert!(matches!(
+        db.mvcc_store.begin_tx(pager.clone()),
+        Err(LimboError::Busy)
+    ));
+    assert!(matches!(
+        db.mvcc_store.begin_exclusive_tx(pager, None),
+        Err(LimboError::Busy)
+    ));
+
+    db.mvcc_store.release_vacuum_gate();
+}
+
+#[test]
+fn mvcc_reset_after_vacuum_installs_header_and_rootpages() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    db.conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+    db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    db.conn.demote_to_mvcc_connection();
+    db.conn.reparse_schema().unwrap();
+    let schema = db.conn.schema.read().clone();
+    db.conn.promote_to_regular_connection();
+    let table_root = match schema.tables.get("t").expect("table t").as_ref() {
+        Table::BTree(btree) => btree.root_page,
+        _ => panic!("expected btree table"),
+    };
+    let index_root = schema
+        .indexes
+        .get("t")
+        .and_then(|indexes| indexes.front())
+        .map(|index| index.root_page)
+        .expect("index idx_t_v");
+
+    let mut header = DatabaseHeader::default();
+    header.schema_cookie = 77.into();
+
+    db.mvcc_store
+        .global_header
+        .write()
+        .replace(DatabaseHeader::default());
+    db.mvcc_store
+        .insert_table_id_to_rootpage(MVTableId::from(-999_i64), Some(999));
+
+    db.mvcc_store.try_begin_vacuum_gate().unwrap();
+    db.mvcc_store.reset_after_vacuum(header, schema.as_ref());
+    db.mvcc_store.release_vacuum_gate();
+
+    assert_eq!(
+        db.mvcc_store
+            .with_header(|header| header.schema_cookie.get(), None)
+            .unwrap(),
+        77
+    );
+    assert_eq!(
+        *db.mvcc_store
+            .table_id_to_rootpage
+            .get(&SQLITE_SCHEMA_MVCC_TABLE_ID)
+            .expect("sqlite_schema mapping")
+            .value(),
+        Some(1)
+    );
+    assert_eq!(
+        *db.mvcc_store
+            .table_id_to_rootpage
+            .get(&MVTableId::from(-(table_root)))
+            .expect("table root mapping")
+            .value(),
+        Some(table_root as u64)
+    );
+    assert_eq!(
+        *db.mvcc_store
+            .table_id_to_rootpage
+            .get(&MVTableId::from(-(index_root)))
+            .expect("index root mapping")
+            .value(),
+        Some(index_root as u64)
+    );
+    assert!(
+        db.mvcc_store
+            .table_id_to_rootpage
+            .get(&MVTableId::from(-999_i64))
+            .is_none(),
+        "stale root-page entries must be cleared"
+    );
+}
+
+#[test]
+fn mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    db.conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+
+    db.conn
+        .execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+        .unwrap();
+    db.conn
+        .execute("UPDATE t SET v = 'z' WHERE id = 1")
+        .unwrap();
+    db.conn.execute("DELETE FROM t WHERE id = 2").unwrap();
+    db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    // Normal MVCC checkpoint GC removes versions but can leave empty map
+    // buckets behind; VACUUM reset must not preserve those stale keys.
+    let checkpointed_row_ids = db
+        .mvcc_store
+        .rows
+        .iter()
+        .filter(|entry| entry.value().read().is_empty())
+        .map(|entry| entry.key().clone())
+        .collect::<Vec<_>>();
+    let checkpointed_index_ids = db
+        .mvcc_store
+        .index_rows
+        .iter()
+        .filter(|entry| {
+            entry
+                .value()
+                .iter()
+                .all(|row_entry| row_entry.value().read().is_empty())
+        })
+        .map(|entry| *entry.key())
+        .collect::<Vec<_>>();
+    assert!(
+        !checkpointed_row_ids.is_empty(),
+        "checkpoint GC should leave empty table row buckets before VACUUM reset"
+    );
+    assert!(
+        !checkpointed_index_ids.is_empty(),
+        "checkpoint GC should leave empty index buckets before VACUUM reset"
+    );
+
+    db.conn.demote_to_mvcc_connection();
+    db.conn.reparse_schema().unwrap();
+    let schema = db.conn.schema.read().clone();
+    db.conn.promote_to_regular_connection();
+
+    db.mvcc_store.try_begin_vacuum_gate().unwrap();
+    db.mvcc_store
+        .reset_after_vacuum(DatabaseHeader::default(), schema.as_ref());
+    db.mvcc_store.release_vacuum_gate();
+
+    for row_id in checkpointed_row_ids {
+        assert!(
+            db.mvcc_store.rows.get(&row_id).is_none(),
+            "checkpointed empty table row buckets must be cleared across VACUUM reset"
+        );
+    }
+    for index_id in checkpointed_index_ids {
+        assert!(
+            db.mvcc_store.index_rows.get(&index_id).is_none(),
+            "checkpointed empty index buckets must be cleared across VACUUM reset"
+        );
+    }
+}
+
 impl MvccTestDbNoConn {
     pub fn new() -> Self {
         let io = Arc::new(MemoryIO::new());

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -524,7 +524,7 @@ impl Statement {
             conn.rollback_current_txn_state(&main_pager, true);
             self.state.auto_txn_cleanup = vdbe::TxnCleanup::None;
         }
-        if conn.get_auto_commit() {
+        if conn.get_auto_commit() && !conn.schema_reparse_in_progress() {
             conn.maybe_reparse_schema()?;
         }
 

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -46,12 +46,7 @@ impl IOContext {
     }
 
     pub fn reset_checksum(&mut self) {
-        if matches!(
-            self.encryption_or_checksum,
-            EncryptionOrChecksum::Checksum(_)
-        ) {
-            self.encryption_or_checksum = EncryptionOrChecksum::None;
-        }
+        self.encryption_or_checksum = EncryptionOrChecksum::None;
     }
 }
 

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -46,7 +46,12 @@ impl IOContext {
     }
 
     pub fn reset_checksum(&mut self) {
-        self.encryption_or_checksum = EncryptionOrChecksum::None;
+        if matches!(
+            self.encryption_or_checksum,
+            EncryptionOrChecksum::Checksum(_)
+        ) {
+            self.encryption_or_checksum = EncryptionOrChecksum::None;
+        }
     }
 }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5,7 +5,7 @@ use crate::io::FileSyncType;
 use crate::io::WriteBatch;
 use crate::storage::btree::PinGuard;
 use crate::storage::subjournal::Subjournal;
-use crate::storage::wal::PreparedFrames;
+use crate::storage::wal::{CheckpointLockSource, PreparedFrames};
 use crate::storage::{
     buffer_pool::BufferPool,
     database::DatabaseStorage,
@@ -1020,16 +1020,6 @@ struct CheckpointState {
     mode: Option<CheckpointMode>,
     /// The checkpoint state machine should acquire the lock or use the one by caller
     lock_source: CheckpointLockSource,
-}
-
-/// CheckpointLockSource says whether the checkpoint state machine should acquire checkpoint_lock
-/// itself or consume checkpoint_lock already held by the caller.
-/// Most of the time, the default `Acquire` is used, except for VACUUM.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-enum CheckpointLockSource {
-    #[default]
-    Acquire,
-    HeldByCaller,
 }
 
 #[derive(Clone, Debug)]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1018,6 +1018,18 @@ struct CheckpointState {
     result: Option<CheckpointResult>,
     /// The checkpoint mode, used to determine if WAL truncation is needed
     mode: Option<CheckpointMode>,
+    /// The checkpoint state machine should acquire the lock or use the one by caller
+    lock_source: CheckpointLockSource,
+}
+
+/// CheckpointLockSource says whether the checkpoint state machine should acquire checkpoint_lock
+/// itself or consume checkpoint_lock already held by the caller.
+/// Most of the time, the default `Acquire` is used, except for VACUUM.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum CheckpointLockSource {
+    #[default]
+    Acquire,
+    HeldByCaller,
 }
 
 #[derive(Clone, Debug)]
@@ -2675,6 +2687,29 @@ impl Pager {
         Ok(IOResult::Done(wal.begin_write_tx()?))
     }
 
+    /// Acquire exclusive WAL access + block new transactions (used by VACUUM).
+    ///
+    /// This is a blocking alternative to normal `begin_read_tx`.
+    ///
+    /// VACUUM runs on an existing database, so page 1 must already be allocated
+    /// and a WAL must be present.
+    pub fn begin_blocking_tx(&self) -> Result<IOResult<()>> {
+        if !self.db_initialized() {
+            return Err(LimboError::InternalError(
+                "begin_blocking_tx can be done on an initialized database (page 1 must already be allocated)".into(),
+            ));
+        }
+        let wal = self.wal.as_ref().ok_or_else(|| {
+            LimboError::InternalError("begin_blocking_tx requires WAL mode".into())
+        })?;
+        wal.begin_blocking_tx()?;
+        // let's be conservative and clear all cache for vacuum
+        // todo: clear cache only if we detect that new writes have occurred like `begin_read_tx`
+        self.clear_page_cache(false);
+        self.set_schema_cookie(None);
+        Ok(IOResult::Done(()))
+    }
+
     /// commit dirty pages from current transaction in WAL mode if this is not nested statement (for nested statements, parent will do the commit)
     /// if update_transaction_state set to false, then [Connection::transaction_state] left unchanged
     /// if update_transaction_state set to true, then [Connection::transaction_state] reset to [TransactionState::None] in case when method completes without error
@@ -3985,11 +4020,16 @@ impl Pager {
         state.phase = CheckpointPhase::NotCheckpointing;
         state.result = None;
         state.mode = None;
+        state.lock_source = CheckpointLockSource::Acquire;
     }
 
     /// Clean up after a auto-checkpoint failure.
     /// Auto-checkpoint executed outside of the main transaction - so WAL transaction was already finalized
     pub fn cleanup_after_auto_checkpoint_failure(&self) {
+        self.cleanup_after_checkpoint_failure();
+    }
+
+    pub fn cleanup_after_checkpoint_failure(&self) {
         self.reset_checkpoint_state();
         if let Some(wal) = self.wal.as_ref() {
             wal.abort_checkpoint();
@@ -4035,6 +4075,35 @@ impl Pager {
         sync_mode: crate::SyncMode,
         clear_page_cache: bool,
     ) -> Result<IOResult<CheckpointResult>> {
+        self.checkpoint_inner(
+            mode,
+            sync_mode,
+            clear_page_cache,
+            CheckpointLockSource::Acquire,
+        )
+    }
+
+    pub fn checkpoint_with_held_checkpoint_lock(
+        &self,
+        mode: CheckpointMode,
+        sync_mode: crate::SyncMode,
+        clear_page_cache: bool,
+    ) -> Result<IOResult<CheckpointResult>> {
+        self.checkpoint_inner(
+            mode,
+            sync_mode,
+            clear_page_cache,
+            CheckpointLockSource::HeldByCaller,
+        )
+    }
+
+    fn checkpoint_inner(
+        &self,
+        mode: CheckpointMode,
+        sync_mode: crate::SyncMode,
+        clear_page_cache: bool,
+        lock_source: CheckpointLockSource,
+    ) -> Result<IOResult<CheckpointResult>> {
         let Some(wal) = self.wal.as_ref() else {
             turso_soft_unreachable!("checkpoint() called on database without WAL");
             return Err(LimboError::InternalError(
@@ -4055,13 +4124,20 @@ impl Pager {
                         clear_page_cache,
                     };
                     state.mode = Some(mode);
+                    state.lock_source = lock_source;
                 }
                 CheckpointPhase::Checkpoint {
                     mode,
                     sync_mode,
                     clear_page_cache,
                 } => {
-                    let res = return_if_io!(wal.checkpoint(self, mode));
+                    let checkpoint_lock_source = self.checkpoint_state.read().lock_source;
+                    let res = return_if_io!(match checkpoint_lock_source {
+                        CheckpointLockSource::Acquire => wal.checkpoint(self, mode),
+                        CheckpointLockSource::HeldByCaller => {
+                            wal.checkpoint_with_held_checkpoint_lock(self, mode)
+                        }
+                    });
                     let mut state = self.checkpoint_state.write();
                     if matches!(mode, CheckpointMode::Truncate { .. })
                         // `should_truncate` will be true for successful truncate checkpoint
@@ -4307,6 +4383,7 @@ impl Pager {
                     let mut res = state.result.take().expect("result should be set");
                     state.phase = CheckpointPhase::NotCheckpointing;
                     state.mode = None;
+                    state.lock_source = CheckpointLockSource::Acquire;
 
                     // Clear page cache only if requested (explicit checkpoints do this, auto-checkpoint does not)
                     if clear_page_cache {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2683,16 +2683,16 @@ impl Pager {
     ///
     /// VACUUM runs on an existing database, so page 1 must already be allocated
     /// and a WAL must be present.
-    pub fn begin_blocking_tx(&self) -> Result<IOResult<()>> {
+    pub fn begin_vacuum_blocking_tx(&self) -> Result<IOResult<()>> {
         if !self.db_initialized() {
             return Err(LimboError::InternalError(
-                "begin_blocking_tx can be done on an initialized database (page 1 must already be allocated)".into(),
+                "begin_vacuum_blocking_tx can be done on an initialized database (page 1 must already be allocated)".into(),
             ));
         }
         let wal = self.wal.as_ref().ok_or_else(|| {
-            LimboError::InternalError("begin_blocking_tx requires WAL mode".into())
+            LimboError::InternalError("begin_vacuum_blocking_tx requires WAL mode".into())
         })?;
-        wal.begin_blocking_tx()?;
+        wal.begin_vacuum_blocking_tx()?;
         // let's be conservative and clear all cache for vacuum
         // todo: clear cache only if we detect that new writes have occurred like `begin_read_tx`
         self.clear_page_cache(false);
@@ -4073,14 +4073,15 @@ impl Pager {
         )
     }
 
-    pub fn checkpoint_with_held_checkpoint_lock(
+    pub fn vacuum_checkpoint_with_held_lock(
         &self,
-        mode: CheckpointMode,
         sync_mode: crate::SyncMode,
         clear_page_cache: bool,
     ) -> Result<IOResult<CheckpointResult>> {
         self.checkpoint_inner(
-            mode,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
             sync_mode,
             clear_page_cache,
             CheckpointLockSource::HeldByCaller,
@@ -4125,7 +4126,7 @@ impl Pager {
                     let res = return_if_io!(match checkpoint_lock_source {
                         CheckpointLockSource::Acquire => wal.checkpoint(self, mode),
                         CheckpointLockSource::HeldByCaller => {
-                            wal.checkpoint_with_held_checkpoint_lock(self, mode)
+                            wal.vacuum_checkpoint_with_held_lock(self)
                         }
                     });
                     let mut state = self.checkpoint_state.write();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1153,6 +1153,14 @@ impl From<u8> for AutoVacuumMode {
     }
 }
 
+const fn auto_vacuum_header_fields(mode: AutoVacuumMode) -> (u32, u32) {
+    match mode {
+        AutoVacuumMode::None => (0, 0),
+        AutoVacuumMode::Full => (1, 0),
+        AutoVacuumMode::Incremental => (1, 1),
+    }
+}
+
 #[derive(Debug, Clone)]
 #[cfg(not(feature = "omit_autovacuum"))]
 enum PtrMapGetState {
@@ -2081,6 +2089,34 @@ impl Pager {
 
     pub fn set_auto_vacuum_mode(&self, mode: AutoVacuumMode) {
         self.auto_vacuum_mode.store(mode.into(), Ordering::SeqCst);
+    }
+
+    /// Persist the auto-vacuum mode to page 1 and keep the pager cache in sync.
+    pub fn persist_auto_vacuum_mode(&self, mode: AutoVacuumMode) -> Result<()> {
+        let (largest_root_page, incremental_vacuum_enabled) = auto_vacuum_header_fields(mode);
+
+        if self.db_initialized() {
+            self.io.block(|| {
+                self.with_header_mut(|header| {
+                    header.vacuum_mode_largest_root_page = largest_root_page.into();
+                    header.incremental_vacuum_enabled = incremental_vacuum_enabled.into();
+                })
+            })?;
+        } else {
+            let IOResult::Done(_) = self.with_header_mut(|header| {
+                header.vacuum_mode_largest_root_page = largest_root_page.into();
+                header.incremental_vacuum_enabled = incremental_vacuum_enabled.into();
+            })?
+            else {
+                panic!("fresh database auto-vacuum setup should not do any IO");
+            };
+            // Clear dirty pages since this is pre-initialization setup, not a real write transaction.
+            // with_header_mut marks page 1 dirty as a side effect, but no transaction is active.
+            self.dirty_pages.write().clear();
+        }
+
+        self.set_auto_vacuum_mode(mode);
+        Ok(())
     }
 
     /// Retrieves the pointer map entry for a given database page.
@@ -5364,12 +5400,8 @@ mod ptrmap_tests {
             );
         }
         pager
-            .io
-            .block(|| {
-                pager.with_header_mut(|header| header.vacuum_mode_largest_root_page = 1.into())
-            })
+            .persist_auto_vacuum_mode(AutoVacuumMode::Full)
             .unwrap();
-        pager.set_auto_vacuum_mode(AutoVacuumMode::Full);
 
         //  Allocate all the pages as btree root pages
         const EXPECTED_FIRST_ROOT_PAGE_ID: u32 = 3; // page1 = 1,  first ptrmap page = 2, root page = 3
@@ -5398,6 +5430,50 @@ mod ptrmap_tests {
         }
 
         pager
+    }
+
+    #[test]
+    fn persist_auto_vacuum_mode_updates_fresh_header_without_dirty_pages() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db_file: Arc<dyn DatabaseStorage> = Arc::new(DatabaseFile::new(
+            io.open_file("fresh-auto-vacuum.db", OpenFlags::Create, true)
+                .unwrap(),
+        ));
+        let buffer_pool = BufferPool::begin_init(&io, 65536);
+        let pager = Pager::new(
+            db_file,
+            None,
+            io,
+            PageCache::new(4),
+            buffer_pool,
+            Arc::new(Mutex::new(())),
+            Arc::new(ArcSwapOption::new(Some(default_page1(None)))),
+        )
+        .unwrap();
+
+        pager
+            .persist_auto_vacuum_mode(AutoVacuumMode::Incremental)
+            .unwrap();
+
+        let IOResult::Done((largest_root_page, incremental_vacuum_enabled)) = pager
+            .with_header(|header| {
+                (
+                    header.vacuum_mode_largest_root_page.get(),
+                    header.incremental_vacuum_enabled.get(),
+                )
+            })
+            .unwrap()
+        else {
+            panic!("fresh database header reads should not do any IO");
+        };
+
+        assert_eq!(largest_root_page, 1);
+        assert_eq!(incremental_vacuum_enabled, 1);
+        assert_eq!(pager.get_auto_vacuum_mode(), AutoVacuumMode::Incremental);
+        assert!(
+            pager.dirty_pages.read().is_empty(),
+            "fresh-db auto-vacuum setup must not leave dirty pages behind"
+        );
     }
 
     #[test]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2616,6 +2616,23 @@ impl Pager {
         Ok(IOResult::Done(wal.begin_write_tx()?))
     }
 
+    /// Acquire exclusive WAL access for VACUUM. Replaces the normal
+    /// `begin_read_tx` + `begin_write_tx` sequence — VACUUM needs exclusive
+    /// locks rather than a shared reader upgraded to a writer.
+    ///
+    /// Caller must already hold the checkpoint lock.
+    pub fn begin_exclusive_tx(&self) -> Result<IOResult<()>> {
+        return_if_io!(self.maybe_allocate_page1());
+        let Some(wal) = self.wal.as_ref() else {
+            return Ok(IOResult::Done(()));
+        };
+        wal.begin_exclusive_tx()?;
+        // Fresh exclusive snapshot — clear any stale page cache.
+        self.clear_page_cache(false);
+        self.set_schema_cookie(None);
+        Ok(IOResult::Done(()))
+    }
+
     /// commit dirty pages from current transaction in WAL mode if this is not nested statement (for nested statements, parent will do the commit)
     /// if update_transaction_state set to false, then [Connection::transaction_state] left unchanged
     /// if update_transaction_state set to true, then [Connection::transaction_state] reset to [TransactionState::None] in case when method completes without error

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4861,6 +4861,10 @@ impl Pager {
 
     pub fn set_reserved_space_bytes(&self, value: u8) {
         self.set_reserved_space(value);
+        #[cfg(feature = "checksum")]
+        if value != crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES {
+            self.reset_checksum_context();
+        }
     }
 
     /// Encryption is an opt-in feature. If the flag is passed, then enable the encryption on

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2626,8 +2626,7 @@ impl Pager {
     pub fn begin_exclusive_tx(&self) -> Result<IOResult<()>> {
         if !self.db_initialized() {
             return Err(LimboError::InternalError(
-                "VACUUM requires an initialized database (page 1 must already be allocated)"
-                    .into(),
+                "VACUUM requires an initialized database (page 1 must already be allocated)".into(),
             ));
         }
         let wal = self
@@ -4869,10 +4868,6 @@ impl Pager {
 
     pub fn set_reserved_space_bytes(&self, value: u8) {
         self.set_reserved_space(value);
-        #[cfg(feature = "checksum")]
-        if value != crate::storage::checksum::CHECKSUM_REQUIRED_RESERVED_BYTES {
-            self.reset_checksum_context();
-        }
     }
 
     /// Encryption is an opt-in feature. If the flag is passed, then enable the encryption on

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2620,12 +2620,20 @@ impl Pager {
     /// `begin_read_tx` + `begin_write_tx` sequence — VACUUM needs exclusive
     /// locks rather than a shared reader upgraded to a writer.
     ///
-    /// Caller must already hold the checkpoint lock.
+    /// Caller must already hold the checkpoint lock. VACUUM runs on an
+    /// existing database, so page 1 must already be allocated and a WAL
+    /// must be present.
     pub fn begin_exclusive_tx(&self) -> Result<IOResult<()>> {
-        return_if_io!(self.maybe_allocate_page1());
-        let Some(wal) = self.wal.as_ref() else {
-            return Ok(IOResult::Done(()));
-        };
+        if !self.db_initialized() {
+            return Err(LimboError::InternalError(
+                "VACUUM requires an initialized database (page 1 must already be allocated)"
+                    .into(),
+            ));
+        }
+        let wal = self
+            .wal
+            .as_ref()
+            .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL mode".into()))?;
         wal.begin_exclusive_tx()?;
         // Fresh exclusive snapshot — clear any stale page cache.
         self.clear_page_cache(false);

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1450,6 +1450,7 @@ pub fn build_shared_wal(
             frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
             file: Some(file.clone()),
             read_locks,
+            vacuum_lock: TursoRwLock::new(),
             write_lock: TursoRwLock::new(),
             checkpoint_lock: TursoRwLock::new(),
             epoch: AtomicU32::new(0),

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -590,6 +590,23 @@ pub trait Wal: Debug + Send + Sync {
         buffer_pool: Arc<BufferPool>,
     ) -> Result<Completion>;
 
+    /// Read a contiguous run of WAL frames with a single `pread`.
+    /// For each `i`, `pages[i]` receives the decoded page body of frame
+    /// `start_frame + i`. This method is a batched version of `read_frame`.
+    ///
+    /// If `scratch_buf` is `Some`, it is used as the pread destination (must
+    /// have length exactly `(page_size + WAL_FRAME_HEADER_SIZE) * pages.len()`).
+    /// Otherwise a fresh temporary buffer is allocated. VACUUM passes a
+    /// pre-allocated buffer to amortize the ~batch-size allocation across
+    /// batches.
+    fn read_frames_batch(
+        &self,
+        start_frame: u64,
+        pages: &[PageRef],
+        buffer_pool: Arc<BufferPool>,
+        scratch_buf: Option<Arc<Buffer>>,
+    ) -> Result<Completion>;
+
     /// Read a raw frame (header included) from the WAL.
     fn read_frame_raw(&self, frame_id: u64, frame: &mut [u8]) -> Result<Completion>;
 
@@ -3038,6 +3055,157 @@ impl Wal for WalFile {
             page_idx,
             &self.io_ctx.read(),
         )
+    }
+
+    #[instrument(skip_all, level = Level::DEBUG)]
+    fn read_frames_batch(
+        &self,
+        start_frame: u64,
+        pages: &[PageRef],
+        buffer_pool: Arc<BufferPool>,
+        scratch_buf: Option<Arc<Buffer>>,
+    ) -> Result<Completion> {
+        turso_assert!(
+            !pages.is_empty(),
+            "read_frames_batch requires at least one page"
+        );
+        let page_size = self.page_size() as usize;
+        turso_assert!(page_size > 0, "WAL page size must be initialized");
+        let frame_size = WAL_FRAME_HEADER_SIZE + page_size;
+        let count = pages.len();
+        let total = frame_size * count;
+        let offset = self.frame_offset(start_frame);
+        if let Some(buf) = &scratch_buf {
+            turso_assert!(
+                buf.len() == total,
+                "read_frames_batch scratch_buf size must match expected pread length",
+                { "buf_len": buf.len(), "expected": total }
+            );
+        }
+
+        // Lock each target page and pre-allocate its destination buffer so the
+        // completion callback only parses headers, decrypts/verifies, and copies.
+        let mut slots: Vec<(PageRef, Arc<Buffer>)> = Vec::with_capacity(count);
+        for page in pages.iter() {
+            #[cfg(debug_assertions)]
+            {
+                turso_assert!(
+                    !page.is_locked(), "read_frames_batch target page must not already be locked",
+                    { "page_id": page.get().id }
+                );
+                turso_assert!(
+                    !page.is_loaded(), "read_frames_batch target page must be an unloaded scratch page",
+                    { "page_id": page.get().id }
+                );
+                turso_assert!(
+                    page.get().buffer.is_none(),
+                    "read_frames_batch target page must not already retain a buffer",
+                    { "page_id": page.get().id }
+                );
+            }
+            page.set_locked();
+            slots.push((page.clone(), Arc::new(buffer_pool.get_page())));
+        }
+
+        let epoch = self.coordination.checkpoint_epoch();
+        let enc_or_csum = self.io_ctx.read().encryption_or_checksum().clone();
+        let raw_buf = scratch_buf.unwrap_or_else(|| Arc::new(Buffer::new_temporary(total)));
+
+        let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+            let clear_slots_on_err = |slots: &[(PageRef, Arc<Buffer>)]| {
+                for (page, _) in slots {
+                    page.clear_locked();
+                    page.clear_wal_tag();
+                }
+            };
+
+            let Ok((buf, bytes_read)) = res else {
+                tracing::debug!(err = ?res.unwrap_err());
+                clear_slots_on_err(&slots);
+                return None;
+            };
+            if bytes_read != total as i32 {
+                tracing::debug!(
+                    "short read on WAL batch at offset {offset}: expected {total} bytes, got {bytes_read}"
+                );
+                clear_slots_on_err(&slots);
+                return Some(CompletionError::ShortReadWalFrame {
+                    offset,
+                    expected: total,
+                    actual: bytes_read as usize,
+                });
+            }
+            let raw = buf.as_slice();
+            for (i, (page, page_buf)) in slots.iter().enumerate() {
+                let frame_start = i * frame_size;
+                let frame = &raw[frame_start..frame_start + frame_size];
+                let (header, page_body) = sqlite3_ondisk::parse_wal_frame_header(frame);
+                let expected_page_id = page.get().id;
+                if header.page_number as usize != expected_page_id {
+                    mark_unlikely();
+                    tracing::error!(
+                        frame_id = start_frame + i as u64,
+                        expected = expected_page_id,
+                        got = header.page_number,
+                        "WAL batch frame page_no mismatch"
+                    );
+                    clear_slots_on_err(&slots);
+                    return Some(CompletionError::WalFramePageMismatch {
+                        frame_id: start_frame + i as u64,
+                        expected: expected_page_id,
+                        actual: header.page_number,
+                    });
+                }
+
+                let body_slice = page_buf.as_mut_slice();
+                turso_assert!(
+                    body_slice.len() == page_size,
+                    "read_frames_batch buffer size must match WAL page size",
+                    { "buffer_len": body_slice.len(), "page_size": page_size }
+                );
+                body_slice.copy_from_slice(page_body);
+
+                match &enc_or_csum {
+                    EncryptionOrChecksum::Encryption(ctx) => {
+                        match ctx.decrypt_page(body_slice, expected_page_id) {
+                            Ok(decrypted) => body_slice.copy_from_slice(&decrypted),
+                            Err(e) => {
+                                mark_unlikely();
+                                tracing::error!(
+                                    "Failed to decrypt WAL batch frame for page_idx={expected_page_id}: {e}"
+                                );
+                                clear_slots_on_err(&slots);
+                                return Some(CompletionError::DecryptionError {
+                                    page_idx: expected_page_id,
+                                });
+                            }
+                        }
+                    }
+                    EncryptionOrChecksum::Checksum(ctx) => {
+                        if let Err(e) = ctx.verify_checksum(body_slice, expected_page_id) {
+                            mark_unlikely();
+                            tracing::error!(
+                                "Failed to verify checksum for page_id={expected_page_id}: {e}"
+                            );
+                            clear_slots_on_err(&slots);
+                            return Some(e);
+                        }
+                    }
+                    EncryptionOrChecksum::None => {}
+                }
+            }
+
+            for (i, (page, page_buf)) in slots.iter().enumerate() {
+                let page_id = page.get().id;
+                finish_read_page(page_id, page_buf.clone(), page.clone());
+                page.set_wal_tag(start_frame + i as u64, epoch);
+            }
+            None
+        });
+
+        let c = Completion::new_read(raw_buf, complete);
+        let file = self.coordination.wal_file()?;
+        file.pread(offset, c)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -496,6 +496,18 @@ trait WalCoordination: Debug + Send + Sync {
         mode: CheckpointMode,
     ) -> Result<CoordinationCheckpointGuardKind>;
 
+    /// Acquire the remaining checkpoint-related locks for `mode` when the
+    /// caller already owns the raw process-local checkpoint lock.
+    ///
+    /// On error, implementations must release that held checkpoint lock before
+    /// returning.
+    ///
+    /// Right now used by VACUUM with mode being `TRUNCATE` always.
+    fn acquire_checkpoint_guard_from_held_lock(
+        &self,
+        mode: CheckpointMode,
+    ) -> Result<CoordinationCheckpointGuardKind>;
+
     /// Release the checkpoint-related locks previously acquired for `guard`.
     fn release_checkpoint_guard(&self, guard: CoordinationCheckpointGuardKind);
 
@@ -519,6 +531,9 @@ trait WalCoordination: Debug + Send + Sync {
 
     /// Return the WAL file used for durable reads and writes.
     fn wal_file(&self) -> Result<Arc<dyn File>>;
+
+    /// Clone the shared WAL state backing this coordination backend.
+    fn shared_wal_state(&self) -> Arc<RwLock<WalFileShared>>;
 
     /// Report whether the WAL header has already been written and synced.
     fn wal_is_initialized(&self) -> bool;
@@ -696,6 +711,44 @@ pub trait Wal: Debug + Send + Sync {
         result: &mut CheckpointResult,
         sync_type: FileSyncType,
     ) -> Result<IOResult<()>>;
+
+    /// Try to acquire the checkpoint serialization lock. Returns `Busy` if
+    /// another checkpointer or VACUUM already holds it. Used by plain VACUUM
+    /// to fail fast if a concurrent checkpoint would block later.
+    fn try_begin_checkpoint_lock(&self) -> Result<()>;
+
+    /// Release the checkpoint serialization lock acquired by
+    /// `try_begin_checkpoint_lock`.
+    fn release_checkpoint_lock(&self);
+
+    /// Acquire exclusive WAL access. This will block all new readers and writers. Also,
+    /// this routine succeeds only if no other transactions are active. This is used by
+    /// VACUUM routine.
+    ///
+    ///
+    /// VACUUM: take `vacuum_lock` exclusively, take the WAL write lock, and install
+    /// the source snapshot that VACUUM will copy from.
+    ///
+    /// This does not acquire a physical read-mark lock. The exclusive snapshot
+    /// is protected by `vacuum_lock`: normal readers hold that lock shared for
+    /// their read transaction, so once the exclusive lock is acquired no new
+    /// normal reader or writer can enter.
+    fn begin_blocking_tx(&self) -> Result<()>;
+
+    /// Checkpoint using a checkpoint lock already held by the caller. The
+    /// method consumes that raw checkpoint-lock ownership: on success the guard
+    /// is held by the checkpoint state machine, and on early failure it is
+    /// released before returning.
+    fn checkpoint_with_held_checkpoint_lock(
+        &self,
+        pager: &Pager,
+        mode: CheckpointMode,
+    ) -> Result<IOResult<CheckpointResult>>;
+
+    /// Release the exclusive VACUUM lock acquired by `begin_blocking_tx`.
+    /// VACUUM calls this once done, after which new
+    /// readers and writers may proceed again.
+    fn release_vacuum_lock(&self);
 
     #[cfg(any(test, debug_assertions))]
     fn as_any(&self) -> &dyn std::any::Any;
@@ -969,6 +1022,28 @@ impl WalCoordination for InProcessWalCoordination {
         }
     }
 
+    fn acquire_checkpoint_guard_from_held_lock(
+        &self,
+        mode: CheckpointMode,
+    ) -> Result<CoordinationCheckpointGuardKind> {
+        turso_assert!(
+            matches!(mode, CheckpointMode::Truncate { .. }),
+            "held checkpoint-lock path currently only supports TRUNCATE checkpoints"
+        );
+        if !self.try_read_mark_exclusive(0) {
+            self.unlock_checkpoint_lock();
+            tracing::trace!("CheckpointGuard: held VACUUM read0 lock failed, returning Busy");
+            return Err(LimboError::Busy);
+        }
+        if !self.try_write_lock() {
+            self.unlock_read_mark(0);
+            self.unlock_checkpoint_lock();
+            tracing::trace!("CheckpointGuard: held VACUUM write lock failed, returning Busy");
+            return Err(LimboError::Busy);
+        }
+        Ok(CoordinationCheckpointGuardKind::Writer)
+    }
+
     fn release_checkpoint_guard(&self, guard: CoordinationCheckpointGuardKind) {
         match guard {
             CoordinationCheckpointGuardKind::Writer => {
@@ -1165,6 +1240,10 @@ impl WalCoordination for InProcessWalCoordination {
     #[cfg(test)]
     fn shared_ptr(&self) -> usize {
         Arc::as_ptr(&self.shared) as usize
+    }
+
+    fn shared_wal_state(&self) -> Arc<RwLock<WalFileShared>> {
+        self.shared.clone()
     }
 }
 
@@ -1932,6 +2011,39 @@ impl WalCoordination for ShmWalCoordination {
         }
     }
 
+    fn acquire_checkpoint_guard_from_held_lock(
+        &self,
+        mode: CheckpointMode,
+    ) -> Result<CoordinationCheckpointGuardKind> {
+        turso_assert!(
+            matches!(mode, CheckpointMode::Truncate { .. }),
+            "held checkpoint-lock path currently only supports TRUNCATE checkpoints"
+        );
+        if !self.authority.try_acquire_checkpoint(self.owner) {
+            self.fallback.unlock_checkpoint_lock();
+            return Err(LimboError::Busy);
+        }
+        if !self.authority.try_acquire_writer(self.owner) {
+            self.authority.release_checkpoint(self.owner);
+            self.fallback.unlock_checkpoint_lock();
+            return Err(LimboError::Busy);
+        }
+        if !self.fallback.try_read_mark_exclusive(0) {
+            self.fallback.unlock_checkpoint_lock();
+            self.authority.release_writer(self.owner);
+            self.authority.release_checkpoint(self.owner);
+            return Err(LimboError::Busy);
+        }
+        if !self.fallback.try_write_lock() {
+            self.fallback.unlock_read_mark(0);
+            self.fallback.unlock_checkpoint_lock();
+            self.authority.release_writer(self.owner);
+            self.authority.release_checkpoint(self.owner);
+            return Err(LimboError::Busy);
+        }
+        Ok(CoordinationCheckpointGuardKind::Writer)
+    }
+
     fn release_checkpoint_guard(&self, guard: CoordinationCheckpointGuardKind) {
         match guard {
             CoordinationCheckpointGuardKind::Writer => {
@@ -2042,6 +2154,10 @@ impl WalCoordination for ShmWalCoordination {
 
     fn wal_file(&self) -> Result<Arc<dyn File>> {
         self.fallback.wal_file()
+    }
+
+    fn shared_wal_state(&self) -> Arc<RwLock<WalFileShared>> {
+        self.shared.clone()
     }
 
     fn wal_is_initialized(&self) -> bool {
@@ -2418,6 +2534,10 @@ pub struct WalFile {
 
     /// Manages locks needed for checkpointing
     checkpoint_guard: RwLock<Option<CheckpointLocks>>,
+    /// Manages locks needed for VACUUM. This is very much similar to `checkpoint_guard`
+    /// This lock is to be held by all readers before they can begin. And VACUUM holds it
+    /// exclusively. See `install_vacuum_lock_guard` for its lifecycle.
+    vacuum_lock_guard: RwLock<Option<VacuumLockGuard>>,
 
     io_ctx: RwLock<IOContext>,
 
@@ -2529,6 +2649,12 @@ pub struct WalSharedRuntime {
     /// Slots 1‑4 carry a frame‑number in value and may be shared by many readers. Slot 1 is the
     /// default read lock and is to contain the max_frame in WAL.
     pub read_locks: [TursoRwLock; 5],
+    /// Lock used by in-place VACUUM to keep new read/write transactions out
+    /// while VACUUM is in progress.
+    /// Normal WAL transactions hold this shared for the lifetime of their
+    /// transaction. VACUUM holds it exclusively until its final truncate
+    /// checkpoint has completed.
+    pub vacuum_lock: TursoRwLock,
     /// There is only one write allowed in WAL mode. This lock takes care of ensuring there is only
     /// one used.
     pub write_lock: TursoRwLock,
@@ -2618,6 +2744,56 @@ impl fmt::Debug for WalFileShared {
     }
 }
 
+#[derive(Debug)]
+enum VacuumLockGuard {
+    Read { ptr: Arc<RwLock<WalFileShared>> },
+    Write { ptr: Arc<RwLock<WalFileShared>> },
+}
+
+impl VacuumLockGuard {
+    fn try_read(ptr: Arc<RwLock<WalFileShared>>) -> Option<Self> {
+        let acquired = {
+            let shared = ptr.read();
+            shared.runtime.vacuum_lock.read()
+        };
+        if acquired {
+            Some(Self::Read { ptr })
+        } else {
+            None
+        }
+    }
+
+    fn try_write(ptr: Arc<RwLock<WalFileShared>>) -> Option<Self> {
+        let acquired = {
+            let shared = ptr.read();
+            shared.runtime.vacuum_lock.write()
+        };
+        if acquired {
+            Some(Self::Write { ptr })
+        } else {
+            None
+        }
+    }
+
+    const fn is_read(&self) -> bool {
+        matches!(self, Self::Read { .. })
+    }
+
+    const fn is_write(&self) -> bool {
+        matches!(self, Self::Write { .. })
+    }
+}
+
+impl Drop for VacuumLockGuard {
+    fn drop(&mut self) {
+        match self {
+            Self::Read { ptr } | Self::Write { ptr } => {
+                ptr.read().runtime.vacuum_lock.unlock();
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 /// To manage and ensure that no locks are leaked during checkpointing in
 /// the case of errors. It is held by the WalFile while checkpoint is ongoing
@@ -2631,6 +2807,12 @@ enum CheckpointLocks {
     },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CheckpointLockSource {
+    Acquire,
+    HeldByCaller,
+}
+
 /// Database checkpointers takes the following locks, in order:
 /// The exclusive CHECKPOINTER lock.
 /// The exclusive WRITER lock (FULL, RESTART and TRUNCATE only).
@@ -2641,6 +2823,22 @@ enum CheckpointLocks {
 impl CheckpointLocks {
     fn new(coordination: Arc<dyn WalCoordination>, mode: CheckpointMode) -> Result<Self> {
         let guard = coordination.acquire_checkpoint_guard(mode)?;
+        Ok(match guard {
+            CoordinationCheckpointGuardKind::Read0 => Self::Read0 { coordination },
+            CoordinationCheckpointGuardKind::Writer => Self::Writer { coordination },
+        })
+    }
+
+    /// Build checkpoint ownership from a checkpoint_lock that the caller
+    /// already holds. This consumes that raw lock ownership: on success the
+    /// returned guard owns checkpoint/read0/write as appropriate, and on error
+    /// the coordination backend releases the held checkpoint lock before
+    /// returning.
+    fn from_held_checkpoint_lock(
+        coordination: Arc<dyn WalCoordination>,
+        mode: CheckpointMode,
+    ) -> Result<Self> {
+        let guard = coordination.acquire_checkpoint_guard_from_held_lock(mode)?;
         Ok(match guard {
             CoordinationCheckpointGuardKind::Read0 => Self::Read0 { coordination },
             CoordinationCheckpointGuardKind::Writer => Self::Writer { coordination },
@@ -2669,6 +2867,12 @@ enum TryBeginReadResult {
     Retry,
     /// Non-retriable failure while preparing the local WAL view.
     Err(LimboError),
+    /// We could get a lock / source snapshot for readers because WAL is exclusively held by
+    /// other transaction.
+    /// This usually happens during VACUUM when it holds the vacuum lock exclusively.
+    /// Retrying will not help until VACUUM releases; caller should surface Busy
+    /// to the client rather than spin.
+    Busy,
 }
 
 impl WalFile {
@@ -2711,6 +2915,55 @@ impl WalFile {
         snapshot != local_state.snapshot
     }
 
+    fn has_vacuum_read_lock_guard(&self) -> bool {
+        self.vacuum_lock_guard
+            .read()
+            .as_ref()
+            .is_some_and(VacuumLockGuard::is_read)
+    }
+
+    // VACUUM lock guard lifecycle:
+    // - Normal readers install a read guard in `try_begin_read_tx` after the
+    //   read-mark slot is selected; `end_read_tx` releases that guard through
+    //   `release_vacuum_read_lock_guard`.
+    // - Normal writers do not install their own VACUUM guard. They are an
+    //   upgrade of an existing read transaction, so their guard is still the
+    //   read guard owned by the read transaction.
+    // - In-place VACUUM installs a write guard and takes the WAL write lock in
+    //   `begin_blocking_tx`. `end_write_tx` releases the WAL write lock, and
+    //   `release_vacuum_lock` releases the write guard.
+    fn install_vacuum_lock_guard(&self, guard: VacuumLockGuard) {
+        let mut slot = self.vacuum_lock_guard.write();
+        turso_assert!(slot.is_none(), "VACUUM lock guard is already installed");
+        *slot = Some(guard);
+    }
+
+    fn release_vacuum_read_lock_guard(&self) {
+        let guard = {
+            let mut slot = self.vacuum_lock_guard.write();
+            turso_assert!(
+                slot.as_ref().is_some_and(VacuumLockGuard::is_read),
+                "VACUUM read lock guard is not held"
+            );
+            slot.take()
+                .expect("VACUUM read lock guard should be present after kind check")
+        };
+        drop(guard);
+    }
+
+    fn release_vacuum_write_lock_guard(&self) {
+        let guard = {
+            let mut slot = self.vacuum_lock_guard.write();
+            turso_assert!(
+                slot.as_ref().is_some_and(VacuumLockGuard::is_write),
+                "VACUUM write lock guard is not held"
+            );
+            slot.take()
+                .expect("VACUUM write lock guard should be present after kind check")
+        };
+        drop(guard);
+    }
+
     /// Try to begin a read transaction. Returns Retry for transient conditions
     /// that should be retried immediately, Ok for success.
     fn try_begin_read_tx(&self) -> TryBeginReadResult {
@@ -2721,6 +2974,20 @@ impl WalFile {
             "cannot start a new read tx without ending an existing one",
             { "lock_value": self.max_frame_read_lock_index.load(Ordering::Acquire), "expected": NO_LOCK_HELD }
         );
+        turso_assert!(
+            self.vacuum_lock_guard.read().is_none(),
+            "VACUUM lock guard already held"
+        );
+
+        // Before we can start the txn, we must first take read lock on the vacuum. If we cannot,
+        // then vacuum is already in progress. Once we acquire a read lock, this would prevent
+        // vacuum to run till the lock is released.
+        let Some(vacuum_lock_guard) =
+            VacuumLockGuard::try_read(self.coordination.shared_wal_state())
+        else {
+            tracing::debug!("begin_read_tx: VACUUM holds the vacuum lock, returning Busy");
+            return TryBeginReadResult::Busy;
+        };
 
         // Snapshot the shared WAL state. We haven't taken a read lock yet, so we need
         // to validate these values later.
@@ -2762,6 +3029,7 @@ impl WalFile {
         let Some(read_guard) = self.coordination.try_begin_read_tx(shared_snapshot) else {
             return TryBeginReadResult::Retry;
         };
+        self.install_vacuum_lock_guard(vacuum_lock_guard);
         self.install_connection_state(WalConnectionState::new(shared_snapshot, read_guard));
         tracing::debug!(
             "begin_read_tx(min={}, max={}, slot={}, max_frame_in_wal={})",
@@ -2787,6 +3055,7 @@ impl Wal for WalFile {
             match self.try_begin_read_tx() {
                 TryBeginReadResult::Ok(changed) => return Ok(changed),
                 TryBeginReadResult::Err(err) => return Err(err),
+                TryBeginReadResult::Busy => return Err(LimboError::Busy),
                 TryBeginReadResult::Retry => {
                     cnt += 1;
                     if cnt > 100 {
@@ -2825,8 +3094,14 @@ impl Wal for WalFile {
                 .end_read_tx(ReadGuardKind::from_lock_index(slot));
             self.max_frame_read_lock_index
                 .store(NO_LOCK_HELD, Ordering::Release);
+            self.release_vacuum_read_lock_guard();
             tracing::debug!("end_read_tx(slot={slot})");
         } else {
+            // if NO_LOCK_HELD, then we must not have vacuum lock either.
+            turso_assert!(
+                !self.has_vacuum_read_lock_guard(),
+                "vacuum read lock guard held without setting lock slot NO_LOCK_HELD"
+            );
             tracing::debug!("end_read_tx(slot=no_lock)");
         }
     }
@@ -3396,11 +3671,25 @@ impl Wal for WalFile {
         pager: &Pager,
         mode: CheckpointMode,
     ) -> Result<IOResult<CheckpointResult>> {
-        self.checkpoint_inner(pager, mode).inspect_err(|e| {
-            tracing::info!("Wal Checkpoint failed: {e}");
-            let _ = self.checkpoint_guard.write().take();
-            self.ongoing_checkpoint.write().state = CheckpointState::Start;
-        })
+        self.checkpoint_inner(pager, mode, CheckpointLockSource::Acquire)
+            .inspect_err(|e| {
+                tracing::info!("Wal Checkpoint failed: {e}");
+                let _ = self.checkpoint_guard.write().take();
+                self.ongoing_checkpoint.write().state = CheckpointState::Start;
+            })
+    }
+
+    fn checkpoint_with_held_checkpoint_lock(
+        &self,
+        pager: &Pager,
+        mode: CheckpointMode,
+    ) -> Result<IOResult<CheckpointResult>> {
+        self.checkpoint_inner(pager, mode, CheckpointLockSource::HeldByCaller)
+            .inspect_err(|e| {
+                tracing::info!("Wal Checkpoint failed: {e}");
+                let _ = self.checkpoint_guard.write().take();
+                self.ongoing_checkpoint.write().state = CheckpointState::Start;
+            })
     }
 
     fn install_durable_backfill_proof(
@@ -3487,6 +3776,84 @@ impl Wal for WalFile {
     fn abort_checkpoint(&self) {
         let _ = self.checkpoint_guard.write().take();
         self.reset_internal_states();
+    }
+
+    fn try_begin_checkpoint_lock(&self) -> Result<()> {
+        self.with_shared(|shared| {
+            if !shared.runtime.checkpoint_lock.write() {
+                return Err(LimboError::Busy);
+            }
+            Ok(())
+        })
+    }
+
+    fn release_checkpoint_lock(&self) {
+        self.with_shared(|shared| {
+            shared.runtime.checkpoint_lock.unlock();
+        });
+    }
+
+    fn begin_blocking_tx(&self) -> Result<()> {
+        turso_assert!(
+            self.max_frame_read_lock_index.load(Ordering::Acquire) == NO_LOCK_HELD,
+            "begin_blocking_tx: must not already hold a read lock"
+        );
+        turso_assert!(
+            !self.holds_write_lock(),
+            "begin_blocking_tx: must not already hold the write lock"
+        );
+        turso_assert!(
+            self.vacuum_lock_guard.read().is_none(),
+            "VACUUM lock guard already held"
+        );
+
+        let Some(vacuum_lock_guard) =
+            VacuumLockGuard::try_write(self.coordination.shared_wal_state())
+        else {
+            return Err(LimboError::Busy);
+        };
+
+        // This block is purely an invariant check. The exclusive VACUUM lock can be held
+        // only if we don't have any other active locks.
+        self.with_shared(|shared| {
+            for idx in 0..shared.runtime.read_locks.len() {
+                // iff there are no read locks active, only then we should be able to
+                // acquire the write lock
+                turso_assert!(
+                    shared.runtime.read_locks[idx].write(),
+                    "begin_blocking_tx: read lock held after VACUUM lock acquired",
+                    { "read_lock_idx": idx }
+                );
+                shared.runtime.read_locks[idx].unlock();
+            }
+        });
+
+        // Install connection state with a fresh snapshot.
+        let snapshot = self.load_coordination_snapshot();
+        self.install_connection_state(WalConnectionState::new(snapshot, ReadGuardKind::None));
+        turso_assert!(
+            self.with_shared(|shared| shared.runtime.write_lock.write()),
+            "begin_blocking_tx: write lock held after VACUUM lock acquired"
+        );
+        if self
+            .write_lock_held
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            turso_assert!(false, "begin_blocking_tx: write_lock_held already set");
+        }
+        self.install_vacuum_lock_guard(vacuum_lock_guard);
+        Ok(())
+    }
+
+    fn release_vacuum_lock(&self) {
+        // This drops the stop-the-world gate after VACUUM is one.
+        // Only after this new readers can proceed.
+        turso_assert!(
+            !self.holds_write_lock(),
+            "release_vacuum_lock called while source write lock is still held"
+        );
+        self.release_vacuum_write_lock_guard();
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -3603,6 +3970,10 @@ impl Wal for WalFile {
         db_size_on_commit: Option<u32>,
         prev: Option<&PreparedFrames>,
     ) -> Result<PreparedFrames> {
+        turso_assert!(
+            !pages.is_empty(),
+            "prepare_frames requires at least one page"
+        );
         turso_assert!(
             pages.len() <= IOV_MAX,
             "supported up to IOV_MAX pages at once"
@@ -3952,6 +4323,7 @@ impl WalFile {
             checkpoint_seq: AtomicU32::new(0),
             syncing: Arc::new(AtomicBool::new(false)),
             write_lock_held: AtomicBool::new(false),
+            vacuum_lock_guard: RwLock::new(None),
             min_frame: AtomicU64::new(0),
             transaction_count: AtomicU64::new(0),
             max_frame_read_lock_index: AtomicUsize::new(NO_LOCK_HELD),
@@ -3975,6 +4347,15 @@ impl WalFile {
     #[cfg(test)]
     pub(crate) fn coordination_open_mode_name(&self) -> Option<&'static str> {
         self.coordination.open_mode_name()
+    }
+
+    fn with_shared<F, R>(&self, func: F) -> R
+    where
+        F: FnOnce(&WalFileShared) -> R,
+    {
+        let shared = self.coordination.shared_wal_state();
+        let guard = shared.read();
+        func(&guard)
     }
 
     fn page_size(&self) -> u32 {
@@ -4020,6 +4401,7 @@ impl WalFile {
         &self,
         pager: &Pager,
         mode: CheckpointMode,
+        lock_source: CheckpointLockSource,
     ) -> Result<IOResult<CheckpointResult>> {
         loop {
             let state = self.ongoing_checkpoint.read().state.clone();
@@ -4034,6 +4416,13 @@ impl WalFile {
                     let nbackfills = snapshot.nbackfills;
                     tracing::info!("shared_wal: max_frame={max_frame}, nbackfills={nbackfills}");
                     let needs_backfill = max_frame > nbackfills;
+                    if matches!(lock_source, CheckpointLockSource::HeldByCaller) {
+                        turso_assert!(
+                            needs_backfill,
+                            "held checkpoint-lock path requires WAL frames to backfill",
+                            { "max_frame": max_frame, "nbackfills": nbackfills }
+                        );
+                    }
                     if !needs_backfill && !mode.should_restart_log() {
                         // there are no frames to copy over and we don't need to reset
                         // the log so we can return early success.
@@ -4042,7 +4431,7 @@ impl WalFile {
                         )));
                     }
                     // acquire the appropriate exclusive locks depending on the checkpoint mode
-                    self.acquire_proper_checkpoint_guard(mode)?;
+                    self.acquire_proper_checkpoint_guard(mode, lock_source)?;
                     let mut max_frame = self.determine_max_safe_checkpoint_frame();
 
                     if let CheckpointMode::Truncate {
@@ -4459,7 +4848,11 @@ impl WalFile {
         }
     }
 
-    fn acquire_proper_checkpoint_guard(&self, mode: CheckpointMode) -> Result<()> {
+    fn acquire_proper_checkpoint_guard(
+        &self,
+        mode: CheckpointMode,
+        lock_source: CheckpointLockSource,
+    ) -> Result<()> {
         let needs_new_guard = {
             let guard = self.checkpoint_guard.read();
             !matches!(
@@ -4478,7 +4871,14 @@ impl WalFile {
             if self.checkpoint_guard.read().is_some() {
                 let _ = self.checkpoint_guard.write().take();
             }
-            let guard = CheckpointLocks::new(self.coordination.clone(), mode)?;
+            let guard = match lock_source {
+                CheckpointLockSource::Acquire => {
+                    CheckpointLocks::new(self.coordination.clone(), mode)?
+                }
+                CheckpointLockSource::HeldByCaller => {
+                    CheckpointLocks::from_held_checkpoint_lock(self.coordination.clone(), mode)?
+                }
+            };
             *self.checkpoint_guard.write() = Some(guard);
         }
         Ok(())
@@ -4911,6 +5311,7 @@ impl WalFileShared {
                 frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
                 file: Some(file),
                 read_locks,
+                vacuum_lock: TursoRwLock::new(),
                 write_lock: TursoRwLock::new(),
                 checkpoint_lock: TursoRwLock::new(),
                 epoch: AtomicU32::new(snapshot.checkpoint_epoch),
@@ -4978,6 +5379,7 @@ impl WalFileShared {
                 frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
                 file: None,
                 read_locks,
+                vacuum_lock: TursoRwLock::new(),
                 write_lock: TursoRwLock::new(),
                 checkpoint_lock: TursoRwLock::new(),
                 epoch: AtomicU32::new(0),
@@ -5018,6 +5420,7 @@ impl WalFileShared {
                 frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
                 file: Some(file),
                 read_locks,
+                vacuum_lock: TursoRwLock::new(),
                 write_lock: TursoRwLock::new(),
                 checkpoint_lock: TursoRwLock::new(),
                 epoch: AtomicU32::new(0),
@@ -5082,8 +5485,8 @@ pub mod test {
         AuthoritySnapshotValidation, ShmWalCoordination,
     };
     use super::{
-        InProcessWalCoordination, ReadGuardKind, Wal, WalCommitState, WalConnectionState,
-        WalCoordination, WalFile, WalSnapshot,
+        CheckpointLocks, InProcessWalCoordination, ReadGuardKind, TryBeginReadResult, Wal,
+        WalCommitState, WalConnectionState, WalCoordination, WalFile, WalSnapshot, NO_LOCK_HELD,
     };
     #[cfg(host_shared_wal)]
     use crate::storage::shared_wal_coordination::{
@@ -5092,16 +5495,18 @@ pub mod test {
     use crate::sync::{atomic::Ordering, Arc};
     use crate::sync::{Mutex, RwLock};
     use crate::{
+        io::FileSyncType,
         storage::{
             buffer_pool::BufferPool,
             database::{DatabaseFile, DatabaseStorage},
+            pager::{allocate_new_page, PageRef},
             sqlite3_ondisk::{self, PageSize, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
         },
         types::IOResult,
         util::IOExt,
-        Buffer, CheckpointMode, CheckpointResult, Completion, Connection, Database, File,
-        LimboError, PlatformIO, SyncMode, WalFileShared, IO,
+        Buffer, CheckpointMode, CheckpointResult, Completion, CompletionError, Connection,
+        Database, File, LimboError, MemoryIO, OpenFlags, PlatformIO, SyncMode, WalFileShared, IO,
     };
     use std::num::NonZeroUsize;
     #[cfg(unix)]
@@ -5386,6 +5791,262 @@ pub mod test {
             Arc::new(InProcessWalCoordination::new(shared.clone()));
         let wal = WalFile::new_with_coordination(io, coordination, ((0, 0), 0), buffer_pool);
         (shared, wal)
+    }
+
+    fn make_test_wal_from_shared(shared: Arc<RwLock<WalFileShared>>) -> WalFile {
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        let snapshot = shared.read().last_checksum_and_max_frame();
+        WalFile::new(io, shared, snapshot, buffer_pool)
+    }
+
+    fn make_initialized_memory_wal(page_size: u32) -> (Arc<dyn IO>, Arc<BufferPool>, WalFile) {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool
+            .finalize_with_page_size(page_size as usize)
+            .unwrap();
+        let file = io
+            .open_file("direct-batch-read.db-wal", OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        let wal = WalFile::new(io.clone(), shared, ((0, 0), 0), buffer_pool.clone());
+        let page_size = PageSize::new(page_size).unwrap();
+
+        if let Some(c) = wal.prepare_wal_start(page_size).unwrap() {
+            io.wait_for_completion(c).unwrap();
+        }
+        let c = wal.prepare_wal_finish(FileSyncType::Fsync).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        (io, buffer_pool, wal)
+    }
+
+    fn page_with_pattern(page_id: i64, seed: u8, buffer_pool: &Arc<BufferPool>) -> PageRef {
+        let page = allocate_new_page(page_id, buffer_pool);
+        for (idx, byte) in page.get_contents().as_ptr().iter_mut().enumerate() {
+            *byte = seed.wrapping_add(idx as u8).wrapping_add(page_id as u8);
+        }
+        page
+    }
+
+    fn append_test_pages(
+        io: &Arc<dyn IO>,
+        wal: &WalFile,
+        page_size: u32,
+        pages: &[PageRef],
+    ) -> Vec<Vec<u8>> {
+        let prepared = wal
+            .prepare_frames(pages, PageSize::new(page_size).unwrap(), Some(99), None)
+            .unwrap();
+        let expected = pages
+            .iter()
+            .map(|page| page.get_contents().as_ptr().to_vec())
+            .collect::<Vec<_>>();
+
+        let file = wal.wal_file().unwrap();
+        let c = file
+            .pwritev(
+                prepared.offset,
+                prepared.bufs.clone(),
+                Completion::new_write(|_| {}),
+            )
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+        wal.commit_prepared_frames(&[prepared]);
+        wal.finish_append_frames_commit().unwrap();
+        expected
+    }
+
+    fn wait_for_completion_error(io: &Arc<dyn IO>, completion: Completion) -> CompletionError {
+        match io.wait_for_completion(completion) {
+            Err(LimboError::CompletionError(err)) => err,
+            other => panic!("expected completion error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_reads_contiguous_wal_frames_directly() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(2, 0x10, &buffer_pool),
+            page_with_pattern(3, 0x20, &buffer_pool),
+            page_with_pattern(4, 0x30, &buffer_pool),
+            page_with_pattern(5, 0x40, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(2)),
+            Arc::new(crate::Page::new(3)),
+            Arc::new(crate::Page::new(4)),
+            Arc::new(crate::Page::new(5)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert!(page.is_loaded(), "page {} should be loaded", page.get().id);
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
+            assert_eq!(page.get_contents().as_ptr(), expected[idx].as_slice());
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_can_start_from_middle_frame() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(10, 0x01, &buffer_pool),
+            page_with_pattern(11, 0x02, &buffer_pool),
+            page_with_pattern(12, 0x03, &buffer_pool),
+            page_with_pattern(13, 0x04, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(11)),
+            Arc::new(crate::Page::new(12)),
+            Arc::new(crate::Page::new(13)),
+        ];
+        let c = wal
+            .read_frames_batch(2, &target_pages, buffer_pool, None)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert!(page.is_loaded(), "page {} should be loaded", page.get().id);
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert_eq!(page.wal_tag_pair(), ((idx + 2) as u64, 0));
+            assert_eq!(page.get_contents().as_ptr(), expected[idx + 1].as_slice());
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_follows_physical_frame_order_not_page_id_order() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(7, 0x71, &buffer_pool),
+            page_with_pattern(2, 0x22, &buffer_pool),
+            page_with_pattern(5, 0x55, &buffer_pool),
+            page_with_pattern(9, 0x99, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(7)),
+            Arc::new(crate::Page::new(2)),
+            Arc::new(crate::Page::new(5)),
+            Arc::new(crate::Page::new(9)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert_eq!(
+                page.get_contents().as_ptr(),
+                expected[idx].as_slice(),
+                "frame-order read should preserve page {} contents",
+                page.get().id
+            );
+            assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_short_read_errors_and_clears_page_locks() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(20, 0x20, &buffer_pool),
+            page_with_pattern(21, 0x21, &buffer_pool),
+        ];
+        append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(20)),
+            Arc::new(crate::Page::new(21)),
+            Arc::new(crate::Page::new(22)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(
+            matches!(err, CompletionError::ShortReadWalFrame { .. }),
+            "unexpected error: {err:?}"
+        );
+        for page in &target_pages {
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert!(
+                !page.is_loaded(),
+                "page {} should not be loaded",
+                page.get().id
+            );
+            assert!(
+                !page.has_wal_tag(),
+                "page {} should not be tagged",
+                page.get().id
+            );
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_page_number_mismatch_returns_error_not_panic() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(30, 0x30, &buffer_pool),
+            page_with_pattern(31, 0x31, &buffer_pool),
+        ];
+        append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(30)),
+            Arc::new(crate::Page::new(99)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(
+            matches!(
+                err,
+                CompletionError::WalFramePageMismatch {
+                    frame_id: 2,
+                    expected: 99,
+                    actual: 31
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+        for page in &target_pages {
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert!(
+                !page.is_loaded(),
+                "page {} should not be loaded",
+                page.get().id
+            );
+            assert!(
+                !page.has_wal_tag(),
+                "page {} should not be tagged",
+                page.get().id
+            );
+            assert!(
+                page.get().buffer.is_none(),
+                "page {} should not retain a buffer",
+                page.get().id
+            );
+        }
     }
 
     fn set_shared_snapshot(shared: &Arc<RwLock<WalFileShared>>, snapshot: WalSnapshot) {
@@ -7657,6 +8318,164 @@ pub mod test {
         assert!(coordination
             .prepare_wal_header(io.as_ref(), PageSize::new(4096).unwrap())
             .is_none());
+    }
+
+    #[test]
+    fn test_vacuum_lock_blocks_new_read_transactions_until_release() {
+        let (shared, vacuum_wal) = make_test_wal();
+        let reader_wal = make_test_wal_from_shared(shared);
+
+        vacuum_wal.try_begin_checkpoint_lock().unwrap();
+        vacuum_wal.begin_blocking_tx().unwrap();
+
+        assert!(
+            matches!(reader_wal.try_begin_read_tx(), TryBeginReadResult::Busy),
+            "VACUUM lock should block new WAL readers before they take a read-mark slot"
+        );
+        assert!(
+            !vacuum_wal.holds_read_lock(),
+            "exclusive VACUUM snapshot must not masquerade as a read-mark lock"
+        );
+        assert!(
+            vacuum_wal.holds_write_lock(),
+            "begin_blocking_tx should acquire the source write lock"
+        );
+
+        vacuum_wal.end_write_tx();
+        vacuum_wal.release_vacuum_lock();
+        vacuum_wal.release_checkpoint_lock();
+
+        assert!(
+            matches!(reader_wal.try_begin_read_tx(), TryBeginReadResult::Ok(_)),
+            "reader should start after VACUUM releases the lock"
+        );
+        reader_wal.end_read_tx();
+    }
+
+    #[test]
+    fn test_active_reader_blocks_vacuum_exclusive_tx() {
+        let (shared, reader_wal) = make_test_wal();
+        let vacuum_wal = make_test_wal_from_shared(shared);
+
+        assert!(matches!(
+            reader_wal.try_begin_read_tx(),
+            TryBeginReadResult::Ok(_)
+        ));
+        vacuum_wal.try_begin_checkpoint_lock().unwrap();
+
+        assert!(
+            matches!(vacuum_wal.begin_blocking_tx(), Err(LimboError::Busy)),
+            "active reader should prevent VACUUM from acquiring its exclusive lock"
+        );
+
+        reader_wal.end_read_tx();
+        vacuum_wal.begin_blocking_tx().unwrap();
+        vacuum_wal.end_write_tx();
+        vacuum_wal.release_vacuum_lock();
+        vacuum_wal.release_checkpoint_lock();
+    }
+
+    #[test]
+    fn test_read_retry_does_not_leak_vacuum_guard_or_block_vacuum() {
+        let (shared, _) = make_test_wal();
+        let retry_reader = make_test_wal_from_shared(shared.clone());
+        let vacuum_wal = make_test_wal_from_shared(shared.clone());
+
+        set_shared_snapshot(
+            &shared,
+            WalSnapshot {
+                max_frame: 5,
+                nbackfills: 0,
+                last_checksum: (0, 0),
+                checkpoint_seq: 0,
+                transaction_count: 1,
+            },
+        );
+
+        for idx in 1..5 {
+            assert!(
+                shared.read().runtime.read_locks[idx].write(),
+                "expected setup to occupy read-mark slot {idx}"
+            );
+        }
+
+        assert!(
+            matches!(retry_reader.try_begin_read_tx(), TryBeginReadResult::Retry),
+            "reader should retry when all read-mark slots are transiently unavailable"
+        );
+        assert!(
+            !retry_reader.has_vacuum_read_lock_guard(),
+            "retry path must not retain a shared VACUUM lock guard"
+        );
+        assert_eq!(
+            retry_reader
+                .max_frame_read_lock_index
+                .load(Ordering::Acquire),
+            NO_LOCK_HELD,
+            "retry path must not retain a read-mark slot"
+        );
+
+        for idx in 1..5 {
+            shared.read().runtime.read_locks[idx].unlock();
+        }
+
+        vacuum_wal.try_begin_checkpoint_lock().unwrap();
+        vacuum_wal.begin_blocking_tx().unwrap();
+        vacuum_wal.end_write_tx();
+        vacuum_wal.release_vacuum_lock();
+        vacuum_wal.release_checkpoint_lock();
+    }
+
+    #[test]
+    fn test_held_vacuum_checkpoint_locks_do_not_release_vacuum_lock() {
+        let (shared, vacuum_wal) = make_test_wal();
+        let contender_wal = make_test_wal_from_shared(shared);
+
+        vacuum_wal.try_begin_checkpoint_lock().unwrap();
+        vacuum_wal.begin_blocking_tx().unwrap();
+
+        assert!(vacuum_wal.holds_write_lock());
+        assert!(!vacuum_wal.holds_read_lock());
+        assert!(
+            matches!(
+                contender_wal.try_begin_checkpoint_lock(),
+                Err(LimboError::Busy)
+            ),
+            "held checkpoint lock should block other checkpointers"
+        );
+
+        vacuum_wal.end_write_tx();
+        assert!(!vacuum_wal.holds_write_lock());
+
+        let guard = CheckpointLocks::from_held_checkpoint_lock(
+            vacuum_wal.coordination.clone(),
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(contender_wal.try_begin_read_tx(), TryBeginReadResult::Busy),
+            "VACUUM lock should continue blocking readers during final checkpoint"
+        );
+
+        drop(guard);
+        assert!(
+            contender_wal.try_begin_checkpoint_lock().is_ok(),
+            "checkpoint cleanup should release the checkpoint lock"
+        );
+        contender_wal.release_checkpoint_lock();
+        assert!(
+            matches!(contender_wal.try_begin_read_tx(), TryBeginReadResult::Busy),
+            "checkpoint cleanup must not release the VACUUM lock"
+        );
+
+        vacuum_wal.release_vacuum_lock();
+        assert!(matches!(
+            contender_wal.try_begin_read_tx(),
+            TryBeginReadResult::Ok(_)
+        ));
+        contender_wal.end_read_tx();
     }
 
     #[test]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2807,8 +2807,12 @@ enum CheckpointLocks {
     },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CheckpointLockSource {
+/// CheckpointLockSource says whether the checkpoint state machine should acquire checkpoint_lock
+/// itself or consume checkpoint_lock already held by the caller.
+/// Most of the time, the default `Acquire` is used, except for VACUUM.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum CheckpointLockSource {
+    #[default]
     Acquire,
     HeldByCaller,
 }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -496,16 +496,14 @@ trait WalCoordination: Debug + Send + Sync {
         mode: CheckpointMode,
     ) -> Result<CoordinationCheckpointGuardKind>;
 
-    /// Acquire the remaining checkpoint-related locks for `mode` when the
+    /// Acquire the remaining checkpoint-related locks for VACUUM when the
     /// caller already owns the raw process-local checkpoint lock.
     ///
     /// On error, implementations must release that held checkpoint lock before
     /// returning.
     ///
-    /// Right now used by VACUUM with mode being `TRUNCATE` always.
-    fn acquire_checkpoint_guard_from_held_lock(
+    fn acquire_vacuum_checkpoint_guard_from_held_lock(
         &self,
-        mode: CheckpointMode,
     ) -> Result<CoordinationCheckpointGuardKind>;
 
     /// Release the checkpoint-related locks previously acquired for `guard`.
@@ -715,11 +713,11 @@ pub trait Wal: Debug + Send + Sync {
     /// Try to acquire the checkpoint serialization lock. Returns `Busy` if
     /// another checkpointer or VACUUM already holds it. Used by plain VACUUM
     /// to fail fast if a concurrent checkpoint would block later.
-    fn try_begin_checkpoint_lock(&self) -> Result<()>;
+    fn try_begin_vacuum_checkpoint_lock(&self) -> Result<()>;
 
     /// Release the checkpoint serialization lock acquired by
-    /// `try_begin_checkpoint_lock`.
-    fn release_checkpoint_lock(&self);
+    /// `try_begin_vacuum_checkpoint_lock`.
+    fn release_vacuum_checkpoint_lock(&self);
 
     /// Acquire exclusive WAL access. This will block all new readers and writers. Also,
     /// this routine succeeds only if no other transactions are active. This is used by
@@ -733,19 +731,16 @@ pub trait Wal: Debug + Send + Sync {
     /// is protected by `vacuum_lock`: normal readers hold that lock shared for
     /// their read transaction, so once the exclusive lock is acquired no new
     /// normal reader or writer can enter.
-    fn begin_blocking_tx(&self) -> Result<()>;
+    fn begin_vacuum_blocking_tx(&self) -> Result<()>;
 
     /// Checkpoint using a checkpoint lock already held by the caller. The
     /// method consumes that raw checkpoint-lock ownership: on success the guard
     /// is held by the checkpoint state machine, and on early failure it is
     /// released before returning.
-    fn checkpoint_with_held_checkpoint_lock(
-        &self,
-        pager: &Pager,
-        mode: CheckpointMode,
-    ) -> Result<IOResult<CheckpointResult>>;
+    fn vacuum_checkpoint_with_held_lock(&self, pager: &Pager)
+        -> Result<IOResult<CheckpointResult>>;
 
-    /// Release the exclusive VACUUM lock acquired by `begin_blocking_tx`.
+    /// Release the exclusive VACUUM lock acquired by `begin_vacuum_blocking_tx`.
     /// VACUUM calls this once done, after which new
     /// readers and writers may proceed again.
     fn release_vacuum_lock(&self);
@@ -1022,14 +1017,9 @@ impl WalCoordination for InProcessWalCoordination {
         }
     }
 
-    fn acquire_checkpoint_guard_from_held_lock(
+    fn acquire_vacuum_checkpoint_guard_from_held_lock(
         &self,
-        mode: CheckpointMode,
     ) -> Result<CoordinationCheckpointGuardKind> {
-        turso_assert!(
-            matches!(mode, CheckpointMode::Truncate { .. }),
-            "held checkpoint-lock path currently only supports TRUNCATE checkpoints"
-        );
         if !self.try_read_mark_exclusive(0) {
             self.unlock_checkpoint_lock();
             tracing::trace!("CheckpointGuard: held VACUUM read0 lock failed, returning Busy");
@@ -2011,14 +2001,9 @@ impl WalCoordination for ShmWalCoordination {
         }
     }
 
-    fn acquire_checkpoint_guard_from_held_lock(
+    fn acquire_vacuum_checkpoint_guard_from_held_lock(
         &self,
-        mode: CheckpointMode,
     ) -> Result<CoordinationCheckpointGuardKind> {
-        turso_assert!(
-            matches!(mode, CheckpointMode::Truncate { .. }),
-            "held checkpoint-lock path currently only supports TRUNCATE checkpoints"
-        );
         if !self.authority.try_acquire_checkpoint(self.owner) {
             self.fallback.unlock_checkpoint_lock();
             return Err(LimboError::Busy);
@@ -2833,16 +2818,13 @@ impl CheckpointLocks {
         })
     }
 
-    /// Build checkpoint ownership from a checkpoint_lock that the caller
-    /// already holds. This consumes that raw lock ownership: on success the
+    /// Build checkpoint ownership from a checkpoint_lock that VACUUM already
+    /// holds. This consumes that raw lock ownership: on success the
     /// returned guard owns checkpoint/read0/write as appropriate, and on error
     /// the coordination backend releases the held checkpoint lock before
     /// returning.
-    fn from_held_checkpoint_lock(
-        coordination: Arc<dyn WalCoordination>,
-        mode: CheckpointMode,
-    ) -> Result<Self> {
-        let guard = coordination.acquire_checkpoint_guard_from_held_lock(mode)?;
+    fn from_held_vacuum_checkpoint_lock(coordination: Arc<dyn WalCoordination>) -> Result<Self> {
+        let guard = coordination.acquire_vacuum_checkpoint_guard_from_held_lock()?;
         Ok(match guard {
             CoordinationCheckpointGuardKind::Read0 => Self::Read0 { coordination },
             CoordinationCheckpointGuardKind::Writer => Self::Writer { coordination },
@@ -2934,7 +2916,7 @@ impl WalFile {
     //   upgrade of an existing read transaction, so their guard is still the
     //   read guard owned by the read transaction.
     // - In-place VACUUM installs a write guard and takes the WAL write lock in
-    //   `begin_blocking_tx`. `end_write_tx` releases the WAL write lock, and
+    //   `begin_vacuum_blocking_tx`. `end_write_tx` releases the WAL write lock, and
     //   `release_vacuum_lock` releases the write guard.
     fn install_vacuum_lock_guard(&self, guard: VacuumLockGuard) {
         let mut slot = self.vacuum_lock_guard.write();
@@ -3683,17 +3665,22 @@ impl Wal for WalFile {
             })
     }
 
-    fn checkpoint_with_held_checkpoint_lock(
+    fn vacuum_checkpoint_with_held_lock(
         &self,
         pager: &Pager,
-        mode: CheckpointMode,
     ) -> Result<IOResult<CheckpointResult>> {
-        self.checkpoint_inner(pager, mode, CheckpointLockSource::HeldByCaller)
-            .inspect_err(|e| {
-                tracing::info!("Wal Checkpoint failed: {e}");
-                let _ = self.checkpoint_guard.write().take();
-                self.ongoing_checkpoint.write().state = CheckpointState::Start;
-            })
+        self.checkpoint_inner(
+            pager,
+            CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            },
+            CheckpointLockSource::HeldByCaller,
+        )
+        .inspect_err(|e| {
+            tracing::info!("Wal Checkpoint failed: {e}");
+            let _ = self.checkpoint_guard.write().take();
+            self.ongoing_checkpoint.write().state = CheckpointState::Start;
+        })
     }
 
     fn install_durable_backfill_proof(
@@ -3782,7 +3769,7 @@ impl Wal for WalFile {
         self.reset_internal_states();
     }
 
-    fn try_begin_checkpoint_lock(&self) -> Result<()> {
+    fn try_begin_vacuum_checkpoint_lock(&self) -> Result<()> {
         self.with_shared(|shared| {
             if !shared.runtime.checkpoint_lock.write() {
                 return Err(LimboError::Busy);
@@ -3791,20 +3778,20 @@ impl Wal for WalFile {
         })
     }
 
-    fn release_checkpoint_lock(&self) {
+    fn release_vacuum_checkpoint_lock(&self) {
         self.with_shared(|shared| {
             shared.runtime.checkpoint_lock.unlock();
         });
     }
 
-    fn begin_blocking_tx(&self) -> Result<()> {
+    fn begin_vacuum_blocking_tx(&self) -> Result<()> {
         turso_assert!(
             self.max_frame_read_lock_index.load(Ordering::Acquire) == NO_LOCK_HELD,
-            "begin_blocking_tx: must not already hold a read lock"
+            "begin_vacuum_blocking_tx: must not already hold a read lock"
         );
         turso_assert!(
             !self.holds_write_lock(),
-            "begin_blocking_tx: must not already hold the write lock"
+            "begin_vacuum_blocking_tx: must not already hold the write lock"
         );
         turso_assert!(
             self.vacuum_lock_guard.read().is_none(),
@@ -3825,7 +3812,7 @@ impl Wal for WalFile {
                 // acquire the write lock
                 turso_assert!(
                     shared.runtime.read_locks[idx].write(),
-                    "begin_blocking_tx: read lock held after VACUUM lock acquired",
+                    "begin_vacuum_blocking_tx: read lock held after VACUUM lock acquired",
                     { "read_lock_idx": idx }
                 );
                 shared.runtime.read_locks[idx].unlock();
@@ -3837,14 +3824,17 @@ impl Wal for WalFile {
         self.install_connection_state(WalConnectionState::new(snapshot, ReadGuardKind::None));
         turso_assert!(
             self.with_shared(|shared| shared.runtime.write_lock.write()),
-            "begin_blocking_tx: write lock held after VACUUM lock acquired"
+            "begin_vacuum_blocking_tx: write lock held after VACUUM lock acquired"
         );
         if self
             .write_lock_held
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
-            turso_assert!(false, "begin_blocking_tx: write_lock_held already set");
+            turso_assert!(
+                false,
+                "begin_vacuum_blocking_tx: write_lock_held already set"
+            );
         }
         self.install_vacuum_lock_guard(vacuum_lock_guard);
         Ok(())
@@ -4880,7 +4870,7 @@ impl WalFile {
                     CheckpointLocks::new(self.coordination.clone(), mode)?
                 }
                 CheckpointLockSource::HeldByCaller => {
-                    CheckpointLocks::from_held_checkpoint_lock(self.coordination.clone(), mode)?
+                    CheckpointLocks::from_held_vacuum_checkpoint_lock(self.coordination.clone())?
                 }
             };
             *self.checkpoint_guard.write() = Some(guard);
@@ -8329,8 +8319,8 @@ pub mod test {
         let (shared, vacuum_wal) = make_test_wal();
         let reader_wal = make_test_wal_from_shared(shared);
 
-        vacuum_wal.try_begin_checkpoint_lock().unwrap();
-        vacuum_wal.begin_blocking_tx().unwrap();
+        vacuum_wal.try_begin_vacuum_checkpoint_lock().unwrap();
+        vacuum_wal.begin_vacuum_blocking_tx().unwrap();
 
         assert!(
             matches!(reader_wal.try_begin_read_tx(), TryBeginReadResult::Busy),
@@ -8342,12 +8332,12 @@ pub mod test {
         );
         assert!(
             vacuum_wal.holds_write_lock(),
-            "begin_blocking_tx should acquire the source write lock"
+            "begin_vacuum_blocking_tx should acquire the source write lock"
         );
 
         vacuum_wal.end_write_tx();
         vacuum_wal.release_vacuum_lock();
-        vacuum_wal.release_checkpoint_lock();
+        vacuum_wal.release_vacuum_checkpoint_lock();
 
         assert!(
             matches!(reader_wal.try_begin_read_tx(), TryBeginReadResult::Ok(_)),
@@ -8365,18 +8355,18 @@ pub mod test {
             reader_wal.try_begin_read_tx(),
             TryBeginReadResult::Ok(_)
         ));
-        vacuum_wal.try_begin_checkpoint_lock().unwrap();
+        vacuum_wal.try_begin_vacuum_checkpoint_lock().unwrap();
 
         assert!(
-            matches!(vacuum_wal.begin_blocking_tx(), Err(LimboError::Busy)),
+            matches!(vacuum_wal.begin_vacuum_blocking_tx(), Err(LimboError::Busy)),
             "active reader should prevent VACUUM from acquiring its exclusive lock"
         );
 
         reader_wal.end_read_tx();
-        vacuum_wal.begin_blocking_tx().unwrap();
+        vacuum_wal.begin_vacuum_blocking_tx().unwrap();
         vacuum_wal.end_write_tx();
         vacuum_wal.release_vacuum_lock();
-        vacuum_wal.release_checkpoint_lock();
+        vacuum_wal.release_vacuum_checkpoint_lock();
     }
 
     #[test]
@@ -8423,11 +8413,11 @@ pub mod test {
             shared.read().runtime.read_locks[idx].unlock();
         }
 
-        vacuum_wal.try_begin_checkpoint_lock().unwrap();
-        vacuum_wal.begin_blocking_tx().unwrap();
+        vacuum_wal.try_begin_vacuum_checkpoint_lock().unwrap();
+        vacuum_wal.begin_vacuum_blocking_tx().unwrap();
         vacuum_wal.end_write_tx();
         vacuum_wal.release_vacuum_lock();
-        vacuum_wal.release_checkpoint_lock();
+        vacuum_wal.release_vacuum_checkpoint_lock();
     }
 
     #[test]
@@ -8435,14 +8425,14 @@ pub mod test {
         let (shared, vacuum_wal) = make_test_wal();
         let contender_wal = make_test_wal_from_shared(shared);
 
-        vacuum_wal.try_begin_checkpoint_lock().unwrap();
-        vacuum_wal.begin_blocking_tx().unwrap();
+        vacuum_wal.try_begin_vacuum_checkpoint_lock().unwrap();
+        vacuum_wal.begin_vacuum_blocking_tx().unwrap();
 
         assert!(vacuum_wal.holds_write_lock());
         assert!(!vacuum_wal.holds_read_lock());
         assert!(
             matches!(
-                contender_wal.try_begin_checkpoint_lock(),
+                contender_wal.try_begin_vacuum_checkpoint_lock(),
                 Err(LimboError::Busy)
             ),
             "held checkpoint lock should block other checkpointers"
@@ -8451,13 +8441,9 @@ pub mod test {
         vacuum_wal.end_write_tx();
         assert!(!vacuum_wal.holds_write_lock());
 
-        let guard = CheckpointLocks::from_held_checkpoint_lock(
-            vacuum_wal.coordination.clone(),
-            CheckpointMode::Truncate {
-                upper_bound_inclusive: None,
-            },
-        )
-        .unwrap();
+        let guard =
+            CheckpointLocks::from_held_vacuum_checkpoint_lock(vacuum_wal.coordination.clone())
+                .unwrap();
         assert!(
             matches!(contender_wal.try_begin_read_tx(), TryBeginReadResult::Busy),
             "VACUUM lock should continue blocking readers during final checkpoint"
@@ -8465,10 +8451,10 @@ pub mod test {
 
         drop(guard);
         assert!(
-            contender_wal.try_begin_checkpoint_lock().is_ok(),
+            contender_wal.try_begin_vacuum_checkpoint_lock().is_ok(),
             "checkpoint cleanup should release the checkpoint lock"
         );
-        contender_wal.release_checkpoint_lock();
+        contender_wal.release_vacuum_checkpoint_lock();
         assert!(
             matches!(contender_wal.try_begin_read_tx(), TryBeginReadResult::Busy),
             "checkpoint cleanup must not release the VACUUM lock"

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -426,11 +426,18 @@ pub trait Wal: Debug + Send + Sync {
     /// For each `i`, `pages[i]` receives the decoded page body of frame
     /// `start_frame + i`. Each page is locked on entry and finished (or
     /// cleared on error) inside the completion callback.
+    ///
+    /// If `scratch_buf` is `Some`, it is used as the pread destination (must
+    /// have length exactly `(page_size + WAL_FRAME_HEADER_SIZE) * pages.len()`).
+    /// Otherwise a fresh temporary buffer is allocated. VACUUM passes a
+    /// pre-allocated buffer to amortize the ~batch-size allocation across
+    /// batches.
     fn read_frames_batch(
         &self,
         start_frame: u64,
         pages: &[PageRef],
         buffer_pool: Arc<BufferPool>,
+        scratch_buf: Option<Arc<Buffer>>,
     ) -> Result<Completion>;
 
     /// Read a raw frame (header included) from the WAL.
@@ -1566,6 +1573,7 @@ impl Wal for WalFile {
         start_frame: u64,
         pages: &[PageRef],
         buffer_pool: Arc<BufferPool>,
+        scratch_buf: Option<Arc<Buffer>>,
     ) -> Result<Completion> {
         turso_assert!(
             !pages.is_empty(),
@@ -1577,6 +1585,13 @@ impl Wal for WalFile {
         let count = pages.len();
         let total = frame_size * count;
         let offset = self.frame_offset(start_frame);
+        if let Some(buf) = &scratch_buf {
+            turso_assert!(
+                buf.len() == total,
+                "read_frames_batch scratch_buf size must match expected pread length",
+                { "buf_len": buf.len(), "expected": total }
+            );
+        }
 
         // Lock each target page and pre-allocate its destination buffer so the
         // completion callback only parses headers, decrypts/verifies, and copies.
@@ -1599,7 +1614,7 @@ impl Wal for WalFile {
         let epoch = self.with_shared(|shared| shared.epoch.load(Ordering::Acquire));
         let enc_or_csum = self.io_ctx.read().encryption_or_checksum().clone();
 
-        let raw_buf = Arc::new(Buffer::new_temporary(total));
+        let raw_buf = scratch_buf.unwrap_or_else(|| Arc::new(Buffer::new_temporary(total)));
 
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
@@ -2059,29 +2074,7 @@ impl Wal for WalFile {
                 .is_ok(),
             "begin_exclusive_tx: write_lock_held already set"
         );
-
-        // Try to restart the log (same as begin_write_tx).
-        let result = self.try_restart_log_before_write();
-        if let Err(LimboError::Busy) | Ok(()) = &result {
-            return Ok(());
-        }
-
-        // Restart failed with a non-Busy error — release locks.
-        self.with_shared(|shared| {
-            shared.write_lock.unlock();
-        });
-        turso_assert!(
-            self.write_lock_held
-                .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok(),
-            "begin_exclusive_tx: write_lock_held not set during rollback"
-        );
-        // Leave read_locks[0] + checkpoint_lock held — caller owns those
-        // via cleanup_state and will release them.
-        // Actually, on error we should release read_locks[0] too.
-        self.end_read_tx();
-
-        Err(result.expect_err("Ok case handled above"))
+        Ok(())
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
@@ -3638,7 +3631,7 @@ pub mod test {
             Arc::new(crate::Page::new(5)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool)
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -3668,7 +3661,7 @@ pub mod test {
             Arc::new(crate::Page::new(13)),
         ];
         let c = wal
-            .read_frames_batch(2, &target_pages, buffer_pool)
+            .read_frames_batch(2, &target_pages, buffer_pool, None)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -3699,7 +3692,7 @@ pub mod test {
             Arc::new(crate::Page::new(9)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool)
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -3730,7 +3723,7 @@ pub mod test {
             Arc::new(crate::Page::new(22)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool)
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
             .unwrap();
         let err = wait_for_completion_error(&io, c);
 
@@ -3768,7 +3761,7 @@ pub mod test {
             Arc::new(crate::Page::new(99)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool)
+            .read_frames_batch(1, &target_pages, buffer_pool, None)
             .unwrap();
         let err = wait_for_completion_error(&io, c);
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -422,6 +422,17 @@ pub trait Wal: Debug + Send + Sync {
         buffer_pool: Arc<BufferPool>,
     ) -> Result<Completion>;
 
+    /// Read a contiguous run of WAL frames with a single `pread`.
+    /// For each `i`, `pages[i]` receives the decoded page body of frame
+    /// `start_frame + i`. Each page is locked on entry and finished (or
+    /// cleared on error) inside the completion callback.
+    fn read_frames_batch(
+        &self,
+        start_frame: u64,
+        pages: &[PageRef],
+        buffer_pool: Arc<BufferPool>,
+    ) -> Result<Completion>;
+
     /// Read a raw frame (header included) from the WAL.
     fn read_frame_raw(&self, frame_id: u64, frame: &mut [u8]) -> Result<Completion>;
 
@@ -1550,6 +1561,132 @@ impl Wal for WalFile {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
+    fn read_frames_batch(
+        &self,
+        start_frame: u64,
+        pages: &[PageRef],
+        buffer_pool: Arc<BufferPool>,
+    ) -> Result<Completion> {
+        turso_assert!(!pages.is_empty(), "read_frames_batch requires at least one page");
+        let page_size = self.page_size() as usize;
+        turso_assert!(page_size > 0, "WAL page size must be initialized");
+        let frame_size = WAL_FRAME_HEADER_SIZE + page_size;
+        let count = pages.len();
+        let total = frame_size * count;
+        let offset = self.frame_offset(start_frame);
+
+        // Lock each target page and pre-allocate its destination buffer so the
+        // completion callback only parses headers, decrypts/verifies, and copies.
+        let mut slots: Vec<(PageRef, Arc<Buffer>)> = Vec::with_capacity(count);
+        for page in pages.iter() {
+            page.set_locked();
+            slots.push((page.clone(), Arc::new(buffer_pool.get_page())));
+        }
+
+        let epoch = self.with_shared(|shared| shared.epoch.load(Ordering::Acquire));
+        let enc_or_csum = self.io_ctx.read().encryption_or_checksum().clone();
+
+        let raw_buf = Arc::new(Buffer::new_temporary(total));
+
+        let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+            let Ok((buf, bytes_read)) = res else {
+                tracing::debug!(err = ?res.unwrap_err());
+                for (page, _) in &slots {
+                    page.clear_locked();
+                    page.clear_wal_tag();
+                }
+                return None;
+            };
+            if bytes_read != total as i32 {
+                tracing::debug!(
+                    "short read on WAL batch at offset {offset}: expected {total} bytes, got {bytes_read}"
+                );
+                for (page, _) in &slots {
+                    page.clear_locked();
+                    page.clear_wal_tag();
+                }
+                return Some(CompletionError::ShortReadWalFrame {
+                    offset,
+                    expected: total,
+                    actual: bytes_read as usize,
+                });
+            }
+            let raw = buf.as_slice();
+            let mut first_err: Option<CompletionError> = None;
+            for (i, (page, page_buf)) in slots.iter().enumerate() {
+                let frame_start = i * frame_size;
+                let (header, page_body) = sqlite3_ondisk::parse_wal_frame_header(
+                    &raw[frame_start..frame_start + frame_size],
+                );
+                let expected_page_id = page.get().id;
+                turso_assert!(
+                    header.page_number as usize == expected_page_id,
+                    "WAL batch frame page_no mismatch",
+                    {
+                        "frame_id": start_frame + i as u64,
+                        "expected": expected_page_id,
+                        "got": header.page_number
+                    }
+                );
+
+                let body_slice = page_buf.as_mut_slice();
+                body_slice.copy_from_slice(page_body);
+
+                match &enc_or_csum {
+                    EncryptionOrChecksum::Encryption(ctx) => {
+                        match ctx.decrypt_page(body_slice, expected_page_id) {
+                            Ok(decrypted) => body_slice.copy_from_slice(&decrypted),
+                            Err(e) => {
+                                mark_unlikely();
+                                tracing::error!(
+                                    "Failed to decrypt WAL batch frame for page_idx={expected_page_id}: {e}"
+                                );
+                                page.clear_locked();
+                                page.clear_wal_tag();
+                                if first_err.is_none() {
+                                    first_err = Some(CompletionError::DecryptionError {
+                                        page_idx: expected_page_id,
+                                    });
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                    EncryptionOrChecksum::Checksum(ctx) => {
+                        if let Err(e) = ctx.verify_checksum(body_slice, expected_page_id) {
+                            mark_unlikely();
+                            tracing::error!(
+                                "Failed to verify checksum for page_id={expected_page_id}: {e}"
+                            );
+                            page.clear_locked();
+                            page.clear_wal_tag();
+                            if first_err.is_none() {
+                                first_err = Some(e);
+                            }
+                            continue;
+                        }
+                    }
+                    EncryptionOrChecksum::None => {}
+                }
+
+                finish_read_page(expected_page_id, page_buf.clone(), page.clone());
+                page.set_wal_tag(start_frame + i as u64, epoch);
+            }
+            first_err
+        });
+
+        let c = Completion::new_read(raw_buf, complete);
+        let file = self.with_shared(|shared| {
+            turso_assert!(
+                shared.enabled.load(Ordering::Relaxed),
+                "WAL must be enabled"
+            );
+            shared.file.as_ref().unwrap().clone()
+        });
+        file.pread(offset, c)
+    }
+
+    #[instrument(skip_all, level = Level::DEBUG)]
     // todo(sivukhin): change API to accept Buffer or some other owned type
     // this method involves IO and cross "async" boundary - so juggling with references is bad and dangerous
     fn read_frame_raw(&self, frame_id: u64, frame: &mut [u8]) -> Result<Completion> {
@@ -1887,10 +2024,7 @@ impl Wal for WalFile {
 
         // Install connection state with a fresh snapshot.
         let snapshot = self.with_shared(Self::load_shared_snapshot);
-        self.install_connection_state(WalConnectionState::new(
-            snapshot,
-            ReadGuardKind::DbFile,
-        ));
+        self.install_connection_state(WalConnectionState::new(snapshot, ReadGuardKind::DbFile));
         turso_assert!(
             self.write_lock_held
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3638,7 +3638,7 @@ pub mod test {
             Arc::new(crate::Page::new(5)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .read_frames_batch(1, &target_pages, buffer_pool)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -3668,7 +3668,7 @@ pub mod test {
             Arc::new(crate::Page::new(13)),
         ];
         let c = wal
-            .read_frames_batch(2, &target_pages, buffer_pool.clone())
+            .read_frames_batch(2, &target_pages, buffer_pool)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -3699,7 +3699,7 @@ pub mod test {
             Arc::new(crate::Page::new(9)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .read_frames_batch(1, &target_pages, buffer_pool)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -3730,7 +3730,7 @@ pub mod test {
             Arc::new(crate::Page::new(22)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .read_frames_batch(1, &target_pages, buffer_pool)
             .unwrap();
         let err = wait_for_completion_error(&io, c);
 
@@ -3768,7 +3768,7 @@ pub mod test {
             Arc::new(crate::Page::new(99)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .read_frames_batch(1, &target_pages, buffer_pool)
             .unwrap();
         let err = wait_for_completion_error(&io, c);
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -513,6 +513,22 @@ pub trait Wal: Debug + Send + Sync {
     /// `try_begin_checkpoint_lock`.
     fn release_checkpoint_lock(&self);
 
+    /// Acquire exclusive access for VACUUM: checkpoint_lock + read_locks[0]
+    /// (exclusive) + write_lock, then install a fresh connection snapshot.
+    ///
+    /// This replaces the normal `begin_read_tx` + `begin_write_tx` path for
+    /// VACUUM, which needs exclusive access rather than a shared reader
+    /// upgraded to a writer. Holding `read_locks[0]` exclusively blocks new
+    /// readers; holding `write_lock` blocks new writers; holding
+    /// `checkpoint_lock` blocks concurrent checkpointers.
+    ///
+    /// The caller must already hold the checkpoint lock (via
+    /// `try_begin_checkpoint_lock`).
+    ///
+    /// On return the connection holds all three locks. Release via the normal
+    /// `end_write_tx` + `end_read_tx` + `release_checkpoint_lock` sequence.
+    fn begin_exclusive_tx(&self) -> Result<()>;
+
     #[cfg(any(test, debug_assertions))]
     fn as_any(&self) -> &dyn std::any::Any;
 }
@@ -1844,6 +1860,66 @@ impl Wal for WalFile {
         self.with_shared(|shared| {
             shared.checkpoint_lock.unlock();
         });
+    }
+
+    fn begin_exclusive_tx(&self) -> Result<()> {
+        turso_assert!(
+            self.max_frame_read_lock_index.load(Ordering::Acquire) == NO_LOCK_HELD,
+            "begin_exclusive_tx: must not already hold a read lock"
+        );
+        turso_assert!(
+            !self.holds_write_lock(),
+            "begin_exclusive_tx: must not already hold the write lock"
+        );
+
+        self.with_shared(|shared| {
+            // 1. Exclusive lock on read_locks[0] — blocks all new readers.
+            if !shared.read_locks[0].write() {
+                return Err(LimboError::Busy);
+            }
+            // 2. Write lock — blocks all writers.
+            if !shared.write_lock.write() {
+                shared.read_locks[0].unlock();
+                return Err(LimboError::Busy);
+            }
+            Ok(())
+        })?;
+
+        // Install connection state with a fresh snapshot.
+        let snapshot = self.with_shared(Self::load_shared_snapshot);
+        self.install_connection_state(WalConnectionState::new(
+            snapshot,
+            ReadGuardKind::DbFile,
+        ));
+        turso_assert!(
+            self.write_lock_held
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok(),
+            "begin_exclusive_tx: write_lock_held already set"
+        );
+
+        // Try to restart the log (same as begin_write_tx).
+        let result = self.try_restart_log_before_write();
+        if let Err(LimboError::Busy) | Ok(()) = &result {
+            return Ok(());
+        }
+
+        // Restart failed with a non-Busy error — release locks.
+        self.with_shared(|shared| {
+            shared.write_lock.unlock();
+        });
+        turso_assert!(
+            self.write_lock_held
+                .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok(),
+            "begin_exclusive_tx: write_lock_held not set during rollback"
+        );
+        // Leave read_locks[0] + checkpoint_lock held — caller owns those
+        // via cleanup_state and will release them.
+        // Actually, on error we should release read_locks[0] too.
+        self.end_read_tx();
+
+        Err(result.expect_err("Ok case handled above"))
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -504,6 +504,15 @@ pub trait Wal: Debug + Send + Sync {
         sync_type: FileSyncType,
     ) -> Result<IOResult<()>>;
 
+    /// Try to acquire the checkpoint serialization lock. Returns `Busy` if
+    /// another checkpointer or VACUUM already holds it. Used by plain VACUUM
+    /// to fail fast if a concurrent checkpoint would block later.
+    fn try_begin_checkpoint_lock(&self) -> Result<()>;
+
+    /// Release the checkpoint serialization lock acquired by
+    /// `try_begin_checkpoint_lock`.
+    fn release_checkpoint_lock(&self);
+
     #[cfg(any(test, debug_assertions))]
     fn as_any(&self) -> &dyn std::any::Any;
 }
@@ -1820,6 +1829,21 @@ impl Wal for WalFile {
     fn abort_checkpoint(&self) {
         let _ = self.checkpoint_guard.write().take();
         self.reset_internal_states();
+    }
+
+    fn try_begin_checkpoint_lock(&self) -> Result<()> {
+        self.with_shared(|shared| {
+            if !shared.checkpoint_lock.write() {
+                return Err(LimboError::Busy);
+            }
+            Ok(())
+        })
+    }
+
+    fn release_checkpoint_lock(&self) {
+        self.with_shared(|shared| {
+            shared.checkpoint_lock.unlock();
+        });
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1582,6 +1582,16 @@ impl Wal for WalFile {
         // completion callback only parses headers, decrypts/verifies, and copies.
         let mut slots: Vec<(PageRef, Arc<Buffer>)> = Vec::with_capacity(count);
         for page in pages.iter() {
+            turso_assert!(
+                page.get().id > 0,
+                "read_frames_batch target page id must be 1-based",
+                { "page_id": page.get().id }
+            );
+            turso_assert!(
+                !page.is_locked(),
+                "read_frames_batch target page must not already be locked",
+                { "page_id": page.get().id }
+            );
             page.set_locked();
             slots.push((page.clone(), Arc::new(buffer_pool.get_page())));
         }
@@ -1643,6 +1653,11 @@ impl Wal for WalFile {
                 }
 
                 let body_slice = page_buf.as_mut_slice();
+                turso_assert!(
+                    body_slice.len() == page_size,
+                    "read_frames_batch buffer size must match WAL page size",
+                    { "buffer_len": body_slice.len(), "page_size": page_size }
+                );
                 body_slice.copy_from_slice(page_body);
 
                 match &enc_or_csum {
@@ -2193,6 +2208,10 @@ impl Wal for WalFile {
         db_size_on_commit: Option<u32>,
         prev: Option<&PreparedFrames>,
     ) -> Result<PreparedFrames> {
+        turso_assert!(
+            !pages.is_empty(),
+            "prepare_frames requires at least one page"
+        );
         turso_assert!(
             pages.len() <= IOV_MAX,
             "supported up to IOV_MAX pages at once"

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1567,7 +1567,10 @@ impl Wal for WalFile {
         pages: &[PageRef],
         buffer_pool: Arc<BufferPool>,
     ) -> Result<Completion> {
-        turso_assert!(!pages.is_empty(), "read_frames_batch requires at least one page");
+        turso_assert!(
+            !pages.is_empty(),
+            "read_frames_batch requires at least one page"
+        );
         let page_size = self.page_size() as usize;
         turso_assert!(page_size > 0, "WAL page size must be initialized");
         let frame_size = WAL_FRAME_HEADER_SIZE + page_size;
@@ -1619,15 +1622,25 @@ impl Wal for WalFile {
                     &raw[frame_start..frame_start + frame_size],
                 );
                 let expected_page_id = page.get().id;
-                turso_assert!(
-                    header.page_number as usize == expected_page_id,
-                    "WAL batch frame page_no mismatch",
-                    {
-                        "frame_id": start_frame + i as u64,
-                        "expected": expected_page_id,
-                        "got": header.page_number
+                if header.page_number as usize != expected_page_id {
+                    mark_unlikely();
+                    tracing::error!(
+                        frame_id = start_frame + i as u64,
+                        expected = expected_page_id,
+                        got = header.page_number,
+                        "WAL batch frame page_no mismatch"
+                    );
+                    page.clear_locked();
+                    page.clear_wal_tag();
+                    if first_err.is_none() {
+                        first_err = Some(CompletionError::WalFramePageMismatch {
+                            frame_id: start_frame + i as u64,
+                            expected: expected_page_id,
+                            actual: header.page_number,
+                        });
                     }
-                );
+                    continue;
+                }
 
                 let body_slice = page_buf.as_mut_slice();
                 body_slice.copy_from_slice(page_body);
@@ -3354,19 +3367,21 @@ impl WalFileShared {
 
 #[cfg(test)]
 pub mod test {
-    use super::{ReadGuardKind, WalConnectionState, WalFile, WalSnapshot};
+    use super::{ReadGuardKind, Wal, WalConnectionState, WalFile, WalSnapshot};
     use crate::sync::{atomic::Ordering, Arc};
     use crate::sync::{Mutex, RwLock};
     use crate::{
+        io::FileSyncType,
         storage::{
             buffer_pool::BufferPool,
-            sqlite3_ondisk::{self, WAL_HEADER_SIZE},
+            pager::{allocate_new_page, PageRef},
+            sqlite3_ondisk::{self, PageSize, WAL_HEADER_SIZE},
             wal::READMARK_NOT_USED,
         },
         types::IOResult,
         util::IOExt,
-        CheckpointMode, CheckpointResult, Completion, Connection, Database, LimboError, PlatformIO,
-        WalFileShared, IO,
+        CheckpointMode, CheckpointResult, Completion, CompletionError, Connection, Database,
+        LimboError, MemoryIO, OpenFlags, PlatformIO, WalFileShared, IO,
     };
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
@@ -3518,6 +3533,246 @@ pub mod test {
         let shared = WalFileShared::new_noop();
         let wal = WalFile::new(io, shared.clone(), ((0, 0), 0), buffer_pool);
         (shared, wal)
+    }
+
+    fn make_initialized_memory_wal(page_size: u32) -> (Arc<dyn IO>, Arc<BufferPool>, WalFile) {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
+        buffer_pool
+            .finalize_with_page_size(page_size as usize)
+            .unwrap();
+        let file = io
+            .open_file("direct-batch-read.db-wal", OpenFlags::Create, false)
+            .unwrap();
+        let shared = WalFileShared::new_shared(file).unwrap();
+        let wal = WalFile::new(io.clone(), shared, ((0, 0), 0), buffer_pool.clone());
+        let page_size = PageSize::new(page_size).unwrap();
+
+        if let Some(c) = wal.prepare_wal_start(page_size).unwrap() {
+            io.wait_for_completion(c).unwrap();
+        }
+        let c = wal.prepare_wal_finish(FileSyncType::Fsync).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        (io, buffer_pool, wal)
+    }
+
+    fn page_with_pattern(page_id: i64, seed: u8, buffer_pool: &Arc<BufferPool>) -> PageRef {
+        let page = allocate_new_page(page_id, buffer_pool);
+        for (idx, byte) in page.get_contents().as_ptr().iter_mut().enumerate() {
+            *byte = seed.wrapping_add(idx as u8).wrapping_add(page_id as u8);
+        }
+        page
+    }
+
+    fn append_test_pages(
+        io: &Arc<dyn IO>,
+        wal: &WalFile,
+        page_size: u32,
+        pages: &[PageRef],
+    ) -> Vec<Vec<u8>> {
+        let prepared = wal
+            .prepare_frames(pages, PageSize::new(page_size).unwrap(), Some(99), None)
+            .unwrap();
+        let expected = pages
+            .iter()
+            .map(|page| page.get_contents().as_ptr().to_vec())
+            .collect::<Vec<_>>();
+
+        let file = wal.wal_file().unwrap();
+        let c = file
+            .pwritev(
+                prepared.offset,
+                prepared.bufs.clone(),
+                Completion::new_write(|_| {}),
+            )
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+        wal.commit_prepared_frames(&[prepared]);
+        wal.finish_append_frames_commit().unwrap();
+        expected
+    }
+
+    fn wait_for_completion_error(io: &Arc<dyn IO>, completion: Completion) -> CompletionError {
+        match io.wait_for_completion(completion) {
+            Err(LimboError::CompletionError(err)) => err,
+            other => panic!("expected completion error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_reads_contiguous_wal_frames_directly() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(2, 0x10, &buffer_pool),
+            page_with_pattern(3, 0x20, &buffer_pool),
+            page_with_pattern(4, 0x30, &buffer_pool),
+            page_with_pattern(5, 0x40, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(2)),
+            Arc::new(crate::Page::new(3)),
+            Arc::new(crate::Page::new(4)),
+            Arc::new(crate::Page::new(5)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert!(page.is_loaded(), "page {} should be loaded", page.get().id);
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
+            assert_eq!(page.get_contents().as_ptr(), expected[idx].as_slice());
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_can_start_from_middle_frame() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(10, 0x01, &buffer_pool),
+            page_with_pattern(11, 0x02, &buffer_pool),
+            page_with_pattern(12, 0x03, &buffer_pool),
+            page_with_pattern(13, 0x04, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(11)),
+            Arc::new(crate::Page::new(12)),
+            Arc::new(crate::Page::new(13)),
+        ];
+        let c = wal
+            .read_frames_batch(2, &target_pages, buffer_pool.clone())
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert!(page.is_loaded(), "page {} should be loaded", page.get().id);
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert_eq!(page.wal_tag_pair(), ((idx + 2) as u64, 0));
+            assert_eq!(page.get_contents().as_ptr(), expected[idx + 1].as_slice());
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_follows_physical_frame_order_not_page_id_order() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(7, 0x71, &buffer_pool),
+            page_with_pattern(2, 0x22, &buffer_pool),
+            page_with_pattern(5, 0x55, &buffer_pool),
+            page_with_pattern(9, 0x99, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(7)),
+            Arc::new(crate::Page::new(2)),
+            Arc::new(crate::Page::new(5)),
+            Arc::new(crate::Page::new(9)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        for (idx, page) in target_pages.iter().enumerate() {
+            assert_eq!(
+                page.get_contents().as_ptr(),
+                expected[idx].as_slice(),
+                "frame-order read should preserve page {} contents",
+                page.get().id
+            );
+            assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_short_read_errors_and_clears_page_locks() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(20, 0x20, &buffer_pool),
+            page_with_pattern(21, 0x21, &buffer_pool),
+        ];
+        append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(20)),
+            Arc::new(crate::Page::new(21)),
+            Arc::new(crate::Page::new(22)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(
+            matches!(err, CompletionError::ShortReadWalFrame { .. }),
+            "unexpected error: {err:?}"
+        );
+        for page in &target_pages {
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert!(
+                !page.is_loaded(),
+                "page {} should not be loaded",
+                page.get().id
+            );
+            assert!(
+                !page.has_wal_tag(),
+                "page {} should not be tagged",
+                page.get().id
+            );
+        }
+    }
+
+    #[test]
+    fn read_frames_batch_page_number_mismatch_returns_error_not_panic() {
+        let page_size = 512;
+        let (io, buffer_pool, wal) = make_initialized_memory_wal(page_size);
+        let source_pages = vec![
+            page_with_pattern(30, 0x30, &buffer_pool),
+            page_with_pattern(31, 0x31, &buffer_pool),
+        ];
+        let expected = append_test_pages(&io, &wal, page_size, &source_pages);
+
+        let target_pages = vec![
+            Arc::new(crate::Page::new(30)),
+            Arc::new(crate::Page::new(99)),
+        ];
+        let c = wal
+            .read_frames_batch(1, &target_pages, buffer_pool.clone())
+            .unwrap();
+        let err = wait_for_completion_error(&io, c);
+
+        assert!(
+            matches!(
+                err,
+                CompletionError::WalFramePageMismatch {
+                    frame_id: 2,
+                    expected: 99,
+                    actual: 31
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+        assert!(target_pages[0].is_loaded());
+        assert_eq!(
+            target_pages[0].get_contents().as_ptr(),
+            expected[0].as_slice()
+        );
+        assert!(!target_pages[0].is_locked());
+        assert!(!target_pages[1].is_loaded());
+        assert!(!target_pages[1].is_locked());
+        assert!(!target_pages[1].has_wal_tag());
     }
 
     fn set_shared_snapshot(shared: &Arc<RwLock<WalFileShared>>, snapshot: WalSnapshot) {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -382,7 +382,7 @@ pub fn translate_inner(
             translate_update(update, resolver, program, connection)?
         }
         ast::Stmt::Vacuum { name, into } => {
-            vacuum::translate_vacuum(program, name.as_ref(), into.as_deref())?
+            vacuum::translate_vacuum(program, name.as_ref(), into.as_deref(), connection.clone())?
         }
         ast::Stmt::Insert {
             with,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -537,9 +537,9 @@ fn update_pragma(
                 }
             };
             match auto_vacuum_mode {
-                0 => update_auto_vacuum_mode(AutoVacuumMode::None, 0, pager)?,
-                1 => update_auto_vacuum_mode(AutoVacuumMode::Full, 1, pager)?,
-                2 => update_auto_vacuum_mode(AutoVacuumMode::Incremental, 1, pager)?,
+                0 => pager.persist_auto_vacuum_mode(AutoVacuumMode::None)?,
+                1 => pager.persist_auto_vacuum_mode(AutoVacuumMode::Full)?,
+                2 => pager.persist_auto_vacuum_mode(AutoVacuumMode::Incremental)?,
                 _ => {
                     return Err(LimboError::InvalidArgument(
                         "invalid auto vacuum mode".to_string(),
@@ -1623,20 +1623,6 @@ fn emit_columns_for_table_info(
 
         program.emit_result_row(base_reg, 6 + if extended { 1 } else { 0 });
     }
-}
-
-fn update_auto_vacuum_mode(
-    auto_vacuum_mode: AutoVacuumMode,
-    largest_root_page_number: u32,
-    pager: Arc<Pager>,
-) -> crate::Result<()> {
-    pager.io.block(|| {
-        pager.with_header_mut(|header| {
-            header.vacuum_mode_largest_root_page = largest_root_page_number.into()
-        })
-    })?;
-    pager.set_auto_vacuum_mode(auto_vacuum_mode);
-    Ok(())
 }
 
 fn update_cache_size(

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -2,13 +2,15 @@
 
 use crate::vdbe::builder::ProgramBuilder;
 use crate::vdbe::insn::Insn;
-use crate::{bail_parse_error, Result};
+use crate::{bail_parse_error, Connection, Result};
+use crate::{sync::Arc, LimboError};
 use turso_parser::ast::{Expr, Literal, Name};
 
 /// Translate a VACUUM statement into VDBE bytecode.
 ///
-/// Currently only VACUUM INTO is supported. Plain VACUUM (which compacts
-/// the database in place) is not yet implemented.
+/// We have `VACUUM INTO`. The in-place `VACUUM` is experimental:
+/// it is enabled by default in debug/test builds and gated behind the
+/// experimental vacuum feature flag in release builds.
 ///
 /// # Arguments
 /// * `program` - The program builder to emit instructions to
@@ -21,6 +23,7 @@ pub fn translate_vacuum(
     program: &mut ProgramBuilder,
     schema_name: Option<&Name>,
     into: Option<&Expr>,
+    connection: Arc<Connection>,
 ) -> Result<()> {
     let schema_name = schema_name.map_or_else(|| "main".to_string(), |n| n.as_str().to_string());
     match into {
@@ -34,10 +37,29 @@ pub fn translate_vacuum(
             Ok(())
         }
         None => {
-            // Plain VACUUM - not yet supported
-            bail_parse_error!(
-                "VACUUM is not supported yet. Use VACUUM INTO 'filename' to create a compacted copy."
-            );
+            if !cfg!(debug_assertions) && !connection.experimental_vacuum_enabled() {
+                return Err(LimboError::ParseError(
+                    "VACUUM is an experimental feature. Enable with --experimental-vacuum flag"
+                        .to_string(),
+                ));
+            }
+            if connection.experimental_multiprocess_wal_enabled() {
+                return Err(LimboError::ParseError(
+                    "VACUUM is incompatible with experimental multiprocess WAL".to_string(),
+                ));
+            }
+
+            // Schema-qualified VACUUM is not supported yet.
+            if schema_name != "main" {
+                bail_parse_error!(
+                    "VACUUM is only supported for the main database; schema '{}' is not supported yet",
+                    schema_name
+                );
+            }
+            program.emit_insn(Insn::Vacuum {
+                db: crate::MAIN_DB_ID,
+            });
+            Ok(())
         }
     }
 }

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -8,9 +8,8 @@ use turso_parser::ast::{Expr, Literal, Name};
 
 /// Translate a VACUUM statement into VDBE bytecode.
 ///
-/// We have `VACUUM INTO`. The in-place `VACUUM` is experimental:
-/// it is enabled by default in debug/test builds and gated behind the
-/// experimental vacuum feature flag in release builds.
+/// We have `VACUUM INTO`. The in-place `VACUUM` is experimental and gated
+/// behind the experimental vacuum feature flag.
 ///
 /// # Arguments
 /// * `program` - The program builder to emit instructions to
@@ -37,7 +36,7 @@ pub fn translate_vacuum(
             Ok(())
         }
         None => {
-            if !cfg!(debug_assertions) && !connection.experimental_vacuum_enabled() {
+            if !connection.experimental_vacuum_enabled() {
                 return Err(LimboError::ParseError(
                     "VACUUM is an experimental feature. Enable with --experimental-vacuum flag"
                         .to_string(),

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -34,10 +34,15 @@ pub fn translate_vacuum(
             Ok(())
         }
         None => {
-            // Plain VACUUM - not yet supported
-            bail_parse_error!(
-                "VACUUM is not supported yet. Use VACUUM INTO 'filename' to create a compacted copy."
-            );
+            // Plain VACUUM - compact database in place.
+            // Schema-qualified VACUUM is not supported yet.
+            if schema_name != "main" {
+                bail_parse_error!("VACUUM of schema '{}' is not supported", schema_name);
+            }
+            program.emit_insn(Insn::Vacuum {
+                db: crate::MAIN_DB_ID,
+            });
+            Ok(())
         }
     }
 }

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -34,15 +34,24 @@ pub fn translate_vacuum(
             Ok(())
         }
         None => {
-            // Plain VACUUM - compact database in place.
-            // Schema-qualified VACUUM is not supported yet.
-            if schema_name != "main" {
-                bail_parse_error!("VACUUM of schema '{}' is not supported", schema_name);
+            // Plain VACUUM is experimental — only available in debug/test builds.
+            #[cfg(not(debug_assertions))]
+            {
+                bail_parse_error!(
+                    "VACUUM is not supported yet. Use VACUUM INTO 'filename' to create a compacted copy."
+                );
             }
-            program.emit_insn(Insn::Vacuum {
-                db: crate::MAIN_DB_ID,
-            });
-            Ok(())
+            #[cfg(debug_assertions)]
+            {
+                // Schema-qualified VACUUM is not supported yet.
+                if schema_name != "main" {
+                    bail_parse_error!("VACUUM of schema '{}' is not supported", schema_name);
+                }
+                program.emit_insn(Insn::Vacuum {
+                    db: crate::MAIN_DB_ID,
+                });
+                Ok(())
+            }
         }
     }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15015,17 +15015,13 @@ pub fn op_vacuum(
         }
         Ok(IOResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
         Err(err) => {
-            if matches!(state.op_vacuum_state, VacuumOpState::InPlace(_)) {
-                let VacuumOpState::InPlace(vacuum_state) =
-                    std::mem::take(&mut state.op_vacuum_state)
-                else {
-                    unreachable!("invalid state, we are inside vacuum op");
-                };
-                if let Err(cleanup_err) =
-                    cleanup_op_vacuum_in_place(&program.connection, vacuum_state)
-                {
-                    tracing::error!("VACUUM cleanup failed after error: {cleanup_err}");
-                }
+            let VacuumOpState::InPlace(vacuum_state) = std::mem::take(&mut state.op_vacuum_state)
+            else {
+                unreachable!("invalid state, we are inside vacuum op");
+            };
+            if let Err(cleanup_err) = cleanup_op_vacuum_in_place(&program.connection, vacuum_state)
+            {
+                tracing::error!("VACUUM cleanup failed after error: {cleanup_err}");
             }
             Err(err)
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15008,15 +15008,12 @@ pub fn op_vacuum(
     };
 
     match vacuum_state.step(&program.connection) {
-        Ok(InsnFunctionStepResult::Step) => {
+        Ok(IOResult::Done(())) => {
             state.op_vacuum_state = VacuumOpState::None;
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
-        Ok(InsnFunctionStepResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
-        Ok(InsnFunctionStepResult::Done | InsnFunctionStepResult::Row) => {
-            unreachable!("in-place VACUUM only returns Step or IO")
-        }
+        Ok(IOResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
         Err(err) => {
             if matches!(state.op_vacuum_state, VacuumOpState::InPlace(_)) {
                 let VacuumOpState::InPlace(vacuum_state) =

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -43,7 +43,7 @@ use crate::vdbe::value::ComparisonOp;
 use crate::vdbe::ValueIteratorExt;
 use crate::vdbe::{
     registers_to_ref_values, DeferredSeekState, EndStatement, OpHashBuildState, OpHashProbeState,
-    StepResult, TxnCleanup,
+    StepResult, TxnCleanup, VacuumOpState,
 };
 use crate::vector::{
     vector1bit, vector32, vector32_sparse, vector64, vector8, vector_concat, vector_distance_cos,
@@ -14717,7 +14717,7 @@ pub fn op_vacuum_into(
     match op_vacuum_into_inner(program, state, insn) {
         Ok(InsnFunctionStepResult::Step) => {
             // Instruction complete, reset state
-            state.op_vacuum_into = None;
+            state.op_vacuum_state = VacuumOpState::None;
             Ok(InsnFunctionStepResult::Step)
         }
         Ok(InsnFunctionStepResult::IO(io)) => {
@@ -14728,8 +14728,17 @@ pub fn op_vacuum_into(
             unreachable!("op_vacuum_into_inner only returns Step or IO")
         }
         Err(err) => {
-            if let Err(cleanup_err) = cleanup_op_vacuum_into(&program.connection, state) {
-                tracing::error!("VACUUM INTO cleanup failed after error: {cleanup_err}");
+            if matches!(state.op_vacuum_state, VacuumOpState::IntoFile(_)) {
+                let VacuumOpState::IntoFile(vacuum_state) =
+                    std::mem::take(&mut state.op_vacuum_state)
+                else {
+                    unreachable!("invalid state, we are inside vacuum into op");
+                };
+                if let Err(cleanup_err) =
+                    cleanup_op_vacuum_into(&program.connection, state, vacuum_state)
+                {
+                    tracing::error!("VACUUM INTO cleanup failed after error: {cleanup_err}");
+                }
             }
             Err(err)
         }
@@ -14737,30 +14746,26 @@ pub fn op_vacuum_into(
 }
 
 /// Clean up any VACUUM or VACUUM INTO state on error or abort.
-/// Only one of the two can be active at a time; this handles whichever is set.
 pub(crate) fn cleanup_vacuum_state(
     connection: &Arc<Connection>,
     state: &mut ProgramState,
 ) -> Result<()> {
-    turso_assert!(
-        !(state.op_vacuum_into.is_some() && state.op_vacuum_in_place.is_some()),
-        "VACUUM INTO and in-place VACUUM state cannot both be active"
-    );
-
-    if state.op_vacuum_into.is_some() {
-        cleanup_op_vacuum_into(connection, state)
-    } else if state.op_vacuum_in_place.is_some() {
-        cleanup_op_vacuum_in_place(connection, state)
-    } else {
-        Ok(())
+    match std::mem::take(&mut state.op_vacuum_state) {
+        VacuumOpState::None => Ok(()),
+        VacuumOpState::IntoFile(vacuum_state) => {
+            cleanup_op_vacuum_into(connection, state, vacuum_state)
+        }
+        VacuumOpState::InPlace(vacuum_state) => {
+            cleanup_op_vacuum_in_place(connection, vacuum_state)
+        }
     }
 }
 
-fn cleanup_op_vacuum_into(connection: &Arc<Connection>, state: &mut ProgramState) -> Result<()> {
-    let Some(mut vacuum_state) = state.op_vacuum_into.take() else {
-        return Ok(());
-    };
-
+fn cleanup_op_vacuum_into(
+    connection: &Arc<Connection>,
+    state: &mut ProgramState,
+    mut vacuum_state: Box<VacuumIntoOpContext>,
+) -> Result<()> {
     if let Some(target_build_context) = vacuum_state.target_build_context.as_mut() {
         target_build_context.cleanup_after_error()?;
     }
@@ -14789,7 +14794,7 @@ fn op_vacuum_into_inner(
         insn
     );
 
-    if state.op_vacuum_into.is_none() {
+    if matches!(state.op_vacuum_state, VacuumOpState::None) {
         let source_db_id = program.connection.get_database_id_by_name(schema_name)?;
 
         // Matches sqlite that treats VACUUM temp INTO as a no-op (no file created)
@@ -14798,14 +14803,18 @@ fn op_vacuum_into_inner(
             return Ok(InsnFunctionStepResult::Step);
         }
 
-        state.op_vacuum_into = Some(Box::new(VacuumIntoOpContext {
+        state.op_vacuum_state = VacuumOpState::IntoFile(Box::new(VacuumIntoOpContext {
             escaped_schema_name: schema_name.replace('"', "\"\""),
             source_db_id,
             ..Default::default()
         }));
     }
 
-    let vacuum_state = state.op_vacuum_into.as_mut().unwrap();
+    let VacuumOpState::IntoFile(vacuum_state) = &mut state.op_vacuum_state else {
+        return Err(LimboError::InternalError(
+            "VACUUM INTO resumed with incompatible VACUUM state".to_string(),
+        ));
+    };
     let escaped_schema_name = &vacuum_state.escaped_schema_name;
     let source_db_id = vacuum_state.source_db_id;
 
@@ -14988,15 +14997,19 @@ pub fn op_vacuum(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Vacuum { db }, insn);
 
-    if state.op_vacuum_in_place.is_none() {
-        state.op_vacuum_in_place = Some(Box::new(VacuumInPlaceOpContext::new(*db)));
+    if matches!(state.op_vacuum_state, VacuumOpState::None) {
+        state.op_vacuum_state = VacuumOpState::InPlace(Box::new(VacuumInPlaceOpContext::new(*db)));
     }
 
-    let vacuum_state = state.op_vacuum_in_place.as_mut().unwrap();
+    let VacuumOpState::InPlace(vacuum_state) = &mut state.op_vacuum_state else {
+        return Err(LimboError::InternalError(
+            "VACUUM resumed with incompatible VACUUM state".to_string(),
+        ));
+    };
 
     match vacuum_state.step(&program.connection) {
         Ok(InsnFunctionStepResult::Step) => {
-            state.op_vacuum_in_place = None;
+            state.op_vacuum_state = VacuumOpState::None;
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
@@ -15005,8 +15018,17 @@ pub fn op_vacuum(
             unreachable!("in-place VACUUM only returns Step or IO")
         }
         Err(err) => {
-            if let Err(cleanup_err) = cleanup_op_vacuum_in_place(&program.connection, state) {
-                tracing::error!("VACUUM cleanup failed after error: {cleanup_err}");
+            if matches!(state.op_vacuum_state, VacuumOpState::InPlace(_)) {
+                let VacuumOpState::InPlace(vacuum_state) =
+                    std::mem::take(&mut state.op_vacuum_state)
+                else {
+                    unreachable!("invalid state, we are inside vacuum op");
+                };
+                if let Err(cleanup_err) =
+                    cleanup_op_vacuum_in_place(&program.connection, vacuum_state)
+                {
+                    tracing::error!("VACUUM cleanup failed after error: {cleanup_err}");
+                }
             }
             Err(err)
         }
@@ -15018,11 +15040,8 @@ pub fn op_vacuum(
 /// temp resources.
 fn cleanup_op_vacuum_in_place(
     connection: &Arc<Connection>,
-    state: &mut ProgramState,
+    vacuum_state: Box<VacuumInPlaceOpContext>,
 ) -> Result<()> {
-    let Some(vacuum_state) = state.op_vacuum_in_place.take() else {
-        return Ok(());
-    };
     vacuum_state.cleanup(connection)
 }
 
@@ -15260,10 +15279,9 @@ mod tests {
         );
 
         let mut state = ProgramState::new(0, 0);
-        state.op_vacuum_into = Some(Box::default());
         state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
 
-        cleanup_op_vacuum_into(&conn, &mut state).unwrap();
+        cleanup_op_vacuum_into(&conn, &mut state, Box::default()).unwrap();
 
         assert!(
             conn.get_auto_commit(),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -112,6 +112,11 @@ use turso_parser::ast::{self, ForeignKeyClause, Name, QualifiedName, ResolveType
 use turso_parser::parser::Parser;
 
 use super::sorter::Sorter;
+use crate::vdbe::vacuum::{
+    capture_custom_types, mirror_symbols, reject_unsupported_vacuum_auto_vacuum_mode,
+    vacuum_target_build_step, vacuum_target_opts_from_source, VacuumDbHeaderMeta,
+    VacuumTargetBuildConfig, VacuumTargetBuildContext,
+};
 
 #[cfg(feature = "json")]
 use crate::{
@@ -14655,42 +14660,50 @@ where
         })
 }
 
-/// Sub-states for the VACUUM INTO operation state machine.
+/// Phases for the VACUUM INTO opcode wrapper.
 #[derive(Default)]
-pub(crate) enum OpVacuumIntoSubState {
-    /// Initial state - validate preconditions and create destination database
+pub(crate) enum VacuumIntoOpPhase {
+    /// Initial state - validate preconditions and create output database.
     #[default]
     Init,
-    /// Build compacted destination database
-    Build(Box<crate::vdbe::vacuum::VacuumInto>),
-    /// Operation complete
+    /// Build compacted output database.
+    Build,
+    /// Force the committed output into a durable self-contained database file.
+    FinalizeOutput,
+    /// Operation complete.
     Done,
 }
 
-/// Holds the state for the VACUUM INTO operation.
+/// Holds the state for the VACUUM INTO opcode operation.
 #[derive(Default)]
-pub(crate) struct OpVacuumIntoState {
-    sub_state: OpVacuumIntoSubState,
-    /// Database index for the target schema
-    database_id: usize,
-    /// Escaped schema name for safe SQL interpolation
+pub(crate) struct VacuumIntoOpContext {
+    phase: VacuumIntoOpPhase,
+    /// Database index for the source schema.
+    source_db_id: usize,
+    /// Escaped schema name for safe SQL interpolation.
     escaped_schema_name: String,
+    /// Keep output database alive while vacuum is in progress.
+    _output_db: Option<Arc<crate::Database>>,
+    /// Configuration for the shared vacuum target build state machine.
+    target_build_config: Option<crate::vdbe::vacuum::VacuumTargetBuildConfig>,
+    /// Context for the shared vacuum target build state machine.
+    target_build_context: Option<crate::vdbe::vacuum::VacuumTargetBuildContext>,
 }
 
 /// VACUUM INTO - create a compacted copy of the database at the specified path.
 ///
 /// This is an async state machine implementation that yields on I/O operations.
 /// It:
-/// 1. Creates a new database at the destination path with matching page_size and
+/// 1. Creates a new output database with matching page_size and
 ///    source feature flags and schema-replay symbols
 /// 2. Queries sqlite_schema for all schema objects including rootpage, ordered by rowid
-/// 3. Creates storage-backed tables (rootpage != 0) in destination, excluding
+/// 3. Creates storage-backed tables (rootpage != 0) in the output, excluding
 ///    sqlite_sequence (auto-created when AUTOINCREMENT tables are created)
 /// 4. Copies data for all storage-backed tables, including sqlite_stat1 and other
 ///    internal storage-backed tables
 /// 5. Creates user-defined secondary indexes after data copy for performance
 ///    (backing-btree indexes for custom index methods are excluded here)
-/// 6. Copies meta values (user_version, application_id) from source to destination
+/// 6. Finalizes output database header metadata
 /// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
@@ -14703,7 +14716,7 @@ pub fn op_vacuum_into(
     match op_vacuum_into_inner(program, state, insn) {
         Ok(InsnFunctionStepResult::Step) => {
             // Instruction complete, reset state
-            state.active_op_state.clear();
+            state.op_vacuum_into = None;
             Ok(InsnFunctionStepResult::Step)
         }
         Ok(InsnFunctionStepResult::IO(io)) => {
@@ -14714,11 +14727,52 @@ pub fn op_vacuum_into(
             unreachable!("op_vacuum_into_inner only returns Step or IO")
         }
         Err(err) => {
-            // Reset state on error
-            state.active_op_state.clear();
+            if let Err(cleanup_err) = cleanup_op_vacuum_into(&program.connection, state) {
+                tracing::error!("VACUUM INTO cleanup failed after error: {cleanup_err}");
+            }
             Err(err)
         }
     }
+}
+
+/// Clean up any VACUUM or VACUUM INTO state on error or abort.
+/// Only one of the two can be active at a time; this handles whichever is set.
+pub(crate) fn cleanup_vacuum_state(
+    connection: &Arc<Connection>,
+    state: &mut ProgramState,
+) -> Result<()> {
+    turso_assert!(
+        !(state.op_vacuum_into.is_some() && state.op_vacuum_in_place.is_some()),
+        "VACUUM INTO and in-place VACUUM state cannot both be active"
+    );
+
+    if state.op_vacuum_into.is_some() {
+        cleanup_op_vacuum_into(connection, state)
+    } else if state.op_vacuum_in_place.is_some() {
+        cleanup_op_vacuum_in_place(connection, state)
+    } else {
+        Ok(())
+    }
+}
+
+fn cleanup_op_vacuum_into(connection: &Arc<Connection>, state: &mut ProgramState) -> Result<()> {
+    let Some(mut vacuum_state) = state.op_vacuum_into.take() else {
+        return Ok(());
+    };
+
+    if let Some(target_build_context) = vacuum_state.target_build_context.as_mut() {
+        target_build_context.cleanup_after_error()?;
+    }
+
+    vacuum_state.target_build_context = None;
+    vacuum_state._output_db = None;
+
+    if state.auto_txn_cleanup == TxnCleanup::RollbackTxn {
+        let pager = connection.pager.load();
+        connection.rollback_manual_txn_cleanup(&pager, true);
+        state.auto_txn_cleanup = TxnCleanup::None;
+    }
+    Ok(())
 }
 
 fn op_vacuum_into_inner(
@@ -14726,8 +14780,6 @@ fn op_vacuum_into_inner(
     state: &mut ProgramState,
     insn: &Insn,
 ) -> Result<InsnFunctionStepResult> {
-    use crate::vdbe::vacuum::{VacuumInto, VacuumIntoConfig};
-
     load_insn!(
         VacuumInto {
             schema_name,
@@ -14736,31 +14788,31 @@ fn op_vacuum_into_inner(
         insn
     );
 
-    if state.active_op_state.vacuum_into().is_none() {
-        let database_id = program.connection.get_database_id_by_name(schema_name)?;
+    if state.op_vacuum_into.is_none() {
+        let source_db_id = program.connection.get_database_id_by_name(schema_name)?;
 
         // Matches sqlite that treats VACUUM temp INTO as a no-op (no file created)
-        if database_id == TEMP_DB_ID {
+        if source_db_id == TEMP_DB_ID {
             state.pc += 1;
             return Ok(InsnFunctionStepResult::Step);
         }
 
-        *state.active_op_state.vacuum_into() = Some(OpVacuumIntoState {
+        state.op_vacuum_into = Some(Box::new(VacuumIntoOpContext {
             escaped_schema_name: schema_name.replace('"', "\"\""),
-            database_id,
+            source_db_id,
             ..Default::default()
-        });
+        }));
     }
 
-    let vacuum_state = state.active_op_state.vacuum_into().as_mut().unwrap();
+    let vacuum_state = state.op_vacuum_into.as_mut().unwrap();
     let escaped_schema_name = &vacuum_state.escaped_schema_name;
-    let database_id = vacuum_state.database_id;
+    let source_db_id = vacuum_state.source_db_id;
 
     loop {
-        let current_sub_state = std::mem::take(&mut vacuum_state.sub_state);
+        let current_phase = std::mem::take(&mut vacuum_state.phase);
 
-        match current_sub_state {
-            OpVacuumIntoSubState::Init => {
+        match current_phase {
+            VacuumIntoOpPhase::Init => {
                 // Check if we're in a transaction
                 // as vacuum cannot be run inside a transaction
                 if !program.connection.auto_commit.load(Ordering::SeqCst) {
@@ -14789,32 +14841,35 @@ fn op_vacuum_into_inner(
                     )));
                 }
 
-                // Pin source metadata before building the destination. The
+                // Pin source metadata before building the output database. The
                 // BEGIN and pragma helpers here are blocking convenience wrappers;
-                // async work starts with the schema scan in vacuum_into_step.
-                let source_db = program.connection.get_source_database(database_id);
+                // async work starts with the schema scan in vacuum_target_build_step.
+                let source_db = program.connection.get_source_database(source_db_id);
                 program.connection.execute("BEGIN")?;
                 state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
-                let user_version: i32 = extract_pragma_int(
-                    &program
-                        .connection
-                        .pragma_query(&format!("\"{escaped_schema_name}\".user_version"))?,
-                    "user_version",
-                )?;
-                let application_id: i32 = extract_pragma_int(
-                    &program
-                        .connection
-                        .pragma_query(&format!("\"{escaped_schema_name}\".application_id"))?,
-                    "application_id",
-                )?;
                 let page_size: u32 = extract_pragma_int(
                     &program
                         .connection
                         .pragma_query(&format!("\"{escaped_schema_name}\".page_size"))?,
                     "page_size",
                 )?;
+                let source_pager = program
+                    .connection
+                    .get_pager_from_database_index(&source_db_id)?;
+                let source_auto_vacuum_mode = source_pager.get_auto_vacuum_mode();
+                reject_unsupported_vacuum_auto_vacuum_mode(source_auto_vacuum_mode)?;
+                let header_meta = if let Some(mv_store) =
+                    program.connection.mv_store_for_db(source_db_id)
+                {
+                    let tx_id = program.connection.get_mv_tx_id_for_db(source_db_id);
+                    mv_store.with_header(VacuumDbHeaderMeta::from_source_header, tx_id.as_ref())?
+                } else {
+                    source_pager.io.block(|| {
+                        source_pager.with_header(VacuumDbHeaderMeta::from_source_header)
+                    })?
+                };
 
-                let reserved_space: u8 = if !is_attached_db(database_id) {
+                let reserved_space: u8 = if !is_attached_db(source_db_id) {
                     // For main or temp db prefer cached value to avoid blocking I/O
                     match program.connection.get_reserved_bytes() {
                         Some(val) => val,
@@ -14829,79 +14884,88 @@ fn op_vacuum_into_inner(
                     // For attached db read from its own pager
                     let pager = program
                         .connection
-                        .get_pager_from_database_index(&database_id)?;
+                        .get_pager_from_database_index(&source_db_id)?;
                     pager
                         .io
                         .block(|| pager.with_header(|header| header.reserved_space))?
                 };
 
-                // Mirror source feature flags to the destination so schema replay
+                // Mirror source feature flags to the output so schema replay
                 // can resolve custom types, generated columns, vtab modules, etc.
-                let dest_opts = crate::DatabaseOpts::new()
-                    .with_views(source_db.experimental_views_enabled())
-                    .with_index_method(source_db.experimental_index_method_enabled())
-                    .with_custom_types(source_db.experimental_custom_types_enabled())
-                    .with_generated_columns(source_db.experimental_generated_columns_enabled());
+                let output_opts = vacuum_target_opts_from_source(&source_db);
 
-                // Always use PlatformIO for the destination file, even if source
+                // Always use PlatformIO for the output file, even if source
                 // is in-memory. This ensures VACUUM INTO writes to disk.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
-                let dest_db = crate::Database::open_file_with_flags(
+                let output_db = crate::Database::open_file_with_flags(
                     io,
                     dest_path,
                     OpenFlags::Create,
-                    dest_opts,
+                    output_opts,
                     None,
                 )?;
-                let dest_conn = dest_db.connect()?;
-                dest_conn.reset_page_size(page_size)?;
-                // set reserved_space on destination to match source
+                let output_conn = output_db.connect()?;
+                output_conn.reset_page_size(page_size)?;
+                // set reserved_space on output to match source
                 // this is important for databases using encryption or checksums
                 // must be set before page 1 is allocated (before any schema operations)
-                dest_conn.set_reserved_bytes(reserved_space)?;
+                output_conn.set_reserved_bytes(reserved_space)?;
 
-                // Capture source custom type definitions so that STRICT tables with
-                // custom type columns can resolve those types during CREATE TABLE
-                // replay on the destination.
-                let source_custom_types: Vec<(String, Arc<crate::schema::TypeDef>)> = program
-                    .connection
-                    .with_schema(database_id, |source_schema| {
-                        source_schema
-                            .type_registry
-                            .iter()
-                            .filter(|(_, td)| !td.is_builtin)
-                            .map(|(name, td)| (name.clone(), td.clone()))
-                            .collect()
-                    });
+                mirror_symbols(&program.connection, &output_conn);
+                let source_custom_types = capture_custom_types(&program.connection, source_db_id);
 
-                let config = VacuumIntoConfig {
+                let config = VacuumTargetBuildConfig {
                     source_conn: program.connection.clone(),
                     escaped_schema_name: escaped_schema_name.clone(),
-                    database_id,
-                    source_user_version: user_version,
-                    source_application_id: application_id,
+                    source_db_id,
+                    header_meta,
                     source_custom_types,
-                    source_mvcc_enabled: source_db.mvcc_enabled(),
+                    target_mvcc_enabled: source_db.mvcc_enabled(),
+                    target_auto_vacuum_mode: source_auto_vacuum_mode,
+                    copy_mvcc_metadata_table: false,
                 };
 
-                vacuum_state.sub_state = OpVacuumIntoSubState::Build(Box::new(VacuumInto::new(
-                    config, dest_db, dest_conn,
-                )));
+                vacuum_state._output_db = Some(output_db);
+                vacuum_state.target_build_config = Some(config);
+                vacuum_state.target_build_context =
+                    Some(VacuumTargetBuildContext::new(output_conn));
+                vacuum_state.phase = VacuumIntoOpPhase::Build;
                 continue;
             }
 
-            OpVacuumIntoSubState::Build(mut vacuum_into) => match vacuum_into.step()? {
-                IOResult::Done(()) => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::Done;
-                    continue;
-                }
-                IOResult::IO(io) => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::Build(vacuum_into);
-                    return Ok(InsnFunctionStepResult::IO(io));
-                }
-            },
+            VacuumIntoOpPhase::Build => {
+                let config = vacuum_state
+                    .target_build_config
+                    .as_ref()
+                    .expect("VacuumTargetBuildConfig must be set in Build state");
+                let target_build_context = vacuum_state
+                    .target_build_context
+                    .as_mut()
+                    .expect("VacuumTargetBuildContext must be set in Build state");
 
-            OpVacuumIntoSubState::Done => {
+                match vacuum_target_build_step(config, target_build_context)? {
+                    crate::IOResult::Done(()) => {
+                        vacuum_state.phase = VacuumIntoOpPhase::FinalizeOutput;
+                        continue;
+                    }
+                    crate::IOResult::IO(io) => {
+                        vacuum_state.phase = VacuumIntoOpPhase::Build;
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                }
+            }
+
+            VacuumIntoOpPhase::FinalizeOutput => {
+                let target_build_context = vacuum_state
+                    .target_build_context
+                    .as_ref()
+                    .expect("VacuumTargetBuildContext must be set in FinalizeOutput state");
+                crate::vdbe::vacuum::finalize_vacuum_into_output(target_build_context)?;
+                vacuum_state.phase = VacuumIntoOpPhase::Done;
+                continue;
+            }
+
+            VacuumIntoOpPhase::Done => {
                 // Commit the source transaction started in Init.
                 program.connection.execute("COMMIT")?;
                 state.auto_txn_cleanup = TxnCleanup::None;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15156,6 +15156,231 @@ mod tests {
         (ht, probe_key, partition_idx)
     }
 
+    /// test to check that vacuum into connection state is reset if it is
+    /// interrupted mid way
+    #[test]
+    fn test_vacuum_into_busy_after_source_begin_rolls_back_source_txn() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            ":memory:",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(x)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+
+        let source_txn_progress_calls = Arc::new(AtomicUsize::new(0));
+        let did_interrupt = Arc::new(AtomicBool::new(false));
+        let conn_for_progress = conn.clone();
+        let source_txn_progress_calls_for_handler = source_txn_progress_calls.clone();
+        let did_interrupt_for_handler = did_interrupt.clone();
+        conn.set_progress_handler(
+            1,
+            Some(Box::new(move || {
+                if !conn_for_progress.get_auto_commit() {
+                    let calls =
+                        source_txn_progress_calls_for_handler.fetch_add(1, Ordering::SeqCst);
+                    calls >= 10 && !did_interrupt_for_handler.swap(true, Ordering::SeqCst)
+                } else {
+                    false
+                }
+            })),
+        );
+
+        let dest_dir = tempfile::TempDir::new().unwrap();
+        let dest_path = dest_dir.path().join("busy_vacuum.db");
+        let dest_path = dest_path.to_str().expect("temp path should be UTF-8");
+        let mut stmt = conn.prepare(format!("VACUUM INTO '{dest_path}'")).unwrap();
+        let step = stmt.step().unwrap();
+        conn.set_progress_handler(0, None);
+
+        assert!(
+            matches!(step, StepResult::Busy),
+            "progress interruption inside VACUUM INTO should surface as Busy, got {step:?}"
+        );
+        assert!(
+            source_txn_progress_calls.load(Ordering::SeqCst) > 10,
+            "test should interrupt after VACUUM INTO opens the source transaction"
+        );
+        assert!(
+            did_interrupt.load(Ordering::SeqCst),
+            "progress handler should have interrupted VACUUM INTO exactly once"
+        );
+        assert!(
+            conn.get_auto_commit(),
+            "Busy cleanup should roll back the source transaction before returning"
+        );
+    }
+
+    /// same like `test_vacuum_into_busy_after_source_begin_rolls_back_source_txn`
+    /// but for attached dbs
+    #[test]
+    fn test_cleanup_vacuum_into_rolls_back_attached_only_source_txn() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let main_path = dir.path().join("vacuum-into-cleanup-main.db");
+        let attached_path = dir.path().join("vacuum-into-cleanup-attached.db");
+
+        let io: Arc<dyn IO> = Arc::new(crate::io::PlatformIO::new().unwrap());
+        let db = Database::open_file_with_flags(
+            io,
+            main_path.to_str().unwrap(),
+            OpenFlags::Create,
+            DatabaseOpts::new().with_attach(true),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute(format!(
+            "ATTACH DATABASE '{}' AS att",
+            attached_path.display()
+        ))
+        .unwrap();
+        conn.execute("CREATE TABLE att.t(x)").unwrap();
+        conn.execute("INSERT INTO att.t VALUES (1)").unwrap();
+
+        conn.execute("BEGIN").unwrap();
+        let attached_db_id = conn.get_database_id_by_name("att").unwrap();
+        let attached_pager = conn.get_pager_from_database_index(&attached_db_id).unwrap();
+        attached_pager.begin_read_tx().unwrap();
+
+        assert!(
+            !conn.pager.load().holds_read_lock(),
+            "attached-only cleanup regression requires the main pager to stay lock-free"
+        );
+        assert!(
+            attached_pager.holds_read_lock(),
+            "attached source pager should hold the pinned read snapshot"
+        );
+
+        let mut state = ProgramState::new(0, 0);
+        state.op_vacuum_into = Some(Box::default());
+        state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+
+        cleanup_op_vacuum_into(&conn, &mut state).unwrap();
+
+        assert!(
+            conn.get_auto_commit(),
+            "cleanup should restore auto-commit without going through SQL ROLLBACK"
+        );
+        assert_eq!(state.auto_txn_cleanup, TxnCleanup::None);
+        assert!(
+            !attached_pager.holds_read_lock(),
+            "cleanup should release the attached source read snapshot"
+        );
+
+        conn.execute("INSERT INTO att.t VALUES (2)").unwrap();
+        let mut stmt = conn.prepare("SELECT COUNT(*) FROM att.t").unwrap();
+        let mut count = 0_i64;
+        stmt.run_with_row_callback(|row| {
+            count = row.get(0)?;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_in_place_vacuum_succeeds_and_releases_source_locks() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            "in-place-vacuum-design-b.db",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        for i in 0..128 {
+            conn.execute(format!("INSERT INTO t VALUES ({i}, 'value-{i}')"))
+                .unwrap();
+        }
+        conn.execute("DELETE FROM t WHERE id % 2 = 0").unwrap();
+
+        conn.execute("VACUUM").unwrap();
+
+        let mut stmt = conn
+            .prepare("SELECT count(*), coalesce(sum(id), 0) FROM t")
+            .unwrap();
+        let mut count = 0_i64;
+        let mut sum = 0_i64;
+        stmt.run_with_row_callback(|row| {
+            count = row.get(0)?;
+            sum = row.get(1)?;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(count, 64);
+        assert_eq!(sum, (1..128).step_by(2).sum::<i64>());
+        assert!(conn.get_auto_commit());
+
+        let pager = conn.pager.load();
+        assert!(!pager.holds_read_lock());
+        assert!(!pager.holds_write_lock());
+    }
+
+    #[test]
+    fn test_in_place_vacuum_busy_before_copyback_restores_source_txn() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            "in-place-vacuum-busy-before-copyback.db",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        for i in 0..32 {
+            conn.execute(format!("INSERT INTO t VALUES ({i}, 'value-{i}')"))
+                .unwrap();
+        }
+
+        let did_interrupt = Arc::new(AtomicBool::new(false));
+        let conn_for_progress = conn.clone();
+        let did_interrupt_for_handler = did_interrupt.clone();
+        conn.set_progress_handler(
+            1,
+            Some(Box::new(move || {
+                !conn_for_progress.get_auto_commit()
+                    && !did_interrupt_for_handler.swap(true, Ordering::SeqCst)
+            })),
+        );
+
+        let mut stmt = conn.prepare("VACUUM").unwrap();
+        let step = stmt.step().unwrap();
+        conn.set_progress_handler(0, None);
+
+        assert!(
+            matches!(step, StepResult::Busy),
+            "progress interruption inside in-place VACUUM should surface as Busy, got {step:?}"
+        );
+        assert!(
+            did_interrupt.load(Ordering::SeqCst),
+            "test should interrupt after in-place VACUUM opens the source snapshot"
+        );
+        assert!(
+            conn.get_auto_commit(),
+            "Busy cleanup should restore auto-commit before returning"
+        );
+        let pager = conn.pager.load();
+        assert!(!pager.holds_read_lock());
+        assert!(!pager.holds_write_lock());
+    }
+
     #[test]
     fn test_hash_probe_rejects_unloaded_spilled_partition_without_probe_rowid() {
         let stmt = prepare_test_statement();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -38,6 +38,7 @@ use crate::vdbe::hash_table::{
 };
 use crate::vdbe::insn::InsertFlags;
 use crate::vdbe::metrics::HashJoinMetrics;
+use crate::vdbe::vacuum::VacuumInPlaceOpContext;
 use crate::vdbe::value::ComparisonOp;
 use crate::vdbe::ValueIteratorExt;
 use crate::vdbe::{
@@ -59,9 +60,9 @@ use crate::{
         builder::CursorType,
         insn::{IdxInsertFlags, Insn, SavepointOp},
     },
-    CaptureDataChangesInfo, CdcVersion, CheckpointMode, Completion, Connection, DatabaseStorage,
-    IOExt, MvCursor, NonNan, OpenFlags, QueryMode, Statement, TransactionState, ValueRef,
-    MAIN_DB_ID, TEMP_DB_ID,
+    CaptureDataChangesInfo, CdcVersion, CheckpointMode, Completion, Connection, Database,
+    DatabaseStorage, IOExt, MvCursor, NonNan, OpenFlags, QueryMode, Statement, TransactionState,
+    ValueRef, MAIN_DB_ID, TEMP_DB_ID,
 };
 use crate::{
     error::{
@@ -14683,11 +14684,11 @@ pub(crate) struct VacuumIntoOpContext {
     /// Escaped schema name for safe SQL interpolation.
     escaped_schema_name: String,
     /// Keep output database alive while vacuum is in progress.
-    _output_db: Option<Arc<crate::Database>>,
+    _output_db: Option<Arc<Database>>,
     /// Configuration for the shared vacuum target build state machine.
-    target_build_config: Option<crate::vdbe::vacuum::VacuumTargetBuildConfig>,
+    target_build_config: Option<VacuumTargetBuildConfig>,
     /// Context for the shared vacuum target build state machine.
-    target_build_context: Option<crate::vdbe::vacuum::VacuumTargetBuildContext>,
+    target_build_context: Option<VacuumTargetBuildContext>,
 }
 
 /// VACUUM INTO - create a compacted copy of the database at the specified path.
@@ -14975,6 +14976,54 @@ fn op_vacuum_into_inner(
             }
         }
     }
+}
+
+/// In-place VACUUM - compact the database via target build + direct-WAL
+/// copy-back. The opcode owns the source transaction lifecycle.
+pub fn op_vacuum(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(Vacuum { db }, insn);
+
+    if state.op_vacuum_in_place.is_none() {
+        state.op_vacuum_in_place = Some(Box::new(VacuumInPlaceOpContext::new(*db)));
+    }
+
+    let vacuum_state = state.op_vacuum_in_place.as_mut().unwrap();
+
+    match vacuum_state.step(&program.connection) {
+        Ok(InsnFunctionStepResult::Step) => {
+            state.op_vacuum_in_place = None;
+            state.pc += 1;
+            Ok(InsnFunctionStepResult::Step)
+        }
+        Ok(InsnFunctionStepResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
+        Ok(InsnFunctionStepResult::Done | InsnFunctionStepResult::Row) => {
+            unreachable!("in-place VACUUM only returns Step or IO")
+        }
+        Err(err) => {
+            if let Err(cleanup_err) = cleanup_op_vacuum_in_place(&program.connection, state) {
+                tracing::error!("VACUUM cleanup failed after error: {cleanup_err}");
+            }
+            Err(err)
+        }
+    }
+}
+
+/// Clean up in-place VACUUM state on error or abort. Rolls back the source
+/// transaction if it was acquired, restores connection state, and drops
+/// temp resources.
+fn cleanup_op_vacuum_in_place(
+    connection: &Arc<Connection>,
+    state: &mut ProgramState,
+) -> Result<()> {
+    let Some(vacuum_state) = state.op_vacuum_in_place.take() else {
+        return Ok(());
+    };
+    vacuum_state.cleanup(connection)
 }
 
 fn with_header<T, F>(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14105,49 +14105,49 @@ where
         })
 }
 
-/// Sub-states for the VACUUM INTO operation state machine.
+/// Stages for the VACUUM INTO opcode wrapper.
 #[derive(Default)]
-pub(crate) enum OpVacuumIntoSubState {
-    /// Initial state - validate preconditions and create destination database
+pub(crate) enum VacuumIntoOpStage {
+    /// Initial state - validate preconditions and create output database.
     #[default]
     Init,
-    /// Build compacted destination database
+    /// Build compacted output database.
     Build,
-    /// Operation complete
+    /// Operation complete.
     Done,
 }
 
-/// Holds the state for the VACUUM INTO operation.
+/// Context for the VACUUM INTO opcode wrapper.
 #[derive(Default)]
-pub(crate) struct OpVacuumIntoState {
-    sub_state: OpVacuumIntoSubState,
-    /// Database index for the target schema
-    database_id: usize,
-    /// Escaped schema name for safe SQL interpolation
+pub(crate) struct VacuumIntoOpContext {
+    stage: VacuumIntoOpStage,
+    /// Database index for the source schema.
+    source_db_id: usize,
+    /// Escaped schema name for safe SQL interpolation.
     escaped_schema_name: String,
-    /// Keep dest_db alive while vacuum is in progress.
+    /// Keep output database alive while vacuum is in progress.
     #[allow(dead_code)]
-    dest_db: Option<Arc<crate::Database>>,
-    /// Configuration for the shared VACUUM INTO build state machine.
-    vacuum_into_config: Option<crate::vdbe::vacuum::VacuumIntoConfig>,
-    /// State for the shared VACUUM INTO build state machine.
-    vacuum_into_state: Option<crate::vdbe::vacuum::VacuumIntoState>,
+    output_db: Option<Arc<crate::Database>>,
+    /// Configuration for the shared vacuum target build state machine.
+    target_build_config: Option<crate::vdbe::vacuum::VacuumTargetBuildConfig>,
+    /// Context for the shared vacuum target build state machine.
+    target_build_context: Option<crate::vdbe::vacuum::VacuumTargetBuildContext>,
 }
 
 /// VACUUM INTO - create a compacted copy of the database at the specified path.
 ///
 /// This is an async state machine implementation that yields on I/O operations.
 /// It:
-/// 1. Creates a new database at the destination path with matching page_size and
+/// 1. Creates a new output database with matching page_size and
 ///    source feature flags and schema-replay symbols
 /// 2. Queries sqlite_schema for all schema objects including rootpage, ordered by rowid
-/// 3. Creates storage-backed tables (rootpage != 0) in destination, excluding
+/// 3. Creates storage-backed tables (rootpage != 0) in the output, excluding
 ///    sqlite_sequence (auto-created when AUTOINCREMENT tables are created)
 /// 4. Copies data for all storage-backed tables, including sqlite_stat1 and other
 ///    internal storage-backed tables
 /// 5. Creates user-defined secondary indexes after data copy for performance
 ///    (backing-btree indexes for custom index methods are excluded here)
-/// 6. Finalizes destination page-1 metadata
+/// 6. Finalizes output page-1 metadata
 /// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
@@ -14160,7 +14160,7 @@ pub fn op_vacuum_into(
     match op_vacuum_into_inner(program, state, insn) {
         Ok(InsnFunctionStepResult::Step) => {
             // Instruction complete, reset state
-            state.op_vacuum_into_state = None;
+            state.op_vacuum_into = None;
             Ok(InsnFunctionStepResult::Step)
         }
         Ok(InsnFunctionStepResult::IO(io)) => {
@@ -14171,7 +14171,7 @@ pub fn op_vacuum_into(
             unreachable!("op_vacuum_into_inner only returns Step or IO")
         }
         Err(err) => {
-            if let Err(cleanup_err) = cleanup_op_vacuum_into_state(&program.connection, state) {
+            if let Err(cleanup_err) = cleanup_op_vacuum_into(&program.connection, state) {
                 tracing::error!("VACUUM INTO cleanup failed after error: {cleanup_err}");
             }
             Err(err)
@@ -14185,31 +14185,28 @@ pub(crate) fn cleanup_vacuum_state(
     connection: &Arc<Connection>,
     state: &mut ProgramState,
 ) -> Result<()> {
-    if state.op_vacuum_into_state.is_some() {
-        cleanup_op_vacuum_into_state(connection, state)
-    } else if state.op_vacuum_state.is_some() {
-        cleanup_op_vacuum_state(connection, state)
+    if state.op_vacuum_into.is_some() {
+        cleanup_op_vacuum_into(connection, state)
+    } else if state.op_vacuum_in_place.is_some() {
+        cleanup_op_vacuum_in_place(connection, state)
     } else {
         Ok(())
     }
 }
 
-fn cleanup_op_vacuum_into_state(
-    connection: &Arc<Connection>,
-    state: &mut ProgramState,
-) -> Result<()> {
-    let Some(mut vacuum_state) = state.op_vacuum_into_state.take() else {
+fn cleanup_op_vacuum_into(connection: &Arc<Connection>, state: &mut ProgramState) -> Result<()> {
+    let Some(mut vacuum_state) = state.op_vacuum_into.take() else {
         return Ok(());
     };
 
     let mut cleanup_error = None;
 
-    if let Some(vacuum_into_state) = vacuum_state.vacuum_into_state.as_mut() {
-        vacuum_into_state.cleanup_after_error();
+    if let Some(target_build_context) = vacuum_state.target_build_context.as_mut() {
+        target_build_context.cleanup_after_error();
     }
 
-    vacuum_state.vacuum_into_state = None;
-    vacuum_state.dest_db = None;
+    vacuum_state.target_build_context = None;
+    vacuum_state.output_db = None;
 
     if state.auto_txn_cleanup == TxnCleanup::RollbackTxn {
         match connection.execute("ROLLBACK") {
@@ -14234,8 +14231,8 @@ fn op_vacuum_into_inner(
     insn: &Insn,
 ) -> Result<InsnFunctionStepResult> {
     use crate::vdbe::vacuum::{
-        vacuum_destination_opts, vacuum_into_step, VacuumDestinationHeader, VacuumIntoConfig,
-        VacuumIntoState,
+        vacuum_target_build_step, vacuum_target_opts_from_source, VacuumPage1Meta,
+        VacuumTargetBuildConfig, VacuumTargetBuildContext,
     };
 
     load_insn!(
@@ -14246,31 +14243,31 @@ fn op_vacuum_into_inner(
         insn
     );
 
-    if state.op_vacuum_into_state.is_none() {
-        let database_id = program.connection.get_database_id_by_name(schema_name)?;
+    if state.op_vacuum_into.is_none() {
+        let source_db_id = program.connection.get_database_id_by_name(schema_name)?;
 
         // Matches sqlite that treats VACUUM temp INTO as a no-op (no file created)
-        if database_id == TEMP_DB_ID {
+        if source_db_id == TEMP_DB_ID {
             state.pc += 1;
             return Ok(InsnFunctionStepResult::Step);
         }
 
-        state.op_vacuum_into_state = Some(Box::new(OpVacuumIntoState {
+        state.op_vacuum_into = Some(Box::new(VacuumIntoOpContext {
             escaped_schema_name: schema_name.replace('"', "\"\""),
-            database_id,
+            source_db_id,
             ..Default::default()
         }));
     }
 
-    let vacuum_state = state.op_vacuum_into_state.as_mut().unwrap();
+    let vacuum_state = state.op_vacuum_into.as_mut().unwrap();
     let escaped_schema_name = &vacuum_state.escaped_schema_name;
-    let database_id = vacuum_state.database_id;
+    let source_db_id = vacuum_state.source_db_id;
 
     loop {
-        let current_sub_state = std::mem::take(&mut vacuum_state.sub_state);
+        let current_stage = std::mem::take(&mut vacuum_state.stage);
 
-        match current_sub_state {
-            OpVacuumIntoSubState::Init => {
+        match current_stage {
+            VacuumIntoOpStage::Init => {
                 // Check if we're in a transaction
                 // as vacuum cannot be run inside a transaction
                 if !program.connection.auto_commit.load(Ordering::SeqCst) {
@@ -14299,11 +14296,11 @@ fn op_vacuum_into_inner(
                     )));
                 }
 
-                // Pin source metadata before building the destination. The
+                // Pin source metadata before building the output database. The
                 // BEGIN and pragma helpers here are blocking convenience wrappers;
-                // async work starts with the schema scan in vacuum_into_step.
+                // async work starts with the schema scan in vacuum_target_build_step.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
-                let source_db = program.connection.get_source_database(database_id);
+                let source_db = program.connection.get_source_database(source_db_id);
                 program.connection.execute("BEGIN")?;
                 state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                 let page_size: u32 = extract_pragma_int(
@@ -14314,23 +14311,18 @@ fn op_vacuum_into_inner(
                 )?;
                 let source_pager = program
                     .connection
-                    .get_pager_from_database_index(&database_id);
-                let destination_header = if let Some(mv_store) =
-                    program.connection.mv_store_for_db(database_id)
-                {
-                    let tx_id = program.connection.get_mv_tx_id_for_db(database_id);
-                    mv_store.with_header(
-                        VacuumDestinationHeader::vacuum_into_from_source_header,
-                        tx_id.as_ref(),
-                    )?
-                } else {
-                    source_pager.io.block(|| {
-                        source_pager
-                            .with_header(VacuumDestinationHeader::vacuum_into_from_source_header)
-                    })?
-                };
+                    .get_pager_from_database_index(&source_db_id);
+                let header_meta =
+                    if let Some(mv_store) = program.connection.mv_store_for_db(source_db_id) {
+                        let tx_id = program.connection.get_mv_tx_id_for_db(source_db_id);
+                        mv_store.with_header(VacuumPage1Meta::from_source_header, tx_id.as_ref())?
+                    } else {
+                        source_pager.io.block(|| {
+                            source_pager.with_header(VacuumPage1Meta::from_source_header)
+                        })?
+                    };
 
-                let reserved_space: u8 = if !is_attached_db(database_id) {
+                let reserved_space: u8 = if !is_attached_db(source_db_id) {
                     // For main or temp db prefer cached value to avoid blocking I/O
                     match program.connection.get_reserved_bytes() {
                         Some(val) => val,
@@ -14343,49 +14335,49 @@ fn op_vacuum_into_inner(
                     // For attached db read from its own pager
                     let pager = program
                         .connection
-                        .get_pager_from_database_index(&database_id);
+                        .get_pager_from_database_index(&source_db_id);
                     io.block(|| pager.with_header(|header| header.reserved_space))?
                 };
 
-                // Mirror source feature flags to the destination so schema replay
+                // Mirror source feature flags to the output so schema replay
                 // can resolve custom types, generated columns, vtab modules, etc.
-                let dest_opts = vacuum_destination_opts(&source_db);
+                let output_opts = vacuum_target_opts_from_source(&source_db);
 
-                // Always use PlatformIO for the destination file, even if source
+                // Always use PlatformIO for the output file, even if source
                 // is in-memory. This ensures VACUUM INTO writes to disk.
                 let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
-                let dest_db = crate::Database::open_file_with_flags(
+                let output_db = crate::Database::open_file_with_flags(
                     io,
                     dest_path,
                     OpenFlags::Create,
-                    dest_opts,
+                    output_opts,
                     None,
                 )?;
-                let dest_conn = dest_db.connect()?;
-                dest_conn.reset_page_size(page_size)?;
-                // set reserved_space on destination to match source
+                let output_conn = output_db.connect()?;
+                output_conn.reset_page_size(page_size)?;
+                // set reserved_space on output to match source
                 // this is important for databases using encryption or checksums
                 // must be set before page 1 is allocated (before any schema operations)
-                dest_conn.set_reserved_bytes(reserved_space)?;
+                output_conn.set_reserved_bytes(reserved_space)?;
 
-                // Mirror source symbols directly into destination for schema replay,
+                // Mirror source symbols directly into output for schema replay,
                 // avoiding an intermediate clone through SourceSymbols.
                 {
                     let source_syms = program.connection.syms.read();
-                    let mut dest_syms = dest_conn.syms.write();
-                    dest_syms.functions.extend(
+                    let mut output_syms = output_conn.syms.write();
+                    output_syms.functions.extend(
                         source_syms
                             .functions
                             .iter()
                             .map(|(k, v)| (k.clone(), v.clone())),
                     );
-                    dest_syms.vtab_modules.extend(
+                    output_syms.vtab_modules.extend(
                         source_syms
                             .vtab_modules
                             .iter()
                             .map(|(k, v)| (k.clone(), v.clone())),
                     );
-                    dest_syms.index_methods.extend(
+                    output_syms.index_methods.extend(
                         source_syms
                             .index_methods
                             .iter()
@@ -14395,10 +14387,10 @@ fn op_vacuum_into_inner(
 
                 // Capture source custom type definitions so that STRICT tables with
                 // custom type columns can resolve those types during CREATE TABLE
-                // replay on the destination.
+                // replay on the output.
                 let source_custom_types: Vec<(String, Arc<crate::schema::TypeDef>)> = program
                     .connection
-                    .with_schema(database_id, |source_schema| {
+                    .with_schema(source_db_id, |source_schema| {
                         source_schema
                             .type_registry
                             .iter()
@@ -14407,48 +14399,46 @@ fn op_vacuum_into_inner(
                             .collect()
                     });
 
-                let config = VacuumIntoConfig {
+                let config = VacuumTargetBuildConfig {
                     source_conn: program.connection.clone(),
                     escaped_schema_name: escaped_schema_name.clone(),
-                    database_id,
-                    destination_header,
+                    source_db_id,
+                    header_meta,
                     source_custom_types,
                     source_mvcc_enabled: source_db.mvcc_enabled(),
                 };
 
-                vacuum_state.dest_db = Some(dest_db);
-                vacuum_state.vacuum_into_config = Some(config);
-                vacuum_state.vacuum_into_state = Some(VacuumIntoState::new(dest_conn));
-                vacuum_state.sub_state = OpVacuumIntoSubState::Build;
+                vacuum_state.output_db = Some(output_db);
+                vacuum_state.target_build_config = Some(config);
+                vacuum_state.target_build_context =
+                    Some(VacuumTargetBuildContext::new(output_conn));
+                vacuum_state.stage = VacuumIntoOpStage::Build;
                 continue;
             }
 
-            OpVacuumIntoSubState::Build => {
+            VacuumIntoOpStage::Build => {
                 let config = vacuum_state
-                    .vacuum_into_config
+                    .target_build_config
                     .as_ref()
-                    .expect("VacuumIntoConfig must be set in Build state");
-                let vi_state = vacuum_state
-                    .vacuum_into_state
+                    .expect("VacuumTargetBuildConfig must be set in Build state");
+                let target_build_context = vacuum_state
+                    .target_build_context
                     .as_mut()
-                    .expect("VacuumIntoState must be set in Build state");
+                    .expect("VacuumTargetBuildContext must be set in Build state");
 
-                match vacuum_into_step(config, vi_state)? {
-                    InsnFunctionStepResult::Step => {
-                        vacuum_state.sub_state = OpVacuumIntoSubState::Done;
+                match vacuum_target_build_step(config, target_build_context)? {
+                    crate::IOResult::Done(()) => {
+                        vacuum_state.stage = VacuumIntoOpStage::Done;
                         continue;
                     }
-                    InsnFunctionStepResult::IO(io) => {
-                        vacuum_state.sub_state = OpVacuumIntoSubState::Build;
+                    crate::IOResult::IO(io) => {
+                        vacuum_state.stage = VacuumIntoOpStage::Build;
                         return Ok(InsnFunctionStepResult::IO(io));
-                    }
-                    InsnFunctionStepResult::Done | InsnFunctionStepResult::Row => {
-                        unreachable!("vacuum_into_step only returns Step or IO")
                     }
                 }
             }
 
-            OpVacuumIntoSubState::Done => {
+            VacuumIntoOpStage::Done => {
                 // Commit the source transaction started in Init.
                 program.connection.execute("COMMIT")?;
                 state.auto_txn_cleanup = TxnCleanup::None;
@@ -14461,21 +14451,20 @@ fn op_vacuum_into_inner(
 }
 
 // ---------------------------------------------------------------------------
-// Plain VACUUM opcode
+// In-place VACUUM opcode
 // ---------------------------------------------------------------------------
 
-/// Holds the state for the plain VACUUM operation across async yields.
-pub(crate) struct OpVacuumState {
+/// Holds the context for the in-place VACUUM operation across async yields.
+pub(crate) struct VacuumInPlaceOpContext {
     /// Database index being vacuumed.
     db: usize,
-    /// State machine for the plain VACUUM operation.
-    sub_state: crate::vdbe::vacuum::PlainVacuumSubState,
-    /// Independent progress flags for cleanup — survive `std::mem::take`
-    /// on `sub_state` so the error/abort path always knows what to undo.
-    progress: crate::vdbe::vacuum::PlainVacuumProgress,
+    /// Current stage for the in-place VACUUM operation.
+    stage: crate::vdbe::vacuum::VacuumInPlaceStage,
+    /// Independent cleanup flags that survive `std::mem::take` on `stage`.
+    cleanup_state: crate::vdbe::vacuum::VacuumInPlaceCleanupState,
 }
 
-/// Plain VACUUM - compact the database in place via temp-build + direct-WAL
+/// In-place VACUUM - compact the database via target build + direct-WAL
 /// copy-back. The opcode owns the source transaction lifecycle.
 pub fn op_vacuum(
     program: &Program,
@@ -14485,33 +14474,33 @@ pub fn op_vacuum(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Vacuum { db }, insn);
 
-    if state.op_vacuum_state.is_none() {
-        state.op_vacuum_state = Some(Box::new(OpVacuumState {
+    if state.op_vacuum_in_place.is_none() {
+        state.op_vacuum_in_place = Some(Box::new(VacuumInPlaceOpContext {
             db: *db,
-            sub_state: crate::vdbe::vacuum::PlainVacuumSubState::Preflight,
-            progress: crate::vdbe::vacuum::PlainVacuumProgress::default(),
+            stage: crate::vdbe::vacuum::VacuumInPlaceStage::Preflight,
+            cleanup_state: crate::vdbe::vacuum::VacuumInPlaceCleanupState::default(),
         }));
     }
 
-    let vacuum_state = state.op_vacuum_state.as_mut().unwrap();
+    let vacuum_state = state.op_vacuum_in_place.as_mut().unwrap();
 
-    match crate::vdbe::vacuum::plain_vacuum_step(
+    match crate::vdbe::vacuum::vacuum_in_place_step(
         &program.connection,
         vacuum_state.db,
-        &mut vacuum_state.sub_state,
-        &mut vacuum_state.progress,
+        &mut vacuum_state.stage,
+        &mut vacuum_state.cleanup_state,
     ) {
         Ok(InsnFunctionStepResult::Step) => {
-            state.op_vacuum_state = None;
+            state.op_vacuum_in_place = None;
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
         Ok(InsnFunctionStepResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
         Ok(InsnFunctionStepResult::Done | InsnFunctionStepResult::Row) => {
-            unreachable!("plain_vacuum_step only returns Step or IO")
+            unreachable!("vacuum_in_place_step only returns Step or IO")
         }
         Err(err) => {
-            if let Err(cleanup_err) = cleanup_op_vacuum_state(&program.connection, state) {
+            if let Err(cleanup_err) = cleanup_op_vacuum_in_place(&program.connection, state) {
                 tracing::error!("VACUUM cleanup failed after error: {cleanup_err}");
             }
             Err(err)
@@ -14519,18 +14508,21 @@ pub fn op_vacuum(
     }
 }
 
-/// Clean up plain VACUUM state on error or abort. Rolls back the source
+/// Clean up in-place VACUUM state on error or abort. Rolls back the source
 /// transaction if it was acquired, restores connection state, and drops
 /// temp resources.
-fn cleanup_op_vacuum_state(connection: &Arc<Connection>, state: &mut ProgramState) -> Result<()> {
-    let Some(vacuum_state) = state.op_vacuum_state.take() else {
+fn cleanup_op_vacuum_in_place(
+    connection: &Arc<Connection>,
+    state: &mut ProgramState,
+) -> Result<()> {
+    let Some(vacuum_state) = state.op_vacuum_in_place.take() else {
         return Ok(());
     };
-    crate::vdbe::vacuum::plain_vacuum_cleanup(
+    crate::vdbe::vacuum::vacuum_in_place_cleanup(
         connection,
         vacuum_state.db,
-        vacuum_state.sub_state,
-        &vacuum_state.progress,
+        vacuum_state.stage,
+        &vacuum_state.cleanup_state,
     );
     Ok(())
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14164,11 +14164,46 @@ pub fn op_vacuum_into(
             unreachable!("op_vacuum_into_inner only returns Step or IO")
         }
         Err(err) => {
-            // Reset state on error
-            state.op_vacuum_into_state = None;
+            if let Err(cleanup_err) = cleanup_op_vacuum_into_state(&program.connection, state) {
+                tracing::error!("VACUUM INTO cleanup failed after error: {cleanup_err}");
+            }
             Err(err)
         }
     }
+}
+
+pub(crate) fn cleanup_op_vacuum_into_state(
+    connection: &Arc<Connection>,
+    state: &mut ProgramState,
+) -> Result<()> {
+    let Some(mut vacuum_state) = state.op_vacuum_into_state.take() else {
+        return Ok(());
+    };
+
+    let mut cleanup_error = None;
+
+    if let Some(vacuum_into_state) = vacuum_state.vacuum_into_state.as_mut() {
+        vacuum_into_state.cleanup_after_error();
+    }
+
+    vacuum_state.vacuum_into_state = None;
+    vacuum_state.dest_db = None;
+
+    if state.auto_txn_cleanup == TxnCleanup::RollbackTxn {
+        match connection.execute("ROLLBACK") {
+            Ok(()) => {
+                state.auto_txn_cleanup = TxnCleanup::None;
+            }
+            Err(err) => {
+                cleanup_error.get_or_insert(err);
+            }
+        }
+    }
+
+    if let Some(err) = cleanup_error {
+        return Err(err);
+    }
+    Ok(())
 }
 
 fn op_vacuum_into_inner(
@@ -14288,6 +14323,8 @@ fn op_vacuum_into_inner(
                     .with_views(source_db.experimental_views_enabled())
                     .with_index_method(source_db.experimental_index_method_enabled())
                     .with_custom_types(source_db.experimental_custom_types_enabled())
+                    .with_encryption(source_db.experimental_encryption_enabled())
+                    .with_attach(source_db.experimental_attach_enabled())
                     .with_generated_columns(source_db.experimental_generated_columns_enabled());
 
                 // Always use PlatformIO for the destination file, even if source
@@ -14488,6 +14525,66 @@ mod tests {
         let partition_idx = ht.partition_for_keys(&probe_key);
 
         (ht, probe_key, partition_idx)
+    }
+
+    #[test]
+    fn test_vacuum_into_busy_after_source_begin_rolls_back_source_txn() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            ":memory:",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE t(x)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+
+        let source_txn_progress_calls = Arc::new(AtomicUsize::new(0));
+        let did_interrupt = Arc::new(AtomicBool::new(false));
+        let conn_for_progress = conn.clone();
+        let source_txn_progress_calls_for_handler = source_txn_progress_calls.clone();
+        let did_interrupt_for_handler = did_interrupt.clone();
+        conn.set_progress_handler(
+            1,
+            Some(Box::new(move || {
+                if !conn_for_progress.get_auto_commit() {
+                    let calls =
+                        source_txn_progress_calls_for_handler.fetch_add(1, Ordering::SeqCst);
+                    calls >= 10 && !did_interrupt_for_handler.swap(true, Ordering::SeqCst)
+                } else {
+                    false
+                }
+            })),
+        );
+
+        let dest_dir = tempfile::TempDir::new().unwrap();
+        let dest_path = dest_dir.path().join("busy_vacuum.db");
+        let dest_path = dest_path.to_str().expect("temp path should be UTF-8");
+        let mut stmt = conn.prepare(format!("VACUUM INTO '{dest_path}'")).unwrap();
+        let step = stmt.step().unwrap();
+        conn.set_progress_handler(0, None);
+
+        assert!(
+            matches!(step, StepResult::Busy),
+            "progress interruption inside VACUUM INTO should surface as Busy, got {step:?}"
+        );
+        assert!(
+            source_txn_progress_calls.load(Ordering::SeqCst) > 10,
+            "test should interrupt after VACUUM INTO opens the source transaction"
+        );
+        assert!(
+            did_interrupt.load(Ordering::SeqCst),
+            "progress handler should have interrupted VACUUM INTO exactly once"
+        );
+        assert!(
+            conn.get_auto_commit(),
+            "Busy cleanup should roll back the source transaction before returning"
+        );
     }
 
     #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14219,8 +14219,8 @@ fn op_vacuum_into_inner(
     insn: &Insn,
 ) -> Result<InsnFunctionStepResult> {
     use crate::vdbe::vacuum::{
-        vacuum_destination_opts, vacuum_into_step, SourceSymbols, VacuumDestinationHeader,
-        VacuumIntoConfig, VacuumIntoState,
+        vacuum_destination_opts, vacuum_into_step, VacuumDestinationHeader, VacuumIntoConfig,
+        VacuumIntoState,
     };
 
     load_insn!(
@@ -14240,11 +14240,11 @@ fn op_vacuum_into_inner(
             return Ok(InsnFunctionStepResult::Step);
         }
 
-        state.op_vacuum_into_state = Some(OpVacuumIntoState {
+        state.op_vacuum_into_state = Some(Box::new(OpVacuumIntoState {
             escaped_schema_name: schema_name.replace('"', "\"\""),
             database_id,
             ..Default::default()
-        });
+        }));
     }
 
     let vacuum_state = state.op_vacuum_into_state.as_mut().unwrap();
@@ -14353,29 +14353,30 @@ fn op_vacuum_into_inner(
                 // must be set before page 1 is allocated (before any schema operations)
                 dest_conn.set_reserved_bytes(reserved_space)?;
 
-                // Capture source symbols needed for schema replay (functions, vtab
-                // modules, index methods). We skip vtabs - those are live instances
-                // tied to the source connection and not needed for compiling schema SQL.
-                let source_symbols = {
+                // Mirror source symbols directly into destination for schema replay,
+                // avoiding an intermediate clone through SourceSymbols.
+                {
                     let source_syms = program.connection.syms.read();
-                    SourceSymbols {
-                        functions: source_syms
+                    let mut dest_syms = dest_conn.syms.write();
+                    dest_syms.functions.extend(
+                        source_syms
                             .functions
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                        vtab_modules: source_syms
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.vtab_modules.extend(
+                        source_syms
                             .vtab_modules
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                        index_methods: source_syms
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.index_methods.extend(
+                        source_syms
                             .index_methods
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                    }
-                };
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                }
 
                 // Capture source custom type definitions so that STRICT tables with
                 // custom type columns can resolve those types during CREATE TABLE
@@ -14396,7 +14397,6 @@ fn op_vacuum_into_inner(
                     escaped_schema_name: escaped_schema_name.clone(),
                     database_id,
                     destination_header,
-                    source_symbols,
                     source_custom_types,
                     source_mvcc_enabled: source_db.mvcc_enabled(),
                 };
@@ -14455,15 +14455,9 @@ pub(crate) struct OpVacuumState {
     db: usize,
     /// State machine for the plain VACUUM operation.
     sub_state: crate::vdbe::vacuum::PlainVacuumSubState,
-}
-
-impl Default for OpVacuumState {
-    fn default() -> Self {
-        Self {
-            db: crate::MAIN_DB_ID,
-            sub_state: crate::vdbe::vacuum::PlainVacuumSubState::Preflight,
-        }
-    }
+    /// Independent progress flags for cleanup — survive `std::mem::take`
+    /// on `sub_state` so the error/abort path always knows what to undo.
+    progress: crate::vdbe::vacuum::PlainVacuumProgress,
 }
 
 /// Plain VACUUM - compact the database in place via temp-build + direct-WAL
@@ -14477,10 +14471,11 @@ pub fn op_vacuum(
     load_insn!(Vacuum { db }, insn);
 
     if state.op_vacuum_state.is_none() {
-        state.op_vacuum_state = Some(OpVacuumState {
+        state.op_vacuum_state = Some(Box::new(OpVacuumState {
             db: *db,
             sub_state: crate::vdbe::vacuum::PlainVacuumSubState::Preflight,
-        });
+            progress: crate::vdbe::vacuum::PlainVacuumProgress::default(),
+        }));
     }
 
     let vacuum_state = state.op_vacuum_state.as_mut().unwrap();
@@ -14489,6 +14484,7 @@ pub fn op_vacuum(
         &program.connection,
         vacuum_state.db,
         &mut vacuum_state.sub_state,
+        &mut vacuum_state.progress,
     ) {
         Ok(InsnFunctionStepResult::Step) => {
             state.op_vacuum_state = None;
@@ -14518,7 +14514,12 @@ pub(crate) fn cleanup_op_vacuum_state(
     let Some(vacuum_state) = state.op_vacuum_state.take() else {
         return Ok(());
     };
-    crate::vdbe::vacuum::plain_vacuum_cleanup(connection, vacuum_state.db, &vacuum_state.sub_state);
+    crate::vdbe::vacuum::plain_vacuum_cleanup(
+        connection,
+        vacuum_state.db,
+        vacuum_state.sub_state,
+        &vacuum_state.progress,
+    );
     Ok(())
 }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14126,8 +14126,7 @@ pub(crate) struct VacuumIntoOpContext {
     /// Escaped schema name for safe SQL interpolation.
     escaped_schema_name: String,
     /// Keep output database alive while vacuum is in progress.
-    #[allow(dead_code)]
-    output_db: Option<Arc<crate::Database>>,
+    _output_db: Option<Arc<crate::Database>>,
     /// Configuration for the shared vacuum target build state machine.
     target_build_config: Option<crate::vdbe::vacuum::VacuumTargetBuildConfig>,
     /// Context for the shared vacuum target build state machine.
@@ -14206,7 +14205,7 @@ fn cleanup_op_vacuum_into(connection: &Arc<Connection>, state: &mut ProgramState
     }
 
     vacuum_state.target_build_context = None;
-    vacuum_state.output_db = None;
+    vacuum_state._output_db = None;
 
     if state.auto_txn_cleanup == TxnCleanup::RollbackTxn {
         match connection.execute("ROLLBACK") {
@@ -14408,7 +14407,7 @@ fn op_vacuum_into_inner(
                     source_mvcc_enabled: source_db.mvcc_enabled(),
                 };
 
-                vacuum_state.output_db = Some(output_db);
+                vacuum_state._output_db = Some(output_db);
                 vacuum_state.target_build_config = Some(config);
                 vacuum_state.target_build_context =
                     Some(VacuumTargetBuildContext::new(output_conn));

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14179,7 +14179,22 @@ pub fn op_vacuum_into(
     }
 }
 
-pub(crate) fn cleanup_op_vacuum_into_state(
+/// Clean up any VACUUM or VACUUM INTO state on error or abort.
+/// Only one of the two can be active at a time; this handles whichever is set.
+pub(crate) fn cleanup_vacuum_state(
+    connection: &Arc<Connection>,
+    state: &mut ProgramState,
+) -> Result<()> {
+    if state.op_vacuum_into_state.is_some() {
+        cleanup_op_vacuum_into_state(connection, state)
+    } else if state.op_vacuum_state.is_some() {
+        cleanup_op_vacuum_state(connection, state)
+    } else {
+        Ok(())
+    }
+}
+
+fn cleanup_op_vacuum_into_state(
     connection: &Arc<Connection>,
     state: &mut ProgramState,
 ) -> Result<()> {
@@ -14507,7 +14522,7 @@ pub fn op_vacuum(
 /// Clean up plain VACUUM state on error or abort. Rolls back the source
 /// transaction if it was acquired, restores connection state, and drops
 /// temp resources.
-pub(crate) fn cleanup_op_vacuum_state(
+fn cleanup_op_vacuum_state(
     connection: &Arc<Connection>,
     state: &mut ProgramState,
 ) -> Result<()> {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14522,10 +14522,7 @@ pub fn op_vacuum(
 /// Clean up plain VACUUM state on error or abort. Rolls back the source
 /// transaction if it was acquired, restores connection state, and drops
 /// temp resources.
-fn cleanup_op_vacuum_state(
-    connection: &Arc<Connection>,
-    state: &mut ProgramState,
-) -> Result<()> {
+fn cleanup_op_vacuum_state(connection: &Arc<Connection>, state: &mut ProgramState) -> Result<()> {
     let Some(vacuum_state) = state.op_vacuum_state.take() else {
         return Ok(());
     };

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14117,7 +14117,7 @@ pub(crate) enum VacuumIntoOpPhase {
     Done,
 }
 
-/// Context for the VACUUM INTO opcode wrapper.
+/// Holds the state for the VACUUM INTO opcode operation.
 #[derive(Default)]
 pub(crate) struct VacuumIntoOpContext {
     phase: VacuumIntoOpPhase,
@@ -14146,7 +14146,7 @@ pub(crate) struct VacuumIntoOpContext {
 ///    internal storage-backed tables
 /// 5. Creates user-defined secondary indexes after data copy for performance
 ///    (backing-btree indexes for custom index methods are excluded here)
-/// 6. Finalizes output page-1 metadata
+/// 6. Finalizes output database header metadata
 /// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
@@ -14230,7 +14230,7 @@ fn op_vacuum_into_inner(
     insn: &Insn,
 ) -> Result<InsnFunctionStepResult> {
     use crate::vdbe::vacuum::{
-        vacuum_target_build_step, vacuum_target_opts_from_source, VacuumPage1Meta,
+        vacuum_target_build_step, vacuum_target_opts_from_source, VacuumDbHeaderMeta,
         VacuumTargetBuildConfig, VacuumTargetBuildContext,
     };
 
@@ -14311,15 +14311,16 @@ fn op_vacuum_into_inner(
                 let source_pager = program
                     .connection
                     .get_pager_from_database_index(&source_db_id);
-                let header_meta =
-                    if let Some(mv_store) = program.connection.mv_store_for_db(source_db_id) {
-                        let tx_id = program.connection.get_mv_tx_id_for_db(source_db_id);
-                        mv_store.with_header(VacuumPage1Meta::from_source_header, tx_id.as_ref())?
-                    } else {
-                        source_pager.io.block(|| {
-                            source_pager.with_header(VacuumPage1Meta::from_source_header)
-                        })?
-                    };
+                let header_meta = if let Some(mv_store) =
+                    program.connection.mv_store_for_db(source_db_id)
+                {
+                    let tx_id = program.connection.get_mv_tx_id_for_db(source_db_id);
+                    mv_store.with_header(VacuumDbHeaderMeta::from_source_header, tx_id.as_ref())?
+                } else {
+                    source_pager.io.block(|| {
+                        source_pager.with_header(VacuumDbHeaderMeta::from_source_header)
+                    })?
+                };
 
                 let reserved_space: u8 = if !is_attached_db(source_db_id) {
                     // For main or temp db prefer cached value to avoid blocking I/O

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14112,7 +14112,7 @@ pub(crate) enum OpVacuumIntoSubState {
     #[default]
     Init,
     /// Build compacted destination database
-    Build(Box<crate::vdbe::vacuum::VacuumInto>),
+    Build,
     /// Operation complete
     Done,
 }
@@ -14125,6 +14125,13 @@ pub(crate) struct OpVacuumIntoState {
     database_id: usize,
     /// Escaped schema name for safe SQL interpolation
     escaped_schema_name: String,
+    /// Keep dest_db alive while vacuum is in progress.
+    #[allow(dead_code)]
+    dest_db: Option<Arc<crate::Database>>,
+    /// Configuration for the shared VACUUM INTO build state machine.
+    vacuum_into_config: Option<crate::vdbe::vacuum::VacuumIntoConfig>,
+    /// State for the shared VACUUM INTO build state machine.
+    vacuum_into_state: Option<crate::vdbe::vacuum::VacuumIntoState>,
 }
 
 /// VACUUM INTO - create a compacted copy of the database at the specified path.
@@ -14346,6 +14353,30 @@ fn op_vacuum_into_inner(
                 // must be set before page 1 is allocated (before any schema operations)
                 dest_conn.set_reserved_bytes(reserved_space)?;
 
+                // Capture source symbols needed for schema replay (functions, vtab
+                // modules, index methods). We skip vtabs - those are live instances
+                // tied to the source connection and not needed for compiling schema SQL.
+                let source_symbols = {
+                    let source_syms = program.connection.syms.read();
+                    SourceSymbols {
+                        functions: source_syms
+                            .functions
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                        vtab_modules: source_syms
+                            .vtab_modules
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                        index_methods: source_syms
+                            .index_methods
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                    }
+                };
+
                 // Capture source custom type definitions so that STRICT tables with
                 // custom type columns can resolve those types during CREATE TABLE
                 // replay on the destination.
@@ -14370,22 +14401,37 @@ fn op_vacuum_into_inner(
                     source_mvcc_enabled: source_db.mvcc_enabled(),
                 };
 
-                vacuum_state.sub_state = OpVacuumIntoSubState::Build(Box::new(VacuumInto::new(
-                    config, dest_db, dest_conn,
-                )));
+                vacuum_state.dest_db = Some(dest_db);
+                vacuum_state.vacuum_into_config = Some(config);
+                vacuum_state.vacuum_into_state = Some(VacuumIntoState::new(dest_conn));
+                vacuum_state.sub_state = OpVacuumIntoSubState::Build;
                 continue;
             }
 
-            OpVacuumIntoSubState::Build(mut vacuum_into) => match vacuum_into.step()? {
-                IOResult::Done(()) => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::Done;
-                    continue;
+            OpVacuumIntoSubState::Build => {
+                let config = vacuum_state
+                    .vacuum_into_config
+                    .as_ref()
+                    .expect("VacuumIntoConfig must be set in Build state");
+                let vi_state = vacuum_state
+                    .vacuum_into_state
+                    .as_mut()
+                    .expect("VacuumIntoState must be set in Build state");
+
+                match vacuum_into_step(config, vi_state)? {
+                    InsnFunctionStepResult::Step => {
+                        vacuum_state.sub_state = OpVacuumIntoSubState::Done;
+                        continue;
+                    }
+                    InsnFunctionStepResult::IO(io) => {
+                        vacuum_state.sub_state = OpVacuumIntoSubState::Build;
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                    InsnFunctionStepResult::Done | InsnFunctionStepResult::Row => {
+                        unreachable!("vacuum_into_step only returns Step or IO")
+                    }
                 }
-                IOResult::IO(io) => {
-                    vacuum_state.sub_state = OpVacuumIntoSubState::Build(vacuum_into);
-                    return Ok(InsnFunctionStepResult::IO(io));
-                }
-            },
+            }
 
             OpVacuumIntoSubState::Done => {
                 // Commit the source transaction started in Init.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14140,7 +14140,7 @@ pub(crate) struct OpVacuumIntoState {
 ///    internal storage-backed tables
 /// 5. Creates user-defined secondary indexes after data copy for performance
 ///    (backing-btree indexes for custom index methods are excluded here)
-/// 6. Copies meta values (user_version, application_id) from source to destination
+/// 6. Finalizes destination page-1 metadata
 /// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
@@ -14211,7 +14211,10 @@ fn op_vacuum_into_inner(
     state: &mut ProgramState,
     insn: &Insn,
 ) -> Result<InsnFunctionStepResult> {
-    use crate::vdbe::vacuum::{VacuumInto, VacuumIntoConfig};
+    use crate::vdbe::vacuum::{
+        vacuum_destination_opts, vacuum_into_step, SourceSymbols, VacuumDestinationHeader,
+        VacuumIntoConfig, VacuumIntoState,
+    };
 
     load_insn!(
         VacuumInto {
@@ -14281,24 +14284,29 @@ fn op_vacuum_into_inner(
                 let source_db = program.connection.get_source_database(database_id);
                 program.connection.execute("BEGIN")?;
                 state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
-                let user_version: i32 = extract_pragma_int(
-                    &program
-                        .connection
-                        .pragma_query(&format!("\"{escaped_schema_name}\".user_version"))?,
-                    "user_version",
-                )?;
-                let application_id: i32 = extract_pragma_int(
-                    &program
-                        .connection
-                        .pragma_query(&format!("\"{escaped_schema_name}\".application_id"))?,
-                    "application_id",
-                )?;
                 let page_size: u32 = extract_pragma_int(
                     &program
                         .connection
                         .pragma_query(&format!("\"{escaped_schema_name}\".page_size"))?,
                     "page_size",
                 )?;
+                let source_pager = program
+                    .connection
+                    .get_pager_from_database_index(&database_id);
+                let destination_header = if let Some(mv_store) =
+                    program.connection.mv_store_for_db(database_id)
+                {
+                    let tx_id = program.connection.get_mv_tx_id_for_db(database_id);
+                    mv_store.with_header(
+                        VacuumDestinationHeader::vacuum_into_from_source_header,
+                        tx_id.as_ref(),
+                    )?
+                } else {
+                    source_pager.io.block(|| {
+                        source_pager
+                            .with_header(VacuumDestinationHeader::vacuum_into_from_source_header)
+                    })?
+                };
 
                 let reserved_space: u8 = if !is_attached_db(database_id) {
                     // For main or temp db prefer cached value to avoid blocking I/O
@@ -14319,13 +14327,7 @@ fn op_vacuum_into_inner(
 
                 // Mirror source feature flags to the destination so schema replay
                 // can resolve custom types, generated columns, vtab modules, etc.
-                let dest_opts = crate::DatabaseOpts::new()
-                    .with_views(source_db.experimental_views_enabled())
-                    .with_index_method(source_db.experimental_index_method_enabled())
-                    .with_custom_types(source_db.experimental_custom_types_enabled())
-                    .with_encryption(source_db.experimental_encryption_enabled())
-                    .with_attach(source_db.experimental_attach_enabled())
-                    .with_generated_columns(source_db.experimental_generated_columns_enabled());
+                let dest_opts = vacuum_destination_opts(&source_db);
 
                 // Always use PlatformIO for the destination file, even if source
                 // is in-memory. This ensures VACUUM INTO writes to disk.
@@ -14362,8 +14364,8 @@ fn op_vacuum_into_inner(
                     source_conn: program.connection.clone(),
                     escaped_schema_name: escaped_schema_name.clone(),
                     database_id,
-                    source_user_version: user_version,
-                    source_application_id: application_id,
+                    destination_header,
+                    source_symbols,
                     source_custom_types,
                     source_mvcc_enabled: source_db.mvcc_enabled(),
                 };

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14105,9 +14105,9 @@ where
         })
 }
 
-/// Stages for the VACUUM INTO opcode wrapper.
+/// Phases for the VACUUM INTO opcode wrapper.
 #[derive(Default)]
-pub(crate) enum VacuumIntoOpStage {
+pub(crate) enum VacuumIntoOpPhase {
     /// Initial state - validate preconditions and create output database.
     #[default]
     Init,
@@ -14120,7 +14120,7 @@ pub(crate) enum VacuumIntoOpStage {
 /// Context for the VACUUM INTO opcode wrapper.
 #[derive(Default)]
 pub(crate) struct VacuumIntoOpContext {
-    stage: VacuumIntoOpStage,
+    phase: VacuumIntoOpPhase,
     /// Database index for the source schema.
     source_db_id: usize,
     /// Escaped schema name for safe SQL interpolation.
@@ -14264,10 +14264,10 @@ fn op_vacuum_into_inner(
     let source_db_id = vacuum_state.source_db_id;
 
     loop {
-        let current_stage = std::mem::take(&mut vacuum_state.stage);
+        let current_phase = std::mem::take(&mut vacuum_state.phase);
 
-        match current_stage {
-            VacuumIntoOpStage::Init => {
+        match current_phase {
+            VacuumIntoOpPhase::Init => {
                 // Check if we're in a transaction
                 // as vacuum cannot be run inside a transaction
                 if !program.connection.auto_commit.load(Ordering::SeqCst) {
@@ -14412,11 +14412,11 @@ fn op_vacuum_into_inner(
                 vacuum_state.target_build_config = Some(config);
                 vacuum_state.target_build_context =
                     Some(VacuumTargetBuildContext::new(output_conn));
-                vacuum_state.stage = VacuumIntoOpStage::Build;
+                vacuum_state.phase = VacuumIntoOpPhase::Build;
                 continue;
             }
 
-            VacuumIntoOpStage::Build => {
+            VacuumIntoOpPhase::Build => {
                 let config = vacuum_state
                     .target_build_config
                     .as_ref()
@@ -14428,17 +14428,17 @@ fn op_vacuum_into_inner(
 
                 match vacuum_target_build_step(config, target_build_context)? {
                     crate::IOResult::Done(()) => {
-                        vacuum_state.stage = VacuumIntoOpStage::Done;
+                        vacuum_state.phase = VacuumIntoOpPhase::Done;
                         continue;
                     }
                     crate::IOResult::IO(io) => {
-                        vacuum_state.stage = VacuumIntoOpStage::Build;
+                        vacuum_state.phase = VacuumIntoOpPhase::Build;
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
                 }
             }
 
-            VacuumIntoOpStage::Done => {
+            VacuumIntoOpPhase::Done => {
                 // Commit the source transaction started in Init.
                 program.connection.execute("COMMIT")?;
                 state.auto_txn_cleanup = TxnCleanup::None;
@@ -14458,9 +14458,9 @@ fn op_vacuum_into_inner(
 pub(crate) struct VacuumInPlaceOpContext {
     /// Database index being vacuumed.
     db: usize,
-    /// Current stage for the in-place VACUUM operation.
-    stage: crate::vdbe::vacuum::VacuumInPlaceStage,
-    /// Independent cleanup flags that survive `std::mem::take` on `stage`.
+    /// Current phase for the in-place VACUUM operation.
+    phase: crate::vdbe::vacuum::VacuumInPlacePhase,
+    /// Independent cleanup flags that survive `std::mem::take` on `phase`.
     cleanup_state: crate::vdbe::vacuum::VacuumInPlaceCleanupState,
 }
 
@@ -14477,7 +14477,7 @@ pub fn op_vacuum(
     if state.op_vacuum_in_place.is_none() {
         state.op_vacuum_in_place = Some(Box::new(VacuumInPlaceOpContext {
             db: *db,
-            stage: crate::vdbe::vacuum::VacuumInPlaceStage::Preflight,
+            phase: crate::vdbe::vacuum::VacuumInPlacePhase::Preflight,
             cleanup_state: crate::vdbe::vacuum::VacuumInPlaceCleanupState::default(),
         }));
     }
@@ -14487,7 +14487,7 @@ pub fn op_vacuum(
     match crate::vdbe::vacuum::vacuum_in_place_step(
         &program.connection,
         vacuum_state.db,
-        &mut vacuum_state.stage,
+        &mut vacuum_state.phase,
         &mut vacuum_state.cleanup_state,
     ) {
         Ok(InsnFunctionStepResult::Step) => {
@@ -14521,7 +14521,7 @@ fn cleanup_op_vacuum_in_place(
     crate::vdbe::vacuum::vacuum_in_place_cleanup(
         connection,
         vacuum_state.db,
-        vacuum_state.stage,
+        vacuum_state.phase,
         &vacuum_state.cleanup_state,
     );
     Ok(())

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14184,6 +14184,11 @@ pub(crate) fn cleanup_vacuum_state(
     connection: &Arc<Connection>,
     state: &mut ProgramState,
 ) -> Result<()> {
+    turso_assert!(
+        !(state.op_vacuum_into.is_some() && state.op_vacuum_in_place.is_some()),
+        "VACUUM INTO and in-place VACUUM state cannot both be active"
+    );
+
     if state.op_vacuum_into.is_some() {
         cleanup_op_vacuum_into(connection, state)
     } else if state.op_vacuum_in_place.is_some() {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14230,8 +14230,9 @@ fn op_vacuum_into_inner(
     insn: &Insn,
 ) -> Result<InsnFunctionStepResult> {
     use crate::vdbe::vacuum::{
-        vacuum_target_build_step, vacuum_target_opts_from_source, VacuumDbHeaderMeta,
-        VacuumTargetBuildConfig, VacuumTargetBuildContext,
+        capture_custom_types, mirror_symbols, vacuum_target_build_step,
+        vacuum_target_opts_from_source, VacuumDbHeaderMeta, VacuumTargetBuildConfig,
+        VacuumTargetBuildContext,
     };
 
     load_insn!(
@@ -14360,44 +14361,9 @@ fn op_vacuum_into_inner(
                 // must be set before page 1 is allocated (before any schema operations)
                 output_conn.set_reserved_bytes(reserved_space)?;
 
-                // Mirror source symbols directly into output for schema replay,
-                // avoiding an intermediate clone through SourceSymbols.
-                {
-                    let source_syms = program.connection.syms.read();
-                    let mut output_syms = output_conn.syms.write();
-                    output_syms.functions.extend(
-                        source_syms
-                            .functions
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    output_syms.vtab_modules.extend(
-                        source_syms
-                            .vtab_modules
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    output_syms.index_methods.extend(
-                        source_syms
-                            .index_methods
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                }
-
-                // Capture source custom type definitions so that STRICT tables with
-                // custom type columns can resolve those types during CREATE TABLE
-                // replay on the output.
-                let source_custom_types: Vec<(String, Arc<crate::schema::TypeDef>)> = program
-                    .connection
-                    .with_schema(source_db_id, |source_schema| {
-                        source_schema
-                            .type_registry
-                            .iter()
-                            .filter(|(_, td)| !td.is_builtin)
-                            .map(|(name, td)| (name.clone(), td.clone()))
-                            .collect()
-                    });
+                mirror_symbols(&program.connection, &output_conn);
+                let source_custom_types =
+                    capture_custom_types(&program.connection, source_db_id);
 
                 let config = VacuumTargetBuildConfig {
                     source_conn: program.connection.clone(),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14399,6 +14399,83 @@ fn op_vacuum_into_inner(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Plain VACUUM opcode
+// ---------------------------------------------------------------------------
+
+/// Holds the state for the plain VACUUM operation across async yields.
+pub(crate) struct OpVacuumState {
+    /// Database index being vacuumed.
+    db: usize,
+    /// State machine for the plain VACUUM operation.
+    sub_state: crate::vdbe::vacuum::PlainVacuumSubState,
+}
+
+impl Default for OpVacuumState {
+    fn default() -> Self {
+        Self {
+            db: crate::MAIN_DB_ID,
+            sub_state: crate::vdbe::vacuum::PlainVacuumSubState::Preflight,
+        }
+    }
+}
+
+/// Plain VACUUM - compact the database in place via temp-build + direct-WAL
+/// copy-back. The opcode owns the source transaction lifecycle.
+pub fn op_vacuum(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(Vacuum { db }, insn);
+
+    if state.op_vacuum_state.is_none() {
+        state.op_vacuum_state = Some(OpVacuumState {
+            db: *db,
+            sub_state: crate::vdbe::vacuum::PlainVacuumSubState::Preflight,
+        });
+    }
+
+    let vacuum_state = state.op_vacuum_state.as_mut().unwrap();
+
+    match crate::vdbe::vacuum::plain_vacuum_step(
+        &program.connection,
+        vacuum_state.db,
+        &mut vacuum_state.sub_state,
+    ) {
+        Ok(InsnFunctionStepResult::Step) => {
+            state.op_vacuum_state = None;
+            state.pc += 1;
+            Ok(InsnFunctionStepResult::Step)
+        }
+        Ok(InsnFunctionStepResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
+        Ok(InsnFunctionStepResult::Done | InsnFunctionStepResult::Row) => {
+            unreachable!("plain_vacuum_step only returns Step or IO")
+        }
+        Err(err) => {
+            if let Err(cleanup_err) = cleanup_op_vacuum_state(&program.connection, state) {
+                tracing::error!("VACUUM cleanup failed after error: {cleanup_err}");
+            }
+            Err(err)
+        }
+    }
+}
+
+/// Clean up plain VACUUM state on error or abort. Rolls back the source
+/// transaction if it was acquired, restores connection state, and drops
+/// temp resources.
+pub(crate) fn cleanup_op_vacuum_state(
+    connection: &Arc<Connection>,
+    state: &mut ProgramState,
+) -> Result<()> {
+    let Some(vacuum_state) = state.op_vacuum_state.take() else {
+        return Ok(());
+    };
+    crate::vdbe::vacuum::plain_vacuum_cleanup(connection, vacuum_state.db, &vacuum_state.sub_state);
+    Ok(())
+}
+
 fn with_header<T, F>(
     pager: &Pager,
     mv_store: Option<&Arc<MvStore>>,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14362,8 +14362,7 @@ fn op_vacuum_into_inner(
                 output_conn.set_reserved_bytes(reserved_space)?;
 
                 mirror_symbols(&program.connection, &output_conn);
-                let source_custom_types =
-                    capture_custom_types(&program.connection, source_db_id);
+                let source_custom_types = capture_custom_types(&program.connection, source_db_id);
 
                 let config = VacuumTargetBuildConfig {
                     source_conn: program.connection.clone(),

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2434,6 +2434,15 @@ pub fn insn_to_row(
             0,
             format!("schema={schema_name}, dest={dest_path}"),
         ),
+        Insn::Vacuum { db } => (
+            "Vacuum",
+            *db as i64,
+            0,
+            0,
+            Value::Null,
+            0,
+            format!("db={db}"),
+        ),
         Insn::InitCdcVersion { cdc_table_name, version, cdc_mode } => (
             "InitCdcVersion",
             0,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2357,6 +2357,15 @@ pub fn insn_to_row(
             0,
             format!("schema={schema_name}, dest={dest_path}"),
         ),
+        Insn::Vacuum { db } => (
+            "Vacuum",
+            *db as i64,
+            0,
+            0,
+            Value::Null,
+            0,
+            format!("db={db}"),
+        ),
         Insn::InitCdcVersion { cdc_table_name, version, cdc_mode } => (
             "InitCdcVersion",
             0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1757,6 +1757,13 @@ pub enum Insn {
         dest_path: String,
     },
 
+    /// In-place VACUUM - compact the database (by writing to a temporary location and then copying
+    /// back)
+    Vacuum {
+        /// Database index to vacuum (0 = main)
+        db: usize,
+    },
+
     /// Ensure turso_cdc_version table exists and insert/replace a version row,
     /// then enable CDC on the connection. Runs nested SQL at VDBE execution time
     /// (same pattern as ParseSchema). CDC is enabled after version table operations
@@ -1993,6 +2000,7 @@ impl InsnVariants {
             InsnVariants::HashGraceNextProbe => execute::op_hash_grace_next_probe,
             InsnVariants::HashGraceAdvancePartition => execute::op_hash_grace_advance_partition,
             InsnVariants::VacuumInto => execute::op_vacuum_into,
+            InsnVariants::Vacuum => execute::op_vacuum,
             InsnVariants::InitCdcVersion => execute::op_init_cdc_version,
         }
     }
@@ -2049,7 +2057,8 @@ impl Insn {
             | Self::DropColumn { .. }
             | Self::AddColumn { .. }
             | Self::AlterColumn { .. }
-            | Self::JournalMode { .. } => false,
+            | Self::JournalMode { .. }
+            | Self::Vacuum { .. } => false,
             Self::MaxPgcnt { new_max, .. } => *new_max == 0,
             Self::Program { program, .. } => program.is_readonly(),
             _ => true,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1676,8 +1676,8 @@ pub enum Insn {
         dest_path: String,
     },
 
-    /// In-place VACUUM - compact the database via target build + direct-WAL copy-back.
-    /// The opcode owns the source transaction lifecycle directly.
+    /// In-place VACUUM - compact the database (by writing to a temporary location and then copying
+    /// back)
     Vacuum {
         /// Database index to vacuum (0 = main)
         db: usize,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1676,6 +1676,13 @@ pub enum Insn {
         dest_path: String,
     },
 
+    /// Plain VACUUM - compact the database in place via temp-build + direct-WAL copy-back.
+    /// The opcode owns the source transaction lifecycle directly (no generic Transaction preamble).
+    Vacuum {
+        /// Database index to vacuum (0 = main)
+        db: usize,
+    },
+
     /// Ensure turso_cdc_version table exists and insert/replace a version row,
     /// then enable CDC on the connection. Runs nested SQL at VDBE execution time
     /// (same pattern as ParseSchema). CDC is enabled after version table operations
@@ -1906,6 +1913,7 @@ impl InsnVariants {
             InsnVariants::HashGraceNextProbe => execute::op_hash_grace_next_probe,
             InsnVariants::HashGraceAdvancePartition => execute::op_hash_grace_advance_partition,
             InsnVariants::VacuumInto => execute::op_vacuum_into,
+            InsnVariants::Vacuum => execute::op_vacuum,
             InsnVariants::InitCdcVersion => execute::op_init_cdc_version,
         }
     }
@@ -1962,7 +1970,8 @@ impl Insn {
             | Self::DropColumn { .. }
             | Self::AddColumn { .. }
             | Self::AlterColumn { .. }
-            | Self::JournalMode { .. } => false,
+            | Self::JournalMode { .. }
+            | Self::Vacuum { .. } => false,
             Self::MaxPgcnt { new_max, .. } => *new_max == 0,
             Self::Program { program, .. } => program.is_readonly(),
             _ => true,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1676,8 +1676,8 @@ pub enum Insn {
         dest_path: String,
     },
 
-    /// Plain VACUUM - compact the database in place via temp-build + direct-WAL copy-back.
-    /// The opcode owns the source transaction lifecycle directly (no generic Transaction preamble).
+    /// In-place VACUUM - compact the database via target build + direct-WAL copy-back.
+    /// The opcode owns the source transaction lifecycle directly.
     Vacuum {
         /// Database index to vacuum (0 = main)
         db: usize,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -562,6 +562,18 @@ pub(crate) struct DeferredSeekState {
     pub table_cursor_id: CursorID,
 }
 
+pub(crate) enum VacuumOpState {
+    None,
+    IntoFile(Box<VacuumIntoOpContext>),
+    InPlace(Box<VacuumInPlaceOpContext>),
+}
+
+impl Default for VacuumOpState {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
 /// The program state describes the environment in which the program executes.
 pub struct ProgramState {
     pub io_completions: Option<IOCompletions>,
@@ -591,8 +603,7 @@ pub struct ProgramState {
     pub metrics: StatementMetrics,
     /// Current collation sequence set by OP_CollSeq instruction
     current_collation: Option<CollationSeq>,
-    op_vacuum_into: Option<Box<VacuumIntoOpContext>>,
-    op_vacuum_in_place: Option<Box<VacuumInPlaceOpContext>>,
+    op_vacuum_state: VacuumOpState,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset
@@ -683,8 +694,7 @@ impl ProgramState {
             metrics: StatementMetrics::new(),
             distinct_key_values: Vec::new(),
             current_collation: None,
-            op_vacuum_into: None,
-            op_vacuum_in_place: None,
+            op_vacuum_state: VacuumOpState::None,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),
@@ -800,8 +810,7 @@ impl ProgramState {
         self.seek_state = OpSeekState::Start;
         self.current_collation = None;
         self.commit_state = CommitState::Ready;
-        self.op_vacuum_into = None;
-        self.op_vacuum_in_place = None;
+        self.op_vacuum_state = VacuumOpState::None;
         self.view_delta_state = ViewDeltaCommitState::NotStarted;
         self.auto_txn_cleanup = TxnCleanup::None;
         self.fk_immediate_violations_during_stmt

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -554,7 +554,6 @@ impl ActiveOpStateSlot {
             _ => None,
         }
     }
-
 }
 
 #[derive(Debug, Clone)]
@@ -2767,6 +2766,7 @@ mod tests {
 ///
 /// These tests verify that the implementation correctly upholds these invariants
 /// under concurrent access patterns.
+
 #[cfg(all(shuttle, test))]
 mod shuttle_tests {
     use super::*;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -51,10 +51,11 @@ use crate::{
             OpColumnState, OpDeleteState, OpDeleteSubState, OpDestroyState, OpIdxInsertState,
             OpInitCdcVersionState, OpInsertState, OpInsertSubState, OpJournalModeState,
             OpNewRowidState, OpNoConflictState, OpParseSchemaState, OpProgramState, OpRowIdState,
-            OpSeekState, OpTransactionState, OpVacuumIntoState,
+            OpSeekState, OpTransactionState, VacuumIntoOpContext,
         },
         hash_table::HashTable,
         metrics::StatementMetrics,
+        vacuum::VacuumInPlaceOpContext,
     },
     ValueRef,
 };
@@ -397,7 +398,6 @@ enum ActiveOpState {
     RowId(OpRowIdState),
     Transaction(OpTransactionState),
     JournalMode(OpJournalModeState),
-    VacuumInto(Option<OpVacuumIntoState>),
     ParseSchema(OpParseSchemaState),
     HashBuild(Option<OpHashBuildState>),
     HashProbe(Option<OpHashProbeState>),
@@ -422,7 +422,6 @@ impl std::fmt::Debug for ActiveOpState {
             ActiveOpState::RowId(_) => "RowId",
             ActiveOpState::Transaction(_) => "Transaction",
             ActiveOpState::JournalMode(_) => "JournalMode",
-            ActiveOpState::VacuumInto(_) => "VacuumInto",
             ActiveOpState::ParseSchema(_) => "ParseSchema",
             ActiveOpState::HashBuild(_) => "HashBuild",
             ActiveOpState::HashProbe(_) => "HashProbe",
@@ -532,7 +531,6 @@ impl ActiveOpStateSlot {
         OpJournalModeState,
         OpJournalModeState::default()
     );
-    active_state_accessor!(vacuum_into, VacuumInto, Option<OpVacuumIntoState>, None);
     active_state_accessor!(parse_schema, ParseSchema, OpParseSchemaState, None);
     active_state_accessor!(hash_build, HashBuild, Option<OpHashBuildState>, None);
     active_state_accessor!(hash_probe, HashProbe, Option<OpHashProbeState>, None);
@@ -557,11 +555,6 @@ impl ActiveOpStateSlot {
         }
     }
 
-    fn reset_vacuum_into(&mut self) {
-        if matches!(self.state, ActiveOpState::VacuumInto(_)) {
-            self.clear();
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -599,6 +592,8 @@ pub struct ProgramState {
     pub metrics: StatementMetrics,
     /// Current collation sequence set by OP_CollSeq instruction
     current_collation: Option<CollationSeq>,
+    op_vacuum_into: Option<Box<VacuumIntoOpContext>>,
+    op_vacuum_in_place: Option<Box<VacuumInPlaceOpContext>>,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset
@@ -689,6 +684,8 @@ impl ProgramState {
             metrics: StatementMetrics::new(),
             distinct_key_values: Vec::new(),
             current_collation: None,
+            op_vacuum_into: None,
+            op_vacuum_in_place: None,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),
@@ -804,6 +801,8 @@ impl ProgramState {
         self.seek_state = OpSeekState::Start;
         self.current_collation = None;
         self.commit_state = CommitState::Ready;
+        self.op_vacuum_into = None;
+        self.op_vacuum_in_place = None;
         self.view_delta_state = ViewDeltaCommitState::NotStarted;
         self.auto_txn_cleanup = TxnCleanup::None;
         self.fk_immediate_violations_during_stmt
@@ -2151,10 +2150,16 @@ impl Program {
 
         let mut abort_error: Option<LimboError> = None;
 
-        // VACUUM INTO state can own internal helper statements whose drop path
-        // releases nested guards. Drop them before checking whether this program
+        // VACUUM (and VACUUM INTO) state can own internal helper statements whose drop path
+        // releases nested guards. Clean it before checking whether this program
         // is itself nested; otherwise abort could skip top-level cleanup.
-        state.active_op_state.reset_vacuum_into();
+        if let Err(err) = execute::cleanup_vacuum_state(&self.connection, state) {
+            capture_abort_error(
+                &mut abort_error,
+                err,
+                "Failed to clean up VACUUM state during abort",
+            );
+        }
 
         // Only end trigger execution if the subprogram was actually running.
         // Cached (pooled) statements may be dropped after their trigger execution
@@ -2720,8 +2725,6 @@ mod tests {
             OpColumnState::Start
         ));
         state.active_op_state.clear();
-        assert!(state.active_op_state.vacuum_into().is_none());
-        state.active_op_state.clear();
         assert!(state.active_op_state.parse_schema().is_none());
     }
 
@@ -2731,7 +2734,7 @@ mod tests {
         *state.active_op_state.column() = OpColumnState::GetColumn;
 
         let panic = catch_unwind(AssertUnwindSafe(|| {
-            let _ = state.active_op_state.vacuum_into();
+            let _ = state.active_op_state.parse_schema();
         }));
         assert!(panic.is_err(), "mismatched opcode resume should panic");
     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -467,7 +467,7 @@ pub struct ProgramState {
     op_transaction_state: OpTransactionState,
     op_journal_mode_state: OpJournalModeState,
     op_vacuum_into_state: Option<Box<OpVacuumIntoState>>,
-    pub(crate) op_vacuum_state: Option<Box<OpVacuumState>>,
+    op_vacuum_state: Option<Box<OpVacuumState>>,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset
@@ -2054,20 +2054,10 @@ impl Program {
 
         let mut abort_error: Option<LimboError> = None;
 
-        // VACUUM INTO state can own internal helper statements whose drop path
+        // VACUUM state can own internal helper statements whose drop path
         // releases nested guards. Clean it before checking whether this program
         // is itself nested; otherwise abort could skip top-level cleanup.
-        if let Err(err) = execute::cleanup_op_vacuum_into_state(&self.connection, state) {
-            capture_abort_error(
-                &mut abort_error,
-                err,
-                "Failed to clean up VACUUM INTO state during abort",
-            );
-        }
-
-        // Plain VACUUM owns the source transaction directly. Roll back and
-        // restore connection state before any further abort logic.
-        if let Err(err) = execute::cleanup_op_vacuum_state(&self.connection, state) {
+        if let Err(err) = execute::cleanup_vacuum_state(&self.connection, state) {
             capture_abort_error(
                 &mut abort_error,
                 err,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -50,7 +50,7 @@ use crate::{
             OpColumnState, OpDeleteState, OpDeleteSubState, OpDestroyState, OpIdxInsertState,
             OpInsertState, OpInsertSubState, OpJournalModeState, OpNewRowidState,
             OpNoConflictState, OpProgramState, OpRowIdState, OpSeekState, OpTransactionState,
-            OpVacuumIntoState,
+            OpVacuumIntoState, OpVacuumState,
         },
         hash_table::HashTable,
         metrics::StatementMetrics,
@@ -467,6 +467,7 @@ pub struct ProgramState {
     op_transaction_state: OpTransactionState,
     op_journal_mode_state: OpJournalModeState,
     op_vacuum_into_state: Option<OpVacuumIntoState>,
+    pub(crate) op_vacuum_state: Option<OpVacuumState>,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset
@@ -583,6 +584,7 @@ impl ProgramState {
             op_transaction_state: OpTransactionState::Start,
             op_journal_mode_state: OpJournalModeState::default(),
             op_vacuum_into_state: None,
+            op_vacuum_state: None,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),
@@ -2060,6 +2062,16 @@ impl Program {
                 &mut abort_error,
                 err,
                 "Failed to clean up VACUUM INTO state during abort",
+            );
+        }
+
+        // Plain VACUUM owns the source transaction directly. Roll back and
+        // restore connection state before any further abort logic.
+        if let Err(err) = execute::cleanup_op_vacuum_state(&self.connection, state) {
+            capture_abort_error(
+                &mut abort_error,
+                err,
+                "Failed to clean up VACUUM state during abort",
             );
         }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2054,7 +2054,7 @@ impl Program {
 
         let mut abort_error: Option<LimboError> = None;
 
-        // VACUUM state can own internal helper statements whose drop path
+        // VACUUM (and VACUUM INTO) state can own internal helper statements whose drop path
         // releases nested guards. Clean it before checking whether this program
         // is itself nested; otherwise abort could skip top-level cleanup.
         if let Err(err) = execute::cleanup_vacuum_state(&self.connection, state) {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -50,7 +50,7 @@ use crate::{
             OpColumnState, OpDeleteState, OpDeleteSubState, OpDestroyState, OpIdxInsertState,
             OpInsertState, OpInsertSubState, OpJournalModeState, OpNewRowidState,
             OpNoConflictState, OpProgramState, OpRowIdState, OpSeekState, OpTransactionState,
-            OpVacuumIntoState, OpVacuumState,
+            VacuumInPlaceOpContext, VacuumIntoOpContext,
         },
         hash_table::HashTable,
         metrics::StatementMetrics,
@@ -466,8 +466,8 @@ pub struct ProgramState {
     op_row_id_state: OpRowIdState,
     op_transaction_state: OpTransactionState,
     op_journal_mode_state: OpJournalModeState,
-    op_vacuum_into_state: Option<Box<OpVacuumIntoState>>,
-    op_vacuum_state: Option<Box<OpVacuumState>>,
+    op_vacuum_into: Option<Box<VacuumIntoOpContext>>,
+    op_vacuum_in_place: Option<Box<VacuumInPlaceOpContext>>,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset
@@ -583,8 +583,8 @@ impl ProgramState {
             op_row_id_state: OpRowIdState::Start,
             op_transaction_state: OpTransactionState::Start,
             op_journal_mode_state: OpJournalModeState::default(),
-            op_vacuum_into_state: None,
-            op_vacuum_state: None,
+            op_vacuum_into: None,
+            op_vacuum_in_place: None,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),
@@ -721,7 +721,7 @@ impl ProgramState {
         self.op_program_state = OpProgramState::Start;
         self.op_transaction_state = OpTransactionState::Start;
         self.op_journal_mode_state = OpJournalModeState::default();
-        self.op_vacuum_into_state = None;
+        self.op_vacuum_into = None;
         self.view_delta_state = ViewDeltaCommitState::NotStarted;
         self.auto_txn_cleanup = TxnCleanup::None;
         self.fk_immediate_violations_during_stmt

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -466,8 +466,8 @@ pub struct ProgramState {
     op_row_id_state: OpRowIdState,
     op_transaction_state: OpTransactionState,
     op_journal_mode_state: OpJournalModeState,
-    op_vacuum_into_state: Option<OpVacuumIntoState>,
-    pub(crate) op_vacuum_state: Option<OpVacuumState>,
+    op_vacuum_into_state: Option<Box<OpVacuumIntoState>>,
+    pub(crate) op_vacuum_state: Option<Box<OpVacuumState>>,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2053,9 +2053,15 @@ impl Program {
         let mut abort_error: Option<LimboError> = None;
 
         // VACUUM INTO state can own internal helper statements whose drop path
-        // releases nested guards. Drop them before checking whether this program
+        // releases nested guards. Clean it before checking whether this program
         // is itself nested; otherwise abort could skip top-level cleanup.
-        state.op_vacuum_into_state = None;
+        if let Err(err) = execute::cleanup_op_vacuum_into_state(&self.connection, state) {
+            capture_abort_error(
+                &mut abort_error,
+                err,
+                "Failed to clean up VACUUM INTO state during abort",
+            );
+        }
 
         // Only end trigger execution if the subprogram was actually running.
         // Cached (pooled) statements may be dropped after their trigger execution

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1319,10 +1319,10 @@ impl VacuumInPlaceOpContext {
         let Self {
             db,
             phase,
-            committed_image: _,
+            committed_image,
             cleanup_state,
         } = self;
-        vacuum_in_place_cleanup(connection, db, phase, cleanup_state)
+        vacuum_in_place_cleanup(connection, db, phase, committed_image, cleanup_state)
     }
 }
 
@@ -2234,10 +2234,10 @@ fn vacuum_in_place_step(
                         tracing::error!("VACUUM post-commit checkpoint failed: {err}");
                         source_pager.cleanup_after_checkpoint_failure();
                         cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::None;
-                        let committed_image = committed_image.as_ref().expect(
+                        let committed_image = committed_image.take().expect(
                             "VACUUM checkpoint failure after publish requires captured metadata",
                         );
-                        install_committed_vacuum_image(connection, db, committed_image);
+                        install_committed_vacuum_image(connection, db, &committed_image);
                         if cleanup_state.vacuum_lock_held {
                             if let Some(wal) = source_pager.wal.as_ref() {
                                 wal.release_vacuum_lock();
@@ -2279,6 +2279,7 @@ fn vacuum_in_place_cleanup(
     connection: &Arc<Connection>,
     db: usize,
     mut phase: VacuumInPlacePhase,
+    committed_image: Option<VacuumCommittedImageMeta>,
     mut cleanup_state: VacuumInPlaceCleanupState,
 ) -> Result<()> {
     if let VacuumInPlacePhase::TargetBuild { context, .. } = &mut phase {
@@ -2305,6 +2306,9 @@ fn vacuum_in_place_cleanup(
 
     // No source transaction to undo. Any raw locks are still released below.
     if !cleanup_state.source_tx_open {
+        if let Some(committed_image) = committed_image.as_ref() {
+            install_committed_vacuum_image(connection, db, committed_image);
+        }
         if cleanup_state.vacuum_lock_held {
             let pager = connection
                 .get_pager_from_database_index(&db)
@@ -2692,6 +2696,48 @@ mod tests {
         assert!(conn.schema.read().generated_columns_enabled);
         let shared = db.clone_schema();
         assert_eq!(shared.schema_version, 42);
+        assert!(shared.generated_columns_enabled);
+
+        Ok(())
+    }
+
+    #[test]
+    fn cleanup_after_published_vacuum_installs_committed_image() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::MemoryIO::new());
+        let db = Database::open_file(io, ":memory:")?;
+        let conn = db.connect()?;
+
+        conn.with_schema_mut(|schema| {
+            schema.schema_version = 1;
+        });
+        db.with_schema_mut(|schema| {
+            schema.schema_version = 1;
+            Ok(())
+        })?;
+
+        let mut header = DatabaseHeader::default();
+        header.schema_cookie = 43.into();
+        let committed = VacuumCommittedImageMeta {
+            header,
+            schema: Arc::new(Schema {
+                generated_columns_enabled: true,
+                schema_version: 43,
+                ..Default::default()
+            }),
+        };
+
+        vacuum_in_place_cleanup(
+            &conn,
+            crate::MAIN_DB_ID,
+            VacuumInPlacePhase::Checkpoint,
+            Some(committed),
+            VacuumInPlaceCleanupState::default(),
+        )?;
+
+        assert_eq!(conn.schema.read().schema_version, 43);
+        assert!(conn.schema.read().generated_columns_enabled);
+        let shared = db.clone_schema();
+        assert_eq!(shared.schema_version, 43);
         assert!(shared.generated_columns_enabled);
 
         Ok(())

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1206,18 +1206,16 @@ enum VacuumInPlacePhase {
     /// Create temp DB and run the shared target-build engine.
     TargetBuild {
         config: Box<VacuumTargetBuildConfig>,
-        temp_db: Box<VacuumTempDb>,
         context: Box<VacuumTargetBuildContext>,
     },
     /// Capture the finalized target schema/header before publishing the
     /// replacement image into the source WAL.
-    CaptureTargetMetadata { temp_db: Box<VacuumTempDb> },
+    CaptureTargetMetadata,
     /// Open a read transaction on the committed temp pager so that we can read the pages back
-    BeginTempReadTx { temp_db: Box<VacuumTempDb> },
+    BeginTempReadTx,
     /// Initialize the source WAL header if needed (one-time before first batch).
     /// Two IO steps: write the header, then fsync to set `initialized = true`.
     InitSourceWalHeader {
-        temp_db: Box<VacuumTempDb>,
         total_pages: u32,
         /// The completion to wait on: first the header write, then the fsync.
         completion: crate::io::Completion,
@@ -1230,7 +1228,6 @@ enum VacuumInPlacePhase {
     /// The state waits on a single `CompletionGroup` completion that
     /// covers every run in the batch.
     ReadTempBatch {
-        temp_db: Box<VacuumTempDb>,
         total_pages: u32,
         /// First page id NOT included in this batch (i.e., the page id
         /// where the next batch will start, 1-based).
@@ -1247,7 +1244,6 @@ enum VacuumInPlacePhase {
     },
     /// Write a prepared batch to the WAL file.
     WriteWalBatch {
-        temp_db: Box<VacuumTempDb>,
         total_pages: u32,
         next_page: u32,
         prev_prepared: Option<Box<crate::storage::wal::PreparedFrames>>,
@@ -1256,13 +1252,12 @@ enum VacuumInPlacePhase {
     },
     /// Fsync the WAL if sync mode requires it.
     SyncSourceWal {
-        temp_db: Box<VacuumTempDb>,
         sync_completion: crate::io::Completion,
     },
     /// Publish: commit_prepared_frames + finish_append_frames_commit, release
     /// source WAL write/source snapshot state, keep the VACUUM lock, and drop
     /// temp resources.
-    PublishWalCommit { temp_db: Box<VacuumTempDb> },
+    PublishWalCommit,
     /// TRUNCATE checkpoint: copy WAL frames back into the DB file and truncate
     /// the WAL to zero. The pager's internal state machine handles the multi-step
     /// IO (backfill → sync DB → truncate WAL). Plain VACUUM requires this fold
@@ -1287,11 +1282,14 @@ pub(crate) struct VacuumInPlaceOpContext {
     db: usize,
     /// Current phase for the in-place VACUUM operation.
     phase: VacuumInPlacePhase,
+    /// File-backed compacted target image used until the replacement WAL frames
+    /// are published into the source database.
+    temp_db: Option<Box<VacuumTempDb>>,
     /// Normalized schema/header snapshot for the new image that will
     /// be published to the source DB. We capture it before source WAL publish so that
     /// post-commit we can install it without reading from disk.
     committed_image: Option<VacuumCommittedImageMeta>,
-    /// Independent cleanup flags that survive `std::mem::take` on `phase`.
+    /// Independent cleanup flags for resources that are not owned by `phase`.
     cleanup_state: VacuumInPlaceCleanupState,
 }
 
@@ -1300,6 +1298,7 @@ impl VacuumInPlaceOpContext {
         Self {
             db,
             phase: VacuumInPlacePhase::Preflight,
+            temp_db: None,
             committed_image: None,
             cleanup_state: VacuumInPlaceCleanupState::default(),
         }
@@ -1310,6 +1309,7 @@ impl VacuumInPlaceOpContext {
             connection,
             self.db,
             &mut self.phase,
+            &mut self.temp_db,
             &mut self.committed_image,
             &mut self.cleanup_state,
         )
@@ -1319,10 +1319,18 @@ impl VacuumInPlaceOpContext {
         let Self {
             db,
             phase,
+            temp_db,
             committed_image,
             cleanup_state,
         } = self;
-        vacuum_in_place_cleanup(connection, db, phase, committed_image, cleanup_state)
+        vacuum_in_place_cleanup(
+            connection,
+            db,
+            phase,
+            temp_db,
+            committed_image,
+            cleanup_state,
+        )
     }
 }
 
@@ -1608,14 +1616,14 @@ fn vacuum_in_place_step(
     connection: &Arc<Connection>,
     db: usize,
     phase: &mut VacuumInPlacePhase,
+    temp_db: &mut Option<Box<VacuumTempDb>>,
     committed_image: &mut Option<VacuumCommittedImageMeta>,
     cleanup_state: &mut VacuumInPlaceCleanupState,
 ) -> Result<IOResult<()>> {
     let source_pager = connection.get_pager_from_database_index(&db)?;
 
     loop {
-        let current_phase = std::mem::take(phase);
-        match current_phase {
+        match phase {
             VacuumInPlacePhase::Preflight => {
                 // 1. Must be in auto-commit mode (no explicit transaction).
                 if !connection.auto_commit.load(Ordering::SeqCst) {
@@ -1748,10 +1756,10 @@ fn vacuum_in_place_step(
                     })
                 })?;
                 // Create temp database.
-                let temp_db =
+                let new_temp_db =
                     open_vacuum_temp_db(connection, &source_db, page_size, reserved_space)?;
 
-                mirror_symbols(connection, &temp_db.conn);
+                mirror_symbols(connection, &new_temp_db.conn);
                 let source_custom_types = capture_custom_types(connection, db);
 
                 let config = VacuumTargetBuildConfig {
@@ -1765,50 +1773,51 @@ fn vacuum_in_place_step(
                     copy_mvcc_metadata_table: source_db.mvcc_enabled(),
                 };
 
-                let target_build_context = VacuumTargetBuildContext::new(temp_db.conn.clone());
+                let target_build_context = VacuumTargetBuildContext::new(new_temp_db.conn.clone());
+                turso_assert!(
+                    temp_db.is_none(),
+                    "VACUUM temp database must not already be installed"
+                );
+                *temp_db = Some(Box::new(new_temp_db));
 
                 *phase = VacuumInPlacePhase::TargetBuild {
                     config: Box::new(config),
-                    temp_db: Box::new(temp_db),
                     context: Box::new(target_build_context),
                 };
                 continue;
             }
 
-            VacuumInPlacePhase::TargetBuild {
-                config,
-                temp_db,
-                mut context,
-            } => {
-                match vacuum_target_build_step(&config, &mut context)? {
+            VacuumInPlacePhase::TargetBuild { config, context } => {
+                match vacuum_target_build_step(config.as_ref(), context.as_mut())? {
                     crate::IOResult::Done(()) => {
                         // Temp build complete. Capture the finalized metadata
                         // snapshot now, before we copy back the pages to main db
-                        *phase = VacuumInPlacePhase::CaptureTargetMetadata { temp_db };
+                        *phase = VacuumInPlacePhase::CaptureTargetMetadata;
                         continue;
                     }
                     crate::IOResult::IO(io) => {
-                        *phase = VacuumInPlacePhase::TargetBuild {
-                            config,
-                            temp_db,
-                            context,
-                        };
                         return Ok(IOResult::IO(io));
                     }
                 }
             }
 
-            VacuumInPlacePhase::CaptureTargetMetadata { temp_db } => {
-                *committed_image = Some(capture_target_metadata(&temp_db)?);
-                *phase = VacuumInPlacePhase::BeginTempReadTx { temp_db };
+            VacuumInPlacePhase::CaptureTargetMetadata => {
+                let temp_db_ref = temp_db
+                    .as_ref()
+                    .expect("VACUUM CaptureTargetMetadata phase requires temp db");
+                *committed_image = Some(capture_target_metadata(temp_db_ref)?);
+                *phase = VacuumInPlacePhase::BeginTempReadTx;
                 continue;
             }
 
-            VacuumInPlacePhase::BeginTempReadTx { temp_db } => {
+            VacuumInPlacePhase::BeginTempReadTx => {
+                let temp_db_ref = temp_db
+                    .as_ref()
+                    .expect("VACUUM BeginTempReadTx phase requires temp db");
                 // The temp db build is now completed and it must have released its WAL read
                 // mark. So we start a fresh read snapshot on the committed temp image.
                 // so `Wal::find_frame` uses the committed temp-WAL frame set for copy-back.
-                let temp_pager = temp_db.conn.get_pager();
+                let temp_pager = temp_db_ref.conn.get_pager();
                 turso_assert!(
                     !temp_pager.holds_read_lock(),
                     "VACUUM temp COMMIT should release the temp WAL read lock"
@@ -1850,7 +1859,6 @@ fn vacuum_in_place_step(
                 if let Some(header_write_c) = wal.prepare_wal_start(page_sz)? {
                     // WAL not yet initialized — yield on the header write.
                     *phase = VacuumInPlacePhase::InitSourceWalHeader {
-                        temp_db,
                         total_pages,
                         completion: header_write_c,
                         fsync_phase: false,
@@ -1859,14 +1867,12 @@ fn vacuum_in_place_step(
                 }
 
                 // WAL already initialized — kick off the first read batch.
-                let temp_pager = temp_db.conn.get_pager();
                 let batch_end = next_vacuum_copy_batch_start(1, total_pages);
                 let read_scratch_buf = new_vacuum_read_scratch_buf(&temp_pager);
                 let (batch_pages, read_completion) =
                     start_temp_batch_reads(&temp_pager, 1, batch_end, &read_scratch_buf)?;
 
                 *phase = VacuumInPlacePhase::ReadTempBatch {
-                    temp_db,
                     total_pages,
                     next_page: batch_end,
                     prev_prepared: None,
@@ -1878,48 +1884,39 @@ fn vacuum_in_place_step(
             }
 
             VacuumInPlacePhase::InitSourceWalHeader {
-                temp_db,
                 total_pages,
                 completion,
                 fsync_phase,
             } => {
                 if !completion.finished() {
-                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
-                        temp_db,
-                        total_pages,
-                        completion: completion.clone(),
-                        fsync_phase,
-                    };
-                    return Ok(IOResult::IO(IOCompletions::Single(completion)));
+                    return Ok(IOResult::IO(IOCompletions::Single(completion.clone())));
                 }
                 if !completion.succeeded() {
                     return Err(vacuum_completion_error(&completion, "WAL header init"));
                 }
 
-                if !fsync_phase {
+                if !*fsync_phase {
                     // Header write done — issue the fsync via prepare_wal_finish
                     // to set WAL `initialized = true`.
                     let wal = source_pager.wal.as_ref().unwrap();
                     let sync_c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
-                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
-                        temp_db,
-                        total_pages,
-                        completion: sync_c,
-                        fsync_phase: true,
-                    };
+                    *completion = sync_c;
+                    *fsync_phase = true;
                     continue;
                 }
 
                 // WAL header fully initialized. Kick off the first read batch.
-                let temp_pager = temp_db.conn.get_pager();
-                let batch_end = next_vacuum_copy_batch_start(1, total_pages);
+                let temp_db_ref = temp_db
+                    .as_ref()
+                    .expect("VACUUM InitSourceWalHeader phase requires temp db");
+                let temp_pager = temp_db_ref.conn.get_pager();
+                let batch_end = next_vacuum_copy_batch_start(1, *total_pages);
                 let read_scratch_buf = new_vacuum_read_scratch_buf(&temp_pager);
                 let (batch_pages, read_completion) =
                     start_temp_batch_reads(&temp_pager, 1, batch_end, &read_scratch_buf)?;
 
                 *phase = VacuumInPlacePhase::ReadTempBatch {
-                    temp_db,
-                    total_pages,
+                    total_pages: *total_pages,
                     next_page: batch_end,
                     prev_prepared: None,
                     read_scratch_buf,
@@ -1930,7 +1927,6 @@ fn vacuum_in_place_step(
             }
 
             VacuumInPlacePhase::ReadTempBatch {
-                temp_db,
                 total_pages,
                 next_page,
                 prev_prepared,
@@ -1939,11 +1935,11 @@ fn vacuum_in_place_step(
                 read_completion,
             } => {
                 turso_assert!(
-                    total_pages < u32::MAX,
+                    *total_pages < u32::MAX,
                     "VACUUM read batch requires a representable exclusive end page",
-                    { "total_pages": total_pages }
+                    { "total_pages": *total_pages }
                 );
-                let database_end = total_pages + 1;
+                let database_end = *total_pages + 1;
                 turso_assert!(
                     !batch_pages.is_empty(),
                     "VACUUM read batch must contain pages"
@@ -1954,29 +1950,20 @@ fn vacuum_in_place_step(
                     { "batch_pages": batch_pages.len(), "batch_size": VACUUM_COPY_BATCH_SIZE }
                 );
                 turso_assert!(
-                    next_page > 1 && next_page <= database_end,
+                    *next_page > 1 && *next_page <= database_end,
                     "VACUUM read batch next page is outside database image",
-                    { "next_page": next_page, "total_pages": total_pages }
+                    { "next_page": *next_page, "total_pages": *total_pages }
                 );
                 // Wait for every run in this batch to finish.
                 if !read_completion.finished() {
-                    *phase = VacuumInPlacePhase::ReadTempBatch {
-                        temp_db,
-                        total_pages,
-                        next_page,
-                        prev_prepared,
-                        read_scratch_buf,
-                        batch_pages,
-                        read_completion: read_completion.clone(),
-                    };
-                    return Ok(IOResult::IO(IOCompletions::Single(read_completion)));
+                    return Ok(IOResult::IO(IOCompletions::Single(read_completion.clone())));
                 }
                 if !read_completion.succeeded() {
                     return Err(vacuum_completion_error(&read_completion, "temp batch read"));
                 }
 
                 // All pages in this batch are loaded. Prepare WAL frames.
-                for page in &batch_pages {
+                for page in batch_pages.iter() {
                     turso_assert!(
                         page.is_loaded(),
                         "VACUUM read batch page must be loaded before WAL prepare",
@@ -1988,14 +1975,14 @@ fn vacuum_in_place_step(
                         { "page_id": page.get().id }
                     );
                 }
-                let all_read = next_page > total_pages;
+                let all_read = *next_page > *total_pages;
                 let wal = source_pager
                     .wal
                     .as_ref()
                     .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
                 let page_sz = source_pager.get_page_size_unchecked();
 
-                let db_size_on_commit = if all_read { Some(total_pages) } else { None };
+                let db_size_on_commit = if all_read { Some(*total_pages) } else { None };
 
                 let prepared = wal.prepare_frames(
                     &batch_pages,
@@ -2011,25 +1998,23 @@ fn vacuum_in_place_step(
                 let completions = batch.submit()?;
 
                 *phase = VacuumInPlacePhase::WriteWalBatch {
-                    temp_db,
-                    total_pages,
-                    next_page,
+                    total_pages: *total_pages,
+                    next_page: *next_page,
                     prev_prepared: Some(Box::new(prepared)),
-                    read_scratch_buf,
+                    read_scratch_buf: Arc::clone(read_scratch_buf),
                     completions,
                 };
                 continue;
             }
 
             VacuumInPlacePhase::WriteWalBatch {
-                temp_db,
                 total_pages,
                 next_page,
                 prev_prepared,
                 read_scratch_buf,
                 completions,
             } => {
-                let database_end = total_pages + 1;
+                let database_end = *total_pages + 1;
                 turso_assert!(
                     prev_prepared.is_some(),
                     "VACUUM WAL write batch requires prepared frames"
@@ -2039,27 +2024,19 @@ fn vacuum_in_place_step(
                     "VACUUM WAL write batch requires write completions"
                 );
                 turso_assert!(
-                    next_page > 1 && next_page <= database_end,
+                    *next_page > 1 && *next_page <= database_end,
                     "VACUUM WAL write batch next page is outside database image",
-                    { "next_page": next_page, "total_pages": total_pages }
+                    { "next_page": *next_page, "total_pages": *total_pages }
                 );
                 // Wait for all writes in this batch. We yield on the first
                 // unfinished completion; re-entry will re-check them all.
                 let pending = completions.iter().find(|c| !c.finished()).cloned();
                 if let Some(pending) = pending {
-                    *phase = VacuumInPlacePhase::WriteWalBatch {
-                        temp_db,
-                        total_pages,
-                        next_page,
-                        prev_prepared,
-                        read_scratch_buf,
-                        completions,
-                    };
                     return Ok(IOResult::IO(IOCompletions::Single(pending)));
                 }
 
                 // Check for write errors.
-                for c in &completions {
+                for c in completions.iter() {
                     if !c.succeeded() {
                         return Err(vacuum_completion_error(c, "WAL write"));
                     }
@@ -2077,27 +2054,34 @@ fn vacuum_in_place_step(
                 // source-cache dirty state or WAL tags to update, and the
                 // source page cache is invalidated wholesale in Publish.
                 let wal = source_pager.wal.as_ref().unwrap();
-                let prepared = prev_prepared.as_ref().unwrap();
+                let prepared = prev_prepared
+                    .as_ref()
+                    .expect("VACUUM WriteWalBatch phase requires prepared frames");
                 wal.commit_prepared_frames(std::slice::from_ref(prepared.as_ref()));
 
                 // More pages to copy?
-                if next_page <= total_pages {
+                if *next_page <= *total_pages {
                     // Kick off the next read batch in parallel.
-                    let temp_pager = temp_db.conn.get_pager();
-                    let batch_end = next_vacuum_copy_batch_start(next_page, total_pages);
+                    let temp_db_ref = temp_db
+                        .as_ref()
+                        .expect("VACUUM WriteWalBatch phase requires temp db");
+                    let temp_pager = temp_db_ref.conn.get_pager();
+                    let batch_end = next_vacuum_copy_batch_start(*next_page, *total_pages);
                     let (batch_pages, read_completion) = start_temp_batch_reads(
                         &temp_pager,
-                        next_page,
+                        *next_page,
                         batch_end,
-                        &read_scratch_buf,
+                        read_scratch_buf,
                     )?;
+                    let prev_prepared = prev_prepared
+                        .take()
+                        .expect("VACUUM WriteWalBatch phase requires prepared frames");
 
                     *phase = VacuumInPlacePhase::ReadTempBatch {
-                        temp_db,
-                        total_pages,
+                        total_pages: *total_pages,
                         next_page: batch_end,
-                        prev_prepared,
-                        read_scratch_buf,
+                        prev_prepared: Some(prev_prepared),
+                        read_scratch_buf: Arc::clone(read_scratch_buf),
                         batch_pages,
                         read_completion,
                     };
@@ -2112,36 +2096,28 @@ fn vacuum_in_place_step(
                 if sync_mode == SyncMode::Full {
                     let sync_c = wal.sync(source_pager.get_sync_type())?;
                     *phase = VacuumInPlacePhase::SyncSourceWal {
-                        temp_db,
                         sync_completion: sync_c,
                     };
                     continue;
                 }
 
                 // No sync needed — proceed directly to publish.
-                *phase = VacuumInPlacePhase::PublishWalCommit { temp_db };
+                *phase = VacuumInPlacePhase::PublishWalCommit;
                 continue;
             }
 
-            VacuumInPlacePhase::SyncSourceWal {
-                temp_db,
-                sync_completion,
-            } => {
+            VacuumInPlacePhase::SyncSourceWal { sync_completion } => {
                 if !sync_completion.finished() {
-                    *phase = VacuumInPlacePhase::SyncSourceWal {
-                        temp_db,
-                        sync_completion: sync_completion.clone(),
-                    };
-                    return Ok(IOResult::IO(IOCompletions::Single(sync_completion)));
+                    return Ok(IOResult::IO(IOCompletions::Single(sync_completion.clone())));
                 }
                 if !sync_completion.succeeded() {
                     return Err(vacuum_completion_error(&sync_completion, "WAL fsync"));
                 }
-                *phase = VacuumInPlacePhase::PublishWalCommit { temp_db };
+                *phase = VacuumInPlacePhase::PublishWalCommit;
                 continue;
             }
 
-            VacuumInPlacePhase::PublishWalCommit { temp_db } => {
+            VacuumInPlacePhase::PublishWalCommit => {
                 turso_assert!(
                     cleanup_state.checkpoint_cleanup == CheckpointLockCleanup::ReleaseRaw,
                     "VACUUM publish phase requires held checkpoint lock"
@@ -2178,6 +2154,9 @@ fn vacuum_in_place_step(
                 source_pager.set_schema_cookie(None);
 
                 // Drop temp resources before checkpoint.
+                let temp_db = temp_db
+                    .take()
+                    .expect("VACUUM PublishWalCommit phase requires temp db");
                 drop(temp_db);
 
                 *phase = VacuumInPlacePhase::Checkpoint;
@@ -2257,7 +2236,7 @@ fn vacuum_in_place_step(
 
 /// Roll back the source transaction and restore connection state after an
 /// in-place VACUUM failure. Uses `cleanup_state` to decide what to undo; this
-/// state is independent of the phase enum and survives `std::mem::take`.
+/// state tracks resources that are not owned by the phase enum.
 ///
 /// `phase` is taken by value so helper statements inside `TargetBuild` are
 /// dropped before we attempt `rollback_tx`. This
@@ -2267,6 +2246,7 @@ fn vacuum_in_place_cleanup(
     connection: &Arc<Connection>,
     db: usize,
     mut phase: VacuumInPlacePhase,
+    temp_db: Option<Box<VacuumTempDb>>,
     committed_image: Option<VacuumCommittedImageMeta>,
     mut cleanup_state: VacuumInPlaceCleanupState,
 ) -> Result<()> {
@@ -2306,6 +2286,7 @@ fn vacuum_in_place_cleanup(
             }
         }
         drop(cleanup_state.mvcc_guard.take());
+        drop(temp_db);
         return Ok(());
     }
 
@@ -2313,6 +2294,7 @@ fn vacuum_in_place_cleanup(
     // Their Drop impls decrement Connection::nestedness, which must happen
     // before rollback_tx (which is a no-op while nested).
     drop(phase);
+    drop(temp_db);
 
     // Write transaction open but not yet committed — roll back.
     let pager = connection
@@ -2718,6 +2700,7 @@ mod tests {
             &conn,
             crate::MAIN_DB_ID,
             VacuumInPlacePhase::Checkpoint,
+            None,
             Some(committed),
             VacuumInPlaceCleanupState::default(),
         )?;

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2342,3 +2342,717 @@ fn vacuum_in_place_cleanup(
     drop(cleanup_state.mvcc_guard.take());
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::{FileId, FileSyncType};
+    use crate::schema::Schema;
+    use crate::storage::encryption::{CipherMode, EncryptionKey};
+    use crate::storage::pager::Page;
+    use crate::util::IOExt;
+    use crate::{
+        Buffer, Clock, Completion, DatabaseOpts, File, MemoryIO, MonotonicInstant, OpenFlags,
+        WallClockInstant, IO,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering as StdOrdering};
+
+    fn page_ref(id: i64) -> crate::storage::pager::PageRef {
+        Arc::new(Page::new(id))
+    }
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct SyncCounts {
+        db: usize,
+        wal: usize,
+    }
+
+    struct SyncCountingIo {
+        inner: Arc<MemoryIO>,
+        tracked_db_path: String,
+        tracked_wal_path: String,
+        db_syncs: Arc<AtomicUsize>,
+        wal_syncs: Arc<AtomicUsize>,
+    }
+
+    impl SyncCountingIo {
+        fn new(tracked_db_path: &str) -> Self {
+            Self {
+                inner: Arc::new(MemoryIO::new()),
+                tracked_db_path: tracked_db_path.to_string(),
+                tracked_wal_path: format!("{tracked_db_path}-wal"),
+                db_syncs: Arc::new(AtomicUsize::new(0)),
+                wal_syncs: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn counts(&self) -> SyncCounts {
+            SyncCounts {
+                db: self.db_syncs.load(StdOrdering::SeqCst),
+                wal: self.wal_syncs.load(StdOrdering::SeqCst),
+            }
+        }
+    }
+
+    impl Clock for SyncCountingIo {
+        fn current_time_monotonic(&self) -> MonotonicInstant {
+            self.inner.current_time_monotonic()
+        }
+
+        fn current_time_wall_clock(&self) -> WallClockInstant {
+            self.inner.current_time_wall_clock()
+        }
+    }
+
+    impl IO for SyncCountingIo {
+        fn open_file(&self, path: &str, flags: OpenFlags, direct: bool) -> Result<Arc<dyn File>> {
+            let inner = self.inner.open_file(path, flags, direct)?;
+            Ok(Arc::new(SyncCountingFile {
+                inner,
+                count_as_db_sync: path == self.tracked_db_path,
+                count_as_wal_sync: path == self.tracked_wal_path,
+                db_syncs: self.db_syncs.clone(),
+                wal_syncs: self.wal_syncs.clone(),
+            }))
+        }
+
+        fn remove_file(&self, path: &str) -> Result<()> {
+            self.inner.remove_file(path)
+        }
+
+        fn step(&self) -> Result<()> {
+            self.inner.step()
+        }
+
+        fn drain(&self) -> Result<()> {
+            self.inner.drain()
+        }
+
+        fn cancel(&self, completions: &[Completion]) -> Result<()> {
+            self.inner.cancel(completions)
+        }
+
+        fn file_id(&self, path: &str) -> Result<FileId> {
+            self.inner.file_id(path)
+        }
+    }
+
+    struct SyncCountingFile {
+        inner: Arc<dyn File>,
+        count_as_db_sync: bool,
+        count_as_wal_sync: bool,
+        db_syncs: Arc<AtomicUsize>,
+        wal_syncs: Arc<AtomicUsize>,
+    }
+
+    impl File for SyncCountingFile {
+        fn lock_file(&self, exclusive: bool) -> Result<()> {
+            self.inner.lock_file(exclusive)
+        }
+
+        fn unlock_file(&self) -> Result<()> {
+            self.inner.unlock_file()
+        }
+
+        fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+            self.inner.pread(pos, c)
+        }
+
+        fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+            self.inner.pwrite(pos, buffer, c)
+        }
+
+        fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion> {
+            if self.count_as_db_sync {
+                self.db_syncs.fetch_add(1, StdOrdering::SeqCst);
+            }
+            if self.count_as_wal_sync {
+                self.wal_syncs.fetch_add(1, StdOrdering::SeqCst);
+            }
+            self.inner.sync(c, sync_type)
+        }
+
+        fn size(&self) -> Result<u64> {
+            self.inner.size()
+        }
+
+        fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+            self.inner.truncate(len, c)
+        }
+    }
+
+    fn vacuum_copy_batch_ranges(total_pages: u32) -> Vec<(u32, u32)> {
+        let mut ranges = Vec::new();
+        let mut start = 1;
+        while start <= total_pages {
+            let end = next_vacuum_copy_batch_start(start, total_pages);
+            ranges.push((start, end));
+            start = end;
+        }
+        ranges
+    }
+
+    #[test]
+    fn coalesce_frame_runs_single_page_is_one_run_of_one() {
+        let runs = coalesce_frame_runs(vec![(page_ref(1), 42)]);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].0, 42);
+        assert_eq!(runs[0].1.len(), 1);
+        assert_eq!(runs[0].1[0].get().id, 1);
+    }
+
+    #[test]
+    fn coalesce_frame_runs_sorts_by_frame_id_then_coalesces_contiguous() {
+        // Target-build writes frames out of page-id order. The input is
+        // sorted by page id (1,2,3,4), but the frame ids interleave with a
+        // gap at frame 3, producing two runs once sorted by frame id.
+        let pairs = vec![
+            (page_ref(1), 10),
+            (page_ref(2), 11),
+            (page_ref(3), 12),
+            (page_ref(4), 14),
+        ];
+        let runs = coalesce_frame_runs(pairs);
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].0, 10);
+        assert_eq!(runs[0].1.len(), 3);
+        assert_eq!(
+            runs[0].1.iter().map(|p| p.get().id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(runs[1].0, 14);
+        assert_eq!(runs[1].1.len(), 1);
+        assert_eq!(runs[1].1[0].get().id, 4);
+    }
+
+    #[test]
+    fn coalesce_frame_runs_handles_non_monotonic_page_to_frame_map() {
+        // Realistic target-build shape: pages 1..=6 but frames assigned by
+        // phase order (schema page goes last, indexes interleave). The
+        // coalescer must still produce runs of length > 1 for contiguous
+        // frame ranges rather than falling back to length-1 runs.
+        let pairs = vec![
+            (page_ref(1), 10), // schema written last (gap between 6 and 10)
+            (page_ref(2), 1),  // data pages written first
+            (page_ref(3), 2),
+            (page_ref(4), 3),
+            (page_ref(5), 5), // index pages later
+            (page_ref(6), 6),
+        ];
+        let runs = coalesce_frame_runs(pairs);
+        // After sort by frame id: frames 1,2,3 contiguous; 5,6 contiguous;
+        // 10 isolated.
+        assert_eq!(runs.len(), 3);
+        assert_eq!(runs[0].0, 1);
+        assert_eq!(runs[0].1.len(), 3);
+        assert_eq!(runs[1].0, 5);
+        assert_eq!(runs[1].1.len(), 2);
+        assert_eq!(runs[2].0, 10);
+        assert_eq!(runs[2].1.len(), 1);
+
+        // Average run length should be non-trivial (>1).
+        let total: usize = runs.iter().map(|(_, pages)| pages.len()).sum();
+        let avg = total as f64 / runs.len() as f64;
+        assert!(avg > 1.0, "expected average run length > 1, got {avg}");
+    }
+
+    #[test]
+    fn coalesce_frame_runs_all_scattered_is_singleton_runs() {
+        let pairs = vec![(page_ref(1), 10), (page_ref(2), 20), (page_ref(3), 30)];
+        let runs = coalesce_frame_runs(pairs);
+        assert_eq!(runs.len(), 3);
+        for (_, pages) in &runs {
+            assert_eq!(pages.len(), 1);
+        }
+    }
+
+    #[test]
+    fn coalesce_frame_runs_keeps_run_pages_in_physical_frame_order() {
+        let runs = coalesce_frame_runs(vec![
+            (page_ref(1), 12),
+            (page_ref(2), 10),
+            (page_ref(3), 11),
+            (page_ref(4), 13),
+        ]);
+
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].0, 10);
+        assert_eq!(
+            runs[0].1.iter().map(|p| p.get().id).collect::<Vec<_>>(),
+            vec![2, 3, 1, 4]
+        );
+    }
+
+    #[test]
+    fn vacuum_copy_batch_ranges_cover_boundary_page_counts() {
+        let size = VACUUM_COPY_BATCH_SIZE;
+        assert!(vacuum_copy_batch_ranges(0).is_empty());
+        assert_eq!(vacuum_copy_batch_ranges(1), vec![(1, 2)]);
+        assert_eq!(vacuum_copy_batch_ranges(2), vec![(1, 3)]);
+        assert_eq!(vacuum_copy_batch_ranges(size - 1), vec![(1, size)]);
+        assert_eq!(vacuum_copy_batch_ranges(size), vec![(1, size + 1)]);
+        assert_eq!(
+            vacuum_copy_batch_ranges(size + 1),
+            vec![(1, size + 1), (size + 1, size + 2)]
+        );
+        assert_eq!(
+            vacuum_copy_batch_ranges(size * 2),
+            vec![(1, size + 1), (size + 1, size * 2 + 1)]
+        );
+        assert_eq!(
+            vacuum_copy_batch_ranges(size * 2 + 1),
+            vec![
+                (1, size + 1),
+                (size + 1, size * 2 + 1),
+                (size * 2 + 1, size * 2 + 2),
+            ]
+        );
+    }
+
+    #[test]
+    fn vacuum_db_header_meta_bumps_schema_cookie_and_preserves_sqlite_metadata() {
+        let mut source = DatabaseHeader::default();
+        source.schema_cookie = u32::MAX.into();
+        source.default_page_cache_size = CacheSize::new(123);
+        source.text_encoding = TextEncoding::Utf8;
+        source.user_version = 7.into();
+        source.application_id = 12.into();
+
+        let VacuumDbHeaderMeta {
+            read_version,
+            write_version,
+            schema_cookie,
+            default_page_cache_size,
+            text_encoding,
+            user_version,
+            application_id,
+        } = VacuumDbHeaderMeta::from_source_header(&source);
+
+        assert_eq!(read_version, source.read_version);
+        assert_eq!(write_version, source.write_version);
+        assert_eq!(schema_cookie, 0);
+        assert_eq!(default_page_cache_size, CacheSize::new(123));
+        assert_eq!(text_encoding, TextEncoding::Utf8);
+        assert_eq!(user_version, 7);
+        assert_eq!(application_id, 12);
+    }
+
+    #[test]
+    fn replace_shared_schema_after_vacuum_replaces_wrapped_schema_cookie() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::MemoryIO::new());
+        let db = Database::open_file(io, ":memory:")?;
+
+        db.with_schema_mut(|schema| {
+            schema.schema_version = u32::MAX;
+            Ok(())
+        })?;
+
+        let replacement = Schema {
+            generated_columns_enabled: true,
+            schema_version: 0,
+            ..Default::default()
+        };
+        replace_shared_schema_after_vacuum(db.as_ref(), Arc::new(replacement));
+
+        let schema = db.clone_schema();
+        assert_eq!(schema.schema_version, 0);
+        assert!(schema.generated_columns_enabled);
+
+        Ok(())
+    }
+
+    #[test]
+    fn install_committed_vacuum_image_updates_connection_and_shared_schema() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::MemoryIO::new());
+        let db = Database::open_file(io, ":memory:")?;
+        let conn = db.connect()?;
+
+        conn.with_schema_mut(|schema| {
+            schema.schema_version = 1;
+        });
+        db.with_schema_mut(|schema| {
+            schema.schema_version = 1;
+            Ok(())
+        })?;
+
+        let mut header = DatabaseHeader::default();
+        header.schema_cookie = 42.into();
+        let committed = VacuumCommittedImageMeta {
+            header,
+            schema: Arc::new(Schema {
+                generated_columns_enabled: true,
+                schema_version: 42,
+                ..Default::default()
+            }),
+        };
+
+        install_committed_vacuum_image(&conn, crate::MAIN_DB_ID, &committed);
+
+        assert_eq!(conn.schema.read().schema_version, 42);
+        assert!(conn.schema.read().generated_columns_enabled);
+        let shared = db.clone_schema();
+        assert_eq!(shared.schema_version, 42);
+        assert!(shared.generated_columns_enabled);
+
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn capture_target_metadata_uses_final_header_cookie_and_preserves_tvfs() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("source.db");
+        let source_path = source_path.to_str().unwrap();
+        let source_db = Database::open_file_with_flags(
+            io,
+            source_path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let source_conn = source_db.connect()?;
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+
+        temp.conn.execute("BEGIN IMMEDIATE")?;
+        temp.conn
+            .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+        temp.conn.execute("CREATE INDEX idx_t_v ON t(v)")?;
+        temp.conn.execute("INSERT INTO t VALUES (1, 'x')")?;
+        let mvcc_version = RawVersion::from(crate::storage::sqlite3_ondisk::Version::Mvcc);
+        let header_meta = VacuumDbHeaderMeta {
+            read_version: mvcc_version,
+            write_version: mvcc_version,
+            schema_cookie: 42,
+            default_page_cache_size: CacheSize::new(321),
+            text_encoding: TextEncoding::Utf8,
+            user_version: 17,
+            application_id: 29,
+        };
+        match finalize_vacuum_target_header(&temp.conn, &header_meta)? {
+            crate::IOResult::Done(()) => {}
+            crate::IOResult::IO(_) => panic!("fresh temp header should not need async I/O"),
+        }
+        temp.conn.execute("COMMIT")?;
+
+        let committed = capture_target_metadata(&temp)?;
+
+        assert_eq!(committed.header.schema_cookie.get(), 42);
+        assert_eq!(committed.header.read_version, mvcc_version);
+        assert_eq!(committed.header.write_version, mvcc_version);
+        assert_eq!(committed.schema.schema_version, 42);
+        assert!(
+            committed.schema.tables.contains_key("generate_series"),
+            "captured schema must retain built-in table-valued functions"
+        );
+        let table_root = match committed.schema.tables.get("t").expect("table t").as_ref() {
+            crate::schema::Table::BTree(btree) => btree.root_page,
+            _ => panic!("expected btree table"),
+        };
+        assert!(table_root > 0);
+        let index_root = committed
+            .schema
+            .indexes
+            .get("t")
+            .and_then(|indexes| indexes.front())
+            .map(|index| index.root_page)
+            .expect("index idx_t_v");
+        assert!(index_root > 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn finalize_vacuum_into_output_syncs_destination_db_file() -> Result<()> {
+        let io = Arc::new(SyncCountingIo::new("vacuum-into-output.db"));
+        let io_dyn: Arc<dyn IO> = io.clone();
+        let db = Database::open_file_with_flags(
+            io_dyn,
+            "vacuum-into-output.db",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let conn = db.connect()?;
+        conn.set_sync_mode(crate::SyncMode::Off);
+        conn.wal_auto_checkpoint_disable();
+
+        conn.execute("BEGIN IMMEDIATE")?;
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+        conn.execute("INSERT INTO t VALUES (1, 'x')")?;
+        conn.execute("COMMIT")?;
+
+        let before = io.counts();
+        assert_eq!(
+            before.db,
+            0,
+            "target build with synchronous=OFF must not sync the destination db file before finalization"
+        );
+
+        finalize_vacuum_into_output(&VacuumTargetBuildContext::new(conn))?;
+
+        let after = io.counts();
+        assert_eq!(
+            after.db - before.db,
+            1,
+            "VACUUM INTO finalization must do exactly one destination DB fsync"
+        );
+        assert_eq!(
+            after.wal - before.wal,
+            1,
+            "VACUUM INTO finalization must do exactly one WAL fsync after truncation"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_place_vacuum_with_sync_off_syncs_source_db_once_and_wal_once() -> Result<()> {
+        let io = Arc::new(SyncCountingIo::new("vacuum-source.db"));
+        let io_dyn: Arc<dyn IO> = io.clone();
+        let db = Database::open_file_with_flags(
+            io_dyn,
+            "vacuum-source.db",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let conn = db.connect()?;
+        conn.set_sync_mode(crate::SyncMode::Off);
+
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+        conn.execute("INSERT INTO t VALUES (1, 'x')")?;
+        conn.execute("INSERT INTO t VALUES (2, 'y')")?;
+
+        let before = io.counts();
+        assert_eq!(
+            before.db, 0,
+            "synchronous=OFF writes should not sync the source db file before VACUUM"
+        );
+
+        conn.execute("VACUUM")?;
+
+        let after = io.counts();
+        assert_eq!(
+            after.db - before.db,
+            1,
+            "in-place VACUUM must do exactly one source DB fsync before truncating WAL"
+        );
+        assert_eq!(
+            after.wal - before.wal,
+            1,
+            "in-place VACUUM with synchronous=OFF must do exactly one WAL fsync after truncation"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn in_place_vacuum_with_sync_full_adds_pre_publish_wal_sync() -> Result<()> {
+        let io = Arc::new(SyncCountingIo::new("vacuum-source-full.db"));
+        let io_dyn: Arc<dyn IO> = io.clone();
+        let db = Database::open_file_with_flags(
+            io_dyn,
+            "vacuum-source-full.db",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let conn = db.connect()?;
+        conn.set_sync_mode(crate::SyncMode::Off);
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+        conn.execute("INSERT INTO t VALUES (1, 'x')")?;
+        conn.execute("INSERT INTO t VALUES (2, 'y')")?;
+
+        conn.set_sync_mode(crate::SyncMode::Full);
+        let before = io.counts();
+
+        conn.execute("VACUUM")?;
+
+        let after = io.counts();
+        assert_eq!(
+            after.db - before.db,
+            1,
+            "in-place VACUUM must still do exactly one source DB fsync under synchronous=FULL"
+        );
+        assert_eq!(
+            after.wal - before.wal,
+            2,
+            "in-place VACUUM with synchronous=FULL must do one WAL fsync before publish and one after truncation"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn vacuum_db_header_meta_updates_target_header() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("source.db");
+        let source_path = source_path.to_str().unwrap();
+        let source_db = Database::open_file_with_flags(
+            io,
+            source_path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let source_conn = source_db.connect()?;
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+
+        let mut source_header = DatabaseHeader::default();
+        source_header.schema_cookie = 41.into();
+        source_header.default_page_cache_size = CacheSize::new(321);
+        source_header.text_encoding = TextEncoding::Utf8;
+        source_header.user_version = 17.into();
+        source_header.application_id = 29.into();
+        let header_meta = VacuumDbHeaderMeta::from_source_header(&source_header);
+
+        temp.conn.execute("BEGIN")?;
+        match finalize_vacuum_target_header(&temp.conn, &header_meta)? {
+            crate::IOResult::Done(()) => {}
+            crate::IOResult::IO(_) => panic!("fresh temp header should not need async I/O"),
+        }
+        temp.conn.execute("COMMIT")?;
+
+        let pager = temp.conn.pager.load();
+        let header = pager.io.block(|| {
+            pager.with_header(|header| {
+                (
+                    header.schema_cookie.get(),
+                    header.default_page_cache_size,
+                    header.text_encoding,
+                    header.user_version.get(),
+                    header.application_id.get(),
+                )
+            })
+        })?;
+
+        assert_eq!(
+            header,
+            (42, CacheSize::new(321), TextEncoding::Utf8, 17, 29)
+        );
+
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn internal_vacuum_temp_db_uses_source_runtime_and_disables_auto_checkpoint() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("source.db");
+        let source_path = source_path.to_str().unwrap();
+        let source_db = Database::open_file_with_flags(
+            io,
+            source_path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let source_conn = source_db.connect()?;
+
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+
+        assert!(Arc::ptr_eq(&temp._db.io, &source_db.io));
+        assert_ne!(temp.path, source_db.path);
+        assert!(temp.conn.is_wal_auto_checkpoint_disabled());
+        assert_eq!(temp.conn.get_page_size().get(), 4096);
+        assert_eq!(temp.conn.get_reserved_bytes(), Some(0));
+
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn internal_vacuum_temp_db_preserves_source_encryption() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("encrypted-source.db");
+        let source_path = source_path.to_str().unwrap();
+        let key_hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        let key = EncryptionKey::from_hex_string(key_hex)?;
+        let source_db = Database::open_file_with_flags(
+            io,
+            source_path,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_encryption(true),
+            Some(EncryptionOpts {
+                cipher: CipherMode::Aes256Gcm.to_string(),
+                hexkey: key_hex.to_string(),
+            }),
+        )?;
+        let source_conn = source_db.connect_with_encryption(Some(key))?;
+        let reserved_space = source_conn
+            .get_reserved_bytes()
+            .expect("encrypted source should have reserved bytes");
+
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, reserved_space)?;
+
+        assert!(temp._db.experimental_encryption_enabled());
+        assert_eq!(
+            temp.conn.get_encryption_cipher_mode(),
+            source_conn.get_encryption_cipher_mode()
+        );
+        assert!(temp.conn.encryption_key.read().is_some());
+        assert_eq!(temp.conn.get_reserved_bytes(), Some(reserved_space));
+
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn vacuum_target_build_cleanup_clears_target_connection_state() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let target_dir = tempfile::tempdir().unwrap();
+        let target_path = target_dir.path().join("target.db");
+        let target_path = target_path.to_str().unwrap();
+        let target_db = Database::open_file_with_flags(
+            io,
+            target_path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let target_conn = target_db.connect()?;
+        target_conn.execute("CREATE TABLE seed(x)")?;
+
+        let mut context = VacuumTargetBuildContext::new(target_conn.clone());
+        let helper_stmt = target_conn.prepare_internal("SELECT 1")?;
+        context.phase = VacuumTargetBuildPhase::CollectSchemaRows {
+            schema_stmt: Box::new(helper_stmt),
+        };
+
+        target_conn.execute("BEGIN IMMEDIATE")?;
+        target_conn.execute("INSERT INTO seed VALUES (1)")?;
+        let pager = target_conn.pager.load();
+
+        assert!(!target_conn.get_auto_commit());
+        assert!(target_conn.is_nested_stmt());
+
+        context.cleanup_after_error()?;
+
+        assert!(target_conn.get_auto_commit());
+        assert_eq!(
+            target_conn.get_tx_state(),
+            crate::connection::TransactionState::None
+        );
+        assert!(!target_conn.is_nested_stmt());
+        assert!(!pager.holds_read_lock());
+        assert!(!pager.holds_write_lock());
+
+        let mut stmt = target_conn.prepare("SELECT COUNT(*) FROM seed")?;
+        let mut saw_row = false;
+        stmt.run_with_row_callback(|_| {
+            saw_row = true;
+            Ok(())
+        })?;
+        assert!(
+            saw_row,
+            "target cleanup should leave the connection queryable"
+        );
+
+        Ok(())
+    }
+}

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,13 +1,19 @@
-use std::sync::Arc;
+use std::sync::{atomic::Ordering, Arc};
 
 use crate::error::LimboError;
-use crate::schema::TypeDef;
-use crate::storage::pager::AutoVacuumMode;
-use crate::storage::sqlite3_ondisk::{CacheSize, DatabaseHeader, RawVersion, TextEncoding};
+use crate::io::{Buffer, Completion, CompletionGroup, WriteBatch as IOWriteBatch};
+use crate::schema::{BTreeTable, Schema, TypeDef};
+use crate::storage::pager::{AutoVacuumMode, Page, PageRef, Pager};
+use crate::storage::sqlite3_ondisk::{
+    CacheSize, DatabaseHeader, PageSize, RawVersion, TextEncoding, WAL_FRAME_HEADER_SIZE,
+};
+use crate::types::IOCompletions;
 use crate::util::IOExt;
-use crate::vdbe::execute::InsnFunctionStepResult;
+use crate::vdbe::{execute::InsnFunctionStepResult, Row};
 use crate::Result;
-use crate::{Connection, Database, DatabaseOpts, EncryptionOpts, OpenFlags};
+use crate::{
+    Connection, Database, DatabaseOpts, EncryptionKey, EncryptionOpts, MvStore, OpenFlags, SyncMode,
+};
 use turso_macros::{turso_assert, turso_assert_eq};
 
 /// A representation of a row from `sqlite_schema`.
@@ -50,7 +56,7 @@ impl SchemaEntryType {
 
 impl SchemaEntry {
     /// Parse from a sqlite_schema row: (type, name, tbl_name, rootpage, sql)
-    pub fn from_row(row: &crate::vdbe::Row) -> crate::Result<Self> {
+    pub fn from_row(row: &Row) -> crate::Result<Self> {
         let entry_type = SchemaEntryType::from_str(row.get::<&str>(0)?)?;
         Ok(Self {
             entry_type,
@@ -217,7 +223,7 @@ pub(crate) struct VacuumTempDb {
 #[cfg(not(target_family = "wasm"))]
 fn vacuum_temp_db_encryption(
     source_conn: &Arc<Connection>,
-) -> Result<(Option<EncryptionOpts>, Option<crate::EncryptionKey>)> {
+) -> Result<(Option<EncryptionOpts>, Option<EncryptionKey>)> {
     let Some(cipher_mode) = source_conn.get_encryption_cipher_mode() else {
         return Ok((None, None));
     };
@@ -1098,8 +1104,1241 @@ pub(crate) fn build_copy_sql(
 
     let select_sql =
         format!("SELECT {select_cols} FROM \"{escaped_schema_name}\".\"{escaped_table_name}\"");
+    let insert_prefix = if or_replace {
+        "INSERT OR REPLACE INTO"
+    } else {
+        "INSERT INTO"
+    };
     let insert_sql =
-        format!("INSERT INTO \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
+        format!("{insert_prefix} \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
 
     Ok((select_sql, insert_sql))
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum CheckpointLockCleanup {
+    #[default]
+    None,
+    /// VACUUM owns only the raw checkpoint_lock; cleanup releases it
+    /// directly with `Wal::release_checkpoint_lock`.
+    ReleaseRaw,
+    /// The checkpoint state machine has consumed the raw checkpoint_lock and
+    /// may now own read0/write too, so cleanup must abort checkpoint state.
+    AbortCheckpoint,
+}
+
+struct MvccVacuumGuard {
+    connection: Arc<Connection>,
+    mv_store: Arc<MvStore>,
+    connection_demoted: bool,
+}
+
+impl MvccVacuumGuard {
+    fn acquire(connection: Arc<Connection>, mv_store: Arc<MvStore>) -> Result<Self> {
+        mv_store.try_begin_vacuum_gate()?;
+        Ok(Self {
+            connection,
+            mv_store,
+            connection_demoted: false,
+        })
+    }
+
+    fn demote_connection(&mut self) {
+        turso_assert!(
+            !self.connection_demoted,
+            "MVCC VACUUM connection is already demoted"
+        );
+        self.connection.demote_to_mvcc_connection();
+        self.connection_demoted = true;
+    }
+}
+
+impl Drop for MvccVacuumGuard {
+    fn drop(&mut self) {
+        if self.connection_demoted && self.connection.is_mvcc_bootstrap_connection() {
+            self.connection.promote_to_regular_connection();
+        }
+        self.mv_store.release_vacuum_gate();
+    }
+}
+
+/// Cleanup state for in-place VACUUM. This tracks resources the opcode has
+/// acquired and is **not** cleared by `std::mem::take` or drop.
+///
+/// Successful acquisition / publish order:
+/// 1. `mvcc_guard` in `Preflight` when the source database is MVCC-enabled.
+/// 2. `checkpoint_cleanup = ReleaseRaw` immediately after acquiring the raw
+///    checkpoint lock in `Preflight`.
+/// 3. `source_tx_open = true` and `vacuum_lock_held = true` together after
+///    `begin_blocking_tx()` succeeds in `BeginSourceTx`.
+/// 4. `source_tx_open` is cleared immediately after
+///    `finish_append_frames_commit()` and `end_write_tx()` in `PublishWalCommit`.
+/// 5. `checkpoint_cleanup` transitions from `ReleaseRaw` to
+///    `AbortCheckpoint` when the raw checkpoint lock is handed to the
+///    checkpoint state machine, and finally to `None` once checkpoint cleanup
+///    is no longer needed.
+///
+/// Since we track the resources explicitly, cleanup can decide what to roll
+/// back regardless of which phase was active when the error occurred.
+#[derive(Default)]
+struct VacuumInPlaceCleanupState {
+    /// MVCC gate/demotion guard held until VACUUM can return to MVCC reads.
+    mvcc_guard: Option<MvccVacuumGuard>,
+    /// Tracks which checkpoint-lock cleanup action is needed.
+    checkpoint_cleanup: CheckpointLockCleanup,
+    /// Source pager exclusive transaction was started.
+    source_tx_open: bool,
+    /// WAL VACUUM lock is held exclusively.
+    vacuum_lock_held: bool,
+}
+
+/// Phases for the in-place VACUUM state machine.
+enum VacuumInPlacePhase {
+    /// Validate preconditions (auto_commit, active statements, readonly, memory,
+    /// MVCC, WAL-backed pager). Then acquire check_point lock
+    Preflight,
+    /// Acquire exclusive source access on the source WAL via
+    /// `begin_blocking_tx`: checkpoint_lock is already held from Preflight;
+    /// this acquires the exclusive VACUUM lock and installs the source snapshot.
+    BeginSourceTx,
+    /// Read source database header metadata for the target-build config.
+    ReadSourceMetadata,
+    /// Create temp DB and run the shared target-build engine.
+    TargetBuild {
+        config: Box<VacuumTargetBuildConfig>,
+        temp_db: Box<VacuumTempDb>,
+        context: Box<VacuumTargetBuildContext>,
+    },
+    /// Capture the finalized target schema/header before publishing the
+    /// replacement image into the source WAL.
+    CaptureTargetMetadata { temp_db: Box<VacuumTempDb> },
+    /// Open a read transaction on the committed temp pager so that we can read the pages back
+    BeginTempReadTx { temp_db: Box<VacuumTempDb> },
+    /// Initialize the source WAL header if needed (one-time before first batch).
+    /// Two IO steps: write the header, then fsync to set `initialized = true`.
+    InitSourceWalHeader {
+        temp_db: Box<VacuumTempDb>,
+        total_pages: u32,
+        /// The completion to wait on: first the header write, then the fsync.
+        completion: crate::io::Completion,
+        /// `false` while waiting for the header write, `true` while waiting for
+        /// the fsync from `prepare_wal_finish`.
+        fsync_phase: bool,
+    },
+    /// Read a batch of temp pages in using multi-inflight
+    /// `Wal::read_frames_batch` calls, one per contiguous frame-id run.
+    /// The state waits on a single `CompletionGroup` completion that
+    /// covers every run in the batch.
+    ReadTempBatch {
+        temp_db: Box<VacuumTempDb>,
+        total_pages: u32,
+        /// First page id NOT included in this batch (i.e., the page id
+        /// where the next batch will start, 1-based).
+        next_page: u32,
+        prev_prepared: Option<Box<crate::storage::wal::PreparedFrames>>,
+        /// Scratch buffer for `Wal::read_frames_batch`, sized to one full copy
+        /// batch and reused across copy-back batches when one frame run exactly
+        /// matches that size.
+        read_scratch_buf: Arc<Buffer>,
+        /// Pages for this batch, pre-allocated in logical page-id order.
+        batch_pages: Vec<PageRef>,
+        /// Aggregate completion for every run issued for this batch.
+        read_completion: Completion,
+    },
+    /// Write a prepared batch to the WAL file.
+    WriteWalBatch {
+        temp_db: Box<VacuumTempDb>,
+        total_pages: u32,
+        next_page: u32,
+        prev_prepared: Option<Box<crate::storage::wal::PreparedFrames>>,
+        read_scratch_buf: Arc<Buffer>,
+        completions: Vec<Completion>,
+    },
+    /// Fsync the WAL if sync mode requires it.
+    SyncSourceWal {
+        temp_db: Box<VacuumTempDb>,
+        sync_completion: crate::io::Completion,
+    },
+    /// Publish: commit_prepared_frames + finish_append_frames_commit, release
+    /// source WAL write/source snapshot state, keep the VACUUM lock, and drop
+    /// temp resources.
+    PublishWalCommit { temp_db: Box<VacuumTempDb> },
+    /// TRUNCATE checkpoint: copy WAL frames back into the DB file and truncate
+    /// the WAL to zero. The pager's internal state machine handles the multi-step
+    /// IO (backfill → sync DB → truncate WAL). Plain VACUUM requires this fold
+    /// to complete before reporting success.
+    Checkpoint,
+    /// Install the pre-captured replacement metadata (from `CaptureTargetMetadata`)
+    /// after the source image is committed, regardless of whether the final checkpoint succeeded.
+    InstallCommittedImage,
+    /// Clean up after successful commit.
+    Done,
+}
+
+impl Default for VacuumInPlacePhase {
+    fn default() -> Self {
+        Self::Preflight
+    }
+}
+
+/// Holds the context for the in-place VACUUM operation across async yields.
+pub(crate) struct VacuumInPlaceOpContext {
+    /// Database index being vacuumed.
+    db: usize,
+    /// Current phase for the in-place VACUUM operation.
+    phase: VacuumInPlacePhase,
+    /// Normalized schema/header snapshot for the new image that will
+    /// be published to the source DB. We capture it before source WAL publish so that
+    /// post-commit we can install it without reading from disk.
+    committed_image: Option<VacuumCommittedImageMeta>,
+    /// Independent cleanup flags that survive `std::mem::take` on `phase`.
+    cleanup_state: VacuumInPlaceCleanupState,
+}
+
+impl VacuumInPlaceOpContext {
+    pub(crate) fn new(db: usize) -> Self {
+        Self {
+            db,
+            phase: VacuumInPlacePhase::Preflight,
+            committed_image: None,
+            cleanup_state: VacuumInPlaceCleanupState::default(),
+        }
+    }
+
+    pub(crate) fn step(&mut self, connection: &Arc<Connection>) -> Result<InsnFunctionStepResult> {
+        vacuum_in_place_step(
+            connection,
+            self.db,
+            &mut self.phase,
+            &mut self.committed_image,
+            &mut self.cleanup_state,
+        )
+    }
+
+    pub(crate) fn cleanup(self, connection: &Arc<Connection>) -> Result<()> {
+        let Self {
+            db,
+            phase,
+            committed_image: _,
+            cleanup_state,
+        } = self;
+        vacuum_in_place_cleanup(connection, db, phase, cleanup_state)
+    }
+}
+
+/// The batch size for copy-back: how many temp pages to read per batch.
+const VACUUM_COPY_BATCH_SIZE: u32 = 64;
+
+/// Returns the first page number of the batch after the one that starts at `start_page`.
+/// The current batch covers the half-open range `[start_page, next_start)`,
+/// capped to at most `VACUUM_COPY_BATCH_SIZE` pages and never past `total_pages + 1`.
+///
+/// e.g. total_pages = 200, batch size = 64, start_page = 1
+///      current batch is [1, 65), next_start == 65
+///
+///    if the current batch is [193, 201), so pages 193..=200
+///    next_start == 201
+fn next_vacuum_copy_batch_start(start_page: u32, total_pages: u32) -> u32 {
+    turso_assert!(
+        start_page > 0,
+        "vacuum copy batch start page must be 1-based",
+        { "start_page": start_page, "total_pages": total_pages }
+    );
+    turso_assert!(
+        start_page <= total_pages,
+        "vacuum copy batch start must be inside database image",
+        { "start_page": start_page, "total_pages": total_pages }
+    );
+    turso_assert!(
+        total_pages < u32::MAX,
+        "vacuum copy batch requires a representable exclusive end page",
+        { "total_pages": total_pages }
+    );
+    start_page
+        .saturating_add(VACUUM_COPY_BATCH_SIZE)
+        .min(total_pages + 1)
+}
+
+fn vacuum_completion_error(completion: &Completion, context: &'static str) -> LimboError {
+    completion.get_error().map_or_else(
+        || LimboError::InternalError(format!("VACUUM: {context} failed")),
+        LimboError::CompletionError,
+    )
+}
+
+/// Coalesce `(page_ref, frame_id)` pairs into contiguous-frame-id runs.
+///
+/// Plain `VACUUM` relies on the temp-WAL-only invariant: every temp page
+/// lives in the temp WAL (auto-checkpoint is disabled on the temp
+/// connection), so for each logical page id we must get a frame id via
+/// `find_frame`. Sorting by `frame_id` before splitting into runs lets
+/// a single `pread` over a contiguous range serve many logical pages at once.
+///
+/// e.g. input pairs in logical page order:
+///   [(page1, 10), (page2, 11), (page3, 14), (page4, 15), (page5, 12)]
+///
+/// after sorting by `frame_id`:
+///   [(page1, 10), (page2, 11), (page5, 12), (page3, 14), (page4, 15)]
+///
+/// output runs:
+///   [(10, [page1, page2, page5]), (14, [page3, page4])]
+fn coalesce_frame_runs(mut pairs: Vec<(PageRef, u64)>) -> Vec<(u64, Vec<PageRef>)> {
+    let mut runs: Vec<(u64, Vec<PageRef>)> = Vec::new();
+    if pairs.is_empty() {
+        return runs;
+    }
+    pairs.sort_by_key(|(_, f)| *f);
+    let mut prev_frame_id = None;
+    for (page, frame_id) in pairs {
+        turso_assert!(frame_id > 0, "WAL frame ids must be 1-based");
+        if let Some(prev) = prev_frame_id {
+            // the current frame id must be greater than the previous one, since it is sorted
+            // however, if there are dupes, then following assertion would fail
+            turso_assert!(
+                frame_id > prev,
+                "VACUUM temp WAL frame ids must be unique",
+                { "previous_frame_id": prev, "frame_id": frame_id }
+            );
+        }
+        prev_frame_id = Some(frame_id);
+        if let Some((run_start, run_pages)) = runs.last_mut() {
+            let next_expected = *run_start + run_pages.len() as u64;
+            if frame_id == next_expected {
+                run_pages.push(page);
+                continue;
+            }
+        }
+        runs.push((frame_id, vec![page]));
+    }
+    runs
+}
+
+/// Start multi-inflight reads for one copy-back batch spanning logical
+/// pages `[batch_start, batch_end)`. Every page must be resident in the
+/// temp WAL (temp-WAL-only invariant). Returns the pre-allocated
+/// per-page `PageRef`s in logical page-id order plus the aggregate
+/// completion covering every run.
+fn start_temp_batch_reads(
+    temp_pager: &Pager,
+    batch_start: u32,
+    batch_end: u32,
+    scratch_buf: &Arc<Buffer>,
+) -> Result<(Vec<PageRef>, Completion)> {
+    turso_assert!(
+        batch_start < batch_end,
+        "empty vacuum read batch",
+        { "batch_start": batch_start, "batch_end": batch_end }
+    );
+    turso_assert!(
+        batch_start > 0,
+        "vacuum read batch start page must be 1-based",
+        { "batch_start": batch_start, "batch_end": batch_end }
+    );
+    turso_assert!(
+        batch_end - batch_start <= VACUUM_COPY_BATCH_SIZE,
+        "vacuum read batch exceeds configured copy batch size",
+        { "batch_start": batch_start, "batch_end": batch_end, "batch_size": VACUUM_COPY_BATCH_SIZE }
+    );
+    let wal = temp_pager
+        .wal
+        .as_ref()
+        .ok_or_else(|| LimboError::InternalError("VACUUM requires a temp WAL pager".into()))?;
+
+    let len = (batch_end - batch_start) as usize;
+    // todo: avoid doing allocation here, instead create a scratch buffer at caller and reuse it here
+    let mut logical_pages: Vec<PageRef> = Vec::with_capacity(len);
+    let mut pairs: Vec<(PageRef, u64)> = Vec::with_capacity(len);
+
+    for page_id in batch_start..batch_end {
+        let page: PageRef = Arc::new(Page::new(page_id as i64));
+        // todo: add find_frames at WAL where you can send batch of page ids and get all the frame ids
+        let frame_id = wal.find_frame(page_id as u64, None)?.ok_or_else(|| {
+            LimboError::InternalError(format!(
+                "VACUUM: page {page_id} not found in target WAL (WAL-only invariant violated)"
+            ))
+        })?;
+        logical_pages.push(page.clone());
+        pairs.push((page, frame_id));
+    }
+
+    // let's coalesce frame ids so that we can fetch maximum frames with a single pread
+    let runs = coalesce_frame_runs(pairs);
+
+    // Reuse the max-batch scratch buffer for one run whose read length matches
+    // exactly (the common case where target-build wrote a contiguous chunk of
+    // at least `VACUUM_COPY_BATCH_SIZE` pages).
+    let frame_size = temp_pager.get_page_size_unchecked().get() as usize + WAL_FRAME_HEADER_SIZE;
+    let scratch_total = frame_size * VACUUM_COPY_BATCH_SIZE as usize;
+    turso_assert!(
+        scratch_buf.len() == scratch_total,
+        "VACUUM scratch buffer size must match max-batch read size",
+        { "buf_len": scratch_buf.len(), "expected": scratch_total }
+    );
+
+    let mut group = CompletionGroup::new(|_| {});
+    let mut scratch_claimed = false;
+    for (start_frame, run_pages) in &runs {
+        let run_total = frame_size * run_pages.len();
+        // right now we only use the scratch buffer if it matches the run size
+        // todo: we should be able to split the scratch buffer and split it across runs
+        let run_scratch = if !scratch_claimed && run_total == scratch_total {
+            scratch_claimed = true;
+            Some(scratch_buf.clone())
+        } else {
+            None
+        };
+        let c = wal.read_frames_batch(
+            *start_frame,
+            run_pages,
+            temp_pager.buffer_pool.clone(),
+            run_scratch,
+        )?;
+        group.add(&c);
+    }
+    let combined = group.build();
+
+    Ok((logical_pages, combined))
+}
+
+fn new_vacuum_read_scratch_buf(temp_pager: &Pager) -> Arc<Buffer> {
+    let frame_size = temp_pager.get_page_size_unchecked().get() as usize + WAL_FRAME_HEADER_SIZE;
+    let scratch_total = frame_size * VACUUM_COPY_BATCH_SIZE as usize;
+    Arc::new(Buffer::new_temporary(scratch_total))
+}
+
+#[derive(Clone)]
+struct VacuumCommittedImageMeta {
+    header: DatabaseHeader,
+    schema: Arc<Schema>,
+}
+
+fn replace_shared_schema_after_vacuum(source_db: &Database, schema: Arc<Schema>) {
+    source_db
+        .with_schema_mut(|current| {
+            *current = schema.as_ref().clone();
+            Ok(())
+        })
+        .expect("VACUUM shared schema replacement should be infallible");
+}
+
+fn install_mvcc_state_after_vacuum_commit(
+    source_db: &Database,
+    mv_store: &MvStore,
+    header: DatabaseHeader,
+    schema: Arc<Schema>,
+) {
+    mv_store.reset_after_vacuum(header, schema.as_ref());
+    replace_shared_schema_after_vacuum(source_db, schema);
+}
+
+/// Capture the finalized replacement metadata from the temp target before the
+/// source WAL publish. Then once temp back pages are committed, we can just install this.
+fn capture_target_metadata(temp_db: &VacuumTempDb) -> Result<VacuumCommittedImageMeta> {
+    let temp_conn = &temp_db.conn;
+    let temp_pager = temp_conn.get_pager();
+    temp_pager.begin_read_tx()?;
+    temp_conn.set_tx_state(crate::connection::TransactionState::Read);
+
+    let capture_result = (|| {
+        let header = temp_pager
+            .io
+            .block(|| temp_pager.with_header(|header| *header))?;
+        temp_conn.reparse_schema_with_cookie(header.schema_cookie.get())?;
+        Ok(VacuumCommittedImageMeta {
+            header,
+            schema: temp_conn.schema.read().clone(),
+        })
+    })();
+
+    temp_pager.end_read_tx();
+    temp_conn.set_tx_state(crate::connection::TransactionState::None);
+    capture_result
+}
+
+/// Install the already-captured replacement schema/header after the source WAL
+/// publish. This must be infallible: the physical replacement image is already
+/// committed, so we only publish the precomputed metadata snapshot.
+fn install_committed_vacuum_image(
+    connection: &Arc<Connection>,
+    db: usize,
+    committed_image: &VacuumCommittedImageMeta,
+) {
+    let source_db = connection.get_source_database(db);
+    let schema = committed_image.schema.clone();
+    *connection.schema.write() = schema.clone();
+
+    if source_db.mvcc_enabled() {
+        let mv_store = source_db
+            .get_mv_store()
+            .as_ref()
+            .cloned()
+            .expect("MVCC database missing MV store during VACUUM metadata install");
+        install_mvcc_state_after_vacuum_commit(
+            source_db.as_ref(),
+            mv_store.as_ref(),
+            committed_image.header,
+            schema,
+        );
+    } else {
+        replace_shared_schema_after_vacuum(source_db.as_ref(), schema);
+    }
+}
+
+fn reload_physical_schema_for_mvcc_vacuum(
+    connection: &Arc<Connection>,
+    source_pager: &Pager,
+) -> Result<()> {
+    source_pager.begin_read_tx()?;
+    connection.set_tx_state(crate::connection::TransactionState::Read);
+
+    let reparse_result = connection.reparse_schema();
+
+    source_pager.end_read_tx();
+    connection.set_tx_state(crate::connection::TransactionState::None);
+
+    reparse_result
+}
+
+/// Step the in-place VACUUM state machine once. Returns `IO` to yield or `Step`
+/// when the entire operation is complete.
+///
+/// `cleanup_state` independently tracks which resources the opcode has acquired so
+/// that cleanup can roll back correctly
+fn vacuum_in_place_step(
+    connection: &Arc<Connection>,
+    db: usize,
+    phase: &mut VacuumInPlacePhase,
+    committed_image: &mut Option<VacuumCommittedImageMeta>,
+    cleanup_state: &mut VacuumInPlaceCleanupState,
+) -> Result<InsnFunctionStepResult> {
+    let source_pager = connection.get_pager_from_database_index(&db)?;
+
+    loop {
+        let current_phase = std::mem::take(phase);
+        match current_phase {
+            VacuumInPlacePhase::Preflight => {
+                // 1. Must be in auto-commit mode (no explicit transaction).
+                if !connection.auto_commit.load(Ordering::SeqCst) {
+                    return Err(LimboError::TxError(
+                        "cannot VACUUM from within a transaction".to_string(),
+                    ));
+                }
+                // 2. No other active root statements on this connection.
+                if connection.n_active_root_statements.load(Ordering::SeqCst) != 1 {
+                    return Err(LimboError::TxError(
+                        "cannot VACUUM - SQL statements in progress".to_string(),
+                    ));
+                }
+                // 3. Reject readonly database, well you cannot edit a readonly db ^_^
+                if connection.is_readonly(db) {
+                    return Err(LimboError::ReadOnly);
+                }
+                // 4. Resolve source database mode.
+                let source_db = connection.get_source_database(db);
+                let source_mvcc_enabled = source_db.mvcc_enabled();
+                // 5. Reject in-memory databases.
+                if source_db.is_in_memory_db() {
+                    return Err(LimboError::InternalError(
+                        "cannot VACUUM an in-memory database".to_string(),
+                    ));
+                }
+                reject_unsupported_vacuum_auto_vacuum_mode(source_pager.get_auto_vacuum_mode())?;
+                // 6. Reject non-WAL pagers.
+                let wal = source_pager.wal.as_ref().ok_or_else(|| {
+                    LimboError::InternalError("VACUUM requires a WAL-mode database".to_string())
+                })?;
+                // 7. In MVCC mode, hold the existing MVCC stop-the-world
+                // gate for the full VACUUM. Callers are expected to run MVCC
+                // checkpoint before VACUUM; this gate only enforces that no
+                // active or new MVCC transactions overlap the physical copy.
+                let mvcc_guard = if source_mvcc_enabled {
+                    let mv_store = source_db.get_mv_store().as_ref().cloned().ok_or_else(|| {
+                        LimboError::InternalError(
+                            "MVCC database missing MV store during VACUUM".to_string(),
+                        )
+                    })?;
+                    // acquire the exclusive lock on the mvcc
+                    let mut guard = MvccVacuumGuard::acquire(connection.clone(), mv_store.clone())?;
+                    if mv_store.has_uncheckpointed_log()? {
+                        return Err(LimboError::TxError(
+                            "cannot VACUUM an MVCC database with uncheckpointed changes; run PRAGMA wal_checkpoint(TRUNCATE) first".to_string(),
+                        ));
+                    }
+                    if connection.get_mv_tx_id_for_db(db).is_some() {
+                        turso_assert!(
+                            false,
+                            "VACUUM must not hold an MVCC transaction after acquiring gate"
+                        );
+                        return Err(LimboError::InternalError(
+                            "VACUUM acquired MVCC gate while this connection has an MVCC transaction"
+                                .to_string(),
+                        ));
+                    }
+                    guard.demote_connection();
+                    // After demotion this connection stops reading schema-cookie state from the
+                    // MV store and starts reading directly from the pager-backed DB image.
+                    // Let's be conservative, and reparse schema
+                    reload_physical_schema_for_mvcc_vacuum(connection, &source_pager)?;
+                    Some(guard)
+                } else {
+                    None
+                };
+                if let Some(mvcc_guard) = mvcc_guard {
+                    turso_assert!(
+                        cleanup_state.mvcc_guard.is_none(),
+                        "MVCC VACUUM cleanup state already owns a guard"
+                    );
+                    cleanup_state.mvcc_guard = Some(mvcc_guard);
+                }
+                // 9. Acquire the checkpoint serialization lock early. This
+                // ensures a post-commit TRUNCATE checkpoint won't fail due
+                // to a concurrent checkpointer. If the lock is unavailable
+                // we fail fast before doing any expensive work.
+                wal.try_begin_checkpoint_lock()?;
+                cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::ReleaseRaw;
+                *phase = VacuumInPlacePhase::BeginSourceTx;
+                continue;
+            }
+
+            VacuumInPlacePhase::BeginSourceTx => {
+                // Acquire exclusive WAL access in one shot:
+                // vacuum lock + WAL write lock + connection snapshot.
+                // Checkpoint lock was already acquired in Preflight.
+                match source_pager.begin_blocking_tx()? {
+                    crate::IOResult::Done(()) => {
+                        connection.auto_commit.store(false, Ordering::SeqCst);
+                        connection.set_tx_state(crate::connection::TransactionState::Write {
+                            schema_did_change: false,
+                        });
+                        cleanup_state.source_tx_open = true;
+                        cleanup_state.vacuum_lock_held = true;
+                        *phase = VacuumInPlacePhase::ReadSourceMetadata;
+                        continue;
+                    }
+                    crate::IOResult::IO(io) => {
+                        *phase = VacuumInPlacePhase::BeginSourceTx;
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                }
+            }
+
+            VacuumInPlacePhase::ReadSourceMetadata => {
+                turso_assert!(
+                    cleanup_state.checkpoint_cleanup == CheckpointLockCleanup::ReleaseRaw,
+                    "VACUUM source metadata phase requires held checkpoint lock"
+                );
+                turso_assert!(
+                    cleanup_state.source_tx_open,
+                    "VACUUM source metadata phase requires source exclusive snapshot"
+                );
+                let source_db = connection.get_source_database(db);
+
+                // Read page size from pager (cached after begin_read_tx).
+                let page_size = source_pager
+                    .get_page_size()
+                    .map(|ps| ps.get())
+                    .unwrap_or(PageSize::DEFAULT as u32);
+
+                // Read reserved bytes and header metadata in a single
+                // with_header call
+                let io = &*source_pager.io;
+                let (reserved_space, header_meta) = io.block(|| {
+                    source_pager.with_header(|h| {
+                        (h.reserved_space, VacuumDbHeaderMeta::from_source_header(h))
+                    })
+                })?;
+                // Create temp database.
+                let temp_db =
+                    open_vacuum_temp_db(connection, &source_db, page_size, reserved_space)?;
+
+                mirror_symbols(connection, &temp_db.conn);
+                let source_custom_types = capture_custom_types(connection, db);
+
+                let config = VacuumTargetBuildConfig {
+                    source_conn: connection.clone(),
+                    escaped_schema_name: "main".to_string(),
+                    source_db_id: db,
+                    header_meta,
+                    source_custom_types,
+                    target_mvcc_enabled: false,
+                    target_auto_vacuum_mode: source_pager.get_auto_vacuum_mode(),
+                    copy_mvcc_metadata_table: source_db.mvcc_enabled(),
+                };
+
+                let target_build_context = VacuumTargetBuildContext::new(temp_db.conn.clone());
+
+                *phase = VacuumInPlacePhase::TargetBuild {
+                    config: Box::new(config),
+                    temp_db: Box::new(temp_db),
+                    context: Box::new(target_build_context),
+                };
+                continue;
+            }
+
+            VacuumInPlacePhase::TargetBuild {
+                config,
+                temp_db,
+                mut context,
+            } => {
+                match vacuum_target_build_step(&config, &mut context)? {
+                    crate::IOResult::Done(()) => {
+                        // Temp build complete. Capture the finalized metadata
+                        // snapshot now, before we copy back the pages to main db
+                        *phase = VacuumInPlacePhase::CaptureTargetMetadata { temp_db };
+                        continue;
+                    }
+                    crate::IOResult::IO(io) => {
+                        *phase = VacuumInPlacePhase::TargetBuild {
+                            config,
+                            temp_db,
+                            context,
+                        };
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                }
+            }
+
+            VacuumInPlacePhase::CaptureTargetMetadata { temp_db } => {
+                *committed_image = Some(capture_target_metadata(&temp_db)?);
+                *phase = VacuumInPlacePhase::BeginTempReadTx { temp_db };
+                continue;
+            }
+
+            VacuumInPlacePhase::BeginTempReadTx { temp_db } => {
+                // The temp db build is now completed and it must have released its WAL read
+                // mark. So we start a fresh read snapshot on the committed temp image.
+                // so `Wal::find_frame` uses the committed temp-WAL frame set for copy-back.
+                let temp_pager = temp_db.conn.get_pager();
+                turso_assert!(
+                    !temp_pager.holds_read_lock(),
+                    "VACUUM temp COMMIT should release the temp WAL read lock"
+                );
+                temp_pager.begin_read_tx()?;
+
+                // one invariant is that temp db should have disabled checkpoints and all raeds
+                // must happen over WAL only. In that case, the db file should be same as the page
+                // size.
+                let temp_page_size = temp_pager.get_page_size_unchecked().get() as u64;
+                let temp_db_file_size = temp_pager.db_file.size()?;
+                turso_assert_eq!(
+                    temp_db_file_size,
+                    temp_page_size,
+                    "VACUUM temp DB file must contain only page 1; compacted pages must remain in temp WAL",
+                    {
+                        "temp_db_file_size": temp_db_file_size,
+                        "temp_page_size": temp_page_size
+                    }
+                );
+
+                // Determine the compacted image size from temp page 1 header.
+                let io = &*temp_pager.io;
+                let total_pages: u32 =
+                    io.block(|| temp_pager.with_header(|h| h.database_size.get()))?;
+                let wal = source_pager
+                    .wal
+                    .as_ref()
+                    .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
+
+                turso_assert!(
+                    total_pages > 0,
+                    "VACUUM target build must produce at least page 1 in the committed temp image"
+                );
+
+                // Initialize the source WAL header before the first batch.
+                let page_sz = source_pager.get_page_size_unchecked();
+
+                if let Some(header_write_c) = wal.prepare_wal_start(page_sz)? {
+                    // WAL not yet initialized — yield on the header write.
+                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
+                        temp_db,
+                        total_pages,
+                        completion: header_write_c,
+                        fsync_phase: false,
+                    };
+                    continue;
+                }
+
+                // WAL already initialized — kick off the first read batch.
+                let temp_pager = temp_db.conn.get_pager();
+                let batch_end = next_vacuum_copy_batch_start(1, total_pages);
+                let read_scratch_buf = new_vacuum_read_scratch_buf(&temp_pager);
+                let (batch_pages, read_completion) =
+                    start_temp_batch_reads(&temp_pager, 1, batch_end, &read_scratch_buf)?;
+
+                *phase = VacuumInPlacePhase::ReadTempBatch {
+                    temp_db,
+                    total_pages,
+                    next_page: batch_end,
+                    prev_prepared: None,
+                    read_scratch_buf,
+                    batch_pages,
+                    read_completion,
+                };
+                continue;
+            }
+
+            VacuumInPlacePhase::InitSourceWalHeader {
+                temp_db,
+                total_pages,
+                completion,
+                fsync_phase,
+            } => {
+                if !completion.finished() {
+                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
+                        temp_db,
+                        total_pages,
+                        completion: completion.clone(),
+                        fsync_phase,
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
+                        completion,
+                    )));
+                }
+                if !completion.succeeded() {
+                    return Err(vacuum_completion_error(&completion, "WAL header init"));
+                }
+
+                if !fsync_phase {
+                    // Header write done — issue the fsync via prepare_wal_finish
+                    // to set WAL `initialized = true`.
+                    let wal = source_pager.wal.as_ref().unwrap();
+                    let sync_c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
+                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
+                        temp_db,
+                        total_pages,
+                        completion: sync_c,
+                        fsync_phase: true,
+                    };
+                    continue;
+                }
+
+                // WAL header fully initialized. Kick off the first read batch.
+                let temp_pager = temp_db.conn.get_pager();
+                let batch_end = next_vacuum_copy_batch_start(1, total_pages);
+                let read_scratch_buf = new_vacuum_read_scratch_buf(&temp_pager);
+                let (batch_pages, read_completion) =
+                    start_temp_batch_reads(&temp_pager, 1, batch_end, &read_scratch_buf)?;
+
+                *phase = VacuumInPlacePhase::ReadTempBatch {
+                    temp_db,
+                    total_pages,
+                    next_page: batch_end,
+                    prev_prepared: None,
+                    read_scratch_buf,
+                    batch_pages,
+                    read_completion,
+                };
+                continue;
+            }
+
+            VacuumInPlacePhase::ReadTempBatch {
+                temp_db,
+                total_pages,
+                next_page,
+                prev_prepared,
+                read_scratch_buf,
+                batch_pages,
+                read_completion,
+            } => {
+                turso_assert!(
+                    total_pages < u32::MAX,
+                    "VACUUM read batch requires a representable exclusive end page",
+                    { "total_pages": total_pages }
+                );
+                let database_end = total_pages + 1;
+                turso_assert!(
+                    !batch_pages.is_empty(),
+                    "VACUUM read batch must contain pages"
+                );
+                turso_assert!(
+                    batch_pages.len() as u32 <= VACUUM_COPY_BATCH_SIZE,
+                    "VACUUM read batch exceeds configured copy batch size",
+                    { "batch_pages": batch_pages.len(), "batch_size": VACUUM_COPY_BATCH_SIZE }
+                );
+                turso_assert!(
+                    next_page > 1 && next_page <= database_end,
+                    "VACUUM read batch next page is outside database image",
+                    { "next_page": next_page, "total_pages": total_pages }
+                );
+                // Wait for every run in this batch to finish.
+                if !read_completion.finished() {
+                    *phase = VacuumInPlacePhase::ReadTempBatch {
+                        temp_db,
+                        total_pages,
+                        next_page,
+                        prev_prepared,
+                        read_scratch_buf,
+                        batch_pages,
+                        read_completion: read_completion.clone(),
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
+                        read_completion,
+                    )));
+                }
+                if !read_completion.succeeded() {
+                    return Err(vacuum_completion_error(&read_completion, "temp batch read"));
+                }
+
+                // All pages in this batch are loaded. Prepare WAL frames.
+                for page in &batch_pages {
+                    turso_assert!(
+                        page.is_loaded(),
+                        "VACUUM read batch page must be loaded before WAL prepare",
+                        { "page_id": page.get().id }
+                    );
+                    turso_assert!(
+                        !page.is_locked(),
+                        "VACUUM read batch page lock leaked before WAL prepare",
+                        { "page_id": page.get().id }
+                    );
+                }
+                let all_read = next_page > total_pages;
+                let wal = source_pager
+                    .wal
+                    .as_ref()
+                    .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
+                let page_sz = source_pager.get_page_size_unchecked();
+
+                let db_size_on_commit = if all_read { Some(total_pages) } else { None };
+
+                let prepared = wal.prepare_frames(
+                    &batch_pages,
+                    page_sz,
+                    db_size_on_commit,
+                    prev_prepared.as_deref(),
+                )?;
+
+                // Submit writes via WriteBatch.
+                let wal_file = wal.wal_file()?;
+                let mut batch = IOWriteBatch::new(wal_file);
+                batch.writev(prepared.offset, &prepared.bufs);
+                let completions = batch.submit()?;
+
+                *phase = VacuumInPlacePhase::WriteWalBatch {
+                    temp_db,
+                    total_pages,
+                    next_page,
+                    prev_prepared: Some(Box::new(prepared)),
+                    read_scratch_buf,
+                    completions,
+                };
+                continue;
+            }
+
+            VacuumInPlacePhase::WriteWalBatch {
+                temp_db,
+                total_pages,
+                next_page,
+                prev_prepared,
+                read_scratch_buf,
+                completions,
+            } => {
+                let database_end = total_pages + 1;
+                turso_assert!(
+                    prev_prepared.is_some(),
+                    "VACUUM WAL write batch requires prepared frames"
+                );
+                turso_assert!(
+                    !completions.is_empty(),
+                    "VACUUM WAL write batch requires write completions"
+                );
+                turso_assert!(
+                    next_page > 1 && next_page <= database_end,
+                    "VACUUM WAL write batch next page is outside database image",
+                    { "next_page": next_page, "total_pages": total_pages }
+                );
+                // Wait for all writes in this batch. We yield on the first
+                // unfinished completion; re-entry will re-check them all.
+                let pending = completions.iter().find(|c| !c.finished()).cloned();
+                if let Some(pending) = pending {
+                    *phase = VacuumInPlacePhase::WriteWalBatch {
+                        temp_db,
+                        total_pages,
+                        next_page,
+                        prev_prepared,
+                        read_scratch_buf,
+                        completions,
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(pending)));
+                }
+
+                // Check for write errors.
+                for c in &completions {
+                    if !c.succeeded() {
+                        return Err(vacuum_completion_error(c, "WAL write"));
+                    }
+                }
+
+                // The batch write has finished, so advance the source WAL's
+                // connection-local state now. `finish_append_frames_commit()`
+                // later publishes `max_frame` and the rolling checksum from
+                // the WAL object itself, so each completed batch must first be
+                // reflected in the local page->frame cache, max_frame, and
+                // checksum state.
+                //
+                // Skip `finalize_committed_pages()`: these PageRefs came from
+                // the temp pager, not the source pager's cache. They carry no
+                // source-cache dirty state or WAL tags to update, and the
+                // source page cache is invalidated wholesale in Publish.
+                let wal = source_pager.wal.as_ref().unwrap();
+                let prepared = prev_prepared.as_ref().unwrap();
+                wal.commit_prepared_frames(std::slice::from_ref(prepared.as_ref()));
+
+                // More pages to copy?
+                if next_page <= total_pages {
+                    // Kick off the next read batch in parallel.
+                    let temp_pager = temp_db.conn.get_pager();
+                    let batch_end = next_vacuum_copy_batch_start(next_page, total_pages);
+                    let (batch_pages, read_completion) = start_temp_batch_reads(
+                        &temp_pager,
+                        next_page,
+                        batch_end,
+                        &read_scratch_buf,
+                    )?;
+
+                    *phase = VacuumInPlacePhase::ReadTempBatch {
+                        temp_db,
+                        total_pages,
+                        next_page: batch_end,
+                        prev_prepared,
+                        read_scratch_buf,
+                        batch_pages,
+                        read_completion,
+                    };
+                    continue;
+                }
+
+                // All pages written. Fsync WAL if sync mode requires it.
+                // NORMAL mode skips fsync on WAL commit (fsyncs happen on
+                // checkpoint and WAL restart instead). This matches the regular
+                // pager commit path in Pager::commit_tx / CommitState.
+                let sync_mode = connection.get_sync_mode();
+                if sync_mode == SyncMode::Full {
+                    let sync_c = wal.sync(source_pager.get_sync_type())?;
+                    *phase = VacuumInPlacePhase::SyncSourceWal {
+                        temp_db,
+                        sync_completion: sync_c,
+                    };
+                    continue;
+                }
+
+                // No sync needed — proceed directly to publish.
+                *phase = VacuumInPlacePhase::PublishWalCommit { temp_db };
+                continue;
+            }
+
+            VacuumInPlacePhase::SyncSourceWal {
+                temp_db,
+                sync_completion,
+            } => {
+                if !sync_completion.finished() {
+                    *phase = VacuumInPlacePhase::SyncSourceWal {
+                        temp_db,
+                        sync_completion: sync_completion.clone(),
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
+                        sync_completion,
+                    )));
+                }
+                if !sync_completion.succeeded() {
+                    return Err(vacuum_completion_error(&sync_completion, "WAL fsync"));
+                }
+                *phase = VacuumInPlacePhase::PublishWalCommit { temp_db };
+                continue;
+            }
+
+            VacuumInPlacePhase::PublishWalCommit { temp_db } => {
+                turso_assert!(
+                    cleanup_state.checkpoint_cleanup == CheckpointLockCleanup::ReleaseRaw,
+                    "VACUUM publish phase requires held checkpoint lock"
+                );
+                turso_assert!(
+                    cleanup_state.source_tx_open,
+                    "VACUUM publish phase requires source exclusive snapshot"
+                );
+                let wal = source_pager
+                    .wal
+                    .as_ref()
+                    .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
+
+                // Publish the copied frames as a committed WAL transaction in the source db.
+                // After this point the source write transaction is committed and visible
+                // through WAL coordination state, so must no longer treat the source write transaction
+                // as abortable via `pager.rollback_tx(connection)`; it may only release remaining
+                // locks/state and continue with checkpoint/schema reload handling.
+                wal.finish_append_frames_commit()?;
+
+                source_pager.end_write_tx();
+                cleanup_state.source_tx_open = false;
+
+                // Restore connection bookkeeping immediately. The commit is
+                // durable so there is nothing to roll back; restoring here
+                // means the connection is never left poisoned even if the
+                // checkpoint or schema reload below fails.
+                connection.auto_commit.store(true, Ordering::SeqCst);
+                connection.set_tx_state(crate::connection::TransactionState::None);
+
+                // Invalidate page cache and schema cookie so fresh reads see
+                // the newly committed WAL frames.
+                source_pager.clear_page_cache(false);
+                source_pager.set_schema_cookie(None);
+
+                // Drop temp resources before checkpoint.
+                drop(temp_db);
+
+                *phase = VacuumInPlacePhase::Checkpoint;
+                continue;
+            }
+
+            VacuumInPlacePhase::Checkpoint => {
+                // TRUNCATE checkpoint: copy WAL frames into the DB file,
+                // force a durable DB sync, then truncate the WAL to zero
+                // bytes. It is possible that user might have set sync to normal/off, but we
+                // must force fsync on db
+                if cleanup_state.checkpoint_cleanup == CheckpointLockCleanup::ReleaseRaw {
+                    cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::AbortCheckpoint;
+                }
+                match source_pager.checkpoint_with_held_checkpoint_lock(
+                    crate::storage::wal::CheckpointMode::Truncate {
+                        upper_bound_inclusive: None,
+                    },
+                    SyncMode::Full,
+                    true,
+                ) {
+                    Ok(crate::IOResult::Done(result)) => {
+                        cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::None;
+                        turso_assert!(
+                            result.should_truncate(),
+                            "VACUUM TRUNCATE checkpoint must fully backfill on success",
+                            {
+                                "wal_max_frame": result.wal_max_frame,
+                                "wal_total_backfilled": result.wal_total_backfilled,
+                                "wal_checkpoint_backfilled": result.wal_checkpoint_backfilled
+                            }
+                        );
+                        if cleanup_state.vacuum_lock_held {
+                            let wal = source_pager.wal.as_ref().ok_or_else(|| {
+                                LimboError::InternalError("VACUUM requires WAL".into())
+                            })?;
+                            wal.release_vacuum_lock();
+                            cleanup_state.vacuum_lock_held = false;
+                        }
+                        *phase = VacuumInPlacePhase::InstallCommittedImage;
+                        continue;
+                    }
+                    Ok(crate::IOResult::IO(io)) => {
+                        *phase = VacuumInPlacePhase::Checkpoint;
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                    Err(err) => {
+                        tracing::error!("VACUUM post-commit checkpoint failed: {err}");
+                        source_pager.cleanup_after_checkpoint_failure();
+                        cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::None;
+                        let committed_image = committed_image.as_ref().expect(
+                            "VACUUM checkpoint failure after publish requires captured metadata",
+                        );
+                        install_committed_vacuum_image(connection, db, committed_image);
+                        if cleanup_state.vacuum_lock_held {
+                            if let Some(wal) = source_pager.wal.as_ref() {
+                                wal.release_vacuum_lock();
+                                cleanup_state.vacuum_lock_held = false;
+                            }
+                        }
+                        return Err(err);
+                    }
+                }
+            }
+
+            VacuumInPlacePhase::InstallCommittedImage => {
+                let committed_image = committed_image
+                    .as_ref()
+                    .expect("VACUUM metadata install requires captured committed image");
+                install_committed_vacuum_image(connection, db, committed_image);
+                drop(cleanup_state.mvcc_guard.take());
+
+                *phase = VacuumInPlacePhase::Done;
+                return Ok(InsnFunctionStepResult::Step);
+            }
+
+            VacuumInPlacePhase::Done => {
+                return Ok(InsnFunctionStepResult::Step);
+            }
+        }
+    }
+}
+
+/// Roll back the source transaction and restore connection state after an
+/// in-place VACUUM failure. Uses `cleanup_state` to decide what to undo; this
+/// state is independent of the phase enum and survives `std::mem::take`.
+///
+/// `phase` is taken by value so helper statements inside `TargetBuild` are
+/// dropped before we attempt `rollback_tx`. This
+/// avoids the nestedness suppression bug where live helper statements keep
+/// `Connection::nestedness > 0`, making `rollback_tx` a no-op.
+fn vacuum_in_place_cleanup(
+    connection: &Arc<Connection>,
+    db: usize,
+    mut phase: VacuumInPlacePhase,
+    mut cleanup_state: VacuumInPlaceCleanupState,
+) -> Result<()> {
+    if let VacuumInPlacePhase::TargetBuild { context, .. } = &mut phase {
+        context.cleanup_after_error()?;
+    }
+
+    match cleanup_state.checkpoint_cleanup {
+        CheckpointLockCleanup::ReleaseRaw => {
+            let pager = connection
+                .get_pager_from_database_index(&db)
+                .expect("VACUUM cleanup requires source pager");
+            if let Some(wal) = pager.wal.as_ref() {
+                wal.release_checkpoint_lock();
+            }
+        }
+        CheckpointLockCleanup::AbortCheckpoint => {
+            let pager = connection
+                .get_pager_from_database_index(&db)
+                .expect("VACUUM cleanup requires source pager");
+            pager.cleanup_after_checkpoint_failure();
+        }
+        CheckpointLockCleanup::None => {}
+    }
+
+    // No source transaction to undo. Any raw locks are still released below.
+    if !cleanup_state.source_tx_open {
+        if cleanup_state.vacuum_lock_held {
+            let pager = connection
+                .get_pager_from_database_index(&db)
+                .expect("VACUUM cleanup requires source pager");
+            if let Some(wal) = pager.wal.as_ref() {
+                wal.release_vacuum_lock();
+            }
+        }
+        drop(cleanup_state.mvcc_guard.take());
+        return Ok(());
+    }
+
+    // Drop the phase first to release any target-build helper statements.
+    // Their Drop impls decrement Connection::nestedness, which must happen
+    // before rollback_tx (which is a no-op while nested).
+    drop(phase);
+
+    // Write transaction open but not yet committed — roll back.
+    let pager = connection
+        .get_pager_from_database_index(&db)
+        .expect("VACUUM cleanup requires source pager");
+    pager.rollback_tx(connection);
+
+    if cleanup_state.vacuum_lock_held {
+        let pager = connection
+            .get_pager_from_database_index(&db)
+            .expect("VACUUM cleanup requires source pager");
+        if let Some(wal) = pager.wal.as_ref() {
+            wal.release_vacuum_lock();
+        }
+    }
+
+    connection.auto_commit.store(true, Ordering::SeqCst);
+    connection.set_tx_state(crate::connection::TransactionState::None);
+    drop(cleanup_state.mvcc_guard.take());
+    Ok(())
 }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2,10 +2,13 @@ use std::sync::Arc;
 
 use crate::error::LimboError;
 use crate::schema::TypeDef;
-use crate::types::IOResult;
+use crate::storage::pager::AutoVacuumMode;
+use crate::storage::sqlite3_ondisk::{CacheSize, DatabaseHeader, RawVersion, TextEncoding};
+use crate::util::IOExt;
+use crate::vdbe::execute::InsnFunctionStepResult;
 use crate::Result;
-use crate::{Connection, Database};
-use turso_macros::turso_assert;
+use crate::{Connection, Database, DatabaseOpts, EncryptionOpts, OpenFlags};
+use turso_macros::{turso_assert, turso_assert_eq};
 
 /// A representation of a row from `sqlite_schema`.
 ///
@@ -98,7 +101,7 @@ pub(crate) fn classify_schema_entries(
                 // All storage-backed tables get their data copied, including
                 // sqlite_stat1 and other internal storage-backed tables.
                 // sqlite_sequence data copy is handled specially by the caller
-                // (only if destination materialized it).
+                // (only if the target materialized it).
                 tables_to_copy.push(idx);
             }
             SchemaEntryType::Index if entry.is_storage_backed() => {
@@ -141,74 +144,265 @@ pub(crate) fn classify_schema_entries(
     )
 }
 
-/// Configuration for the VACUUM INTO engine. Provided by the caller (opcode
-/// handler) after reading source metadata and setting up the destination DB.
-pub(crate) struct VacuumIntoConfig {
-    /// Source connection - used for `prepare_internal` and `with_schema` during
-    /// schema collection and data copy.
+/// Target database feature flags needed for schema replay during a vacuum build.
+pub(crate) fn vacuum_target_opts_from_source(source_db: &Database) -> DatabaseOpts {
+    DatabaseOpts::new()
+        .with_views(source_db.experimental_views_enabled())
+        .with_index_method(source_db.experimental_index_method_enabled())
+        .with_custom_types(source_db.experimental_custom_types_enabled())
+        .with_encryption(source_db.experimental_encryption_enabled())
+        .with_autovacuum(source_db.experimental_autovacuum_enabled())
+        .with_attach(source_db.experimental_attach_enabled())
+        .with_generated_columns(source_db.experimental_generated_columns_enabled())
+}
+
+pub(crate) fn reject_unsupported_vacuum_auto_vacuum_mode(mode: AutoVacuumMode) -> Result<()> {
+    if matches!(mode, AutoVacuumMode::Incremental) {
+        return Err(LimboError::InternalError(
+            "Incremental auto-vacuum is not supported".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Database header metadata that the target build must finalize before commit.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct VacuumDbHeaderMeta {
+    read_version: RawVersion,
+    write_version: RawVersion,
+    schema_cookie: u32,
+    default_page_cache_size: CacheSize,
+    text_encoding: TextEncoding,
+    user_version: i32,
+    application_id: i32,
+}
+
+impl VacuumDbHeaderMeta {
+    pub(crate) fn from_source_header(source: &DatabaseHeader) -> Self {
+        Self {
+            read_version: source.read_version,
+            write_version: source.write_version,
+            schema_cookie: source.schema_cookie.get().wrapping_add(1),
+            default_page_cache_size: source.default_page_cache_size,
+            text_encoding: source.text_encoding,
+            user_version: source.user_version.get(),
+            application_id: source.application_id.get(),
+        }
+    }
+
+    fn apply_to(self, header: &mut DatabaseHeader) {
+        header.read_version = self.read_version;
+        header.write_version = self.write_version;
+        header.schema_cookie = self.schema_cookie.into();
+        header.default_page_cache_size = self.default_page_cache_size;
+        header.text_encoding = self.text_encoding;
+        header.user_version = self.user_version.into();
+        header.application_id = self.application_id.into();
+    }
+}
+
+/// File-backed internal temp database used by in-place `VACUUM`.
+///
+/// The temp directory is dropped after the connection and database handles so
+/// host files can be closed before the directory cleanup runs.
+pub(crate) struct VacuumTempDb {
+    pub conn: Arc<Connection>,
+    _db: Arc<Database>,
+    #[cfg(test)]
+    path: String,
+    #[cfg(not(target_family = "wasm"))]
+    _temp_dir: tempfile::TempDir,
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn vacuum_temp_db_encryption(
+    source_conn: &Arc<Connection>,
+) -> Result<(Option<EncryptionOpts>, Option<crate::EncryptionKey>)> {
+    let Some(cipher_mode) = source_conn.get_encryption_cipher_mode() else {
+        return Ok((None, None));
+    };
+    let encryption_key = source_conn.encryption_key.read().clone().ok_or_else(|| {
+        LimboError::InternalError(
+            "encrypted in-place VACUUM temp database requires source encryption key".to_string(),
+        )
+    })?;
+    let encryption_opts = EncryptionOpts {
+        cipher: cipher_mode.to_string(),
+        hexkey: hex::encode(encryption_key.as_slice()),
+    };
+    Ok((Some(encryption_opts), Some(encryption_key)))
+}
+
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn open_vacuum_temp_db(
+    source_conn: &Arc<Connection>,
+    source_db: &Arc<Database>,
+    page_size: u32,
+    reserved_space: u8,
+) -> Result<VacuumTempDb> {
+    // todo: let users specify the temp dir path
+    let temp_dir = tempfile::tempdir().map_err(|e| crate::error::io_error(e, "tempdir"))?;
+    let source_db_name = std::path::Path::new(&source_db.path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("tursodb_vacuum_temp.db");
+    // all temp files we will prefix with `etilqs_` as an homage to SQLite's lore
+    let path = temp_dir.path().join(format!("etilqs_{source_db_name}"));
+    let path = path
+        .to_str()
+        .ok_or_else(|| LimboError::InternalError("vacuum temp path is not valid UTF-8".into()))?
+        .to_string();
+    #[cfg(test)]
+    let test_path = path.clone();
+
+    let (encryption_opts, encryption_key) = vacuum_temp_db_encryption(source_conn)?;
+    let db = Database::open_file_with_flags(
+        source_db.io.clone(),
+        &path,
+        OpenFlags::Create,
+        vacuum_target_opts_from_source(source_db),
+        encryption_opts,
+    )?;
+    let conn = db.connect_with_encryption(encryption_key)?;
+    conn.reset_page_size(page_size)?;
+    conn.set_reserved_bytes(reserved_space)?;
+    conn.wal_auto_checkpoint_disable();
+
+    Ok(VacuumTempDb {
+        conn,
+        _db: db,
+        #[cfg(test)]
+        path: test_path,
+        _temp_dir: temp_dir,
+    })
+}
+
+#[cfg(target_family = "wasm")]
+pub(crate) fn open_vacuum_temp_db(
+    _source_conn: &Arc<Connection>,
+    _source_db: &Arc<Database>,
+    _page_size: u32,
+    _reserved_space: u8,
+) -> Result<VacuumTempDb> {
+    Err(LimboError::InternalError(
+        "in-place VACUUM requires a file-backed internal temp database".to_string(),
+    ))
+}
+
+fn finalize_vacuum_target_header(
+    target_conn: &Arc<Connection>,
+    header_meta: &VacuumDbHeaderMeta,
+) -> Result<crate::IOResult<()>> {
+    if let Some(mv_store) = target_conn.mv_store_for_db(crate::MAIN_DB_ID) {
+        let tx_id = target_conn.get_mv_tx_id_for_db(crate::MAIN_DB_ID);
+        return mv_store
+            .with_header_mut(|header| header_meta.apply_to(header), tx_id.as_ref())
+            .map(crate::IOResult::Done);
+    }
+    let pager = target_conn.pager.load();
+    pager.with_header_mut(|header| header_meta.apply_to(header))
+}
+
+/// Finish a VACUUM INTO output database with durable on-disk state.
+///
+/// Target build runs with `synchronous=OFF` for speed, so its commit alone is
+/// not the durability boundary. Before reporting success, VACUUM INTO forces a
+/// final TRUNCATE checkpoint under `SyncMode::Full` so the destination's main
+/// database file is self-contained and synced.
+pub(crate) fn finalize_vacuum_into_output(target: &VacuumTargetBuildContext) -> Result<()> {
+    target.target_conn.set_sync_mode(crate::SyncMode::Full);
+    target
+        .target_conn
+        .checkpoint(crate::CheckpointMode::Truncate {
+            upper_bound_inclusive: None,
+        })?;
+    Ok(())
+}
+
+/// Copy functions, vtab modules, and index methods from one connection to
+/// another so that schema replay on the target sees the same symbols as
+/// the source.
+pub(crate) fn mirror_symbols(source: &Connection, target: &Connection) {
+    let source_syms = source.syms.read();
+    let mut target_syms = target.syms.write();
+    target_syms.functions.extend(
+        source_syms
+            .functions
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+    target_syms.vtab_modules.extend(
+        source_syms
+            .vtab_modules
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+    target_syms.index_methods.extend(
+        source_syms
+            .index_methods
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+}
+
+/// Capture non-builtin custom type definitions from the source schema.
+pub(crate) fn capture_custom_types(
+    source: &Connection,
+    db_id: usize,
+) -> Vec<(String, Arc<TypeDef>)> {
+    source.with_schema(db_id, |schema| {
+        schema
+            .type_registry
+            .iter()
+            .filter(|(_, td)| !td.is_builtin)
+            .map(|(name, td)| (name.clone(), td.clone()))
+            .collect()
+    })
+}
+
+/// Configuration for building a compacted vacuum target database.
+/// Callers must mirror source symbols (functions, vtab modules, index methods)
+/// directly into the target connection before starting the state machine.
+pub(crate) struct VacuumTargetBuildConfig {
     pub source_conn: Arc<Connection>,
     /// Escaped schema name for safe SQL interpolation (e.g. `"main"`).
     pub escaped_schema_name: String,
     /// Database index for schema lookups on the source connection.
-    pub database_id: usize,
-    /// Source `user_version` pragma value to copy to destination.
-    pub source_user_version: i32,
-    /// Source `application_id` pragma value to copy to destination.
-    pub source_application_id: i32,
+    pub source_db_id: usize,
+    /// Database header metadata to write before committing the target database.
+    pub header_meta: VacuumDbHeaderMeta,
     /// Pre-captured source custom type definitions for STRICT table replay.
     pub source_custom_types: Vec<(String, Arc<TypeDef>)>,
-    /// Whether the source database has MVCC enabled.
-    pub source_mvcc_enabled: bool,
+    /// Whether the target database should be placed in MVCC journal mode.
+    pub target_mvcc_enabled: bool,
+    /// Auto-vacuum mode to use while rebuilding the target image.
+    pub target_auto_vacuum_mode: AutoVacuumMode,
+    /// Whether to copy the source MVCC metadata table into the target image.
+    pub copy_mvcc_metadata_table: bool,
 }
 
-pub(crate) struct VacuumInto {
-    config: VacuumIntoConfig,
-    state: VacuumIntoState,
-}
-
-impl VacuumInto {
-    pub fn new(
-        config: VacuumIntoConfig,
-        dest_db: Arc<Database>,
-        dest_conn: Arc<Connection>,
-    ) -> Self {
-        Self {
-            config,
-            state: VacuumIntoState::new(dest_db, dest_conn),
-        }
-    }
-
-    pub fn step(&mut self) -> Result<IOResult<()>> {
-        vacuum_into_step(&self.config, &mut self.state)
-    }
-}
-
-/// State for the VACUUM INTO engine. Holds the destination connection and all
+/// Context for the vacuum target build. Holds the target connection and all
 /// intermediate state needed across async yields.
-struct VacuumIntoState {
-    /// Keep the destination database alive while VACUUM INTO is in progress.
-    #[allow(dead_code)]
-    dest_db: Arc<Database>,
-    dest_conn: Arc<Connection>,
-    sub_state: VacuumIntoSubState,
+pub(crate) struct VacuumTargetBuildContext {
+    target_conn: Arc<Connection>,
+    phase: VacuumTargetBuildPhase,
     /// Typed schema entries collected from sqlite_schema, ordered by rowid.
     schema_entries: Vec<SchemaEntry>,
     /// Storage-backed tables to CREATE (excludes sqlite_sequence).
     tables_to_create: Vec<usize>,
     /// Storage-backed tables whose data to copy.
     tables_to_copy: Vec<usize>,
-    /// User-defined secondary indexes to CREATE.
+    /// User-defined secondary indexes to CREATE
     indexes_to_create: Vec<usize>,
-    /// Triggers, views, custom indexes, and rootpage = 0 objects.
+    /// Triggers, views, and rootpage = 0 objects
     post_data_entries: Vec<usize>,
 }
 
-impl VacuumIntoState {
-    fn new(dest_db: Arc<Database>, dest_conn: Arc<Connection>) -> Self {
+impl VacuumTargetBuildContext {
+    pub fn new(target_conn: Arc<Connection>) -> Self {
         Self {
-            dest_db,
-            dest_conn,
-            sub_state: VacuumIntoSubState::Init,
+            target_conn,
+            phase: VacuumTargetBuildPhase::Init,
             schema_entries: Vec::new(),
             tables_to_create: Vec::new(),
             tables_to_copy: Vec::new(),
@@ -216,163 +410,173 @@ impl VacuumIntoState {
             post_data_entries: Vec::new(),
         }
     }
+
+    pub(crate) fn cleanup_after_error(&mut self) -> Result<()> {
+        self.phase = VacuumTargetBuildPhase::Done;
+        if !self.target_conn.get_auto_commit() {
+            // Target-build connections are disposable. On error we only need to
+            // unwind connection-local transaction state before the caller drops
+            // the target database handle.
+            let pager = self.target_conn.pager.load();
+            self.target_conn.rollback_manual_txn_cleanup(&pager, true);
+        }
+        Ok(())
+    }
 }
 
-/// Sub-states for the VACUUM INTO engine state machine.
+/// Phases for the vacuum target build state machine.
 #[derive(Default)]
-enum VacuumIntoSubState {
-    /// Mirror symbols/types, set perf flags, begin dest tx, prepare schema query.
+pub(crate) enum VacuumTargetBuildPhase {
+    /// Mirror symbols/types, set perf flags, begin target tx, prepare schema query.
     #[default]
     Init,
     /// Step through schema query to collect rows
     CollectSchemaRows { schema_stmt: Box<crate::Statement> },
-    /// Prepare CREATE TABLE statement on destination (idx into tables_to_create)
+    /// Prepare CREATE TABLE statement on the target (idx into tables_to_create)
     PrepareCreateTable { idx: usize },
-    /// Step through CREATE TABLE statement on destination (async)
+    /// Step through CREATE TABLE statement on the target (async)
     StepCreateTable {
-        dest_schema_stmt: Box<crate::Statement>,
+        target_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
     /// Start copying a table's data
     StartCopyTable { table_idx: usize },
-    /// Select rows from source table and insert into destination
+    /// Select rows from source table and insert into the target.
     CopyRows {
         select_stmt: Box<crate::Statement>,
-        dest_insert_stmt: Box<crate::Statement>,
+        target_insert_stmt: Box<crate::Statement>,
         table_idx: usize,
     },
-    /// Step through INSERT statement on destination
-    StepDestInsert {
+    /// Step through INSERT statement on the target.
+    StepTargetInsert {
         select_stmt: Box<crate::Statement>,
-        dest_insert_stmt: Box<crate::Statement>,
+        target_insert_stmt: Box<crate::Statement>,
         table_idx: usize,
     },
-    /// Copy meta values (user_version, application_id) from source to destination
-    CopyMetaValues,
-    /// Prepare CREATE INDEX statement on destination (idx into indexes_to_create)
+    /// Prepare CREATE INDEX statement on the target (idx into indexes_to_create)
     PrepareCreateIndex { idx: usize },
-    /// Step through CREATE INDEX statement on destination
+    /// Step through CREATE INDEX statement on the target.
     StepCreateIndex {
-        dest_schema_stmt: Box<crate::Statement>,
+        target_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
     /// Prepare post-data schema objects (triggers, views, rootpage = 0 entries)
     PreparePostData { idx: usize },
-    /// Step through post-data CREATE statement on destination
+    /// Step through post-data CREATE statement on the target.
     StepPostData {
-        dest_schema_stmt: Box<crate::Statement>,
+        target_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
+    /// Finalize database header metadata before committing the target database.
+    FinalizeTargetHeader,
     /// Operation complete
     Done,
 }
 
-/// VACUUM INTO - create a compacted copy of the database at the specified path.
+/// Build a compacted vacuum target database.
 ///
 /// This is an async state machine implementation that yields on I/O operations.
-/// The caller creates a new database at the destination path with matching
+/// The caller creates a target database with matching
 /// page_size, reserved bytes, source feature flags, and schema-replay symbols.
 ///
 /// It:
-/// 1. Mirrors source symbols and custom types to destination
+/// 1. Mirrors source symbols and custom types to the target
 /// 2. Queries sqlite_schema for all schema objects including rootpage, ordered by rowid
-/// 3. Creates storage-backed tables (rootpage != 0) in destination, excluding
+/// 3. Creates storage-backed tables (rootpage != 0) in the target, excluding
 ///    sqlite_sequence (auto-created when AUTOINCREMENT tables are created)
 /// 4. Copies data for all storage-backed tables, including sqlite_stat1 and other
 ///    internal storage-backed tables
 /// 5. Creates user-defined secondary indexes after data copy for performance
 ///    (backing-btree indexes for custom index methods are excluded here)
-/// 6. Copies meta values (user_version, application_id) from source to destination
-/// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
+/// 6. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
-fn vacuum_into_step(
-    config: &VacuumIntoConfig,
-    state: &mut VacuumIntoState,
-) -> Result<IOResult<()>> {
+/// 7. Finalizes target database header metadata, then commits the target transaction.
+pub(crate) fn vacuum_target_build_step(
+    config: &VacuumTargetBuildConfig,
+    state: &mut VacuumTargetBuildContext,
+) -> Result<crate::IOResult<()>> {
     loop {
-        let current_sub_state = std::mem::take(&mut state.sub_state);
+        let current_phase = std::mem::take(&mut state.phase);
 
-        match current_sub_state {
-            VacuumIntoSubState::Init => {
-                // Mirror source symbols needed for schema replay (functions, vtab
-                // modules, index methods). We skip vtabs - those are live instances
-                // tied to the source connection and not needed for compiling schema SQL.
-                {
-                    let source_syms = config.source_conn.syms.read();
-                    let mut dest_syms = state.dest_conn.syms.write();
-                    dest_syms.functions.extend(
-                        source_syms
-                            .functions
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    dest_syms.vtab_modules.extend(
-                        source_syms
-                            .vtab_modules
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    dest_syms.index_methods.extend(
-                        source_syms
-                            .index_methods
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                }
-
-                // Mirror source custom type definitions into destination schema
+        match current_phase {
+            VacuumTargetBuildPhase::Init => {
+                // Mirror source custom type definitions into the target schema
                 // so that STRICT tables with custom type columns can resolve
                 // those types during CREATE TABLE replay.
                 if !config.source_custom_types.is_empty() {
-                    state.dest_conn.with_schema_mut(|dest_schema| {
+                    state.target_conn.with_schema_mut(|target_schema| {
                         for (name, td) in &config.source_custom_types {
-                            dest_schema.type_registry.insert(name.clone(), td.clone());
+                            target_schema.type_registry.insert(name.clone(), td.clone());
                         }
                     });
                 }
 
-                // Enable MVCC on destination if source has it enabled
-                // Must be done before any schema operations to ensure the log file is created
-                if config.source_mvcc_enabled {
-                    state.dest_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+                // Auto-vacuum must be installed before MVCC bootstrap creates
+                // internal tables, otherwise full auto-vacuum can reserve page
+                // 2 as a ptrmap page after MVCC has already used it as a root.
+                state
+                    .target_conn
+                    .pager
+                    .load()
+                    .persist_auto_vacuum_mode(config.target_auto_vacuum_mode)?;
+
+                // Enable MVCC on targets that should persist as MVCC.
+                if config.target_mvcc_enabled {
+                    state.target_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
                 }
 
-                // Performance optimizations for destination database (matches SQLite vacuum.c):
-                // 1. Disable fsync - destination is a new file, if crash occurs we just delete it
+                // Performance optimizations for the target database (matches SQLite vacuum.c):
+                // 1. Disable fsync - the target is a new output/temp database, if crash occurs we just delete it
                 // 2. Disable foreign key checks - source data is already consistent
+                // 3. Defer auto-checkpoint until the caller performs the final durable checkpoint
                 // These match SQLite's vacuum.c optimizations (PAGER_SYNCHRONOUS_OFF, ~SQLITE_ForeignKeys)
-                state.dest_conn.set_sync_mode(crate::SyncMode::Off);
-                state.dest_conn.set_foreign_keys_enabled(false);
+                state.target_conn.set_sync_mode(crate::SyncMode::Off);
+                state.target_conn.set_foreign_keys_enabled(false);
+                state.target_conn.set_check_constraints_ignored(true);
+                state.target_conn.wal_auto_checkpoint_disable();
 
-                // Wrap all operations in a single transaction for atomicity.
-                state.dest_conn.execute("BEGIN")?;
+                // Wrap all operations in a single write transaction so helper
+                // statements share one durable target build and cleanup can
+                // roll it back reliably on error.
+                state.target_conn.execute("BEGIN IMMEDIATE")?;
 
                 // Query sqlite_schema with rootpage, ordered by rowid.
-                // Exclude the MVCC metadata table - it is an internal artifact.
+                // Decide whether schema replay should include the internal MVCC metadata table.
+                // VACUUM INTO excludes it because an MVCC destination bootstraps that table
+                // itself. In-place VACUUM includes it because the temp image is the future
+                // physical source database and must preserve the table as-is.
                 let escaped_schema_name = &config.escaped_schema_name;
-                let schema_sql = format!(
-                    "SELECT type, name, tbl_name, rootpage, sql \
-                     FROM \"{escaped_schema_name}\".sqlite_schema \
-                     WHERE sql IS NOT NULL AND name <> '{}' ORDER BY rowid",
-                    crate::mvcc::database::MVCC_META_TABLE_NAME
-                );
+                let schema_sql = if config.copy_mvcc_metadata_table {
+                    format!(
+                        "SELECT type, name, tbl_name, rootpage, sql \
+                         FROM \"{escaped_schema_name}\".sqlite_schema \
+                         WHERE sql IS NOT NULL ORDER BY rowid"
+                    )
+                } else {
+                    format!(
+                        "SELECT type, name, tbl_name, rootpage, sql \
+                         FROM \"{escaped_schema_name}\".sqlite_schema \
+                         WHERE sql IS NOT NULL AND name <> '{}' ORDER BY rowid",
+                        crate::mvcc::database::MVCC_META_TABLE_NAME
+                    )
+                };
                 let schema_stmt = config.source_conn.prepare_internal(schema_sql.as_str())?;
 
-                state.sub_state = VacuumIntoSubState::CollectSchemaRows {
+                state.phase = VacuumTargetBuildPhase::CollectSchemaRows {
                     schema_stmt: Box::new(schema_stmt),
                 };
                 continue;
             }
 
-            VacuumIntoSubState::CollectSchemaRows { mut schema_stmt } => {
+            VacuumTargetBuildPhase::CollectSchemaRows { mut schema_stmt } => {
                 match schema_stmt.step()? {
                     crate::StepResult::Row => {
                         let row = schema_stmt
                             .row()
                             .expect("StepResult::Row but row() returned None");
                         state.schema_entries.push(SchemaEntry::from_row(row)?);
-                        state.sub_state = VacuumIntoSubState::CollectSchemaRows { schema_stmt };
+                        state.phase = VacuumTargetBuildPhase::CollectSchemaRows { schema_stmt };
                         continue;
                     }
                     crate::StepResult::Done => {
@@ -392,7 +596,7 @@ fn vacuum_into_step(
                                 let entry = &state.schema_entries[*entry_ordinal];
                                 !config
                                     .source_conn
-                                    .with_schema(config.database_id, |schema| {
+                                    .with_schema(config.source_db_id, |schema| {
                                         schema
                                             .get_index(&entry.tbl_name, &entry.name)
                                             .is_some_and(|idx| idx.is_backing_btree_index())
@@ -401,15 +605,15 @@ fn vacuum_into_step(
                             .collect();
                         state.post_data_entries = post_data;
 
-                        state.sub_state = VacuumIntoSubState::PrepareCreateTable { idx: 0 };
+                        state.phase = VacuumTargetBuildPhase::PrepareCreateTable { idx: 0 };
                         continue;
                     }
                     crate::StepResult::IO => {
                         let io = schema_stmt
                             .take_io_completions()
                             .expect("StepResult::IO returned but no completions available");
-                        state.sub_state = VacuumIntoSubState::CollectSchemaRows { schema_stmt };
-                        return Ok(IOResult::IO(io));
+                        state.phase = VacuumTargetBuildPhase::CollectSchemaRows { schema_stmt };
+                        return Ok(crate::IOResult::IO(io));
                     }
                     crate::StepResult::Busy | crate::StepResult::Interrupt => {
                         return Err(LimboError::Busy);
@@ -419,11 +623,11 @@ fn vacuum_into_step(
 
             // Phase 1: Create storage-backed tables (rootpage != 0, type=table),
             // excluding sqlite_sequence (auto-created by AUTOINCREMENT tables).
-            VacuumIntoSubState::PrepareCreateTable { idx } => {
+            VacuumTargetBuildPhase::PrepareCreateTable { idx } => {
                 let entries_len = state.tables_to_create.len();
                 if idx >= entries_len {
                     // Done creating tables, start copying data
-                    state.sub_state = VacuumIntoSubState::StartCopyTable { table_idx: 0 };
+                    state.phase = VacuumTargetBuildPhase::StartCopyTable { table_idx: 0 };
                     continue;
                 }
 
@@ -433,47 +637,47 @@ fn vacuum_into_step(
 
                 // System tables (sqlite_stat1, __turso_internal_types, etc.) have
                 // reserved name prefixes that translate_create_table rejects for
-                // user SQL. Temporarily mark the dest connection as nested during
+                // user SQL. Temporarily mark the target connection as nested during
                 // prepare() so the reserved-name check is bypassed at compile
                 // time. The guard is only for prepare: keeping it during step()
                 // would make this CREATE TABLE look nested, so its Transaction
                 // opcode would skip write setup.
                 let is_system = crate::schema::is_system_table(&entry.name);
                 if is_system {
-                    state.dest_conn.start_nested();
+                    state.target_conn.start_nested();
                 }
-                let dest_stmt = state.dest_conn.prepare(sql_str);
+                let target_stmt = state.target_conn.prepare(sql_str);
                 if is_system {
-                    state.dest_conn.end_nested();
+                    state.target_conn.end_nested();
                 }
-                let dest_stmt = dest_stmt?;
-                state.sub_state = VacuumIntoSubState::StepCreateTable {
-                    dest_schema_stmt: Box::new(dest_stmt),
+                let target_stmt = target_stmt?;
+                state.phase = VacuumTargetBuildPhase::StepCreateTable {
+                    target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::StepCreateTable {
-                mut dest_schema_stmt,
+            VacuumTargetBuildPhase::StepCreateTable {
+                mut target_schema_stmt,
                 idx,
-            } => match dest_schema_stmt.step()? {
+            } => match target_schema_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("CREATE TABLE statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.sub_state = VacuumIntoSubState::PrepareCreateTable { idx: idx + 1 };
+                    state.phase = VacuumTargetBuildPhase::PrepareCreateTable { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_schema_stmt
+                    let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepCreateTable {
-                        dest_schema_stmt,
+                    state.phase = VacuumTargetBuildPhase::StepCreateTable {
+                        target_schema_stmt,
                         idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -484,11 +688,11 @@ fn vacuum_into_step(
             // Column lists are derived from BTreeTable.columns in the schema,
             // not PRAGMA table_info, because table_info omits generated columns
             // while SELECT * includes them - causing a column count mismatch.
-            VacuumIntoSubState::StartCopyTable { table_idx } => {
+            VacuumTargetBuildPhase::StartCopyTable { table_idx } => {
                 let tables_len = state.tables_to_copy.len();
                 if table_idx >= tables_len {
-                    // Done copying all tables, proceed to meta values
-                    state.sub_state = VacuumIntoSubState::CopyMetaValues;
+                    // Done copying all tables, proceed to deferred indexes.
+                    state.phase = VacuumTargetBuildPhase::PrepareCreateIndex { idx: 0 };
                     continue;
                 }
 
@@ -496,21 +700,21 @@ fn vacuum_into_step(
                 let entry = &state.schema_entries[entry_ordinal];
                 let table_name = &entry.name;
 
-                // sqlite_sequence: only copy data if the destination has it
+                // sqlite_sequence: only copy data if the target has it
                 // (auto-created when an AUTOINCREMENT table was created in
                 // phase 1). If not present, skip — no AUTOINCREMENT tables
                 // means no counters to preserve. The explicit copy is needed
                 // because inserting rows with the `rowid` pseudo-column does
                 // not update sqlite_sequence counters automatically.
                 if entry.is_sqlite_sequence() {
-                    let dest_has_sequence = state
-                        .dest_conn
+                    let target_has_sequence = state
+                        .target_conn
                         .schema
                         .read()
                         .get_btree_table(crate::schema::SQLITE_SEQUENCE_TABLE_NAME)
                         .is_some();
-                    if !dest_has_sequence {
-                        state.sub_state = VacuumIntoSubState::StartCopyTable {
+                    if !target_has_sequence {
+                        state.phase = VacuumTargetBuildPhase::StartCopyTable {
                             table_idx: table_idx + 1,
                         };
                         continue;
@@ -523,17 +727,23 @@ fn vacuum_into_step(
                 // INSERT arities stay aligned.
                 let source_btree_table = config
                     .source_conn
-                    .with_schema(config.database_id, |schema| {
+                    .with_schema(config.source_db_id, |schema| {
                         schema.get_btree_table(table_name)
                     });
 
+                // sqlite_sequence may already have rows from the AUTOINCREMENT
+                // tracking that ran during the table data copy. Use INSERT OR
+                // REPLACE so the source counter values overwrite any stale
+                // auto-generated ones (matches SQLite vacuum.c behavior).
+                // todo: sqlite disables AUTOINCREMENT during vacuum, but we don't have such a way yet
                 let (select_sql, insert_sql) = build_copy_sql(
                     &config.escaped_schema_name,
                     &escaped_table_name,
                     source_btree_table.as_deref(),
+                    entry.is_sqlite_sequence(),
                 )?;
 
-                // SELECT from source, INSERT into destination.
+                // SELECT from source, INSERT into the target.
                 let select_stmt = config.source_conn.prepare_internal(&select_sql)?;
 
                 // System tables need nested mode during prepare() to bypass
@@ -542,25 +752,25 @@ fn vacuum_into_step(
                 // Transaction opcode needs to run for page-level write setup.
                 let is_system = crate::schema::is_system_table(table_name);
                 if is_system {
-                    state.dest_conn.start_nested();
+                    state.target_conn.start_nested();
                 }
-                let dest_insert_stmt = state.dest_conn.prepare(&insert_sql);
+                let target_insert_stmt = state.target_conn.prepare(&insert_sql);
                 if is_system {
-                    state.dest_conn.end_nested();
+                    state.target_conn.end_nested();
                 }
-                let dest_insert_stmt = dest_insert_stmt?;
+                let target_insert_stmt = target_insert_stmt?;
 
-                state.sub_state = VacuumIntoSubState::CopyRows {
+                state.phase = VacuumTargetBuildPhase::CopyRows {
                     select_stmt: Box::new(select_stmt),
-                    dest_insert_stmt: Box::new(dest_insert_stmt),
+                    target_insert_stmt: Box::new(target_insert_stmt),
                     table_idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::CopyRows {
+            VacuumTargetBuildPhase::CopyRows {
                 mut select_stmt,
-                mut dest_insert_stmt,
+                mut target_insert_stmt,
                 table_idx,
             } => match select_stmt.step()? {
                 crate::StepResult::Row => {
@@ -568,24 +778,24 @@ fn vacuum_into_step(
                         .row()
                         .expect("StepResult::Row but row() returned None");
 
-                    dest_insert_stmt.reset()?;
-                    dest_insert_stmt.clear_bindings();
+                    target_insert_stmt.reset()?;
+                    target_insert_stmt.clear_bindings();
                     for (i, value) in row.get_values().cloned().enumerate() {
                         let index =
                             std::num::NonZero::new(i + 1).expect("i + 1 is always non-zero");
-                        dest_insert_stmt.bind_at(index, value);
+                        target_insert_stmt.bind_at(index, value);
                     }
 
-                    state.sub_state = VacuumIntoSubState::StepDestInsert {
+                    state.phase = VacuumTargetBuildPhase::StepTargetInsert {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
                     continue;
                 }
                 crate::StepResult::Done => {
                     // Move to next table
-                    state.sub_state = VacuumIntoSubState::StartCopyTable {
+                    state.phase = VacuumTargetBuildPhase::StartCopyTable {
                         table_idx: table_idx + 1,
                     };
                     continue;
@@ -594,76 +804,57 @@ fn vacuum_into_step(
                     let io = select_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::CopyRows {
+                    state.phase = VacuumTargetBuildPhase::CopyRows {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
                 }
             },
 
-            VacuumIntoSubState::StepDestInsert {
+            VacuumTargetBuildPhase::StepTargetInsert {
                 select_stmt,
-                mut dest_insert_stmt,
+                mut target_insert_stmt,
                 table_idx,
-            } => match dest_insert_stmt.step()? {
+            } => match target_insert_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("INSERT statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
                     // Go back to get next row from source
-                    state.sub_state = VacuumIntoSubState::CopyRows {
+                    state.phase = VacuumTargetBuildPhase::CopyRows {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_insert_stmt
+                    let io = target_insert_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepDestInsert {
+                    state.phase = VacuumTargetBuildPhase::StepTargetInsert {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
                 }
             },
 
-            VacuumIntoSubState::CopyMetaValues => {
-                // Copy meta values to destination database
-                // Use pragma_update to set user_version and application_id
-                // Note: schema_version is not copied - VACUUM INTO creates a new file so
-                // there's no cache to invalidate. The destination will have its own
-                // schema_version based on the schema operations performed.
-                state
-                    .dest_conn
-                    .pragma_update("user_version", config.source_user_version.to_string())?;
-                state
-                    .dest_conn
-                    .pragma_update("application_id", config.source_application_id.to_string())?;
-
-                // Phase 3: Create user-defined secondary indexes after data copy
-                // for performance (avoids maintaining indexes during bulk insert).
-                state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: 0 };
-                continue;
-            }
-
             // Phase 3: Create user-defined secondary indexes.
-            VacuumIntoSubState::PrepareCreateIndex { idx } => {
+            VacuumTargetBuildPhase::PrepareCreateIndex { idx } => {
                 let entries_len = state.indexes_to_create.len();
                 if idx >= entries_len {
                     // Done creating indexes, move to post-data objects
-                    state.sub_state = VacuumIntoSubState::PreparePostData { idx: 0 };
+                    state.phase = VacuumTargetBuildPhase::PreparePostData { idx: 0 };
                     continue;
                 }
 
@@ -672,34 +863,34 @@ fn vacuum_into_step(
                 // Backing-btree indexes for custom index methods were filtered
                 // out when indexes_to_create was built. The remaining CREATE
                 // INDEX statements are user-visible and can use ordinary prepare.
-                let dest_stmt = state.dest_conn.prepare(&entry.sql)?;
-                state.sub_state = VacuumIntoSubState::StepCreateIndex {
-                    dest_schema_stmt: Box::new(dest_stmt),
+                let target_stmt = state.target_conn.prepare(&entry.sql)?;
+                state.phase = VacuumTargetBuildPhase::StepCreateIndex {
+                    target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::StepCreateIndex {
-                mut dest_schema_stmt,
+            VacuumTargetBuildPhase::StepCreateIndex {
+                mut target_schema_stmt,
                 idx,
-            } => match dest_schema_stmt.step()? {
+            } => match target_schema_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("CREATE INDEX statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: idx + 1 };
+                    state.phase = VacuumTargetBuildPhase::PrepareCreateIndex { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_schema_stmt
+                    let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepCreateIndex {
-                        dest_schema_stmt,
+                    state.phase = VacuumTargetBuildPhase::StepCreateIndex {
+                        target_schema_stmt,
                         idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -707,53 +898,66 @@ fn vacuum_into_step(
             },
 
             // Phase 4: Create triggers, views, and rootpage=0 schema objects.
-            VacuumIntoSubState::PreparePostData { idx } => {
+            VacuumTargetBuildPhase::PreparePostData { idx } => {
                 let entries_len = state.post_data_entries.len();
                 if idx >= entries_len {
-                    state.sub_state = VacuumIntoSubState::Done;
+                    state.phase = VacuumTargetBuildPhase::FinalizeTargetHeader;
                     continue;
                 }
 
                 let entry_ordinal = state.post_data_entries[idx];
                 let entry = &state.schema_entries[entry_ordinal];
-                let dest_stmt = state.dest_conn.prepare(&entry.sql)?;
-                state.sub_state = VacuumIntoSubState::StepPostData {
-                    dest_schema_stmt: Box::new(dest_stmt),
+                let target_stmt = state.target_conn.prepare(&entry.sql)?;
+                state.phase = VacuumTargetBuildPhase::StepPostData {
+                    target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::StepPostData {
-                mut dest_schema_stmt,
+            VacuumTargetBuildPhase::StepPostData {
+                mut target_schema_stmt,
                 idx,
-            } => match dest_schema_stmt.step()? {
+            } => match target_schema_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("CREATE statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.sub_state = VacuumIntoSubState::PreparePostData { idx: idx + 1 };
+                    state.phase = VacuumTargetBuildPhase::PreparePostData { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_schema_stmt
+                    let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepPostData {
-                        dest_schema_stmt,
+                    state.phase = VacuumTargetBuildPhase::StepPostData {
+                        target_schema_stmt,
                         idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
                 }
             },
 
-            VacuumIntoSubState::Done => {
-                // Commit the destination transaction started in Init state.
-                state.dest_conn.execute("COMMIT")?;
-                return Ok(IOResult::Done(()));
+            VacuumTargetBuildPhase::FinalizeTargetHeader => {
+                match finalize_vacuum_target_header(&state.target_conn, &config.header_meta)? {
+                    crate::IOResult::Done(()) => {}
+                    crate::IOResult::IO(io) => {
+                        state.phase = VacuumTargetBuildPhase::FinalizeTargetHeader;
+                        return Ok(crate::IOResult::IO(io));
+                    }
+                }
+
+                state.phase = VacuumTargetBuildPhase::Done;
+                continue;
+            }
+
+            VacuumTargetBuildPhase::Done => {
+                // Commit the target transaction started in Init phase.
+                state.target_conn.execute("COMMIT")?;
+                return Ok(crate::IOResult::Done(()));
             }
         }
     }
@@ -780,7 +984,8 @@ fn vacuum_into_step(
 pub(crate) fn build_copy_sql(
     escaped_schema_name: &str,
     escaped_table_name: &str,
-    source_btree_table: Option<&crate::schema::BTreeTable>,
+    source_btree_table: Option<&BTreeTable>,
+    or_replace: bool,
 ) -> Result<(String, String)> {
     let Some(btree) = source_btree_table else {
         // Storage-backed tables must have schema metadata. If we get here,

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -7,9 +7,9 @@ use crate::storage::pager::{AutoVacuumMode, Page, PageRef, Pager};
 use crate::storage::sqlite3_ondisk::{
     CacheSize, DatabaseHeader, PageSize, RawVersion, TextEncoding, WAL_FRAME_HEADER_SIZE,
 };
-use crate::types::IOCompletions;
+use crate::types::{IOCompletions, IOResult};
 use crate::util::IOExt;
-use crate::vdbe::{execute::InsnFunctionStepResult, Row};
+use crate::vdbe::Row;
 use crate::Result;
 use crate::{
     Connection, Database, DatabaseOpts, EncryptionKey, EncryptionOpts, MvStore, OpenFlags, SyncMode,
@@ -1305,7 +1305,7 @@ impl VacuumInPlaceOpContext {
         }
     }
 
-    pub(crate) fn step(&mut self, connection: &Arc<Connection>) -> Result<InsnFunctionStepResult> {
+    pub(crate) fn step(&mut self, connection: &Arc<Connection>) -> Result<IOResult<()>> {
         vacuum_in_place_step(
             connection,
             self.db,
@@ -1599,8 +1599,8 @@ fn reload_physical_schema_for_mvcc_vacuum(
     reparse_result
 }
 
-/// Step the in-place VACUUM state machine once. Returns `IO` to yield or `Step`
-/// when the entire operation is complete.
+/// Step the in-place VACUUM state machine once. Returns `IO` to yield or
+/// `Done(())` when the entire operation is complete.
 ///
 /// `cleanup_state` independently tracks which resources the opcode has acquired so
 /// that cleanup can roll back correctly
@@ -1610,7 +1610,7 @@ fn vacuum_in_place_step(
     phase: &mut VacuumInPlacePhase,
     committed_image: &mut Option<VacuumCommittedImageMeta>,
     cleanup_state: &mut VacuumInPlaceCleanupState,
-) -> Result<InsnFunctionStepResult> {
+) -> Result<IOResult<()>> {
     let source_pager = connection.get_pager_from_database_index(&db)?;
 
     loop {
@@ -1717,7 +1717,7 @@ fn vacuum_in_place_step(
                     }
                     crate::IOResult::IO(io) => {
                         *phase = VacuumInPlacePhase::BeginSourceTx;
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(IOResult::IO(io));
                     }
                 }
             }
@@ -1793,7 +1793,7 @@ fn vacuum_in_place_step(
                             temp_db,
                             context,
                         };
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(IOResult::IO(io));
                     }
                 }
             }
@@ -1890,9 +1890,7 @@ fn vacuum_in_place_step(
                         completion: completion.clone(),
                         fsync_phase,
                     };
-                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
-                        completion,
-                    )));
+                    return Ok(IOResult::IO(IOCompletions::Single(completion)));
                 }
                 if !completion.succeeded() {
                     return Err(vacuum_completion_error(&completion, "WAL header init"));
@@ -1971,9 +1969,7 @@ fn vacuum_in_place_step(
                         batch_pages,
                         read_completion: read_completion.clone(),
                     };
-                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
-                        read_completion,
-                    )));
+                    return Ok(IOResult::IO(IOCompletions::Single(read_completion)));
                 }
                 if !read_completion.succeeded() {
                     return Err(vacuum_completion_error(&read_completion, "temp batch read"));
@@ -2059,7 +2055,7 @@ fn vacuum_in_place_step(
                         read_scratch_buf,
                         completions,
                     };
-                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(pending)));
+                    return Ok(IOResult::IO(IOCompletions::Single(pending)));
                 }
 
                 // Check for write errors.
@@ -2136,9 +2132,7 @@ fn vacuum_in_place_step(
                         temp_db,
                         sync_completion: sync_completion.clone(),
                     };
-                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
-                        sync_completion,
-                    )));
+                    return Ok(IOResult::IO(IOCompletions::Single(sync_completion)));
                 }
                 if !sync_completion.succeeded() {
                     return Err(vacuum_completion_error(&sync_completion, "WAL fsync"));
@@ -2228,7 +2222,7 @@ fn vacuum_in_place_step(
                     }
                     Ok(crate::IOResult::IO(io)) => {
                         *phase = VacuumInPlacePhase::Checkpoint;
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(IOResult::IO(io));
                     }
                     Err(err) => {
                         tracing::error!("VACUUM post-commit checkpoint failed: {err}");
@@ -2257,11 +2251,11 @@ fn vacuum_in_place_step(
                 drop(cleanup_state.mvcc_guard.take());
 
                 *phase = VacuumInPlacePhase::Done;
-                return Ok(InsnFunctionStepResult::Step);
+                return Ok(IOResult::Done(()));
             }
 
             VacuumInPlacePhase::Done => {
-                return Ok(InsnFunctionStepResult::Step);
+                return Ok(IOResult::Done(()));
             }
         }
     }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1120,7 +1120,7 @@ enum CheckpointLockCleanup {
     #[default]
     None,
     /// VACUUM owns only the raw checkpoint_lock; cleanup releases it
-    /// directly with `Wal::release_checkpoint_lock`.
+    /// directly with `Wal::release_vacuum_checkpoint_lock`.
     ReleaseRaw,
     /// The checkpoint state machine has consumed the raw checkpoint_lock and
     /// may now own read0/write too, so cleanup must abort checkpoint state.
@@ -1170,7 +1170,7 @@ impl Drop for MvccVacuumGuard {
 /// 2. `checkpoint_cleanup = ReleaseRaw` immediately after acquiring the raw
 ///    checkpoint lock in `Preflight`.
 /// 3. `source_tx_open = true` and `vacuum_lock_held = true` together after
-///    `begin_blocking_tx()` succeeds in `BeginSourceTx`.
+///    `begin_vacuum_blocking_tx()` succeeds in `BeginSourceTx`.
 /// 4. `source_tx_open` is cleared immediately after
 ///    `finish_append_frames_commit()` and `end_write_tx()` in `PublishWalCommit`.
 /// 5. `checkpoint_cleanup` transitions from `ReleaseRaw` to
@@ -1198,7 +1198,7 @@ enum VacuumInPlacePhase {
     /// MVCC, WAL-backed pager). Then acquire check_point lock
     Preflight,
     /// Acquire exclusive source access on the source WAL via
-    /// `begin_blocking_tx`: checkpoint_lock is already held from Preflight;
+    /// `begin_vacuum_blocking_tx`: checkpoint_lock is already held from Preflight;
     /// this acquires the exclusive VACUUM lock and installs the source snapshot.
     BeginSourceTx,
     /// Read source database header metadata for the target-build config.
@@ -1694,7 +1694,7 @@ fn vacuum_in_place_step(
                 // ensures a post-commit TRUNCATE checkpoint won't fail due
                 // to a concurrent checkpointer. If the lock is unavailable
                 // we fail fast before doing any expensive work.
-                wal.try_begin_checkpoint_lock()?;
+                wal.try_begin_vacuum_checkpoint_lock()?;
                 cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::ReleaseRaw;
                 *phase = VacuumInPlacePhase::BeginSourceTx;
                 continue;
@@ -1704,7 +1704,7 @@ fn vacuum_in_place_step(
                 // Acquire exclusive WAL access in one shot:
                 // vacuum lock + WAL write lock + connection snapshot.
                 // Checkpoint lock was already acquired in Preflight.
-                match source_pager.begin_blocking_tx()? {
+                match source_pager.begin_vacuum_blocking_tx()? {
                     crate::IOResult::Done(()) => {
                         connection.auto_commit.store(false, Ordering::SeqCst);
                         connection.set_tx_state(crate::connection::TransactionState::Write {
@@ -2192,13 +2192,7 @@ fn vacuum_in_place_step(
                 if cleanup_state.checkpoint_cleanup == CheckpointLockCleanup::ReleaseRaw {
                     cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::AbortCheckpoint;
                 }
-                match source_pager.checkpoint_with_held_checkpoint_lock(
-                    crate::storage::wal::CheckpointMode::Truncate {
-                        upper_bound_inclusive: None,
-                    },
-                    SyncMode::Full,
-                    true,
-                ) {
+                match source_pager.vacuum_checkpoint_with_held_lock(SyncMode::Full, true) {
                     Ok(crate::IOResult::Done(result)) => {
                         cleanup_state.checkpoint_cleanup = CheckpointLockCleanup::None;
                         turso_assert!(
@@ -2286,7 +2280,7 @@ fn vacuum_in_place_cleanup(
                 .get_pager_from_database_index(&db)
                 .expect("VACUUM cleanup requires source pager");
             if let Some(wal) = pager.wal.as_ref() {
-                wal.release_checkpoint_lock();
+                wal.release_vacuum_checkpoint_lock();
             }
         }
         CheckpointLockCleanup::AbortCheckpoint => {

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -158,9 +158,9 @@ pub(crate) fn vacuum_target_opts_from_source(source_db: &Database) -> DatabaseOp
         .with_generated_columns(source_db.experimental_generated_columns_enabled())
 }
 
-/// Page-1 metadata that the target build must finalize before commit.
+/// Database header metadata that the target build must finalize before commit.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct VacuumPage1Meta {
+pub(crate) struct VacuumDbHeaderMeta {
     schema_cookie: u32,
     default_page_cache_size: CacheSize,
     text_encoding: TextEncoding,
@@ -168,7 +168,7 @@ pub(crate) struct VacuumPage1Meta {
     application_id: i32,
 }
 
-impl VacuumPage1Meta {
+impl VacuumDbHeaderMeta {
     pub(crate) fn from_source_header(source: &DatabaseHeader) -> Self {
         Self {
             schema_cookie: source.schema_cookie.get().wrapping_add(1),
@@ -272,7 +272,7 @@ pub(crate) fn open_vacuum_temp_db(
 
 fn finalize_vacuum_target_header(
     target_conn: &Arc<Connection>,
-    header_meta: &VacuumPage1Meta,
+    header_meta: &VacuumDbHeaderMeta,
 ) -> Result<crate::IOResult<()>> {
     if let Some(mv_store) = target_conn.mv_store_for_db(crate::MAIN_DB_ID) {
         let tx_id = target_conn.get_mv_tx_id_for_db(crate::MAIN_DB_ID);
@@ -300,8 +300,8 @@ pub(crate) struct VacuumTargetBuildConfig {
     pub escaped_schema_name: String,
     /// Database index for schema lookups on the source connection.
     pub source_db_id: usize,
-    /// Page-1 metadata to write before committing the target database.
-    pub header_meta: VacuumPage1Meta,
+    /// Database header metadata to write before committing the target database.
+    pub header_meta: VacuumDbHeaderMeta,
     /// Pre-captured source custom type definitions for STRICT table replay.
     pub source_custom_types: Vec<(String, Arc<TypeDef>)>,
     /// Whether the source database has MVCC enabled.
@@ -311,8 +311,7 @@ pub(crate) struct VacuumTargetBuildConfig {
 /// Context for the vacuum target build. Holds the target connection and all
 /// intermediate state needed across async yields.
 pub(crate) struct VacuumTargetBuildContext {
-    /// Target connection - lives here, not in each phase variant.
-    pub target_conn: Arc<Connection>,
+    target_conn: Arc<Connection>,
     phase: VacuumTargetBuildPhase,
     /// Typed schema entries collected from sqlite_schema, ordered by rowid.
     schema_entries: Vec<SchemaEntry>,
@@ -387,7 +386,7 @@ pub(crate) enum VacuumTargetBuildPhase {
         target_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
-    /// Finalize page-1 metadata before committing the target database.
+    /// Finalize database header metadata before committing the target database.
     FinalizeTargetHeader,
     /// Operation complete
     Done,
@@ -411,7 +410,7 @@ pub(crate) enum VacuumTargetBuildPhase {
 /// 6. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
-/// 7. Finalizes target page-1 metadata, then commits the target transaction.
+/// 7. Finalizes target database header metadata, then commits the target transaction.
 pub(crate) fn vacuum_target_build_step(
     config: &VacuumTargetBuildConfig,
     state: &mut VacuumTargetBuildContext,
@@ -1041,7 +1040,7 @@ pub(crate) enum VacuumInPlacePhase {
     /// this is a two-phase state: first attempt acquires read + tries write,
     /// re-entry after IO yield retries only the write (read is already held).
     BeginSourceTx,
-    /// Read source page-1 header metadata for the target-build config.
+    /// Read source database header metadata for the target-build config.
     ReadSourceMetadata,
     /// Create temp DB and run the shared target-build engine.
     TargetBuild {
@@ -1228,17 +1227,17 @@ pub(crate) fn vacuum_in_place_step(
                 // Read reserved bytes and header metadata in a single
                 // with_header call to avoid redundant page-1 access.
                 let io = &*source_pager.io;
-                let (reserved_space, header_meta): (u8, VacuumPage1Meta) =
+                let (reserved_space, header_meta): (u8, VacuumDbHeaderMeta) =
                     match connection.get_reserved_bytes() {
                         Some(val) => {
                             let dh = io.block(|| {
-                                source_pager.with_header(VacuumPage1Meta::from_source_header)
+                                source_pager.with_header(VacuumDbHeaderMeta::from_source_header)
                             })?;
                             (val, dh)
                         }
                         None => io.block(|| {
                             source_pager.with_header(|h| {
-                                (h.reserved_space, VacuumPage1Meta::from_source_header(h))
+                                (h.reserved_space, VacuumDbHeaderMeta::from_source_header(h))
                             })
                         })?,
                     };
@@ -1754,7 +1753,7 @@ mod tests {
     use crate::util::IOExt;
 
     #[test]
-    fn vacuum_page1_meta_bumps_schema_cookie_and_preserves_sqlite_metadata() {
+    fn vacuum_db_header_meta_bumps_schema_cookie_and_preserves_sqlite_metadata() {
         let mut source = DatabaseHeader::default();
         source.schema_cookie = u32::MAX.into();
         source.default_page_cache_size = CacheSize::new(123);
@@ -1762,13 +1761,13 @@ mod tests {
         source.user_version = 7.into();
         source.application_id = 12.into();
 
-        let VacuumPage1Meta {
+        let VacuumDbHeaderMeta {
             schema_cookie,
             default_page_cache_size,
             text_encoding,
             user_version,
             application_id,
-        } = VacuumPage1Meta::from_source_header(&source);
+        } = VacuumDbHeaderMeta::from_source_header(&source);
 
         assert_eq!(schema_cookie, 0);
         assert_eq!(default_page_cache_size, CacheSize::new(123));
@@ -1779,7 +1778,7 @@ mod tests {
 
     #[cfg(not(target_family = "wasm"))]
     #[test]
-    fn vacuum_page1_meta_updates_target_header() -> Result<()> {
+    fn vacuum_db_header_meta_updates_target_header() -> Result<()> {
         let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
         let source_dir = tempfile::tempdir().unwrap();
         let source_path = source_dir.path().join("source.db");
@@ -1800,7 +1799,7 @@ mod tests {
         source_header.text_encoding = TextEncoding::Utf8;
         source_header.user_version = 17.into();
         source_header.application_id = 29.into();
-        let header_meta = VacuumPage1Meta::from_source_header(&source_header);
+        let header_meta = VacuumDbHeaderMeta::from_source_header(&source_header);
 
         temp.conn.execute("BEGIN")?;
         match finalize_vacuum_target_header(&temp.conn, &header_meta)? {

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1133,8 +1133,16 @@ pub(crate) enum VacuumInPlacePhase {
         temp_db: Box<VacuumTempDb>,
         sync_completion: crate::io::Completion,
     },
-    /// Publish: commit_prepared_frames + finish_append_frames_commit + schema reload.
+    /// Publish: commit_prepared_frames + finish_append_frames_commit, release
+    /// locks, drop temp resources.
     PublishWalCommit { temp_db: Box<VacuumTempDb> },
+    /// TRUNCATE checkpoint: copy WAL frames back into the DB file and truncate
+    /// the WAL to zero. The pager's internal state machine handles the multi-step
+    /// IO (backfill → sync DB → truncate WAL). Non-fatal if it fails — data is
+    /// already durable in the WAL.
+    Checkpoint,
+    /// Reload the schema from the freshly committed (and possibly checkpointed) DB.
+    SchemaReload,
     /// Clean up after successful commit.
     Done,
 }
@@ -1650,23 +1658,21 @@ pub(crate) fn vacuum_in_place_step(
                 wal.finish_append_frames_commit()?;
                 cleanup_state.wal_commit_published = true;
 
-                // Release source write lock and old read lock.
+                // Release source write lock and read lock.
                 source_pager.end_write_tx();
                 source_pager.end_read_tx();
                 cleanup_state.source_write_tx_open = false;
                 cleanup_state.source_read_tx_open = false;
 
-                // Release the checkpoint serialization lock now that commit
-                // is done. Future checkpoint support will run here, before
-                // releasing this lock.
+                // Release the checkpoint serialization lock so the TRUNCATE
+                // checkpoint below can re-acquire it through the normal path.
                 wal.release_checkpoint_lock();
                 cleanup_state.checkpoint_lock_held = false;
 
                 // Restore connection bookkeeping immediately. The commit is
                 // durable so there is nothing to roll back; restoring here
                 // means the connection is never left poisoned even if the
-                // schema reload below fails. (Matches SQLite vacuum.c which
-                // restores autocommit before schema reset.)
+                // checkpoint or schema reload below fails.
                 connection.auto_commit.store(true, Ordering::SeqCst);
                 connection.set_tx_state(crate::connection::TransactionState::None);
 
@@ -1675,9 +1681,43 @@ pub(crate) fn vacuum_in_place_step(
                 source_pager.clear_page_cache(false);
                 source_pager.set_schema_cookie(None);
 
-                // Drop temp resources before schema reload.
+                // Drop temp resources before checkpoint.
                 drop(temp_db);
 
+                *phase = VacuumInPlacePhase::Checkpoint;
+                continue;
+            }
+
+            VacuumInPlacePhase::Checkpoint => {
+                // TRUNCATE checkpoint: copy WAL frames into the DB file,
+                // sync the DB, then truncate the WAL to zero bytes.
+                // Non-fatal if it fails — data is already durable in the WAL
+                // and will be checkpointed by the next auto-checkpoint.
+                let sync_mode = connection.get_sync_mode();
+                match source_pager.checkpoint(
+                    crate::storage::wal::CheckpointMode::Truncate {
+                        upper_bound_inclusive: None,
+                    },
+                    sync_mode,
+                    true,
+                ) {
+                    Ok(crate::IOResult::Done(_)) => {
+                        *phase = VacuumInPlacePhase::SchemaReload;
+                        continue;
+                    }
+                    Ok(crate::IOResult::IO(io)) => {
+                        *phase = VacuumInPlacePhase::Checkpoint;
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                    Err(err) => {
+                        tracing::info!("VACUUM post-commit checkpoint failed (non-fatal): {err}");
+                        *phase = VacuumInPlacePhase::SchemaReload;
+                        continue;
+                    }
+                }
+            }
+
+            VacuumInPlacePhase::SchemaReload => {
                 // Schema reload under a self-contained read guard. If this
                 // fails the connection is still usable — the cleared schema
                 // cookie will trigger a re-read on the next operation.

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1158,7 +1158,24 @@ impl Default for VacuumInPlacePhase {
 const VACUUM_COPY_BATCH_SIZE: u32 = 64;
 
 fn vacuum_copy_batch_end(start_page: u32, total_pages: u32) -> u32 {
-    (start_page + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1)
+    turso_assert!(
+        start_page > 0,
+        "vacuum copy batch start page must be 1-based",
+        { "start_page": start_page, "total_pages": total_pages }
+    );
+    turso_assert!(
+        start_page <= total_pages,
+        "vacuum copy batch start must be inside database image",
+        { "start_page": start_page, "total_pages": total_pages }
+    );
+    turso_assert!(
+        total_pages < u32::MAX,
+        "vacuum copy batch requires a representable exclusive end page",
+        { "total_pages": total_pages }
+    );
+    start_page
+        .saturating_add(VACUUM_COPY_BATCH_SIZE)
+        .min(total_pages + 1)
 }
 
 #[cfg(test)]
@@ -1191,7 +1208,17 @@ fn coalesce_frame_runs(
     }
     pairs.sort_by_key(|(_, f)| *f);
     let mut runs: Vec<(u64, Vec<crate::storage::pager::PageRef>)> = Vec::new();
+    let mut prev_frame_id = None;
     for (page, frame_id) in pairs {
+        turso_assert!(frame_id > 0, "WAL frame ids must be 1-based");
+        if let Some(prev) = prev_frame_id {
+            turso_assert!(
+                frame_id > prev,
+                "VACUUM temp WAL frame ids must be unique",
+                { "previous_frame_id": prev, "frame_id": frame_id }
+            );
+        }
+        prev_frame_id = Some(frame_id);
         if let Some((run_start, run_pages)) = runs.last_mut() {
             let next_expected = *run_start + run_pages.len() as u64;
             if frame_id == next_expected {
@@ -1221,6 +1248,16 @@ fn start_temp_batch_reads(
         batch_start < batch_end,
         "empty vacuum read batch",
         { "batch_start": batch_start, "batch_end": batch_end }
+    );
+    turso_assert!(
+        batch_start > 0,
+        "vacuum read batch start page must be 1-based",
+        { "batch_start": batch_start, "batch_end": batch_end }
+    );
+    turso_assert!(
+        batch_end - batch_start <= VACUUM_COPY_BATCH_SIZE,
+        "vacuum read batch exceeds configured copy batch size",
+        { "batch_start": batch_start, "batch_end": batch_end, "batch_size": VACUUM_COPY_BATCH_SIZE }
     );
     let wal = temp_pager
         .wal
@@ -1259,6 +1296,13 @@ fn reload_schema_after_vacuum_commit(
     db: usize,
     source_pager: &crate::storage::pager::Pager,
 ) -> Result<()> {
+    turso_assert!(
+        connection
+            .auto_commit
+            .load(std::sync::atomic::Ordering::SeqCst),
+        "VACUUM schema reload must run after restoring auto-commit"
+    );
+
     // Schema reload under a self-contained read guard. If this fails the
     // cleared schema cookie will trigger a re-read on the next operation.
     source_pager.begin_read_tx()?;
@@ -1390,6 +1434,18 @@ pub(crate) fn vacuum_in_place_step(
             }
 
             VacuumInPlacePhase::ReadSourceMetadata => {
+                turso_assert!(
+                    cleanup_state.checkpoint_lock_held,
+                    "VACUUM source metadata phase requires checkpoint lock"
+                );
+                turso_assert!(
+                    cleanup_state.source_read_tx_open,
+                    "VACUUM source metadata phase requires source read tx"
+                );
+                turso_assert!(
+                    cleanup_state.source_write_tx_open,
+                    "VACUUM source metadata phase requires source write tx"
+                );
                 let source_db = connection.get_source_database(db);
 
                 // Read page size from pager (cached after begin_read_tx).
@@ -1534,6 +1590,10 @@ pub(crate) fn vacuum_in_place_step(
                 completion,
                 fsync_phase,
             } => {
+                turso_assert!(
+                    total_pages > 0,
+                    "VACUUM source WAL header initialization requires pages to copy"
+                );
                 if !completion.finished() {
                     *phase = VacuumInPlacePhase::InitSourceWalHeader {
                         temp_db,
@@ -1590,6 +1650,26 @@ pub(crate) fn vacuum_in_place_step(
                 batch_pages,
                 read_completion,
             } => {
+                turso_assert!(
+                    total_pages < u32::MAX,
+                    "VACUUM read batch requires a representable exclusive end page",
+                    { "total_pages": total_pages }
+                );
+                let database_end = total_pages + 1;
+                turso_assert!(
+                    !batch_pages.is_empty(),
+                    "VACUUM read batch must contain pages"
+                );
+                turso_assert!(
+                    batch_pages.len() as u32 <= VACUUM_COPY_BATCH_SIZE,
+                    "VACUUM read batch exceeds configured copy batch size",
+                    { "batch_pages": batch_pages.len(), "batch_size": VACUUM_COPY_BATCH_SIZE }
+                );
+                turso_assert!(
+                    next_page > 1 && next_page <= database_end,
+                    "VACUUM read batch next page is outside database image",
+                    { "next_page": next_page, "total_pages": total_pages }
+                );
                 // Wait for every run in this batch to finish.
                 if !read_completion.finished() {
                     *phase = VacuumInPlacePhase::ReadTempBatch {
@@ -1611,6 +1691,18 @@ pub(crate) fn vacuum_in_place_step(
                 }
 
                 // All pages in this batch are loaded. Prepare WAL frames.
+                for page in &batch_pages {
+                    turso_assert!(
+                        page.is_loaded(),
+                        "VACUUM read batch page must be loaded before WAL prepare",
+                        { "page_id": page.get().id }
+                    );
+                    turso_assert!(
+                        !page.is_locked(),
+                        "VACUUM read batch page lock leaked before WAL prepare",
+                        { "page_id": page.get().id }
+                    );
+                }
                 let all_read = next_page > total_pages;
                 let wal = source_pager
                     .wal
@@ -1650,6 +1742,25 @@ pub(crate) fn vacuum_in_place_step(
                 prev_prepared,
                 completions,
             } => {
+                turso_assert!(
+                    total_pages < u32::MAX,
+                    "VACUUM WAL write batch requires a representable exclusive end page",
+                    { "total_pages": total_pages }
+                );
+                let database_end = total_pages + 1;
+                turso_assert!(
+                    prev_prepared.is_some(),
+                    "VACUUM WAL write batch requires prepared frames"
+                );
+                turso_assert!(
+                    !completions.is_empty(),
+                    "VACUUM WAL write batch requires write completions"
+                );
+                turso_assert!(
+                    next_page > 1 && next_page <= database_end,
+                    "VACUUM WAL write batch next page is outside database image",
+                    { "next_page": next_page, "total_pages": total_pages }
+                );
                 // Wait for all writes in this batch. We yield on the first
                 // unfinished completion; re-entry will re-check them all.
                 let pending = completions.iter().find(|c| !c.finished()).cloned();
@@ -1683,9 +1794,8 @@ pub(crate) fn vacuum_in_place_step(
                 // cache and have no dirty state to clear. The source page cache
                 // is invalidated wholesale via clear_page_cache() in Publish.
                 let wal = source_pager.wal.as_ref().unwrap();
-                if let Some(ref prepared) = prev_prepared {
-                    wal.commit_prepared_frames(std::slice::from_ref(prepared.as_ref()));
-                }
+                let prepared = prev_prepared.as_ref().unwrap();
+                wal.commit_prepared_frames(std::slice::from_ref(prepared.as_ref()));
 
                 // More pages to copy?
                 if next_page <= total_pages {
@@ -1748,6 +1858,18 @@ pub(crate) fn vacuum_in_place_step(
             }
 
             VacuumInPlacePhase::PublishWalCommit { temp_db } => {
+                turso_assert!(
+                    cleanup_state.checkpoint_lock_held,
+                    "VACUUM publish phase requires checkpoint lock"
+                );
+                turso_assert!(
+                    cleanup_state.source_read_tx_open,
+                    "VACUUM publish phase requires source read tx"
+                );
+                turso_assert!(
+                    cleanup_state.source_write_tx_open,
+                    "VACUUM publish phase requires source write tx"
+                );
                 let wal = source_pager
                     .wal
                     .as_ref()
@@ -1854,6 +1976,11 @@ pub(crate) fn vacuum_in_place_cleanup(
     cleanup_state: &VacuumInPlaceCleanupState,
 ) {
     use std::sync::atomic::Ordering;
+
+    turso_assert!(
+        !cleanup_state.source_write_tx_open || cleanup_state.source_read_tx_open,
+        "VACUUM cleanup cannot have source write tx without source read tx"
+    );
 
     // Release the checkpoint lock if we acquired it.
     if cleanup_state.checkpoint_lock_held {

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -192,16 +192,16 @@ impl VacuumPage1Meta {
 ///
 /// The temp directory is dropped after the connection and database handles so
 /// host files can be closed before the directory cleanup runs.
-#[allow(dead_code)]
 pub(crate) struct VacuumTempDb {
     pub conn: Arc<Connection>,
-    pub db: Arc<Database>,
-    pub path: String,
+    _db: Arc<Database>,
+    #[cfg(test)]
+    path: String,
     #[cfg(not(target_family = "wasm"))]
     _temp_dir: tempfile::TempDir,
 }
 
-#[allow(dead_code)]
+#[cfg(not(target_family = "wasm"))]
 fn vacuum_temp_db_encryption(
     source_conn: &Arc<Connection>,
 ) -> Result<(Option<EncryptionOpts>, Option<crate::EncryptionKey>)> {
@@ -221,7 +221,6 @@ fn vacuum_temp_db_encryption(
 }
 
 #[cfg(not(target_family = "wasm"))]
-#[allow(dead_code)]
 pub(crate) fn open_vacuum_temp_db(
     source_conn: &Arc<Connection>,
     source_db: &Arc<Database>,
@@ -234,6 +233,8 @@ pub(crate) fn open_vacuum_temp_db(
         .to_str()
         .ok_or_else(|| LimboError::InternalError("vacuum temp path is not valid UTF-8".into()))?
         .to_string();
+    #[cfg(test)]
+    let test_path = path.clone();
 
     let (encryption_opts, encryption_key) = vacuum_temp_db_encryption(source_conn)?;
     let db = Database::open_file_with_flags(
@@ -250,14 +251,14 @@ pub(crate) fn open_vacuum_temp_db(
 
     Ok(VacuumTempDb {
         conn,
-        db,
-        path,
+        _db: db,
+        #[cfg(test)]
+        path: test_path,
         _temp_dir: temp_dir,
     })
 }
 
 #[cfg(target_family = "wasm")]
-#[allow(dead_code)]
 pub(crate) fn open_vacuum_temp_db(
     _source_conn: &Arc<Connection>,
     _source_db: &Arc<Database>,
@@ -1847,7 +1848,7 @@ mod tests {
 
         let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
 
-        assert!(Arc::ptr_eq(&temp.db.io, &source_db.io));
+        assert!(Arc::ptr_eq(&temp._db.io, &source_db.io));
         assert_ne!(temp.path, source_db.path);
         assert!(temp.conn.is_wal_auto_checkpoint_disabled());
         assert_eq!(temp.conn.get_page_size().get(), 4096);
@@ -1882,7 +1883,7 @@ mod tests {
 
         let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, reserved_space)?;
 
-        assert!(temp.db.experimental_encryption_enabled());
+        assert!(temp._db.experimental_encryption_enabled());
         assert_eq!(
             temp.conn.get_encryption_cipher_mode(),
             source_conn.get_encryption_cipher_mode()

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -288,6 +288,47 @@ fn finalize_vacuum_target_header(
 // Vacuum target build engine
 // ---------------------------------------------------------------------------
 
+/// Copy functions, vtab modules, and index methods from one connection to
+/// another so that schema replay on the target sees the same symbols as
+/// the source.
+pub(crate) fn mirror_symbols(source: &Connection, target: &Connection) {
+    let source_syms = source.syms.read();
+    let mut target_syms = target.syms.write();
+    target_syms.functions.extend(
+        source_syms
+            .functions
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+    target_syms.vtab_modules.extend(
+        source_syms
+            .vtab_modules
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+    target_syms.index_methods.extend(
+        source_syms
+            .index_methods
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone())),
+    );
+}
+
+/// Capture non-builtin custom type definitions from the source schema.
+pub(crate) fn capture_custom_types(
+    source: &Connection,
+    db_id: usize,
+) -> Vec<(String, Arc<TypeDef>)> {
+    source.with_schema(db_id, |schema| {
+        schema
+            .type_registry
+            .iter()
+            .filter(|(_, td)| !td.is_builtin)
+            .map(|(name, td)| (name.clone(), td.clone()))
+            .collect()
+    })
+}
+
 /// Configuration for building a compacted vacuum target database. Provided by
 /// the caller after reading source metadata and setting up the target DB.
 /// Callers must mirror source symbols (functions, vtab modules, index methods)
@@ -1036,11 +1077,9 @@ pub(crate) enum VacuumInPlacePhase {
     /// Validate preconditions (auto_commit, active statements, readonly, memory,
     /// MVCC, WAL-backed pager).
     Preflight,
-    /// Acquire both read and write transactions on the source pager.
-    /// The WAL requires a read tx before a write tx (the write path needs the
-    /// read snapshot). `begin_write_tx` may yield IO for page1 allocation, so
-    /// this is a two-phase state: first attempt acquires read + tries write,
-    /// re-entry after IO yield retries only the write (read is already held).
+    /// Acquire exclusive access on the source WAL via `begin_exclusive_tx`:
+    /// checkpoint_lock is already held from Preflight, this acquires
+    /// read_locks[0] exclusively + write_lock in one shot.
     BeginSourceTx,
     /// Read source database header metadata for the target-build config.
     ReadSourceMetadata,
@@ -1195,26 +1234,21 @@ pub(crate) fn vacuum_in_place_step(
             }
 
             VacuumInPlacePhase::BeginSourceTx => {
-                // The WAL requires a read tx before a write tx. On first
-                // entry we start the read tx; on re-entry after an IO yield
-                // from begin_write_tx the read tx is already held.
-                if !cleanup_state.source_read_tx_open {
-                    source_pager.begin_read_tx()?;
-                    cleanup_state.source_read_tx_open = true;
-                }
-                match source_pager.begin_write_tx()? {
+                // Acquire exclusive WAL access in one shot:
+                // read_locks[0] exclusively + write_lock + connection snapshot.
+                // Checkpoint lock was already acquired in Preflight.
+                match source_pager.begin_exclusive_tx()? {
                     crate::IOResult::Done(()) => {
-                        // Write lock acquired. Set connection state.
                         connection.auto_commit.store(false, Ordering::SeqCst);
                         connection.set_tx_state(crate::connection::TransactionState::Write {
                             schema_did_change: false,
                         });
+                        cleanup_state.source_read_tx_open = true;
                         cleanup_state.source_write_tx_open = true;
                         *phase = VacuumInPlacePhase::ReadSourceMetadata;
                         continue;
                     }
                     crate::IOResult::IO(io) => {
-                        // Need to yield for IO (e.g. page1 allocation).
                         *phase = VacuumInPlacePhase::BeginSourceTx;
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
@@ -1251,41 +1285,8 @@ pub(crate) fn vacuum_in_place_step(
                 let temp_db =
                     open_vacuum_temp_db(connection, &source_db, page_size, reserved_space)?;
 
-                // Mirror source symbols directly into temp DB for schema replay,
-                // avoiding an intermediate clone through SourceSymbols.
-                {
-                    let source_syms = connection.syms.read();
-                    let mut target_syms = temp_db.conn.syms.write();
-                    target_syms.functions.extend(
-                        source_syms
-                            .functions
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    target_syms.vtab_modules.extend(
-                        source_syms
-                            .vtab_modules
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    target_syms.index_methods.extend(
-                        source_syms
-                            .index_methods
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                }
-
-                // Capture custom types.
-                let source_custom_types: Vec<(String, Arc<TypeDef>)> =
-                    connection.with_schema(db, |schema| {
-                        schema
-                            .type_registry
-                            .iter()
-                            .filter(|(_, td)| !td.is_builtin)
-                            .map(|(name, td)| (name.clone(), td.clone()))
-                            .collect()
-                    });
+                mirror_symbols(connection, &temp_db.conn);
+                let source_custom_types = capture_custom_types(connection, db);
 
                 let config = VacuumTargetBuildConfig {
                     source_conn: connection.clone(),

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::error::LimboError;
+use crate::ext::VTabImpl;
+use crate::function::ExternalFunc;
+use crate::index_method::IndexMethod;
 use crate::schema::TypeDef;
 use crate::storage::sqlite3_ondisk::{CacheSize, DatabaseHeader, TextEncoding};
 use crate::util::IOExt;
@@ -343,35 +347,11 @@ pub(crate) struct VacuumIntoConfig {
     pub source_mvcc_enabled: bool,
 }
 
-pub(crate) struct VacuumInto {
-    config: VacuumIntoConfig,
-    state: VacuumIntoState,
-}
-
-impl VacuumInto {
-    pub fn new(
-        config: VacuumIntoConfig,
-        dest_db: Arc<Database>,
-        dest_conn: Arc<Connection>,
-    ) -> Self {
-        Self {
-            config,
-            state: VacuumIntoState::new(dest_db, dest_conn),
-        }
-    }
-
-    pub fn step(&mut self) -> Result<IOResult<()>> {
-        vacuum_into_step(&self.config, &mut self.state)
-    }
-}
-
 /// State for the VACUUM INTO engine. Holds the destination connection and all
 /// intermediate state needed across async yields.
-struct VacuumIntoState {
-    /// Keep the destination database alive while VACUUM INTO is in progress.
-    #[allow(dead_code)]
-    dest_db: Arc<Database>,
-    dest_conn: Arc<Connection>,
+pub(crate) struct VacuumIntoState {
+    /// Destination connection - lives here, not in each sub-state variant.
+    pub dest_conn: Arc<Connection>,
     sub_state: VacuumIntoSubState,
     /// Typed schema entries collected from sqlite_schema, ordered by rowid.
     schema_entries: Vec<SchemaEntry>,
@@ -379,16 +359,15 @@ struct VacuumIntoState {
     tables_to_create: Vec<usize>,
     /// Storage-backed tables whose data to copy.
     tables_to_copy: Vec<usize>,
-    /// User-defined secondary indexes to CREATE.
+    /// User-defined secondary indexes to CREATE (deferred for performance).
     indexes_to_create: Vec<usize>,
-    /// Triggers, views, custom indexes, and rootpage = 0 objects.
+    /// Triggers, views, and rootpage = 0 objects (deferred to avoid trigger firing).
     post_data_entries: Vec<usize>,
 }
 
 impl VacuumIntoState {
-    fn new(dest_db: Arc<Database>, dest_conn: Arc<Connection>) -> Self {
+    pub fn new(dest_conn: Arc<Connection>) -> Self {
         Self {
-            dest_db,
             dest_conn,
             sub_state: VacuumIntoSubState::Init,
             schema_entries: Vec::new(),
@@ -406,7 +385,7 @@ impl VacuumIntoState {
 
 /// Sub-states for the VACUUM INTO engine state machine.
 #[derive(Default)]
-enum VacuumIntoSubState {
+pub(crate) enum VacuumIntoSubState {
     /// Mirror symbols/types, set perf flags, begin dest tx, prepare schema query.
     #[default]
     Init,
@@ -475,7 +454,7 @@ enum VacuumIntoSubState {
 pub(crate) fn vacuum_into_step(
     config: &VacuumIntoConfig,
     state: &mut VacuumIntoState,
-) -> Result<IOResult<()>> {
+) -> Result<InsnFunctionStepResult> {
     loop {
         let current_sub_state = std::mem::take(&mut state.sub_state);
 
@@ -485,22 +464,24 @@ pub(crate) fn vacuum_into_step(
                 // modules, index methods). We skip vtabs - those are live instances
                 // tied to the source connection and not needed for compiling schema SQL.
                 {
-                    let source_syms = config.source_conn.syms.read();
                     let mut dest_syms = state.dest_conn.syms.write();
                     dest_syms.functions.extend(
-                        source_syms
+                        config
+                            .source_symbols
                             .functions
                             .iter()
                             .map(|(k, v)| (k.clone(), v.clone())),
                     );
                     dest_syms.vtab_modules.extend(
-                        source_syms
+                        config
+                            .source_symbols
                             .vtab_modules
                             .iter()
                             .map(|(k, v)| (k.clone(), v.clone())),
                     );
                     dest_syms.index_methods.extend(
-                        source_syms
+                        config
+                            .source_symbols
                             .index_methods
                             .iter()
                             .map(|(k, v)| (k.clone(), v.clone())),
@@ -595,7 +576,7 @@ pub(crate) fn vacuum_into_step(
                             .take_io_completions()
                             .expect("StepResult::IO returned but no completions available");
                         state.sub_state = VacuumIntoSubState::CollectSchemaRows { schema_stmt };
-                        return Ok(IOResult::IO(io));
+                        return Ok(InsnFunctionStepResult::IO(io));
                     }
                     crate::StepResult::Busy | crate::StepResult::Interrupt => {
                         return Err(LimboError::Busy);
@@ -659,7 +640,7 @@ pub(crate) fn vacuum_into_step(
                         dest_schema_stmt,
                         idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(InsnFunctionStepResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -793,7 +774,7 @@ pub(crate) fn vacuum_into_step(
                         dest_insert_stmt,
                         table_idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(InsnFunctionStepResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -826,7 +807,7 @@ pub(crate) fn vacuum_into_step(
                         dest_insert_stmt,
                         table_idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(InsnFunctionStepResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -874,7 +855,7 @@ pub(crate) fn vacuum_into_step(
                         dest_schema_stmt,
                         idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(InsnFunctionStepResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -918,7 +899,7 @@ pub(crate) fn vacuum_into_step(
                         dest_schema_stmt,
                         idx,
                     };
-                    return Ok(IOResult::IO(io));
+                    return Ok(InsnFunctionStepResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -941,7 +922,7 @@ pub(crate) fn vacuum_into_step(
             VacuumIntoSubState::Done => {
                 // Commit the destination transaction started in Init state.
                 state.dest_conn.execute("COMMIT")?;
-                return Ok(IOResult::Done(()));
+                return Ok(InsnFunctionStepResult::Step);
             }
         }
     }
@@ -1115,6 +1096,17 @@ pub(crate) enum PlainVacuumSubState {
     },
     /// Open a read transaction on the committed temp pager for copy-back reads.
     BeginTempReadTx { temp_db: Box<InternalVacuumTempDb> },
+    /// Initialize the source WAL header if needed (one-time before first batch).
+    /// Two IO steps: write the header, then fsync to set `initialized = true`.
+    PrepareSourceWal {
+        temp_db: Box<InternalVacuumTempDb>,
+        total_pages: u32,
+        /// The completion to wait on: first the header write, then the fsync.
+        completion: crate::io::Completion,
+        /// `false` while waiting for the header write, `true` while waiting for
+        /// the fsync from `prepare_wal_finish`.
+        fsync_phase: bool,
+    },
     /// Read a single temp page for the current batch.
     ReadTempPage {
         temp_db: Box<InternalVacuumTempDb>,
@@ -1375,7 +1367,26 @@ pub(crate) fn plain_vacuum_step(
                     continue;
                 }
 
-                // Start reading the first temp page.
+                // Initialize the source WAL header before the first batch.
+                let source_pager = connection.get_pager_from_database_index(&db);
+                let wal = source_pager
+                    .wal
+                    .as_ref()
+                    .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
+                let page_sz = source_pager.get_page_size_unchecked();
+
+                if let Some(header_write_c) = wal.prepare_wal_start(page_sz)? {
+                    // WAL not yet initialized — yield on the header write.
+                    *sub_state = PlainVacuumSubState::PrepareSourceWal {
+                        temp_db,
+                        total_pages,
+                        completion: header_write_c,
+                        fsync_phase: false,
+                    };
+                    continue;
+                }
+
+                // WAL already initialized — go straight to reading temp pages.
                 let temp_pager = temp_db.conn.get_pager();
                 let (page_ref, completion) = temp_pager.read_page_no_cache(1, None, false)?;
 
@@ -1386,6 +1397,60 @@ pub(crate) fn plain_vacuum_step(
                     prev_prepared: None,
                     batch_pages: Vec::new(),
                     read_completion: completion,
+                    reading_page: page_ref,
+                };
+                continue;
+            }
+
+            PlainVacuumSubState::PrepareSourceWal {
+                temp_db,
+                total_pages,
+                completion,
+                fsync_phase,
+            } => {
+                if !completion.finished() {
+                    *sub_state = PlainVacuumSubState::PrepareSourceWal {
+                        temp_db,
+                        total_pages,
+                        completion: completion.clone(),
+                        fsync_phase,
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
+                        completion,
+                    )));
+                }
+                if !completion.succeeded() {
+                    return Err(LimboError::InternalError(
+                        "VACUUM: WAL header init failed".to_string(),
+                    ));
+                }
+
+                if !fsync_phase {
+                    // Header write done — issue the fsync via prepare_wal_finish
+                    // to set WAL `initialized = true`.
+                    let source_pager = connection.get_pager_from_database_index(&db);
+                    let wal = source_pager.wal.as_ref().unwrap();
+                    let sync_c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
+                    *sub_state = PlainVacuumSubState::PrepareSourceWal {
+                        temp_db,
+                        total_pages,
+                        completion: sync_c,
+                        fsync_phase: true,
+                    };
+                    continue;
+                }
+
+                // WAL header fully initialized. Start reading temp pages.
+                let temp_pager = temp_db.conn.get_pager();
+                let (page_ref, read_c) = temp_pager.read_page_no_cache(1, None, false)?;
+
+                *sub_state = PlainVacuumSubState::ReadTempPage {
+                    temp_db,
+                    total_pages,
+                    next_page: 2,
+                    prev_prepared: None,
+                    batch_pages: Vec::new(),
+                    read_completion: read_c,
                     reading_page: page_ref,
                 };
                 continue;
@@ -1429,22 +1494,14 @@ pub(crate) fn plain_vacuum_step(
                 let all_read = next_page > total_pages;
 
                 if batch_full || all_read {
-                    // Prepare WAL frames from this batch.
+                    // Prepare WAL frames from this batch. WAL header was already
+                    // initialized in PrepareSourceWal before reading started.
                     let source_pager = connection.get_pager_from_database_index(&db);
                     let wal = source_pager
                         .wal
                         .as_ref()
                         .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
                     let page_sz = source_pager.get_page_size_unchecked();
-
-                    // Initialize WAL header if needed (first batch only).
-                    if prev_prepared.is_none() {
-                        if let Some(c) = wal.prepare_wal_start(page_sz)? {
-                            source_pager.io.wait_for_completion(c)?;
-                            let c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
-                            source_pager.io.wait_for_completion(c)?;
-                        }
-                    }
 
                     let db_size_on_commit = if all_read { Some(total_pages) } else { None };
 
@@ -1518,7 +1575,15 @@ pub(crate) fn plain_vacuum_step(
                     }
                 }
 
-                // Commit this batch's prepared frames to advance WAL state.
+                // Commit this batch's prepared frames to advance local WAL
+                // index state (page→frame mapping, max_frame, checksum).
+                //
+                // We intentionally skip finalize_committed_pages() here. That
+                // call clears dirty flags and sets WAL tags on PageRefs that
+                // live in the source page cache. Our pages come from the temp
+                // pager's read_page_no_cache — they are not in the source page
+                // cache and have no dirty state to clear. The source page cache
+                // is invalidated wholesale via clear_page_cache() in Publish.
                 let source_pager = connection.get_pager_from_database_index(&db);
                 let wal = source_pager.wal.as_ref().unwrap();
                 if let Some(ref prepared) = prev_prepared {
@@ -1544,7 +1609,10 @@ pub(crate) fn plain_vacuum_step(
                     continue;
                 }
 
-                // All pages written. Fsync if sync mode requires it.
+                // All pages written. Fsync WAL if sync mode requires it.
+                // NORMAL mode skips fsync on WAL commit (fsyncs happen on
+                // checkpoint and WAL restart instead). This matches the regular
+                // pager commit path in Pager::commit_tx / CommitState.
                 let sync_mode = connection.get_sync_mode();
                 if sync_mode == SyncMode::Full {
                     let sync_c = wal.sync(source_pager.get_sync_type())?;

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1014,6 +1014,8 @@ pub(crate) fn build_copy_sql(
 /// when the error occurred.
 #[derive(Default)]
 pub(crate) struct VacuumInPlaceCleanupState {
+    /// WAL checkpoint serialization lock is held.
+    pub checkpoint_lock_held: bool,
     /// Source pager read transaction was started.
     pub source_read_tx_open: bool,
     /// Source pager write transaction was acquired and `auto_commit`/`tx_state`
@@ -1179,11 +1181,15 @@ pub(crate) fn vacuum_in_place_step(
                     ));
                 }
                 // 7. Reject non-WAL pagers.
-                if source_pager.wal.is_none() {
-                    return Err(LimboError::InternalError(
-                        "VACUUM requires a WAL-mode database".to_string(),
-                    ));
-                }
+                let wal = source_pager.wal.as_ref().ok_or_else(|| {
+                    LimboError::InternalError("VACUUM requires a WAL-mode database".to_string())
+                })?;
+                // 8. Acquire the checkpoint serialization lock early. This
+                // ensures a post-commit TRUNCATE checkpoint won't fail due
+                // to a concurrent checkpointer. If the lock is unavailable
+                // we fail fast before doing any expensive work.
+                wal.try_begin_checkpoint_lock()?;
+                cleanup_state.checkpoint_lock_held = true;
                 *phase = VacuumInPlacePhase::BeginSourceTx;
                 continue;
             }
@@ -1649,6 +1655,12 @@ pub(crate) fn vacuum_in_place_step(
                 cleanup_state.source_write_tx_open = false;
                 cleanup_state.source_read_tx_open = false;
 
+                // Release the checkpoint serialization lock now that commit
+                // is done. Future checkpoint support will run here, before
+                // releasing this lock.
+                wal.release_checkpoint_lock();
+                cleanup_state.checkpoint_lock_held = false;
+
                 // Restore connection bookkeeping immediately. The commit is
                 // durable so there is nothing to roll back; restoring here
                 // means the connection is never left poisoned even if the
@@ -1715,7 +1727,15 @@ pub(crate) fn vacuum_in_place_cleanup(
 ) {
     use std::sync::atomic::Ordering;
 
-    // Nothing acquired — nothing to undo.
+    // Release the checkpoint lock if we acquired it.
+    if cleanup_state.checkpoint_lock_held {
+        let pager = connection.get_pager_from_database_index(&db);
+        if let Some(wal) = pager.wal.as_ref() {
+            wal.release_checkpoint_lock();
+        }
+    }
+
+    // Nothing else acquired — nothing to undo.
     if !cleanup_state.source_read_tx_open && !cleanup_state.source_write_tx_open {
         return;
     }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::error::LimboError;
 use crate::schema::TypeDef;
 use crate::storage::sqlite3_ondisk::{CacheSize, DatabaseHeader, TextEncoding};
-use crate::types::IOResult;
+use crate::util::IOExt;
 use crate::vdbe::execute::InsnFunctionStepResult;
 use crate::Result;
 use crate::{Connection, Database, DatabaseOpts, EncryptionOpts, OpenFlags};
@@ -713,11 +713,19 @@ pub(crate) fn vacuum_into_step(
                         schema.get_btree_table(table_name)
                     });
 
-                let (select_sql, insert_sql) = build_copy_sql(
+                let (select_sql, mut insert_sql) = build_copy_sql(
                     &config.escaped_schema_name,
                     &escaped_table_name,
                     source_btree_table.as_deref(),
                 )?;
+
+                // sqlite_sequence may already have rows from the AUTOINCREMENT
+                // tracking that ran during the table data copy. Use INSERT OR
+                // REPLACE so the source counter values overwrite any stale
+                // auto-generated ones (matches SQLite vacuum.c behavior).
+                if entry.is_sqlite_sequence() {
+                    insert_sql = insert_sql.replacen("INSERT INTO", "INSERT OR REPLACE INTO", 1);
+                }
 
                 // SELECT from source, INSERT into destination.
                 let select_stmt = config.source_conn.prepare_internal(&select_sql)?;
@@ -1077,6 +1085,607 @@ pub(crate) fn build_copy_sql(
         format!("INSERT INTO \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
 
     Ok((select_sql, insert_sql))
+}
+
+// ---------------------------------------------------------------------------
+// Plain VACUUM engine - copy-back state machine
+// ---------------------------------------------------------------------------
+
+/// Sub-states for the plain VACUUM opcode state machine.
+///
+/// The opcode owns the source transaction lifecycle directly: it begins the
+/// read and write transactions on the source pager, builds a temp image via
+/// the shared temp-build engine, then copies the compacted image back into the
+/// source WAL using the batched prepare_frames → WriteBatch → commit path.
+pub(crate) enum PlainVacuumSubState {
+    /// Validate preconditions (auto_commit, active statements, readonly, memory,
+    /// MVCC, WAL-backed pager).
+    Preflight,
+    /// `pager.begin_read_tx()` on the source.
+    BeginSourceReadTx,
+    /// `pager.begin_write_tx()` on the source. May yield IO.
+    BeginSourceWriteTx,
+    /// Read source page-1 header metadata for the temp-build config.
+    ReadSourceMetadata,
+    /// Create temp DB and run the shared temp-build engine.
+    BuildTempImage {
+        config: Box<VacuumIntoConfig>,
+        temp_db: Box<InternalVacuumTempDb>,
+        state: Box<VacuumIntoState>,
+    },
+    /// Open a read transaction on the committed temp pager for copy-back reads.
+    BeginTempReadTx { temp_db: Box<InternalVacuumTempDb> },
+    /// Read a single temp page for the current batch.
+    ReadTempPage {
+        temp_db: Box<InternalVacuumTempDb>,
+        total_pages: u32,
+        /// Next page number to read (1-based). The page at `next_page - 1` is
+        /// the one we just issued a read for and are awaiting.
+        next_page: u32,
+        prev_prepared: Option<crate::storage::wal::PreparedFrames>,
+        /// Accumulated pages for the current batch.
+        batch_pages: Vec<crate::storage::pager::PageRef>,
+        /// Completion for the in-flight read.
+        read_completion: crate::io::Completion,
+        /// The PageRef being read.
+        reading_page: crate::storage::pager::PageRef,
+    },
+    /// Write a prepared batch to the WAL file.
+    WriteBatch {
+        temp_db: Box<InternalVacuumTempDb>,
+        total_pages: u32,
+        next_page: u32,
+        prev_prepared: Option<crate::storage::wal::PreparedFrames>,
+        completions: Vec<crate::io::Completion>,
+    },
+    /// Fsync the WAL if sync mode requires it.
+    SyncWal {
+        temp_db: Box<InternalVacuumTempDb>,
+        sync_completion: crate::io::Completion,
+    },
+    /// Publish: commit_prepared_frames + finish_append_frames_commit + schema reload.
+    Publish { temp_db: Box<InternalVacuumTempDb> },
+    /// Clean up after successful commit.
+    Done,
+}
+
+impl Default for PlainVacuumSubState {
+    fn default() -> Self {
+        Self::Preflight
+    }
+}
+
+/// The batch size for copy-back: how many temp pages to read per batch.
+const VACUUM_COPY_BATCH_SIZE: u32 = 64;
+
+/// Step the plain VACUUM state machine once. Returns `IO` to yield or `Step`
+/// when the entire operation is complete.
+pub(crate) fn plain_vacuum_step(
+    connection: &Arc<Connection>,
+    db: usize,
+    sub_state: &mut PlainVacuumSubState,
+) -> Result<InsnFunctionStepResult> {
+    use crate::io::WriteBatch as IOWriteBatch;
+    use crate::types::IOCompletions;
+    use crate::SyncMode;
+    use std::sync::atomic::Ordering;
+
+    loop {
+        let current = std::mem::take(sub_state);
+        match current {
+            PlainVacuumSubState::Preflight => {
+                // 1. Must be in auto-commit mode (no explicit transaction).
+                if !connection.auto_commit.load(Ordering::SeqCst) {
+                    return Err(LimboError::TxError(
+                        "cannot VACUUM from within a transaction".to_string(),
+                    ));
+                }
+                // 2. No other active root statements on this connection.
+                if connection.n_active_root_statements.load(Ordering::SeqCst) != 1 {
+                    return Err(LimboError::TxError(
+                        "cannot VACUUM - SQL statements in progress".to_string(),
+                    ));
+                }
+                // 3. Reject readonly database.
+                if connection.is_readonly(db) {
+                    return Err(LimboError::ReadOnly);
+                }
+                // 4. Reject MVCC mode.
+                let source_db = connection.get_source_database(db);
+                if source_db.mvcc_enabled() {
+                    return Err(LimboError::InternalError(
+                        "VACUUM is not supported in MVCC mode yet".to_string(),
+                    ));
+                }
+                // 5. Reject in-memory databases.
+                if source_db.path.starts_with(":memory:") || source_db.path.is_empty() {
+                    return Err(LimboError::InternalError(
+                        "cannot VACUUM an in-memory database".to_string(),
+                    ));
+                }
+                // 6. Reject non-WAL pagers.
+                let pager = connection.get_pager_from_database_index(&db);
+                if pager.wal.is_none() {
+                    return Err(LimboError::InternalError(
+                        "VACUUM requires a WAL-mode database".to_string(),
+                    ));
+                }
+                *sub_state = PlainVacuumSubState::BeginSourceReadTx;
+                continue;
+            }
+
+            PlainVacuumSubState::BeginSourceReadTx => {
+                let pager = connection.get_pager_from_database_index(&db);
+                pager.begin_read_tx()?;
+                *sub_state = PlainVacuumSubState::BeginSourceWriteTx;
+                continue;
+            }
+
+            PlainVacuumSubState::BeginSourceWriteTx => {
+                let pager = connection.get_pager_from_database_index(&db);
+                match pager.begin_write_tx()? {
+                    crate::IOResult::Done(()) => {
+                        // Write lock acquired. Set connection state.
+                        connection.auto_commit.store(false, Ordering::SeqCst);
+                        connection.set_tx_state(crate::connection::TransactionState::Write {
+                            schema_did_change: false,
+                        });
+                        *sub_state = PlainVacuumSubState::ReadSourceMetadata;
+                        continue;
+                    }
+                    crate::IOResult::IO(io) => {
+                        // Need to yield for IO (e.g. page1 allocation).
+                        *sub_state = PlainVacuumSubState::BeginSourceWriteTx;
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                }
+            }
+
+            PlainVacuumSubState::ReadSourceMetadata => {
+                let source_db = connection.get_source_database(db);
+                let pager = connection.get_pager_from_database_index(&db);
+
+                // Read page size from pager (cached after begin_read_tx).
+                let page_size = pager.get_page_size().map(|ps| ps.get()).unwrap_or(4096);
+
+                // Read reserved bytes.
+                let reserved_space: u8 = match connection.get_reserved_bytes() {
+                    Some(val) => val,
+                    None => {
+                        let io = &*pager.io;
+                        io.block(|| pager.with_header(|h| h.reserved_space))?
+                    }
+                };
+
+                // Read header metadata for the destination.
+                let io = &*pager.io;
+                let destination_header: VacuumDestinationHeader = io.block(|| {
+                    pager.with_header(VacuumDestinationHeader::plain_vacuum_from_source_header)
+                })?;
+                // Create temp database.
+                let temp_db = open_internal_vacuum_temp_db(
+                    connection,
+                    &source_db,
+                    page_size,
+                    reserved_space,
+                )?;
+
+                // Capture source symbols for schema replay.
+                let source_symbols = {
+                    let syms = connection.syms.read();
+                    SourceSymbols {
+                        functions: syms
+                            .functions
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                        vtab_modules: syms
+                            .vtab_modules
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                        index_methods: syms
+                            .index_methods
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect(),
+                    }
+                };
+
+                // Capture custom types.
+                let source_custom_types: Vec<(String, Arc<TypeDef>)> =
+                    connection.with_schema(db, |schema| {
+                        schema
+                            .type_registry
+                            .iter()
+                            .filter(|(_, td)| !td.is_builtin)
+                            .map(|(name, td)| (name.clone(), td.clone()))
+                            .collect()
+                    });
+
+                let config = VacuumIntoConfig {
+                    source_conn: connection.clone(),
+                    escaped_schema_name: "main".to_string(),
+                    database_id: db,
+                    destination_header,
+                    source_symbols,
+                    source_custom_types,
+                    source_mvcc_enabled: false, // Rejected MVCC above
+                };
+
+                let vi_state = VacuumIntoState::new(temp_db.conn.clone());
+
+                *sub_state = PlainVacuumSubState::BuildTempImage {
+                    config: Box::new(config),
+                    temp_db: Box::new(temp_db),
+                    state: Box::new(vi_state),
+                };
+                continue;
+            }
+
+            PlainVacuumSubState::BuildTempImage {
+                config,
+                temp_db,
+                mut state,
+            } => {
+                match vacuum_into_step(&config, &mut state)? {
+                    InsnFunctionStepResult::Step => {
+                        // Temp build complete. Move to read tx on temp.
+                        drop(config);
+                        drop(state);
+                        *sub_state = PlainVacuumSubState::BeginTempReadTx { temp_db };
+                        continue;
+                    }
+                    InsnFunctionStepResult::IO(io) => {
+                        *sub_state = PlainVacuumSubState::BuildTempImage {
+                            config,
+                            temp_db,
+                            state,
+                        };
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                    _ => unreachable!("vacuum_into_step only returns Step or IO"),
+                }
+            }
+
+            PlainVacuumSubState::BeginTempReadTx { temp_db } => {
+                // The shared temp-build engine committed via SQL COMMIT, which
+                // ends the write transaction but leaves the WAL read mark held.
+                // End that read tx first, then start a fresh one so WAL lookups
+                // see the committed temp image.
+                let temp_pager = temp_db.conn.get_pager();
+                temp_pager.end_read_tx();
+                temp_pager.begin_read_tx()?;
+
+                // Determine the compacted image size from temp page 1 header.
+                let io = &*temp_pager.io;
+                let total_pages: u32 =
+                    io.block(|| temp_pager.with_header(|h| h.database_size.get()))?;
+
+                if total_pages == 0 {
+                    // Empty database — nothing to copy back. Clean up the
+                    // source write tx and connection state we acquired earlier.
+                    drop(temp_db);
+                    let source_pager = connection.get_pager_from_database_index(&db);
+                    source_pager.end_write_tx();
+                    source_pager.end_read_tx();
+                    connection.auto_commit.store(true, Ordering::SeqCst);
+                    connection.set_tx_state(crate::connection::TransactionState::None);
+                    *sub_state = PlainVacuumSubState::Done;
+                    continue;
+                }
+
+                // Start reading the first temp page.
+                let temp_pager = temp_db.conn.get_pager();
+                let (page_ref, completion) = temp_pager.read_page_no_cache(1, None, false)?;
+
+                *sub_state = PlainVacuumSubState::ReadTempPage {
+                    temp_db,
+                    total_pages,
+                    next_page: 2, // page 1 is being read now
+                    prev_prepared: None,
+                    batch_pages: Vec::new(),
+                    read_completion: completion,
+                    reading_page: page_ref,
+                };
+                continue;
+            }
+
+            PlainVacuumSubState::ReadTempPage {
+                temp_db,
+                total_pages,
+                next_page,
+                prev_prepared,
+                mut batch_pages,
+                read_completion,
+                reading_page,
+            } => {
+                // Wait for the current read to complete.
+                if !read_completion.finished() {
+                    *sub_state = PlainVacuumSubState::ReadTempPage {
+                        temp_db,
+                        total_pages,
+                        next_page,
+                        prev_prepared,
+                        batch_pages,
+                        read_completion: read_completion.clone(),
+                        reading_page,
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
+                        read_completion,
+                    )));
+                }
+                if !read_completion.succeeded() {
+                    return Err(LimboError::InternalError(
+                        "VACUUM: temp page read failed".to_string(),
+                    ));
+                }
+
+                // Accumulate the completed page.
+                batch_pages.push(reading_page);
+
+                // If batch is full or we've read all pages, prepare WAL frames.
+                let batch_full = batch_pages.len() >= VACUUM_COPY_BATCH_SIZE as usize;
+                let all_read = next_page > total_pages;
+
+                if batch_full || all_read {
+                    // Prepare WAL frames from this batch.
+                    let source_pager = connection.get_pager_from_database_index(&db);
+                    let wal = source_pager
+                        .wal
+                        .as_ref()
+                        .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
+                    let page_sz = source_pager.get_page_size_unchecked();
+
+                    // Initialize WAL header if needed (first batch only).
+                    if prev_prepared.is_none() {
+                        if let Some(c) = wal.prepare_wal_start(page_sz)? {
+                            source_pager.io.wait_for_completion(c)?;
+                            let c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
+                            source_pager.io.wait_for_completion(c)?;
+                        }
+                    }
+
+                    let db_size_on_commit = if all_read { Some(total_pages) } else { None };
+
+                    let prepared = wal.prepare_frames(
+                        &batch_pages,
+                        page_sz,
+                        db_size_on_commit,
+                        prev_prepared.as_ref(),
+                    )?;
+
+                    // Submit writes via WriteBatch.
+                    let wal_file = wal.wal_file()?;
+                    let mut batch = IOWriteBatch::new(wal_file);
+                    batch.writev(prepared.offset, &prepared.bufs);
+                    let completions = batch.submit()?;
+
+                    *sub_state = PlainVacuumSubState::WriteBatch {
+                        temp_db,
+                        total_pages,
+                        next_page,
+                        prev_prepared: Some(prepared),
+                        completions,
+                    };
+                    continue;
+                }
+
+                // Batch not full, more pages to read. Issue next read.
+                let temp_pager = temp_db.conn.get_pager();
+                let (page_ref, completion) =
+                    temp_pager.read_page_no_cache(next_page as i64, None, false)?;
+
+                *sub_state = PlainVacuumSubState::ReadTempPage {
+                    temp_db,
+                    total_pages,
+                    next_page: next_page + 1,
+                    prev_prepared,
+                    batch_pages,
+                    read_completion: completion,
+                    reading_page: page_ref,
+                };
+                continue;
+            }
+
+            PlainVacuumSubState::WriteBatch {
+                temp_db,
+                total_pages,
+                next_page,
+                prev_prepared,
+                completions,
+            } => {
+                // Wait for all writes in this batch. We yield on the first
+                // unfinished completion; re-entry will re-check them all.
+                let pending = completions.iter().find(|c| !c.finished()).cloned();
+                if let Some(pending) = pending {
+                    *sub_state = PlainVacuumSubState::WriteBatch {
+                        temp_db,
+                        total_pages,
+                        next_page,
+                        prev_prepared,
+                        completions,
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(pending)));
+                }
+
+                // Check for write errors.
+                for c in &completions {
+                    if !c.succeeded() {
+                        return Err(LimboError::InternalError(
+                            "VACUUM: WAL write failed".to_string(),
+                        ));
+                    }
+                }
+
+                // Commit this batch's prepared frames to advance WAL state.
+                let source_pager = connection.get_pager_from_database_index(&db);
+                let wal = source_pager.wal.as_ref().unwrap();
+                if let Some(ref prepared) = prev_prepared {
+                    wal.commit_prepared_frames(std::slice::from_ref(prepared));
+                }
+
+                // More pages to copy?
+                if next_page <= total_pages {
+                    // Start reading the next page.
+                    let temp_pager = temp_db.conn.get_pager();
+                    let (page_ref, completion) =
+                        temp_pager.read_page_no_cache(next_page as i64, None, false)?;
+
+                    *sub_state = PlainVacuumSubState::ReadTempPage {
+                        temp_db,
+                        total_pages,
+                        next_page: next_page + 1,
+                        prev_prepared,
+                        batch_pages: Vec::new(),
+                        read_completion: completion,
+                        reading_page: page_ref,
+                    };
+                    continue;
+                }
+
+                // All pages written. Fsync if sync mode requires it.
+                let sync_mode = connection.get_sync_mode();
+                if sync_mode == SyncMode::Full {
+                    let sync_c = wal.sync(source_pager.get_sync_type())?;
+                    *sub_state = PlainVacuumSubState::SyncWal {
+                        temp_db,
+                        sync_completion: sync_c,
+                    };
+                    continue;
+                }
+
+                // No sync needed — proceed directly to publish.
+                *sub_state = PlainVacuumSubState::Publish { temp_db };
+                continue;
+            }
+
+            PlainVacuumSubState::SyncWal {
+                temp_db,
+                sync_completion,
+            } => {
+                if !sync_completion.finished() {
+                    *sub_state = PlainVacuumSubState::SyncWal {
+                        temp_db,
+                        sync_completion: sync_completion.clone(),
+                    };
+                    return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
+                        sync_completion,
+                    )));
+                }
+                if !sync_completion.succeeded() {
+                    return Err(LimboError::InternalError(
+                        "VACUUM: WAL fsync failed".to_string(),
+                    ));
+                }
+                *sub_state = PlainVacuumSubState::Publish { temp_db };
+                continue;
+            }
+
+            PlainVacuumSubState::Publish { temp_db } => {
+                let source_pager = connection.get_pager_from_database_index(&db);
+                let wal = source_pager
+                    .wal
+                    .as_ref()
+                    .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
+
+                // Publish the WAL transaction to shared state.
+                wal.finish_append_frames_commit()?;
+
+                // Release source write lock and old read lock.
+                source_pager.end_write_tx();
+                source_pager.end_read_tx();
+
+                // Invalidate page cache and schema cookie so fresh reads see
+                // the newly committed WAL frames.
+                source_pager.clear_page_cache(false);
+                source_pager.set_schema_cookie(None);
+
+                // Drop temp resources before schema reload.
+                drop(temp_db);
+
+                // Start a fresh read tx that sees the committed WAL frames.
+                // Set tx_state to Read so `reparse_schema`'s internal
+                // Transaction opcode skips begin_read_tx (one is already active).
+                source_pager.begin_read_tx()?;
+                connection.set_tx_state(crate::connection::TransactionState::Read);
+
+                // Reload the schema from the new database pages. The compacted
+                // image may have different rootpage assignments, so the in-memory
+                // schema must be rebuilt from sqlite_schema on disk rather than
+                // reusing the old table definitions with a bumped cookie.
+                connection.reparse_schema()?;
+
+                // Publish the freshly parsed schema to the shared Database so
+                // other connections see the new cookie and table definitions.
+                {
+                    let schema = connection.schema.read().clone();
+                    let source_db = connection.get_source_database(db);
+                    source_db.update_schema_if_newer(schema);
+                }
+
+                // End the schema-reload read tx.
+                source_pager.end_read_tx();
+
+                // Restore connection state.
+                connection.auto_commit.store(true, Ordering::SeqCst);
+                connection.set_tx_state(crate::connection::TransactionState::None);
+
+                *sub_state = PlainVacuumSubState::Done;
+                return Ok(InsnFunctionStepResult::Step);
+            }
+
+            PlainVacuumSubState::Done => {
+                return Ok(InsnFunctionStepResult::Step);
+            }
+        }
+    }
+}
+
+/// Roll back the source transaction and restore connection state after a
+/// plain VACUUM failure. This must be called before dropping the vacuum
+/// opcode state to preserve rollback-before-unlock ordering.
+///
+/// The `sub_state` tells us how far the vacuum progressed; if it never got
+/// past Preflight we have not touched any pager or connection state so
+/// there is nothing to undo (and blindly resetting auto_commit / tx_state
+/// would clobber an existing user transaction).
+pub(crate) fn plain_vacuum_cleanup(
+    connection: &Arc<Connection>,
+    db: usize,
+    sub_state: &PlainVacuumSubState,
+) {
+    use std::sync::atomic::Ordering;
+
+    // Preflight is the initial check phase — no locks acquired, no
+    // connection state modified.  Nothing to clean up.
+    if matches!(sub_state, PlainVacuumSubState::Preflight) {
+        return;
+    }
+
+    // BeginSourceReadTx started a pager read tx but has not yet changed
+    // auto_commit or tx_state.  End the read lock and return.
+    if matches!(sub_state, PlainVacuumSubState::BeginSourceReadTx) {
+        let pager = connection.get_pager_from_database_index(&db);
+        pager.end_read_tx();
+        return;
+    }
+
+    // Past BeginSourceWriteTx: we modified auto_commit and tx_state and
+    // may hold a write lock.  Roll back the pager transaction and restore
+    // connection state.
+    let tx_state = connection.get_tx_state();
+    if matches!(
+        tx_state,
+        crate::connection::TransactionState::Write { .. }
+            | crate::connection::TransactionState::Read
+    ) {
+        let pager = connection.get_pager_from_database_index(&db);
+        pager.rollback_tx(connection);
+    }
+
+    connection.auto_commit.store(true, Ordering::SeqCst);
+    connection.set_tx_state(crate::connection::TransactionState::None);
 }
 
 #[cfg(test)]

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -195,7 +195,6 @@ pub(crate) enum VacuumDestinationHeader {
     VacuumInto(VacuumHeaderMetadata),
     /// Plain `VACUUM` builds a replacement image, so the temp image's page 1
     /// must already contain the final source header values before copy-back.
-    #[allow(dead_code)]
     PlainVacuum(VacuumHeaderMetadata),
 }
 

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1139,8 +1139,8 @@ pub(crate) enum VacuumInPlacePhase {
     PublishWalCommit { temp_db: Box<VacuumTempDb> },
     /// TRUNCATE checkpoint: copy WAL frames back into the DB file and truncate
     /// the WAL to zero. The pager's internal state machine handles the multi-step
-    /// IO (backfill → sync DB → truncate WAL). Non-fatal if it fails — data is
-    /// already durable in the WAL.
+    /// IO (backfill → sync DB → truncate WAL). Plain VACUUM requires this fold
+    /// to complete before reporting success.
     Checkpoint,
     /// Reload the schema from the freshly committed (and possibly checkpointed) DB.
     SchemaReload,
@@ -1156,6 +1156,22 @@ impl Default for VacuumInPlacePhase {
 
 /// The batch size for copy-back: how many temp pages to read per batch.
 const VACUUM_COPY_BATCH_SIZE: u32 = 64;
+
+fn vacuum_copy_batch_end(start_page: u32, total_pages: u32) -> u32 {
+    (start_page + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1)
+}
+
+#[cfg(test)]
+fn vacuum_copy_batch_ranges(total_pages: u32) -> Vec<(u32, u32)> {
+    let mut ranges = Vec::new();
+    let mut start = 1;
+    while start <= total_pages {
+        let end = vacuum_copy_batch_end(start, total_pages);
+        ranges.push((start, end));
+        start = end;
+    }
+    ranges
+}
 
 /// Coalesce `(page_ref, frame_id)` pairs into contiguous-frame-id runs.
 ///
@@ -1206,9 +1222,10 @@ fn start_temp_batch_reads(
         "empty vacuum read batch",
         { "batch_start": batch_start, "batch_end": batch_end }
     );
-    let wal = temp_pager.wal.as_ref().ok_or_else(|| {
-        LimboError::InternalError("VACUUM requires a temp WAL pager".into())
-    })?;
+    let wal = temp_pager
+        .wal
+        .as_ref()
+        .ok_or_else(|| LimboError::InternalError("VACUUM requires a temp WAL pager".into()))?;
 
     let len = (batch_end - batch_start) as usize;
     let mut logical_pages: Vec<crate::storage::pager::PageRef> = Vec::with_capacity(len);
@@ -1229,16 +1246,40 @@ fn start_temp_batch_reads(
 
     let mut group = CompletionGroup::new(|_| {});
     for (start_frame, run_pages) in &runs {
-        let c = wal.read_frames_batch(
-            *start_frame,
-            run_pages,
-            temp_pager.buffer_pool.clone(),
-        )?;
+        let c = wal.read_frames_batch(*start_frame, run_pages, temp_pager.buffer_pool.clone())?;
         group.add(&c);
     }
     let combined = group.build();
 
     Ok((logical_pages, combined))
+}
+
+fn reload_schema_after_vacuum_commit(
+    connection: &Arc<Connection>,
+    db: usize,
+    source_pager: &crate::storage::pager::Pager,
+) -> Result<()> {
+    // Schema reload under a self-contained read guard. If this fails the
+    // cleared schema cookie will trigger a re-read on the next operation.
+    source_pager.begin_read_tx()?;
+    connection.set_tx_state(crate::connection::TransactionState::Read);
+
+    let reload_result = connection.reparse_schema();
+
+    if reload_result.is_ok() {
+        // Publish the freshly parsed schema to the shared Database so other
+        // connections see the new cookie and table defs.
+        let schema = connection.schema.read().clone();
+        let source_db = connection.get_source_database(db);
+        source_db.update_schema_if_newer(schema);
+    }
+
+    // Always end the schema-reload read tx and restore state, whether the
+    // reload succeeded or failed.
+    source_pager.end_read_tx();
+    connection.set_tx_state(crate::connection::TransactionState::None);
+
+    reload_result
 }
 
 /// Step the in-place VACUUM state machine once. Returns `IO` to yield or `Step`
@@ -1472,7 +1513,7 @@ pub(crate) fn vacuum_in_place_step(
 
                 // WAL already initialized — kick off the first read batch.
                 let temp_pager = temp_db.conn.get_pager();
-                let batch_end = (1 + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1);
+                let batch_end = vacuum_copy_batch_end(1, total_pages);
                 let (batch_pages, read_completion) =
                     start_temp_batch_reads(&temp_pager, 1, batch_end)?;
 
@@ -1526,7 +1567,7 @@ pub(crate) fn vacuum_in_place_step(
 
                 // WAL header fully initialized. Kick off the first read batch.
                 let temp_pager = temp_db.conn.get_pager();
-                let batch_end = (1 + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1);
+                let batch_end = vacuum_copy_batch_end(1, total_pages);
                 let (batch_pages, read_completion) =
                     start_temp_batch_reads(&temp_pager, 1, batch_end)?;
 
@@ -1650,8 +1691,7 @@ pub(crate) fn vacuum_in_place_step(
                 if next_page <= total_pages {
                     // Kick off the next read batch in parallel.
                     let temp_pager = temp_db.conn.get_pager();
-                    let batch_end =
-                        (next_page + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1);
+                    let batch_end = vacuum_copy_batch_end(next_page, total_pages);
                     let (batch_pages, read_completion) =
                         start_temp_batch_reads(&temp_pager, next_page, batch_end)?;
 
@@ -1752,8 +1792,6 @@ pub(crate) fn vacuum_in_place_step(
             VacuumInPlacePhase::Checkpoint => {
                 // TRUNCATE checkpoint: copy WAL frames into the DB file,
                 // sync the DB, then truncate the WAL to zero bytes.
-                // Non-fatal if it fails — data is already durable in the WAL
-                // and will be checkpointed by the next auto-checkpoint.
                 let sync_mode = connection.get_sync_mode();
                 match source_pager.checkpoint(
                     crate::storage::wal::CheckpointMode::Truncate {
@@ -1762,7 +1800,10 @@ pub(crate) fn vacuum_in_place_step(
                     sync_mode,
                     true,
                 ) {
-                    Ok(crate::IOResult::Done(_)) => {
+                    Ok(crate::IOResult::Done(result)) => {
+                        if !result.should_truncate() {
+                            return Err(LimboError::Busy);
+                        }
                         *phase = VacuumInPlacePhase::SchemaReload;
                         continue;
                     }
@@ -1771,36 +1812,21 @@ pub(crate) fn vacuum_in_place_step(
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
                     Err(err) => {
-                        tracing::info!("VACUUM post-commit checkpoint failed (non-fatal): {err}");
-                        *phase = VacuumInPlacePhase::SchemaReload;
-                        continue;
+                        tracing::info!("VACUUM post-commit checkpoint failed: {err}");
+                        if let Err(reload_err) =
+                            reload_schema_after_vacuum_commit(connection, db, &source_pager)
+                        {
+                            tracing::info!(
+                                "VACUUM schema reload after checkpoint failure also failed: {reload_err}"
+                            );
+                        }
+                        return Err(err);
                     }
                 }
             }
 
             VacuumInPlacePhase::SchemaReload => {
-                // Schema reload under a self-contained read guard. If this
-                // fails the connection is still usable — the cleared schema
-                // cookie will trigger a re-read on the next operation.
-                source_pager.begin_read_tx()?;
-                connection.set_tx_state(crate::connection::TransactionState::Read);
-
-                let reload_result = connection.reparse_schema();
-
-                if reload_result.is_ok() {
-                    // Publish the freshly parsed schema to the shared Database
-                    // so other connections see the new cookie and table defs.
-                    let schema = connection.schema.read().clone();
-                    let source_db = connection.get_source_database(db);
-                    source_db.update_schema_if_newer(schema);
-                }
-
-                // Always end the schema-reload read tx and restore state,
-                // whether the reload succeeded or failed.
-                source_pager.end_read_tx();
-                connection.set_tx_state(crate::connection::TransactionState::None);
-
-                reload_result?;
+                reload_schema_after_vacuum_commit(connection, db, &source_pager)?;
 
                 *phase = VacuumInPlacePhase::Done;
                 return Ok(InsnFunctionStepResult::Step);
@@ -1957,6 +1983,49 @@ mod tests {
         for (_, pages) in &runs {
             assert_eq!(pages.len(), 1);
         }
+    }
+
+    #[test]
+    fn coalesce_frame_runs_keeps_run_pages_in_physical_frame_order() {
+        let runs = coalesce_frame_runs(vec![
+            (page_ref(1), 12),
+            (page_ref(2), 10),
+            (page_ref(3), 11),
+            (page_ref(4), 13),
+        ]);
+
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].0, 10);
+        assert_eq!(
+            runs[0].1.iter().map(|p| p.get().id).collect::<Vec<_>>(),
+            vec![2, 3, 1, 4]
+        );
+    }
+
+    #[test]
+    fn vacuum_copy_batch_ranges_cover_boundary_page_counts() {
+        let size = VACUUM_COPY_BATCH_SIZE;
+        assert!(vacuum_copy_batch_ranges(0).is_empty());
+        assert_eq!(vacuum_copy_batch_ranges(1), vec![(1, 2)]);
+        assert_eq!(vacuum_copy_batch_ranges(2), vec![(1, 3)]);
+        assert_eq!(vacuum_copy_batch_ranges(size - 1), vec![(1, size)]);
+        assert_eq!(vacuum_copy_batch_ranges(size), vec![(1, size + 1)]);
+        assert_eq!(
+            vacuum_copy_batch_ranges(size + 1),
+            vec![(1, size + 1), (size + 1, size + 2)]
+        );
+        assert_eq!(
+            vacuum_copy_batch_ranges(size * 2),
+            vec![(1, size + 1), (size + 1, size * 2 + 1)]
+        );
+        assert_eq!(
+            vacuum_copy_batch_ranges(size * 2 + 1),
+            vec![
+                (1, size + 1),
+                (size + 1, size * 2 + 1),
+                (size * 2 + 1, size * 2 + 2),
+            ]
+        );
     }
 
     #[test]

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -216,6 +216,10 @@ impl VacuumIntoState {
             post_data_entries: Vec::new(),
         }
     }
+
+    pub(crate) fn cleanup_after_error(&mut self) {
+        self.sub_state = VacuumIntoSubState::Done;
+    }
 }
 
 /// Sub-states for the VACUUM INTO engine state machine.
@@ -339,7 +343,7 @@ fn vacuum_into_step(
                 }
 
                 // Performance optimizations for destination database (matches SQLite vacuum.c):
-                // 1. Disable fsync - destination is a new file, if crash occurs we just delete it
+                // 1. Disable fsync - destination is a new user-visible output file
                 // 2. Disable foreign key checks - source data is already consistent
                 // These match SQLite's vacuum.c optimizations (PAGER_SYNCHRONOUS_OFF, ~SQLITE_ForeignKeys)
                 state.dest_conn.set_sync_mode(crate::SyncMode::Off);

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -100,7 +100,7 @@ pub(crate) fn classify_schema_entries(
                 // All storage-backed tables get their data copied, including
                 // sqlite_stat1 and other internal storage-backed tables.
                 // sqlite_sequence data copy is handled specially by the caller
-                // (only if destination materialized it).
+                // (only if the target materialized it).
                 tables_to_copy.push(idx);
             }
             SchemaEntryType::Index if entry.is_storage_backed() => {
@@ -147,8 +147,8 @@ pub(crate) fn classify_schema_entries(
 // Destination configuration and metadata policy
 // ---------------------------------------------------------------------------
 
-/// Destination feature flags needed for schema replay during a vacuum build.
-pub(crate) fn vacuum_destination_opts(source_db: &Database) -> DatabaseOpts {
+/// Target database feature flags needed for schema replay during a vacuum build.
+pub(crate) fn vacuum_target_opts_from_source(source_db: &Database) -> DatabaseOpts {
     DatabaseOpts::new()
         .with_views(source_db.experimental_views_enabled())
         .with_index_method(source_db.experimental_index_method_enabled())
@@ -158,9 +158,9 @@ pub(crate) fn vacuum_destination_opts(source_db: &Database) -> DatabaseOpts {
         .with_generated_columns(source_db.experimental_generated_columns_enabled())
 }
 
-/// Page-1 metadata that the build engine must finalize before destination commit.
+/// Page-1 metadata that the target build must finalize before commit.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct VacuumHeaderMetadata {
+pub(crate) struct VacuumPage1Meta {
     schema_cookie: u32,
     default_page_cache_size: CacheSize,
     text_encoding: TextEncoding,
@@ -168,8 +168,8 @@ pub(crate) struct VacuumHeaderMetadata {
     application_id: i32,
 }
 
-impl VacuumHeaderMetadata {
-    fn from_source_header(source: &DatabaseHeader) -> Self {
+impl VacuumPage1Meta {
+    pub(crate) fn from_source_header(source: &DatabaseHeader) -> Self {
         Self {
             schema_cookie: source.schema_cookie.get().wrapping_add(1),
             default_page_cache_size: source.default_page_cache_size,
@@ -188,39 +188,12 @@ impl VacuumHeaderMetadata {
     }
 }
 
-/// Header policy for the compacted destination image.
-pub(crate) enum VacuumDestinationHeader {
-    /// `VACUUM INTO` creates an independent output database, but SQLite still
-    /// writes the same compacted-image metadata as plain `VACUUM`.
-    VacuumInto(VacuumHeaderMetadata),
-    /// Plain `VACUUM` builds a replacement image, so the temp image's page 1
-    /// must already contain the final source header values before copy-back.
-    PlainVacuum(VacuumHeaderMetadata),
-}
-
-impl VacuumDestinationHeader {
-    pub(crate) fn vacuum_into_from_source_header(source: &DatabaseHeader) -> Self {
-        Self::VacuumInto(VacuumHeaderMetadata::from_source_header(source))
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn plain_vacuum_from_source_header(source: &DatabaseHeader) -> Self {
-        Self::PlainVacuum(VacuumHeaderMetadata::from_source_header(source))
-    }
-
-    fn metadata(&self) -> VacuumHeaderMetadata {
-        match self {
-            Self::VacuumInto(metadata) | Self::PlainVacuum(metadata) => *metadata,
-        }
-    }
-}
-
-/// File-backed internal temp database used by plain `VACUUM`.
+/// File-backed internal temp database used by in-place `VACUUM`.
 ///
 /// The temp directory is dropped after the connection and database handles so
 /// host files can be closed before the directory cleanup runs.
 #[allow(dead_code)]
-pub(crate) struct InternalVacuumTempDb {
+pub(crate) struct VacuumTempDb {
     pub conn: Arc<Connection>,
     pub db: Arc<Database>,
     pub path: String,
@@ -229,7 +202,7 @@ pub(crate) struct InternalVacuumTempDb {
 }
 
 #[allow(dead_code)]
-fn internal_temp_encryption(
+fn vacuum_temp_db_encryption(
     source_conn: &Arc<Connection>,
 ) -> Result<(Option<EncryptionOpts>, Option<crate::EncryptionKey>)> {
     let Some(cipher_mode) = source_conn.get_encryption_cipher_mode() else {
@@ -237,7 +210,7 @@ fn internal_temp_encryption(
     };
     let encryption_key = source_conn.encryption_key.read().clone().ok_or_else(|| {
         LimboError::InternalError(
-            "encrypted plain VACUUM temp image requires source encryption key".to_string(),
+            "encrypted in-place VACUUM temp database requires source encryption key".to_string(),
         )
     })?;
     let encryption_opts = EncryptionOpts {
@@ -249,12 +222,12 @@ fn internal_temp_encryption(
 
 #[cfg(not(target_family = "wasm"))]
 #[allow(dead_code)]
-pub(crate) fn open_internal_vacuum_temp_db(
+pub(crate) fn open_vacuum_temp_db(
     source_conn: &Arc<Connection>,
     source_db: &Arc<Database>,
     page_size: u32,
     reserved_space: u8,
-) -> Result<InternalVacuumTempDb> {
+) -> Result<VacuumTempDb> {
     let temp_dir = tempfile::tempdir().map_err(|e| crate::error::io_error(e, "tempdir"))?;
     let path = temp_dir.path().join("tursodb_vacuum_temp.db");
     let path = path
@@ -262,12 +235,12 @@ pub(crate) fn open_internal_vacuum_temp_db(
         .ok_or_else(|| LimboError::InternalError("vacuum temp path is not valid UTF-8".into()))?
         .to_string();
 
-    let (encryption_opts, encryption_key) = internal_temp_encryption(source_conn)?;
+    let (encryption_opts, encryption_key) = vacuum_temp_db_encryption(source_conn)?;
     let db = Database::open_file_with_flags(
         source_db.io.clone(),
         &path,
         OpenFlags::Create,
-        vacuum_destination_opts(source_db),
+        vacuum_target_opts_from_source(source_db),
         encryption_opts,
     )?;
     let conn = db.connect_with_encryption(encryption_key)?;
@@ -275,7 +248,7 @@ pub(crate) fn open_internal_vacuum_temp_db(
     conn.set_reserved_bytes(reserved_space)?;
     conn.wal_auto_checkpoint_disable();
 
-    Ok(InternalVacuumTempDb {
+    Ok(VacuumTempDb {
         conn,
         db,
         path,
@@ -285,62 +258,61 @@ pub(crate) fn open_internal_vacuum_temp_db(
 
 #[cfg(target_family = "wasm")]
 #[allow(dead_code)]
-pub(crate) fn open_internal_vacuum_temp_db(
+pub(crate) fn open_vacuum_temp_db(
     _source_conn: &Arc<Connection>,
     _source_db: &Arc<Database>,
     _page_size: u32,
     _reserved_space: u8,
-) -> Result<InternalVacuumTempDb> {
+) -> Result<VacuumTempDb> {
     Err(LimboError::InternalError(
-        "plain VACUUM requires a file-backed internal temp database".to_string(),
+        "in-place VACUUM requires a file-backed internal temp database".to_string(),
     ))
 }
 
-fn finalize_destination_header(
-    dest_conn: &Arc<Connection>,
-    destination_header: &VacuumDestinationHeader,
+fn finalize_vacuum_target_header(
+    target_conn: &Arc<Connection>,
+    header_meta: &VacuumPage1Meta,
 ) -> Result<crate::IOResult<()>> {
-    let metadata = destination_header.metadata();
-    if let Some(mv_store) = dest_conn.mv_store_for_db(crate::MAIN_DB_ID) {
-        let tx_id = dest_conn.get_mv_tx_id_for_db(crate::MAIN_DB_ID);
+    if let Some(mv_store) = target_conn.mv_store_for_db(crate::MAIN_DB_ID) {
+        let tx_id = target_conn.get_mv_tx_id_for_db(crate::MAIN_DB_ID);
         return mv_store
-            .with_header_mut(|header| metadata.apply_to(header), tx_id.as_ref())
+            .with_header_mut(|header| header_meta.apply_to(header), tx_id.as_ref())
             .map(crate::IOResult::Done);
     }
-    let pager = dest_conn.pager.load();
-    pager.with_header_mut(|header| metadata.apply_to(header))
+    let pager = target_conn.pager.load();
+    pager.with_header_mut(|header| header_meta.apply_to(header))
 }
 
 // ---------------------------------------------------------------------------
-// VACUUM INTO engine - reusable "build compacted copy" state machine
+// Vacuum target build engine
 // ---------------------------------------------------------------------------
 
-/// Configuration for the VACUUM INTO engine. Provided by the caller (opcode
-/// handler) after reading source metadata and setting up the destination DB.
+/// Configuration for building a compacted vacuum target database. Provided by
+/// the caller after reading source metadata and setting up the target DB.
 /// Callers must mirror source symbols (functions, vtab modules, index methods)
-/// directly into dest_conn.syms before starting the state machine.
-pub(crate) struct VacuumIntoConfig {
+/// directly into the target connection before starting the state machine.
+pub(crate) struct VacuumTargetBuildConfig {
     /// Source connection - used for `prepare_internal` and `with_schema` during
     /// schema collection and data copy.
     pub source_conn: Arc<Connection>,
     /// Escaped schema name for safe SQL interpolation (e.g. `"main"`).
     pub escaped_schema_name: String,
     /// Database index for schema lookups on the source connection.
-    pub database_id: usize,
-    /// Destination header metadata policy.
-    pub destination_header: VacuumDestinationHeader,
+    pub source_db_id: usize,
+    /// Page-1 metadata to write before committing the target database.
+    pub header_meta: VacuumPage1Meta,
     /// Pre-captured source custom type definitions for STRICT table replay.
     pub source_custom_types: Vec<(String, Arc<TypeDef>)>,
     /// Whether the source database has MVCC enabled.
     pub source_mvcc_enabled: bool,
 }
 
-/// State for the VACUUM INTO engine. Holds the destination connection and all
+/// Context for the vacuum target build. Holds the target connection and all
 /// intermediate state needed across async yields.
-pub(crate) struct VacuumIntoState {
-    /// Destination connection - lives here, not in each sub-state variant.
-    pub dest_conn: Arc<Connection>,
-    sub_state: VacuumIntoSubState,
+pub(crate) struct VacuumTargetBuildContext {
+    /// Target connection - lives here, not in each stage variant.
+    pub target_conn: Arc<Connection>,
+    stage: VacuumTargetBuildStage,
     /// Typed schema entries collected from sqlite_schema, ordered by rowid.
     schema_entries: Vec<SchemaEntry>,
     /// Storage-backed tables to CREATE (excludes sqlite_sequence).
@@ -353,11 +325,11 @@ pub(crate) struct VacuumIntoState {
     post_data_entries: Vec<usize>,
 }
 
-impl VacuumIntoState {
-    pub fn new(dest_conn: Arc<Connection>) -> Self {
+impl VacuumTargetBuildContext {
+    pub fn new(target_conn: Arc<Connection>) -> Self {
         Self {
-            dest_conn,
-            sub_state: VacuumIntoSubState::Init,
+            target_conn,
+            stage: VacuumTargetBuildStage::Init,
             schema_entries: Vec::new(),
             tables_to_create: Vec::new(),
             tables_to_copy: Vec::new(),
@@ -367,69 +339,69 @@ impl VacuumIntoState {
     }
 
     pub(crate) fn cleanup_after_error(&mut self) {
-        self.sub_state = VacuumIntoSubState::Done;
+        self.stage = VacuumTargetBuildStage::Done;
     }
 }
 
-/// Sub-states for the VACUUM INTO engine state machine.
+/// Stages for the vacuum target build state machine.
 #[derive(Default)]
-pub(crate) enum VacuumIntoSubState {
-    /// Mirror symbols/types, set perf flags, begin dest tx, prepare schema query.
+pub(crate) enum VacuumTargetBuildStage {
+    /// Mirror symbols/types, set perf flags, begin target tx, prepare schema query.
     #[default]
     Init,
     /// Step through schema query to collect rows
     CollectSchemaRows { schema_stmt: Box<crate::Statement> },
-    /// Prepare CREATE TABLE statement on destination (idx into tables_to_create)
+    /// Prepare CREATE TABLE statement on the target (idx into tables_to_create)
     PrepareCreateTable { idx: usize },
-    /// Step through CREATE TABLE statement on destination (async)
+    /// Step through CREATE TABLE statement on the target (async)
     StepCreateTable {
-        dest_schema_stmt: Box<crate::Statement>,
+        target_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
     /// Start copying a table's data
     StartCopyTable { table_idx: usize },
-    /// Select rows from source table and insert into destination
+    /// Select rows from source table and insert into the target.
     CopyRows {
         select_stmt: Box<crate::Statement>,
-        dest_insert_stmt: Box<crate::Statement>,
+        target_insert_stmt: Box<crate::Statement>,
         table_idx: usize,
     },
-    /// Step through INSERT statement on destination
-    StepDestInsert {
+    /// Step through INSERT statement on the target.
+    StepTargetInsert {
         select_stmt: Box<crate::Statement>,
-        dest_insert_stmt: Box<crate::Statement>,
+        target_insert_stmt: Box<crate::Statement>,
         table_idx: usize,
     },
-    /// Prepare CREATE INDEX statement on destination (idx into indexes_to_create)
+    /// Prepare CREATE INDEX statement on the target (idx into indexes_to_create)
     PrepareCreateIndex { idx: usize },
-    /// Step through CREATE INDEX statement on destination
+    /// Step through CREATE INDEX statement on the target.
     StepCreateIndex {
-        dest_schema_stmt: Box<crate::Statement>,
+        target_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
     /// Prepare post-data schema objects (triggers, views, rootpage = 0 entries)
     PreparePostData { idx: usize },
-    /// Step through post-data CREATE statement on destination
+    /// Step through post-data CREATE statement on the target.
     StepPostData {
-        dest_schema_stmt: Box<crate::Statement>,
+        target_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
-    /// Finalize page-1 metadata before committing the destination image.
-    FinalizeDestinationHeader,
+    /// Finalize page-1 metadata before committing the target database.
+    FinalizeTargetHeader,
     /// Operation complete
     Done,
 }
 
-/// VACUUM INTO - create a compacted copy of the database at the specified path.
+/// Build a compacted vacuum target database.
 ///
 /// This is an async state machine implementation that yields on I/O operations.
-/// The caller creates a new database at the destination path with matching
+/// The caller creates a target database with matching
 /// page_size, reserved bytes, source feature flags, and schema-replay symbols.
 ///
 /// It:
-/// 1. Mirrors source symbols and custom types to destination
+/// 1. Mirrors source symbols and custom types to the target
 /// 2. Queries sqlite_schema for all schema objects including rootpage, ordered by rowid
-/// 3. Creates storage-backed tables (rootpage != 0) in destination, excluding
+/// 3. Creates storage-backed tables (rootpage != 0) in the target, excluding
 ///    sqlite_sequence (auto-created when AUTOINCREMENT tables are created)
 /// 4. Copies data for all storage-backed tables, including sqlite_stat1 and other
 ///    internal storage-backed tables
@@ -438,42 +410,42 @@ pub(crate) enum VacuumIntoSubState {
 /// 6. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
-/// 7. Finalizes destination page-1 metadata, then commits the destination transaction.
-pub(crate) fn vacuum_into_step(
-    config: &VacuumIntoConfig,
-    state: &mut VacuumIntoState,
-) -> Result<InsnFunctionStepResult> {
+/// 7. Finalizes target page-1 metadata, then commits the target transaction.
+pub(crate) fn vacuum_target_build_step(
+    config: &VacuumTargetBuildConfig,
+    state: &mut VacuumTargetBuildContext,
+) -> Result<crate::IOResult<()>> {
     loop {
-        let current_sub_state = std::mem::take(&mut state.sub_state);
+        let current_stage = std::mem::take(&mut state.stage);
 
-        match current_sub_state {
-            VacuumIntoSubState::Init => {
-                // Mirror source custom type definitions into destination schema
+        match current_stage {
+            VacuumTargetBuildStage::Init => {
+                // Mirror source custom type definitions into the target schema
                 // so that STRICT tables with custom type columns can resolve
                 // those types during CREATE TABLE replay.
                 if !config.source_custom_types.is_empty() {
-                    state.dest_conn.with_schema_mut(|dest_schema| {
+                    state.target_conn.with_schema_mut(|target_schema| {
                         for (name, td) in &config.source_custom_types {
-                            dest_schema.type_registry.insert(name.clone(), td.clone());
+                            target_schema.type_registry.insert(name.clone(), td.clone());
                         }
                     });
                 }
 
-                // Enable MVCC on destination if source has it enabled
+                // Enable MVCC on the target if source has it enabled.
                 // Must be done before any schema operations to ensure the log file is created
                 if config.source_mvcc_enabled {
-                    state.dest_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+                    state.target_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
                 }
 
-                // Performance optimizations for destination database (matches SQLite vacuum.c):
-                // 1. Disable fsync - destination is a new user-visible output file
+                // Performance optimizations for the target database (matches SQLite vacuum.c):
+                // 1. Disable fsync - the target is a new output/temp database
                 // 2. Disable foreign key checks - source data is already consistent
                 // These match SQLite's vacuum.c optimizations (PAGER_SYNCHRONOUS_OFF, ~SQLITE_ForeignKeys)
-                state.dest_conn.set_sync_mode(crate::SyncMode::Off);
-                state.dest_conn.set_foreign_keys_enabled(false);
+                state.target_conn.set_sync_mode(crate::SyncMode::Off);
+                state.target_conn.set_foreign_keys_enabled(false);
 
                 // Wrap all operations in a single transaction for atomicity.
-                state.dest_conn.execute("BEGIN")?;
+                state.target_conn.execute("BEGIN")?;
 
                 // Query sqlite_schema with rootpage, ordered by rowid.
                 // Exclude the MVCC metadata table - it is an internal artifact.
@@ -486,20 +458,20 @@ pub(crate) fn vacuum_into_step(
                 );
                 let schema_stmt = config.source_conn.prepare_internal(schema_sql.as_str())?;
 
-                state.sub_state = VacuumIntoSubState::CollectSchemaRows {
+                state.stage = VacuumTargetBuildStage::CollectSchemaRows {
                     schema_stmt: Box::new(schema_stmt),
                 };
                 continue;
             }
 
-            VacuumIntoSubState::CollectSchemaRows { mut schema_stmt } => {
+            VacuumTargetBuildStage::CollectSchemaRows { mut schema_stmt } => {
                 match schema_stmt.step()? {
                     crate::StepResult::Row => {
                         let row = schema_stmt
                             .row()
                             .expect("StepResult::Row but row() returned None");
                         state.schema_entries.push(SchemaEntry::from_row(row)?);
-                        state.sub_state = VacuumIntoSubState::CollectSchemaRows { schema_stmt };
+                        state.stage = VacuumTargetBuildStage::CollectSchemaRows { schema_stmt };
                         continue;
                     }
                     crate::StepResult::Done => {
@@ -519,7 +491,7 @@ pub(crate) fn vacuum_into_step(
                                 let entry = &state.schema_entries[*entry_ordinal];
                                 !config
                                     .source_conn
-                                    .with_schema(config.database_id, |schema| {
+                                    .with_schema(config.source_db_id, |schema| {
                                         schema
                                             .get_index(&entry.tbl_name, &entry.name)
                                             .is_some_and(|idx| idx.is_backing_btree_index())
@@ -528,15 +500,15 @@ pub(crate) fn vacuum_into_step(
                             .collect();
                         state.post_data_entries = post_data;
 
-                        state.sub_state = VacuumIntoSubState::PrepareCreateTable { idx: 0 };
+                        state.stage = VacuumTargetBuildStage::PrepareCreateTable { idx: 0 };
                         continue;
                     }
                     crate::StepResult::IO => {
                         let io = schema_stmt
                             .take_io_completions()
                             .expect("StepResult::IO returned but no completions available");
-                        state.sub_state = VacuumIntoSubState::CollectSchemaRows { schema_stmt };
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        state.stage = VacuumTargetBuildStage::CollectSchemaRows { schema_stmt };
+                        return Ok(crate::IOResult::IO(io));
                     }
                     crate::StepResult::Busy | crate::StepResult::Interrupt => {
                         return Err(LimboError::Busy);
@@ -546,11 +518,11 @@ pub(crate) fn vacuum_into_step(
 
             // Phase 1: Create storage-backed tables (rootpage != 0, type=table),
             // excluding sqlite_sequence (auto-created by AUTOINCREMENT tables).
-            VacuumIntoSubState::PrepareCreateTable { idx } => {
+            VacuumTargetBuildStage::PrepareCreateTable { idx } => {
                 let entries_len = state.tables_to_create.len();
                 if idx >= entries_len {
                     // Done creating tables, start copying data
-                    state.sub_state = VacuumIntoSubState::StartCopyTable { table_idx: 0 };
+                    state.stage = VacuumTargetBuildStage::StartCopyTable { table_idx: 0 };
                     continue;
                 }
 
@@ -560,47 +532,47 @@ pub(crate) fn vacuum_into_step(
 
                 // System tables (sqlite_stat1, __turso_internal_types, etc.) have
                 // reserved name prefixes that translate_create_table rejects for
-                // user SQL. Temporarily mark the dest connection as nested during
+                // user SQL. Temporarily mark the target connection as nested during
                 // prepare() so the reserved-name check is bypassed at compile
                 // time. The guard is only for prepare: keeping it during step()
                 // would make this CREATE TABLE look nested, so its Transaction
                 // opcode would skip write setup.
                 let is_system = crate::schema::is_system_table(&entry.name);
                 if is_system {
-                    state.dest_conn.start_nested();
+                    state.target_conn.start_nested();
                 }
-                let dest_stmt = state.dest_conn.prepare(sql_str);
+                let target_stmt = state.target_conn.prepare(sql_str);
                 if is_system {
-                    state.dest_conn.end_nested();
+                    state.target_conn.end_nested();
                 }
-                let dest_stmt = dest_stmt?;
-                state.sub_state = VacuumIntoSubState::StepCreateTable {
-                    dest_schema_stmt: Box::new(dest_stmt),
+                let target_stmt = target_stmt?;
+                state.stage = VacuumTargetBuildStage::StepCreateTable {
+                    target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::StepCreateTable {
-                mut dest_schema_stmt,
+            VacuumTargetBuildStage::StepCreateTable {
+                mut target_schema_stmt,
                 idx,
-            } => match dest_schema_stmt.step()? {
+            } => match target_schema_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("CREATE TABLE statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.sub_state = VacuumIntoSubState::PrepareCreateTable { idx: idx + 1 };
+                    state.stage = VacuumTargetBuildStage::PrepareCreateTable { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_schema_stmt
+                    let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepCreateTable {
-                        dest_schema_stmt,
+                    state.stage = VacuumTargetBuildStage::StepCreateTable {
+                        target_schema_stmt,
                         idx,
                     };
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -611,11 +583,11 @@ pub(crate) fn vacuum_into_step(
             // Column lists are derived from BTreeTable.columns in the schema,
             // not PRAGMA table_info, because table_info omits generated columns
             // while SELECT * includes them - causing a column count mismatch.
-            VacuumIntoSubState::StartCopyTable { table_idx } => {
+            VacuumTargetBuildStage::StartCopyTable { table_idx } => {
                 let tables_len = state.tables_to_copy.len();
                 if table_idx >= tables_len {
                     // Done copying all tables, proceed to deferred indexes.
-                    state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: 0 };
+                    state.stage = VacuumTargetBuildStage::PrepareCreateIndex { idx: 0 };
                     continue;
                 }
 
@@ -623,21 +595,21 @@ pub(crate) fn vacuum_into_step(
                 let entry = &state.schema_entries[entry_ordinal];
                 let table_name = &entry.name;
 
-                // sqlite_sequence: only copy data if the destination has it
+                // sqlite_sequence: only copy data if the target has it
                 // (auto-created when an AUTOINCREMENT table was created in
                 // phase 1). If not present, skip — no AUTOINCREMENT tables
                 // means no counters to preserve. The explicit copy is needed
                 // because inserting rows with the `rowid` pseudo-column does
                 // not update sqlite_sequence counters automatically.
                 if entry.is_sqlite_sequence() {
-                    let dest_has_sequence = state
-                        .dest_conn
+                    let target_has_sequence = state
+                        .target_conn
                         .schema
                         .read()
                         .get_btree_table(crate::schema::SQLITE_SEQUENCE_TABLE_NAME)
                         .is_some();
-                    if !dest_has_sequence {
-                        state.sub_state = VacuumIntoSubState::StartCopyTable {
+                    if !target_has_sequence {
+                        state.stage = VacuumTargetBuildStage::StartCopyTable {
                             table_idx: table_idx + 1,
                         };
                         continue;
@@ -650,7 +622,7 @@ pub(crate) fn vacuum_into_step(
                 // INSERT arities stay aligned.
                 let source_btree_table = config
                     .source_conn
-                    .with_schema(config.database_id, |schema| {
+                    .with_schema(config.source_db_id, |schema| {
                         schema.get_btree_table(table_name)
                     });
 
@@ -665,7 +637,7 @@ pub(crate) fn vacuum_into_step(
                     entry.is_sqlite_sequence(),
                 )?;
 
-                // SELECT from source, INSERT into destination.
+                // SELECT from source, INSERT into the target.
                 let select_stmt = config.source_conn.prepare_internal(&select_sql)?;
 
                 // System tables need nested mode during prepare() to bypass
@@ -674,25 +646,25 @@ pub(crate) fn vacuum_into_step(
                 // Transaction opcode needs to run for page-level write setup.
                 let is_system = crate::schema::is_system_table(table_name);
                 if is_system {
-                    state.dest_conn.start_nested();
+                    state.target_conn.start_nested();
                 }
-                let dest_insert_stmt = state.dest_conn.prepare(&insert_sql);
+                let target_insert_stmt = state.target_conn.prepare(&insert_sql);
                 if is_system {
-                    state.dest_conn.end_nested();
+                    state.target_conn.end_nested();
                 }
-                let dest_insert_stmt = dest_insert_stmt?;
+                let target_insert_stmt = target_insert_stmt?;
 
-                state.sub_state = VacuumIntoSubState::CopyRows {
+                state.stage = VacuumTargetBuildStage::CopyRows {
                     select_stmt: Box::new(select_stmt),
-                    dest_insert_stmt: Box::new(dest_insert_stmt),
+                    target_insert_stmt: Box::new(target_insert_stmt),
                     table_idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::CopyRows {
+            VacuumTargetBuildStage::CopyRows {
                 mut select_stmt,
-                mut dest_insert_stmt,
+                mut target_insert_stmt,
                 table_idx,
             } => match select_stmt.step()? {
                 crate::StepResult::Row => {
@@ -700,24 +672,24 @@ pub(crate) fn vacuum_into_step(
                         .row()
                         .expect("StepResult::Row but row() returned None");
 
-                    dest_insert_stmt.reset()?;
-                    dest_insert_stmt.clear_bindings();
+                    target_insert_stmt.reset()?;
+                    target_insert_stmt.clear_bindings();
                     for (i, value) in row.get_values().cloned().enumerate() {
                         let index =
                             std::num::NonZero::new(i + 1).expect("i + 1 is always non-zero");
-                        dest_insert_stmt.bind_at(index, value);
+                        target_insert_stmt.bind_at(index, value);
                     }
 
-                    state.sub_state = VacuumIntoSubState::StepDestInsert {
+                    state.stage = VacuumTargetBuildStage::StepTargetInsert {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
                     continue;
                 }
                 crate::StepResult::Done => {
                     // Move to next table
-                    state.sub_state = VacuumIntoSubState::StartCopyTable {
+                    state.stage = VacuumTargetBuildStage::StartCopyTable {
                         table_idx: table_idx + 1,
                     };
                     continue;
@@ -726,45 +698,45 @@ pub(crate) fn vacuum_into_step(
                     let io = select_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::CopyRows {
+                    state.stage = VacuumTargetBuildStage::CopyRows {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
                 }
             },
 
-            VacuumIntoSubState::StepDestInsert {
+            VacuumTargetBuildStage::StepTargetInsert {
                 select_stmt,
-                mut dest_insert_stmt,
+                mut target_insert_stmt,
                 table_idx,
-            } => match dest_insert_stmt.step()? {
+            } => match target_insert_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("INSERT statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
                     // Go back to get next row from source
-                    state.sub_state = VacuumIntoSubState::CopyRows {
+                    state.stage = VacuumTargetBuildStage::CopyRows {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_insert_stmt
+                    let io = target_insert_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepDestInsert {
+                    state.stage = VacuumTargetBuildStage::StepTargetInsert {
                         select_stmt,
-                        dest_insert_stmt,
+                        target_insert_stmt,
                         table_idx,
                     };
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -772,11 +744,11 @@ pub(crate) fn vacuum_into_step(
             },
 
             // Phase 3: Create user-defined secondary indexes.
-            VacuumIntoSubState::PrepareCreateIndex { idx } => {
+            VacuumTargetBuildStage::PrepareCreateIndex { idx } => {
                 let entries_len = state.indexes_to_create.len();
                 if idx >= entries_len {
                     // Done creating indexes, move to post-data objects
-                    state.sub_state = VacuumIntoSubState::PreparePostData { idx: 0 };
+                    state.stage = VacuumTargetBuildStage::PreparePostData { idx: 0 };
                     continue;
                 }
 
@@ -785,34 +757,34 @@ pub(crate) fn vacuum_into_step(
                 // Backing-btree indexes for custom index methods were filtered
                 // out when indexes_to_create was built. The remaining CREATE
                 // INDEX statements are user-visible and can use ordinary prepare.
-                let dest_stmt = state.dest_conn.prepare(&entry.sql)?;
-                state.sub_state = VacuumIntoSubState::StepCreateIndex {
-                    dest_schema_stmt: Box::new(dest_stmt),
+                let target_stmt = state.target_conn.prepare(&entry.sql)?;
+                state.stage = VacuumTargetBuildStage::StepCreateIndex {
+                    target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::StepCreateIndex {
-                mut dest_schema_stmt,
+            VacuumTargetBuildStage::StepCreateIndex {
+                mut target_schema_stmt,
                 idx,
-            } => match dest_schema_stmt.step()? {
+            } => match target_schema_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("CREATE INDEX statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: idx + 1 };
+                    state.stage = VacuumTargetBuildStage::PrepareCreateIndex { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_schema_stmt
+                    let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepCreateIndex {
-                        dest_schema_stmt,
+                    state.stage = VacuumTargetBuildStage::StepCreateIndex {
+                        target_schema_stmt,
                         idx,
                     };
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
@@ -820,66 +792,66 @@ pub(crate) fn vacuum_into_step(
             },
 
             // Phase 4: Create triggers, views, and rootpage=0 schema objects.
-            VacuumIntoSubState::PreparePostData { idx } => {
+            VacuumTargetBuildStage::PreparePostData { idx } => {
                 let entries_len = state.post_data_entries.len();
                 if idx >= entries_len {
-                    state.sub_state = VacuumIntoSubState::FinalizeDestinationHeader;
+                    state.stage = VacuumTargetBuildStage::FinalizeTargetHeader;
                     continue;
                 }
 
                 let entry_ordinal = state.post_data_entries[idx];
                 let entry = &state.schema_entries[entry_ordinal];
-                let dest_stmt = state.dest_conn.prepare(&entry.sql)?;
-                state.sub_state = VacuumIntoSubState::StepPostData {
-                    dest_schema_stmt: Box::new(dest_stmt),
+                let target_stmt = state.target_conn.prepare(&entry.sql)?;
+                state.stage = VacuumTargetBuildStage::StepPostData {
+                    target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumIntoSubState::StepPostData {
-                mut dest_schema_stmt,
+            VacuumTargetBuildStage::StepPostData {
+                mut target_schema_stmt,
                 idx,
-            } => match dest_schema_stmt.step()? {
+            } => match target_schema_stmt.step()? {
                 crate::StepResult::Row => {
                     unreachable!("CREATE statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.sub_state = VacuumIntoSubState::PreparePostData { idx: idx + 1 };
+                    state.stage = VacuumTargetBuildStage::PreparePostData { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
-                    let io = dest_schema_stmt
+                    let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.sub_state = VacuumIntoSubState::StepPostData {
-                        dest_schema_stmt,
+                    state.stage = VacuumTargetBuildStage::StepPostData {
+                        target_schema_stmt,
                         idx,
                     };
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
                     return Err(LimboError::Busy);
                 }
             },
 
-            VacuumIntoSubState::FinalizeDestinationHeader => {
-                match finalize_destination_header(&state.dest_conn, &config.destination_header)? {
+            VacuumTargetBuildStage::FinalizeTargetHeader => {
+                match finalize_vacuum_target_header(&state.target_conn, &config.header_meta)? {
                     crate::IOResult::Done(()) => {}
                     crate::IOResult::IO(io) => {
-                        state.sub_state = VacuumIntoSubState::FinalizeDestinationHeader;
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        state.stage = VacuumTargetBuildStage::FinalizeTargetHeader;
+                        return Ok(crate::IOResult::IO(io));
                     }
                 }
 
-                state.sub_state = VacuumIntoSubState::Done;
+                state.stage = VacuumTargetBuildStage::Done;
                 continue;
             }
 
-            VacuumIntoSubState::Done => {
-                // Commit the destination transaction started in Init state.
-                state.dest_conn.execute("COMMIT")?;
-                return Ok(InsnFunctionStepResult::Step);
+            VacuumTargetBuildStage::Done => {
+                // Commit the target transaction started in Init stage.
+                state.target_conn.execute("COMMIT")?;
+                return Ok(crate::IOResult::Done(()));
             }
         }
     }
@@ -1032,54 +1004,56 @@ pub(crate) fn build_copy_sql(
 }
 
 // ---------------------------------------------------------------------------
-// Plain VACUUM engine - copy-back state machine
+// In-place VACUUM engine - copy-back state machine
 // ---------------------------------------------------------------------------
 
-/// Independent progress flags for plain VACUUM cleanup. These track which
+/// Independent cleanup flags for in-place VACUUM. These track which
 /// resources the opcode has acquired and are **not** cleared by
-/// `std::mem::take` on the sub-state enum. The cleanup function reads these
+/// `std::mem::take` on the stage enum. The cleanup function reads these
 /// to decide what to roll back regardless of where the state machine was
 /// when the error occurred.
 #[derive(Default)]
-pub(crate) struct PlainVacuumProgress {
+pub(crate) struct VacuumInPlaceCleanupState {
     /// Source pager read transaction was started.
-    pub read_tx_open: bool,
+    pub source_read_tx_open: bool,
     /// Source pager write transaction was acquired and `auto_commit`/`tx_state`
     /// were modified.
-    pub write_tx_open: bool,
+    pub source_write_tx_open: bool,
     /// WAL commit was published via `finish_append_frames_commit`. Once true
     /// the compacted image is durable and rollback must not be attempted.
-    pub commit_published: bool,
+    pub wal_commit_published: bool,
 }
 
-/// Sub-states for the plain VACUUM opcode state machine.
+/// Stages for the in-place VACUUM state machine.
 ///
 /// The opcode owns the source transaction lifecycle directly: it begins the
 /// read and write transactions on the source pager, builds a temp image via
-/// the shared temp-build engine, then copies the compacted image back into the
+/// the shared target-build engine, then copies the compacted target back into the
 /// source WAL using the batched prepare_frames → WriteBatch → commit path.
-pub(crate) enum PlainVacuumSubState {
+pub(crate) enum VacuumInPlaceStage {
     /// Validate preconditions (auto_commit, active statements, readonly, memory,
     /// MVCC, WAL-backed pager).
     Preflight,
-    /// `pager.begin_read_tx()` on the source.
-    BeginSourceReadTx,
-    /// `pager.begin_write_tx()` on the source. May yield IO.
-    BeginSourceWriteTx,
-    /// Read source page-1 header metadata for the temp-build config.
+    /// Acquire both read and write transactions on the source pager.
+    /// The WAL requires a read tx before a write tx (the write path needs the
+    /// read snapshot). `begin_write_tx` may yield IO for page1 allocation, so
+    /// this is a two-phase state: first attempt acquires read + tries write,
+    /// re-entry after IO yield retries only the write (read is already held).
+    BeginSourceTx,
+    /// Read source page-1 header metadata for the target-build config.
     ReadSourceMetadata,
-    /// Create temp DB and run the shared temp-build engine.
-    BuildTempImage {
-        config: Box<VacuumIntoConfig>,
-        temp_db: Box<InternalVacuumTempDb>,
-        state: Box<VacuumIntoState>,
+    /// Create temp DB and run the shared target-build engine.
+    TargetBuild {
+        config: Box<VacuumTargetBuildConfig>,
+        temp_db: Box<VacuumTempDb>,
+        context: Box<VacuumTargetBuildContext>,
     },
     /// Open a read transaction on the committed temp pager for copy-back reads.
-    BeginTempReadTx { temp_db: Box<InternalVacuumTempDb> },
+    BeginTempReadTx { temp_db: Box<VacuumTempDb> },
     /// Initialize the source WAL header if needed (one-time before first batch).
     /// Two IO steps: write the header, then fsync to set `initialized = true`.
-    PrepareSourceWal {
-        temp_db: Box<InternalVacuumTempDb>,
+    InitSourceWalHeader {
+        temp_db: Box<VacuumTempDb>,
         total_pages: u32,
         /// The completion to wait on: first the header write, then the fsync.
         completion: crate::io::Completion,
@@ -1089,7 +1063,7 @@ pub(crate) enum PlainVacuumSubState {
     },
     /// Read a single temp page for the current batch.
     ReadTempPage {
-        temp_db: Box<InternalVacuumTempDb>,
+        temp_db: Box<VacuumTempDb>,
         total_pages: u32,
         /// Next page number to read (1-based). The page at `next_page - 1` is
         /// the one we just issued a read for and are awaiting.
@@ -1106,25 +1080,25 @@ pub(crate) enum PlainVacuumSubState {
         reading_page: crate::storage::pager::PageRef,
     },
     /// Write a prepared batch to the WAL file.
-    WriteBatch {
-        temp_db: Box<InternalVacuumTempDb>,
+    WriteWalBatch {
+        temp_db: Box<VacuumTempDb>,
         total_pages: u32,
         next_page: u32,
         prev_prepared: Option<Box<crate::storage::wal::PreparedFrames>>,
         completions: Vec<crate::io::Completion>,
     },
     /// Fsync the WAL if sync mode requires it.
-    SyncWal {
-        temp_db: Box<InternalVacuumTempDb>,
+    SyncSourceWal {
+        temp_db: Box<VacuumTempDb>,
         sync_completion: crate::io::Completion,
     },
     /// Publish: commit_prepared_frames + finish_append_frames_commit + schema reload.
-    Publish { temp_db: Box<InternalVacuumTempDb> },
+    PublishWalCommit { temp_db: Box<VacuumTempDb> },
     /// Clean up after successful commit.
     Done,
 }
 
-impl Default for PlainVacuumSubState {
+impl Default for VacuumInPlaceStage {
     fn default() -> Self {
         Self::Preflight
     }
@@ -1133,17 +1107,17 @@ impl Default for PlainVacuumSubState {
 /// The batch size for copy-back: how many temp pages to read per batch.
 const VACUUM_COPY_BATCH_SIZE: u32 = 64;
 
-/// Step the plain VACUUM state machine once. Returns `IO` to yield or `Step`
+/// Step the in-place VACUUM state machine once. Returns `IO` to yield or `Step`
 /// when the entire operation is complete.
 ///
-/// `progress` independently tracks which resources the opcode has acquired so
-/// that cleanup can roll back correctly even when `sub_state` has been taken
+/// `cleanup_state` independently tracks which resources the opcode has acquired so
+/// that cleanup can roll back correctly even when `stage` has been taken
 /// by `std::mem::take` at the top of the loop.
-pub(crate) fn plain_vacuum_step(
+pub(crate) fn vacuum_in_place_step(
     connection: &Arc<Connection>,
     db: usize,
-    sub_state: &mut PlainVacuumSubState,
-    progress: &mut PlainVacuumProgress,
+    stage: &mut VacuumInPlaceStage,
+    cleanup_state: &mut VacuumInPlaceCleanupState,
 ) -> Result<InsnFunctionStepResult> {
     use crate::io::WriteBatch as IOWriteBatch;
     use crate::types::IOCompletions;
@@ -1155,9 +1129,9 @@ pub(crate) fn plain_vacuum_step(
     let source_pager = connection.get_pager_from_database_index(&db);
 
     loop {
-        let current = std::mem::take(sub_state);
+        let current = std::mem::take(stage);
         match current {
-            PlainVacuumSubState::Preflight => {
+            VacuumInPlaceStage::Preflight => {
                 // 1. Must be in auto-commit mode (no explicit transaction).
                 if !connection.auto_commit.load(Ordering::SeqCst) {
                     return Err(LimboError::TxError(
@@ -1210,18 +1184,18 @@ pub(crate) fn plain_vacuum_step(
                         "VACUUM requires a WAL-mode database".to_string(),
                     ));
                 }
-                *sub_state = PlainVacuumSubState::BeginSourceReadTx;
+                *stage = VacuumInPlaceStage::BeginSourceTx;
                 continue;
             }
 
-            PlainVacuumSubState::BeginSourceReadTx => {
-                source_pager.begin_read_tx()?;
-                progress.read_tx_open = true;
-                *sub_state = PlainVacuumSubState::BeginSourceWriteTx;
-                continue;
-            }
-
-            PlainVacuumSubState::BeginSourceWriteTx => {
+            VacuumInPlaceStage::BeginSourceTx => {
+                // The WAL requires a read tx before a write tx. On first
+                // entry we start the read tx; on re-entry after an IO yield
+                // from begin_write_tx the read tx is already held.
+                if !cleanup_state.source_read_tx_open {
+                    source_pager.begin_read_tx()?;
+                    cleanup_state.source_read_tx_open = true;
+                }
                 match source_pager.begin_write_tx()? {
                     crate::IOResult::Done(()) => {
                         // Write lock acquired. Set connection state.
@@ -1229,19 +1203,19 @@ pub(crate) fn plain_vacuum_step(
                         connection.set_tx_state(crate::connection::TransactionState::Write {
                             schema_did_change: false,
                         });
-                        progress.write_tx_open = true;
-                        *sub_state = PlainVacuumSubState::ReadSourceMetadata;
+                        cleanup_state.source_write_tx_open = true;
+                        *stage = VacuumInPlaceStage::ReadSourceMetadata;
                         continue;
                     }
                     crate::IOResult::IO(io) => {
                         // Need to yield for IO (e.g. page1 allocation).
-                        *sub_state = PlainVacuumSubState::BeginSourceWriteTx;
+                        *stage = VacuumInPlaceStage::BeginSourceTx;
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
                 }
             }
 
-            PlainVacuumSubState::ReadSourceMetadata => {
+            VacuumInPlaceStage::ReadSourceMetadata => {
                 let source_db = connection.get_source_database(db);
 
                 // Read page size from pager (cached after begin_read_tx).
@@ -1253,51 +1227,42 @@ pub(crate) fn plain_vacuum_step(
                 // Read reserved bytes and header metadata in a single
                 // with_header call to avoid redundant page-1 access.
                 let io = &*source_pager.io;
-                let (reserved_space, destination_header): (u8, VacuumDestinationHeader) =
+                let (reserved_space, header_meta): (u8, VacuumPage1Meta) =
                     match connection.get_reserved_bytes() {
                         Some(val) => {
                             let dh = io.block(|| {
-                                source_pager.with_header(
-                                    VacuumDestinationHeader::plain_vacuum_from_source_header,
-                                )
+                                source_pager.with_header(VacuumPage1Meta::from_source_header)
                             })?;
                             (val, dh)
                         }
                         None => io.block(|| {
                             source_pager.with_header(|h| {
-                                (
-                                    h.reserved_space,
-                                    VacuumDestinationHeader::plain_vacuum_from_source_header(h),
-                                )
+                                (h.reserved_space, VacuumPage1Meta::from_source_header(h))
                             })
                         })?,
                     };
                 // Create temp database.
-                let temp_db = open_internal_vacuum_temp_db(
-                    connection,
-                    &source_db,
-                    page_size,
-                    reserved_space,
-                )?;
+                let temp_db =
+                    open_vacuum_temp_db(connection, &source_db, page_size, reserved_space)?;
 
                 // Mirror source symbols directly into temp DB for schema replay,
                 // avoiding an intermediate clone through SourceSymbols.
                 {
                     let source_syms = connection.syms.read();
-                    let mut dest_syms = temp_db.conn.syms.write();
-                    dest_syms.functions.extend(
+                    let mut target_syms = temp_db.conn.syms.write();
+                    target_syms.functions.extend(
                         source_syms
                             .functions
                             .iter()
                             .map(|(k, v)| (k.clone(), v.clone())),
                     );
-                    dest_syms.vtab_modules.extend(
+                    target_syms.vtab_modules.extend(
                         source_syms
                             .vtab_modules
                             .iter()
                             .map(|(k, v)| (k.clone(), v.clone())),
                     );
-                    dest_syms.index_methods.extend(
+                    target_syms.index_methods.extend(
                         source_syms
                             .index_methods
                             .iter()
@@ -1316,51 +1281,50 @@ pub(crate) fn plain_vacuum_step(
                             .collect()
                     });
 
-                let config = VacuumIntoConfig {
+                let config = VacuumTargetBuildConfig {
                     source_conn: connection.clone(),
                     escaped_schema_name: "main".to_string(),
-                    database_id: db,
-                    destination_header,
+                    source_db_id: db,
+                    header_meta,
                     source_custom_types,
                     source_mvcc_enabled: false, // Rejected MVCC above
                 };
 
-                let vi_state = VacuumIntoState::new(temp_db.conn.clone());
+                let target_build_context = VacuumTargetBuildContext::new(temp_db.conn.clone());
 
-                *sub_state = PlainVacuumSubState::BuildTempImage {
+                *stage = VacuumInPlaceStage::TargetBuild {
                     config: Box::new(config),
                     temp_db: Box::new(temp_db),
-                    state: Box::new(vi_state),
+                    context: Box::new(target_build_context),
                 };
                 continue;
             }
 
-            PlainVacuumSubState::BuildTempImage {
+            VacuumInPlaceStage::TargetBuild {
                 config,
                 temp_db,
-                mut state,
+                mut context,
             } => {
-                match vacuum_into_step(&config, &mut state)? {
-                    InsnFunctionStepResult::Step => {
+                match vacuum_target_build_step(&config, &mut context)? {
+                    crate::IOResult::Done(()) => {
                         // Temp build complete. Move to read tx on temp.
                         drop(config);
-                        drop(state);
-                        *sub_state = PlainVacuumSubState::BeginTempReadTx { temp_db };
+                        drop(context);
+                        *stage = VacuumInPlaceStage::BeginTempReadTx { temp_db };
                         continue;
                     }
-                    InsnFunctionStepResult::IO(io) => {
-                        *sub_state = PlainVacuumSubState::BuildTempImage {
+                    crate::IOResult::IO(io) => {
+                        *stage = VacuumInPlaceStage::TargetBuild {
                             config,
                             temp_db,
-                            state,
+                            context,
                         };
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
-                    _ => unreachable!("vacuum_into_step only returns Step or IO"),
                 }
             }
 
-            PlainVacuumSubState::BeginTempReadTx { temp_db } => {
+            VacuumInPlaceStage::BeginTempReadTx { temp_db } => {
                 // The shared temp-build engine committed via SQL COMMIT, which
                 // ends the write transaction but leaves the WAL read mark held.
                 // End that read tx first, then start a fresh one so WAL lookups
@@ -1380,11 +1344,11 @@ pub(crate) fn plain_vacuum_step(
                     drop(temp_db);
                     source_pager.end_write_tx();
                     source_pager.end_read_tx();
-                    progress.write_tx_open = false;
-                    progress.read_tx_open = false;
+                    cleanup_state.source_write_tx_open = false;
+                    cleanup_state.source_read_tx_open = false;
                     connection.auto_commit.store(true, Ordering::SeqCst);
                     connection.set_tx_state(crate::connection::TransactionState::None);
-                    *sub_state = PlainVacuumSubState::Done;
+                    *stage = VacuumInPlaceStage::Done;
                     continue;
                 }
 
@@ -1397,7 +1361,7 @@ pub(crate) fn plain_vacuum_step(
 
                 if let Some(header_write_c) = wal.prepare_wal_start(page_sz)? {
                     // WAL not yet initialized — yield on the header write.
-                    *sub_state = PlainVacuumSubState::PrepareSourceWal {
+                    *stage = VacuumInPlaceStage::InitSourceWalHeader {
                         temp_db,
                         total_pages,
                         completion: header_write_c,
@@ -1410,7 +1374,7 @@ pub(crate) fn plain_vacuum_step(
                 let temp_pager = temp_db.conn.get_pager();
                 let (page_ref, completion) = temp_pager.read_page_no_cache(1, None, false)?;
 
-                *sub_state = PlainVacuumSubState::ReadTempPage {
+                *stage = VacuumInPlaceStage::ReadTempPage {
                     temp_db,
                     total_pages,
                     next_page: 2, // page 1 is being read now
@@ -1422,14 +1386,14 @@ pub(crate) fn plain_vacuum_step(
                 continue;
             }
 
-            PlainVacuumSubState::PrepareSourceWal {
+            VacuumInPlaceStage::InitSourceWalHeader {
                 temp_db,
                 total_pages,
                 completion,
                 fsync_phase,
             } => {
                 if !completion.finished() {
-                    *sub_state = PlainVacuumSubState::PrepareSourceWal {
+                    *stage = VacuumInPlaceStage::InitSourceWalHeader {
                         temp_db,
                         total_pages,
                         completion: completion.clone(),
@@ -1450,7 +1414,7 @@ pub(crate) fn plain_vacuum_step(
                     // to set WAL `initialized = true`.
                     let wal = source_pager.wal.as_ref().unwrap();
                     let sync_c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
-                    *sub_state = PlainVacuumSubState::PrepareSourceWal {
+                    *stage = VacuumInPlaceStage::InitSourceWalHeader {
                         temp_db,
                         total_pages,
                         completion: sync_c,
@@ -1463,7 +1427,7 @@ pub(crate) fn plain_vacuum_step(
                 let temp_pager = temp_db.conn.get_pager();
                 let (page_ref, read_c) = temp_pager.read_page_no_cache(1, None, false)?;
 
-                *sub_state = PlainVacuumSubState::ReadTempPage {
+                *stage = VacuumInPlaceStage::ReadTempPage {
                     temp_db,
                     total_pages,
                     next_page: 2,
@@ -1475,7 +1439,7 @@ pub(crate) fn plain_vacuum_step(
                 continue;
             }
 
-            PlainVacuumSubState::ReadTempPage {
+            VacuumInPlaceStage::ReadTempPage {
                 temp_db,
                 total_pages,
                 next_page,
@@ -1486,7 +1450,7 @@ pub(crate) fn plain_vacuum_step(
             } => {
                 // Wait for the current read to complete.
                 if !read_completion.finished() {
-                    *sub_state = PlainVacuumSubState::ReadTempPage {
+                    *stage = VacuumInPlaceStage::ReadTempPage {
                         temp_db,
                         total_pages,
                         next_page,
@@ -1514,7 +1478,7 @@ pub(crate) fn plain_vacuum_step(
 
                 if batch_full || all_read {
                     // Prepare WAL frames from this batch. WAL header was already
-                    // initialized in PrepareSourceWal before reading started.
+                    // initialized in InitSourceWalHeader before reading started.
                     let wal = source_pager
                         .wal
                         .as_ref()
@@ -1536,7 +1500,7 @@ pub(crate) fn plain_vacuum_step(
                     batch.writev(prepared.offset, &prepared.bufs);
                     let completions = batch.submit()?;
 
-                    *sub_state = PlainVacuumSubState::WriteBatch {
+                    *stage = VacuumInPlaceStage::WriteWalBatch {
                         temp_db,
                         total_pages,
                         next_page,
@@ -1551,7 +1515,7 @@ pub(crate) fn plain_vacuum_step(
                 let (page_ref, completion) =
                     temp_pager.read_page_no_cache(next_page as i64, None, false)?;
 
-                *sub_state = PlainVacuumSubState::ReadTempPage {
+                *stage = VacuumInPlaceStage::ReadTempPage {
                     temp_db,
                     total_pages,
                     next_page: next_page + 1,
@@ -1563,7 +1527,7 @@ pub(crate) fn plain_vacuum_step(
                 continue;
             }
 
-            PlainVacuumSubState::WriteBatch {
+            VacuumInPlaceStage::WriteWalBatch {
                 temp_db,
                 total_pages,
                 next_page,
@@ -1574,7 +1538,7 @@ pub(crate) fn plain_vacuum_step(
                 // unfinished completion; re-entry will re-check them all.
                 let pending = completions.iter().find(|c| !c.finished()).cloned();
                 if let Some(pending) = pending {
-                    *sub_state = PlainVacuumSubState::WriteBatch {
+                    *stage = VacuumInPlaceStage::WriteWalBatch {
                         temp_db,
                         total_pages,
                         next_page,
@@ -1614,7 +1578,7 @@ pub(crate) fn plain_vacuum_step(
                     let (page_ref, completion) =
                         temp_pager.read_page_no_cache(next_page as i64, None, false)?;
 
-                    *sub_state = PlainVacuumSubState::ReadTempPage {
+                    *stage = VacuumInPlaceStage::ReadTempPage {
                         temp_db,
                         total_pages,
                         next_page: next_page + 1,
@@ -1633,7 +1597,7 @@ pub(crate) fn plain_vacuum_step(
                 let sync_mode = connection.get_sync_mode();
                 if sync_mode == SyncMode::Full {
                     let sync_c = wal.sync(source_pager.get_sync_type())?;
-                    *sub_state = PlainVacuumSubState::SyncWal {
+                    *stage = VacuumInPlaceStage::SyncSourceWal {
                         temp_db,
                         sync_completion: sync_c,
                     };
@@ -1641,16 +1605,16 @@ pub(crate) fn plain_vacuum_step(
                 }
 
                 // No sync needed — proceed directly to publish.
-                *sub_state = PlainVacuumSubState::Publish { temp_db };
+                *stage = VacuumInPlaceStage::PublishWalCommit { temp_db };
                 continue;
             }
 
-            PlainVacuumSubState::SyncWal {
+            VacuumInPlaceStage::SyncSourceWal {
                 temp_db,
                 sync_completion,
             } => {
                 if !sync_completion.finished() {
-                    *sub_state = PlainVacuumSubState::SyncWal {
+                    *stage = VacuumInPlaceStage::SyncSourceWal {
                         temp_db,
                         sync_completion: sync_completion.clone(),
                     };
@@ -1663,11 +1627,11 @@ pub(crate) fn plain_vacuum_step(
                         "VACUUM: WAL fsync failed".to_string(),
                     ));
                 }
-                *sub_state = PlainVacuumSubState::Publish { temp_db };
+                *stage = VacuumInPlaceStage::PublishWalCommit { temp_db };
                 continue;
             }
 
-            PlainVacuumSubState::Publish { temp_db } => {
+            VacuumInPlaceStage::PublishWalCommit { temp_db } => {
                 let wal = source_pager
                     .wal
                     .as_ref()
@@ -1677,13 +1641,13 @@ pub(crate) fn plain_vacuum_step(
                 // succeeds the compacted image is durable — rollback must
                 // not be attempted even if later schema reload fails.
                 wal.finish_append_frames_commit()?;
-                progress.commit_published = true;
+                cleanup_state.wal_commit_published = true;
 
                 // Release source write lock and old read lock.
                 source_pager.end_write_tx();
                 source_pager.end_read_tx();
-                progress.write_tx_open = false;
-                progress.read_tx_open = false;
+                cleanup_state.source_write_tx_open = false;
+                cleanup_state.source_read_tx_open = false;
 
                 // Restore connection bookkeeping immediately. The commit is
                 // durable so there is nothing to roll back; restoring here
@@ -1724,11 +1688,11 @@ pub(crate) fn plain_vacuum_step(
 
                 reload_result?;
 
-                *sub_state = PlainVacuumSubState::Done;
+                *stage = VacuumInPlaceStage::Done;
                 return Ok(InsnFunctionStepResult::Step);
             }
 
-            PlainVacuumSubState::Done => {
+            VacuumInPlaceStage::Done => {
                 return Ok(InsnFunctionStepResult::Step);
             }
         }
@@ -1736,38 +1700,38 @@ pub(crate) fn plain_vacuum_step(
 }
 
 /// Roll back the source transaction and restore connection state after a
-/// plain VACUUM failure. Uses `progress` flags to decide what to undo —
-/// these are independent of the sub-state enum and survive `std::mem::take`.
+/// in-place VACUUM failure. Uses `cleanup_state` flags to decide what to undo;
+/// these are independent of the stage enum and survive `std::mem::take`.
 ///
-/// `sub_state` is taken by value so helper statements inside
-/// `BuildTempImage` are dropped before we attempt `rollback_tx`. This
+/// `stage` is taken by value so helper statements inside `TargetBuild` are
+/// dropped before we attempt `rollback_tx`. This
 /// avoids the nestedness suppression bug where live helper statements keep
 /// `Connection::nestedness > 0`, making `rollback_tx` a no-op.
-pub(crate) fn plain_vacuum_cleanup(
+pub(crate) fn vacuum_in_place_cleanup(
     connection: &Arc<Connection>,
     db: usize,
-    sub_state: PlainVacuumSubState,
-    progress: &PlainVacuumProgress,
+    stage: VacuumInPlaceStage,
+    cleanup_state: &VacuumInPlaceCleanupState,
 ) {
     use std::sync::atomic::Ordering;
 
     // Nothing acquired — nothing to undo.
-    if !progress.read_tx_open && !progress.write_tx_open {
+    if !cleanup_state.source_read_tx_open && !cleanup_state.source_write_tx_open {
         return;
     }
 
-    // Drop the sub-state first to release any temp-build helper statements.
+    // Drop the stage first to release any target-build helper statements.
     // Their Drop impls decrement Connection::nestedness, which must happen
     // before rollback_tx (which is a no-op while nested).
-    drop(sub_state);
+    drop(stage);
 
-    if progress.commit_published {
+    if cleanup_state.wal_commit_published {
         // The compacted image was already durably committed. We must not
         // roll back — just restore connection bookkeeping.
         let pager = connection.get_pager_from_database_index(&db);
         pager.end_write_tx();
         pager.end_read_tx();
-    } else if progress.write_tx_open {
+    } else if cleanup_state.source_write_tx_open {
         // Write transaction open but not yet committed — roll back.
         let pager = connection.get_pager_from_database_index(&db);
         pager.rollback_tx(connection);
@@ -1789,7 +1753,7 @@ mod tests {
     use crate::util::IOExt;
 
     #[test]
-    fn vacuum_header_policy_bumps_schema_cookie_and_preserves_sqlite_metadata() {
+    fn vacuum_page1_meta_bumps_schema_cookie_and_preserves_sqlite_metadata() {
         let mut source = DatabaseHeader::default();
         source.schema_cookie = u32::MAX.into();
         source.default_page_cache_size = CacheSize::new(123);
@@ -1797,38 +1761,24 @@ mod tests {
         source.user_version = 7.into();
         source.application_id = 12.into();
 
-        let VacuumHeaderMetadata {
+        let VacuumPage1Meta {
             schema_cookie,
             default_page_cache_size,
             text_encoding,
             user_version,
             application_id,
-        } = VacuumHeaderMetadata::from_source_header(&source);
+        } = VacuumPage1Meta::from_source_header(&source);
 
         assert_eq!(schema_cookie, 0);
         assert_eq!(default_page_cache_size, CacheSize::new(123));
         assert_eq!(text_encoding, TextEncoding::Utf8);
         assert_eq!(user_version, 7);
         assert_eq!(application_id, 12);
-
-        let VacuumDestinationHeader::VacuumInto(into_metadata) =
-            VacuumDestinationHeader::vacuum_into_from_source_header(&source)
-        else {
-            panic!("vacuum_into_from_source_header must build the VACUUM INTO policy");
-        };
-        assert_eq!(into_metadata.schema_cookie, 0);
-
-        let VacuumDestinationHeader::PlainVacuum(plain_metadata) =
-            VacuumDestinationHeader::plain_vacuum_from_source_header(&source)
-        else {
-            panic!("plain_vacuum_from_source_header must build the plain VACUUM policy");
-        };
-        assert_eq!(plain_metadata.schema_cookie, 0);
     }
 
     #[cfg(not(target_family = "wasm"))]
     #[test]
-    fn vacuum_header_policy_updates_destination_header() -> Result<()> {
+    fn vacuum_page1_meta_updates_target_header() -> Result<()> {
         let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
         let source_dir = tempfile::tempdir().unwrap();
         let source_path = source_dir.path().join("source.db");
@@ -1841,7 +1791,7 @@ mod tests {
             None,
         )?;
         let source_conn = source_db.connect()?;
-        let temp = open_internal_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
 
         let mut source_header = DatabaseHeader::default();
         source_header.schema_cookie = 41.into();
@@ -1849,10 +1799,10 @@ mod tests {
         source_header.text_encoding = TextEncoding::Utf8;
         source_header.user_version = 17.into();
         source_header.application_id = 29.into();
-        let policy = VacuumDestinationHeader::vacuum_into_from_source_header(&source_header);
+        let header_meta = VacuumPage1Meta::from_source_header(&source_header);
 
         temp.conn.execute("BEGIN")?;
-        match finalize_destination_header(&temp.conn, &policy)? {
+        match finalize_vacuum_target_header(&temp.conn, &header_meta)? {
             crate::IOResult::Done(()) => {}
             crate::IOResult::IO(_) => panic!("fresh temp header should not need async I/O"),
         }
@@ -1895,7 +1845,7 @@ mod tests {
         )?;
         let source_conn = source_db.connect()?;
 
-        let temp = open_internal_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
 
         assert!(Arc::ptr_eq(&temp.db.io, &source_db.io));
         assert_ne!(temp.path, source_db.path);
@@ -1930,7 +1880,7 @@ mod tests {
             .get_reserved_bytes()
             .expect("encrypted source should have reserved bytes");
 
-        let temp = open_internal_vacuum_temp_db(&source_conn, &source_db, 4096, reserved_space)?;
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, reserved_space)?;
 
         assert!(temp.db.experimental_encryption_enabled());
         assert_eq!(

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1102,23 +1102,24 @@ pub(crate) enum VacuumInPlacePhase {
         /// the fsync from `prepare_wal_finish`.
         fsync_phase: bool,
     },
-    /// Read a single temp page for the current batch.
-    ReadTempPage {
+    /// Read a batch of temp pages in parallel using multi-inflight
+    /// `Wal::read_frames_batch` calls, one per contiguous frame-id run.
+    /// The state waits on a single `CompletionGroup` completion that
+    /// covers every run in the batch.
+    ReadTempBatch {
         temp_db: Box<VacuumTempDb>,
         total_pages: u32,
-        /// Next page number to read (1-based). The page at `next_page - 1` is
-        /// the one we just issued a read for and are awaiting.
+        /// First page id NOT included in this batch (i.e., the page id
+        /// where the next batch will start, 1-based).
         next_page: u32,
         /// Boxed to shrink the enum — PreparedFrames contains Vecs and is ~80+
         /// bytes unboxed. Only created once per batch, so boxing adds no
         /// allocation overhead in the hot path.
         prev_prepared: Option<Box<crate::storage::wal::PreparedFrames>>,
-        /// Accumulated pages for the current batch.
+        /// Pages for this batch, pre-allocated in logical page-id order.
         batch_pages: Vec<crate::storage::pager::PageRef>,
-        /// Completion for the in-flight read.
+        /// Aggregate completion for every run issued for this batch.
         read_completion: crate::io::Completion,
-        /// The PageRef being read.
-        reading_page: crate::storage::pager::PageRef,
     },
     /// Write a prepared batch to the WAL file.
     WriteWalBatch {
@@ -1155,6 +1156,90 @@ impl Default for VacuumInPlacePhase {
 
 /// The batch size for copy-back: how many temp pages to read per batch.
 const VACUUM_COPY_BATCH_SIZE: u32 = 64;
+
+/// Coalesce `(page_ref, frame_id)` pairs into contiguous-frame-id runs.
+///
+/// Plain `VACUUM` relies on the temp-WAL-only invariant: every temp page
+/// lives in the temp WAL (auto-checkpoint is disabled on the temp
+/// connection), so for each logical page id we get a single frame id via
+/// `find_frame`. Because target-build appends frames in phase order
+/// (schema → rows → indexes → post-data), `find_frame(1), find_frame(2),
+/// …` on the temp WAL returns a non-monotonic frame-id sequence. Sorting
+/// by `frame_id` before splitting into runs lets a single `pread` over a
+/// contiguous range serve many logical pages at once.
+fn coalesce_frame_runs(
+    mut pairs: Vec<(crate::storage::pager::PageRef, u64)>,
+) -> Vec<(u64, Vec<crate::storage::pager::PageRef>)> {
+    if pairs.is_empty() {
+        return Vec::new();
+    }
+    pairs.sort_by_key(|(_, f)| *f);
+    let mut runs: Vec<(u64, Vec<crate::storage::pager::PageRef>)> = Vec::new();
+    for (page, frame_id) in pairs {
+        if let Some((run_start, run_pages)) = runs.last_mut() {
+            let next_expected = *run_start + run_pages.len() as u64;
+            if frame_id == next_expected {
+                run_pages.push(page);
+                continue;
+            }
+        }
+        runs.push((frame_id, vec![page]));
+    }
+    runs
+}
+
+/// Start multi-inflight reads for one copy-back batch spanning logical
+/// pages `[batch_start, batch_end)`. Every page must be resident in the
+/// temp WAL (temp-WAL-only invariant). Returns the pre-allocated
+/// per-page `PageRef`s in logical page-id order plus the aggregate
+/// completion covering every run.
+fn start_temp_batch_reads(
+    temp_pager: &crate::storage::pager::Pager,
+    batch_start: u32,
+    batch_end: u32,
+) -> Result<(Vec<crate::storage::pager::PageRef>, crate::io::Completion)> {
+    use crate::io::CompletionGroup;
+    use crate::storage::pager::Page;
+
+    turso_assert!(
+        batch_start < batch_end,
+        "empty vacuum read batch",
+        { "batch_start": batch_start, "batch_end": batch_end }
+    );
+    let wal = temp_pager.wal.as_ref().ok_or_else(|| {
+        LimboError::InternalError("VACUUM requires a temp WAL pager".into())
+    })?;
+
+    let len = (batch_end - batch_start) as usize;
+    let mut logical_pages: Vec<crate::storage::pager::PageRef> = Vec::with_capacity(len);
+    let mut pairs: Vec<(crate::storage::pager::PageRef, u64)> = Vec::with_capacity(len);
+
+    for page_id in batch_start..batch_end {
+        let page: crate::storage::pager::PageRef = Arc::new(Page::new(page_id as i64));
+        let frame_id = wal.find_frame(page_id as u64, None)?.ok_or_else(|| {
+            LimboError::InternalError(format!(
+                "VACUUM: temp page {page_id} not found in temp WAL (temp-WAL-only invariant violated)"
+            ))
+        })?;
+        logical_pages.push(page.clone());
+        pairs.push((page, frame_id));
+    }
+
+    let runs = coalesce_frame_runs(pairs);
+
+    let mut group = CompletionGroup::new(|_| {});
+    for (start_frame, run_pages) in &runs {
+        let c = wal.read_frames_batch(
+            *start_frame,
+            run_pages,
+            temp_pager.buffer_pool.clone(),
+        )?;
+        group.add(&c);
+    }
+    let combined = group.build();
+
+    Ok((logical_pages, combined))
+}
 
 /// Step the in-place VACUUM state machine once. Returns `IO` to yield or `Step`
 /// when the entire operation is complete.
@@ -1385,18 +1470,19 @@ pub(crate) fn vacuum_in_place_step(
                     continue;
                 }
 
-                // WAL already initialized — go straight to reading temp pages.
+                // WAL already initialized — kick off the first read batch.
                 let temp_pager = temp_db.conn.get_pager();
-                let (page_ref, completion) = temp_pager.read_page_no_cache(1, None, false)?;
+                let batch_end = (1 + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1);
+                let (batch_pages, read_completion) =
+                    start_temp_batch_reads(&temp_pager, 1, batch_end)?;
 
-                *phase = VacuumInPlacePhase::ReadTempPage {
+                *phase = VacuumInPlacePhase::ReadTempBatch {
                     temp_db,
                     total_pages,
-                    next_page: 2, // page 1 is being read now
+                    next_page: batch_end,
                     prev_prepared: None,
-                    batch_pages: Vec::with_capacity(VACUUM_COPY_BATCH_SIZE as usize),
-                    read_completion: completion,
-                    reading_page: page_ref,
+                    batch_pages,
+                    read_completion,
                 };
                 continue;
             }
@@ -1438,41 +1524,40 @@ pub(crate) fn vacuum_in_place_step(
                     continue;
                 }
 
-                // WAL header fully initialized. Start reading temp pages.
+                // WAL header fully initialized. Kick off the first read batch.
                 let temp_pager = temp_db.conn.get_pager();
-                let (page_ref, read_c) = temp_pager.read_page_no_cache(1, None, false)?;
+                let batch_end = (1 + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1);
+                let (batch_pages, read_completion) =
+                    start_temp_batch_reads(&temp_pager, 1, batch_end)?;
 
-                *phase = VacuumInPlacePhase::ReadTempPage {
+                *phase = VacuumInPlacePhase::ReadTempBatch {
                     temp_db,
                     total_pages,
-                    next_page: 2,
+                    next_page: batch_end,
                     prev_prepared: None,
-                    batch_pages: Vec::with_capacity(VACUUM_COPY_BATCH_SIZE as usize),
-                    read_completion: read_c,
-                    reading_page: page_ref,
+                    batch_pages,
+                    read_completion,
                 };
                 continue;
             }
 
-            VacuumInPlacePhase::ReadTempPage {
+            VacuumInPlacePhase::ReadTempBatch {
                 temp_db,
                 total_pages,
                 next_page,
                 prev_prepared,
-                mut batch_pages,
+                batch_pages,
                 read_completion,
-                reading_page,
             } => {
-                // Wait for the current read to complete.
+                // Wait for every run in this batch to finish.
                 if !read_completion.finished() {
-                    *phase = VacuumInPlacePhase::ReadTempPage {
+                    *phase = VacuumInPlacePhase::ReadTempBatch {
                         temp_db,
                         total_pages,
                         next_page,
                         prev_prepared,
                         batch_pages,
                         read_completion: read_completion.clone(),
-                        reading_page,
                     };
                     return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
                         read_completion,
@@ -1480,64 +1565,39 @@ pub(crate) fn vacuum_in_place_step(
                 }
                 if !read_completion.succeeded() {
                     return Err(LimboError::InternalError(
-                        "VACUUM: temp page read failed".to_string(),
+                        "VACUUM: temp batch read failed".to_string(),
                     ));
                 }
 
-                // Accumulate the completed page.
-                batch_pages.push(reading_page);
-
-                // If batch is full or we've read all pages, prepare WAL frames.
-                let batch_full = batch_pages.len() >= VACUUM_COPY_BATCH_SIZE as usize;
+                // All pages in this batch are loaded. Prepare WAL frames.
                 let all_read = next_page > total_pages;
+                let wal = source_pager
+                    .wal
+                    .as_ref()
+                    .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
+                let page_sz = source_pager.get_page_size_unchecked();
 
-                if batch_full || all_read {
-                    // Prepare WAL frames from this batch. WAL header was already
-                    // initialized in InitSourceWalHeader before reading started.
-                    let wal = source_pager
-                        .wal
-                        .as_ref()
-                        .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
-                    let page_sz = source_pager.get_page_size_unchecked();
+                let db_size_on_commit = if all_read { Some(total_pages) } else { None };
 
-                    let db_size_on_commit = if all_read { Some(total_pages) } else { None };
+                let prepared = wal.prepare_frames(
+                    &batch_pages,
+                    page_sz,
+                    db_size_on_commit,
+                    prev_prepared.as_deref(),
+                )?;
 
-                    let prepared = wal.prepare_frames(
-                        &batch_pages,
-                        page_sz,
-                        db_size_on_commit,
-                        prev_prepared.as_deref(),
-                    )?;
+                // Submit writes via WriteBatch.
+                let wal_file = wal.wal_file()?;
+                let mut batch = IOWriteBatch::new(wal_file);
+                batch.writev(prepared.offset, &prepared.bufs);
+                let completions = batch.submit()?;
 
-                    // Submit writes via WriteBatch.
-                    let wal_file = wal.wal_file()?;
-                    let mut batch = IOWriteBatch::new(wal_file);
-                    batch.writev(prepared.offset, &prepared.bufs);
-                    let completions = batch.submit()?;
-
-                    *phase = VacuumInPlacePhase::WriteWalBatch {
-                        temp_db,
-                        total_pages,
-                        next_page,
-                        prev_prepared: Some(Box::new(prepared)),
-                        completions,
-                    };
-                    continue;
-                }
-
-                // Batch not full, more pages to read. Issue next read.
-                let temp_pager = temp_db.conn.get_pager();
-                let (page_ref, completion) =
-                    temp_pager.read_page_no_cache(next_page as i64, None, false)?;
-
-                *phase = VacuumInPlacePhase::ReadTempPage {
+                *phase = VacuumInPlacePhase::WriteWalBatch {
                     temp_db,
                     total_pages,
-                    next_page: next_page + 1,
-                    prev_prepared,
-                    batch_pages,
-                    read_completion: completion,
-                    reading_page: page_ref,
+                    next_page,
+                    prev_prepared: Some(Box::new(prepared)),
+                    completions,
                 };
                 continue;
             }
@@ -1588,19 +1648,20 @@ pub(crate) fn vacuum_in_place_step(
 
                 // More pages to copy?
                 if next_page <= total_pages {
-                    // Start reading the next page.
+                    // Kick off the next read batch in parallel.
                     let temp_pager = temp_db.conn.get_pager();
-                    let (page_ref, completion) =
-                        temp_pager.read_page_no_cache(next_page as i64, None, false)?;
+                    let batch_end =
+                        (next_page + VACUUM_COPY_BATCH_SIZE).min(total_pages + 1);
+                    let (batch_pages, read_completion) =
+                        start_temp_batch_reads(&temp_pager, next_page, batch_end)?;
 
-                    *phase = VacuumInPlacePhase::ReadTempPage {
+                    *phase = VacuumInPlacePhase::ReadTempBatch {
                         temp_db,
                         total_pages,
-                        next_page: next_page + 1,
+                        next_page: batch_end,
                         prev_prepared,
-                        batch_pages: Vec::with_capacity(VACUUM_COPY_BATCH_SIZE as usize),
-                        read_completion: completion,
-                        reading_page: page_ref,
+                        batch_pages,
+                        read_completion,
                     };
                     continue;
                 }
@@ -1811,7 +1872,92 @@ pub(crate) fn vacuum_in_place_cleanup(
 mod tests {
     use super::*;
     use crate::storage::encryption::{CipherMode, EncryptionKey};
+    use crate::storage::pager::Page;
     use crate::util::IOExt;
+
+    fn page_ref(id: i64) -> crate::storage::pager::PageRef {
+        Arc::new(Page::new(id))
+    }
+
+    #[test]
+    fn coalesce_frame_runs_empty_returns_empty() {
+        let runs = coalesce_frame_runs(Vec::new());
+        assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn coalesce_frame_runs_single_page_is_one_run_of_one() {
+        let runs = coalesce_frame_runs(vec![(page_ref(1), 42)]);
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].0, 42);
+        assert_eq!(runs[0].1.len(), 1);
+        assert_eq!(runs[0].1[0].get().id, 1);
+    }
+
+    #[test]
+    fn coalesce_frame_runs_sorts_by_frame_id_then_coalesces_contiguous() {
+        // Target-build writes frames out of page-id order. The input is
+        // sorted by page id (1,2,3,4), but the frame ids interleave with a
+        // gap at frame 3, producing two runs once sorted by frame id.
+        let pairs = vec![
+            (page_ref(1), 10),
+            (page_ref(2), 11),
+            (page_ref(3), 12),
+            (page_ref(4), 14),
+        ];
+        let runs = coalesce_frame_runs(pairs);
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].0, 10);
+        assert_eq!(runs[0].1.len(), 3);
+        assert_eq!(
+            runs[0].1.iter().map(|p| p.get().id).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(runs[1].0, 14);
+        assert_eq!(runs[1].1.len(), 1);
+        assert_eq!(runs[1].1[0].get().id, 4);
+    }
+
+    #[test]
+    fn coalesce_frame_runs_handles_non_monotonic_page_to_frame_map() {
+        // Realistic target-build shape: pages 1..=6 but frames assigned by
+        // phase order (schema page goes last, indexes interleave). The
+        // coalescer must still produce runs of length > 1 for contiguous
+        // frame ranges rather than falling back to length-1 runs.
+        let pairs = vec![
+            (page_ref(1), 10), // schema written last (gap between 6 and 10)
+            (page_ref(2), 1),  // data pages written first
+            (page_ref(3), 2),
+            (page_ref(4), 3),
+            (page_ref(5), 5), // index pages later
+            (page_ref(6), 6),
+        ];
+        let runs = coalesce_frame_runs(pairs);
+        // After sort by frame id: frames 1,2,3 contiguous; 5,6 contiguous;
+        // 10 isolated.
+        assert_eq!(runs.len(), 3);
+        assert_eq!(runs[0].0, 1);
+        assert_eq!(runs[0].1.len(), 3);
+        assert_eq!(runs[1].0, 5);
+        assert_eq!(runs[1].1.len(), 2);
+        assert_eq!(runs[2].0, 10);
+        assert_eq!(runs[2].1.len(), 1);
+
+        // Average run length should be non-trivial (>1).
+        let total: usize = runs.iter().map(|(_, pages)| pages.len()).sum();
+        let avg = total as f64 / runs.len() as f64;
+        assert!(avg > 1.0, "expected average run length > 1, got {avg}");
+    }
+
+    #[test]
+    fn coalesce_frame_runs_all_scattered_is_singleton_runs() {
+        let pairs = vec![(page_ref(1), 10), (page_ref(2), 20), (page_ref(3), 30)];
+        let runs = coalesce_frame_runs(pairs);
+        assert_eq!(runs.len(), 3);
+        for (_, pages) in &runs {
+            assert_eq!(pages.len(), 1);
+        }
+    }
 
     #[test]
     fn vacuum_db_header_meta_bumps_schema_cookie_and_preserves_sqlite_metadata() {

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -310,9 +310,9 @@ pub(crate) struct VacuumTargetBuildConfig {
 /// Context for the vacuum target build. Holds the target connection and all
 /// intermediate state needed across async yields.
 pub(crate) struct VacuumTargetBuildContext {
-    /// Target connection - lives here, not in each stage variant.
+    /// Target connection - lives here, not in each phase variant.
     pub target_conn: Arc<Connection>,
-    stage: VacuumTargetBuildStage,
+    phase: VacuumTargetBuildPhase,
     /// Typed schema entries collected from sqlite_schema, ordered by rowid.
     schema_entries: Vec<SchemaEntry>,
     /// Storage-backed tables to CREATE (excludes sqlite_sequence).
@@ -329,7 +329,7 @@ impl VacuumTargetBuildContext {
     pub fn new(target_conn: Arc<Connection>) -> Self {
         Self {
             target_conn,
-            stage: VacuumTargetBuildStage::Init,
+            phase: VacuumTargetBuildPhase::Init,
             schema_entries: Vec::new(),
             tables_to_create: Vec::new(),
             tables_to_copy: Vec::new(),
@@ -339,13 +339,13 @@ impl VacuumTargetBuildContext {
     }
 
     pub(crate) fn cleanup_after_error(&mut self) {
-        self.stage = VacuumTargetBuildStage::Done;
+        self.phase = VacuumTargetBuildPhase::Done;
     }
 }
 
-/// Stages for the vacuum target build state machine.
+/// Phases for the vacuum target build state machine.
 #[derive(Default)]
-pub(crate) enum VacuumTargetBuildStage {
+pub(crate) enum VacuumTargetBuildPhase {
     /// Mirror symbols/types, set perf flags, begin target tx, prepare schema query.
     #[default]
     Init,
@@ -416,10 +416,10 @@ pub(crate) fn vacuum_target_build_step(
     state: &mut VacuumTargetBuildContext,
 ) -> Result<crate::IOResult<()>> {
     loop {
-        let current_stage = std::mem::take(&mut state.stage);
+        let current_phase = std::mem::take(&mut state.phase);
 
-        match current_stage {
-            VacuumTargetBuildStage::Init => {
+        match current_phase {
+            VacuumTargetBuildPhase::Init => {
                 // Mirror source custom type definitions into the target schema
                 // so that STRICT tables with custom type columns can resolve
                 // those types during CREATE TABLE replay.
@@ -458,20 +458,20 @@ pub(crate) fn vacuum_target_build_step(
                 );
                 let schema_stmt = config.source_conn.prepare_internal(schema_sql.as_str())?;
 
-                state.stage = VacuumTargetBuildStage::CollectSchemaRows {
+                state.phase = VacuumTargetBuildPhase::CollectSchemaRows {
                     schema_stmt: Box::new(schema_stmt),
                 };
                 continue;
             }
 
-            VacuumTargetBuildStage::CollectSchemaRows { mut schema_stmt } => {
+            VacuumTargetBuildPhase::CollectSchemaRows { mut schema_stmt } => {
                 match schema_stmt.step()? {
                     crate::StepResult::Row => {
                         let row = schema_stmt
                             .row()
                             .expect("StepResult::Row but row() returned None");
                         state.schema_entries.push(SchemaEntry::from_row(row)?);
-                        state.stage = VacuumTargetBuildStage::CollectSchemaRows { schema_stmt };
+                        state.phase = VacuumTargetBuildPhase::CollectSchemaRows { schema_stmt };
                         continue;
                     }
                     crate::StepResult::Done => {
@@ -500,14 +500,14 @@ pub(crate) fn vacuum_target_build_step(
                             .collect();
                         state.post_data_entries = post_data;
 
-                        state.stage = VacuumTargetBuildStage::PrepareCreateTable { idx: 0 };
+                        state.phase = VacuumTargetBuildPhase::PrepareCreateTable { idx: 0 };
                         continue;
                     }
                     crate::StepResult::IO => {
                         let io = schema_stmt
                             .take_io_completions()
                             .expect("StepResult::IO returned but no completions available");
-                        state.stage = VacuumTargetBuildStage::CollectSchemaRows { schema_stmt };
+                        state.phase = VacuumTargetBuildPhase::CollectSchemaRows { schema_stmt };
                         return Ok(crate::IOResult::IO(io));
                     }
                     crate::StepResult::Busy | crate::StepResult::Interrupt => {
@@ -518,11 +518,11 @@ pub(crate) fn vacuum_target_build_step(
 
             // Phase 1: Create storage-backed tables (rootpage != 0, type=table),
             // excluding sqlite_sequence (auto-created by AUTOINCREMENT tables).
-            VacuumTargetBuildStage::PrepareCreateTable { idx } => {
+            VacuumTargetBuildPhase::PrepareCreateTable { idx } => {
                 let entries_len = state.tables_to_create.len();
                 if idx >= entries_len {
                     // Done creating tables, start copying data
-                    state.stage = VacuumTargetBuildStage::StartCopyTable { table_idx: 0 };
+                    state.phase = VacuumTargetBuildPhase::StartCopyTable { table_idx: 0 };
                     continue;
                 }
 
@@ -546,14 +546,14 @@ pub(crate) fn vacuum_target_build_step(
                     state.target_conn.end_nested();
                 }
                 let target_stmt = target_stmt?;
-                state.stage = VacuumTargetBuildStage::StepCreateTable {
+                state.phase = VacuumTargetBuildPhase::StepCreateTable {
                     target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumTargetBuildStage::StepCreateTable {
+            VacuumTargetBuildPhase::StepCreateTable {
                 mut target_schema_stmt,
                 idx,
             } => match target_schema_stmt.step()? {
@@ -561,14 +561,14 @@ pub(crate) fn vacuum_target_build_step(
                     unreachable!("CREATE TABLE statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.stage = VacuumTargetBuildStage::PrepareCreateTable { idx: idx + 1 };
+                    state.phase = VacuumTargetBuildPhase::PrepareCreateTable { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
                     let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.stage = VacuumTargetBuildStage::StepCreateTable {
+                    state.phase = VacuumTargetBuildPhase::StepCreateTable {
                         target_schema_stmt,
                         idx,
                     };
@@ -583,11 +583,11 @@ pub(crate) fn vacuum_target_build_step(
             // Column lists are derived from BTreeTable.columns in the schema,
             // not PRAGMA table_info, because table_info omits generated columns
             // while SELECT * includes them - causing a column count mismatch.
-            VacuumTargetBuildStage::StartCopyTable { table_idx } => {
+            VacuumTargetBuildPhase::StartCopyTable { table_idx } => {
                 let tables_len = state.tables_to_copy.len();
                 if table_idx >= tables_len {
                     // Done copying all tables, proceed to deferred indexes.
-                    state.stage = VacuumTargetBuildStage::PrepareCreateIndex { idx: 0 };
+                    state.phase = VacuumTargetBuildPhase::PrepareCreateIndex { idx: 0 };
                     continue;
                 }
 
@@ -609,7 +609,7 @@ pub(crate) fn vacuum_target_build_step(
                         .get_btree_table(crate::schema::SQLITE_SEQUENCE_TABLE_NAME)
                         .is_some();
                     if !target_has_sequence {
-                        state.stage = VacuumTargetBuildStage::StartCopyTable {
+                        state.phase = VacuumTargetBuildPhase::StartCopyTable {
                             table_idx: table_idx + 1,
                         };
                         continue;
@@ -654,7 +654,7 @@ pub(crate) fn vacuum_target_build_step(
                 }
                 let target_insert_stmt = target_insert_stmt?;
 
-                state.stage = VacuumTargetBuildStage::CopyRows {
+                state.phase = VacuumTargetBuildPhase::CopyRows {
                     select_stmt: Box::new(select_stmt),
                     target_insert_stmt: Box::new(target_insert_stmt),
                     table_idx,
@@ -662,7 +662,7 @@ pub(crate) fn vacuum_target_build_step(
                 continue;
             }
 
-            VacuumTargetBuildStage::CopyRows {
+            VacuumTargetBuildPhase::CopyRows {
                 mut select_stmt,
                 mut target_insert_stmt,
                 table_idx,
@@ -680,7 +680,7 @@ pub(crate) fn vacuum_target_build_step(
                         target_insert_stmt.bind_at(index, value);
                     }
 
-                    state.stage = VacuumTargetBuildStage::StepTargetInsert {
+                    state.phase = VacuumTargetBuildPhase::StepTargetInsert {
                         select_stmt,
                         target_insert_stmt,
                         table_idx,
@@ -689,7 +689,7 @@ pub(crate) fn vacuum_target_build_step(
                 }
                 crate::StepResult::Done => {
                     // Move to next table
-                    state.stage = VacuumTargetBuildStage::StartCopyTable {
+                    state.phase = VacuumTargetBuildPhase::StartCopyTable {
                         table_idx: table_idx + 1,
                     };
                     continue;
@@ -698,7 +698,7 @@ pub(crate) fn vacuum_target_build_step(
                     let io = select_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.stage = VacuumTargetBuildStage::CopyRows {
+                    state.phase = VacuumTargetBuildPhase::CopyRows {
                         select_stmt,
                         target_insert_stmt,
                         table_idx,
@@ -710,7 +710,7 @@ pub(crate) fn vacuum_target_build_step(
                 }
             },
 
-            VacuumTargetBuildStage::StepTargetInsert {
+            VacuumTargetBuildPhase::StepTargetInsert {
                 select_stmt,
                 mut target_insert_stmt,
                 table_idx,
@@ -720,7 +720,7 @@ pub(crate) fn vacuum_target_build_step(
                 }
                 crate::StepResult::Done => {
                     // Go back to get next row from source
-                    state.stage = VacuumTargetBuildStage::CopyRows {
+                    state.phase = VacuumTargetBuildPhase::CopyRows {
                         select_stmt,
                         target_insert_stmt,
                         table_idx,
@@ -731,7 +731,7 @@ pub(crate) fn vacuum_target_build_step(
                     let io = target_insert_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.stage = VacuumTargetBuildStage::StepTargetInsert {
+                    state.phase = VacuumTargetBuildPhase::StepTargetInsert {
                         select_stmt,
                         target_insert_stmt,
                         table_idx,
@@ -744,11 +744,11 @@ pub(crate) fn vacuum_target_build_step(
             },
 
             // Phase 3: Create user-defined secondary indexes.
-            VacuumTargetBuildStage::PrepareCreateIndex { idx } => {
+            VacuumTargetBuildPhase::PrepareCreateIndex { idx } => {
                 let entries_len = state.indexes_to_create.len();
                 if idx >= entries_len {
                     // Done creating indexes, move to post-data objects
-                    state.stage = VacuumTargetBuildStage::PreparePostData { idx: 0 };
+                    state.phase = VacuumTargetBuildPhase::PreparePostData { idx: 0 };
                     continue;
                 }
 
@@ -758,14 +758,14 @@ pub(crate) fn vacuum_target_build_step(
                 // out when indexes_to_create was built. The remaining CREATE
                 // INDEX statements are user-visible and can use ordinary prepare.
                 let target_stmt = state.target_conn.prepare(&entry.sql)?;
-                state.stage = VacuumTargetBuildStage::StepCreateIndex {
+                state.phase = VacuumTargetBuildPhase::StepCreateIndex {
                     target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumTargetBuildStage::StepCreateIndex {
+            VacuumTargetBuildPhase::StepCreateIndex {
                 mut target_schema_stmt,
                 idx,
             } => match target_schema_stmt.step()? {
@@ -773,14 +773,14 @@ pub(crate) fn vacuum_target_build_step(
                     unreachable!("CREATE INDEX statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.stage = VacuumTargetBuildStage::PrepareCreateIndex { idx: idx + 1 };
+                    state.phase = VacuumTargetBuildPhase::PrepareCreateIndex { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
                     let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.stage = VacuumTargetBuildStage::StepCreateIndex {
+                    state.phase = VacuumTargetBuildPhase::StepCreateIndex {
                         target_schema_stmt,
                         idx,
                     };
@@ -792,24 +792,24 @@ pub(crate) fn vacuum_target_build_step(
             },
 
             // Phase 4: Create triggers, views, and rootpage=0 schema objects.
-            VacuumTargetBuildStage::PreparePostData { idx } => {
+            VacuumTargetBuildPhase::PreparePostData { idx } => {
                 let entries_len = state.post_data_entries.len();
                 if idx >= entries_len {
-                    state.stage = VacuumTargetBuildStage::FinalizeTargetHeader;
+                    state.phase = VacuumTargetBuildPhase::FinalizeTargetHeader;
                     continue;
                 }
 
                 let entry_ordinal = state.post_data_entries[idx];
                 let entry = &state.schema_entries[entry_ordinal];
                 let target_stmt = state.target_conn.prepare(&entry.sql)?;
-                state.stage = VacuumTargetBuildStage::StepPostData {
+                state.phase = VacuumTargetBuildPhase::StepPostData {
                     target_schema_stmt: Box::new(target_stmt),
                     idx,
                 };
                 continue;
             }
 
-            VacuumTargetBuildStage::StepPostData {
+            VacuumTargetBuildPhase::StepPostData {
                 mut target_schema_stmt,
                 idx,
             } => match target_schema_stmt.step()? {
@@ -817,14 +817,14 @@ pub(crate) fn vacuum_target_build_step(
                     unreachable!("CREATE statement unexpectedly returned a row");
                 }
                 crate::StepResult::Done => {
-                    state.stage = VacuumTargetBuildStage::PreparePostData { idx: idx + 1 };
+                    state.phase = VacuumTargetBuildPhase::PreparePostData { idx: idx + 1 };
                     continue;
                 }
                 crate::StepResult::IO => {
                     let io = target_schema_stmt
                         .take_io_completions()
                         .expect("StepResult::IO returned but no completions available");
-                    state.stage = VacuumTargetBuildStage::StepPostData {
+                    state.phase = VacuumTargetBuildPhase::StepPostData {
                         target_schema_stmt,
                         idx,
                     };
@@ -835,21 +835,21 @@ pub(crate) fn vacuum_target_build_step(
                 }
             },
 
-            VacuumTargetBuildStage::FinalizeTargetHeader => {
+            VacuumTargetBuildPhase::FinalizeTargetHeader => {
                 match finalize_vacuum_target_header(&state.target_conn, &config.header_meta)? {
                     crate::IOResult::Done(()) => {}
                     crate::IOResult::IO(io) => {
-                        state.stage = VacuumTargetBuildStage::FinalizeTargetHeader;
+                        state.phase = VacuumTargetBuildPhase::FinalizeTargetHeader;
                         return Ok(crate::IOResult::IO(io));
                     }
                 }
 
-                state.stage = VacuumTargetBuildStage::Done;
+                state.phase = VacuumTargetBuildPhase::Done;
                 continue;
             }
 
-            VacuumTargetBuildStage::Done => {
-                // Commit the target transaction started in Init stage.
+            VacuumTargetBuildPhase::Done => {
+                // Commit the target transaction started in Init phase.
                 state.target_conn.execute("COMMIT")?;
                 return Ok(crate::IOResult::Done(()));
             }
@@ -1009,7 +1009,7 @@ pub(crate) fn build_copy_sql(
 
 /// Independent cleanup flags for in-place VACUUM. These track which
 /// resources the opcode has acquired and are **not** cleared by
-/// `std::mem::take` on the stage enum. The cleanup function reads these
+/// `std::mem::take` on the phase enum. The cleanup function reads these
 /// to decide what to roll back regardless of where the state machine was
 /// when the error occurred.
 #[derive(Default)]
@@ -1024,13 +1024,13 @@ pub(crate) struct VacuumInPlaceCleanupState {
     pub wal_commit_published: bool,
 }
 
-/// Stages for the in-place VACUUM state machine.
+/// Phases for the in-place VACUUM state machine.
 ///
 /// The opcode owns the source transaction lifecycle directly: it begins the
 /// read and write transactions on the source pager, builds a temp image via
 /// the shared target-build engine, then copies the compacted target back into the
 /// source WAL using the batched prepare_frames → WriteBatch → commit path.
-pub(crate) enum VacuumInPlaceStage {
+pub(crate) enum VacuumInPlacePhase {
     /// Validate preconditions (auto_commit, active statements, readonly, memory,
     /// MVCC, WAL-backed pager).
     Preflight,
@@ -1098,7 +1098,7 @@ pub(crate) enum VacuumInPlaceStage {
     Done,
 }
 
-impl Default for VacuumInPlaceStage {
+impl Default for VacuumInPlacePhase {
     fn default() -> Self {
         Self::Preflight
     }
@@ -1111,12 +1111,12 @@ const VACUUM_COPY_BATCH_SIZE: u32 = 64;
 /// when the entire operation is complete.
 ///
 /// `cleanup_state` independently tracks which resources the opcode has acquired so
-/// that cleanup can roll back correctly even when `stage` has been taken
+/// that cleanup can roll back correctly even when `phase` has been taken
 /// by `std::mem::take` at the top of the loop.
 pub(crate) fn vacuum_in_place_step(
     connection: &Arc<Connection>,
     db: usize,
-    stage: &mut VacuumInPlaceStage,
+    phase: &mut VacuumInPlacePhase,
     cleanup_state: &mut VacuumInPlaceCleanupState,
 ) -> Result<InsnFunctionStepResult> {
     use crate::io::WriteBatch as IOWriteBatch;
@@ -1129,9 +1129,9 @@ pub(crate) fn vacuum_in_place_step(
     let source_pager = connection.get_pager_from_database_index(&db);
 
     loop {
-        let current = std::mem::take(stage);
+        let current = std::mem::take(phase);
         match current {
-            VacuumInPlaceStage::Preflight => {
+            VacuumInPlacePhase::Preflight => {
                 // 1. Must be in auto-commit mode (no explicit transaction).
                 if !connection.auto_commit.load(Ordering::SeqCst) {
                     return Err(LimboError::TxError(
@@ -1184,11 +1184,11 @@ pub(crate) fn vacuum_in_place_step(
                         "VACUUM requires a WAL-mode database".to_string(),
                     ));
                 }
-                *stage = VacuumInPlaceStage::BeginSourceTx;
+                *phase = VacuumInPlacePhase::BeginSourceTx;
                 continue;
             }
 
-            VacuumInPlaceStage::BeginSourceTx => {
+            VacuumInPlacePhase::BeginSourceTx => {
                 // The WAL requires a read tx before a write tx. On first
                 // entry we start the read tx; on re-entry after an IO yield
                 // from begin_write_tx the read tx is already held.
@@ -1204,18 +1204,18 @@ pub(crate) fn vacuum_in_place_step(
                             schema_did_change: false,
                         });
                         cleanup_state.source_write_tx_open = true;
-                        *stage = VacuumInPlaceStage::ReadSourceMetadata;
+                        *phase = VacuumInPlacePhase::ReadSourceMetadata;
                         continue;
                     }
                     crate::IOResult::IO(io) => {
                         // Need to yield for IO (e.g. page1 allocation).
-                        *stage = VacuumInPlaceStage::BeginSourceTx;
+                        *phase = VacuumInPlacePhase::BeginSourceTx;
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
                 }
             }
 
-            VacuumInPlaceStage::ReadSourceMetadata => {
+            VacuumInPlacePhase::ReadSourceMetadata => {
                 let source_db = connection.get_source_database(db);
 
                 // Read page size from pager (cached after begin_read_tx).
@@ -1292,7 +1292,7 @@ pub(crate) fn vacuum_in_place_step(
 
                 let target_build_context = VacuumTargetBuildContext::new(temp_db.conn.clone());
 
-                *stage = VacuumInPlaceStage::TargetBuild {
+                *phase = VacuumInPlacePhase::TargetBuild {
                     config: Box::new(config),
                     temp_db: Box::new(temp_db),
                     context: Box::new(target_build_context),
@@ -1300,7 +1300,7 @@ pub(crate) fn vacuum_in_place_step(
                 continue;
             }
 
-            VacuumInPlaceStage::TargetBuild {
+            VacuumInPlacePhase::TargetBuild {
                 config,
                 temp_db,
                 mut context,
@@ -1310,11 +1310,11 @@ pub(crate) fn vacuum_in_place_step(
                         // Temp build complete. Move to read tx on temp.
                         drop(config);
                         drop(context);
-                        *stage = VacuumInPlaceStage::BeginTempReadTx { temp_db };
+                        *phase = VacuumInPlacePhase::BeginTempReadTx { temp_db };
                         continue;
                     }
                     crate::IOResult::IO(io) => {
-                        *stage = VacuumInPlaceStage::TargetBuild {
+                        *phase = VacuumInPlacePhase::TargetBuild {
                             config,
                             temp_db,
                             context,
@@ -1324,7 +1324,7 @@ pub(crate) fn vacuum_in_place_step(
                 }
             }
 
-            VacuumInPlaceStage::BeginTempReadTx { temp_db } => {
+            VacuumInPlacePhase::BeginTempReadTx { temp_db } => {
                 // The shared temp-build engine committed via SQL COMMIT, which
                 // ends the write transaction but leaves the WAL read mark held.
                 // End that read tx first, then start a fresh one so WAL lookups
@@ -1348,7 +1348,7 @@ pub(crate) fn vacuum_in_place_step(
                     cleanup_state.source_read_tx_open = false;
                     connection.auto_commit.store(true, Ordering::SeqCst);
                     connection.set_tx_state(crate::connection::TransactionState::None);
-                    *stage = VacuumInPlaceStage::Done;
+                    *phase = VacuumInPlacePhase::Done;
                     continue;
                 }
 
@@ -1361,7 +1361,7 @@ pub(crate) fn vacuum_in_place_step(
 
                 if let Some(header_write_c) = wal.prepare_wal_start(page_sz)? {
                     // WAL not yet initialized — yield on the header write.
-                    *stage = VacuumInPlaceStage::InitSourceWalHeader {
+                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
                         temp_db,
                         total_pages,
                         completion: header_write_c,
@@ -1374,7 +1374,7 @@ pub(crate) fn vacuum_in_place_step(
                 let temp_pager = temp_db.conn.get_pager();
                 let (page_ref, completion) = temp_pager.read_page_no_cache(1, None, false)?;
 
-                *stage = VacuumInPlaceStage::ReadTempPage {
+                *phase = VacuumInPlacePhase::ReadTempPage {
                     temp_db,
                     total_pages,
                     next_page: 2, // page 1 is being read now
@@ -1386,14 +1386,14 @@ pub(crate) fn vacuum_in_place_step(
                 continue;
             }
 
-            VacuumInPlaceStage::InitSourceWalHeader {
+            VacuumInPlacePhase::InitSourceWalHeader {
                 temp_db,
                 total_pages,
                 completion,
                 fsync_phase,
             } => {
                 if !completion.finished() {
-                    *stage = VacuumInPlaceStage::InitSourceWalHeader {
+                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
                         temp_db,
                         total_pages,
                         completion: completion.clone(),
@@ -1414,7 +1414,7 @@ pub(crate) fn vacuum_in_place_step(
                     // to set WAL `initialized = true`.
                     let wal = source_pager.wal.as_ref().unwrap();
                     let sync_c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
-                    *stage = VacuumInPlaceStage::InitSourceWalHeader {
+                    *phase = VacuumInPlacePhase::InitSourceWalHeader {
                         temp_db,
                         total_pages,
                         completion: sync_c,
@@ -1427,7 +1427,7 @@ pub(crate) fn vacuum_in_place_step(
                 let temp_pager = temp_db.conn.get_pager();
                 let (page_ref, read_c) = temp_pager.read_page_no_cache(1, None, false)?;
 
-                *stage = VacuumInPlaceStage::ReadTempPage {
+                *phase = VacuumInPlacePhase::ReadTempPage {
                     temp_db,
                     total_pages,
                     next_page: 2,
@@ -1439,7 +1439,7 @@ pub(crate) fn vacuum_in_place_step(
                 continue;
             }
 
-            VacuumInPlaceStage::ReadTempPage {
+            VacuumInPlacePhase::ReadTempPage {
                 temp_db,
                 total_pages,
                 next_page,
@@ -1450,7 +1450,7 @@ pub(crate) fn vacuum_in_place_step(
             } => {
                 // Wait for the current read to complete.
                 if !read_completion.finished() {
-                    *stage = VacuumInPlaceStage::ReadTempPage {
+                    *phase = VacuumInPlacePhase::ReadTempPage {
                         temp_db,
                         total_pages,
                         next_page,
@@ -1500,7 +1500,7 @@ pub(crate) fn vacuum_in_place_step(
                     batch.writev(prepared.offset, &prepared.bufs);
                     let completions = batch.submit()?;
 
-                    *stage = VacuumInPlaceStage::WriteWalBatch {
+                    *phase = VacuumInPlacePhase::WriteWalBatch {
                         temp_db,
                         total_pages,
                         next_page,
@@ -1515,7 +1515,7 @@ pub(crate) fn vacuum_in_place_step(
                 let (page_ref, completion) =
                     temp_pager.read_page_no_cache(next_page as i64, None, false)?;
 
-                *stage = VacuumInPlaceStage::ReadTempPage {
+                *phase = VacuumInPlacePhase::ReadTempPage {
                     temp_db,
                     total_pages,
                     next_page: next_page + 1,
@@ -1527,7 +1527,7 @@ pub(crate) fn vacuum_in_place_step(
                 continue;
             }
 
-            VacuumInPlaceStage::WriteWalBatch {
+            VacuumInPlacePhase::WriteWalBatch {
                 temp_db,
                 total_pages,
                 next_page,
@@ -1538,7 +1538,7 @@ pub(crate) fn vacuum_in_place_step(
                 // unfinished completion; re-entry will re-check them all.
                 let pending = completions.iter().find(|c| !c.finished()).cloned();
                 if let Some(pending) = pending {
-                    *stage = VacuumInPlaceStage::WriteWalBatch {
+                    *phase = VacuumInPlacePhase::WriteWalBatch {
                         temp_db,
                         total_pages,
                         next_page,
@@ -1578,7 +1578,7 @@ pub(crate) fn vacuum_in_place_step(
                     let (page_ref, completion) =
                         temp_pager.read_page_no_cache(next_page as i64, None, false)?;
 
-                    *stage = VacuumInPlaceStage::ReadTempPage {
+                    *phase = VacuumInPlacePhase::ReadTempPage {
                         temp_db,
                         total_pages,
                         next_page: next_page + 1,
@@ -1597,7 +1597,7 @@ pub(crate) fn vacuum_in_place_step(
                 let sync_mode = connection.get_sync_mode();
                 if sync_mode == SyncMode::Full {
                     let sync_c = wal.sync(source_pager.get_sync_type())?;
-                    *stage = VacuumInPlaceStage::SyncSourceWal {
+                    *phase = VacuumInPlacePhase::SyncSourceWal {
                         temp_db,
                         sync_completion: sync_c,
                     };
@@ -1605,16 +1605,16 @@ pub(crate) fn vacuum_in_place_step(
                 }
 
                 // No sync needed — proceed directly to publish.
-                *stage = VacuumInPlaceStage::PublishWalCommit { temp_db };
+                *phase = VacuumInPlacePhase::PublishWalCommit { temp_db };
                 continue;
             }
 
-            VacuumInPlaceStage::SyncSourceWal {
+            VacuumInPlacePhase::SyncSourceWal {
                 temp_db,
                 sync_completion,
             } => {
                 if !sync_completion.finished() {
-                    *stage = VacuumInPlaceStage::SyncSourceWal {
+                    *phase = VacuumInPlacePhase::SyncSourceWal {
                         temp_db,
                         sync_completion: sync_completion.clone(),
                     };
@@ -1627,11 +1627,11 @@ pub(crate) fn vacuum_in_place_step(
                         "VACUUM: WAL fsync failed".to_string(),
                     ));
                 }
-                *stage = VacuumInPlaceStage::PublishWalCommit { temp_db };
+                *phase = VacuumInPlacePhase::PublishWalCommit { temp_db };
                 continue;
             }
 
-            VacuumInPlaceStage::PublishWalCommit { temp_db } => {
+            VacuumInPlacePhase::PublishWalCommit { temp_db } => {
                 let wal = source_pager
                     .wal
                     .as_ref()
@@ -1688,11 +1688,11 @@ pub(crate) fn vacuum_in_place_step(
 
                 reload_result?;
 
-                *stage = VacuumInPlaceStage::Done;
+                *phase = VacuumInPlacePhase::Done;
                 return Ok(InsnFunctionStepResult::Step);
             }
 
-            VacuumInPlaceStage::Done => {
+            VacuumInPlacePhase::Done => {
                 return Ok(InsnFunctionStepResult::Step);
             }
         }
@@ -1701,16 +1701,16 @@ pub(crate) fn vacuum_in_place_step(
 
 /// Roll back the source transaction and restore connection state after a
 /// in-place VACUUM failure. Uses `cleanup_state` flags to decide what to undo;
-/// these are independent of the stage enum and survive `std::mem::take`.
+/// these are independent of the phase enum and survive `std::mem::take`.
 ///
-/// `stage` is taken by value so helper statements inside `TargetBuild` are
+/// `phase` is taken by value so helper statements inside `TargetBuild` are
 /// dropped before we attempt `rollback_tx`. This
 /// avoids the nestedness suppression bug where live helper statements keep
 /// `Connection::nestedness > 0`, making `rollback_tx` a no-op.
 pub(crate) fn vacuum_in_place_cleanup(
     connection: &Arc<Connection>,
     db: usize,
-    stage: VacuumInPlaceStage,
+    phase: VacuumInPlacePhase,
     cleanup_state: &VacuumInPlaceCleanupState,
 ) {
     use std::sync::atomic::Ordering;
@@ -1720,10 +1720,10 @@ pub(crate) fn vacuum_in_place_cleanup(
         return;
     }
 
-    // Drop the stage first to release any target-build helper statements.
+    // Drop the phase first to release any target-build helper statements.
     // Their Drop impls decrement Connection::nestedness, which must happen
     // before rollback_tx (which is a no-op while nested).
-    drop(stage);
+    drop(phase);
 
     if cleanup_state.wal_commit_published {
         // The compacted image was already durably committed. We must not

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1065,6 +1065,12 @@ pub(crate) struct VacuumInPlaceCleanupState {
     /// WAL commit was published via `finish_append_frames_commit`. Once true
     /// the compacted image is durable and rollback must not be attempted.
     pub wal_commit_published: bool,
+    /// Scratch buffer for `Wal::read_frames_batch`, sized to one full copy
+    /// batch. Allocated lazily on first use and reused across every batch to
+    /// avoid a ~(page_size + 24) × `VACUUM_COPY_BATCH_SIZE` allocation per
+    /// batch. Only runs whose total size matches this buffer's length can
+    /// reuse it (which is the common, max-sized run case).
+    pub read_scratch_buf: Option<Arc<crate::io::Buffer>>,
 }
 
 /// Phases for the in-place VACUUM state machine.
@@ -1240,9 +1246,11 @@ fn start_temp_batch_reads(
     temp_pager: &crate::storage::pager::Pager,
     batch_start: u32,
     batch_end: u32,
+    scratch_buf: &mut Option<Arc<crate::io::Buffer>>,
 ) -> Result<(Vec<crate::storage::pager::PageRef>, crate::io::Completion)> {
     use crate::io::CompletionGroup;
     use crate::storage::pager::Page;
+    use crate::storage::sqlite3_ondisk::WAL_FRAME_HEADER_SIZE;
 
     turso_assert!(
         batch_start < batch_end,
@@ -1281,9 +1289,34 @@ fn start_temp_batch_reads(
 
     let runs = coalesce_frame_runs(pairs);
 
+    // Lazy-init the scratch buffer at max-batch size. It is reused by any run
+    // whose read length matches exactly (the common case where target-build
+    // wrote a contiguous chunk of at least `VACUUM_COPY_BATCH_SIZE` pages).
+    let frame_size = temp_pager.get_page_size_unchecked().get() as usize + WAL_FRAME_HEADER_SIZE;
+    let scratch_total = frame_size * VACUUM_COPY_BATCH_SIZE as usize;
+    if scratch_buf
+        .as_ref()
+        .is_none_or(|b| b.len() != scratch_total)
+    {
+        *scratch_buf = Some(Arc::new(crate::io::Buffer::new_temporary(scratch_total)));
+    }
+
     let mut group = CompletionGroup::new(|_| {});
+    let mut scratch_claimed = false;
     for (start_frame, run_pages) in &runs {
-        let c = wal.read_frames_batch(*start_frame, run_pages, temp_pager.buffer_pool.clone())?;
+        let run_total = frame_size * run_pages.len();
+        let run_scratch = if !scratch_claimed && run_total == scratch_total {
+            scratch_claimed = true;
+            scratch_buf.clone()
+        } else {
+            None
+        };
+        let c = wal.read_frames_batch(
+            *start_frame,
+            run_pages,
+            temp_pager.buffer_pool.clone(),
+            run_scratch,
+        )?;
         group.add(&c);
     }
     let combined = group.build();
@@ -1570,8 +1603,12 @@ pub(crate) fn vacuum_in_place_step(
                 // WAL already initialized — kick off the first read batch.
                 let temp_pager = temp_db.conn.get_pager();
                 let batch_end = vacuum_copy_batch_end(1, total_pages);
-                let (batch_pages, read_completion) =
-                    start_temp_batch_reads(&temp_pager, 1, batch_end)?;
+                let (batch_pages, read_completion) = start_temp_batch_reads(
+                    &temp_pager,
+                    1,
+                    batch_end,
+                    &mut cleanup_state.read_scratch_buf,
+                )?;
 
                 *phase = VacuumInPlacePhase::ReadTempBatch {
                     temp_db,
@@ -1628,8 +1665,12 @@ pub(crate) fn vacuum_in_place_step(
                 // WAL header fully initialized. Kick off the first read batch.
                 let temp_pager = temp_db.conn.get_pager();
                 let batch_end = vacuum_copy_batch_end(1, total_pages);
-                let (batch_pages, read_completion) =
-                    start_temp_batch_reads(&temp_pager, 1, batch_end)?;
+                let (batch_pages, read_completion) = start_temp_batch_reads(
+                    &temp_pager,
+                    1,
+                    batch_end,
+                    &mut cleanup_state.read_scratch_buf,
+                )?;
 
                 *phase = VacuumInPlacePhase::ReadTempBatch {
                     temp_db,
@@ -1802,8 +1843,12 @@ pub(crate) fn vacuum_in_place_step(
                     // Kick off the next read batch in parallel.
                     let temp_pager = temp_db.conn.get_pager();
                     let batch_end = vacuum_copy_batch_end(next_page, total_pages);
-                    let (batch_pages, read_completion) =
-                        start_temp_batch_reads(&temp_pager, next_page, batch_end)?;
+                    let (batch_pages, read_completion) = start_temp_batch_reads(
+                        &temp_pager,
+                        next_page,
+                        batch_end,
+                        &mut cleanup_state.read_scratch_buf,
+                    )?;
 
                     *phase = VacuumInPlacePhase::ReadTempBatch {
                         temp_db,

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use crate::error::LimboError;
 use crate::schema::TypeDef;
+use crate::storage::sqlite3_ondisk::{CacheSize, DatabaseHeader, TextEncoding};
 use crate::types::IOResult;
+use crate::vdbe::execute::InsnFunctionStepResult;
 use crate::Result;
-use crate::{Connection, Database};
+use crate::{Connection, Database, DatabaseOpts, EncryptionOpts, OpenFlags};
 use turso_macros::turso_assert;
 
 /// A representation of a row from `sqlite_schema`.
@@ -141,6 +143,186 @@ pub(crate) fn classify_schema_entries(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Destination configuration and metadata policy
+// ---------------------------------------------------------------------------
+
+/// Destination feature flags needed for schema replay during a vacuum build.
+pub(crate) fn vacuum_destination_opts(source_db: &Database) -> DatabaseOpts {
+    DatabaseOpts::new()
+        .with_views(source_db.experimental_views_enabled())
+        .with_index_method(source_db.experimental_index_method_enabled())
+        .with_custom_types(source_db.experimental_custom_types_enabled())
+        .with_encryption(source_db.experimental_encryption_enabled())
+        .with_attach(source_db.experimental_attach_enabled())
+        .with_generated_columns(source_db.experimental_generated_columns_enabled())
+}
+
+/// Page-1 metadata that the build engine must finalize before destination commit.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct VacuumHeaderMetadata {
+    schema_cookie: u32,
+    default_page_cache_size: CacheSize,
+    text_encoding: TextEncoding,
+    user_version: i32,
+    application_id: i32,
+}
+
+impl VacuumHeaderMetadata {
+    fn from_source_header(source: &DatabaseHeader) -> Self {
+        Self {
+            schema_cookie: source.schema_cookie.get().wrapping_add(1),
+            default_page_cache_size: source.default_page_cache_size,
+            text_encoding: source.text_encoding,
+            user_version: source.user_version.get(),
+            application_id: source.application_id.get(),
+        }
+    }
+
+    fn apply_to(self, header: &mut DatabaseHeader) {
+        header.schema_cookie = self.schema_cookie.into();
+        header.default_page_cache_size = self.default_page_cache_size;
+        header.text_encoding = self.text_encoding;
+        header.user_version = self.user_version.into();
+        header.application_id = self.application_id.into();
+    }
+}
+
+/// Header policy for the compacted destination image.
+pub(crate) enum VacuumDestinationHeader {
+    /// `VACUUM INTO` creates an independent output database, but SQLite still
+    /// writes the same compacted-image metadata as plain `VACUUM`.
+    VacuumInto(VacuumHeaderMetadata),
+    /// Plain `VACUUM` builds a replacement image, so the temp image's page 1
+    /// must already contain the final source header values before copy-back.
+    #[allow(dead_code)]
+    PlainVacuum(VacuumHeaderMetadata),
+}
+
+impl VacuumDestinationHeader {
+    pub(crate) fn vacuum_into_from_source_header(source: &DatabaseHeader) -> Self {
+        Self::VacuumInto(VacuumHeaderMetadata::from_source_header(source))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn plain_vacuum_from_source_header(source: &DatabaseHeader) -> Self {
+        Self::PlainVacuum(VacuumHeaderMetadata::from_source_header(source))
+    }
+
+    fn metadata(&self) -> VacuumHeaderMetadata {
+        match self {
+            Self::VacuumInto(metadata) | Self::PlainVacuum(metadata) => *metadata,
+        }
+    }
+}
+
+/// File-backed internal temp database used by plain `VACUUM`.
+///
+/// The temp directory is dropped after the connection and database handles so
+/// host files can be closed before the directory cleanup runs.
+#[allow(dead_code)]
+pub(crate) struct InternalVacuumTempDb {
+    pub conn: Arc<Connection>,
+    pub db: Arc<Database>,
+    pub path: String,
+    #[cfg(not(target_family = "wasm"))]
+    _temp_dir: tempfile::TempDir,
+}
+
+#[allow(dead_code)]
+fn internal_temp_encryption(
+    source_conn: &Arc<Connection>,
+) -> Result<(Option<EncryptionOpts>, Option<crate::EncryptionKey>)> {
+    let Some(cipher_mode) = source_conn.get_encryption_cipher_mode() else {
+        return Ok((None, None));
+    };
+    let encryption_key = source_conn.encryption_key.read().clone().ok_or_else(|| {
+        LimboError::InternalError(
+            "encrypted plain VACUUM temp image requires source encryption key".to_string(),
+        )
+    })?;
+    let encryption_opts = EncryptionOpts {
+        cipher: cipher_mode.to_string(),
+        hexkey: hex::encode(encryption_key.as_slice()),
+    };
+    Ok((Some(encryption_opts), Some(encryption_key)))
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[allow(dead_code)]
+pub(crate) fn open_internal_vacuum_temp_db(
+    source_conn: &Arc<Connection>,
+    source_db: &Arc<Database>,
+    page_size: u32,
+    reserved_space: u8,
+) -> Result<InternalVacuumTempDb> {
+    let temp_dir = tempfile::tempdir().map_err(|e| crate::error::io_error(e, "tempdir"))?;
+    let path = temp_dir.path().join("tursodb_vacuum_temp.db");
+    let path = path
+        .to_str()
+        .ok_or_else(|| LimboError::InternalError("vacuum temp path is not valid UTF-8".into()))?
+        .to_string();
+
+    let (encryption_opts, encryption_key) = internal_temp_encryption(source_conn)?;
+    let db = Database::open_file_with_flags(
+        source_db.io.clone(),
+        &path,
+        OpenFlags::Create,
+        vacuum_destination_opts(source_db),
+        encryption_opts,
+    )?;
+    let conn = db.connect_with_encryption(encryption_key)?;
+    conn.reset_page_size(page_size)?;
+    conn.set_reserved_bytes(reserved_space)?;
+    conn.wal_auto_checkpoint_disable();
+
+    Ok(InternalVacuumTempDb {
+        conn,
+        db,
+        path,
+        _temp_dir: temp_dir,
+    })
+}
+
+#[cfg(target_family = "wasm")]
+#[allow(dead_code)]
+pub(crate) fn open_internal_vacuum_temp_db(
+    _source_conn: &Arc<Connection>,
+    _source_db: &Arc<Database>,
+    _page_size: u32,
+    _reserved_space: u8,
+) -> Result<InternalVacuumTempDb> {
+    Err(LimboError::InternalError(
+        "plain VACUUM requires a file-backed internal temp database".to_string(),
+    ))
+}
+
+fn finalize_destination_header(
+    dest_conn: &Arc<Connection>,
+    destination_header: &VacuumDestinationHeader,
+) -> Result<crate::IOResult<()>> {
+    let metadata = destination_header.metadata();
+    if let Some(mv_store) = dest_conn.mv_store_for_db(crate::MAIN_DB_ID) {
+        let tx_id = dest_conn.get_mv_tx_id_for_db(crate::MAIN_DB_ID);
+        return mv_store
+            .with_header_mut(|header| metadata.apply_to(header), tx_id.as_ref())
+            .map(crate::IOResult::Done);
+    }
+    let pager = dest_conn.pager.load();
+    pager.with_header_mut(|header| metadata.apply_to(header))
+}
+
+// ---------------------------------------------------------------------------
+// VACUUM INTO engine - reusable "build compacted copy" state machine
+// ---------------------------------------------------------------------------
+
+/// Pre-captured source symbols needed for schema replay on the destination.
+pub(crate) struct SourceSymbols {
+    pub functions: HashMap<String, Arc<ExternalFunc>>,
+    pub vtab_modules: HashMap<String, Arc<VTabImpl>>,
+    pub index_methods: HashMap<String, Arc<dyn IndexMethod>>,
+}
+
 /// Configuration for the VACUUM INTO engine. Provided by the caller (opcode
 /// handler) after reading source metadata and setting up the destination DB.
 pub(crate) struct VacuumIntoConfig {
@@ -151,10 +333,10 @@ pub(crate) struct VacuumIntoConfig {
     pub escaped_schema_name: String,
     /// Database index for schema lookups on the source connection.
     pub database_id: usize,
-    /// Source `user_version` pragma value to copy to destination.
-    pub source_user_version: i32,
-    /// Source `application_id` pragma value to copy to destination.
-    pub source_application_id: i32,
+    /// Destination header metadata policy.
+    pub destination_header: VacuumDestinationHeader,
+    /// Pre-captured source symbols (functions, vtab modules, index methods).
+    pub source_symbols: SourceSymbols,
     /// Pre-captured source custom type definitions for STRICT table replay.
     pub source_custom_types: Vec<(String, Arc<TypeDef>)>,
     /// Whether the source database has MVCC enabled.
@@ -251,8 +433,6 @@ enum VacuumIntoSubState {
         dest_insert_stmt: Box<crate::Statement>,
         table_idx: usize,
     },
-    /// Copy meta values (user_version, application_id) from source to destination
-    CopyMetaValues,
     /// Prepare CREATE INDEX statement on destination (idx into indexes_to_create)
     PrepareCreateIndex { idx: usize },
     /// Step through CREATE INDEX statement on destination
@@ -267,6 +447,8 @@ enum VacuumIntoSubState {
         dest_schema_stmt: Box<crate::Statement>,
         idx: usize,
     },
+    /// Finalize page-1 metadata before committing the destination image.
+    FinalizeDestinationHeader,
     /// Operation complete
     Done,
 }
@@ -286,11 +468,11 @@ enum VacuumIntoSubState {
 ///    internal storage-backed tables
 /// 5. Creates user-defined secondary indexes after data copy for performance
 ///    (backing-btree indexes for custom index methods are excluded here)
-/// 6. Copies meta values (user_version, application_id) from source to destination
-/// 7. Creates triggers, views, and rootpage = 0 objects last (after data copy).
+/// 6. Creates triggers, views, and rootpage = 0 objects last (after data copy).
 ///    Custom index methods (FTS, vector) recreate and backfill their backing
 ///    indexes from the copied table data in this phase.
-fn vacuum_into_step(
+/// 7. Finalizes destination page-1 metadata, then commits the destination transaction.
+pub(crate) fn vacuum_into_step(
     config: &VacuumIntoConfig,
     state: &mut VacuumIntoState,
 ) -> Result<IOResult<()>> {
@@ -491,8 +673,8 @@ fn vacuum_into_step(
             VacuumIntoSubState::StartCopyTable { table_idx } => {
                 let tables_len = state.tables_to_copy.len();
                 if table_idx >= tables_len {
-                    // Done copying all tables, proceed to meta values
-                    state.sub_state = VacuumIntoSubState::CopyMetaValues;
+                    // Done copying all tables, proceed to deferred indexes.
+                    state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: 0 };
                     continue;
                 }
 
@@ -643,25 +825,6 @@ fn vacuum_into_step(
                 }
             },
 
-            VacuumIntoSubState::CopyMetaValues => {
-                // Copy meta values to destination database
-                // Use pragma_update to set user_version and application_id
-                // Note: schema_version is not copied - VACUUM INTO creates a new file so
-                // there's no cache to invalidate. The destination will have its own
-                // schema_version based on the schema operations performed.
-                state
-                    .dest_conn
-                    .pragma_update("user_version", config.source_user_version.to_string())?;
-                state
-                    .dest_conn
-                    .pragma_update("application_id", config.source_application_id.to_string())?;
-
-                // Phase 3: Create user-defined secondary indexes after data copy
-                // for performance (avoids maintaining indexes during bulk insert).
-                state.sub_state = VacuumIntoSubState::PrepareCreateIndex { idx: 0 };
-                continue;
-            }
-
             // Phase 3: Create user-defined secondary indexes.
             VacuumIntoSubState::PrepareCreateIndex { idx } => {
                 let entries_len = state.indexes_to_create.len();
@@ -714,7 +877,7 @@ fn vacuum_into_step(
             VacuumIntoSubState::PreparePostData { idx } => {
                 let entries_len = state.post_data_entries.len();
                 if idx >= entries_len {
-                    state.sub_state = VacuumIntoSubState::Done;
+                    state.sub_state = VacuumIntoSubState::FinalizeDestinationHeader;
                     continue;
                 }
 
@@ -753,6 +916,19 @@ fn vacuum_into_step(
                     return Err(LimboError::Busy);
                 }
             },
+
+            VacuumIntoSubState::FinalizeDestinationHeader => {
+                match finalize_destination_header(&state.dest_conn, &config.destination_header)? {
+                    crate::IOResult::Done(()) => {}
+                    crate::IOResult::IO(io) => {
+                        state.sub_state = VacuumIntoSubState::FinalizeDestinationHeader;
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                }
+
+                state.sub_state = VacuumIntoSubState::Done;
+                continue;
+            }
 
             VacuumIntoSubState::Done => {
                 // Commit the destination transaction started in Init state.
@@ -901,4 +1077,166 @@ pub(crate) fn build_copy_sql(
         format!("INSERT INTO \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
 
     Ok((select_sql, insert_sql))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::encryption::{CipherMode, EncryptionKey};
+    use crate::util::IOExt;
+
+    #[test]
+    fn vacuum_header_policy_bumps_schema_cookie_and_preserves_sqlite_metadata() {
+        let mut source = DatabaseHeader::default();
+        source.schema_cookie = u32::MAX.into();
+        source.default_page_cache_size = CacheSize::new(123);
+        source.text_encoding = TextEncoding::Utf8;
+        source.user_version = 7.into();
+        source.application_id = 12.into();
+
+        let VacuumHeaderMetadata {
+            schema_cookie,
+            default_page_cache_size,
+            text_encoding,
+            user_version,
+            application_id,
+        } = VacuumHeaderMetadata::from_source_header(&source);
+
+        assert_eq!(schema_cookie, 0);
+        assert_eq!(default_page_cache_size, CacheSize::new(123));
+        assert_eq!(text_encoding, TextEncoding::Utf8);
+        assert_eq!(user_version, 7);
+        assert_eq!(application_id, 12);
+
+        let VacuumDestinationHeader::VacuumInto(into_metadata) =
+            VacuumDestinationHeader::vacuum_into_from_source_header(&source)
+        else {
+            panic!("vacuum_into_from_source_header must build the VACUUM INTO policy");
+        };
+        assert_eq!(into_metadata.schema_cookie, 0);
+
+        let VacuumDestinationHeader::PlainVacuum(plain_metadata) =
+            VacuumDestinationHeader::plain_vacuum_from_source_header(&source)
+        else {
+            panic!("plain_vacuum_from_source_header must build the plain VACUUM policy");
+        };
+        assert_eq!(plain_metadata.schema_cookie, 0);
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn vacuum_header_policy_updates_destination_header() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("source.db");
+        let source_path = source_path.to_str().unwrap();
+        let source_db = Database::open_file_with_flags(
+            io,
+            source_path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let source_conn = source_db.connect()?;
+        let temp = open_internal_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+
+        let mut source_header = DatabaseHeader::default();
+        source_header.schema_cookie = 41.into();
+        source_header.default_page_cache_size = CacheSize::new(321);
+        source_header.text_encoding = TextEncoding::Utf8;
+        source_header.user_version = 17.into();
+        source_header.application_id = 29.into();
+        let policy = VacuumDestinationHeader::vacuum_into_from_source_header(&source_header);
+
+        temp.conn.execute("BEGIN")?;
+        match finalize_destination_header(&temp.conn, &policy)? {
+            crate::IOResult::Done(()) => {}
+            crate::IOResult::IO(_) => panic!("fresh temp header should not need async I/O"),
+        }
+        temp.conn.execute("COMMIT")?;
+
+        let pager = temp.conn.pager.load();
+        let header = pager.io.block(|| {
+            pager.with_header(|header| {
+                (
+                    header.schema_cookie.get(),
+                    header.default_page_cache_size,
+                    header.text_encoding,
+                    header.user_version.get(),
+                    header.application_id.get(),
+                )
+            })
+        })?;
+
+        assert_eq!(
+            header,
+            (42, CacheSize::new(321), TextEncoding::Utf8, 17, 29)
+        );
+
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn internal_vacuum_temp_db_uses_source_runtime_and_disables_auto_checkpoint() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("source.db");
+        let source_path = source_path.to_str().unwrap();
+        let source_db = Database::open_file_with_flags(
+            io,
+            source_path,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )?;
+        let source_conn = source_db.connect()?;
+
+        let temp = open_internal_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+
+        assert!(Arc::ptr_eq(&temp.db.io, &source_db.io));
+        assert_ne!(temp.path, source_db.path);
+        assert!(temp.conn.is_wal_auto_checkpoint_disabled());
+        assert_eq!(temp.conn.get_page_size().get(), 4096);
+        assert_eq!(temp.conn.get_reserved_bytes(), Some(0));
+
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn internal_vacuum_temp_db_preserves_source_encryption() -> Result<()> {
+        let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("encrypted-source.db");
+        let source_path = source_path.to_str().unwrap();
+        let key_hex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+        let key = EncryptionKey::from_hex_string(key_hex)?;
+        let source_db = Database::open_file_with_flags(
+            io,
+            source_path,
+            OpenFlags::Create,
+            DatabaseOpts::new().with_encryption(true),
+            Some(EncryptionOpts {
+                cipher: CipherMode::Aes256Gcm.to_string(),
+                hexkey: key_hex.to_string(),
+            }),
+        )?;
+        let source_conn = source_db.connect_with_encryption(Some(key))?;
+        let reserved_space = source_conn
+            .get_reserved_bytes()
+            .expect("encrypted source should have reserved bytes");
+
+        let temp = open_internal_vacuum_temp_db(&source_conn, &source_db, 4096, reserved_space)?;
+
+        assert!(temp.db.experimental_encryption_enabled());
+        assert_eq!(
+            temp.conn.get_encryption_cipher_mode(),
+            source_conn.get_encryption_cipher_mode()
+        );
+        assert!(temp.conn.encryption_key.read().is_some());
+        assert_eq!(temp.conn.get_reserved_bytes(), Some(reserved_space));
+
+        Ok(())
+    }
 }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,10 +1,6 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::error::LimboError;
-use crate::ext::VTabImpl;
-use crate::function::ExternalFunc;
-use crate::index_method::IndexMethod;
 use crate::schema::TypeDef;
 use crate::storage::sqlite3_ondisk::{CacheSize, DatabaseHeader, TextEncoding};
 use crate::util::IOExt;
@@ -320,15 +316,10 @@ fn finalize_destination_header(
 // VACUUM INTO engine - reusable "build compacted copy" state machine
 // ---------------------------------------------------------------------------
 
-/// Pre-captured source symbols needed for schema replay on the destination.
-pub(crate) struct SourceSymbols {
-    pub functions: HashMap<String, Arc<ExternalFunc>>,
-    pub vtab_modules: HashMap<String, Arc<VTabImpl>>,
-    pub index_methods: HashMap<String, Arc<dyn IndexMethod>>,
-}
-
 /// Configuration for the VACUUM INTO engine. Provided by the caller (opcode
 /// handler) after reading source metadata and setting up the destination DB.
+/// Callers must mirror source symbols (functions, vtab modules, index methods)
+/// directly into dest_conn.syms before starting the state machine.
 pub(crate) struct VacuumIntoConfig {
     /// Source connection - used for `prepare_internal` and `with_schema` during
     /// schema collection and data copy.
@@ -339,8 +330,6 @@ pub(crate) struct VacuumIntoConfig {
     pub database_id: usize,
     /// Destination header metadata policy.
     pub destination_header: VacuumDestinationHeader,
-    /// Pre-captured source symbols (functions, vtab modules, index methods).
-    pub source_symbols: SourceSymbols,
     /// Pre-captured source custom type definitions for STRICT table replay.
     pub source_custom_types: Vec<(String, Arc<TypeDef>)>,
     /// Whether the source database has MVCC enabled.
@@ -460,34 +449,6 @@ pub(crate) fn vacuum_into_step(
 
         match current_sub_state {
             VacuumIntoSubState::Init => {
-                // Mirror source symbols needed for schema replay (functions, vtab
-                // modules, index methods). We skip vtabs - those are live instances
-                // tied to the source connection and not needed for compiling schema SQL.
-                {
-                    let mut dest_syms = state.dest_conn.syms.write();
-                    dest_syms.functions.extend(
-                        config
-                            .source_symbols
-                            .functions
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    dest_syms.vtab_modules.extend(
-                        config
-                            .source_symbols
-                            .vtab_modules
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                    dest_syms.index_methods.extend(
-                        config
-                            .source_symbols
-                            .index_methods
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone())),
-                    );
-                }
-
                 // Mirror source custom type definitions into destination schema
                 // so that STRICT tables with custom type columns can resolve
                 // those types during CREATE TABLE replay.
@@ -694,19 +655,16 @@ pub(crate) fn vacuum_into_step(
                         schema.get_btree_table(table_name)
                     });
 
-                let (select_sql, mut insert_sql) = build_copy_sql(
-                    &config.escaped_schema_name,
-                    &escaped_table_name,
-                    source_btree_table.as_deref(),
-                )?;
-
                 // sqlite_sequence may already have rows from the AUTOINCREMENT
                 // tracking that ran during the table data copy. Use INSERT OR
                 // REPLACE so the source counter values overwrite any stale
                 // auto-generated ones (matches SQLite vacuum.c behavior).
-                if entry.is_sqlite_sequence() {
-                    insert_sql = insert_sql.replacen("INSERT INTO", "INSERT OR REPLACE INTO", 1);
-                }
+                let (select_sql, insert_sql) = build_copy_sql(
+                    &config.escaped_schema_name,
+                    &escaped_table_name,
+                    source_btree_table.as_deref(),
+                    entry.is_sqlite_sequence(),
+                )?;
 
                 // SELECT from source, INSERT into destination.
                 let select_stmt = config.source_conn.prepare_internal(&select_sql)?;
@@ -950,6 +908,7 @@ pub(crate) fn build_copy_sql(
     escaped_schema_name: &str,
     escaped_table_name: &str,
     source_btree_table: Option<&crate::schema::BTreeTable>,
+    or_replace: bool,
 ) -> Result<(String, String)> {
     let Some(btree) = source_btree_table else {
         // Storage-backed tables must have schema metadata. If we get here,
@@ -1062,8 +1021,13 @@ pub(crate) fn build_copy_sql(
 
     let select_sql =
         format!("SELECT {select_cols} FROM \"{escaped_schema_name}\".\"{escaped_table_name}\"");
+    let insert_prefix = if or_replace {
+        "INSERT OR REPLACE INTO"
+    } else {
+        "INSERT INTO"
+    };
     let insert_sql =
-        format!("INSERT INTO \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
+        format!("{insert_prefix} \"{escaped_table_name}\" ({insert_cols}) VALUES ({placeholders})");
 
     Ok((select_sql, insert_sql))
 }
@@ -1071,6 +1035,23 @@ pub(crate) fn build_copy_sql(
 // ---------------------------------------------------------------------------
 // Plain VACUUM engine - copy-back state machine
 // ---------------------------------------------------------------------------
+
+/// Independent progress flags for plain VACUUM cleanup. These track which
+/// resources the opcode has acquired and are **not** cleared by
+/// `std::mem::take` on the sub-state enum. The cleanup function reads these
+/// to decide what to roll back regardless of where the state machine was
+/// when the error occurred.
+#[derive(Default)]
+pub(crate) struct PlainVacuumProgress {
+    /// Source pager read transaction was started.
+    pub read_tx_open: bool,
+    /// Source pager write transaction was acquired and `auto_commit`/`tx_state`
+    /// were modified.
+    pub write_tx_open: bool,
+    /// WAL commit was published via `finish_append_frames_commit`. Once true
+    /// the compacted image is durable and rollback must not be attempted.
+    pub commit_published: bool,
+}
 
 /// Sub-states for the plain VACUUM opcode state machine.
 ///
@@ -1114,7 +1095,10 @@ pub(crate) enum PlainVacuumSubState {
         /// Next page number to read (1-based). The page at `next_page - 1` is
         /// the one we just issued a read for and are awaiting.
         next_page: u32,
-        prev_prepared: Option<crate::storage::wal::PreparedFrames>,
+        /// Boxed to shrink the enum — PreparedFrames contains Vecs and is ~80+
+        /// bytes unboxed. Only created once per batch, so boxing adds no
+        /// allocation overhead in the hot path.
+        prev_prepared: Option<Box<crate::storage::wal::PreparedFrames>>,
         /// Accumulated pages for the current batch.
         batch_pages: Vec<crate::storage::pager::PageRef>,
         /// Completion for the in-flight read.
@@ -1127,7 +1111,7 @@ pub(crate) enum PlainVacuumSubState {
         temp_db: Box<InternalVacuumTempDb>,
         total_pages: u32,
         next_page: u32,
-        prev_prepared: Option<crate::storage::wal::PreparedFrames>,
+        prev_prepared: Option<Box<crate::storage::wal::PreparedFrames>>,
         completions: Vec<crate::io::Completion>,
     },
     /// Fsync the WAL if sync mode requires it.
@@ -1152,15 +1136,24 @@ const VACUUM_COPY_BATCH_SIZE: u32 = 64;
 
 /// Step the plain VACUUM state machine once. Returns `IO` to yield or `Step`
 /// when the entire operation is complete.
+///
+/// `progress` independently tracks which resources the opcode has acquired so
+/// that cleanup can roll back correctly even when `sub_state` has been taken
+/// by `std::mem::take` at the top of the loop.
 pub(crate) fn plain_vacuum_step(
     connection: &Arc<Connection>,
     db: usize,
     sub_state: &mut PlainVacuumSubState,
+    progress: &mut PlainVacuumProgress,
 ) -> Result<InsnFunctionStepResult> {
     use crate::io::WriteBatch as IOWriteBatch;
     use crate::types::IOCompletions;
     use crate::SyncMode;
     use std::sync::atomic::Ordering;
+
+    // Capture the source pager once per step call. The pager never changes
+    // during a VACUUM, so this avoids repeated ArcSwap loads in the loop.
+    let source_pager = connection.get_pager_from_database_index(&db);
 
     loop {
         let current = std::mem::take(sub_state);
@@ -1189,15 +1182,31 @@ pub(crate) fn plain_vacuum_step(
                         "VACUUM is not supported in MVCC mode yet".to_string(),
                     ));
                 }
-                // 5. Reject in-memory databases.
-                if source_db.path.starts_with(":memory:") || source_db.path.is_empty() {
+                // 5. Reject in-memory databases. Use the same memory-like
+                // path classification as attach/open (connection.rs:2216).
+                {
+                    let path = &source_db.path;
+                    let is_memory_db =
+                        path == ":memory:" || path.starts_with("file::memory:") || path.is_empty();
+                    if is_memory_db {
+                        return Err(LimboError::InternalError(
+                            "cannot VACUUM an in-memory database".to_string(),
+                        ));
+                    }
+                }
+                // 6. Reject auto-vacuum databases until preservation is
+                // implemented. An auto-vacuum source overwritten with a
+                // non-auto-vacuum temp image would leave the pager's
+                // in-memory mode stale, causing pointer-map corruption.
+                if source_pager.get_auto_vacuum_mode()
+                    != crate::storage::pager::AutoVacuumMode::None
+                {
                     return Err(LimboError::InternalError(
-                        "cannot VACUUM an in-memory database".to_string(),
+                        "VACUUM is not supported for auto-vacuum databases yet".to_string(),
                     ));
                 }
-                // 6. Reject non-WAL pagers.
-                let pager = connection.get_pager_from_database_index(&db);
-                if pager.wal.is_none() {
+                // 7. Reject non-WAL pagers.
+                if source_pager.wal.is_none() {
                     return Err(LimboError::InternalError(
                         "VACUUM requires a WAL-mode database".to_string(),
                     ));
@@ -1207,21 +1216,21 @@ pub(crate) fn plain_vacuum_step(
             }
 
             PlainVacuumSubState::BeginSourceReadTx => {
-                let pager = connection.get_pager_from_database_index(&db);
-                pager.begin_read_tx()?;
+                source_pager.begin_read_tx()?;
+                progress.read_tx_open = true;
                 *sub_state = PlainVacuumSubState::BeginSourceWriteTx;
                 continue;
             }
 
             PlainVacuumSubState::BeginSourceWriteTx => {
-                let pager = connection.get_pager_from_database_index(&db);
-                match pager.begin_write_tx()? {
+                match source_pager.begin_write_tx()? {
                     crate::IOResult::Done(()) => {
                         // Write lock acquired. Set connection state.
                         connection.auto_commit.store(false, Ordering::SeqCst);
                         connection.set_tx_state(crate::connection::TransactionState::Write {
                             schema_did_change: false,
                         });
+                        progress.write_tx_open = true;
                         *sub_state = PlainVacuumSubState::ReadSourceMetadata;
                         continue;
                     }
@@ -1235,25 +1244,35 @@ pub(crate) fn plain_vacuum_step(
 
             PlainVacuumSubState::ReadSourceMetadata => {
                 let source_db = connection.get_source_database(db);
-                let pager = connection.get_pager_from_database_index(&db);
 
                 // Read page size from pager (cached after begin_read_tx).
-                let page_size = pager.get_page_size().map(|ps| ps.get()).unwrap_or(4096);
+                let page_size = source_pager
+                    .get_page_size()
+                    .map(|ps| ps.get())
+                    .unwrap_or(4096);
 
-                // Read reserved bytes.
-                let reserved_space: u8 = match connection.get_reserved_bytes() {
-                    Some(val) => val,
-                    None => {
-                        let io = &*pager.io;
-                        io.block(|| pager.with_header(|h| h.reserved_space))?
-                    }
-                };
-
-                // Read header metadata for the destination.
-                let io = &*pager.io;
-                let destination_header: VacuumDestinationHeader = io.block(|| {
-                    pager.with_header(VacuumDestinationHeader::plain_vacuum_from_source_header)
-                })?;
+                // Read reserved bytes and header metadata in a single
+                // with_header call to avoid redundant page-1 access.
+                let io = &*source_pager.io;
+                let (reserved_space, destination_header): (u8, VacuumDestinationHeader) =
+                    match connection.get_reserved_bytes() {
+                        Some(val) => {
+                            let dh = io.block(|| {
+                                source_pager.with_header(
+                                    VacuumDestinationHeader::plain_vacuum_from_source_header,
+                                )
+                            })?;
+                            (val, dh)
+                        }
+                        None => io.block(|| {
+                            source_pager.with_header(|h| {
+                                (
+                                    h.reserved_space,
+                                    VacuumDestinationHeader::plain_vacuum_from_source_header(h),
+                                )
+                            })
+                        })?,
+                    };
                 // Create temp database.
                 let temp_db = open_internal_vacuum_temp_db(
                     connection,
@@ -1262,27 +1281,30 @@ pub(crate) fn plain_vacuum_step(
                     reserved_space,
                 )?;
 
-                // Capture source symbols for schema replay.
-                let source_symbols = {
-                    let syms = connection.syms.read();
-                    SourceSymbols {
-                        functions: syms
+                // Mirror source symbols directly into temp DB for schema replay,
+                // avoiding an intermediate clone through SourceSymbols.
+                {
+                    let source_syms = connection.syms.read();
+                    let mut dest_syms = temp_db.conn.syms.write();
+                    dest_syms.functions.extend(
+                        source_syms
                             .functions
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                        vtab_modules: syms
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.vtab_modules.extend(
+                        source_syms
                             .vtab_modules
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                        index_methods: syms
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                    dest_syms.index_methods.extend(
+                        source_syms
                             .index_methods
                             .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect(),
-                    }
-                };
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                }
 
                 // Capture custom types.
                 let source_custom_types: Vec<(String, Arc<TypeDef>)> =
@@ -1300,7 +1322,6 @@ pub(crate) fn plain_vacuum_step(
                     escaped_schema_name: "main".to_string(),
                     database_id: db,
                     destination_header,
-                    source_symbols,
                     source_custom_types,
                     source_mvcc_enabled: false, // Rejected MVCC above
                 };
@@ -1358,9 +1379,10 @@ pub(crate) fn plain_vacuum_step(
                     // Empty database — nothing to copy back. Clean up the
                     // source write tx and connection state we acquired earlier.
                     drop(temp_db);
-                    let source_pager = connection.get_pager_from_database_index(&db);
                     source_pager.end_write_tx();
                     source_pager.end_read_tx();
+                    progress.write_tx_open = false;
+                    progress.read_tx_open = false;
                     connection.auto_commit.store(true, Ordering::SeqCst);
                     connection.set_tx_state(crate::connection::TransactionState::None);
                     *sub_state = PlainVacuumSubState::Done;
@@ -1368,7 +1390,6 @@ pub(crate) fn plain_vacuum_step(
                 }
 
                 // Initialize the source WAL header before the first batch.
-                let source_pager = connection.get_pager_from_database_index(&db);
                 let wal = source_pager
                     .wal
                     .as_ref()
@@ -1395,7 +1416,7 @@ pub(crate) fn plain_vacuum_step(
                     total_pages,
                     next_page: 2, // page 1 is being read now
                     prev_prepared: None,
-                    batch_pages: Vec::new(),
+                    batch_pages: Vec::with_capacity(VACUUM_COPY_BATCH_SIZE as usize),
                     read_completion: completion,
                     reading_page: page_ref,
                 };
@@ -1428,7 +1449,6 @@ pub(crate) fn plain_vacuum_step(
                 if !fsync_phase {
                     // Header write done — issue the fsync via prepare_wal_finish
                     // to set WAL `initialized = true`.
-                    let source_pager = connection.get_pager_from_database_index(&db);
                     let wal = source_pager.wal.as_ref().unwrap();
                     let sync_c = wal.prepare_wal_finish(source_pager.get_sync_type())?;
                     *sub_state = PlainVacuumSubState::PrepareSourceWal {
@@ -1449,7 +1469,7 @@ pub(crate) fn plain_vacuum_step(
                     total_pages,
                     next_page: 2,
                     prev_prepared: None,
-                    batch_pages: Vec::new(),
+                    batch_pages: Vec::with_capacity(VACUUM_COPY_BATCH_SIZE as usize),
                     read_completion: read_c,
                     reading_page: page_ref,
                 };
@@ -1496,7 +1516,6 @@ pub(crate) fn plain_vacuum_step(
                 if batch_full || all_read {
                     // Prepare WAL frames from this batch. WAL header was already
                     // initialized in PrepareSourceWal before reading started.
-                    let source_pager = connection.get_pager_from_database_index(&db);
                     let wal = source_pager
                         .wal
                         .as_ref()
@@ -1509,7 +1528,7 @@ pub(crate) fn plain_vacuum_step(
                         &batch_pages,
                         page_sz,
                         db_size_on_commit,
-                        prev_prepared.as_ref(),
+                        prev_prepared.as_deref(),
                     )?;
 
                     // Submit writes via WriteBatch.
@@ -1522,7 +1541,7 @@ pub(crate) fn plain_vacuum_step(
                         temp_db,
                         total_pages,
                         next_page,
-                        prev_prepared: Some(prepared),
+                        prev_prepared: Some(Box::new(prepared)),
                         completions,
                     };
                     continue;
@@ -1584,10 +1603,9 @@ pub(crate) fn plain_vacuum_step(
                 // pager's read_page_no_cache — they are not in the source page
                 // cache and have no dirty state to clear. The source page cache
                 // is invalidated wholesale via clear_page_cache() in Publish.
-                let source_pager = connection.get_pager_from_database_index(&db);
                 let wal = source_pager.wal.as_ref().unwrap();
                 if let Some(ref prepared) = prev_prepared {
-                    wal.commit_prepared_frames(std::slice::from_ref(prepared));
+                    wal.commit_prepared_frames(std::slice::from_ref(prepared.as_ref()));
                 }
 
                 // More pages to copy?
@@ -1602,7 +1620,7 @@ pub(crate) fn plain_vacuum_step(
                         total_pages,
                         next_page: next_page + 1,
                         prev_prepared,
-                        batch_pages: Vec::new(),
+                        batch_pages: Vec::with_capacity(VACUUM_COPY_BATCH_SIZE as usize),
                         read_completion: completion,
                         reading_page: page_ref,
                     };
@@ -1651,18 +1669,30 @@ pub(crate) fn plain_vacuum_step(
             }
 
             PlainVacuumSubState::Publish { temp_db } => {
-                let source_pager = connection.get_pager_from_database_index(&db);
                 let wal = source_pager
                     .wal
                     .as_ref()
                     .ok_or_else(|| LimboError::InternalError("VACUUM requires WAL".into()))?;
 
-                // Publish the WAL transaction to shared state.
+                // Publish the WAL transaction to shared state. Once this
+                // succeeds the compacted image is durable — rollback must
+                // not be attempted even if later schema reload fails.
                 wal.finish_append_frames_commit()?;
+                progress.commit_published = true;
 
                 // Release source write lock and old read lock.
                 source_pager.end_write_tx();
                 source_pager.end_read_tx();
+                progress.write_tx_open = false;
+                progress.read_tx_open = false;
+
+                // Restore connection bookkeeping immediately. The commit is
+                // durable so there is nothing to roll back; restoring here
+                // means the connection is never left poisoned even if the
+                // schema reload below fails. (Matches SQLite vacuum.c which
+                // restores autocommit before schema reset.)
+                connection.auto_commit.store(true, Ordering::SeqCst);
+                connection.set_tx_state(crate::connection::TransactionState::None);
 
                 // Invalidate page cache and schema cookie so fresh reads see
                 // the newly committed WAL frames.
@@ -1672,32 +1702,28 @@ pub(crate) fn plain_vacuum_step(
                 // Drop temp resources before schema reload.
                 drop(temp_db);
 
-                // Start a fresh read tx that sees the committed WAL frames.
-                // Set tx_state to Read so `reparse_schema`'s internal
-                // Transaction opcode skips begin_read_tx (one is already active).
+                // Schema reload under a self-contained read guard. If this
+                // fails the connection is still usable — the cleared schema
+                // cookie will trigger a re-read on the next operation.
                 source_pager.begin_read_tx()?;
                 connection.set_tx_state(crate::connection::TransactionState::Read);
 
-                // Reload the schema from the new database pages. The compacted
-                // image may have different rootpage assignments, so the in-memory
-                // schema must be rebuilt from sqlite_schema on disk rather than
-                // reusing the old table definitions with a bumped cookie.
-                connection.reparse_schema()?;
+                let reload_result = connection.reparse_schema();
 
-                // Publish the freshly parsed schema to the shared Database so
-                // other connections see the new cookie and table definitions.
-                {
+                if reload_result.is_ok() {
+                    // Publish the freshly parsed schema to the shared Database
+                    // so other connections see the new cookie and table defs.
                     let schema = connection.schema.read().clone();
                     let source_db = connection.get_source_database(db);
                     source_db.update_schema_if_newer(schema);
                 }
 
-                // End the schema-reload read tx.
+                // Always end the schema-reload read tx and restore state,
+                // whether the reload succeeded or failed.
                 source_pager.end_read_tx();
-
-                // Restore connection state.
-                connection.auto_commit.store(true, Ordering::SeqCst);
                 connection.set_tx_state(crate::connection::TransactionState::None);
+
+                reload_result?;
 
                 *sub_state = PlainVacuumSubState::Done;
                 return Ok(InsnFunctionStepResult::Step);
@@ -1711,45 +1737,46 @@ pub(crate) fn plain_vacuum_step(
 }
 
 /// Roll back the source transaction and restore connection state after a
-/// plain VACUUM failure. This must be called before dropping the vacuum
-/// opcode state to preserve rollback-before-unlock ordering.
+/// plain VACUUM failure. Uses `progress` flags to decide what to undo —
+/// these are independent of the sub-state enum and survive `std::mem::take`.
 ///
-/// The `sub_state` tells us how far the vacuum progressed; if it never got
-/// past Preflight we have not touched any pager or connection state so
-/// there is nothing to undo (and blindly resetting auto_commit / tx_state
-/// would clobber an existing user transaction).
+/// `sub_state` is taken by value so helper statements inside
+/// `BuildTempImage` are dropped before we attempt `rollback_tx`. This
+/// avoids the nestedness suppression bug where live helper statements keep
+/// `Connection::nestedness > 0`, making `rollback_tx` a no-op.
 pub(crate) fn plain_vacuum_cleanup(
     connection: &Arc<Connection>,
     db: usize,
-    sub_state: &PlainVacuumSubState,
+    sub_state: PlainVacuumSubState,
+    progress: &PlainVacuumProgress,
 ) {
     use std::sync::atomic::Ordering;
 
-    // Preflight is the initial check phase — no locks acquired, no
-    // connection state modified.  Nothing to clean up.
-    if matches!(sub_state, PlainVacuumSubState::Preflight) {
+    // Nothing acquired — nothing to undo.
+    if !progress.read_tx_open && !progress.write_tx_open {
         return;
     }
 
-    // BeginSourceReadTx started a pager read tx but has not yet changed
-    // auto_commit or tx_state.  End the read lock and return.
-    if matches!(sub_state, PlainVacuumSubState::BeginSourceReadTx) {
+    // Drop the sub-state first to release any temp-build helper statements.
+    // Their Drop impls decrement Connection::nestedness, which must happen
+    // before rollback_tx (which is a no-op while nested).
+    drop(sub_state);
+
+    if progress.commit_published {
+        // The compacted image was already durably committed. We must not
+        // roll back — just restore connection bookkeeping.
         let pager = connection.get_pager_from_database_index(&db);
+        pager.end_write_tx();
         pager.end_read_tx();
-        return;
-    }
-
-    // Past BeginSourceWriteTx: we modified auto_commit and tx_state and
-    // may hold a write lock.  Roll back the pager transaction and restore
-    // connection state.
-    let tx_state = connection.get_tx_state();
-    if matches!(
-        tx_state,
-        crate::connection::TransactionState::Write { .. }
-            | crate::connection::TransactionState::Read
-    ) {
+    } else if progress.write_tx_open {
+        // Write transaction open but not yet committed — roll back.
         let pager = connection.get_pager_from_database_index(&db);
         pager.rollback_tx(connection);
+    } else {
+        // Only read transaction — just release the read lock.
+        let pager = connection.get_pager_from_database_index(&db);
+        pager.end_read_tx();
+        return; // auto_commit and tx_state were never modified.
     }
 
     connection.auto_commit.store(true, Ordering::SeqCst);

--- a/docs/sql-reference/cli/command-line-options.mdx
+++ b/docs/sql-reference/cli/command-line-options.mdx
@@ -146,12 +146,13 @@ Experimental features may have incomplete implementations or known limitations. 
 | `--experimental-encryption` | Enable at-rest database encryption |
 | `--experimental-index-method` | Enable custom index methods. Necessary for FTS and Sparse Vector indexes |
 | `--experimental-autovacuum` | Enable automatic database vacuuming |
+| `--experimental-vacuum` | Enable in-place `VACUUM` |
 | `--experimental-triggers` | Enable triggers (`CREATE TRIGGER` / `DROP TRIGGER`) |
 | `--experimental-attach` | Enable `ATTACH DATABASE` / `DETACH DATABASE` |
 
 ```bash
-# Enable views and triggers
-tursodb --experimental-views --experimental-triggers mydata.db
+# Enable views, triggers, and in-place VACUUM
+tursodb --experimental-views --experimental-triggers --experimental-vacuum mydata.db
 ```
 
 ## Other Flags

--- a/docs/sql-reference/experimental-features.mdx
+++ b/docs/sql-reference/experimental-features.mdx
@@ -18,6 +18,7 @@ Some Turso features are still experimental and must be explicitly enabled before
 | Encryption | `encryption` | At-rest encryption via [PRAGMA cipher / hexkey](/docs/sql-reference/pragmas#encryption) |
 | Index Methods | `index_method` | [CREATE INDEX ... USING](/docs/sql-reference/statements/create-index#using-clause) for FTS and custom index types |
 | Autovacuum | `autovacuum` | Automatic database file compaction |
+| Vacuum | `vacuum` | In-place [VACUUM](/docs/sql-reference/statements/vacuum) compaction |
 | Attach | `attach` | [ATTACH DATABASE](/docs/sql-reference/statements/attach-database) and [DETACH DATABASE](/docs/sql-reference/statements/detach-database) |
 | Multi-Process WAL | `multiprocess_wal` | [Multi-Process Access](/docs/sql-reference/multiprocess-access) — share a database file between OS processes via a shared WAL coordinator |
 
@@ -38,6 +39,7 @@ tursodb \
   --experimental-triggers \
   --experimental-encryption \
   --experimental-index-method \
+  --experimental-vacuum \
   database.db
 ```
 
@@ -54,6 +56,7 @@ let db = Builder::new_local("database.db")
     .experimental_materialized_views(true)
     .experimental_custom_types(true)
     .experimental_index_method(true)
+    .experimental_vacuum(true)
     .experimental_attach(true)
     .experimental_multiprocess_wal(true)
     .build()?;
@@ -68,7 +71,7 @@ import turso
 
 conn = turso.connect(
     "database.db",
-    experimental_features="views,triggers,custom_types",
+    experimental_features="views,triggers,custom_types,vacuum",
 )
 ```
 
@@ -80,7 +83,7 @@ Pass an array of feature strings to the `experimental` option:
 import { Database } from "@tursodatabase/libsql";
 
 const db = new Database("file:database.db", {
-    experimental: ["views", "triggers", "custom_types", "encryption"],
+    experimental: ["views", "triggers", "custom_types", "encryption", "vacuum"],
 });
 ```
 
@@ -91,14 +94,14 @@ Set the `ExperimentalFeatures` field as a comma-separated string:
 ```go
 db, err := turso.NewDatabase(turso.TursoDatabaseConfig{
     Path: "database.db",
-    ExperimentalFeatures: "views,triggers,custom_types",
+    ExperimentalFeatures: "views,triggers,custom_types,vacuum",
 })
 ```
 
 The Go driver also supports DSN query parameters:
 
 ```go
-db, err := sql.Open("turso", "database.db?experimental=views,triggers")
+db, err := sql.Open("turso", "database.db?experimental=views,triggers,vacuum")
 ```
 
 ## Java SDK

--- a/docs/sql-reference/preview.sh
+++ b/docs/sql-reference/preview.sh
@@ -90,6 +90,7 @@ cat > src/SUMMARY.md << 'EOF'
 - [ATTACH DATABASE](statements/attach-database.md)
 - [DETACH DATABASE](statements/detach-database.md)
 - [ANALYZE](statements/analyze.md)
+- [VACUUM](statements/vacuum.md)
 - [EXPLAIN](statements/explain.md)
 
 # Functions

--- a/docs/sql-reference/statements/vacuum.mdx
+++ b/docs/sql-reference/statements/vacuum.mdx
@@ -1,0 +1,166 @@
+---
+title: VACUUM
+description: Rebuild the database file to reclaim unused space and defragment storage
+sidebarTitle: VACUUM
+---
+
+# VACUUM
+
+The VACUUM statement rebuilds the database file to reclaim unused space, defragment tables and indexes, and reduce the file size. Two forms are supported: `VACUUM` rebuilds the current database in place, while `VACUUM INTO` writes a compacted copy to a new file without modifying the source.
+
+## Syntax
+
+```sql
+VACUUM [schema-name];
+VACUUM [schema-name] INTO filename;
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `schema-name` | The database to vacuum. For in-place `VACUUM` only `main` is supported. For `VACUUM INTO` any attached schema is accepted; `temp` is a no-op and produces no file. Defaults to `main`. |
+| `filename` | A string literal giving the destination file path for `VACUUM INTO`. Bind parameters are not accepted. |
+
+## Common Requirements
+
+These rules apply to both `VACUUM` and `VACUUM INTO`:
+
+- The connection must be in autocommit mode — neither form can run inside an explicit `BEGIN` transaction.
+- No other statement may be active on the same connection.
+- The connection must not be in `query_only` mode.
+- The source database must not have `auto_vacuum = incremental`. Incremental autovacuum is not supported.
+
+## VACUUM
+
+<Info>
+In-place `VACUUM` is experimental and must be [enabled before use](/docs/sql-reference/experimental-features). `VACUUM INTO` does not require the flag and is always available.
+</Info>
+
+In-place `VACUUM` rebuilds the main database by writing a compacted image into an internal temp database and then copying those pages back over the original file. When it completes, unused pages have been released and all storage-backed objects have been recreated.
+
+### Effect
+
+- Unused pages from deleted rows and dropped objects are removed, shrinking the file.
+- All storage-backed tables are recreated and their rows reinserted, which rebuilds the associated indexes.
+- `sqlite_sequence` counters used by `AUTOINCREMENT` columns are preserved.
+- The schema cookie is bumped so that other connections reload their cached schema on their next access.
+- The page size, reserved space, text encoding, user version, and application ID are preserved exactly.
+
+### Requirements
+
+In addition to the [common requirements](#common-requirements):
+
+- The database must be opened in WAL journal mode.
+- The database must not be in-memory.
+- The database must not be read-only.
+- Only the `main` database is supported. Vacuuming an attached schema in place is not supported yet.
+- No other process may currently hold the multi-process WAL.
+
+### MVCC Databases
+
+When the database uses MVCC (`PRAGMA journal_mode = mvcc`), additional rules apply to in-place `VACUUM`:
+
+- All MVCC changes must be checkpointed first. If the MVCC log contains uncheckpointed changes, `VACUUM` returns an error — run `PRAGMA wal_checkpoint(TRUNCATE)` first.
+- No other MVCC transaction may be active on any connection. `VACUUM` returns a busy error if one is found.
+- During the operation the MVCC subsystem is paused so that the rebuilt schema and log can be reconciled atomically.
+
+## VACUUM INTO
+
+`VACUUM INTO` builds a compacted copy of the database at the given path and leaves the source database untouched. The destination is a fully self-contained database file that can be opened independently.
+
+### Effect
+
+- A new database file is created at `filename` containing all user tables, indexes, triggers, views, and virtual table content from the source.
+- Indexes, triggers, and views are recreated after the data is copied so that triggers do not fire during the copy.
+- Custom index methods (for example FTS and vector) rebuild their backing structures from the copied data.
+- `sqlite_sequence` counters used by `AUTOINCREMENT` columns are preserved.
+- Page size, reserved space, text encoding, user version, and application ID are copied from the source.
+- If the source uses MVCC, the destination is created with MVCC enabled but with fresh state. The source's MVCC metadata table is not copied across.
+- The file is fully synced and a TRUNCATE checkpoint is performed before the statement returns, so the destination is durable without further action.
+
+<Warning>
+`VACUUM INTO` does not carry encryption through to the destination. Even when the source is encrypted, the compacted copy is written as an ordinary unencrypted database file and can be opened without a key. Reserved header bytes are still copied across, so the destination's page layout matches the source.
+</Warning>
+
+### Requirements
+
+In addition to the [common requirements](#common-requirements):
+
+- The destination file must not already exist. Delete or move it first if you want to overwrite.
+- The path must be provided as a string literal in the SQL statement.
+- `VACUUM temp INTO filename` is a no-op and does not create a file, matching SQLite's behavior.
+
+`VACUUM INTO` takes a consistent view of the source by starting an implicit read transaction for the duration of the copy, so the destination always reflects a single snapshot of the source even if other connections write to it during the copy.
+
+## Examples
+
+### Rebuild the Main Database
+
+```sql
+-- Reclaim space and defragment the current database
+VACUUM;
+```
+
+### Write a Compacted Copy to a New File
+
+```sql
+VACUUM INTO 'backup.db';
+```
+
+The source database is unchanged. `backup.db` can be opened as a standalone database:
+
+```bash
+tursodb backup.db
+```
+
+### Vacuum an Attached Database Into a New File
+
+```sql
+ATTACH DATABASE 'archive.db' AS archive;
+
+-- Write a compacted copy of the archive schema to a new file
+VACUUM archive INTO 'archive-compact.db';
+```
+
+### Use VACUUM INTO for a Backup Snapshot
+
+Because `VACUUM INTO` copies from a consistent snapshot, it is a simple way to capture a point-in-time backup of an active database:
+
+```sql
+VACUUM INTO '/var/backups/app-2026-04-23.db';
+```
+
+### Restore Performance After Heavy Churn
+
+After bulk deletes or long-running workloads that leave indexes fragmented, `VACUUM` rebuilds the indexes and often improves scan speed:
+
+```sql
+DELETE FROM events WHERE created_at < '2025-01-01';
+VACUUM;
+```
+
+## Errors
+
+| Error | Cause |
+|-------|-------|
+| `VACUUM is an experimental feature. Enable with --experimental-vacuum flag` | In-place `VACUUM` used in a release build without the experimental flag. |
+| `VACUUM is only supported for the main database; schema '<name>' is not supported yet` | In-place `VACUUM schema-name` with a schema other than `main`. |
+| `Cannot execute VACUUM in query_only mode` | `VACUUM` or `VACUUM INTO` run on a connection where `PRAGMA query_only` is set. |
+| `cannot VACUUM from within a transaction` / `cannot VACUUM INTO from within a transaction` | Run inside an explicit `BEGIN`. |
+| `cannot VACUUM - SQL statements in progress` | Another statement is still active on the same connection. |
+| `Incremental auto-vacuum is not supported` | The source database has `auto_vacuum = incremental`. Applies to both `VACUUM` and `VACUUM INTO`. |
+| `VACUUM requires a WAL-mode database` | In-place `VACUUM` on a non-WAL database. |
+| `cannot VACUUM an in-memory database` | In-place `VACUUM` on an in-memory database. |
+| `ReadOnly` | In-place `VACUUM` on a read-only database. |
+| `cannot VACUUM while experimental multiprocess WAL is active in another process` | In-place `VACUUM` while another process holds the multi-process WAL. |
+| `cannot VACUUM an MVCC database with uncheckpointed changes; run PRAGMA wal_checkpoint(TRUNCATE) first` | In-place `VACUUM` on an MVCC database with pending log entries. |
+| `output file already exists: <path>` | The destination for `VACUUM INTO` already exists. |
+| `VACUUM INTO path cannot be empty` | `VACUUM INTO ''` was used. |
+| `VACUUM INTO requires a string literal path` | A non-literal expression (for example a bind parameter) was used for the destination. |
+| `no such database: <name>` | `VACUUM <schema> INTO` referenced an unknown schema. |
+
+## See Also
+
+- [Experimental Features](/docs/sql-reference/experimental-features) for enabling in-place `VACUUM`
+- [PRAGMAs](/docs/sql-reference/pragmas) for `auto_vacuum`, `journal_mode`, `query_only`, and `wal_checkpoint`
+- [ATTACH DATABASE](/docs/sql-reference/statements/attach-database) for attaching a schema that can be targeted by `VACUUM INTO`
+- [ANALYZE](/docs/sql-reference/statements/analyze) for refreshing query planner statistics after a vacuum

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -658,6 +658,7 @@ impl TursoDatabase {
                                 "strict" => opts, // strict is always enabled, kept for backwards compatibility
                                 "custom_types" => opts.with_custom_types(true),
                                 "autovacuum" => opts.with_autovacuum(true),
+                                "vacuum" => opts.with_vacuum(true),
                                 "encryption" => opts.with_encryption(true),
                                 "attach" => opts.with_attach(true),
                                 "generated_columns" => opts.with_generated_columns(true),

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -29,7 +29,7 @@ pub extern "C" fn turso_enable_experimental() {
 fn default_db_opts() -> DatabaseOpts {
     let mut opts = DatabaseOpts::new();
     if EXPERIMENTAL_ENABLED.load(Ordering::Acquire) {
-        opts = opts.with_generated_columns(true);
+        opts = opts.with_generated_columns(true).with_vacuum(true);
     }
     opts
 }

--- a/testing/sqltests/src/backends/cli.rs
+++ b/testing/sqltests/src/backends/cli.rs
@@ -14,6 +14,15 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tokio::time::timeout;
 
+const TURSO_CLI_EXPERIMENTAL_FLAGS: &[&str] = &[
+    "--experimental-views",
+    "--experimental-custom-types",
+    "--experimental-attach",
+    "--experimental-index-method",
+    "--experimental-generated-columns",
+    "--experimental-vacuum",
+];
+
 /// CLI backend that executes SQL via the tursodb CLI tool
 pub struct CliBackend {
     /// Path to the tursodb binary
@@ -262,11 +271,9 @@ impl CliDatabaseInstance {
             cmd.arg(&self.db_path);
             cmd.arg("-q"); // Quiet mode - suppress banner
             cmd.arg("-m").arg("list"); // List mode for pipe-separated output
-            cmd.arg("--experimental-views");
-            cmd.arg("--experimental-custom-types");
-            cmd.arg("--experimental-attach");
-            cmd.arg("--experimental-index-method");
-            cmd.arg("--experimental-generated-columns");
+            for flag in TURSO_CLI_EXPERIMENTAL_FLAGS {
+                cmd.arg(flag);
+            }
         }
 
         if self.readonly {

--- a/testing/sqltests/src/backends/rust.rs
+++ b/testing/sqltests/src/backends/rust.rs
@@ -9,6 +9,30 @@ use std::sync::Arc;
 use tempfile::NamedTempFile;
 use turso::{Builder, Connection, Database, Value};
 
+const TURSO_RUST_EXPERIMENTAL_FEATURES: &[&str] = &[
+    "attach",
+    "index_method",
+    "views",
+    "custom_types",
+    "generated_columns",
+    "vacuum",
+];
+
+fn apply_turso_experimental_features(mut builder: Builder) -> Builder {
+    for feature in TURSO_RUST_EXPERIMENTAL_FEATURES {
+        builder = match *feature {
+            "attach" => builder.experimental_attach(true),
+            "index_method" => builder.experimental_index_method(true),
+            "views" => builder.experimental_materialized_views(true),
+            "custom_types" => builder.experimental_custom_types(true),
+            "generated_columns" => builder.experimental_generated_columns(true),
+            "vacuum" => builder.experimental_vacuum(true),
+            _ => unreachable!("unexpected sqltests Rust backend experimental feature"),
+        };
+    }
+    builder
+}
+
 /// Native Rust backend using Turso bindings directly
 pub struct RustBackend {
     /// Resolver for default database paths
@@ -95,12 +119,7 @@ impl SqlBackend for RustBackend {
         };
 
         // Create the database using the Turso builder
-        let db = Builder::new_local(&db_path)
-            .experimental_attach(true)
-            .experimental_index_method(true)
-            .experimental_materialized_views(true)
-            .experimental_custom_types(true)
-            .experimental_generated_columns(true)
+        let db = apply_turso_experimental_features(Builder::new_local(&db_path))
             .build()
             .await
             .map_err(|e| BackendError::CreateDatabase(e.to_string()))?;

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -170,6 +170,7 @@ impl TempDatabaseBuilder {
         let mut opts = self
             .opts
             .unwrap_or_else(|| turso_core::DatabaseOpts::new().with_encryption(true));
+        opts = opts.with_vacuum(true);
 
         if self.enable_views {
             opts = opts.with_views(true);

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -12,6 +12,7 @@ mod mvcc;
 mod pragma;
 mod query_processing;
 mod query_timeout;
+mod queued_io;
 mod statement_reset;
 mod stmt_journal;
 mod stmt_readonly;

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -6106,7 +6106,13 @@ fn test_mvcc_plain_vacuum_active_tx_returns_busy() -> anyhow::Result<()> {
 }
 
 fn open_queued_db(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Database>> {
-    Ok(Database::open_file(io, path)?)
+    Ok(Database::open_file_with_flags(
+        io,
+        path,
+        Default::default(),
+        DatabaseOpts::new().with_vacuum(true),
+        None,
+    )?)
 }
 
 fn populate_queued_multibatch(conn: &Arc<Connection>) -> anyhow::Result<()> {

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -1,34 +1,526 @@
 use crate::common::{
     compute_dbhash, compute_dbhash_with_database_opts, compute_dbhash_with_options,
-    compute_dbhash_with_options_and_database_opts, ExecRows, TempDatabase,
+    compute_dbhash_with_options_and_database_opts, do_flush, ExecRows, TempDatabase,
 };
+use crate::queued_io::{QueuedIo, QueuedIoEvent, QueuedIoOpKind};
 use rusqlite::Connection as SqliteConnection;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 use tempfile::TempDir;
-use turso_core::{Connection, StepResult, Value};
+use turso_core::{Connection, Database, DatabaseOpts, LimboError, StepResult, Value, IO};
+use turso_parser::{ast::Cmd, parser::Parser};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedSchemaRow {
+    object_type: String,
+    name: String,
+    table_name: String,
+    sql: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlainVacuumInvariant {
+    hash: String,
+    normalized_schema: Vec<NormalizedSchemaRow>,
+}
 
 /// Helper to run integrity_check and return the result string
 fn run_integrity_check(conn: &Arc<Connection>) -> String {
-    let rows = conn
-        .pragma_query("integrity_check")
-        .expect("integrity_check pragma query failed");
-
+    let rows: Vec<(String,)> = conn.exec_rows("PRAGMA integrity_check");
     rows.into_iter()
-        .filter_map(|row| {
-            row.into_iter().next().and_then(|v| {
-                if let Value::Text(text) = v {
-                    Some(text.as_str().to_string())
-                } else {
-                    None
-                }
-            })
-        })
+        .map(|(text,)| text)
         .collect::<Vec<_>>()
         .join("\n")
 }
 
+fn normalize_sql_whitespace(sql: &str) -> String {
+    sql.split_ascii_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn canonicalize_schema_sql(sql: &str) -> String {
+    let mut parser = Parser::new(sql.as_bytes());
+    let Ok(Some(cmd)) = parser.next_cmd() else {
+        return normalize_sql_whitespace(sql);
+    };
+    if !matches!(parser.next_cmd(), Ok(None)) {
+        return normalize_sql_whitespace(sql);
+    }
+    match cmd {
+        Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt) => stmt.to_string(),
+    }
+}
+
+fn normalized_schema_snapshot(conn: &Arc<Connection>) -> Vec<NormalizedSchemaRow> {
+    let rows: Vec<(String, String, String, String)> = conn.exec_rows(
+        "SELECT type, name, tbl_name, COALESCE(sql, '') \
+         FROM sqlite_schema \
+         ORDER BY type, name, tbl_name, COALESCE(sql, '')",
+    );
+    rows.into_iter()
+        .map(|(object_type, name, table_name, sql)| NormalizedSchemaRow {
+            object_type,
+            name,
+            table_name,
+            sql: (!sql.is_empty()).then(|| canonicalize_schema_sql(&sql)),
+        })
+        .collect()
+}
+
+fn compute_default_dbhash(tmp_db: &TempDatabase) -> String {
+    compute_dbhash_with_database_opts(tmp_db, tmp_db.db_opts).hash
+}
+
+fn compute_plain_vacuum_dbhash(tmp_db: &TempDatabase) -> PlainVacuumInvariant {
+    let options = turso_dbhash::DbHashOptions {
+        without_schema: true,
+        ..Default::default()
+    };
+    let reopened = TempDatabase::new_with_existent_with_opts(&tmp_db.path, tmp_db.db_opts);
+    let reopened_conn = reopened.connect_limbo();
+    PlainVacuumInvariant {
+        hash: compute_dbhash_with_options_and_database_opts(tmp_db, &options, tmp_db.db_opts).hash,
+        normalized_schema: normalized_schema_snapshot(&reopened_conn),
+    }
+}
+
+fn compute_plain_vacuum_file_dbhash(path: &str) -> PlainVacuumInvariant {
+    let options = turso_dbhash::DbHashOptions {
+        without_schema: true,
+        ..Default::default()
+    };
+    let reopened = TempDatabase::new_with_existent_with_opts(Path::new(path), DatabaseOpts::new());
+    let reopened_conn = reopened.connect_limbo();
+    PlainVacuumInvariant {
+        hash: turso_dbhash::hash_database(path, &options)
+            .expect("dbhash failed")
+            .hash,
+        normalized_schema: normalized_schema_snapshot(&reopened_conn),
+    }
+}
+
+fn assert_plain_vacuum_integrity_and_hash(
+    tmp_db: &TempDatabase,
+    conn: &Arc<Connection>,
+    expected: &PlainVacuumInvariant,
+) {
+    assert_eq!(run_integrity_check(conn), "ok");
+    assert_eq!(
+        compute_plain_vacuum_dbhash(tmp_db).hash,
+        expected.hash,
+        "plain VACUUM should preserve logical database content"
+    );
+    assert_eq!(
+        normalized_schema_snapshot(conn),
+        expected.normalized_schema,
+        "plain VACUUM should preserve normalized sqlite_schema entries"
+    );
+}
+
+fn assert_plain_vacuum_integrity_and_hash_for_path(
+    path: &str,
+    conn: &Arc<Connection>,
+    expected: &PlainVacuumInvariant,
+) {
+    assert_eq!(run_integrity_check(conn), "ok");
+    assert_eq!(
+        compute_plain_vacuum_file_dbhash(path).hash,
+        expected.hash,
+        "plain VACUUM should preserve logical database content"
+    );
+    assert_eq!(
+        normalized_schema_snapshot(conn),
+        expected.normalized_schema,
+        "plain VACUUM should preserve normalized sqlite_schema entries"
+    );
+}
+
+fn run_plain_vacuum_and_assert_round_trip(
+    tmp_db: &TempDatabase,
+    conn: &Arc<Connection>,
+) -> anyhow::Result<()> {
+    checkpoint_if_mvcc(tmp_db, conn)?;
+    let before_hash = compute_plain_vacuum_dbhash(tmp_db);
+    conn.execute("VACUUM")?;
+    assert_plain_vacuum_integrity_and_hash(tmp_db, conn, &before_hash);
+    Ok(())
+}
+
+fn assert_vacuum_into_destination_integrity_and_default_hash(
+    dest_db: &TempDatabase,
+    dest_conn: &Arc<Connection>,
+    expected_hash: &str,
+) {
+    assert_eq!(run_integrity_check(dest_conn), "ok");
+    assert_eq!(
+        compute_default_dbhash(dest_db),
+        expected_hash,
+        "VACUUM INTO should preserve logical database content"
+    );
+}
+
+fn run_vacuum_into_and_assert_round_trip(
+    tmp_db: &TempDatabase,
+    conn: &Arc<Connection>,
+    dest_path: &std::path::Path,
+) -> anyhow::Result<(TempDatabase, Arc<Connection>)> {
+    let source_hash = compute_default_dbhash(tmp_db);
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(dest_path, tmp_db.db_opts);
+    let dest_conn = dest_db.connect_limbo();
+    assert_vacuum_into_destination_integrity_and_default_hash(&dest_db, &dest_conn, &source_hash);
+    Ok((dest_db, dest_conn))
+}
+
+fn checkpoint_if_mvcc(tmp_db: &TempDatabase, conn: &Arc<Connection>) -> anyhow::Result<()> {
+    if tmp_db.enable_mvcc {
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    }
+    Ok(())
+}
+
+fn connect_existing_with_opts(
+    path: &Path,
+    db_opts: DatabaseOpts,
+) -> (TempDatabase, Arc<Connection>) {
+    let db = TempDatabase::new_with_existent_with_opts(path, db_opts);
+    let conn = db.connect_limbo();
+    (db, conn)
+}
+
 fn escape_sqlite_string_literal(text: &str) -> String {
     text.replace('\'', "''")
+}
+
+fn scalar_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
+    let rows: Vec<(i64,)> = conn.exec_rows(sql);
+    assert_eq!(rows.len(), 1, "expected one row for {sql}");
+    rows[0].0
+}
+
+fn sqlite_scalar_i64(conn: &SqliteConnection, sql: &str) -> i64 {
+    conn.query_row(sql, [], |row| row.get(0))
+        .unwrap_or_else(|err| panic!("expected one row for {sql}: {err}"))
+}
+
+fn create_employees_with_check_constraints(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    conn.execute(
+        "CREATE TABLE employees (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL CHECK(length(name) > 0),
+            age INTEGER CHECK(age >= 18 AND age <= 120),
+            salary REAL CHECK(salary > 0),
+            status TEXT CHECK(status IN ('active', 'inactive', 'pending'))
+        )",
+    )?;
+    Ok(())
+}
+
+fn insert_valid_employee_rows(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    conn.execute("INSERT INTO employees VALUES (1, 'Alice', 30, 50000.0, 'active')")?;
+    conn.execute("INSERT INTO employees VALUES (2, 'Bob', 45, 75000.0, 'inactive')")?;
+    conn.execute("INSERT INTO employees VALUES (3, 'Charlie', 18, 35000.0, 'pending')")?;
+    Ok(())
+}
+
+fn employee_rows(conn: &Arc<Connection>) -> Vec<(i64, String, i64, f64, String)> {
+    conn.exec_rows("SELECT id, name, age, salary, status FROM employees ORDER BY id")
+}
+
+fn custom_type_sql_snapshot(conn: &Arc<Connection>) -> Vec<(String, String)> {
+    let rows: Vec<(String, String)> =
+        conn.exec_rows("SELECT name, sql FROM sqlite_turso_types ORDER BY name");
+    rows.into_iter()
+        .map(|(name, sql)| (name, normalize_sql_whitespace(&sql)))
+        .collect()
+}
+
+fn create_custom_type_ordering_fixture(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    conn.execute(
+        "CREATE TYPE rev_cmp \
+         BASE text \
+         ENCODE string_reverse(value) \
+         DECODE string_reverse(value) \
+         OPERATOR '<' string_reverse",
+    )?;
+    conn.execute(
+        "CREATE TABLE words(
+            id INTEGER PRIMARY KEY,
+            word rev_cmp NOT NULL DEFAULT 'banana'
+        ) STRICT",
+    )?;
+    conn.execute("CREATE INDEX words_word_idx ON words(word)")?;
+    conn.execute("INSERT INTO words(id, word) VALUES (1, 'cherry')")?;
+    conn.execute("INSERT INTO words(id, word) VALUES (2, 'apple')")?;
+    conn.execute("INSERT INTO words(id, word) VALUES (3, 'banana')")?;
+    conn.execute("INSERT INTO words(id) VALUES (4)")?;
+    Ok(())
+}
+
+fn assert_custom_type_ordering_fixture(conn: &Arc<Connection>) {
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, word FROM words ORDER BY id");
+    assert_eq!(
+        rows,
+        vec![
+            (1, "cherry".to_string()),
+            (2, "apple".to_string()),
+            (3, "banana".to_string()),
+            (4, "banana".to_string()),
+        ],
+    );
+
+    let ordered: Vec<(i64, String)> = conn.exec_rows(
+        "SELECT id, word FROM words INDEXED BY words_word_idx ORDER BY word ASC, id ASC",
+    );
+    assert_eq!(
+        ordered,
+        vec![
+            (2, "apple".to_string()),
+            (3, "banana".to_string()),
+            (4, "banana".to_string()),
+            (1, "cherry".to_string()),
+        ],
+        "custom comparator order should survive when scanning the custom-type index",
+    );
+
+    let desc: Vec<(i64, String)> = conn.exec_rows(
+        "SELECT id, word FROM words INDEXED BY words_word_idx ORDER BY word DESC, id DESC",
+    );
+    assert_eq!(
+        desc,
+        vec![
+            (1, "cherry".to_string()),
+            (4, "banana".to_string()),
+            (3, "banana".to_string()),
+            (2, "apple".to_string()),
+        ],
+        "descending scans over the custom-type index should preserve comparator semantics",
+    );
+}
+
+fn assert_custom_type_reusable_for_new_schema(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    conn.execute(
+        "CREATE TABLE extra_words(
+            id INTEGER PRIMARY KEY,
+            word rev_cmp NOT NULL DEFAULT 'kiwi'
+        ) STRICT",
+    )?;
+    conn.execute("CREATE INDEX extra_words_word_idx ON extra_words(word)")?;
+    conn.execute("INSERT INTO extra_words(id) VALUES (1)")?;
+    conn.execute("INSERT INTO extra_words(id, word) VALUES (2, 'apricot')")?;
+    conn.execute("INSERT INTO extra_words(id, word) VALUES (3, 'pear')")?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows(
+        "SELECT id, word FROM extra_words INDEXED BY extra_words_word_idx ORDER BY word ASC, id ASC",
+    );
+    assert_eq!(
+        rows,
+        vec![
+            (2, "apricot".to_string()),
+            (1, "kiwi".to_string()),
+            (3, "pear".to_string()),
+        ],
+        "the preserved custom type should remain usable in new tables and indexes after VACUUM",
+    );
+    Ok(())
+}
+
+fn wal_file_size(tmp_db: &TempDatabase) -> u64 {
+    let wal_path = format!("{}-wal", tmp_db.path.display());
+    std::fs::metadata(wal_path).map(|m| m.len()).unwrap_or(0)
+}
+
+fn mvcc_log_file_size(tmp_db: &TempDatabase) -> u64 {
+    std::fs::metadata(tmp_db.path.with_extension("db-log"))
+        .map(|m| m.len())
+        .unwrap_or(0)
+}
+
+fn assert_plain_vacuum_folded_into_db_file(tmp_db: &TempDatabase, conn: &Arc<Connection>) {
+    let page_count = scalar_i64(conn, "PRAGMA page_count") as u64;
+    let page_size = scalar_i64(conn, "PRAGMA page_size") as u64;
+    let db_size = std::fs::metadata(&tmp_db.path)
+        .unwrap_or_else(|err| panic!("database file should exist after VACUUM: {err}"))
+        .len();
+
+    assert_eq!(
+        db_size,
+        page_count * page_size,
+        "VACUUM should checkpoint the compacted image into the db file"
+    );
+    assert_eq!(
+        wal_file_size(tmp_db),
+        0,
+        "VACUUM should truncate the source WAL after checkpoint"
+    );
+}
+
+fn assert_plain_vacuum_preserves_content_hash(
+    tmp_db: &TempDatabase,
+    conn: &Arc<Connection>,
+) -> anyhow::Result<()> {
+    // Plain VACUUM can rebuild equivalent sqlite_schema SQL text with different
+    // formatting, so compare a parser-normalized sqlite_schema snapshot rather
+    // than raw schema SQL text. Integrity-check still covers the structural
+    // side, and the data hash stays schema-free so formatting churn does not
+    // create false failures.
+    //
+    // Intentionally do not `cacheflush()` after VACUUM here. Some callers
+    // assert that plain VACUUM left the physical `-wal` folded into the DB
+    // file; a post-VACUUM cacheflush can emit a fresh WAL frame from the live
+    // connection and obscure that invariant.
+    let hash_opts = turso_dbhash::DbHashOptions {
+        without_schema: true,
+        ..Default::default()
+    };
+    do_flush(conn, tmp_db)?;
+    let before_schema = normalized_schema_snapshot(conn);
+    let before = compute_dbhash_with_options_and_database_opts(tmp_db, &hash_opts, tmp_db.db_opts);
+
+    conn.execute("VACUUM")?;
+
+    let after = compute_dbhash_with_options_and_database_opts(tmp_db, &hash_opts, tmp_db.db_opts);
+    assert_eq!(
+        before.hash, after.hash,
+        "plain VACUUM changed logical database content: before={}, after={}",
+        before.hash, after.hash
+    );
+    assert_eq!(
+        normalized_schema_snapshot(conn),
+        before_schema,
+        "plain VACUUM should preserve normalized sqlite_schema entries"
+    );
+    Ok(())
+}
+
+fn assert_plain_vacuum_preserves_autovacuum_mode(
+    pragma_value: &str,
+    expected_mode: i64,
+) -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new()
+        .with_encryption(true)
+        .with_autovacuum(true);
+    let (_temp_dir, tmp_db) = open_sqlite_autovacuum_db(pragma_value, opts)?;
+    let conn = tmp_db.connect_limbo();
+
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), expected_mode);
+
+    checkpoint_if_mvcc(&tmp_db, &conn)?;
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), expected_mode);
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 120);
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&tmp_db.path, opts);
+    let reopened_conn = reopened.connect_limbo();
+    assert_eq!(
+        scalar_i64(&reopened_conn, "PRAGMA auto_vacuum"),
+        expected_mode
+    );
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+
+    Ok(())
+}
+
+fn assert_vacuum_into_preserves_autovacuum_mode(
+    pragma_value: &str,
+    expected_mode: i64,
+) -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new()
+        .with_encryption(true)
+        .with_autovacuum(true);
+    let (_temp_dir, tmp_db) = open_sqlite_autovacuum_db(pragma_value, opts)?;
+    let conn = tmp_db.connect_limbo();
+
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), expected_mode);
+
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("t".to_string()),
+        without_schema: true,
+        ..Default::default()
+    };
+    let source_hash = compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, opts);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("vacuum-into-autovacuum.db");
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let dest_conn = dest_db.connect_limbo();
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(scalar_i64(&dest_conn, "PRAGMA auto_vacuum"), expected_mode);
+    assert_eq!(scalar_i64(&dest_conn, "SELECT COUNT(*) FROM t"), 120);
+    assert_eq!(
+        compute_dbhash_with_options_and_database_opts(&dest_db, &hash_opts, opts).hash,
+        source_hash.hash,
+        "VACUUM INTO should preserve logical table content for auto-vacuum databases"
+    );
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let reopened_conn = reopened.connect_limbo();
+    assert_eq!(
+        scalar_i64(&reopened_conn, "PRAGMA auto_vacuum"),
+        expected_mode
+    );
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+
+    Ok(())
+}
+
+fn open_sqlite_autovacuum_db(
+    pragma_value: &str,
+    opts: DatabaseOpts,
+) -> anyhow::Result<(TempDir, TempDatabase)> {
+    let temp_dir = TempDir::new()?;
+    let db_path = temp_dir.path().join("autovacuum.db");
+    let sqlite_conn = SqliteConnection::open(&db_path)?;
+    sqlite_conn.pragma_update(None, "page_size", 1024)?;
+    sqlite_conn.pragma_update(None, "auto_vacuum", pragma_value)?;
+    sqlite_conn.execute_batch("VACUUM")?;
+    sqlite_conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)", ())?;
+    sqlite_conn.execute("CREATE INDEX idx_t_payload ON t(payload)", ())?;
+    for i in 0..160 {
+        sqlite_conn.execute(
+            "INSERT INTO t VALUES(?1, ?2)",
+            rusqlite::params![i, "autovacuum-payload-".repeat(20)],
+        )?;
+    }
+    sqlite_conn.execute("DELETE FROM t WHERE id % 4 = 0", ())?;
+    drop(sqlite_conn);
+
+    let tmp_db = TempDatabase::new_with_existent_with_opts(&db_path, opts);
+    Ok((temp_dir, tmp_db))
+}
+
+fn populate_until_page_count(
+    conn: &Arc<Connection>,
+    target_pages: i64,
+    payload_len: usize,
+) -> anyhow::Result<i64> {
+    let payload = "x".repeat(payload_len);
+    let mut next_id = 0_i64;
+
+    loop {
+        let page_count = scalar_i64(conn, "PRAGMA page_count");
+        if page_count == target_pages {
+            return Ok(next_id);
+        }
+        assert!(
+            page_count < target_pages,
+            "page_count skipped target {target_pages}; current={page_count}, rows={next_id}"
+        );
+        conn.execute(format!(
+            "INSERT INTO t VALUES({next_id}, '{}')",
+            escape_sqlite_string_literal(&payload)
+        ))?;
+        next_id += 1;
+        assert!(
+            next_id < target_pages * 20 + 100,
+            "could not reach page_count {target_pages}"
+        );
+    }
 }
 
 #[cfg_attr(feature = "checksum", ignore)]
@@ -49,7 +541,7 @@ fn test_vacuum_into_basic(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
 
-    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
     let dest_conn = dest_db.connect_limbo();
 
     let integrity_result = run_integrity_check(&dest_conn);
@@ -103,17 +595,19 @@ fn test_vacuum_into_basic(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
 /// Test VACUUM INTO error cases: plain VACUUM, existing file, within
 /// transaction, and query_only mode.
-#[turso_macros::test(mvcc, init_sql = "CREATE TABLE t (a INTEGER);")]
+#[turso_macros::test(mvcc)]
 fn test_vacuum_into_error_cases(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER)")?;
     conn.execute("INSERT INTO t VALUES (1)")?;
 
     let dest_dir = TempDir::new()?;
 
-    // 1. plain VACUUM should fail
+    // 1. plain VACUUM should succeed; MVCC databases must checkpoint first.
+    checkpoint_if_mvcc(&tmp_db, &conn)?;
     let result = conn.execute("VACUUM");
-    assert!(result.is_err(), "Plain VACUUM should fail");
+    assert!(result.is_ok(), "Plain VACUUM should succeed");
 
     // 2. VACUUM INTO existing file should fail
     let existing_path = dest_dir.path().join("existing.db");
@@ -613,7 +1107,7 @@ fn test_vacuum_into_with_triggers(tmp_db: TempDatabase) {
     );
 }
 
-/// Test VACUUM INTO preserves meta values: user_version, application_id
+/// Test VACUUM INTO preserves and bumps meta values like SQLite.
 /// Note: Some pragmas don't work correctly with MVCC yet
 #[cfg_attr(feature = "checksum", ignore)]
 #[turso_macros::test(init_sql = "CREATE TABLE t (a INTEGER);")]
@@ -626,6 +1120,7 @@ fn test_vacuum_into_preserves_meta_values(tmp_db: TempDatabase) -> anyhow::Resul
     // Test 1: Normal positive values
     conn.execute("PRAGMA user_version = 42")?;
     conn.execute("PRAGMA application_id = 12345")?;
+    let source_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
 
     let source_hash1 = compute_dbhash(&tmp_db);
     let dest_path1 = dest_dir.path().join("vacuumed1.db");
@@ -640,6 +1135,12 @@ fn test_vacuum_into_preserves_meta_values(tmp_db: TempDatabase) -> anyhow::Resul
     assert_eq!(uv, vec![(42,)], "user_version should be 42");
     let aid: Vec<(i64,)> = dest_conn1.exec_rows("PRAGMA application_id");
     assert_eq!(aid, vec![(12345,)], "application_id should be 12345");
+    let schema_version: Vec<(i64,)> = dest_conn1.exec_rows("PRAGMA schema_version");
+    assert_eq!(
+        schema_version,
+        vec![(source_schema_version[0].0 + 1,)],
+        "schema_version should be source schema_version + 1"
+    );
 
     // Test 2: Boundary values (negative user_version, max application_id)
     conn.execute("PRAGMA user_version = -1")?;
@@ -884,16 +1385,24 @@ fn test_vacuum_into_rowid_compat_with_sqlite_reference(tmp_db: TempDatabase) -> 
     conn.execute("CREATE TABLE t (a TEXT)")?;
     conn.execute("INSERT INTO t(rowid, a) VALUES(5, 'x')")?;
     conn.execute("INSERT INTO t(rowid, a) VALUES(42, 'y')")?;
-    let source_hash = compute_dbhash(&tmp_db);
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("t".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts);
 
     let dest_dir = TempDir::new()?;
     let turso_dest = dest_dir.path().join("turso_rowid_vacuum.db");
     conn.execute(format!("VACUUM INTO '{}'", turso_dest.to_str().unwrap()))?;
-    let turso_dest_db = TempDatabase::new_with_existent(&turso_dest);
+    let turso_dest_db = TempDatabase::new_with_existent_with_opts(&turso_dest, tmp_db.db_opts);
     let turso_dest_conn = turso_dest_db.connect_limbo();
-    if !tmp_db.enable_mvcc {
-        assert_eq!(source_hash.hash, compute_dbhash(&turso_dest_db).hash);
-    }
+    assert_eq!(run_integrity_check(&turso_dest_conn), "ok");
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_options_and_database_opts(&turso_dest_db, &hash_opts, tmp_db.db_opts)
+            .hash
+    );
     let turso_rows: Vec<(i64, String)> =
         turso_dest_conn.exec_rows("SELECT rowid, a FROM t ORDER BY rowid");
 
@@ -943,16 +1452,24 @@ fn test_vacuum_into_integer_pk_and_indexes_compat_with_sqlite(
     conn.execute("INSERT INTO t_idx(id, a, b) VALUES (10, 'alpha', 50)")?;
     conn.execute("INSERT INTO t_idx(id, a, b) VALUES (25, 'beta', 150)")?;
     conn.execute("INSERT INTO t_idx(id, a, b) VALUES (50, 'gamma', 200)")?;
-    let source_hash = compute_dbhash(&tmp_db);
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("t_idx".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts);
 
     let dest_dir = TempDir::new()?;
     let turso_dest = dest_dir.path().join("turso_index_vacuum.db");
     conn.execute(format!("VACUUM INTO '{}'", turso_dest.to_str().unwrap()))?;
-    let turso_dest_db = TempDatabase::new_with_existent(&turso_dest);
+    let turso_dest_db = TempDatabase::new_with_existent_with_opts(&turso_dest, tmp_db.db_opts);
     let turso_dest_conn = turso_dest_db.connect_limbo();
-    if !tmp_db.enable_mvcc {
-        assert_eq!(source_hash.hash, compute_dbhash(&turso_dest_db).hash);
-    }
+    assert_eq!(run_integrity_check(&turso_dest_conn), "ok");
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_options_and_database_opts(&turso_dest_db, &hash_opts, tmp_db.db_opts)
+            .hash
+    );
     let turso_rows: Vec<(i64, i64, String, i64)> =
         turso_dest_conn.exec_rows("SELECT rowid, id, a, b FROM t_idx ORDER BY id");
     let turso_index_names_rows: Vec<(String,)> = turso_dest_conn.exec_rows(
@@ -1763,13 +2280,7 @@ fn test_vacuum_into_large_generate_series_with_index(tmp_db: TempDatabase) -> an
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("vacuumed_generate_series_index.db");
-
-    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
-
-    let dest_db = TempDatabase::new_with_existent(&dest_path);
-    let dest_conn = dest_db.connect_limbo();
-
-    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    let (_dest_db, dest_conn) = run_vacuum_into_and_assert_round_trip(&tmp_db, &conn, &dest_path)?;
 
     let count: Vec<(i64,)> = dest_conn.exec_rows("SELECT COUNT(*) FROM t1");
     assert_eq!(count, vec![(10000,)]);
@@ -2068,15 +2579,23 @@ fn test_vacuum_into_preserves_mvcc_after_reopen(tmp_db: TempDatabase) -> anyhow:
     conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, data TEXT)")?;
     conn.execute("INSERT INTO t VALUES (1, 'hello')")?;
     conn.execute("INSERT INTO t VALUES (2, 'world')")?;
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("t".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts);
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("vacuumed_mvcc.db");
-    let dest_path_str = dest_path.to_str().unwrap();
-
-    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
-
-    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
     let dest_conn = dest_db.connect_limbo();
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_options_and_database_opts(&dest_db, &hash_opts, tmp_db.db_opts).hash
+    );
     let dest_mode: Vec<(String,)> = dest_conn.exec_rows("PRAGMA journal_mode");
     assert_eq!(
         dest_mode,
@@ -2092,7 +2611,6 @@ fn test_vacuum_into_preserves_mvcc_after_reopen(tmp_db: TempDatabase) -> anyhow:
     );
 
     // verify data was copied correctly
-    assert_eq!(run_integrity_check(&dest_conn), "ok");
     let rows: Vec<(i64, String)> = dest_conn.exec_rows("SELECT id, data FROM t ORDER BY id");
     assert_eq!(
         rows,
@@ -2206,31 +2724,14 @@ fn test_vacuum_into_from_memory_database() -> anyhow::Result<()> {
 // 2. WITHOUT ROWID tables
 // 3. table without any columns (which sqlite does kek)
 
-/// Test VACUUM INTO with CHECK constraints
-/// Skips if CHECK constraints are not supported.
+/// Test VACUUM INTO with CHECK constraints.
 #[turso_macros::test(mvcc)]
 fn test_vacuum_into_with_check_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
 
-    // Skip if CHECK constraints are not supported
-    if conn
-        .execute(
-            "CREATE TABLE employees (
-            id INTEGER PRIMARY KEY,
-            name TEXT NOT NULL CHECK(length(name) > 0),
-            age INTEGER CHECK(age >= 18 AND age <= 120),
-            salary REAL CHECK(salary > 0),
-            status TEXT CHECK(status IN ('active', 'inactive', 'pending'))
-        )",
-        )
-        .is_err()
-    {
-        return Ok(());
-    }
-
-    conn.execute("INSERT INTO employees VALUES (1, 'Alice', 30, 50000.0, 'active')")?;
-    conn.execute("INSERT INTO employees VALUES (2, 'Bob', 45, 75000.0, 'inactive')")?;
-    conn.execute("INSERT INTO employees VALUES (3, 'Charlie', 18, 35000.0, 'pending')")?;
+    create_employees_with_check_constraints(&conn)?;
+    insert_valid_employee_rows(&conn)?;
+    checkpoint_if_mvcc(&tmp_db, &conn)?;
 
     let source_hash = compute_dbhash(&tmp_db);
 
@@ -2272,6 +2773,170 @@ fn test_vacuum_into_with_check_constraints(tmp_db: TempDatabase) -> anyhow::Resu
             .execute("INSERT INTO employees VALUES (4, 'Dan', 10, 40000.0, 'active')")
             .is_err(),
         "CHECK constraint on age should reject value < 18"
+    );
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve CHECK-constrained tables and keep those
+/// constraints enforced after the rewrite.
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_with_check_constraints(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    create_employees_with_check_constraints(&conn)?;
+    insert_valid_employee_rows(&conn)?;
+    checkpoint_if_mvcc(&tmp_db, &conn)?;
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+
+    conn.execute("VACUUM")?;
+
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+
+    let employees_sql: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 'employees'");
+    assert!(
+        employees_sql[0].0.contains("CHECK"),
+        "CHECK constraints should be preserved"
+    );
+
+    assert_eq!(
+        employee_rows(&conn),
+        vec![
+            (1, "Alice".to_string(), 30, 50000.0, "active".to_string()),
+            (2, "Bob".to_string(), 45, 75000.0, "inactive".to_string()),
+            (3, "Charlie".to_string(), 18, 35000.0, "pending".to_string()),
+        ]
+    );
+
+    assert!(
+        conn.execute("INSERT INTO employees VALUES (4, 'Dan', 10, 40000.0, 'active')")
+            .is_err(),
+        "CHECK constraint on age should reject value < 18"
+    );
+
+    Ok(())
+}
+
+/// Rows inserted while CHECK constraints are ignored must survive a plain
+/// VACUUM unchanged. The rewrite should preserve the data as-is without
+/// re-validating historical rows, while still keeping constraints enabled for
+/// future writes.
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_with_ignored_check_constraint_rows(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    create_employees_with_check_constraints(&conn)?;
+    insert_valid_employee_rows(&conn)?;
+    conn.execute("PRAGMA ignore_check_constraints = ON")?;
+    conn.execute("INSERT INTO employees VALUES (4, '', 16, -10.0, 'ghost')")?;
+    conn.execute("INSERT INTO employees VALUES (5, 'Eve', 130, 12345.0, 'active')")?;
+    conn.execute("PRAGMA ignore_check_constraints = OFF")?;
+    checkpoint_if_mvcc(&tmp_db, &conn)?;
+
+    let (_before_db, before_conn) = connect_existing_with_opts(&tmp_db.path, tmp_db.db_opts);
+    let before_integrity = run_integrity_check(&before_conn);
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+
+    conn.execute("VACUUM")?;
+
+    let (_after_db, after_conn) = connect_existing_with_opts(&tmp_db.path, tmp_db.db_opts);
+    assert_eq!(
+        run_integrity_check(&after_conn),
+        before_integrity,
+        "plain VACUUM must preserve the existing integrity_check result"
+    );
+    assert_eq!(
+        normalized_schema_snapshot(&after_conn),
+        before_hash.normalized_schema,
+        "plain VACUUM must preserve normalized sqlite_schema entries for rows inserted with ignored CHECK constraints"
+    );
+    assert_eq!(
+        compute_plain_vacuum_dbhash(&tmp_db).hash,
+        before_hash.hash,
+        "plain VACUUM must preserve logical content even for rows inserted with ignored CHECK constraints"
+    );
+    assert_eq!(
+        employee_rows(&after_conn),
+        vec![
+            (1, "Alice".to_string(), 30, 50000.0, "active".to_string()),
+            (2, "Bob".to_string(), 45, 75000.0, "inactive".to_string()),
+            (3, "Charlie".to_string(), 18, 35000.0, "pending".to_string()),
+            (4, "".to_string(), 16, -10.0, "ghost".to_string()),
+            (5, "Eve".to_string(), 130, 12345.0, "active".to_string()),
+        ]
+    );
+    assert!(
+        after_conn
+            .execute("INSERT INTO employees VALUES (6, '', 16, -10.0, 'ghost')")
+            .is_err(),
+        "future violating inserts should still fail once CHECK constraints are re-enabled"
+    );
+
+    Ok(())
+}
+
+/// VACUUM INTO must also preserve rows that were inserted while CHECK
+/// constraints were ignored, without re-validating them during the copy.
+#[turso_macros::test(mvcc)]
+fn test_vacuum_into_with_ignored_check_constraint_rows(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    create_employees_with_check_constraints(&conn)?;
+    insert_valid_employee_rows(&conn)?;
+    conn.execute("PRAGMA ignore_check_constraints = ON")?;
+    conn.execute("INSERT INTO employees VALUES (4, '', 16, -10.0, 'ghost')")?;
+    conn.execute("INSERT INTO employees VALUES (5, 'Eve', 130, 12345.0, 'active')")?;
+    conn.execute("PRAGMA ignore_check_constraints = OFF")?;
+    checkpoint_if_mvcc(&tmp_db, &conn)?;
+
+    let (_source_db, source_conn) = connect_existing_with_opts(&tmp_db.path, tmp_db.db_opts);
+    let source_integrity = run_integrity_check(&source_conn);
+    let source_hash = compute_dbhash(&tmp_db);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("vacuumed_ignored_check.db");
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
+    let dest_conn = dest_db.connect_limbo();
+
+    assert_eq!(
+        run_integrity_check(&dest_conn),
+        source_integrity,
+        "VACUUM INTO must preserve the existing integrity_check result"
+    );
+    if !tmp_db.enable_mvcc {
+        assert_eq!(
+            source_hash.hash,
+            compute_dbhash(&dest_db).hash,
+            "VACUUM INTO must preserve logical content even for rows inserted with ignored CHECK constraints"
+        );
+    }
+
+    let employees_sql: Vec<(String,)> =
+        dest_conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 'employees'");
+    assert!(
+        employees_sql[0].0.contains("CHECK"),
+        "CHECK constraints should be preserved in the destination schema"
+    );
+    assert_eq!(
+        employee_rows(&dest_conn),
+        vec![
+            (1, "Alice".to_string(), 30, 50000.0, "active".to_string()),
+            (2, "Bob".to_string(), 45, 75000.0, "inactive".to_string()),
+            (3, "Charlie".to_string(), 18, 35000.0, "pending".to_string()),
+            (4, "".to_string(), 16, -10.0, "ghost".to_string()),
+            (5, "Eve".to_string(), 130, 12345.0, "active".to_string()),
+        ]
+    );
+    assert!(
+        dest_conn
+            .execute("INSERT INTO employees VALUES (6, '', 16, -10.0, 'ghost')")
+            .is_err(),
+        "future violating inserts should still fail in the destination"
     );
 
     Ok(())
@@ -2628,30 +3293,32 @@ fn test_vacuum_into_compacts_fragmented_database(tmp_db: TempDatabase) -> anyhow
         );
     }
 
-    let source_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
-    let dest_pages: Vec<(i64,)> = dest_conn.exec_rows("PRAGMA page_count");
+    if !tmp_db.enable_mvcc {
+        let source_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+        let dest_pages: Vec<(i64,)> = dest_conn.exec_rows("PRAGMA page_count");
 
-    assert!(
-        dest_pages[0].0 < source_pages[0].0,
-        "Page count should reduce from {} to {}",
-        source_pages[0].0,
-        dest_pages[0].0
-    );
+        assert!(
+            dest_pages[0].0 < source_pages[0].0,
+            "Page count should reduce from {} to {}",
+            source_pages[0].0,
+            dest_pages[0].0
+        );
+    }
 
     let dest_count: Vec<(i64,)> = dest_conn.exec_rows("SELECT COUNT(*) FROM fragmented_data");
     assert_eq!(dest_count[0].0, 40, "Vacuumed db should have 40 rows");
 
-    let dest_size = std::fs::metadata(&dest_path)?.len();
-    assert!(
-        dest_size < source_size,
-        "VACUUM INTO should reduce file size. Source: {source_size} bytes, Destination: {dest_size} bytes"
-    );
+    if !tmp_db.enable_mvcc {
+        let dest_size = std::fs::metadata(&dest_path)?.len();
+        assert!(
+            dest_size < source_size,
+            "VACUUM INTO should reduce file size. Source: {source_size} bytes, Destination: {dest_size} bytes"
+        );
+    }
 
     Ok(())
 }
 
-// checksum feature changes reserved_space which breaks VACUUM INTO hash comparison
-#[cfg_attr(feature = "checksum", ignore)]
 #[turso_macros::test(init_sql = "CREATE TABLE main_t(x INTEGER);")]
 fn test_vacuum_into_attached_database(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
@@ -2923,17 +3590,23 @@ fn test_vacuum_into_preserves_sqlite_stat1(tmp_db: TempDatabase) -> anyhow::Resu
         !source_stats.is_empty(),
         "ANALYZE should populate sqlite_stat1"
     );
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("t".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts);
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("sqlite_stat1.db");
-    let dest_path_str = dest_path.to_str().unwrap();
-
-    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
-
-    let dest_db = TempDatabase::new_with_existent(&dest_path);
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
     let dest_conn = dest_db.connect_limbo();
-
     assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_options_and_database_opts(&dest_db, &hash_opts, tmp_db.db_opts).hash
+    );
     let dest_stats: Vec<(String, String, String)> = dest_conn
         .exec_rows("SELECT tbl, COALESCE(idx, ''), stat FROM sqlite_stat1 ORDER BY tbl, idx");
     assert_eq!(dest_stats, source_stats);
@@ -3065,7 +3738,6 @@ fn test_vacuum_into_preserves_custom_types() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::builder().with_opts(opts).build();
     let conn = tmp_db.connect_limbo();
 
-    // Create a custom type with encode/decode transforms
     conn.execute("CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100")?;
     conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, amount cents) STRICT")?;
     conn.execute("INSERT INTO t VALUES (1, 42)")?;
@@ -3102,6 +3774,44 @@ fn test_vacuum_into_preserves_custom_types() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// VACUUM INTO must preserve custom types that carry non-monotonic encoders,
+/// custom comparators, and indexes. The copied destination must still order
+/// through the preserved index and remain usable for new schema objects that
+/// reference the copied type.
+#[test]
+fn test_vacuum_into_preserves_custom_type_ordering_and_schema_reuse() -> anyhow::Result<()> {
+    let opts = turso_core::DatabaseOpts::new().with_custom_types(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    create_custom_type_ordering_fixture(&conn)?;
+    assert_custom_type_ordering_fixture(&conn);
+    let source_type_sqls = custom_type_sql_snapshot(&conn);
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("words".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts).hash;
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("custom_type_ordering.db");
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let dest_conn = dest_db.connect_limbo();
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(
+        compute_dbhash_with_options_and_database_opts(&dest_db, &hash_opts, opts).hash,
+        source_hash,
+    );
+    assert_eq!(custom_type_sql_snapshot(&dest_conn), source_type_sqls);
+    assert_custom_type_ordering_fixture(&dest_conn);
+    assert_custom_type_reusable_for_new_schema(&dest_conn)?;
+
+    Ok(())
+}
+
 /// VACUUM INTO must preserve AUTOINCREMENT counters so that
 /// new inserts on both source and destination get the same next rowid.
 #[turso_macros::test]
@@ -3118,9 +3828,7 @@ fn test_vacuum_into_preserves_autoincrement_counter(tmp_db: TempDatabase) -> any
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("autoincr.db");
-    let dest_path_str = dest_path.to_str().unwrap();
-
-    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
+    let (dest_db, dest_conn) = run_vacuum_into_and_assert_round_trip(&tmp_db, &conn, &dest_path)?;
 
     // Insert a new row on the source - should get id=4 (not 2, because AUTOINCREMENT)
     conn.execute("INSERT INTO t (val) VALUES ('d')")?;
@@ -3128,9 +3836,7 @@ fn test_vacuum_into_preserves_autoincrement_counter(tmp_db: TempDatabase) -> any
     assert_eq!(source_new, vec![(4, "d".to_string())]);
 
     // Insert a new row on the destination - should also get id=4
-    let dest_db = TempDatabase::new_with_existent(&dest_path);
     assert_eq!(source_hash.hash, compute_dbhash(&dest_db).hash);
-    let dest_conn = dest_db.connect_limbo();
     dest_conn.execute("INSERT INTO t (val) VALUES ('d')")?;
     let dest_new: Vec<(i64, String)> = dest_conn.exec_rows("SELECT id, val FROM t WHERE val = 'd'");
     assert_eq!(
@@ -3153,19 +3859,21 @@ fn test_vacuum_into_preserves_custom_index_method(tmp_db: TempDatabase) -> anyho
     conn.execute("INSERT INTO vectors VALUES (1, 'cat', vector32_sparse('[1, 0, 0, 0]'))")?;
     conn.execute("INSERT INTO vectors VALUES (2, 'dog', vector32_sparse('[0, 1, 0, 0]'))")?;
     conn.execute("INSERT INTO vectors VALUES (3, 'fish', vector32_sparse('[0, 0, 1, 0]'))")?;
-    let source_hash = compute_dbhash_with_database_opts(&tmp_db, tmp_db.db_opts);
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("vectors".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts);
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("vectors.db");
-    let dest_path_str = dest_path.to_str().unwrap();
-
-    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
-
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
     let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
     let dest_conn = dest_db.connect_limbo();
     assert_eq!(
         source_hash.hash,
-        compute_dbhash_with_database_opts(&dest_db, tmp_db.db_opts).hash
+        compute_dbhash_with_options_and_database_opts(&dest_db, &hash_opts, tmp_db.db_opts).hash
     );
 
     let indexes: Vec<(String,)> = dest_conn.exec_rows(
@@ -3218,15 +3926,22 @@ fn test_vacuum_into_preserves_fts_index(tmp_db: TempDatabase) -> anyhow::Result<
     let source_database_matches: Vec<(i64,)> = conn
         .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'database') ORDER BY id");
     assert_eq!(source_database_matches, vec![(1,), (3,)]);
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("articles".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts);
 
     let dest_dir = TempDir::new()?;
     let dest_path = dest_dir.path().join("fts_vacuumed.db");
-    let dest_path_str = dest_path.to_str().unwrap();
-
-    conn.execute(format!("VACUUM INTO '{dest_path_str}'"))?;
-
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
     let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
     let dest_conn = dest_db.connect_limbo();
+    assert_eq!(
+        source_hash.hash,
+        compute_dbhash_with_options_and_database_opts(&dest_db, &hash_opts, tmp_db.db_opts).hash
+    );
 
     let dest_database_matches: Vec<(i64,)> = dest_conn
         .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'database') ORDER BY id");
@@ -3302,4 +4017,2481 @@ fn test_vacuum_into_preserves_vector_blobs(tmp_db: TempDatabase) -> anyhow::Resu
     assert_eq!(source_dist, dest_dist);
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Plain VACUUM tests
+// ---------------------------------------------------------------------------
+
+/// Plain VACUUM must preserve generated column values.
+#[test]
+fn test_plain_vacuum_preserves_generated_columns() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new().with_generated_columns(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute(
+        "CREATE TABLE t (
+            a INTEGER,
+            b INTEGER,
+            c INTEGER GENERATED ALWAYS AS (a + b) VIRTUAL
+        )",
+    )?;
+    conn.execute("INSERT INTO t (a, b) VALUES (10, 20), (100, 200), (7, 8)")?;
+    conn.execute("DELETE FROM t WHERE a = 7")?;
+
+    let before_rows: Vec<(i64, i64, i64)> = conn.exec_rows("SELECT a, b, c FROM t ORDER BY a");
+    assert_eq!(before_rows, vec![(10, 20, 30), (100, 200, 300)]);
+
+    assert_plain_vacuum_preserves_content_hash(&tmp_db, &conn)?;
+
+    let after_rows: Vec<(i64, i64, i64)> = conn.exec_rows("SELECT a, b, c FROM t ORDER BY a");
+    assert_eq!(after_rows, before_rows);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve custom type definitions and keep decoded values
+/// usable on both the current and reopened connections.
+#[test]
+fn test_plain_vacuum_preserves_custom_types() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new().with_custom_types(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100")?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, amount cents) STRICT")?;
+    conn.execute("INSERT INTO t VALUES (1, 42), (2, 100)")?;
+
+    let before_rows: Vec<(i64, i64)> = conn.exec_rows("SELECT id, amount FROM t ORDER BY id");
+    assert_eq!(before_rows, vec![(1, 42), (2, 100)]);
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db).hash;
+
+    conn.execute("VACUUM")?;
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_eq!(compute_plain_vacuum_dbhash(&tmp_db).hash, before_hash);
+
+    let after_rows: Vec<(i64, i64)> = conn.exec_rows("SELECT id, amount FROM t ORDER BY id");
+    assert_eq!(after_rows, before_rows);
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&tmp_db.path, opts);
+    let reopened_conn = reopened.connect_limbo();
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+    assert_eq!(compute_plain_vacuum_dbhash(&reopened).hash, before_hash);
+    let reopened_rows: Vec<(i64, i64)> =
+        reopened_conn.exec_rows("SELECT id, amount FROM t ORDER BY id");
+    assert_eq!(reopened_rows, before_rows);
+
+    Ok(())
+}
+
+/// Plain VACUUM reparses the live schema on the same connection. Custom types
+/// that rely on a comparator-backed index must still order correctly after the
+/// rewrite, and the same connection must remain able to use that type in new
+/// DDL immediately afterward.
+#[test]
+fn test_plain_vacuum_preserves_custom_type_ordering_and_schema_reuse() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new().with_custom_types(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    create_custom_type_ordering_fixture(&conn)?;
+    assert_custom_type_ordering_fixture(&conn);
+    let source_type_sqls = custom_type_sql_snapshot(&conn);
+    let hash_opts = turso_dbhash::DbHashOptions {
+        table_filter: Some("words".to_string()),
+        ..Default::default()
+    };
+    let source_hash =
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts).hash;
+
+    conn.execute("VACUUM")?;
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_eq!(
+        compute_dbhash_with_options_and_database_opts(&tmp_db, &hash_opts, tmp_db.db_opts).hash,
+        source_hash,
+    );
+    assert_eq!(custom_type_sql_snapshot(&conn), source_type_sqls);
+    assert_custom_type_ordering_fixture(&conn);
+    assert_custom_type_reusable_for_new_schema(&conn)?;
+
+    Ok(())
+}
+
+/// Plain VACUUM reparses the main schema only; an initialized temp schema on
+/// the same connection must remain usable across the reload.
+#[turso_macros::test]
+fn test_plain_vacuum_keeps_temp_schema_on_same_connection(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE main_t(id INTEGER PRIMARY KEY, payload TEXT)")?;
+    for id in 0..80 {
+        conn.execute(format!(
+            "INSERT INTO main_t VALUES({id}, '{}')",
+            "m".repeat(180)
+        ))?;
+    }
+    conn.execute("DELETE FROM main_t WHERE id >= 20")?;
+
+    conn.execute("CREATE TEMP TABLE temp_ids(id INTEGER PRIMARY KEY, note TEXT)")?;
+    conn.execute("INSERT INTO temp.temp_ids VALUES (1, 'one'), (2, 'two')")?;
+
+    assert_plain_vacuum_preserves_content_hash(&tmp_db, &conn)?;
+
+    let temp_rows: Vec<(i64, String)> =
+        conn.exec_rows("SELECT id, note FROM temp.temp_ids ORDER BY id");
+    assert_eq!(
+        temp_rows,
+        vec![(1, "one".to_string()), (2, "two".to_string())]
+    );
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM main_t"), 20);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    conn.execute("INSERT INTO temp.temp_ids VALUES (3, 'three')")?;
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM temp.temp_ids"), 3);
+
+    Ok(())
+}
+
+/// Basic plain VACUUM: data survives the compaction round-trip.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c REAL);")]
+fn test_plain_vacuum_basic(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t1 VALUES(1, 'hello', 3.125)")?;
+    conn.execute("INSERT INTO t1 VALUES(2, 'world', 2.725)")?;
+    conn.execute("INSERT INTO t1 VALUES(3, 'test', 1.625)")?;
+    conn.execute("DELETE FROM t1 WHERE a = 2")?;
+    conn.execute("VACUUM")?;
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    let rows: Vec<(i64, String, f64)> = conn.exec_rows("SELECT a, b, c FROM t1 ORDER BY a");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], (1, "hello".into(), 3.125));
+    assert_eq!(rows[1], (3, "test".into(), 1.625));
+
+    Ok(())
+}
+
+/// Plain VACUUM preserves user_version and application_id metadata.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_preserves_metadata(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1)")?;
+    conn.execute("PRAGMA user_version = 42")?;
+    conn.execute("PRAGMA application_id = 99")?;
+
+    let pre_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
+
+    conn.execute("VACUUM")?;
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    let user_version: Vec<(i64,)> = conn.exec_rows("PRAGMA user_version");
+    assert_eq!(user_version[0].0, 42);
+
+    let application_id: Vec<(i64,)> = conn.exec_rows("PRAGMA application_id");
+    assert_eq!(application_id[0].0, 99);
+
+    // Schema version should be bumped by 1.
+    let post_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
+    assert_eq!(post_schema_version[0].0, pre_schema_version[0].0 + 1);
+
+    let journal_mode: Vec<(String,)> = conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode[0].0, "wal");
+
+    Ok(())
+}
+
+/// Plain VACUUM preserves AUTOINCREMENT counters.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT);")]
+fn test_plain_vacuum_preserves_autoincrement(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t1(b) VALUES('one')")?;
+    conn.execute("INSERT INTO t1(b) VALUES('two')")?;
+    conn.execute("INSERT INTO t1(b) VALUES('three')")?;
+    conn.execute("DELETE FROM t1 WHERE b = 'two'")?;
+    conn.execute("VACUUM")?;
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    // Verify sqlite_sequence preserved
+    let seq: Vec<(String, i64)> = conn.exec_rows("SELECT name, seq FROM sqlite_sequence");
+    assert_eq!(seq.len(), 1);
+    assert_eq!(seq[0].0, "t1");
+    assert_eq!(seq[0].1, 3);
+
+    // Next insert should continue from 4, not restart
+    conn.execute("INSERT INTO t1(b) VALUES('four')")?;
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t1 ORDER BY a");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], (1, "one".into()));
+    assert_eq!(rows[1], (3, "three".into()));
+    assert_eq!(rows[2], (4, "four".into()));
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve hidden rowid values for ordinary rowid tables.
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_preserves_rowid_for_rowid_tables(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (a TEXT)")?;
+    conn.execute("INSERT INTO t(rowid, a) VALUES(5, 'x')")?;
+    conn.execute("INSERT INTO t(rowid, a) VALUES(42, 'y')")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT rowid, a FROM t ORDER BY rowid");
+    assert_eq!(rows, vec![(5, "x".to_string()), (42, "y".to_string())]);
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve hidden rowid values when the visible `rowid`
+/// column name is shadowed by a real column.
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_preserves_rowid_when_rowid_alias_is_shadowed(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (rowid TEXT, a TEXT)")?;
+    conn.execute("INSERT INTO t(_rowid_, rowid, a) VALUES(77, 'visible', 'x')")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let rows: Vec<(i64, String, String)> =
+        conn.exec_rows("SELECT _rowid_, rowid, a FROM t ORDER BY _rowid_");
+    assert_eq!(rows, vec![(77, "visible".to_string(), "x".to_string())]);
+
+    Ok(())
+}
+
+/// Plain VACUUM must succeed when all three hidden rowid aliases are shadowed
+/// by user columns.
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_when_all_rowid_aliases_are_shadowed(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (rowid TEXT, _rowid_ TEXT, oid TEXT, a TEXT)")?;
+    conn.execute("INSERT INTO t(rowid, _rowid_, oid, a) VALUES('r1', 'u1', 'o1', 'x')")?;
+    conn.execute("INSERT INTO t(rowid, _rowid_, oid, a) VALUES('r2', 'u2', 'o2', 'y')")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let rows: Vec<(String, String, String, String)> =
+        conn.exec_rows("SELECT rowid, _rowid_, oid, a FROM t ORDER BY a");
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "r1".to_string(),
+                "u1".to_string(),
+                "o1".to_string(),
+                "x".to_string()
+            ),
+            (
+                "r2".to_string(),
+                "u2".to_string(),
+                "o2".to_string(),
+                "y".to_string()
+            ),
+        ]
+    );
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve WITHOUT ROWID tables and their data.
+#[turso_macros::test]
+fn test_plain_vacuum_with_without_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    if conn
+        .execute(
+            "CREATE TABLE config (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at TEXT
+            ) WITHOUT ROWID",
+        )
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    conn.execute("INSERT INTO config VALUES ('theme', 'dark', '2024-01-01')")?;
+    conn.execute("INSERT INTO config VALUES ('language', 'en', '2024-01-02')")?;
+    conn.execute("INSERT INTO config VALUES ('timezone', 'UTC', '2024-01-03')")?;
+
+    conn.execute("CREATE TABLE regular (id INTEGER PRIMARY KEY, data TEXT)")?;
+    conn.execute("INSERT INTO regular VALUES (1, 'test')")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let config_sql: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 'config'");
+    assert!(
+        config_sql[0].0.contains("WITHOUT ROWID"),
+        "WITHOUT ROWID should be preserved in schema"
+    );
+
+    let config: Vec<(String, String, String)> =
+        conn.exec_rows("SELECT key, value, updated_at FROM config ORDER BY key");
+    assert_eq!(
+        config,
+        vec![
+            (
+                "language".to_string(),
+                "en".to_string(),
+                "2024-01-02".to_string()
+            ),
+            (
+                "theme".to_string(),
+                "dark".to_string(),
+                "2024-01-01".to_string()
+            ),
+            (
+                "timezone".to_string(),
+                "UTC".to_string(),
+                "2024-01-03".to_string()
+            ),
+        ]
+    );
+
+    let regular: Vec<(i64, String)> = conn.exec_rows("SELECT id, data FROM regular");
+    assert_eq!(regular, vec![(1, "test".to_string())]);
+
+    Ok(())
+}
+
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_with_strict_table(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute(
+        "CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email TEXT NOT NULL,
+            username TEXT NOT NULL,
+            score INTEGER
+        ) STRICT",
+    )?;
+    conn.execute("CREATE UNIQUE INDEX idx_users_email ON users (email)")?;
+    conn.execute("CREATE INDEX idx_users_username ON users (username)")?;
+    conn.execute("CREATE INDEX idx_users_score ON users (score)")?;
+
+    conn.execute("INSERT INTO users VALUES (1, 'alice@example.com', 'alice', 100)")?;
+    conn.execute("INSERT INTO users VALUES (2, 'bob@example.com', 'bob', 200)")?;
+    conn.execute("INSERT INTO users VALUES (3, 'charlie@example.com', 'charlie', 150)")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let rows: Vec<(i64, String, String, i64)> =
+        conn.exec_rows("SELECT id, email, username, score FROM users ORDER BY id");
+    assert_eq!(
+        rows,
+        vec![
+            (1, "alice@example.com".to_string(), "alice".to_string(), 100),
+            (2, "bob@example.com".to_string(), "bob".to_string(), 200),
+            (
+                3,
+                "charlie@example.com".to_string(),
+                "charlie".to_string(),
+                150
+            ),
+        ]
+    );
+
+    let indexes: Vec<(String,)> = conn.exec_rows(
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'users' ORDER BY name",
+    );
+    assert_eq!(indexes.len(), 3);
+    assert_eq!(indexes[0].0, "idx_users_email");
+    assert_eq!(indexes[1].0, "idx_users_score");
+    assert_eq!(indexes[2].0, "idx_users_username");
+
+    assert!(
+        conn.execute("INSERT INTO users VALUES (4, 'alice@example.com', 'alice2', 50)")
+            .is_err(),
+        "Unique index should reject duplicate email"
+    );
+
+    Ok(())
+}
+
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_with_strict_without_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    if conn
+        .execute(
+            "CREATE TABLE settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at INTEGER
+            ) STRICT, WITHOUT ROWID",
+        )
+        .is_err()
+    {
+        return Ok(());
+    }
+
+    conn.execute("INSERT INTO settings VALUES ('theme', 'dark', 1704067200)")?;
+    conn.execute("INSERT INTO settings VALUES ('language', 'en', 1704153600)")?;
+    conn.execute("INSERT INTO settings VALUES ('timezone', 'UTC', 1704240000)")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let settings_sql: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 'settings'");
+    assert!(
+        settings_sql[0].0.contains("STRICT"),
+        "STRICT should be preserved in schema"
+    );
+    assert!(
+        settings_sql[0].0.contains("WITHOUT ROWID"),
+        "WITHOUT ROWID should be preserved in schema"
+    );
+
+    let rows: Vec<(String, String, i64)> =
+        conn.exec_rows("SELECT key, value, updated_at FROM settings ORDER BY key");
+    assert_eq!(
+        rows,
+        vec![
+            ("language".to_string(), "en".to_string(), 1704153600),
+            ("theme".to_string(), "dark".to_string(), 1704067200),
+            ("timezone".to_string(), "UTC".to_string(), 1704240000),
+        ]
+    );
+
+    assert!(
+        conn.execute("INSERT INTO settings VALUES ('test', 123, 'not_an_int')")
+            .is_err(),
+        "STRICT should reject wrong types"
+    );
+
+    Ok(())
+}
+
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_with_multiple_strict_tables(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute(
+        "CREATE TABLE orders (
+            id INTEGER PRIMARY KEY,
+            customer_id INTEGER NOT NULL,
+            total REAL NOT NULL
+        ) STRICT",
+    )?;
+
+    conn.execute(
+        "CREATE TABLE order_items (
+            id INTEGER PRIMARY KEY,
+            order_id INTEGER NOT NULL,
+            product_name TEXT NOT NULL,
+            quantity INTEGER NOT NULL,
+            price REAL NOT NULL
+        ) STRICT",
+    )?;
+
+    conn.execute("CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)")?;
+
+    conn.execute("INSERT INTO orders VALUES (1, 100, 59.97)")?;
+    conn.execute("INSERT INTO orders VALUES (2, 101, 29.99)")?;
+
+    conn.execute("INSERT INTO order_items VALUES (1, 1, 'Widget', 2, 19.99)")?;
+    conn.execute("INSERT INTO order_items VALUES (2, 1, 'Gadget', 1, 19.99)")?;
+    conn.execute("INSERT INTO order_items VALUES (3, 2, 'Gizmo', 3, 9.99)")?;
+
+    conn.execute("INSERT INTO logs VALUES (1, 'Order 1 created')")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let orders_sql: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 'orders'");
+    assert!(orders_sql[0].0.contains("STRICT"));
+
+    let order_items_sql: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 'order_items'");
+    assert!(order_items_sql[0].0.contains("STRICT"));
+
+    let order_rows: Vec<(i64, i64, f64)> =
+        conn.exec_rows("SELECT id, customer_id, total FROM orders ORDER BY id");
+    assert_eq!(order_rows, vec![(1, 100, 59.97), (2, 101, 29.99)]);
+
+    let item_rows: Vec<(i64, i64, String, i64, f64)> = conn.exec_rows(
+        "SELECT id, order_id, product_name, quantity, price FROM order_items ORDER BY id",
+    );
+    assert_eq!(
+        item_rows,
+        vec![
+            (1, 1, "Widget".to_string(), 2, 19.99),
+            (2, 1, "Gadget".to_string(), 1, 19.99),
+            (3, 2, "Gizmo".to_string(), 3, 9.99),
+        ]
+    );
+
+    let log_rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, message FROM logs");
+    assert_eq!(log_rows, vec![(1, "Order 1 created".to_string())]);
+
+    assert!(
+        conn.execute("INSERT INTO orders VALUES ('oops', 999, 1.0)")
+            .is_err(),
+        "STRICT tables should continue rejecting wrong types after plain VACUUM"
+    );
+
+    Ok(())
+}
+
+/// Plain VACUUM preserves indexes (queries using them still work).
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_preserves_indexes(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE INDEX idx_t1_b ON t1(b)")?;
+    conn.execute("INSERT INTO t1 VALUES(1, 'alpha')")?;
+    conn.execute("INSERT INTO t1 VALUES(2, 'beta')")?;
+    conn.execute("INSERT INTO t1 VALUES(3, 'gamma')")?;
+    conn.execute("DELETE FROM t1 WHERE a = 2")?;
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let indexes: Vec<(String,)> = conn.exec_rows(
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 't1' ORDER BY name",
+    );
+    assert_eq!(indexes, vec![("idx_t1_b".to_string(),)]);
+
+    let eqp: Vec<(i64, i64, i64, String)> = conn
+        .exec_rows("EXPLAIN QUERY PLAN SELECT a, b FROM t1 INDEXED BY idx_t1_b WHERE b = 'gamma'");
+    assert!(
+        eqp.iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX") && detail.contains("idx_t1_b")),
+        "expected lookup to use idx_t1_b after plain VACUUM, got plan: {eqp:?}",
+    );
+
+    let rows: Vec<(i64, String)> =
+        conn.exec_rows("SELECT a, b FROM t1 INDEXED BY idx_t1_b WHERE b = 'gamma'");
+    assert_eq!(rows, vec![(3, "gamma".to_string())]);
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve `sqlite_stat1` rows produced by ANALYZE.
+#[turso_macros::test(mvcc)]
+fn test_plain_vacuum_preserves_sqlite_stat1(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, category TEXT, value INTEGER)")?;
+    conn.execute("CREATE INDEX idx_t_category_value ON t(category, value)")?;
+    for i in 0..50 {
+        let category = if i % 2 == 0 { "even" } else { "odd" };
+        conn.execute(format!(
+            "INSERT INTO t VALUES ({i}, '{category}', {})",
+            i * 10
+        ))?;
+    }
+    conn.execute("ANALYZE")?;
+
+    let source_stats: Vec<(String, String, String)> =
+        conn.exec_rows("SELECT tbl, COALESCE(idx, ''), stat FROM sqlite_stat1 ORDER BY tbl, idx");
+    assert!(
+        !source_stats.is_empty(),
+        "ANALYZE should populate sqlite_stat1"
+    );
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let dest_stats: Vec<(String, String, String)> =
+        conn.exec_rows("SELECT tbl, COALESCE(idx, ''), stat FROM sqlite_stat1 ORDER BY tbl, idx");
+    assert_eq!(dest_stats, source_stats);
+
+    let count: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t WHERE category = 'even'");
+    assert_eq!(count, vec![(25,)]);
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve custom index-method indexes on the source
+/// connection after schema reload.
+#[turso_macros::test]
+fn test_plain_vacuum_preserves_custom_index_method(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE vectors (id INTEGER PRIMARY KEY, label TEXT, embedding BLOB)")?;
+    conn.execute("CREATE INDEX vec_idx ON vectors USING toy_vector_sparse_ivf (embedding)")?;
+    conn.execute("INSERT INTO vectors VALUES (1, 'cat', vector32_sparse('[1, 0, 0, 0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (2, 'dog', vector32_sparse('[0, 1, 0, 0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (3, 'fish', vector32_sparse('[0, 0, 1, 0]'))")?;
+    let before_nearest: Vec<(i64, String, f64)> = conn.exec_rows(
+        "SELECT id, label, vector_distance_jaccard(embedding, vector32_sparse('[1, 0, 0, 0]')) AS distance \
+         FROM vectors ORDER BY distance LIMIT 1",
+    );
+
+    assert_plain_vacuum_preserves_content_hash(&tmp_db, &conn)?;
+
+    let indexes: Vec<(String,)> = conn.exec_rows(
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'vectors' ORDER BY name",
+    );
+    assert_eq!(
+        indexes,
+        vec![
+            ("vec_idx".to_string(),),
+            ("vec_idx_inverted_index".to_string(),),
+            ("vec_idx_stats".to_string(),),
+        ],
+    );
+
+    let eqp: Vec<(i64, i64, i64, String)> = conn.exec_rows(
+        "EXPLAIN QUERY PLAN \
+         SELECT id, label, vector_distance_jaccard(embedding, vector32_sparse('[1, 0, 0, 0]')) AS distance \
+         FROM vectors ORDER BY distance LIMIT 1",
+    );
+    assert!(
+        eqp.iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX METHOD")),
+        "nearest-neighbor query should use custom index method after plain VACUUM, got plan: {eqp:?}",
+    );
+
+    let nearest: Vec<(i64, String, f64)> = conn.exec_rows(
+        "SELECT id, label, vector_distance_jaccard(embedding, vector32_sparse('[1, 0, 0, 0]')) AS distance \
+         FROM vectors ORDER BY distance LIMIT 1",
+    );
+    assert_eq!(nearest, before_nearest);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    Ok(())
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_plain_vacuum_preserves_fts_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE articles(id INTEGER PRIMARY KEY, title TEXT, body TEXT)")?;
+    conn.execute("CREATE INDEX fts_articles ON articles USING fts (title, body)")?;
+    conn.execute("INSERT INTO articles VALUES (1, 'Database Performance', 'Optimizing database queries is important for performance')")?;
+    conn.execute("INSERT INTO articles VALUES (2, 'Web Development', 'Modern web applications use JavaScript and APIs')")?;
+    conn.execute("INSERT INTO articles VALUES (3, 'Database Design', 'Good database design leads to better performance')")?;
+    conn.execute("INSERT INTO articles VALUES (4, 'API Development', 'RESTful APIs are common in web services')")?;
+
+    let before_database_matches: Vec<(i64,)> = conn
+        .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'database') ORDER BY id");
+
+    assert_plain_vacuum_preserves_content_hash(&tmp_db, &conn)?;
+
+    let after_database_matches: Vec<(i64,)> = conn
+        .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'database') ORDER BY id");
+    assert_eq!(after_database_matches, before_database_matches);
+
+    let web_matches: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'web') ORDER BY id");
+    assert_eq!(web_matches, vec![(2,), (4,)]);
+
+    let eqp: Vec<(i64, i64, i64, String)> = conn.exec_rows(
+        "EXPLAIN QUERY PLAN \
+         SELECT id FROM articles WHERE fts_match(title, body, 'database')",
+    );
+    assert!(
+        eqp.iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX METHOD")),
+        "FTS query should use an index method after plain VACUUM, got plan: {eqp:?}",
+    );
+
+    conn.execute(
+        "INSERT INTO articles VALUES (5, 'Vacuum Export', 'Full text search stays usable after vacuum')",
+    )?;
+    let vacuum_matches: Vec<(i64,)> = conn
+        .exec_rows("SELECT id FROM articles WHERE fts_match(title, body, 'vacuum') ORDER BY id");
+    assert_eq!(vacuum_matches, vec![(5,)]);
+
+    Ok(())
+}
+
+/// Plain VACUUM must preserve vector blobs stored as ordinary BLOB data.
+#[turso_macros::test]
+fn test_plain_vacuum_preserves_vector_blobs(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE vectors (id INTEGER PRIMARY KEY, label TEXT, embedding BLOB)")?;
+    conn.execute("INSERT INTO vectors VALUES (1, 'cat', vector32('[1.0, 0.0, 0.0, 0.0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (2, 'dog', vector32('[0.0, 1.0, 0.0, 0.0]'))")?;
+    conn.execute("INSERT INTO vectors VALUES (3, 'fish', vector32('[0.0, 0.0, 1.0, 0.0]'))")?;
+
+    let before_dist: Vec<(f64,)> = conn.exec_rows(
+        "SELECT vector_distance_cos(
+            (SELECT embedding FROM vectors WHERE id = 1),
+            (SELECT embedding FROM vectors WHERE id = 2)
+        )",
+    );
+
+    assert_plain_vacuum_preserves_content_hash(&tmp_db, &conn)?;
+
+    let count: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM vectors");
+    assert_eq!(count[0].0, 3);
+
+    let after_dist: Vec<(f64,)> = conn.exec_rows(
+        "SELECT vector_distance_cos(
+            (SELECT embedding FROM vectors WHERE id = 1),
+            (SELECT embedding FROM vectors WHERE id = 2)
+        )",
+    );
+    assert_eq!(after_dist, before_dist);
+
+    Ok(())
+}
+
+/// Plain VACUUM preserves views.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(views, init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_preserves_views(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE VIEW v1 AS SELECT * FROM t1 WHERE a > 1")?;
+    conn.execute("INSERT INTO t1 VALUES(1, 'one')")?;
+    conn.execute("INSERT INTO t1 VALUES(2, 'two')")?;
+    conn.execute("INSERT INTO t1 VALUES(3, 'three')")?;
+    conn.execute("DELETE FROM t1 WHERE a = 2")?;
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let views: Vec<(String,)> =
+        conn.exec_rows("SELECT name FROM sqlite_schema WHERE type = 'view' ORDER BY name");
+    assert_eq!(views, vec![("v1".to_string(),)]);
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM v1 ORDER BY a");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], (3, "three".into()));
+
+    Ok(())
+}
+
+/// Plain VACUUM rejects active transactions.
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_rejects_active_transaction(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("BEGIN")?;
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Transaction error: cannot VACUUM from within a transaction",
+        "unexpected error: {err}"
+    );
+    conn.execute("ROLLBACK")?;
+    Ok(())
+}
+
+/// Plain VACUUM works on empty databases.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_empty_table(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA user_version = 42")?;
+    conn.execute("PRAGMA application_id = 99")?;
+    let pre_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let tables: Vec<(String, String)> =
+        conn.exec_rows("SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name = 't'");
+    assert_eq!(
+        tables
+            .into_iter()
+            .map(|(name, sql)| (name, canonicalize_schema_sql(&sql)))
+            .collect::<Vec<_>>(),
+        vec![("t".to_string(), "CREATE TABLE t (a INTEGER)".to_string())]
+    );
+
+    let user_version: Vec<(i64,)> = conn.exec_rows("PRAGMA user_version");
+    assert_eq!(user_version[0].0, 42);
+
+    let application_id: Vec<(i64,)> = conn.exec_rows("PRAGMA application_id");
+    assert_eq!(application_id[0].0, 99);
+
+    let post_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
+    assert_eq!(post_schema_version[0].0, pre_schema_version[0].0 + 1);
+
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(rows[0].0, 0);
+    Ok(())
+}
+
+/// Plain VACUUM preserves an empty table after heavy insert/update/delete churn.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT);")]
+fn test_plain_vacuum_empty_table_after_updates(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    let initial_payload = "a".repeat(300);
+    let updated_even_payload = "b".repeat(700);
+    let updated_odd_payload = "c".repeat(900);
+
+    for i in 0..240 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", initial_payload))?;
+    }
+
+    conn.execute(format!(
+        "UPDATE t SET payload = '{}' WHERE id % 2 = 0",
+        updated_even_payload
+    ))?;
+    conn.execute(format!(
+        "UPDATE t SET payload = '{}' WHERE id % 2 = 1",
+        updated_odd_payload
+    ))?;
+    conn.execute("DELETE FROM t")?;
+
+    let pre_vacuum_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(
+        pre_vacuum_pages > 10,
+        "workload should span many pages before VACUUM, got page_count={pre_vacuum_pages}"
+    );
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let tables: Vec<(String, String)> =
+        conn.exec_rows("SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name = 't'");
+    assert_eq!(
+        tables
+            .into_iter()
+            .map(|(name, sql)| (name, canonicalize_schema_sql(&sql)))
+            .collect::<Vec<_>>(),
+        vec![(
+            "t".to_string(),
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, payload TEXT)".to_string()
+        )]
+    );
+
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(rows[0].0, 0);
+
+    let post_vacuum_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert_eq!(
+        post_vacuum_pages, 2,
+        "VACUUM should reduce an emptied table back to the header page plus the empty table root page: before={pre_vacuum_pages}, after={post_vacuum_pages}"
+    );
+
+    Ok(())
+}
+
+/// Multiple VACUUMs in a row work correctly.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_repeated(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1, 'one')")?;
+    conn.execute("INSERT INTO t VALUES(2, 'two')")?;
+    conn.execute("INSERT INTO t VALUES(3, 'three')")?;
+    conn.execute("DELETE FROM t WHERE a = 2")?;
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t ORDER BY a");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], (1, "one".into()));
+    assert_eq!(rows[1], (3, "three".into()));
+
+    Ok(())
+}
+
+/// Writes after VACUUM work correctly.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_then_write(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1, 'one')")?;
+    conn.execute("INSERT INTO t VALUES(2, 'two')")?;
+    conn.execute("DELETE FROM t WHERE a = 1")?;
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+    conn.execute("INSERT INTO t VALUES(3, 'three')")?;
+    conn.execute("INSERT INTO t VALUES(4, 'four')")?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t ORDER BY a");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], (2, "two".into()));
+    assert_eq!(rows[1], (3, "three".into()));
+    assert_eq!(rows[2], (4, "four".into()));
+
+    Ok(())
+}
+
+/// Plain VACUUM rejects query_only mode.
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_rejects_query_only(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA query_only = 1")?;
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Parse error: Cannot execute VACUUM in query_only mode",
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
+/// Plain VACUUM rejects active statements on same connection.
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_rejects_active_statement(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1)")?;
+    conn.execute("INSERT INTO t VALUES(2)")?;
+
+    // Hold an active SELECT open
+    let mut stmt = conn.prepare("SELECT * FROM t")?;
+    let step_result = stmt.step()?;
+    assert!(matches!(step_result, StepResult::Row));
+
+    // VACUUM should fail while the SELECT is active
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Transaction error: cannot VACUUM - SQL statements in progress",
+        "unexpected error: {err}"
+    );
+
+    stmt.reset()?;
+    Ok(())
+}
+
+/// Plain VACUUM reduces page_count when rows are deleted, and a subsequent
+/// checkpoint truncates the .db file to the compacted size.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_reduces_page_count(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    // Insert enough data to grow the database well past the minimum.
+    for i in 0..200 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", "x".repeat(100)))?;
+    }
+
+    let pre_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert!(
+        pre_pages[0].0 > 5,
+        "source should have multiple pages, got: {}",
+        pre_pages[0].0
+    );
+
+    // Delete most rows to create free pages.
+    conn.execute("DELETE FROM t WHERE a >= 10")?;
+
+    // page_count should not have decreased yet (deleted pages are on freelist).
+    let after_delete_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert_eq!(after_delete_pages[0].0, pre_pages[0].0);
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+
+    // After VACUUM the compacted image should be smaller.
+    let post_vacuum_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert!(
+        post_vacuum_pages[0].0 < pre_pages[0].0,
+        "page_count should decrease after VACUUM: before={}, after={}",
+        pre_pages[0].0,
+        post_vacuum_pages[0].0
+    );
+
+    // VACUUM includes a TRUNCATE checkpoint, so the WAL should be empty.
+    let wal_path = format!("{}-wal", tmp_db.path.display());
+    let wal_size = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
+    assert_eq!(wal_size, 0, "WAL should be truncated to zero after VACUUM");
+
+    // Data integrity: the 10 remaining rows should be intact.
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(rows[0].0, 10);
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    Ok(())
+}
+
+/// Plain VACUUM should compact the same fragmented workload down to the same
+/// final page count as SQLite.
+#[test]
+fn test_plain_vacuum_matches_sqlite_page_count_after_updates_and_deletes() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    let sqlite_dir = TempDir::new()?;
+    let sqlite_path = sqlite_dir.path().join("sqlite_vacuum_reference.db");
+    let sqlite_conn = SqliteConnection::open(&sqlite_path)?;
+
+    for sql in [
+        "PRAGMA page_size = 1024",
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT NOT NULL)",
+    ] {
+        conn.execute(sql)?;
+        sqlite_conn.execute_batch(sql)?;
+    }
+
+    conn.execute("BEGIN IMMEDIATE")?;
+    sqlite_conn.execute_batch("BEGIN IMMEDIATE")?;
+
+    for i in 0..3500_i64 {
+        let payload = format!("seed-{i:04}-{}", "payload".repeat(35));
+        conn.execute(format!(
+            "INSERT INTO t VALUES({i}, '{}')",
+            escape_sqlite_string_literal(&payload)
+        ))?;
+        sqlite_conn.execute(
+            "INSERT INTO t VALUES(?1, ?2)",
+            rusqlite::params![i, payload],
+        )?;
+    }
+
+    for i in (0..3500_i64).step_by(3) {
+        let payload = format!("wide-{i:04}-{}", "updated".repeat(55));
+        conn.execute(format!(
+            "UPDATE t SET payload = '{}' WHERE id = {i}",
+            escape_sqlite_string_literal(&payload)
+        ))?;
+        sqlite_conn.execute(
+            "UPDATE t SET payload = ?1 WHERE id = ?2",
+            rusqlite::params![payload, i],
+        )?;
+    }
+
+    conn.execute("DELETE FROM t WHERE id % 4 = 0")?;
+    sqlite_conn.execute("DELETE FROM t WHERE id % 4 = 0", [])?;
+
+    for i in (1..3500_i64).step_by(5) {
+        let payload = format!("tail-{i:04}-{}", "rewrite".repeat(28));
+        conn.execute(format!(
+            "UPDATE t SET payload = '{}' WHERE id = {i} AND id % 4 != 0",
+            escape_sqlite_string_literal(&payload)
+        ))?;
+        sqlite_conn.execute(
+            "UPDATE t SET payload = ?1 WHERE id = ?2 AND id % 4 != 0",
+            rusqlite::params![payload, i],
+        )?;
+    }
+
+    conn.execute("COMMIT")?;
+    sqlite_conn.execute_batch("COMMIT")?;
+
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    let pre_sqlite_pages = sqlite_scalar_i64(&sqlite_conn, "PRAGMA page_count");
+    assert!(
+        pre_pages > 100,
+        "Turso reference workload should exceed 100 pages before VACUUM, got {pre_pages}"
+    );
+    assert!(
+        pre_sqlite_pages > 100,
+        "SQLite reference workload should exceed 100 pages before VACUUM, got {pre_sqlite_pages}"
+    );
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+    sqlite_conn.execute_batch("VACUUM")?;
+
+    let post_pages = scalar_i64(&conn, "PRAGMA page_count");
+    let post_sqlite_pages = sqlite_scalar_i64(&sqlite_conn, "PRAGMA page_count");
+    assert_eq!(
+        post_pages, post_sqlite_pages,
+        "plain VACUUM should match SQLite final page count for the same fragmented workload"
+    );
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    Ok(())
+}
+
+/// Plain VACUUM copy-back batch boundaries. The core unit tests assert the
+/// exact range math; this integration test builds compacted images around the
+/// 64-page boundary so the read/write batch state machine crosses one-page,
+/// exact-boundary, and one-over-boundary cases.
+#[test]
+fn test_plain_vacuum_copy_batch_page_count_boundaries() -> anyhow::Result<()> {
+    for target_pages in [2_i64, 63, 64, 65, 128, 129] {
+        let tmp_db = TempDatabase::new_empty();
+        let conn = tmp_db.connect_limbo();
+        conn.execute("PRAGMA page_size = 512")?;
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")?;
+
+        let inserted = populate_until_page_count(&conn, target_pages, 350)?;
+        assert!(
+            inserted > 0 || target_pages == 2,
+            "boundary workload should insert rows for target {target_pages}"
+        );
+
+        let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+        conn.execute("VACUUM")?;
+
+        assert_eq!(
+            scalar_i64(&conn, "PRAGMA page_count"),
+            target_pages,
+            "VACUUM should preserve compacted page count for boundary target {target_pages}"
+        );
+        assert_eq!(
+            scalar_i64(&conn, "SELECT COUNT(*) FROM t"),
+            inserted,
+            "row count should survive boundary VACUUM for target {target_pages}"
+        );
+        assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+        assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    }
+
+    Ok(())
+}
+
+/// Truly empty databases exercise the lower edge of the copy-back setup: there
+/// may be no user schema pages to copy, but VACUUM still must leave the file
+/// usable and folded.
+#[test]
+fn test_plain_vacuum_empty_schema_physical_contract() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    // A truly empty DB (page 1 never allocated) is not a valid VACUUM target —
+    // an existing database that "looks empty" indicates a problem, not a no-op.
+    let err = conn
+        .execute("VACUUM")
+        .expect_err("VACUUM on an uninitialized database should return an error");
+    assert_eq!(
+        err.to_string(),
+        "Internal error: begin_blocking_tx can be done on an initialized database (page 1 must already be allocated)",
+        "expected initialization error, got: {err}"
+    );
+    Ok(())
+}
+
+/// Initialized DB whose user schema has been fully torn down — page 1 exists,
+/// but there are no user tables or indexes. VACUUM must succeed and leave the
+/// DB queryable at the minimum page count.
+///
+/// FIXME: currently ignored because Turso's VACUUM does not reclaim the root
+/// page of the dropped table. SQLite produces page_count=1 for the same
+/// sequence; Turso produces page_count > 1. The integrity_check passes, so
+/// this is a compaction/correctness gap in the target-pager rebuild rather
+/// than a data-loss bug.
+#[ignore = "VACUUM does not reclaim dropped-table root pages (diverges from SQLite)"]
+#[test]
+fn test_plain_vacuum_initialized_but_empty_schema() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE _scratch(i)")?;
+    conn.execute("DROP TABLE _scratch")?;
+
+    run_plain_vacuum_and_assert_round_trip(&tmp_db, &conn)?;
+
+    assert!(
+        scalar_i64(&conn, "PRAGMA page_count") <= 1,
+        "empty schema should stay at the minimum page count"
+    );
+    let tables: Vec<(i64,)> =
+        conn.exec_rows("SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table'");
+    assert_eq!(tables[0].0, 0, "no user tables should remain after DROP");
+    Ok(())
+}
+
+/// Plain VACUUM on a workload with several tables and indexes, large enough
+/// to span multiple copy-back batches and exercise a non-monotonic
+/// page→frame map in the temp WAL. This is the path that drives
+/// `coalesce_frame_runs` to build more than one run per batch.
+#[test]
+fn test_plain_vacuum_multi_table_multi_batch() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE c(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE INDEX idx_a_v ON a(v)")?;
+    conn.execute("CREATE INDEX idx_b_v ON b(v)")?;
+    conn.execute("CREATE INDEX idx_c_v ON c(v)")?;
+
+    // Enough rows to push total_pages past VACUUM_COPY_BATCH_SIZE (64) so the
+    // batch path is hit more than once, and to grow each table's b-tree
+    // across several pages so target-build interleaves table/index frames.
+    for i in 0..800 {
+        conn.execute(format!("INSERT INTO a VALUES({i}, '{}')", "a".repeat(200)))?;
+        conn.execute(format!("INSERT INTO b VALUES({i}, '{}')", "b".repeat(200)))?;
+        conn.execute(format!("INSERT INTO c VALUES({i}, '{}')", "c".repeat(200)))?;
+    }
+    // Delete half of each table so the pre-VACUUM image has freelist holes.
+    conn.execute("DELETE FROM a WHERE id % 2 = 0")?;
+    conn.execute("DELETE FROM b WHERE id % 2 = 0")?;
+    conn.execute("DELETE FROM c WHERE id % 2 = 0")?;
+
+    let pre_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert!(
+        pre_pages[0].0 > 64,
+        "workload should span multiple copy-back batches, got page_count={}",
+        pre_pages[0].0
+    );
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+
+    // Row counts preserved.
+    let counts: Vec<(i64,)> = conn.exec_rows(
+        "SELECT (SELECT COUNT(*) FROM a) + (SELECT COUNT(*) FROM b) + (SELECT COUNT(*) FROM c)",
+    );
+    assert_eq!(counts[0].0, 1200);
+
+    // Index-covered reads still work.
+    let via_idx_a: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM a WHERE v = 'aaaaaaaa' ORDER BY id");
+    assert_eq!(via_idx_a.len(), 0); // sanity: no row matches short value
+    let via_idx_b: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM b WHERE v LIKE 'b%'");
+    assert_eq!(via_idx_b[0].0, 400);
+
+    // Spot-check specific rows round-trip.
+    let a_one: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM a WHERE id = 1");
+    assert_eq!(a_one.len(), 1);
+    assert_eq!(a_one[0], (1, "a".repeat(200)));
+    let c_last: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM c WHERE id = 799");
+    assert_eq!(c_last.len(), 1);
+    assert_eq!(c_last[0], (799, "c".repeat(200)));
+
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    Ok(())
+}
+
+/// Page-size coverage for the batched read/write path. Small pages force many
+/// frames; the large page checks that frame sizing and DB-file truncation do
+/// not assume the default 4096-byte page size.
+#[test]
+fn test_plain_vacuum_page_size_variants_fold_and_integrity() -> anyhow::Result<()> {
+    for page_size in [512_i64, 1024, 4096, 65536] {
+        let tmp_db = TempDatabase::new_empty();
+        let conn = tmp_db.connect_limbo();
+        conn.execute(format!("PRAGMA page_size = {page_size}"))?;
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload BLOB, tag TEXT)")?;
+        conn.execute("CREATE INDEX idx_t_tag ON t(tag)")?;
+
+        let rows = if page_size <= 1024 { 180 } else { 40 };
+        let blob_size = if page_size <= 1024 { 1800 } else { 9000 };
+        for i in 0..rows {
+            conn.execute(format!(
+                "INSERT INTO t VALUES({i}, zeroblob({}), 'tag-{}')",
+                blob_size + i % 17,
+                i % 11
+            ))?;
+        }
+        conn.execute("DELETE FROM t WHERE id % 3 = 0")?;
+
+        let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+        let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+        conn.execute("VACUUM")?;
+
+        assert_eq!(scalar_i64(&conn, "PRAGMA page_size"), page_size);
+        assert!(
+            scalar_i64(&conn, "PRAGMA page_count") <= pre_pages,
+            "VACUUM should not grow page_count for page_size={page_size}"
+        );
+        assert_eq!(
+            scalar_i64(&conn, "SELECT COUNT(*) FROM t"),
+            rows - (rows + 2) / 3
+        );
+        assert_eq!(
+            scalar_i64(&conn, "SELECT COUNT(*) FROM t WHERE tag = 'tag-5'"),
+            scalar_i64(
+                &conn,
+                "SELECT COUNT(*) FROM t NOT INDEXED WHERE tag = 'tag-5'"
+            )
+        );
+        assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+        assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    }
+
+    Ok(())
+}
+
+/// Stress the storage shapes that make batched VACUUM risky: overflow chains,
+/// freelist pages, table and index b-trees, triggers, views, and a second
+/// primary-key table all in one compacted image.
+#[test]
+fn test_plain_vacuum_complex_batched_storage_shapes() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::builder().with_views(true).build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size = 1024")?;
+    conn.execute(
+        "CREATE TABLE docs(
+            id INTEGER PRIMARY KEY,
+            category TEXT NOT NULL,
+            payload BLOB NOT NULL,
+            note TEXT
+        )",
+    )?;
+    conn.execute("CREATE INDEX idx_docs_category_note ON docs(category, note)")?;
+    conn.execute("CREATE INDEX idx_docs_note_partial ON docs(note) WHERE category = 'keep'")?;
+    conn.execute("CREATE TABLE audit(doc_id INTEGER, payload_len INTEGER)")?;
+    conn.execute(
+        "CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+            INSERT INTO audit VALUES(new.id, length(new.payload));
+        END",
+    )?;
+    conn.execute("CREATE TABLE kv(k TEXT PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE VIEW kept_docs AS SELECT id, note FROM docs WHERE category = 'keep'")?;
+
+    for i in 0..180 {
+        let category = if i % 4 == 0 { "drop" } else { "keep" };
+        conn.execute(format!(
+            "INSERT INTO docs VALUES({i}, '{category}', zeroblob({}), 'note-{}')",
+            2500 + (i % 13),
+            i % 23
+        ))?;
+        conn.execute(format!(
+            "INSERT INTO kv VALUES('k-{i:03}', '{}')",
+            "v".repeat(90)
+        ))?;
+    }
+    conn.execute("DELETE FROM docs WHERE category = 'drop'")?;
+    conn.execute("DELETE FROM kv WHERE k > 'k-120'")?;
+
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(
+        pre_pages > 64,
+        "complex workload should force multiple copy-back batches, got {pre_pages}"
+    );
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+
+    let indexes: Vec<(String,)> = conn.exec_rows(
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'docs' ORDER BY name",
+    );
+    assert_eq!(
+        indexes,
+        vec![
+            ("idx_docs_category_note".to_string(),),
+            ("idx_docs_note_partial".to_string(),),
+        ]
+    );
+
+    let views: Vec<(String,)> =
+        conn.exec_rows("SELECT name FROM sqlite_schema WHERE type = 'view' ORDER BY name");
+    assert_eq!(views, vec![("kept_docs".to_string(),)]);
+
+    let eqp_composite: Vec<(i64, i64, i64, String)> = conn.exec_rows(
+        "EXPLAIN QUERY PLAN \
+         SELECT id, note FROM docs INDEXED BY idx_docs_category_note \
+         WHERE category = 'keep' AND note = 'note-7' ORDER BY id",
+    );
+    assert!(
+        eqp_composite.iter().any(|(_, _, _, detail)| {
+            detail.contains("INDEX") && detail.contains("idx_docs_category_note")
+        }),
+        "expected lookup to use idx_docs_category_note after plain VACUUM, got plan: {eqp_composite:?}",
+    );
+
+    let eqp_partial: Vec<(i64, i64, i64, String)> = conn.exec_rows(
+        "EXPLAIN QUERY PLAN \
+         SELECT id, note FROM docs INDEXED BY idx_docs_note_partial \
+         WHERE category = 'keep' AND note = 'note-7' ORDER BY id",
+    );
+    assert!(
+        eqp_partial
+            .iter()
+            .any(|(_, _, _, detail)| detail.contains("INDEX") && detail.contains("idx_docs_note_partial")),
+        "expected lookup to use idx_docs_note_partial after plain VACUUM, got plan: {eqp_partial:?}",
+    );
+
+    let eqp_view: Vec<(i64, i64, i64, String)> = conn.exec_rows(
+        "EXPLAIN QUERY PLAN \
+         SELECT id, note FROM kept_docs WHERE note = 'note-7' ORDER BY id",
+    );
+    assert!(
+        eqp_view.iter().any(|(_, _, _, detail)| {
+            detail.contains("INDEX")
+                && (detail.contains("idx_docs_category_note")
+                    || detail.contains("idx_docs_note_partial"))
+        }),
+        "expected kept_docs query to remain plannable through a docs index after plain VACUUM, got plan: {eqp_view:?}",
+    );
+
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM docs"), 135);
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM kept_docs"), 135);
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM kv"), 121);
+    let kept_note_rows: Vec<(i64, String)> =
+        conn.exec_rows("SELECT id, note FROM kept_docs WHERE note = 'note-7' ORDER BY id");
+    assert_eq!(
+        kept_note_rows,
+        vec![
+            (7, "note-7".to_string()),
+            (30, "note-7".to_string()),
+            (53, "note-7".to_string()),
+            (99, "note-7".to_string()),
+            (122, "note-7".to_string()),
+            (145, "note-7".to_string()),
+        ]
+    );
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT COUNT(*) FROM docs WHERE category = 'keep' AND note = 'note-7'"
+        ),
+        scalar_i64(
+            &conn,
+            "SELECT COUNT(*) FROM docs NOT INDEXED WHERE category = 'keep' AND note = 'note-7'"
+        )
+    );
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT SUM(length(payload)) FROM docs WHERE id BETWEEN 1 AND 20"
+        ),
+        scalar_i64(
+            &conn,
+            "SELECT SUM(length(payload)) FROM docs NOT INDEXED WHERE id BETWEEN 1 AND 20"
+        )
+    );
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    conn.execute("INSERT INTO docs VALUES(1000, 'keep', zeroblob(4097), 'after-vacuum')")?;
+    assert_eq!(
+        scalar_i64(&conn, "SELECT payload_len FROM audit WHERE doc_id = 1000"),
+        4097
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Plain VACUUM on an encrypted source database. Exercises the per-frame
+/// decrypt branch inside `Wal::read_frames_batch`: encryption is
+/// propagated to the temp pager (see `vacuum_temp_db_encryption`), so the
+/// batch read path decrypts each frame before feeding it into the source
+/// WAL write batch.
+#[test]
+fn test_plain_vacuum_encrypted() -> anyhow::Result<()> {
+    const HEXKEY: &str = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute(format!("PRAGMA hexkey = '{HEXKEY}'"))?;
+    conn.execute("PRAGMA cipher = 'aegis256'")?;
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+    for i in 0..150 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", "z".repeat(80)))?;
+    }
+    conn.execute("DELETE FROM t WHERE id >= 30")?;
+
+    conn.execute("VACUUM")?;
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    // Data round-trips through encrypted temp WAL → encrypted source WAL.
+    let count: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(count[0].0, 30);
+    let first: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t WHERE id = 0");
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0], (0, "z".repeat(80)));
+    let last: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t WHERE id = 29");
+    assert_eq!(last.len(), 1);
+    assert_eq!(last[0], (29, "z".repeat(80)));
+
+    Ok(())
+}
+
+/// Plain VACUUM on an existing encrypted database after the original
+/// connection is closed. This exercises the restart path where a fresh
+/// connection must reapply the key before reading the source image.
+#[test]
+fn test_plain_vacuum_encrypted_existing() -> anyhow::Result<()> {
+    const HEXKEY: &str = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+    let tmp_db = TempDatabase::new_empty();
+    {
+        let conn = tmp_db.connect_limbo();
+        conn.execute(format!("PRAGMA hexkey = '{HEXKEY}'"))?;
+        conn.execute("PRAGMA cipher = 'aegis256'")?;
+
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+        for i in 0..150 {
+            conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", "z".repeat(80)))?;
+        }
+        conn.execute("DELETE FROM t WHERE id >= 30")?;
+        do_flush(&conn, &tmp_db)?;
+    }
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&tmp_db.path, tmp_db.db_opts);
+    let reopened_conn = reopened.connect_limbo();
+    reopened_conn.execute(format!("PRAGMA hexkey = '{HEXKEY}'"))?;
+    reopened_conn.execute("PRAGMA cipher = 'aegis256'")?;
+
+    reopened_conn.execute("VACUUM")?;
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+
+    let count: Vec<(i64,)> = reopened_conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(count[0].0, 30);
+    let first: Vec<(i64, String)> = reopened_conn.exec_rows("SELECT id, v FROM t WHERE id = 0");
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0], (0, "z".repeat(80)));
+    let last: Vec<(i64, String)> = reopened_conn.exec_rows("SELECT id, v FROM t WHERE id = 29");
+    assert_eq!(last.len(), 1);
+    assert_eq!(last[0], (29, "z".repeat(80)));
+
+    let post_vacuum = TempDatabase::new_with_existent_with_opts(&tmp_db.path, tmp_db.db_opts);
+    let post_vacuum_conn = post_vacuum.connect_limbo();
+    post_vacuum_conn.execute(format!("PRAGMA hexkey = '{HEXKEY}'"))?;
+    post_vacuum_conn.execute("PRAGMA cipher = 'aegis256'")?;
+    assert_eq!(run_integrity_check(&post_vacuum_conn), "ok");
+    assert_eq!(scalar_i64(&post_vacuum_conn, "SELECT COUNT(*) FROM t"), 30);
+
+    Ok(())
+}
+
+#[test]
+fn test_plain_vacuum_preserves_full_autovacuum() -> anyhow::Result<()> {
+    assert_plain_vacuum_preserves_autovacuum_mode("full", 1)
+}
+
+#[test]
+fn test_mvcc_plain_vacuum_preserves_full_autovacuum_after_reopen() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new().with_autovacuum(true);
+    let (_temp_dir, tmp_db) = open_sqlite_autovacuum_db("full", opts)?;
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), 1);
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+    let journal_mode: Vec<(String,)> = conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode, vec![("mvcc".to_string(),)]);
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), 1);
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 120);
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    let path = tmp_db.path.clone();
+    drop(conn);
+    drop(tmp_db);
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&path, opts);
+    let reopened_conn = reopened.connect_limbo();
+    let journal_mode: Vec<(String,)> = reopened_conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode, vec![("mvcc".to_string(),)]);
+    assert_eq!(scalar_i64(&reopened_conn, "PRAGMA auto_vacuum"), 1);
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+    assert_eq!(scalar_i64(&reopened_conn, "SELECT COUNT(*) FROM t"), 120);
+
+    Ok(())
+}
+
+#[test]
+fn test_vacuum_into_preserves_full_autovacuum() -> anyhow::Result<()> {
+    assert_vacuum_into_preserves_autovacuum_mode("full", 1)
+}
+
+#[test]
+fn test_mvcc_vacuum_into_preserves_full_autovacuum_after_reopen() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new().with_autovacuum(true);
+    let (_temp_dir, tmp_db) = open_sqlite_autovacuum_db("full", opts)?;
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), 1);
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("mvcc-vacuum-into-full-autovacuum.db");
+    conn.execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))?;
+
+    let dest_db = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let dest_conn = dest_db.connect_limbo();
+    let journal_mode: Vec<(String,)> = dest_conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode, vec![("mvcc".to_string(),)]);
+    assert_eq!(scalar_i64(&dest_conn, "PRAGMA auto_vacuum"), 1);
+    assert_eq!(run_integrity_check(&dest_conn), "ok");
+    assert_eq!(scalar_i64(&dest_conn, "SELECT COUNT(*) FROM t"), 120);
+
+    drop(dest_conn);
+    drop(dest_db);
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&dest_path, opts);
+    let reopened_conn = reopened.connect_limbo();
+    let journal_mode: Vec<(String,)> = reopened_conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode, vec![("mvcc".to_string(),)]);
+    assert_eq!(scalar_i64(&reopened_conn, "PRAGMA auto_vacuum"), 1);
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+
+    Ok(())
+}
+
+#[test]
+fn test_plain_vacuum_incremental_autovacuum_still_unsupported() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new()
+        .with_encryption(true)
+        .with_autovacuum(true);
+    let (_temp_dir, tmp_db) = open_sqlite_autovacuum_db("incremental", opts)?;
+    let conn = tmp_db.connect_limbo();
+
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Internal error: Incremental auto-vacuum is not supported",
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_vacuum_into_incremental_autovacuum_still_unsupported() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new()
+        .with_encryption(true)
+        .with_autovacuum(true);
+    let (_temp_dir, tmp_db) = open_sqlite_autovacuum_db("incremental", opts)?;
+    let conn = tmp_db.connect_limbo();
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("vacuum-into.db");
+
+    let err = conn
+        .execute(format!("VACUUM INTO '{}'", dest_path.to_str().unwrap()))
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Internal error: Incremental auto-vacuum is not supported",
+        "unexpected error: {err}"
+    );
+    assert!(
+        !dest_path.exists(),
+        "unsupported VACUUM INTO should not leave an output file behind"
+    );
+
+    Ok(())
+}
+
+/// Keep one non-ignored plain VACUUM test under the checksum feature so
+/// `read_frames_batch` verifies checksums while reading the temp WAL and
+/// `prepare_frames` writes checksummed source-WAL frames.
+#[cfg(feature = "checksum")]
+#[test]
+fn test_plain_vacuum_checksum_multi_batch() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size = 1024")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload BLOB, tag TEXT)")?;
+    conn.execute("CREATE INDEX idx_t_tag ON t(tag)")?;
+    for i in 0..160 {
+        conn.execute(format!(
+            "INSERT INTO t VALUES({i}, zeroblob({}), 'tag-{}')",
+            1400 + i % 19,
+            i % 9
+        ))?;
+    }
+    conn.execute("DELETE FROM t WHERE id % 4 = 0")?;
+
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(
+        pre_pages > 64,
+        "checksum workload should cross copy-back batch boundary, got {pre_pages}"
+    );
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 120);
+    assert_eq!(
+        scalar_i64(&conn, "SELECT COUNT(*) FROM t WHERE tag = 'tag-3'"),
+        scalar_i64(
+            &conn,
+            "SELECT COUNT(*) FROM t NOT INDEXED WHERE tag = 'tag-3'"
+        )
+    );
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    Ok(())
+}
+
+/// Active readers must make VACUUM fail before publishing a new WAL image. The
+/// same operation must succeed after the reader releases its snapshot.
+#[test]
+fn test_plain_vacuum_active_reader_blocks_fold_contract() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let writer = tmp_db.connect_limbo();
+    let reader = tmp_db.connect_limbo();
+
+    writer.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")?;
+    for i in 0..120 {
+        writer.execute(format!("INSERT INTO t VALUES({i}, '{}')", "x".repeat(300)))?;
+    }
+    writer.execute("DELETE FROM t WHERE id >= 20")?;
+
+    reader.execute("BEGIN")?;
+    assert_eq!(scalar_i64(&reader, "SELECT COUNT(*) FROM t"), 20);
+
+    let result = writer.execute("VACUUM");
+    assert!(
+        result.is_err(),
+        "VACUUM must fail while another connection holds a WAL read snapshot"
+    );
+
+    reader.execute("ROLLBACK")?;
+    let final_writer = tmp_db.connect_limbo();
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    final_writer.execute("VACUUM")?;
+
+    assert_eq!(scalar_i64(&final_writer, "SELECT COUNT(*) FROM t"), 20);
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &final_writer, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &final_writer);
+    Ok(())
+}
+
+fn populate_mvcc_vacuum_workload(conn: &Arc<Connection>) -> anyhow::Result<Vec<(i64, String)>> {
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, tag TEXT NOT NULL, payload TEXT)")?;
+    conn.execute("CREATE INDEX idx_t_tag ON t(tag)")?;
+
+    for id in 0..200 {
+        conn.execute(format!(
+            "INSERT INTO t VALUES({id}, 'tag-{}', '{}')",
+            id % 5,
+            "x".repeat(300)
+        ))?;
+    }
+    conn.execute("DELETE FROM t WHERE id % 3 = 0")?;
+    conn.execute(format!(
+        "UPDATE t SET tag = 'hot', payload = '{}' WHERE id % 10 = 1",
+        "y".repeat(350)
+    ))?;
+
+    Ok((0..200)
+        .filter(|id| id % 3 != 0)
+        .map(|id| {
+            let tag = if id % 10 == 1 {
+                "hot".to_string()
+            } else {
+                format!("tag-{}", id % 5)
+            };
+            (id, tag)
+        })
+        .collect())
+}
+
+fn assert_mvcc_vacuum_workload(
+    conn: &Arc<Connection>,
+    expected_rows: &[(i64, String)],
+) -> anyhow::Result<()> {
+    assert_eq!(run_integrity_check(conn), "ok");
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, tag FROM t ORDER BY id");
+    assert_eq!(rows, expected_rows);
+
+    let indexed_hot: Vec<(i64,)> = conn.exec_rows("SELECT id FROM t WHERE tag = 'hot' ORDER BY id");
+    let table_scan_hot: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM t NOT INDEXED WHERE tag = 'hot' ORDER BY id");
+    assert_eq!(indexed_hot, table_scan_hot);
+
+    Ok(())
+}
+
+fn populate_mvcc_multi_object_vacuum_workload(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    for table in ["a", "b", "c"] {
+        conn.execute(format!(
+            "CREATE TABLE {table}(id INTEGER PRIMARY KEY, tag TEXT NOT NULL, payload TEXT)"
+        ))?;
+        conn.execute(format!("CREATE INDEX idx_{table}_tag ON {table}(tag)"))?;
+    }
+
+    for id in 0..90 {
+        conn.execute(format!(
+            "INSERT INTO a VALUES({id}, 'tag-{}', '{}')",
+            id % 3,
+            "a".repeat(120)
+        ))?;
+        conn.execute(format!(
+            "INSERT INTO b VALUES({id}, 'tag-{}', '{}')",
+            id % 4,
+            "b".repeat(120)
+        ))?;
+        conn.execute(format!(
+            "INSERT INTO c VALUES({id}, 'tag-{}', '{}')",
+            id % 5,
+            "c".repeat(120)
+        ))?;
+    }
+
+    conn.execute("DELETE FROM a WHERE id % 4 = 0")?;
+    conn.execute("DELETE FROM b WHERE id % 5 = 0")?;
+    conn.execute("DELETE FROM c WHERE id % 6 = 0")?;
+    conn.execute("UPDATE a SET tag = 'hot-a' WHERE id % 10 = 1")?;
+    conn.execute("UPDATE b SET tag = 'hot-b' WHERE id % 9 = 2")?;
+    conn.execute("UPDATE c SET tag = 'hot-c' WHERE id % 8 = 3")?;
+    Ok(())
+}
+
+fn assert_mvcc_multi_object_vacuum_workload(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    assert_eq!(run_integrity_check(conn), "ok");
+
+    assert_eq!(scalar_i64(conn, "SELECT COUNT(*) FROM a"), 67);
+    assert_eq!(scalar_i64(conn, "SELECT COUNT(*) FROM b"), 72);
+    assert_eq!(scalar_i64(conn, "SELECT COUNT(*) FROM c"), 75);
+
+    let hot_a: Vec<(i64,)> = conn.exec_rows("SELECT id FROM a WHERE tag = 'hot-a' ORDER BY id");
+    let hot_a_scan: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM a NOT INDEXED WHERE tag = 'hot-a' ORDER BY id");
+    assert_eq!(hot_a, hot_a_scan);
+    assert_eq!(
+        hot_a,
+        vec![(1,), (11,), (21,), (31,), (41,), (51,), (61,), (71,), (81,)]
+    );
+
+    let hot_b: Vec<(i64,)> = conn.exec_rows("SELECT id FROM b WHERE tag = 'hot-b' ORDER BY id");
+    let hot_b_scan: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM b NOT INDEXED WHERE tag = 'hot-b' ORDER BY id");
+    assert_eq!(hot_b, hot_b_scan);
+    assert_eq!(
+        hot_b,
+        vec![(2,), (11,), (29,), (38,), (47,), (56,), (74,), (83,)]
+    );
+
+    let hot_c: Vec<(i64,)> = conn.exec_rows("SELECT id FROM c WHERE tag = 'hot-c' ORDER BY id");
+    let hot_c_scan: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM c NOT INDEXED WHERE tag = 'hot-c' ORDER BY id");
+    assert_eq!(hot_c, hot_c_scan);
+    assert_eq!(
+        hot_c,
+        vec![
+            (3,),
+            (11,),
+            (19,),
+            (27,),
+            (35,),
+            (43,),
+            (51,),
+            (59,),
+            (67,),
+            (75,),
+            (83,)
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_mvcc_plain_vacuum_multi_object_rootpage_reset() -> anyhow::Result<()> {
+    let tmp_db =
+        TempDatabase::new_with_mvcc("test_mvcc_plain_vacuum_multi_object_rootpage_reset.db");
+    let conn = tmp_db.connect_limbo();
+
+    populate_mvcc_multi_object_vacuum_workload(&conn)?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(mvcc_log_file_size(&tmp_db), 0);
+
+    assert_plain_vacuum_preserves_content_hash(&tmp_db, &conn)?;
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    assert_mvcc_multi_object_vacuum_workload(&conn)?;
+
+    conn.execute("INSERT INTO a VALUES(1000, 'after-a', 'payload-a')")?;
+    conn.execute("UPDATE a SET tag = 'after-a-updated' WHERE id = 1")?;
+    conn.execute("INSERT INTO b VALUES(1001, 'after-b', 'payload-b')")?;
+    conn.execute("DELETE FROM b WHERE id = 3")?;
+    conn.execute("INSERT INTO c VALUES(1002, 'after-c', 'payload-c')")?;
+    conn.execute("UPDATE c SET tag = 'after-c-updated' WHERE id = 11")?;
+
+    let after_a: Vec<(i64,)> = conn.exec_rows("SELECT id FROM a WHERE tag = 'after-a' ORDER BY id");
+    assert_eq!(after_a, vec![(1000,)]);
+    let after_a_updated: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM a WHERE tag = 'after-a-updated' ORDER BY id");
+    assert_eq!(after_a_updated, vec![(1,)]);
+    let after_b: Vec<(i64,)> = conn.exec_rows("SELECT id FROM b WHERE tag = 'after-b' ORDER BY id");
+    assert_eq!(after_b, vec![(1001,)]);
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM b WHERE id = 3"), 0);
+    let after_c: Vec<(i64,)> = conn.exec_rows("SELECT id FROM c WHERE tag = 'after-c' ORDER BY id");
+    assert_eq!(after_c, vec![(1002,)]);
+    let after_c_updated: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM c WHERE tag = 'after-c-updated' ORDER BY id");
+    assert_eq!(after_c_updated, vec![(11,)]);
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(mvcc_log_file_size(&tmp_db), 0);
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&tmp_db.path, tmp_db.db_opts);
+    let reopened_conn = reopened.connect_limbo();
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+    let reopened_a: Vec<(i64,)> =
+        reopened_conn.exec_rows("SELECT id FROM a WHERE tag = 'after-a' ORDER BY id");
+    assert_eq!(reopened_a, vec![(1000,)]);
+    let reopened_b: Vec<(i64,)> =
+        reopened_conn.exec_rows("SELECT id FROM b WHERE tag = 'after-b' ORDER BY id");
+    assert_eq!(reopened_b, vec![(1001,)]);
+    let reopened_c: Vec<(i64,)> =
+        reopened_conn.exec_rows("SELECT id FROM c WHERE tag = 'after-c' ORDER BY id");
+    assert_eq!(reopened_c, vec![(1002,)]);
+
+    Ok(())
+}
+
+#[test]
+fn test_mvcc_plain_vacuum_discards_reused_index_rootpage_state() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_with_mvcc(
+        "test_mvcc_plain_vacuum_discards_reused_index_rootpage_state.db",
+    );
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE UNIQUE INDEX idx_old ON t(v COLLATE NOCASE)")?;
+    conn.execute("INSERT INTO t VALUES (1, 'a'), (2, 'b')")?;
+    conn.execute("UPDATE t SET v = 'c' WHERE id = 1")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(mvcc_log_file_size(&tmp_db), 0);
+
+    conn.execute("DROP INDEX idx_old")?;
+    conn.execute("DROP TABLE t")?;
+    conn.execute("CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE UNIQUE INDEX idx_new ON u(v COLLATE BINARY)")?;
+    // Plain MVCC VACUUM is only legal after logical changes are checkpointed
+    // into the B-tree image. The stale state being tested is the empty MVCC
+    // index bucket that checkpoint GC leaves behind.
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(mvcc_log_file_size(&tmp_db), 0);
+
+    conn.execute("VACUUM")?;
+    conn.execute("INSERT INTO u VALUES (1, 'a')")?;
+    conn.execute("INSERT INTO u VALUES (2, 'A')")?;
+
+    let indexed: Vec<(String,)> = conn.exec_rows("SELECT v FROM u INDEXED BY idx_new ORDER BY v");
+    let scanned: Vec<(String,)> = conn.exec_rows("SELECT v FROM u NOT INDEXED ORDER BY v");
+    assert_eq!(scanned, vec![("A".to_string(),), ("a".to_string(),)]);
+    assert_eq!(
+        indexed, scanned,
+        "post-VACUUM MVCC index state must use idx_new's BINARY collation"
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    Ok(())
+}
+
+#[test]
+fn test_mvcc_plain_vacuum_requires_checkpointed_image() -> anyhow::Result<()> {
+    let tmp_db =
+        TempDatabase::new_with_mvcc("test_mvcc_plain_vacuum_requires_checkpointed_image.db");
+    let conn = tmp_db.connect_limbo();
+
+    let expected_rows = populate_mvcc_vacuum_workload(&conn)?;
+
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Transaction error: cannot VACUUM an MVCC database with uncheckpointed changes; run PRAGMA wal_checkpoint(TRUNCATE) first",
+        "MVCC VACUUM must reject uncheckpointed logical changes"
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(
+        mvcc_log_file_size(&tmp_db),
+        0,
+        "MVCC log should be empty before plain VACUUM starts"
+    );
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    assert_mvcc_vacuum_workload(&conn, &expected_rows)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_mvcc_plain_vacuum_after_checkpoint_preserves_mvcc_state() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_with_mvcc(
+        "test_mvcc_plain_vacuum_after_checkpoint_preserves_mvcc_state.db",
+    );
+    let conn = tmp_db.connect_limbo();
+    let mut expected_rows = populate_mvcc_vacuum_workload(&conn)?;
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(
+        mvcc_log_file_size(&tmp_db),
+        0,
+        "MVCC log should be empty before plain VACUUM starts"
+    );
+
+    let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+    conn.execute("VACUUM")?;
+    assert_plain_vacuum_integrity_and_hash(&tmp_db, &conn, &before_hash);
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    assert_mvcc_vacuum_workload(&conn, &expected_rows)?;
+
+    conn.execute("INSERT INTO t VALUES(1000, 'after-vacuum', 'z')")?;
+    conn.execute("UPDATE t SET tag = 'after-update' WHERE id = 1")?;
+    conn.execute("DELETE FROM t WHERE id = 2")?;
+
+    expected_rows.retain(|(id, _)| *id != 2);
+    if let Some((_, tag)) = expected_rows.iter_mut().find(|(id, _)| *id == 1) {
+        *tag = "after-update".to_string();
+    }
+    expected_rows.push((1000, "after-vacuum".to_string()));
+    expected_rows.sort_by_key(|(id, _)| *id);
+
+    assert_mvcc_vacuum_workload(&conn, &expected_rows)?;
+    assert!(
+        mvcc_log_file_size(&tmp_db) > 0,
+        "post-VACUUM MVCC writes should use the logical log"
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(
+        mvcc_log_file_size(&tmp_db),
+        0,
+        "checkpoint after post-VACUUM writes should truncate the MVCC log"
+    );
+
+    let path = tmp_db.path.clone();
+    drop(conn);
+    drop(tmp_db);
+
+    let reopened = TempDatabase::new_with_existent(&path);
+    let reopened_conn = reopened.connect_limbo();
+    assert_mvcc_vacuum_workload(&reopened_conn, &expected_rows)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_mvcc_plain_vacuum_active_tx_returns_busy() -> anyhow::Result<()> {
+    for (scenario, db_name) in [
+        (
+            "read",
+            "test_mvcc_plain_vacuum_active_read_tx_returns_busy.db",
+        ),
+        (
+            "write",
+            "test_mvcc_plain_vacuum_active_write_tx_returns_busy.db",
+        ),
+    ] {
+        let tmp_db = TempDatabase::new_with_mvcc(db_name);
+        let vacuum_conn = tmp_db.connect_limbo();
+        let blocker = tmp_db.connect_limbo();
+
+        let expected_rows = populate_mvcc_vacuum_workload(&vacuum_conn)?;
+        vacuum_conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+        match scenario {
+            "read" => {
+                blocker.execute("BEGIN")?;
+                let rows: Vec<(i64,)> = blocker.exec_rows("SELECT COUNT(*) FROM t");
+                assert_eq!(rows, vec![(expected_rows.len() as i64,)]);
+            }
+            "write" => {
+                blocker.execute("BEGIN IMMEDIATE")?;
+                blocker.execute("INSERT INTO t VALUES(1000, 'uncommitted', 'pending')")?;
+            }
+            other => unreachable!("unexpected MVCC VACUUM blocker scenario: {other}"),
+        }
+
+        let result = vacuum_conn.execute("VACUUM");
+        assert!(
+            matches!(result, Err(LimboError::Busy)),
+            "active MVCC {scenario} transaction should make VACUUM return Busy, got {result:?}"
+        );
+
+        blocker.execute("ROLLBACK")?;
+        let before_hash = compute_plain_vacuum_dbhash(&tmp_db);
+        vacuum_conn.execute("VACUUM")?;
+        assert_plain_vacuum_integrity_and_hash(&tmp_db, &vacuum_conn, &before_hash);
+        assert_plain_vacuum_folded_into_db_file(&tmp_db, &vacuum_conn);
+        assert_mvcc_vacuum_workload(&vacuum_conn, &expected_rows)?;
+    }
+
+    Ok(())
+}
+
+fn open_queued_db(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Database>> {
+    Ok(Database::open_file(io, path)?)
+}
+
+fn populate_queued_multibatch(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    conn.execute("PRAGMA page_size = 512")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")?;
+    conn.execute("CREATE INDEX idx_t_payload ON t(payload)")?;
+    for i in 0..220 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", "q".repeat(350)))?;
+    }
+    conn.execute("DELETE FROM t WHERE id % 5 = 0")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_queued_io_reentry_multi_batch() -> anyhow::Result<()> {
+    // Exercises the queued-IO async path for a multi-batch plain VACUUM and
+    // asserts the source WAL copy-back re-enters cleanly across more than one
+    // batched read/write cycle.
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-reentry.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(pre_pages > 64, "queued IO workload should be multi-batch");
+
+    let before_hash = compute_plain_vacuum_file_dbhash(path);
+    conn.execute("VACUUM")?;
+
+    assert!(
+        io.count_events("-wal", QueuedIoOpKind::Pread) > 0,
+        "batch reads should issue queued WAL preads"
+    );
+    assert!(
+        io.count_events("-wal", QueuedIoOpKind::Pwritev) > 1,
+        "multi-batch copy-back should issue multiple source WAL pwritev operations"
+    );
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 176);
+    assert!(
+        scalar_i64(&conn, "PRAGMA page_count") < pre_pages,
+        "VACUUM should compact the queued-IO workload"
+    );
+    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_reinitializes_source_wal_header_after_truncate_checkpoint(
+) -> anyhow::Result<()> {
+    // `wal_checkpoint(TRUNCATE)` leaves the source WAL uninitialized for the
+    // next writer. Plain VACUUM must rewrite and fsync that source WAL header
+    // before it starts copying compacted frames back into the source WAL.
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-source-wal-header-init.db";
+    let source_wal_path = format!("{path}-wal");
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let history_start = io.history_len();
+
+    let before_hash = compute_plain_vacuum_file_dbhash(path);
+    conn.execute("VACUUM")?;
+
+    let source_wal_events: Vec<QueuedIoEvent> = io
+        .history_since(history_start)
+        .into_iter()
+        .filter(|event| {
+            event.path == source_wal_path
+                && matches!(
+                    event.kind,
+                    QueuedIoOpKind::Pwrite | QueuedIoOpKind::Pwritev | QueuedIoOpKind::Sync
+                )
+        })
+        .collect();
+
+    let first_batch_write = source_wal_events
+        .iter()
+        .position(|event| event.kind == QueuedIoOpKind::Pwritev)
+        .expect("VACUUM should write copied frames into the source WAL");
+    let header_write = source_wal_events
+        .iter()
+        .position(|event| event.kind == QueuedIoOpKind::Pwrite)
+        .expect("VACUUM should rewrite the source WAL header after TRUNCATE");
+    let header_sync = source_wal_events
+        .iter()
+        .position(|event| event.kind == QueuedIoOpKind::Sync)
+        .expect("VACUUM should fsync the rewritten source WAL header before copy-back");
+
+    assert!(
+        header_write < header_sync,
+        "source WAL header write must complete before its fsync"
+    );
+    assert!(
+        header_sync < first_batch_write,
+        "source WAL header must be rewritten and fsynced before the first copied frame batch"
+    );
+
+    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_second_statement_same_connection_fails_while_first_active(
+) -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-same-conn-active.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let before_hash = compute_plain_vacuum_file_dbhash(path);
+
+    let mut first = conn.prepare("VACUUM")?;
+    loop {
+        match first.step()? {
+            StepResult::Done => {
+                anyhow::bail!("VACUUM finished before reaching an in-flight IO state")
+            }
+            StepResult::Row => continue,
+            StepResult::Busy => anyhow::bail!("unexpected Busy while staging first VACUUM"),
+            StepResult::Interrupt => {
+                anyhow::bail!("unexpected Interrupt while staging first VACUUM")
+            }
+            StepResult::IO => {
+                if !conn.get_auto_commit() {
+                    break;
+                }
+                io.step()?;
+            }
+        }
+    }
+
+    let mut second = conn.prepare("VACUUM")?;
+    let err = second
+        .step()
+        .expect_err("second VACUUM on the same connection should fail while the first is active");
+    let message = err.to_string();
+    assert_eq!(
+        message, "Transaction error: cannot VACUUM from within a transaction",
+        "expected same-connection VACUUM rejection, got {err:?}"
+    );
+
+    loop {
+        match first.step()? {
+            StepResult::Done => break,
+            StepResult::Row => continue,
+            StepResult::Busy => anyhow::bail!("unexpected Busy while completing first VACUUM"),
+            StepResult::Interrupt => {
+                anyhow::bail!("unexpected Interrupt while completing first VACUUM")
+            }
+            StepResult::IO => io.step()?,
+        }
+    }
+
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 176);
+    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+    Ok(())
+}
+
+fn assert_failed_vacuum_left_queued_db_usable(
+    conn: &Arc<Connection>,
+    pre_pages: i64,
+) -> anyhow::Result<()> {
+    assert_eq!(
+        scalar_i64(conn, "PRAGMA page_count"),
+        pre_pages,
+        "failed VACUUM must not publish a partial compacted image"
+    );
+    assert_eq!(scalar_i64(conn, "SELECT COUNT(*) FROM t"), 176);
+    assert_eq!(
+        scalar_i64(conn, "SELECT COUNT(*) FROM t WHERE payload = '{}'",),
+        0
+    );
+    conn.execute("INSERT INTO t VALUES(10000, 'after-failure')")?;
+    conn.execute("DELETE FROM t WHERE id = 10000")?;
+    assert_eq!(run_integrity_check(conn), "ok");
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_source_wal_first_batch_write_failure_rolls_back() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-first-write-failure.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+
+    io.fail_after_successes("-wal", QueuedIoOpKind::Pwritev, 0);
+    let err = conn.execute("VACUUM").unwrap_err();
+    io.clear_fault();
+    assert_eq!(
+        err.to_string(),
+        "Completion was aborted",
+        "unexpected error for first batch write fault: {err}"
+    );
+
+    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
+    let before_hash = compute_plain_vacuum_file_dbhash(path);
+    conn.execute("VACUUM")?;
+    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
+    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_source_wal_later_batch_write_failure_rolls_back() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-later-write-failure.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+
+    io.fail_after_successes("-wal", QueuedIoOpKind::Pwritev, 1);
+    let err = conn.execute("VACUUM").unwrap_err();
+    io.clear_fault();
+    assert_eq!(
+        err.to_string(),
+        "Completion was aborted",
+        "unexpected error for later batch write fault: {err}"
+    );
+
+    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
+    let before_hash = compute_plain_vacuum_file_dbhash(path);
+    conn.execute("VACUUM")?;
+    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
+    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_source_wal_sync_failure_rolls_back() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-sync-failure.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+
+    io.fail_after_successes("-wal", QueuedIoOpKind::Sync, 0);
+    let err = conn.execute("VACUUM").unwrap_err();
+    io.clear_fault();
+    assert_eq!(
+        err.to_string(),
+        "Completion was aborted",
+        "unexpected error for source WAL sync fault: {err}"
+    );
+
+    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
+    let before_hash = compute_plain_vacuum_file_dbhash(path);
+    conn.execute("VACUUM")?;
+    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
+    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_reset_during_checkpoint_io_cleans_up_checkpoint_and_vacuum_locks(
+) -> anyhow::Result<()> {
+    // Park plain VACUUM after copy-back has committed but while the final
+    // TRUNCATE checkpoint is still yielding I/O. Resetting the statement from
+    // that state exercises the fallback `AbortCheckpoint` cleanup path in
+    // `vacuum_in_place_cleanup()`: it must tear down checkpoint state and
+    // release the VACUUM gate so a fresh reader, checkpoint, and VACUUM can
+    // all proceed on the same database afterward.
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-reset-during-checkpoint.db";
+    let source_wal_path = format!("{path}-wal");
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+
+    let mut stmt = conn.prepare("VACUUM")?;
+    let mut saw_source_wal_batch_write = false;
+    let mut reached_checkpoint_io = false;
+
+    loop {
+        match stmt.step()? {
+            StepResult::Done => {
+                anyhow::bail!("VACUUM finished before reaching checkpoint I/O")
+            }
+            StepResult::Row => continue,
+            StepResult::Busy | StepResult::Interrupt => {
+                anyhow::bail!("unexpected non-IO result while staging checkpoint cleanup test")
+            }
+            StepResult::IO => {
+                while let Some(event) = io.step_one()? {
+                    if event.path == source_wal_path && event.kind == QueuedIoOpKind::Pwritev {
+                        saw_source_wal_batch_write = true;
+                    }
+
+                    if saw_source_wal_batch_write
+                        && event.path == path
+                        && matches!(
+                            event.kind,
+                            QueuedIoOpKind::Pwrite
+                                | QueuedIoOpKind::Sync
+                                | QueuedIoOpKind::Truncate
+                        )
+                    {
+                        reached_checkpoint_io = true;
+                        break;
+                    }
+                }
+
+                if reached_checkpoint_io {
+                    break;
+                }
+            }
+        }
+    }
+
+    stmt.reset()?;
+
+    let reader = db.connect()?;
+    assert_eq!(scalar_i64(&reader, "SELECT COUNT(*) FROM t"), 176);
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    let before_hash = compute_plain_vacuum_file_dbhash(path);
+    conn.execute("VACUUM")?;
+    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_crash_after_nonfinal_source_wal_batch_recovers_original() -> anyhow::Result<()>
+{
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-vacuum-crash-after-nonfinal-batch.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(
+        pre_pages > 64,
+        "crash test requires a non-final first batch"
+    );
+
+    let mut stmt = conn.prepare("VACUUM")?;
+    loop {
+        match stmt.step()? {
+            StepResult::Done => {
+                panic!("VACUUM finished before source WAL batch write was observed")
+            }
+            StepResult::Row => continue,
+            StepResult::Busy | StepResult::Interrupt => {
+                panic!("unexpected non-IO VACUUM result during crash test")
+            }
+            StepResult::IO => {
+                while let Some(event) = io.step_one()? {
+                    if event.path.ends_with("-wal") && event.kind == QueuedIoOpKind::Pwritev {
+                        std::mem::forget(stmt);
+                        std::mem::forget(conn);
+                        std::mem::forget(db);
+
+                        let reopened = open_queued_db(io.clone(), path)?;
+                        let reopened_conn = reopened.connect()?;
+                        assert_eq!(
+                            scalar_i64(&reopened_conn, "PRAGMA page_count"),
+                            pre_pages,
+                            "non-final VACUUM frames without a commit marker must be ignored on recovery"
+                        );
+                        assert_eq!(scalar_i64(&reopened_conn, "SELECT COUNT(*) FROM t"), 176);
+                        assert_eq!(run_integrity_check(&reopened_conn), "ok");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
 }

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -2055,7 +2055,7 @@ fn test_vacuum_into_with_mixed_index_types(tmp_db: TempDatabase) -> anyhow::Resu
 /// Test VACUUM INTO preserves MVCC journal mode from source database.
 /// If source has mvcc enabled, destination should too.
 #[turso_macros::test]
-fn test_vacuum_into_preserves_mvcc(tmp_db: TempDatabase) -> anyhow::Result<()> {
+fn test_vacuum_into_preserves_mvcc_after_reopen(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
     conn.execute("PRAGMA journal_mode = 'mvcc'")?;
     let source_mode: Vec<(String,)> = conn.exec_rows("PRAGMA journal_mode");
@@ -2098,6 +2098,49 @@ fn test_vacuum_into_preserves_mvcc(tmp_db: TempDatabase) -> anyhow::Result<()> {
         rows,
         vec![(1, "hello".to_string()), (2, "world".to_string())]
     );
+
+    drop(dest_conn);
+    drop(dest_db);
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&dest_path, tmp_db.db_opts);
+    let reopened_conn = reopened.connect_limbo();
+    let reopened_mode: Vec<(String,)> = reopened_conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(reopened_mode, vec![("mvcc".to_string(),)]);
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+    let reopened_rows: Vec<(i64, String)> =
+        reopened_conn.exec_rows("SELECT id, data FROM t ORDER BY id");
+    assert_eq!(
+        reopened_rows,
+        vec![(1, "hello".to_string()), (2, "world".to_string())]
+    );
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_plain_vacuum_preserves_mvcc_after_reopen(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = 'mvcc'")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT)")?;
+    conn.execute("INSERT INTO t VALUES (1, 'hello'), (2, 'world')")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    conn.execute("VACUUM")?;
+    assert_eq!(run_integrity_check(&conn), "ok");
+    let journal_mode: Vec<(String,)> = conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode, vec![("mvcc".to_string(),)]);
+
+    let path = tmp_db.path.clone();
+    let opts = tmp_db.db_opts;
+    drop(conn);
+    drop(tmp_db);
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&path, opts);
+    let reopened_conn = reopened.connect_limbo();
+    let journal_mode: Vec<(String,)> = reopened_conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode, vec![("mvcc".to_string(),)]);
+    assert_eq!(run_integrity_check(&reopened_conn), "ok");
+    assert_eq!(scalar_i64(&reopened_conn, "SELECT COUNT(*) FROM t"), 2);
 
     Ok(())
 }

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -6439,9 +6439,15 @@ fn test_plain_vacuum_reset_during_checkpoint_io_cleans_up_checkpoint_and_vacuum_
     let reader = db.connect()?;
     assert_eq!(scalar_i64(&reader, "SELECT COUNT(*) FROM t"), 176);
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
-    let before_hash = compute_plain_vacuum_file_dbhash(path);
+    let before_schema = normalized_schema_snapshot(&conn);
     conn.execute("VACUUM")?;
-    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 176);
+    assert_eq!(
+        normalized_schema_snapshot(&conn),
+        before_schema,
+        "plain VACUUM should preserve normalized sqlite_schema entries"
+    );
 
     Ok(())
 }

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -2,11 +2,11 @@ use crate::common::{
     compute_dbhash, compute_dbhash_with_database_opts, compute_dbhash_with_options,
     compute_dbhash_with_options_and_database_opts, do_flush, ExecRows, TempDatabase,
 };
-use crate::queued_io::{QueuedIo, QueuedIoEvent, QueuedIoOpKind};
+use crate::queued_io::{QueuedIo, QueuedIoOpKind};
 use rusqlite::Connection as SqliteConnection;
 use std::{path::Path, sync::Arc};
 use tempfile::TempDir;
-use turso_core::{Connection, Database, DatabaseOpts, LimboError, StepResult, Value, IO};
+use turso_core::{Connection, Database, DatabaseOpts, LimboError, StepResult, Value};
 use turso_parser::{ast::Cmd, parser::Parser};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,21 +82,6 @@ fn compute_plain_vacuum_dbhash(tmp_db: &TempDatabase) -> PlainVacuumInvariant {
     }
 }
 
-fn compute_plain_vacuum_file_dbhash(path: &str) -> PlainVacuumInvariant {
-    let options = turso_dbhash::DbHashOptions {
-        without_schema: true,
-        ..Default::default()
-    };
-    let reopened = TempDatabase::new_with_existent_with_opts(Path::new(path), DatabaseOpts::new());
-    let reopened_conn = reopened.connect_limbo();
-    PlainVacuumInvariant {
-        hash: turso_dbhash::hash_database(path, &options)
-            .expect("dbhash failed")
-            .hash,
-        normalized_schema: normalized_schema_snapshot(&reopened_conn),
-    }
-}
-
 fn assert_plain_vacuum_integrity_and_hash(
     tmp_db: &TempDatabase,
     conn: &Arc<Connection>,
@@ -105,24 +90,6 @@ fn assert_plain_vacuum_integrity_and_hash(
     assert_eq!(run_integrity_check(conn), "ok");
     assert_eq!(
         compute_plain_vacuum_dbhash(tmp_db).hash,
-        expected.hash,
-        "plain VACUUM should preserve logical database content"
-    );
-    assert_eq!(
-        normalized_schema_snapshot(conn),
-        expected.normalized_schema,
-        "plain VACUUM should preserve normalized sqlite_schema entries"
-    );
-}
-
-fn assert_plain_vacuum_integrity_and_hash_for_path(
-    path: &str,
-    conn: &Arc<Connection>,
-    expected: &PlainVacuumInvariant,
-) {
-    assert_eq!(run_integrity_check(conn), "ok");
-    assert_eq!(
-        compute_plain_vacuum_file_dbhash(path).hash,
         expected.hash,
         "plain VACUUM should preserve logical database content"
     );
@@ -6129,261 +6096,6 @@ fn populate_queued_multibatch(conn: &Arc<Connection>) -> anyhow::Result<()> {
 
 #[cfg_attr(feature = "checksum", ignore)]
 #[test]
-fn test_plain_vacuum_queued_io_reentry_multi_batch() -> anyhow::Result<()> {
-    // Exercises the queued-IO async path for a multi-batch plain VACUUM and
-    // asserts the source WAL copy-back re-enters cleanly across more than one
-    // batched read/write cycle.
-    let io = Arc::new(QueuedIo::new());
-    let path = "queued-vacuum-reentry.db";
-    let db = open_queued_db(io.clone(), path)?;
-    let conn = db.connect()?;
-
-    populate_queued_multibatch(&conn)?;
-    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
-    assert!(pre_pages > 64, "queued IO workload should be multi-batch");
-
-    let before_hash = compute_plain_vacuum_file_dbhash(path);
-    conn.execute("VACUUM")?;
-
-    assert!(
-        io.count_events("-wal", QueuedIoOpKind::Pread) > 0,
-        "batch reads should issue queued WAL preads"
-    );
-    assert!(
-        io.count_events("-wal", QueuedIoOpKind::Pwritev) > 1,
-        "multi-batch copy-back should issue multiple source WAL pwritev operations"
-    );
-    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 176);
-    assert!(
-        scalar_i64(&conn, "PRAGMA page_count") < pre_pages,
-        "VACUUM should compact the queued-IO workload"
-    );
-    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
-    Ok(())
-}
-
-#[cfg_attr(feature = "checksum", ignore)]
-#[test]
-fn test_plain_vacuum_reinitializes_source_wal_header_after_truncate_checkpoint(
-) -> anyhow::Result<()> {
-    // `wal_checkpoint(TRUNCATE)` leaves the source WAL uninitialized for the
-    // next writer. Plain VACUUM must rewrite and fsync that source WAL header
-    // before it starts copying compacted frames back into the source WAL.
-    let io = Arc::new(QueuedIo::new());
-    let path = "queued-vacuum-source-wal-header-init.db";
-    let source_wal_path = format!("{path}-wal");
-    let db = open_queued_db(io.clone(), path)?;
-    let conn = db.connect()?;
-
-    populate_queued_multibatch(&conn)?;
-    let history_start = io.history_len();
-
-    let before_hash = compute_plain_vacuum_file_dbhash(path);
-    conn.execute("VACUUM")?;
-
-    let source_wal_events: Vec<QueuedIoEvent> = io
-        .history_since(history_start)
-        .into_iter()
-        .filter(|event| {
-            event.path == source_wal_path
-                && matches!(
-                    event.kind,
-                    QueuedIoOpKind::Pwrite | QueuedIoOpKind::Pwritev | QueuedIoOpKind::Sync
-                )
-        })
-        .collect();
-
-    let first_batch_write = source_wal_events
-        .iter()
-        .position(|event| event.kind == QueuedIoOpKind::Pwritev)
-        .expect("VACUUM should write copied frames into the source WAL");
-    let header_write = source_wal_events
-        .iter()
-        .position(|event| event.kind == QueuedIoOpKind::Pwrite)
-        .expect("VACUUM should rewrite the source WAL header after TRUNCATE");
-    let header_sync = source_wal_events
-        .iter()
-        .position(|event| event.kind == QueuedIoOpKind::Sync)
-        .expect("VACUUM should fsync the rewritten source WAL header before copy-back");
-
-    assert!(
-        header_write < header_sync,
-        "source WAL header write must complete before its fsync"
-    );
-    assert!(
-        header_sync < first_batch_write,
-        "source WAL header must be rewritten and fsynced before the first copied frame batch"
-    );
-
-    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
-    Ok(())
-}
-
-#[cfg_attr(feature = "checksum", ignore)]
-#[test]
-fn test_plain_vacuum_second_statement_same_connection_fails_while_first_active(
-) -> anyhow::Result<()> {
-    let io = Arc::new(QueuedIo::new());
-    let path = "queued-vacuum-same-conn-active.db";
-    let db = open_queued_db(io.clone(), path)?;
-    let conn = db.connect()?;
-
-    populate_queued_multibatch(&conn)?;
-    let before_hash = compute_plain_vacuum_file_dbhash(path);
-
-    let mut first = conn.prepare("VACUUM")?;
-    loop {
-        match first.step()? {
-            StepResult::Done => {
-                anyhow::bail!("VACUUM finished before reaching an in-flight IO state")
-            }
-            StepResult::Row => continue,
-            StepResult::Busy => anyhow::bail!("unexpected Busy while staging first VACUUM"),
-            StepResult::Interrupt => {
-                anyhow::bail!("unexpected Interrupt while staging first VACUUM")
-            }
-            StepResult::IO => {
-                if !conn.get_auto_commit() {
-                    break;
-                }
-                io.step()?;
-            }
-        }
-    }
-
-    let mut second = conn.prepare("VACUUM")?;
-    let err = second
-        .step()
-        .expect_err("second VACUUM on the same connection should fail while the first is active");
-    let message = err.to_string();
-    assert_eq!(
-        message, "Transaction error: cannot VACUUM from within a transaction",
-        "expected same-connection VACUUM rejection, got {err:?}"
-    );
-
-    loop {
-        match first.step()? {
-            StepResult::Done => break,
-            StepResult::Row => continue,
-            StepResult::Busy => anyhow::bail!("unexpected Busy while completing first VACUUM"),
-            StepResult::Interrupt => {
-                anyhow::bail!("unexpected Interrupt while completing first VACUUM")
-            }
-            StepResult::IO => io.step()?,
-        }
-    }
-
-    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 176);
-    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
-    Ok(())
-}
-
-fn assert_failed_vacuum_left_queued_db_usable(
-    conn: &Arc<Connection>,
-    pre_pages: i64,
-) -> anyhow::Result<()> {
-    assert_eq!(
-        scalar_i64(conn, "PRAGMA page_count"),
-        pre_pages,
-        "failed VACUUM must not publish a partial compacted image"
-    );
-    assert_eq!(scalar_i64(conn, "SELECT COUNT(*) FROM t"), 176);
-    assert_eq!(
-        scalar_i64(conn, "SELECT COUNT(*) FROM t WHERE payload = '{}'",),
-        0
-    );
-    conn.execute("INSERT INTO t VALUES(10000, 'after-failure')")?;
-    conn.execute("DELETE FROM t WHERE id = 10000")?;
-    assert_eq!(run_integrity_check(conn), "ok");
-    Ok(())
-}
-
-#[cfg_attr(feature = "checksum", ignore)]
-#[test]
-fn test_plain_vacuum_source_wal_first_batch_write_failure_rolls_back() -> anyhow::Result<()> {
-    let io = Arc::new(QueuedIo::new());
-    let path = "queued-vacuum-first-write-failure.db";
-    let db = open_queued_db(io.clone(), path)?;
-    let conn = db.connect()?;
-
-    populate_queued_multibatch(&conn)?;
-    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
-
-    io.fail_after_successes("-wal", QueuedIoOpKind::Pwritev, 0);
-    let err = conn.execute("VACUUM").unwrap_err();
-    io.clear_fault();
-    assert_eq!(
-        err.to_string(),
-        "Completion was aborted",
-        "unexpected error for first batch write fault: {err}"
-    );
-
-    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
-    let before_hash = compute_plain_vacuum_file_dbhash(path);
-    conn.execute("VACUUM")?;
-    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
-    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
-    Ok(())
-}
-
-#[cfg_attr(feature = "checksum", ignore)]
-#[test]
-fn test_plain_vacuum_source_wal_later_batch_write_failure_rolls_back() -> anyhow::Result<()> {
-    let io = Arc::new(QueuedIo::new());
-    let path = "queued-vacuum-later-write-failure.db";
-    let db = open_queued_db(io.clone(), path)?;
-    let conn = db.connect()?;
-
-    populate_queued_multibatch(&conn)?;
-    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
-
-    io.fail_after_successes("-wal", QueuedIoOpKind::Pwritev, 1);
-    let err = conn.execute("VACUUM").unwrap_err();
-    io.clear_fault();
-    assert_eq!(
-        err.to_string(),
-        "Completion was aborted",
-        "unexpected error for later batch write fault: {err}"
-    );
-
-    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
-    let before_hash = compute_plain_vacuum_file_dbhash(path);
-    conn.execute("VACUUM")?;
-    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
-    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
-    Ok(())
-}
-
-#[cfg_attr(feature = "checksum", ignore)]
-#[test]
-fn test_plain_vacuum_source_wal_sync_failure_rolls_back() -> anyhow::Result<()> {
-    let io = Arc::new(QueuedIo::new());
-    let path = "queued-vacuum-sync-failure.db";
-    let db = open_queued_db(io.clone(), path)?;
-    let conn = db.connect()?;
-
-    populate_queued_multibatch(&conn)?;
-    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
-
-    io.fail_after_successes("-wal", QueuedIoOpKind::Sync, 0);
-    let err = conn.execute("VACUUM").unwrap_err();
-    io.clear_fault();
-    assert_eq!(
-        err.to_string(),
-        "Completion was aborted",
-        "unexpected error for source WAL sync fault: {err}"
-    );
-
-    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
-    let before_hash = compute_plain_vacuum_file_dbhash(path);
-    conn.execute("VACUUM")?;
-    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
-    assert_plain_vacuum_integrity_and_hash_for_path(path, &conn, &before_hash);
-    Ok(())
-}
-
-#[cfg_attr(feature = "checksum", ignore)]
-#[test]
 fn test_plain_vacuum_reset_during_checkpoint_io_cleans_up_checkpoint_and_vacuum_locks(
 ) -> anyhow::Result<()> {
     // Park plain VACUUM after copy-back has committed but while the final
@@ -6456,54 +6168,4 @@ fn test_plain_vacuum_reset_during_checkpoint_io_cleans_up_checkpoint_and_vacuum_
     );
 
     Ok(())
-}
-
-#[cfg_attr(feature = "checksum", ignore)]
-#[test]
-fn test_plain_vacuum_crash_after_nonfinal_source_wal_batch_recovers_original() -> anyhow::Result<()>
-{
-    let io = Arc::new(QueuedIo::new());
-    let path = "queued-vacuum-crash-after-nonfinal-batch.db";
-    let db = open_queued_db(io.clone(), path)?;
-    let conn = db.connect()?;
-
-    populate_queued_multibatch(&conn)?;
-    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
-    assert!(
-        pre_pages > 64,
-        "crash test requires a non-final first batch"
-    );
-
-    let mut stmt = conn.prepare("VACUUM")?;
-    loop {
-        match stmt.step()? {
-            StepResult::Done => {
-                panic!("VACUUM finished before source WAL batch write was observed")
-            }
-            StepResult::Row => continue,
-            StepResult::Busy | StepResult::Interrupt => {
-                panic!("unexpected non-IO VACUUM result during crash test")
-            }
-            StepResult::IO => {
-                while let Some(event) = io.step_one()? {
-                    if event.path.ends_with("-wal") && event.kind == QueuedIoOpKind::Pwritev {
-                        std::mem::forget(stmt);
-                        std::mem::forget(conn);
-                        std::mem::forget(db);
-
-                        let reopened = open_queued_db(io.clone(), path)?;
-                        let reopened_conn = reopened.connect()?;
-                        assert_eq!(
-                            scalar_i64(&reopened_conn, "PRAGMA page_count"),
-                            pre_pages,
-                            "non-final VACUUM frames without a commit marker must be ignored on recovery"
-                        );
-                        assert_eq!(scalar_i64(&reopened_conn, "SELECT COUNT(*) FROM t"), 176);
-                        assert_eq!(run_integrity_check(&reopened_conn), "ok");
-                        return Ok(());
-                    }
-                }
-            }
-        }
-    }
 }

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -445,10 +445,11 @@ fn test_vacuum_into_basic(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
 /// Test VACUUM INTO error cases: plain VACUUM, existing file, within
 /// transaction, and query_only mode.
-#[turso_macros::test(mvcc, init_sql = "CREATE TABLE t (a INTEGER);")]
+#[turso_macros::test(mvcc)]
 fn test_vacuum_into_error_cases(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER)")?;
     conn.execute("INSERT INTO t VALUES (1)")?;
 
     let dest_dir = TempDir::new()?;

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -3546,9 +3546,7 @@ fn test_plain_vacuum_reduces_page_count(tmp_db: TempDatabase) -> anyhow::Result<
 
     // VACUUM includes a TRUNCATE checkpoint, so the WAL should be empty.
     let wal_path = format!("{}-wal", tmp_db.path.display());
-    let wal_size = std::fs::metadata(&wal_path)
-        .map(|m| m.len())
-        .unwrap_or(0);
+    let wal_size = std::fs::metadata(&wal_path).map(|m| m.len()).unwrap_or(0);
     assert_eq!(wal_size, 0, "WAL should be truncated to zero after VACUUM");
 
     // Data integrity: the 10 remaining rows should be intact.

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -3945,6 +3945,36 @@ fn test_plain_vacuum_empty_schema_physical_contract() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_empty();
     let conn = tmp_db.connect_limbo();
 
+    // A truly empty DB (page 1 never allocated) is not a valid VACUUM target —
+    // an existing database that "looks empty" indicates a problem, not a no-op.
+    let err = conn
+        .execute("VACUUM")
+        .expect_err("VACUUM on an uninitialized database should return an error");
+    assert!(
+        err.to_string().contains("initialized"),
+        "expected initialization error, got: {err}"
+    );
+    Ok(())
+}
+
+/// Initialized DB whose user schema has been fully torn down — page 1 exists,
+/// but there are no user tables or indexes. VACUUM must succeed and leave the
+/// DB queryable at the minimum page count.
+///
+/// FIXME: currently ignored because Turso's VACUUM does not reclaim the root
+/// page of the dropped table. SQLite produces page_count=1 for the same
+/// sequence; Turso produces page_count > 1. The integrity_check passes, so
+/// this is a compaction/correctness gap in the target-pager rebuild rather
+/// than a data-loss bug.
+#[ignore = "VACUUM does not reclaim dropped-table root pages (diverges from SQLite)"]
+#[test]
+fn test_plain_vacuum_initialized_but_empty_schema() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE _scratch(i)")?;
+    conn.execute("DROP TABLE _scratch")?;
+
     conn.execute("VACUUM")?;
 
     assert!(
@@ -3952,7 +3982,9 @@ fn test_plain_vacuum_empty_schema_physical_contract() -> anyhow::Result<()> {
         "empty schema should stay at the minimum page count"
     );
     assert_eq!(run_integrity_check(&conn), "ok");
-    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    let tables: Vec<(i64,)> =
+        conn.exec_rows("SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table'");
+    assert_eq!(tables[0].0, 0, "no user tables should remain after DROP");
     Ok(())
 }
 

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -3555,3 +3555,113 @@ fn test_plain_vacuum_reduces_page_count(tmp_db: TempDatabase) -> anyhow::Result<
     assert_eq!(run_integrity_check(&conn), "ok");
     Ok(())
 }
+
+/// Plain VACUUM on a workload with several tables and indexes, large enough
+/// to span multiple copy-back batches and exercise a non-monotonic
+/// page→frame map in the temp WAL. This is the path that drives
+/// `coalesce_frame_runs` to build more than one run per batch.
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_multi_table_multi_batch() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE c(id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE INDEX idx_a_v ON a(v)")?;
+    conn.execute("CREATE INDEX idx_b_v ON b(v)")?;
+    conn.execute("CREATE INDEX idx_c_v ON c(v)")?;
+
+    // Enough rows to push total_pages past VACUUM_COPY_BATCH_SIZE (64) so the
+    // batch path is hit more than once, and to grow each table's b-tree
+    // across several pages so target-build interleaves table/index frames.
+    for i in 0..800 {
+        conn.execute(format!(
+            "INSERT INTO a VALUES({i}, '{}')",
+            "a".repeat(200)
+        ))?;
+        conn.execute(format!(
+            "INSERT INTO b VALUES({i}, '{}')",
+            "b".repeat(200)
+        ))?;
+        conn.execute(format!(
+            "INSERT INTO c VALUES({i}, '{}')",
+            "c".repeat(200)
+        ))?;
+    }
+    // Delete half of each table so the pre-VACUUM image has freelist holes.
+    conn.execute("DELETE FROM a WHERE id % 2 = 0")?;
+    conn.execute("DELETE FROM b WHERE id % 2 = 0")?;
+    conn.execute("DELETE FROM c WHERE id % 2 = 0")?;
+
+    let pre_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert!(
+        pre_pages[0].0 > 64,
+        "workload should span multiple copy-back batches, got page_count={}",
+        pre_pages[0].0
+    );
+
+    conn.execute("VACUUM")?;
+
+    // Row counts preserved.
+    let counts: Vec<(i64,)> = conn
+        .exec_rows("SELECT (SELECT COUNT(*) FROM a) + (SELECT COUNT(*) FROM b) + (SELECT COUNT(*) FROM c)");
+    assert_eq!(counts[0].0, 1200);
+
+    // Index-covered reads still work.
+    let via_idx_a: Vec<(i64,)> = conn.exec_rows("SELECT id FROM a WHERE v = 'aaaaaaaa' ORDER BY id");
+    assert_eq!(via_idx_a.len(), 0); // sanity: no row matches short value
+    let via_idx_b: Vec<(i64,)> =
+        conn.exec_rows("SELECT COUNT(*) FROM b WHERE v LIKE 'b%'");
+    assert_eq!(via_idx_b[0].0, 400);
+
+    // Spot-check specific rows round-trip.
+    let a_one: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM a WHERE id = 1");
+    assert_eq!(a_one.len(), 1);
+    assert_eq!(a_one[0], (1, "a".repeat(200)));
+    let c_last: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM c WHERE id = 799");
+    assert_eq!(c_last.len(), 1);
+    assert_eq!(c_last[0], (799, "c".repeat(200)));
+
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Plain VACUUM on an encrypted source database. Exercises the per-frame
+/// decrypt branch inside `Wal::read_frames_batch`: encryption is
+/// propagated to the temp pager (see `vacuum_temp_db_encryption`), so the
+/// batch read path decrypts each frame before feeding it into the source
+/// WAL write batch.
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_encrypted() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute(
+        "PRAGMA hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327'",
+    )?;
+    conn.execute("PRAGMA cipher = 'aegis256'")?;
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+    for i in 0..150 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", "z".repeat(80)))?;
+    }
+    conn.execute("DELETE FROM t WHERE id >= 30")?;
+
+    conn.execute("VACUUM")?;
+
+    // Data round-trips through encrypted temp WAL → encrypted source WAL.
+    let count: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(count[0].0, 30);
+    let first: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t WHERE id = 0");
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0], (0, "z".repeat(80)));
+    let last: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t WHERE id = 29");
+    assert_eq!(last.len(), 1);
+    assert_eq!(last[0], (29, "z".repeat(80)));
+
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -3,9 +3,16 @@ use crate::common::{
     compute_dbhash_with_options_and_database_opts, ExecRows, TempDatabase,
 };
 use rusqlite::Connection as SqliteConnection;
-use std::sync::Arc;
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
 use tempfile::TempDir;
-use turso_core::{Connection, StepResult, Value};
+use turso_core::{
+    io::{FileId, FileSyncType},
+    Buffer, Clock, Completion, Connection, Database, File, MonotonicInstant, OpenFlags, StepResult,
+    Value, WallClockInstant, IO,
+};
 
 /// Helper to run integrity_check and return the result string
 fn run_integrity_check(conn: &Arc<Connection>) -> String {
@@ -29,6 +36,341 @@ fn run_integrity_check(conn: &Arc<Connection>) -> String {
 
 fn escape_sqlite_string_literal(text: &str) -> String {
     text.replace('\'', "''")
+}
+
+fn scalar_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
+    let rows: Vec<(i64,)> = conn.exec_rows(sql);
+    assert_eq!(rows.len(), 1, "expected one row for {sql}");
+    rows[0].0
+}
+
+fn wal_file_size(tmp_db: &TempDatabase) -> u64 {
+    let wal_path = format!("{}-wal", tmp_db.path.display());
+    std::fs::metadata(wal_path).map(|m| m.len()).unwrap_or(0)
+}
+
+fn assert_plain_vacuum_folded_into_db_file(tmp_db: &TempDatabase, conn: &Arc<Connection>) {
+    let page_count = scalar_i64(conn, "PRAGMA page_count") as u64;
+    let page_size = scalar_i64(conn, "PRAGMA page_size") as u64;
+    let db_size = std::fs::metadata(&tmp_db.path)
+        .unwrap_or_else(|err| panic!("database file should exist after VACUUM: {err}"))
+        .len();
+
+    assert_eq!(
+        db_size,
+        page_count * page_size,
+        "VACUUM should checkpoint the compacted image into the db file"
+    );
+    assert_eq!(
+        wal_file_size(tmp_db),
+        0,
+        "VACUUM should truncate the source WAL after checkpoint"
+    );
+}
+
+fn populate_until_page_count(
+    conn: &Arc<Connection>,
+    target_pages: i64,
+    payload_len: usize,
+) -> anyhow::Result<i64> {
+    let payload = "x".repeat(payload_len);
+    let mut next_id = 0_i64;
+
+    loop {
+        let page_count = scalar_i64(conn, "PRAGMA page_count");
+        if page_count == target_pages {
+            return Ok(next_id);
+        }
+        assert!(
+            page_count < target_pages,
+            "page_count skipped target {target_pages}; current={page_count}, rows={next_id}"
+        );
+        conn.execute(format!(
+            "INSERT INTO t VALUES({next_id}, '{}')",
+            escape_sqlite_string_literal(&payload)
+        ))?;
+        next_id += 1;
+        assert!(
+            next_id < target_pages * 20 + 100,
+            "could not reach page_count {target_pages}"
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum QueuedIoOpKind {
+    Pread,
+    Pwrite,
+    Pwritev,
+    Sync,
+    Truncate,
+}
+
+#[derive(Clone, Debug)]
+struct QueuedIoEvent {
+    path: String,
+    kind: QueuedIoOpKind,
+}
+
+struct QueuedIoOp {
+    event: QueuedIoEvent,
+    action: Box<dyn FnOnce() -> turso_core::Result<()> + Send>,
+}
+
+#[derive(Debug)]
+struct QueuedIoFault {
+    path_suffix: String,
+    kind: QueuedIoOpKind,
+    allowed_successes: usize,
+    seen: usize,
+}
+
+struct QueuedIoState {
+    pending: Mutex<VecDeque<QueuedIoOp>>,
+    history: Mutex<Vec<QueuedIoEvent>>,
+    fault: Mutex<Option<QueuedIoFault>>,
+}
+
+impl QueuedIoState {
+    fn new() -> Self {
+        Self {
+            pending: Mutex::new(VecDeque::new()),
+            history: Mutex::new(Vec::new()),
+            fault: Mutex::new(None),
+        }
+    }
+}
+
+struct QueuedIo {
+    inner: Arc<dyn IO>,
+    state: Arc<QueuedIoState>,
+}
+
+impl QueuedIo {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(turso_core::MemoryIO::new()),
+            state: Arc::new(QueuedIoState::new()),
+        }
+    }
+
+    fn fail_after_successes(
+        &self,
+        path_suffix: &str,
+        kind: QueuedIoOpKind,
+        allowed_successes: usize,
+    ) {
+        *self.state.fault.lock().unwrap() = Some(QueuedIoFault {
+            path_suffix: path_suffix.to_string(),
+            kind,
+            allowed_successes,
+            seen: 0,
+        });
+    }
+
+    fn clear_fault(&self) {
+        *self.state.fault.lock().unwrap() = None;
+    }
+
+    fn count_events(&self, path_suffix: &str, kind: QueuedIoOpKind) -> usize {
+        self.state
+            .history
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|event| event.path.ends_with(path_suffix) && event.kind == kind)
+            .count()
+    }
+
+    fn step_one(&self) -> turso_core::Result<Option<QueuedIoEvent>> {
+        let Some(op) = self.state.pending.lock().unwrap().pop_front() else {
+            return Ok(None);
+        };
+        let event = op.event.clone();
+        (op.action)()?;
+        self.state.history.lock().unwrap().push(event.clone());
+        Ok(Some(event))
+    }
+}
+
+impl Clock for QueuedIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for QueuedIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        let inner = self.inner.open_file(path, flags, direct)?;
+        Ok(Arc::new(QueuedFile {
+            path: path.to_string(),
+            inner,
+            state: self.state.clone(),
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.step_one().map(|_| ())
+    }
+
+    fn drain(&self) -> turso_core::Result<()> {
+        while self.step_one()?.is_some() {}
+        Ok(())
+    }
+
+    fn cancel(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        for completion in completions {
+            completion.abort();
+        }
+        Ok(())
+    }
+
+    fn file_id(&self, path: &str) -> turso_core::Result<FileId> {
+        self.inner.file_id(path)
+    }
+
+    fn fill_bytes(&self, dest: &mut [u8]) {
+        self.inner.fill_bytes(dest);
+    }
+
+    fn generate_random_number(&self) -> i64 {
+        self.inner.generate_random_number()
+    }
+}
+
+struct QueuedFile {
+    path: String,
+    inner: Arc<dyn File>,
+    state: Arc<QueuedIoState>,
+}
+
+impl QueuedFile {
+    fn enqueue(
+        &self,
+        kind: QueuedIoOpKind,
+        completion: Completion,
+        action: impl FnOnce() -> turso_core::Result<()> + Send + 'static,
+    ) -> turso_core::Result<Completion> {
+        let event = QueuedIoEvent {
+            path: self.path.clone(),
+            kind,
+        };
+        let fault_this_op = {
+            let mut fault = self.state.fault.lock().unwrap();
+            if let Some(fault) = fault.as_mut() {
+                if self.path.ends_with(&fault.path_suffix) && kind == fault.kind {
+                    fault.seen += 1;
+                    fault.seen > fault.allowed_successes
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        let queued_completion = completion.clone();
+        let queued_action: Box<dyn FnOnce() -> turso_core::Result<()> + Send> = if fault_this_op {
+            Box::new(move || {
+                queued_completion.abort();
+                Ok(())
+            })
+        } else {
+            Box::new(action)
+        };
+
+        self.state.pending.lock().unwrap().push_back(QueuedIoOp {
+            event,
+            action: queued_action,
+        });
+        Ok(completion)
+    }
+}
+
+impl File for QueuedFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, completion: Completion) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Pread, completion, move || {
+            let _ = inner.pread(pos, c)?;
+            Ok(())
+        })
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        completion: Completion,
+    ) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Pwrite, completion, move || {
+            let _ = inner.pwrite(pos, buffer, c)?;
+            Ok(())
+        })
+    }
+
+    fn sync(
+        &self,
+        completion: Completion,
+        sync_type: FileSyncType,
+    ) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Sync, completion, move || {
+            let _ = inner.sync(c, sync_type)?;
+            Ok(())
+        })
+    }
+
+    fn pwritev(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<Buffer>>,
+        completion: Completion,
+    ) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Pwritev, completion, move || {
+            let _ = inner.pwritev(pos, buffers, c)?;
+            Ok(())
+        })
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+
+    fn truncate(&self, len: u64, completion: Completion) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Truncate, completion, move || {
+            let _ = inner.truncate(len, c)?;
+            Ok(())
+        })
+    }
 }
 
 #[cfg_attr(feature = "checksum", ignore)]
@@ -3556,6 +3898,64 @@ fn test_plain_vacuum_reduces_page_count(tmp_db: TempDatabase) -> anyhow::Result<
     Ok(())
 }
 
+/// Plain VACUUM copy-back batch boundaries. The core unit tests assert the
+/// exact range math; this integration test builds compacted images around the
+/// 64-page boundary so the read/write batch state machine crosses one-page,
+/// exact-boundary, and one-over-boundary cases.
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_copy_batch_page_count_boundaries() -> anyhow::Result<()> {
+    for target_pages in [2_i64, 63, 64, 65, 128, 129] {
+        let tmp_db = TempDatabase::new_empty();
+        let conn = tmp_db.connect_limbo();
+        conn.execute("PRAGMA page_size = 512")?;
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")?;
+
+        let inserted = populate_until_page_count(&conn, target_pages, 350)?;
+        assert!(
+            inserted > 0 || target_pages == 2,
+            "boundary workload should insert rows for target {target_pages}"
+        );
+
+        conn.execute("VACUUM")?;
+
+        assert_eq!(
+            scalar_i64(&conn, "PRAGMA page_count"),
+            target_pages,
+            "VACUUM should preserve compacted page count for boundary target {target_pages}"
+        );
+        assert_eq!(
+            scalar_i64(&conn, "SELECT COUNT(*) FROM t"),
+            inserted,
+            "row count should survive boundary VACUUM for target {target_pages}"
+        );
+        assert_eq!(run_integrity_check(&conn), "ok");
+        assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    }
+
+    Ok(())
+}
+
+/// Truly empty databases exercise the lower edge of the copy-back setup: there
+/// may be no user schema pages to copy, but VACUUM still must leave the file
+/// usable and folded.
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_empty_schema_physical_contract() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("VACUUM")?;
+
+    assert!(
+        scalar_i64(&conn, "PRAGMA page_count") <= 1,
+        "empty schema should stay at the minimum page count"
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    Ok(())
+}
+
 /// Plain VACUUM on a workload with several tables and indexes, large enough
 /// to span multiple copy-back batches and exercise a non-monotonic
 /// page→frame map in the temp WAL. This is the path that drives
@@ -3577,18 +3977,9 @@ fn test_plain_vacuum_multi_table_multi_batch() -> anyhow::Result<()> {
     // batch path is hit more than once, and to grow each table's b-tree
     // across several pages so target-build interleaves table/index frames.
     for i in 0..800 {
-        conn.execute(format!(
-            "INSERT INTO a VALUES({i}, '{}')",
-            "a".repeat(200)
-        ))?;
-        conn.execute(format!(
-            "INSERT INTO b VALUES({i}, '{}')",
-            "b".repeat(200)
-        ))?;
-        conn.execute(format!(
-            "INSERT INTO c VALUES({i}, '{}')",
-            "c".repeat(200)
-        ))?;
+        conn.execute(format!("INSERT INTO a VALUES({i}, '{}')", "a".repeat(200)))?;
+        conn.execute(format!("INSERT INTO b VALUES({i}, '{}')", "b".repeat(200)))?;
+        conn.execute(format!("INSERT INTO c VALUES({i}, '{}')", "c".repeat(200)))?;
     }
     // Delete half of each table so the pre-VACUUM image has freelist holes.
     conn.execute("DELETE FROM a WHERE id % 2 = 0")?;
@@ -3605,15 +3996,16 @@ fn test_plain_vacuum_multi_table_multi_batch() -> anyhow::Result<()> {
     conn.execute("VACUUM")?;
 
     // Row counts preserved.
-    let counts: Vec<(i64,)> = conn
-        .exec_rows("SELECT (SELECT COUNT(*) FROM a) + (SELECT COUNT(*) FROM b) + (SELECT COUNT(*) FROM c)");
+    let counts: Vec<(i64,)> = conn.exec_rows(
+        "SELECT (SELECT COUNT(*) FROM a) + (SELECT COUNT(*) FROM b) + (SELECT COUNT(*) FROM c)",
+    );
     assert_eq!(counts[0].0, 1200);
 
     // Index-covered reads still work.
-    let via_idx_a: Vec<(i64,)> = conn.exec_rows("SELECT id FROM a WHERE v = 'aaaaaaaa' ORDER BY id");
+    let via_idx_a: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM a WHERE v = 'aaaaaaaa' ORDER BY id");
     assert_eq!(via_idx_a.len(), 0); // sanity: no row matches short value
-    let via_idx_b: Vec<(i64,)> =
-        conn.exec_rows("SELECT COUNT(*) FROM b WHERE v LIKE 'b%'");
+    let via_idx_b: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM b WHERE v LIKE 'b%'");
     assert_eq!(via_idx_b[0].0, 400);
 
     // Spot-check specific rows round-trip.
@@ -3624,6 +4016,143 @@ fn test_plain_vacuum_multi_table_multi_batch() -> anyhow::Result<()> {
     assert_eq!(c_last.len(), 1);
     assert_eq!(c_last[0], (799, "c".repeat(200)));
 
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Page-size coverage for the batched read/write path. Small pages force many
+/// frames; the large page checks that frame sizing and DB-file truncation do
+/// not assume the default 4096-byte page size.
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_page_size_variants_fold_and_integrity() -> anyhow::Result<()> {
+    for page_size in [512_i64, 1024, 4096, 65536] {
+        let tmp_db = TempDatabase::new_empty();
+        let conn = tmp_db.connect_limbo();
+        conn.execute(format!("PRAGMA page_size = {page_size}"))?;
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload BLOB, tag TEXT)")?;
+        conn.execute("CREATE INDEX idx_t_tag ON t(tag)")?;
+
+        let rows = if page_size <= 1024 { 180 } else { 40 };
+        let blob_size = if page_size <= 1024 { 1800 } else { 9000 };
+        for i in 0..rows {
+            conn.execute(format!(
+                "INSERT INTO t VALUES({i}, zeroblob({}), 'tag-{}')",
+                blob_size + i % 17,
+                i % 11
+            ))?;
+        }
+        conn.execute("DELETE FROM t WHERE id % 3 = 0")?;
+
+        let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+        conn.execute("VACUUM")?;
+
+        assert_eq!(scalar_i64(&conn, "PRAGMA page_size"), page_size);
+        assert!(
+            scalar_i64(&conn, "PRAGMA page_count") <= pre_pages,
+            "VACUUM should not grow page_count for page_size={page_size}"
+        );
+        assert_eq!(
+            scalar_i64(&conn, "SELECT COUNT(*) FROM t"),
+            rows - (rows + 2) / 3
+        );
+        assert_eq!(
+            scalar_i64(&conn, "SELECT COUNT(*) FROM t WHERE tag = 'tag-5'"),
+            scalar_i64(
+                &conn,
+                "SELECT COUNT(*) FROM t NOT INDEXED WHERE tag = 'tag-5'"
+            )
+        );
+        assert_eq!(run_integrity_check(&conn), "ok");
+        assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    }
+
+    Ok(())
+}
+
+/// Stress the storage shapes that make batched VACUUM risky: overflow chains,
+/// freelist pages, table and index b-trees, triggers, views, and a second
+/// primary-key table all in one compacted image.
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_complex_batched_storage_shapes() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::builder().with_views(true).build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size = 1024")?;
+    conn.execute(
+        "CREATE TABLE docs(
+            id INTEGER PRIMARY KEY,
+            category TEXT NOT NULL,
+            payload BLOB NOT NULL,
+            note TEXT
+        )",
+    )?;
+    conn.execute("CREATE INDEX idx_docs_category_note ON docs(category, note)")?;
+    conn.execute("CREATE INDEX idx_docs_note_partial ON docs(note) WHERE category = 'keep'")?;
+    conn.execute("CREATE TABLE audit(doc_id INTEGER, payload_len INTEGER)")?;
+    conn.execute(
+        "CREATE TRIGGER docs_ai AFTER INSERT ON docs BEGIN
+            INSERT INTO audit VALUES(new.id, length(new.payload));
+        END",
+    )?;
+    conn.execute("CREATE TABLE kv(k TEXT PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE VIEW kept_docs AS SELECT id, note FROM docs WHERE category = 'keep'")?;
+
+    for i in 0..180 {
+        let category = if i % 4 == 0 { "drop" } else { "keep" };
+        conn.execute(format!(
+            "INSERT INTO docs VALUES({i}, '{category}', zeroblob({}), 'note-{}')",
+            2500 + (i % 13),
+            i % 23
+        ))?;
+        conn.execute(format!(
+            "INSERT INTO kv VALUES('k-{i:03}', '{}')",
+            "v".repeat(90)
+        ))?;
+    }
+    conn.execute("DELETE FROM docs WHERE category = 'drop'")?;
+    conn.execute("DELETE FROM kv WHERE k > 'k-120'")?;
+
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(
+        pre_pages > 64,
+        "complex workload should force multiple copy-back batches, got {pre_pages}"
+    );
+
+    conn.execute("VACUUM")?;
+
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM docs"), 135);
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM kept_docs"), 135);
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM kv"), 121);
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT COUNT(*) FROM docs WHERE category = 'keep' AND note = 'note-7'"
+        ),
+        scalar_i64(
+            &conn,
+            "SELECT COUNT(*) FROM docs NOT INDEXED WHERE category = 'keep' AND note = 'note-7'"
+        )
+    );
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT SUM(length(payload)) FROM docs WHERE id BETWEEN 1 AND 20"
+        ),
+        scalar_i64(
+            &conn,
+            "SELECT SUM(length(payload)) FROM docs NOT INDEXED WHERE id BETWEEN 1 AND 20"
+        )
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+
+    conn.execute("INSERT INTO docs VALUES(1000, 'keep', zeroblob(4097), 'after-vacuum')")?;
+    assert_eq!(
+        scalar_i64(&conn, "SELECT payload_len FROM audit WHERE doc_id = 1000"),
+        4097
+    );
     assert_eq!(run_integrity_check(&conn), "ok");
     Ok(())
 }
@@ -3664,4 +4193,292 @@ fn test_plain_vacuum_encrypted() -> anyhow::Result<()> {
 
     assert_eq!(run_integrity_check(&conn), "ok");
     Ok(())
+}
+
+/// Keep one non-ignored plain VACUUM test under the checksum feature so
+/// `read_frames_batch` verifies checksums while reading the temp WAL and
+/// `prepare_frames` writes checksummed source-WAL frames.
+#[cfg(feature = "checksum")]
+#[test]
+fn test_plain_vacuum_checksum_multi_batch() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size = 1024")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload BLOB, tag TEXT)")?;
+    conn.execute("CREATE INDEX idx_t_tag ON t(tag)")?;
+    for i in 0..160 {
+        conn.execute(format!(
+            "INSERT INTO t VALUES({i}, zeroblob({}), 'tag-{}')",
+            1400 + i % 19,
+            i % 9
+        ))?;
+    }
+    conn.execute("DELETE FROM t WHERE id % 4 = 0")?;
+
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(
+        pre_pages > 64,
+        "checksum workload should cross copy-back batch boundary, got {pre_pages}"
+    );
+
+    conn.execute("VACUUM")?;
+
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 120);
+    assert_eq!(
+        scalar_i64(&conn, "SELECT COUNT(*) FROM t WHERE tag = 'tag-3'"),
+        scalar_i64(
+            &conn,
+            "SELECT COUNT(*) FROM t NOT INDEXED WHERE tag = 'tag-3'"
+        )
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &conn);
+    Ok(())
+}
+
+/// Active readers are allowed to coexist with VACUUM only if the statement
+/// still satisfies the physical fold contract when it reports success. If the
+/// reader blocks the exclusive/fold path, VACUUM may return an error and the
+/// same operation must succeed after the reader releases its snapshot.
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_active_reader_blocks_fold_contract() -> anyhow::Result<()> {
+    let tmp_db = TempDatabase::new_empty();
+    let writer = tmp_db.connect_limbo();
+    let reader = tmp_db.connect_limbo();
+
+    writer.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")?;
+    for i in 0..120 {
+        writer.execute(format!("INSERT INTO t VALUES({i}, '{}')", "x".repeat(300)))?;
+    }
+    writer.execute("DELETE FROM t WHERE id >= 20")?;
+
+    reader.execute("BEGIN")?;
+    assert_eq!(scalar_i64(&reader, "SELECT COUNT(*) FROM t"), 20);
+
+    let result = writer.execute("VACUUM");
+    let vacuum_succeeded = result.is_ok();
+    match result {
+        Ok(()) => {
+            assert_eq!(scalar_i64(&writer, "SELECT COUNT(*) FROM t"), 20);
+            assert_eq!(run_integrity_check(&writer), "ok");
+            assert_plain_vacuum_folded_into_db_file(&tmp_db, &writer);
+        }
+        Err(_) => {}
+    }
+
+    if let Err(err) = reader.execute("ROLLBACK") {
+        assert!(
+            vacuum_succeeded && err.to_string().contains("schema changed"),
+            "unexpected reader rollback error after VACUUM: {err}"
+        );
+    }
+    let final_writer = if vacuum_succeeded {
+        writer.clone()
+    } else {
+        let conn = tmp_db.connect_limbo();
+        conn.execute("VACUUM")?;
+        conn
+    };
+
+    assert_eq!(scalar_i64(&final_writer, "SELECT COUNT(*) FROM t"), 20);
+    assert_eq!(run_integrity_check(&final_writer), "ok");
+    assert_plain_vacuum_folded_into_db_file(&tmp_db, &final_writer);
+    Ok(())
+}
+
+fn open_queued_db(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Database>> {
+    Ok(Database::open_file(io, path)?)
+}
+
+fn populate_queued_multibatch(conn: &Arc<Connection>) -> anyhow::Result<()> {
+    conn.execute("PRAGMA page_size = 512")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT)")?;
+    conn.execute("CREATE INDEX idx_t_payload ON t(payload)")?;
+    for i in 0..220 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", "q".repeat(350)))?;
+    }
+    conn.execute("DELETE FROM t WHERE id % 5 = 0")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_queued_io_reentry_multi_batch() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = ":memory:queued-vacuum-reentry.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(pre_pages > 64, "queued IO workload should be multi-batch");
+
+    conn.execute("VACUUM")?;
+
+    assert!(
+        io.count_events("-wal", QueuedIoOpKind::Pread) > 0,
+        "batch reads should issue queued WAL preads"
+    );
+    assert!(
+        io.count_events("-wal", QueuedIoOpKind::Pwritev) > 1,
+        "multi-batch copy-back should issue multiple source WAL pwritev operations"
+    );
+    assert_eq!(scalar_i64(&conn, "SELECT COUNT(*) FROM t"), 176);
+    assert!(
+        scalar_i64(&conn, "PRAGMA page_count") < pre_pages,
+        "VACUUM should compact the queued-IO workload"
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+fn assert_failed_vacuum_left_queued_db_usable(
+    conn: &Arc<Connection>,
+    pre_pages: i64,
+) -> anyhow::Result<()> {
+    assert_eq!(
+        scalar_i64(conn, "PRAGMA page_count"),
+        pre_pages,
+        "failed VACUUM must not publish a partial compacted image"
+    );
+    assert_eq!(scalar_i64(conn, "SELECT COUNT(*) FROM t"), 176);
+    assert_eq!(
+        scalar_i64(conn, "SELECT COUNT(*) FROM t WHERE payload = '{}'",),
+        0
+    );
+    conn.execute("INSERT INTO t VALUES(10000, 'after-failure')")?;
+    conn.execute("DELETE FROM t WHERE id = 10000")?;
+    assert_eq!(run_integrity_check(conn), "ok");
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_source_wal_first_batch_write_failure_rolls_back() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = ":memory:queued-vacuum-first-write-failure.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+
+    io.fail_after_successes("-wal", QueuedIoOpKind::Pwritev, 0);
+    let err = conn.execute("VACUUM").unwrap_err();
+    io.clear_fault();
+    assert!(
+        err.to_string().contains("VACUUM") || err.to_string().contains("aborted"),
+        "unexpected error for first batch write fault: {err}"
+    );
+
+    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
+    conn.execute("VACUUM")?;
+    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_source_wal_later_batch_write_failure_rolls_back() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = ":memory:queued-vacuum-later-write-failure.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+
+    io.fail_after_successes("-wal", QueuedIoOpKind::Pwritev, 1);
+    let err = conn.execute("VACUUM").unwrap_err();
+    io.clear_fault();
+    assert!(
+        err.to_string().contains("VACUUM") || err.to_string().contains("aborted"),
+        "unexpected error for later batch write fault: {err}"
+    );
+
+    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
+    conn.execute("VACUUM")?;
+    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_source_wal_sync_failure_rolls_back() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let path = ":memory:queued-vacuum-sync-failure.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+
+    io.fail_after_successes("-wal", QueuedIoOpKind::Sync, 0);
+    let err = conn.execute("VACUUM").unwrap_err();
+    io.clear_fault();
+    assert!(
+        err.to_string().contains("VACUUM") || err.to_string().contains("aborted"),
+        "unexpected error for source WAL sync fault: {err}"
+    );
+
+    assert_failed_vacuum_left_queued_db_usable(&conn, pre_pages)?;
+    conn.execute("VACUUM")?;
+    assert!(scalar_i64(&conn, "PRAGMA page_count") < pre_pages);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+#[cfg_attr(feature = "checksum", ignore)]
+#[test]
+fn test_plain_vacuum_crash_after_nonfinal_source_wal_batch_recovers_original() -> anyhow::Result<()>
+{
+    let io = Arc::new(QueuedIo::new());
+    let path = ":memory:queued-vacuum-crash-after-nonfinal-batch.db";
+    let db = open_queued_db(io.clone(), path)?;
+    let conn = db.connect()?;
+
+    populate_queued_multibatch(&conn)?;
+    let pre_pages = scalar_i64(&conn, "PRAGMA page_count");
+    assert!(
+        pre_pages > 64,
+        "crash test requires a non-final first batch"
+    );
+
+    let mut stmt = conn.prepare("VACUUM")?;
+    loop {
+        match stmt.step()? {
+            StepResult::Done => {
+                panic!("VACUUM finished before source WAL batch write was observed")
+            }
+            StepResult::Row => continue,
+            StepResult::Busy | StepResult::Interrupt => {
+                panic!("unexpected non-IO VACUUM result during crash test")
+            }
+            StepResult::IO => {
+                while let Some(event) = io.step_one()? {
+                    if event.path.ends_with("-wal") && event.kind == QueuedIoOpKind::Pwritev {
+                        std::mem::forget(stmt);
+                        std::mem::forget(conn);
+                        std::mem::forget(db);
+
+                        let reopened = open_queued_db(io.clone(), path)?;
+                        let reopened_conn = reopened.connect()?;
+                        assert_eq!(
+                            scalar_i64(&reopened_conn, "PRAGMA page_count"),
+                            pre_pages,
+                            "non-final VACUUM frames without a commit marker must be ignored on recovery"
+                        );
+                        assert_eq!(scalar_i64(&reopened_conn, "SELECT COUNT(*) FROM t"), 176);
+                        assert_eq!(run_integrity_check(&reopened_conn), "ok");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
 }

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -111,9 +111,16 @@ fn test_vacuum_into_error_cases(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     let dest_dir = TempDir::new()?;
 
-    // 1. plain VACUUM should fail
+    // 1. plain VACUUM behavior depends on MVCC mode
     let result = conn.execute("VACUUM");
-    assert!(result.is_err(), "Plain VACUUM should fail");
+    if tmp_db.enable_mvcc {
+        assert!(result.is_err(), "Plain VACUUM should fail in MVCC mode");
+    } else {
+        assert!(
+            result.is_ok(),
+            "Plain VACUUM should succeed in non-MVCC mode"
+        );
+    }
 
     // 2. VACUUM INTO existing file should fail
     let existing_path = dest_dir.path().join("existing.db");
@@ -3265,5 +3272,237 @@ fn test_vacuum_into_preserves_vector_blobs(tmp_db: TempDatabase) -> anyhow::Resu
     );
     assert_eq!(source_dist, dest_dist);
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Plain VACUUM tests
+// ---------------------------------------------------------------------------
+
+/// Basic plain VACUUM: data survives the compaction round-trip.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c REAL);")]
+fn test_plain_vacuum_basic(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t1 VALUES(1, 'hello', 3.125)")?;
+    conn.execute("INSERT INTO t1 VALUES(2, 'world', 2.725)")?;
+    conn.execute("INSERT INTO t1 VALUES(3, 'test', 1.625)")?;
+    conn.execute("DELETE FROM t1 WHERE a = 2")?;
+    conn.execute("VACUUM")?;
+
+    let rows: Vec<(i64, String, f64)> = conn.exec_rows("SELECT a, b, c FROM t1 ORDER BY a");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], (1, "hello".into(), 3.125));
+    assert_eq!(rows[1], (3, "test".into(), 1.625));
+
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Plain VACUUM preserves user_version and application_id metadata.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_preserves_metadata(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1)")?;
+    conn.execute("PRAGMA user_version = 42")?;
+    conn.execute("PRAGMA application_id = 99")?;
+
+    let pre_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
+
+    conn.execute("VACUUM")?;
+
+    let user_version: Vec<(i64,)> = conn.exec_rows("PRAGMA user_version");
+    assert_eq!(user_version[0].0, 42);
+
+    let application_id: Vec<(i64,)> = conn.exec_rows("PRAGMA application_id");
+    assert_eq!(application_id[0].0, 99);
+
+    // Schema version should be bumped by 1.
+    let post_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
+    assert_eq!(post_schema_version[0].0, pre_schema_version[0].0 + 1);
+
+    let journal_mode: Vec<(String,)> = conn.exec_rows("PRAGMA journal_mode");
+    assert_eq!(journal_mode[0].0, "wal");
+
+    Ok(())
+}
+
+/// Plain VACUUM preserves AUTOINCREMENT counters.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT);")]
+fn test_plain_vacuum_preserves_autoincrement(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t1(b) VALUES('one')")?;
+    conn.execute("INSERT INTO t1(b) VALUES('two')")?;
+    conn.execute("INSERT INTO t1(b) VALUES('three')")?;
+    conn.execute("DELETE FROM t1 WHERE b = 'two'")?;
+    conn.execute("VACUUM")?;
+
+    // Verify sqlite_sequence preserved
+    let seq: Vec<(String, i64)> = conn.exec_rows("SELECT name, seq FROM sqlite_sequence");
+    assert_eq!(seq.len(), 1);
+    assert_eq!(seq[0].0, "t1");
+    assert_eq!(seq[0].1, 3);
+
+    // Next insert should continue from 4, not restart
+    conn.execute("INSERT INTO t1(b) VALUES('four')")?;
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t1 ORDER BY a");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], (1, "one".into()));
+    assert_eq!(rows[1], (3, "three".into()));
+    assert_eq!(rows[2], (4, "four".into()));
+
+    Ok(())
+}
+
+/// Plain VACUUM preserves indexes (queries using them still work).
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_preserves_indexes(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE INDEX idx_t1_b ON t1(b)")?;
+    conn.execute("INSERT INTO t1 VALUES(1, 'alpha')")?;
+    conn.execute("INSERT INTO t1 VALUES(2, 'beta')")?;
+    conn.execute("INSERT INTO t1 VALUES(3, 'gamma')")?;
+    conn.execute("DELETE FROM t1 WHERE a = 2")?;
+    conn.execute("VACUUM")?;
+
+    // Use index-covered query
+    let rows: Vec<(String,)> = conn.exec_rows("SELECT b FROM t1 WHERE b > 'b' ORDER BY b");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "gamma");
+
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Plain VACUUM preserves views.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(views, init_sql = "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_preserves_views(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE VIEW v1 AS SELECT * FROM t1 WHERE a > 1")?;
+    conn.execute("INSERT INTO t1 VALUES(1, 'one')")?;
+    conn.execute("INSERT INTO t1 VALUES(2, 'two')")?;
+    conn.execute("INSERT INTO t1 VALUES(3, 'three')")?;
+    conn.execute("DELETE FROM t1 WHERE a = 2")?;
+    conn.execute("VACUUM")?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM v1 ORDER BY a");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0], (3, "three".into()));
+
+    Ok(())
+}
+
+/// Plain VACUUM rejects active transactions.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_rejects_active_transaction(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("BEGIN")?;
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("cannot VACUUM from within a transaction"),
+        "unexpected error: {err}"
+    );
+    conn.execute("ROLLBACK")?;
+    Ok(())
+}
+
+/// Plain VACUUM works on empty databases.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_empty_table(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("VACUUM")?;
+
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(rows[0].0, 0);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Multiple VACUUMs in a row work correctly.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_repeated(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1, 'one')")?;
+    conn.execute("INSERT INTO t VALUES(2, 'two')")?;
+    conn.execute("INSERT INTO t VALUES(3, 'three')")?;
+    conn.execute("DELETE FROM t WHERE a = 2")?;
+    conn.execute("VACUUM")?;
+    conn.execute("VACUUM")?;
+    conn.execute("VACUUM")?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t ORDER BY a");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], (1, "one".into()));
+    assert_eq!(rows[1], (3, "three".into()));
+
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Writes after VACUUM work correctly.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_then_write(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1, 'one')")?;
+    conn.execute("INSERT INTO t VALUES(2, 'two')")?;
+    conn.execute("DELETE FROM t WHERE a = 1")?;
+    conn.execute("VACUUM")?;
+    conn.execute("INSERT INTO t VALUES(3, 'three')")?;
+    conn.execute("INSERT INTO t VALUES(4, 'four')")?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t ORDER BY a");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0], (2, "two".into()));
+    assert_eq!(rows[1], (3, "three".into()));
+    assert_eq!(rows[2], (4, "four".into()));
+
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}
+
+/// Plain VACUUM rejects query_only mode.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_rejects_query_only(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA query_only = 1")?;
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert!(
+        err.to_string().contains("query_only"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
+/// Plain VACUUM rejects active statements on same connection.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER);")]
+fn test_plain_vacuum_rejects_active_statement(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES(1)")?;
+    conn.execute("INSERT INTO t VALUES(2)")?;
+
+    // Hold an active SELECT open
+    let mut stmt = conn.prepare("SELECT * FROM t")?;
+    let step_result = stmt.step()?;
+    assert!(matches!(step_result, StepResult::Row));
+
+    // VACUUM should fail while the SELECT is active
+    let err = conn.execute("VACUUM").unwrap_err();
+    assert!(
+        err.to_string().contains("SQL statements in progress"),
+        "unexpected error: {err}"
+    );
+
+    stmt.reset()?;
     Ok(())
 }

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -3544,13 +3544,12 @@ fn test_plain_vacuum_reduces_page_count(tmp_db: TempDatabase) -> anyhow::Result<
         post_vacuum_pages[0].0
     );
 
-    // Checkpoint to flush WAL into .db file.
-    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
-
-    // After checkpoint the reported page count should still reflect the
-    // compacted size.
-    let post_checkpoint_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
-    assert_eq!(post_checkpoint_pages[0].0, post_vacuum_pages[0].0);
+    // VACUUM includes a TRUNCATE checkpoint, so the WAL should be empty.
+    let wal_path = format!("{}-wal", tmp_db.path.display());
+    let wal_size = std::fs::metadata(&wal_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+    assert_eq!(wal_size, 0, "WAL should be truncated to zero after VACUUM");
 
     // Data integrity: the 10 remaining rows should be intact.
     let rows: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -3506,3 +3506,55 @@ fn test_plain_vacuum_rejects_active_statement(tmp_db: TempDatabase) -> anyhow::R
     stmt.reset()?;
     Ok(())
 }
+
+/// Plain VACUUM reduces page_count when rows are deleted, and a subsequent
+/// checkpoint truncates the .db file to the compacted size.
+#[cfg_attr(feature = "checksum", ignore)]
+#[turso_macros::test(init_sql = "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);")]
+fn test_plain_vacuum_reduces_page_count(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    // Insert enough data to grow the database well past the minimum.
+    for i in 0..200 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{}')", "x".repeat(100)))?;
+    }
+
+    let pre_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert!(
+        pre_pages[0].0 > 5,
+        "source should have multiple pages, got: {}",
+        pre_pages[0].0
+    );
+
+    // Delete most rows to create free pages.
+    conn.execute("DELETE FROM t WHERE a >= 10")?;
+
+    // page_count should not have decreased yet (deleted pages are on freelist).
+    let after_delete_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert_eq!(after_delete_pages[0].0, pre_pages[0].0);
+
+    conn.execute("VACUUM")?;
+
+    // After VACUUM the compacted image should be smaller.
+    let post_vacuum_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert!(
+        post_vacuum_pages[0].0 < pre_pages[0].0,
+        "page_count should decrease after VACUUM: before={}, after={}",
+        pre_pages[0].0,
+        post_vacuum_pages[0].0
+    );
+
+    // Checkpoint to flush WAL into .db file.
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    // After checkpoint the reported page count should still reflect the
+    // compacted size.
+    let post_checkpoint_pages: Vec<(i64,)> = conn.exec_rows("PRAGMA page_count");
+    assert_eq!(post_checkpoint_pages[0].0, post_vacuum_pages[0].0);
+
+    // Data integrity: the 10 remaining rows should be intact.
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(rows[0].0, 10);
+    assert_eq!(run_integrity_check(&conn), "ok");
+    Ok(())
+}

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -313,7 +313,7 @@ impl File for QueuedFile {
         let inner = self.inner.clone();
         let c = completion.clone();
         self.enqueue(QueuedIoOpKind::Pread, completion, move || {
-            let _ = inner.pread(pos, c)?;
+            drop(inner.pread(pos, c)?);
             Ok(())
         })
     }
@@ -327,7 +327,7 @@ impl File for QueuedFile {
         let inner = self.inner.clone();
         let c = completion.clone();
         self.enqueue(QueuedIoOpKind::Pwrite, completion, move || {
-            let _ = inner.pwrite(pos, buffer, c)?;
+            drop(inner.pwrite(pos, buffer, c)?);
             Ok(())
         })
     }
@@ -340,7 +340,7 @@ impl File for QueuedFile {
         let inner = self.inner.clone();
         let c = completion.clone();
         self.enqueue(QueuedIoOpKind::Sync, completion, move || {
-            let _ = inner.sync(c, sync_type)?;
+            drop(inner.sync(c, sync_type)?);
             Ok(())
         })
     }
@@ -354,7 +354,7 @@ impl File for QueuedFile {
         let inner = self.inner.clone();
         let c = completion.clone();
         self.enqueue(QueuedIoOpKind::Pwritev, completion, move || {
-            let _ = inner.pwritev(pos, buffers, c)?;
+            drop(inner.pwritev(pos, buffers, c)?);
             Ok(())
         })
     }
@@ -367,7 +367,7 @@ impl File for QueuedFile {
         let inner = self.inner.clone();
         let c = completion.clone();
         self.enqueue(QueuedIoOpKind::Truncate, completion, move || {
-            let _ = inner.truncate(len, c)?;
+            drop(inner.truncate(len, c)?);
             Ok(())
         })
     }
@@ -4259,13 +4259,10 @@ fn test_plain_vacuum_active_reader_blocks_fold_contract() -> anyhow::Result<()> 
 
     let result = writer.execute("VACUUM");
     let vacuum_succeeded = result.is_ok();
-    match result {
-        Ok(()) => {
-            assert_eq!(scalar_i64(&writer, "SELECT COUNT(*) FROM t"), 20);
-            assert_eq!(run_integrity_check(&writer), "ok");
-            assert_plain_vacuum_folded_into_db_file(&tmp_db, &writer);
-        }
-        Err(_) => {}
+    if let Ok(()) = result {
+        assert_eq!(scalar_i64(&writer, "SELECT COUNT(*) FROM t"), 20);
+        assert_eq!(run_integrity_check(&writer), "ok");
+        assert_plain_vacuum_folded_into_db_file(&tmp_db, &writer);
     }
 
     if let Err(err) = reader.execute("ROLLBACK") {

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -613,7 +613,7 @@ fn test_vacuum_into_with_triggers(tmp_db: TempDatabase) {
     );
 }
 
-/// Test VACUUM INTO preserves meta values: user_version, application_id
+/// Test VACUUM INTO preserves and bumps meta values like SQLite.
 /// Note: Some pragmas don't work correctly with MVCC yet
 #[cfg_attr(feature = "checksum", ignore)]
 #[turso_macros::test(init_sql = "CREATE TABLE t (a INTEGER);")]
@@ -626,6 +626,7 @@ fn test_vacuum_into_preserves_meta_values(tmp_db: TempDatabase) -> anyhow::Resul
     // Test 1: Normal positive values
     conn.execute("PRAGMA user_version = 42")?;
     conn.execute("PRAGMA application_id = 12345")?;
+    let source_schema_version: Vec<(i64,)> = conn.exec_rows("PRAGMA schema_version");
 
     let source_hash1 = compute_dbhash(&tmp_db);
     let dest_path1 = dest_dir.path().join("vacuumed1.db");
@@ -640,6 +641,12 @@ fn test_vacuum_into_preserves_meta_values(tmp_db: TempDatabase) -> anyhow::Resul
     assert_eq!(uv, vec![(42,)], "user_version should be 42");
     let aid: Vec<(i64,)> = dest_conn1.exec_rows("PRAGMA application_id");
     assert_eq!(aid, vec![(12345,)], "application_id should be 12345");
+    let schema_version: Vec<(i64,)> = dest_conn1.exec_rows("PRAGMA schema_version");
+    assert_eq!(
+        schema_version,
+        vec![(source_schema_version[0].0 + 1,)],
+        "schema_version should be source schema_version + 1"
+    );
 
     // Test 2: Boundary values (negative user_version, max application_id)
     conn.execute("PRAGMA user_version = -1")?;

--- a/tests/integration/queued_io.rs
+++ b/tests/integration/queued_io.rs
@@ -65,42 +65,6 @@ impl QueuedIo {
         }
     }
 
-    pub(crate) fn fail_after_successes(
-        &self,
-        path_suffix: &str,
-        kind: QueuedIoOpKind,
-        allowed_successes: usize,
-    ) {
-        *self.state.fault.lock().unwrap() = Some(QueuedIoFault {
-            path_suffix: path_suffix.to_string(),
-            kind,
-            allowed_successes,
-            seen: 0,
-        });
-    }
-
-    pub(crate) fn clear_fault(&self) {
-        *self.state.fault.lock().unwrap() = None;
-    }
-
-    pub(crate) fn count_events(&self, path_suffix: &str, kind: QueuedIoOpKind) -> usize {
-        self.state
-            .history
-            .lock()
-            .unwrap()
-            .iter()
-            .filter(|event| event.path.ends_with(path_suffix) && event.kind == kind)
-            .count()
-    }
-
-    pub(crate) fn history_len(&self) -> usize {
-        self.state.history.lock().unwrap().len()
-    }
-
-    pub(crate) fn history_since(&self, start: usize) -> Vec<QueuedIoEvent> {
-        self.state.history.lock().unwrap()[start..].to_vec()
-    }
-
     pub(crate) fn step_one(&self) -> turso_core::Result<Option<QueuedIoEvent>> {
         let Some(op) = self.state.pending.lock().unwrap().pop_front() else {
             return Ok(None);

--- a/tests/integration/queued_io.rs
+++ b/tests/integration/queued_io.rs
@@ -1,0 +1,293 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+
+use turso_core::{
+    io::{FileId, FileSyncType},
+    Buffer, Clock, Completion, File, MonotonicInstant, OpenFlags, WallClockInstant, IO,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum QueuedIoOpKind {
+    Pread,
+    Pwrite,
+    Pwritev,
+    Sync,
+    Truncate,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct QueuedIoEvent {
+    pub(crate) path: String,
+    pub(crate) kind: QueuedIoOpKind,
+}
+
+struct QueuedIoOp {
+    event: QueuedIoEvent,
+    action: Box<dyn FnOnce() -> turso_core::Result<()> + Send>,
+}
+
+#[derive(Debug)]
+struct QueuedIoFault {
+    path_suffix: String,
+    kind: QueuedIoOpKind,
+    allowed_successes: usize,
+    seen: usize,
+}
+
+struct QueuedIoState {
+    pending: Mutex<VecDeque<QueuedIoOp>>,
+    history: Mutex<Vec<QueuedIoEvent>>,
+    fault: Mutex<Option<QueuedIoFault>>,
+}
+
+impl QueuedIoState {
+    fn new() -> Self {
+        Self {
+            pending: Mutex::new(VecDeque::new()),
+            history: Mutex::new(Vec::new()),
+            fault: Mutex::new(None),
+        }
+    }
+}
+
+pub(crate) struct QueuedIo {
+    inner: Arc<dyn IO>,
+    state: Arc<QueuedIoState>,
+}
+
+impl QueuedIo {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(turso_core::MemoryIO::new()),
+            state: Arc::new(QueuedIoState::new()),
+        }
+    }
+
+    pub(crate) fn fail_after_successes(
+        &self,
+        path_suffix: &str,
+        kind: QueuedIoOpKind,
+        allowed_successes: usize,
+    ) {
+        *self.state.fault.lock().unwrap() = Some(QueuedIoFault {
+            path_suffix: path_suffix.to_string(),
+            kind,
+            allowed_successes,
+            seen: 0,
+        });
+    }
+
+    pub(crate) fn clear_fault(&self) {
+        *self.state.fault.lock().unwrap() = None;
+    }
+
+    pub(crate) fn count_events(&self, path_suffix: &str, kind: QueuedIoOpKind) -> usize {
+        self.state
+            .history
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|event| event.path.ends_with(path_suffix) && event.kind == kind)
+            .count()
+    }
+
+    pub(crate) fn history_len(&self) -> usize {
+        self.state.history.lock().unwrap().len()
+    }
+
+    pub(crate) fn history_since(&self, start: usize) -> Vec<QueuedIoEvent> {
+        self.state.history.lock().unwrap()[start..].to_vec()
+    }
+
+    pub(crate) fn step_one(&self) -> turso_core::Result<Option<QueuedIoEvent>> {
+        let Some(op) = self.state.pending.lock().unwrap().pop_front() else {
+            return Ok(None);
+        };
+        let event = op.event.clone();
+        (op.action)()?;
+        self.state.history.lock().unwrap().push(event.clone());
+        Ok(Some(event))
+    }
+}
+
+impl Clock for QueuedIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for QueuedIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        let inner = self.inner.open_file(path, flags, direct)?;
+        Ok(Arc::new(QueuedFile {
+            path: path.to_string(),
+            inner,
+            state: self.state.clone(),
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.step_one().map(|_| ())
+    }
+
+    fn drain(&self) -> turso_core::Result<()> {
+        while self.step_one()?.is_some() {}
+        Ok(())
+    }
+
+    fn cancel(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        for completion in completions {
+            completion.abort();
+        }
+        Ok(())
+    }
+
+    fn file_id(&self, path: &str) -> turso_core::Result<FileId> {
+        self.inner.file_id(path)
+    }
+
+    fn fill_bytes(&self, dest: &mut [u8]) {
+        self.inner.fill_bytes(dest);
+    }
+
+    fn generate_random_number(&self) -> i64 {
+        self.inner.generate_random_number()
+    }
+}
+
+struct QueuedFile {
+    path: String,
+    inner: Arc<dyn File>,
+    state: Arc<QueuedIoState>,
+}
+
+impl QueuedFile {
+    fn enqueue(
+        &self,
+        kind: QueuedIoOpKind,
+        completion: Completion,
+        action: impl FnOnce() -> turso_core::Result<()> + Send + 'static,
+    ) -> turso_core::Result<Completion> {
+        let event = QueuedIoEvent {
+            path: self.path.clone(),
+            kind,
+        };
+        let fault_this_op = {
+            let mut fault = self.state.fault.lock().unwrap();
+            if let Some(fault) = fault.as_mut() {
+                if self.path.ends_with(&fault.path_suffix) && kind == fault.kind {
+                    fault.seen += 1;
+                    fault.seen > fault.allowed_successes
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        let queued_completion = completion.clone();
+        let queued_action: Box<dyn FnOnce() -> turso_core::Result<()> + Send> = if fault_this_op {
+            Box::new(move || {
+                queued_completion.abort();
+                Ok(())
+            })
+        } else {
+            Box::new(action)
+        };
+
+        self.state.pending.lock().unwrap().push_back(QueuedIoOp {
+            event,
+            action: queued_action,
+        });
+        Ok(completion)
+    }
+}
+
+impl File for QueuedFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, completion: Completion) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Pread, completion, move || {
+            drop(inner.pread(pos, c)?);
+            Ok(())
+        })
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        completion: Completion,
+    ) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Pwrite, completion, move || {
+            drop(inner.pwrite(pos, buffer, c)?);
+            Ok(())
+        })
+    }
+
+    fn sync(
+        &self,
+        completion: Completion,
+        sync_type: FileSyncType,
+    ) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Sync, completion, move || {
+            drop(inner.sync(c, sync_type)?);
+            Ok(())
+        })
+    }
+
+    fn pwritev(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<Buffer>>,
+        completion: Completion,
+    ) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Pwritev, completion, move || {
+            drop(inner.pwritev(pos, buffers, c)?);
+            Ok(())
+        })
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+
+    fn truncate(&self, len: u64, completion: Completion) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        self.enqueue(QueuedIoOpKind::Truncate, completion, move || {
+            drop(inner.truncate(len, c)?);
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
## Description
This PR adds initial support for `vacuum`, the last standing major SQLite feature missing in Turso.

## Motivation and context

We already have `vacuum into`; now this patch adds `vacuum`. `vacuum` op is experimental, users need to opt in to use.

Vacuum is a defragmentation op. When you update/delete some rows, the space isn't claimed but rather reused. Vacuum compacts that, releasing the free space. The logic of vacuum is quite simple:

1. Reinsert all the rows to a temporary db
2. Copy the pages from temporary db to main db

The complexities are in the copy back logic: you need the right lock semantics, commit/transaction semantics, fsync. The tricky part is copying those pages safely.

1. Vacuum as an op is very conservative. Vacuum can start only when there are no readers or writers. We cannot move around pages if we have readers. New writes during vacuum could get missed during the copy phase, causing data loss.
2. Vacuum also blocks new readers and writers. Hence this patch introduces a new vacuum lock, very similar to the checkpoint lock. Every read txn needs to acquire this, and the vacuum op takes an exclusive lock on this.
3. During copy back, we need to atomically copy the pages from temp db to main db. A partial commit will cause a weird inconsistent state and/or data loss.
4. When building the temp db, we have to make sure we are rewriting everything. A missing internal table or index can cause corruption / data loss.

The vacuum implementation is different from SQLite's. In SQLite:
1. A temporary db is created and attached
2. DB is rewritten into the temporary file
3. Then it is copied back to the main db
4. Then auto checkpoint

Ours:
1. We don't have stable attach, so we keep a separate connection with the temporary db
2. We don't have a rollback journal, so we write the frames back to the WAL using WAL APIs
3. Do checkpoint truncate 

Here is a quick overview of the vacuum state machine:

1. Do base validations: like no txns are active, etc.
2. Acquire checkpoint lock
3. Acquire vacuum lock
4. Rewrite the DB to a temporary path. This uses the existing code from vacuum into. We disable auto checkpoint so that during copy back we can copy the frames from WAL.
5. Once the temporary db is ready, we copy frames from WAL to the source DB's WAL. This will be done as a single transaction. If something fails midway, those frames will be discarded on the next run.
6. Then we checkpoint using the checkpoint state machine. Previously, we hand off the locks we held earlier to the checkpoint machine.
7. Once checkpoint is done, we refresh the schema.
8. Release them locks.

### Performance

Right now Turso's vacuum is slightly slower than SQLite for small dbs and faster for large databases. I haven't started perf work yet, but here are some reasons which I will optimise next: 

1. We copy row by row, doing insert via SQL. SQLite has a fast path optimisation for vacuum where it copies bytes to bytes without parsing overhead.
2. Current vacuum implementation does more fsync than required. It is safe, but for temporary db it is not needed. 
3. We have lot more allocations in the vacuum path which can be optimised 
4. We could probably introduce a fast path checkpoint op just for vacuum. 
5. We don't do read and writes concurrently. Right now it reads a bunch of frames, waits for IO to complete and then writes them, and so on. We can issue read and write i/o concurrently. 


### How to review

This is a large PR; however, it is split into small commits nicely. You can review commit by commit.
1. The first commit is a refactor of our `vacuum into` so that vacuum machinery can use the existing code (~300 lines of diff). While extracting, I also fixed some bugs related to check constraints, custom types and auto vacuum which were present in vacuum into as well. I tried extracting that first, then fixing, but it became bit awkward since i had to make changes for vacuum as well. 
2. The next commits add new APIs which vacuum will use (~1000 lines with tests). For example, I added `read_batch_frame` where we can read a batch of frames from WAL, instead of `read_frame` which lets you read a single frame.
7. The vacuum state machine. In a way it is small because it uses the existing vacuum into state machine and checkpoint state machine (~1500 lines)
8. Tests (~5000 lines). I have more tests, but I will add them in a follow-up PR.

Where do I need your eyes most:

- Lock semantics
- RAW WAL API usage
- Clean up on error

### What's next
This patch adds only the foundational support, and we still have a lot to do before we can remove the experimental tag:
- [ ] Multiprocess support
- [ ] Integration with all bindings, SDKs and tests
- [ ] More tests covering the feature matrix (including experimental): mvcc, encryption, views, custom types, fts, checksum etc
- [ ] VACUUM to change page_size, reserved bytes
- [ ] Performance: `preadv` and parallel read/writes
- [ ] Checksum, Encryption
- [ ] Let users specify the temp space for vacuum
- [ ] CDC, Sync, IVM
- [ ] Simulator and whopper tests
- [ ] Antithesis tests
- [ ] Documentation / Manual

I already have a working branch here: https://github.com/tursodatabase/turso/pull/6516 and https://github.com/tursodatabase/turso/pull/6577 There are also some minor bugs / edge cases. I am tracking them separately and those are fixed in #6516 

## Description of AI Usage
AI did quite horribly on this feature, which is kinda expected. You cannot just one shot into VACUUM. I made a plan first, learning from SQLite's implementation. Yet that implementation sucked and had many bugs: vacuum would try to replace the main file with the temp one, incorrect lock semantics, not blocking readers, incorrect checkpoint handling, and many more. I let AI write the skeleton, then went in to rewrite all the parts. However, some of the bugs introduced by me, due to oversight, were caught by AI. Anyways, AGI when?