### PR TITLE
testing/javascript: regression test for stale query timeout guards

### DIFF
--- a/bindings/javascript/packages/native/index.d.ts
+++ b/bindings/javascript/packages/native/index.d.ts
@@ -5,10 +5,6 @@ export declare class BatchExecutor {
   reset(): void
 }
 
-export interface QueryOptions {
-  queryTimeout?: number
-}
-
 /** A database connection. */
 export declare class Database {
   /**
@@ -179,4 +175,8 @@ export interface EncryptionOpts {
   cipher: EncryptionCipher
   /** The hex-encoded encryption key */
   hexkey: string
+}
+
+export interface QueryOptions {
+  queryTimeout?: number
 }

--- a/bindings/javascript/packages/native/index.js
+++ b/bindings/javascript/packages/native/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-android-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-android-arm-eabi')
         const bindingPackageVersion = require('@tursodatabase/database-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-x64-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-ia32-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-arm64-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@tursodatabase/database-darwin-universal')
       const bindingPackageVersion = require('@tursodatabase/database-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-darwin-x64')
         const bindingPackageVersion = require('@tursodatabase/database-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-darwin-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-freebsd-x64')
         const bindingPackageVersion = require('@tursodatabase/database-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-freebsd-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-x64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-x64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm-musleabihf')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-riscv64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-riscv64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-linux-ppc64-gnu')
         const bindingPackageVersion = require('@tursodatabase/database-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-linux-s390x-gnu')
         const bindingPackageVersion = require('@tursodatabase/database-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -428,8 +428,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-x64')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-arm')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.5.0-pre.20' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.5.0-pre.20 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.6.0-pre.17' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.17 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/testing/javascript/__test__/async.test.js
+++ b/testing/javascript/__test__/async.test.js
@@ -561,6 +561,34 @@ test.serial("Query timeout option allows short-running query", async (t) => {
   cleanupDatabaseFiles(path);
 });
 
+test.serial("Stale timeout guard from exhausted iterator does not interrupt later queries", async (t) => {
+  if (process.env.PROVIDER === "serverless") {
+    t.pass("Skipping in-memory test for serverless");
+    return;
+  }
+  t.timeout(30_000);
+  const [db] = await connect(":memory:", { defaultQueryTimeout: 1_000 });
+
+  // Insert test data.
+  await db.exec("CREATE TABLE t(x INTEGER)");
+  const insert = await db.prepare("INSERT INTO t VALUES (?)");
+  for (let i = 0; i < 2_000; i++) {
+    await insert.run(i);
+  }
+
+  // Run many sequential queries via stmt.all() (which uses iterate() internally).
+  // Each query finishes well under the timeout, but if the RowsIterator's
+  // TimeoutGuard is not released until GC, stale guards will fire and
+  // interrupt unrelated later queries.
+  const stmt = await db.prepare("SELECT * FROM t ORDER BY x ASC");
+  for (let i = 0; i < 150; i++) {
+    const rows = await stmt.all();
+    t.is(rows.length, 2_000);
+  }
+
+  db.close();
+});
+
 test.serial("Per-query timeout option interrupts long-running Statement.get()", async (t) => {
   const path = genDatabaseFilename();
   const [db] = await connect(path);

--- a/testing/javascript/package-lock.json
+++ b/testing/javascript/package-lock.json
@@ -9,7 +9,7 @@
         "@tursodatabase/database": "../../bindings/javascript/packages/native",
         "@tursodatabase/serverless": "../../serverless/javascript",
         "better-sqlite3": "^11.9.1",
-        "libsql": "^0.6.0-pre.30"
+        "libsql": "^0.6.0-pre.33"
       },
       "devDependencies": {
         "ava": "^5.3.0"
@@ -17,10 +17,10 @@
     },
     "../../bindings/javascript/packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.6.0-pre.15",
+      "version": "0.6.0-pre.17",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0-pre.15"
+        "@tursodatabase/database-common": "^0.6.0-pre.17"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -233,7 +233,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3023,9 +3022,9 @@
       }
     },
     "node_modules/libsql": {
-      "version": "0.6.0-pre.30",
-      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.6.0-pre.30.tgz",
-      "integrity": "sha512-6KJlMlTJD1nQl9H7EBeCCDj68ZihRnGMUZg/i0DHnB9g7ldlZHn6q31SU6Vl2o8YajcevHRCQie75157lKJs7g==",
+      "version": "0.6.0-pre.33",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.6.0-pre.33.tgz",
+      "integrity": "sha512-M0i+uaBkAtPPsb5FJkaulfCzG4P7oBuEeUbSwHJLtSczjjqBU2q0XwCkICMHSsOaj4YjMbzsUu7WqT2WmJTQ1w==",
       "cpu": [
         "x64",
         "arm64",
@@ -3042,19 +3041,19 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "libsql-darwin-arm64": "0.6.0-pre.30",
-        "libsql-darwin-x64": "0.6.0-pre.30",
-        "libsql-linux-arm64-gnu": "0.6.0-pre.30",
-        "libsql-linux-arm64-musl": "0.6.0-pre.30",
-        "libsql-linux-x64-gnu": "0.6.0-pre.30",
-        "libsql-linux-x64-musl": "0.6.0-pre.30",
-        "libsql-win32-x64-msvc": "0.6.0-pre.30"
+        "libsql-darwin-arm64": "0.6.0-pre.33",
+        "libsql-darwin-x64": "0.6.0-pre.33",
+        "libsql-linux-arm64-gnu": "0.6.0-pre.33",
+        "libsql-linux-arm64-musl": "0.6.0-pre.33",
+        "libsql-linux-x64-gnu": "0.6.0-pre.33",
+        "libsql-linux-x64-musl": "0.6.0-pre.33",
+        "libsql-win32-x64-msvc": "0.6.0-pre.33"
       }
     },
     "node_modules/libsql-darwin-arm64": {
-      "version": "0.6.0-pre.30",
-      "resolved": "https://registry.npmjs.org/libsql-darwin-arm64/-/libsql-darwin-arm64-0.6.0-pre.30.tgz",
-      "integrity": "sha512-zafUt72dtvIRdSY1N1HpZgJ2pN3TnQMZihIagopcgaK3b6VY6ZrGrdocr9nEC7tyttEyJplXsIMxDyYAQbTV6Q==",
+      "version": "0.6.0-pre.33",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-arm64/-/libsql-darwin-arm64-0.6.0-pre.33.tgz",
+      "integrity": "sha512-TlRfFfYu7F+8Zgks/uEA5MWs7rh3TbZuAmFeVJdNNSKzDtg+mqTMJJhZlyhpVn7jZDMBxEo9+QSl+O3fIZgkGQ==",
       "cpu": [
         "arm64"
       ],
@@ -3068,9 +3067,9 @@
       }
     },
     "node_modules/libsql-darwin-x64": {
-      "version": "0.6.0-pre.30",
-      "resolved": "https://registry.npmjs.org/libsql-darwin-x64/-/libsql-darwin-x64-0.6.0-pre.30.tgz",
-      "integrity": "sha512-QWVzIp9TWXMSPm4uKKnx6VD15hFyQLhVvUXQAAQq8rmYZP78QrOOX8ETiVDBWBBYmKG7N/B8r/3UKWdV+ynB8g==",
+      "version": "0.6.0-pre.33",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-x64/-/libsql-darwin-x64-0.6.0-pre.33.tgz",
+      "integrity": "sha512-oUoY1zcmrNzZbahA9DUu8PRT55IMLzcbDUYe356ddnmd3580OJf7bvO3Pzh1UbD0b4yHalBtgn74CbD3cGnkXw==",
       "cpu": [
         "x64"
       ],
@@ -3084,9 +3083,9 @@
       }
     },
     "node_modules/libsql-linux-arm64-gnu": {
-      "version": "0.6.0-pre.30",
-      "resolved": "https://registry.npmjs.org/libsql-linux-arm64-gnu/-/libsql-linux-arm64-gnu-0.6.0-pre.30.tgz",
-      "integrity": "sha512-GSOe+0bPgxrIMvw+QzAgS5gbfJG3pZsWIP+xIbrfUs+BKnkAfKSSh/qr+5FoCb92/v5BhFK+OrdOO+mUPhXM+Q==",
+      "version": "0.6.0-pre.33",
+      "resolved": "https://registry.npmjs.org/libsql-linux-arm64-gnu/-/libsql-linux-arm64-gnu-0.6.0-pre.33.tgz",
+      "integrity": "sha512-RIcrMGWZVbvYkoH/0jfCdnkuUx/+935QJhwGn/SQixhG2pkP8WIbc/AnNU2FQjNnJqJNvVtWpo2n8RlUDXf3Ww==",
       "cpu": [
         "arm64"
       ],
@@ -3100,9 +3099,9 @@
       }
     },
     "node_modules/libsql-linux-x64-gnu": {
-      "version": "0.6.0-pre.30",
-      "resolved": "https://registry.npmjs.org/libsql-linux-x64-gnu/-/libsql-linux-x64-gnu-0.6.0-pre.30.tgz",
-      "integrity": "sha512-jsJHv2mDxqMX73DVDuJgU0VbYaV9CIzLL4k390i0ObnlPEbd82b3k3mQTw2rdN9MbfsMbyAMFtDaue7JlI1cdQ==",
+      "version": "0.6.0-pre.33",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-gnu/-/libsql-linux-x64-gnu-0.6.0-pre.33.tgz",
+      "integrity": "sha512-jc83hD/SoZu8qrNDwkNtmLbPeTZHZUWOlSjL91nBzK0gC9VontlW5cX5KIuGH04L3rd4PFbBizk2RVtIlO37fg==",
       "cpu": [
         "x64"
       ],
@@ -3116,9 +3115,9 @@
       }
     },
     "node_modules/libsql-linux-x64-musl": {
-      "version": "0.6.0-pre.30",
-      "resolved": "https://registry.npmjs.org/libsql-linux-x64-musl/-/libsql-linux-x64-musl-0.6.0-pre.30.tgz",
-      "integrity": "sha512-LzCiwK0x/ivXRLHgNndETNULxSjYOclwCvho4nEAwA6s47gZEPkEY2gibVFCrznaoWTZPsCt7QGmfC7Sq3YerA==",
+      "version": "0.6.0-pre.33",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-musl/-/libsql-linux-x64-musl-0.6.0-pre.33.tgz",
+      "integrity": "sha512-GZ2fqJ9jJZH6UgOvhneO9+lx1t1mIIg7Xj14rlmWLw3UCVRPLY7QuJEMqXtxPBG7TaWrQ0767hZHOiSdFrrXOw==",
       "cpu": [
         "x64"
       ],
@@ -3130,12 +3129,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/libsql/node_modules/libsql-linux-arm64-musl": {
-      "optional": true
-    },
-    "node_modules/libsql/node_modules/libsql-win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/load-json-file": {
       "version": "7.0.1",

--- a/testing/javascript/package.json
+++ b/testing/javascript/package.json
@@ -16,6 +16,6 @@
     "@tursodatabase/serverless": "../../serverless/javascript",
     "@tursodatabase/database": "../../bindings/javascript/packages/native",
     "better-sqlite3": "^11.9.1",
-    "libsql": "^0.6.0-pre.30"
+    "libsql": "^0.6.0-pre.33"
   }
 }


### PR DESCRIPTION
Runs 150 sequential stmt.all() calls against a 2000-row table with a 1s defaultQueryTimeout. Each query finishes well under the timeout, so none should ever be interrupted. If a previous query's timeout guard outlives the iterator (e.g. held until GC) it can fire against an unrelated later query and raise SQLITE_INTERRUPT.