### PR TITLE
core/connection: add a small helper to check if db is in-memory

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1562,7 +1562,7 @@ impl Connection {
     }
 
     pub fn get_database_canonical_path(&self) -> String {
-        if self.db.path == ":memory:" {
+        if self.db.is_in_memory_db() {
             // For in-memory databases, SQLite shows empty string
             String::new()
         } else {
@@ -2209,11 +2209,10 @@ impl Connection {
         //   file-based (important for simulator fault injection and WAL coordination)
         // - If the parent is :memory: (MemoryIO) but the attached DB is file-based,
         //   we need a file-capable IO layer since MemoryIO can't read real files
-        let is_memory_db =
-            path == ":memory:" || path.starts_with("file::memory:") || path.is_empty();
+        let is_memory_db = Database::is_memory_path(path);
         let io: Arc<dyn IO> = if is_memory_db {
             Arc::new(MemoryIO::new())
-        } else if self.db.path.starts_with(":memory:") {
+        } else if self.db.is_in_memory_db() {
             Database::io_for_path(path)?
         } else {
             self.db.io.clone()
@@ -2445,7 +2444,7 @@ impl Connection {
 
     // Get the canonical path for a database given its Database object
     fn get_canonical_path_for_database(db: &Database) -> String {
-        if db.path == ":memory:" {
+        if db.is_in_memory_db() {
             // For in-memory databases, SQLite shows empty string
             String::new()
         } else {
@@ -3078,17 +3077,21 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn open_connection(path: &std::path::Path) -> Arc<Connection> {
+    fn open_connection_with_opts(path: &std::path::Path, opts: DatabaseOpts) -> Arc<Connection> {
         let io: Arc<dyn IO> = Arc::new(crate::PlatformIO::new().unwrap());
         let db = Database::open_file_with_flags(
             io,
             path.to_str().unwrap(),
             OpenFlags::default(),
-            DatabaseOpts::new(),
+            opts,
             None,
         )
         .unwrap();
         db.connect().unwrap()
+    }
+
+    fn open_connection(path: &std::path::Path) -> Arc<Connection> {
+        open_connection_with_opts(path, DatabaseOpts::new())
     }
 
     fn query_single_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
@@ -3099,11 +3102,106 @@ mod tests {
         }
     }
 
+    fn text_value(value: &Value) -> &str {
+        match value {
+            Value::Text(text) => text.as_str(),
+            other => panic!("expected text value, got {other:?}"),
+        }
+    }
+
     // given a attached 'alias', return the Database and Pager for that attached database
     fn attached_entry(conn: &Connection, alias: &str) -> (Arc<Database>, Arc<Pager>) {
         let catalog = conn.attached_databases.read();
         let index = *catalog.name_to_index.get(alias).unwrap();
         catalog.index_to_data.get(&index).unwrap().clone()
+    }
+
+    #[test]
+    fn test_named_memory_databases_on_same_io_are_distinct() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let draft_db = Database::open_file(io.clone(), ":memory:sync-draft").unwrap();
+        let synced_db = Database::open_file(io, ":memory:sync-synced").unwrap();
+        assert!(!Arc::ptr_eq(&draft_db, &synced_db));
+
+        let draft = draft_db.connect().unwrap();
+        let synced = synced_db.connect().unwrap();
+
+        for conn in [&draft, &synced] {
+            assert_eq!(conn.get_database_canonical_path(), "");
+            assert_eq!(
+                conn.list_all_databases(),
+                vec![(MAIN_DB_ID, "main".to_string(), String::new())]
+            );
+        }
+
+        draft
+            .execute("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES(11)")
+            .unwrap();
+        synced
+            .execute("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES(22)")
+            .unwrap();
+
+        assert_eq!(query_single_i64(&draft, "SELECT x FROM t"), 11);
+        assert_eq!(query_single_i64(&synced, "SELECT x FROM t"), 22);
+    }
+
+    #[test]
+    fn test_named_memory_database_reopened_on_same_io_sees_same_rows() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+
+        let first_db = Database::open_file(io.clone(), ":memory:reopen").unwrap();
+        let first = first_db.connect().unwrap();
+        first
+            .execute("CREATE TABLE t(x INTEGER); INSERT INTO t VALUES(99)")
+            .unwrap();
+
+        let second_db = Database::open_file(io, ":memory:reopen").unwrap();
+        let second = second_db.connect().unwrap();
+        assert_eq!(query_single_i64(&second, "SELECT x FROM t"), 99);
+    }
+
+    #[test]
+    fn test_attach_named_memory_database_reports_empty_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let main_path = temp_dir.path().join("main.db");
+        let conn = open_connection_with_opts(&main_path, DatabaseOpts::new().with_attach(true));
+
+        conn.execute("ATTACH ':memory:aux' AS aux").unwrap();
+        conn.execute("CREATE TABLE aux.t(x INTEGER); INSERT INTO aux.t VALUES(5)")
+            .unwrap();
+
+        assert_eq!(query_single_i64(&conn, "SELECT x FROM aux.t"), 5);
+        let database_list = conn.pragma_query("database_list").unwrap();
+        let aux = database_list
+            .iter()
+            .find(|row| text_value(&row[1]) == "aux")
+            .expect("attached aux database must be listed");
+        assert_eq!(text_value(&aux[2]), "");
+    }
+
+    #[test]
+    fn test_named_memory_parent_can_attach_real_file_database() {
+        let temp_dir = TempDir::new().unwrap();
+        let aux_path = temp_dir.path().join("aux.db");
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            ":memory:named-main",
+            OpenFlags::default(),
+            DatabaseOpts::new().with_attach(true),
+            None,
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute(format!("ATTACH '{}' AS aux", aux_path.to_str().unwrap()))
+            .unwrap();
+        conn.execute("CREATE TABLE aux.t(x INTEGER); INSERT INTO aux.t VALUES(7)")
+            .unwrap();
+        conn.execute("DETACH aux").unwrap();
+
+        let reopened = open_connection(&aux_path);
+        assert_eq!(query_single_i64(&reopened, "SELECT x FROM t"), 7);
     }
 
     #[test]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -486,6 +486,19 @@ impl fmt::Debug for Database {
 }
 
 impl Database {
+    /// Returns true for database path forms backed by MemoryIO.
+    ///
+    /// Turso treats every path with the `:memory:` prefix as a named
+    /// in-memory database.
+    pub fn is_memory_path(path: &str) -> bool {
+        path.starts_with(util::MEMORY_PATH) || path.starts_with("file::memory:") || path.is_empty()
+    }
+
+    /// Returns true if this database is backed by MemoryIO.
+    pub fn is_in_memory_db(&self) -> bool {
+        Self::is_memory_path(&self.path)
+    }
+
     fn new(
         opts: DatabaseOpts,
         flags: OpenFlags,
@@ -600,7 +613,7 @@ impl Database {
         path: &str,
         encryption_opts: &Option<EncryptionOpts>,
     ) -> Result<Option<Arc<Database>>> {
-        if path.starts_with(":memory:") {
+        if Self::is_memory_path(path) {
             return Ok(None);
         }
         let file_id = match io::get_file_id(path) {
@@ -772,9 +785,9 @@ impl Database {
     ) -> Result<IOResult<Arc<Database>>> {
         // turso-sync-engine creates 2 databases with different names in the same IO if MemoryIO is used
         // in this case we need to bypass registry (as this is MemoryIO DB) but also preserve original distinction in names (e.g. :memory:-draft and :memory:-synced)
-        // so, we bypass registry for all db paths which starts with ":memory:"
+        // so, we bypass registry for all in memory dbs (i.e. db paths which starts with ":memory:")
 
-        if matches!(state.phase, OpenDbAsyncPhase::Init) && !path.starts_with(":memory:") {
+        if matches!(state.phase, OpenDbAsyncPhase::Init) && !Self::is_memory_path(path) {
             // Briefly lock the registry to check/reserve — never hold across I/O yields.
             let mut registry = DATABASE_MANAGER.lock();
 
@@ -1611,10 +1624,10 @@ impl Database {
 
     #[cfg(feature = "fs")]
     pub fn io_for_path(path: &str) -> Result<Arc<dyn IO>> {
-        use crate::util::MEMORY_PATH;
-        let io: Arc<dyn IO> = match path.trim() {
-            MEMORY_PATH => Arc::new(MemoryIO::new()),
-            _ => Arc::new(PlatformIO::new()?),
+        let io: Arc<dyn IO> = if Self::is_memory_path(path.trim()) {
+            Arc::new(MemoryIO::new())
+        } else {
+            Arc::new(PlatformIO::new()?)
         };
         Ok(io)
     }
@@ -2023,5 +2036,32 @@ impl Iterator for QueryRunner<'_> {
             Ok(None) => None,
             Err(err) => Some(Result::Err(LimboError::from(err))),
         }
+    }
+}
+
+#[cfg(test)]
+mod database_tests {
+    use super::Database;
+
+    #[test]
+    fn memory_path_classifies_named_memory_databases() {
+        assert!(Database::is_memory_path(":memory:"));
+        assert!(Database::is_memory_path(":memory:sync-draft"));
+        assert!(Database::is_memory_path("file::memory:?cache=shared"));
+        assert!(Database::is_memory_path(""));
+        assert!(!Database::is_memory_path("memory.db"));
+        assert!(!Database::is_memory_path("file:memory.db"));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn io_for_path_uses_memory_io_for_named_memory_database() {
+        let path = format!(":memory:named-io-selection-{}", std::process::id());
+        assert!(std::fs::metadata(&path).is_err());
+
+        let io = Database::io_for_path(&path).unwrap();
+
+        assert!(io.file_id(&path).is_ok());
+        assert!(std::fs::metadata(&path).is_err());
     }
 }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -276,8 +276,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 table.columns.len(),
             )
         });
-        let durable_mvcc_metadata =
-            !connection.db.path.starts_with(":memory:") && mvcc_meta_table.is_some();
+        let durable_mvcc_metadata = !connection.db.is_in_memory_db() && mvcc_meta_table.is_some();
         let durable_tx_max = mvstore.durable_txid_max.load(Ordering::SeqCst);
         let durable_txid_max_old = NonZeroU64::new(durable_tx_max);
         Self {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2247,7 +2247,7 @@ pub struct MvStore<Clock: LogicalClock> {
 
 impl<Clock: LogicalClock> MvStore<Clock> {
     fn uses_durable_mvcc_metadata(&self, connection: &Arc<Connection>) -> bool {
-        !connection.db.path.starts_with(":memory:")
+        !connection.db.is_in_memory_db()
     }
 
     /// Captures table-valued functions (e.g. generate_series) from the schema before


### PR DESCRIPTION
## Description

I noticed we have `db.path == ":memory:"` scattered all over, so I added a smoll helper method. Also added some tests.
