### PR TITLE
core/translate: Fix UPDATE rowid with indexed generated column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,15 +5,16 @@ SQLite rewrite in Rust. 40+ crate workspace.
 ## Quick Reference
 
 ```bash
-cargo build                    # build. never build with release.
+cargo build                    # build. never build with --release
 cargo test                     # rust unit/integration tests
 cargo fmt                      # format (required)
 cargo clippy --workspace --all-features --all-targets -- --deny=warnings  # lint
-cargo run -q --bin tursodb -- -q # run the interactive cli
+cargo run -q --bin tursodb -- -q # run the interactive cli. never run with --release
 
 make test                      # TCL compat + sqlite3 + extensions + MVCC
 make test-single TEST=foo.test # single TCL test
-CI=1 make -C testing/sqltests run-rust  # sqltest runner (preferred for new tests)
+make -C testing/sqltests run-rust ARGS='--snapshot-filter __never__'  # sqltest runner (preferred for new tests)
+CI=1 make -C testing/sqltests run-rust  # use only if snapshot tests are required
 
 scripts/diff.sh "SQL" [label]  # compare sqlite3 vs tursodb output
 ```

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1682,15 +1682,11 @@ pub(crate) fn emit_index_column_value_old_image(
             BindingBehavior::ResultColumnsNotAllowed,
         )?;
 
-        let self_table_context =
-            table_references
-                .joined_tables()
-                .first()
-                .map(|jt| SelfTableContext::ForSelect {
-                    table_ref_id: jt.internal_id,
-                    referenced_tables: table_references.clone(),
-                });
-        program.with_self_table_context(self_table_context.as_ref(), |program, _| {
+        let self_table_context = SelfTableContext::ForSelect {
+            table_ref_id: table_internal_id,
+            referenced_tables: table_references.clone(),
+        };
+        program.with_self_table_context(Some(&self_table_context), |program, _| {
             translate_expr_no_constant_opt(
                 program,
                 Some(table_references),

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4483,3 +4483,11 @@ test update-with-virtual-column-before-pk {
 } expect {
     1|2|99
 }
+
+test update-ipk-with-indexed-virtual-col {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b, c AS (b * 2));
+    CREATE INDEX idx ON t(c);
+    INSERT INTO t(a, b) VALUES (1, 5);
+    UPDATE t SET a = 100 WHERE a = 1;
+} expect {
+}


### PR DESCRIPTION
## Description

## Motivation and context

when materializing the updated rows and emitting the old index column values, the `self_table_context` (used for computing virtual columns) was incorrectly set to the ephemeral table, resulting in "column index out of bounds".

Closes https://github.com/tursodatabase/turso/issues/6404

## Description of AI Usage

CC found and fixed the bug