### PR TITLE
core/translate: `UPDATE FROM` support

### DIFF
--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -486,8 +486,10 @@ impl fmt::Display for UpdatePlan {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "QUERY PLAN")?;
 
-        for (i, reference) in self.table_references.joined_tables().iter().enumerate() {
-            let is_last = i == self.table_references.joined_tables().len() - 1;
+        let read_scope_tables = self.build_read_scope_tables();
+
+        for (i, reference) in read_scope_tables.joined_tables().iter().enumerate() {
+            let is_last = i == read_scope_tables.joined_tables().len() - 1;
             let indent = if i == 0 {
                 if is_last { "`--" } else { "|--" }.to_string()
             } else {
@@ -585,12 +587,6 @@ impl fmt::Display for UpdatePlan {
                 Operation::MultiIndexScan(_) => {
                     unreachable!("Update plan should not have multi-index scans");
                 }
-            }
-        }
-        if !self.order_by.is_empty() {
-            writeln!(f, "ORDER BY:")?;
-            for (expr, dir, nulls) in &self.order_by {
-                fmt_order_by_item(f, expr, *dir, *nulls)?;
             }
         }
         if let Some(limit) = self.limit.as_ref() {
@@ -958,12 +954,9 @@ impl ToTokens for UpdatePlan {
         s: &mut S,
         _: &C,
     ) -> Result<(), S::Error> {
-        let table = self
-            .table_references
-            .joined_tables()
-            .first()
-            .expect("UPDATE Plan should have only one table reference");
-        let context = [&self.table_references];
+        let table = &self.target_table;
+        let read_scope_tables = self.build_read_scope_tables();
+        let context = [&read_scope_tables];
         let context = &PlanContext(&context);
 
         s.append(TokenType::TK_UPDATE, None)?;
@@ -971,10 +964,10 @@ impl ToTokens for UpdatePlan {
         s.append(TokenType::TK_SET, None)?;
 
         s.comma(
-            self.set_clauses.iter().map(|(col_idx, set_expr)| {
+            self.set_clauses.iter().map(|set_clause| {
                 let col_name = table
                     .table
-                    .get_column_at(*col_idx)
+                    .get_column_at(set_clause.column_index)
                     .as_ref()
                     .unwrap()
                     .name
@@ -983,7 +976,7 @@ impl ToTokens for UpdatePlan {
 
                 ast::Set {
                     col_names: vec![ast::Name::exact(col_name.clone())],
-                    expr: set_expr.clone(),
+                    expr: set_clause.expr.clone(),
                 }
             }),
             context,
@@ -1003,22 +996,6 @@ impl ToTokens for UpdatePlan {
                 s.append(TokenType::TK_AND, None)?;
                 expr.to_tokens(s, context)?;
             }
-        }
-
-        if !self.order_by.is_empty() {
-            s.append(TokenType::TK_ORDER, None)?;
-            s.append(TokenType::TK_BY, None)?;
-
-            s.comma(
-                self.order_by
-                    .iter()
-                    .map(|(expr, order, nulls)| ast::SortedColumn {
-                        expr: expr.clone(),
-                        order: Some(*order),
-                        nulls: *nulls,
-                    }),
-                context,
-            )?;
         }
 
         if let Some(limit) = &self.limit {

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -512,12 +512,12 @@ impl UpdateColumnCtx<'_> {
 /// Emit the VDBE instructions that enforce a `NOT NULL` constraint on the
 /// value currently in `target_reg`, honoring the UPDATE's OR conflict clause:
 ///
-/// - `OR IGNORE`  : branch to `skip_row_label` when the value is NULL, leaving
-///                  the existing row untouched.
-/// - `OR REPLACE` : if the column has a DEFAULT, evaluate it into `target_reg`;
-///                  otherwise halt with `SQLITE_CONSTRAINT_NOTNULL`.
+/// - `OR IGNORE`: branch to `skip_row_label` when the value is NULL, leaving
+///   the existing row untouched.
+/// - `OR REPLACE`: if the column has a DEFAULT, evaluate it into `target_reg`;
+///   otherwise halt with `SQLITE_CONSTRAINT_NOTNULL`.
 /// - everything else (ABORT/ROLLBACK/FAIL, or the default): halt with
-///                  `SQLITE_CONSTRAINT_NOTNULL`.
+///   `SQLITE_CONSTRAINT_NOTNULL`.
 #[allow(clippy::too_many_arguments)]
 fn emit_notnull_constraint_check(
     program: &mut ProgramBuilder,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -67,14 +67,14 @@ fn rowid_update_info(
     target_table: &JoinedTable,
     set_clauses: &[UpdateSetClause],
 ) -> RowidUpdateInfo {
+    let has_direct_rowid_update = set_clauses
+        .iter()
+        .any(|set_clause| set_clause.column_index == ROWID_SENTINEL);
     let rowid_alias_index = target_table
         .table
         .columns()
         .iter()
         .position(|column| column.is_rowid_alias());
-    let has_direct_rowid_update = set_clauses
-        .iter()
-        .any(|set_clause| set_clause.column_index == ROWID_SENTINEL);
     let updates_rowid = has_direct_rowid_update
         || rowid_alias_index.is_some_and(|alias_idx| {
             set_clauses
@@ -128,13 +128,16 @@ pub fn emit_program_for_update(
         plan.from_tables.outer_query_refs().to_vec(),
     );
     let write_set_plan = plan.write_set_plan.take();
-    let temp_cursor_id = write_set_plan.as_ref().map(|plan| {
-        let QueryDestination::EphemeralTable { cursor_id, .. } = &plan.select.query_destination
-        else {
-            unreachable!()
-        };
-        *cursor_id
-    });
+    let temp_cursor_id = match write_set_plan.as_ref() {
+        Some(plan) => {
+            let QueryDestination::EphemeralTable { cursor_id, .. } = &plan.select.query_destination
+            else {
+                crate::bail_parse_error!("write set plan must use an ephemeral table destination");
+            };
+            Some(*cursor_id)
+        }
+        None => None,
+    };
     // If an ephemeral scratch table is used (either for UPDATE...FROM or general Halloween protection)
     // then the write phase will just iterate and read from the scratch table.
     // The target table is kept as an outer query reference so that RETURNING can reference the target table
@@ -146,7 +149,7 @@ pub fn emit_program_for_update(
             ..
         } = &write_set_plan.select.query_destination
         else {
-            unreachable!()
+            crate::bail_parse_error!("write set plan must use an ephemeral table destination");
         };
         let scratch_table = scratch_table.clone();
         let scratch_table_internal_id = write_set_plan.scratch_table_id;
@@ -529,14 +532,16 @@ fn emit_notnull_constraint_check(
     skip_row_label: BranchOffset,
     resolver: &Resolver,
 ) -> crate::Result<()> {
-    let description = format!(
-        "{}.{}",
-        table_name,
-        table_column
-            .name
-            .as_ref()
-            .expect("Column name must be present")
-    );
+    let description = || {
+        format!(
+            "{}.{}",
+            table_name,
+            table_column
+                .name
+                .as_ref()
+                .expect("Column name must be present")
+        )
+    };
     match or_conflict {
         ResolveType::Ignore => {
             program.emit_insn(Insn::IsNull {
@@ -564,7 +569,7 @@ fn emit_notnull_constraint_check(
                 program.emit_insn(Insn::HaltIfNull {
                     target_reg,
                     err_code: SQLITE_CONSTRAINT_NOTNULL,
-                    description,
+                    description: description(),
                 });
             }
         }
@@ -572,7 +577,7 @@ fn emit_notnull_constraint_check(
             program.emit_insn(Insn::HaltIfNull {
                 target_reg,
                 err_code: SQLITE_CONSTRAINT_NOTNULL,
-                description,
+                description: description(),
             });
         }
     }
@@ -593,12 +598,13 @@ fn update_trigger_context(
     new_registers: Option<Vec<usize>>,
     old_registers: Option<Vec<usize>>,
     or_conflict: ResolveType,
-    after: bool,
+    timing: TriggerTime,
 ) -> TriggerContext {
     let override_conflict = program
         .trigger_conflict_override
         .or_else(|| (!matches!(or_conflict, ResolveType::Abort)).then_some(or_conflict));
 
+    let after = matches!(timing, TriggerTime::After);
     match (after, override_conflict) {
         (true, Some(override_conflict)) => TriggerContext::new_after_with_override_conflict(
             btree_table.clone(),
@@ -1085,10 +1091,14 @@ fn emit_update_insns<'a>(
             (None, false)
         }
         Operation::HashJoin(_) => {
-            unreachable!("access through HashJoin is not supported for update operations")
+            crate::bail_parse_error!(
+                "access through HashJoin is not supported for update operations"
+            )
         }
         Operation::MultiIndexScan(_) => {
-            unreachable!("access through MultiIndexScan is not supported for update operations")
+            crate::bail_parse_error!(
+                "access through MultiIndexScan is not supported for update operations"
+            )
         }
     };
     turso_assert!(
@@ -1370,7 +1380,7 @@ fn emit_update_insns<'a>(
                     Some(new_registers),
                     Some(old_registers.clone()),
                     or_conflict,
-                    false,
+                    TriggerTime::Before,
                 );
 
                 for trigger in relevant_before_update_triggers {
@@ -2357,7 +2367,7 @@ fn emit_update_insns<'a>(
                         Some(new_registers_after),
                         old_registers_after,
                         or_conflict,
-                        true,
+                        TriggerTime::After,
                     );
 
                     // RAISE(IGNORE) in an AFTER trigger should only abort the trigger body,
@@ -2517,7 +2527,7 @@ fn emit_update_insns<'a>(
                 conflict_action: 0u16,
             });
         }
-        _ => unreachable!("cannot UPDATE a subquery table"),
+        _ => crate::bail_parse_error!("cannot UPDATE a subquery table"),
     }
 
     if let Some(limit_ctx) = t_ctx.limit_ctx {

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1,13 +1,13 @@
 use super::gencol::compute_virtual_columns;
 use super::TranslateCtx;
-use crate::schema::{ColumnLayout, GeneratedType, Table};
+use crate::schema::{Column, ColumnLayout, GeneratedType, Table};
 use crate::translate::insert::halt_desc_and_on_error;
 use crate::translate::plan::ColumnMask;
 use crate::translate::stmt_journal::any_effective_replace;
 use crate::vdbe::builder::SelfTableContext;
 use crate::{
     ast, emit_explain,
-    error::{SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
+    error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
     schema::{BTreeTable, CheckConstraint, Index, ROWID_SENTINEL},
     sync::Arc,
     translate::{
@@ -32,9 +32,9 @@ use crate::{
         },
         main_loop::{CloseLoop, InitLoop, OpenLoop},
         plan::{
-            EvalAt, JoinOrderMember, JoinedTable, NonFromClauseSubquery, Operation,
-            QueryDestination, ResultSetColumn, Scan, Search, SelectPlan, SubqueryEvalPhase,
-            TableReferences, UpdatePlan,
+            EvalAt, IterationDirection, JoinOrderMember, JoinedTable, NonFromClauseSubquery,
+            Operation, OuterQueryReference, QueryDestination, ResultSetColumn, Scan, Search,
+            SubqueryEvalPhase, TableReferences, UpdatePlan, UpdateSetClause,
         },
         planner::ROWID_STRS,
         subquery::{emit_non_from_clause_subqueries_for_eval_at, emit_non_from_clause_subquery},
@@ -50,12 +50,43 @@ use crate::{
         insn::{to_u16, CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral},
         BranchOffset,
     },
-    CaptureDataChangesExt, Connection, HashSet, Result,
+    CaptureDataChangesExt, Connection, HashSet, Result, MAIN_DB_ID,
 };
 use std::num::NonZeroUsize;
 use tracing::{instrument, Level};
 use turso_macros::{turso_assert, turso_assert_eq};
 use turso_parser::ast::{ResolveType, TriggerEvent, TriggerTime};
+
+/// Info about position of rowid alias in the table if present + whether the current UPDATE statement will update the rowid.
+struct RowidUpdateInfo {
+    rowid_alias_index: Option<usize>,
+    updates_rowid: bool,
+}
+
+fn rowid_update_info(
+    target_table: &JoinedTable,
+    set_clauses: &[UpdateSetClause],
+) -> RowidUpdateInfo {
+    let rowid_alias_index = target_table
+        .table
+        .columns()
+        .iter()
+        .position(|column| column.is_rowid_alias());
+    let has_direct_rowid_update = set_clauses
+        .iter()
+        .any(|set_clause| set_clause.column_index == ROWID_SENTINEL);
+    let updates_rowid = has_direct_rowid_update
+        || rowid_alias_index.is_some_and(|alias_idx| {
+            set_clauses
+                .iter()
+                .any(|set_clause| set_clause.column_index == alias_idx)
+        });
+
+    RowidUpdateInfo {
+        rowid_alias_index,
+        updates_rowid,
+    }
+}
 
 #[instrument(skip_all, level = Level::DEBUG)]
 pub fn emit_program_for_update(
@@ -70,21 +101,11 @@ pub fn emit_program_for_update(
         .flags
         .set_has_statement_conflict(plan.or_conflict.is_some());
 
-    let mut t_ctx = Box::new(TranslateCtx::new(
-        program,
-        resolver.fork(),
-        plan.table_references.joined_tables().len(),
-        connection.db.opts.unsafe_testing,
-    ));
-
-    let after_main_loop_label = program.allocate_label();
-    t_ctx.label_main_loop_end = Some(after_main_loop_label);
-
     // Open an ephemeral table for buffering RETURNING results.
     // All DML completes before any RETURNING rows are yielded to the caller.
     let returning_buffer = if plan.returning.as_ref().is_some_and(|r| !r.is_empty()) {
-        let table_ref = plan.table_references.joined_tables().first().unwrap();
-        let btree_table = table_ref
+        let btree_table = plan
+            .target_table
             .table
             .btree()
             .expect("UPDATE target must be a BTree table");
@@ -101,6 +122,90 @@ pub fn emit_program_for_update(
         None
     };
 
+    let target_table = Arc::new(plan.target_table.clone());
+    let target_tables = TableReferences::new(
+        vec![plan.target_table.clone()],
+        plan.from_tables.outer_query_refs().to_vec(),
+    );
+    let write_set_plan = plan.write_set_plan.take();
+    let temp_cursor_id = write_set_plan.as_ref().map(|plan| {
+        let QueryDestination::EphemeralTable { cursor_id, .. } = &plan.select.query_destination
+        else {
+            unreachable!()
+        };
+        *cursor_id
+    });
+    // If an ephemeral scratch table is used (either for UPDATE...FROM or general Halloween protection)
+    // then the write phase will just iterate and read from the scratch table.
+    // The target table is kept as an outer query reference so that RETURNING can reference the target table
+    // during the write phase.
+    let uses_write_set = temp_cursor_id.is_some();
+    let mut write_phase_tables = if let Some(write_set_plan) = write_set_plan {
+        let QueryDestination::EphemeralTable {
+            table: scratch_table,
+            ..
+        } = &write_set_plan.select.query_destination
+        else {
+            unreachable!()
+        };
+        let scratch_table = scratch_table.clone();
+        let scratch_table_internal_id = write_set_plan.scratch_table_id;
+        program.emit_insn(Insn::OpenEphemeral {
+            cursor_id: temp_cursor_id.unwrap(),
+            is_table: true,
+        });
+        program
+            .nested(|program| emit_program_for_select(program, resolver, write_set_plan.select))?;
+        let mut write_phase_tables = TableReferences::new(
+            vec![JoinedTable {
+                table: Table::BTree(scratch_table),
+                identifier: "ephemeral_scratch".to_string(),
+                internal_id: scratch_table_internal_id,
+                op: Operation::Scan(Scan::BTreeTable {
+                    iter_dir: IterationDirection::Forwards,
+                    index: None,
+                }),
+                join_info: None,
+                col_used_mask: Default::default(),
+                column_use_counts: Vec::new(),
+                expression_index_usages: Vec::new(),
+                database_id: MAIN_DB_ID,
+                indexed: None,
+            }],
+            vec![],
+        );
+        write_phase_tables.add_outer_query_reference(OuterQueryReference {
+            identifier: target_table.identifier.clone(),
+            internal_id: target_table.internal_id,
+            table: target_table.table.clone(),
+            using_dedup_hidden_cols: ColumnMask::default(),
+            col_used_mask: target_table.col_used_mask.clone(),
+            cte_select: None,
+            cte_explicit_columns: vec![],
+            cte_id: None,
+            cte_definition_only: false,
+            rowid_referenced: false,
+            scope_depth: 0,
+        });
+        // CTEs are also visible during the write phase, so add them here.
+        for outer_ref in plan.from_tables.outer_query_refs() {
+            write_phase_tables.add_outer_query_reference(outer_ref.clone());
+        }
+        write_phase_tables
+    } else {
+        target_tables
+    };
+
+    let mut t_ctx = TranslateCtx::new(
+        program,
+        resolver.fork(),
+        write_phase_tables.joined_tables().len(),
+        connection.db.opts.unsafe_testing,
+    );
+
+    let after_main_loop_label = program.allocate_label();
+    t_ctx.label_main_loop_end = Some(after_main_loop_label);
+
     init_limit(program, &mut t_ctx, &plan.limit, &plan.offset)?;
 
     // No rows will be read from source table loops if there is a constant false condition eg. WHERE 0
@@ -110,42 +215,10 @@ pub fn emit_program_for_update(
         });
     }
 
-    let ephemeral_plan = plan.ephemeral_plan.take();
-    let temp_cursor_id = ephemeral_plan.as_ref().map(|plan| {
-        let QueryDestination::EphemeralTable { cursor_id, .. } = &plan.query_destination else {
-            unreachable!()
-        };
-        *cursor_id
-    });
-    let has_ephemeral_table = ephemeral_plan.is_some();
-
-    let target_table = if let Some(ephemeral_plan) = ephemeral_plan {
-        let table = ephemeral_plan
-            .table_references
-            .joined_tables()
-            .first()
-            .unwrap()
-            .clone();
-        program.emit_insn(Insn::OpenEphemeral {
-            cursor_id: temp_cursor_id.unwrap(),
-            is_table: true,
-        });
-        program.nested(|program| emit_program_for_select(program, resolver, ephemeral_plan))?;
-        Arc::new(table)
-    } else {
-        Arc::new(
-            plan.table_references
-                .joined_tables()
-                .first()
-                .unwrap()
-                .clone(),
-        )
-    };
-
-    let mode = OperationMode::UPDATE(if has_ephemeral_table {
+    let mode = OperationMode::UPDATE(if uses_write_set {
         UpdateRowSource::PrebuiltEphemeralTable {
             ephemeral_table_cursor_id: temp_cursor_id.expect(
-                "ephemeral table cursor id is always allocated if has_ephemeral_table is true",
+                "ephemeral table cursor id is always allocated when UPDATE uses a write set",
             ),
             target_table: target_table.clone(),
         }
@@ -153,8 +226,7 @@ pub fn emit_program_for_update(
         UpdateRowSource::Normal
     });
 
-    let join_order = plan
-        .table_references
+    let join_order = write_phase_tables
         .joined_tables()
         .iter()
         .enumerate()
@@ -165,17 +237,17 @@ pub fn emit_program_for_update(
         })
         .collect::<Vec<_>>();
 
-    // Evaluate uncorrelated subqueries as early as possible (only for normal path without ephemeral table).
-    // For the ephemeral path, WHERE clause subqueries are handled by emit_program_for_select
-    // on the ephemeral_plan. SET clause subqueries remain in the main plan and are emitted
+    // Evaluate uncorrelated subqueries as early as possible (only for the direct path).
+    // For the ephemeral write-set path, WHERE clause subqueries are handled by emit_program_for_select
+    // on the ephemeral SELECT. SET clause subqueries remain in the main plan and are emitted
     // inside the update loop (after open_loop) where the write cursor is correctly positioned.
-    if !has_ephemeral_table {
+    if !uses_write_set {
         emit_non_from_clause_subqueries_for_eval_at(
             program,
             &t_ctx.resolver,
             &mut plan.non_from_clause_subqueries,
             &join_order,
-            Some(&plan.table_references),
+            Some(&write_phase_tables),
             EvalAt::BeforeLoop,
             |_| true,
         )?;
@@ -184,7 +256,7 @@ pub fn emit_program_for_update(
     // Drain write-phase subqueries so init_loop/open_loop only handle WHERE-clause
     // subqueries. SET subqueries must run after NotExists positions the write cursor,
     // and RETURNING subqueries must run after the row has been written.
-    // This applies to both the normal and ephemeral UPDATE paths.
+    // This applies to both the direct and ephemeral write-set UPDATE paths.
     let mut update_subqueries = Vec::new();
     {
         let mut i = 0;
@@ -209,7 +281,7 @@ pub fn emit_program_for_update(
     InitLoop::emit(
         program,
         &mut t_ctx,
-        &plan.table_references,
+        &write_phase_tables,
         &mut [],
         &mode,
         &plan.where_clause,
@@ -218,14 +290,11 @@ pub fn emit_program_for_update(
     )?;
 
     // Prepare index cursors
-    // Use target_table.database_id because in the PrebuiltEphemeralTable case,
-    // plan.table_references contains the ephemeral table (database_id=0),
-    // not the actual target table.
     let target_database_id = target_table.database_id;
     let mut index_cursors = Vec::with_capacity(plan.indexes_to_update.len());
     for index in &plan.indexes_to_update {
         let index_cursor = if let Some(cursor) = program.resolve_cursor_id_safe(&CursorKey::index(
-            plan.table_references
+            write_phase_tables
                 .joined_tables()
                 .first()
                 .unwrap()
@@ -246,22 +315,17 @@ pub fn emit_program_for_update(
         index_cursors.push((index_cursor, record_reg));
     }
 
-    // Emit EXPLAIN QUERY PLAN annotation (only for non-ephemeral path;
-    // ephemeral path already emits EQP via emit_program_for_select).
-    if !has_ephemeral_table {
-        let table_ref = plan
-            .table_references
-            .joined_tables()
-            .first()
-            .expect("UPDATE must have a joined table");
-        emit_explain!(program, true, format_eqp_detail(table_ref));
+    // Emit EXPLAIN QUERY PLAN annotation (only for the direct path;
+    // write-set UPDATE already emits EQP via emit_program_for_select).
+    if !uses_write_set {
+        emit_explain!(program, true, format_eqp_detail(&plan.target_table));
     }
 
     // Open the main loop
     OpenLoop::emit(
         program,
         &mut t_ctx,
-        &plan.table_references,
+        &write_phase_tables,
         &join_order,
         &plan.where_clause,
         temp_cursor_id,
@@ -271,12 +335,7 @@ pub fn emit_program_for_update(
 
     let target_table_cursor_id =
         program.resolve_cursor_id(&CursorKey::table(target_table.internal_id));
-
-    let iteration_cursor_id = if has_ephemeral_table {
-        temp_cursor_id.unwrap()
-    } else {
-        target_table_cursor_id
-    };
+    let rowid_update = rowid_update_info(target_table.as_ref(), &plan.set_clauses);
 
     // When any conflict resolution path may use REPLACE, we need cursors on ALL
     // indexes — deleting a conflicting row requires removing its entries from every
@@ -288,20 +347,7 @@ pub fn emit_program_for_update(
     // updated can trigger a conflict, so we only check indexes_to_update.
     // Only consider PK REPLACE when the UPDATE actually changes the rowid,
     // since PK REPLACE can only fire on rowid collisions.
-    let updates_rowid = {
-        let has_direct_rowid = plan
-            .set_clauses
-            .iter()
-            .any(|(idx, _)| *idx == ROWID_SENTINEL);
-        let has_alias_rowid = target_table
-            .table
-            .columns()
-            .iter()
-            .position(|c| c.is_rowid_alias())
-            .is_some_and(|alias_idx| plan.set_clauses.iter().any(|(idx, _)| *idx == alias_idx));
-        has_direct_rowid || has_alias_rowid
-    };
-    let rowid_alias_conflict = if updates_rowid {
+    let rowid_alias_conflict = if rowid_update.updates_rowid {
         target_table
             .table
             .btree()
@@ -320,8 +366,7 @@ pub fn emit_program_for_update(
         let all_indexes: Vec<_> = resolver.with_schema(target_database_id, |s| {
             s.get_indices(table_name).cloned().collect()
         });
-        let source_table = plan
-            .table_references
+        let source_table = write_phase_tables
             .joined_tables()
             .first()
             .expect("UPDATE must have a joined table");
@@ -374,19 +419,26 @@ pub fn emit_program_for_update(
     };
 
     // Emit update instructions
+    turso_assert!(
+        plan.set_clauses.iter().all(|set_clause| {
+            set_clause.update_from_result.as_ref().is_none_or(|result| {
+                matches!(result.as_ref(), ast::Expr::Column { .. })
+            })
+        }),
+        "materialized UPDATE set clauses must stay attached to their original clause and read from scratch-table columns"
+    );
     emit_update_insns(
         connection,
-        &mut plan.table_references,
+        &mut write_phase_tables,
         &plan.set_clauses,
         plan.cdc_update_alter_statement.as_deref(),
         &plan.indexes_to_update,
         plan.returning.as_ref(),
-        plan.ephemeral_plan.as_ref(),
+        temp_cursor_id,
         &mut t_ctx,
         program,
         &index_cursors,
         &all_index_cursors,
-        iteration_cursor_id,
         target_table_cursor_id,
         target_table,
         resolver,
@@ -398,7 +450,7 @@ pub fn emit_program_for_update(
     CloseLoop::emit(
         program,
         &mut t_ctx,
-        &plan.table_references,
+        &write_phase_tables,
         &join_order,
         mode,
         None,
@@ -419,7 +471,262 @@ pub fn emit_program_for_update(
     after(program);
 
     program.result_columns = plan.returning.unwrap_or_default();
-    program.table_references.extend(plan.table_references);
+    program.table_references.extend(write_phase_tables);
+    Ok(())
+}
+
+/// Shared state threaded through the per-column emission loop of an UPDATE.
+///
+/// Bundles everything a column-level emitter needs to produce the NEW-image
+/// register for a single target column: the target table and its cursor, the
+/// register layout (`start` + `layout`) that maps column index → register,
+/// rowid bookkeeping (including whether the UPDATE changes the rowid and
+/// where the new value comes from), the optional partial-index cursor in use,
+/// CDC tracking registers, and the mask of columns actually named in the SET
+/// clause so untouched columns can be copied from the OLD image.
+struct UpdateColumnCtx<'a> {
+    cdc_update_alter_statement: Option<&'a str>,
+    target_table: &'a Arc<JoinedTable>,
+    target_table_cursor_id: usize,
+    start: usize,
+    rowid_reg: usize,
+    updates_rowid: bool,
+    rowid_set_clause_reg: Option<usize>,
+    is_virtual_table: bool,
+    index: &'a Option<(Arc<Index>, usize)>,
+    cdc_updates_register: Option<usize>,
+    layout: &'a ColumnLayout,
+    affected_columns: &'a ColumnMask,
+}
+
+impl UpdateColumnCtx<'_> {
+    fn col_len(&self) -> usize {
+        self.target_table.table.columns().len()
+    }
+
+    fn table_name(&self) -> &str {
+        self.target_table.table.get_name()
+    }
+}
+
+/// Emit the VDBE instructions that enforce a `NOT NULL` constraint on the
+/// value currently in `target_reg`, honoring the UPDATE's OR conflict clause:
+///
+/// - `OR IGNORE`  : branch to `skip_row_label` when the value is NULL, leaving
+///                  the existing row untouched.
+/// - `OR REPLACE` : if the column has a DEFAULT, evaluate it into `target_reg`;
+///                  otherwise halt with `SQLITE_CONSTRAINT_NOTNULL`.
+/// - everything else (ABORT/ROLLBACK/FAIL, or the default): halt with
+///                  `SQLITE_CONSTRAINT_NOTNULL`.
+#[allow(clippy::too_many_arguments)]
+fn emit_notnull_constraint_check(
+    program: &mut ProgramBuilder,
+    table_references: &TableReferences,
+    target_reg: usize,
+    table_column: &Column,
+    table_name: &str,
+    or_conflict: ResolveType,
+    skip_row_label: BranchOffset,
+    resolver: &Resolver,
+) -> crate::Result<()> {
+    let description = format!(
+        "{}.{}",
+        table_name,
+        table_column
+            .name
+            .as_ref()
+            .expect("Column name must be present")
+    );
+    match or_conflict {
+        ResolveType::Ignore => {
+            program.emit_insn(Insn::IsNull {
+                reg: target_reg,
+                target_pc: skip_row_label,
+            });
+        }
+        ResolveType::Replace => {
+            if let Some(default_expr) = table_column.default.as_ref() {
+                let continue_label = program.allocate_label();
+                program.emit_insn(Insn::NotNull {
+                    reg: target_reg,
+                    target_pc: continue_label,
+                });
+                translate_expr_no_constant_opt(
+                    program,
+                    Some(table_references),
+                    default_expr,
+                    target_reg,
+                    resolver,
+                    NoConstantOptReason::RegisterReuse,
+                )?;
+                program.preassign_label_to_next_insn(continue_label);
+            } else {
+                program.emit_insn(Insn::HaltIfNull {
+                    target_reg,
+                    err_code: SQLITE_CONSTRAINT_NOTNULL,
+                    description,
+                });
+            }
+        }
+        _ => {
+            program.emit_insn(Insn::HaltIfNull {
+                target_reg,
+                err_code: SQLITE_CONSTRAINT_NOTNULL,
+                description,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Build the `TriggerContext` used to fire BEFORE/AFTER row triggers for this
+/// UPDATE. Carries the NEW and OLD register snapshots the trigger body will
+/// read, and propagates a conflict-resolution override when one is in effect:
+/// a `trigger_conflict_override` pushed by an enclosing UPSERT `DO UPDATE`
+/// wins, otherwise the outer UPDATE's explicit `OR <conflict>` overrides the
+/// trigger's own conflict resolution (except for the default `ABORT`, which
+/// is left unset so the trigger's own resolution applies). `after` selects
+/// between the BEFORE and AFTER constructors.
+fn update_trigger_context(
+    program: &ProgramBuilder,
+    btree_table: &Arc<BTreeTable>,
+    new_registers: Option<Vec<usize>>,
+    old_registers: Option<Vec<usize>>,
+    or_conflict: ResolveType,
+    after: bool,
+) -> TriggerContext {
+    let override_conflict = program
+        .trigger_conflict_override
+        .or_else(|| (!matches!(or_conflict, ResolveType::Abort)).then_some(or_conflict));
+
+    match (after, override_conflict) {
+        (true, Some(override_conflict)) => TriggerContext::new_after_with_override_conflict(
+            btree_table.clone(),
+            new_registers,
+            old_registers,
+            override_conflict,
+        ),
+        (true, None) => {
+            TriggerContext::new_after(btree_table.clone(), new_registers, old_registers)
+        }
+        (false, Some(override_conflict)) => TriggerContext::new_with_override_conflict(
+            btree_table.clone(),
+            new_registers,
+            old_registers,
+            override_conflict,
+        ),
+        (false, None) => TriggerContext::new(btree_table.clone(), new_registers, old_registers),
+    }
+}
+
+/// Emit the delete half of `OR REPLACE` conflict resolution during an UPDATE.
+///
+/// When the new image of the row being updated would violate a UNIQUE or
+/// PRIMARY KEY constraint and `OR REPLACE` is in effect, the existing
+/// conflicting row (identified by `conflicting_rowid_reg`) must be removed
+/// before the UPDATE can proceed. This function emits that delete:
+/// it removes every index entry belonging to the conflicting row from
+/// `all_index_cursors`, deletes the btree row itself, and — when foreign
+/// keys are enabled — prepares and fires the appropriate FK actions and
+/// child-FK counter decrements. `new_row_registers`, when provided, lets
+/// FK action emission see the incoming NEW image so it can distinguish a
+/// cascading REPLACE from an unrelated delete.
+#[allow(clippy::too_many_arguments)]
+fn emit_replace_delete<'a>(
+    program: &mut ProgramBuilder,
+    connection: &Arc<Connection>,
+    table_references: &mut TableReferences,
+    target_table: &Arc<JoinedTable>,
+    target_table_cursor_id: usize,
+    all_index_cursors: &[(Arc<Index>, usize)],
+    conflicting_rowid_reg: usize,
+    new_row_registers: Option<(usize, usize)>,
+    update_database_id: usize,
+    t_ctx: &mut TranslateCtx<'a>,
+) -> crate::Result<()> {
+    let table_name = target_table.table.get_name();
+    let internal_id = target_table.internal_id;
+    let prepared_fk_actions = if connection.foreign_keys_enabled() {
+        let prepared = if t_ctx.resolver.with_schema(update_database_id, |s| {
+            s.any_resolved_fks_referencing(table_name)
+        }) {
+            ForeignKeyActions::prepare_fk_delete_actions(
+                program,
+                &mut t_ctx.resolver,
+                table_name,
+                target_table_cursor_id,
+                conflicting_rowid_reg,
+                new_row_registers,
+                update_database_id,
+            )?
+        } else {
+            ForeignKeyActions::default()
+        };
+        if t_ctx
+            .resolver
+            .with_schema(update_database_id, |s| s.has_child_fks(table_name))
+        {
+            emit_fk_child_decrement_on_delete(
+                program,
+                &target_table
+                    .table
+                    .btree()
+                    .expect("UPDATE target must be a BTree table"),
+                table_name,
+                target_table_cursor_id,
+                conflicting_rowid_reg,
+                update_database_id,
+                &t_ctx.resolver,
+            )?;
+        }
+        prepared
+    } else {
+        ForeignKeyActions::default()
+    };
+
+    for (other_index, other_idx_cursor_id) in all_index_cursors {
+        let other_num_regs = other_index.columns.len() + 1;
+        let other_start_reg = program.alloc_registers(other_num_regs);
+
+        for (reg_offset, column_index) in other_index.columns.iter().enumerate() {
+            emit_index_column_value_old_image(
+                program,
+                &t_ctx.resolver,
+                table_references,
+                target_table_cursor_id,
+                internal_id,
+                column_index,
+                other_start_reg + reg_offset,
+            )?;
+        }
+
+        program.emit_insn(Insn::Copy {
+            src_reg: conflicting_rowid_reg,
+            dst_reg: other_start_reg + other_num_regs - 1,
+            extra_amount: 0,
+        });
+
+        program.emit_insn(Insn::IdxDelete {
+            start_reg: other_start_reg,
+            num_regs: other_num_regs,
+            cursor_id: *other_idx_cursor_id,
+            raise_error_if_no_matching_entry: other_index.where_clause.is_none(),
+        });
+    }
+
+    program.emit_insn(Insn::Delete {
+        cursor_id: target_table_cursor_id,
+        table_name: table_name.to_string(),
+        is_part_of_update: false,
+    });
+
+    prepared_fk_actions.fire_prepared_fk_delete_actions(
+        program,
+        &mut t_ctx.resolver,
+        connection,
+        update_database_id,
+    )?;
+
     Ok(())
 }
 
@@ -431,52 +738,37 @@ pub fn emit_program_for_update(
 fn emit_update_column_values<'a>(
     program: &mut ProgramBuilder,
     table_references: &mut TableReferences,
-    set_clauses: &[(usize, Box<ast::Expr>)],
-    cdc_update_alter_statement: Option<&str>,
-    target_table: &Arc<JoinedTable>,
-    target_table_cursor_id: usize,
-    start: usize,
-    rowid_reg: usize,
-    col_len: usize,
-    table_name: &str,
-    has_direct_rowid_update: bool,
-    updates_rowid: bool,
-    rowid_set_clause_reg: Option<usize>,
-    is_virtual_table: bool,
-    index: &Option<(Arc<Index>, usize)>,
-    cdc_updates_register: Option<usize>,
+    set_clauses: &[UpdateSetClause],
+    column_ctx: &UpdateColumnCtx<'_>,
     t_ctx: &mut TranslateCtx<'a>,
     skip_set_clauses: bool,
     skip_row_label: BranchOffset,
     skip_notnull_checks: bool,
-    layout: &ColumnLayout,
 ) -> crate::Result<()> {
     let or_conflict = program.resolve_type;
-    if has_direct_rowid_update {
-        if let Some((_, expr)) = set_clauses.iter().find(|(i, _)| *i == ROWID_SENTINEL) {
-            if !skip_set_clauses {
-                let rowid_set_clause_reg = rowid_set_clause_reg.unwrap();
-                translate_expr(
-                    program,
-                    Some(table_references),
-                    expr,
-                    rowid_set_clause_reg,
-                    &t_ctx.resolver,
-                )?;
-                program.emit_insn(Insn::MustBeInt {
-                    reg: rowid_set_clause_reg,
-                });
-            }
+    if let Some(expr) = set_clauses
+        .iter()
+        .find(|set_clause| set_clause.column_index == ROWID_SENTINEL)
+        .map(UpdateSetClause::emitted_expr)
+    {
+        if !skip_set_clauses {
+            let rowid_set_clause_reg = column_ctx.rowid_set_clause_reg.unwrap();
+            translate_expr(
+                program,
+                Some(table_references),
+                expr,
+                rowid_set_clause_reg,
+                &t_ctx.resolver,
+            )?;
+            program.emit_insn(Insn::MustBeInt {
+                reg: rowid_set_clause_reg,
+            });
         }
     }
-    let target_table_columns = target_table.table.columns();
-    let affected_columns = match target_table.table.btree() {
-        Some(btree) => btree.columns_affected_by_update(set_clauses.iter().map(|(idx, _)| *idx))?,
-        None => set_clauses.iter().map(|(idx, _)| *idx).collect(),
-    };
+    let target_table_columns = column_ctx.target_table.table.columns();
 
     for (idx, table_column) in target_table_columns.iter().enumerate() {
-        let target_reg = layout.to_register(start, idx);
+        let target_reg = column_ctx.layout.to_register(column_ctx.start, idx);
 
         // If the column needs to be updated, retrieve its column index, or its expression.
         // Such a column can be directly updated, in which case `expr` is the right-side of the SET
@@ -484,10 +776,10 @@ fn emit_update_column_values<'a>(
         // column's expression.
         let update_expr = set_clauses
             .iter()
-            .find(|(i, _)| *i == idx)
-            .map(|(_, expr)| expr.as_ref())
+            .find(|set_clause| set_clause.column_index == idx)
+            .map(UpdateSetClause::emitted_expr)
             .or_else(|| {
-                if affected_columns.get(idx) {
+                if column_ctx.affected_columns.get(idx) {
                     table_column.generated_expr()
                 } else {
                     None
@@ -500,11 +792,11 @@ fn emit_update_column_values<'a>(
                 if idx == ROWID_SENTINEL {
                     continue;
                 }
-                if updates_rowid
+                if column_ctx.updates_rowid
                     && (table_column.primary_key() || table_column.is_rowid_alias())
-                    && !is_virtual_table
+                    && !column_ctx.is_virtual_table
                 {
-                    let rowid_set_clause_reg = rowid_set_clause_reg.unwrap();
+                    let rowid_set_clause_reg = column_ctx.rowid_set_clause_reg.unwrap();
                     translate_expr(
                         program,
                         Some(table_references),
@@ -522,12 +814,12 @@ fn emit_update_column_values<'a>(
                     let self_table_context = match table_column.generated_type() {
                         GeneratedType::Virtual { .. } => Some(SelfTableContext::ForDML {
                             dml_ctx: DmlColumnContext::layout(
-                                target_table.table.columns(),
-                                start,
-                                rowid_reg,
-                                layout.clone(),
+                                column_ctx.target_table.table.columns(),
+                                column_ctx.start,
+                                column_ctx.rowid_reg,
+                                column_ctx.layout.clone(),
                             ),
-                            table: target_table.table.require_btree()?,
+                            table: column_ctx.target_table.table.require_btree()?,
                         }),
                         GeneratedType::NotGenerated => None,
                     };
@@ -586,83 +878,29 @@ fn emit_update_column_values<'a>(
                                         .notnull_conflict_clause
                                         .unwrap_or(ResolveType::Abort)
                                 };
-                                match notnull_conflict {
-                                    ResolveType::Ignore => {
-                                        // For IGNORE, skip this row on NOT NULL violation
-                                        program.emit_insn(Insn::IsNull {
-                                            reg: target_reg,
-                                            target_pc: skip_row_label,
-                                        });
-                                    }
-                                    ResolveType::Replace => {
-                                        // For REPLACE with NOT NULL, use default value if available
-                                        if let Some(default_expr) = table_column.default.as_ref() {
-                                            let continue_label = program.allocate_label();
-
-                                            // If not null, skip to continue
-                                            program.emit_insn(Insn::NotNull {
-                                                reg: target_reg,
-                                                target_pc: continue_label,
-                                            });
-
-                                            // Value is null, use default.
-                                            translate_expr_no_constant_opt(
-                                                program,
-                                                Some(table_references),
-                                                default_expr,
-                                                target_reg,
-                                                &t_ctx.resolver,
-                                                NoConstantOptReason::RegisterReuse,
-                                            )?;
-
-                                            program.preassign_label_to_next_insn(continue_label);
-                                        } else {
-                                            // No default value, fall through to ABORT behavior
-                                            use crate::error::SQLITE_CONSTRAINT_NOTNULL;
-                                            program.emit_insn(Insn::HaltIfNull {
-                                                target_reg,
-                                                err_code: SQLITE_CONSTRAINT_NOTNULL,
-                                                description: format!(
-                                                    "{}.{}",
-                                                    table_name,
-                                                    table_column
-                                                        .name
-                                                        .as_ref()
-                                                        .expect("Column name must be present")
-                                                ),
-                                            });
-                                        }
-                                    }
-                                    _ => {
-                                        // Default ABORT behavior
-                                        use crate::error::SQLITE_CONSTRAINT_NOTNULL;
-                                        program.emit_insn(Insn::HaltIfNull {
-                                            target_reg,
-                                            err_code: SQLITE_CONSTRAINT_NOTNULL,
-                                            description: format!(
-                                                "{}.{}",
-                                                table_name,
-                                                table_column
-                                                    .name
-                                                    .as_ref()
-                                                    .expect("Column name must be present")
-                                            ),
-                                        });
-                                    }
-                                }
+                                emit_notnull_constraint_check(
+                                    program,
+                                    table_references,
+                                    target_reg,
+                                    table_column,
+                                    column_ctx.table_name(),
+                                    notnull_conflict,
+                                    skip_row_label,
+                                    &t_ctx.resolver,
+                                )?;
                             }
                             Ok(())
                         },
                     )?;
                 }
 
-                if let Some(cdc_updates_register) = cdc_updates_register {
+                if let Some(cdc_updates_register) = column_ctx.cdc_updates_register {
                     let change_reg = cdc_updates_register + idx;
-                    let value_reg = cdc_updates_register + col_len + idx;
+                    let value_reg = cdc_updates_register + column_ctx.col_len() + idx;
                     program.emit_bool(true, change_reg);
                     program.mark_last_insn_constant();
                     let mut updated = false;
-                    if let Some(ddl_query_for_cdc_update) = cdc_update_alter_statement {
+                    if let Some(ddl_query_for_cdc_update) = column_ctx.cdc_update_alter_statement {
                         if table_column.name.as_deref() == Some("sql") {
                             program.emit_string8(ddl_query_for_cdc_update.to_string(), value_reg);
                             updated = true;
@@ -681,7 +919,7 @@ fn emit_update_column_values<'a>(
             // Column is not being updated, read it from the table
             match table_column.generated_type() {
                 GeneratedType::NotGenerated => {
-                    let column_idx_in_index = index.as_ref().and_then(|(idx, _)| {
+                    let column_idx_in_index = column_ctx.index.as_ref().and_then(|(idx, _)| {
                         idx.columns.iter().position(|c| {
                             table_column
                                 .name
@@ -692,25 +930,21 @@ fn emit_update_column_values<'a>(
 
                     // don't emit null for pkey of virtual tables. they require first two args
                     // before the 'record' to be explicitly non-null
-                    if table_column.is_rowid_alias() && !is_virtual_table {
+                    if table_column.is_rowid_alias() && !column_ctx.is_virtual_table {
                         program.emit_null(target_reg, None);
-                    } else if is_virtual_table {
+                    } else if column_ctx.is_virtual_table {
                         program.emit_insn(Insn::VColumn {
-                            cursor_id: target_table_cursor_id,
+                            cursor_id: column_ctx.target_table_cursor_id,
                             column: idx,
                             dest: target_reg,
                         });
                     } else {
-                        let cursor_id = *index
+                        let cursor_id = column_ctx
+                            .index
                             .as_ref()
-                            .and_then(|(_, id)| {
-                                if column_idx_in_index.is_some() {
-                                    Some(id)
-                                } else {
-                                    None
-                                }
-                            })
-                            .unwrap_or(&target_table_cursor_id);
+                            .filter(|_| column_idx_in_index.is_some())
+                            .map(|(_, id)| *id)
+                            .unwrap_or(column_ctx.target_table_cursor_id);
                         program.emit_column_or_rowid(
                             cursor_id,
                             column_idx_in_index.unwrap_or(idx),
@@ -723,9 +957,9 @@ fn emit_update_column_values<'a>(
                 }
             }
 
-            if let Some(cdc_updates_register) = cdc_updates_register {
+            if let Some(cdc_updates_register) = column_ctx.cdc_updates_register {
                 let change_bit_reg = cdc_updates_register + idx;
-                let value_reg = cdc_updates_register + col_len + idx;
+                let value_reg = cdc_updates_register + column_ctx.col_len() + idx;
                 program.emit_bool(false, change_bit_reg);
                 program.mark_last_insn_constant();
                 program.emit_null(value_reg, None);
@@ -739,17 +973,14 @@ fn emit_update_column_values<'a>(
 /// Emit NOT NULL constraint checks for SET clause columns after BEFORE triggers have fired.
 /// This is deferred from the first `emit_update_column_values` call so that triggers
 /// run before constraint checks, matching SQLite's behavior.
-#[allow(clippy::too_many_arguments)]
 fn emit_deferred_notnull_checks<'a>(
     program: &mut ProgramBuilder,
     table_references: &mut TableReferences,
     target_table: &Arc<JoinedTable>,
-    set_clauses: &[(usize, Box<ast::Expr>)],
-    start: usize,
-    table_name: &str,
+    updated_column_indices: &ColumnMask,
+    column_ctx: &UpdateColumnCtx<'_>,
     skip_row_label: BranchOffset,
     t_ctx: &mut TranslateCtx<'a>,
-    layout: &ColumnLayout,
 ) -> crate::Result<()> {
     let or_conflict = program.resolve_type;
     for (idx, table_column) in target_table.table.columns().iter().enumerate() {
@@ -757,65 +988,20 @@ fn emit_deferred_notnull_checks<'a>(
             continue;
         }
         // Only check columns that are in SET clauses
-        if !set_clauses.iter().any(|(i, _)| *i == idx) {
+        if !updated_column_indices.get(idx) {
             continue;
         }
-        let target_reg = layout.to_register(start, idx);
-        match or_conflict {
-            ResolveType::Ignore => {
-                program.emit_insn(Insn::IsNull {
-                    reg: target_reg,
-                    target_pc: skip_row_label,
-                });
-            }
-            ResolveType::Replace => {
-                if let Some(default_expr) = table_column.default.as_ref() {
-                    let continue_label = program.allocate_label();
-                    program.emit_insn(Insn::NotNull {
-                        reg: target_reg,
-                        target_pc: continue_label,
-                    });
-                    translate_expr_no_constant_opt(
-                        program,
-                        Some(table_references),
-                        default_expr,
-                        target_reg,
-                        &t_ctx.resolver,
-                        NoConstantOptReason::RegisterReuse,
-                    )?;
-                    program.preassign_label_to_next_insn(continue_label);
-                } else {
-                    use crate::error::SQLITE_CONSTRAINT_NOTNULL;
-                    program.emit_insn(Insn::HaltIfNull {
-                        target_reg,
-                        err_code: SQLITE_CONSTRAINT_NOTNULL,
-                        description: format!(
-                            "{}.{}",
-                            table_name,
-                            table_column
-                                .name
-                                .as_ref()
-                                .expect("Column name must be present")
-                        ),
-                    });
-                }
-            }
-            _ => {
-                use crate::error::SQLITE_CONSTRAINT_NOTNULL;
-                program.emit_insn(Insn::HaltIfNull {
-                    target_reg,
-                    err_code: SQLITE_CONSTRAINT_NOTNULL,
-                    description: format!(
-                        "{}.{}",
-                        table_name,
-                        table_column
-                            .name
-                            .as_ref()
-                            .expect("Column name must be present")
-                    ),
-                });
-            }
-        }
+        let target_reg = column_ctx.layout.to_register(column_ctx.start, idx);
+        emit_notnull_constraint_check(
+            program,
+            table_references,
+            target_reg,
+            table_column,
+            column_ctx.table_name(),
+            or_conflict,
+            skip_row_label,
+            &t_ctx.resolver,
+        )?;
     }
     Ok(())
 }
@@ -824,35 +1010,34 @@ fn emit_deferred_notnull_checks<'a>(
 #[allow(clippy::too_many_arguments)]
 /// Emits the instructions for the UPDATE loop.
 ///
-/// `iteration_cursor_id` is the cursor id of the table that is being iterated over. This can be either the table itself, an index, or an ephemeral table (see [crate::translate::plan::UpdatePlan]).
+/// `temp_cursor_id` is the cursor id of the prebuilt write set, when UPDATE is using one.
 ///
 /// `target_table_cursor_id` is the cursor id of the table that is being updated.
 ///
 /// `target_table` is the table that is being updated.
-///
-/// `or_conflict` specifies the conflict resolution strategy (IGNORE, REPLACE, ABORT).
 ///
 /// `all_index_cursors` contains cursors for ALL indexes on the table (used for REPLACE to delete
 /// conflicting rows from all indexes, not just those being updated).
 fn emit_update_insns<'a>(
     connection: &Arc<Connection>,
     table_references: &mut TableReferences,
-    set_clauses: &[(usize, Box<ast::Expr>)],
+    set_clauses: &[UpdateSetClause],
     cdc_update_alter_statement: Option<&str>,
     indexes_to_update: &[Arc<Index>],
     returning: Option<&'a Vec<ResultSetColumn>>,
-    ephemeral_plan: Option<&SelectPlan>,
+    temp_cursor_id: Option<usize>,
     t_ctx: &mut TranslateCtx<'a>,
     program: &mut ProgramBuilder,
     index_cursors: &[(usize, usize)],
     all_index_cursors: &[(Arc<Index>, usize)],
-    iteration_cursor_id: usize,
     target_table_cursor_id: usize,
     target_table: Arc<JoinedTable>,
     resolver: &Resolver,
     returning_buffer: Option<&ReturningBufferCtx>,
     non_from_clause_subqueries: &mut [NonFromClauseSubquery],
 ) -> crate::Result<()> {
+    let uses_write_set = temp_cursor_id.is_some();
+    let iteration_cursor_id = temp_cursor_id.unwrap_or(target_table_cursor_id);
     let or_conflict = program.resolve_type;
     let internal_id = target_table.internal_id;
     // Copy loop labels early to avoid borrow conflicts with mutable t_ctx borrow later
@@ -862,11 +1047,11 @@ fn emit_update_insns<'a>(
         .expect("loop labels to exist");
     // Label to skip to the next row on conflict (for IGNORE mode)
     let skip_row_label = loop_labels.next;
-    let source_table = table_references
+    let access_table = table_references
         .joined_tables()
         .first()
         .expect("UPDATE must have a source table");
-    let (index, is_virtual_table) = match &source_table.op {
+    let (index, is_virtual_table) = match &access_table.op {
         Operation::Scan(Scan::BTreeTable { index, .. }) => (
             index.as_ref().map(|index| {
                 (
@@ -906,6 +1091,14 @@ fn emit_update_insns<'a>(
             unreachable!("access through MultiIndexScan is not supported for update operations")
         }
     };
+    turso_assert!(
+        !uses_write_set || index.is_none(),
+        "prebuilt UPDATE write set must not scan an index directly"
+    );
+
+    let rowid_update = rowid_update_info(target_table.as_ref(), set_clauses);
+    let rowid_alias_index = rowid_update.rowid_alias_index;
+    let updates_rowid = rowid_update.updates_rowid;
 
     let beg = program.alloc_registers(
         target_table.table.columns().len()
@@ -920,26 +1113,12 @@ fn emit_update_insns<'a>(
         dest: beg,
     });
 
-    // Check if rowid was provided (through INTEGER PRIMARY KEY as a rowid alias)
-    let rowid_alias_index = target_table
-        .table
-        .columns()
-        .iter()
-        .position(|c| c.is_rowid_alias());
-
-    let has_direct_rowid_update = set_clauses.iter().any(|(idx, _)| *idx == ROWID_SENTINEL);
-
-    let updates_rowid = if let Some(index) = rowid_alias_index {
-        set_clauses.iter().any(|(idx, _)| *idx == index)
-    } else {
-        has_direct_rowid_update
-    };
-
     let rowid_set_clause_reg = if updates_rowid {
         Some(program.alloc_register())
     } else {
         None
     };
+    let effective_rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
 
     // Effective INTEGER PK conflict resolution: statement-level OR clause takes precedence;
     // otherwise use the constraint-level rowid_alias_conflict_clause from the table DDL.
@@ -955,8 +1134,11 @@ fn emit_update_insns<'a>(
 
     let not_exists_check_required = updates_rowid || iteration_cursor_id != target_table_cursor_id;
     let update_database_id = target_table.database_id;
-    let has_before_update_triggers = if let Some(btree_table) = target_table.table.btree() {
-        let updated_column_indices = set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
+    let updated_column_indices: ColumnMask = set_clauses
+        .iter()
+        .map(|set_clause| set_clause.column_index)
+        .collect();
+    let has_any_update_triggers = if let Some(btree_table) = target_table.table.btree() {
         has_triggers_including_temp(
             &t_ctx.resolver,
             update_database_id,
@@ -968,7 +1150,7 @@ fn emit_update_insns<'a>(
         false
     };
 
-    let check_rowid_not_exists_label = if not_exists_check_required || has_before_update_triggers {
+    let check_rowid_not_exists_label = if not_exists_check_required || has_any_update_triggers {
         Some(program.allocate_label())
     } else {
         None
@@ -991,10 +1173,11 @@ fn emit_update_insns<'a>(
         });
     }
 
-    // Emit remaining SET clause subqueries inside the loop, after the write cursor
-    // is positioned via NotExists. In the ephemeral path, these subqueries were kept
-    // in the main plan (not moved to the ephemeral plan) and need the write cursor
-    // to be positioned so correlated references resolve correctly.
+    // Emit any remaining SET-clause subqueries inside the loop, after the write cursor
+    // is positioned via NotExists. This only applies to the non-FROM ephemeral path:
+    // UPDATE ... FROM moves SET expressions into the ephemeral SELECT payload, but
+    // trigger/REPLACE/FK-driven ephemeral updates still keep SET subqueries in the
+    // main plan so correlated references resolve against the positioned write cursor.
     // RETURNING subqueries are skipped here and emitted after Insert so that
     // correlated column references read post-UPDATE values from the cursor.
     for subquery in non_from_clause_subqueries
@@ -1042,30 +1225,35 @@ fn emit_update_insns<'a>(
     let table_name = target_table.table.get_name();
     let start = if is_virtual_table { beg + 2 } else { beg + 1 };
     let layout = ColumnLayout::from_table(&target_table.as_ref().table);
+    let affected_columns = match target_table.table.btree() {
+        Some(btree) => btree.columns_affected_by_update(&updated_column_indices)?,
+        None => updated_column_indices.clone(),
+    };
+    let column_ctx = UpdateColumnCtx {
+        cdc_update_alter_statement,
+        target_table: &target_table,
+        target_table_cursor_id,
+        start,
+        rowid_reg: beg,
+        updates_rowid,
+        rowid_set_clause_reg,
+        is_virtual_table,
+        index: &index,
+        cdc_updates_register,
+        layout: &layout,
+        affected_columns: &affected_columns,
+    };
     let skip_set_clauses = false;
 
     emit_update_column_values(
         program,
         table_references,
         set_clauses,
-        cdc_update_alter_statement,
-        &target_table,
-        target_table_cursor_id,
-        start,
-        beg,
-        col_len,
-        table_name,
-        has_direct_rowid_update,
-        updates_rowid,
-        rowid_set_clause_reg,
-        is_virtual_table,
-        &index,
-        cdc_updates_register,
+        &column_ctx,
         t_ctx,
         skip_set_clauses,
         skip_row_label,
-        has_before_update_triggers,
-        &layout,
+        has_any_update_triggers,
     )?;
 
     // For non-STRICT tables, apply column affinity to the NEW values early.
@@ -1095,126 +1283,110 @@ fn emit_update_insns<'a>(
     // Fire BEFORE UPDATE triggers and preserve old_registers for AFTER triggers
     let mut has_before_triggers = false;
     let mut has_after_triggers = false;
-    let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) =
-        target_table.table.btree()
-    {
-        let updated_column_indices: ColumnMask =
-            set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
-        let relevant_before_update_triggers = get_triggers_including_temp(
-            &t_ctx.resolver,
-            update_database_id,
-            TriggerEvent::Update,
-            TriggerTime::Before,
-            Some(updated_column_indices.clone()),
-            &btree_table,
-        );
-        has_after_triggers = has_triggers_including_temp(
-            &t_ctx.resolver,
-            update_database_id,
-            TriggerEvent::Update,
-            Some(&updated_column_indices),
-            &btree_table,
-        );
-
-        let has_fk_cascade = connection.foreign_keys_enabled()
-            && t_ctx.resolver.with_schema(update_database_id, |s| {
-                s.any_resolved_fks_referencing(table_name)
-            });
-
-        has_before_triggers = !relevant_before_update_triggers.is_empty();
-        let needs_old_registers = has_before_triggers || has_after_triggers || has_fk_cascade;
-
-        // Only read OLD row values when triggers or FK cascades need them
-        let columns = target_table.table.columns();
-        let old_registers: Option<Vec<usize>> = if needs_old_registers {
-            let mut regs = Vec::with_capacity(col_len + 1);
-            for (i, column) in columns.iter().enumerate() {
-                let reg = program.alloc_register();
-                emit_table_column(
-                    program,
-                    target_table_cursor_id,
-                    internal_id,
-                    table_references,
-                    column,
-                    i,
-                    reg,
-                    &t_ctx.resolver,
-                )?;
-                regs.push(reg);
-            }
-            regs.push(beg);
-            Some(regs)
-        } else {
-            None
-        };
-
-        if has_before_triggers {
-            let old_registers =
-                old_registers.expect("old_registers allocated when has_before_triggers");
-            // NEW row values are already in 'start' registers.
-            // If the rowid is being updated (INTEGER PRIMARY KEY in SET clause),
-            // use the new rowid register; otherwise use the current rowid (beg).
-            let new_rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
-
-            // Compute virtual columns for NEW values
-            //TODO only emit required virtual columns
-            let bt = target_table.table.btree().ok_or_else(|| {
-                crate::LimboError::InternalError("cannot create triggers on virtual tables".into())
-            })?;
-            let new_ctx = DmlColumnContext::layout(columns, start, new_rowid_reg, layout.clone());
-            compute_virtual_columns(
-                program,
-                &bt.columns_topo_sort()?,
-                &new_ctx,
+    let preserved_old_registers: Option<Vec<usize>> =
+        if let Some(btree_table) = target_table.table.btree() {
+            let relevant_before_update_triggers = get_triggers_including_temp(
                 &t_ctx.resolver,
-                &bt,
-            )?;
+                update_database_id,
+                TriggerEvent::Update,
+                TriggerTime::Before,
+                Some(updated_column_indices.clone()),
+                &btree_table,
+            );
+            has_after_triggers = has_triggers_including_temp(
+                &t_ctx.resolver,
+                update_database_id,
+                TriggerEvent::Update,
+                Some(&updated_column_indices),
+                &btree_table,
+            );
 
-            let new_registers = (0..col_len)
-                .map(|i| layout.to_register(start, i))
-                .chain(std::iter::once(new_rowid_reg))
-                .collect();
+            let has_fk_cascade = connection.foreign_keys_enabled()
+                && t_ctx.resolver.with_schema(update_database_id, |s| {
+                    s.any_resolved_fks_referencing(table_name)
+                });
 
-            // Propagate conflict resolution to trigger context:
-            // 1. UPSERT DO UPDATE override takes precedence
-            // 2. Outer UPDATE's explicit ON CONFLICT overrides trigger body
-            // 3. Otherwise, use trigger's own conflict resolution
-            let trigger_ctx = if let Some(override_conflict) = program.trigger_conflict_override {
-                TriggerContext::new_with_override_conflict(
-                    btree_table,
-                    Some(new_registers),
-                    Some(old_registers.clone()), // Clone for AFTER trigger
-                    override_conflict,
-                )
-            } else if !matches!(or_conflict, ResolveType::Abort) {
-                TriggerContext::new_with_override_conflict(
-                    btree_table,
+            has_before_triggers = !relevant_before_update_triggers.is_empty();
+            let needs_old_registers = has_before_triggers || has_after_triggers || has_fk_cascade;
+
+            // Only read OLD row values when triggers or FK cascades need them
+            let columns = target_table.table.columns();
+            let old_registers: Option<Vec<usize>> = if needs_old_registers {
+                let mut regs = Vec::with_capacity(col_len + 1);
+                for (i, column) in columns.iter().enumerate() {
+                    let reg = program.alloc_register();
+                    emit_table_column(
+                        program,
+                        target_table_cursor_id,
+                        internal_id,
+                        table_references,
+                        column,
+                        i,
+                        reg,
+                        &t_ctx.resolver,
+                    )?;
+                    regs.push(reg);
+                }
+                regs.push(beg);
+                Some(regs)
+            } else {
+                None
+            };
+
+            if has_before_triggers {
+                let old_registers =
+                    old_registers.expect("old_registers allocated when has_before_triggers");
+                // NEW row values are already in 'start' registers.
+                // If the rowid is being updated (INTEGER PRIMARY KEY in SET clause),
+                // use the new rowid register; otherwise use the current rowid (beg).
+                let new_rowid_reg = effective_rowid_reg;
+
+                // Compute virtual columns for NEW values
+                //TODO only emit required virtual columns
+                if let Table::BTree(ref btree) = target_table.table {
+                    let new_ctx =
+                        DmlColumnContext::layout(columns, start, new_rowid_reg, layout.clone());
+                    compute_virtual_columns(
+                        program,
+                        &btree.columns_topo_sort()?,
+                        &new_ctx,
+                        &t_ctx.resolver,
+                        btree,
+                    )?;
+                }
+
+                let new_registers = (0..col_len)
+                    .map(|i| layout.to_register(start, i))
+                    .chain(std::iter::once(new_rowid_reg))
+                    .collect();
+
+                // Propagate conflict resolution to trigger context:
+                // 1. UPSERT DO UPDATE override takes precedence
+                // 2. Outer UPDATE's explicit ON CONFLICT overrides trigger body
+                // 3. Otherwise, use trigger's own conflict resolution
+                let trigger_ctx = update_trigger_context(
+                    program,
+                    &btree_table,
                     Some(new_registers),
                     Some(old_registers.clone()),
                     or_conflict,
-                )
-            } else {
-                TriggerContext::new(
-                    btree_table,
-                    Some(new_registers),
-                    Some(old_registers.clone()), // Clone for AFTER trigger
-                )
-            };
+                    false,
+                );
 
-            for trigger in relevant_before_update_triggers {
-                fire_trigger(
-                    program,
-                    &mut t_ctx.resolver,
-                    trigger,
-                    &trigger_ctx,
-                    connection,
-                    update_database_id,
-                    trigger_ignore_jump_label,
-                )?;
-            }
+                for trigger in relevant_before_update_triggers {
+                    fire_trigger(
+                        program,
+                        &mut t_ctx.resolver,
+                        trigger,
+                        &trigger_ctx,
+                        connection,
+                        update_database_id,
+                        trigger_ignore_jump_label,
+                    )?;
+                }
 
-            // BEFORE UPDATE Triggers may have altered the btree so we need to seek again.
-            program.emit_insn(Insn::NotExists {
+                // BEFORE UPDATE Triggers may have altered the btree so we need to seek again.
+                program.emit_insn(Insn::NotExists {
                 cursor: target_table_cursor_id,
                 rowid_reg: beg,
                 target_pc: check_rowid_not_exists_label.expect(
@@ -1222,32 +1394,32 @@ fn emit_update_insns<'a>(
                 ),
             });
 
-            if has_after_triggers {
-                // Preserve pseudo-row 'OLD' for AFTER triggers by copying to new registers
-                // (since registers might be overwritten during trigger execution)
-                let preserved: Vec<usize> = old_registers
-                    .iter()
-                    .map(|old_reg| {
-                        let preserved_reg = program.alloc_register();
-                        program.emit_insn(Insn::Copy {
-                            src_reg: *old_reg,
-                            dst_reg: preserved_reg,
-                            extra_amount: 0,
-                        });
-                        preserved_reg
-                    })
-                    .collect();
-                Some(preserved)
+                if has_after_triggers {
+                    // Preserve pseudo-row 'OLD' for AFTER triggers by copying to new registers
+                    // (since registers might be overwritten during trigger execution)
+                    let preserved: Vec<usize> = old_registers
+                        .iter()
+                        .map(|old_reg| {
+                            let preserved_reg = program.alloc_register();
+                            program.emit_insn(Insn::Copy {
+                                src_reg: *old_reg,
+                                dst_reg: preserved_reg,
+                                extra_amount: 0,
+                            });
+                            preserved_reg
+                        })
+                        .collect();
+                    Some(preserved)
+                } else {
+                    Some(old_registers)
+                }
             } else {
-                Some(old_registers)
+                // No BEFORE triggers — pass through whatever old_registers we have
+                old_registers
             }
         } else {
-            // No BEFORE triggers — pass through whatever old_registers we have
-            old_registers
-        }
-    } else {
-        None
-    };
+            None
+        };
 
     // If BEFORE UPDATE triggers fired, they may have modified the row being updated.
     // According to the SQLite documentation, the behavior in these cases is undefined:
@@ -1269,24 +1441,11 @@ fn emit_update_insns<'a>(
             program,
             table_references,
             set_clauses,
-            cdc_update_alter_statement,
-            &target_table,
-            target_table_cursor_id,
-            start,
-            beg,
-            col_len,
-            table_name,
-            has_direct_rowid_update,
-            updates_rowid,
-            rowid_set_clause_reg,
-            is_virtual_table,
-            &index,
-            cdc_updates_register,
+            &column_ctx,
             t_ctx,
             skip_set_clauses,
             skip_row_label,
             false,
-            &layout,
         )?;
 
         // Now emit NOT NULL checks for SET clause columns that were deferred
@@ -1296,23 +1455,27 @@ fn emit_update_insns<'a>(
             program,
             table_references,
             &target_table,
-            set_clauses,
-            start,
-            table_name,
+            &updated_column_indices,
+            &column_ctx,
             skip_row_label,
             t_ctx,
-            &layout,
         )?;
     }
 
     let mut deferred_new_key_plans = Vec::new();
     if connection.foreign_keys_enabled() {
-        let rowid_new_reg = rowid_set_clause_reg.unwrap_or(beg);
+        let rowid_new_reg = effective_rowid_reg;
         if let Some(table_btree) = target_table.table.btree() {
+            let updated_set_columns: ColumnMask = set_clauses
+                .iter()
+                .filter_map(|set_clause| {
+                    (set_clause.column_index != ROWID_SENTINEL).then_some(set_clause.column_index)
+                })
+                .collect();
             stabilize_new_row_for_fk(
                 program,
                 &table_btree,
-                set_clauses,
+                &updated_set_columns,
                 target_table_cursor_id,
                 start,
                 rowid_new_reg,
@@ -1346,7 +1509,7 @@ fn emit_update_insns<'a>(
                     start,
                     rowid_new_reg,
                     rowid_set_clause_reg,
-                    set_clauses,
+                    &updated_set_columns,
                     new_key_probe_mode,
                     update_database_id,
                     &t_ctx.resolver,
@@ -1360,7 +1523,6 @@ fn emit_update_insns<'a>(
     // operators need the original column affinity. This is set once here and cleared at
     // the end of the function.
     {
-        let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
         let columns = target_table.table.columns();
         t_ctx.resolver.self_table_column_affinities =
             columns.iter().map(|c| c.affinity()).collect();
@@ -1373,18 +1535,10 @@ fn emit_update_insns<'a>(
         t_ctx
             .resolver
             .register_affinities
-            .insert(rowid_reg, Affinity::Integer);
+            .insert(effective_rowid_reg, Affinity::Integer);
     }
 
-    let mut set_clause_cols = ColumnMask::default();
-    for (idx, _) in set_clauses {
-        set_clause_cols.set(*idx);
-    }
-    let affected_columns = match target_table.table.btree() {
-        Some(btree) => btree.columns_affected_by_update(&set_clause_cols)?,
-        None => set_clause_cols.clone(),
-    };
-    let update_affects_virtual_columns = affected_columns.count() > set_clause_cols.count();
+    let update_affects_virtual_columns = affected_columns.count() > updated_column_indices.count();
     let has_returning = returning.as_ref().is_some_and(|r| !r.is_empty());
     if let Table::BTree(ref btree) = target_table.table {
         let has_check_constraints = !btree.check_constraints.is_empty();
@@ -1396,17 +1550,16 @@ fn emit_update_insns<'a>(
             || has_check_constraints
         {
             let columns = target_table.table.columns();
-            let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
-            let bt = btree.clone();
 
             //TODO don't emit all virtual columns
-            let dml_ctx = DmlColumnContext::layout(columns, start, rowid_reg, layout.clone());
+            let dml_ctx =
+                DmlColumnContext::layout(columns, start, effective_rowid_reg, layout.clone());
             compute_virtual_columns(
                 program,
                 &btree.columns_topo_sort()?,
                 &dml_ctx,
                 &t_ctx.resolver,
-                &bt,
+                btree,
             )?;
         }
     }
@@ -1500,7 +1653,10 @@ fn emit_update_insns<'a>(
     // This ensures that if a constraint fails, indexes remain consistent.
     if let Some(btree_table) = target_table.table.btree() {
         if btree_table.is_strict {
-            let set_col_indices: ColumnMask = set_clauses.iter().map(|(idx, _)| *idx).collect();
+            let set_col_indices: ColumnMask = set_clauses
+                .iter()
+                .map(|set_clause| set_clause.column_index)
+                .collect();
 
             // Pre-encode TypeCheck: validate SET column input types.
             // Non-SET columns hold encoded values from disk, so skip them (ANY).
@@ -1543,21 +1699,18 @@ fn emit_update_insns<'a>(
             // SQLite only evaluates CHECK constraints that reference at least one
             // column in the SET clause. Build a set of updated column names to filter.
             let mut updated_col_names: HashSet<String> = btree_table
-                .columns_affected_by_update(set_clauses.iter().map(|(idx, _)| *idx))?
-                .into_iter()
-                .filter_map(|col_idx| btree_table.columns().get(col_idx))
-                .filter_map(|col| col.name.as_deref())
+                .columns()
+                .iter()
+                .enumerate()
+                .filter(|(idx, _)| affected_columns.get(*idx))
+                .filter_map(|(_, col)| col.name.as_deref())
                 .map(normalize_ident)
                 .collect();
 
             // If the rowid is being updated (either directly via ROWID_SENTINEL or
             // through a rowid alias column), also include the rowid pseudo-column
             // names so that CHECK(rowid > 0) etc. are properly triggered.
-            let rowid_updated = set_clauses.iter().any(|(idx, _)| *idx == ROWID_SENTINEL)
-                || btree_table.columns().iter().enumerate().any(|(i, c)| {
-                    c.is_rowid_alias() && set_clauses.iter().any(|(idx, _)| *idx == i)
-                });
-            if rowid_updated {
+            if updates_rowid {
                 for name in ROWID_STRS {
                     updated_col_names.insert(name.to_string());
                 }
@@ -1577,7 +1730,7 @@ fn emit_update_insns<'a>(
                 &relevant_checks,
                 &mut t_ctx.resolver,
                 &btree_table.name,
-                rowid_set_clause_reg.unwrap_or(beg),
+                effective_rowid_reg,
                 btree_table
                     .columns()
                     .iter()
@@ -1585,7 +1738,7 @@ fn emit_update_insns<'a>(
                     .filter_map(|(idx, col)| {
                         col.name.as_deref().map(|n| {
                             if col.is_rowid_alias() {
-                                (n, rowid_set_clause_reg.unwrap_or(beg))
+                                (n, effective_rowid_reg)
                             } else {
                                 (n, layout.to_register(start, idx))
                             }
@@ -1604,21 +1757,14 @@ fn emit_update_insns<'a>(
     if connection.foreign_keys_enabled() {
         if let Some(table_btree) = target_table.table.btree() {
             if t_ctx.resolver.schema().has_child_fks(table_name) {
-                let rowid_new_reg = rowid_set_clause_reg.unwrap_or(beg);
-                let mut directly_and_indirectly_updated_columns = ColumnMask::default();
-                directly_and_indirectly_updated_columns.union_with(
-                    &table_btree
-                        .columns_affected_by_update(set_clauses.iter().map(|(idx, _)| *idx))?,
-                );
-
                 emit_fk_child_update_counters(
                     program,
                     &table_btree,
                     table_name,
                     target_table_cursor_id,
                     start,
-                    rowid_new_reg,
-                    &directly_and_indirectly_updated_columns,
+                    effective_rowid_reg,
+                    &affected_columns,
                     update_database_id,
                     &t_ctx.resolver,
                     &layout,
@@ -1680,13 +1826,12 @@ fn emit_update_insns<'a>(
                 .as_ref()
                 .clone();
             let columns = target_table.table.columns();
-            let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
             let mut column_regs: Vec<usize> = columns
                 .iter()
                 .enumerate()
                 .map(|(i, col)| {
                     if col.is_rowid_alias() {
-                        rowid_reg
+                        effective_rowid_reg
                     } else {
                         layout.to_register(start, i)
                     }
@@ -1715,7 +1860,7 @@ fn emit_update_insns<'a>(
         // Build new index key for constraint checking and later insertion (Phase 3).
         let num_cols = index.columns.len();
         let idx_start_reg = program.alloc_registers(num_cols + 1);
-        let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
+        let rowid_reg = effective_rowid_reg;
 
         for (i, col) in index.columns.iter().enumerate() {
             emit_index_column_value_new_image(
@@ -1833,8 +1978,6 @@ fn emit_update_insns<'a>(
                     });
                 }
                 ResolveType::Replace => {
-                    // For REPLACE with unique constraint, delete the conflicting row
-                    // Save original rowid before seeking to conflicting row
                     let original_rowid_reg = program.alloc_register();
                     program.emit_insn(Insn::Copy {
                         src_reg: beg,
@@ -1850,95 +1993,17 @@ fn emit_update_insns<'a>(
                         target_pc: after_delete_label, // Skip if row doesn't exist
                     });
 
-                    // Phase 1: Before Delete - prepare FK cascade actions for implicitly-deleted row
-                    // CASCADE/SetNull/SetDefault actions are prepared but deferred until after Delete.
-                    let prepared_fk_actions = if connection.foreign_keys_enabled() {
-                        let prepared = if t_ctx.resolver.with_schema(update_database_id, |s| {
-                            s.any_resolved_fks_referencing(table_name)
-                        }) {
-                            ForeignKeyActions::prepare_fk_delete_actions(
-                                program,
-                                &mut t_ctx.resolver,
-                                table_name,
-                                target_table_cursor_id,
-                                idx_rowid_reg,
-                                Some((start, rowid_set_clause_reg.unwrap_or(beg))),
-                                update_database_id,
-                            )?
-                        } else {
-                            ForeignKeyActions::default()
-                        };
-                        if t_ctx
-                            .resolver
-                            .with_schema(update_database_id, |s| s.has_child_fks(table_name))
-                        {
-                            emit_fk_child_decrement_on_delete(
-                                program,
-                                &target_table
-                                    .table
-                                    .btree()
-                                    .expect("UPDATE target must be a BTree table"),
-                                table_name,
-                                target_table_cursor_id,
-                                idx_rowid_reg,
-                                update_database_id,
-                                &t_ctx.resolver,
-                            )?;
-                        }
-                        prepared
-                    } else {
-                        ForeignKeyActions::default()
-                    };
-
-                    // Delete from ALL indexes for the conflicting row
-                    // We must delete from all indexes, not just indexes_to_update,
-                    // because the conflicting row may have entries in indexes
-                    // whose columns are not being modified by this UPDATE.
-                    for (other_index, other_idx_cursor_id) in all_index_cursors {
-                        // Build index key for the conflicting row
-                        let other_num_regs = other_index.columns.len() + 1;
-                        let other_start_reg = program.alloc_registers(other_num_regs);
-
-                        for (reg_offset, column_index) in other_index.columns.iter().enumerate() {
-                            emit_index_column_value_old_image(
-                                program,
-                                &t_ctx.resolver,
-                                table_references,
-                                target_table_cursor_id,
-                                internal_id,
-                                column_index,
-                                other_start_reg + reg_offset,
-                            )?;
-                        }
-
-                        // Add the conflicting rowid
-                        program.emit_insn(Insn::Copy {
-                            src_reg: idx_rowid_reg,
-                            dst_reg: other_start_reg + other_num_regs - 1,
-                            extra_amount: 0,
-                        });
-
-                        program.emit_insn(Insn::IdxDelete {
-                            start_reg: other_start_reg,
-                            num_regs: other_num_regs,
-                            cursor_id: *other_idx_cursor_id,
-                            raise_error_if_no_matching_entry: other_index.where_clause.is_none(),
-                        });
-                    }
-
-                    // Delete the conflicting row from the main table
-                    program.emit_insn(Insn::Delete {
-                        cursor_id: target_table_cursor_id,
-                        table_name: table_name.to_string(),
-                        is_part_of_update: false,
-                    });
-
-                    // Phase 2: After Delete - fire CASCADE/SetNull/SetDefault FK actions.
-                    prepared_fk_actions.fire_prepared_fk_delete_actions(
+                    emit_replace_delete(
                         program,
-                        &mut t_ctx.resolver,
                         connection,
+                        table_references,
+                        &target_table,
+                        target_table_cursor_id,
+                        all_index_cursors,
+                        idx_rowid_reg,
+                        Some((start, effective_rowid_reg)),
                         update_database_id,
+                        t_ctx,
                     )?;
 
                     program.preassign_label_to_next_insn(after_delete_label);
@@ -2002,7 +2067,7 @@ fn emit_update_insns<'a>(
     // PK REPLACE: when the new rowid conflicts with an existing row, delete it.
     // Runs AFTER Phase 1 (all index constraint checks) so that non-REPLACE index
     // constraints fire before this deletion, matching SQLite's ordering.
-    if let Some(btree) = target_table.table.btree() {
+    if target_table.table.btree().is_some() {
         if updates_rowid && matches!(effective_rowid_alias_conflict, ResolveType::Replace) {
             let target_reg = rowid_set_clause_reg.expect("rowid_set_clause_reg must be set");
             let no_rowid_conflict_label = program.allocate_label();
@@ -2025,84 +2090,17 @@ fn emit_update_insns<'a>(
                 target_pc: no_rowid_conflict_label,
             });
 
-            // Before Delete - prepare FK cascade actions for implicitly-deleted row.
-            let prepared_fk_actions = if connection.foreign_keys_enabled() {
-                let prepared = if t_ctx.resolver.with_schema(update_database_id, |s| {
-                    s.any_resolved_fks_referencing(table_name)
-                }) {
-                    ForeignKeyActions::prepare_fk_delete_actions(
-                        program,
-                        &mut t_ctx.resolver,
-                        table_name,
-                        target_table_cursor_id,
-                        target_reg,
-                        Some((start, rowid_set_clause_reg.unwrap_or(beg))),
-                        update_database_id,
-                    )?
-                } else {
-                    ForeignKeyActions::default()
-                };
-                if t_ctx
-                    .resolver
-                    .with_schema(update_database_id, |s| s.has_child_fks(table_name))
-                {
-                    emit_fk_child_decrement_on_delete(
-                        program,
-                        &btree,
-                        table_name,
-                        target_table_cursor_id,
-                        target_reg,
-                        update_database_id,
-                        &t_ctx.resolver,
-                    )?;
-                }
-                prepared
-            } else {
-                ForeignKeyActions::default()
-            };
-
-            for (other_index, other_idx_cursor_id) in all_index_cursors {
-                let other_num_regs = other_index.columns.len() + 1;
-                let other_start_reg = program.alloc_registers(other_num_regs);
-
-                for (reg_offset, column_index) in other_index.columns.iter().enumerate() {
-                    emit_index_column_value_old_image(
-                        program,
-                        &t_ctx.resolver,
-                        table_references,
-                        target_table_cursor_id,
-                        internal_id,
-                        column_index,
-                        other_start_reg + reg_offset,
-                    )?;
-                }
-
-                program.emit_insn(Insn::Copy {
-                    src_reg: target_reg,
-                    dst_reg: other_start_reg + other_num_regs - 1,
-                    extra_amount: 0,
-                });
-
-                program.emit_insn(Insn::IdxDelete {
-                    start_reg: other_start_reg,
-                    num_regs: other_num_regs,
-                    cursor_id: *other_idx_cursor_id,
-                    raise_error_if_no_matching_entry: other_index.where_clause.is_none(),
-                });
-            }
-
-            program.emit_insn(Insn::Delete {
-                cursor_id: target_table_cursor_id,
-                table_name: table_name.to_string(),
-                is_part_of_update: false,
-            });
-
-            // After Delete - fire CASCADE/SetNull/SetDefault FK actions.
-            prepared_fk_actions.fire_prepared_fk_delete_actions(
+            emit_replace_delete(
                 program,
-                &mut t_ctx.resolver,
                 connection,
+                table_references,
+                &target_table,
+                target_table_cursor_id,
+                all_index_cursors,
+                target_reg,
+                Some((start, effective_rowid_reg)),
                 update_database_id,
+                t_ctx,
             )?;
 
             // Re-seek to the row under update so Phase 2's old-image reads are correct.
@@ -2204,7 +2202,7 @@ fn emit_update_insns<'a>(
             }
 
             // create alias for CDC rowid after the change (will differ from cdc_rowid_before_reg only in case of UPDATE with change in rowid alias)
-            let cdc_rowid_after_reg = rowid_set_clause_reg.unwrap_or(beg);
+            let cdc_rowid_after_reg = effective_rowid_reg;
 
             // create separate register with rowid before UPDATE for CDC
             let cdc_rowid_before_reg = if t_ctx.cdc_cursor_id.is_some() {
@@ -2251,7 +2249,7 @@ fn emit_update_insns<'a>(
 
             program.emit_insn(Insn::Insert {
                 cursor: target_table_cursor_id,
-                key_reg: rowid_set_clause_reg.unwrap_or(beg),
+                key_reg: effective_rowid_reg,
                 record_reg,
                 flag: if not_exists_check_required {
                     // The previous Insn::NotExists and Insn::Delete seek to the old rowid,
@@ -2282,7 +2280,6 @@ fn emit_update_insns<'a>(
                     s.any_resolved_fks_referencing(table_name)
                 })
             {
-                let new_rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
                 // OLD column values are stored in preserved_old_registers (contiguous registers)
                 let old_values_start = preserved_old_registers
                     .as_ref()
@@ -2294,7 +2291,7 @@ fn emit_update_insns<'a>(
                     beg, // old_rowid_reg
                     old_values_start,
                     start, // new_values_start
-                    new_rowid_reg,
+                    effective_rowid_reg,
                     connection,
                     update_database_id,
                 )?;
@@ -2302,14 +2299,12 @@ fn emit_update_insns<'a>(
 
             // Fire AFTER UPDATE triggers
             if let Some(btree_table) = target_table.table.btree() {
-                let updated_column_indices: ColumnMask =
-                    set_clauses.iter().map(|(col_idx, _)| *col_idx).collect();
                 let relevant_triggers = get_triggers_including_temp(
                     &t_ctx.resolver,
                     update_database_id,
                     TriggerEvent::Update,
                     TriggerTime::After,
-                    Some(updated_column_indices),
+                    Some(updated_column_indices.clone()),
                     &btree_table,
                 );
                 if !relevant_triggers.is_empty() {
@@ -2345,40 +2340,25 @@ fn emit_update_insns<'a>(
                         )?;
                     }
 
-                    let new_rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
                     // Build raw NEW registers. Values are encoded at this point;
                     // fire_trigger will decode them via decode_trigger_registers.
                     let new_registers_after: Vec<usize> = (0..col_len)
                         .map(|i| layout.to_register(start, i))
-                        .chain(std::iter::once(new_rowid_reg))
+                        .chain(std::iter::once(effective_rowid_reg))
                         .collect();
 
                     // Use preserved OLD registers from BEFORE trigger
                     let old_registers_after = preserved_old_registers;
 
                     // Propagate conflict resolution to AFTER trigger context (same logic as BEFORE)
-                    let trigger_ctx_after =
-                        if let Some(override_conflict) = program.trigger_conflict_override {
-                            TriggerContext::new_after_with_override_conflict(
-                                btree_table,
-                                Some(new_registers_after),
-                                old_registers_after, // OLD values preserved from BEFORE trigger
-                                override_conflict,
-                            )
-                        } else if !matches!(or_conflict, ResolveType::Abort) {
-                            TriggerContext::new_after_with_override_conflict(
-                                btree_table,
-                                Some(new_registers_after),
-                                old_registers_after,
-                                or_conflict,
-                            )
-                        } else {
-                            TriggerContext::new_after(
-                                btree_table,
-                                Some(new_registers_after),
-                                old_registers_after, // OLD values preserved from BEFORE trigger
-                            )
-                        };
+                    let trigger_ctx_after = update_trigger_context(
+                        program,
+                        &btree_table,
+                        Some(new_registers_after),
+                        old_registers_after,
+                        or_conflict,
+                        true,
+                    );
 
                     // RAISE(IGNORE) in an AFTER trigger should only abort the trigger body,
                     // not skip post-row work (RETURNING, CDC).
@@ -2406,7 +2386,7 @@ fn emit_update_insns<'a>(
                     program,
                     table_references,
                     start,
-                    rowid_set_clause_reg.unwrap_or(beg),
+                    effective_rowid_reg,
                     &mut t_ctx.resolver,
                     &layout,
                 )?;
@@ -2443,7 +2423,7 @@ fn emit_update_insns<'a>(
                         table_references,
                         returning_columns,
                         start,
-                        rowid_set_clause_reg.unwrap_or(beg),
+                        effective_rowid_reg,
                         &mut t_ctx.resolver,
                         returning_buffer,
                         &layout,
@@ -2510,7 +2490,7 @@ fn emit_update_insns<'a>(
                     emit_cdc_insns(
                         program,
                         &t_ctx.resolver,
-                        OperationMode::UPDATE(if ephemeral_plan.is_some() {
+                        OperationMode::UPDATE(if uses_write_set {
                             UpdateRowSource::PrebuiltEphemeralTable {
                                 ephemeral_table_cursor_id: iteration_cursor_id,
                                 target_table: target_table.clone(),
@@ -2537,7 +2517,7 @@ fn emit_update_insns<'a>(
                 conflict_action: 0u16,
             });
         }
-        _ => {}
+        _ => unreachable!("cannot UPDATE a subquery table"),
     }
 
     if let Some(limit_ctx) = t_ctx.limit_ctx {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -6012,8 +6012,20 @@ pub fn bind_and_rewrite_expr<'a>(
                             id.as_str()
                         );
                     }
+                    // search joined_tables first, then outer_query_refs, returning
+                    // (internal_id, &table) of the first match.
                     let matching_tbl = referenced_tables
-                        .find_table_and_internal_id_by_identifier(&normalized_table_name);
+                        .joined_tables()
+                        .iter()
+                        .find(|t| t.identifier == normalized_table_name)
+                        .map(|t| (t.internal_id, &t.table))
+                        .or_else(|| {
+                            referenced_tables
+                                .outer_query_refs()
+                                .iter()
+                                .find(|t| t.identifier == normalized_table_name)
+                                .map(|t| (t.internal_id, &t.table))
+                        });
                     if matching_tbl.is_none() {
                         // CTEs preplanned for subquery FROM visibility are kept as
                         // definition-only outer refs. They are not valid column sources

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -6160,8 +6160,20 @@ pub fn bind_and_rewrite_expr<'a>(
                                     continue;
                                 };
 
+                                // When multiple outer refs share this identifier
+                                // (e.g. self-join `t1 JOIN t1 USING(a)`), a USING-hidden
+                                // column on the duplicate side lets the first match stand,
+                                // mirroring the Stage 1 logic for local-scope tables.
                                 if resolved.is_some() {
-                                    return Err(ambiguous());
+                                    let allowed_by_using = matches!(
+                                        candidate,
+                                        QualifiedMatch::Column { col_idx, .. }
+                                            if outer_ref.using_dedup_hidden_cols.get(col_idx)
+                                    );
+                                    if !allowed_by_using {
+                                        return Err(ambiguous());
+                                    }
+                                    continue;
                                 }
                                 resolved = Some((outer_ref.internal_id, candidate));
                             }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5824,8 +5824,8 @@ enum QualifiedMatch {
         col_idx: usize,
         is_rowid_alias: bool,
     },
-    /// `<id>` named the rowid alias (`rowid`/`oid`/`_rowid_`) of a btree
-    /// with rowids. There is no column index — the result must become an
+    /// `<id>` named the rowid (`rowid`/`oid`/`_rowid_`) of a btree.
+    /// There is no column index — the result must become an
     /// `Expr::RowId`, not an `Expr::Column`.
     RowId,
 }
@@ -6137,7 +6137,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             .outer_query_refs()
                             .iter()
                             .filter(|t| {
-                                t.identifier == normalized_table_name && !t.cte_definition_only
+                                !t.cte_definition_only && t.identifier == normalized_table_name
                             })
                             .map(|t| t.scope_depth)
                             .min();
@@ -6146,9 +6146,9 @@ pub fn bind_and_rewrite_expr<'a>(
                             identifier_matched = true;
                             for outer_ref in
                                 referenced_tables.outer_query_refs().iter().filter(|t| {
-                                    t.identifier == normalized_table_name
-                                        && !t.cte_definition_only
+                                    !t.cte_definition_only
                                         && t.scope_depth == scope_depth
+                                        && t.identifier == normalized_table_name
                                 })
                             {
                                 let Some(candidate) = resolve_qualified_on_ref(
@@ -6160,14 +6160,6 @@ pub fn bind_and_rewrite_expr<'a>(
                                     continue;
                                 };
 
-                                // Columns hidden by a USING/NATURAL join in the outer scope
-                                // are invisible here too. Rowid matches are not subject to
-                                // USING hiding (rowid isn't a real column).
-                                if let QualifiedMatch::Column { col_idx, .. } = candidate {
-                                    if outer_ref.using_dedup_hidden_cols.get(col_idx) {
-                                        continue;
-                                    }
-                                }
                                 if resolved.is_some() {
                                     return Err(ambiguous());
                                 }
@@ -6259,6 +6251,7 @@ pub fn bind_and_rewrite_expr<'a>(
                                 database: None, // TODO: support different databases
                                 table: tbl_id,
                             };
+                            tracing::debug!("rewritten to rowid");
                             referenced_tables.mark_rowid_referenced(tbl_id);
                         }
                     }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5814,6 +5814,64 @@ pub enum BindingBehavior {
     AllowUnboundIdentifiers,
 }
 
+/// The result of resolving the `<id>` half of a qualified `<tbl>.<id>`
+/// reference against a single candidate table whose identifier already
+/// matches `<tbl>`.
+#[derive(Debug, Clone, Copy)]
+enum QualifiedMatch {
+    /// `<id>` named a real column on the candidate table.
+    Column {
+        col_idx: usize,
+        is_rowid_alias: bool,
+    },
+    /// `<id>` named the rowid alias (`rowid`/`oid`/`_rowid_`) of a btree
+    /// with rowids. There is no column index — the result must become an
+    /// `Expr::RowId`, not an `Expr::Column`.
+    RowId,
+}
+
+/// Resolve `<id>` against a single table reference.
+///
+/// The caller is responsible for:
+///   * filtering candidate refs down to those whose identifier matches `<tbl>`,
+///   * detecting ambiguity across multiple candidate refs,
+///   * applying any scope-specific USING/NATURAL dedup rules.
+///
+/// Returns:
+///   * `Ok(Some(Column { .. }))` — `<id>` is a real column on `table`.
+///   * `Ok(Some(RowId))` — `<id>` is a rowid alias on a rowid btree.
+///   * `Ok(None)` — `<id>` is not present on this ref.
+///   * `Err(_)` — `<id>` is a rowid alias but the btree has no rowid
+///     (definitively invalid; reported as "no such column: <id>" per SQLite).
+fn resolve_qualified_on_ref(
+    table: &Table,
+    internal_id: TableInternalId,
+    normalized_id: &str,
+) -> Result<Option<QualifiedMatch>> {
+    if let Some(col_idx) = table.columns().iter().position(|c| {
+        c.name
+            .as_ref()
+            .is_some_and(|name| name.eq_ignore_ascii_case(normalized_id))
+    }) {
+        let col = table.columns().get(col_idx).unwrap();
+        return Ok(Some(QualifiedMatch::Column {
+            col_idx,
+            is_rowid_alias: col.is_rowid_alias(),
+        }));
+    }
+
+    if let Table::BTree(btree) = table {
+        if parse_row_id(normalized_id, internal_id, || false)?.is_some() {
+            if !btree.has_rowid {
+                crate::bail_parse_error!("no such column: {}", normalized_id);
+            }
+            return Ok(Some(QualifiedMatch::RowId));
+        }
+    }
+
+    Ok(None)
+}
+
 /// Rewrite ast::Expr in place, binding Column references/rewriting Expr::Id -> Expr::Column
 /// using the provided TableReferences, and replacing anonymous parameters with internal named
 /// ones
@@ -5850,9 +5908,10 @@ pub fn bind_and_rewrite_expr<'a>(
                         }
                     }
                     let mut match_result = None;
+                    let joined_tables = referenced_tables.joined_tables();
 
                     // First check joined tables
-                    for joined_table in referenced_tables.joined_tables().iter() {
+                    for joined_table in joined_tables.iter() {
                         let col_idx = joined_table.table.columns().iter().position(|c| {
                             c.name
                                 .as_ref()
@@ -5887,11 +5946,11 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                         // only if we haven't found a match, check for explicit rowid reference
                         } else if let Table::BTree(btree) = &joined_table.table {
-                            if let Some(row_id_expr) = parse_row_id(
-                                &normalized_id,
-                                referenced_tables.joined_tables()[0].internal_id,
-                                || referenced_tables.joined_tables().len() != 1,
-                            )? {
+                            if let Some(row_id_expr) =
+                                parse_row_id(&normalized_id, joined_tables[0].internal_id, || {
+                                    joined_tables.len() != 1
+                                })?
+                            {
                                 if !btree.has_rowid {
                                     crate::bail_parse_error!("no such column: {}", id.as_str());
                                 }
@@ -5986,6 +6045,16 @@ pub fn bind_and_rewrite_expr<'a>(
                     }
                 }
                 Expr::Qualified(tbl, id) => {
+                    // Resolve a `<tbl>.<id>` reference.
+                    //
+                    // Two-stage lookup with shadowing:
+                    //   1. Search the current scope's FROM tables (`joined_tables`).
+                    //   2. Fall back to enclosing scopes (`outer_query_refs`), restricted to
+                    //      the *nearest* scope whose identifier matches — so an inner alias
+                    //      shadows a same-named alias in an outer scope instead of conflicting.
+                    //
+                    // Produces either `Expr::Column` (real column) or `Expr::RowId`
+                    // (bare rowid alias like `t.rowid` on a btree with rowids).
                     tracing::debug!("bind_and_rewrite_expr({:?}, {:?})", tbl, id);
                     let Some(referenced_tables) = &mut referenced_tables else {
                         if binding_behavior == BindingBehavior::AllowUnboundIdentifiers {
@@ -5998,40 +6067,127 @@ pub fn bind_and_rewrite_expr<'a>(
                         );
                     };
                     let normalized_table_name = normalize_ident(tbl.as_str());
-                    // Check for duplicate table aliases — if multiple joined tables
-                    // share the same identifier, the qualified column ref is ambiguous.
-                    let duplicate_count = referenced_tables
-                        .joined_tables()
-                        .iter()
-                        .filter(|t| t.identifier == normalized_table_name)
-                        .count();
-                    if duplicate_count > 1 {
-                        crate::bail_parse_error!(
+                    let normalized_id = normalize_ident(id.as_str());
+
+                    // `resolved` holds the accepted binding (at most one).
+                    // `identifier_matched` is true once *any* scope produced a table whose
+                    // identifier equals `tbl`; it distinguishes "no such table" from
+                    // "no such column" in error reporting below.
+                    let mut resolved: Option<(TableInternalId, QualifiedMatch)> = None;
+                    let mut identifier_matched = false;
+
+                    let ambiguous = || -> LimboError {
+                        LimboError::ParseError(format!(
                             "ambiguous column name: {}.{}",
                             tbl.as_str(),
                             id.as_str()
-                        );
-                    }
-                    // search joined_tables first, then outer_query_refs, returning
-                    // (internal_id, &table) of the first match.
-                    let matching_tbl = referenced_tables
+                        ))
+                    };
+
+                    // --- Stage 1: search the current scope's FROM tables. ---
+                    for joined_table in referenced_tables
                         .joined_tables()
                         .iter()
-                        .find(|t| t.identifier == normalized_table_name)
-                        .map(|t| (t.internal_id, &t.table))
-                        .or_else(|| {
-                            referenced_tables
-                                .outer_query_refs()
-                                .iter()
-                                .find(|t| t.identifier == normalized_table_name)
-                                .map(|t| (t.internal_id, &t.table))
-                        });
-                    if matching_tbl.is_none() {
-                        // CTEs preplanned for subquery FROM visibility are kept as
-                        // definition-only outer refs. They are not valid column sources
-                        // unless explicitly referenced in this scope's FROM clause.
-                        // Restrict this branch to actual CTE definition refs so other
-                        // definition-only uses (if added later) still report "no such table".
+                        .filter(|t| t.identifier == normalized_table_name)
+                    {
+                        identifier_matched = true;
+                        let Some(candidate) = resolve_qualified_on_ref(
+                            &joined_table.table,
+                            joined_table.internal_id,
+                            &normalized_id,
+                        )?
+                        else {
+                            continue;
+                        };
+
+                        // Multiple FROM tables share this identifier and both contain `id`.
+                        // For column matches, a USING/NATURAL join on `id` lets the first
+                        // match stand (the duplicate side is implicitly merged). Rowid
+                        // matches never get this exception (rowid isn't a USING column).
+                        if resolved.is_some() {
+                            let allowed_by_using =
+                                matches!(candidate, QualifiedMatch::Column { .. })
+                                    && joined_table.join_info.as_ref().is_some_and(|ji| {
+                                        ji.using.iter().any(|u| {
+                                            u.as_str().eq_ignore_ascii_case(&normalized_id)
+                                        })
+                                    });
+                            if !allowed_by_using {
+                                return Err(ambiguous());
+                            }
+                            continue;
+                        }
+                        resolved = Some((joined_table.internal_id, candidate));
+                    }
+                    // --- Stage 2: fall back to enclosing scopes ---
+                    // Only attempted if no inner-scope table matched the identifier — an
+                    // inner alias of the same name shadows everything outside.
+                    //
+                    // We pick the *nearest* outer scope that contains a matching identifier
+                    // (smallest `scope_depth`) and search only refs at that depth. This lets
+                    // the same alias be reused at different nesting levels without triggering
+                    // spurious "ambiguous column" errors across unrelated scopes.
+                    //
+                    // `cte_definition_only` refs are excluded: those entries exist purely so
+                    // that a subquery's FROM clause can *look up* the CTE by name; once the
+                    // CTE is consumed into a FROM, column resolution must go through the
+                    // corresponding `joined_table`, not the definition-only ref.
+                    if !identifier_matched {
+                        let nearest_outer_scope = referenced_tables
+                            .outer_query_refs()
+                            .iter()
+                            .filter(|t| {
+                                t.identifier == normalized_table_name && !t.cte_definition_only
+                            })
+                            .map(|t| t.scope_depth)
+                            .min();
+
+                        if let Some(scope_depth) = nearest_outer_scope {
+                            identifier_matched = true;
+                            for outer_ref in
+                                referenced_tables.outer_query_refs().iter().filter(|t| {
+                                    t.identifier == normalized_table_name
+                                        && !t.cte_definition_only
+                                        && t.scope_depth == scope_depth
+                                })
+                            {
+                                let Some(candidate) = resolve_qualified_on_ref(
+                                    &outer_ref.table,
+                                    outer_ref.internal_id,
+                                    &normalized_id,
+                                )?
+                                else {
+                                    continue;
+                                };
+
+                                // Columns hidden by a USING/NATURAL join in the outer scope
+                                // are invisible here too. Rowid matches are not subject to
+                                // USING hiding (rowid isn't a real column).
+                                if let QualifiedMatch::Column { col_idx, .. } = candidate {
+                                    if outer_ref.using_dedup_hidden_cols.get(col_idx) {
+                                        continue;
+                                    }
+                                }
+                                if resolved.is_some() {
+                                    return Err(ambiguous());
+                                }
+                                resolved = Some((outer_ref.internal_id, candidate));
+                            }
+                        }
+                    }
+
+                    // --- Error reporting. ---
+                    if resolved.is_none() && !identifier_matched {
+                        // No scope contains a table with this identifier. Normally we
+                        // report "no such table", but there is one case where SQLite
+                        // reports "no such column" instead: when the identifier names a
+                        // CTE that was preplanned for subquery FROM visibility and kept
+                        // as a definition-only outer ref. The CTE *name* is valid in
+                        // principle; it's the column access through it that isn't,
+                        // because the CTE hasn't been brought into this scope's FROM.
+                        // The `cte_id`/`cte_select` check restricts this to real CTE
+                        // definition refs so any other future use of `cte_definition_only`
+                        // still falls through to "no such table".
                         if referenced_tables
                             .find_outer_query_ref_by_identifier(&normalized_table_name)
                             .is_some_and(|outer_ref| {
@@ -6078,45 +6234,34 @@ pub fn bind_and_rewrite_expr<'a>(
                         }
                         crate::bail_parse_error!("no such table: {}", normalized_table_name);
                     }
-                    let (tbl_id, tbl) = matching_tbl.unwrap();
-                    let normalized_id = normalize_ident(id.as_str());
-                    let col_idx = tbl.columns().iter().position(|c| {
-                        c.name
-                            .as_ref()
-                            .is_some_and(|name| name.eq_ignore_ascii_case(&normalized_id))
-                    });
-                    // User-defined columns take precedence over rowid aliases
-                    // (oid, rowid, _rowid_). Only fall back to parse_row_id()
-                    // when no matching user column exists.
-                    // Note: Only BTree tables have rowid; derived tables (FromClauseSubquery)
-                    // don't have a rowid.
-                    let Some(col_idx) = col_idx else {
-                        if let Table::BTree(btree) = tbl {
-                            if let Some(row_id_expr) =
-                                parse_row_id(&normalized_id, tbl_id, || false)?
-                            {
-                                if !btree.has_rowid {
-                                    crate::bail_parse_error!("no such column: {}", normalized_id);
-                                }
-                                *expr = row_id_expr;
-                                // Mark the table's rowid as referenced so correlated
-                                // subquery detection works correctly when a rowid
-                                // reference is the only link to the outer query.
-                                referenced_tables.mark_rowid_referenced(tbl_id);
-                                return Ok(WalkControl::Continue);
-                            }
-                        }
+                    // Identifier matched somewhere but no column/rowid binding was
+                    // produced — the table exists, the column doesn't.
+                    let Some((tbl_id, binding)) = resolved else {
                         crate::bail_parse_error!("no such column: {}", normalized_id);
                     };
-                    let col = tbl.columns().get(col_idx).unwrap();
-                    *expr = Expr::Column {
-                        database: None, // TODO: support different databases
-                        table: tbl_id,
-                        column: col_idx,
-                        is_rowid_alias: col.is_rowid_alias(),
-                    };
-                    tracing::debug!("rewritten to column");
-                    referenced_tables.mark_column_used(tbl_id, col_idx);
+
+                    match binding {
+                        QualifiedMatch::Column {
+                            col_idx,
+                            is_rowid_alias,
+                        } => {
+                            *expr = Expr::Column {
+                                database: None, // TODO: support different databases
+                                table: tbl_id,
+                                column: col_idx,
+                                is_rowid_alias,
+                            };
+                            tracing::debug!("rewritten to column");
+                            referenced_tables.mark_column_used(tbl_id, col_idx);
+                        }
+                        QualifiedMatch::RowId => {
+                            *expr = Expr::RowId {
+                                database: None, // TODO: support different databases
+                                table: tbl_id,
+                            };
+                            referenced_tables.mark_rowid_referenced(tbl_id);
+                        }
+                    }
                     return Ok(WalkControl::Continue);
                 }
                 Expr::DoublyQualified(db_name, tbl_name, col_name) => {
@@ -6267,10 +6412,12 @@ pub fn bind_and_rewrite_expr<'a>(
                             if func.needs_star_expansion() {
                                 // Only expand if there are actual tables - otherwise leave as
                                 // FunctionCallStar so translate_expr can generate the error
-                                if !referenced_tables.joined_tables().is_empty() {
+                                let joined_tables = referenced_tables.joined_tables();
+                                if !joined_tables.is_empty() {
                                     // Mark all columns as used so the optimizer doesn't
                                     // create partial covering indexes that would miss columns
-                                    for table in referenced_tables.joined_tables_mut().iter_mut() {
+                                    let joined_tables = referenced_tables.joined_tables_mut();
+                                    for table in joined_tables.iter_mut() {
                                         for col_idx in 0..table.columns().len() {
                                             table.mark_column_used(col_idx);
                                         }
@@ -6279,7 +6426,8 @@ pub fn bind_and_rewrite_expr<'a>(
                                     // Build arguments: alternating column_name (as string literal), column_value (as column reference)
                                     let mut args: Vec<Box<ast::Expr>> = Vec::new();
 
-                                    for table in referenced_tables.joined_tables().iter() {
+                                    let joined_tables = referenced_tables.joined_tables();
+                                    for table in joined_tables.iter() {
                                         for (col_idx, col) in table.columns().iter().enumerate() {
                                             // Skip hidden columns (like rowid in some cases)
                                             if col.hidden() {

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -6,7 +6,7 @@ use crate::translate::expr::emit_table_column_for_dml;
 use crate::translate::plan::ColumnMask;
 use crate::{
     error::SQLITE_CONSTRAINT_FOREIGNKEY,
-    schema::{BTreeTable, ColumnLayout, ForeignKey, Index, ResolvedFkRef, ROWID_SENTINEL},
+    schema::{BTreeTable, ColumnLayout, ForeignKey, Index, ResolvedFkRef},
     translate::{collate::CollationSeq, emitter::Resolver, planner::ROWID_STRS},
     vdbe::{
         builder::{CursorType, DmlColumnContext, QueryMode},
@@ -364,7 +364,7 @@ pub fn emit_fk_restrict_halt(program: &mut ProgramBuilder) -> Result<()> {
 pub fn stabilize_new_row_for_fk(
     program: &mut ProgramBuilder,
     table_btree: &BTreeTable,
-    set_clauses: &[(usize, Box<Expr>)],
+    set_cols: &ColumnMask,
     cursor_id: usize,
     start: usize,
     rowid_new_reg: usize,
@@ -372,10 +372,6 @@ pub fn stabilize_new_row_for_fk(
     if table_btree.primary_key_columns.is_empty() {
         return Ok(());
     }
-    let set_cols: ColumnMask = set_clauses
-        .iter()
-        .filter_map(|(i, _)| if *i == ROWID_SENTINEL { None } else { Some(*i) })
-        .collect();
 
     let layout = table_btree.column_layout();
     for (pk_name, _) in &table_btree.primary_key_columns {
@@ -1125,19 +1121,18 @@ pub fn emit_fk_update_parent_actions(
     start: usize,
     rowid_new_reg: usize,
     rowid_set_clause_reg: Option<usize>,
-    set_clauses: &[(usize, Box<Expr>)],
+    updated_positions: &ColumnMask,
     new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<Vec<DeferredNewKeyProbePlan>> {
     let mut deferred_new_key_plans = Vec::new();
-    let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
     let mut check_fks: Vec<_> = Vec::new();
     let referencing = resolver.with_schema(database_id, |s| {
         s.resolved_fks_referencing(&table_btree.name)
     })?;
     for fk in referencing {
-        if !fk.parent_key_may_change(&updated_positions, table_btree)? {
+        if !fk.parent_key_may_change(updated_positions, table_btree)? {
             continue;
         }
         if !matches!(fk.fk.on_update, RefAct::NoAction | RefAct::Restrict) {

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1024,6 +1024,12 @@ pub fn try_hash_join_access_method(
     if build_root_page == probe_root_page {
         return None;
     }
+    // Explicit INDEXED BY / NOT INDEXED directives must be honored. A hash join
+    // bypasses the normal access-path selection for the build/probe pair, so it
+    // would ignore the user's requested scan shape.
+    if build_table.indexed.is_some() || probe_table.indexed.is_some() {
+        return None;
+    }
     // No hash join for semi/anti-joins (nested loop with index seek is preferred).
     if probe_table
         .join_info

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2,12 +2,13 @@ use super::{
     collate::get_collseq_from_expr,
     emitter::Resolver,
     plan::{
-        DeletePlan, GroupBy, InSeekSource, IterationDirection, JoinOrderMember, JoinType,
+        DeletePlan, GroupBy, InSeekSource, IterationDirection, JoinInfo, JoinOrderMember, JoinType,
         JoinedTable, MinMaxDef, MultiIndexBranch, MultiIndexScanOp, Operation, Plan, Search,
         SeekDef, SeekKey, SelectPlan, SetOperation, SimpleAggregate, TableReferences, UpdatePlan,
         WhereTerm,
     },
 };
+use crate::schema::GeneratedType;
 use crate::translate::expression_index::expression_index_column_usage;
 use crate::translate::plan::{BitSet, ColumnMask, MultiIndexBranchAccess};
 use crate::translate::planner::TableMask;
@@ -15,7 +16,10 @@ use crate::{
     function::{AggFunc, Deterministic},
     index_method::IndexMethodCostEstimate,
     numeric::Numeric,
-    schema::{BTreeCharacteristics, BTreeTable, Index, IndexColumn, Schema, Table, ROWID_SENTINEL},
+    schema::{
+        BTreeCharacteristics, BTreeTable, ColDef, Column, Index, IndexColumn, Schema, Table, Type,
+        ROWID_SENTINEL,
+    },
     translate::{
         insert::ROWID_COLUMN,
         optimizer::{
@@ -28,9 +32,9 @@ use crate::{
             order::{ColumnTarget, OrderTarget},
         },
         plan::{
-            ColumnUsedMask, DmlSafetyReason, EphemeralRowidMode, HashJoinOp, IndexMethodQuery,
-            NonFromClauseSubquery, OuterQueryReference, QueryDestination, ResultSetColumn, Scan,
-            SeekKeyComponent, SubqueryState,
+            DmlSafetyReason, EphemeralRowidMode, HashJoinOp, IndexMethodQuery,
+            NonFromClauseSubquery, QueryDestination, ResultSetColumn, Scan, SeekKeyComponent,
+            SubqueryEvalPhase, SubqueryOrigin, SubqueryState, UpdateSetClause, WriteSetPlan,
         },
         trigger_exec::has_triggers_including_temp,
     },
@@ -45,7 +49,6 @@ use crate::{
     },
     LimboError, Result,
 };
-use crate::{schema::GeneratedType, MAIN_DB_ID};
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert, turso_soft_unreachable};
 use constraints::{
     constraints_from_where_clause, usable_constraints_for_join_order, Constraint,
@@ -58,7 +61,7 @@ use order::{
     compute_order_target, plan_satisfies_order_target, simple_aggregate_order_target,
     EliminatesSortBy, OrderTargetPurpose,
 };
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintUsage};
 use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TriggerEvent};
@@ -769,22 +772,49 @@ fn optimize_update_plan(
     resolver: &Resolver,
 ) -> Result<()> {
     let schema = resolver.schema();
+    let is_update_from = !plan.from_tables.joined_tables().is_empty();
+    if is_update_from {
+        plan.safety.require(DmlSafetyReason::UpdateFrom);
+    }
+    let mut target_tables = TableReferences::new(
+        vec![plan.target_table.clone()],
+        plan.from_tables.outer_query_refs().to_vec(),
+    );
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(&mut plan.where_clause, schema, &target_tables)?;
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
     {
         plan.contains_constant_false_condition = true;
+        if is_update_from {
+            let update_from_set_result_columns = update_from_set_result_columns(&plan.set_clauses);
+            build_update_write_set_plan(program, plan, update_from_set_result_columns)?;
+        }
         return Ok(());
     }
-    let _ = optimize_table_access(
+    if is_update_from {
+        let update_from_set_result_columns = update_from_set_result_columns(&plan.set_clauses);
+        build_update_write_set_plan(program, plan, update_from_set_result_columns)?;
+        optimize_select_plan(
+            &mut plan
+                .write_set_plan
+                .as_mut()
+                .expect("UPDATE ... FROM must build its write-set SELECT before optimization")
+                .select,
+            schema,
+        )?;
+        return Ok(());
+    }
+
+    let mut order_by = vec![];
+    let optimize_result = optimize_table_access(
         schema,
         &mut [],
-        &mut plan.table_references,
+        &mut target_tables,
         &schema.indexes,
         &mut plan.where_clause,
-        &mut plan.order_by,
+        &mut order_by,
         &mut None,
         None,
         &plan.non_from_clause_subqueries,
@@ -792,8 +822,13 @@ fn optimize_update_plan(
         &mut plan.offset,
         1.0,
     )?;
+    plan.target_table = target_tables
+        .joined_tables()
+        .first()
+        .expect("UPDATE must optimize exactly one target table")
+        .clone();
 
-    if let Some(reason) = first_update_safety_reason(plan, resolver)? {
+    if let Some(reason) = update_write_set_reason(plan, resolver)? {
         plan.safety.require(reason);
     }
 
@@ -801,14 +836,24 @@ fn optimize_update_plan(
         return Ok(());
     }
 
-    add_ephemeral_table_to_update_plan(program, plan)
+    let join_order = optimize_result
+        .map(|result| result.join_order)
+        .unwrap_or_else(|| default_join_order(&target_tables));
+
+    build_update_write_set_plan(program, plan, Vec::new())?;
+    plan.write_set_plan
+        .as_mut()
+        .expect("stable-write-set UPDATE must build a write-set SELECT")
+        .select
+        .join_order = join_order;
+    Ok(())
 }
 
-fn first_update_safety_reason(
+fn update_write_set_reason(
     plan: &UpdatePlan,
     resolver: &Resolver,
 ) -> Result<Option<DmlSafetyReason>> {
-    let table_ref = &plan.table_references.joined_tables()[0];
+    let table_ref = &plan.target_table;
     let reason = 'requires: {
         let Some(btree_table_arc) = table_ref.table.btree() else {
             break 'requires None;
@@ -835,7 +880,11 @@ fn first_update_safety_reason(
         }
 
         // Check if there are UPDATE triggers
-        let updated_cols: ColumnMask = plan.set_clauses.iter().map(|(i, _)| *i).collect();
+        let updated_cols: ColumnMask = plan
+            .set_clauses
+            .iter()
+            .map(|set_clause| set_clause.column_index)
+            .collect();
         let database_id = table_ref.database_id;
         if has_triggers_including_temp(
             resolver,
@@ -857,8 +906,9 @@ fn first_update_safety_reason(
         }
 
         let Some(index) = table_ref.op.index() else {
-            let rowid_alias_used = plan.set_clauses.iter().fold(false, |accum, (idx, _)| {
-                accum || (*idx != ROWID_SENTINEL && btree_table.columns()[*idx].is_rowid_alias())
+            let rowid_alias_used = plan.set_clauses.iter().any(|set_clause| {
+                set_clause.column_index != ROWID_SENTINEL
+                    && btree_table.columns()[set_clause.column_index].is_rowid_alias()
             });
             if rowid_alias_used {
                 break 'requires Some(DmlSafetyReason::KeyMutation);
@@ -866,19 +916,19 @@ fn first_update_safety_reason(
             let direct_rowid_update = plan
                 .set_clauses
                 .iter()
-                .any(|(idx, _)| *idx == ROWID_SENTINEL);
+                .any(|set_clause| set_clause.column_index == ROWID_SENTINEL);
             if direct_rowid_update {
                 break 'requires Some(DmlSafetyReason::KeyMutation);
             }
             break 'requires None;
         };
 
-        for (set_clause_col_idx, _) in plan.set_clauses.iter() {
+        for set_clause in plan.set_clauses.iter() {
             for c in index.columns.iter() {
                 if let Some(ref expr) = c.expr {
                     let expr_idx_cols_mask =
                         expression_index_column_usage(expr.as_ref(), table_ref, resolver)?;
-                    if expr_idx_cols_mask.get(*set_clause_col_idx) {
+                    if expr_idx_cols_mask.get(set_clause.column_index) {
                         break 'requires Some(DmlSafetyReason::KeyMutation);
                     }
                 }
@@ -899,52 +949,84 @@ fn first_update_safety_reason(
     Ok(reason)
 }
 
+fn collect_subquery_ids_from_exprs<'a>(
+    exprs: impl IntoIterator<Item = &'a ast::Expr>,
+) -> Result<BitSet<turso_parser::ast::TableInternalId>> {
+    use crate::translate::expr::walk_expr;
+    use crate::translate::expr::WalkControl;
+
+    let mut ids = BitSet::<turso_parser::ast::TableInternalId>::default();
+    let mut collector = |e: &ast::Expr| -> Result<WalkControl> {
+        if let ast::Expr::SubqueryResult { subquery_id, .. } = e {
+            ids.set(*subquery_id);
+        }
+        Ok(WalkControl::Continue)
+    };
+    for expr in exprs {
+        walk_expr(expr, &mut collector)?;
+    }
+    Ok(ids)
+}
+
 /// Collect SubqueryResult IDs referenced in SET clause and RETURNING expressions.
 /// These subqueries must stay in the main update plan (evaluated during the update phase),
 /// not be moved to the ephemeral plan (which only collects rowids).
 fn collect_update_phase_subquery_ids(
     plan: &UpdatePlan,
-) -> HashSet<turso_parser::ast::TableInternalId> {
-    use crate::translate::expr::walk_expr;
-    use crate::translate::expr::WalkControl;
-
-    let mut ids = HashSet::default();
-    let mut collector = |e: &ast::Expr| -> Result<WalkControl> {
-        if let ast::Expr::SubqueryResult { subquery_id, .. } = e {
-            ids.insert(*subquery_id);
-        }
-        Ok(WalkControl::Continue)
-    };
-    for (_, expr) in plan.set_clauses.iter() {
-        let _ = walk_expr(expr, &mut collector);
-    }
-    if let Some(returning) = &plan.returning {
-        for rc in returning {
-            let _ = walk_expr(&rc.expr, &mut collector);
-        }
-    }
-    ids
+) -> Result<BitSet<turso_parser::ast::TableInternalId>> {
+    let mut ids = collect_subquery_ids_from_exprs(
+        plan.set_clauses
+            .iter()
+            .map(|set_clause| set_clause.expr.as_ref()),
+    )?;
+    ids.union_with(&collect_subquery_ids_from_exprs(
+        plan.returning
+            .iter()
+            .flat_map(|returning| returning.iter().map(|column| &column.expr)),
+    )?);
+    Ok(ids)
 }
 
-/// An ephemeral table is required if:
-/// 1. The UPDATE modifies any column that is present in the key of the btree used to iterate over the table.
-///    For regular table scans or seeks, the key is the rowid or the rowid alias column (INTEGER PRIMARY KEY).
-///    For index scans and seeks, the key is any column in the index used.
-/// 2. There are UPDATE triggers on the table (SQLite always uses ephemeral tables when triggers exist).
+fn update_from_scratch_col_name(idx: usize) -> String {
+    format!("__update_from_{idx}")
+}
+
+fn update_from_scratch_columns(set_clause_count: usize) -> Vec<Column> {
+    (0..set_clause_count)
+        .map(|idx| {
+            // Keep scratch-table columns at BLOB affinity so materializing SET payloads
+            // does not coerce values before the real target-column affinity is applied.
+            Column::new(
+                Some(update_from_scratch_col_name(idx)),
+                "BLOB".to_string(),
+                None,
+                None,
+                Type::Blob,
+                None,
+                ColDef::default(),
+            )
+        })
+        .collect()
+}
+
+/// Build the SELECT that gathers the stable write set for an UPDATE before the
+/// mutating write loop runs.
 ///
-/// The ephemeral table will accumulate all the rowids of the rows that are affected by the UPDATE,
-/// and then the temp table will be iterated over and the actual row updates performed.
-///
-/// This is necessary because an UPDATE is implemented as a DELETE-then-INSERT operation, which could
-/// mess up the iteration order of the rows by changing the keys in the table/index that the iteration
-/// is performed over. The ephemeral table ensures stable iteration because it is not modified during
-/// the UPDATE loop.
-fn add_ephemeral_table_to_update_plan(
+/// Plain UPDATE materializes only target rowids. `UPDATE ... FROM` materializes
+/// both the chosen SET payloads and the target rowid, using the FROM-side graph
+/// plus the target table as the read-side SELECT source.
+fn build_update_write_set_plan(
     program: &mut ProgramBuilder,
     plan: &mut UpdatePlan,
+    update_from_set_result_columns: Vec<ResultSetColumn>,
 ) -> Result<()> {
-    let internal_id = program.table_reference_counter.next();
-    let columns = vec![(*ROWID_COLUMN).clone()];
+    let scratch_table_id = program.table_reference_counter.next();
+    let is_update_from = !plan.from_tables.joined_tables().is_empty();
+    let columns = if is_update_from {
+        update_from_scratch_columns(plan.set_clauses.len())
+    } else {
+        vec![(*ROWID_COLUMN).clone()]
+    };
     let ephemeral_table = Arc::new(BTreeTable::new(
         0, // root_page, not relevant for ephemeral table definition
         "ephemeral_scratch".to_string(),
@@ -958,90 +1040,44 @@ fn add_ephemeral_table_to_update_plan(
     ));
 
     let temp_cursor_id = program.alloc_cursor_id_keyed(
-        CursorKey::table(internal_id),
+        CursorKey::table(scratch_table_id),
         CursorType::BTreeTable(ephemeral_table.clone()),
     );
 
-    // The actual update loop will use the ephemeral table as the single [JoinedTable] which it then loops over.
-    let table_references_update = TableReferences::new(
-        vec![JoinedTable {
-            table: Table::BTree(ephemeral_table.clone()),
-            identifier: "ephemeral_scratch".to_string(),
-            internal_id,
-            op: Operation::Scan(Scan::BTreeTable {
-                iter_dir: IterationDirection::Forwards,
-                index: None,
-            }),
-            join_info: None,
-            col_used_mask: ColumnUsedMask::default(),
-            column_use_counts: Vec::new(),
-            expression_index_usages: Vec::new(),
-            database_id: MAIN_DB_ID,
-            indexed: None,
-        }],
-        vec![],
-    );
+    let write_set_tables = if is_update_from {
+        let mut from_tables = plan.from_tables.clone();
+        let mut target_table = plan.target_table.clone();
+        target_table.join_info = Some(JoinInfo {
+            join_type: JoinType::Inner,
+            using: vec![],
+            no_reorder: false,
+        });
+        from_tables.add_joined_table(target_table);
+        from_tables
+    } else {
+        TableReferences::new(
+            vec![plan.target_table.clone()],
+            plan.from_tables.outer_query_refs().to_vec(),
+        )
+    };
+    let rowid_internal_id = plan.target_table.internal_id;
 
-    // Building the ephemeral table will use the TableReferences from the original plan -- i.e. if we chose an index scan originally,
-    // we will build the ephemeral table by using the same index scan and using the same WHERE filters.
-    let table_references_ephemeral_select =
-        std::mem::replace(&mut plan.table_references, table_references_update);
+    let mut result_columns = update_from_set_result_columns;
+    result_columns.push(ResultSetColumn {
+        expr: Expr::RowId {
+            database: None,
+            table: rowid_internal_id,
+        },
+        alias: None,
+        implicit_column_name: None,
+        contains_aggregates: false,
+    });
 
-    for table in table_references_ephemeral_select.joined_tables() {
-        // The update loop needs to reference columns from the original source table, so we add it as an outer query reference.
-        plan.table_references
-            .add_outer_query_reference(OuterQueryReference {
-                identifier: table.identifier.clone(),
-                internal_id: table.internal_id,
-                table: table.table.clone(),
-                using_dedup_hidden_cols: ColumnMask::default(),
-                col_used_mask: table.col_used_mask.clone(),
-                cte_select: None,
-                cte_explicit_columns: vec![],
-                cte_id: None,
-                cte_definition_only: false,
-                rowid_referenced: false,
-                scope_depth: 0,
-            });
-    }
-
-    // Preserve outer query references (e.g. CTEs) from the original plan.
-    for outer_ref in table_references_ephemeral_select.outer_query_refs() {
-        plan.table_references
-            .add_outer_query_reference(outer_ref.clone());
-    }
-
-    let join_order = table_references_ephemeral_select
-        .joined_tables()
-        .iter()
-        .enumerate()
-        .map(|(i, t)| JoinOrderMember {
-            table_id: t.internal_id,
-            original_idx: i,
-            is_outer: t
-                .join_info
-                .as_ref()
-                .is_some_and(|join_info| join_info.is_outer()),
-        })
-        .collect();
-    let rowid_internal_id = table_references_ephemeral_select
-        .joined_tables()
-        .first()
-        .unwrap()
-        .internal_id;
-
-    let ephemeral_plan = SelectPlan {
-        table_references: table_references_ephemeral_select,
-        result_columns: vec![ResultSetColumn {
-            expr: Expr::RowId {
-                database: None,
-                table: rowid_internal_id,
-            },
-            alias: None,
-            implicit_column_name: None,
-            contains_aggregates: false,
-        }],
-        where_clause: plan.where_clause.drain(..).collect(),
+    let join_order = default_join_order(&write_set_tables);
+    let write_set_select = SelectPlan {
+        table_references: write_set_tables,
+        result_columns,
+        where_clause: std::mem::take(&mut plan.where_clause),
         group_by: None,     // N/A
         order_by: vec![],   // N/A
         aggregates: vec![], // N/A
@@ -1059,19 +1095,29 @@ fn add_ephemeral_table_to_update_plan(
         window: None,
         input_cardinality_hint: None,
         estimated_output_rows: None,
-        // Only move WHERE clause subqueries to the ephemeral plan.
-        // SET clause and RETURNING clause subqueries must remain in the main update plan
-        // because they compute new column values during the update phase (second pass),
-        // not during row collection (first pass). Moving them here would cause correlated
-        // subqueries in SET to evaluate with wrong cursor positions.
+        // For regular UPDATEs, only WHERE-clause subqueries move into the ephemeral plan.
+        // For UPDATE ... FROM, SET expressions become part of the ephemeral SELECT payload,
+        // so their subqueries move too.
+        // RETURNING subqueries always remain in the main update plan.
         non_from_clause_subqueries: {
-            let update_phase_ids = collect_update_phase_subquery_ids(plan);
+            let ids_to_keep_in_main_plan = if is_update_from {
+                collect_subquery_ids_from_exprs(
+                    plan.returning
+                        .iter()
+                        .flat_map(|returning| returning.iter().map(|column| &column.expr)),
+                )?
+            } else {
+                collect_update_phase_subquery_ids(plan)?
+            };
             let mut ephemeral_subs = Vec::new();
             let mut remaining = Vec::new();
-            for sq in plan.non_from_clause_subqueries.drain(..) {
-                if update_phase_ids.contains(&sq.internal_id) {
+            for mut sq in plan.non_from_clause_subqueries.drain(..) {
+                if ids_to_keep_in_main_plan.get(sq.internal_id) {
                     remaining.push(sq);
                 } else {
+                    if is_update_from && sq.origin == SubqueryOrigin::DmlSet {
+                        sq.eval_phase = SubqueryEvalPhase::BeforeLoop;
+                    }
                     ephemeral_subs.push(sq);
                 }
             }
@@ -1082,9 +1128,54 @@ fn add_ephemeral_table_to_update_plan(
         phantom_params: vec![],
     };
 
-    plan.ephemeral_plan = Some(ephemeral_plan);
+    plan.write_set_plan = Some(WriteSetPlan {
+        select: write_set_select,
+        scratch_table_id,
+    });
+
+    if is_update_from {
+        // For UPDATE ... FROM, the SET expression payloads are materialized, so they are direct
+        // column references to the scratch table.
+        for (idx, set_clause) in plan.set_clauses.iter_mut().enumerate() {
+            set_clause.update_from_result = Some(Box::new(Expr::Column {
+                database: None,
+                table: scratch_table_id,
+                column: idx,
+                is_rowid_alias: false,
+            }));
+        }
+    }
 
     Ok(())
+}
+
+fn default_join_order(table_references: &TableReferences) -> Vec<JoinOrderMember> {
+    table_references
+        .joined_tables()
+        .iter()
+        .enumerate()
+        .map(|(i, t)| JoinOrderMember {
+            table_id: t.internal_id,
+            original_idx: i,
+            is_outer: t
+                .join_info
+                .as_ref()
+                .is_some_and(|join_info| join_info.is_outer()),
+        })
+        .collect()
+}
+
+fn update_from_set_result_columns(set_clauses: &[UpdateSetClause]) -> Vec<ResultSetColumn> {
+    set_clauses
+        .iter()
+        .enumerate()
+        .map(|(idx, set_clause)| ResultSetColumn {
+            expr: set_clause.expr.as_ref().clone(),
+            alias: Some(update_from_scratch_col_name(idx)),
+            implicit_column_name: None,
+            contains_aggregates: false,
+        })
+        .collect()
 }
 
 fn optimize_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -319,6 +319,7 @@ impl SubqueryOrigin {
 /// (returns from plan builders, argument to emitters) costs a pointer
 /// move rather than ~880 B on the stack.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum Plan {
     Select(Box<SelectPlan>),
     CompoundSelect {
@@ -718,6 +719,8 @@ impl SelectPlan {
 /// Why an UPDATE/DELETE must gather target rowids first, then apply writes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DmlSafetyReason {
+    /// UPDATE ... FROM computes writes from the materialized result of the FROM clause.
+    UpdateFrom,
     /// Triggers exist, so we lock in target rows before writing.
     Trigger,
     /// WHERE has a subquery, so we lock in target rows before writing.
@@ -781,33 +784,87 @@ pub struct DeletePlan {
 }
 
 #[derive(Debug, Clone)]
+pub struct UpdateSetClause {
+    pub column_index: usize,
+    /// Original user-visible SET expression.
+    pub expr: Box<ast::Expr>,
+    /// In UPDATE FROM, SET clause expressions are rewritten to read from the
+    /// scratch table populated before the write loop.
+    pub update_from_result: Option<Box<ast::Expr>>,
+}
+
+impl UpdateSetClause {
+    pub fn new(column_index: usize, expr: Box<ast::Expr>) -> Self {
+        Self {
+            column_index,
+            expr,
+            update_from_result: None,
+        }
+    }
+
+    /// If UPDATE ... FROM, the this is the materialized result of a SET clause expression derived from the FROM clause;
+    /// otherwise, it is the original expression.
+    pub fn emitted_expr(&self) -> &ast::Expr {
+        self.update_from_result.as_deref().unwrap_or(&self.expr)
+    }
+}
+
+/// The SELECT plan that is used for either a) UPDATE...FROM or b) a normal UPDATE where the write set must be prematerialized;
+/// see [crate::translate::plan::DmlSafety].
+#[derive(Debug, Clone)]
+pub struct WriteSetPlan {
+    pub select: SelectPlan,
+    pub scratch_table_id: TableInternalId,
+}
+
+#[derive(Debug, Clone)]
 pub struct UpdatePlan {
-    pub table_references: TableReferences,
+    /// The table whose rows this UPDATE mutates.
+    pub target_table: JoinedTable,
+    /// The read-side FROM graph for `UPDATE ... FROM`.
+    ///
+    /// Plain UPDATE statements keep this empty except for any outer-query
+    /// references (for example preplanned CTE definitions) that are still needed
+    /// when binding subqueries later in the pipeline.
+    pub from_tables: TableReferences,
     /// Conflict resolution strategy (e.g., OR IGNORE, OR REPLACE)
     pub or_conflict: Option<ResolveType>,
-    // (column index, new value) pairs
-    pub set_clauses: Vec<(usize, Box<ast::Expr>)>,
+    /// SET clause assignments
+    pub set_clauses: Vec<UpdateSetClause>,
     pub where_clause: Vec<WhereTerm>,
-    pub order_by: Vec<(Box<ast::Expr>, SortOrder, Option<ast::NullsOrder>)>,
     pub limit: Option<Box<Expr>>,
     pub offset: Option<Box<Expr>>,
-    // TODO: optional RETURNING clause
+    /// Optional RETURNING clause.
     pub returning: Option<Vec<ResultSetColumn>>,
-    // whether the WHERE clause is always false
+    /// Whether the WHERE clause is always false.
     pub contains_constant_false_condition: bool,
     pub indexes_to_update: Vec<Arc<Index>>,
-    // If the UPDATE modifies any column that is present in the key of the btree used to iterate over the table (either the table itself or an index),
-    // gather all the target rowids into an ephemeral table, and then use that table as the single JoinedTable for the actual UPDATE loop.
-    // This ensures the keys of the btree used to iterate cannot be changed during the UPDATE loop itself, ensuring all the intended rows actually get
-    // updated and none are skipped.
-    pub ephemeral_plan: Option<SelectPlan>,
-    // For ALTER TABLE turso-db emits appropriate DDL statement in the "updates" cell of CDC table
-    // This field is present only for update plan created for ALTER TABLE when CDC mode has "updates" values
+    /// Prebuilt write-set SELECT for Halloween protection / UPDATE FROM.
+    pub write_set_plan: Option<WriteSetPlan>,
+    /// For ALTER TABLE turso-db emits appropriate DDL statement in the "updates"
+    /// cell of CDC table. This field is present only for update plans created for
+    /// ALTER TABLE when CDC mode has "updates" values.
     pub cdc_update_alter_statement: Option<String>,
     /// Subqueries that appear in the WHERE clause (for non-ephemeral path)
     pub non_from_clause_subqueries: Vec<NonFromClauseSubquery>,
     /// Whether this UPDATE plan uses the safer pre-materialization path, and why.
     pub safety: DmlSafety,
+}
+
+impl UpdatePlan {
+    /// Combine the UPDATE target (always first) and the `FROM`-clause tables
+    /// into one `TableReferences` — the read-side scope used for planning
+    /// outer-`WHERE` subqueries, `EXPLAIN QUERY PLAN`, and SQL serialization.
+    /// The plan stores the two separately because the write-side emitter
+    /// treats the target table specially; this helper rejoins them for readers.
+    pub fn build_read_scope_tables(&self) -> TableReferences {
+        let mut read_scope_tables = TableReferences::new(vec![self.target_table.clone()], vec![]);
+        if self.from_tables.right_join_swapped() {
+            read_scope_tables.set_right_join_swapped();
+        }
+        read_scope_tables.extend(self.from_tables.clone());
+        read_scope_tables
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1325,7 +1382,9 @@ impl TableReferences {
         }
     }
 
-    /// Returns the internal ID and immutable reference to the [Table] with the given identifier,
+    /// Returns `(internal_id, &Table)` for the table with the given identifier.
+    /// Searches `joined_tables` first, then visible `outer_query_refs`
+    /// (excluding CTE-definition-only entries).
     pub fn find_table_and_internal_id_by_identifier(
         &self,
         identifier: &str,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -860,7 +860,8 @@ pub struct UpdatePlan {
 impl UpdatePlan {
     /// Combine the UPDATE target (always first) and the `FROM`-clause tables
     /// into one `TableReferences` — the read-side scope used for planning
-    /// outer-`WHERE` subqueries, `EXPLAIN QUERY PLAN`, and SQL serialization.
+    /// outer-`WHERE` subqueries, `EXPLAIN QUERY PLAN`, and rendering the plan
+    /// back to SQL text via `ToTokens`.
     /// The plan stores the two separately because the write-side emitter
     /// treats the target table specially; this helper rejoins them for readers.
     pub fn build_read_scope_tables(&self) -> TableReferences {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -790,6 +790,12 @@ pub struct UpdateSetClause {
     pub expr: Box<ast::Expr>,
     /// In UPDATE FROM, SET clause expressions are rewritten to read from the
     /// scratch table populated before the write loop.
+    ///
+    /// For example, `UPDATE t SET a = s.x + 1 FROM s WHERE t.id = s.id` rewrites
+    /// the SET expression `s.x + 1` (a column reference into the FROM table + a literal 1) into a
+    /// `Column` read from the ephemeral scratch table that was populated during
+    /// the collection phase. That column in the scratch table contains the evaluated result
+    /// of s.x + 1.
     pub update_from_result: Option<Box<ast::Expr>>,
 }
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -621,7 +621,6 @@ pub fn plan_ctes_as_outer_refs(
         let cte_select_ast = cte.select.clone();
         // AS MATERIALIZED forces materialization
         let materialize_hint = cte.materialized == Materialized::Yes;
-
         // Block the CTE's own name from resolving to a schema object during
         // planning of its body (see push_cte_being_defined).
         program.push_cte_being_defined(cte_name.clone());
@@ -672,7 +671,7 @@ pub fn plan_ctes_as_outer_refs(
             col_used_mask: ColumnUsedMask::default(),
             cte_select: Some(cte_select_ast),
             cte_explicit_columns: explicit_columns,
-            cte_id: None, // DML CTEs don't share materialized data (TODO: implement if needed)
+            cte_id: None, // DML CTEs don't track CTE sharing (TODO: implement if needed)
             cte_definition_only: true,
             rowid_referenced: false,
             scope_depth: 0,
@@ -1765,7 +1764,7 @@ fn parse_join(
                     turso_assert!(!left_tables.is_empty());
                     let right_table = table_references.joined_tables().last().unwrap();
                     let mut left_col = None;
-                    for (left_table_idx, left_table) in left_tables.iter().enumerate() {
+                    for (left_table_offset, left_table) in left_tables.iter().enumerate() {
                         left_col = left_table
                             .columns()
                             .iter()
@@ -1776,7 +1775,9 @@ fn parse_join(
                                     .as_ref()
                                     .is_some_and(|name| *name == name_normalized)
                             })
-                            .map(|(idx, col)| (left_table_idx, left_table.internal_id, idx, col));
+                            .map(|(idx, col)| {
+                                (left_table_offset, left_table.internal_id, idx, col)
+                            });
                         if left_col.is_some() {
                             break;
                         }
@@ -1863,6 +1864,56 @@ fn parse_join(
     Ok(())
 }
 
+pub(crate) fn append_vtab_predicates_to_where_clause(
+    vtab_predicates: &mut Vec<Expr>,
+    table_references: &mut TableReferences,
+    result_columns: &[ResultSetColumn],
+    out_where_clause: &mut Vec<WhereTerm>,
+    resolver: &Resolver,
+) -> Result<()> {
+    for mut expr in vtab_predicates.drain(..) {
+        bind_and_rewrite_expr(
+            &mut expr,
+            Some(table_references),
+            Some(result_columns),
+            resolver,
+            BindingBehavior::TryCanonicalColumnsFirst,
+        )?;
+
+        // Virtual table argument predicates (e.g. the 't2' in pragma_table_info('t2'))
+        // must be associated with the virtual table's outer join context if the table is
+        // the RHS of a LEFT JOIN. Otherwise the optimizer may incorrectly simplify the
+        // LEFT JOIN into an INNER JOIN, breaking NULL row emission for unmatched rows.
+        let from_outer_join = vtab_predicate_table_id(&expr).and_then(|table_id| {
+            table_references
+                .find_joined_table_by_internal_id(table_id)
+                .and_then(|table_ref| {
+                    table_ref
+                        .join_info
+                        .as_ref()
+                        .and_then(|join_info| join_info.is_outer().then_some(table_id))
+                })
+        });
+        out_where_clause.push(WhereTerm {
+            expr,
+            from_outer_join,
+            consumed: false,
+        });
+    }
+    Ok(())
+}
+
+/// Extract the table internal_id from a virtual table argument predicate.
+/// These are always of the form `Column { table, .. } = literal` or `IsNull(Column { table, .. })`.
+fn vtab_predicate_table_id(expr: &Expr) -> Option<TableInternalId> {
+    match expr {
+        Expr::Binary(lhs, _, _) | Expr::IsNull(lhs) => match lhs.as_ref() {
+            Expr::Column { table, .. } => Some(*table),
+            _ => None,
+        },
+        _ => None,
+    }
+}
 pub fn break_predicate_at_and_boundaries<T: From<Expr>>(
     predicate: &Expr,
     out_predicates: &mut Vec<T>,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1,7 +1,7 @@
 use super::emitter::{emit_program, TranslateCtx};
 use super::plan::{
     select_star, Distinctness, InSeekSource, JoinOrderMember, Operation, OuterQueryReference,
-    QueryDestination, Search, TableReferences, WhereTerm, Window,
+    QueryDestination, Search, TableReferences, Window,
 };
 use crate::schema::Table;
 use crate::sync::Arc;
@@ -13,8 +13,8 @@ use crate::translate::group_by::compute_group_by_sort_order;
 use crate::translate::optimizer::optimize_plan;
 use crate::translate::plan::{GroupBy, Plan, ResultSetColumn, SelectPlan, SubqueryState};
 use crate::translate::planner::{
-    break_predicate_at_and_boundaries, parse_from, parse_limit, parse_where,
-    plan_ctes_as_outer_refs, resolve_window_and_aggregate_functions,
+    append_vtab_predicates_to_where_clause, break_predicate_at_and_boundaries, parse_from,
+    parse_limit, parse_where, plan_ctes_as_outer_refs, resolve_window_and_aggregate_functions,
 };
 use crate::translate::result_row::emit_select_result;
 use crate::translate::subquery::{plan_subqueries_from_select_plan, plan_subqueries_from_values};
@@ -1027,48 +1027,13 @@ fn add_vtab_predicates_to_where_clause(
     plan: &mut SelectPlan,
     resolver: &Resolver,
 ) -> Result<()> {
-    for expr in vtab_predicates.iter_mut() {
-        bind_and_rewrite_expr(
-            expr,
-            Some(&mut plan.table_references),
-            Some(&plan.result_columns),
-            resolver,
-            BindingBehavior::TryCanonicalColumnsFirst,
-        )?;
-    }
-    for expr in vtab_predicates.drain(..) {
-        // Virtual table argument predicates (e.g. the 't2' in pragma_table_info('t2'))
-        // must be associated with the virtual table's outer join context if the table is
-        // the RHS of a LEFT JOIN. Otherwise the optimizer may incorrectly simplify the
-        // LEFT JOIN into an INNER JOIN, breaking NULL row emission for unmatched rows.
-        let from_outer_join = vtab_predicate_table_id(&expr).and_then(|table_id| {
-            plan.table_references
-                .find_joined_table_by_internal_id(table_id)
-                .and_then(|t| {
-                    t.join_info
-                        .as_ref()
-                        .and_then(|ji| ji.is_outer().then_some(table_id))
-                })
-        });
-        plan.where_clause.push(WhereTerm {
-            expr,
-            from_outer_join,
-            consumed: false,
-        });
-    }
-    Ok(())
-}
-
-/// Extract the table internal_id from a virtual table argument predicate.
-/// These are always of the form `Column { table, .. } = literal` or `IsNull(Column { table, .. })`.
-fn vtab_predicate_table_id(expr: &Expr) -> Option<ast::TableInternalId> {
-    match expr {
-        Expr::Binary(lhs, _, _) | Expr::IsNull(lhs) => match lhs.as_ref() {
-            Expr::Column { table, .. } => Some(*table),
-            _ => None,
-        },
-        _ => None,
-    }
+    append_vtab_predicates_to_where_clause(
+        vtab_predicates,
+        &mut plan.table_references,
+        &plan.result_columns,
+        &mut plan.where_clause,
+        resolver,
+    )
 }
 
 /// Replaces a column number in an ORDER BY or GROUP BY expression with a copy of the column expression.

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -180,22 +180,17 @@ pub(crate) fn set_update_stmt_journal_flags(
     resolver: &Resolver,
     connection: &crate::sync::Arc<crate::Connection>,
 ) -> Result<()> {
-    // When an ephemeral table is used (key mutation / Halloween protection),
-    // the actual target table is in the ephemeral_plan's table_references.
-    let table_refs = plan
-        .ephemeral_plan
-        .as_ref()
-        .map(|ep| &ep.table_references)
-        .unwrap_or(&plan.table_references);
-    let Some(target_table) = table_refs.joined_tables().first() else {
-        crate::bail_parse_error!("UPDATE should have one target table");
-    };
+    let target_table = &plan.target_table;
     let Some(btree_table) = target_table.btree() else {
         return Ok(()); // Virtual table — keep conservative defaults.
     };
     let database_id = target_table.database_id;
 
-    let updated_cols = plan.set_clauses.iter().map(|(i, _)| *i).collect();
+    let updated_cols = plan
+        .set_clauses
+        .iter()
+        .map(|set_clause| set_clause.column_index)
+        .collect();
     let has_triggers = has_triggers_including_temp(
         resolver,
         database_id,
@@ -223,13 +218,13 @@ pub(crate) fn set_update_stmt_journal_flags(
         program.set_multi_write(false);
     }
 
-    let has_notnull_cols = plan.set_clauses.iter().any(|(col_idx, _)| {
-        if *col_idx == crate::schema::ROWID_SENTINEL {
+    let has_notnull_cols = plan.set_clauses.iter().any(|set_clause| {
+        if set_clause.column_index == crate::schema::ROWID_SENTINEL {
             return false;
         }
         btree_table
             .columns()
-            .get(*col_idx)
+            .get(set_clause.column_index)
             .is_some_and(|c| c.notnull() && !c.is_rowid_alias())
     });
     let has_check = !btree_table.check_constraints.is_empty();

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -358,7 +358,7 @@ pub fn plan_subqueries_from_where_clause(
         non_from_clause_subqueries,
         table_references,
         resolver,
-        where_clause.iter_mut().map(|t| &mut t.expr),
+        where_clause.iter_mut().map(|term| &mut term.expr),
         connection,
         SubqueryPosition::Where,
         SubqueryOrigin::DmlWhere,
@@ -400,11 +400,11 @@ pub fn plan_subqueries_from_values(
 /// Compute query plans for subqueries in UPDATE SET clause expressions.
 /// This is used by UPDATE statements where SET clause values contain scalar subqueries.
 /// e.g. `UPDATE t SET col = (SELECT max(id) FROM t2)`
-pub fn plan_subqueries_from_set_clauses(
+pub fn plan_subqueries_from_update_sets(
     program: &mut ProgramBuilder,
     non_from_clause_subqueries: &mut Vec<NonFromClauseSubquery>,
     table_references: &mut TableReferences,
-    set_clauses: &mut [(usize, Box<ast::Expr>)],
+    sets: &mut [ast::Set],
     resolver: &Resolver,
     connection: &Arc<Connection>,
 ) -> Result<()> {
@@ -413,9 +413,9 @@ pub fn plan_subqueries_from_set_clauses(
         non_from_clause_subqueries,
         table_references,
         resolver,
-        set_clauses.iter_mut().map(|(_, expr)| expr.as_mut()),
+        sets.iter_mut().map(|set| set.expr.as_mut()),
         connection,
-        SubqueryPosition::ResultColumn, // SET clause subqueries are similar to result columns
+        SubqueryPosition::ResultColumn,
         SubqueryOrigin::DmlSet,
         SubqueryPosition::ResultColumn.allow_correlated(),
     )?;
@@ -568,7 +568,7 @@ fn get_subquery_parser<'a>(
     referenced_tables: &'a mut TableReferences,
     resolver: &'a Resolver,
     connection: &'a Arc<Connection>,
-    get_outer_query_refs: fn(&TableReferences) -> Vec<OuterQueryReference>,
+    get_outer_query_refs: impl Fn(&TableReferences) -> Vec<OuterQueryReference> + 'a,
     position: SubqueryPosition,
     origin: SubqueryOrigin,
     allow_correlated: bool,
@@ -985,7 +985,9 @@ fn update_column_used_masks(
                 }
                 propagate_outer_refs_from_select_plan(table_refs, right_most);
             }
-            Plan::Delete(_) | Plan::Update(_) => {}
+            Plan::Delete(_) | Plan::Update(_) => {
+                unreachable!("DELETE/UPDATE plans should not appear in FROM clause subqueries")
+            }
         }
     }
 

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -337,7 +337,7 @@ pub fn plan_subqueries_from_select_plan(
     update_column_used_masks(
         &mut plan.table_references,
         &mut plan.non_from_clause_subqueries,
-    );
+    )?;
     Ok(())
 }
 
@@ -365,7 +365,7 @@ pub fn plan_subqueries_from_where_clause(
         SubqueryPosition::Where.allow_correlated(),
     )?;
 
-    update_column_used_masks(table_references, non_from_clause_subqueries);
+    update_column_used_masks(table_references, non_from_clause_subqueries)?;
     Ok(())
 }
 
@@ -393,7 +393,7 @@ pub fn plan_subqueries_from_values(
         SubqueryPosition::ResultColumn.allow_correlated(),
     )?;
 
-    update_column_used_masks(table_references, non_from_clause_subqueries);
+    update_column_used_masks(table_references, non_from_clause_subqueries)?;
     Ok(())
 }
 
@@ -420,7 +420,7 @@ pub fn plan_subqueries_from_update_sets(
         SubqueryPosition::ResultColumn.allow_correlated(),
     )?;
 
-    update_column_used_masks(table_references, non_from_clause_subqueries);
+    update_column_used_masks(table_references, non_from_clause_subqueries)?;
     Ok(())
 }
 
@@ -453,7 +453,7 @@ pub fn plan_subqueries_from_returning(
         SubqueryPosition::ResultColumn.allow_correlated(),
     )?;
 
-    update_column_used_masks(table_references, non_from_clause_subqueries);
+    update_column_used_masks(table_references, non_from_clause_subqueries)?;
     Ok(())
 }
 
@@ -934,8 +934,11 @@ fn recollect_aggregates(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()
 fn update_column_used_masks(
     table_refs: &mut TableReferences,
     subqueries: &mut [NonFromClauseSubquery],
-) {
-    fn propagate_outer_refs_from_select_plan(table_refs: &mut TableReferences, plan: &SelectPlan) {
+) -> Result<()> {
+    fn propagate_outer_refs_from_select_plan(
+        table_refs: &mut TableReferences,
+        plan: &SelectPlan,
+    ) -> Result<()> {
         for child_outer_query_ref in plan
             .table_references
             .outer_query_refs()
@@ -967,39 +970,47 @@ fn update_column_used_masks(
 
         for joined_table in plan.table_references.joined_tables().iter() {
             if let Table::FromClauseSubquery(from_clause_subquery) = &joined_table.table {
-                propagate_outer_refs_from_plan(table_refs, from_clause_subquery.plan.as_ref());
+                propagate_outer_refs_from_plan(table_refs, from_clause_subquery.plan.as_ref())?;
             }
         }
+        Ok(())
     }
 
-    fn propagate_outer_refs_from_plan(table_refs: &mut TableReferences, plan: &Plan) {
+    fn propagate_outer_refs_from_plan(table_refs: &mut TableReferences, plan: &Plan) -> Result<()> {
         match plan {
             Plan::Select(select_plan) => {
-                propagate_outer_refs_from_select_plan(table_refs, select_plan);
+                propagate_outer_refs_from_select_plan(table_refs, select_plan)?;
             }
             Plan::CompoundSelect {
                 left, right_most, ..
             } => {
                 for (select_plan, _) in left.iter() {
-                    propagate_outer_refs_from_select_plan(table_refs, select_plan);
+                    propagate_outer_refs_from_select_plan(table_refs, select_plan)?;
                 }
-                propagate_outer_refs_from_select_plan(table_refs, right_most);
+                propagate_outer_refs_from_select_plan(table_refs, right_most)?;
             }
             Plan::Delete(_) | Plan::Update(_) => {
-                unreachable!("DELETE/UPDATE plans should not appear in FROM clause subqueries")
+                return Err(crate::LimboError::InternalError(
+                    "DELETE/UPDATE plans should not appear in FROM clause subqueries".into(),
+                ));
             }
         }
+        Ok(())
     }
 
     for subquery in subqueries.iter_mut() {
         let SubqueryState::Unevaluated { plan } = &mut subquery.state else {
-            panic!("subquery has already been evaluated");
+            return Err(crate::LimboError::InternalError(
+                "subquery has already been evaluated".into(),
+            ));
         };
         let Some(child_plan) = plan.as_mut() else {
-            panic!("subquery has no plan");
+            return Err(crate::LimboError::InternalError(
+                "subquery has no plan".into(),
+            ));
         };
 
-        propagate_outer_refs_from_plan(table_refs, child_plan);
+        propagate_outer_refs_from_plan(table_refs, child_plan)?;
     }
 
     // Collect raw plan pointers to avoid cloning while sidestepping borrow rules.
@@ -1016,8 +1027,9 @@ fn update_column_used_masks(
     for plan in from_clause_plans {
         // SAFETY: plans live within table_refs for the duration of this function.
         let plan = unsafe { &*plan };
-        propagate_outer_refs_from_plan(table_refs, plan);
+        propagate_outer_refs_from_plan(table_refs, plan)?;
     }
+    Ok(())
 }
 
 /// Recursively pre-materialize all multi-ref CTEs in a plan tree.

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -326,10 +326,18 @@ fn trigger_cmd_to_stmt_for_subprogram(
             from,
             where_clause,
         } => {
-            // Rewrite NEW/OLD references in SET clauses and WHERE clause
+            // Rewrite NEW/OLD references anywhere an UPDATE trigger body can
+            // legally read them: SET, FROM-derived sources, and WHERE.
             let mut sets_clone = sets.clone();
             for set in &mut sets_clone {
                 rewrite_trigger_expr_for_subprogram(&mut set.expr, subprogram_ctx)?;
+            }
+
+            let mut from_clone = from.clone();
+            if let Some(ref mut from_clause) = from_clone {
+                rewrite_from_clause_expressions(from_clause, &mut |e: &mut ast::Expr| {
+                    rewrite_trigger_expr_single_for_subprogram(e, subprogram_ctx)
+                })?;
             }
 
             let mut where_clause_clone = where_clause.clone();
@@ -350,7 +358,7 @@ fn trigger_cmd_to_stmt_for_subprogram(
                 },
                 indexed: None,
                 sets: sets_clone,
-                from: from.clone(),
+                from: from_clone,
                 where_clause: where_clause_clone,
                 returning: vec![],
                 order_by: vec![],

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -195,7 +195,7 @@ fn prepare_and_optimize_update_plan(
     update_plan.target_table = read_scope_tables.joined_tables_mut().remove(0);
     update_plan.from_tables = read_scope_tables;
 
-    let mut plan = Plan::Update(update_plan);
+    let mut plan = Plan::Update(Box::new(update_plan));
     optimize_plan(program, &mut plan, resolver)?;
     Ok(plan)
 }

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -625,19 +625,21 @@ fn collect_indexes_to_update(
 
 /// Proactive column-ambiguity check for UPDATE FROM.
 ///
-/// SQLite rejects UPDATE FROM when a NATURAL JOIN (or USING) introduces a column
-/// name that also exists in another FROM-side table without deduplication. In a
-/// regular SELECT this is only caught when an unqualified reference is resolved,
-/// but UPDATE FROM checks it eagerly regardless of whether the column is referenced.
+/// SQLite rejects UPDATE FROM when:
+/// 1. The same table identifier appears more than once in the FROM clause
+///    (duplicate unaliased tables or duplicate aliases).
+/// 2. A NATURAL JOIN or USING deduplicates a column, but another table in
+///    the FROM graph also exposes that column without deduplication.
+///
+/// In a regular SELECT these are only caught when an unqualified reference
+/// is resolved, but UPDATE FROM checks eagerly regardless of whether the
+/// column is actually referenced.
 fn check_update_from_column_ambiguity(
     joined_tables: &[JoinedTable],
     connection: &Connection,
 ) -> crate::Result<()> {
+    // Check 1: reject duplicate table identifiers (e.g. FROM t2, t2).
     for (i, table) in joined_tables.iter().enumerate() {
-        let using = match &table.join_info {
-            Some(info) if !info.using.is_empty() => &info.using,
-            _ => continue,
-        };
         if joined_tables[..i]
             .iter()
             .any(|preceding| preceding.identifier == table.identifier)
@@ -650,13 +652,27 @@ fn check_update_from_column_ambiguity(
                 table.identifier
             );
         }
+    }
+
+    // Check 2: for each USING/NATURAL-deduplicated column, verify that no
+    // other table in the FROM graph (preceding or following) exposes the
+    // same column without its own deduplication.
+    for (i, table) in joined_tables.iter().enumerate() {
+        let using = match &table.join_info {
+            Some(info) if !info.using.is_empty() => &info.using,
+            _ => continue,
+        };
         for using_col in using {
             let col_name = normalize_ident(using_col.as_str());
-            // Count how many preceding FROM-side tables expose this column
-            // without it already being deduplicated by their own USING clause.
+
+            // Count how many *other* tables expose this column without it
+            // being covered by their own USING clause.
             let mut found_count = 0usize;
-            for preceding in &joined_tables[..i] {
-                let has_col = preceding.columns().iter().any(|c| {
+            for (j, other) in joined_tables.iter().enumerate() {
+                if j == i {
+                    continue;
+                }
+                let has_col = other.columns().iter().any(|c| {
                     c.name
                         .as_ref()
                         .is_some_and(|n| n.eq_ignore_ascii_case(&col_name))
@@ -664,9 +680,9 @@ fn check_update_from_column_ambiguity(
                 if !has_col {
                     continue;
                 }
-                // If this preceding table's own USING already covers the column,
-                // it was deduplicated by an earlier NATURAL/USING JOIN — skip it.
-                let already_deduped = preceding.join_info.as_ref().is_some_and(|info| {
+                // If this table's own USING already covers the column,
+                // it was deduplicated by its own NATURAL/USING JOIN — skip.
+                let already_deduped = other.join_info.as_ref().is_some_and(|info| {
                     info.using
                         .iter()
                         .any(|u| u.as_str().eq_ignore_ascii_case(&col_name))

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -5,7 +5,7 @@ use crate::schema::{EXPR_INDEX_SENTINEL, ROWID_SENTINEL};
 use crate::translate::emitter::Resolver;
 use crate::translate::expr::{bind_and_rewrite_expr, BindingBehavior};
 use crate::translate::expression_index::expression_index_column_usage;
-use crate::translate::plan::{ColumnMask, Operation, Scan};
+use crate::translate::plan::{ColumnMask, Operation};
 use crate::translate::planner::{parse_limit, ROWID_STRS};
 use crate::{
     bail_parse_error,
@@ -14,18 +14,18 @@ use crate::{
     vdbe::builder::{ProgramBuilder, ProgramBuilderOpts},
     CaptureDataChangesExt, Connection,
 };
-use turso_parser::ast::{self, Expr, SortOrder};
+use turso_parser::ast::{self, Expr};
 
 use super::emitter::emit_program;
 use super::expr::process_returning_clause;
 use super::optimizer::optimize_plan;
 use super::plan::{
-    ColumnUsedMask, DmlSafety, IterationDirection, JoinedTable, Plan, TableReferences, UpdatePlan,
+    ColumnUsedMask, DmlSafety, JoinedTable, Plan, TableReferences, UpdatePlan, UpdateSetClause,
 };
-use super::planner::{parse_where, plan_ctes_as_outer_refs};
+use super::planner::{append_vtab_predicates_to_where_clause, parse_from, parse_where};
 use super::subquery::{
-    plan_subqueries_from_returning, plan_subqueries_from_select_plan,
-    plan_subqueries_from_set_clauses, plan_subqueries_from_where_clause,
+    mark_shared_cte_materialization_requirements, plan_subqueries_from_returning,
+    plan_subqueries_from_update_sets, plan_subqueries_from_where_clause,
 };
 /*
 * Update is simple. By default we scan the table, and for each row, we check the WHERE
@@ -62,50 +62,78 @@ pub fn translate_update(
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> crate::Result<()> {
-    let mut plan = prepare_update_plan(program, resolver, body, connection, false)?;
-
-    // Plan subqueries in the WHERE clause and SET clause
-    if let Plan::Update(ref mut update_plan) = plan {
-        if let Some(ref mut ephemeral_plan) = update_plan.ephemeral_plan {
-            // When using ephemeral plan (key columns are being updated), subqueries are in the ephemeral_plan's WHERE
-            plan_subqueries_from_select_plan(program, ephemeral_plan, resolver, connection)?;
-        } else {
-            // Normal path: subqueries are in the UPDATE plan's WHERE
-            plan_subqueries_from_where_clause(
-                program,
-                &mut update_plan.non_from_clause_subqueries,
-                &mut update_plan.table_references,
-                &mut update_plan.where_clause,
-                resolver,
-                connection,
-            )?;
-        }
-        // Plan subqueries in the SET clause (e.g. UPDATE t SET col = (SELECT ...))
-        plan_subqueries_from_set_clauses(
-            program,
-            &mut update_plan.non_from_clause_subqueries,
-            &mut update_plan.table_references,
-            &mut update_plan.set_clauses,
-            resolver,
-            connection,
-        )?;
-    }
-
-    optimize_plan(program, &mut plan, resolver)?;
-
-    if let Plan::Update(ref update_plan) = plan {
-        super::stmt_journal::set_update_stmt_journal_flags(
-            program,
-            update_plan,
-            resolver,
-            connection,
-        )?;
-    }
+    let plan = prepare_and_optimize_update_plan(program, resolver, body, connection, false, None)?;
+    let Plan::Update(ref update_plan) = plan else {
+        unreachable!("prepare_and_optimize_update_plan must return Plan::Update");
+    };
+    super::stmt_journal::set_update_stmt_journal_flags(program, update_plan, resolver, connection)?;
 
     let opts = ProgramBuilderOpts::new(1, 20, 4);
     program.extend(&opts);
     emit_program(connection, resolver, program, plan, |_| {})?;
     Ok(())
+}
+
+/// Normalize a planned UPDATE RHS into the per-column expressions consumed by SET.
+///
+/// Example:
+/// UPDATE t SET (a, b) = (SELECT x, y FROM s)
+/// After planning, the right-hand side (SELECT x, y FROM s) becomes a
+/// SubqueryResult with 2 columns, and this is split into 2 1-column SubqueryResult expressions
+/// i.e. one per each SET assignment.
+fn split_update_set_values(mut expr: Expr, target_count: usize) -> crate::Result<Vec<Expr>> {
+    while let Expr::Parenthesized(mut exprs) = expr {
+        match exprs.len() {
+            1 => expr = *exprs.pop().expect("single parenthesized expr"),
+            _ => {
+                expr = Expr::Parenthesized(exprs);
+                break;
+            }
+        }
+    }
+
+    match expr {
+        Expr::Parenthesized(vals) => {
+            if vals.len() != target_count {
+                bail_parse_error!("{} columns assigned {} values", target_count, vals.len());
+            }
+            Ok(vals.into_iter().map(|expr| *expr).collect())
+        }
+        Expr::SubqueryResult {
+            subquery_id,
+            lhs,
+            not_in,
+            query_type:
+                ast::SubqueryType::RowValue {
+                    result_reg_start,
+                    num_regs,
+                },
+        } => {
+            if num_regs != target_count {
+                bail_parse_error!("{} columns assigned {} values", target_count, num_regs);
+            }
+            Ok((0..num_regs)
+                .map(|offset| Expr::SubqueryResult {
+                    subquery_id,
+                    lhs: lhs.clone(),
+                    not_in,
+                    query_type: ast::SubqueryType::RowValue {
+                        result_reg_start: result_reg_start + offset,
+                        num_regs: 1,
+                    },
+                })
+                .collect())
+        }
+        Expr::Subquery(_) => Err(crate::LimboError::InternalError(
+            "UPDATE set clause subquery should be planned before normalization".to_string(),
+        )),
+        expr => {
+            if target_count != 1 {
+                bail_parse_error!("{} columns assigned 1 values", target_count);
+            }
+            Ok(vec![expr])
+        }
+    }
 }
 
 pub fn translate_update_for_schema_change(
@@ -116,42 +144,60 @@ pub fn translate_update_for_schema_change(
     ddl_query: &str,
     after: impl FnOnce(&mut ProgramBuilder),
 ) -> crate::Result<()> {
-    let mut plan = prepare_update_plan(program, resolver, body, connection, true)?;
-
-    if let Plan::Update(update_plan) = &mut plan {
-        if program.capture_data_changes_info().has_updates() {
-            update_plan.cdc_update_alter_statement = Some(ddl_query.to_string());
-        }
-
-        // Plan subqueries in the WHERE clause
-        if let Some(ref mut ephemeral_plan) = update_plan.ephemeral_plan {
-            plan_subqueries_from_select_plan(program, ephemeral_plan, resolver, connection)?;
-        } else {
-            plan_subqueries_from_where_clause(
-                program,
-                &mut update_plan.non_from_clause_subqueries,
-                &mut update_plan.table_references,
-                &mut update_plan.where_clause,
-                resolver,
-                connection,
-            )?;
-        }
-        // Plan subqueries in the SET clause (e.g. UPDATE t SET col = (SELECT ...))
-        plan_subqueries_from_set_clauses(
-            program,
-            &mut update_plan.non_from_clause_subqueries,
-            &mut update_plan.table_references,
-            &mut update_plan.set_clauses,
-            resolver,
-            connection,
-        )?;
-    }
-
-    optimize_plan(program, &mut plan, resolver)?;
+    let plan = prepare_and_optimize_update_plan(
+        program,
+        resolver,
+        body,
+        connection,
+        true,
+        Some(ddl_query),
+    )?;
     let opts = ProgramBuilderOpts::new(1, 20, 4);
     program.extend(&opts);
     emit_program(connection, resolver, program, plan, after)?;
     Ok(())
+}
+
+fn prepare_and_optimize_update_plan(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    body: ast::Update,
+    connection: &Arc<crate::Connection>,
+    is_internal_schema_change: bool,
+    ddl_query_for_cdc_update: Option<&str>,
+) -> crate::Result<Plan> {
+    let mut update_plan = prepare_update_plan(
+        program,
+        resolver,
+        body,
+        connection,
+        is_internal_schema_change,
+    )?;
+
+    if let Some(ddl_query_for_cdc_update) = ddl_query_for_cdc_update {
+        if program.capture_data_changes_info().has_updates() {
+            update_plan.cdc_update_alter_statement = Some(ddl_query_for_cdc_update.to_string());
+        }
+    }
+    let mut read_scope_tables = update_plan.build_read_scope_tables();
+    plan_subqueries_from_where_clause(
+        program,
+        &mut update_plan.non_from_clause_subqueries,
+        &mut read_scope_tables,
+        &mut update_plan.where_clause,
+        resolver,
+        connection,
+    )?;
+    mark_shared_cte_materialization_requirements(
+        &mut read_scope_tables,
+        &mut update_plan.non_from_clause_subqueries,
+    );
+    update_plan.target_table = read_scope_tables.joined_tables_mut().remove(0);
+    update_plan.from_tables = read_scope_tables;
+
+    let mut plan = Plan::Update(update_plan);
+    optimize_plan(program, &mut plan, resolver)?;
+    Ok(plan)
 }
 
 fn validate_update(
@@ -169,9 +215,6 @@ fn validate_update(
     {
         crate::bail_parse_error!("table {} may not be modified", table_name);
     }
-    if body.from.is_some() {
-        bail_parse_error!("FROM clause is not supported in UPDATE");
-    }
     if !body.order_by.is_empty() {
         bail_parse_error!("ORDER BY is not supported in UPDATE");
     }
@@ -185,29 +228,29 @@ fn validate_update(
     if !views.is_empty() {
         use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
         crate::bail_parse_error!(
-            "Cannot DELETE from table '{table_name}' because it has incompatible dependent materialized view(s): {}. \n\
+            "Cannot UPDATE table '{table_name}' because it has incompatible dependent materialized view(s): {}. \n\
              These views were created with a different DBSP version than the current version ({DBSP_CIRCUIT_VERSION}). \n\
              Please DROP and recreate the view(s) before modifying this table.",
-            views.iter().fold(String::new(), |_, s| s.to_string() + ", "),
+            views.iter().map(|view| view.as_str()).collect::<Vec<_>>().join(", "),
         );
     }
     Ok(())
     })
 }
 
-pub fn prepare_update_plan(
+fn prepare_update_plan(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     mut body: ast::Update,
     connection: &Arc<crate::Connection>,
     is_internal_schema_change: bool,
-) -> crate::Result<Plan> {
+) -> crate::Result<UpdatePlan> {
     let database_id = resolver.resolve_existing_table_database_id_qualified(&body.tbl_name)?;
     let schema = resolver.schema();
-    let table_name = &body.tbl_name.name;
-    let table = match resolver.with_schema(database_id, |s| s.get_table(table_name.as_str())) {
+    let target_name = &body.tbl_name.name;
+    let table = match resolver.with_schema(database_id, |s| s.get_table(target_name.as_str())) {
         Some(table) => table,
-        None => bail_parse_error!("Parse error: no such table: {}", table_name),
+        None => bail_parse_error!("Parse error: no such table: {}", target_name),
     };
     if program.trigger.is_some() && table.virtual_table().is_some() {
         bail_parse_error!(
@@ -223,7 +266,7 @@ pub fn prepare_update_plan(
     validate_update(
         schema,
         &body,
-        table_name.as_str(),
+        target_name.as_str(),
         is_internal_schema_change,
         connection,
     )?;
@@ -234,220 +277,291 @@ pub fn prepare_update_plan(
     let indexed = body.indexed.take();
 
     let table_name = table.get_name();
-    let iter_dir = body
-        .order_by
-        .first()
-        .and_then(|ob| {
-            ob.order.map(|o| match o {
-                SortOrder::Asc => IterationDirection::Forwards,
-                SortOrder::Desc => IterationDirection::Backwards,
-            })
-        })
-        .unwrap_or(IterationDirection::Forwards);
 
-    let joined_tables = vec![JoinedTable {
-        table: match table.as_ref() {
-            Table::Virtual(vtab) => Table::Virtual(vtab.clone()),
-            Table::BTree(btree_table) => Table::BTree(btree_table.clone()),
-            _ => unreachable!(),
-        },
+    let target_table = JoinedTable {
+        table: table.as_ref().clone(),
         identifier: body.tbl_name.identifier(),
         internal_id: program.table_reference_counter.next(),
-        op: build_scan_op(&table, iter_dir),
+        op: Operation::default_scan_for(&table),
         join_info: None,
         col_used_mask: ColumnUsedMask::default(),
         column_use_counts: Vec::new(),
         expression_index_usages: Vec::new(),
         database_id,
         indexed,
-    }];
-    let mut table_references = TableReferences::new(joined_tables, vec![]);
+    };
+    let mut from_tables = TableReferences::new_empty();
+    let mut where_clause = vec![];
+    let mut vtab_predicates = vec![];
+    parse_from(
+        body.from.take(),
+        resolver,
+        program,
+        with,
+        true,
+        &mut where_clause,
+        &mut vtab_predicates,
+        &mut from_tables,
+        connection,
+    )?;
 
-    // Plan CTEs and add them as outer query references for subquery resolution
-    plan_ctes_as_outer_refs(with, resolver, program, &mut table_references, connection)?;
+    // SQLite rejects UPDATE FROM when a NATURAL JOIN (or explicit USING) introduces
+    // a column name that already appears in another FROM-side table without being
+    // deduplicated. This proactive check mirrors what SQLite does even when no
+    // unqualified column reference appears in the query.
+    if !from_tables.joined_tables().is_empty() {
+        check_update_from_column_ambiguity(from_tables.joined_tables(), connection.as_ref())?;
+    }
 
+    let target_identifier = body.tbl_name.alias.as_ref().map_or_else(
+        || normalize_ident(body.tbl_name.name.as_str()),
+        |alias| normalize_ident(alias.as_str()),
+    );
+    let target_table_name = normalize_ident(body.tbl_name.name.as_str());
+    let mut non_from_clause_subqueries = vec![];
+    // Reject fairly specific cases like UPDATE t SET x=5 FROM t.
+    let illegal_target_reference = from_tables.joined_tables().iter().any(|joined| {
+        joined.database_id == database_id
+            && normalize_ident(joined.identifier.as_str()) == target_identifier
+            && normalize_ident(joined.table.get_name()) == target_table_name
+    });
+    if illegal_target_reference {
+        bail_parse_error!(
+            "target object/alias may not appear in FROM clause: {}",
+            body.tbl_name
+                .alias
+                .as_ref()
+                .map_or(body.tbl_name.name.as_str(), |alias| alias.as_str())
+        );
+    }
+
+    // At this point where_clause only contains items collected from the FROM clause's JOIN ON conditions.
+    // Subqueries within those conditions are not allowed to reference the UPDATE target table, so we do a subquery
+    // planning pass here before extending the table scope with the target table.
+    plan_subqueries_from_where_clause(
+        program,
+        &mut non_from_clause_subqueries,
+        &mut from_tables,
+        &mut where_clause,
+        resolver,
+        connection,
+    )?;
+
+    let mut read_scope_tables = TableReferences::new(vec![target_table], vec![]);
+    if from_tables.right_join_swapped() {
+        read_scope_tables.set_right_join_swapped();
+    }
+    read_scope_tables.extend(from_tables);
+
+    for set in &mut body.sets {
+        bind_and_rewrite_expr(
+            &mut set.expr,
+            Some(&mut read_scope_tables),
+            None,
+            resolver,
+            BindingBehavior::ResultColumnsNotAllowed,
+        )?;
+    }
+
+    plan_subqueries_from_update_sets(
+        program,
+        &mut non_from_clause_subqueries,
+        &mut read_scope_tables,
+        &mut body.sets,
+        resolver,
+        connection,
+    )?;
+
+    let set_clauses = collect_update_set_clauses(&mut body.sets, &table, table_name)?;
+
+    let result_columns = if !body.returning.is_empty() {
+        // Plan subqueries in RETURNING expressions before processing
+        // (so SubqueryResult nodes are cloned into result_columns)
+        let mut returning_target = read_scope_tables.joined_tables()[0].clone();
+        // SQLite resolves RETURNING columns for an aliased UPDATE target through the
+        // base table name, not the UPDATE alias. Keep the target table in scope, but
+        // under its schema name so `RETURNING t.col` works while `RETURNING alias.col`
+        // still fails.
+        returning_target.identifier = table_name.to_string();
+        let mut returning_table_references = TableReferences::new(
+            vec![returning_target],
+            read_scope_tables.outer_query_refs().to_vec(),
+        );
+        plan_subqueries_from_returning(
+            program,
+            &mut non_from_clause_subqueries,
+            &mut returning_table_references,
+            &mut body.returning,
+            resolver,
+            connection,
+        )?;
+
+        process_returning_clause(
+            &mut body.returning,
+            &mut returning_table_references,
+            resolver,
+        )?
+    } else {
+        vec![]
+    };
+
+    let columns = table.columns();
+    append_vtab_predicates_to_where_clause(
+        &mut vtab_predicates,
+        &mut read_scope_tables,
+        &result_columns,
+        &mut where_clause,
+        resolver,
+    )?;
+    parse_where(
+        body.where_clause.as_deref(),
+        &mut read_scope_tables,
+        Some(&result_columns),
+        &mut where_clause,
+        resolver,
+    )?;
+
+    let (limit, offset) = body
+        .limit
+        .map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
+
+    let indexes_to_update = collect_indexes_to_update(
+        &table,
+        table_name,
+        database_id,
+        columns,
+        &set_clauses,
+        &mut read_scope_tables,
+        resolver,
+    )?;
+
+    // read_scope_tables was only used for visibility in SET clause expressions, so reconstruct
+    // target_table and from_tables here.
+    let target_table = read_scope_tables.joined_tables_mut().remove(0);
+    let from_tables = read_scope_tables;
+
+    Ok(UpdatePlan {
+        target_table,
+        from_tables,
+        or_conflict,
+        set_clauses,
+        where_clause,
+        returning: (!result_columns.is_empty()).then_some(result_columns),
+        limit,
+        offset,
+        contains_constant_false_condition: false,
+        indexes_to_update,
+        write_set_plan: None,
+        cdc_update_alter_statement: None,
+        non_from_clause_subqueries,
+        safety: DmlSafety::default(),
+    })
+}
+
+fn collect_update_set_clauses(
+    sets: &mut [ast::Set],
+    table: &Table,
+    table_name: &str,
+) -> crate::Result<Vec<UpdateSetClause>> {
     let column_lookup: HashMap<String, usize> = table
         .columns()
         .iter()
         .enumerate()
         .filter_map(|(i, col)| col.name.as_ref().map(|name| (name.to_lowercase(), i)))
         .collect();
+    let mut set_clauses: Vec<UpdateSetClause> = Vec::with_capacity(sets.len());
 
-    let mut set_clauses: Vec<(usize, Box<Expr>)> = Vec::with_capacity(body.sets.len());
+    for set in sets {
+        let expr = std::mem::replace(&mut set.expr, Box::new(Expr::Literal(ast::Literal::Null)));
+        let values = split_update_set_values(*expr, set.col_names.len())?;
 
-    // Process each SET assignment and map column names to expressions
-    // e.g the statement `SET x = 1, y = 2, z = 3` has 3 set assigments
-    for set in &mut body.sets {
-        bind_and_rewrite_expr(
-            &mut set.expr,
-            Some(&mut table_references),
-            None,
-            resolver,
-            BindingBehavior::ResultColumnsNotAllowed,
-        )?;
-
-        let values = match set.expr.as_ref() {
-            Expr::Parenthesized(vals) => vals.clone(),
-            expr => vec![expr.clone().into()],
-        };
-
-        if set.col_names.len() != values.len() {
-            bail_parse_error!(
-                "{} columns assigned {} values",
-                set.col_names.len(),
-                values.len()
-            );
-        }
-
-        for (col_name, expr) in set.col_names.iter().zip(values.iter()) {
+        for (col_name, expr) in set.col_names.iter().zip(values.into_iter()) {
+            let expr = Box::new(expr);
             let ident = normalize_ident(col_name.as_str());
 
             let col_index = match column_lookup.get(&ident) {
                 Some(idx) => {
-                    // cannot update generated columns directly
                     table.columns()[*idx].ensure_not_generated("UPDATE", col_name.as_str())?;
                     *idx
                 }
-                None => {
-                    // Check if this is the 'rowid' keyword
-                    if ROWID_STRS.iter().any(|s| s.eq_ignore_ascii_case(&ident)) {
-                        // Find the rowid alias column if it exists
-                        if let Some((idx, _col)) = table
-                            .columns()
-                            .iter()
-                            .enumerate()
-                            .find(|(_i, c)| c.is_rowid_alias())
-                        {
-                            // Use the rowid alias column index
-                            match set_clauses.iter_mut().find(|(i, _)| i == &idx) {
-                                Some((_, existing_expr)) => existing_expr.clone_from(expr),
-                                None => set_clauses.push((idx, expr.clone())),
-                            }
-                            idx
-                        } else {
-                            // No rowid alias, use sentinel value for actual rowid
-                            match set_clauses.iter_mut().find(|(i, _)| *i == ROWID_SENTINEL) {
-                                Some((_, existing_expr)) => existing_expr.clone_from(expr),
-                                None => set_clauses.push((ROWID_SENTINEL, expr.clone())),
-                            }
-                            ROWID_SENTINEL
-                        }
-                    } else {
-                        crate::bail_parse_error!("no such column: {}.{}", table_name, col_name);
-                    }
-                }
+                None if ROWID_STRS.iter().any(|s| s.eq_ignore_ascii_case(&ident)) => table
+                    .columns()
+                    .iter()
+                    .enumerate()
+                    .find(|(_i, c)| c.is_rowid_alias())
+                    .map_or(ROWID_SENTINEL, |(idx, _col)| idx),
+                None => crate::bail_parse_error!("no such column: {}.{}", table_name, col_name),
             };
-            match set_clauses.iter_mut().find(|(idx, _)| *idx == col_index) {
-                Some((_, existing_expr)) => {
-                    // When multiple SET col[n] = val for the same column are desugared,
-                    // compose them: replace the column reference in the new expression
-                    // with the existing expression, so
-                    //   col = array_set_element(col, 0, 'X')  then  col = array_set_element(col, 2, 'Z')
-                    // becomes col = array_set_element(array_set_element(col, 0, 'X'), 2, 'Z')
-                    if let Expr::FunctionCall {
-                        name,
-                        args: new_args,
-                        ..
-                    } = expr.as_ref()
-                    {
-                        if name.as_str().eq_ignore_ascii_case("array_set_element")
-                            && new_args.len() == 3
-                        {
-                            let mut composed_args = new_args.clone();
-                            composed_args[0].clone_from(existing_expr);
-                            *existing_expr = Box::new(Expr::FunctionCall {
-                                name: name.clone(),
-                                distinctness: None,
-                                args: composed_args,
-                                order_by: vec![],
-                                filter_over: turso_parser::ast::FunctionTail {
-                                    filter_clause: None,
-                                    over_clause: None,
-                                },
-                            });
-                        } else {
-                            existing_expr.clone_from(expr);
-                        }
-                    } else {
-                        existing_expr.clone_from(expr);
-                    }
-                }
-                None => set_clauses.push((col_index, expr.clone())),
+
+            match set_clauses
+                .iter_mut()
+                .find(|set| set.column_index == col_index)
+            {
+                Some(existing) => compose_update_set_clause(existing, expr),
+                None => set_clauses.push(UpdateSetClause::new(col_index, expr)),
             }
         }
     }
 
-    // Plan subqueries in RETURNING expressions before processing
-    // (so SubqueryResult nodes are cloned into result_columns)
-    let mut non_from_clause_subqueries = vec![];
-    plan_subqueries_from_returning(
-        program,
-        &mut non_from_clause_subqueries,
-        &mut table_references,
-        &mut body.returning,
-        resolver,
-        connection,
-    )?;
+    Ok(set_clauses)
+}
 
-    let result_columns =
-        process_returning_clause(&mut body.returning, &mut table_references, resolver)?;
+fn compose_update_set_clause(existing: &mut UpdateSetClause, expr: Box<Expr>) {
+    if let Expr::FunctionCall {
+        name,
+        args: new_args,
+        ..
+    } = expr.as_ref()
+    {
+        if name.as_str().eq_ignore_ascii_case("array_set_element") && new_args.len() == 3 {
+            let mut composed_args = new_args.clone();
+            composed_args[0].clone_from(&existing.expr);
+            existing.expr = Box::new(Expr::FunctionCall {
+                name: name.clone(),
+                distinctness: None,
+                args: composed_args,
+                order_by: vec![],
+                filter_over: turso_parser::ast::FunctionTail {
+                    filter_clause: None,
+                    over_clause: None,
+                },
+            });
+            return;
+        }
+    }
 
-    let order_by = body
-        .order_by
-        .iter_mut()
-        .map(|o| {
-            let _ = bind_and_rewrite_expr(
-                &mut o.expr,
-                Some(&mut table_references),
-                Some(&result_columns),
-                resolver,
-                BindingBehavior::ResultColumnsNotAllowed,
-            );
-            (o.expr.clone(), o.order.unwrap_or(SortOrder::Asc), o.nulls)
-        })
-        .collect();
+    existing.expr = expr;
+}
 
-    // Sqlite determines we should create an ephemeral table if we do not have a FROM clause
-    // Difficult to say what items from the plan can be checked for this so currently just checking if a RowId Alias is referenced
-    // https://github.com/sqlite/sqlite/blob/master/src/update.c#L395
-    // https://github.com/sqlite/sqlite/blob/master/src/update.c#L670
-    let columns = table.columns();
-    let mut where_clause = vec![];
-    // Parse the WHERE clause
-    parse_where(
-        body.where_clause.as_deref(),
-        &mut table_references,
-        Some(&result_columns),
-        &mut where_clause,
-        resolver,
-    )?;
-
-    // Parse the LIMIT/OFFSET clause
-    let (limit, offset) = body
-        .limit
-        .map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
-
-    // Determine which indexes need updating
+fn collect_indexes_to_update(
+    table: &Table,
+    table_name: &str,
+    database_id: usize,
+    columns: &[crate::schema::Column],
+    set_clauses: &[UpdateSetClause],
+    read_scope_tables: &mut TableReferences,
+    resolver: &Resolver,
+) -> crate::Result<Vec<Arc<crate::schema::Index>>> {
     let indexes: Vec<_> = resolver.with_schema(database_id, |s| {
         s.get_indices(table_name).cloned().collect()
     });
-    let target_table_ref = table_references
+    let target_table_ref = read_scope_tables
         .joined_tables()
         .first()
         .expect("UPDATE must have a target table reference");
     let target_table_internal_id = target_table_ref.internal_id;
-    let target_table_ref = target_table_ref.clone();
-    let rowid_alias_used = set_clauses
-        .iter()
-        .any(|(idx, _)| *idx == ROWID_SENTINEL || columns[*idx].is_rowid_alias());
+    let rowid_alias_used = set_clauses.iter().any(|set| {
+        set.column_index == ROWID_SENTINEL || columns[set.column_index].is_rowid_alias()
+    });
     let updated_cols: Option<ColumnMask> =
-        (!rowid_alias_used).then(|| set_clauses.iter().map(|(i, _)| *i).collect());
+        (!rowid_alias_used).then(|| set_clauses.iter().map(|set| set.column_index).collect());
     let affected_cols = match (table.btree(), updated_cols.as_ref()) {
         (Some(bt), Some(updated)) => Some(bt.columns_affected_by_update(updated)?),
         (None, Some(updated)) => Some(updated.clone()),
         _ => None,
     };
     let mut indexes_to_update = Vec::new();
+    let mut columns_to_mark_used = Vec::new();
 
     for idx in indexes {
         let mut must_update = rowid_alias_used;
@@ -456,9 +570,7 @@ pub fn prepare_update_plan(
         for col in idx.columns.iter() {
             if let Some(expr) = col.expr.as_ref() {
                 let cols_used =
-                    expression_index_column_usage(expr.as_ref(), &target_table_ref, resolver)?;
-                // if it turns out that we need to update the index, we'll need to use all columns
-                // that are used by indexed expressions
+                    expression_index_column_usage(expr.as_ref(), target_table_ref, resolver)?;
                 expression_cols_used |= &cols_used;
 
                 if !must_update
@@ -466,7 +578,6 @@ pub fn prepare_update_plan(
                         cols_used.iter().any(|cidx| affected_cols.get(cidx))
                     })
                 {
-                    // an index must be updated if any of the affected columns is used in an indexed expression
                     must_update = true;
                 }
             } else if !must_update
@@ -474,19 +585,14 @@ pub fn prepare_update_plan(
                     .as_ref()
                     .is_some_and(|affected_cols| affected_cols.get(col.pos_in_table))
             {
-                // an index must be updated if any of its columns is affected by the update
                 must_update = true;
             }
         }
 
         if !must_update {
             if let Some(where_expr) = &idx.where_clause {
-                let cols_used = expression_index_column_usage(
-                    where_expr.as_ref(),
-                    &target_table_ref,
-                    resolver,
-                )?;
-                // a partial index must be updated if any column of its WHERE clause is affected
+                let cols_used =
+                    expression_index_column_usage(where_expr.as_ref(), target_table_ref, resolver)?;
                 must_update = affected_cols.as_ref().is_some_and(|affected_cols| {
                     cols_used.iter().any(|cidx| affected_cols.get(cidx))
                 });
@@ -494,10 +600,7 @@ pub fn prepare_update_plan(
         }
 
         if must_update {
-            // mark as used dependencies of expression indexes
-            for col_idx in expression_cols_used.iter() {
-                table_references.mark_column_used(target_table_internal_id, col_idx);
-            }
+            columns_to_mark_used.extend(expression_cols_used.iter());
             // mark as used dependencies of virtual columns
             if let Some(btree) = target_table_ref.table.btree() {
                 let virtual_cols_in_index = idx
@@ -507,43 +610,75 @@ pub fn prepare_update_plan(
                     .map(|c| c.pos_in_table)
                     .filter(|&pos| btree.columns()[pos].is_virtual_generated());
                 let deps = btree.dependencies_of_columns(virtual_cols_in_index)?;
-                for dep_idx in deps.iter() {
-                    table_references.mark_column_used(target_table_internal_id, dep_idx);
-                }
+                columns_to_mark_used.extend(deps.iter());
             }
             indexes_to_update.push(idx);
         }
     }
 
-    Ok(Plan::Update(Box::new(UpdatePlan {
-        table_references,
-        or_conflict,
-        set_clauses,
-        where_clause,
-        returning: if result_columns.is_empty() {
-            None
-        } else {
-            Some(result_columns)
-        },
-        order_by,
-        limit,
-        offset,
-        contains_constant_false_condition: false,
-        indexes_to_update,
-        ephemeral_plan: None,
-        cdc_update_alter_statement: None,
-        non_from_clause_subqueries,
-        safety: DmlSafety::default(),
-    })))
+    for col_idx in columns_to_mark_used {
+        read_scope_tables.mark_column_used(target_table_internal_id, col_idx);
+    }
+
+    Ok(indexes_to_update)
 }
 
-fn build_scan_op(table: &Table, iter_dir: IterationDirection) -> Operation {
-    match table {
-        Table::BTree(_) => Operation::Scan(Scan::BTreeTable {
-            iter_dir,
-            index: None,
-        }),
-        Table::Virtual(_) => Operation::default_scan_for(table),
-        _ => unreachable!(),
+/// Proactive column-ambiguity check for UPDATE FROM.
+///
+/// SQLite rejects UPDATE FROM when a NATURAL JOIN (or USING) introduces a column
+/// name that also exists in another FROM-side table without deduplication. In a
+/// regular SELECT this is only caught when an unqualified reference is resolved,
+/// but UPDATE FROM checks it eagerly regardless of whether the column is referenced.
+fn check_update_from_column_ambiguity(
+    joined_tables: &[JoinedTable],
+    connection: &Connection,
+) -> crate::Result<()> {
+    for (i, table) in joined_tables.iter().enumerate() {
+        let using = match &table.join_info {
+            Some(info) if !info.using.is_empty() => &info.using,
+            _ => continue,
+        };
+        if joined_tables[..i]
+            .iter()
+            .any(|preceding| preceding.identifier == table.identifier)
+        {
+            let db_name = connection
+                .get_database_name_by_index(table.database_id)
+                .unwrap_or_else(|| "main".to_string());
+            bail_parse_error!(
+                "ambiguous column name: {db_name}.{}._ROWID_",
+                table.identifier
+            );
+        }
+        for using_col in using {
+            let col_name = normalize_ident(using_col.as_str());
+            // Count how many preceding FROM-side tables expose this column
+            // without it already being deduplicated by their own USING clause.
+            let mut found_count = 0usize;
+            for preceding in &joined_tables[..i] {
+                let has_col = preceding.columns().iter().any(|c| {
+                    c.name
+                        .as_ref()
+                        .is_some_and(|n| n.eq_ignore_ascii_case(&col_name))
+                });
+                if !has_col {
+                    continue;
+                }
+                // If this preceding table's own USING already covers the column,
+                // it was deduplicated by an earlier NATURAL/USING JOIN — skip it.
+                let already_deduped = preceding.join_info.as_ref().is_some_and(|info| {
+                    info.using
+                        .iter()
+                        .any(|u| u.as_str().eq_ignore_ascii_case(&col_name))
+                });
+                if !already_deduped {
+                    found_count += 1;
+                }
+            }
+            if found_count > 1 {
+                bail_parse_error!("ambiguous column name: {}", using_col.as_str());
+            }
+        }
     }
+    Ok(())
 }

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -802,6 +802,7 @@ pub fn emit_upsert(
     } else {
         None
     };
+    let updated_positions: ColumnMask = set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
     if let Some(bt) = table.btree() {
         if connection.foreign_keys_enabled() {
             let rowid_new_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
@@ -841,7 +842,7 @@ pub fn emit_upsert(
                 new_start,
                 new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg),
                 rowid_set_clause_reg,
-                set_pairs,
+                &updated_positions,
                 ParentKeyNewProbeMode::BeforeWrite,
                 upsert_database_id,
                 resolver,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1077,6 +1077,8 @@ pub fn op_open_read(
         insn
     );
 
+    invalidate_deferred_seeks_for_cursor(state, *cursor_id);
+
     let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
 
@@ -10285,6 +10287,7 @@ pub fn op_open_write(
         },
         insn
     );
+    invalidate_deferred_seeks_for_cursor(state, *cursor_id);
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
@@ -10452,6 +10455,22 @@ pub fn op_copy(
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
+}
+
+/// Reopening a cursor slot invalidates any deferred seek that points to it or
+/// uses it as the driving index cursor. For example, UPDATE ... FROM may use a
+/// target-table cursor in the collection phase behind a DeferredSeek, then
+/// reopen that same slot for the write phase. If the stale deferred seek
+/// survives, the first Column/RowId read in the write loop can jump back to the
+/// collection-phase index cursor and read the wrong row.
+fn invalidate_deferred_seeks_for_cursor(state: &mut ProgramState, cursor_id: usize) {
+    for deferred_seek in &mut state.deferred_seeks {
+        if let Some(ds) = deferred_seek {
+            if ds.index_cursor_id == cursor_id || ds.table_cursor_id == cursor_id {
+                *deferred_seek = None;
+            }
+        }
+    }
 }
 
 pub fn op_create_btree(
@@ -11828,15 +11847,7 @@ pub fn op_open_ephemeral(
             let btree_cursor = cursor.as_btree_mut();
             btree_cursor.set_null_flag(false);
             return_if_io!(btree_cursor.clear_btree());
-            // iterate over existing deferred seeks and clear them as well,
-            // as any deferred seek on this cursor is now invalid.
-            for deferred_seek in &mut state.deferred_seeks {
-                if let Some(ds) = deferred_seek {
-                    if ds.index_cursor_id == cursor_id || ds.table_cursor_id == cursor_id {
-                        *deferred_seek = None;
-                    }
-                }
-            }
+            invalidate_deferred_seeks_for_cursor(state, cursor_id);
             *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::RewindExisting;
         }
         OpOpenEphemeralState::RewindExisting => {

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -13,6 +13,7 @@ use sql_gen::{Full, Policy, SqlGen, StmtKind};
 pub struct GeneratedStatement {
     pub sql: String,
     pub is_ddl: bool,
+    pub mutates_data: bool,
     pub has_unordered_limit: bool,
     pub unordered_limit_reason: Option<String>,
 }
@@ -55,19 +56,28 @@ impl SqlGenBackend {
         let ctx = sql_gen::Context::new_with_seed(seed);
         let mut policy = Policy::default()
             .with_stmt_weights(sql_gen::StmtWeights {
+                update: 30,
                 ..sql_gen::StmtWeights::default()
             })
             .with_function_config(
                 sql_gen::FunctionConfig::deterministic().disable(&["LIKELY", "UNLIKELY"]),
             );
         policy.select_config.require_order_by_with_limit = true;
-        // Disable expression values and conflict clauses for now
+        // Disable expression values for inserts, enable conflict clauses for updates
         policy.insert_config.expression_value_probability = 0.0;
         policy.insert_config.or_replace_probability = 0.0;
         policy.insert_config.or_ignore_probability = 0.0;
         policy.update_config.expression_value_probability = 0.0;
-        policy.update_config.or_replace_probability = 0.0;
-        policy.update_config.or_ignore_probability = 0.0;
+        policy.update_config.or_replace_probability = 0.1;
+        policy.update_config.or_ignore_probability = 0.1;
+        // Boost UPDATE FROM coverage
+        policy.update_config.from_probability = 0.4;
+        policy.update_config.returning_probability = 0.2;
+        policy.update_config.self_join_probability = 0.3;
+        policy.update_config.join_in_from_probability = 0.3;
+        policy.update_config.subquery_from_probability = 0.15;
+        policy.update_config.target_alias_probability = 0.2;
+        policy.update_config.from_set_reference_probability = 0.5;
         Self { ctx, policy }
     }
 }
@@ -79,7 +89,12 @@ impl SqlGenerator for SqlGenBackend {
             .statement(&mut self.ctx)
             .map_err(|e| anyhow::anyhow!("Failed to generate statement: {e}"))?;
         let sql = stmt.to_string();
-        let is_ddl = StmtKind::from(&stmt).is_ddl();
+        let stmt_kind = StmtKind::from(&stmt);
+        let is_ddl = stmt_kind.is_ddl();
+        let mutates_data = matches!(
+            stmt_kind,
+            StmtKind::Insert | StmtKind::Update | StmtKind::Delete
+        );
         let has_unordered_limit =
             stmt.has_unordered_limit() || stmt.non_unique_order_by_reason(schema).is_some();
         let unordered_limit_reason = stmt
@@ -89,6 +104,7 @@ impl SqlGenerator for SqlGenBackend {
         Ok(GeneratedStatement {
             sql,
             is_ddl,
+            mutates_data,
             has_unordered_limit,
             unordered_limit_reason,
         })
@@ -136,11 +152,19 @@ impl SqlGenerator for PropTestBackend {
             .map_err(|e| anyhow::anyhow!("Failed to generate statement: {e}"))?;
         let stmt = value_tree.current();
         let sql = stmt.to_string();
-        let is_ddl = sql_gen_prop::StatementKind::from(&stmt).is_ddl();
+        let stmt_kind = sql_gen_prop::StatementKind::from(&stmt);
+        let is_ddl = stmt_kind.is_ddl();
+        let mutates_data = matches!(
+            stmt_kind,
+            sql_gen_prop::StatementKind::Insert
+                | sql_gen_prop::StatementKind::Update
+                | sql_gen_prop::StatementKind::Delete
+        );
         let has_unordered_limit = stmt.has_unordered_limit();
         Ok(GeneratedStatement {
             sql,
             is_ddl,
+            mutates_data,
             has_unordered_limit,
             unordered_limit_reason: None,
         })

--- a/testing/differential-oracle/fuzzer/oracle.rs
+++ b/testing/differential-oracle/fuzzer/oracle.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use anyhow::Result;
+use sql_gen::Schema;
 use sql_gen_prop::SqlValue;
 use sql_gen_prop::result::diff_results;
 use turso_core::{Numeric, Value};
@@ -298,26 +299,107 @@ impl DifferentialOracle {
             Some(rusqlite::types::ValueRef::Blob(b)) => SqlValue::Blob(b.to_vec()),
         }
     }
+
+    fn snapshot_query(table: &sql_gen::Table) -> String {
+        format!(
+            "SELECT rowid, * FROM {} ORDER BY rowid",
+            table.qualified_name()
+        )
+    }
+
+    fn verify_table_snapshots(
+        turso_conn: &Arc<turso_core::Connection>,
+        sqlite_conn: &rusqlite::Connection,
+        schema: &Schema,
+        stmt: &GeneratedStatement,
+    ) -> OracleResult {
+        for table in &schema.tables {
+            let snapshot_sql = Self::snapshot_query(table);
+            let turso_rows = Self::execute_turso(turso_conn, &snapshot_sql);
+            let sqlite_rows = Self::execute_sqlite(sqlite_conn, &snapshot_sql);
+            match (turso_rows, sqlite_rows) {
+                (QueryResult::Rows(turso_rows), QueryResult::Rows(sqlite_rows)) => {
+                    let diff = diff_results(&turso_rows, &sqlite_rows);
+                    if !diff.is_empty() {
+                        return OracleResult::Fail(format!(
+                            "Post-DML table snapshot mismatch for {}:\n  SQL: {stmt}\n  Only in Turso: {:?}\n  Only in SQLite: {:?}",
+                            table.qualified_name(),
+                            diff.only_in_first,
+                            diff.only_in_second
+                        ));
+                    }
+                }
+                (QueryResult::Ok, QueryResult::Ok) => {}
+                (QueryResult::Error(turso_err), QueryResult::Error(sqlite_err)) => {
+                    return OracleResult::Fail(format!(
+                        "Post-DML snapshot failed on both engines for {}:\n  SQL: {stmt}\n  Turso: {turso_err}\n  SQLite: {sqlite_err}",
+                        table.qualified_name()
+                    ));
+                }
+                (QueryResult::Error(turso_err), _) => {
+                    return OracleResult::Fail(format!(
+                        "Turso snapshot failed for {} after DML:\n  SQL: {stmt}\n  Error: {turso_err}",
+                        table.qualified_name()
+                    ));
+                }
+                (_, QueryResult::Error(sqlite_err)) => {
+                    return OracleResult::Fail(format!(
+                        "SQLite snapshot failed for {} after DML:\n  SQL: {stmt}\n  Error: {sqlite_err}",
+                        table.qualified_name()
+                    ));
+                }
+                (QueryResult::Rows(turso_rows), QueryResult::Ok) => {
+                    if !turso_rows.is_empty() {
+                        return OracleResult::Fail(format!(
+                            "Turso snapshot returned rows for {} but SQLite returned none:\n  SQL: {stmt}",
+                            table.qualified_name()
+                        ));
+                    }
+                }
+                (QueryResult::Ok, QueryResult::Rows(sqlite_rows)) => {
+                    if !sqlite_rows.is_empty() {
+                        return OracleResult::Fail(format!(
+                            "SQLite snapshot returned rows for {} but Turso returned none:\n  SQL: {stmt}",
+                            table.qualified_name()
+                        ));
+                    }
+                }
+            }
+        }
+
+        OracleResult::Pass
+    }
 }
 
 /// Execute a statement on both databases and check the differential oracle.
 pub fn check_differential(
     turso_conn: &Arc<turso_core::Connection>,
     sqlite_conn: &rusqlite::Connection,
+    schema: &Schema,
     stmt: &GeneratedStatement,
 ) -> OracleResult {
     let turso_result = DifferentialOracle::execute_turso(turso_conn, &stmt.sql);
     let sqlite_result = DifferentialOracle::execute_sqlite(sqlite_conn, &stmt.sql);
 
     let oracle = DifferentialOracle;
-    oracle.check(stmt, &turso_result, &sqlite_result)
+    let direct_result = oracle.check(stmt, &turso_result, &sqlite_result);
+    if !stmt.mutates_data || !direct_result.is_pass() {
+        return direct_result;
+    }
+
+    DifferentialOracle::verify_table_snapshots(turso_conn, sqlite_conn, schema, stmt)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use core::f64;
 
     use super::*;
+    use crate::memory::MemorySimIO;
+    use sql_gen::{ColumnDef, DataType, SchemaBuilder, Table};
+    use turso_core::Database;
 
     #[test]
     fn test_sql_value_equality() {
@@ -354,6 +436,7 @@ mod tests {
         let stmt = GeneratedStatement {
             sql: "SELECT 1 LIMIT 1".to_string(),
             is_ddl: false,
+            mutates_data: false,
             has_unordered_limit: true,
             unordered_limit_reason: Some("limit_order_by_scalar_subquery".to_string()),
         };
@@ -372,5 +455,63 @@ mod tests {
             }
             other => panic!("expected warning, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_check_differential_fails_on_hidden_table_state_mismatch() {
+        let io = Arc::new(MemorySimIO::new(123));
+        let turso_db = Database::open_file_with_flags(
+            io,
+            "oracle-state-mismatch.db",
+            turso_core::OpenFlags::default(),
+            turso_core::DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        let turso_conn = turso_db.connect().unwrap();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "t",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("v", DataType::Integer),
+                ],
+            ))
+            .build();
+
+        for sql in [
+            "CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER)",
+            "INSERT INTO t VALUES (1, 10)",
+        ] {
+            assert!(matches!(
+                DifferentialOracle::execute_turso(&turso_conn, sql),
+                QueryResult::Ok
+            ));
+            assert!(matches!(
+                DifferentialOracle::execute_sqlite(&sqlite_conn, sql),
+                QueryResult::Ok
+            ));
+        }
+
+        assert!(matches!(
+            DifferentialOracle::execute_turso(&turso_conn, "UPDATE t SET v = 11 WHERE id = 1"),
+            QueryResult::Ok
+        ));
+
+        let stmt = GeneratedStatement {
+            sql: "UPDATE t SET v = v WHERE id = 999".to_string(),
+            is_ddl: false,
+            mutates_data: true,
+            has_unordered_limit: false,
+            unordered_limit_reason: None,
+        };
+
+        let result = check_differential(&turso_conn, &sqlite_conn, &schema, &stmt);
+        assert!(
+            result.is_fail(),
+            "post-DML state verification should catch hidden row mismatches"
+        );
     }
 }

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -366,7 +366,7 @@ impl Fuzzer {
             }));
 
             let oracle_result = std::panic::catch_unwind(|| {
-                check_differential(&self.turso_conn, &self.sqlite_conn, &stmt)
+                check_differential(&self.turso_conn, &self.sqlite_conn, &schema, &stmt)
             });
 
             std::panic::set_hook(prev_hook);

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -993,9 +993,13 @@ impl fmt::Display for InsertStmt {
 pub struct UpdateStmt {
     pub with_clause: Option<WithClause>,
     pub table: String,
+    pub alias: Option<String>,
     pub sets: Vec<(String, Expr)>,
+    pub from: Option<FromClause>,
+    pub joins: Vec<JoinClause>,
     pub where_clause: Option<Expr>,
     pub conflict: Option<ConflictClause>,
+    pub returning: Option<Vec<Expr>>,
 }
 
 impl fmt::Display for UpdateStmt {
@@ -1007,7 +1011,11 @@ impl fmt::Display for UpdateStmt {
         if let Some(conflict) = &self.conflict {
             write!(f, "{conflict}")?;
         }
-        write!(f, " {} SET ", self.table)?;
+        write!(f, " {}", self.table)?;
+        if let Some(alias) = &self.alias {
+            write!(f, " AS {alias}")?;
+        }
+        write!(f, " SET ")?;
 
         for (i, (col, val)) in self.sets.iter().enumerate() {
             if i > 0 {
@@ -1016,8 +1024,40 @@ impl fmt::Display for UpdateStmt {
             write!(f, "{col} = {val}")?;
         }
 
+        if let Some(from) = &self.from {
+            write!(f, " FROM {}", from.table)?;
+            if let Some(alias) = &from.alias {
+                write!(f, " AS {alias}")?;
+            }
+        }
+
+        for join in &self.joins {
+            match join.join_type {
+                JoinType::Inner => write!(f, " JOIN {}", join.table)?,
+                JoinType::Left => write!(f, " LEFT JOIN {}", join.table)?,
+                JoinType::Cross => write!(f, " CROSS JOIN {}", join.table)?,
+                JoinType::Natural => write!(f, " NATURAL JOIN {}", join.table)?,
+            }
+            if let Some(alias) = &join.alias {
+                write!(f, " AS {alias}")?;
+            }
+            if let Some(JoinConstraint::On(expr)) = &join.constraint {
+                write!(f, " ON {expr}")?;
+            }
+        }
+
         if let Some(where_clause) = &self.where_clause {
             write!(f, " WHERE {where_clause}")?;
+        }
+
+        if let Some(returning) = &self.returning {
+            write!(f, " RETURNING ")?;
+            for (i, expr) in returning.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{expr}")?;
+            }
         }
 
         Ok(())

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -827,7 +827,7 @@ fn select_nulls_order(
 /// Picks a random number of joins (1..=max_joins), selects join types by weight,
 /// and generates ON conditions for INNER/LEFT joins. Each joined table is pushed
 /// into the current scope before generating its ON condition.
-fn generate_join_clauses<C: Capabilities>(
+pub(crate) fn generate_join_clauses<C: Capabilities>(
     generator: &SqlGen<C>,
     ctx: &mut Context,
 ) -> Result<Vec<JoinClause>, GenError> {
@@ -945,7 +945,7 @@ fn generate_join_clauses<C: Capabilities>(
 /// using compatible columns. Otherwise generates a general boolean expression.
 /// Both tables are read from the current scope: the primary table is `[0]` and the
 /// just-pushed joined table is the last entry.
-fn generate_join_on_condition<C: Capabilities>(
+pub(crate) fn generate_join_on_condition<C: Capabilities>(
     generator: &SqlGen<C>,
     ctx: &mut Context,
 ) -> Result<Expr, GenError> {

--- a/testing/differential-oracle/sql_gen/src/generate/stmt.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/stmt.rs
@@ -381,7 +381,44 @@ pub fn generate_update<C: Capabilities>(
         return Err(GenError::schema_empty("columns"));
     }
 
-    ctx.with_table_scope([(table.clone(), None)], |ctx| {
+    let from_result = if ctx.gen_bool_with_prob(update_config.from_probability) {
+        generate_update_from(generator, ctx, &table)?
+    } else {
+        None
+    };
+
+    // Target table alias (UPDATE t AS x SET x.col = ...) — only when FROM is present
+    let target_alias = if from_result.is_some()
+        && ctx.gen_bool_with_prob(update_config.target_alias_probability)
+    {
+        Some(ctx.next_table_alias())
+    } else {
+        None
+    };
+
+    // Build the scope: target table (with optional alias), FROM table, JOIN tables
+    let mut scope_tables = vec![(table.clone(), target_alias.clone())];
+    let mut from_table_for_scope = None;
+    let (from_clause, joins) = if let Some(ref result) = from_result {
+        from_table_for_scope = Some(result.from_table.clone());
+        scope_tables.push((result.from_table.clone(), result.from_clause.alias.clone()));
+        // Add any JOIN tables to scope
+        for join in &result.joins {
+            if let Some(join_table) = generator
+                .schema()
+                .tables
+                .iter()
+                .find(|t| t.qualified_name() == join.table)
+            {
+                scope_tables.push((join_table.clone(), join.alias.clone()));
+            }
+        }
+        (Some(result.from_clause.clone()), result.joins.clone())
+    } else {
+        (None, vec![])
+    };
+
+    ctx.with_table_scope(scope_tables, |ctx| {
         // Generate conflict clause
         let conflict = generate_conflict_clause(
             ctx,
@@ -393,28 +430,39 @@ pub fn generate_update<C: Capabilities>(
         let sets = generate_update_sets(generator, ctx)?;
 
         // Generate optional WHERE clause
-        let where_clause = if ctx.gen_bool_with_prob(update_config.where_probability) {
-            Some(generate_condition(generator, ctx)?)
+        let where_clause =
+            if let (Some(fc), Some(from_table)) = (&from_clause, &from_table_for_scope) {
+                generate_update_from_where_clause(
+                    generator,
+                    ctx,
+                    &table,
+                    from_table,
+                    fc.alias.as_deref(),
+                    update_config.where_probability,
+                )?
+            } else if ctx.gen_bool_with_prob(update_config.where_probability) {
+                Some(generate_condition(generator, ctx)?)
+            } else {
+                None
+            };
+
+        // --- RETURNING ---
+        let returning = if ctx.gen_bool_with_prob(update_config.returning_probability) {
+            generate_update_returning(generator, ctx).ok()
         } else {
             None
         };
 
-        // --- UPDATE ... FROM (not yet implemented) ---
-        if ctx.gen_bool_with_prob(update_config.from_probability) {
-            let _ = generate_update_from(generator, ctx);
-        }
-
-        // --- RETURNING (not yet implemented) ---
-        if ctx.gen_bool_with_prob(update_config.returning_probability) {
-            let _ = generate_update_returning(generator, ctx);
-        }
-
         Ok(Stmt::Update(UpdateStmt {
             with_clause: with_clause.clone(),
             table: table.qualified_name(),
+            alias: target_alias.clone(),
             sets,
+            from: from_clause.clone(),
+            joins: joins.clone(),
             where_clause,
             conflict,
+            returning,
         }))
     })
 }
@@ -425,6 +473,10 @@ pub fn generate_update<C: Capabilities>(
 /// probability controlled by `UpdateConfig::primary_key_update_probability`.
 /// Each assignment value may be an expression (with column refs enabled, so
 /// `SET x = x + 1` is valid) controlled by `UpdateConfig::expression_value_probability`.
+///
+/// When a FROM clause is active (multiple tables in scope), SET values may
+/// reference FROM-side columns (e.g. `SET x = src.y`), controlled by
+/// `UpdateConfig::from_set_reference_probability`.
 #[trace_gen(Origin::UpdateSet)]
 fn generate_update_sets<C: Capabilities>(
     generator: &SqlGen<C>,
@@ -434,9 +486,20 @@ fn generate_update_sets<C: Capabilities>(
     let pk_prob = update_config.primary_key_update_probability;
     let expr_prob = update_config.expression_value_probability;
     let expr_max_depth = update_config.expression_value_max_depth;
+    let from_ref_prob = update_config.from_set_reference_probability;
 
     // Read table columns from scope
     let table_columns = ctx.tables_in_scope()[0].table.columns.clone();
+
+    // Collect FROM-side tables for cross-table references
+    let from_tables: Vec<_> = if ctx.tables_in_scope().len() > 1 {
+        ctx.tables_in_scope()[1..]
+            .iter()
+            .map(|st| (st.qualifier.clone(), st.table.columns.clone()))
+            .collect()
+    } else {
+        vec![]
+    };
 
     // Build candidate columns: always include non-PK, include PK with probability
     let candidates: Vec<_> = table_columns
@@ -506,6 +569,15 @@ fn generate_update_sets<C: Capabilities>(
             continue;
         }
 
+        // When FROM is active, try referencing a FROM-side column
+        if !from_tables.is_empty() && ctx.gen_bool_with_prob(from_ref_prob) {
+            if let Some(expr) = generate_from_column_ref(ctx, col, &from_tables, generator.policy())
+            {
+                sets.push((col.name.clone(), expr));
+                continue;
+            }
+        }
+
         if let Some(ref expr_gen) = update_expr_gen {
             if ctx.gen_bool_with_prob(expr_prob) {
                 if let Ok(expr) = generate_expr(expr_gen, ctx, 0) {
@@ -519,6 +591,51 @@ fn generate_update_sets<C: Capabilities>(
     }
 
     Ok(sets)
+}
+
+/// Generate a column reference from a FROM-side table for use in a SET clause.
+///
+/// Tries to find a type-compatible column from one of the FROM tables. Falls back
+/// to any column if no exact type match exists. Returns None if no columns available.
+fn generate_from_column_ref(
+    ctx: &mut Context,
+    target_col: &crate::schema::ColumnDef,
+    from_tables: &[(String, Vec<crate::schema::ColumnDef>)],
+    policy: &crate::policy::Policy,
+) -> Option<Expr> {
+    // Pick a random FROM table
+    let (qualifier, columns) = ctx.choose(from_tables)?;
+    if columns.is_empty() {
+        return None;
+    }
+
+    // Try to find a type-compatible column
+    let compatible: Vec<_> = columns
+        .iter()
+        .filter(|c| c.data_type == target_col.data_type && !c.data_type.is_array())
+        .collect();
+    let non_array: Vec<_> = columns.iter().filter(|c| !c.data_type.is_array()).collect();
+    let source_col = if compatible.is_empty() {
+        // Fall back to any non-array column
+        ctx.choose(&non_array)?
+    } else {
+        ctx.choose(&compatible)?
+    };
+
+    // 50% bare ref, 50% expression wrapping the ref (e.g. src.col + 1)
+    let col_ref = Expr::column_ref(ctx, Some(qualifier.clone()), source_col.name.clone());
+    if ctx.gen_bool_with_prob(0.5) {
+        Some(col_ref)
+    } else {
+        let lit = generate_literal(ctx, source_col.data_type, policy);
+        let lit_expr = Expr::literal(ctx, lit);
+        let op = if source_col.data_type == DataType::Text {
+            BinOp::Concat
+        } else {
+            *ctx.choose(&[BinOp::Add, BinOp::Sub, BinOp::Mul]).unwrap()
+        };
+        Some(Expr::binary_op(ctx, col_ref, op, lit_expr))
+    }
 }
 
 /// Generate an optional conflict clause (OR ABORT/FAIL/IGNORE/REPLACE/ROLLBACK).
@@ -1219,20 +1336,154 @@ fn generate_insert_returning<C: Capabilities>(
 
 // ---- UPDATE features ----
 
+/// Generate the FROM clause for an UPDATE ... FROM statement.
+///
+/// Supports self-join (target table with mandatory alias), other tables, and
+/// optional JOINs after the FROM table. Returns the FromClause, any JoinClauses,
+/// and the list of tables to push into scope.
 #[trace_gen(Origin::UpdateFrom)]
 fn generate_update_from<C: Capabilities>(
-    _generator: &SqlGen<C>,
-    _ctx: &mut Context,
-) -> Result<(), GenError> {
-    todo!("UPDATE ... FROM generation")
+    generator: &SqlGen<C>,
+    ctx: &mut Context,
+    target_table: &crate::schema::Table,
+) -> Result<Option<UpdateFromResult>, GenError> {
+    let update_config = &generator.policy().update_config;
+    let schema_tables = &generator.schema().tables;
+
+    // Decide: self-join (FROM target AS alias) or a different table
+    let is_self_join = ctx.gen_bool_with_prob(update_config.self_join_probability);
+
+    let from_table = if is_self_join {
+        target_table.clone()
+    } else {
+        let candidates: Vec<_> = schema_tables
+            .iter()
+            .filter(|t| t.qualified_name() != target_table.qualified_name())
+            .cloned()
+            .collect();
+        match ctx.choose(&candidates).cloned() {
+            Some(t) => t,
+            None => return Ok(None),
+        }
+    };
+
+    // Self-joins and same-name tables require an alias to avoid ambiguity
+    let needs_alias = is_self_join
+        || from_table.name == target_table.name
+        || (generator.policy().identifier_config.generate_table_aliases
+            && ctx.gen_bool_with_prob(generator.policy().select_config.table_alias_probability));
+    let use_subquery_source = ctx.gen_bool_with_prob(update_config.subquery_from_probability);
+    let alias = if needs_alias || use_subquery_source {
+        Some(ctx.next_table_alias())
+    } else {
+        None
+    };
+
+    let from_clause = crate::ast::FromClause {
+        table: if use_subquery_source {
+            format!("(SELECT * FROM {})", from_table.qualified_name())
+        } else {
+            from_table.qualified_name()
+        },
+        alias: alias.clone(),
+    };
+
+    // Optionally generate JOINs after the FROM table
+    let joins = if ctx.gen_bool_with_prob(update_config.join_in_from_probability) {
+        // Push the FROM table into scope so generate_join_clauses can see it as [0]
+        let from_scope = vec![(from_table.clone(), alias)];
+        ctx.with_table_scope(from_scope, |ctx| {
+            super::select::generate_join_clauses(generator, ctx)
+        })?
+    } else {
+        vec![]
+    };
+
+    Ok(Some(UpdateFromResult {
+        from_clause,
+        from_table,
+        joins,
+    }))
 }
 
+/// Result of generating an UPDATE ... FROM clause.
+struct UpdateFromResult {
+    from_clause: crate::ast::FromClause,
+    from_table: crate::schema::Table,
+    joins: Vec<crate::ast::JoinClause>,
+}
+
+fn generate_update_from_where_clause<C: Capabilities>(
+    generator: &SqlGen<C>,
+    ctx: &mut Context,
+    target_table: &crate::schema::Table,
+    from_table: &crate::schema::Table,
+    from_alias: Option<&str>,
+    extra_where_probability: f64,
+) -> Result<Option<Expr>, GenError> {
+    let target_qualifier = Some(target_table.name.clone());
+    let source_qualifier = Some(
+        from_alias
+            .map(str::to_string)
+            .unwrap_or_else(|| from_table.name.clone()),
+    );
+    let comparable_pairs: Vec<_> = target_table
+        .columns
+        .iter()
+        .filter(|target_col| !target_col.data_type.is_array())
+        .flat_map(|target_col| {
+            from_table
+                .columns
+                .iter()
+                .filter(move |source_col| {
+                    source_col.data_type == target_col.data_type && !source_col.data_type.is_array()
+                })
+                .map(move |source_col| (target_col, source_col))
+        })
+        .collect();
+
+    let correlated = ctx
+        .choose(&comparable_pairs)
+        .map(|(target_col, source_col)| {
+            let left = Expr::column_ref(ctx, target_qualifier.clone(), target_col.name.clone());
+            let right = Expr::column_ref(ctx, source_qualifier.clone(), source_col.name.clone());
+            Expr::binary_op(ctx, left, BinOp::Eq, right)
+        });
+
+    let extra = if ctx.gen_bool_with_prob(extra_where_probability) {
+        Some(generate_condition(generator, ctx)?)
+    } else {
+        None
+    };
+
+    Ok(match (correlated, extra) {
+        (Some(lhs), Some(rhs)) => Some(Expr::binary_op(ctx, lhs, BinOp::And, rhs)),
+        (Some(expr), None) | (None, Some(expr)) => Some(expr),
+        (None, None) => None,
+    })
+}
+
+/// Generate a RETURNING clause for an UPDATE statement.
+///
+/// Produces 1-3 column references from the target table (scope position 0).
 #[trace_gen(Origin::UpdateReturning)]
 fn generate_update_returning<C: Capabilities>(
     _generator: &SqlGen<C>,
-    _ctx: &mut Context,
+    ctx: &mut Context,
 ) -> Result<Vec<Expr>, GenError> {
-    todo!("UPDATE ... RETURNING generation")
+    let columns = ctx.tables_in_scope()[0].table.columns.clone();
+
+    if columns.is_empty() {
+        return Err(GenError::schema_empty("returning columns"));
+    }
+
+    let num_cols = ctx.gen_range_inclusive(1, columns.len().min(3));
+    let mut exprs = Vec::with_capacity(num_cols);
+    for _ in 0..num_cols {
+        let col = ctx.choose(&columns).unwrap();
+        exprs.push(Expr::column_ref(ctx, None, col.name.clone()));
+    }
+    Ok(exprs)
 }
 
 // ---- DELETE features ----
@@ -1672,6 +1923,218 @@ mod tests {
             }
         }
         assert!(found_cte, "Should generate UPDATE with CTE");
+    }
+
+    #[test]
+    fn test_update_with_from() {
+        let policy = Policy::default().with_update_config(crate::policy::UpdateConfig {
+            from_probability: 1.0,
+            ..Default::default()
+        });
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "users",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("name", DataType::Text),
+                ],
+            ))
+            .table(Table::new(
+                "posts",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("user_id", DataType::Integer),
+                ],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, policy);
+
+        let mut found_from = false;
+        for seed in 0..50 {
+            let mut ctx = Context::new_with_seed(seed);
+            if let Ok(stmt) = generate_update(&generator, &mut ctx) {
+                let sql = stmt.to_string();
+                if sql.starts_with("UPDATE") && sql.contains(" FROM ") {
+                    found_from = true;
+                    break;
+                }
+            }
+        }
+        assert!(found_from, "Should generate UPDATE with FROM");
+    }
+
+    #[test]
+    fn test_update_with_from_one_table_can_self_join() {
+        let policy = Policy::default().with_update_config(crate::policy::UpdateConfig {
+            from_probability: 1.0,
+            self_join_probability: 1.0,
+            ..Default::default()
+        });
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "users",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("name", DataType::Text),
+                ],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, policy);
+
+        let mut found_self_join = false;
+        for seed in 0..50 {
+            let mut ctx = Context::new_with_seed(seed);
+            let stmt = generate_update(&generator, &mut ctx)
+                .expect("single-table schemas should still generate UPDATE");
+            if let Stmt::Update(update) = stmt {
+                if update.from.is_some() {
+                    // Self-join: FROM same table with alias
+                    assert!(
+                        update.from.as_ref().unwrap().alias.is_some(),
+                        "Self-join FROM must have an alias"
+                    );
+                    found_self_join = true;
+                }
+            }
+        }
+        assert!(
+            found_self_join,
+            "Should generate UPDATE FROM with self-join on single-table schema"
+        );
+    }
+
+    #[test]
+    fn test_update_with_from_can_alias_source_table() {
+        let policy = Policy::default()
+            .with_update_config(crate::policy::UpdateConfig {
+                from_probability: 1.0,
+                ..Default::default()
+            })
+            .with_select_config(crate::policy::SelectConfig {
+                table_alias_probability: 1.0,
+                ..Default::default()
+            });
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "users",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("name", DataType::Text),
+                ],
+            ))
+            .table(Table::new(
+                "posts",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("user_id", DataType::Integer),
+                ],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, policy);
+
+        let mut found_alias = false;
+        for seed in 0..50 {
+            let mut ctx = Context::new_with_seed(seed);
+            if let Ok(stmt) = generate_update(&generator, &mut ctx) {
+                let sql = stmt.to_string();
+                if sql.contains(" FROM ") && sql.contains(" AS t") {
+                    found_alias = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            found_alias,
+            "Should generate UPDATE FROM with a source alias"
+        );
+    }
+
+    #[test]
+    fn test_update_with_from_generates_correlated_where_clause() {
+        let policy = Policy::default().with_update_config(crate::policy::UpdateConfig {
+            from_probability: 1.0,
+            where_probability: 0.0,
+            ..Default::default()
+        });
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "users",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("name", DataType::Text),
+                ],
+            ))
+            .table(Table::new(
+                "posts",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("user_id", DataType::Integer),
+                ],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, policy);
+
+        let mut found_correlated_where = false;
+        for seed in 0..50 {
+            let mut ctx = Context::new_with_seed(seed);
+            if let Ok(Stmt::Update(update)) = generate_update(&generator, &mut ctx) {
+                if update.from.is_some()
+                    && update.where_clause.as_ref().is_some_and(|expr| {
+                        let rendered = expr.to_string();
+                        rendered.contains("users.") && rendered.contains("posts.")
+                    })
+                {
+                    found_correlated_where = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            found_correlated_where,
+            "Should generate UPDATE FROM with a correlated WHERE clause"
+        );
+    }
+
+    #[test]
+    fn test_update_with_from_can_use_subquery_source() {
+        let policy = Policy::default().with_update_config(crate::policy::UpdateConfig {
+            from_probability: 1.0,
+            subquery_from_probability: 1.0,
+            ..Default::default()
+        });
+        let schema = SchemaBuilder::new()
+            .table(Table::new(
+                "users",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("name", DataType::Text),
+                ],
+            ))
+            .table(Table::new(
+                "posts",
+                vec![
+                    ColumnDef::new("id", DataType::Integer).primary_key(),
+                    ColumnDef::new("user_id", DataType::Integer),
+                ],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, policy);
+
+        let mut found_subquery_source = false;
+        for seed in 0..50 {
+            let mut ctx = Context::new_with_seed(seed);
+            if let Ok(stmt) = generate_update(&generator, &mut ctx) {
+                let sql = stmt.to_string();
+                if sql.contains(" FROM (SELECT ") {
+                    found_subquery_source = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            found_subquery_source,
+            "Should generate UPDATE FROM with a subquery source when configured"
+        );
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/policy.rs
+++ b/testing/differential-oracle/sql_gen/src/policy.rs
@@ -1440,12 +1440,26 @@ pub struct UpdateConfig {
     /// Probability of generating a CTE (WITH clause) for UPDATE.
     pub cte_probability: f64,
 
-    // Stubs (not yet implemented, probability 0.0)
     /// Probability of UPDATE ... FROM.
     pub from_probability: f64,
 
     /// Probability of RETURNING clause.
     pub returning_probability: f64,
+
+    /// Probability of self-join (target table in FROM with alias).
+    pub self_join_probability: f64,
+
+    /// Probability of adding JOINs after the FROM table.
+    pub join_in_from_probability: f64,
+
+    /// Probability of using a subquery in FROM instead of a bare table.
+    pub subquery_from_probability: f64,
+
+    /// Probability of aliasing the target table (UPDATE t AS x).
+    pub target_alias_probability: f64,
+
+    /// Probability that a SET clause references a FROM-side column.
+    pub from_set_reference_probability: f64,
 }
 
 impl Default for UpdateConfig {
@@ -1460,9 +1474,13 @@ impl Default for UpdateConfig {
             expression_value_probability: 0.4,
             expression_value_max_depth: 2,
             cte_probability: 0.1,
-            // Stubs
-            from_probability: 0.0,
+            from_probability: 0.15,
             returning_probability: 0.0,
+            self_join_probability: 0.0,
+            join_in_from_probability: 0.0,
+            subquery_from_probability: 0.0,
+            target_alias_probability: 0.0,
+            from_set_reference_probability: 0.0,
         }
     }
 }

--- a/testing/sqltests/tests/returning.sqltest
+++ b/testing/sqltests/tests/returning.sqltest
@@ -800,6 +800,41 @@ expect {
     2|mordor
 }
 
+test update-returning-may-not-reference-target-alias {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, parent INTEGER, label TEXT);
+    INSERT INTO t VALUES (1, NULL, 'root'), (2, 1, 'child');
+    UPDATE t AS child
+       SET label = label || '!'
+    RETURNING child.id, child.parent, child.label;
+}
+expect error {
+}
+
+@cross-check-integrity
+test update-returning-may-reference-base-table-name-when-aliased {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, label TEXT);
+    INSERT INTO t VALUES (1, 'a');
+    UPDATE t AS child
+       SET label = 'x'
+    RETURNING t.id, t.label;
+}
+expect {
+    1|x
+}
+
+test update-from-returning-may-not-reference-target-alias {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, parent INTEGER, label TEXT);
+    INSERT INTO t VALUES (1, NULL, 'root'), (2, 1, 'a'), (3, 1, 'b'), (4, 2, 'c');
+    UPDATE t AS child
+       SET label = parent.label || '>' || child.label
+      FROM t AS parent
+     WHERE child.parent = parent.id
+    RETURNING child.id, child.label,
+              (SELECT count(*) FROM t t2 WHERE t2.parent = child.parent);
+}
+expect error {
+}
+
 @cross-check-integrity
 test update-returning-correlated-in-selfread {
     CREATE TABLE t (id INTEGER PRIMARY KEY, grp INTEGER, val INTEGER, note TEXT);

--- a/testing/sqltests/tests/update-from.sqltest
+++ b/testing/sqltests/tests/update-from.sqltest
@@ -2761,3 +2761,342 @@ expect {
     1|hello
     2|world
 }
+
+# === Adversarial bughunt regressions (hunt summary: 435+ scenarios, no bugs). ===
+# These verify invariants that are specifically load-bearing for UPDATE…FROM.
+
+# Multi-match with an accumulating SET expression: the SET RHS is evaluated
+# from the pre-update (snapshot) row image, so multiple matches do NOT each
+# re-increment. All matches write the same pre-image calculation.
+@cross-check-integrity
+test update-from-snapshot-accumulate-stays-one {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, cnt INTEGER);
+    CREATE TABLE s(id INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1),(1),(1),(2);
+    UPDATE t SET cnt = cnt + 1 FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|1
+}
+
+# BEFORE UPDATE trigger that RAISE(IGNORE)s based on NEW values skips
+# individual rows; other matched rows still update normally.
+@cross-check-integrity
+test update-from-before-trigger-raise-ignore-conditional {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0),(3,0);
+    INSERT INTO s VALUES(1,100),(2,200),(3,300);
+    CREATE TRIGGER trg BEFORE UPDATE ON t FOR EACH ROW WHEN NEW.v > 150 AND NEW.v < 250 BEGIN
+      SELECT RAISE(IGNORE);
+    END;
+    UPDATE t SET v = s.v FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|100
+    2|0
+    3|300
+}
+
+# A trigger that deletes rows from the source mid-update must not affect the
+# already-materialized write set: both target rows still update.
+@cross-check-integrity
+test update-from-trigger-deletes-source-mid-flight {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20);
+    INSERT INTO s VALUES(1,100),(2,200);
+    CREATE TRIGGER trg BEFORE UPDATE ON t FOR EACH ROW BEGIN
+      DELETE FROM s;
+    END;
+    UPDATE t SET v = s.v FROM s WHERE t.id = s.id;
+    SELECT 't'; SELECT * FROM t ORDER BY id;
+    SELECT 's'; SELECT count(*) FROM s;
+}
+expect {
+    t
+    1|100
+    2|200
+    s
+    0
+}
+
+# A trigger that inserts new target rows during the write phase does NOT
+# observe those inserts as new join matches: the write set is frozen.
+@cross-check-integrity
+test update-from-trigger-inserts-target-not-matched {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,10);
+    INSERT INTO s VALUES(1,100),(2,200);
+    CREATE TRIGGER trg AFTER UPDATE ON t FOR EACH ROW BEGIN
+      INSERT INTO t(id, v) VALUES(2, 0);
+    END;
+    UPDATE t SET v = s.v FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|100
+    2|0
+}
+
+# GLOB pattern as the join predicate.
+@cross-check-integrity
+test update-from-glob-pattern-join {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE TABLE s(pat TEXT, newv TEXT);
+    INSERT INTO t VALUES(1,'foo1'),(2,'bar2'),(3,'foo3');
+    INSERT INTO s VALUES('foo*','F'),('bar*','B');
+    UPDATE t SET v = s.newv FROM s WHERE t.v GLOB s.pat;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|F
+    2|B
+    3|F
+}
+
+# LIKE … ESCAPE with the source supplying the pattern.
+@cross-check-integrity
+test update-from-like-escape-join {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE TABLE s(p TEXT, newv TEXT);
+    INSERT INTO t VALUES(1,'x%y'),(2,'x_y'),(3,'xAy');
+    INSERT INTO s VALUES('x\%y','escaped-percent');
+    UPDATE t SET v = s.newv FROM s WHERE t.v LIKE s.p ESCAPE '\';
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|escaped-percent
+    2|x_y
+    3|xAy
+}
+
+# Row-value equality as the join predicate: (t.a, t.b) = (s.a, s.b).
+@cross-check-integrity
+test update-from-row-value-equality-join {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, v INTEGER);
+    CREATE TABLE s(a INTEGER, b INTEGER, newv INTEGER);
+    INSERT INTO t VALUES(1,1,2,10),(2,3,4,20),(3,5,6,30);
+    INSERT INTO s VALUES(1,2,100),(3,4,200);
+    UPDATE t SET v = s.newv FROM s WHERE (t.a, t.b) = (s.a, s.b);
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1|2|100
+    2|3|4|200
+    3|5|6|30
+}
+
+# IS NOT DISTINCT FROM is NULL-safe: NULL=NULL matches in the join.
+@cross-check-integrity
+test update-from-is-not-distinct-from-join {
+    CREATE TABLE t(id INTEGER, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,10),(NULL,20),(2,30);
+    INSERT INTO s VALUES(1,100),(NULL,999),(2,200);
+    UPDATE t SET v = s.v FROM s WHERE t.id IS NOT DISTINCT FROM s.id;
+    SELECT coalesce(id,-1), v FROM t ORDER BY coalesce(id,-1);
+}
+expect {
+    -1|999
+    1|100
+    2|200
+}
+
+# A table-valued function (pragma_table_info) can serve as the FROM source.
+@cross-check-integrity
+test update-from-pragma-table-info-source {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, colname TEXT);
+    INSERT INTO t VALUES(0,''),(1,'');
+    UPDATE t SET colname = pi.name FROM pragma_table_info('t') AS pi WHERE t.id = pi.cid;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    0|id
+    1|colname
+}
+
+# Source rowid in the SET RHS expression.
+@cross-check-integrity
+test update-from-source-rowid-in-set-expr {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(v INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    INSERT INTO s VALUES(100),(200),(300);
+    UPDATE t SET v = s.v + s.rowid * 1000 FROM s WHERE t.id = s.rowid;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1100
+    2|2200
+    3|3300
+}
+
+# Explicit CROSS JOIN syntax in the FROM clause.
+@cross-check-integrity
+test update-from-explicit-cross-join {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE a(id INTEGER, x INTEGER);
+    CREATE TABLE b(id INTEGER, y INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20);
+    INSERT INTO a VALUES(1,1),(2,2);
+    INSERT INTO b VALUES(1,10),(2,20);
+    UPDATE t SET v = a.x + b.y FROM a CROSS JOIN b WHERE a.id = t.id AND b.id = t.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|11
+    2|22
+}
+
+# BETWEEN with source-side bounds as the join predicate.
+@cross-check-integrity
+test update-from-between-source-bounds {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(lo INTEGER, hi INTEGER, delta INTEGER);
+    INSERT INTO t VALUES(5,0),(10,0),(15,0),(20,0);
+    INSERT INTO s VALUES(0,9,1),(10,19,5),(20,29,10);
+    UPDATE t SET v = v + s.delta FROM s WHERE t.id BETWEEN s.lo AND s.hi;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    5|1
+    10|5
+    15|5
+    20|10
+}
+
+# Chain rowid remap (5→8, 6→5, 7→6) — each update observes the pre-update
+# target rowid image; no intermediate collision.
+@cross-check-integrity
+test update-from-chain-rowid-remap {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(old INTEGER, newk INTEGER);
+    INSERT INTO t VALUES(5,5),(6,6),(7,7);
+    INSERT INTO s VALUES(5,8),(6,5),(7,6);
+    UPDATE t SET id = s.newk FROM s WHERE t.id = s.old;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    5|6
+    6|7
+    8|5
+}
+
+# Setting the rowid alias AND another column together in one UPDATE FROM.
+@cross-check-integrity
+test update-from-rowid-alias-plus-column {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(old INTEGER, newk INTEGER, newv INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20);
+    INSERT INTO s VALUES(1,100,1000);
+    UPDATE t SET id = s.newk, v = s.newv FROM s WHERE t.id = s.old;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    2|20
+    100|1000
+}
+
+# OR IGNORE with multi-match where each target's intended value conflicts
+# with another target's current (pre-update) unique value: SQLite leaves
+# all rows untouched because per-row IGNORE is a no-op at the statement
+# level when none of the applied SETs ever commits successfully under
+# write-set semantics.
+@cross-check-integrity
+test update-from-or-ignore-mutual-unique-conflict {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, u INTEGER UNIQUE);
+    CREATE TABLE s(id INTEGER, u INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    INSERT INTO s VALUES(1,20),(2,10);
+    UPDATE OR IGNORE t SET u = s.u FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|10
+    2|20
+    3|30
+}
+
+# BEFORE UPDATE trigger observes NEW.<col> as the source-provided value.
+@cross-check-integrity
+test update-from-before-trigger-new-is-source-value {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    CREATE TABLE log(id INTEGER, oldv INTEGER, newv INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20);
+    INSERT INTO s VALUES(1,100),(2,200);
+    CREATE TRIGGER trg BEFORE UPDATE ON t FOR EACH ROW BEGIN
+      INSERT INTO log VALUES(OLD.id, OLD.v, NEW.v);
+    END;
+    UPDATE t SET v = s.v FROM s WHERE t.id = s.id;
+    SELECT * FROM log ORDER BY id;
+}
+expect {
+    1|10|100
+    2|20|200
+}
+
+# LEFT JOIN in the source where the right side is absent: SET expression
+# sees NULL on the FROM side and coalesces to a target-derived default.
+@cross-check-integrity
+test update-from-left-join-null-in-set {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE a(id INTEGER);
+    CREATE TABLE b(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20);
+    INSERT INTO a VALUES(1),(2);
+    INSERT INTO b VALUES(1,100);
+    UPDATE t SET v = coalesce(b.v, -1) FROM a LEFT JOIN b ON a.id = b.id WHERE t.id = a.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|100
+    2|-1
+}
+
+# Cascade of AFTER-UPDATE triggers: UPDATE FROM on t fires trg_t which
+# updates u, which fires trg_u which updates w.
+@cross-check-integrity
+test update-from-cascade-afters-through-three-tables {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE u(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE w(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,0);
+    INSERT INTO u VALUES(1,0);
+    INSERT INTO w VALUES(1,0);
+    INSERT INTO s VALUES(1,100);
+    CREATE TRIGGER trg_t AFTER UPDATE ON t BEGIN UPDATE u SET v = NEW.v + 1 WHERE id = NEW.id; END;
+    CREATE TRIGGER trg_u AFTER UPDATE ON u BEGIN UPDATE w SET v = NEW.v + 1 WHERE id = NEW.id; END;
+    UPDATE t SET v = s.v FROM s WHERE t.id = s.id;
+    SELECT 't'; SELECT * FROM t;
+    SELECT 'u'; SELECT * FROM u;
+    SELECT 'w'; SELECT * FROM w;
+}
+expect {
+    t
+    1|100
+    u
+    1|101
+    w
+    1|102
+}
+
+# A CTE that shadows the base source table with a self-reference is a
+# circular CTE and must be rejected at planning time.
+test update-from-cte-shadows-source-is-circular {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,10);
+    INSERT INTO s VALUES(1,100);
+    WITH s(id, v) AS (SELECT id, v*10 FROM s)
+    UPDATE t SET v = s.v FROM s WHERE t.id = s.id;
+}
+expect error {
+}

--- a/testing/sqltests/tests/update-from.sqltest
+++ b/testing/sqltests/tests/update-from.sqltest
@@ -1863,3 +1863,901 @@ test update-from-duplicate-source-alias-natural-is-ambiguous {
 expect error {
     ambiguous column name: main.x._ROWID_
 }
+
+#-----------------------------------------------------------------------
+# Duplicate unaliased table in FROM should error (same table name, no alias).
+#-----------------------------------------------------------------------
+
+test update-from-dup-unaliased-comma {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT);
+    INSERT INTO t1 VALUES(1,'x');
+    INSERT INTO t2 VALUES(1);
+    UPDATE t1 SET b = 'changed' FROM t2, t2 WHERE t1.a = 1;
+}
+expect error {
+    ambiguous column name
+}
+
+test update-from-dup-unaliased-cross-join {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT);
+    INSERT INTO t1 VALUES(1,'x');
+    INSERT INTO t2 VALUES(1);
+    UPDATE t1 SET b = 'changed' FROM t2 CROSS JOIN t2 WHERE t1.a = 1;
+}
+expect error {
+    ambiguous column name
+}
+
+test update-from-dup-unaliased-triple {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT);
+    INSERT INTO t1 VALUES(1,'x');
+    INSERT INTO t2 VALUES(1);
+    UPDATE t1 SET b = 'changed' FROM t2, t2, t2 WHERE t1.a = 1;
+}
+expect error {
+    ambiguous column name
+}
+
+#-----------------------------------------------------------------------
+# NATURAL/USING + additional JOIN: column shared by the deduplicated pair
+# and another table is ambiguous.
+#-----------------------------------------------------------------------
+
+test update-from-natural-plus-join-ambiguous {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE s1(x INT, y TEXT);
+    CREATE TABLE s2(x INT, z TEXT);
+    CREATE TABLE s3(x INT, w TEXT);
+    INSERT INTO t1 VALUES(1,'orig');
+    INSERT INTO s1 VALUES(1,'hello');
+    INSERT INTO s2 VALUES(1,'world');
+    INSERT INTO s3 VALUES(1,'extra');
+    UPDATE t1 SET b = s1.y
+    FROM s1 NATURAL JOIN s2 JOIN s3 ON s1.x = s3.x
+    WHERE s1.x = t1.a;
+}
+expect error {
+    ambiguous column name
+}
+
+test update-from-using-plus-join-ambiguous {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE s1(x INT, y TEXT);
+    CREATE TABLE s2(x INT, z TEXT);
+    CREATE TABLE s3(x INT, w TEXT);
+    INSERT INTO t1 VALUES(1,'orig');
+    INSERT INTO s1 VALUES(1,'hello');
+    INSERT INTO s2 VALUES(1,'world');
+    INSERT INTO s3 VALUES(1,'extra');
+    UPDATE t1 SET b = s1.y
+    FROM s1 JOIN s2 USING(x) JOIN s3 ON s1.x = s3.x
+    WHERE s1.x = t1.a;
+}
+expect error {
+    ambiguous column name
+}
+
+test update-from-natural-plus-left-join-ambiguous {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c INT);
+    INSERT INTO t1 VALUES(1,'x',10);
+    UPDATE t1 SET b = 'new'
+    FROM t1 AS t8 NATURAL JOIN t1 AS t9 LEFT JOIN t1 AS t10 ON t8.c = t10.c
+    WHERE t1.a = t8.a;
+}
+expect error {
+    ambiguous column name
+}
+
+test update-from-natural-plus-inner-join-ambiguous {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c INT);
+    INSERT INTO t1 VALUES(1,'x',10);
+    UPDATE t1 SET b = 'new'
+    FROM t1 AS t8 NATURAL JOIN t1 AS t9 JOIN t1 AS t10 ON t8.c = t10.c
+    WHERE t1.a = t8.a;
+}
+expect error {
+    ambiguous column name
+}
+
+#-----------------------------------------------------------------------
+# Additional positive edge-case coverage.
+#-----------------------------------------------------------------------
+
+# Subquery as FROM source with expression
+@cross-check-integrity
+test update-from-subquery-source {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INTEGER, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y');
+    UPDATE t1 SET b = sub.val
+    FROM (SELECT id, upper(val) as val FROM t2) AS sub
+    WHERE sub.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|X
+    2|Y
+    3|c
+}
+
+# Three-way join in FROM
+@cross-check-integrity
+test update-from-three-way-join {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(x INTEGER, y TEXT);
+    CREATE TABLE t3(x INTEGER, z TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y');
+    INSERT INTO t3 VALUES(1,'Z1'),(2,'Z2');
+    UPDATE t1 SET b = t2.y || t3.z FROM t2 JOIN t3 ON t2.x = t3.x WHERE t2.x = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|XZ1
+    2|YZ2
+    3|c
+}
+
+# Cross join with no WHERE (single-row FROM)
+@cross-check-integrity
+test update-from-cross-join-no-where {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES('ONLY');
+    UPDATE t1 SET b = t2.val FROM t2;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|ONLY
+    2|ONLY
+}
+
+# No matching rows between target and source
+@cross-check-integrity
+test update-from-no-matches-extra {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES(10,'X'),(20,'Y');
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|a
+    2|b
+}
+
+# NULL source value
+@cross-check-integrity
+test update-from-null-source-value {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES(1,NULL),(2,'X');
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT a, b, typeof(b) FROM t1 ORDER BY a;
+}
+expect {
+    1||null
+    2|X|text
+}
+
+# NULL join key (NULL = NULL is false)
+@cross-check-integrity
+test update-from-null-join-key-extra {
+    CREATE TABLE t1(a INT, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(NULL,'a'),(1,'b'),(2,'c');
+    INSERT INTO t2 VALUES(NULL,'X'),(1,'Y');
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT a, b FROM t1 ORDER BY rowid;
+}
+expect {
+    |a
+    1|Y
+    2|c
+}
+
+# IS join (NULL matches NULL)
+@cross-check-integrity
+test update-from-is-join {
+    CREATE TABLE t1(a INT, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(NULL,'a'),(1,'b'),(2,'c');
+    INSERT INTO t2 VALUES(NULL,'X'),(1,'Y');
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id IS t1.a;
+    SELECT a, b FROM t1 ORDER BY rowid;
+}
+expect {
+    |X
+    1|Y
+    2|c
+}
+
+# Range/inequality join
+@cross-check-integrity
+test update-from-range-join {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t2(threshold INT, label TEXT);
+    INSERT INTO t1 VALUES(1,10),(2,20),(3,30);
+    INSERT INTO t2 VALUES(15,'high');
+    UPDATE t1 SET b = 0 FROM t2 WHERE t1.b > t2.threshold;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|10
+    2|0
+    3|0
+}
+
+# View as FROM source
+@cross-check-integrity
+test update-from-view-source {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    CREATE VIEW v2 AS SELECT 1 as id, 'VIEW' as val;
+    UPDATE t1 SET b = v2.val FROM v2 WHERE v2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|VIEW
+    2|b
+    3|c
+}
+
+# Aggregate subquery in FROM
+@cross-check-integrity
+test update-from-aggregate-subquery-extra {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t2(grp INT, val INT);
+    INSERT INTO t1 VALUES(1,0),(2,0),(3,0);
+    INSERT INTO t2 VALUES(1,10),(1,20),(2,30),(2,40),(3,50);
+    UPDATE t1 SET b = sub.s
+    FROM (SELECT grp, SUM(val) as s FROM t2 GROUP BY grp) AS sub
+    WHERE sub.grp = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|30
+    2|70
+    3|50
+}
+
+# HAVING in FROM subquery
+@cross-check-integrity
+test update-from-having-subquery {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t2(grp INT, val INT);
+    INSERT INTO t1 VALUES(1,0),(2,0),(3,0);
+    INSERT INTO t2 VALUES(1,5),(1,10),(2,3),(2,7),(3,1);
+    UPDATE t1 SET b = src.total
+    FROM (SELECT grp, SUM(val) as total FROM t2 GROUP BY grp HAVING SUM(val) > 5) AS src
+    WHERE src.grp = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|15
+    2|10
+    3|0
+}
+
+# Window function in FROM subquery
+@cross-check-integrity
+test update-from-window-function-extra {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t2(id INT, val INT);
+    INSERT INTO t1 VALUES(1,0),(2,0),(3,0);
+    INSERT INTO t2 VALUES(1,10),(2,20),(3,30);
+    UPDATE t1 SET b = sub.running_sum
+    FROM (SELECT id, SUM(val) OVER (ORDER BY id) as running_sum FROM t2) AS sub
+    WHERE sub.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|10
+    2|30
+    3|60
+}
+
+# UNION ALL in FROM subquery
+@cross-check-integrity
+test update-from-union-all {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    UPDATE t1 SET b = src.val
+    FROM (SELECT 1 as id, 'U1' as val UNION ALL SELECT 2, 'U2') AS src
+    WHERE src.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|U1
+    2|U2
+    3|c
+}
+
+# INTERSECT in FROM subquery
+@cross-check-integrity
+test update-from-intersect {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    CREATE TABLE t3(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y'),(3,'Z');
+    INSERT INTO t3 VALUES(1,'X'),(4,'W');
+    UPDATE t1 SET b = src.val
+    FROM (SELECT id, val FROM t2 INTERSECT SELECT id, val FROM t3) AS src
+    WHERE src.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|X
+    2|b
+}
+
+# EXCEPT in FROM subquery
+@cross-check-integrity
+test update-from-except {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    CREATE TABLE t3(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y'),(3,'Z');
+    INSERT INTO t3 VALUES(2,'Y');
+    UPDATE t1 SET b = src.val
+    FROM (SELECT id, val FROM t2 EXCEPT SELECT id, val FROM t3) AS src
+    WHERE src.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|X
+    2|b
+    3|Z
+}
+
+# Multiple CTEs, one referencing another
+@cross-check-integrity
+test update-from-cte-chain {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    WITH
+      base AS (SELECT 1 as id, 'X' as val UNION ALL SELECT 2, 'Y' UNION ALL SELECT 3, 'Z'),
+      derived AS (SELECT id, val || '!' as val FROM base WHERE id <= 2)
+    UPDATE t1 SET b = derived.val FROM derived WHERE derived.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|X!
+    2|Y!
+    3|c
+}
+
+# Self-join shift: each row gets the value of the next row
+@cross-check-integrity
+test update-from-self-join-shift {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, c INT);
+    INSERT INTO t1 VALUES(1,10),(2,20),(3,30);
+    UPDATE t1 SET c = t1_src.c FROM t1 AS t1_src WHERE t1_src.a = t1.a + 1;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|20
+    2|30
+    3|30
+}
+
+# Value rotation using CASE in self-join
+@cross-check-integrity
+test update-from-rotate-values {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    INSERT INTO t1 VALUES(1,100),(2,200),(3,300);
+    UPDATE t1 SET b = src.b FROM t1 AS src
+    WHERE src.a = CASE t1.a WHEN 1 THEN 2 WHEN 2 THEN 3 WHEN 3 THEN 1 END;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|200
+    2|300
+    3|100
+}
+
+# Self-referential aggregate: each row gets average of all original values
+@cross-check-integrity
+test update-from-self-ref-aggregate {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    INSERT INTO t1 VALUES(1,10),(2,20),(3,30);
+    UPDATE t1 SET b = src.avg_b FROM (SELECT AVG(b) as avg_b FROM t1) AS src;
+    SELECT a, CAST(b AS INT) FROM t1 ORDER BY a;
+}
+expect {
+    1|20
+    2|20
+    3|20
+}
+
+# Snapshot semantics: WHERE references column being SET
+@cross-check-integrity
+test update-from-snapshot-where-set-same-col {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c TEXT);
+    INSERT INTO t1 VALUES(1,100,'a'),(2,200,'b'),(3,300,'c');
+    UPDATE t1 SET b = 999 FROM (SELECT 1 as x) AS src WHERE t1.b = 200;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|100|a
+    2|999|b
+    3|300|c
+}
+
+# Correlated subquery in SET referencing FROM table
+@cross-check-integrity
+test update-from-correlated-sub-refs-from-extra {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t2(id INT, multiplier INT);
+    CREATE TABLE t3(ref_id INT, bonus INT);
+    INSERT INTO t1 VALUES(1,0),(2,0),(3,0);
+    INSERT INTO t2 VALUES(1,2),(2,3);
+    INSERT INTO t3 VALUES(1,5),(2,10),(3,15);
+    UPDATE t1 SET b = (SELECT t3.bonus FROM t3 WHERE t3.ref_id = t2.id) FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|5
+    2|10
+    3|0
+}
+
+# Scalar subquery referencing FROM + third table
+@cross-check-integrity
+test update-from-nested-join-subquery {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t2(id INT, group_id INT);
+    CREATE TABLE t3(group_id INT, value INT);
+    INSERT INTO t1 VALUES(1,0),(2,0);
+    INSERT INTO t2 VALUES(1,10),(2,20);
+    INSERT INTO t3 VALUES(10,1000),(20,2000);
+    UPDATE t1 SET b = (SELECT t3.value FROM t3 WHERE t3.group_id = t2.group_id)
+    FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|1000
+    2|2000
+}
+
+# Deeply nested join chain (4 FROM tables)
+@cross-check-integrity
+test update-from-deep-join-chain {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE j1(id INT, v1 TEXT);
+    CREATE TABLE j2(id INT, v2 TEXT);
+    CREATE TABLE j3(id INT, v3 TEXT);
+    CREATE TABLE j4(id INT, v4 TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO j1 VALUES(1,'j1_1'),(2,'j1_2');
+    INSERT INTO j2 VALUES(1,'j2_1'),(2,'j2_2');
+    INSERT INTO j3 VALUES(1,'j3_1'),(2,'j3_2');
+    INSERT INTO j4 VALUES(1,'j4_1'),(2,'j4_2');
+    UPDATE t1 SET b = j1.v1 || ',' || j2.v2 || ',' || j3.v3 || ',' || j4.v4
+    FROM j1 JOIN j2 ON j1.id = j2.id JOIN j3 ON j2.id = j3.id JOIN j4 ON j3.id = j4.id
+    WHERE j1.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|j1_1,j2_1,j3_1,j4_1
+    2|j1_2,j2_2,j3_2,j4_2
+}
+
+# FROM subquery with LIMIT
+@cross-check-integrity
+test update-from-subquery-with-limit {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y'),(3,'Z');
+    UPDATE t1 SET b = sub.val
+    FROM (SELECT id, val FROM t2 ORDER BY id LIMIT 2) AS sub
+    WHERE sub.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|X
+    2|Y
+    3|c
+}
+
+# CASE expression with FROM columns
+@cross-check-integrity
+test update-from-case-expression {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y'),(3,'Z');
+    UPDATE t1 SET b = CASE WHEN t2.val = 'X' THEN 'matched_x' WHEN t2.val = 'Y' THEN 'matched_y' ELSE 'other' END
+    FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|matched_x
+    2|matched_y
+    3|other
+}
+
+# Mixed target+source in SET expression
+@cross-check-integrity
+test update-from-mixed-target-source-set {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c TEXT);
+    CREATE TABLE t2(id INT, factor INT);
+    INSERT INTO t1 VALUES(1,10,'x'),(2,20,'y'),(3,30,'z');
+    INSERT INTO t2 VALUES(1,2),(2,3);
+    UPDATE t1 SET b = t1.b * t2.factor, c = t1.c || cast(t2.factor as text) FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|20|x2
+    2|60|y3
+    3|30|z
+}
+
+# Multiple FROM tables (comma-join)
+@cross-check-integrity
+test update-from-multi-tables {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c INT);
+    CREATE TABLE t2(id INT, name TEXT);
+    CREATE TABLE t3(id INT, score INT);
+    INSERT INTO t1 VALUES(1,'a',0),(2,'b',0),(3,'c',0);
+    INSERT INTO t2 VALUES(1,'alpha'),(2,'beta');
+    INSERT INTO t3 VALUES(1,100),(2,200);
+    UPDATE t1 SET b = t2.name, c = t3.score FROM t2, t3 WHERE t2.id = t1.a AND t3.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|alpha|100
+    2|beta|200
+    3|c|0
+}
+
+# GROUP_CONCAT in FROM subquery
+@cross-check-integrity
+test update-from-group-concat {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(grp INT, item TEXT);
+    INSERT INTO t1 VALUES(1,''),(2,''),(3,'');
+    INSERT INTO t2 VALUES(1,'a'),(1,'b'),(1,'c'),(2,'x'),(2,'y'),(3,'z');
+    UPDATE t1 SET b = src.items
+    FROM (SELECT grp, GROUP_CONCAT(item, ',') as items FROM t2 GROUP BY grp) AS src
+    WHERE src.grp = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|a,b,c
+    2|x,y
+    3|z
+}
+
+# Complex multi-column expression update
+@cross-check-integrity
+test update-from-complex-multi-col {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c INT, d REAL);
+    CREATE TABLE t2(id INT, category TEXT, weight REAL);
+    INSERT INTO t1 VALUES(1,'alpha',10,1.1),(2,'beta',20,2.2),(3,'gamma',30,3.3);
+    INSERT INTO t2 VALUES(1,'A',0.5),(2,'B',1.5),(3,'A',2.5);
+    UPDATE t1 SET
+      b = CASE t2.category
+        WHEN 'A' THEN upper(t1.b)
+        WHEN 'B' THEN lower(t1.b)
+        ELSE t1.b
+      END,
+      c = CAST(t1.c * t2.weight AS INT),
+      d = ROUND(t1.d + t2.weight, 2)
+    FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|ALPHA|5|1.6
+    2|beta|30|3.7
+    3|GAMMA|75|5.8
+}
+
+# Sequential UPDATE FROMs building on each other
+@cross-check-integrity
+test update-from-sequential-visibility {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT, c TEXT);
+    CREATE TABLE t2(id INT, val INT);
+    INSERT INTO t1 VALUES(1,0,'a'),(2,0,'b'),(3,0,'c');
+    INSERT INTO t2 VALUES(1,100),(2,200),(3,300);
+    BEGIN;
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    UPDATE t1 SET c = 'updated_' || t1.b FROM t2 WHERE t2.id = t1.a;
+    COMMIT;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|100|updated_100
+    2|200|updated_200
+    3|300|updated_300
+}
+
+# Repeated UPDATE FROMs accumulating changes
+@cross-check-integrity
+test update-from-repeated-accumulate {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE deltas(id INT, delta INT);
+    INSERT INTO t1 VALUES(1,0),(2,0),(3,0);
+    INSERT INTO deltas VALUES(1,1),(2,2),(3,3);
+    UPDATE t1 SET b = t1.b + deltas.delta FROM deltas WHERE deltas.id = t1.a;
+    UPDATE t1 SET b = t1.b + deltas.delta FROM deltas WHERE deltas.id = t1.a;
+    UPDATE t1 SET b = t1.b + deltas.delta FROM deltas WHERE deltas.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|3
+    2|6
+    3|9
+}
+
+# LIKE in join condition
+@cross-check-integrity
+test update-from-like-join {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT, c TEXT);
+    CREATE TABLE t2(pattern TEXT, replacement TEXT);
+    INSERT INTO t1 VALUES(1,'hello','old'),(2,'world','old'),(3,'help','old');
+    INSERT INTO t2 VALUES('hel%','matched');
+    UPDATE t1 SET c = t2.replacement FROM t2 WHERE t1.b LIKE t2.pattern;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|hello|matched
+    2|world|old
+    3|help|matched
+}
+
+# NATURAL JOIN of same table is OK when all joins are NATURAL
+@cross-check-integrity
+test update-from-double-natural-join-ok {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE s1(x INT, y TEXT);
+    CREATE TABLE s2(x INT, z TEXT);
+    CREATE TABLE s3(x INT, w TEXT);
+    INSERT INTO t1 VALUES(1,'orig');
+    INSERT INTO s1 VALUES(1,'s1');
+    INSERT INTO s2 VALUES(1,'s2');
+    INSERT INTO s3 VALUES(1,'s3');
+    UPDATE t1 SET b = s1.y FROM s1 NATURAL JOIN s2 NATURAL JOIN s3 WHERE s1.x = t1.a;
+    SELECT * FROM t1;
+}
+expect {
+    1|s1
+}
+
+# Multiple USING columns
+@cross-check-integrity
+test update-from-multi-using-cols {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(x INT, y INT, val TEXT);
+    CREATE TABLE t3(x INT, y INT, extra TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES(1,10,'X'),(2,20,'Y');
+    INSERT INTO t3 VALUES(1,10,'E1'),(2,20,'E2');
+    UPDATE t1 SET b = t2.val || t3.extra FROM t2 JOIN t3 USING(x, y) WHERE t2.x = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|XE1
+    2|YE2
+}
+
+# LEFT JOIN in FROM with COALESCE
+@cross-check-integrity
+test update-from-left-join-coalesce {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, x TEXT);
+    CREATE TABLE t3(id INT, y TEXT);
+    INSERT INTO t1 VALUES(1,'orig');
+    INSERT INTO t2 VALUES(1,'X1');
+    INSERT INTO t3 VALUES(1,'Y1'),(2,'Y2');
+    UPDATE t1 SET b = COALESCE(t2.x, '') || COALESCE(t3.y, '')
+    FROM t2 LEFT JOIN t3 ON t2.id = t3.id WHERE t2.id = t1.a;
+    SELECT * FROM t1;
+}
+expect {
+    1|X1Y1
+}
+
+# Mixed types from UNION subquery
+@cross-check-integrity
+test update-from-mixed-types-union {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b);
+    INSERT INTO t1 VALUES(1,NULL),(2,NULL),(3,NULL);
+    UPDATE t1 SET b = src.val
+    FROM (SELECT 1 as id, 42 as val UNION ALL SELECT 2, 'text' UNION ALL SELECT 3, 3.14) AS src
+    WHERE src.id = t1.a;
+    SELECT a, b, typeof(b) FROM t1 ORDER BY a;
+}
+expect {
+    1|42|integer
+    2|text|text
+    3|3.14|real
+}
+
+# All value types through UPDATE FROM
+@cross-check-integrity
+test update-from-all-types {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b);
+    CREATE TABLE t2(id INT, val);
+    INSERT INTO t1 VALUES(1,NULL),(2,NULL),(3,NULL),(4,NULL),(5,NULL);
+    INSERT INTO t2 VALUES(1, 42);
+    INSERT INTO t2 VALUES(2, 3.14);
+    INSERT INTO t2 VALUES(3, 'hello');
+    INSERT INTO t2 VALUES(4, x'DEADBEEF');
+    INSERT INTO t2 VALUES(5, NULL);
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT a, typeof(b) FROM t1 ORDER BY a;
+}
+expect {
+    1|integer
+    2|real
+    3|text
+    4|blob
+    5|null
+}
+
+# NUMERIC affinity through ephemeral table
+@cross-check-integrity
+test update-from-numeric-affinity {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b NUMERIC);
+    CREATE TABLE t2(id INT, val);
+    INSERT INTO t1 VALUES(1,0),(2,0),(3,0);
+    INSERT INTO t2 VALUES(1, '123');
+    INSERT INTO t2 VALUES(2, '12.5');
+    INSERT INTO t2 VALUES(3, 'abc');
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT a, b, typeof(b) FROM t1 ORDER BY a;
+}
+expect {
+    1|123|integer
+    2|12.5|real
+    3|abc|text
+}
+
+# INTEGER affinity
+@cross-check-integrity
+test update-from-integer-affinity {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER);
+    CREATE TABLE t2(id INT, val);
+    INSERT INTO t1 VALUES(1,0),(2,0),(3,0);
+    INSERT INTO t2 VALUES(1, 3.0);
+    INSERT INTO t2 VALUES(2, 3.5);
+    INSERT INTO t2 VALUES(3, '42');
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT a, b, typeof(b) FROM t1 ORDER BY a;
+}
+expect {
+    1|3|integer
+    2|3.5|real
+    3|42|integer
+}
+
+# Trigger (BEFORE + AFTER) with UPDATE FROM
+@cross-check-integrity
+test update-from-before-after-triggers {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    CREATE TABLE audit(msg TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y');
+    CREATE TRIGGER tr_before BEFORE UPDATE ON t1 BEGIN
+      INSERT INTO audit VALUES('before: old=' || OLD.b || ' new=' || NEW.b);
+    END;
+    CREATE TRIGGER tr_after AFTER UPDATE ON t1 BEGIN
+      INSERT INTO audit VALUES('after: old=' || OLD.b || ' new=' || NEW.b);
+    END;
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+    SELECT * FROM audit ORDER BY rowid;
+}
+expect {
+    1|X
+    2|Y
+    before: old=a new=X
+    after: old=a new=X
+    before: old=b new=Y
+    after: old=b new=Y
+}
+
+# Trigger doing cascading UPDATE
+@cross-check-integrity
+test update-from-trigger-cascading-update {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b INT);
+    CREATE TABLE t2(id INT, val INT);
+    CREATE TABLE t3(x INT);
+    INSERT INTO t1 VALUES(1,10),(2,20),(3,30);
+    INSERT INTO t2 VALUES(1,100);
+    INSERT INTO t3 VALUES(0);
+    CREATE TRIGGER tr AFTER UPDATE ON t1 BEGIN
+      UPDATE t3 SET x = x + 1;
+    END;
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+    SELECT * FROM t3;
+}
+expect {
+    1|100
+    2|20
+    3|30
+    1
+}
+
+# FK cascade via UPDATE FROM
+@cross-check-integrity
+test update-from-fk-cascade-extra {
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id) ON UPDATE CASCADE, val TEXT);
+    CREATE TABLE src(old_id INTEGER, new_id INTEGER);
+    INSERT INTO parent VALUES(1,'p1'),(2,'p2');
+    INSERT INTO child VALUES(10,1,'c1'),(20,2,'c2');
+    INSERT INTO src VALUES(1,100);
+    PRAGMA foreign_keys = ON;
+    UPDATE parent SET id = src.new_id FROM src WHERE src.old_id = parent.id;
+    SELECT * FROM parent ORDER BY id;
+    SELECT * FROM child ORDER BY id;
+}
+expect {
+    2|p2
+    100|p1
+    10|100|c1
+    20|2|c2
+}
+
+# Savepoint + rollback
+@cross-check-integrity
+test update-from-savepoint-rollback {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y');
+    SAVEPOINT sp1;
+    UPDATE t1 SET b = t2.val FROM t2 WHERE t2.id = t1.a;
+    ROLLBACK TO sp1;
+    SELECT * FROM t1 ORDER BY a;
+    RELEASE sp1;
+}
+expect {
+    1|a
+    2|b
+}
+
+# WHERE 0 should match nothing
+@cross-check-integrity
+test update-from-where-false {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, val TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b'),(3,'c');
+    INSERT INTO t2 VALUES(1,'X'),(2,'Y'),(3,'Z');
+    UPDATE t1 SET b = t2.val FROM t2 WHERE 0;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|a
+    2|b
+    3|c
+}
+
+# json_extract in SET
+@cross-check-integrity
+test update-from-json-extract {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    CREATE TABLE t2(id INT, data TEXT);
+    INSERT INTO t1 VALUES(1,'old'),(2,'old');
+    INSERT INTO t2 VALUES(1,'{"name":"hello"}'),(2,'{"name":"world"}');
+    UPDATE t1 SET b = json_extract(t2.data, '$.name') FROM t2 WHERE t2.id = t1.a;
+    SELECT * FROM t1 ORDER BY a;
+}
+expect {
+    1|hello
+    2|world
+}

--- a/testing/sqltests/tests/update-from.sqltest
+++ b/testing/sqltests/tests/update-from.sqltest
@@ -1,0 +1,1865 @@
+@database :memory:
+
+# UPDATE ... FROM basic tests.
+# See https://sqlite.org/lang_update.html — added in SQLite 3.33.0.
+# The target table is NOT part of the FROM clause, unless the intent is a
+# self-join (in which case the FROM-side reference must be aliased).
+
+# Simple two-table UPDATE ... FROM with equality join on primary key.
+@cross-check-integrity
+test update-from-basic-equijoin {
+    CREATE TABLE inventory (itemId INTEGER PRIMARY KEY, quantity INTEGER);
+    CREATE TABLE sales (itemId INTEGER, qty INTEGER);
+    INSERT INTO inventory VALUES (1, 100), (2, 200), (3, 300);
+    INSERT INTO sales VALUES (1, 5), (2, 15);
+    UPDATE inventory SET quantity = quantity - sales.qty
+      FROM sales
+     WHERE inventory.itemId = sales.itemId;
+    SELECT itemId, quantity FROM inventory ORDER BY itemId;
+}
+expect {
+    1|95
+    2|185
+    3|300
+}
+
+# Update multiple columns from a source table.
+@cross-check-integrity
+test update-from-multiple-columns {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, name TEXT, value INTEGER);
+    CREATE TABLE src (id INTEGER, new_name TEXT, new_value INTEGER);
+    INSERT INTO target VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30);
+    INSERT INTO src VALUES (1, 'alpha', 100), (3, 'gamma', 300);
+    UPDATE target SET name = src.new_name, value = src.new_value
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, name, value FROM target ORDER BY id;
+}
+expect {
+    1|alpha|100
+    2|b|20
+    3|gamma|300
+}
+
+# Expression on the right-hand side using both target and source columns.
+@cross-check-integrity
+test update-from-expression-mixing-sides {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, delta INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO src VALUES (1, 1), (2, 2), (3, 3);
+    UPDATE target SET val = target.val * 10 + src.delta
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|101
+    2|202
+    3|303
+}
+
+# Additional WHERE predicate beyond the join condition.
+@cross-check-integrity
+test update-from-extra-where-filter {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER, flag INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10, 0), (2, 20, 1), (3, 30, 0), (4, 40, 1);
+    INSERT INTO src VALUES (1, 100), (2, 200), (3, 300), (4, 400);
+    UPDATE target SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id AND target.flag = 1;
+    SELECT id, val, flag FROM target ORDER BY id;
+}
+expect {
+    1|10|0
+    2|220|1
+    3|30|0
+    4|440|1
+}
+
+# Unqualified column references in SET should bind to the target table.
+@cross-check-integrity
+test update-from-unqualified-set-columns {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (1, 999), (2, 888);
+    UPDATE target SET val = src.val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|999
+    2|888
+}
+
+# Rows in target with no matching source row stay unchanged.
+@cross-check-integrity
+test update-from-no-match-leaves-unchanged {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO src VALUES (2, 200);
+    UPDATE target SET val = src.val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|10
+    2|200
+    3|30
+}
+
+# Empty source — update should be a no-op.
+@cross-check-integrity
+test update-from-empty-source {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    UPDATE target SET val = src.val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|10
+    2|20
+}
+
+# NULL join keys don't match (standard SQL equality semantics).
+@cross-check-integrity
+test update-from-null-join-key-no-match {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (NULL, 999), (1, 111);
+    UPDATE target SET val = src.val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|111
+    2|20
+}
+
+# Subquery as the FROM source (the canonical SQLite docs example).
+@cross-check-integrity
+test update-from-aggregated-subquery {
+    CREATE TABLE inventory (itemId INTEGER PRIMARY KEY, quantity INTEGER);
+    CREATE TABLE sales (itemId INTEGER, quantity INTEGER);
+    INSERT INTO inventory VALUES (1, 100), (2, 200), (3, 300);
+    INSERT INTO sales VALUES (1, 5), (1, 2), (2, 15), (2, 5), (2, 10);
+    UPDATE inventory
+       SET quantity = quantity - daily.amt
+      FROM (SELECT sum(quantity) AS amt, itemId FROM sales GROUP BY itemId) AS daily
+     WHERE inventory.itemId = daily.itemId;
+    SELECT itemId, quantity FROM inventory ORDER BY itemId;
+}
+expect {
+    1|93
+    2|170
+    3|300
+}
+
+# Explicit INNER JOIN in the FROM clause.
+@cross-check-integrity
+test update-from-explicit-inner-join {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE a (id INTEGER, key INTEGER);
+    CREATE TABLE b (key INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO a VALUES (1, 100), (2, 200);
+    INSERT INTO b VALUES (100, 1), (200, 2);
+    UPDATE target SET val = val + b.bump
+      FROM a JOIN b ON a.key = b.key
+     WHERE target.id = a.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|11
+    2|22
+    3|30
+}
+
+# JOIN ... USING in the FROM clause should bind shared join columns correctly.
+@cross-check-integrity
+test update-from-join-using {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE s1 (id INTEGER, k INTEGER);
+    CREATE TABLE s2 (k INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO s1 VALUES (1, 100), (2, 200);
+    INSERT INTO s2 VALUES (100, 7), (200, 8);
+    UPDATE target
+       SET val = val + bump
+      FROM s1 JOIN s2 USING (k)
+     WHERE target.id = s1.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|17
+    2|28
+    3|30
+}
+
+# NATURAL JOIN in the FROM clause should only use the overlapping source columns.
+@cross-check-integrity
+test update-from-natural-join {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE s1 (id INTEGER, k INTEGER, shared TEXT);
+    CREATE TABLE s2 (k INTEGER, bump INTEGER, shared TEXT);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO s1 VALUES (1, 100, 'm'), (2, 200, 'n');
+    INSERT INTO s2 VALUES (100, 5, 'm'), (200, 6, 'n'), (200, 99, 'x');
+    UPDATE target
+       SET val = val + bump
+      FROM s1 NATURAL JOIN s2
+     WHERE target.id = s1.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|15
+    2|26
+    3|30
+}
+
+# CTE in the FROM clause.
+@cross-check-integrity
+test update-from-with-cte {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, val INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO src VALUES (1, 1), (1, 2), (2, 3), (2, 4), (3, 5);
+    WITH totals AS (SELECT id, sum(val) AS s FROM src GROUP BY id)
+    UPDATE target SET val = totals.s
+      FROM totals
+     WHERE target.id = totals.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|3
+    2|7
+    3|5
+}
+
+# A VALUES-backed CTE may act as the FROM-side source.
+@cross-check-integrity
+test update-from-values-cte-source {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO target VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    WITH src(id, new_val) AS (VALUES (1, 'x'), (3, 'z'))
+    UPDATE target
+       SET val = src.new_val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|x
+    2|b
+    3|z
+}
+
+# Self-join: the target appears in FROM but must be aliased to a different name.
+@cross-check-integrity
+test update-from-self-join-aliased {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, parent INTEGER, label TEXT);
+    INSERT INTO t VALUES (1, NULL, 'root'), (2, 1, 'child-a'), (3, 1, 'child-b'), (4, 2, 'grandchild');
+    UPDATE t SET label = p.label || '->' || t.label
+      FROM t AS p
+     WHERE t.parent = p.id;
+    SELECT id, parent, label FROM t ORDER BY id;
+}
+expect {
+    1||root
+    2|1|root->child-a
+    3|1|root->child-b
+    4|2|child-a->grandchild
+}
+
+# Unaliased self-reference in FROM is illegal when the target is also unaliased.
+test update-from-self-reference-unaliased-errors {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES (1, 10);
+    UPDATE t
+       SET v = 1
+      FROM t
+     WHERE t.id = t.id;
+}
+expect error {
+}
+
+test update-from-self-reference-unaliased-case-insensitive-errors {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES (1, 10);
+    UPDATE t
+       SET v = 1
+      FROM T
+     WHERE t.id = T.id;
+}
+expect error {
+}
+
+# Three-table FROM list (comma-join).
+@cross-check-integrity
+test update-from-three-tables {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE a (id INTEGER, ak INTEGER);
+    CREATE TABLE b (ak INTEGER, bk INTEGER);
+    CREATE TABLE c (bk INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO a VALUES (1, 100), (2, 200);
+    INSERT INTO b VALUES (100, 1000), (200, 2000);
+    INSERT INTO c VALUES (1000, 7), (2000, 9);
+    UPDATE target SET val = val + c.bump
+      FROM a, b, c
+     WHERE target.id = a.id AND a.ak = b.ak AND b.bk = c.bk;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|17
+    2|29
+    3|30
+}
+
+# RETURNING clause sees the updated target row. Per SQLite, RETURNING
+# may only reference columns of the modified table, not FROM-side columns.
+@cross-check-integrity
+test update-from-returning-target {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (1, 5), (2, 6);
+    UPDATE target SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id
+    RETURNING id, val;
+}
+expect {
+    1|15
+    2|26
+}
+
+@cross-check-integrity
+test update-from-returning-star {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (1, 5), (2, 6);
+    UPDATE target SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id
+    RETURNING *;
+}
+expect {
+    1|15
+    2|26
+}
+
+@cross-check-integrity
+test update-from-returning-complex-expressions {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, name TEXT, val INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER, suffix TEXT);
+    INSERT INTO target VALUES (1, 'alpha', 10), (2, 'beta', 20);
+    INSERT INTO src VALUES (1, 5, '!'), (2, 7, '?');
+    UPDATE target
+       SET val = val + src.bump,
+           name = upper(name) || src.suffix
+      FROM src
+     WHERE target.id = src.id
+    RETURNING id, length(name), val * 2, substr(name, 1, 2);
+    SELECT id, name, val FROM target ORDER BY id;
+}
+expect {
+    1|6|30|AL
+    2|5|54|BE
+    1|ALPHA!|15
+    2|BETA?|27
+}
+
+@cross-check-integrity
+test update-from-returning-correlated-subquery-can-see-target {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, grp INTEGER, val INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 1, 10), (2, 1, 20), (3, 2, 30);
+    INSERT INTO src VALUES (1, 5), (3, 7);
+    UPDATE target
+       SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id
+    RETURNING id, grp, (SELECT count(*) FROM target t2 WHERE t2.grp = target.grp);
+}
+expect {
+    1|1|2
+    3|2|1
+}
+
+test update-from-returning-may-not-reference-source-columns {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10);
+    INSERT INTO src VALUES (1, 5);
+    UPDATE target SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id
+    RETURNING src.bump;
+}
+expect error {
+}
+
+# UPDATE ... FROM must still evaluate scalar subqueries in SET.
+@cross-check-integrity
+test update-from-set-subquery {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO target VALUES (1, 0), (2, 0);
+    INSERT INTO src VALUES (1, 7), (2, 8);
+    WITH c(x) AS (SELECT 42)
+    UPDATE target
+       SET val = (SELECT x FROM c)
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|42
+    2|42
+}
+
+@cross-check-integrity
+test update-from-row-value-set {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, a TEXT, b INTEGER);
+    CREATE TABLE src (id INTEGER, x TEXT, y INTEGER);
+    INSERT INTO target VALUES (1, 'old', 1), (2, 'older', 2);
+    INSERT INTO src VALUES (1, 'new', 10), (2, 'newer', 20);
+    UPDATE target
+       SET (a, b) = (src.x, src.y)
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, a, b FROM target ORDER BY id;
+}
+expect {
+    1|new|10
+    2|newer|20
+}
+
+@cross-check-integrity
+test update-from-row-value-set-extra-parens {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, a TEXT, b INTEGER);
+    CREATE TABLE src (id INTEGER, x TEXT, y INTEGER);
+    INSERT INTO target VALUES (1, 'old', 1), (2, 'older', 2);
+    INSERT INTO src VALUES (1, 'new', 10), (2, 'newer', 20);
+    UPDATE target
+       SET (a, b) = ((src.x, src.y))
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, a, b FROM target ORDER BY id;
+}
+expect {
+    1|new|10
+    2|newer|20
+}
+
+@cross-check-integrity
+test update-from-row-value-set-subquery {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, a TEXT, b INTEGER);
+    CREATE TABLE src (id INTEGER PRIMARY KEY, lookup_id INTEGER);
+    CREATE TABLE payload (lookup_id INTEGER PRIMARY KEY, x TEXT, y INTEGER);
+    INSERT INTO target VALUES (1, 'old', 1), (2, 'older', 2);
+    INSERT INTO src VALUES (1, 100), (2, 200);
+    INSERT INTO payload VALUES (100, 'new', 10), (200, 'newer', 20);
+    UPDATE target
+       SET (a, b) = (
+            SELECT payload.x, payload.y
+              FROM payload
+             WHERE payload.lookup_id = src.lookup_id
+       )
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, a, b FROM target ORDER BY id;
+}
+expect {
+    1|new|10
+    2|newer|20
+}
+
+@cross-check-integrity
+test update-from-set-subquery-may-reference-source-table {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (1, 7), (2, 8);
+    UPDATE target
+       SET val = (SELECT target.val + src.bump * 10)
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|80
+    2|100
+}
+
+# RETURNING subqueries may still reference statement-scoped CTEs.
+@cross-check-integrity
+test update-from-returning-subquery-can-see-cte {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (1, 5), (2, 6);
+    WITH c(x) AS (SELECT 42)
+    UPDATE target
+       SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id
+    RETURNING id, (SELECT x FROM c);
+}
+expect {
+    1|42
+    2|42
+}
+
+# When a FROM-side CTE is reused from RETURNING, both reads must see the same
+# statement snapshot even if a trigger mutates the CTE's base table mid-update.
+@cross-check-integrity
+test update-from-returning-reuses-cte-snapshot-after-trigger-mutation {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0),(3,0);
+    INSERT INTO s VALUES(1,1),(2,2),(3,3);
+    CREATE TRIGGER bu BEFORE UPDATE ON t
+    WHEN NEW.id = 1
+    BEGIN
+        UPDATE s SET bump = 100 WHERE id = 2;
+    END;
+    WITH c(sum_bump) AS (SELECT sum(bump) FROM s)
+    UPDATE t
+       SET v = 0
+      FROM c
+     WHERE t.id > 0
+    RETURNING id, v, (SELECT sum_bump FROM c);
+}
+expect {
+    1|0|6
+    2|0|6
+    3|0|6
+}
+
+# The FROM-side CTE read is done before the trigger mutates `s`, but the
+# correlated RETURNING subquery re-runs after each row is written. Those two
+# reads must not share one materialized CTE result.
+@cross-check-integrity
+test update-from-returning-reuses-row-cte-snapshot-after-trigger-mutation {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0),(3,0);
+    INSERT INTO s VALUES(1,1),(2,2),(3,3);
+    CREATE TRIGGER bu BEFORE UPDATE ON t
+    WHEN NEW.id = 1
+    BEGIN
+        UPDATE s SET bump = 100 WHERE id = 2;
+    END;
+    WITH c(id, bump) AS (SELECT id, bump FROM s)
+    UPDATE t
+       SET v = src.bump
+      FROM c AS src
+     WHERE t.id = src.id
+    RETURNING id, (SELECT bump FROM c WHERE c.id = t.id);
+}
+expect {
+    1|1
+    2|100
+    3|3
+}
+
+# Aliasing the target in UPDATE and referring to the alias in SET/WHERE.
+@cross-check-integrity
+test update-from-target-alias {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (1, 100), (2, 200);
+    UPDATE target AS t SET val = t.val + src.bump
+      FROM src
+     WHERE t.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|110
+    2|220
+}
+
+# Once the target is aliased, a FROM-side alias may reuse the base table name.
+@cross-check-integrity
+test update-from-target-alias-allows-source-alias-matching-base-name {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE u (id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO t VALUES (1, 10), (2, 20);
+    INSERT INTO u VALUES (1, 100), (2, 200);
+    UPDATE t AS x
+       SET val = t.val
+      FROM u AS t
+     WHERE x.id = t.id;
+    SELECT id, val FROM t ORDER BY id;
+}
+expect {
+    1|100
+    2|200
+}
+
+# Reusing the target alias for a different physical source table is legal.
+@cross-check-integrity
+test update-from-target-alias-allows-different-table-same-alias {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE s (id INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO t VALUES (1, 10), (2, 20);
+    INSERT INTO s VALUES (1, 100), (2, 200);
+    UPDATE t AS x
+       SET val = val + 1
+      FROM s AS x
+     WHERE 1;
+    SELECT id, val FROM t ORDER BY id;
+}
+expect {
+    1|11
+    2|21
+}
+
+@cross-check-integrity
+test update-from-source-alias-collision-still-allows-source-only-column {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    CREATE TABLE s(id INT, w INT);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    UPDATE t AS x
+       SET v = 1
+      FROM s AS x
+     WHERE x.w = 20;
+    SELECT id, v FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|1
+}
+
+@cross-check-integrity
+test update-from-source-alias-collision-still-allows-source-only-column-in-subquery {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    CREATE TABLE s(id INT, w INT);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    UPDATE t AS x
+       SET v = 1
+      FROM s AS x
+     WHERE EXISTS(SELECT 1 WHERE x.w = 10);
+    SELECT id, v FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|1
+}
+
+test update-from-target-not-visible-in-join-on {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    CREATE TABLE s(id INT, w INT);
+    CREATE TABLE u(id INT);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    INSERT INTO u VALUES(1),(2);
+    UPDATE t
+       SET v = s.w
+      FROM s JOIN u ON u.id = t.id AND s.id = u.id
+     WHERE t.id = s.id;
+}
+expect error {
+}
+
+test update-from-target-not-visible-in-join-on-subquery {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    CREATE TABLE s(id INT, w INT);
+    CREATE TABLE u(id INT);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    INSERT INTO u VALUES(1),(2);
+    UPDATE t
+       SET v = s.w
+      FROM s JOIN u
+        ON EXISTS(SELECT 1 WHERE t.id = u.id) AND s.id = u.id
+     WHERE t.id = s.id;
+}
+expect error {
+}
+
+test update-from-target-alias-not-visible-in-join-on {
+    CREATE TABLE t(id INT PRIMARY KEY, v INT);
+    CREATE TABLE s(id INT, w INT);
+    CREATE TABLE u(id INT);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    INSERT INTO u VALUES(1),(2);
+    UPDATE t AS x
+       SET v = s.w
+      FROM s JOIN u ON u.id = x.id AND s.id = u.id
+     WHERE x.id = s.id;
+}
+expect error {
+}
+
+# Once the target is aliased, an unaliased FROM-side self-reference is legal.
+@cross-check-integrity
+test update-from-target-alias-allows-unaliased-self-reference {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, parent INTEGER, label TEXT);
+    INSERT INTO t VALUES (1, NULL, 'root'), (2, 1, 'child-a'), (3, 1, 'child-b');
+    UPDATE t AS child
+       SET label = t.label || '->' || child.label
+      FROM t
+     WHERE child.parent = t.id;
+    SELECT id, parent, label FROM t ORDER BY id;
+}
+expect {
+    1||root
+    2|1|root->child-a
+    3|1|root->child-b
+}
+
+# Updating a column that is also an indexed column — indexes must be maintained.
+@cross-check-integrity
+test update-from-updates-indexed-column {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+    CREATE INDEX target_k ON target(k);
+    CREATE TABLE src (id INTEGER, new_k INTEGER);
+    INSERT INTO target VALUES (1, 10, 100), (2, 20, 200), (3, 30, 300);
+    INSERT INTO src VALUES (1, 11), (3, 33);
+    UPDATE target SET k = src.new_k
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, v FROM target WHERE k = 11;
+    SELECT id, v FROM target WHERE k = 20;
+    SELECT id, v FROM target WHERE k = 33;
+}
+expect {
+    1|100
+    2|200
+    3|300
+}
+
+# If multiple FROM-side rows match the same target row, SQLite updates from one
+# arbitrary match. It must not apply multiple matches cumulatively.
+@cross-check-integrity
+test update-from-duplicate-match-updates-once {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src (id INTEGER, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20);
+    INSERT INTO src VALUES (1, 1), (1, 100), (2, 7);
+    UPDATE target
+       SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id;
+    SELECT val IN (11, 110), val != 111 FROM target WHERE id = 1;
+    SELECT val FROM target WHERE id = 2;
+}
+expect {
+    1|1
+    27
+}
+
+# When multiple source rows match, all SET columns must come from the same
+# chosen source row, not from a mixture of different matching rows.
+@cross-check-integrity
+test update-from-duplicate-match-keeps-set-columns-consistent {
+    CREATE TABLE target (id INTEGER PRIMARY KEY, name TEXT, value INTEGER);
+    CREATE TABLE src (id INTEGER, new_name TEXT, new_value INTEGER);
+    INSERT INTO target VALUES (1, 'orig', 0);
+    INSERT INTO src VALUES (1, 'alpha', 100), (1, 'beta', 200);
+    UPDATE target
+       SET name = src.new_name, value = src.new_value
+      FROM src
+     WHERE target.id = src.id;
+    SELECT
+        (name = 'alpha' AND value = 100) OR (name = 'beta' AND value = 200),
+        NOT ((name = 'alpha' AND value = 200) OR (name = 'beta' AND value = 100))
+    FROM target WHERE id = 1;
+}
+expect {
+    1|1
+}
+
+# An explicit INDEXED BY on the target table must still be honored when
+# UPDATE ... FROM builds its internal write-set SELECT.
+@cross-check-integrity
+test update-from-indexed-by-target-hint-is-preserved {
+    CREATE TABLE p(id INT PRIMARY KEY, v TEXT, k INT);
+    CREATE INDEX p_k ON p(k);
+    CREATE TABLE s(id INT, newv TEXT);
+    INSERT INTO p VALUES(1,'x',10),(2,'y',20);
+    INSERT INTO s VALUES(1,'b'),(1,'a');
+
+    UPDATE p INDEXED BY p_k
+       SET v = newv
+      FROM s
+     WHERE p.id = s.id;
+
+    SELECT id, v, k FROM p ORDER BY id;
+}
+expect {
+    1|b|10
+    2|y|20
+}
+
+# Virtual-table/table-valued-function arguments from FROM must be preserved.
+@cross-check-integrity
+test update-from-vtab-source-arguments {
+    CREATE TABLE dst (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO dst VALUES (0, 'a'), (1, 'b');
+    UPDATE dst
+       SET val = p.name
+      FROM pragma_table_info('dst') AS p
+     WHERE dst.id = p.cid;
+    SELECT id, val FROM dst ORDER BY id;
+}
+expect {
+    0|id
+    1|val
+}
+
+# Regression for differential fuzzing: dead UPDATE ... FROM statements must not
+# hit the single-table update path during compilation. In SQLite, a non-numeric
+# string in WHERE coerces to 0, so this statement updates no rows.
+@cross-check-integrity
+test update-from-attached-constant-where-literal-set {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, v BLOB);
+    CREATE TABLE aux.t2(id INTEGER PRIMARY KEY, x INTEGER);
+    INSERT INTO aux.t1 VALUES (1, X'01'), (2, X'02');
+    INSERT INTO aux.t2 VALUES (10, 1), (20, 2);
+    UPDATE aux.t1
+       SET v = X'AA'
+      FROM aux.t2
+     WHERE 'constant true';
+    SELECT hex(v) FROM aux.t1 ORDER BY id;
+}
+expect {
+    01
+    02
+}
+
+# Numeric-false WHERE follows the same dead-code path and must likewise avoid
+# the normal two-table UPDATE loop.
+@cross-check-integrity
+test update-from-attached-constant-where-zero {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE aux.t2(id INTEGER PRIMARY KEY, x INTEGER);
+    INSERT INTO aux.t1 VALUES (1, 10), (2, 20);
+    INSERT INTO aux.t2 VALUES (10, 1), (20, 2);
+    UPDATE aux.t1
+       SET v = 7
+      FROM aux.t2
+     WHERE 0;
+    SELECT id, v FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|10
+    2|20
+}
+
+# Same regression shape, but with a numeric constant WHERE.
+@cross-check-integrity
+test update-from-attached-constant-where-one {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE aux.t2(id INTEGER PRIMARY KEY, x INTEGER);
+    INSERT INTO aux.t1 VALUES (1, 10), (2, 20);
+    INSERT INTO aux.t2 VALUES (10, 1);
+    UPDATE aux.t1
+       SET v = 7
+      FROM aux.t2
+     WHERE 1;
+    SELECT id, v FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|7
+    2|7
+}
+
+# Constant WHERE with a no-op SET should still execute through UPDATE ... FROM
+# without panicking, including on attached databases.
+@cross-check-integrity
+test update-from-attached-constant-where-noop-set {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE aux.t2(id INTEGER PRIMARY KEY, x INTEGER);
+    INSERT INTO aux.t1 VALUES (1, 10), (2, 20);
+    INSERT INTO aux.t2 VALUES (10, 1), (20, 2);
+    UPDATE aux.t1
+       SET v = v
+      FROM aux.t2
+     WHERE 1;
+    SELECT id, v FROM aux.t1 ORDER BY id;
+}
+expect {
+    1|10
+    2|20
+}
+
+# BEFORE/AFTER triggers on the target should see the same row transitions as a
+# plain UPDATE, even when values come from a FROM-side source.
+@cross-check-integrity
+test update-from-triggers-see-updated-values {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_val TEXT);
+    CREATE TABLE log(seq INTEGER PRIMARY KEY, kind TEXT, payload TEXT);
+    INSERT INTO target VALUES (1, 'a'), (2, 'b');
+    INSERT INTO src VALUES (1, 'x'), (2, 'y');
+    CREATE TRIGGER bu BEFORE UPDATE ON target BEGIN
+        INSERT INTO log(kind, payload)
+        VALUES('before', OLD.id || ':' || OLD.val || '->' || NEW.val);
+    END;
+    CREATE TRIGGER au AFTER UPDATE ON target BEGIN
+        INSERT INTO log(kind, payload)
+        VALUES('after', NEW.id || ':' || NEW.val);
+    END;
+    UPDATE target
+       SET val = src.new_val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT kind, payload FROM log ORDER BY seq;
+}
+expect {
+    before|1:a->x
+    after|1:x
+    before|2:b->y
+    after|2:y
+}
+
+@cross-check-integrity
+test update-from-before-trigger-raise-ignore-skips-row {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE src(id INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO src VALUES (1, 1), (2, 2), (3, 3);
+    CREATE TRIGGER bu BEFORE UPDATE ON target
+    WHEN NEW.id = 2
+    BEGIN
+        SELECT RAISE(IGNORE);
+    END;
+    UPDATE target
+       SET val = val + src.bump
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|11
+    2|20
+    3|33
+}
+
+# Trigger-body UPDATE ... FROM must rewrite NEW references inside FROM-side
+# derived subqueries, not just top-level SET/WHERE expressions.
+@cross-check-integrity
+test update-from-trigger-derived-source-sees-new {
+    CREATE TABLE src(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE dst(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, w INTEGER);
+    INSERT INTO src VALUES (1, 10), (2, 20);
+    INSERT INTO dst VALUES (1, 0), (2, 0);
+    INSERT INTO s VALUES (1, 100), (2, 200);
+    CREATE TRIGGER trg AFTER UPDATE ON src BEGIN
+        UPDATE dst
+           SET v = q.w
+          FROM (SELECT id, w FROM s WHERE NEW.id = id) AS q
+         WHERE dst.id = q.id;
+    END;
+    UPDATE src SET v = v + 1 WHERE id = 1;
+    SELECT id, v FROM dst ORDER BY id;
+}
+expect {
+    1|100
+    2|0
+}
+
+# LIMIT/OFFSET inside that derived source must see OLD/NEW too; SQLite permits
+# trigger pseudo-tables there as outer references.
+@cross-check-integrity
+test update-from-trigger-derived-source-limit-sees-old {
+    CREATE TABLE src(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE dst(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, w INTEGER);
+    INSERT INTO src VALUES (1, 10), (2, 20);
+    INSERT INTO dst VALUES (1, 0), (2, 0);
+    INSERT INTO s VALUES (1, 100), (2, 200);
+    CREATE TRIGGER trg AFTER UPDATE ON src BEGIN
+        UPDATE dst
+           SET v = q.w
+          FROM (SELECT id, w FROM s ORDER BY id LIMIT OLD.id) AS q
+         WHERE dst.id = q.id;
+    END;
+    UPDATE src SET v = v + 1 WHERE id = 1;
+    SELECT id, v FROM dst ORDER BY id;
+}
+expect {
+    1|100
+    2|0
+}
+
+# LEFT JOIN sources in the FROM clause should preserve unmatched rows from the
+# joined source graph and still drive the target update once per matched target.
+@cross-check-integrity
+test update-from-left-join-source-graph {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, val INTEGER);
+    CREATE TABLE a(id INTEGER PRIMARY KEY, k INTEGER);
+    CREATE TABLE b(k INTEGER PRIMARY KEY, bump INTEGER);
+    INSERT INTO target VALUES (1, 10), (2, 20), (3, 30);
+    INSERT INTO a VALUES (1, 100), (2, 200), (3, 300);
+    INSERT INTO b VALUES (100, 7), (300, 9);
+    UPDATE target
+       SET val = COALESCE(b.bump, -1)
+      FROM a LEFT JOIN b ON a.k = b.k
+     WHERE target.id = a.id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|7
+    2|-1
+    3|9
+}
+
+# RIGHT JOIN sources in the FROM clause should preserve unmatched rows from the
+# right side of the join and still drive target updates through the preserved map.
+@cross-check-integrity
+test update-from-right-join-source-graph {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE src(src_id INTEGER PRIMARY KEY, txt TEXT);
+    CREATE TABLE map(target_id INTEGER PRIMARY KEY, src_id INTEGER);
+    INSERT INTO target VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    INSERT INTO src VALUES (10, 'ten'), (30, 'thirty');
+    INSERT INTO map VALUES (1, 10), (2, 20), (3, 30);
+    UPDATE target
+       SET val = COALESCE(src.txt, 'missing')
+      FROM src RIGHT JOIN map ON src.src_id = map.src_id
+     WHERE target.id = map.target_id;
+    SELECT id, val FROM target ORDER BY id;
+}
+expect {
+    1|ten
+    2|missing
+    3|thirty
+}
+
+# RIGHT JOIN ... USING(...) must preserve the matched right-row payload and must
+# not update target rows that only exist on the unmatched left side of the join.
+@cross-check-integrity
+test update-from-right-join-using-preserves-right-row-payload {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE TABLE s(id INTEGER, src TEXT);
+    CREATE TABLE u(id INTEGER, extra TEXT);
+    INSERT INTO t VALUES(1, 'x'), (2, 'x'), (3, 'x'), (4, 'x');
+    INSERT INTO s VALUES(1, 's1'), (4, 's4');
+    INSERT INTO u VALUES(1, 'u1'), (2, 'u2');
+    UPDATE t
+       SET v = extra
+      FROM s RIGHT JOIN u USING(id)
+     WHERE t.id = COALESCE(s.id, u.id);
+    SELECT id, v FROM t ORDER BY id;
+}
+expect {
+    1|u1
+    2|u2
+    3|x
+    4|x
+}
+
+# Partial indexes must stay query-correct when UPDATE ... FROM moves rows in
+# and out of the index predicate while also changing indexed values.
+@cross-check-integrity
+test update-from-maintains-partial-index {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, flag INTEGER, val INTEGER);
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_flag INTEGER, new_val INTEGER);
+    CREATE INDEX target_partial ON target(val) WHERE flag = 1;
+    INSERT INTO target VALUES (1, 1, 10), (2, 0, 20), (3, 1, 30);
+    INSERT INTO src VALUES (1, 0, 100), (2, 1, 200), (3, 1, 300);
+    UPDATE target
+       SET flag = src.new_flag,
+           val = src.new_val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id FROM target WHERE flag = 1 AND val = 100 ORDER BY id;
+    SELECT id FROM target WHERE flag = 1 AND val = 200 ORDER BY id;
+    SELECT id FROM target WHERE flag = 1 AND val = 300 ORDER BY id;
+}
+expect {
+    2
+    3
+}
+
+# Expression indexes must also stay query-correct when values are replaced from
+# a FROM-side source.
+@cross-check-integrity
+test update-from-maintains-expression-index {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_val TEXT);
+    CREATE INDEX target_expr ON target(lower(val));
+    INSERT INTO target VALUES (1, 'Alpha'), (2, 'Beta'), (3, 'Gamma');
+    INSERT INTO src VALUES (1, 'ONE'), (3, 'THREE');
+    UPDATE target
+       SET val = src.new_val
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id FROM target WHERE lower(val) = 'one' ORDER BY id;
+    SELECT id FROM target WHERE lower(val) = 'beta' ORDER BY id;
+    SELECT id FROM target WHERE lower(val) = 'three' ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+}
+
+# Updating the INTEGER PRIMARY KEY from a FROM-side source must still fire
+# ON UPDATE CASCADE on child tables.
+@cross-check-integrity
+test update-from-rowid-update-cascades-foreign-keys {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT REFERENCES parent(id) ON UPDATE CASCADE
+    );
+    CREATE TABLE src(old_id INTEGER PRIMARY KEY, new_id INTEGER);
+    INSERT INTO parent VALUES (1, 'a'), (2, 'b');
+    INSERT INTO child VALUES (10, 1), (20, 2);
+    INSERT INTO src VALUES (1, 11), (2, 22);
+    UPDATE parent
+       SET id = src.new_id
+      FROM src
+     WHERE parent.id = src.old_id;
+    SELECT id, parent_id FROM child ORDER BY id;
+}
+expect {
+    10|11
+    20|22
+}
+
+# Composite parent keys should also cascade correctly when updated from a source table.
+@cross-check-integrity
+test update-from-composite-key-update-cascades-foreign-keys {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        ca INTEGER,
+        cb INTEGER,
+        FOREIGN KEY(ca, cb) REFERENCES parent(a, b) ON UPDATE CASCADE
+    );
+    CREATE TABLE src(a INTEGER, b INTEGER, new_a INTEGER, new_b INTEGER);
+    INSERT INTO parent VALUES (1, 10, 'x'), (2, 20, 'y');
+    INSERT INTO child VALUES (1, 1, 10), (2, 2, 20);
+    INSERT INTO src VALUES (1, 10, 11, 110), (2, 20, 22, 220);
+    UPDATE parent
+       SET a = src.new_a,
+           b = src.new_b
+      FROM src
+     WHERE parent.a = src.a
+       AND parent.b = src.b;
+    SELECT id, ca, cb FROM child ORDER BY id;
+}
+expect {
+    1|11|110
+    2|22|220
+}
+
+# OR IGNORE should keep rows that would conflict unchanged while still applying
+# non-conflicting source-driven updates.
+@cross-check-integrity
+test update-from-or-ignore-skips-conflicting-row {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, u TEXT UNIQUE, v INTEGER);
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_u TEXT, new_v INTEGER);
+    INSERT INTO target VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30);
+    INSERT INTO src VALUES (1, 'b', 111), (2, 'z', 222);
+    UPDATE OR IGNORE target
+       SET u = src.new_u,
+           v = src.new_v
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, u, v FROM target ORDER BY id;
+}
+expect {
+    1|a|10
+    2|z|222
+    3|c|30
+}
+
+# OR REPLACE should delete the conflicting row and apply the replacement row
+# chosen by the UPDATE ... FROM source.
+@cross-check-integrity
+test update-from-or-replace-deletes-conflicting-row {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, u TEXT UNIQUE, v INTEGER);
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_u TEXT, new_v INTEGER);
+    INSERT INTO target VALUES (1, 'a', 10), (2, 'b', 20), (3, 'c', 30);
+    INSERT INTO src VALUES (1, 'b', 111), (2, 'z', 222);
+    UPDATE OR REPLACE target
+       SET u = src.new_u,
+           v = src.new_v
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, u, v FROM target ORDER BY id;
+}
+expect {
+    1|b|111
+    3|c|30
+}
+
+test update-from-source-null-violates-not-null {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, v TEXT NOT NULL);
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_v TEXT);
+    INSERT INTO target VALUES (1, 'x');
+    INSERT INTO src VALUES (1, NULL);
+    UPDATE target
+       SET v = src.new_v
+      FROM src
+     WHERE target.id = src.id;
+}
+expect error {
+}
+
+test update-from-source-value-violates-check {
+    CREATE TABLE target(
+        id INTEGER PRIMARY KEY,
+        score INTEGER CHECK(score BETWEEN 0 AND 10)
+    );
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_score INTEGER);
+    INSERT INTO target VALUES (1, 5);
+    INSERT INTO src VALUES (1, 99);
+    UPDATE target
+       SET score = src.new_score
+      FROM src
+     WHERE target.id = src.id;
+}
+expect error {
+}
+
+@cross-check-integrity
+test update-from-strict-table-coerces-compatible-values {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, v INTEGER) STRICT;
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_v TEXT);
+    INSERT INTO target VALUES (1, 1);
+    INSERT INTO src VALUES (1, '7');
+    UPDATE target
+       SET v = src.new_v
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, typeof(v), v FROM target;
+}
+expect {
+    1|integer|7
+}
+
+test update-from-strict-table-rejects-incompatible-values {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, v INTEGER) STRICT;
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_v TEXT);
+    INSERT INTO target VALUES (1, 1);
+    INSERT INTO src VALUES (1, 'abc');
+    UPDATE target
+       SET v = src.new_v
+      FROM src
+     WHERE target.id = src.id;
+}
+expect error {
+}
+
+@cross-check-integrity
+test update-from-updates-generated-columns {
+    CREATE TABLE target(
+        id INTEGER PRIMARY KEY,
+        base INTEGER,
+        doubled INTEGER GENERATED ALWAYS AS (base * 2) VIRTUAL
+    );
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_base INTEGER);
+    INSERT INTO target(id, base) VALUES (1, 3), (2, 4);
+    INSERT INTO src VALUES (1, 7), (2, 9);
+    UPDATE target
+       SET base = src.new_base
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, base, doubled FROM target ORDER BY id;
+}
+expect {
+    1|7|14
+    2|9|18
+}
+
+@cross-check-integrity
+test update-from-or-replace-cascades-foreign-key-deletes {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE target(id INTEGER PRIMARY KEY, u TEXT UNIQUE, v INTEGER);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        target_u TEXT REFERENCES target(u) ON DELETE CASCADE
+    );
+    CREATE TABLE src(id INTEGER PRIMARY KEY, new_u TEXT);
+    INSERT INTO target VALUES (1, 'a', 10), (2, 'b', 20);
+    INSERT INTO child VALUES (10, 'b');
+    INSERT INTO src VALUES (1, 'b');
+    UPDATE OR REPLACE target
+       SET u = src.new_u
+      FROM src
+     WHERE target.id = src.id;
+    SELECT id, u, v FROM target ORDER BY id;
+    SELECT id, target_u FROM child ORDER BY id;
+}
+expect {
+    1|b|10
+}
+
+# ─── Adversarial: ephemeral materialization / snapshot semantics ───
+
+# Shift every row's value to its predecessor's value. Without snapshot
+# semantics (ephemeral materialization), row 2 would see the already-updated
+# row 1 value instead of the original.
+@cross-check-integrity
+test update-from-snapshot-shift-predecessor {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES(1,1),(2,2),(3,3),(4,4),(5,5);
+    UPDATE t SET v = prev.v
+      FROM t AS prev
+     WHERE t.id = prev.id + 1;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|1
+    3|2
+    4|3
+    5|4
+}
+
+# Mirror of the above — shift to successor values.
+@cross-check-integrity
+test update-from-snapshot-shift-successor {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES(1,1),(2,2),(3,3),(4,4),(5,5);
+    UPDATE t SET v = nxt.v
+      FROM t AS nxt
+     WHERE t.id + 1 = nxt.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|2
+    2|3
+    3|4
+    4|5
+    5|5
+}
+
+# Reverse the ordering of values via self-join. This swaps rows 1↔3
+# simultaneously — without snapshot semantics row 3 would see row 1's
+# already-updated value.
+@cross-check-integrity
+test update-from-snapshot-reverse-three-rows {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES(1,100),(2,200),(3,300);
+    UPDATE t AS a SET v = b.v
+      FROM t AS b
+     WHERE a.id = 4 - b.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|300
+    2|200
+    3|100
+}
+
+# FROM-subquery sources that read the target table must also see the pre-update snapshot.
+@cross-check-integrity
+test update-from-from-subquery-reads-target-snapshot {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+    INSERT INTO t VALUES(1,10,20),(2,30,40);
+    UPDATE t
+       SET a = src.b,
+           b = src.a
+      FROM (SELECT id, a, b FROM t) AS src
+     WHERE t.id = src.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|20|10
+    2|40|30
+}
+
+# Set every row to the pre-update sum. The subquery must read the
+# pre-materialization snapshot, not partially-updated rows.
+@cross-check-integrity
+test update-from-snapshot-set-to-pre-update-aggregate {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    UPDATE t SET v = (SELECT sum(v) FROM t) FROM (SELECT 1) AS dummy;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|60
+    2|60
+    3|60
+}
+
+# ─── Adversarial: type preservation through ephemeral table ───
+
+# Mixed storage classes must survive the round-trip through the BLOB-affinity
+# ephemeral scratch table without coercion.
+@cross-check-integrity
+test update-from-type-preservation-mixed-types {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v);
+    CREATE TABLE s(id INTEGER, v);
+    INSERT INTO t VALUES(1,NULL),(2,'hello'),(3,42),(4,3.14),(5,X'DEADBEEF');
+    INSERT INTO s VALUES(1,'replaced'),(2,NULL),(3,X'CAFE'),(4,999),(5,0.5);
+    UPDATE t SET v=s.v FROM s WHERE t.id=s.id;
+    SELECT id, typeof(v), quote(v) FROM t ORDER BY id;
+}
+expect {
+    1|text|'replaced'
+    2|null|NULL
+    3|blob|X'CAFE'
+    4|integer|999
+    5|real|0.5
+}
+
+# Integer affinity column receiving a text value that looks like a number.
+# The ephemeral table uses BLOB affinity, so the coercion must happen
+# during the final INSERT, not during materialization.
+@cross-check-integrity
+test update-from-affinity-coercion-at-insert {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v TEXT);
+    INSERT INTO t VALUES(1,10);
+    INSERT INTO s VALUES(1,'99');
+    UPDATE t SET v=s.v FROM s WHERE t.id=s.id;
+    SELECT typeof(v), v FROM t;
+}
+expect {
+    integer|99
+}
+
+# i64 extremes must survive the ephemeral round-trip.
+@cross-check-integrity
+test update-from-i64-extremes-through-ephemeral {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,9223372036854775807),(2,-9223372036854775808);
+    UPDATE t SET v=s.v FROM s WHERE t.id=s.id;
+    SELECT id, v FROM t ORDER BY id;
+}
+expect {
+    1|9223372036854775807
+    2|-9223372036854775808
+}
+
+# ─── Adversarial: self-join cursor confusion ───
+
+# Triple self-join: the same physical table is opened three times. Cursor
+# management must keep the write cursor, the two read aliases, and the
+# ephemeral scratch table separate.
+@cross-check-integrity
+test update-from-triple-self-join {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20);
+    UPDATE t AS x SET v = y.v + z.v
+      FROM t AS y, t AS z
+     WHERE x.id = y.id AND x.id = z.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|20
+    2|40
+}
+
+# Linked-list traversal via self-join. Each node gets its parent's value.
+@cross-check-integrity
+test update-from-self-join-linked-list {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, next_id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,2,10),(2,3,20),(3,NULL,30);
+    UPDATE t SET v = nxt.v FROM t AS nxt WHERE t.next_id = nxt.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|2|20
+    2|3|30
+    3||30
+}
+
+# When the source is a self-join alias on the same physical table and the join
+# column is unindexed, the write phase must re-read preserved columns from the
+# freshly-seeked target row, not from stale source-side cursor state.
+@cross-check-integrity
+test update-from-self-join-preserves-non-set-columns {
+    CREATE TABLE t(id INT, v INT);
+    INSERT INTO t VALUES(1,10),(2,20);
+    UPDATE t
+       SET v=99
+      FROM t AS s
+     WHERE t.id=s.id AND s.id=1
+    RETURNING *;
+    SELECT rowid, id, v FROM t ORDER BY rowid;
+}
+expect {
+    1|99
+    1|1|99
+    2|2|20
+}
+
+# The same cursor-state hazard appears through USING when the self-join aliases
+# are tied together on the shared column.
+@cross-check-integrity
+test update-from-self-join-using-preserves-non-set-columns {
+    CREATE TABLE t(id INT, v INT);
+    INSERT INTO t VALUES(1,10),(2,20);
+    UPDATE t
+       SET v=99
+      FROM t AS s
+      JOIN t AS u USING(id)
+     WHERE t.id=s.id AND s.id=1;
+    SELECT rowid, id, v FROM t ORDER BY rowid;
+}
+expect {
+    1|1|99
+    2|2|20
+}
+
+# ─── Adversarial: index consistency after FROM-driven mutations ───
+
+# Three separate indexes all updated in one UPDATE FROM statement.
+@cross-check-integrity
+test update-from-three-indexes-maintained {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b TEXT, c REAL);
+    CREATE INDEX t_a ON t(a);
+    CREATE INDEX t_b ON t(b);
+    CREATE INDEX t_c ON t(c);
+    CREATE TABLE s(id INTEGER, na INTEGER, nb TEXT, nc REAL);
+    INSERT INTO t VALUES(1,10,'x',1.0),(2,20,'y',2.0),(3,30,'z',3.0);
+    INSERT INTO s VALUES(1,11,'xx',1.1),(3,33,'zz',3.3);
+    UPDATE t SET a=s.na, b=s.nb, c=s.nc FROM s WHERE t.id=s.id;
+    SELECT * FROM t ORDER BY id;
+    SELECT id FROM t WHERE a=11;
+    SELECT id FROM t WHERE b='y';
+    SELECT id FROM t WHERE c=3.3;
+}
+expect {
+    1|11|xx|1.1
+    2|20|y|2.0
+    3|33|zz|3.3
+    1
+    2
+    3
+}
+expect @js {
+    1|11|xx|1.1
+    2|20|y|2
+    3|33|zz|3.3
+    1
+    2
+    3
+}
+
+# Expression index on (a+b) must stay correct when only 'a' is updated.
+@cross-check-integrity
+test update-from-expression-index-partial-column-update {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+    CREATE INDEX t_expr ON t(a + b);
+    CREATE TABLE s(id INTEGER, new_a INTEGER);
+    INSERT INTO t VALUES(1,10,5),(2,20,10);
+    INSERT INTO s VALUES(1,100);
+    UPDATE t SET a=s.new_a FROM s WHERE t.id=s.id;
+    SELECT * FROM t ORDER BY id;
+    SELECT id FROM t WHERE a + b = 105;
+    SELECT id FROM t WHERE a + b = 30;
+}
+expect {
+    1|100|5
+    2|20|10
+    1
+    2
+}
+
+# ─── Adversarial: OR REPLACE cascading through ephemeral plan ───
+
+# All four rows chain-conflict: row 1→gets key of row 2 (deleting 2),
+# row 2→gets key of row 3 (but row 2 is already gone), etc.
+# The ephemeral snapshot means the conflict set is computed before any
+# deletes happen.
+@cross-check-integrity
+test update-from-or-replace-cascading-unique-chain {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER UNIQUE);
+    CREATE TABLE s(id INTEGER, new_k INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30),(4,40);
+    INSERT INTO s VALUES(1,20),(2,30),(3,40),(4,50);
+    UPDATE OR REPLACE t SET k=s.new_k FROM s WHERE t.id=s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|20
+    3|40
+}
+
+# OR REPLACE that swaps unique keys between two rows simultaneously.
+# Without snapshot semantics, the second row's update would fail because
+# the first row already holds the conflicting key.
+@cross-check-integrity
+test update-from-or-replace-swap-unique-keys {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER UNIQUE, v TEXT);
+    CREATE TABLE s(id INTEGER, new_k INTEGER, new_v TEXT);
+    INSERT INTO t VALUES(1,10,'a'),(2,20,'b'),(3,30,'c');
+    INSERT INTO s VALUES(1,20,'aa'),(3,10,'cc');
+    UPDATE OR REPLACE t SET k=s.new_k, v=s.new_v FROM s WHERE t.id=s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|20|aa
+    3|10|cc
+}
+
+# ─── Adversarial: OR IGNORE with NOT NULL and CHECK ───
+
+# OR IGNORE + NOT NULL: source provides NULL for some rows. Those rows
+# should be skipped while the rest update normally.
+@cross-check-integrity
+test update-from-or-ignore-skips-notnull-violation {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER NOT NULL DEFAULT 0);
+    CREATE TABLE s(id INTEGER, v INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    INSERT INTO s VALUES(1,NULL),(2,100),(3,NULL);
+    UPDATE OR IGNORE t SET v = s.v FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|10
+    2|100
+    3|30
+}
+
+# OR IGNORE + CHECK: only the row violating the CHECK is skipped.
+@cross-check-integrity
+test update-from-or-ignore-skips-check-violation {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER CHECK(v > 0));
+    CREATE TABLE s(id INTEGER, new_v INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    INSERT INTO s VALUES(1,100),(2,-5),(3,300);
+    UPDATE OR IGNORE t SET v = s.new_v FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|100
+    2|20
+    3|300
+}
+
+# ─── Adversarial: BEFORE trigger modifies the row being updated ───
+
+# The BEFORE trigger bumps a non-SET column. After the trigger fires the
+# row is re-read; the SET value from the FROM source must still apply, and
+# the trigger's change to the non-SET column must be visible in the result.
+@cross-check-integrity
+test update-from-before-trigger-modifies-target-row {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER, extra INTEGER);
+    CREATE TABLE s(id INTEGER, new_v INTEGER);
+    CREATE TRIGGER t_bu BEFORE UPDATE ON t BEGIN
+      UPDATE t SET extra = extra + 1000 WHERE id = NEW.id;
+    END;
+    INSERT INTO t VALUES(1,10,0),(2,20,0);
+    INSERT INTO s VALUES(1,100),(2,200);
+    UPDATE t SET v = s.new_v FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|100|1000
+    2|200|1000
+}
+
+# ─── Adversarial: cartesian product and duplicate source rows ───
+
+# Cartesian product: FROM source has multiple rows but no join condition
+# to the target. Each target row should be updated exactly once (not N
+# times for N source rows).
+@cross-check-integrity
+test update-from-cartesian-updates-once {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(x INTEGER);
+    INSERT INTO t VALUES(1,0);
+    INSERT INTO s VALUES(1),(2),(3);
+    UPDATE t SET v = 999 FROM s;
+    SELECT * FROM t;
+}
+expect {
+    1|999
+}
+
+# No-PK table with duplicate target rows matching the same source row.
+# Both target rows should be updated.
+@cross-check-integrity
+test update-from-no-pk-duplicate-target-rows {
+    CREATE TABLE t(a, b, c);
+    CREATE TABLE s(a, x);
+    INSERT INTO t VALUES(1,2,3),(1,5,6);
+    INSERT INTO s VALUES(1,99);
+    UPDATE t SET b=s.x FROM s WHERE t.a=s.a;
+    SELECT * FROM t ORDER BY c;
+}
+expect {
+    1|99|3
+    1|99|6
+}
+
+# ─── Adversarial: correlated subquery in SET referencing FROM source ───
+
+# The subquery in SET references the FROM-side table. This exercises the
+# subquery re-phasing logic that moves SET subqueries into the ephemeral
+# plan for UPDATE FROM.
+@cross-check-integrity
+test update-from-correlated-subquery-refs-from-source {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, category INTEGER);
+    CREATE TABLE lookup(category INTEGER, bonus INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    INSERT INTO lookup VALUES(10,5),(20,8);
+    UPDATE t SET v = (SELECT bonus FROM lookup WHERE lookup.category = s.category)
+      FROM s WHERE t.id = s.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|5
+    2|8
+}
+
+# ─── Adversarial: window function in FROM subquery ───
+
+@cross-check-integrity
+test update-from-window-function-in-from-subquery {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, rank INTEGER);
+    INSERT INTO t VALUES(1,3),(2,1),(3,2);
+    UPDATE t SET rank = sub.new_rank
+      FROM (
+        SELECT id, row_number() OVER (ORDER BY rank) AS new_rank FROM t
+      ) AS sub
+     WHERE t.id = sub.id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|3
+    2|1
+    3|2
+}
+
+# ─── Adversarial: rowid mutation via FROM ───
+
+# Changing the INTEGER PRIMARY KEY (rowid alias) via a FROM source.
+@cross-check-integrity
+test update-from-rowid-mutation {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(old_id INTEGER, new_id INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    INSERT INTO s VALUES(1,100);
+    UPDATE t SET id = s.new_id FROM s WHERE t.id = s.old_id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    2|20
+    3|30
+    100|10
+}
+
+# Rowid mutation that conflicts with an existing row should ABORT.
+test update-from-rowid-mutation-conflict {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(old_id INTEGER, new_id INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    INSERT INTO s VALUES(1,2);
+    UPDATE t SET id = s.new_id FROM s WHERE t.id = s.old_id;
+}
+expect error {
+}
+
+# OR REPLACE on a rowid collision via FROM should delete the conflicting row.
+@cross-check-integrity
+test update-from-or-replace-rowid-collision {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(old_id INTEGER, new_id INTEGER);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    INSERT INTO s VALUES(1,2);
+    UPDATE OR REPLACE t SET id = s.new_id FROM s WHERE t.id = s.old_id;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    2|10
+    3|30
+}
+
+# ─── Adversarial: NATURAL JOIN inside UPDATE FROM ───
+
+# A regular JOIN followed by a NATURAL JOIN in the FROM clause merges
+# column names from the NATURAL JOIN. SQLite rejects this with
+# "ambiguous column name" even when no bare column reference appears,
+# because the merged NATURAL JOIN columns conflict with identically-named
+# columns from the preceding JOIN. Turso must reject it too.
+test update-from-natural-join-after-join-is-ambiguous {
+    CREATE TABLE t(x INTEGER PRIMARY KEY, y TEXT);
+    CREATE TABLE u(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t VALUES(1, 'x');
+    INSERT INTO u VALUES(1, 'x');
+    UPDATE t SET y = 'z'
+      FROM u AS u1
+      JOIN u AS u2 ON u1.b = u2.b
+      NATURAL JOIN u AS u3
+     WHERE t.y = u1.b;
+}
+expect error {
+}
+
+test update-from-unqualified-set-rhs-is-ambiguous {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t VALUES(1, 10);
+    INSERT INTO s VALUES(1, 99);
+    UPDATE t
+       SET v = v + 1
+      FROM s
+     WHERE t.id = s.id;
+}
+expect error {
+    ambiguous column name: v
+}
+
+test update-from-duplicate-source-alias-using-is-ambiguous {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, w INTEGER);
+    CREATE TABLE u(id INTEGER, z INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    INSERT INTO u VALUES(1,100),(2,200);
+    UPDATE t
+       SET v = 1
+      FROM s AS x JOIN u AS x USING(id)
+     WHERE x.id = 1;
+}
+expect error {
+    ambiguous column name: main.x._ROWID_
+}
+
+test update-from-duplicate-source-alias-natural-is-ambiguous {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE s(id INTEGER, w INTEGER);
+    CREATE TABLE u(id INTEGER, z INTEGER);
+    INSERT INTO t VALUES(1,0),(2,0);
+    INSERT INTO s VALUES(1,10),(2,20);
+    INSERT INTO u VALUES(1,100),(2,200);
+    UPDATE t
+       SET v = 1
+      FROM s AS x NATURAL JOIN u AS x
+     WHERE x.id = 1;
+}
+expect error {
+    ambiguous column name: main.x._ROWID_
+}

--- a/testing/sqltests/tests/update.sqltest
+++ b/testing/sqltests/tests/update.sqltest
@@ -581,6 +581,66 @@ expect {
 }
 
 @cross-check-integrity
+test row-values-from-subquery {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, name TEXT, value INTEGER);
+    CREATE TABLE src(id INTEGER, new_name TEXT, new_value INTEGER);
+    INSERT INTO target VALUES (1, 'old', 1), (2, 'older', 2);
+    INSERT INTO src VALUES (1, 'new', 10), (2, 'newer', 20);
+    UPDATE target
+       SET (name, value) = (
+           SELECT src.new_name, src.new_value
+             FROM src
+            WHERE src.id = target.id
+       );
+    SELECT id, name, value FROM target ORDER BY id;
+}
+expect {
+    1|new|10
+    2|newer|20
+}
+
+@cross-check-integrity
+test row-values-from-subquery-star {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, name TEXT, value INTEGER);
+    CREATE TABLE src(new_name TEXT, new_value INTEGER);
+    INSERT INTO target VALUES (1, 'old', 1);
+    INSERT INTO src VALUES ('new', 10);
+    UPDATE target
+       SET (name, value) = (SELECT * FROM src);
+    SELECT id, name, value FROM target;
+}
+expect {
+    1|new|10
+}
+
+@cross-check-integrity
+test row-values-from-volatile-subquery-project-same-row {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+    INSERT INTO t VALUES (1, 0, 0);
+    UPDATE t
+       SET (a, b) = (
+           SELECT x, x
+             FROM (SELECT abs(random()) AS x)
+       );
+    SELECT a = b, a IS NOT NULL, b IS NOT NULL FROM t;
+}
+expect {
+    1|1|1
+}
+
+@cross-check-integrity
+test row-values-from-subquery-star-width-mismatch {
+    CREATE TABLE target(id INTEGER PRIMARY KEY, name TEXT, value INTEGER);
+    CREATE TABLE src(new_name TEXT, new_value INTEGER, ignored INTEGER);
+    INSERT INTO target VALUES (1, 'old', 1);
+    INSERT INTO src VALUES ('new', 10, 99);
+    UPDATE target
+       SET (name, value) = (SELECT * FROM src);
+}
+expect error {
+}
+
+@cross-check-integrity
 test rowid-update-updates-all-indexes {
     CREATE TABLE t (a INTEGER PRIMARY KEY, b UNIQUE, c UNIQUE);
     INSERT INTO t VALUES (1,1,1);
@@ -594,6 +654,21 @@ expect {
     2|3|1
     2|3|1
     2|3|1
+}
+
+@cross-check-integrity
+test update-with-trigger-and-index-scan-preserves-unchanged-indexed-columns {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, c INTEGER);
+    CREATE INDEX t_a ON t(a);
+    CREATE TRIGGER trg BEFORE UPDATE ON t BEGIN SELECT 1; END;
+    INSERT INTO t VALUES (1, 1, 10, 100), (2, 2, 20, 200), (3, 3, 30, 300);
+    UPDATE t SET b = b + 1 WHERE a = 2;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1|10|100
+    2|2|21|200
+    3|3|30|300
 }
 
 # https://github.com/tursodatabase/turso/issues/3276
@@ -1018,4 +1093,3 @@ expect {
     1|2
     2|1
 }
-

--- a/testing/sqltests/tests/using-dedup-outer-ref.sqltest
+++ b/testing/sqltests/tests/using-dedup-outer-ref.sqltest
@@ -20,3 +20,20 @@ expect {
     a|note1
     b|note2
 }
+
+# Qualified reference (t2.key) to a USING-hidden column in a correlated
+# subquery. SQLite allows this — USING dedup only hides columns from
+# unqualified resolution and * expansion, not from qualified table.column
+# references.
+@cross-check-integrity
+test qualified-ref-to-using-hidden-col-in-subquery {
+    CREATE TABLE t1(key INT, val TEXT);
+    CREATE TABLE t2(key INT, label TEXT);
+    INSERT INTO t1 VALUES(1,'a'),(2,'b');
+    INSERT INTO t2 VALUES(1,'x'),(2,'y');
+    SELECT val, (SELECT t2.key) FROM t1 NATURAL JOIN t2 ORDER BY val;
+}
+expect {
+    a|1
+    b|2
+}


### PR DESCRIPTION
(note: @jussisaurio took over this branch from pekka's initial draft, so blame any unclarity in this PR description on me)

## Beef

Implements `UPDATE target SET val = target.foo + source.bar + source2.baz FROM source JOIN source2...`

## What UPDATE FROM is in a nutshell

Let's take this example query:

```sql
UPDATE target
   SET val = target.val + src.bump
  FROM src
 WHERE target.id = src.id;
```

We essentially want to set `target.val` to the expression above for all rows where `target.id` matches `src.id`. If there are multiple matches, then we follow the `"last matched src row wins"` principle, but the choice is essentially undefined. The extreme example would be `WHERE 1` where every row of `src` matches and we'd end up picking the last one. From SQLite docs:

> If the join between the target table and the FROM clause results in multiple output rows for the same target table row, then only one of those output rows is used for updating the target table. The output row selected is arbitrary and might change from one release of SQLite to the next, or from one run to the next.

## How we implement this mechanism

`UPDATE FROM` is implemented as a two-phase operation:

1. First we materialize each matched target row’s computed SET payloads together with its rowid into an ephemeral scratch table.
2. Then, using the rowids in the scratch table as seek keys, we iterate it & seek to the target table to rewrite the real target rows. This is necessary both because:
  a) FROM-side rows are no longer in scope during the write phase
  b) and primarily because the ephemeral result set must remain stable while the target table is being mutated, as is the case with other DML queries that would cause Halloween problems otherwise.

### Example

Let's take the same simple example:

```sql
UPDATE target
   SET val = target.val + src.bump
  FROM src
 WHERE target.id = src.id;
```

As noted, we already have a mechanism for pre-materializing a stable read set for mutation safety (`DmlSafety` / `ephemeral_plan`), so we extend the use of that mechanism to this as well.

Here, the following planning steps happen:

- An ephemeral scratch table is created, whose columns will contain the materialized results of all `SET` expressions, plus `target.rowid`. Here, the columns are then effectively: `(target.val + src.bump, target.rowid)`.
- Both `target` and `src` `JoinedTable`s get moved into an ephemeral `SELECT` plan. Here, there is only one `FROM` table (`src`), but there can be arbitrarily many as in any other `SELECT ... FROM`.
- The results of what is effectively `SELECT target.val + src.bump, target.rowid FROM target JOIN src WHERE target.id = src.id` get written to the ephemeral scratch table. Since the values of `target.rowid` function as the ephemeral table's rowid, any duplicate matches overwrite previous ones; as discussed in the "in a nutshell" section, this choice of last-one-wins is arbitrary and the behavior is generally undefined.
- Then, we iterate over the scratch table and seek `target.rowid = scratch.rowid`, and update the `target.val` column to be the materialized column result for that row of the scratch table.

## UPDATE FROM ... RETURNING

Let's take a modified example:

```sql
UPDATE target as t
   SET val = t.val + src.bump
  FROM src
 WHERE t.id = src.id
 RETURNING target.val, target.somecol
-- referring to src is not allowed in RETURNING, but
-- note that referring to both 't' and 'target' is valid in the SET clause,
-- but ONLY the canonical name 'target' is allowed in RETURNING!
 ```
 
 For this case, `target` is kept as an `OuterQueryReference` for the top level `UPDATE` so that `RETURNING can resolve its column references correctly for the live row that was updated.

## CTEs & UPDATE FROM

CTEs are also kept live for RETURNING:

```sql
WITH c(x) AS (SELECT 42)
UPDATE target
   SET ...
  FROM src
 WHERE ...
RETURNING (SELECT x FROM c);
```

## Subqueries & UPDATE FROM

In regular `UPDATE`, subqueries in the `SET` clauses are evaluated using regular subquery timing machinery during the write phase itself. In `UPDATE ... FROM`, the SET-subqueries must be moved to the ephemeral prematerialization plan, because they are allowed to reference the FROM-tables, which are not valid during the write phase anymore.

An exception here is again `RETURNING` which evaluates its subqueries during the write phase (because RETURNING is semantically about the target row being mutated), so those subqueries are not moved. Those subqueries are not allowed to reference the `UPDATE ... FROM` tables so they can't violate visibility.

### Special case: row-valued SET clause subqueries

We also support this kind of construction:

```sql
UPDATE t
   SET (a, b) = (SELECT x, y FROM src WHERE src.id = t.id);
```

This is implemented so that the row-valued subquery on the RHS is planned as normal, and then the LHS (i.e. `(a, b)`) is written as scalar projections into the result columns of that row-valued subquery - i.e. a `SubqueryResult` of `n` result columns referencing `subquery_id: x` is split into `n` `SubqueryResult` expressions with `1` result column each, all referencing `subquery_id: x`.