### PR TITLE
Update rand crate to 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a645c34bad5551ed4b2496536985efdc4373b097c0e57abf2eb14774538278"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1092,7 +1092,7 @@ dependencies = [
  "ctor 0.5.0",
  "env_logger",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rusqlite",
  "serial_test",
@@ -1573,7 +1573,7 @@ dependencies = [
  "indexmap 2.11.1",
  "parking_lot",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rusqlite",
  "serde",
@@ -1762,7 +1762,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
  "tracing-subscriber",
  "turso",
@@ -1846,7 +1846,7 @@ dependencies = [
  "deunicode",
  "dummy",
  "either",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_core 0.9.3",
 ]
 
@@ -1880,7 +1880,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.2",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -3111,7 +3111,7 @@ dependencies = [
  "json5",
  "notify",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "regex",
  "regex-syntax 0.8.5",
@@ -3328,7 +3328,7 @@ dependencies = [
  "clap",
  "dhat",
  "memory-stats",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "tokio",
@@ -4117,7 +4117,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.9.4",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -4350,9 +4350,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5273,7 +5273,7 @@ version = "0.6.0-pre.18"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "sql_gen_macros",
  "strum",
@@ -5308,7 +5308,7 @@ dependencies = [
  "hex",
  "indexmap 2.11.1",
  "itertools 0.14.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -5770,7 +5770,7 @@ dependencies = [
  "num_cpus",
  "owo-colors 4.2.3",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "regex",
  "serde",
@@ -6247,7 +6247,7 @@ dependencies = [
  "hyper-tls",
  "hyper-util",
  "mimalloc",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "reqwest",
  "serde_json",
@@ -6374,7 +6374,7 @@ dependencies = [
  "pprof",
  "quickcheck",
  "quickcheck_macros",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rapidhash",
  "regex",
@@ -6515,7 +6515,7 @@ dependencies = [
  "clap",
  "hex",
  "indicatif",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rusqlite",
  "serde_json",
  "shuttle",
@@ -6539,7 +6539,7 @@ dependencies = [
  "http",
  "libc",
  "prost 0.14.1",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "roaring",
  "serde",
@@ -6594,7 +6594,7 @@ dependencies = [
  "clap",
  "hex",
  "memmap2",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "sql_generation",
  "tracing",
@@ -6609,7 +6609,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]


### PR DESCRIPTION
We're using two version of rand. We just fixed the 0.8 one, now let's
fix the 0.9 one too..
