### PR TITLE
Reduce allocations in multi-index analysis optimizer

### DIFF
--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1251,26 +1251,32 @@ pub struct AnalyzedTerm {
     pub constraint_refs: Vec<RangeConstraintRef>,
 }
 
-/// Analyzes a single binary expression to determine if it can use an index.
-///
-/// This is a shared helper for both OR and AND multi-index analysis.
-/// Returns `Some(AnalyzedTerm)` if the expression is a usable indexed constraint,
-/// `None` otherwise.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn analyze_binary_term_for_index(
-    expr: &ast::Expr,
-    where_term_idx: usize,
+/// Lightweight prepass result for a binary term that can seed a multi-index branch.
+#[derive(Debug, Clone)]
+pub struct IndexableTermSummary {
+    /// The constrained table column, if any.
+    pub table_col_pos: Option<usize>,
+    /// The other tables referenced by the constraining expression.
+    pub lhs_mask: TableMask,
+    /// The chosen index for this term, or `None` for rowid access.
+    pub best_index: Option<Arc<Index>>,
+}
+
+struct BinaryTermIndexInfo<'a> {
+    lhs: &'a ast::Expr,
+    rhs: &'a ast::Expr,
+    operator: ConstraintOperator,
+    table_col_pos: Option<usize>,
+    constraining_expr: &'a ast::Expr,
+    side: BinaryExprSide,
+    is_rowid: bool,
+}
+
+fn analyze_binary_term_index_info<'a>(
+    expr: &'a ast::Expr,
     table_id: TableInternalId,
-    table_reference: &JoinedTable,
-    indexes: Option<&VecDeque<Arc<Index>>>,
     rowid_alias_column: Option<usize>,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
-    table_references: &TableReferences,
-    subqueries: &[NonFromClauseSubquery],
-    schema: &Schema,
-    params: &CostModelParams,
-) -> Option<AnalyzedTerm> {
-    // Try to extract a binary comparison
+) -> Option<BinaryTermIndexInfo<'a>> {
     let (lhs, operator, rhs) = as_binary_components(expr).ok().flatten()?;
 
     // Check if the operator is usable for index seeks
@@ -1292,17 +1298,17 @@ pub(crate) fn analyze_binary_term_for_index(
     // Check if this is an indexable constraint on our table
     let (table_col_pos, constraining_expr, side, is_rowid) = match lhs {
         ast::Expr::Column { table, column, .. } if *table == table_id => {
-            (Some(*column), rhs.clone(), BinaryExprSide::Rhs, false)
+            (Some(*column), rhs, BinaryExprSide::Rhs, false)
         }
         ast::Expr::RowId { table, .. } if *table == table_id => {
-            (rowid_alias_column, rhs.clone(), BinaryExprSide::Rhs, true)
+            (rowid_alias_column, rhs, BinaryExprSide::Rhs, true)
         }
         _ => match rhs {
             ast::Expr::Column { table, column, .. } if *table == table_id => {
-                (Some(*column), lhs.clone(), BinaryExprSide::Lhs, false)
+                (Some(*column), lhs, BinaryExprSide::Lhs, false)
             }
             ast::Expr::RowId { table, .. } if *table == table_id => {
-                (rowid_alias_column, lhs.clone(), BinaryExprSide::Lhs, true)
+                (rowid_alias_column, lhs, BinaryExprSide::Lhs, true)
             }
             _ => return None, // Doesn't reference our table
         },
@@ -1315,6 +1321,93 @@ pub(crate) fn analyze_binary_term_for_index(
     } else {
         operator
     };
+
+    Some(BinaryTermIndexInfo {
+        lhs,
+        rhs,
+        operator,
+        table_col_pos,
+        constraining_expr,
+        side,
+        is_rowid,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn summarize_binary_term_for_index(
+    expr: &ast::Expr,
+    table_id: TableInternalId,
+    indexes: Option<&VecDeque<Arc<Index>>>,
+    rowid_alias_column: Option<usize>,
+    table_references: &TableReferences,
+    subqueries: &[NonFromClauseSubquery],
+) -> Option<IndexableTermSummary> {
+    let BinaryTermIndexInfo {
+        operator,
+        table_col_pos,
+        constraining_expr,
+        is_rowid,
+        ..
+    } = analyze_binary_term_index_info(expr, table_id, rowid_alias_column)?;
+
+    let (best_index, constraint_refs) = find_best_index_for_constraint(
+        table_col_pos,
+        operator,
+        indexes,
+        rowid_alias_column,
+        is_rowid,
+    );
+    if constraint_refs.is_empty() {
+        return None;
+    }
+
+    let lhs_mask = table_mask_from_expr(constraining_expr, table_references, subqueries)
+        .unwrap_or_else(|_| TableMask::default());
+
+    let table_pos = table_references
+        .joined_tables()
+        .iter()
+        .position(|t| t.internal_id == table_id)
+        .expect("target table must exist in table_references");
+    if lhs_mask.get(table_pos) {
+        return None;
+    }
+
+    Some(IndexableTermSummary {
+        table_col_pos,
+        lhs_mask,
+        best_index,
+    })
+}
+
+/// Analyzes a single binary expression to determine if it can use an index.
+///
+/// This is a shared helper for both OR and AND multi-index analysis.
+/// Returns `Some(AnalyzedTerm)` if the expression is a usable indexed constraint,
+/// `None` otherwise.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn analyze_binary_term_for_index(
+    expr: &ast::Expr,
+    where_term_idx: usize,
+    table_id: TableInternalId,
+    table_reference: &JoinedTable,
+    indexes: Option<&VecDeque<Arc<Index>>>,
+    rowid_alias_column: Option<usize>,
+    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    table_references: &TableReferences,
+    subqueries: &[NonFromClauseSubquery],
+    schema: &Schema,
+    params: &CostModelParams,
+) -> Option<AnalyzedTerm> {
+    let BinaryTermIndexInfo {
+        lhs,
+        rhs,
+        operator,
+        table_col_pos,
+        constraining_expr,
+        side,
+        is_rowid,
+    } = analyze_binary_term_index_info(expr, table_id, rowid_alias_column)?;
 
     // Find the best index for this constraint
     let (best_index, constraint_refs) = find_best_index_for_constraint(
@@ -1342,7 +1435,7 @@ pub(crate) fn analyze_binary_term_for_index(
         is_rowid,
     );
 
-    let lhs_mask = table_mask_from_expr(&constraining_expr, table_references, subqueries)
+    let lhs_mask = table_mask_from_expr(constraining_expr, table_references, subqueries)
         .unwrap_or_else(|_| TableMask::default());
 
     // Cannot use index seek if the constraining expression references the same table

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -14,8 +14,8 @@ use crate::translate::optimizer::access_method::{
     BranchReadMode, ChosenInSeekCandidate, ResidualConstraintMode,
 };
 use crate::translate::optimizer::constraints::{
-    analyze_binary_term_for_index, constraints_from_where_clause, Constraint, RangeConstraintRef,
-    TableConstraints,
+    analyze_binary_term_for_index, constraints_from_where_clause, summarize_binary_term_for_index,
+    Constraint, RangeConstraintRef, TableConstraints,
 };
 use crate::translate::optimizer::cost::{
     estimate_cost_for_scan_or_seek, estimate_rows_per_seek, rows_per_leaf_page_for_index,
@@ -30,6 +30,7 @@ use crate::translate::planner::{table_mask_from_expr, TableMask};
 use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 use std::{collections::VecDeque, sync::Arc};
+use turso_macros::turso_assert_eq;
 use turso_parser::ast::{self, TableInternalId};
 
 #[derive(Debug, Clone)]
@@ -70,6 +71,12 @@ struct AndBranch {
     constraint: Constraint,
     index: Option<Arc<Index>>,
     constraint_refs: Vec<RangeConstraintRef>,
+}
+
+struct AndBranchSummary {
+    where_term_idx: usize,
+    table_col_pos: Option<usize>,
+    index: Option<Arc<Index>>,
 }
 
 /// Internal branch representation while evaluating a candidate multi-index plan.
@@ -769,43 +776,32 @@ fn analyze_and_terms_for_multi_index(
     // 3. Can use an index
     // 4. Are not already consumed
     // 5. Are local constraints rather than cross-table join conditions
-    let mut candidate_branches: Vec<AndBranch> = Vec::new();
-    let mut columns_used: Vec<Option<usize>> = Vec::new();
+    let mut candidate_branches: Vec<AndBranchSummary> = Vec::new();
 
     for (where_term_idx, term) in where_clause.iter().enumerate() {
-        if term.consumed {
-            continue;
-        }
-        if matches!(&term.expr, ast::Expr::Binary(_, ast::Operator::Or, _)) {
+        if term.consumed || matches!(&term.expr, ast::Expr::Binary(_, ast::Operator::Or, _)) {
             continue;
         }
 
-        let Some(analyzed) = analyze_binary_term_for_index(
+        let Some(summary) = summarize_binary_term_for_index(
             &term.expr,
-            where_term_idx,
             table_id,
-            table_reference,
             indexes,
             rowid_alias_column,
-            available_indexes,
             table_references,
             subqueries,
-            schema,
-            params,
         ) else {
             continue;
         };
 
-        if !analyzed.constraint.lhs_mask.is_empty() {
+        if !summary.lhs_mask.is_empty() {
             continue;
         }
 
-        columns_used.push(analyzed.constraint.table_col_pos);
-        candidate_branches.push(AndBranch {
+        candidate_branches.push(AndBranchSummary {
             where_term_idx,
-            constraint: analyzed.constraint,
-            index: analyzed.best_index,
-            constraint_refs: analyzed.constraint_refs,
+            table_col_pos: summary.table_col_pos,
+            index: summary.best_index,
         });
     }
 
@@ -818,12 +814,15 @@ fn analyze_and_terms_for_multi_index(
     if let Some(indexes) = indexes {
         for index in indexes.iter().filter(|idx| idx.index_method.is_none()) {
             let mut columns_covered = 0;
-            for (i, col_pos) in columns_used.iter().enumerate() {
+            for (i, branch) in candidate_branches.iter().enumerate() {
+                let col_pos = branch.table_col_pos;
                 if let Some(col_pos) = col_pos {
-                    if let Some(idx_pos) = index.column_table_pos_to_index_pos(*col_pos) {
+                    if let Some(idx_pos) = index.column_table_pos_to_index_pos(col_pos) {
                         if idx_pos < index.columns.len() {
-                            let earlier_covered =
-                                columns_used[..i].iter().filter_map(|c| *c).any(|c| {
+                            let earlier_covered = candidate_branches[..i]
+                                .iter()
+                                .filter_map(|candidate| candidate.table_col_pos)
+                                .any(|c| {
                                     index
                                         .column_table_pos_to_index_pos(c)
                                         .is_some_and(|p| p < idx_pos)
@@ -843,20 +842,51 @@ fn analyze_and_terms_for_multi_index(
 
     // Keep only branches that use distinct named indexes. Rowid (`None`) may
     // still appear more than once because it is not tied to a named index.
-    let mut unique_branches: Vec<AndBranch> = Vec::new();
-    let mut seen_indexes: Vec<Option<String>> = Vec::new();
+    let mut selected_branches: Vec<AndBranchSummary> = Vec::new();
+    let mut seen_indexes: Vec<*const Index> = Vec::new();
     for branch in candidate_branches {
-        let index_name = branch.index.as_ref().map(|idx| idx.name.clone());
-        if index_name.is_some() && seen_indexes.contains(&index_name) {
-            continue;
+        if let Some(index) = branch.index.as_ref() {
+            let index_ptr = Arc::as_ptr(index);
+            if seen_indexes.contains(&index_ptr) {
+                continue;
+            }
+            seen_indexes.push(index_ptr);
         }
-        seen_indexes.push(index_name);
-        unique_branches.push(branch);
+        selected_branches.push(branch);
     }
 
-    if unique_branches.len() < 2 {
+    if selected_branches.len() < 2 {
         return None;
     }
+
+    let unique_branches = selected_branches
+        .into_iter()
+        .map(|branch| {
+            let analyzed = analyze_binary_term_for_index(
+                &where_clause[branch.where_term_idx].expr,
+                branch.where_term_idx,
+                table_id,
+                table_reference,
+                indexes,
+                rowid_alias_column,
+                available_indexes,
+                table_references,
+                subqueries,
+                schema,
+                params,
+            )
+            .expect("multi-index prepass accepted a term that full analysis rejected");
+
+            turso_assert_eq!(analyzed.constraint.table_col_pos, branch.table_col_pos);
+
+            AndBranch {
+                where_term_idx: branch.where_term_idx,
+                constraint: analyzed.constraint,
+                index: analyzed.best_index,
+                constraint_refs: analyzed.constraint_refs,
+            }
+        })
+        .collect::<Vec<_>>();
 
     Some(AndClauseDecomposition {
         term_indices: unique_branches.iter().map(|b| b.where_term_idx).collect(),


### PR DESCRIPTION
## Description
According to `dhat` reduced allocation churn from `255.35 MB` -> `20.75 MB`. This does not affect peak memory usage for the workload as this memory is only allocated in the optimizer path and discarded after well, everything has been optimized.

The main idea of the changes here is that there is some data that is transient and that can be borrowed (like `BinaryTermIndexInfo`) and so we don't need to clone or allocate it together in the same `struct` with `AndBranch`. This means `AndBranch` total size decreases which means we allocate a lot less on the heap. 

## Motivation and context
Reduce allocation churn


## Description of AI Usage
Caught this with Codex when running memory benchmark and he helped devise the best solution here for allocation churn and mem usage.
