### PR TITLE
core/translate: remove some clones

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -551,8 +551,8 @@ fn prepare_one_select_plan(
                     plan.group_by = Some(GroupBy {
                         sort_order: Vec::new(),
                         nulls_order: Vec::new(),
+                        exprs: group_by.exprs.into_iter().map(|expr| *expr).collect(),
                         sort_elided: false,
-                        exprs: group_by.exprs.iter().map(|expr| *expr.clone()).collect(),
                         having: having_predicates,
                     });
                 } else {
@@ -770,8 +770,8 @@ fn prepare_one_select_plan(
                 query_destination,
                 distinctness: Distinctness::NonDistinct,
                 values: values
-                    .iter()
-                    .map(|values| values.iter().map(|value| *value.clone()).collect())
+                    .into_iter()
+                    .map(|values| values.into_iter().map(|value| *value).collect())
                     .collect(),
                 window: None,
                 non_from_clause_subqueries,


### PR DESCRIPTION
## Description

We were cloning expressions too eagerly even though we already own the `expr` vec. This simply uses `into_iter` instead so we can move stuff around.


## Description of AI Usage

Worked with codex to setup a new wide table benchmark with dhat-rs to find some heap allocation issues.
