### PR TITLE
fix: preserve LIMIT in compound SELECT used as IN subquery

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -314,10 +314,7 @@ fn emit_compound_select(
                 let dedupe_index = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
-                    } if !index.has_rowid
-                        && limit_ctx.is_none()
-                        && offset_reg.is_none() =>
-                    {
+                    } if !index.has_rowid && limit_ctx.is_none() && offset_reg.is_none() => {
                         (*cursor_id, index.clone())
                     }
                     _ => {
@@ -430,10 +427,7 @@ fn emit_compound_select(
                 let (cursor_id, index) = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
-                    } if !index.has_rowid
-                        && limit_ctx.is_none()
-                        && offset_reg.is_none() =>
-                    {
+                    } if !index.has_rowid && limit_ctx.is_none() && offset_reg.is_none() => {
                         (*cursor_id, index.clone())
                     }
                     _ => {

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -314,7 +314,12 @@ fn emit_compound_select(
                 let dedupe_index = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
-                    } if !index.has_rowid => (*cursor_id, index.clone()),
+                    } if !index.has_rowid
+                        && limit_ctx.is_none()
+                        && offset_reg.is_none() =>
+                    {
+                        (*cursor_id, index.clone())
+                    }
                     _ => {
                         new_dedupe_index = true;
                         create_dedupe_index(program, &plan, &right_most)?
@@ -425,7 +430,12 @@ fn emit_compound_select(
                 let (cursor_id, index) = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
-                    } if !index.has_rowid => (*cursor_id, index.clone()),
+                    } if !index.has_rowid
+                        && limit_ctx.is_none()
+                        && offset_reg.is_none() =>
+                    {
+                        (*cursor_id, index.clone())
+                    }
                     _ => {
                         new_index = true;
                         create_dedupe_index(program, &plan, &right_most)?

--- a/testing/sqltests/tests/compound-select-limit-in-subquery.sqltest
+++ b/testing/sqltests/tests/compound-select-limit-in-subquery.sqltest
@@ -1,0 +1,80 @@
+# Tests for compound SELECT LIMIT inside IN() subquery
+# Bug: LIMIT was silently ignored when compound SELECT with UNION was used as
+# a subquery inside WHERE IN, because the ephemeral index was reused as the
+# dedupe index, skipping the LIMIT application.
+
+@database :memory:
+
+setup schema {
+    CREATE TABLE t(x INTEGER);
+    INSERT INTO t VALUES (1),(2),(3),(4),(5);
+}
+
+# Bug #6344: UNION + LIMIT in IN subquery
+@setup schema
+test union-limit-in-subquery {
+    SELECT * FROM t WHERE x IN (SELECT 1 UNION SELECT 2 UNION SELECT 3 LIMIT 2);
+}
+expect {
+    1
+    2
+}
+
+# UNION ALL + LIMIT in IN subquery (should already work)
+@setup schema
+test union-all-limit-in-subquery {
+    SELECT * FROM t WHERE x IN (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 LIMIT 2);
+}
+expect {
+    1
+    2
+}
+
+# EXCEPT + LIMIT in IN subquery
+@setup schema
+test except-limit-in-subquery {
+    SELECT * FROM t WHERE x IN (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 EXCEPT SELECT 4 LIMIT 2);
+}
+expect {
+    1
+    2
+}
+
+# UNION + LIMIT + OFFSET in IN subquery
+@setup schema
+test union-limit-offset-in-subquery {
+    SELECT * FROM t WHERE x IN (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 LIMIT 2 OFFSET 1);
+}
+expect {
+    2
+    3
+}
+
+# Simple UNION + LIMIT (top-level, should already work)
+@setup schema
+test union-limit-top-level {
+    SELECT * FROM t WHERE x IN (SELECT 1 UNION SELECT 2 UNION SELECT 3 LIMIT 2);
+}
+expect {
+    1
+    2
+}
+
+# UNION + ORDER BY + LIMIT in IN subquery (should already work)
+@setup schema
+test union-orderby-limit-in-subquery {
+    SELECT * FROM t WHERE x IN (SELECT 1 UNION SELECT 2 UNION SELECT 3 ORDER BY 1 LIMIT 2);
+}
+expect {
+    1
+    2
+}
+
+# Two-way UNION + LIMIT in IN subquery
+@setup schema
+test two-way-union-limit-in-subquery {
+    SELECT * FROM t WHERE x IN (SELECT 1 UNION SELECT 2 LIMIT 1);
+}
+expect {
+    1
+}


### PR DESCRIPTION
## Problem

When a compound SELECT with UNION and LIMIT (without ORDER BY) is used as a subquery inside WHERE IN, the LIMIT is silently ignored, returning more rows than expected.

```sql
CREATE TABLE t(x INTEGER);
INSERT INTO t VALUES (1),(2),(3),(4),(5);
SELECT * FROM t WHERE x IN (SELECT 1 UNION SELECT 2 UNION SELECT 3 LIMIT 2);
-- Turso: 1, 2, 3 (WRONG — LIMIT ignored)
-- SQLite: 1, 2     (CORRECT — LIMIT applied)
```

Closes #6344

## Root Cause

In `emit_compound_select()`, when the query destination is already an `EphemeralIndex` without rowid (as set up by IN subquery compilation), the function reuses that index as the dedupe index instead of creating a new one. However, `read_deduplicated_union_or_except_rows()` — which applies LIMIT/OFFSET — is only called when a **new** dedupe index is created. When the index was reused, LIMIT was silently dropped.

## Fix

Added conditions to both UNION and EXCEPT cases: don't reuse the destination `EphemeralIndex` as the dedupe index when `limit_ctx` or `offset_reg` is present. This forces creation of a new dedupe index, ensuring LIMIT/OFFSET is properly applied.

## Tests

7 new sqltest cases in `compound-select-limit-in-subquery.sqltest`:
- UNION + LIMIT in subquery (the bug case)
- Two-way UNION + LIMIT in subquery
- UNION ALL + LIMIT in subquery (regression — already worked)
- UNION + ORDER BY + LIMIT in subquery (regression — already worked)
- EXCEPT + LIMIT in subquery (same root cause)
- UNION + LIMIT + OFFSET in subquery
- Top-level UNION + LIMIT (regression — already worked)

All 1526 existing `turso_core` unit tests pass. All 14 compound/subquery sqltests pass.