### PR TITLE
Update oneshot crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3694,9 +3694,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oneshot"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+checksum = "3ce66197e99546da6c6d991285f605192e794ceae69686c17163844a7bf8fcc2"
 
 [[package]]
 name = "oorandom"


### PR DESCRIPTION
Fixes the following security advisory:

https://github.com/tursodatabase/turso/security/dependabot/158
