### PR TITLE
Fix `ORDER BY` and `GROUP BY` column-number terms when they are wrapped by `COLLATE`

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -4,7 +4,7 @@ use crate::translate::collate::get_collseq_from_expr;
 use crate::translate::emitter::{select::emit_query, LimitCtx, Resolver, TranslateCtx};
 use crate::translate::expr::translate_expr;
 use crate::translate::order_by::{custom_type_comparator, sorter_insert};
-use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
+use crate::translate::plan::{CompoundSelectOrderByTerm, Plan, QueryDestination, SelectPlan};
 use crate::translate::result_row::emit_columns_to_destination;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::Insn;
@@ -781,7 +781,7 @@ fn create_collection_index(
 #[allow(clippy::too_many_arguments)]
 fn emit_compound_order_by(
     program: &mut ProgramBuilder,
-    order_by: &[(usize, SortOrder, Option<turso_parser::ast::NullsOrder>)],
+    order_by: &[CompoundSelectOrderByTerm],
     collection_cursor_id: usize,
     collection_index: &Index,
     num_result_cols: usize,
@@ -804,11 +804,13 @@ fn emit_compound_order_by(
         Option<turso_parser::ast::NullsOrder>,
     )> = order_by
         .iter()
-        .map(|(col_idx, order, nulls)| {
-            let collation = collection_index
-                .columns
-                .get(*col_idx)
-                .and_then(|c| c.collation);
+        .map(|(col_idx, order, nulls, explicit_collation)| {
+            let collation = explicit_collation.or_else(|| {
+                collection_index
+                    .columns
+                    .get(*col_idx)
+                    .and_then(|c| c.collation)
+            });
             (*order, collation, *nulls)
         })
         .collect();
@@ -825,7 +827,7 @@ fn emit_compound_order_by(
         if let Some((sort_key_idx, _)) = order_by
             .iter()
             .enumerate()
-            .find(|(_, (ob_col, _, _))| *ob_col == col_idx)
+            .find(|(_, (ob_col, _, _, _))| *ob_col == col_idx)
         {
             // This result column is also a sort key - deduplicate
             remappings.push((sort_key_idx, true));
@@ -841,7 +843,7 @@ fn emit_compound_order_by(
     // NumericLt to sort correctly instead of default blob/text comparison).
     let mut comparators: Vec<Option<crate::vdbe::insn::SortComparatorType>> = order_by
         .iter()
-        .map(|(col_idx, _, _)| {
+        .map(|(col_idx, _, _, _)| {
             program.result_columns.get(*col_idx).and_then(|rc| {
                 custom_type_comparator(
                     &rc.expr,
@@ -893,7 +895,7 @@ fn emit_compound_order_by(
     // Build sorter record: [sort_keys..., sequence, non-dedup result cols...]
     let sorter_regs = program.alloc_registers(sorter_column_count);
     // First emit sort keys
-    for (sort_key_idx, (col_idx, _, _)) in order_by.iter().enumerate() {
+    for (sort_key_idx, (col_idx, _, _, _)) in order_by.iter().enumerate() {
         program.emit_insn(Insn::Copy {
             src_reg: read_regs + col_idx,
             dst_reg: sorter_regs + sort_key_idx,

--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -25,17 +25,22 @@ fn fmt_order_by_item(
     expr: &impl fmt::Display,
     dir: SortOrder,
     nulls: Option<turso_parser::ast::NullsOrder>,
+    collation: Option<crate::translate::collate::CollationSeq>,
 ) -> fmt::Result {
     let dir_str = match dir {
         SortOrder::Asc => "ASC",
         SortOrder::Desc => "DESC",
     };
+    let collation = collation.map(|collation| format!(" COLLATE {collation}"));
+    let collation = collation.as_deref().unwrap_or("");
     match nulls {
         Some(turso_parser::ast::NullsOrder::First) => {
-            writeln!(f, "  - {expr} {dir_str} NULLS FIRST")
+            writeln!(f, "  - {expr}{collation} {dir_str} NULLS FIRST")
         }
-        Some(turso_parser::ast::NullsOrder::Last) => writeln!(f, "  - {expr} {dir_str} NULLS LAST"),
-        None => writeln!(f, "  - {expr} {dir_str}"),
+        Some(turso_parser::ast::NullsOrder::Last) => {
+            writeln!(f, "  - {expr}{collation} {dir_str} NULLS LAST")
+        }
+        None => writeln!(f, "  - {expr}{collation} {dir_str}"),
     }
 }
 
@@ -222,8 +227,8 @@ impl Display for Plan {
                 }
                 if let Some(order_by) = order_by {
                     writeln!(f, "ORDER BY:")?;
-                    for (expr, dir, nulls) in order_by {
-                        fmt_order_by_item(f, expr, *dir, *nulls)?;
+                    for (expr, dir, nulls, collation) in order_by {
+                        fmt_order_by_item(f, expr, *dir, *nulls, *collation)?;
                     }
                 }
                 Ok(())
@@ -590,7 +595,7 @@ impl fmt::Display for UpdatePlan {
         if !self.order_by.is_empty() {
             writeln!(f, "ORDER BY:")?;
             for (expr, dir, nulls) in &self.order_by {
-                fmt_order_by_item(f, expr, *dir, *nulls)?;
+                fmt_order_by_item(f, expr, *dir, *nulls, None)?;
             }
         }
         if let Some(limit) = self.limit.as_ref() {
@@ -673,15 +678,24 @@ impl ToTokens for Plan {
                     s.append(TokenType::TK_BY, None)?;
 
                     s.comma(
-                        order_by
-                            .iter()
-                            .map(|(col_idx, order, nulls)| ast::SortedColumn {
-                                expr: Box::new(ast::Expr::Literal(ast::Literal::Numeric(
-                                    (col_idx + 1).to_string(),
-                                ))),
+                        order_by.iter().map(|(col_idx, order, nulls, collation)| {
+                            let expr = ast::Expr::Literal(ast::Literal::Numeric(
+                                (col_idx + 1).to_string(),
+                            ));
+                            let expr = if let Some(collation) = collation {
+                                ast::Expr::collate(
+                                    expr,
+                                    ast::Name::from_string(collation.to_string()),
+                                )
+                            } else {
+                                expr
+                            };
+                            ast::SortedColumn {
+                                expr: Box::new(expr),
                                 order: Some(*order),
                                 nulls: *nulls,
-                            }),
+                            }
+                        }),
                         context,
                     )?;
                 }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -311,13 +311,22 @@ pub enum Plan {
         right_most: SelectPlan,
         limit: Option<Box<Expr>>,
         offset: Option<Box<Expr>>,
-        /// ORDER BY for compound selects. Each entry is (result_column_index, sort_order, nulls_order).
+        /// ORDER BY for compound selects.
+        /// Each entry is
+        /// (result_column_index, sort_order, nulls_order, explicit_collation_override).
         /// The column index is 0-based into the result set.
-        order_by: Option<Vec<(usize, SortOrder, Option<ast::NullsOrder>)>>,
+        order_by: Option<Vec<CompoundSelectOrderByTerm>>,
     },
     Delete(DeletePlan),
     Update(UpdatePlan),
 }
+
+pub type CompoundSelectOrderByTerm = (
+    usize,
+    SortOrder,
+    Option<ast::NullsOrder>,
+    Option<CollationSeq>,
+);
 
 impl Plan {
     /// Returns true if this SELECT plan contains a reference to the given table.

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -3,6 +3,7 @@ use super::plan::{
     select_star, Distinctness, InSeekSource, JoinOrderMember, Operation, OuterQueryReference,
     QueryDestination, Search, TableReferences, WhereTerm, Window,
 };
+use crate::function::{Func, ScalarFunc};
 use crate::schema::Table;
 use crate::sync::Arc;
 use crate::translate::collate::CollationSeq;
@@ -112,7 +113,7 @@ fn select_plan_first_virtual_table_name(select_plan: &SelectPlan) -> Option<Stri
     for joined_table in select_plan.joined_tables() {
         match &joined_table.table {
             Table::Virtual(virtual_table) if !virtual_table.innocuous => {
-                return Some(virtual_table.name.clone())
+                return Some(virtual_table.name.clone());
             }
             Table::FromClauseSubquery(from_clause_subquery) => {
                 if let Some(name) = plan_first_virtual_table_name(&from_clause_subquery.plan) {
@@ -553,6 +554,7 @@ fn prepare_one_select_plan(
                             resolver,
                             BindingBehavior::TryCanonicalColumnsFirst,
                         )?;
+                        strip_shadowed_inner_collations(expr, resolver)?;
                     }
 
                     plan.group_by = Some(GroupBy {
@@ -608,6 +610,7 @@ fn prepare_one_select_plan(
                     resolver,
                     BindingBehavior::TryResultColumnsFirst,
                 )?;
+                strip_shadowed_inner_collations(&mut o.expr, resolver)?;
                 let had_agg = resolve_window_and_aggregate_functions(
                     &o.expr,
                     resolver,
@@ -1070,33 +1073,339 @@ fn vtab_predicate_table_id(expr: &Expr) -> Option<ast::TableInternalId> {
 /// For example, in SELECT u.first_name, count(1) FROM users u GROUP BY 1 ORDER BY 2,
 /// the column number 1 is replaced with u.first_name and the column number 2 is replaced with count(1).
 ///
-/// Per SQLite documentation, only constant integers are treated as column references.
-/// Non-integer numeric literals (floats) are treated as constant expressions.
-/// Root COLLATE wrappers still apply after ordinal resolution.
-fn unwrap_order_or_group_by_alias_expr(mut expr: &ast::Expr) -> (&ast::Expr, Vec<ast::Name>) {
-    let mut collations = Vec::new();
+/// Mirrors SQLite's root-level sqlite3ExprSkipCollateAndLikely() for ORDER/GROUP BY
+/// ordinal detection. Our AST keeps single-item parentheses, so we skip those too.
+/// Only the outermost explicit COLLATE matters once an ordinal is replaced.
+fn unwrap_order_or_group_by_root_collation(
+    mut expr: &ast::Expr,
+) -> (&ast::Expr, Option<ast::Name>) {
+    let mut outermost_collation = None;
     loop {
         match expr {
+            ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+                expr = exprs[0].as_ref();
+            }
             ast::Expr::Collate(inner, collation) => {
-                collations.push(collation.clone());
+                if outermost_collation.is_none() {
+                    outermost_collation = Some(collation.clone());
+                }
                 expr = inner.as_ref();
             }
+            _ => return (expr, outermost_collation),
+        }
+    }
+}
+
+fn wrap_expr_with_collation(expr: ast::Expr, collation: Option<ast::Name>) -> ast::Expr {
+    match collation {
+        Some(collation) => ast::Expr::collate(expr, collation),
+        None => expr,
+    }
+}
+
+fn unwrap_single_parenthesized_expr(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        match expr {
+            ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+                expr = exprs[0].as_ref();
+            }
+            _ => return expr,
+        }
+    }
+}
+
+fn expr_is_null_or_boolean_literal(expr: &ast::Expr) -> bool {
+    let expr = unwrap_single_parenthesized_expr(expr);
+    matches!(
+        expr,
+        ast::Expr::Literal(ast::Literal::Null | ast::Literal::True | ast::Literal::False)
+    )
+}
+
+fn binary_expr_is_collation_transparent(op: ast::Operator, rhs: &ast::Expr) -> bool {
+    !op.is_comparison()
+        || matches!(op, ast::Operator::Is | ast::Operator::IsNot)
+            && expr_is_null_or_boolean_literal(rhs)
+}
+
+fn function_call_is_collation_transparent(
+    name: &ast::Name,
+    arg_count: usize,
+    resolver: &Resolver,
+) -> Result<bool> {
+    Ok(match resolver.resolve_function(name.as_str(), arg_count)? {
+        Some(Func::Scalar(scalar_func)) => !matches!(
+            scalar_func,
+            ScalarFunc::Min | ScalarFunc::Max | ScalarFunc::Nullif
+        ),
+        Some(Func::Math(_) | Func::Vector(_) | Func::AlterTable(_)) => true,
+        _ => false,
+    })
+}
+
+/// Scalar subqueries only contribute a single output expression to the outer
+/// ORDER/GROUP BY term. Leave wider result sets alone so normal column-count
+/// validation still reports those errors.
+fn rewrite_scalar_subquery_output_exprs(
+    select: &mut ast::Select,
+    resolver: &Resolver,
+    rewrite_expr: fn(&mut ast::Expr, &Resolver) -> Result<()>,
+) -> Result<()> {
+    rewrite_one_select_scalar_subquery_output_exprs(
+        &mut select.body.select,
+        resolver,
+        rewrite_expr,
+    )?;
+    for compound in select.body.compounds.iter_mut() {
+        rewrite_one_select_scalar_subquery_output_exprs(
+            &mut compound.select,
+            resolver,
+            rewrite_expr,
+        )?;
+    }
+    Ok(())
+}
+
+fn rewrite_one_select_scalar_subquery_output_exprs(
+    one_select: &mut ast::OneSelect,
+    resolver: &Resolver,
+    rewrite_expr: fn(&mut ast::Expr, &Resolver) -> Result<()>,
+) -> Result<()> {
+    match one_select {
+        ast::OneSelect::Select { columns, .. } => {
+            if let [ast::ResultColumn::Expr(expr, _)] = columns.as_mut_slice() {
+                rewrite_expr(expr.as_mut(), resolver)?;
+            }
+        }
+        ast::OneSelect::Values(rows) => {
+            for row in rows.iter_mut() {
+                if let [expr] = row.as_mut_slice() {
+                    rewrite_expr(expr.as_mut(), resolver)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// SQLite only validates the explicit COLLATE that actually controls an
+/// ORDER/GROUP BY subexpression. If a subtree already has `... COLLATE X`,
+/// then deeper `COLLATE Y` nodes reached only through collation-transparent
+/// operators are shadowed and must not raise `no such collation sequence`.
+fn strip_shadowed_collations_below_explicit_collation(
+    expr: &mut ast::Expr,
+    resolver: &Resolver,
+) -> Result<()> {
+    match expr {
+        ast::Expr::Collate(inner, _) => {
+            *expr = inner.as_ref().clone();
+            strip_shadowed_collations_below_explicit_collation(expr, resolver)
+        }
+        ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+            strip_shadowed_collations_below_explicit_collation(exprs[0].as_mut(), resolver)
+        }
+        ast::Expr::Cast { expr, .. }
+        | ast::Expr::IsNull(expr)
+        | ast::Expr::NotNull(expr)
+        | ast::Expr::Unary(_, expr) => {
+            strip_shadowed_collations_below_explicit_collation(expr.as_mut(), resolver)
+        }
+        ast::Expr::Binary(lhs, op, rhs) if binary_expr_is_collation_transparent(*op, rhs) => {
+            strip_shadowed_collations_below_explicit_collation(lhs.as_mut(), resolver)?;
+            strip_shadowed_collations_below_explicit_collation(rhs.as_mut(), resolver)
+        }
+        ast::Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            if base.is_none() {
+                for (when_expr, then_expr) in when_then_pairs.iter_mut() {
+                    strip_shadowed_collations_below_explicit_collation(
+                        when_expr.as_mut(),
+                        resolver,
+                    )?;
+                    strip_shadowed_collations_below_explicit_collation(
+                        then_expr.as_mut(),
+                        resolver,
+                    )?;
+                }
+            } else {
+                for (_, then_expr) in when_then_pairs.iter_mut() {
+                    strip_shadowed_collations_below_explicit_collation(
+                        then_expr.as_mut(),
+                        resolver,
+                    )?;
+                }
+            }
+            if let Some(else_expr) = else_expr.as_mut() {
+                strip_shadowed_collations_below_explicit_collation(else_expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::FunctionCall {
+            name,
+            args,
+            filter_over,
+            ..
+        } if function_call_is_collation_transparent(name, args.len(), resolver)? => {
+            for arg in args.iter_mut() {
+                strip_shadowed_collations_below_explicit_collation(arg.as_mut(), resolver)?;
+            }
+            if let Some(filter_expr) = filter_over.filter_clause.as_mut() {
+                strip_shadowed_collations_below_explicit_collation(filter_expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::FunctionCallStar { filter_over, .. } => {
+            if let Some(filter_expr) = filter_over.filter_clause.as_mut() {
+                strip_shadowed_collations_below_explicit_collation(filter_expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::Like {
+            lhs, rhs, escape, ..
+        } => {
+            strip_shadowed_collations_below_explicit_collation(lhs.as_mut(), resolver)?;
+            strip_shadowed_collations_below_explicit_collation(rhs.as_mut(), resolver)?;
+            if let Some(escape) = escape.as_mut() {
+                strip_shadowed_collations_below_explicit_collation(escape.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::Subquery(select) => rewrite_scalar_subquery_output_exprs(
+            select,
+            resolver,
+            strip_shadowed_collations_below_explicit_collation,
+        ),
+        _ => Ok(()),
+    }
+}
+
+fn strip_shadowed_inner_collations(expr: &mut ast::Expr, resolver: &Resolver) -> Result<()> {
+    match expr {
+        ast::Expr::Between {
+            lhs, start, end, ..
+        } => {
+            strip_shadowed_inner_collations(lhs.as_mut(), resolver)?;
+            strip_shadowed_inner_collations(start.as_mut(), resolver)?;
+            strip_shadowed_inner_collations(end.as_mut(), resolver)
+        }
+        ast::Expr::Binary(lhs, _, rhs) => {
+            strip_shadowed_inner_collations(lhs.as_mut(), resolver)?;
+            strip_shadowed_inner_collations(rhs.as_mut(), resolver)
+        }
+        ast::Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            if let Some(base) = base.as_mut() {
+                strip_shadowed_inner_collations(base.as_mut(), resolver)?;
+            }
+            for (when_expr, then_expr) in when_then_pairs.iter_mut() {
+                strip_shadowed_inner_collations(when_expr.as_mut(), resolver)?;
+                strip_shadowed_inner_collations(then_expr.as_mut(), resolver)?;
+            }
+            if let Some(else_expr) = else_expr.as_mut() {
+                strip_shadowed_inner_collations(else_expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::Collate(expr, _) => {
+            strip_shadowed_collations_below_explicit_collation(expr.as_mut(), resolver)?;
+            strip_shadowed_inner_collations(expr.as_mut(), resolver)
+        }
+        ast::Expr::Cast { expr, .. }
+        | ast::Expr::IsNull(expr)
+        | ast::Expr::NotNull(expr)
+        | ast::Expr::Unary(_, expr) => strip_shadowed_inner_collations(expr.as_mut(), resolver),
+        ast::Expr::FunctionCall {
+            args,
+            order_by,
+            filter_over,
+            ..
+        } => {
+            for arg in args.iter_mut() {
+                strip_shadowed_inner_collations(arg.as_mut(), resolver)?;
+            }
+            for sorted_expr in order_by.iter_mut() {
+                strip_shadowed_inner_collations(sorted_expr.expr.as_mut(), resolver)?;
+            }
+            if let Some(filter_expr) = filter_over.filter_clause.as_mut() {
+                strip_shadowed_inner_collations(filter_expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::FunctionCallStar { filter_over, .. } => {
+            if let Some(filter_expr) = filter_over.filter_clause.as_mut() {
+                strip_shadowed_inner_collations(filter_expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::InList { lhs, rhs, .. } => {
+            strip_shadowed_inner_collations(lhs.as_mut(), resolver)?;
+            for expr in rhs.iter_mut() {
+                strip_shadowed_inner_collations(expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::InSelect { lhs, .. } => strip_shadowed_inner_collations(lhs.as_mut(), resolver),
+        ast::Expr::InTable { lhs, args, .. } => {
+            strip_shadowed_inner_collations(lhs.as_mut(), resolver)?;
+            for expr in args.iter_mut() {
+                strip_shadowed_inner_collations(expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::Like {
+            lhs, rhs, escape, ..
+        } => {
+            strip_shadowed_inner_collations(lhs.as_mut(), resolver)?;
+            strip_shadowed_inner_collations(rhs.as_mut(), resolver)?;
+            if let Some(escape) = escape.as_mut() {
+                strip_shadowed_inner_collations(escape.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::Parenthesized(exprs) => {
+            for expr in exprs.iter_mut() {
+                strip_shadowed_inner_collations(expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::Subquery(select) => {
+            rewrite_scalar_subquery_output_exprs(select, resolver, strip_shadowed_inner_collations)
+        }
+        ast::Expr::Array { elements } => {
+            for expr in elements.iter_mut() {
+                strip_shadowed_inner_collations(expr.as_mut(), resolver)?;
+            }
+            Ok(())
+        }
+        ast::Expr::Subscript { base, index } => {
+            strip_shadowed_inner_collations(base.as_mut(), resolver)?;
+            strip_shadowed_inner_collations(index.as_mut(), resolver)
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Mirrors sqlite3ExprIsInteger() for our AST. We peel unary + and single-item
+/// parentheses, but never cross a COLLATE node because +(1 COLLATE X) is not an
+/// ordinal alias in SQLite.
+fn unwrap_order_or_group_by_integer_expr(mut expr: &ast::Expr) -> &ast::Expr {
+    loop {
+        match expr {
             ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
                 expr = exprs[0].as_ref();
             }
             ast::Expr::Unary(ast::UnaryOperator::Positive, inner) => {
                 expr = inner.as_ref();
             }
-            _ => return (expr, collations),
+            _ => return expr,
         }
     }
-}
-
-fn wrap_expr_with_collations(mut expr: ast::Expr, collations: &[ast::Name]) -> ast::Expr {
-    for collation in collations.iter().rev() {
-        expr = ast::Expr::collate(expr, collation.clone());
-    }
-    expr
 }
 
 fn replace_column_number_with_copy_of_column_expr(
@@ -1104,11 +1413,13 @@ fn replace_column_number_with_copy_of_column_expr(
     columns: &[ResultSetColumn],
     clause_name: &str,
 ) -> Result<()> {
-    let (alias_expr, collations) = unwrap_order_or_group_by_alias_expr(order_by_or_group_by_expr);
+    let (alias_expr, collation) =
+        unwrap_order_or_group_by_root_collation(order_by_or_group_by_expr);
+    let alias_expr = unwrap_order_or_group_by_integer_expr(alias_expr);
     let num_str = match alias_expr {
         ast::Expr::Literal(ast::Literal::Numeric(num)) => Some(num.clone()),
         ast::Expr::Unary(ast::UnaryOperator::Negative, inner) => {
-            let (inner, _) = unwrap_order_or_group_by_alias_expr(inner.as_ref());
+            let inner = unwrap_order_or_group_by_integer_expr(inner.as_ref());
             if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner {
                 if num.parse::<usize>().is_ok() {
                     crate::bail_parse_error!(
@@ -1134,7 +1445,7 @@ fn replace_column_number_with_copy_of_column_expr(
                 );
             }
             let ResultSetColumn { expr, .. } = &columns[column_number - 1];
-            *order_by_or_group_by_expr = wrap_expr_with_collations(expr.clone(), &collations);
+            *order_by_or_group_by_expr = wrap_expr_with_collation(expr.clone(), collation);
         }
         // Otherwise, leave the expression as-is (constant expression, case 3 per SQLite docs)
     }
@@ -1151,14 +1462,13 @@ fn resolve_compound_order_by_expr(
     term_number: usize,
 ) -> Result<(usize, Option<CollationSeq>)> {
     let num_result_columns = all_plans[0].result_columns.len();
-    let (alias_expr, collations) = unwrap_order_or_group_by_alias_expr(expr);
-    // Compound ORDER BY only needs the effective explicit collation.
-    // For stacked postfix COLLATE operators, the outermost one is the active collation.
-    let collation = collations
-        .first()
+    let (alias_expr, collation) = unwrap_order_or_group_by_root_collation(expr);
+    let integer_expr = unwrap_order_or_group_by_integer_expr(alias_expr);
+    let collation = collation
+        .as_ref()
         .map(|name| CollationSeq::new(name.as_str()))
         .transpose()?;
-    match alias_expr {
+    match integer_expr {
         // Case 1: Numeric column reference (e.g., ORDER BY 1)
         ast::Expr::Literal(ast::Literal::Numeric(num)) => {
             if let Ok(column_number) = num.parse::<usize>() {
@@ -1169,7 +1479,7 @@ fn resolve_compound_order_by_expr(
                         num_result_columns
                     );
                 }
-                Ok((column_number - 1, collation))
+                return Ok((column_number - 1, collation));
             } else {
                 crate::bail_parse_error!(
                     "{} ORDER BY term does not match any column in the result set",
@@ -1178,7 +1488,7 @@ fn resolve_compound_order_by_expr(
             }
         }
         ast::Expr::Unary(ast::UnaryOperator::Negative, inner) => {
-            let (inner, _) = unwrap_order_or_group_by_alias_expr(inner.as_ref());
+            let inner = unwrap_order_or_group_by_integer_expr(inner.as_ref());
             if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner {
                 if num.parse::<usize>().is_ok() {
                     crate::bail_parse_error!(
@@ -1193,42 +1503,37 @@ fn resolve_compound_order_by_expr(
                 ordinal(term_number)
             );
         }
+        _ => {}
+    }
+    if let ast::Expr::Id(name) = alias_expr {
         // Case 2: Name reference (e.g., ORDER BY name or ORDER BY alias)
-        ast::Expr::Id(name) => {
-            let name_normalized = normalize_ident(name.as_str());
-            // Check aliases and column names across all constituent SELECTs
-            for plan in all_plans {
-                let result_columns = &plan.result_columns;
-                let table_references = &plan.table_references;
-                // Try matching against aliases
-                for (i, rc) in result_columns.iter().enumerate() {
-                    if let Some(alias) = &rc.alias {
-                        if normalize_ident(alias) == name_normalized {
-                            return Ok((i, collation));
-                        }
-                    }
-                }
-                // Try matching against column names from the table references
-                for (i, rc) in result_columns.iter().enumerate() {
-                    if let Some(col_name) = rc.name(table_references) {
-                        if normalize_ident(col_name) == name_normalized {
-                            return Ok((i, collation));
-                        }
+        let name_normalized = normalize_ident(name.as_str());
+        // Check aliases and column names across all constituent SELECTs
+        for plan in all_plans {
+            let result_columns = &plan.result_columns;
+            let table_references = &plan.table_references;
+            // Try matching against aliases
+            for (i, rc) in result_columns.iter().enumerate() {
+                if let Some(alias) = &rc.alias {
+                    if normalize_ident(alias) == name_normalized {
+                        return Ok((i, collation));
                     }
                 }
             }
-            crate::bail_parse_error!(
-                "{} ORDER BY term does not match any column in the result set",
-                ordinal(term_number)
-            );
-        }
-        _ => {
-            crate::bail_parse_error!(
-                "{} ORDER BY term does not match any column in the result set",
-                ordinal(term_number)
-            );
+            // Try matching against column names from the table references
+            for (i, rc) in result_columns.iter().enumerate() {
+                if let Some(col_name) = rc.name(table_references) {
+                    if normalize_ident(col_name) == name_normalized {
+                        return Ok((i, collation));
+                    }
+                }
+            }
         }
     }
+    crate::bail_parse_error!(
+        "{} ORDER BY term does not match any column in the result set",
+        ordinal(term_number)
+    );
 }
 
 fn ordinal(n: usize) -> String {

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -5,6 +5,7 @@ use super::plan::{
 };
 use crate::schema::Table;
 use crate::sync::Arc;
+use crate::translate::collate::CollationSeq;
 use crate::translate::emitter::{OperationMode, Resolver};
 use crate::translate::expr::{
     bind_and_rewrite_expr, expr_vector_size, walk_expr, BindingBehavior, WalkControl,
@@ -219,8 +220,14 @@ pub fn prepare_select_plan(
             } else {
                 let mut key = Vec::with_capacity(select.order_by.len());
                 for (i, o) in select.order_by.iter().enumerate() {
-                    let col_idx = resolve_compound_order_by_expr(&o.expr, &all_plans, i + 1)?;
-                    key.push((col_idx, o.order.unwrap_or(ast::SortOrder::Asc), o.nulls));
+                    let (col_idx, collation) =
+                        resolve_compound_order_by_expr(&o.expr, &all_plans, i + 1)?;
+                    key.push((
+                        col_idx,
+                        o.order.unwrap_or(ast::SortOrder::Asc),
+                        o.nulls,
+                        collation,
+                    ));
                 }
                 Some(key)
             };
@@ -1065,25 +1072,44 @@ fn vtab_predicate_table_id(expr: &Expr) -> Option<ast::TableInternalId> {
 ///
 /// Per SQLite documentation, only constant integers are treated as column references.
 /// Non-integer numeric literals (floats) are treated as constant expressions.
+/// Root COLLATE wrappers still apply after ordinal resolution.
+fn unwrap_order_or_group_by_alias_expr(mut expr: &ast::Expr) -> (&ast::Expr, Vec<ast::Name>) {
+    let mut collations = Vec::new();
+    loop {
+        match expr {
+            ast::Expr::Collate(inner, collation) => {
+                collations.push(collation.clone());
+                expr = inner.as_ref();
+            }
+            ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+                expr = exprs[0].as_ref();
+            }
+            ast::Expr::Unary(ast::UnaryOperator::Positive, inner) => {
+                expr = inner.as_ref();
+            }
+            _ => return (expr, collations),
+        }
+    }
+}
+
+fn wrap_expr_with_collations(mut expr: ast::Expr, collations: &[ast::Name]) -> ast::Expr {
+    for collation in collations.iter().rev() {
+        expr = ast::Expr::collate(expr, collation.clone());
+    }
+    expr
+}
+
 fn replace_column_number_with_copy_of_column_expr(
     order_by_or_group_by_expr: &mut ast::Expr,
     columns: &[ResultSetColumn],
     clause_name: &str,
 ) -> Result<()> {
-    // Extract the numeric literal string, handling both bare integers (e.g. `2`)
-    // and unary-plus integers (e.g. `+2`). In SQLite, `ORDER BY +2` strips the
-    // unary plus and still resolves `2` as a column index reference.
-    let num_str = match order_by_or_group_by_expr {
+    let (alias_expr, collations) = unwrap_order_or_group_by_alias_expr(order_by_or_group_by_expr);
+    let num_str = match alias_expr {
         ast::Expr::Literal(ast::Literal::Numeric(num)) => Some(num.clone()),
-        ast::Expr::Unary(ast::UnaryOperator::Positive, inner) => {
-            if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner.as_ref() {
-                Some(num.clone())
-            } else {
-                None
-            }
-        }
         ast::Expr::Unary(ast::UnaryOperator::Negative, inner) => {
-            if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner.as_ref() {
+            let (inner, _) = unwrap_order_or_group_by_alias_expr(inner.as_ref());
+            if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner {
                 if num.parse::<usize>().is_ok() {
                     crate::bail_parse_error!(
                         "1st {} term out of range - should be between 1 and {}",
@@ -1108,7 +1134,7 @@ fn replace_column_number_with_copy_of_column_expr(
                 );
             }
             let ResultSetColumn { expr, .. } = &columns[column_number - 1];
-            *order_by_or_group_by_expr = expr.clone();
+            *order_by_or_group_by_expr = wrap_expr_with_collations(expr.clone(), &collations);
         }
         // Otherwise, leave the expression as-is (constant expression, case 3 per SQLite docs)
     }
@@ -1123,9 +1149,16 @@ fn resolve_compound_order_by_expr(
     expr: &ast::Expr,
     all_plans: &[&SelectPlan],
     term_number: usize,
-) -> Result<usize> {
+) -> Result<(usize, Option<CollationSeq>)> {
     let num_result_columns = all_plans[0].result_columns.len();
-    match expr {
+    let (alias_expr, collations) = unwrap_order_or_group_by_alias_expr(expr);
+    // Compound ORDER BY only needs the effective explicit collation.
+    // For stacked postfix COLLATE operators, the outermost one is the active collation.
+    let collation = collations
+        .first()
+        .map(|name| CollationSeq::new(name.as_str()))
+        .transpose()?;
+    match alias_expr {
         // Case 1: Numeric column reference (e.g., ORDER BY 1)
         ast::Expr::Literal(ast::Literal::Numeric(num)) => {
             if let Ok(column_number) = num.parse::<usize>() {
@@ -1136,13 +1169,29 @@ fn resolve_compound_order_by_expr(
                         num_result_columns
                     );
                 }
-                Ok(column_number - 1)
+                Ok((column_number - 1, collation))
             } else {
                 crate::bail_parse_error!(
                     "{} ORDER BY term does not match any column in the result set",
                     ordinal(term_number)
                 );
             }
+        }
+        ast::Expr::Unary(ast::UnaryOperator::Negative, inner) => {
+            let (inner, _) = unwrap_order_or_group_by_alias_expr(inner.as_ref());
+            if let ast::Expr::Literal(ast::Literal::Numeric(num)) = inner {
+                if num.parse::<usize>().is_ok() {
+                    crate::bail_parse_error!(
+                        "{} ORDER BY term out of range - should be between 1 and {}",
+                        ordinal(term_number),
+                        num_result_columns
+                    );
+                }
+            }
+            crate::bail_parse_error!(
+                "{} ORDER BY term does not match any column in the result set",
+                ordinal(term_number)
+            );
         }
         // Case 2: Name reference (e.g., ORDER BY name or ORDER BY alias)
         ast::Expr::Id(name) => {
@@ -1155,7 +1204,7 @@ fn resolve_compound_order_by_expr(
                 for (i, rc) in result_columns.iter().enumerate() {
                     if let Some(alias) = &rc.alias {
                         if normalize_ident(alias) == name_normalized {
-                            return Ok(i);
+                            return Ok((i, collation));
                         }
                     }
                 }
@@ -1163,7 +1212,7 @@ fn resolve_compound_order_by_expr(
                 for (i, rc) in result_columns.iter().enumerate() {
                     if let Some(col_name) = rc.name(table_references) {
                         if normalize_ident(col_name) == name_normalized {
-                            return Ok(i);
+                            return Ok((i, collation));
                         }
                     }
                 }

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -64,6 +64,112 @@ expect {
     1
 }
 
+@cross-check-integrity
+test collate_order_by_ordinal_preserves_explicit_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 2), ('A', 1), ('c', 3), ('a', 3);
+    SELECT x FROM t ORDER BY 1 COLLATE NOCASE;
+}
+expect {
+    A
+    a
+    b
+    c
+}
+
+@cross-check-integrity
+test collate_order_by_parenthesized_ordinal_preserves_explicit_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('c'), ('a');
+    SELECT x FROM t ORDER BY (1) COLLATE NOCASE;
+}
+expect {
+    A
+    a
+    b
+    c
+}
+
+@cross-check-integrity
+test collate_order_by_positive_ordinal_preserves_explicit_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('c'), ('a');
+    SELECT x FROM t ORDER BY +1 COLLATE NOCASE;
+}
+expect {
+    A
+    a
+    b
+    c
+}
+
+@cross-check-integrity
+test collate_group_by_ordinal_preserves_explicit_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 2), ('A', 1), ('c', 3), ('a', 3);
+    SELECT x, sum(v) FROM t GROUP BY 1 COLLATE NOCASE ORDER BY 1 COLLATE NOCASE;
+}
+expect {
+    A|4
+    b|2
+    c|3
+}
+
+@cross-check-integrity
+test collate_order_by_stacked_collations_preserve_wrapper_order {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('a'), ('B'), ('A');
+    SELECT x FROM t ORDER BY 1 COLLATE RTRIM COLLATE NOCASE;
+}
+expect {
+    a
+    A
+    B
+}
+
+test collate_order_by_negative_ordinal_with_collation_errors {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A');
+    SELECT x FROM t ORDER BY -1 COLLATE NOCASE;
+}
+expect error {
+    1st ORDER BY term out of range - should be between 1 and 1
+}
+
+@cross-check-integrity
+test collate_compound_order_by_ordinal_preserves_explicit_collation {
+    SELECT 'a' AS x
+    UNION ALL
+    SELECT 'A'
+    ORDER BY 1 COLLATE NOCASE;
+}
+expect {
+    a
+    A
+}
+
+test collate_compound_order_by_negative_ordinal_with_collation_errors {
+    SELECT 'a' AS x
+    UNION ALL
+    SELECT 'A'
+    ORDER BY -1 COLLATE NOCASE;
+}
+expect error {
+    1st ORDER BY term out of range - should be between 1 and 1
+}
+
+@cross-check-integrity
+test collate_compound_order_by_alias_preserves_explicit_collation {
+    SELECT 'a' AS x
+    UNION ALL
+    SELECT 'A'
+    ORDER BY x COLLATE NOCASE;
+}
+expect {
+    a
+    A
+}
+
 
 
 @cross-check-integrity

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -104,6 +104,178 @@ expect {
 }
 
 @cross-check-integrity
+test collate_order_by_positive_inner_collation_is_not_ordinal {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY +(1 COLLATE NOCASE);
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_positive_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY +(1 COLLATE UNKNOWN) COLLATE NOCASE;
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_nested_positive_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY +((1 COLLATE UNKNOWN) COLLATE NOCASE);
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_concat_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x INT);
+    INSERT INTO t VALUES(1), (2);
+    SELECT x FROM t ORDER BY ((1 COLLATE UNKNOWN) || '') COLLATE NOCASE;
+}
+expect {
+    1
+    2
+}
+
+@cross-check-integrity
+test collate_order_by_coalesce_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A');
+    SELECT x FROM t ORDER BY COALESCE(x COLLATE UNKNOWN, '') COLLATE NOCASE;
+}
+expect {
+    A
+    b
+}
+
+@cross-check-integrity
+test collate_order_by_case_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x INT);
+    INSERT INTO t VALUES(1), (2);
+    SELECT x FROM t ORDER BY CASE WHEN 1 THEN (1 COLLATE UNKNOWN) ELSE 2 END COLLATE NOCASE;
+}
+expect {
+    1
+    2
+}
+
+@cross-check-integrity
+test collate_order_by_is_null_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY ((1 COLLATE UNKNOWN) IS NULL) COLLATE NOCASE;
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_is_true_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY ((1 COLLATE UNKNOWN) IS TRUE) COLLATE NOCASE;
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_is_parenthesized_null_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY ((1 COLLATE UNKNOWN) IS (NULL)) COLLATE NOCASE;
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_is_not_parenthesized_true_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY ((1 COLLATE UNKNOWN) IS NOT (TRUE)) COLLATE NOCASE;
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_scalar_subquery_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY ((SELECT 1 COLLATE UNKNOWN)) COLLATE NOCASE;
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_wrapped_scalar_subquery_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY COALESCE((SELECT 1 COLLATE UNKNOWN), 0) COLLATE NOCASE;
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_order_by_scalar_subquery_inner_unknown_collation_is_shadowed_by_subquery_output_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY (SELECT (1 COLLATE UNKNOWN) COLLATE NOCASE);
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+test collate_order_by_nullif_inner_unknown_collation_is_not_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A');
+    SELECT x FROM t ORDER BY NULLIF(x COLLATE UNKNOWN, 'a') COLLATE NOCASE;
+}
+expect error {
+    no such collation sequence: UNKNOWN
+}
+
+@cross-check-integrity
 test collate_group_by_ordinal_preserves_explicit_collation {
     CREATE TABLE t(x TEXT, v INT);
     INSERT INTO t VALUES('b', 2), ('A', 1), ('c', 3), ('a', 3);
@@ -116,15 +288,122 @@ expect {
 }
 
 @cross-check-integrity
-test collate_order_by_stacked_collations_preserve_wrapper_order {
-    CREATE TABLE t(x TEXT);
-    INSERT INTO t VALUES('a'), ('B'), ('A');
-    SELECT x FROM t ORDER BY 1 COLLATE RTRIM COLLATE NOCASE;
+test collate_group_by_positive_inner_collation_is_not_ordinal {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY +(1 COLLATE NOCASE);
 }
 expect {
-    a
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_positive_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY +(1 COLLATE UNKNOWN) COLLATE NOCASE;
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_is_not_null_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY ((1 COLLATE UNKNOWN) IS NOT NULL) COLLATE NOCASE;
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_is_false_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY ((1 COLLATE UNKNOWN) IS FALSE) COLLATE NOCASE;
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_is_parenthesized_false_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY ((1 COLLATE UNKNOWN) IS (FALSE)) COLLATE NOCASE;
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_scalar_subquery_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY ((SELECT 1 COLLATE UNKNOWN)) COLLATE NOCASE;
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_wrapped_scalar_subquery_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY COALESCE((SELECT 1 COLLATE UNKNOWN), 0) COLLATE NOCASE;
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_scalar_subquery_inner_unknown_collation_is_shadowed_by_subquery_output_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY (SELECT (1 COLLATE UNKNOWN) COLLATE NOCASE);
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_group_by_nested_negative_inner_unknown_collation_is_shadowed_by_outer_collation {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY -(((1 COLLATE UNKNOWN) COLLATE NOCASE));
+}
+expect {
+    b|10
+}
+
+@cross-check-integrity
+test collate_order_by_nested_collations_use_outermost_sequence {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY (1 COLLATE NOCASE) COLLATE BINARY;
+}
+expect {
     A
-    B
+    C
+    a
+    b
+}
+
+@cross-check-integrity
+test collate_group_by_nested_collations_use_outermost_sequence {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v)
+    FROM t
+    GROUP BY (1 COLLATE NOCASE) COLLATE BINARY
+    ORDER BY 1 COLLATE BINARY;
+}
+expect {
+    A|2
+    C|3
+    a|4
+    b|1
 }
 
 test collate_order_by_negative_ordinal_with_collation_errors {
@@ -134,6 +413,29 @@ test collate_order_by_negative_ordinal_with_collation_errors {
 }
 expect error {
     1st ORDER BY term out of range - should be between 1 and 1
+}
+
+@cross-check-integrity
+test collate_order_by_negative_inner_collation_is_not_ordinal {
+    CREATE TABLE t(x TEXT);
+    INSERT INTO t VALUES('b'), ('A'), ('C'), ('a');
+    SELECT x FROM t ORDER BY -(1 COLLATE NOCASE);
+}
+expect {
+    b
+    A
+    C
+    a
+}
+
+@cross-check-integrity
+test collate_group_by_negative_inner_collation_is_not_ordinal {
+    CREATE TABLE t(x TEXT, v INT);
+    INSERT INTO t VALUES('b', 1), ('A', 2), ('C', 3), ('a', 4);
+    SELECT x, sum(v) FROM t GROUP BY -(1 COLLATE NOCASE);
+}
+expect {
+    b|10
 }
 
 @cross-check-integrity
@@ -156,6 +458,28 @@ test collate_compound_order_by_negative_ordinal_with_collation_errors {
 }
 expect error {
     1st ORDER BY term out of range - should be between 1 and 1
+}
+
+@cross-check-integrity
+test collate_compound_order_by_negative_inner_collation_is_not_ordinal {
+    SELECT 'b' AS x
+    UNION ALL
+    SELECT 'A'
+    ORDER BY -(1 COLLATE NOCASE);
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
+}
+
+@cross-check-integrity
+test collate_compound_order_by_positive_inner_collation_is_not_ordinal {
+    SELECT 'b' AS x
+    UNION ALL
+    SELECT 'A'
+    ORDER BY +(1 COLLATE NOCASE);
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
 }
 
 @cross-check-integrity


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Before this change, queries like `ORDER BY 1 COLLATE NOCASE` and `GROUP BY 1 COLLATE NOCASE` could stop working as ordinal references.That made Turso treat the term like a constant or ignore the intended collation.
This change makes Turso resolve the column number first and then keep the explicit `COLLATE` on the final expression.
Fixes the same problem for compound `SELECT` `ORDER BY` terms that resolve by ordinal or alias.

  Added regression tests for:
  - `ORDER BY 1 COLLATE NOCASE`
  - `ORDER BY (1) COLLATE NOCASE`
  - `ORDER BY +1 COLLATE NOCASE`
  - `ORDER BY -1 COLLATE NOCASE`
  - `GROUP BY 1 COLLATE NOCASE`
  - stacked `COLLATE` wrappers
  - compound `ORDER BY 1 COLLATE NOCASE`
  - compound `ORDER BY alias COLLATE NOCASE`
  - compound `ORDER BY -1 COLLATE NOCASE`

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Closes #6410.

SQLite treats a constant integer in `ORDER BY` as a reference to the  matching result column. `GROUP BY` uses the same expression-processing rules. An explicit postfix `COLLATE` must still control the text  comparison after that resolution.

Turso was not preserving that behavior when the ordinal term was wrapped  by `COLLATE`

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

I used LLM agent to explain to me how sqlite does this. I used to this finding to generate the first draft then i reviewed the code changes based on my understanding of the problem and the code, in the end I asked the agent to review the changes on some of the parameters I wanted to address, before committing, i reviewed once more.

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
