### PR TITLE
Update rand crate to 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a645c34bad5551ed4b2496536985efdc4373b097c0e57abf2eb14774538278"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -1092,7 +1092,7 @@ dependencies = [
  "ctor 0.5.0",
  "env_logger",
  "log",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rusqlite",
  "serial_test",
@@ -1573,7 +1573,7 @@ dependencies = [
  "indexmap 2.11.1",
  "parking_lot",
  "proptest",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rusqlite",
  "serde",
@@ -1762,7 +1762,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
- "rand 0.9.4",
+ "rand 0.9.2",
  "tokio",
  "tracing-subscriber",
  "turso",
@@ -1846,7 +1846,7 @@ dependencies = [
  "deunicode",
  "dummy",
  "either",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_core 0.9.3",
 ]
 
@@ -1880,7 +1880,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.2",
  "libm",
- "rand 0.9.4",
+ "rand 0.9.2",
  "siphasher",
 ]
 
@@ -3111,7 +3111,7 @@ dependencies = [
  "json5",
  "notify",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "regex",
  "regex-syntax 0.8.5",
@@ -3328,7 +3328,7 @@ dependencies = [
  "clap",
  "dhat",
  "memory-stats",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "tokio",
@@ -4117,7 +4117,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.9.4",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -4350,9 +4350,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5273,7 +5273,7 @@ version = "0.6.0-pre.18"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "proptest",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serde",
  "sql_gen_macros",
  "strum",
@@ -5308,7 +5308,7 @@ dependencies = [
  "hex",
  "indexmap 2.11.1",
  "itertools 0.14.0",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -5770,7 +5770,7 @@ dependencies = [
  "num_cpus",
  "owo-colors 4.2.3",
  "pretty_assertions",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "regex",
  "serde",
@@ -6247,7 +6247,7 @@ dependencies = [
  "hyper-tls",
  "hyper-util",
  "mimalloc",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "reqwest",
  "serde_json",
@@ -6310,7 +6310,7 @@ dependencies = [
  "mimalloc",
  "nu-ansi-term",
  "prost 0.14.1",
- "rand 0.9.4",
+ "rand 0.8.5",
  "roaring",
  "rustyline",
  "schemars 0.8.22",
@@ -6374,7 +6374,7 @@ dependencies = [
  "pprof",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rapidhash",
  "regex",
@@ -6515,7 +6515,7 @@ dependencies = [
  "clap",
  "hex",
  "indicatif",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rusqlite",
  "serde_json",
  "shuttle",
@@ -6539,7 +6539,7 @@ dependencies = [
  "http",
  "libc",
  "prost 0.14.1",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "roaring",
  "serde",
@@ -6594,7 +6594,7 @@ dependencies = [
  "clap",
  "hex",
  "memmap2",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "sql_generation",
  "tracing",
@@ -6609,7 +6609,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.9.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "libloading 0.8.6",
  "linkme",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version_runtime",
  "serde",
  "serde_json",
@@ -4292,7 +4292,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4339,9 +4339,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4403,7 +4403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5135,7 +5135,7 @@ dependencies = [
  "generator",
  "hex",
  "owo-colors 3.5.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_pcg",
  "scoped-tls",
@@ -6090,7 +6090,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -6310,7 +6310,7 @@ dependencies = [
  "mimalloc",
  "nu-ansi-term",
  "prost 0.14.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "roaring",
  "rustyline",
  "schemars 0.8.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ anyhow = "1.0.98"
 mimalloc = { version = "0.1.47", default-features = false }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 itertools = "0.14.0"
-rand = "0.9.4"
+rand = "0.9.2"
 rand_chacha = "0.9.0"
 tracing = "0.1.41"
 schemars = "1.0.4"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -57,7 +57,7 @@ toml_edit = { version = "0.22.24", features = ["serde"] }
 serde_json = "1.0"
 termimad = "0.30"
 include_dir = "0.7"
-rand = { workspace = true }
+rand = "0.8"
 mimalloc = { workspace = true, optional = true }
 prost = "0.14.1"
 roaring = "0.11.2"

--- a/cli/manual.rs
+++ b/cli/manual.rs
@@ -1,5 +1,5 @@
 use include_dir::{include_dir, Dir};
-use rand::seq::IndexedRandom;
+use rand::seq::SliceRandom;
 use std::io::{stdout, IsTerminal, Write};
 
 use termimad::{
@@ -36,7 +36,7 @@ pub fn get_random_feature_hint() -> Option<String> {
     }
 
     features
-        .choose(&mut rand::rng())
+        .choose(&mut rand::thread_rng())
         .map(|(feature, display_name)| {
             format!("Did you know that Turso supports {display_name}? Type .manual {feature} to learn more.")
         })


### PR DESCRIPTION
Revert the previous update, and switch to 0.8.6 crate, which is compatible with Antithesis SDK.