### PR TITLE
bindings/rust: Add n_change method to Statement

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -486,6 +486,11 @@ impl Statement {
         Ok(())
     }
 
+    /// Returns the number of rows modified (insert/delete operations) by the most recent executed statement.
+    pub fn n_change(&self) -> u64 {
+        self.inner.lock().unwrap().n_change() as u64
+    }
+
     /// Execute a query that returns the first [`Row`].
     ///
     /// # Errors


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

This PR exposes the internal n_change method for Statement so that we can retrieve the affected rows.

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

`.query` method only retrieves the result.
`.execute` only retrieves the affected rows.

When executing arbitrary SQL, we cannot simultaneously retrieve either the result and the affected rows.
Now we can call `.query()` to get the result, and then call `.n_change()` to get the affected rows.

## Description of AI Usage

No AI

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
