### PR TITLE
core/translate: fix UPDATE with FK when virtual generated column precedes non-rowid-alias PK

### DIFF
--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -377,24 +377,21 @@ pub fn stabilize_new_row_for_fk(
         .filter_map(|(i, _)| if *i == ROWID_SENTINEL { None } else { Some(*i) })
         .collect();
 
+    let layout = table_btree.column_layout();
     for (pk_name, _) in &table_btree.primary_key_columns {
         let (pos, col) = table_btree
             .get_column(pk_name)
             .ok_or_else(|| LimboError::InternalError(format!("pk col {pk_name} missing")))?;
         if !set_cols.get(pos) {
+            let dst_reg = layout.to_register(start, pos);
             if col.is_rowid_alias() {
                 program.emit_insn(Insn::Copy {
                     src_reg: rowid_new_reg,
-                    dst_reg: start + pos,
+                    dst_reg,
                     extra_amount: 0,
                 });
             } else {
-                program.emit_insn(Insn::Column {
-                    cursor_id,
-                    column: pos,
-                    dest: start + pos,
-                    default: None,
-                });
+                program.emit_column_or_rowid(cursor_id, pos, dst_reg);
             }
         }
     }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4473,3 +4473,13 @@ test delete-using-indexed-virtual-column {
     DELETE FROM t WHERE b = 2;
 } expect {
 }
+
+test update-with-virtual-column-before-pk {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE t(a AS (1), b, c, PRIMARY KEY (b));
+    INSERT INTO t(b, c) VALUES (2, 3);
+    UPDATE t SET c = 99;
+    SELECT * FROM t;
+} expect {
+    1|2|99
+}


### PR DESCRIPTION
## Summary

- `stabilize_new_row_for_fk` filled unmodified PK columns into the NEW-row register image using `start + pos` for the destination register and passed the logical `pos` to `Insn::Column`. Both assume schema-index register layout and a physical column index.
- When the table has a virtual generated column, the register layout places virtual columns at the end, so the schema index no longer maps directly to a register offset, and `Insn::Column` expects a physical index.
- Net effect: with `PRAGMA foreign_keys = ON`, `UPDATE` on a table like `t(a AS (1), b, c, PRIMARY KEY(b))` wrote the wrong value into the record (or silently dropped the update, depending on register aliasing).

Fix: use `ColumnLayout::to_register` for the destination register and emit the read through `emit_column_or_rowid`, which performs the logical→physical mapping.

Closes https://github.com/tursodatabase/turso/issues/6405

Regression test added in `testing/sqltests/tests/gencol.sqltest` as `update-with-virtual-column-before-pk`.