### PR TITLE
Add CREATE TABLE AS SELECT support

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -110,6 +110,19 @@ impl ResultSetColumn {
             _ => self.implicit_column_name.as_deref(),
         }
     }
+
+    /// Returns the column name, falling back to the expression's display form.
+    pub fn name_or_expr(&self, tables: &TableReferences) -> String {
+        self.name(tables)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| self.expr.to_string())
+    }
+
+    /// Returns the canonical short type name for this column's affinity,
+    /// matching SQLite's `azType[]` in `createTableStmt()` (build.c).
+    pub fn declared_type(&self, tables: &TableReferences) -> &'static str {
+        get_expr_affinity(&self.expr, Some(tables), None).short_type_name()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1,4 +1,5 @@
 use crate::sync::Arc;
+use crate::HashMap;
 
 use crate::ext::VTabImpl;
 use crate::function::{Deterministic, Func, MathFunc, ScalarFunc};
@@ -14,10 +15,13 @@ use crate::translate::emitter::{
 };
 use crate::translate::expr::{walk_expr, WalkControl};
 use crate::translate::fkeys::emit_fk_drop_table_check;
+use crate::translate::plan::{Plan, QueryDestination};
 use crate::translate::planner::ROWID_STRS;
+use crate::translate::select::{emit_select_plan, prepare_select_plan};
 use crate::translate::{ProgramBuilder, ProgramBuilderOpts};
 use crate::util::{
-    escape_sql_string_literal, normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX,
+    escape_sql_string_literal, normalize_ident, quote_identifier,
+    PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX,
 };
 use crate::vdbe::builder::CursorType;
 use crate::vdbe::insn::{
@@ -851,6 +855,210 @@ fn validate(
     Ok(())
 }
 
+/// Schema information derived from a CTAS SELECT.
+struct CtasInfo {
+    plan: Plan,
+    schema_sql: String,
+}
+
+/// Pre-plan the SELECT to derive the schema for a CTAS table.
+/// Returns the plan (for reuse in emission) along with the complete schema SQL and column definitions.
+fn derive_ctas_schema(
+    select: ast::Select,
+    table_name: &str,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    connection: &Arc<Connection>,
+) -> Result<(CtasInfo, Vec<ColumnDefinition>)> {
+    let plan = prepare_select_plan(
+        select,
+        resolver,
+        program,
+        &[],
+        QueryDestination::ResultRows,
+        connection,
+    )?;
+
+    // For compound selects, use the leftmost select's columns for naming (matching SQLite).
+    // The planner guarantees `left` is always non-empty in a CompoundSelect.
+    let (result_columns, table_refs) = match &plan {
+        Plan::Select(sp) => (&sp.result_columns, &sp.table_references),
+        Plan::CompoundSelect { left, .. } => {
+            (&left[0].0.result_columns, &left[0].0.table_references)
+        }
+        _ => bail_parse_error!("unexpected plan type for CTAS"),
+    };
+
+    // Collect names first, then deduplicate using SQLite's :N suffix convention.
+    let mut names: Vec<String> = result_columns
+        .iter()
+        .map(|col| col.name_or_expr(table_refs))
+        .collect();
+
+    let mut seen: HashMap<String, usize> = HashMap::default();
+    for name in &mut names {
+        let lower = name.to_lowercase();
+        let count = seen.entry(lower).or_insert(0);
+        if *count > 0 {
+            *name = format!("{name}:{count}");
+        }
+        *count += 1;
+    }
+
+    let mut sql_parts = Vec::with_capacity(result_columns.len());
+    let mut col_defs = Vec::with_capacity(result_columns.len());
+
+    for (col, name) in result_columns.iter().zip(names) {
+        let ty = col.declared_type(table_refs);
+
+        let quoted = quote_identifier(&name);
+        if ty.is_empty() {
+            sql_parts.push(quoted);
+        } else {
+            sql_parts.push(format!("{quoted} {ty}"));
+        }
+
+        let col_type = if ty.is_empty() {
+            None
+        } else {
+            Some(ast::Type {
+                name: ty.to_string(),
+                size: None,
+                array_dimensions: 0,
+            })
+        };
+        col_defs.push(ColumnDefinition {
+            col_name: ast::Name::exact(name),
+            col_type,
+            constraints: vec![],
+        });
+    }
+
+    let info = CtasInfo {
+        plan,
+        schema_sql: format!("CREATE TABLE {table_name}({})", sql_parts.join(",")),
+    };
+    Ok((info, col_defs))
+}
+
+/// Emit bytecode to populate a newly-created CTAS table from the SELECT.
+/// Uses a coroutine to run the SELECT and insert each result row.
+/// Takes an already-prepared plan (from `derive_ctas_schema`) to avoid double planning.
+#[allow(clippy::too_many_arguments)]
+fn emit_ctas_insert(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    mut plan: Plan,
+    body: &ast::CreateTableBody,
+    table_root_reg: usize,
+    col_count: usize,
+    database_id: usize,
+    table_name: &str,
+    connection: &Arc<Connection>,
+) -> Result<()> {
+    let opts = ProgramBuilderOpts {
+        num_cursors: 2,
+        approx_num_insns: 20,
+        approx_num_labels: 3,
+    };
+    program.extend(&opts);
+
+    // Set up coroutine for the SELECT
+    let yield_reg = program.alloc_register();
+    let jump_on_definition_label = program.allocate_label();
+    let start_offset_label = program.allocate_label();
+    let halt_label = program.allocate_label();
+
+    program.emit_insn(Insn::InitCoroutine {
+        yield_reg,
+        jump_on_definition: jump_on_definition_label,
+        start_offset: start_offset_label,
+    });
+    program.preassign_label_to_next_insn(start_offset_label);
+
+    // Switch the plan's destination to coroutine yield mode.
+    let dest = plan.select_query_destination_mut().ok_or_else(|| {
+        crate::LimboError::InternalError("CTAS plan must be a SELECT or CompoundSelect".into())
+    })?;
+    *dest = QueryDestination::CoroutineYield {
+        yield_reg,
+        coroutine_implementation_start: halt_label,
+    };
+
+    let num_result_cols =
+        program.nested(|program| emit_select_plan(plan, resolver, program, connection))?;
+
+    if num_result_cols != col_count {
+        bail_parse_error!(
+            "CTAS internal error: expected {} columns from SELECT but got {}",
+            col_count,
+            num_result_cols
+        );
+    }
+
+    program.emit_insn(Insn::EndCoroutine { yield_reg });
+    program.preassign_label_to_next_insn(jump_on_definition_label);
+
+    // Open the new table for writing using the root page from CreateBtree.
+    let ctas_btree = Arc::new(create_table(table_name, body, 0)?);
+    let new_table_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(ctas_btree));
+    program.emit_insn(Insn::OpenWrite {
+        cursor_id: new_table_cursor_id,
+        root_page: RegisterOrLiteral::Register(table_root_reg),
+        db: database_id,
+    });
+
+    // Main insert loop: yield from coroutine, make record, insert
+    let loop_start = program.allocate_label();
+    let loop_end = program.allocate_label();
+
+    program.preassign_label_to_next_insn(loop_start);
+    program.emit_insn(Insn::Yield {
+        yield_reg,
+        end_offset: loop_end,
+        subtype_clear_start_reg: 0,
+        subtype_clear_count: 0,
+    });
+
+    let result_start_reg = program.reg_result_cols_start.ok_or_else(|| {
+        crate::LimboError::InternalError(
+            "CTAS internal error: result column start register not set".into(),
+        )
+    })?;
+    let record_reg = program.alloc_register();
+    program.emit_insn(Insn::MakeRecord {
+        start_reg: to_u16(result_start_reg),
+        count: to_u16(col_count),
+        dest_reg: to_u16(record_reg),
+        index_name: None,
+        affinity_str: None,
+    });
+
+    let rowid_reg = program.alloc_register();
+    program.emit_insn(Insn::NewRowid {
+        cursor: new_table_cursor_id,
+        rowid_reg,
+        prev_largest_reg: 0,
+    });
+
+    program.emit_insn(Insn::Insert {
+        cursor: new_table_cursor_id,
+        key_reg: rowid_reg,
+        record_reg,
+        flag: InsertFlags::new(),
+        table_name: table_name.to_string(),
+    });
+
+    program.emit_insn(Insn::Goto {
+        target_pc: loop_start,
+    });
+
+    program.preassign_label_to_next_insn(loop_end);
+    program.preassign_label_to_next_insn(halt_label);
+
+    Ok(())
+}
+
 pub fn translate_create_table(
     tbl_name: ast::QualifiedName,
     resolver: &Resolver,
@@ -858,8 +1066,29 @@ pub fn translate_create_table(
     if_not_exists: bool,
     body: ast::CreateTableBody,
     program: &mut ProgramBuilder,
-    connection: &Connection,
+    connection: &Arc<Connection>,
 ) -> Result<()> {
+    // For CTAS, extract the SELECT, determine column info, and convert to a
+    // regular ColumnsAndConstraints body + separate SELECT for data insertion.
+    let (body, ctas_info) = match body {
+        ast::CreateTableBody::AsSelect(select) => {
+            let (info, col_defs) = derive_ctas_schema(
+                select,
+                &tbl_name.name.as_ident(),
+                resolver,
+                program,
+                connection,
+            )?;
+            let body = ast::CreateTableBody::ColumnsAndConstraints {
+                columns: col_defs,
+                constraints: vec![],
+                options: ast::TableOptions::empty(),
+            };
+            (body, Some(info))
+        }
+        other => (other, None),
+    };
+
     let database_id = if temporary {
         crate::TEMP_DB_ID
     } else {
@@ -1028,7 +1257,12 @@ pub fn translate_create_table(
         false
     };
 
-    let sql = create_table_body_to_str(&tbl_name, &body)?;
+    // For CTAS, use the pre-built SQL string; for regular CREATE TABLE, build it from the body.
+    let sql = if let Some(ref info) = ctas_info {
+        info.schema_sql.clone()
+    } else {
+        create_table_body_to_str(&tbl_name, &body)?
+    };
 
     let parse_schema_label = program.allocate_label();
 
@@ -1139,7 +1373,24 @@ pub fn translate_create_table(
         where_clause: Some(parse_schema_where_clause),
     });
 
-    // TODO: SqlExec
+    // For CTAS, emit bytecode to populate the new table from the SELECT
+    if let Some(info) = ctas_info {
+        let col_count = match &body {
+            ast::CreateTableBody::ColumnsAndConstraints { columns, .. } => columns.len(),
+            _ => unreachable!("CTAS body was converted to ColumnsAndConstraints above"),
+        };
+        emit_ctas_insert(
+            program,
+            resolver,
+            info.plan,
+            &body,
+            table_root_reg,
+            col_count,
+            database_id,
+            &normalized_tbl_name,
+            connection,
+        )?;
+    }
 
     Ok(())
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -38,7 +38,7 @@ pub fn translate_select(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
-    let mut select_plan = prepare_select_plan(
+    let plan = prepare_select_plan(
         select,
         resolver,
         program,
@@ -47,13 +47,23 @@ pub fn translate_select(
         connection,
     )?;
     if program.trigger.is_some() {
-        if let Some(virtual_table) = plan_first_virtual_table_name(&select_plan) {
+        if let Some(virtual_table) = plan_first_virtual_table_name(&plan) {
             crate::bail_parse_error!("unsafe use of virtual table \"{}\"", virtual_table);
         }
     }
-    optimize_plan(program, &mut select_plan, resolver)?;
+    emit_select_plan(plan, resolver, program, connection)
+}
+
+/// Optimize and emit bytecode for an already-prepared select plan.
+pub fn emit_select_plan(
+    mut plan: Plan,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    connection: &Arc<crate::Connection>,
+) -> Result<usize> {
+    optimize_plan(program, &mut plan, resolver)?;
     let num_result_cols;
-    let opts = match &select_plan {
+    let opts = match &plan {
         Plan::Select(select) => {
             num_result_cols = select.result_columns.len();
             ProgramBuilderOpts {
@@ -86,11 +96,11 @@ pub fn translate_select(
                         .sum::<usize>(),
             }
         }
-        other => panic!("plan is not a SelectPlan: {other:?}"),
+        _ => crate::bail_parse_error!("emit_select_plan called with non-SELECT plan"),
     };
 
     program.extend(&opts);
-    emit_program(connection, resolver, program, select_plan, |_| {})?;
+    emit_program(connection, resolver, program, plan, |_| {})?;
     Ok(num_result_cols)
 }
 

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -133,6 +133,21 @@ impl Affinity {
         !matches!(self, Affinity::Blob)
     }
 
+    /// Returns the canonical short type name for this affinity, matching
+    /// SQLite's `azType[]` in `createTableStmt()` (`build.c`).
+    ///
+    /// Used when generating schema SQL (e.g. for `sqlite_schema.sql`).
+    /// Returns an empty string for BLOB affinity (no declared type).
+    pub fn short_type_name(&self) -> &'static str {
+        match self {
+            Affinity::Blob => "",
+            Affinity::Text => "TEXT",
+            Affinity::Numeric => "NUM",
+            Affinity::Integer => "INT",
+            Affinity::Real => "REAL",
+        }
+    }
+
     /// 3.1. Determination Of Column Affinity
     /// For tables not declared as STRICT, the affinity of a column is determined by the declared type of the column, according to the following rules in the order shown:
     ///

--- a/testing/differential-oracle/sql_gen_prop/create_table_as.rs
+++ b/testing/differential-oracle/sql_gen_prop/create_table_as.rs
@@ -1,0 +1,173 @@
+//! CREATE TABLE AS SELECT statement generation.
+
+use std::collections::HashSet;
+use std::fmt;
+
+use proptest::prelude::*;
+
+use crate::create_table::identifier_excluding;
+use crate::profile::StatementProfile;
+use crate::schema::Schema;
+use crate::select::select_for_table;
+
+/// CREATE TABLE AS SELECT statement.
+#[derive(Debug, Clone)]
+pub struct CreateTableAsStatement {
+    /// Whether to use IF NOT EXISTS clause.
+    pub if_not_exists: bool,
+    /// Table name.
+    pub table_name: String,
+    /// SELECT statement as string.
+    pub select_sql: String,
+}
+
+impl fmt::Display for CreateTableAsStatement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CREATE TABLE")?;
+        if self.if_not_exists {
+            write!(f, " IF NOT EXISTS")?;
+        }
+        write!(f, " {} AS {}", self.table_name, self.select_sql)
+    }
+}
+
+/// Generate a CREATE TABLE AS SELECT statement for a schema.
+///
+/// Generates varied SELECT statements including column subsets, expressions,
+/// WHERE clauses, ORDER BY/LIMIT, and cross-joins that produce duplicate column names.
+pub fn create_table_as(schema: &Schema) -> BoxedStrategy<CreateTableAsStatement> {
+    assert!(
+        !schema.tables.is_empty(),
+        "Schema must have at least one table to create a table AS SELECT"
+    );
+
+    let tables = schema.tables.clone();
+    let existing_names: HashSet<String> = schema
+        .table_names()
+        .into_iter()
+        .chain(schema.view_names())
+        .collect();
+
+    let schema_clone = schema.clone();
+    let profile = StatementProfile::default();
+
+    (
+        any::<bool>(),
+        identifier_excluding(existing_names),
+        proptest::sample::select((*tables).clone()),
+    )
+        .prop_flat_map(move |(if_not_exists, table_name, table)| {
+            let schema = schema_clone.clone();
+            let profile = profile.clone();
+
+            // Use the full select generator for richer coverage
+            let rich_select = select_for_table(&table, &schema, &profile)
+                .prop_map(|stmt| stmt.to_string())
+                .boxed();
+
+            // Join variant: cross-join two tables to exercise duplicate column names
+            let join_select = if schema.tables.len() >= 2 {
+                let tables_vec: Vec<_> = schema.tables.iter().cloned().collect();
+                proptest::sample::subsequence(tables_vec, 2..=2)
+                    .prop_map(|pair| {
+                        let t1 = &pair[0];
+                        let t2 = &pair[1];
+                        format!(
+                            "SELECT {t1}.*, {t2}.* FROM {t1}, {t2}",
+                            t1 = t1.qualified_name(),
+                            t2 = t2.qualified_name(),
+                        )
+                    })
+                    .boxed()
+            } else {
+                // Fallback: self-join with aliases
+                let tname = table.qualified_name();
+                Just(format!("SELECT a.*, b.* FROM {tname} AS a, {tname} AS b")).boxed()
+            };
+
+            // SELECT * (simple, original behavior)
+            let star_select = {
+                let tname = table.qualified_name();
+                Just(format!("SELECT * FROM {tname}")).boxed()
+            };
+
+            // Weight: rich selects most common, joins for dup coverage, star for simplicity
+            let select_strategy = proptest::strategy::Union::new_weighted(vec![
+                (5, rich_select),
+                (3, join_select),
+                (2, star_select),
+            ]);
+
+            select_strategy.prop_map(move |select_sql| CreateTableAsStatement {
+                if_not_exists,
+                table_name: table_name.clone(),
+                select_sql,
+            })
+        })
+        .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{ColumnDef, DataType, SchemaBuilder, Table};
+
+    fn test_schema() -> Schema {
+        SchemaBuilder::new()
+            .add_table(Table::new(
+                "users",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("name", DataType::Text),
+                ],
+            ))
+            .add_table(Table::new(
+                "orders",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("user_id", DataType::Integer),
+                    ColumnDef::new("amount", DataType::Real),
+                ],
+            ))
+            .build()
+    }
+
+    proptest! {
+        #[test]
+        fn create_table_as_generates_valid_sql(stmt in create_table_as(&test_schema())) {
+            let sql = stmt.to_string();
+            prop_assert!(sql.starts_with("CREATE TABLE"));
+            // The SELECT part may start with WITH (CTE) or SELECT
+            prop_assert!(sql.contains(" AS "));
+            prop_assert!(stmt.select_sql.contains("SELECT"));
+        }
+
+        #[test]
+        fn create_table_as_join_variant_generates_cross_joins(
+            stmt in create_table_as(&test_schema())
+        ) {
+            // Just ensure generation doesn't panic and produces valid SQL
+            let sql = stmt.to_string();
+            prop_assert!(sql.starts_with("CREATE TABLE"));
+        }
+    }
+
+    #[test]
+    fn single_table_schema_still_works() {
+        let schema = SchemaBuilder::new()
+            .add_table(Table::new(
+                "t1",
+                vec![
+                    ColumnDef::new("a", DataType::Integer),
+                    ColumnDef::new("b", DataType::Text),
+                ],
+            ))
+            .build();
+
+        proptest!(|(stmt in create_table_as(&schema))| {
+            let sql = stmt.to_string();
+            prop_assert!(sql.starts_with("CREATE TABLE"));
+            prop_assert!(stmt.select_sql.contains("SELECT"));
+        });
+    }
+}

--- a/testing/differential-oracle/sql_gen_prop/lib.rs
+++ b/testing/differential-oracle/sql_gen_prop/lib.rs
@@ -15,6 +15,7 @@
 pub mod alter_table;
 pub mod create_index;
 pub mod create_table;
+pub mod create_table_as;
 pub mod create_trigger;
 pub mod cte;
 pub mod delete;
@@ -42,6 +43,7 @@ pub use alter_table::{
 };
 pub use create_index::{CreateIndexStatement, IndexColumn};
 pub use create_table::{ColumnProfile, CreateTableStatement, DataTypeWeights, PrimaryKeyProfile};
+pub use create_table_as::CreateTableAsStatement;
 pub use create_trigger::{
     CreateTriggerContext, CreateTriggerKind, CreateTriggerOpWeights, CreateTriggerStatement,
     TriggerEvent, TriggerTiming,
@@ -95,6 +97,8 @@ pub mod strategies {
         column_def, create_table, data_type, identifier, identifier_excluding,
         primary_key_column_def,
     };
+    // CREATE TABLE AS SELECT
+    pub use crate::create_table_as::create_table_as;
     // DELETE
     pub use crate::delete::delete_for_table;
     // DROP INDEX

--- a/testing/differential-oracle/sql_gen_prop/profile.rs
+++ b/testing/differential-oracle/sql_gen_prop/profile.rs
@@ -160,6 +160,8 @@ pub struct StatementProfile {
     // DDL weights - Tables
     /// CREATE TABLE weight and optional generation profile.
     pub create_table: WeightedProfile<CreateTableProfile>,
+    /// CREATE TABLE AS SELECT weight (no extra profile needed).
+    pub create_table_as_weight: u32,
     /// DROP TABLE weight (no extra profile needed).
     pub drop_table_weight: u32,
     /// ALTER TABLE weight and optional operation-level weights.
@@ -211,6 +213,7 @@ impl Default for StatementProfile {
 
             // DDL - less frequent
             create_table: WeightedProfile::new(2),
+            create_table_as_weight: 1,
             drop_table_weight: 1,
             alter_table: WeightedProfile::new(1),
             create_index: WeightedProfile::new(2),
@@ -247,6 +250,7 @@ impl StatementProfile {
             update: WeightedProfile::new(0),
             delete: WeightedProfile::new(0),
             create_table: WeightedProfile::new(0),
+            create_table_as_weight: 0,
             drop_table_weight: 0,
             alter_table: WeightedProfile::new(0),
             create_index: WeightedProfile::new(0),
@@ -403,6 +407,12 @@ impl StatementProfile {
         self
     }
 
+    /// Builder method to set CREATE TABLE AS SELECT weight.
+    pub fn with_create_table_as(mut self, weight: u32) -> Self {
+        self.create_table_as_weight = weight;
+        self
+    }
+
     /// Builder method to set DROP TABLE weight.
     pub fn with_drop_table(mut self, weight: u32) -> Self {
         self.drop_table_weight = weight;
@@ -552,6 +562,7 @@ impl StatementProfile {
     /// Returns the total DDL weight.
     pub fn ddl_weight(&self) -> u32 {
         self.create_table.weight
+            + self.create_table_as_weight
             + self.drop_table_weight
             + self.alter_table.weight
             + self.create_index.weight
@@ -609,6 +620,7 @@ impl StatementProfile {
             StatementKind::Update => self.update.weight,
             StatementKind::Delete => self.delete.weight,
             StatementKind::CreateTable => self.create_table.weight,
+            StatementKind::CreateTableAs => self.create_table_as_weight,
             StatementKind::DropTable => self.drop_table_weight,
             StatementKind::AlterTable => self.alter_table.weight,
             StatementKind::CreateIndex => self.create_index.weight,

--- a/testing/differential-oracle/sql_gen_prop/statement.rs
+++ b/testing/differential-oracle/sql_gen_prop/statement.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use crate::alter_table::{AlterTableStatement, alter_table_for_schema};
 use crate::create_index::{CreateIndexStatement, create_index, create_index_for_table};
 use crate::create_table::{CreateTableStatement, create_table};
+use crate::create_table_as::{CreateTableAsStatement, create_table_as};
 use crate::create_trigger::{CreateTriggerStatement, create_trigger_for_schema};
 use crate::delete::{DeleteStatement, delete_for_table};
 use crate::drop_index::DropIndexStatement;
@@ -50,6 +51,7 @@ pub enum SqlStatement {
 
     // DDL - Tables
     CreateTable(CreateTableStatement),
+    CreateTableAs(CreateTableAsStatement),
     DropTable(DropTableStatement),
     AlterTable(AlterTableStatement),
 
@@ -86,6 +88,7 @@ impl fmt::Display for SqlStatement {
             SqlStatement::Update(s) => write!(f, "{s}"),
             SqlStatement::Delete(s) => write!(f, "{s}"),
             SqlStatement::CreateTable(s) => write!(f, "{s}"),
+            SqlStatement::CreateTableAs(s) => write!(f, "{s}"),
             SqlStatement::DropTable(s) => write!(f, "{s}"),
             SqlStatement::AlterTable(s) => write!(f, "{s}"),
             SqlStatement::CreateIndex(s) => write!(f, "{s}"),
@@ -125,6 +128,7 @@ impl StatementKind {
         matches!(
             self,
             StatementKind::CreateTable
+                | StatementKind::CreateTableAs
                 | StatementKind::DropTable
                 | StatementKind::AlterTable
                 | StatementKind::CreateIndex
@@ -175,6 +179,7 @@ impl SqlGeneratorKind for StatementKind {
 
             // DDL - Table operations
             StatementKind::CreateTable => true,
+            StatementKind::CreateTableAs => !schema.tables.is_empty(),
             StatementKind::DropTable | StatementKind::AlterTable => !schema.tables.is_empty(),
 
             // DDL - Index operations
@@ -211,6 +216,7 @@ impl SqlGeneratorKind for StatementKind {
 
             // DDL - Table operations
             StatementKind::CreateTable => true,
+            StatementKind::CreateTableAs => true,
             StatementKind::DropTable | StatementKind::AlterTable => true,
 
             // DDL - Index operations
@@ -274,6 +280,9 @@ impl SqlGeneratorKind for StatementKind {
             // DDL - Tables
             StatementKind::CreateTable => create_table(schema, profile)
                 .prop_map(SqlStatement::CreateTable)
+                .boxed(),
+            StatementKind::CreateTableAs => create_table_as(schema)
+                .prop_map(SqlStatement::CreateTableAs)
                 .boxed(),
             StatementKind::DropTable => drop_table_for_schema(schema)
                 .prop_map(SqlStatement::DropTable)

--- a/testing/sqltests/tests/create_table_as_select.sqltest
+++ b/testing/sqltests/tests/create_table_as_select.sqltest
@@ -1,0 +1,631 @@
+@database :memory:
+
+# Basic CREATE TABLE AS SELECT
+
+@cross-check-integrity
+test ctas_basic {
+    CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT, value REAL);
+    INSERT INTO src VALUES (1, 'alice', 10.5);
+    INSERT INTO src VALUES (2, 'bob', 20.3);
+    INSERT INTO src VALUES (3, 'charlie', 30.7);
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    1|alice|10.5
+    2|bob|20.3
+    3|charlie|30.7
+}
+
+@cross-check-integrity
+test ctas_select_columns {
+    CREATE TABLE src (id INTEGER, name TEXT, value REAL);
+    INSERT INTO src VALUES (1, 'alice', 10.5);
+    INSERT INTO src VALUES (2, 'bob', 20.3);
+    CREATE TABLE dst AS SELECT id, name FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    1|alice
+    2|bob
+}
+
+@cross-check-integrity
+test ctas_with_expressions {
+    CREATE TABLE src (a INTEGER, b INTEGER);
+    INSERT INTO src VALUES (10, 3);
+    INSERT INTO src VALUES (20, 7);
+    CREATE TABLE dst AS SELECT a + b AS sum, a * b AS product FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    13|30
+    27|140
+}
+
+@cross-check-integrity
+test ctas_with_where {
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO src VALUES (1, 100);
+    INSERT INTO src VALUES (2, 200);
+    INSERT INTO src VALUES (3, 300);
+    CREATE TABLE dst AS SELECT * FROM src WHERE val > 150;
+    SELECT * FROM dst;
+}
+expect {
+    2|200
+    3|300
+}
+
+@cross-check-integrity
+test ctas_with_order_by_limit {
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO src VALUES (1, 30);
+    INSERT INTO src VALUES (2, 10);
+    INSERT INTO src VALUES (3, 20);
+    CREATE TABLE dst AS SELECT * FROM src ORDER BY val LIMIT 2;
+    SELECT * FROM dst;
+}
+expect {
+    2|10
+    3|20
+}
+
+# Aggregates
+
+@cross-check-integrity
+test ctas_aggregate {
+    CREATE TABLE src (category TEXT, amount REAL);
+    INSERT INTO src VALUES ('a', 10.5);
+    INSERT INTO src VALUES ('a', 20.3);
+    INSERT INTO src VALUES ('b', 30.7);
+    CREATE TABLE dst AS SELECT category, SUM(amount) AS total FROM src GROUP BY category;
+    SELECT * FROM dst ORDER BY category;
+}
+expect {
+    a|30.8
+    b|30.7
+}
+
+@cross-check-integrity
+test ctas_aggregate_count {
+    CREATE TABLE src (x INTEGER);
+    INSERT INTO src VALUES (1);
+    INSERT INTO src VALUES (2);
+    INSERT INTO src VALUES (3);
+    CREATE TABLE dst AS SELECT COUNT(*) AS cnt FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    3
+}
+
+# Joins
+
+@cross-check-integrity
+test ctas_join {
+    CREATE TABLE t1 (id INTEGER, name TEXT);
+    CREATE TABLE t2 (id INTEGER, t1_id INTEGER, value REAL);
+    INSERT INTO t1 VALUES (1, 'alice');
+    INSERT INTO t1 VALUES (2, 'bob');
+    INSERT INTO t2 VALUES (1, 1, 100.5);
+    INSERT INTO t2 VALUES (2, 2, 200.3);
+    CREATE TABLE dst AS SELECT t1.name, t2.value FROM t1 JOIN t2 ON t1.id = t2.t1_id;
+    SELECT * FROM dst ORDER BY name;
+}
+expect {
+    alice|100.5
+    bob|200.3
+}
+
+@cross-check-integrity
+test ctas_left_join {
+    CREATE TABLE t1 (id INTEGER, name TEXT);
+    CREATE TABLE t2 (t1_id INTEGER, val TEXT);
+    INSERT INTO t1 VALUES (1, 'alice');
+    INSERT INTO t1 VALUES (2, 'bob');
+    INSERT INTO t2 VALUES (1, 'x');
+    CREATE TABLE dst AS SELECT t1.name, t2.val FROM t1 LEFT JOIN t2 ON t1.id = t2.t1_id;
+    SELECT * FROM dst ORDER BY name;
+}
+expect {
+    alice|x
+    bob|
+}
+
+# NULL handling
+
+@cross-check-integrity
+test ctas_nulls {
+    CREATE TABLE src (a INTEGER, b TEXT);
+    INSERT INTO src VALUES (1, NULL);
+    INSERT INTO src VALUES (NULL, 'hello');
+    INSERT INTO src VALUES (NULL, NULL);
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    1|
+    |hello
+    |
+}
+
+# Empty result set
+
+@cross-check-integrity
+test ctas_empty_result {
+    CREATE TABLE src (id INTEGER, name TEXT);
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT COUNT(*) FROM dst;
+}
+expect {
+    0
+}
+
+@cross-check-integrity
+test ctas_empty_with_where_false {
+    CREATE TABLE src (id INTEGER, name TEXT);
+    INSERT INTO src VALUES (1, 'alice');
+    CREATE TABLE dst AS SELECT * FROM src WHERE 0;
+    SELECT COUNT(*) FROM dst;
+}
+expect {
+    0
+}
+
+# Type affinity
+
+@cross-check-integrity
+test ctas_type_preservation {
+    CREATE TABLE src (i INTEGER, r REAL, t TEXT, b BLOB);
+    INSERT INTO src VALUES (42, 3.14, 'hello', X'DEADBEEF');
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT typeof(i), typeof(r), typeof(t), typeof(b) FROM dst;
+}
+expect {
+    integer|real|text|blob
+}
+
+# Literals and constants
+
+@cross-check-integrity
+test ctas_literals {
+    CREATE TABLE dst AS SELECT 1 AS a, 'text' AS b, 3.14 AS c, NULL AS d;
+    SELECT * FROM dst;
+}
+expect {
+    1|text|3.14|
+}
+
+# UNION
+
+@cross-check-integrity
+test ctas_union {
+    CREATE TABLE t1 (x INTEGER);
+    CREATE TABLE t2 (x INTEGER);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (2), (3);
+    CREATE TABLE dst AS SELECT x FROM t1 UNION SELECT x FROM t2;
+    SELECT * FROM dst ORDER BY x;
+}
+expect {
+    1
+    2
+    3
+}
+
+@cross-check-integrity
+test ctas_union_all {
+    CREATE TABLE t1 (x INTEGER);
+    CREATE TABLE t2 (x INTEGER);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (2), (3);
+    CREATE TABLE dst AS SELECT x FROM t1 UNION ALL SELECT x FROM t2;
+    SELECT * FROM dst ORDER BY x;
+}
+expect {
+    1
+    2
+    2
+    3
+}
+
+# Subquery
+
+@cross-check-integrity
+test ctas_subquery {
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO src VALUES (1, 10);
+    INSERT INTO src VALUES (2, 20);
+    INSERT INTO src VALUES (3, 30);
+    CREATE TABLE dst AS SELECT * FROM (SELECT id, val * 2 AS doubled FROM src) sub WHERE doubled > 25;
+    SELECT * FROM dst;
+}
+expect {
+    2|40
+    3|60
+}
+
+# IF NOT EXISTS
+
+@cross-check-integrity
+test ctas_if_not_exists {
+    CREATE TABLE dst (x INTEGER);
+    INSERT INTO dst VALUES (999);
+    CREATE TABLE IF NOT EXISTS dst AS SELECT 1 AS x;
+    SELECT * FROM dst;
+}
+expect {
+    999
+}
+
+# Duplicate table name error
+
+@cross-check-integrity
+test ctas_duplicate_table {
+    CREATE TABLE dst (x INTEGER);
+    CREATE TABLE dst AS SELECT 1 AS x;
+}
+expect error {
+}
+
+# CTAS from schema introspection
+
+@cross-check-integrity
+test ctas_column_names {
+    CREATE TABLE src (alpha INTEGER, beta TEXT, gamma REAL);
+    CREATE TABLE dst AS SELECT alpha, beta, gamma FROM src;
+    SELECT name FROM pragma_table_info('dst') ORDER BY cid;
+}
+expect {
+    alpha
+    beta
+    gamma
+}
+
+@cross-check-integrity
+test ctas_aliased_columns {
+    CREATE TABLE src (x INTEGER);
+    INSERT INTO src VALUES (1);
+    CREATE TABLE dst AS SELECT x AS renamed FROM src;
+    SELECT name FROM pragma_table_info('dst');
+}
+expect {
+    renamed
+}
+
+@cross-check-integrity
+test ctas_expression_column_names {
+    CREATE TABLE src (a INTEGER, b INTEGER);
+    INSERT INTO src VALUES (1, 2);
+    CREATE TABLE dst AS SELECT a + b AS result FROM src;
+    SELECT name FROM pragma_table_info('dst');
+}
+expect {
+    result
+}
+
+# DISTINCT
+
+@cross-check-integrity
+test ctas_distinct {
+    CREATE TABLE src (x INTEGER);
+    INSERT INTO src VALUES (1), (1), (2), (2), (3);
+    CREATE TABLE dst AS SELECT DISTINCT x FROM src;
+    SELECT * FROM dst ORDER BY x;
+}
+expect {
+    1
+    2
+    3
+}
+
+# HAVING
+
+@cross-check-integrity
+test ctas_group_by_having {
+    CREATE TABLE src (cat TEXT, val INTEGER);
+    INSERT INTO src VALUES ('a', 1), ('a', 2), ('b', 10), ('b', 20), ('c', 100);
+    CREATE TABLE dst AS SELECT cat, SUM(val) AS total FROM src GROUP BY cat HAVING total > 5;
+    SELECT * FROM dst ORDER BY cat;
+}
+expect {
+    b|30
+    c|100
+}
+
+# CASE expression
+
+@cross-check-integrity
+test ctas_case_expression {
+    CREATE TABLE src (val INTEGER);
+    INSERT INTO src VALUES (1), (2), (3);
+    CREATE TABLE dst AS SELECT val, CASE WHEN val < 2 THEN 'low' WHEN val < 3 THEN 'med' ELSE 'high' END AS label FROM src;
+    SELECT * FROM dst ORDER BY val;
+}
+expect {
+    1|low
+    2|med
+    3|high
+}
+
+# COALESCE / IFNULL
+
+@cross-check-integrity
+test ctas_coalesce {
+    CREATE TABLE src (a INTEGER, b INTEGER);
+    INSERT INTO src VALUES (NULL, 10);
+    INSERT INTO src VALUES (5, 20);
+    CREATE TABLE dst AS SELECT COALESCE(a, b) AS result FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    10
+    5
+}
+
+# Multiple tables with same columns
+
+@cross-check-integrity
+test ctas_cross_join {
+    CREATE TABLE t1 (a INTEGER);
+    CREATE TABLE t2 (b TEXT);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES ('x'), ('y');
+    CREATE TABLE dst AS SELECT a, b FROM t1, t2;
+    SELECT * FROM dst ORDER BY a, b;
+}
+expect {
+    1|x
+    1|y
+    2|x
+    2|y
+}
+
+# Schema: verify dst is insertable after CTAS
+
+@cross-check-integrity
+test ctas_insert_after_create {
+    CREATE TABLE src (id INTEGER, name TEXT);
+    INSERT INTO src VALUES (1, 'alice');
+    CREATE TABLE dst AS SELECT * FROM src;
+    INSERT INTO dst VALUES (2, 'bob');
+    SELECT * FROM dst ORDER BY id;
+}
+expect {
+    1|alice
+    2|bob
+}
+
+# Verify table schema is stored correctly (sqlite_schema)
+
+@cross-check-integrity
+test ctas_schema_sql {
+    CREATE TABLE src (id INTEGER, name TEXT);
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst(id INT,name TEXT)
+}
+
+# Schema SQL: expression column names must be double-quoted
+
+@cross-check-integrity
+test ctas_schema_sql_expression_columns {
+    CREATE TABLE src (a INTEGER, b TEXT);
+    INSERT INTO src VALUES(1, 'hello');
+    CREATE TABLE dst AS SELECT a + 1, count(*) FROM src GROUP BY a;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst("a + 1","count(*)")
+}
+
+# Schema SQL: mixed aliased and expression columns
+
+@cross-check-integrity
+test ctas_schema_sql_mixed_alias_expr {
+    CREATE TABLE src (a INTEGER, b TEXT, c REAL);
+    CREATE TABLE dst AS SELECT a as id, b || c, length(b) FROM src;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst(id INT,"b || c","length(b)")
+}
+
+# Schema SQL: literal-only columns
+
+@cross-check-integrity
+test ctas_schema_sql_literals {
+    CREATE TABLE dst AS SELECT 1, 'text', 3.14, NULL;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst("1","'text'","3.14","NULL")
+}
+
+# Schema SQL: source column with spaces needs quoting
+
+@cross-check-integrity
+test ctas_schema_sql_quoted_source_col {
+    CREATE TABLE src ("weird col" TEXT);
+    CREATE TABLE dst AS SELECT "weird col" FROM src;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst("weird col" TEXT)
+}
+
+# Schema SQL: verify expression-derived schema is re-parseable (can query the table)
+
+@cross-check-integrity
+test ctas_schema_expr_reparseable {
+    CREATE TABLE src (a INTEGER, b TEXT);
+    INSERT INTO src VALUES(1, 'hello');
+    INSERT INTO src VALUES(2, 'world');
+    CREATE TABLE dst AS SELECT a + 1, length(b) FROM src;
+    SELECT * FROM dst ORDER BY "a + 1";
+}
+expect {
+    2|5
+    3|5
+}
+
+# Values from different types in same column
+
+@cross-check-integrity
+test ctas_mixed_types {
+    CREATE TABLE src (x);
+    INSERT INTO src VALUES (1);
+    INSERT INTO src VALUES ('hello');
+    INSERT INTO src VALUES (3.14);
+    INSERT INTO src VALUES (NULL);
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT typeof(x), x FROM dst;
+}
+expect {
+    integer|1
+    text|hello
+    real|3.14
+    null|
+}
+
+# Scalar functions
+
+@cross-check-integrity
+test ctas_with_functions {
+    CREATE TABLE src (name TEXT);
+    INSERT INTO src VALUES ('hello');
+    INSERT INTO src VALUES ('world');
+    CREATE TABLE dst AS SELECT UPPER(name) AS uname, LENGTH(name) AS len FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    HELLO|5
+    WORLD|5
+}
+
+# EXCEPT / INTERSECT
+
+@cross-check-integrity
+test ctas_intersect {
+    CREATE TABLE t1 (x INTEGER);
+    CREATE TABLE t2 (x INTEGER);
+    INSERT INTO t1 VALUES (1), (2), (3);
+    INSERT INTO t2 VALUES (2), (3), (4);
+    CREATE TABLE dst AS SELECT x FROM t1 INTERSECT SELECT x FROM t2;
+    SELECT * FROM dst ORDER BY x;
+}
+expect {
+    2
+    3
+}
+
+@cross-check-integrity
+test ctas_except {
+    CREATE TABLE t1 (x INTEGER);
+    CREATE TABLE t2 (x INTEGER);
+    INSERT INTO t1 VALUES (1), (2), (3);
+    INSERT INTO t2 VALUES (2), (3), (4);
+    CREATE TABLE dst AS SELECT x FROM t1 EXCEPT SELECT x FROM t2;
+    SELECT * FROM dst;
+}
+expect {
+    1
+}
+
+# Large number of columns
+
+@cross-check-integrity
+test ctas_many_columns {
+    CREATE TABLE src (a, b, c, d, e, f, g, h, i, j);
+    INSERT INTO src VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    1|2|3|4|5|6|7|8|9|10
+}
+
+# Verify rowid behavior (CTAS tables should have implicit rowid)
+
+@cross-check-integrity
+test ctas_rowid {
+    CREATE TABLE src (a INTEGER, b TEXT);
+    INSERT INTO src VALUES (10, 'x');
+    INSERT INTO src VALUES (20, 'y');
+    CREATE TABLE dst AS SELECT * FROM src;
+    SELECT rowid, a, b FROM dst;
+}
+expect {
+    1|10|x
+    2|20|y
+}
+
+# CTAS with OFFSET
+
+@cross-check-integrity
+test ctas_offset {
+    CREATE TABLE src (id INTEGER);
+    INSERT INTO src VALUES (1), (2), (3), (4), (5);
+    CREATE TABLE dst AS SELECT * FROM src ORDER BY id LIMIT 2 OFFSET 2;
+    SELECT * FROM dst;
+}
+expect {
+    3
+    4
+}
+
+# CTAS with multiple aliases on same source column
+
+@cross-check-integrity
+test ctas_duplicate_source_different_alias {
+    CREATE TABLE src (x INTEGER);
+    INSERT INTO src VALUES (42);
+    CREATE TABLE dst AS SELECT x AS a, x AS b, x AS c FROM src;
+    SELECT * FROM dst;
+}
+expect {
+    42|42|42
+}
+
+# Duplicate column names from join
+
+@cross-check-integrity
+test ctas_duplicate_column_names {
+    CREATE TABLE t1 (id INTEGER, name TEXT);
+    CREATE TABLE t2 (id INTEGER, value TEXT);
+    CREATE TABLE dst AS SELECT t1.id, t2.id, t1.name, t2.value FROM t1, t2;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst(id INT,"id:1" INT,name TEXT,value TEXT)
+}
+
+# Triple duplicate column names
+
+@cross-check-integrity
+test ctas_triple_duplicate_columns {
+    CREATE TABLE t1 (x INTEGER);
+    CREATE TABLE t2 (x INTEGER);
+    CREATE TABLE t3 (x INTEGER);
+    CREATE TABLE dst AS SELECT t1.x, t2.x, t3.x FROM t1, t2, t3;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst(x INT,"x:1" INT,"x:2" INT)
+}
+
+# Compound SELECT uses leftmost column names
+
+@cross-check-integrity
+test ctas_compound_select_column_names {
+    CREATE TABLE t1 (a INTEGER, b TEXT);
+    CREATE TABLE t2 (x INTEGER, y TEXT);
+    CREATE TABLE dst AS SELECT a, b FROM t1 UNION ALL SELECT x, y FROM t2;
+    SELECT sql FROM sqlite_schema WHERE name = 'dst';
+}
+expect {
+    CREATE TABLE dst(a INT,b TEXT)
+}

--- a/testing/sqltests/tests/temp_tables.sqltest
+++ b/testing/sqltests/tests/temp_tables.sqltest
@@ -95,13 +95,15 @@ expect {
     2
 }
 
-@skip-if sqlite "supported in sqlite"
-test create-temp-table-as-select-not-yet-supported {
+test create-temp-table-as-select {
     CREATE TABLE src(x INTEGER);
     INSERT INTO src VALUES (3), (4);
     CREATE TEMP TABLE t_as AS SELECT x * 2 AS y FROM src ORDER BY x;
+    SELECT * FROM t_as;
 }
-expect error {
+expect {
+    6
+    8
 }
 
 test temp-schema-visible-only-via-temp-sqlite-schema {


### PR DESCRIPTION
Implement CTAS by deriving column definitions from the SELECT result set, creating the table with canonical schema SQL (matching SQLite type mapping), and inserting rows via a coroutine-based SELECT execution.

Includes 37 sqltest cases covering basic usage, expressions, joins, aggregates, UNION/INTERSECT/EXCEPT, subqueries, NULL handling, DISTINCT, IF NOT EXISTS, schema introspection, and error cases.

Also adds CTAS statement generation to the differential fuzzer (sql_gen_prop).

## Motivation

I was doing something else that needed support for this, that we don't have (nor list in COMPAT.md). So implement it.