### PR TITLE
translate: fix deferred FK violation counting

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -27,9 +27,9 @@ use crate::{
             ReturningBufferCtx,
         },
         fkeys::{
-            emit_fk_child_update_counters, emit_fk_parent_new_key_reconcile,
+            emit_fk_child_update_counters, emit_fk_parent_deferred_new_key_probes,
             emit_fk_update_parent_actions, fire_fk_update_actions, stabilize_new_row_for_fk,
-            ForeignKeyActions,
+            ForeignKeyActions, ParentKeyNewProbeMode,
         },
         main_loop::{CloseLoop, InitLoop, OpenLoop},
         plan::{
@@ -1281,6 +1281,7 @@ fn emit_update_insns<'a>(
         )?;
     }
 
+    let mut deferred_new_key_plans = Vec::new();
     if connection.foreign_keys_enabled() {
         let rowid_new_reg = rowid_set_clause_reg.unwrap_or(beg);
         if let Some(table_btree) = target_table.table.btree() {
@@ -1302,7 +1303,17 @@ fn emit_update_insns<'a>(
             if t_ctx.resolver.with_schema(update_database_id, |s| {
                 s.any_resolved_fks_referencing(table_name)
             }) {
-                emit_fk_update_parent_actions(
+                let new_key_probe_mode = if any_effective_replace(
+                    program.has_statement_conflict,
+                    or_conflict,
+                    table_btree.rowid_alias_conflict_clause,
+                    indexes_to_update.iter().map(|idx| idx.on_conflict),
+                ) {
+                    ParentKeyNewProbeMode::AfterReplace
+                } else {
+                    ParentKeyNewProbeMode::BeforeWrite
+                };
+                deferred_new_key_plans = emit_fk_update_parent_actions(
                     program,
                     &table_btree,
                     indexes_to_update.iter(),
@@ -1312,31 +1323,13 @@ fn emit_update_insns<'a>(
                     rowid_new_reg,
                     rowid_set_clause_reg,
                     set_clauses,
-                    false,
+                    new_key_probe_mode,
                     update_database_id,
                     &t_ctx.resolver,
                 )?;
             }
         }
     }
-
-    // Parent-key reconciliation after the new row is inserted is only valid if this row
-    // actually deleted a conflicting parent row via REPLACE. Otherwise it double-decrements
-    // deferred FK counters for ordinary parent-key updates.
-    let parent_replace_reconcile_reg = if connection.foreign_keys_enabled()
-        && target_table.table.btree().is_some()
-        && t_ctx.resolver.with_schema(update_database_id, |s| {
-            s.any_resolved_fks_referencing(table_name)
-        }) {
-        let reg = program.alloc_register();
-        program.emit_insn(Insn::Integer {
-            value: 0,
-            dest: reg,
-        });
-        Some(reg)
-    } else {
-        None
-    };
 
     // Populate register-to-affinity map for expression index evaluation.
     // When column references are rewritten to Expr::Register during UPDATE, comparison
@@ -1797,12 +1790,6 @@ fn emit_update_insns<'a>(
                     });
                 }
                 ResolveType::Replace => {
-                    if let Some(parent_replace_reconcile_reg) = parent_replace_reconcile_reg {
-                        program.emit_insn(Insn::Integer {
-                            value: 1,
-                            dest: parent_replace_reconcile_reg,
-                        });
-                    }
                     // For REPLACE with unique constraint, delete the conflicting row
                     // Save original rowid before seeking to conflicting row
                     let original_rowid_reg = program.alloc_register();
@@ -1975,12 +1962,6 @@ fn emit_update_insns<'a>(
         && updates_rowid
         && matches!(effective_rowid_alias_conflict, ResolveType::Replace)
     {
-        if let Some(parent_replace_reconcile_reg) = parent_replace_reconcile_reg {
-            program.emit_insn(Insn::Integer {
-                value: 1,
-                dest: parent_replace_reconcile_reg,
-            });
-        }
         let target_reg = rowid_set_clause_reg.expect("rowid_set_clause_reg must be set");
         let no_rowid_conflict_label = program.allocate_label();
         let row_not_found_label = check_rowid_not_exists_label
@@ -2244,29 +2225,13 @@ fn emit_update_insns<'a>(
                 table_name: target_table.identifier.clone(),
             });
 
-            // Reconcile deferred FK violations after REPLACE.
-            // If Phase 1 REPLACE deleted a parent row referenced by deferred FK children,
-            // the counter was incremented. Now that the new row is inserted with the
-            // (potentially same) parent key, scan children and decrement.
             if connection.foreign_keys_enabled() {
-                if let Some(parent_replace_reconcile_reg) = parent_replace_reconcile_reg {
-                    let skip_fk_parent_reconcile = program.allocate_label();
-                    program.emit_insn(Insn::IfNot {
-                        reg: parent_replace_reconcile_reg,
-                        target_pc: skip_fk_parent_reconcile,
-                        jump_if_null: true,
-                    });
-                    emit_fk_parent_new_key_reconcile(
-                        program,
-                        table,
-                        start,
-                        rowid_set_clause_reg.unwrap_or(beg),
-                        set_clauses,
-                        update_database_id,
-                        &t_ctx.resolver,
-                    )?;
-                    program.preassign_label_to_next_insn(skip_fk_parent_reconcile);
-                }
+                emit_fk_parent_deferred_new_key_probes(
+                    program,
+                    &deferred_new_key_plans,
+                    update_database_id,
+                    &t_ctx.resolver,
+                )?;
             }
 
             // Fire FK CASCADE/SET NULL actions AFTER the parent row is updated

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -34,6 +34,118 @@ pub fn emit_guarded_fk_decrement(
     });
 }
 
+/// Chooses when the parent-side NEW-key probe runs.
+///
+/// `BeforeWrite` is correct for plain `UPDATE` and `UPSERT .. DO UPDATE`:
+/// if a child row matches the NEW key, that child is genuinely missing its
+/// parent until this statement creates it.
+///
+/// `AfterReplace` is required for REPLACE-style updates: before the write, a
+/// child row may still be valid only because some other parent row still owns
+/// the NEW key. Counting that child too early can clear the wrong deferred FK
+/// violation.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ParentKeyNewProbeMode {
+    BeforeWrite,
+    AfterReplace,
+}
+
+/// A NEW-key probe that must wait until after a REPLACE-style write.
+///
+/// The guard register is set only when OLD != NEW, so no-op statements like
+/// `UPDATE OR REPLACE p SET id = 10 WHERE id = 10` do not clear unrelated
+/// deferred violations. The register range points at the already-built NEW key
+/// so the post-write path does not need to rebuild it.
+pub struct DeferredNewKeyProbePlan {
+    guard_reg: usize,
+    incoming: Vec<ResolvedFkRef>,
+    new_key_start: usize,
+    new_key_len: usize,
+}
+
+/// Emit parent-side OLD/NEW key probes when a parent key actually changes.
+///
+/// In `AfterReplace` mode this returns the deferred NEW-key probe needed after
+/// the write. In `BeforeWrite` mode the NEW-key probe is emitted inline here.
+#[expect(clippy::too_many_arguments)]
+fn emit_parent_key_change_probes(
+    program: &mut ProgramBuilder,
+    incoming: &[ResolvedFkRef],
+    old_key_start: usize,
+    new_key_start: usize,
+    n_cols: usize,
+    new_key_probe_mode: ParentKeyNewProbeMode,
+    database_id: usize,
+    resolver: &Resolver,
+) -> Result<Option<DeferredNewKeyProbePlan>> {
+    let skip = program.allocate_label();
+    let changed = program.allocate_label();
+    let deferred_new_key_probe =
+        if matches!(new_key_probe_mode, ParentKeyNewProbeMode::AfterReplace) {
+            let deferred_fks: Vec<_> = incoming
+                .iter()
+                .filter(|fk_ref| fk_ref.fk.deferred)
+                .cloned()
+                .collect();
+            if deferred_fks.is_empty() {
+                None
+            } else {
+                let guard_reg = program.alloc_register();
+                program.emit_insn(Insn::Integer {
+                    value: 0,
+                    dest: guard_reg,
+                });
+                Some(DeferredNewKeyProbePlan {
+                    guard_reg,
+                    incoming: deferred_fks,
+                    new_key_start,
+                    new_key_len: n_cols,
+                })
+            }
+        } else {
+            None
+        };
+
+    for i in 0..n_cols {
+        let next = if i + 1 == n_cols {
+            skip
+        } else {
+            program.allocate_label()
+        };
+        program.emit_insn(Insn::Eq {
+            lhs: old_key_start + i,
+            rhs: new_key_start + i,
+            target_pc: next,
+            flags: CmpInsFlags::default(),
+            collation: None,
+        });
+        program.emit_insn(Insn::Goto { target_pc: changed });
+        if i + 1 != n_cols {
+            program.preassign_label_to_next_insn(next);
+        }
+    }
+
+    program.preassign_label_to_next_insn(changed);
+    if let Some(ref plan) = deferred_new_key_probe {
+        program.emit_insn(Insn::Integer {
+            value: 1,
+            dest: plan.guard_reg,
+        });
+    }
+    emit_fk_parent_pk_change_counters(
+        program,
+        incoming,
+        old_key_start,
+        new_key_start,
+        n_cols,
+        new_key_probe_mode,
+        database_id,
+        resolver,
+    )?;
+    program.preassign_label_to_next_insn(skip);
+    Ok(deferred_new_key_probe)
+}
+
 /// Open a read cursor on an index and return its cursor id.
 #[inline]
 pub fn open_read_index(program: &mut ProgramBuilder, idx: &Arc<Index>, db: usize) -> usize {
@@ -290,129 +402,29 @@ pub fn stabilize_new_row_for_fk(
     Ok(())
 }
 
-/// Parent-side checks when the parent key might change (UPDATE on parent):
-/// Detect if any child references the OLD key (potential violation), and if any references the NEW key
-/// (which cancels one potential violation). For composite keys this builds OLD/NEW vectors first.
-#[allow(clippy::too_many_arguments)]
-pub fn emit_parent_key_change_checks(
-    program: &mut ProgramBuilder,
-    table_btree: &BTreeTable,
-    indexes_to_update: impl Iterator<Item = impl AsRef<Index>>,
-    cursor_id: usize,
-    old_rowid_reg: usize,
-    start: usize,
-    rowid_new_reg: usize,
-    rowid_set_clause_reg: Option<usize>,
-    set_clauses: &[(usize, Box<Expr>)],
-    reconcile_new_key: bool,
-    database_id: usize,
-    resolver: &Resolver,
-) -> Result<()> {
-    let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
-    let incoming = resolver.with_schema(database_id, |s| {
-        s.resolved_fks_referencing(&table_btree.name)
-    })?;
-    let affects_pk = incoming
-        .iter()
-        .any(|r| r.parent_key_may_change(&updated_positions, table_btree));
-    if !affects_pk {
-        return Ok(());
-    }
-
-    let primary_key_is_rowid_alias = table_btree.get_rowid_alias_column().is_some();
-
-    if primary_key_is_rowid_alias || table_btree.primary_key_columns.is_empty() {
-        emit_rowid_pk_change_check(
-            program,
-            &incoming,
-            old_rowid_reg,
-            rowid_set_clause_reg.unwrap_or(old_rowid_reg),
-            reconcile_new_key,
-            database_id,
-            resolver,
-        )?;
-    }
-
-    for index in indexes_to_update {
-        emit_parent_index_key_change_checks(
-            program,
-            cursor_id,
-            start,
-            old_rowid_reg,
-            rowid_new_reg,
-            &incoming,
-            table_btree,
-            index.as_ref(),
-            reconcile_new_key,
-            database_id,
-            resolver,
-        )?;
-    }
-    Ok(())
-}
-
-/// Rowid-table parent PK change: compare rowid OLD vs NEW; if changed, run two-pass counters.
+/// Handles rowid and `INTEGER PRIMARY KEY` parent-key updates.
 pub fn emit_rowid_pk_change_check(
     program: &mut ProgramBuilder,
     incoming: &[ResolvedFkRef],
     old_rowid_reg: usize,
     new_rowid_reg: usize,
-    reconcile_new_key: bool,
+    new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
-) -> Result<()> {
-    let skip = program.allocate_label();
-    program.emit_insn(Insn::Eq {
-        lhs: new_rowid_reg,
-        rhs: old_rowid_reg,
-        target_pc: skip,
-        flags: CmpInsFlags::default(),
-        collation: None,
-    });
-
-    let old_pk = program.alloc_register();
-    let new_pk = program.alloc_register();
-    program.emit_insn(Insn::Copy {
-        src_reg: old_rowid_reg,
-        dst_reg: old_pk,
-        extra_amount: 0,
-    });
-    program.emit_insn(Insn::Copy {
-        src_reg: new_rowid_reg,
-        dst_reg: new_pk,
-        extra_amount: 0,
-    });
-
-    emit_fk_parent_pk_change_counters(
+) -> Result<Option<DeferredNewKeyProbePlan>> {
+    emit_parent_key_change_probes(
         program,
         incoming,
-        old_pk,
-        new_pk,
+        old_rowid_reg,
+        new_rowid_reg,
         1,
-        reconcile_new_key,
+        new_key_probe_mode,
         database_id,
         resolver,
-    )?;
-    program.preassign_label_to_next_insn(skip);
-    Ok(())
+    )
 }
 
-/// Foreign keys are only legal if the referenced parent key is:
-/// 1. The rowid alias (no separate index)
-/// 2. Part of a primary key / unique index (there is no practical difference between the two)
-///
-/// If the foreign key references a composite key, all of the columns in the key must be referenced.
-/// E.g.
-/// CREATE TABLE parent (a, b, c, PRIMARY KEY (a, b, c));
-/// CREATE TABLE child (a, b, c, FOREIGN KEY (a, b, c) REFERENCES parent (a, b, c));
-///
-/// Whereas this is not allowed:
-/// CREATE TABLE parent (a, b, c, PRIMARY KEY (a, b, c));
-/// CREATE TABLE child (a, b, c, FOREIGN KEY (a, b) REFERENCES parent (a, b, c));
-///
-/// This function checks if the parent key has changed by comparing the OLD and NEW values.
-/// If the parent key has changed, it emits the counters for the foreign keys.
-/// If the parent key has not changed, it does nothing.
+/// Handles parent-key updates backed by a UNIQUE index.
 #[allow(clippy::too_many_arguments)]
 pub fn emit_parent_index_key_change_checks(
     program: &mut ProgramBuilder,
@@ -423,30 +435,24 @@ pub fn emit_parent_index_key_change_checks(
     incoming: &[ResolvedFkRef],
     table_btree: &BTreeTable,
     index: &Index,
-    reconcile_new_key: bool,
+    new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
-) -> Result<()> {
-    // Only process FKs that:
-    // 1. Reference this specific index (OLD/NEW key vectors are built from this index's columns)
-    // 2. Have NO ACTION or RESTRICT on_update action (CASCADE/SET NULL/SET DEFAULT are handled
-    //    later by fire_fk_update_actions AFTER the update completes)
+) -> Result<Option<DeferredNewKeyProbePlan>> {
+    // Only process FKs that reference this specific index.
     let matching_fks: Vec<_> = incoming
         .iter()
         .filter(|fk_ref| {
-            let matches_index = fk_ref
+            fk_ref
                 .parent_unique_index
                 .as_ref()
-                .is_some_and(|idx| idx.name == index.name);
-            let is_noaction_or_restrict =
-                matches!(fk_ref.fk.on_update, RefAct::NoAction | RefAct::Restrict);
-            matches_index && is_noaction_or_restrict
+                .is_some_and(|idx| idx.name == index.name)
         })
         .cloned()
         .collect();
 
     if matching_fks.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
 
     let idx_len = index.columns.len();
@@ -498,47 +504,22 @@ pub fn emit_parent_index_key_change_checks(
         });
     }
 
-    let skip = program.allocate_label();
-    let changed = program.allocate_label();
-    for i in 0..idx_len {
-        let next = if i + 1 == idx_len {
-            None
-        } else {
-            Some(program.allocate_label())
-        };
-        program.emit_insn(Insn::Eq {
-            lhs: old_key + i,
-            rhs: new_key + i,
-            target_pc: next.unwrap_or(skip),
-            flags: CmpInsFlags::default(),
-            collation: None,
-        });
-        program.emit_insn(Insn::Goto { target_pc: changed });
-        if let Some(n) = next {
-            program.preassign_label_to_next_insn(n);
-        }
-    }
-
-    program.preassign_label_to_next_insn(changed);
-    emit_fk_parent_pk_change_counters(
+    emit_parent_key_change_probes(
         program,
         &matching_fks,
         old_key,
         new_key,
         idx_len,
-        reconcile_new_key,
+        new_key_probe_mode,
         database_id,
         resolver,
-    )?;
-    program.preassign_label_to_next_insn(skip);
-    Ok(())
+    )
 }
 
-/// Parent-side maintenance for UPDATE of a parent key:
-/// probe child for OLD key and increment deferred counter if references exist.
+/// Emits OLD-key probe (always) and NEW-key probe (only in `BeforeWrite` mode).
 ///
-/// When statement conflict handling is active (e.g. UPSERT/REPLACE paths),
-/// also probe the NEW key to reconcile pre-existing deferred violations.
+/// In `AfterReplace` mode the NEW-key probe is handled later by
+/// `emit_fk_parent_deferred_new_key_probes` once the REPLACE write is done.
 #[allow(clippy::too_many_arguments)]
 pub fn emit_fk_parent_pk_change_counters(
     program: &mut ProgramBuilder,
@@ -546,7 +527,7 @@ pub fn emit_fk_parent_pk_change_counters(
     old_pk_start: usize,
     new_pk_start: usize,
     n_cols: usize,
-    reconcile_new_key: bool,
+    new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<()> {
@@ -561,7 +542,7 @@ pub fn emit_fk_parent_pk_change_counters(
             resolver,
         )?;
 
-        if reconcile_new_key {
+        if matches!(new_key_probe_mode, ParentKeyNewProbeMode::BeforeWrite) {
             emit_fk_parent_key_probe(
                 program,
                 fk_ref,
@@ -576,97 +557,44 @@ pub fn emit_fk_parent_pk_change_counters(
     Ok(())
 }
 
-/// After INSERT in the UPDATE path, if REPLACE fired during Phase 1,
-/// children referencing the NEW parent key may resolve deferred FK violations
-/// that the REPLACE delete incremented. This emits a FkIfZero-guarded scan
-/// that decrements the counter for each matching child row.
+/// Run deferred NEW-key probes after the row write completes.
 ///
-/// Matches SQLite's post-delete / pre-insert FK reconciliation
-/// (sqlite3FkCheck → fkScanChildren with isIgnoreErr=1 path).
-#[allow(clippy::too_many_arguments)]
-pub fn emit_fk_parent_new_key_reconcile(
+/// Each plan carries the register range where the NEW key was built during
+/// the check phase, so no key reconstruction is needed here.
+pub fn emit_fk_parent_deferred_new_key_probes(
     program: &mut ProgramBuilder,
-    table_btree: &BTreeTable,
-    new_values_start: usize,
-    new_rowid_reg: usize,
-    set_clauses: &[(usize, Box<ast::Expr>)],
+    deferred_new_key_plans: &[DeferredNewKeyProbePlan],
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<()> {
-    let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
-    let incoming = resolver.with_schema(database_id, |s| {
-        s.resolved_fks_referencing(&table_btree.name)
-    })?;
-
-    let is_relevant = |fk: &ResolvedFkRef| -> bool {
-        fk.fk.deferred && fk.parent_key_may_change(&updated_positions, table_btree)
-    };
-    if !incoming.iter().any(&is_relevant) {
+    if deferred_new_key_plans.is_empty() {
         return Ok(());
     }
-
-    // FkIfZero guard: skip entire section if counter is already zero.
     let skip_all = program.allocate_label();
     program.emit_insn(Insn::FkIfZero {
         deferred: true,
         target_pc: skip_all,
     });
 
-    for fk_ref in incoming.iter().filter(|fk| is_relevant(fk)) {
-        if fk_ref.parent_uses_rowid {
+    for plan in deferred_new_key_plans {
+        let skip_plan = program.allocate_label();
+        program.emit_insn(Insn::IfNot {
+            reg: plan.guard_reg,
+            target_pc: skip_plan,
+            jump_if_null: true,
+        });
+        for fk_ref in &plan.incoming {
             emit_fk_parent_key_probe(
                 program,
                 fk_ref,
-                new_rowid_reg,
-                1,
+                plan.new_key_start,
+                plan.new_key_len,
                 ParentProbePass::New,
                 database_id,
                 resolver,
             )?;
-            continue;
         }
-
-        // Build contiguous NEW key registers from the parent column positions.
-        // Parent columns come from explicit FK declaration, or implicitly from PK.
-        let explicit = &fk_ref.fk.parent_columns;
-        let pk = &table_btree.primary_key_columns;
-        let n_cols = if explicit.is_empty() {
-            pk.len()
-        } else {
-            explicit.len()
-        };
-        let new_key = program.alloc_registers(n_cols);
-
-        for i in 0..n_cols {
-            let col_name = if explicit.is_empty() {
-                pk[i].0.as_str()
-            } else {
-                explicit[i].as_str()
-            };
-            let (pos, col) = table_btree
-                .get_column(col_name)
-                .ok_or_else(|| LimboError::InternalError(format!("col {col_name} missing")))?;
-            let src = if col.is_rowid_alias() {
-                new_rowid_reg
-            } else {
-                new_values_start + pos
-            };
-            program.emit_insn(Insn::Copy {
-                src_reg: src,
-                dst_reg: new_key + i,
-                extra_amount: 0,
-            });
-        }
-
-        emit_fk_parent_key_probe(
-            program,
-            fk_ref,
-            new_key,
-            n_cols,
-            ParentProbePass::New,
-            database_id,
-            resolver,
-        )?;
+        program.preassign_label_to_next_insn(skip_plan);
     }
 
     program.preassign_label_to_next_insn(skip_all);
@@ -1166,7 +1094,15 @@ fn emit_fk_delete_parent_existence_check_single(
     Ok(())
 }
 
-/// Handle all parent-side FK actions on UPDATE based on ON UPDATE action type.
+/// Parent-side FK counter checks for UPDATE.
+///
+/// CASCADE/SET NULL/SET DEFAULT actions are handled later by
+/// `fire_fk_update_actions`; this function only emits counter-based checks
+/// for NO ACTION / RESTRICT foreign keys.
+///
+/// Returns deferred NEW-key probes when `new_key_probe_mode` is `AfterReplace`,
+/// so the caller can run them only after the REPLACE write has established the
+/// final parent row at the NEW key.
 #[allow(clippy::too_many_arguments)]
 pub fn emit_fk_update_parent_actions(
     program: &mut ProgramBuilder,
@@ -1178,113 +1114,65 @@ pub fn emit_fk_update_parent_actions(
     rowid_new_reg: usize,
     rowid_set_clause_reg: Option<usize>,
     set_clauses: &[(usize, Box<Expr>)],
-    reconcile_new_key: bool,
+    new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
-) -> Result<()> {
+) -> Result<Vec<DeferredNewKeyProbePlan>> {
+    let mut deferred_new_key_plans = Vec::new();
     let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
-    let incoming = resolver.with_schema(database_id, |s| {
-        s.resolved_fks_referencing(&table_btree.name)
-    })?;
-    let affects_pk = incoming
-        .iter()
-        .any(|r| r.parent_key_may_change(&updated_positions, table_btree));
-    if !affects_pk {
-        return Ok(());
+    let check_fks: Vec<_> = resolver
+        .with_schema(database_id, |s| {
+            s.resolved_fks_referencing(&table_btree.name)
+        })?
+        .into_iter()
+        .filter(|fk| fk.parent_key_may_change(&updated_positions, table_btree))
+        .filter(|fk| matches!(fk.fk.on_update, RefAct::NoAction | RefAct::Restrict))
+        .collect();
+    if check_fks.is_empty() {
+        return Ok(deferred_new_key_plans);
     }
 
-    // Collect indexes to update into a Vec so we can iterate multiple times
-    let indexes: Vec<_> = indexes_to_update.collect();
-
-    // Check if any FK has CASCADE or SET NULL/SET DEFAULT action
-    let has_cascade_or_set = incoming
-        .iter()
-        .any(|fk_ref| !matches!(fk_ref.fk.on_update, RefAct::NoAction | RefAct::Restrict));
-
-    if has_cascade_or_set {
-        // We have CASCADE or SET NULL/DEFAULT - need to handle them
-        let primary_key_is_rowid_alias = table_btree.get_rowid_alias_column().is_some();
-
-        for fk_ref in &incoming {
-            if !fk_ref.parent_key_may_change(&updated_positions, table_btree) {
-                continue;
-            }
-
-            match fk_ref.fk.on_update {
-                RefAct::NoAction | RefAct::Restrict => {
-                    // Use existing counter-based logic for just this FK
-                    // We need to emit check for this specific FK
-                    if (primary_key_is_rowid_alias || table_btree.primary_key_columns.is_empty())
-                        && fk_ref.parent_uses_rowid
-                    {
-                        emit_rowid_pk_change_check(
-                            program,
-                            &[fk_ref.clone()],
-                            old_rowid_reg,
-                            rowid_set_clause_reg.unwrap_or(old_rowid_reg),
-                            reconcile_new_key,
-                            database_id,
-                            resolver,
-                        )?;
-                    }
-
-                    for index in &indexes {
-                        emit_parent_index_key_change_checks(
-                            program,
-                            cursor_id,
-                            start,
-                            old_rowid_reg,
-                            rowid_new_reg,
-                            &[fk_ref.clone()],
-                            table_btree,
-                            index.as_ref(),
-                            reconcile_new_key,
-                            database_id,
-                            resolver,
-                        )?;
-                    }
-                }
-                RefAct::Cascade | RefAct::SetNull | RefAct::SetDefault => {
-                    // CASCADE, SET NULL, and SET DEFAULT actions are handled by
-                    // fire_fk_update_actions AFTER the parent update (not here).
-                    // This function only handles NO ACTION/RESTRICT checks.
-                }
-            }
-        }
-    } else {
-        // All FKs use NoAction/Restrict - use original counter-based approach
-        let primary_key_is_rowid_alias = table_btree.get_rowid_alias_column().is_some();
-
-        if primary_key_is_rowid_alias || table_btree.primary_key_columns.is_empty() {
-            emit_rowid_pk_change_check(
+    let primary_key_is_rowid_alias = table_btree.get_rowid_alias_column().is_some();
+    if primary_key_is_rowid_alias || table_btree.primary_key_columns.is_empty() {
+        let rowid_fks: Vec<_> = check_fks
+            .iter()
+            .filter(|fk| fk.parent_uses_rowid)
+            .cloned()
+            .collect();
+        if !rowid_fks.is_empty() {
+            if let Some(plan) = emit_rowid_pk_change_check(
                 program,
-                &incoming,
+                &rowid_fks,
                 old_rowid_reg,
                 rowid_set_clause_reg.unwrap_or(old_rowid_reg),
-                reconcile_new_key,
+                new_key_probe_mode,
                 database_id,
                 resolver,
-            )?;
-        }
-
-        for index in indexes {
-            emit_parent_index_key_change_checks(
-                program,
-                cursor_id,
-                start,
-                old_rowid_reg,
-                rowid_new_reg,
-                &incoming,
-                table_btree,
-                index.as_ref(),
-                reconcile_new_key,
-                database_id,
-                resolver,
-            )?;
+            )? {
+                deferred_new_key_plans.push(plan);
+            }
         }
     }
 
-    Ok(())
+    for index in indexes_to_update {
+        if let Some(plan) = emit_parent_index_key_change_checks(
+            program,
+            cursor_id,
+            start,
+            old_rowid_reg,
+            rowid_new_reg,
+            &check_fks,
+            table_btree,
+            index.as_ref(),
+            new_key_probe_mode,
+            database_id,
+            resolver,
+        )? {
+            deferred_new_key_plans.push(plan);
+        }
+    }
+
+    Ok(deferred_new_key_plans)
 }
 
 /// Context for FK action execution: holds register info for OLD/NEW parent key values

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -12,7 +12,8 @@ use crate::schema::{
 use crate::translate::emitter::{emit_check_constraints, emit_make_record, UpdateRowSource};
 use crate::translate::expr::{walk_expr, WalkControl};
 use crate::translate::fkeys::{
-    emit_fk_child_update_counters, emit_parent_key_change_checks, fire_fk_update_actions,
+    emit_fk_child_update_counters, emit_fk_update_parent_actions, fire_fk_update_actions,
+    ParentKeyNewProbeMode,
 };
 use crate::translate::insert::{format_unique_violation_desc, InsertEmitCtx};
 use crate::translate::plan::ColumnMask;
@@ -808,7 +809,7 @@ pub fn emit_upsert(
             let upsert_indices: Vec<_> = resolver.with_schema(upsert_database_id, |s| {
                 s.get_indices(table.get_name()).cloned().collect()
             });
-            emit_parent_key_change_checks(
+            let _ = emit_fk_update_parent_actions(
                 program,
                 &bt,
                 upsert_indices.iter().filter(|idx| {
@@ -820,7 +821,7 @@ pub fn emit_upsert(
                 new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg),
                 rowid_set_clause_reg,
                 set_pairs,
-                true,
+                ParentKeyNewProbeMode::BeforeWrite,
                 upsert_database_id,
                 resolver,
             )?;

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -1216,6 +1216,126 @@ expect {
     1|20
 }
 
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-pk-resolves-without-conflict {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(10);
+    BEGIN;
+    INSERT INTO c VALUES(1, 20);   -- violation
+    UPDATE OR REPLACE p SET id=20 WHERE id=10; -- resolve via parent without triggering REPLACE
+    COMMIT;
+    SELECT * FROM c;
+}
+expect {
+    1|20
+}
+
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-unique-key-resolves {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY, u TEXT UNIQUE);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pu TEXT REFERENCES p(u) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(1, 'a');
+    BEGIN;
+    INSERT INTO c VALUES(1, 'b');   -- violation: no parent with u='b'
+    UPDATE OR REPLACE p SET u='b' WHERE id=1; -- resolve via UNIQUE key change
+    COMMIT;
+    SELECT * FROM c;
+}
+expect {
+    1|b
+}
+
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-pk-conflict-does-not-clear-unrelated {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(10), (20);
+    INSERT INTO c VALUES(1, 20);   -- valid child of the row REPLACE will delete
+    BEGIN;
+    INSERT INTO c VALUES(2, 30);   -- unrelated violation
+    UPDATE OR REPLACE p SET id=20 WHERE id=10; -- deletes the old parent at 20, then inserts the new one
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-unique-key-conflict-does-not-clear-unrelated {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY, u TEXT UNIQUE);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pu TEXT REFERENCES p(u) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(1, 'a'), (2, 'b');
+    INSERT INTO c VALUES(1, 'b');   -- valid child of the row REPLACE will delete
+    BEGIN;
+    INSERT INTO c VALUES(2, 'missing');   -- unrelated violation
+    UPDATE OR REPLACE p SET u='b' WHERE id=1; -- deletes the old parent with u='b', then inserts the new one
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-unique-key-noop-does-not-clear {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY, u TEXT UNIQUE);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pu TEXT REFERENCES p(u) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(1, 'a');
+    BEGIN;
+    INSERT INTO c VALUES(1, 'b');   -- violation: no parent with u='b'
+    UPDATE OR REPLACE p SET u='a' WHERE id=1; -- no-op, must not repair the violation
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-unique-key-noop-does-not-clear-unrelated {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY, u TEXT UNIQUE);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pu TEXT REFERENCES p(u) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(1, 'a');
+    INSERT INTO c VALUES(1, 'a');   -- valid child of the unchanged parent row
+    BEGIN;
+    INSERT INTO c VALUES(2, 'missing');   -- unrelated violation
+    UPDATE OR REPLACE p SET u='a' WHERE id=1; -- no-op, must not clear the unrelated violation
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-pk-noop-does-not-clear {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(10);
+    BEGIN;
+    INSERT INTO c VALUES(1, 20);   -- violation
+    UPDATE OR REPLACE p SET id=10 WHERE id=10; -- no-op, must not repair the violation
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-update-or-replace-parent-pk-noop-does-not-clear-unrelated {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED);
+    INSERT INTO p VALUES(10);
+    INSERT INTO c VALUES(1, 10);   -- valid child of the unchanged parent row
+    BEGIN;
+    INSERT INTO c VALUES(2, 20);   -- unrelated violation
+    UPDATE OR REPLACE p SET id=10 WHERE id=10; -- no-op, must not clear the unrelated violation
+    COMMIT;
+}
+expect error {
+}
+
 # Two-table cycle; both inserted before COMMIT -> OK
 @cross-check-integrity
 test fk-deferred-cycle-two-tables-ok {


### PR DESCRIPTION
## Beef

Fix deferred FK handling by separating UPDATE paths that can safely probe the NEW key before the write from UPDATE paths that may REPLACE another row.

- Plain UPDATE / UPSERT .. DO UPDATE -> probe the NEW key before the write.
- Any UPDATE statement whose effective conflict mode is REPLACE -> probe the child table for the NEW parent key after the write, but only if the parent key actually changed

`main` has two bugs:

1. Plain UPDATE / UPSERT .. DO UPDATE could leave repaired deferred violations uncleared
2. REPLACE updates could clear unrelated deferred FK violations, including on no-op updates.

## Concrete example of bug where we weren't clearing violation counter properly:

```sql
PRAGMA foreign_keys=ON;

CREATE TABLE p(id INTEGER PRIMARY KEY);
CREATE TABLE c(
    id INTEGER PRIMARY KEY,
    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
);

INSERT INTO p VALUES(10);

BEGIN;
INSERT INTO c VALUES(1, 20);          -- deferred violation: no parent 20 yet
UPDATE p SET id = 20 WHERE id = 10;   -- repairs the violation by creating parent 20
COMMIT;                               -- should succeed, but fails on main because the NEW probe doesnt run
```



## Concrete example of bug where REPLACE was clearing deferred violations incorrectly:

```sql
PRAGMA foreign_keys=ON;

CREATE TABLE p(id INTEGER PRIMARY KEY);
CREATE TABLE c(
    id INTEGER PRIMARY KEY,
    pid INT REFERENCES p(id) DEFERRABLE INITIALLY DEFERRED
);

INSERT INTO p VALUES(10);
INSERT INTO c VALUES(1, 10);          -- valid child row

BEGIN;
INSERT INTO c VALUES(2, 20);          -- unrelated deferred violation: no parent 20
UPDATE OR REPLACE p SET id = 10 WHERE id = 10;  -- no-op
COMMIT;                               -- should fail, but succeeds on main

-- main incorrectly probes child table for c.pid=10, which it does find, and then
-- incorrectly decrements violation counter
```