### PR TITLE
Update cli history file path to use .tursodb_history

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -37,7 +37,7 @@ fn rustyline_config() -> Config {
 pub static HOME_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| dirs::home_dir().expect("Could not determine home directory"));
 
-pub static HISTORY_FILE: LazyLock<PathBuf> = LazyLock::new(|| HOME_DIR.join(".turso_history"));
+pub static HISTORY_FILE: LazyLock<PathBuf> = LazyLock::new(|| HOME_DIR.join(".tursodb_history"));
 
 fn run_mcp_server(app: app::Limbo) -> anyhow::Result<()> {
     let conn = app.get_connection();

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -37,7 +37,7 @@ fn rustyline_config() -> Config {
 pub static HOME_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| dirs::home_dir().expect("Could not determine home directory"));
 
-pub static HISTORY_FILE: LazyLock<PathBuf> = LazyLock::new(|| HOME_DIR.join(".limbo_history"));
+pub static HISTORY_FILE: LazyLock<PathBuf> = LazyLock::new(|| HOME_DIR.join(".turso_history"));
 
 fn run_mcp_server(app: app::Limbo) -> anyhow::Result<()> {
     let conn = app.get_connection();

--- a/docs/sql-reference/cli/getting-started.mdx
+++ b/docs/sql-reference/cli/getting-started.mdx
@@ -54,7 +54,7 @@ tursodb> SELECT *
 
 ### Command History
 
-Command history is saved automatically to `~/.turso_history` and accessible with up/down arrow keys.
+Command history is saved automatically to `~/.tursodb_history` and accessible with up/down arrow keys.
 
 ### Exiting
 

--- a/docs/sql-reference/cli/getting-started.mdx
+++ b/docs/sql-reference/cli/getting-started.mdx
@@ -54,7 +54,7 @@ tursodb> SELECT *
 
 ### Command History
 
-Command history is saved automatically to `~/.limbo_history` and accessible with up/down arrow keys.
+Command history is saved automatically to `~/.turso_history` and accessible with up/down arrow keys.
 
 ### Exiting
 


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Update cli history file path to use .tursodb_history

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

Perhaps this is an oversight in renaming limbo to turso.

Note: This is a disruptive change; people will no longer be able to navigate to previous history records.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

No AI

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
