### PR TITLE
don't consider virtual columns for covering indexes

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2280,7 +2280,20 @@ impl JoinedTable {
                 // rowid is always implicitly covered by the index
                 continue;
             }
-            let covered_by_index = index.columns.iter().any(|c| c.pos_in_table == required_col);
+            let covered_by_index = index
+                .columns
+                .iter()
+                .filter(|c| c.pos_in_table == required_col)
+                .any(|c| {
+                    // SQLite doesn't consider fulfill covering indexes with virtual columns,
+                    // see `recomputeColumnsNotIndexed` in `build.c`. We might be able to improve this
+                    // in the future, but for now we do this to ensure correctness.
+                    !btree
+                        .columns
+                        .get(c.pos_in_table)
+                        .expect("column should be in table")
+                        .is_virtual_generated()
+                });
             if !covered_by_index {
                 return false;
             }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4465,3 +4465,11 @@ test replace-conflict-on-virtual-column {
     2|4
     3|6
 }
+
+test delete-using-indexed-virtual-column {
+    CREATE TABLE t(a, b AS (a * 2));
+    CREATE INDEX idx ON t(b);
+    INSERT INTO t VALUES (1);
+    DELETE FROM t WHERE b = 2;
+} expect {
+}


### PR DESCRIPTION
## Description

## Motivation and context

In queries like:

```sql
CREATE TABLE t(a, b AS (a * 2));
CREATE INDEX idx ON t(b);
INSERT INTO t VALUES (1);
DELETE FROM t WHERE b = 2; --this one
```

the `Expr::Column` was resolved to the index instead of the table, so the vdbe computed `idx.b * 2` instead of `t.a * 2`. This is because the planner chose a covering index scan, because it didn't see that `a` was required to compute `b`.

In this PR I'm doing the lazy thing and disregarding virtual columns for covering index scans. This is what SQLite does:

```
** 2019-10-24:  For the purpose of this computation, virtual columns are
** not considered to be covered by the index, even if they are in the
** index, because we do not trust the logic in whereIndexExprTrans() to be
** able to find all instances of a reference to the indexed table column
** and convert them into references to the index.  Hence we always want
** the actual table at hand in order to recompute the virtual column, if
** necessary.
```

Closes #6152

## Description of AI Usage

50/50