### PR TITLE
translate: fix incorrect immediate FK violation when REPLACE restores a parent with the same key

### DIFF
--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -642,6 +642,7 @@ fn emit_delete_row_common(
                     table_name,
                     main_table_cursor_id,
                     rowid_reg,
+                    None,
                     delete_db_id,
                 )?
             } else {

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1819,6 +1819,7 @@ fn emit_update_insns<'a>(
                                 table_name,
                                 target_table_cursor_id,
                                 idx_rowid_reg,
+                                Some((start, rowid_set_clause_reg.unwrap_or(beg))),
                                 update_database_id,
                             )?
                         } else {
@@ -1994,6 +1995,7 @@ fn emit_update_insns<'a>(
                     table_name,
                     target_table_cursor_id,
                     target_reg,
+                    Some((start, rowid_set_clause_reg.unwrap_or(beg))),
                     update_database_id,
                 )?
             } else {

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -1694,12 +1694,18 @@ impl ForeignKeyActions<PreparedFkDeleteAction> {
     /// NoAction/Restrict checks. Returns prepared actions for CASCADE/SetNull/
     /// SetDefault that must be fired AFTER the parent row is deleted (step 4 per
     /// SQLite docs: delete parent row first, then perform FK cascade actions).
+    ///
+    /// `replace_new_parent_regs` is only needed for REPLACE-style updates.
+    /// When present, an immediate `ON DELETE NO ACTION` check is skipped if the
+    /// row being inserted right after the implicit delete restores the same
+    /// parent key, because that delete cannot leave any child orphaned.
     pub fn prepare_fk_delete_actions(
         program: &mut ProgramBuilder,
         resolver: &mut Resolver,
         parent_table_name: &str,
         parent_cursor_id: usize,
         parent_rowid_reg: usize,
+        replace_new_parent_regs: Option<(usize, usize)>,
         database_id: usize,
     ) -> Result<ForeignKeyActions<PreparedFkDeleteAction>> {
         let parent_bt = resolver
@@ -1726,7 +1732,60 @@ impl ForeignKeyActions<PreparedFkDeleteAction> {
             )?;
 
             match fk_ref.fk.on_delete {
-                RefAct::NoAction | RefAct::Restrict => {
+                RefAct::NoAction => {
+                    // For REPLACE-style updates with immediate NO ACTION: skip the
+                    // check when the replacement row restores the same parent key,
+                    // since the implicit delete cannot orphan any children.
+                    if !fk_ref.fk.deferred {
+                        if let Some((replace_values_start, replace_rowid_reg)) =
+                            replace_new_parent_regs
+                        {
+                            let skip = program.allocate_label();
+                            let changed = program.allocate_label();
+                            let new_key_start = program.alloc_registers(ncols);
+                            copy_key_from_values(
+                                program,
+                                &parent_bt,
+                                &parent_cols,
+                                replace_values_start,
+                                replace_rowid_reg,
+                                new_key_start,
+                            )?;
+                            emit_key_change_check(
+                                program,
+                                key_regs_start,
+                                new_key_start,
+                                ncols,
+                                skip,
+                                changed,
+                            );
+                            program.preassign_label_to_next_insn(changed);
+                            emit_fk_delete_parent_existence_check_single(
+                                program,
+                                &fk_ref,
+                                &parent_bt,
+                                parent_table_name,
+                                parent_cursor_id,
+                                parent_rowid_reg,
+                                database_id,
+                                resolver,
+                            )?;
+                            program.preassign_label_to_next_insn(skip);
+                            continue;
+                        }
+                    }
+                    emit_fk_delete_parent_existence_check_single(
+                        program,
+                        &fk_ref,
+                        &parent_bt,
+                        parent_table_name,
+                        parent_cursor_id,
+                        parent_rowid_reg,
+                        database_id,
+                        resolver,
+                    )?;
+                }
+                RefAct::Restrict => {
                     emit_fk_delete_parent_existence_check_single(
                         program,
                         &fk_ref,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3657,6 +3657,7 @@ fn emit_replace_delete_conflicting_row(
             ctx.table.name.as_str(),
             ctx.cursor_id,
             ctx.conflict_rowid_reg,
+            None,
             ctx.database_id,
         )?;
         if resolver.schema().has_child_fks(ctx.table.name.as_str()) {

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -2986,6 +2986,143 @@ expect {
     1|20
 }
 
+# UPDATE OR REPLACE on rowid conflict should fire FK SET NULL on the
+# implicitly-deleted conflicting parent row before the surviving parent row is
+# updated into that key.
+@cross-check-integrity
+test fk-update-or-replace-set-null-on-rowid-conflict {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT REFERENCES parent(id) ON DELETE SET NULL ON UPDATE CASCADE
+    );
+    INSERT INTO parent VALUES (10, 'x'), (20, 'y');
+    INSERT INTO child VALUES (1, 10), (2, 20);
+    UPDATE OR REPLACE parent SET id = 20 WHERE id = 10;
+    SELECT * FROM child ORDER BY id;
+}
+expect {
+    1|20
+    2|
+}
+
+# UPDATE OR REPLACE on rowid conflict should fire FK SET DEFAULT on the
+# implicitly-deleted conflicting parent row before the surviving parent row is
+# updated into that key.
+@cross-check-integrity
+test fk-update-or-replace-set-default-on-rowid-conflict {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT DEFAULT NULL REFERENCES parent(id) ON DELETE SET DEFAULT ON UPDATE CASCADE
+    );
+    INSERT INTO parent VALUES (10, 'x'), (20, 'y');
+    INSERT INTO child VALUES (1, 10), (2, 20);
+    UPDATE OR REPLACE parent SET id = 20 WHERE id = 10;
+    SELECT * FROM child ORDER BY id;
+}
+expect {
+    1|20
+    2|
+}
+
+# UPDATE OR REPLACE on rowid conflict should honor FK RESTRICT on the
+# implicitly-deleted conflicting parent row.
+@cross-check-integrity
+test fk-update-or-replace-restrict-on-rowid-conflict {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT REFERENCES parent(id) ON DELETE RESTRICT ON UPDATE CASCADE
+    );
+    INSERT INTO parent VALUES (10, 'x'), (20, 'y');
+    INSERT INTO child VALUES (1, 10), (2, 20);
+    UPDATE OR REPLACE parent SET id = 20 WHERE id = 10;
+}
+expect error {
+}
+
+# UPDATE OR REPLACE on rowid conflict should still apply the child's ON UPDATE
+# action for rows that referenced the updated parent, while preserving rows
+# that referenced the surviving conflicting parent key.
+@cross-check-integrity
+test fk-update-or-replace-set-null-update-on-rowid-conflict {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT REFERENCES parent(id) ON DELETE NO ACTION ON UPDATE SET NULL
+    );
+    INSERT INTO parent VALUES (10, 'x'), (20, 'y');
+    INSERT INTO child VALUES (1, 10), (2, 20);
+    UPDATE OR REPLACE parent SET id = 20 WHERE id = 10;
+    SELECT * FROM child ORDER BY id;
+}
+expect {
+    1|
+    2|20
+}
+
+# UPDATE OR REPLACE on rowid conflict should still apply the child's ON UPDATE
+# action for rows that referenced the updated parent, while preserving rows
+# that referenced the surviving conflicting parent key.
+@cross-check-integrity
+test fk-update-or-replace-set-default-update-on-rowid-conflict {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT DEFAULT 999 REFERENCES parent(id) ON DELETE NO ACTION ON UPDATE SET DEFAULT
+    );
+    INSERT INTO parent VALUES (10, 'x'), (20, 'y'), (999, 'd');
+    INSERT INTO child VALUES (1, 10), (2, 20);
+    UPDATE OR REPLACE parent SET id = 20 WHERE id = 10;
+    SELECT * FROM child ORDER BY id;
+}
+expect {
+    1|999
+    2|20
+}
+
+# UPDATE OR REPLACE on rowid conflict should still fail when the child's
+# ON UPDATE action is NO ACTION, even if the conflicting row's ON DELETE check
+# is skipped.
+@cross-check-integrity
+test fk-update-or-replace-restrict-update-on-rowid-conflict-blocks {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT REFERENCES parent(id) ON DELETE CASCADE ON UPDATE RESTRICT
+    );
+    INSERT INTO parent VALUES (10, 'x'), (20, 'y');
+    INSERT INTO child VALUES (1, 10), (2, 20);
+    UPDATE OR REPLACE parent SET id = 20 WHERE id = 10;
+}
+expect error {
+}
+
+# UPDATE OR REPLACE on rowid conflict should still fail when the child's
+# ON UPDATE action is NO ACTION, even if the conflicting row's ON DELETE check
+# is skipped.
+@cross-check-integrity
+test fk-update-or-replace-no-action-update-on-rowid-conflict-blocks {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT REFERENCES parent(id) ON DELETE CASCADE ON UPDATE NO ACTION
+    );
+    INSERT INTO parent VALUES (10, 'x'), (20, 'y');
+    INSERT INTO child VALUES (1, 10), (2, 20);
+    UPDATE OR REPLACE parent SET id = 20 WHERE id = 10;
+}
+expect error {
+}
+
 # UPDATE OR REPLACE that retargets an INTEGER PRIMARY KEY onto an existing row.
 # This is a regression test for a case where REPLACE used to raise an immediate FK error
 # while deleting the conflicting parent row, even though the surviving parent

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -2986,6 +2986,30 @@ expect {
     1|20
 }
 
+# UPDATE OR REPLACE that retargets an INTEGER PRIMARY KEY onto an existing row.
+# This is a regression test for a case where REPLACE used to raise an immediate FK error
+# while deleting the conflicting parent row, even though the surviving parent
+# row kept the same key and the children should remain valid. The child FK only
+# declares ON UPDATE CASCADE, so the omitted ON DELETE clause still defaults to
+# NO ACTION.
+@cross-check-integrity
+test fk-update-or-replace-rowid-conflict-with-update-cascade-only {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT UNIQUE);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        parent_id INT REFERENCES parent(id) ON UPDATE CASCADE
+    );
+    INSERT INTO parent VALUES (1, 'x'), (2, 'y');
+    INSERT INTO child VALUES (1, 1), (2, 2);
+    UPDATE OR REPLACE parent SET id = 2, name = 'z' WHERE id = 1;
+    SELECT * FROM child ORDER BY id;
+}
+expect {
+    1|2
+    2|2
+}
+
 # UPDATE OR REPLACE with NO ACTION FK should block the implicit delete
 @cross-check-integrity
 test fk-update-or-replace-no-action-blocks {


### PR DESCRIPTION
## Bug

When UPDATE OR REPLACE causes an implicit DELETE of a conflicting parent row, the immediate foreign key violation check for the default implicit ON DELETE NO ACTION path can fail even though the replacement row preserves the same parent key and no violation actually occurs.

## Example

```sql
  CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT UNIQUE);
  CREATE TABLE child(
      id INTEGER PRIMARY KEY,
      parent_id INT REFERENCES parent(id) ON UPDATE CASCADE
  );
  INSERT INTO parent VALUES (1, 'x'), (2, 'y');
  INSERT INTO child VALUES (1, 1), (2, 2);
  UPDATE OR REPLACE parent SET id = 2 WHERE id = 1;
  -- This should result in children (1,2) and (2,2) but instead an immediate FK
  -- error was raised because child (1,1)'s parent reference to 1 was temporarily invalid
```

## Fix

Thread the new row registers into the delete FK path so that this immediate FK
violation check is skipped when the key is unchanged.

## Note

Also adds some more tests for different ON UPDATE + ON DELETE interactions even though those aren't regression tests since they already worked.