### PR TITLE
replace container types with BitSet

### DIFF
--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -11,6 +11,7 @@ use crate::numeric::Numeric;
 use crate::storage::btree::CursorTrait;
 use crate::sync::Arc;
 use crate::sync::Mutex;
+use crate::translate::plan::ColumnMask;
 use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult, ValueRef};
 use crate::{return_and_restore_if_io, return_if_io, LimboError, Result, Value};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -445,7 +446,7 @@ pub struct AggregateOperator {
     // Map from column index to aggregate info for quick lookup
     pub column_min_max: HashMap<usize, AggColumnInfo>,
     // Set of column indices that have distinct aggregates
-    pub distinct_columns: HashSet<usize>,
+    pub distinct_columns: ColumnMask,
     tracker: Option<Arc<Mutex<ComputationTracker>>>,
 
     // State machine for commit operation
@@ -1068,8 +1069,8 @@ impl AggregateState {
         // Track which columns have had their distinct counts/sums updated
         // This prevents double-counting when multiple distinct aggregates
         // operate on the same column (e.g., COUNT(DISTINCT col), SUM(DISTINCT col), AVG(DISTINCT col))
-        let mut processed_counts: HashSet<usize> = HashSet::default();
-        let mut processed_sums: HashSet<usize> = HashSet::default();
+        let mut processed_counts = ColumnMask::default();
+        let mut processed_sums = ColumnMask::default();
 
         // Update distinct aggregate state
         for agg in aggregates {
@@ -1079,7 +1080,7 @@ impl AggregateState {
                 }
                 AggregateFunction::CountDistinct(col_idx) => {
                     // Only update count if we haven't processed this column yet
-                    if !processed_counts.contains(col_idx) {
+                    if !processed_counts.get(*col_idx) {
                         if let Some(transition) = distinct_transitions.get(col_idx) {
                             let current_count =
                                 self.distinct_counts.get(col_idx).copied().unwrap_or(0);
@@ -1088,7 +1089,7 @@ impl AggregateState {
                                 TransitionType::Removed => current_count - 1,
                             };
                             self.distinct_counts.insert(*col_idx, new_count);
-                            processed_counts.insert(*col_idx);
+                            processed_counts.set(*col_idx);
                         }
                     }
                 }
@@ -1096,7 +1097,7 @@ impl AggregateState {
                 | AggregateFunction::AvgDistinct(col_idx) => {
                     if let Some(transition) = distinct_transitions.get(col_idx) {
                         // Update count if not already processed (needed for AVG)
-                        if !processed_counts.contains(col_idx) {
+                        if !processed_counts.get(*col_idx) {
                             let current_count =
                                 self.distinct_counts.get(col_idx).copied().unwrap_or(0);
                             let new_count = match transition.transition_type {
@@ -1104,11 +1105,11 @@ impl AggregateState {
                                 TransitionType::Removed => current_count - 1,
                             };
                             self.distinct_counts.insert(*col_idx, new_count);
-                            processed_counts.insert(*col_idx);
+                            processed_counts.set(*col_idx);
                         }
 
                         // Update sum if not already processed
-                        if !processed_sums.contains(col_idx) {
+                        if !processed_sums.get(*col_idx) {
                             let current_sum =
                                 self.distinct_sums.get(col_idx).copied().unwrap_or(0.0);
                             let value_as_float = match &transition.transitioned_value {
@@ -1122,7 +1123,7 @@ impl AggregateState {
                                 TransitionType::Removed => current_sum - value_as_float,
                             };
                             self.distinct_sums.insert(*col_idx, new_sum);
-                            processed_sums.insert(*col_idx);
+                            processed_sums.set(*col_idx);
                         }
                     }
                 }
@@ -1313,7 +1314,7 @@ impl AggregateOperator {
         }
 
         // Process each distinct column
-        for &col_idx in &self.distinct_columns {
+        for col_idx in &self.distinct_columns {
             let val = match row_values.get(col_idx) {
                 Some(v) => v,
                 None => continue,
@@ -1401,13 +1402,13 @@ impl AggregateOperator {
         }
 
         // Build the distinct columns set
-        let mut distinct_columns = HashSet::default();
+        let mut distinct_columns = ColumnMask::default();
         for agg in &aggregates {
             match agg {
                 AggregateFunction::CountDistinct(col_idx)
                 | AggregateFunction::SumDistinct(col_idx)
                 | AggregateFunction::AvgDistinct(col_idx) => {
-                    distinct_columns.insert(*col_idx);
+                    distinct_columns.set(*col_idx);
                 }
                 _ => {}
             }
@@ -1533,7 +1534,7 @@ impl AggregateOperator {
 
             // Update batch weights after detecting transitions
             if self.has_distinct() {
-                for &col_idx in &self.distinct_columns {
+                for col_idx in &self.distinct_columns {
                     if let Some(val) = row.values.get(col_idx) {
                         if val != &Value::Null {
                             let hashable_row = HashableRow::new(col_idx as i64, vec![val.clone()]);
@@ -1653,7 +1654,7 @@ impl AggregateOperator {
                 *value_entry += weight;
             } else {
                 // For DISTINCT aggregates, track individual column values
-                for &col_idx in &self.distinct_columns {
+                for col_idx in &self.distinct_columns {
                     if let Some(val) = row.values.get(col_idx) {
                         // Skip NULL values
                         if val == &Value::Null {
@@ -2566,9 +2567,9 @@ impl FetchDistinctState {
     fn add_aggregate_distinct_fetch(
         group_entry: &mut HashMap<usize, HashSet<HashableRow>>,
         row_values: &[Value],
-        distinct_columns: &HashSet<usize>,
+        distinct_columns: &ColumnMask,
     ) {
-        for &col_idx in distinct_columns {
+        for col_idx in distinct_columns {
             if let Some(val) = row_values.get(col_idx) {
                 if val != &Value::Null {
                     group_entry
@@ -2582,7 +2583,7 @@ impl FetchDistinctState {
 
     pub fn new(
         delta: &Delta,
-        distinct_columns: &HashSet<usize>,
+        distinct_columns: &ColumnMask,
         extract_group_key: impl Fn(&[Value]) -> Vec<Value>,
         group_key_to_string: impl Fn(&[Value]) -> String,
         existing_groups: &HashMap<String, AggregateState>,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2282,7 +2282,7 @@ impl BTreeTable {
     pub fn input_type_check_table_ref(
         table: &Arc<BTreeTable>,
         schema: &Schema,
-        only_columns: Option<&std::collections::HashSet<usize>>,
+        only_columns: Option<&ColumnMask>,
     ) -> Arc<BTreeTable> {
         let has_virtual = table.has_virtual_columns();
         let has_custom = table
@@ -2295,14 +2295,14 @@ impl BTreeTable {
         let mut modified = (**table).clone();
         let remapped_only_columns = if has_virtual {
             let remapped = only_columns.map(|only| {
-                let mut new_set = std::collections::HashSet::new();
+                let mut new_set = ColumnMask::default();
                 let mut physical = 0usize;
                 for (orig, col) in modified.columns.iter().enumerate() {
                     if col.is_virtual_generated() {
                         continue;
                     }
-                    if only.contains(&orig) {
-                        new_set.insert(physical);
+                    if only.get(orig) {
+                        new_set.set(physical);
                     }
                     physical += 1;
                 }
@@ -2317,7 +2317,7 @@ impl BTreeTable {
         let effective_only = remapped_only_columns.as_ref().or(only_columns);
         for (i, col) in modified.columns.iter_mut().enumerate() {
             if let Some(only) = effective_only {
-                if !only.contains(&i) {
+                if !only.get(i) {
                     col.ty_str = "ANY".to_string();
                     continue;
                 }

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -18,7 +18,7 @@ use crate::{
     parameters,
     schema::Trigger,
     stats::refresh_analyze_stats,
-    translate::{self, display::PlanContext, emitter::TransactionMode},
+    translate::{self, display::PlanContext, emitter::TransactionMode, plan::BitSet},
     vdbe::{
         self,
         explain::{EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE},
@@ -496,7 +496,7 @@ impl Statement {
         // with the stale schema cookie, causing an infinite SchemaUpdated loop.
         // SchemaUpdated can occur at different points in the Transaction opcode,
         // so the attached pager may or may not hold locks at this point.
-        let attached_db_ids: Vec<usize> = self
+        let attached_db_ids: BitSet = self
             .program
             .prepared
             .write_databases
@@ -505,7 +505,7 @@ impl Statement {
             .filter(|&&id| id != crate::MAIN_DB_ID)
             .copied()
             .collect();
-        for db_id in attached_db_ids {
+        for db_id in &attached_db_ids {
             // Discard any connection-local schema changes for this non-main DB
             // (temp or attached) so the re-translate reads the committed schema.
             conn.database_schemas().write().remove(&db_id);

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -502,8 +502,7 @@ impl Statement {
             .write_databases
             .iter()
             .chain(self.program.prepared.read_databases.iter())
-            .filter(|&&id| id != crate::MAIN_DB_ID)
-            .copied()
+            .filter(|&id| id != crate::MAIN_DB_ID)
             .collect();
         for db_id in &attached_db_ids {
             // Discard any connection-local schema changes for this non-main DB

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -16,7 +16,7 @@ use super::expr::{emit_table_column, translate_expr, ExprAffinityInfo};
 use super::group_by::GroupByMetadata;
 use super::main_loop::{LeftJoinMetadata, LoopLabels};
 use super::order_by::SortMetadata;
-use super::plan::{HashJoinType, TableReferences};
+use super::plan::{BitSet, HashJoinType, TableReferences};
 use crate::error::SQLITE_CONSTRAINT_CHECK;
 use crate::function::Func;
 use crate::schema::dependencies_of_columns;
@@ -404,16 +404,13 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub(crate) fn attached_database_ids_in_search_order(&self) -> Vec<usize> {
-        let mut database_ids: Vec<_> = self
-            .attached_databases
+    pub(crate) fn attached_database_ids_in_search_order(&self) -> BitSet {
+        self.attached_databases
             .read()
             .index_to_data
             .keys()
             .copied()
-            .collect();
-        database_ids.sort_unstable();
-        database_ids
+            .collect()
     }
 
     fn resolve_unqualified_existing_database_id<F>(

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -13,8 +13,9 @@ use crate::{
         main_loop::{init_distinct, CloseLoop, InitLoop, LoopBodyEmitter, OpenLoop},
         order_by::EmitOrderBy,
         plan::{
-            Distinctness, EphemeralRowidMode, EvalAt, IndexMethodQuery, JoinOrderMember, Operation,
-            QueryDestination, Scan, Search, SeekKeyComponent, SelectPlan, SimpleAggregate,
+            BitSet, Distinctness, EphemeralRowidMode, EvalAt, IndexMethodQuery, JoinOrderMember,
+            Operation, QueryDestination, Scan, Search, SeekKeyComponent, SelectPlan,
+            SimpleAggregate,
         },
         planner::table_mask_from_expr,
         select::emit_simple_count,
@@ -317,7 +318,7 @@ fn emit_materialized_build_inputs(
 ) -> Result<HashMap<usize, MaterializedBuildInput>> {
     let mut build_inputs: HashMap<usize, MaterializedBuildInput> = HashMap::default();
     let mut materializations: Vec<MaterializationSpec> = Vec::new();
-    let mut hash_tables_to_keep_open: HashSet<usize> = HashSet::default();
+    let mut hash_tables_to_keep_open = BitSet::default();
 
     // Keep hash tables open while running materialization subplans so we can reuse them.
     // A build table may appear in multiple hash joins when chaining, so we do not
@@ -325,21 +326,22 @@ fn emit_materialized_build_inputs(
     for table in plan.table_references.joined_tables().iter() {
         if let Operation::HashJoin(hash_join_op) = &table.op {
             let build_table = &plan.table_references.joined_tables()[hash_join_op.build_table_idx];
-            hash_tables_to_keep_open.insert(build_table.internal_id.into());
+            hash_tables_to_keep_open.set(build_table.internal_id.into());
         }
     }
 
-    let mut seen_build_tables: HashSet<usize> = HashSet::default();
+    let mut seen_build_tables: TableMask = TableMask::default();
 
     // decide per-hash-join materialization mode (rowid-only vs key+payload).
     for member in plan.join_order.iter() {
         let table = &plan.table_references.joined_tables()[member.original_idx];
         if let Operation::HashJoin(hash_join_op) = &table.op {
             if !hash_join_op.materialize_build_input
-                || !seen_build_tables.insert(hash_join_op.build_table_idx)
+                || seen_build_tables.get(hash_join_op.build_table_idx)
             {
                 continue;
             }
+            seen_build_tables.set(hash_join_op.build_table_idx);
 
             let probe_table_idx = hash_join_op.probe_table_idx;
             let probe_pos = plan
@@ -566,17 +568,17 @@ fn prune_join_order_for_materialized_inputs(
         return Ok(());
     }
 
-    let mut build_tables_in_plan = HashSet::default();
+    let mut build_tables_in_plan = TableMask::default();
     for member in plan.join_order.iter() {
         let table = &plan.table_references.joined_tables()[member.original_idx];
         if let Operation::HashJoin(hash_join_op) = &table.op {
-            build_tables_in_plan.insert(hash_join_op.build_table_idx);
+            build_tables_in_plan.set(hash_join_op.build_table_idx);
         }
     }
 
-    let mut tables_to_remove: HashSet<usize> = HashSet::default();
+    let mut tables_to_remove: TableMask = TableMask::default();
     for (build_table_idx, input) in build_inputs.iter() {
-        if !build_tables_in_plan.contains(build_table_idx) {
+        if !build_tables_in_plan.get(*build_table_idx) {
             continue;
         }
         if matches!(input.mode, MaterializedBuildInputMode::KeyPayload { .. }) {
@@ -588,7 +590,6 @@ fn prune_join_order_for_materialized_inputs(
         return Ok(());
     }
 
-    let prefix_mask: TableMask = tables_to_remove.iter().cloned().collect();
     for term in plan.where_clause.iter_mut() {
         if term.consumed {
             continue;
@@ -606,12 +607,12 @@ fn prune_join_order_for_materialized_inputs(
             &plan.table_references,
             &plan.non_from_clause_subqueries,
         )?;
-        if prefix_mask.contains_all_set_bits_of(&mask) {
+        if tables_to_remove.contains_all_set_bits_of(&mask) {
             term.consumed = true;
         }
     }
     plan.join_order
-        .retain(|member| !tables_to_remove.contains(&member.original_idx));
+        .retain(|member| !tables_to_remove.get(member.original_idx));
     Ok(())
 }
 

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1471,8 +1471,7 @@ fn emit_update_insns<'a>(
     // This ensures that if a constraint fails, indexes remain consistent.
     if let Some(btree_table) = target_table.table.btree() {
         if btree_table.is_strict {
-            let set_col_indices: std::collections::HashSet<usize> =
-                set_clauses.iter().map(|(idx, _)| *idx).collect();
+            let set_col_indices: ColumnMask = set_clauses.iter().map(|(idx, _)| *idx).collect();
 
             // Pre-encode TypeCheck: validate SET column input types.
             // Non-SET columns hold encoded values from disk, so skip them (ANY).

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -19,7 +19,7 @@ use crate::sync::Arc;
 use crate::translate::expression_index::{
     normalize_expr_for_index_matching, single_table_column_usage,
 };
-use crate::translate::plan::{Operation, ResultSetColumn, Search};
+use crate::translate::plan::{ColumnMask, Operation, ResultSetColumn, Search};
 use crate::translate::planner::parse_row_id;
 use crate::util::{exprs_are_equivalent, normalize_ident, parse_numeric_literal};
 use crate::vdbe::affinity::Affinity;
@@ -30,7 +30,6 @@ use crate::vdbe::{
     BranchOffset, CursorID,
 };
 use crate::{LimboError, Numeric, Result, Value};
-use std::collections::HashSet;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ConditionMetadata {
@@ -7665,13 +7664,13 @@ pub(crate) fn emit_custom_type_encode_columns(
     resolver: &Resolver,
     columns: &[Column],
     start_reg: usize,
-    only_columns: Option<&HashSet<usize>>,
+    only_columns: Option<&ColumnMask>,
     table_name: &str,
     layout: &ColumnLayout,
 ) -> Result<()> {
     for (i, col) in columns.iter().enumerate() {
         if let Some(filter) = only_columns {
-            if !filter.contains(&i) {
+            if !filter.get(i) {
                 continue;
             }
         }
@@ -7725,12 +7724,12 @@ pub(crate) fn emit_custom_type_decode_columns(
     resolver: &Resolver,
     columns: &[Column],
     start_reg: usize,
-    only_columns: Option<&HashSet<usize>>,
+    only_columns: Option<&ColumnMask>,
     layout: &ColumnLayout,
 ) -> Result<()> {
     for (i, col) in columns.iter().enumerate() {
         if let Some(filter) = only_columns {
-            if !filter.contains(&i) {
+            if !filter.get(i) {
                 continue;
             }
         }

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -1,4 +1,3 @@
-use rustc_hash::FxHashSet as HashSet;
 use turso_parser::ast::{self, Expr, Literal, Name, QualifiedName, RefAct};
 
 use super::{translate_inner, ProgramBuilder, ProgramBuilderOpts};
@@ -261,7 +260,7 @@ pub fn stabilize_new_row_for_fk(
     if table_btree.primary_key_columns.is_empty() {
         return Ok(());
     }
-    let set_cols: HashSet<usize> = set_clauses
+    let set_cols: ColumnMask = set_clauses
         .iter()
         .filter_map(|(i, _)| if *i == ROWID_SENTINEL { None } else { Some(*i) })
         .collect();
@@ -270,7 +269,7 @@ pub fn stabilize_new_row_for_fk(
         let (pos, col) = table_btree
             .get_column(pk_name)
             .ok_or_else(|| LimboError::InternalError(format!("pk col {pk_name} missing")))?;
-        if !set_cols.contains(&pos) {
+        if !set_cols.get(pos) {
             if col.is_rowid_alias() {
                 program.emit_insn(Insn::Copy {
                     src_reg: rowid_new_reg,

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::schema::GeneratedType;
 use crate::translate::emitter::HashLabels;
+use crate::translate::plan::ColumnUsedMask;
 use crate::vdbe::builder::SelfTableContext;
 
 #[derive(Debug, Clone)]
@@ -35,7 +36,7 @@ fn expr_references_outer_query(expr: &Expr, table_references: &TableReferences) 
 /// Static configuration for a fresh hash-table build.
 struct HashBuildConfig {
     payload_columns: Vec<MaterializedColumnRef>,
-    payload_signature_columns: Vec<usize>,
+    payload_signature_columns: ColumnUsedMask,
     key_affinities: String,
     collations: Vec<CollationSeq>,
     use_bloom_filter: bool,
@@ -155,7 +156,7 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
                         *payload_num_keys == num_keys,
                         "materialized hash build input key count mismatch"
                     );
-                    let payload_signature_columns = (0..payload_columns.len())
+                    let payload_signature_columns: ColumnUsedMask = (0..payload_columns.len())
                         .map(|i| *payload_num_keys + i)
                         .collect();
                     (
@@ -166,18 +167,18 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
                     )
                 }
                 _ => {
-                    let payload_signature_columns: Vec<usize> =
-                        build_table.col_used_mask.iter().collect();
+                    let payload_signature_columns: ColumnUsedMask =
+                        build_table.col_used_mask.clone();
                     let payload_columns = payload_signature_columns
                         .iter()
                         .map(|col_idx| {
                             let column = build_table
                                 .columns()
-                                .get(*col_idx)
+                                .get(col_idx)
                                 .expect("build table column missing");
                             MaterializedColumnRef::Column {
                                 table_id: build_table.internal_id,
-                                column_idx: *col_idx,
+                                column_idx: col_idx,
                                 is_rowid_alias: column.is_rowid_alias(),
                             }
                         })
@@ -414,7 +415,7 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
         let num_payload = config.payload_columns.len();
         let (payload_start_reg, mut payload_info) = if num_payload > 0 {
             let payload_reg = planner.program.alloc_registers(num_payload);
-            for (i, &col_idx) in config.payload_signature_columns.iter().enumerate() {
+            for (i, col_idx) in config.payload_signature_columns.iter().enumerate() {
                 match build_table
                     .columns()
                     .get(col_idx)

--- a/core/translate/main_loop/init.rs
+++ b/core/translate/main_loop/init.rs
@@ -87,18 +87,18 @@ impl InitLoop {
             );
         }
         // Include hash-join build tables so their cursors are opened for hash build.
-        let mut required_tables: HashSet<usize> = join_order
+        let mut required_tables: TableMask = join_order
             .iter()
             .map(|member| member.original_idx)
             .collect();
         for table in tables.joined_tables().iter() {
             if let Operation::HashJoin(hash_join_op) = &table.op {
-                required_tables.insert(hash_join_op.build_table_idx);
+                required_tables.set(hash_join_op.build_table_idx);
             }
         }
 
         for (table_index, table) in tables.joined_tables().iter().enumerate() {
-            if !required_tables.contains(&table_index) {
+            if !required_tables.get(table_index) {
                 continue;
             }
             // Ensure non-main databases have a Transaction instruction for read access.

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -274,7 +274,7 @@ pub fn join_lhs_and_rhs<'a>(
     if let Some(lhs) = lhs {
         let rhs_table_idx = join_order.last().unwrap().original_idx;
         let last_lhs_table_idx = join_order[join_order.len() - 2].original_idx;
-        let lhs_table_numbers: Vec<usize> = lhs.table_numbers().collect();
+        let lhs_table_numbers: TableMask = lhs.table_numbers().collect();
 
         let rhs_has_selective_seek = matches!(
             best_access_method.params,
@@ -375,7 +375,7 @@ pub fn join_lhs_and_rhs<'a>(
             // - products has constraint from items, BUT items is build of an earlier hash join where products was probe
             // - So the constraint IS consumed, and products cursor IS positioned via SeekRowid
             // Get the set of tables that are build tables for hash joins where build_table_idx was probe
-            let tables_already_hash_joined_as_build: Vec<usize> = {
+            let prior_hash_build_mask: TableMask = {
                 let arena = &access_methods_arena;
                 lhs.data
                     .iter()
@@ -399,10 +399,6 @@ pub fn join_lhs_and_rhs<'a>(
                     })
                     .collect()
             };
-            let prior_hash_build_mask: TableMask = tables_already_hash_joined_as_build
-                .iter()
-                .cloned()
-                .collect();
 
             let build_has_prior_constraints = {
                 build_constraints.constraints.iter().any(|c| {
@@ -416,7 +412,7 @@ pub fn join_lhs_and_rhs<'a>(
                     for table_idx in 0..64 {
                         if c.lhs_mask.get(table_idx)
                             && prior_mask.get(table_idx)
-                            && !tables_already_hash_joined_as_build.contains(&table_idx)
+                            && !prior_hash_build_mask.get(table_idx)
                         {
                             // This prior table is NOT handled by a hash join, constraint not consumed
                             return true;
@@ -1173,9 +1169,8 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                 };
 
                 // Stable iteration keeps tie-breaks consistent across runs.
-                let mut lhs_keys: Vec<usize> = lhs_variants.keys().copied().collect();
-                lhs_keys.sort_unstable();
-                for lhs_key in lhs_keys {
+                let lhs_keys: TableMask = lhs_variants.keys().copied().collect();
+                for lhs_key in &lhs_keys {
                     let lhs = &lhs_variants[&lhs_key];
                     // Build a JoinOrder out of the table bitmask under consideration.
                     for table_no in lhs.table_numbers() {
@@ -1396,7 +1391,7 @@ pub fn compute_greedy_join_order<'a>(
         })
         .collect();
 
-    let mut remaining: Vec<usize> = (0..num_tables).collect();
+    let mut remaining: TableMask = (0..num_tables).collect();
     let mut join_order: Vec<JoinOrderMember> = Vec::with_capacity(num_tables);
 
     // Pick starting table: prefer tables with high "hub score" (referenced by many constraints).
@@ -1408,7 +1403,7 @@ pub fn compute_greedy_join_order<'a>(
         original_idx: first_idx,
         is_outer: false, // First table cannot be outer join RHS
     });
-    remaining.retain(|&x| x != first_idx);
+    remaining.clear(first_idx);
 
     let mut current_plan: Option<JoinN> = join_lhs_and_rhs(
         None,
@@ -1449,7 +1444,7 @@ pub fn compute_greedy_join_order<'a>(
         let mut best: Option<(usize, JoinN)> = None;
 
         let mut has_connected_candidate = false;
-        for &idx in &remaining {
+        for idx in &remaining {
             // Outer join RHS requires all preceding tables joined first
             if let Some(required) = left_join_deps.get(&idx) {
                 if !current_mask.contains_all_set_bits_of(required) {
@@ -1470,7 +1465,7 @@ pub fn compute_greedy_join_order<'a>(
             }
         }
 
-        for &idx in &remaining {
+        for idx in &remaining {
             // Outer join RHS requires all preceding tables joined first
             if let Some(required) = left_join_deps.get(&idx) {
                 if !current_mask.contains_all_set_bits_of(required) {
@@ -1540,7 +1535,7 @@ pub fn compute_greedy_join_order<'a>(
                 .as_ref()
                 .is_some_and(|ji| ji.is_outer()),
         });
-        remaining.retain(|&x| x != next_idx);
+        remaining.clear(next_idx);
         current_plan = Some(next_plan);
     }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -9,7 +9,8 @@ use super::{
     },
 };
 use crate::translate::expression_index::expression_index_column_usage;
-use crate::translate::plan::{ColumnMask, MultiIndexBranchAccess};
+use crate::translate::plan::{BitSet, ColumnMask, MultiIndexBranchAccess};
+use crate::translate::planner::TableMask;
 use crate::{
     function::{AggFunc, Deterministic},
     index_method::IndexMethodCostEstimate,
@@ -1881,7 +1882,7 @@ fn optimize_table_access(
     // Collect hash join build/probe table indices. Build tables are excluded from the main
     // join order because they are consumed during hash build. A table may appear as both
     // probe and build (probe->build chaining) only when the build input is materialized.
-    let (hash_join_build_tables, hash_join_probe_tables): (Vec<usize>, Vec<usize>) =
+    let (hash_join_build_tables, hash_join_probe_tables): (TableMask, TableMask) =
         best_access_methods
             .iter()
             .filter_map(|&am_idx| {
@@ -1945,17 +1946,16 @@ fn optimize_table_access(
             }
         }
     }
-    let hash_join_build_only_tables: HashSet<usize> = hash_join_build_tables
+    let hash_join_build_only_tables: TableMask = hash_join_build_tables
         .iter()
-        .copied()
-        .filter(|table_idx| !hash_join_probe_tables.contains(table_idx))
+        .filter(|table_idx| !hash_join_probe_tables.get(*table_idx))
         .collect();
 
     let best_join_order: Vec<JoinOrderMember> = best_table_numbers
         .iter()
         .filter(|table_number| {
-            !hash_join_build_tables.contains(table_number)
-                || hash_join_probe_tables.contains(table_number)
+            !hash_join_build_tables.get(**table_number)
+                || hash_join_probe_tables.get(**table_number)
         })
         .map(|&table_number| JoinOrderMember {
             table_id: table_references.joined_tables_mut()[table_number].internal_id,
@@ -2051,12 +2051,10 @@ fn optimize_table_access(
                     // assigned sequential index positions (0, 1, 2), the seek key would include
                     // 3 components but the ephemeral index only has 2 key columns (t2.a, t2.c),
                     // causing the seek to compare against the wrong columns and return no results.
-                    let mut unique_col_positions: Vec<usize> = usable
+                    let unique_col_positions: BitSet = usable
                         .iter()
                         .map(|(_, c)| c.table_col_pos.expect("table_col_pos was Some above"))
                         .collect();
-                    unique_col_positions.sort_unstable();
-                    unique_col_positions.dedup();
                     // Map each usable constraint to a ConstraintRef.
                     // Multiple constraints with the same table_col_pos share the same index_col_pos.
                     let mut temp_constraint_refs: Vec<ConstraintRef> = usable
@@ -2064,9 +2062,7 @@ fn optimize_table_access(
                         .map(|(orig_idx, c)| {
                             let table_col_pos =
                                 c.table_col_pos.expect("table_col_pos was Some above");
-                            let index_col_pos = unique_col_positions
-                                .binary_search(&table_col_pos)
-                                .expect("table_col_pos must exist in unique_col_positions");
+                            let index_col_pos = unique_col_positions.rank(table_col_pos);
                             ConstraintRef {
                                 constraint_vec_pos: *orig_idx, // index in the original constraints vec
                                 index_col_pos,
@@ -2103,7 +2099,7 @@ fn optimize_table_access(
                             .join_info
                             .as_ref()
                             .is_some_and(|ji| ji.is_outer()),
-                        hash_join_build_only_tables.contains(&table_idx),
+                        hash_join_build_only_tables.get(table_idx),
                     );
 
                     let ephemeral_index = Arc::new(ephemeral_index);
@@ -2123,8 +2119,7 @@ fn optimize_table_access(
                         .join_info
                         .as_ref()
                         .is_some_and(|join_info| join_info.is_outer());
-                    let defer_cross_table_constraints =
-                        hash_join_build_only_tables.contains(&table_idx);
+                    let defer_cross_table_constraints = hash_join_build_only_tables.get(table_idx);
                     mark_seek_constraints_consumed(
                         &constraints_per_table[table_idx].constraints,
                         constraint_refs,
@@ -2279,7 +2274,7 @@ fn optimize_table_access(
                 } = set_op
                 {
                     for term_idx in additional_consumed_terms.iter() {
-                        where_clause[*term_idx].consumed = true;
+                        where_clause[term_idx].consumed = true;
                     }
                 }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1903,7 +1903,7 @@ fn optimize_table_access(
             .unzip();
     #[cfg(debug_assertions)]
     {
-        let mut probe_tables: HashSet<usize> = HashSet::default();
+        let mut probe_tables: TableMask = TableMask::default();
         let mut build_tables: HashMap<usize, bool> = HashMap::default();
         let mut pos_by_table: Vec<Option<usize>> =
             vec![None; table_references.joined_tables().len()];
@@ -1932,13 +1932,13 @@ fn optimize_table_access(
                         "hash join build/probe tables are not adjacent in join order"
                     );
                 }
-                probe_tables.insert(*probe_table_idx);
+                probe_tables.set(*probe_table_idx);
                 build_tables.insert(*build_table_idx, *materialize_build_input);
             }
         }
 
         for (build_table_idx, materialize_build_input) in build_tables {
-            if probe_tables.contains(&build_table_idx) {
+            if probe_tables.get(build_table_idx) {
                 turso_assert!(
                     materialize_build_input,
                     "probe->build chaining requires materialized build input"
@@ -2387,7 +2387,7 @@ fn optimize_table_access(
             .iter()
             .map(|member| member.original_idx)
             .collect();
-        let join_key_indices: HashSet<usize> = hash_join_op
+        let join_key_indices: BitSet = hash_join_op
             .join_keys
             .iter()
             .map(|key| key.where_clause_idx)
@@ -2398,7 +2398,7 @@ fn optimize_table_access(
             if !constraint.lhs_mask.intersects(&prior_mask) {
                 continue;
             }
-            if join_key_indices.contains(&constraint.where_clause_pos.0) {
+            if join_key_indices.get(constraint.where_clause_pos.0) {
                 continue;
             }
             has_prior_constraints = true;

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -23,7 +23,7 @@ use crate::translate::optimizer::cost::{
 };
 use crate::translate::optimizer::cost_params::CostModelParams;
 use crate::translate::plan::{
-    InSeekSource, JoinedTable, NonFromClauseSubquery, SetOperation, TableReferences,
+    BitSet, InSeekSource, JoinedTable, NonFromClauseSubquery, SetOperation, TableReferences,
     UnionBranchPrePostFilters, WhereTerm,
 };
 use crate::translate::planner::{table_mask_from_expr, TableMask};
@@ -705,7 +705,7 @@ fn evaluate_multi_index_branches(
             additional_consumed_terms,
         } = &set_op
         {
-            for term_idx in additional_consumed_terms.iter().copied() {
+            for term_idx in additional_consumed_terms.iter() {
                 if !consumed_where_terms.contains(&term_idx) {
                     consumed_where_terms.push(term_idx);
                 }
@@ -1081,7 +1081,7 @@ pub fn consider_multi_index_intersection(
         .collect();
 
     let where_term_idx = decomposition.term_indices[0];
-    let additional_consumed_terms: Vec<usize> =
+    let additional_consumed_terms: BitSet =
         decomposition.term_indices.iter().skip(1).copied().collect();
 
     evaluate_multi_index_branches(

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1403,6 +1403,14 @@ impl FromIterator<usize> for ColumnMask {
     }
 }
 
+impl Extend<usize> for ColumnMask {
+    fn extend<I: IntoIterator<Item = usize>>(&mut self, iter: I) {
+        for idx in iter {
+            self.set(idx);
+        }
+    }
+}
+
 pub struct ColumnMaskIter<B: std::borrow::Borrow<BitSet>> {
     inner: BitSetIter<B>,
     pending_rowid: bool,
@@ -1724,6 +1732,14 @@ impl FromIterator<usize> for BitSet {
     }
 }
 
+impl Extend<usize> for BitSet {
+    fn extend<I: IntoIterator<Item = usize>>(&mut self, iter: I) {
+        for index in iter {
+            self.set(index);
+        }
+    }
+}
+
 impl From<u128> for BitSet {
     fn from(from: u128) -> Self {
         let high = (from >> 64) as u64;
@@ -1822,9 +1838,7 @@ pub enum SetOperation {
     Union,
     /// Intersection: rowid appears in result only if it's in ALL branches (AND).
     /// Carries the indices of additional WHERE terms consumed beyond the primary one.
-    Intersection {
-        additional_consumed_terms: Vec<usize>,
-    },
+    Intersection { additional_consumed_terms: BitSet },
 }
 
 /// Multi-index scan operation metadata for OR-by-union or AND-by-intersection optimization.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1367,29 +1367,33 @@ pub type ColumnUsedMask = BitSet;
 // just like we have `CursorID`, so that we can make [ColumnMask] type-safe.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ColumnMask {
-    columns: BitSet,
-    has_rowid_update: bool,
+    bitset: BitSet,
+    has_rowid_sentinel: bool,
 }
 
 impl ColumnMask {
     pub fn set(&mut self, idx: usize) {
         if idx == ROWID_SENTINEL {
-            self.has_rowid_update = true;
+            self.has_rowid_sentinel = true;
         } else {
-            self.columns.set(idx);
+            self.bitset.set(idx);
         }
     }
 
     pub fn get(&self, idx: usize) -> bool {
         if idx == ROWID_SENTINEL {
-            self.has_rowid_update
+            self.has_rowid_sentinel
         } else {
-            self.columns.get(idx)
+            self.bitset.get(idx)
         }
     }
 
     pub fn count(&self) -> usize {
-        self.columns.count() + self.has_rowid_update as usize
+        self.bitset.count() + self.has_rowid_sentinel as usize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bitset.is_empty() && !self.has_rowid_sentinel
     }
 }
 
@@ -1437,8 +1441,8 @@ impl<'a> IntoIterator for &'a ColumnMask {
 
     fn into_iter(self) -> Self::IntoIter {
         ColumnMaskIter {
-            inner: (&self.columns).into_iter(),
-            pending_rowid: self.has_rowid_update,
+            inner: (&self.bitset).into_iter(),
+            pending_rowid: self.has_rowid_sentinel,
         }
     }
 }
@@ -1449,8 +1453,8 @@ impl IntoIterator for ColumnMask {
 
     fn into_iter(self) -> Self::IntoIter {
         ColumnMaskIter {
-            inner: self.columns.into_iter(),
-            pending_rowid: self.has_rowid_update,
+            inner: self.bitset.into_iter(),
+            pending_rowid: self.has_rowid_sentinel,
         }
     }
 }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -20,6 +20,7 @@ use crate::storage::pager::Pager;
 use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
 use crate::translate::emitter::{Resolver, TransactionMode};
+use crate::translate::plan::BitSet;
 use crate::util::{normalize_ident, parse_signed_number, parse_string, IOExt as _};
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
 use crate::vdbe::insn::{Cookie, Insn};
@@ -46,17 +47,18 @@ fn parse_max_errors_from_value(value: &Option<Expr>) -> usize {
     }
 }
 
-fn visible_database_ids_for_table_list(connection: &crate::Connection) -> Vec<usize> {
-    let mut ids = vec![crate::MAIN_DB_ID, crate::TEMP_DB_ID];
-    let mut attached_ids: Vec<_> = connection
-        .attached_databases()
-        .read()
-        .index_to_data
-        .keys()
-        .copied()
-        .collect();
-    attached_ids.sort_unstable();
-    ids.extend(attached_ids);
+fn visible_database_ids_for_table_list(connection: &crate::Connection) -> BitSet {
+    let mut ids = BitSet::default();
+    ids.set(crate::MAIN_DB_ID);
+    ids.set(crate::TEMP_DB_ID);
+    ids.extend(
+        connection
+            .attached_databases()
+            .read()
+            .index_to_data
+            .keys()
+            .copied(),
+    );
     ids
 }
 
@@ -1147,11 +1149,11 @@ fn query_pragma(
             program.alloc_registers(5);
 
             let database_ids = if schema_was_explicit {
-                vec![database_id]
+                [database_id].into_iter().collect::<BitSet>()
             } else {
                 visible_database_ids_for_table_list(connection.as_ref())
             };
-            for current_database_id in database_ids {
+            for current_database_id in &database_ids {
                 let database_name = connection
                     .get_database_name_by_index(current_database_id)
                     .unwrap_or_else(|| "main".to_string());

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use turso_parser::ast::{self, SortOrder, SubqueryType};
 
 use crate::{
@@ -38,7 +38,7 @@ use super::{
     emitter::{Resolver, TranslateCtx},
     main_loop::LoopLabels,
     plan::{Aggregate, Operation, QueryDestination, Scan, Search, SelectPlan},
-    planner::resolve_window_and_aggregate_functions,
+    planner::{resolve_window_and_aggregate_functions, TableMask},
 };
 
 struct DirectMaterializedSubquery {
@@ -1095,18 +1095,18 @@ pub fn emit_from_clause_subqueries(
         .iter()
         .map(|member| member.original_idx)
         .collect();
-    let visit_set: HashSet<usize> = visit_order.iter().copied().collect();
+    let visit_set: TableMask = visit_order.iter().copied().collect();
     for table in tables.joined_tables().iter() {
         if let Operation::HashJoin(hash_join_op) = &table.op {
             let build_idx = hash_join_op.build_table_idx;
-            if !visit_set.contains(&build_idx) {
+            if !visit_set.get(build_idx) {
                 visit_order.push(build_idx);
             }
         }
     }
 
     // Build lookup from table index to is_outer for LEFT-JOIN annotations
-    let outer_table_set: HashSet<usize> = join_order
+    let outer_table_set: TableMask = join_order
         .iter()
         .filter(|m| m.is_outer)
         .map(|m| m.original_idx)
@@ -1114,7 +1114,7 @@ pub fn emit_from_clause_subqueries(
 
     for table_index in visit_order {
         let table_reference = &mut tables.joined_tables_mut()[table_index];
-        let left_join_suffix = if outer_table_set.contains(&table_index) {
+        let left_join_suffix = if outer_table_set.get(table_index) {
             " LEFT-JOIN"
         } else {
             ""

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -615,7 +615,7 @@ fn execute_trigger_commands(
     // Trigger subprograms do not emit Transaction opcodes, so the parent statement
     // must acquire any attached/temp database transactions the trigger body needs
     // before OP_Program enters the subprogram.
-    for &db_id in &subprogram_prepared.write_databases {
+    for db_id in &subprogram_prepared.write_databases {
         if db_id == crate::MAIN_DB_ID {
             program.begin_write_operation();
         } else {
@@ -623,8 +623,8 @@ fn execute_trigger_commands(
             program.begin_write_on_database(db_id, schema_cookie);
         }
     }
-    for &db_id in &subprogram_prepared.read_databases {
-        if subprogram_prepared.write_databases.contains(&db_id) {
+    for db_id in &subprogram_prepared.read_databases {
+        if subprogram_prepared.write_databases.get(db_id) {
             continue;
         }
         if db_id == crate::MAIN_DB_ID {

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -1,4 +1,4 @@
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -191,24 +191,24 @@ fn upsert_index_is_affected(
     if rowid_changed {
         return true;
     }
-    let km: HashSet<usize> = idx
+    let km: ColumnMask = idx
         .columns
         .iter()
         .filter_map(|ic| ic.expr.is_none().then_some(ic.pos_in_table))
         .collect();
     let pm = referenced_index_cols(idx, table);
-    for c in km.iter().chain(pm.iter()) {
-        if changed_cols.get(*c) {
+    for c in km.into_iter().chain(pm.into_iter()) {
+        if changed_cols.get(c) {
             return true;
         }
     }
     false
 }
 
-/// Collect HashSet of columns referenced by the partial WHERE (empty if none), or
+/// Collect the set of columns referenced by the partial WHERE (empty if none), or
 /// by the expression of any IndexColumn on the index.
-fn referenced_index_cols(idx: &Index, table: &Table) -> HashSet<usize> {
-    let mut out = HashSet::default();
+fn referenced_index_cols(idx: &Index, table: &Table) -> ColumnMask {
+    let mut out = ColumnMask::default();
     if let Some(expr) = &idx.where_clause {
         index_expression_cols(table, &mut out, expr);
     }
@@ -221,13 +221,13 @@ fn referenced_index_cols(idx: &Index, table: &Table) -> HashSet<usize> {
 }
 
 /// Columns referenced by any expression index columns on the index.
-fn index_expression_cols(table: &Table, out: &mut HashSet<usize>, expr: &ast::Expr) {
+fn index_expression_cols(table: &Table, out: &mut ColumnMask, expr: &ast::Expr) {
     use ast::Expr;
     let _ = walk_expr(expr, &mut |e: &ast::Expr| -> crate::Result<WalkControl> {
         match e {
             Expr::Id(n) => {
                 if let Some((i, _)) = table.get_column_by_name(&normalize_ident(n.as_str())) {
-                    out.insert(i);
+                    out.set(i);
                 } else if ROWID_STRS
                     .iter()
                     .any(|r| r.eq_ignore_ascii_case(n.as_str()))
@@ -236,7 +236,7 @@ fn index_expression_cols(table: &Table, out: &mut HashSet<usize>, expr: &ast::Ex
                         .btree()
                         .and_then(|t| t.get_rowid_alias_column().map(|(p, _)| p))
                     {
-                        out.insert(rowid_pos);
+                        out.set(rowid_pos);
                     }
                 }
             }
@@ -245,7 +245,7 @@ fn index_expression_cols(table: &Table, out: &mut HashSet<usize>, expr: &ast::Ex
                 let tname = normalize_ident(table.get_name());
                 if nsn.eq_ignore_ascii_case(&tname) {
                     if let Some((i, _)) = table.get_column_by_name(&normalize_ident(c.as_str())) {
-                        out.insert(i);
+                        out.set(i);
                     }
                 }
             }

--- a/core/util.rs
+++ b/core/util.rs
@@ -4,7 +4,7 @@ use crate::schema::ColDef;
 use crate::sync::Mutex;
 use crate::translate::emitter::TransactionMode;
 use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
-use crate::translate::plan::{JoinedTable, TableReferences};
+use crate::translate::plan::{BitSet, JoinedTable, TableReferences};
 use crate::translate::planner::{parse_row_id, TableMask};
 use crate::types::IOResult;
 use crate::IO;
@@ -642,16 +642,16 @@ pub fn try_capture_parameters_column_agnostic(
 
     // For column arguments: check that the same set of columns is used (order-independent)
     // We use a greedy matching approach: for each query column, find a matching pattern column
-    let mut matched_pattern_indices: HashSet<usize> = HashSet::default();
+    let mut matched_pattern_indices = BitSet::default();
 
     for query_col in query_col_args {
         let mut found_match = false;
         for (i, pattern_col) in pattern_col_args.iter().enumerate() {
-            if matched_pattern_indices.contains(&i) {
+            if matched_pattern_indices.get(i) {
                 continue;
             }
             if exprs_are_equivalent(pattern_col, query_col) {
-                matched_pattern_indices.insert(i);
+                matched_pattern_indices.set(i);
                 found_match = true;
                 break;
             }
@@ -661,7 +661,7 @@ pub fn try_capture_parameters_column_agnostic(
         }
     }
     // All pattern columns must be matched
-    if matched_pattern_indices.len() != pattern_col_args.len() {
+    if matched_pattern_indices.count() != pattern_col_args.len() {
         return None;
     }
     // Remaining args must match positionally (includes the query string parameter)

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,5 +1,5 @@
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use tracing::{instrument, Level};
 use turso_parser::ast::{self, Expr, ResolveType, SortOrder, TableInternalId};
 
@@ -262,9 +262,9 @@ pub struct ProgramBuilder {
     // TODO: when we support multiple dbs, this should be a write mask to track which DBs need to be written
     txn_mode: TransactionMode,
     /// Set of database IDs that need write transactions (for attached databases).
-    write_databases: HashSet<usize>,
+    write_databases: BitSet,
     /// Set of attached database IDs that need read transactions.
-    read_databases: HashSet<usize>,
+    read_databases: BitSet,
     /// Schema cookies for attached databases at prepare time.
     write_database_cookies: HashMap<usize, u32>,
     /// Schema cookies for attached databases opened for reading.
@@ -319,7 +319,7 @@ pub struct ProgramBuilder {
     /// Hash join build signatures keyed by hash table id.
     hash_build_signatures: HashMap<usize, HashBuildSignature>,
     /// Hash tables to keep open across subplans (e.g. materialization).
-    hash_tables_to_keep_open: HashSet<usize>,
+    hash_tables_to_keep_open: BitSet,
     /// Maps table internal_id to result_columns_start_reg for FROM clause subqueries.
     /// Used when nested subqueries need to reference columns from outer query subqueries.
     subquery_result_regs: HashMap<TableInternalId, usize>,
@@ -559,8 +559,8 @@ impl ProgramBuilder {
             start_offset: BranchOffset::Placeholder,
             capture_data_changes_info,
             txn_mode: TransactionMode::None,
-            write_databases: HashSet::default(),
-            read_databases: HashSet::default(),
+            write_databases: BitSet::default(),
+            read_databases: BitSet::default(),
             write_database_cookies: HashMap::default(),
             read_database_cookies: HashMap::default(),
             rollback: false,
@@ -580,7 +580,7 @@ impl ProgramBuilder {
             suppress_custom_type_decode: false,
             suppress_column_default: false,
             hash_build_signatures: HashMap::default(),
-            hash_tables_to_keep_open: HashSet::default(),
+            hash_tables_to_keep_open: BitSet::default(),
             subquery_result_regs: HashMap::default(),
             self_table_context: None,
             next_cte_id: 0,
@@ -677,17 +677,17 @@ impl ProgramBuilder {
 
     /// Returns true if the given hash table id should be kept open across subplans.
     pub fn should_keep_hash_table_open(&self, hash_table_id: usize) -> bool {
-        self.hash_tables_to_keep_open.contains(&hash_table_id)
+        self.hash_tables_to_keep_open.get(hash_table_id)
     }
 
     /// Set the set of hash tables to keep open across subplans.
-    pub fn set_hash_tables_to_keep_open(&mut self, tables: &HashSet<usize>) {
+    pub fn set_hash_tables_to_keep_open(&mut self, tables: &BitSet) {
         self.hash_tables_to_keep_open.clone_from(tables);
     }
 
     /// Reset the set of hash tables to keep open.
     pub fn clear_hash_tables_to_keep_open(&mut self) {
-        self.hash_tables_to_keep_open.clear();
+        self.hash_tables_to_keep_open = BitSet::default();
     }
 
     /// Returns true if the given hash build signature matches the recorded one for the given hash table id.
@@ -1537,13 +1537,13 @@ impl ProgramBuilder {
     /// Tries to mirror: https://github.com/sqlite/sqlite/blob/e77e589a35862f6ac9c4141cfd1beb2844b84c61/src/build.c#L5379
     pub fn begin_write_operation(&mut self) {
         self.txn_mode = TransactionMode::Write;
-        self.write_databases.insert(crate::MAIN_DB_ID);
+        self.write_databases.set(crate::MAIN_DB_ID);
     }
 
     /// Begin a write operation on a specific database (for attached databases).
     pub fn begin_write_on_database(&mut self, database_id: usize, schema_cookie: u32) {
         self.txn_mode = TransactionMode::Write;
-        self.write_databases.insert(database_id);
+        self.write_databases.set(database_id);
         self.write_database_cookies
             .insert(database_id, schema_cookie);
     }
@@ -1553,7 +1553,7 @@ impl ProgramBuilder {
         if matches!(self.txn_mode, TransactionMode::None) {
             self.txn_mode = TransactionMode::Read;
         }
-        self.read_databases.insert(crate::MAIN_DB_ID);
+        self.read_databases.set(crate::MAIN_DB_ID);
     }
 
     /// Begin a read operation on a specific attached database.
@@ -1563,7 +1563,7 @@ impl ProgramBuilder {
         if matches!(self.txn_mode, TransactionMode::None) {
             self.txn_mode = TransactionMode::Read;
         }
-        self.read_databases.insert(database_id);
+        self.read_databases.set(database_id);
         self.read_database_cookies
             .insert(database_id, schema_cookie);
     }
@@ -1602,9 +1602,8 @@ impl ProgramBuilder {
             self.preassign_label_to_next_insn(self.init_label);
 
             if !matches!(self.txn_mode, TransactionMode::None) {
-                let mut write_db_ids: Vec<_> = self.write_databases.iter().copied().collect();
-                write_db_ids.sort_unstable();
-                for db_id in write_db_ids {
+                let write_dbs = self.write_databases.clone();
+                for db_id in &write_dbs {
                     let schema_cookie = if db_id == crate::MAIN_DB_ID {
                         schema.schema_version
                     } else {
@@ -1621,10 +1620,9 @@ impl ProgramBuilder {
                 }
                 // Emit Transaction for each non-main database that only needs a read
                 // (skip databases already covered by write_databases)
-                let mut read_db_ids: Vec<_> = self.read_databases.iter().copied().collect();
-                read_db_ids.sort_unstable();
-                for db_id in read_db_ids {
-                    if !self.write_databases.contains(&db_id) {
+                let read_dbs = self.read_databases.clone();
+                for db_id in &read_dbs {
+                    if !write_dbs.get(db_id) {
                         let schema_cookie = if db_id == crate::MAIN_DB_ID {
                             schema.schema_version
                         } else {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -17,8 +17,9 @@
 //!
 //! https://www.sqlite.org/opcode.html
 
+use crate::translate::plan::BitSet;
 use crate::types::{Extendable, Text};
-use crate::{turso_assert, turso_assert_ne, turso_debug_assert, HashSet, NonNan};
+use crate::{turso_assert, turso_assert_ne, turso_debug_assert, NonNan};
 pub mod affinity;
 pub mod array;
 pub mod bloom_filter;
@@ -1112,9 +1113,9 @@ pub struct PreparedProgram {
     pub resolve_type: ResolveType,
     pub prepare_context: PrepareContext,
     /// Set of attached database indices that need write transactions.
-    pub write_databases: HashSet<usize>,
+    pub write_databases: BitSet,
     /// Set of attached database indices that need read transactions.
-    pub read_databases: HashSet<usize>,
+    pub read_databases: BitSet,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Description

Replace `HashSet<usize>` and `Vec<usize>` where it was used with set semantics and small elements with bitsets, for less allocations and faster set operations.

## Description of AI Usage

clauded