### PR TITLE
Introduce BTree constructor and RAII mutation guard

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -2267,7 +2267,9 @@ mod tests {
     use super::*;
     use crate::incremental::dbsp::Delta;
     use crate::incremental::operator::{FilterOperator, FilterPredicate};
-    use crate::schema::{BTreeTable, ColDef, Column as SchemaColumn, Schema, Type};
+    use crate::schema::{
+        BTreeCharacteristics, BTreeTable, ColDef, Column as SchemaColumn, Schema, Type,
+    };
     use crate::storage::pager::CreateBTreeFlags;
     use crate::sync::Arc;
     use crate::translate::logical::{ColumnInfo, LogicalPlanBuilder, LogicalSchema};
@@ -2303,23 +2305,17 @@ mod tests {
                     None,
                 ),
             ];
-            let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-            let users_table = BTreeTable {
-                name: "users".to_string(),
-                root_page: 2,
-                primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
+            let users_table = BTreeTable::new(
+                2,
+                "users".to_string(),
+                vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
                 columns,
-                has_rowid: true,
-                is_strict: false,
-                has_autoincrement: false,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            };
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            );
             schema
                 .add_btree_table(Arc::new(users_table))
                 .expect("Test setup: failed to add users table");
@@ -2351,26 +2347,17 @@ mod tests {
                     None,
                 ),
             ];
-            let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-            let products_table = BTreeTable {
-                name: "products".to_string(),
-                root_page: 3,
-                primary_key_columns: vec![(
-                    "product_id".to_string(),
-                    turso_parser::ast::SortOrder::Asc,
-                )],
+            let products_table = BTreeTable::new(
+                3,
+                "products".to_string(),
+                vec![("product_id".to_string(), turso_parser::ast::SortOrder::Asc)],
                 columns,
-                has_rowid: true,
-                is_strict: false,
-                has_autoincrement: false,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            };
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            );
             schema
                 .add_btree_table(Arc::new(products_table))
                 .expect("Test setup: failed to add products table");
@@ -2407,26 +2394,17 @@ mod tests {
                     None,
                 ),
             ];
-            let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-            let orders_table = BTreeTable {
-                name: "orders".to_string(),
-                root_page: 4,
-                primary_key_columns: vec![(
-                    "order_id".to_string(),
-                    turso_parser::ast::SortOrder::Asc,
-                )],
+            let orders_table = BTreeTable::new(
+                4,
+                "orders".to_string(),
+                vec![("order_id".to_string(), turso_parser::ast::SortOrder::Asc)],
                 columns,
-                has_rowid: true,
-                has_autoincrement: false,
-                is_strict: false,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            };
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            );
             schema
                 .add_btree_table(Arc::new(orders_table))
                 .expect("Test setup: failed to add orders table");
@@ -2449,23 +2427,17 @@ mod tests {
                 ),
                 SchemaColumn::new_default_text(Some("name".to_string()), "TEXT".to_string(), None),
             ];
-            let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-            let customers_table = BTreeTable {
-                name: "customers".to_string(),
-                root_page: 6,
-                primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
+            let customers_table = BTreeTable::new(
+                6,
+                "customers".to_string(),
+                vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
                 columns,
-                has_rowid: true,
-                is_strict: false,
-                has_autoincrement: false,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            };
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            );
             schema
                 .add_btree_table(Arc::new(customers_table))
                 .expect("Test setup: failed to add customers table");
@@ -2502,23 +2474,17 @@ mod tests {
                     None,
                 ),
             ];
-            let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-            let purchases_table = BTreeTable {
-                name: "purchases".to_string(),
-                root_page: 7,
-                primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
+            let purchases_table = BTreeTable::new(
+                7,
+                "purchases".to_string(),
+                vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
                 columns,
-                has_rowid: true,
-                is_strict: false,
-                has_autoincrement: false,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            };
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            );
             schema
                 .add_btree_table(Arc::new(purchases_table))
                 .expect("Test setup: failed to add purchases table");
@@ -2546,23 +2512,17 @@ mod tests {
                     None,
                 ),
             ];
-            let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-            let vendors_table = BTreeTable {
-                name: "vendors".to_string(),
-                root_page: 8,
-                primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
+            let vendors_table = BTreeTable::new(
+                8,
+                "vendors".to_string(),
+                vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
                 columns,
-                has_rowid: true,
-                is_strict: false,
-                has_autoincrement: false,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            };
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            );
             schema
                 .add_btree_table(Arc::new(vendors_table))
                 .expect("Test setup: failed to add vendors table");
@@ -2579,23 +2539,17 @@ mod tests {
                     None,
                 ),
             ];
-            let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-            let sales_table = BTreeTable {
-                name: "sales".to_string(),
-                root_page: 2,
-                primary_key_columns: vec![],
+            let sales_table = BTreeTable::new(
+                2,
+                "sales".to_string(),
+                vec![],
                 columns,
-                has_rowid: true,
-                is_strict: false,
-                has_autoincrement: false,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            };
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            );
             schema
                 .add_btree_table(Arc::new(sales_table))
                 .expect("Test setup: failed to add sales table");

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -1421,7 +1421,9 @@ impl IncrementalView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::{BTreeTable, ColDef, Column as SchemaColumn, Schema, Type};
+    use crate::schema::{
+        BTreeCharacteristics, BTreeTable, ColDef, Column as SchemaColumn, Schema, Type,
+    };
     use crate::sync::Arc;
     use turso_parser::ast;
     use turso_parser::parser::Parser;
@@ -1450,23 +1452,17 @@ mod tests {
             ),
             SchemaColumn::new_default_text(Some("name".to_string()), "TEXT".to_string(), None),
         ];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let customers_table = BTreeTable {
-            name: "customers".to_string(),
-            root_page: 2,
-            primary_key_columns: vec![("id".to_string(), ast::SortOrder::Asc)],
+        let customers_table = BTreeTable::new(
+            2,
+            "customers".to_string(),
+            vec![("id".to_string(), ast::SortOrder::Asc)],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_autoincrement: false,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        };
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
 
         // Create orders table
         let columns = vec![
@@ -1501,23 +1497,17 @@ mod tests {
                 None,
             ),
         ];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let orders_table = BTreeTable {
-            name: "orders".to_string(),
-            root_page: 3,
-            primary_key_columns: vec![("id".to_string(), ast::SortOrder::Asc)],
+        let orders_table = BTreeTable::new(
+            3,
+            "orders".to_string(),
+            vec![("id".to_string(), ast::SortOrder::Asc)],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            has_autoincrement: false,
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            unique_sets: vec![],
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        };
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
 
         // Create products table
         let columns = vec![
@@ -1548,23 +1538,17 @@ mod tests {
                 ColDef::default(),
             ),
         ];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let products_table = BTreeTable {
-            name: "products".to_string(),
-            root_page: 4,
-            primary_key_columns: vec![("id".to_string(), ast::SortOrder::Asc)],
+        let products_table = BTreeTable::new(
+            4,
+            "products".to_string(),
+            vec![("id".to_string(), ast::SortOrder::Asc)],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            has_autoincrement: false,
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            unique_sets: vec![],
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        };
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
 
         // Create logs table - without a rowid alias (no INTEGER PRIMARY KEY)
         let columns = vec![
@@ -1588,23 +1572,18 @@ mod tests {
                 None,
             ),
         ];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let logs_table = BTreeTable {
-            name: "logs".to_string(),
-            root_page: 5,
-            primary_key_columns: vec![], // No primary key, so no rowid alias
+        // logs has no primary key (no rowid alias) but does have an implicit rowid.
+        let logs_table = BTreeTable::new(
+            5,
+            "logs".to_string(),
+            vec![],
             columns,
-            has_rowid: true, // Has implicit rowid but no alias
-            is_strict: false,
-            has_autoincrement: false,
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            unique_sets: vec![],
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        };
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
 
         schema
             .add_btree_table(Arc::new(customers_table))

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2305,7 +2305,7 @@ impl GeneratedColGraph {
                 );
             }
             let direct_mask: ColumnMask = ColumnMask::from_iter(direct.iter());
-            direct_deps[j].set_all(&direct_mask);
+            direct_deps[j].union_with(&direct_mask);
             for i in direct.iter() {
                 direct_dependents[i].set(j);
                 in_degree[j] += 1;
@@ -2932,7 +2932,7 @@ impl BTreeTable {
             affected.set(i);
             if i < graph.dependents.len() {
                 let snapshot = graph.dependents[i].clone();
-                affected.set_all(&snapshot);
+                affected.union_with(&snapshot);
             }
         }
         Ok(affected)
@@ -5696,7 +5696,7 @@ mod tests {
         )?;
         let mut expected = t.columns_affected_by_update([0])?;
         let b_mask = t.columns_affected_by_update([1])?;
-        expected.set_all(&b_mask);
+        expected.union_with(&b_mask);
         let union_mask = t.columns_affected_by_update([0, 1])?;
         assert_eq!(indices(&union_mask), indices(&expected));
         Ok(())

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2260,17 +2260,13 @@ impl<T: Default> Clone for ResetOnClone<T> {
 }
 
 bitflags! {
-    /// Set of boolean table-level properties passed to [`BTreeTable::new`].
-    /// These correspond to SQL CREATE TABLE clauses/flags and end up stored
-    /// as individual `bool` fields on [`BTreeTable`]; the bitflags form is
-    /// just an ergonomic way to pass several at once.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct BTreeCharacteristics: u8 {
         /// Table has a rowid column (i.e. not `WITHOUT ROWID`).
         const HAS_ROWID         = 0b0000_0001;
         /// Table is declared `STRICT`.
         const STRICT            = 0b0000_0010;
-        /// Table has an INTEGER PRIMARY KEY AUTOINCREMENT column.
+        /// Table has an `AUTOINCREMENT` column.
         const HAS_AUTOINCREMENT = 0b0000_0100;
     }
 }
@@ -2369,10 +2365,6 @@ pub struct BTreeTable {
     pub root_page: i64,
     pub name: String,
     pub primary_key_columns: Vec<(String, SortOrder)>,
-    /// Read via [`BTreeTable::columns`]; mutate via [`BTreeTable::columns_mut`],
-    /// which invalidates [`BTreeTable::column_dependencies`]. Construction goes
-    /// through [`BTreeTable::new`] so that `column_dependencies` is never
-    /// supplied by a caller — it is always initialized to empty.
     columns: Vec<Column>,
     pub has_rowid: bool,
     pub is_strict: bool,
@@ -2388,10 +2380,6 @@ pub struct BTreeTable {
     column_dependencies: ResetOnClone<OnceLock<GeneratedColGraph>>,
 }
 
-/// RAII guard returned by [`BTreeTable::columns_mut`]. Deref-accesses the
-/// inner `Vec<Column>`; on drop, refreshes derived state that must stay in
-/// lockstep with the columns (cached dependency graph, virtual-columns flag,
-/// logical-to-physical map).
 pub struct ColumnsMut<'a> {
     table: &'a mut BTreeTable,
 }
@@ -2913,10 +2901,6 @@ impl BTreeTable {
             .expect("column_dependencies was just initialized"))
     }
 
-    /// Test-only accessor that returns the cached dependency graph without
-    /// triggering a build. Useful for asserting cache-invalidation semantics
-    /// (Clone resets the cache, `columns_mut()` resets the cache, etc.) without
-    /// observing those assertions through a method that would repopulate it.
     #[cfg(test)]
     pub(crate) fn peek_column_dependencies(&self) -> Option<&GeneratedColGraph> {
         self.column_dependencies.0.get()

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -153,6 +153,7 @@ use crate::{
     bail_parse_error, contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case,
     LimboError, MvCursor, Pager, SymbolTable, ValueRef, VirtualTable,
 };
+use bitflags::bitflags;
 use core::fmt;
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::VecDeque;
@@ -2258,6 +2259,22 @@ impl<T: Default> Clone for ResetOnClone<T> {
     }
 }
 
+bitflags! {
+    /// Set of boolean table-level properties passed to [`BTreeTable::new`].
+    /// These correspond to SQL CREATE TABLE clauses/flags and end up stored
+    /// as individual `bool` fields on [`BTreeTable`]; the bitflags form is
+    /// just an ergonomic way to pass several at once.
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    pub struct BTreeCharacteristics: u8 {
+        /// Table has a rowid column (i.e. not `WITHOUT ROWID`).
+        const HAS_ROWID         = 0b0000_0001;
+        /// Table is declared `STRICT`.
+        const STRICT            = 0b0000_0010;
+        /// Table has an INTEGER PRIMARY KEY AUTOINCREMENT column.
+        const HAS_AUTOINCREMENT = 0b0000_0100;
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct GeneratedColGraph {
     /// `dependencies[j]` = columns `j` transitively reads from (excludes `j`).
@@ -2281,14 +2298,15 @@ impl GeneratedColGraph {
             };
             let mut direct = BitSet::default();
             collect_column_dependencies_of_gencol(expr, columns, &mut direct);
+            if direct.get(j) {
+                bail_parse_error!(
+                    "generated column \"{}\" cannot reference itself",
+                    col.name.as_deref().unwrap_or("?")
+                );
+            }
+            let direct_mask: ColumnMask = ColumnMask::from_iter(direct.iter());
+            direct_deps[j].set_all(&direct_mask);
             for i in direct.iter() {
-                if i == j {
-                    bail_parse_error!(
-                        "generated column \"{}\" cannot reference itself",
-                        col.name.as_deref().unwrap_or("?")
-                    );
-                }
-                direct_deps[j].set(i);
                 direct_dependents[i].set(j);
                 in_degree[j] += 1;
             }
@@ -2351,7 +2369,11 @@ pub struct BTreeTable {
     pub root_page: i64,
     pub name: String,
     pub primary_key_columns: Vec<(String, SortOrder)>,
-    pub(crate) columns: Vec<Column>,
+    /// Read via [`BTreeTable::columns`]; mutate via [`BTreeTable::columns_mut`],
+    /// which invalidates [`BTreeTable::column_dependencies`]. Construction goes
+    /// through [`BTreeTable::new`] so that `column_dependencies` is never
+    /// supplied by a caller — it is always initialized to empty.
+    columns: Vec<Column>,
     pub has_rowid: bool,
     pub is_strict: bool,
     pub has_autoincrement: bool,
@@ -2363,17 +2385,79 @@ pub struct BTreeTable {
     pub rowid_alias_conflict_clause: Option<ResolveType>,
     pub has_virtual_columns: bool,
     pub logical_to_physical_map: Vec<usize>,
-    pub(crate) column_dependencies: ResetOnClone<OnceLock<GeneratedColGraph>>,
+    column_dependencies: ResetOnClone<OnceLock<GeneratedColGraph>>,
+}
+
+/// RAII guard returned by [`BTreeTable::columns_mut`]. Deref-accesses the
+/// inner `Vec<Column>`; on drop, refreshes derived state that must stay in
+/// lockstep with the columns (cached dependency graph, virtual-columns flag,
+/// logical-to-physical map).
+pub struct ColumnsMut<'a> {
+    table: &'a mut BTreeTable,
+}
+
+impl std::ops::Deref for ColumnsMut<'_> {
+    type Target = Vec<Column>;
+    fn deref(&self) -> &Vec<Column> {
+        &self.table.columns
+    }
+}
+
+impl std::ops::DerefMut for ColumnsMut<'_> {
+    fn deref_mut(&mut self) -> &mut Vec<Column> {
+        &mut self.table.columns
+    }
+}
+
+impl Drop for ColumnsMut<'_> {
+    fn drop(&mut self) {
+        self.table.column_dependencies.0 = OnceLock::new();
+        self.table.has_virtual_columns =
+            self.table.columns.iter().any(|c| c.is_virtual_generated());
+        self.table.logical_to_physical_map =
+            BTreeTable::build_logical_to_physical_map(&self.table.columns);
+    }
 }
 
 impl BTreeTable {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        root_page: i64,
+        name: String,
+        primary_key_columns: Vec<(String, SortOrder)>,
+        columns: Vec<Column>,
+        characteristics: BTreeCharacteristics,
+        unique_sets: Vec<UniqueSet>,
+        foreign_keys: Vec<Arc<ForeignKey>>,
+        check_constraints: Vec<CheckConstraint>,
+        rowid_alias_conflict_clause: Option<ResolveType>,
+    ) -> Self {
+        let has_virtual_columns = columns.iter().any(|c| c.is_virtual_generated());
+        let logical_to_physical_map = Self::build_logical_to_physical_map(&columns);
+        Self {
+            root_page,
+            name,
+            primary_key_columns,
+            columns,
+            has_rowid: characteristics.contains(BTreeCharacteristics::HAS_ROWID),
+            is_strict: characteristics.contains(BTreeCharacteristics::STRICT),
+            has_autoincrement: characteristics.contains(BTreeCharacteristics::HAS_AUTOINCREMENT),
+            unique_sets,
+            foreign_keys,
+            check_constraints,
+            rowid_alias_conflict_clause,
+            has_virtual_columns,
+            logical_to_physical_map,
+            column_dependencies: Default::default(),
+        }
+    }
+
     pub fn columns(&self) -> &[Column] {
         &self.columns
     }
 
-    pub fn columns_mut(&mut self) -> &mut Vec<Column> {
-        self.column_dependencies.0 = OnceLock::new();
-        &mut self.columns
+    pub fn columns_mut(&mut self) -> ColumnsMut<'_> {
+        ColumnsMut { table: self }
     }
 
     /// Create a table reference for TypeCheck where custom type columns have
@@ -2764,16 +2848,14 @@ impl BTreeTable {
     }
 
     pub fn prepare_generated_columns(&mut self) -> Result<()> {
-        self.column_dependencies.0 = OnceLock::new();
-        self.has_virtual_columns = self.columns.iter().any(|c| c.is_virtual_generated());
-        if !self.has_virtual_columns {
-            return Ok(());
-        }
-        for i in 0..self.columns.len() {
-            if self.columns[i].is_virtual_generated() {
-                let mut expr = self.columns[i].generated_expr().cloned().unwrap();
-                resolve_gencol_expr_columns(&mut expr, &self.columns)?;
-                *self.columns[i].generated_expr_mut().unwrap() = expr;
+        {
+            let mut guard = self.columns_mut();
+            for i in 0..guard.len() {
+                if guard[i].is_virtual_generated() {
+                    let mut expr = guard[i].generated_expr().cloned().unwrap();
+                    resolve_gencol_expr_columns(&mut expr, &guard)?;
+                    *guard[i].generated_expr_mut().unwrap() = expr;
+                }
             }
         }
         self.column_graph()?;
@@ -2828,7 +2910,16 @@ impl BTreeTable {
             .column_dependencies
             .0
             .get()
-            .expect("cached_graph was just initialized"))
+            .expect("column_dependencies was just initialized"))
+    }
+
+    /// Test-only accessor that returns the cached dependency graph without
+    /// triggering a build. Useful for asserting cache-invalidation semantics
+    /// (Clone resets the cache, `columns_mut()` resets the cache, etc.) without
+    /// observing those assertions through a method that would repopulate it.
+    #[cfg(test)]
+    pub(crate) fn peek_column_dependencies(&self) -> Option<&GeneratedColGraph> {
+        self.column_dependencies.0.get()
     }
 
     pub(crate) fn columns_affected_by_update(
@@ -2841,7 +2932,7 @@ impl BTreeTable {
             affected.set(i);
             if i < graph.dependents.len() {
                 let snapshot = graph.dependents[i].clone();
-                affected.union_with(&snapshot);
+                affected.set_all(&snapshot);
             }
         }
         Ok(affected)
@@ -5605,7 +5696,7 @@ mod tests {
         )?;
         let mut expected = t.columns_affected_by_update([0])?;
         let b_mask = t.columns_affected_by_update([1])?;
-        expected.union_with(&b_mask);
+        expected.set_all(&b_mask);
         let union_mask = t.columns_affected_by_update([0, 1])?;
         assert_eq!(indices(&union_mask), indices(&expected));
         Ok(())
@@ -5653,22 +5744,22 @@ mod tests {
         let original = BTreeTable::from_sql("CREATE TABLE t(a, b AS (a) VIRTUAL)", 0)?;
         // Force the cache to be populated on the original.
         let _ = original.columns_affected_by_update([0])?;
-        assert!(original.column_dependencies.0.get().is_some());
+        assert!(original.peek_column_dependencies().is_some());
 
         // Clone: ResetOnClone makes the cloned cache empty. We keep a real clone
         // (not a move) because the point of the test is that Clone produces a
         // fresh cache independently from the original.
         let cloned = original.clone();
-        assert!(cloned.column_dependencies.0.get().is_none());
+        assert!(cloned.peek_column_dependencies().is_none());
         // Original's cache is still populated — clone didn't touch it.
-        assert!(original.column_dependencies.0.get().is_some());
+        assert!(original.peek_column_dependencies().is_some());
 
         // The clone still returns correct results — cache rebuilds lazily.
         assert_eq!(
             indices(&cloned.columns_affected_by_update([0])?),
             vec![0, 1]
         );
-        assert!(cloned.column_dependencies.0.get().is_some());
+        assert!(cloned.peek_column_dependencies().is_some());
         Ok(())
     }
 
@@ -5677,11 +5768,11 @@ mod tests {
         let mut t = BTreeTable::from_sql("CREATE TABLE t(a, b AS (a) VIRTUAL)", 0)?;
         // Force the cache to be populated.
         let _ = t.columns_affected_by_update([0])?;
-        assert!(t.column_dependencies.0.get().is_some());
+        assert!(t.peek_column_dependencies().is_some());
 
         // Any access through columns_mut() wipes the cache, even if we don't mutate.
         let _ = t.columns_mut();
-        assert!(t.column_dependencies.0.get().is_none());
+        assert!(t.peek_column_dependencies().is_none());
         Ok(())
     }
 }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -429,9 +429,6 @@ fn emit_add_virtual_column_validation(
     original_table
         .columns_mut()
         .retain(|c| !c.is_virtual_generated());
-    original_table.has_virtual_columns = false;
-    original_table.logical_to_physical_map =
-        BTreeTable::build_logical_to_physical_map(original_table.columns());
     let original_table = Arc::new(original_table);
     let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(original_table.clone()));
     program.emit_insn(Insn::OpenRead {
@@ -1646,8 +1643,6 @@ pub fn translate_alter_table(
                 table.columns_mut()[column_index] =
                     replacement_column.expect("replacement_column must exist for ALTER COLUMN");
                 table.prepare_generated_columns()?;
-                table.logical_to_physical_map =
-                    BTreeTable::build_logical_to_physical_map(table.columns());
                 Some(table)
             } else {
                 None

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -233,7 +233,7 @@ mod tests {
     use turso_parser::ast::{Literal, Name, Operator, TableInternalId, UnaryOperator};
 
     use crate::{
-        schema::{BTreeTable, ColDef, Column, Table, Type},
+        schema::{BTreeCharacteristics, BTreeTable, ColDef, Column, Table, Type},
         translate::plan::{ColumnUsedMask, IterationDirection, JoinedTable, Operation, Scan},
     };
 
@@ -521,23 +521,17 @@ mod tests {
             collation,
             ColDef::default(),
         )];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let table = Table::BTree(Arc::new(BTreeTable {
-            root_page: 0,
-            has_autoincrement: false,
-            has_rowid: false,
-            is_strict: false,
-            name: "foo".to_string(),
-            primary_key_columns: vec![],
+        let table = Table::BTree(Arc::new(BTreeTable::new(
+            0,
+            "foo".to_string(),
+            vec![],
             columns,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        }));
+            BTreeCharacteristics::empty(),
+            vec![],
+            vec![],
+            vec![],
+            None,
+        )));
         table_references.add_joined_table(JoinedTable {
             op: Operation::Scan(Scan::BTreeTable {
                 iter_dir: IterationDirection::Forwards,
@@ -572,7 +566,6 @@ mod tests {
             left,
             ColDef::default(),
         )];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
         table_references.add_joined_table(JoinedTable {
             op: Operation::Scan(Scan::BTreeTable {
                 iter_dir: IterationDirection::Forwards,
@@ -585,22 +578,17 @@ mod tests {
             identifier: "t1".to_string(),
             internal_id: TableInternalId::from(1),
             join_info: None,
-            table: Table::BTree(Arc::new(BTreeTable {
-                root_page: 0,
-                has_autoincrement: false,
-                has_rowid: true,
-                is_strict: false,
-                name: "t1".to_string(),
-                primary_key_columns: vec![],
+            table: Table::BTree(Arc::new(BTreeTable::new(
+                0,
+                "t1".to_string(),
+                vec![],
                 columns,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            })),
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            ))),
             indexed: None,
         });
         // Right table t2(id=2)
@@ -613,7 +601,6 @@ mod tests {
             right,
             ColDef::default(),
         )];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
         table_references.add_joined_table(JoinedTable {
             op: Operation::Scan(Scan::BTreeTable {
                 iter_dir: IterationDirection::Forwards,
@@ -626,22 +613,17 @@ mod tests {
             identifier: "t2".to_string(),
             internal_id: TableInternalId::from(2),
             join_info: None,
-            table: Table::BTree(Arc::new(BTreeTable {
-                root_page: 0,
-                has_autoincrement: false,
-                has_rowid: true,
-                is_strict: false,
-                name: "t2".to_string(),
-                primary_key_columns: vec![],
+            table: Table::BTree(Arc::new(BTreeTable::new(
+                0,
+                "t2".to_string(),
+                vec![],
                 columns,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            })),
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            ))),
             indexed: None,
         });
         table_references
@@ -668,7 +650,6 @@ mod tests {
                 notnull_conflict_clause: None,
             },
         )];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
         table_references.add_joined_table(JoinedTable {
             op: Operation::Scan(Scan::BTreeTable {
                 iter_dir: IterationDirection::Forwards,
@@ -682,22 +663,17 @@ mod tests {
             internal_id: TableInternalId::from(1),
             join_info: None,
             indexed: None,
-            table: Table::BTree(Arc::new(BTreeTable {
-                root_page: 0,
-                has_autoincrement: false,
-                has_rowid: true,
-                is_strict: false,
-                name: "bar".to_string(),
-                primary_key_columns: vec![("id".to_string(), SortOrder::Asc)],
+            table: Table::BTree(Arc::new(BTreeTable::new(
+                0,
+                "bar".to_string(),
+                vec![("id".to_string(), SortOrder::Asc)],
                 columns,
-                unique_sets: vec![],
-                foreign_keys: vec![],
-                check_constraints: vec![],
-                rowid_alias_conflict_clause: None,
-                has_virtual_columns: false,
-                logical_to_physical_map,
-                column_dependencies: Default::default(),
-            })),
+                BTreeCharacteristics::HAS_ROWID,
+                vec![],
+                vec![],
+                vec![],
+                None,
+            ))),
         });
         table_references
     }

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -1,6 +1,6 @@
 use crate::{
     emit_explain,
-    schema::BTreeTable,
+    schema::{BTreeCharacteristics, BTreeTable},
     sync::Arc,
     translate::{
         aggregation::emit_ungrouped_aggregation,
@@ -449,23 +449,17 @@ fn emit_materialized_build_inputs(
                 payload_columns,
             } => build_materialized_input_columns(*num_keys, payload_columns),
         };
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let ephemeral_table = Arc::new(BTreeTable {
-            root_page: 0,
-            name: format!("hash_build_input_{internal_id}"),
-            has_rowid: true,
-            has_autoincrement: false,
-            primary_key_columns: vec![],
+        let ephemeral_table = Arc::new(BTreeTable::new(
+            0,
+            format!("hash_build_input_{internal_id}"),
+            vec![],
             columns,
-            is_strict: false,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        });
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        ));
         let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(ephemeral_table.clone()));
 
         // Build a plan that emits only rowids for the build table using the join prefix

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -2400,7 +2400,9 @@ impl<'a> LogicalPlanBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::{BTreeTable, ColDef, Column as SchemaColumn, Schema, Type};
+    use crate::schema::{
+        BTreeCharacteristics, BTreeTable, ColDef, Column as SchemaColumn, Schema, Type,
+    };
     use turso_parser::parser::Parser;
 
     fn create_test_schema() -> Schema {
@@ -2426,23 +2428,17 @@ mod tests {
             SchemaColumn::new_default_integer(Some("age".to_string()), "INTEGER".to_string(), None),
             SchemaColumn::new_default_text(Some("email".to_string()), "TEXT".to_string(), None),
         ];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let users_table = BTreeTable {
-            name: "users".to_string(),
-            root_page: 2,
-            primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
+        let users_table = BTreeTable::new(
+            2,
+            "users".to_string(),
+            vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            has_autoincrement: false,
-            unique_sets: vec![],
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        };
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
         schema
             .add_btree_table(Arc::new(users_table))
             .expect("Test setup: failed to add users table");
@@ -2479,23 +2475,17 @@ mod tests {
                 ColDef::default(),
             ),
         ];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let orders_table = BTreeTable {
-            name: "orders".to_string(),
-            root_page: 3,
-            primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
+        let orders_table = BTreeTable::new(
+            3,
+            "orders".to_string(),
+            vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            has_autoincrement: false,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        };
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
         schema
             .add_btree_table(Arc::new(orders_table))
             .expect("Test setup: failed to add orders table");
@@ -2532,23 +2522,17 @@ mod tests {
                 None,
             ),
         ];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let products_table = BTreeTable {
-            name: "products".to_string(),
-            root_page: 4,
-            primary_key_columns: vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
+        let products_table = BTreeTable::new(
+            4,
+            "products".to_string(),
+            vec![("id".to_string(), turso_parser::ast::SortOrder::Asc)],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            has_autoincrement: false,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        };
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        );
         schema
             .add_btree_table(Arc::new(products_table))
             .expect("Test setup: failed to add products table");

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1788,7 +1788,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        schema::{BTreeTable, ColDef, Column, Index, IndexColumn, Schema, Table, Type},
+        schema::{
+            BTreeCharacteristics, BTreeTable, ColDef, Column, Index, IndexColumn, Schema, Table,
+            Type,
+        },
         stats::AnalyzeStats,
         translate::{
             optimizer::{
@@ -3203,23 +3206,17 @@ mod tests {
 
     /// Creates a BTreeTable with the given name and columns
     fn _create_btree_table(name: &str, columns: Vec<Column>) -> Arc<BTreeTable> {
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        Arc::new(BTreeTable {
-            root_page: 1, // Page number doesn't matter for tests
-            name: name.to_string(),
-            has_autoincrement: false,
-            primary_key_columns: vec![],
+        Arc::new(BTreeTable::new(
+            1, // root_page, doesn't matter for tests
+            name.to_string(),
+            vec![],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        })
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        ))
     }
 
     /// Creates a TableReference for a BTreeTable

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     function::{AggFunc, Deterministic},
     index_method::IndexMethodCostEstimate,
     numeric::Numeric,
-    schema::{BTreeTable, Index, IndexColumn, Schema, Table, ROWID_SENTINEL},
+    schema::{BTreeCharacteristics, BTreeTable, Index, IndexColumn, Schema, Table, ROWID_SENTINEL},
     translate::{
         insert::ROWID_COLUMN,
         optimizer::{
@@ -944,23 +944,17 @@ fn add_ephemeral_table_to_update_plan(
 ) -> Result<()> {
     let internal_id = program.table_reference_counter.next();
     let columns = vec![(*ROWID_COLUMN).clone()];
-    let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-    let ephemeral_table = Arc::new(BTreeTable {
-        root_page: 0, // Not relevant for ephemeral table definition
-        name: "ephemeral_scratch".to_string(),
-        has_rowid: true,
-        has_autoincrement: false,
-        primary_key_columns: vec![],
+    let ephemeral_table = Arc::new(BTreeTable::new(
+        0, // root_page, not relevant for ephemeral table definition
+        "ephemeral_scratch".to_string(),
+        vec![],
         columns,
-        is_strict: false,
-        unique_sets: vec![],
-        foreign_keys: vec![],
-        check_constraints: vec![],
-        rowid_alias_conflict_clause: None,
-        has_virtual_columns: false,
-        logical_to_physical_map,
-        column_dependencies: Default::default(),
-    });
+        BTreeCharacteristics::HAS_ROWID,
+        vec![],
+        vec![],
+        vec![],
+        None,
+    ));
 
     let temp_cursor_id = program.alloc_cursor_id_keyed(
         CursorKey::table(internal_id),

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -1139,7 +1139,10 @@ mod tests {
         MultiIndexBranchParams,
     };
     use crate::{
-        schema::{BTreeTable, ColDef, Column, Index, IndexColumn, Schema, Table, Type},
+        schema::{
+            BTreeCharacteristics, BTreeTable, ColDef, Column, Index, IndexColumn, Schema, Table,
+            Type,
+        },
         translate::{
             optimizer::{
                 access_method::AccessMethodParams,
@@ -1194,23 +1197,17 @@ mod tests {
     }
 
     fn create_btree_table(name: &str, columns: Vec<Column>) -> Arc<BTreeTable> {
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        Arc::new(BTreeTable {
-            root_page: 1,
-            name: name.to_string(),
-            has_autoincrement: false,
-            primary_key_columns: vec![],
+        Arc::new(BTreeTable::new(
+            1,
+            name.to_string(),
+            vec![],
             columns,
-            has_rowid: true,
-            is_strict: false,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        })
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        ))
     }
 
     fn create_table_reference(

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1411,10 +1411,7 @@ impl ColumnMask {
         }
     }
 
-    /// Sets every bit that is set in `other`. Inner word-granularity loop
-    /// (via [`BitSet::union_with`]) is written in a shape that LLVM
-    /// auto-vectorizes when the `overflow` vecs are long enough to matter.
-    pub fn set_all(&mut self, other: &ColumnMask) {
+    pub fn union_with(&mut self, other: &ColumnMask) {
         self.bitset.union_with(&other.bitset);
         self.has_rowid_sentinel |= other.has_rowid_sentinel;
     }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1411,6 +1411,14 @@ impl ColumnMask {
         }
     }
 
+    /// Sets every bit that is set in `other`. Inner word-granularity loop
+    /// (via [`BitSet::union_with`]) is written in a shape that LLVM
+    /// auto-vectorizes when the `overflow` vecs are long enough to matter.
+    pub fn set_all(&mut self, other: &ColumnMask) {
+        self.bitset.union_with(&other.bitset);
+        self.has_rowid_sentinel |= other.has_rowid_sentinel;
+    }
+
     pub fn get(&self, idx: usize) -> bool {
         if idx == ROWID_SENTINEL {
             self.has_rowid_sentinel
@@ -1432,10 +1440,6 @@ impl ColumnMask {
         self.bitset.iter().chain(rowid_sentinel)
     }
 
-    pub fn union_with(&mut self, other: &ColumnMask) {
-        self.bitset.union_with(&other.bitset);
-        self.has_rowid_sentinel |= other.has_rowid_sentinel;
-    }
 }
 
 impl FromIterator<usize> for ColumnMask {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1436,7 +1436,6 @@ impl ColumnMask {
         let rowid_sentinel = self.has_rowid_sentinel.then_some(ROWID_SENTINEL);
         self.bitset.iter().chain(rowid_sentinel)
     }
-
 }
 
 impl FromIterator<usize> for ColumnMask {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1055,25 +1055,17 @@ fn parse_table(
         // This is a materialized view with storage - treat it as a regular BTree table
         // Create a BTreeTable from the view's metadata
         let columns = view_guard.column_schema.flat_columns();
-        let logical_to_physical_map =
-            crate::schema::BTreeTable::build_logical_to_physical_map(&columns);
-        let btree_table = Arc::new(crate::schema::BTreeTable {
-            name: view_guard.name().to_string(),
+        let btree_table = Arc::new(crate::schema::BTreeTable::new(
             root_page,
+            view_guard.name().to_string(),
+            Vec::new(),
             columns,
-            primary_key_columns: Vec::new(),
-            has_rowid: true,
-            is_strict: false,
-            has_autoincrement: false,
-
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        });
+            crate::schema::BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        ));
         drop(view_guard);
 
         let alias = maybe_alias.map(|a| normalize_ident(a.name().as_str()));

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -4,8 +4,9 @@ use crate::HashMap;
 use crate::ext::VTabImpl;
 use crate::function::{Deterministic, Func, MathFunc, ScalarFunc};
 use crate::schema::{
-    create_table, translate_ident_to_string_literal, BTreeTable, ColDef, Column, SchemaObjectType,
-    Table, Type, RESERVED_TABLE_PREFIXES, SQLITE_SEQUENCE_TABLE_NAME, TURSO_TYPES_TABLE_NAME,
+    create_table, translate_ident_to_string_literal, BTreeCharacteristics, BTreeTable, ColDef,
+    Column, SchemaObjectType, Table, Type, RESERVED_TABLE_PREFIXES, SQLITE_SEQUENCE_TABLE_NAME,
+    TURSO_TYPES_TABLE_NAME,
 };
 use crate::stats::STATS_TABLE;
 use crate::storage::pager::CreateBTreeFlags;
@@ -2057,23 +2058,17 @@ pub fn translate_drop_table(
             None,
             ColDef::default(),
         )];
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&columns);
-        let simple_table_rc = Arc::new(BTreeTable {
-            root_page: 0, // Not relevant for ephemeral table definition
-            name: "ephemeral_scratch".to_string(),
-            has_rowid: true,
-            has_autoincrement: false,
-            primary_key_columns: vec![],
+        let simple_table_rc = Arc::new(BTreeTable::new(
+            0, // root_page, not relevant for ephemeral table definition
+            "ephemeral_scratch".to_string(),
+            vec![],
             columns,
-            is_strict: false,
-            unique_sets: vec![],
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        });
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        ));
         // cursor id 2
         let ephemeral_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(simple_table_rc));
         program.emit_insn(Insn::OpenEphemeral {

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -5,7 +5,7 @@ use turso_parser::ast::{self, SortOrder, SubqueryType};
 
 use crate::{
     emit_explain,
-    schema::{BTreeTable, Column, Index, IndexColumn, Table},
+    schema::{BTreeCharacteristics, BTreeTable, Column, Index, IndexColumn, Table},
     translate::{
         collate::get_collseq_from_expr,
         compound_select::emit_program_for_compound_select,
@@ -1528,23 +1528,17 @@ fn emit_materialized_subquery_table(
     // insertion order, which SQL semantics require for UNION ALL. It also
     // needs the subquery's column layout so later Column opcodes can read
     // materialized rows through the normal table-cursor path.
-    let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(columns);
-    let ephemeral_table = Arc::new(BTreeTable {
-        root_page: 0,
-        name: String::new(),
-        columns: columns.to_vec(),
-        primary_key_columns: vec![],
-        has_rowid: true,
-        is_strict: false,
-        has_autoincrement: false,
-        unique_sets: vec![],
-        foreign_keys: vec![],
-        check_constraints: vec![],
-        rowid_alias_conflict_clause: None,
-        has_virtual_columns: false,
-        logical_to_physical_map,
-        column_dependencies: Default::default(),
-    });
+    let ephemeral_table = Arc::new(BTreeTable::new(
+        0,
+        String::new(),
+        vec![],
+        columns.to_vec(),
+        BTreeCharacteristics::HAS_ROWID,
+        vec![],
+        vec![],
+        vec![],
+        None,
+    ));
 
     let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(ephemeral_table.clone()));
 

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -107,10 +107,10 @@ pub fn translate_create_materialized_view(
         vec![], // primary_key_columns — materialized views use implicit rowid
         view_columns,
         BTreeCharacteristics::HAS_ROWID,
-        vec![], // unique_sets
-        vec![], // foreign_keys
-        vec![], // check_constraints
-        None,   // rowid_alias_conflict_clause
+        vec![],
+        vec![],
+        vec![],
+        None,
     ));
 
     // Allocate a cursor for writing to the view's btree during population

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -1,5 +1,7 @@
 use crate::incremental::{compiler::DBSP_CIRCUIT_VERSION, view::IncrementalView};
-use crate::schema::{BTreeTable, SchemaObjectType, DBSP_TABLE_PREFIX, RESERVED_TABLE_PREFIXES};
+use crate::schema::{
+    BTreeCharacteristics, BTreeTable, SchemaObjectType, DBSP_TABLE_PREFIX, RESERVED_TABLE_PREFIXES,
+};
 use crate::storage::pager::CreateBTreeFlags;
 use crate::sync::Arc;
 use crate::translate::{
@@ -99,24 +101,17 @@ pub fn translate_create_materialized_view(
     });
 
     // Create a proper BTreeTable for the cursor with the actual view columns
-    let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&view_columns);
-    let view_table = Arc::new(BTreeTable {
-        root_page: 0, // Will be set to actual root page after creation
-        name: normalized_view_name.clone(),
-        columns: view_columns,
-        primary_key_columns: vec![], // Materialized views use implicit rowid
-        has_rowid: true,
-        is_strict: false,
-        has_autoincrement: false,
-
-        unique_sets: vec![],
-        foreign_keys: vec![],
-        check_constraints: vec![],
-        rowid_alias_conflict_clause: None,
-        has_virtual_columns: false,
-        logical_to_physical_map,
-        column_dependencies: Default::default(),
-    });
+    let view_table = Arc::new(BTreeTable::new(
+        0, // root_page, will be set to actual root page after creation
+        normalized_view_name.clone(),
+        vec![], // primary_key_columns — materialized views use implicit rowid
+        view_columns,
+        BTreeCharacteristics::HAS_ROWID,
+        vec![], // unique_sets
+        vec![], // foreign_keys
+        vec![], // check_constraints
+        None,   // rowid_alias_conflict_clause
+    ));
 
     // Allocate a cursor for writing to the view's btree during population
     let view_cursor_id =

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -539,12 +539,12 @@ impl EmitWindow {
         let window_function_count = window.functions.len();
 
         // An ephemeral table used to buffer rows for the current frame
-        // TODO: Generating the name this way may cause collisions with real tables in the
-        //  attached database. Other ephemeral tables are created similarly, so it's left
-        //  as-is for now. Ideally, there should be a way to mark tables as ephemeral so
-        //  they can be handled differently from regular tables.
         let buffer_table = Arc::new(BTreeTable::new(
             0,
+            // TODO: Generating the name this way may cause collisions with real tables in the
+            //  attached database. Other ephemeral tables are created similarly, so it's left
+            //  as-is for now. Ideally, there should be a way to mark tables as ephemeral so
+            //  they can be handled differently from regular tables.
             format!("buffer_table_{window_name}"),
             vec![],
             src_columns,

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1,5 +1,5 @@
 use crate::function::WindowFunc;
-use crate::schema::{BTreeTable, Table};
+use crate::schema::{BTreeCharacteristics, BTreeTable, Table};
 use crate::sync::Arc;
 use crate::translate::aggregation::{translate_aggregation_step, AggArgumentSource};
 use crate::translate::collate::{get_collseq_from_expr, CollationSeq};
@@ -539,27 +539,21 @@ impl EmitWindow {
         let window_function_count = window.functions.len();
 
         // An ephemeral table used to buffer rows for the current frame
-        let logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&src_columns);
-        let buffer_table = Arc::new(BTreeTable {
-            root_page: 0,
-            // TODO: Generating the name this way may cause collisions with real tables in the
-            //  attached database. Other ephemeral tables are created similarly, so it’s left
-            //  as-is for now. Ideally, there should be a way to mark tables as ephemeral so
-            //  they can be handled differently from regular tables.
-            name: format!("buffer_table_{window_name}"),
-            has_rowid: true,
-            primary_key_columns: vec![],
-            columns: src_columns,
-            is_strict: false,
-            unique_sets: vec![],
-            has_autoincrement: false,
-            foreign_keys: vec![],
-            check_constraints: vec![],
-            rowid_alias_conflict_clause: None,
-            has_virtual_columns: false,
-            logical_to_physical_map,
-            column_dependencies: Default::default(),
-        });
+        // TODO: Generating the name this way may cause collisions with real tables in the
+        //  attached database. Other ephemeral tables are created similarly, so it's left
+        //  as-is for now. Ideally, there should be a way to mark tables as ephemeral so
+        //  they can be handled differently from regular tables.
+        let buffer_table = Arc::new(BTreeTable::new(
+            0,
+            format!("buffer_table_{window_name}"),
+            vec![],
+            src_columns,
+            BTreeCharacteristics::HAS_ROWID,
+            vec![],
+            vec![],
+            vec![],
+            None,
+        ));
         let cursor_buffer_read =
             program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));
         let cursor_buffer_write =

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12320,8 +12320,6 @@ pub fn op_drop_column(
 
         let btree = Arc::make_mut(btree);
         btree.columns_mut().remove(*column_index);
-        btree.logical_to_physical_map =
-            crate::schema::BTreeTable::build_logical_to_physical_map(btree.columns());
         // Remove column-level CHECK constraints for the dropped column
         let col_name = column_name.clone();
         btree.check_constraints.retain(|c| {
@@ -12330,7 +12328,6 @@ pub fn op_drop_column(
                 .is_none_or(|col| normalize_ident(col) != normalize_ident(&col_name))
         });
 
-        btree.has_virtual_columns = btree.columns().iter().any(|c| c.is_virtual_generated());
         btree.shift_generated_column_indices_after_drop(*column_index)?;
         Ok(())
     })?;
@@ -12418,8 +12415,6 @@ pub fn op_add_column(
 
         let btree = Arc::make_mut(btree);
         btree.columns_mut().push((**column).clone());
-        btree.logical_to_physical_map =
-            crate::schema::BTreeTable::build_logical_to_physical_map(btree.columns());
         // Update CHECK constraints to include any constraints from the new column
         btree.check_constraints.clone_from(check_constraints);
         // Update foreign keys to include any FK constraints from the new column
@@ -12564,8 +12559,6 @@ pub fn op_alter_column(
         }
 
         btree.prepare_generated_columns()?;
-        btree.logical_to_physical_map =
-            crate::schema::BTreeTable::build_logical_to_physical_map(btree.columns());
 
         // Keep primary_key_columns consistent (names may change on rename)
         for (pk_name, _ord) in &mut btree.primary_key_columns {


### PR DESCRIPTION
## Description

In this PR, stacked onto https://github.com/tursodatabase/turso/pull/6457:
*  the `columns_mut()` now takes care of some required bookkeeping when columns are mutated through a RAII guard
* a type-safe constructor (no 2 parameters share a common type) on `BTreeTable` that hides some of the fields
* a new method on `ColumnMask`.

## Description of AI Usage

Claude Code, with some cleanup and a lot of planning