### PR TITLE
Compute and cache generated column dependencies eagerly

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -2318,6 +2318,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             };
             schema
                 .add_btree_table(Arc::new(users_table))
@@ -2368,6 +2369,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             };
             schema
                 .add_btree_table(Arc::new(products_table))
@@ -2423,6 +2425,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             };
             schema
                 .add_btree_table(Arc::new(orders_table))
@@ -2461,6 +2464,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             };
             schema
                 .add_btree_table(Arc::new(customers_table))
@@ -2513,6 +2517,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             };
             schema
                 .add_btree_table(Arc::new(purchases_table))
@@ -2556,6 +2561,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             };
             schema
                 .add_btree_table(Arc::new(vendors_table))
@@ -2588,6 +2594,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             };
             schema
                 .add_btree_table(Arc::new(sales_table))

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -703,7 +703,7 @@ impl IncrementalView {
 
         for table in referenced_tables {
             // Check if the table has a rowid alias (INTEGER PRIMARY KEY column)
-            let has_rowid_alias = table.columns.iter().any(|col| col.is_rowid_alias());
+            let has_rowid_alias = table.columns().iter().any(|col| col.is_rowid_alias());
 
             // Select all columns. The circuit will handle filtering and projection
             // If there's a rowid alias, we don't need to select rowid separately
@@ -1098,7 +1098,7 @@ impl IncrementalView {
                     for table_name in all_tables {
                         if let Some(table) = schema.get_btree_table(table_name) {
                             if table
-                                .columns
+                                .columns()
                                 .iter()
                                 .any(|col| col.name.as_deref() == Some(column.as_str()))
                             {
@@ -1465,6 +1465,7 @@ mod tests {
             has_autoincrement: false,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
 
         // Create orders table
@@ -1515,6 +1516,7 @@ mod tests {
             unique_sets: vec![],
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
 
         // Create products table
@@ -1561,6 +1563,7 @@ mod tests {
             unique_sets: vec![],
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
 
         // Create logs table - without a rowid alias (no INTEGER PRIMARY KEY)
@@ -1600,6 +1603,7 @@ mod tests {
             unique_sets: vec![],
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
 
         schema

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -273,7 +273,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             );
             (
                 mvstore.get_table_id_from_root_page(table.root_page),
-                table.columns.len(),
+                table.columns().len(),
             )
         });
         let durable_mvcc_metadata =

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -155,6 +155,7 @@ use core::fmt;
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::VecDeque;
 use std::ops::Deref;
+use std::sync::OnceLock;
 use tracing::trace;
 use turso_parser::ast::{
     self, ColumnDefinition, Expr, InitDeferredPred, Literal, Name, RefAct, ResolveType, SortOrder,
@@ -1325,6 +1326,7 @@ impl Schema {
                 unique_sets: vec![],
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             })));
 
             // Only add to schema if compatible
@@ -2226,12 +2228,118 @@ impl CheckConstraint {
     }
 }
 
+/// Wrapper whose `Clone` resets the inner value to its `Default`. Used to
+/// hang derived caches off structs that want `#[derive(Clone)]` without
+/// propagating stale cache state into the clone.
+#[derive(Debug, Default)]
+pub struct ResetOnClone<T: Default>(pub T);
+
+impl<T: Default> Clone for ResetOnClone<T> {
+    fn clone(&self) -> Self {
+        Self(T::default())
+    }
+}
+
+/// Transitive closure of the generated-column dependency DAG, computed
+/// lazily via [`OnceLock`]. Accessed through [`BTreeTable::columns_affected_by_update`]
+/// and [`BTreeTable::dependencies_of_columns`].
+#[derive(Debug)]
+pub(crate) struct GeneratedColGraph {
+    /// `dependencies[j]` = columns `j` transitively reads from (excludes `j`).
+    dependencies: Vec<ColumnMask>,
+    /// `dependents[i]` = columns that transitively read from `i` (excludes `i`).
+    dependents: Vec<ColumnMask>,
+}
+
+impl GeneratedColGraph {
+    fn build(columns: &[Column]) -> Result<Self> {
+        let n = columns.len();
+
+        // Step 1: walk each virtual column's expression once → direct edges.
+        let mut direct_deps = vec![ColumnMask::default(); n];
+        let mut direct_dependents = vec![ColumnMask::default(); n];
+        let mut in_degree: Vec<u32> = vec![0; n];
+        for (j, col) in columns.iter().enumerate() {
+            let GeneratedType::Virtual { ref expr, .. } = col.generated_type() else {
+                continue;
+            };
+            let mut direct = BitSet::default();
+            collect_column_dependencies_of_gencol(expr, columns, &mut direct);
+            for i in direct.iter() {
+                if i == j {
+                    bail_parse_error!(
+                        "generated column \"{}\" cannot reference itself",
+                        col.name.as_deref().unwrap_or("?")
+                    );
+                }
+                direct_deps[j].set(i);
+                direct_dependents[i].set(j);
+                in_degree[j] += 1;
+            }
+        }
+
+        // Step 2: Kahn's topological sort over direct_deps. Unordered nodes = cycle.
+        let mut topo: Vec<usize> = Vec::with_capacity(n);
+        let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+        while let Some(i) = ready.pop() {
+            topo.push(i);
+            for j in direct_dependents[i].iter() {
+                in_degree[j] -= 1;
+                if in_degree[j] == 0 {
+                    ready.push(j);
+                }
+            }
+        }
+        if topo.len() != n {
+            let cycle_names: Vec<&str> = (0..n)
+                .filter(|i| in_degree[*i] > 0)
+                .filter_map(|i| columns[i].name.as_deref())
+                .collect();
+            bail_parse_error!(
+                "circular dependency in generated columns: {}",
+                cycle_names.join(", ")
+            );
+        }
+
+        // Step 3: forward DP in topo order → transitive dependencies.
+        let mut dependencies = vec![ColumnMask::default(); n];
+        for &j in &topo {
+            dependencies[j] = direct_deps[j].clone();
+            for i in direct_deps[j].iter() {
+                let snapshot = dependencies[i].clone();
+                dependencies[j].union_with(&snapshot);
+            }
+        }
+
+        // Step 4: reverse DP → transitive dependents.
+        let mut dependents = vec![ColumnMask::default(); n];
+        for &i in topo.iter().rev() {
+            dependents[i] = direct_dependents[i].clone();
+            for j in direct_dependents[i].iter() {
+                let snapshot = dependents[j].clone();
+                dependents[i].union_with(&snapshot);
+            }
+        }
+
+        Ok(Self {
+            dependencies,
+            dependents,
+        })
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct BTreeTable {
     pub root_page: i64,
     pub name: String,
     pub primary_key_columns: Vec<(String, SortOrder)>,
-    pub columns: Vec<Column>,
+    /// Prefer mutating through [`BTreeTable::columns_mut`], which invalidates
+    /// [`BTreeTable::cached_graph`]. `pub(crate)` so struct-literal callers
+    /// inside this crate can construct tables without a builder; external
+    /// crates (bindings, CLI) must go through the accessors. Internal
+    /// mutations must still route through `columns_mut()` to keep the cache
+    /// consistent.
+    pub(crate) columns: Vec<Column>,
     pub has_rowid: bool,
     pub is_strict: bool,
     pub has_autoincrement: bool,
@@ -2243,9 +2351,21 @@ pub struct BTreeTable {
     pub rowid_alias_conflict_clause: Option<ResolveType>,
     pub has_virtual_columns: bool,
     pub logical_to_physical_map: Vec<usize>,
+    pub(crate) column_dependencies: ResetOnClone<OnceLock<GeneratedColGraph>>,
 }
 
 impl BTreeTable {
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    /// Returns a mutable reference to the columns vector, invalidating the
+    /// cached dependency graph so it is rebuilt on the next query.
+    pub fn columns_mut(&mut self) -> &mut Vec<Column> {
+        self.column_dependencies.0 = OnceLock::new();
+        &mut self.columns
+    }
+
     /// Create a table reference for TypeCheck where custom type columns have
     /// their `ty_str` replaced with the base type name, and where virtual columns
     /// are skipped. This ensures TypeCheck validates the encoded value against the
@@ -2588,6 +2708,11 @@ impl BTreeTable {
     }
 
     pub fn prepare_generated_columns(&mut self) -> Result<()> {
+        // Any mutation of columns happened through `columns_mut()` upstream,
+        // which already reset the cache; rebuild here is lazy-on-next-access.
+        // Reset explicitly to cover callers that constructed this BTreeTable
+        // via struct literal and populated columns before calling us.
+        self.column_dependencies.0 = OnceLock::new();
         self.has_virtual_columns = self.columns.iter().any(|c| c.is_virtual_generated());
         if !self.has_virtual_columns {
             return Ok(());
@@ -2599,6 +2724,8 @@ impl BTreeTable {
                 *self.columns[i].generated_expr_mut().unwrap() = expr;
             }
         }
+        // Force eager cache build so cycle errors surface at CREATE TABLE / ALTER time.
+        self.column_graph()?;
         Ok(())
     }
 
@@ -2637,6 +2764,61 @@ impl BTreeTable {
         }
 
         Ok(())
+    }
+
+    fn column_graph(&self) -> Result<&GeneratedColGraph> {
+        if let Some(graph) = self.column_dependencies.0.get() {
+            return Ok(graph);
+        }
+        let graph = GeneratedColGraph::build(&self.columns)?;
+        // If a concurrent reader already initialized the cache, our `set` is a
+        // no-op and we return the already-stored value below. Either version is
+        // correct because the cache is a pure function of `self.columns`.
+        let _ = self.column_dependencies.0.set(graph);
+        Ok(self
+            .column_dependencies
+            .0
+            .get()
+            .expect("cached_graph was just initialized"))
+    }
+
+    pub(crate) fn columns_affected_by_update(
+        &self,
+        updated_cols: impl IntoIterator<Item = usize>,
+    ) -> Result<ColumnMask> {
+        let graph = self.column_graph()?;
+        let mut affected = ColumnMask::default();
+        for i in updated_cols {
+            affected.set(i);
+            if i < graph.dependents.len() {
+                let snapshot = graph.dependents[i].clone();
+                affected.union_with(&snapshot);
+            }
+        }
+        Ok(affected)
+    }
+
+    /// Returns a bitset containing the indexes of `targets` that are stored
+    /// columns, plus the stored columns that virtual `targets` transitively
+    /// depend on.
+    pub(crate) fn dependencies_of_columns(
+        &self,
+        targets: impl IntoIterator<Item = usize>,
+    ) -> Result<ColumnUsedMask> {
+        let graph = self.column_graph()?;
+        let mut deps = BitSet::default();
+        for j in targets {
+            if !self.columns[j].is_virtual_generated() {
+                deps.set(j);
+                continue;
+            }
+            for i in graph.dependencies[j].iter() {
+                if !self.columns[i].is_virtual_generated() {
+                    deps.set(i);
+                }
+            }
+        }
+        Ok(deps)
     }
 }
 
@@ -2760,128 +2942,32 @@ pub fn collect_column_dependencies_of_expr(expr: &Expr, columns: &[Column]) -> H
     refs
 }
 
-//TODO this computation be replaced with a table-level cache of column->dependencies, and then
-// columns_affected_by_update could just do a union of the dependencies of all columns.
-pub(crate) fn columns_affected_by_update(
-    columns: &[Column],
-    updated_cols: impl IntoIterator<Item = usize>,
-) -> ColumnMask {
-    let mut affected = ColumnMask::default();
-    for idx in updated_cols {
-        affected.set(idx);
-    }
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for (idx, col) in columns.iter().enumerate() {
-            if affected.get(idx) {
-                continue;
-            }
-            let GeneratedType::Virtual { ref expr, .. } = col.generated_type() else {
-                continue;
-            };
-            if expr_refers_one_of(expr, columns, &affected) {
-                affected.set(idx);
-                changed = true;
-            }
-        }
-    }
-    affected
-}
-
-/// returns a bitset containing the indexes of `targets` and of the stored columns that the
-/// virtual columns in `targets` depend on.
-pub(crate) fn dependencies_of_columns(
-    columns: &[Column],
-    targets: impl IntoIterator<Item = usize>,
-) -> ColumnUsedMask {
-    fn collect_column_dependencies_of_gencol(expr: &Expr, columns: &[Column], out: &mut BitSet) {
-        let _ = walk_expr(expr, &mut |e| {
-            match e {
-                Expr::Column { table, column, .. } if table.is_self_table() => {
-                    out.set(*column);
-                }
-                Expr::Id(name) | Expr::Name(name) => {
-                    if let Some(idx) = find_column_index_by_name(columns, name.as_str()) {
-                        out.set(idx);
-                    }
-                }
-                Expr::Qualified(_, col) | Expr::DoublyQualified(_, _, col) => {
-                    if let Some(idx) = find_column_index_by_name(columns, col.as_str()) {
-                        out.set(idx);
-                    }
-                }
-                Expr::Subquery(_)
-                | Expr::Exists(_)
-                | Expr::InTable { .. }
-                | Expr::SubqueryResult { .. } => {
-                    unreachable!("generated columns cannot contain subqueries")
-                }
-                _ => {}
-            }
-            Ok(WalkControl::Continue)
-        });
-    }
-
-    let mut dependencies = BitSet::default();
-    let mut visited = BitSet::default();
-    let mut pending = BitSet::default();
-    for idx in targets {
-        pending.set(idx);
-    }
-    loop {
-        let mut next = BitSet::default();
-        for idx in pending.iter() {
-            if visited.get(idx) {
-                continue;
-            }
-            visited.set(idx);
-            if let GeneratedType::Virtual { ref expr, .. } = columns[idx].generated_type() {
-                collect_column_dependencies_of_gencol(expr, columns, &mut next);
-            } else {
-                dependencies.set(idx);
-            }
-        }
-        if next.is_empty() {
-            break;
-        }
-        pending = next;
-    }
-    dependencies
-}
-
-/// Returns true if `expr` references any column in `target_set`.
-fn expr_refers_one_of(expr: &Expr, columns: &[Column], target_set: &ColumnMask) -> bool {
-    let mut found = false;
+fn collect_column_dependencies_of_gencol(expr: &Expr, columns: &[Column], out: &mut BitSet) {
     let _ = walk_expr(expr, &mut |e| {
-        if found {
-            return Ok(WalkControl::SkipChildren);
-        }
         match e {
             Expr::Column { table, column, .. } if table.is_self_table() => {
-                found = target_set.get(*column);
-                Ok(WalkControl::Continue)
+                out.set(*column);
             }
             Expr::Id(name) | Expr::Name(name) => {
                 if let Some(idx) = find_column_index_by_name(columns, name.as_str()) {
-                    found = target_set.get(idx);
+                    out.set(idx);
                 }
-                Ok(WalkControl::Continue)
             }
             Expr::Qualified(_, col) | Expr::DoublyQualified(_, _, col) => {
                 if let Some(idx) = find_column_index_by_name(columns, col.as_str()) {
-                    found = target_set.get(idx);
+                    out.set(idx);
                 }
-                Ok(WalkControl::Continue)
             }
             Expr::Subquery(_)
             | Expr::Exists(_)
             | Expr::InTable { .. }
-            | Expr::SubqueryResult { .. } => Ok(WalkControl::SkipChildren),
-            _ => Ok(WalkControl::Continue),
+            | Expr::SubqueryResult { .. } => {
+                unreachable!("generated columns cannot contain subqueries")
+            }
+            _ => {}
         }
+        Ok(WalkControl::Continue)
     });
-    found
 }
 
 fn find_column_index_by_name(columns: &[Column], col_name: &str) -> Option<usize> {
@@ -2891,44 +2977,6 @@ fn find_column_index_by_name(columns: &[Column], col_name: &str) -> Option<usize
             .filter(|name| name.eq_ignore_ascii_case(col_name))
             .map(|_| i)
     })
-}
-
-fn has_transitive_dependency(start: &str, target: &str, columns: &[Column]) -> bool {
-    let mut visited = std::collections::HashSet::new();
-    has_transitive_dependency_inner(start, target, columns, &mut visited)
-}
-
-fn has_transitive_dependency_inner(
-    start: &str,
-    target: &str,
-    columns: &[Column],
-    visited: &mut std::collections::HashSet<String>,
-) -> bool {
-    if !visited.insert(start.to_owned()) {
-        return false;
-    }
-
-    let Some(col) = columns.iter().find(|c| c.name.as_deref() == Some(start)) else {
-        return false;
-    };
-
-    let GeneratedType::Virtual { ref expr, .. } = col.generated_type() else {
-        return false;
-    };
-
-    let deps = collect_column_refs(expr);
-
-    if deps.contains(target) {
-        return true;
-    }
-
-    for dep in deps {
-        if has_transitive_dependency_inner(&dep, target, columns, visited) {
-            return true;
-        }
-    }
-
-    false
 }
 
 /// Resolve [Expr::Id] / [Expr::Qualified] in a generated column expression to
@@ -3448,16 +3496,9 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     if referenced_cols.iter().any(|c| c == &current_col_name) {
                         bail_parse_error!("generated column \"{}\" cannot reference itself", name);
                     }
-
-                    for ref_col in &referenced_cols {
-                        if has_transitive_dependency(ref_col, &current_col_name, &cols) {
-                            bail_parse_error!(
-                                "circular dependency in generated columns \"{}\" and \"{}\"",
-                                name,
-                                ref_col
-                            );
-                        }
-                    }
+                    // Transitive-cycle detection happens inside
+                    // `prepare_generated_columns()` via Kahn's algorithm when
+                    // `GeneratedColGraph::build` is forced.
                 }
 
                 if primary_key {
@@ -3626,6 +3667,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
         rowid_alias_conflict_clause,
         has_virtual_columns: false,
         logical_to_physical_map: Vec::new(),
+        column_dependencies: Default::default(),
     };
     table.prepare_generated_columns()?;
     table.logical_to_physical_map = BTreeTable::build_logical_to_physical_map(&table.columns);
@@ -3717,7 +3759,7 @@ impl ResolvedFkRef {
         &self,
         updated_parent_positions: &ColumnMask,
         parent_tbl: &BTreeTable,
-    ) -> bool {
+    ) -> Result<bool> {
         if self.parent_uses_rowid {
             // parent rowid changes if the parent's rowid or alias is updated
             if let Some((idx, _)) = parent_tbl
@@ -3726,13 +3768,13 @@ impl ResolvedFkRef {
                 .enumerate()
                 .find(|(_, c)| c.is_rowid_alias())
             {
-                return updated_parent_positions.get(idx);
+                return Ok(updated_parent_positions.get(idx));
             }
             // Without a rowid alias, a direct rowid update is represented separately with ROWID_SENTINEL
-            return true;
+            return Ok(true);
         }
-        let affected = columns_affected_by_update(&parent_tbl.columns, updated_parent_positions);
-        self.parent_pos.iter().any(|p| affected.get(*p))
+        let affected = parent_tbl.columns_affected_by_update(updated_parent_positions)?;
+        Ok(self.parent_pos.iter().any(|p| affected.get(*p)))
     }
 
     /// Returns if any child column of this FK is in `updated_child_positions`
@@ -4232,6 +4274,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
         unique_sets: vec![],
         has_virtual_columns: false,
         logical_to_physical_map,
+        column_dependencies: Default::default(),
     }
 }
 
@@ -5014,6 +5057,7 @@ mod tests {
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
 
         let result = Index::automatic_from_primary_key(
@@ -5328,5 +5372,264 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("generated columns"));
+    }
+
+    // --- generated-column dependency graph ---
+
+    fn indices(mask: &ColumnMask) -> Vec<usize> {
+        let mut v: Vec<usize> = mask.iter().collect();
+        v.sort_unstable();
+        v
+    }
+
+    fn stored(bits: &BitSet) -> Vec<usize> {
+        let mut v: Vec<usize> = bits.iter().collect();
+        v.sort_unstable();
+        v
+    }
+
+    #[test]
+    fn gencol_graph_no_virtual_columns() -> Result<()> {
+        let t = BTreeTable::from_sql("CREATE TABLE t(a, b)", 0)?;
+        assert_eq!(indices(&t.columns_affected_by_update([0])?), vec![0]);
+        assert_eq!(indices(&t.columns_affected_by_update([0, 1])?), vec![0, 1]);
+        assert_eq!(stored(&t.dependencies_of_columns([0])?), vec![0]);
+        assert_eq!(stored(&t.dependencies_of_columns([])?), Vec::<usize>::new());
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_linear_chain() -> Result<()> {
+        let t = BTreeTable::from_sql("CREATE TABLE t(a, b AS (a) VIRTUAL, c AS (b) VIRTUAL)", 0)?;
+        // affected-by({a}) = {a, b, c}
+        assert_eq!(indices(&t.columns_affected_by_update([0])?), vec![0, 1, 2]);
+        // affected-by({b}) = {b, c} (b is virtual, but updating it still propagates through dependents)
+        assert_eq!(indices(&t.columns_affected_by_update([1])?), vec![1, 2]);
+        // deps-of({c}) = {a} (transitive stored deps of virtual c)
+        assert_eq!(stored(&t.dependencies_of_columns([2])?), vec![0]);
+        // deps-of({b}) = {a}
+        assert_eq!(stored(&t.dependencies_of_columns([1])?), vec![0]);
+        // deps-of({a}) = {a} (stored target included)
+        assert_eq!(stored(&t.dependencies_of_columns([0])?), vec![0]);
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_diamond() -> Result<()> {
+        let t = BTreeTable::from_sql(
+            "CREATE TABLE t(a, b AS (a) VIRTUAL, c AS (a) VIRTUAL, d AS (b + c) VIRTUAL)",
+            0,
+        )?;
+        assert_eq!(
+            indices(&t.columns_affected_by_update([0])?),
+            vec![0, 1, 2, 3]
+        );
+        assert_eq!(stored(&t.dependencies_of_columns([3])?), vec![0]);
+        assert_eq!(stored(&t.dependencies_of_columns([1])?), vec![0]);
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_multiple_stored_roots() -> Result<()> {
+        let t = BTreeTable::from_sql("CREATE TABLE t(a, b, c AS (a + b) VIRTUAL)", 0)?;
+        assert_eq!(indices(&t.columns_affected_by_update([0])?), vec![0, 2]);
+        assert_eq!(indices(&t.columns_affected_by_update([1])?), vec![1, 2]);
+        assert_eq!(
+            indices(&t.columns_affected_by_update([0, 1])?),
+            vec![0, 1, 2]
+        );
+        assert_eq!(stored(&t.dependencies_of_columns([2])?), vec![0, 1]);
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_empty_input() -> Result<()> {
+        let t = BTreeTable::from_sql("CREATE TABLE t(a, b AS (a) VIRTUAL)", 0)?;
+        assert!(t.columns_affected_by_update(std::iter::empty())?.is_empty());
+        assert!(t.dependencies_of_columns(std::iter::empty())?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_disjoint_components() -> Result<()> {
+        let t = BTreeTable::from_sql(
+            "CREATE TABLE t(a, b AS (a) VIRTUAL, c, d AS (c) VIRTUAL)",
+            0,
+        )?;
+        assert_eq!(indices(&t.columns_affected_by_update([0])?), vec![0, 1]);
+        assert_eq!(indices(&t.columns_affected_by_update([2])?), vec![2, 3]);
+        assert_eq!(stored(&t.dependencies_of_columns([1])?), vec![0]);
+        assert_eq!(stored(&t.dependencies_of_columns([3])?), vec![2]);
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_deep_chain() -> Result<()> {
+        // Build 50-long chain: c0 (stored), c1 := c0, c2 := c1, ... c49 := c48.
+        let mut sql = String::from("CREATE TABLE t(c0");
+        for i in 1..50 {
+            sql.push_str(&format!(", c{i} AS (c{prev}) VIRTUAL", prev = i - 1));
+        }
+        sql.push(')');
+        let t = BTreeTable::from_sql(&sql, 0)?;
+        // affected-by({c0}) = {c0..c49}
+        let affected = t.columns_affected_by_update([0])?;
+        assert_eq!(affected.count(), 50);
+        // deps-of({c49}) = {c0}
+        assert_eq!(stored(&t.dependencies_of_columns([49])?), vec![0]);
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_very_deep_chain_no_stack_overflow() -> Result<()> {
+        // Validates that the iterative Kahn's + DP don't blow the stack on
+        // realistic worst-case generated-column depth.
+        let mut sql = String::from("CREATE TABLE t(c0");
+        for i in 1..500 {
+            sql.push_str(&format!(", c{i} AS (c{prev}) VIRTUAL", prev = i - 1));
+        }
+        sql.push(')');
+        let t = BTreeTable::from_sql(&sql, 0)?;
+        assert_eq!(t.columns_affected_by_update([0])?.count(), 500);
+        assert_eq!(stored(&t.dependencies_of_columns([499])?), vec![0]);
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_rowid_sentinel_passthrough() -> Result<()> {
+        let t = BTreeTable::from_sql("CREATE TABLE t(a, b AS (a) VIRTUAL)", 0)?;
+        let affected = t.columns_affected_by_update([ROWID_SENTINEL])?;
+        // ROWID_SENTINEL is preserved in the mask flag but does not propagate through the graph
+        // (no generated column can depend on ROWID_SENTINEL directly).
+        assert!(affected.get(ROWID_SENTINEL));
+        assert_eq!(affected.count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_transpose_duality() -> Result<()> {
+        let t = BTreeTable::from_sql(
+            "CREATE TABLE t(a, b AS (a) VIRTUAL, c AS (b) VIRTUAL, d AS (a + c) VIRTUAL)",
+            0,
+        )?;
+        let graph = t.column_graph()?;
+        // j ∈ dependencies[i] iff i ∈ dependents[j]
+        for i in 0..graph.dependencies.len() {
+            for j in graph.dependencies[i].iter() {
+                assert!(
+                    graph.dependents[j].get(i),
+                    "transpose violated: {j} is in dependencies[{i}] but {i} is not in dependents[{j}]"
+                );
+            }
+            for j in graph.dependents[i].iter() {
+                assert!(
+                    graph.dependencies[j].get(i),
+                    "transpose violated: {j} is in dependents[{i}] but {i} is not in dependencies[{j}]"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_idempotence() -> Result<()> {
+        // affected_by(affected_by(xs)) == affected_by(xs).
+        let t = BTreeTable::from_sql(
+            "CREATE TABLE t(a, b, c AS (a) VIRTUAL, d AS (b + c) VIRTUAL)",
+            0,
+        )?;
+        let once = t.columns_affected_by_update([0, 1])?;
+        let twice = t.columns_affected_by_update(once.iter())?;
+        assert_eq!(indices(&twice), indices(&once));
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_union_monotonicity() -> Result<()> {
+        // affected_by(A ∪ B) == affected_by(A) ∪ affected_by(B).
+        let t = BTreeTable::from_sql(
+            "CREATE TABLE t(a, b, c AS (a) VIRTUAL, d AS (b) VIRTUAL, e AS (c + d) VIRTUAL)",
+            0,
+        )?;
+        let mut expected = t.columns_affected_by_update([0])?;
+        let b_mask = t.columns_affected_by_update([1])?;
+        expected.union_with(&b_mask);
+        let union_mask = t.columns_affected_by_update([0, 1])?;
+        assert_eq!(indices(&union_mask), indices(&expected));
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_cycle_rejected() {
+        // Two-cycle: a := b, b := a. Must be rejected at CREATE TABLE time by Kahn's.
+        let err = BTreeTable::from_sql(
+            "CREATE TABLE t(stored, a AS (b) VIRTUAL, b AS (a) VIRTUAL)",
+            0,
+        )
+        .expect_err("cycle must be rejected");
+        assert!(
+            err.to_string().contains("circular dependency")
+                || err.to_string().contains("cannot reference itself"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn gencol_graph_three_cycle_rejected() {
+        // Three-cycle: a := b, b := c, c := a.
+        let err = BTreeTable::from_sql(
+            "CREATE TABLE t(stored, a AS (b) VIRTUAL, b AS (c) VIRTUAL, c AS (a) VIRTUAL)",
+            0,
+        )
+        .expect_err("cycle must be rejected");
+        assert!(err.to_string().contains("circular dependency"));
+    }
+
+    #[test]
+    fn gencol_graph_self_reference_rejected() {
+        let err = BTreeTable::from_sql("CREATE TABLE t(a, b AS (b) VIRTUAL)", 0)
+            .expect_err("self-reference must be rejected");
+        assert!(err.to_string().contains("cannot reference itself"));
+    }
+
+    #[test]
+    #[allow(clippy::redundant_clone)]
+    fn gencol_graph_clone_invalidates_cache() -> Result<()> {
+        // After cloning a BTreeTable, the cache is fresh. Mutating columns on
+        // the clone via `columns_mut()` keeps it fresh; `prepare_generated_columns`
+        // rebuilds correctly.
+        let original = BTreeTable::from_sql("CREATE TABLE t(a, b AS (a) VIRTUAL)", 0)?;
+        // Force the cache to be populated on the original.
+        let _ = original.columns_affected_by_update([0])?;
+        assert!(original.column_dependencies.0.get().is_some());
+
+        // Clone: ResetOnClone makes the cloned cache empty. We keep a real clone
+        // (not a move) because the point of the test is that Clone produces a
+        // fresh cache independently from the original.
+        let cloned = original.clone();
+        assert!(cloned.column_dependencies.0.get().is_none());
+        // Original's cache is still populated — clone didn't touch it.
+        assert!(original.column_dependencies.0.get().is_some());
+
+        // The clone still returns correct results — cache rebuilds lazily.
+        assert_eq!(
+            indices(&cloned.columns_affected_by_update([0])?),
+            vec![0, 1]
+        );
+        assert!(cloned.column_dependencies.0.get().is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn gencol_graph_columns_mut_invalidates_cache() -> Result<()> {
+        let mut t = BTreeTable::from_sql("CREATE TABLE t(a, b AS (a) VIRTUAL)", 0)?;
+        // Force the cache to be populated.
+        let _ = t.columns_affected_by_update([0])?;
+        assert!(t.column_dependencies.0.get().is_some());
+
+        // Any access through columns_mut() wipes the cache, even if we don't mutate.
+        let _ = t.columns_mut();
+        assert!(t.column_dependencies.0.get().is_none());
+        Ok(())
     }
 }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -142,7 +142,7 @@ use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::translate::collate::CollationSeq;
-use crate::translate::plan::{BitSet, ColumnMask, ColumnUsedMask, Plan, TableReferences};
+use crate::translate::plan::{BitSet, ColumnMask, Plan, TableReferences};
 use crate::util::{
     module_args_from_sql, module_name_from_sql, type_from_name, UnparsedFromSqlIndex,
 };
@@ -2228,11 +2228,9 @@ impl CheckConstraint {
     }
 }
 
-/// Wrapper whose `Clone` resets the inner value to its `Default`. Used to
-/// hang derived caches off structs that want `#[derive(Clone)]` without
-/// propagating stale cache state into the clone.
+/// RAII wrapper that resets its inner value when cloned.
 #[derive(Debug, Default)]
-pub struct ResetOnClone<T: Default>(pub T);
+pub struct ResetOnClone<T: Default>(T);
 
 impl<T: Default> Clone for ResetOnClone<T> {
     fn clone(&self) -> Self {
@@ -2240,9 +2238,6 @@ impl<T: Default> Clone for ResetOnClone<T> {
     }
 }
 
-/// Transitive closure of the generated-column dependency DAG, computed
-/// lazily via [`OnceLock`]. Accessed through [`BTreeTable::columns_affected_by_update`]
-/// and [`BTreeTable::dependencies_of_columns`].
 #[derive(Debug)]
 pub(crate) struct GeneratedColGraph {
     /// `dependencies[j]` = columns `j` transitively reads from (excludes `j`).
@@ -2255,10 +2250,11 @@ impl GeneratedColGraph {
     fn build(columns: &[Column]) -> Result<Self> {
         let n = columns.len();
 
-        // Step 1: walk each virtual column's expression once → direct edges.
         let mut direct_deps = vec![ColumnMask::default(); n];
         let mut direct_dependents = vec![ColumnMask::default(); n];
         let mut in_degree: Vec<u32> = vec![0; n];
+
+        // walk each virtual column's expression once to extract edges
         for (j, col) in columns.iter().enumerate() {
             let GeneratedType::Virtual { ref expr, .. } = col.generated_type() else {
                 continue;
@@ -2278,7 +2274,7 @@ impl GeneratedColGraph {
             }
         }
 
-        // Step 2: Kahn's topological sort over direct_deps. Unordered nodes = cycle.
+        // Kahn's algorithm (topological sort) over direct_deps.
         let mut topo: Vec<usize> = Vec::with_capacity(n);
         let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
         while let Some(i) = ready.pop() {
@@ -2290,6 +2286,8 @@ impl GeneratedColGraph {
                 }
             }
         }
+
+        // see if there's cycles in the graph
         if topo.len() != n {
             let cycle_names: Vec<&str> = (0..n)
                 .filter(|i| in_degree[*i] > 0)
@@ -2301,7 +2299,7 @@ impl GeneratedColGraph {
             );
         }
 
-        // Step 3: forward DP in topo order → transitive dependencies.
+        // compute transitive closures.
         let mut dependencies = vec![ColumnMask::default(); n];
         for &j in &topo {
             dependencies[j] = direct_deps[j].clone();
@@ -2311,7 +2309,7 @@ impl GeneratedColGraph {
             }
         }
 
-        // Step 4: reverse DP → transitive dependents.
+        // compute transitive closures of the transpose graph (dependents)
         let mut dependents = vec![ColumnMask::default(); n];
         for &i in topo.iter().rev() {
             dependents[i] = direct_dependents[i].clone();
@@ -2771,9 +2769,7 @@ impl BTreeTable {
             return Ok(graph);
         }
         let graph = GeneratedColGraph::build(&self.columns)?;
-        // If a concurrent reader already initialized the cache, our `set` is a
-        // no-op and we return the already-stored value below. Either version is
-        // correct because the cache is a pure function of `self.columns`.
+        // we ignore a concurrent initialization, because OnceLock::get_or_try_init is still nightly-only
         let _ = self.column_dependencies.0.set(graph);
         Ok(self
             .column_dependencies
@@ -2798,15 +2794,12 @@ impl BTreeTable {
         Ok(affected)
     }
 
-    /// Returns a bitset containing the indexes of `targets` that are stored
-    /// columns, plus the stored columns that virtual `targets` transitively
-    /// depend on.
     pub(crate) fn dependencies_of_columns(
         &self,
         targets: impl IntoIterator<Item = usize>,
-    ) -> Result<ColumnUsedMask> {
+    ) -> Result<ColumnMask> {
         let graph = self.column_graph()?;
-        let mut deps = BitSet::default();
+        let mut deps = ColumnMask::default();
         for j in targets {
             if !self.columns[j].is_virtual_generated() {
                 deps.set(j);
@@ -5382,7 +5375,7 @@ mod tests {
         v
     }
 
-    fn stored(bits: &BitSet) -> Vec<usize> {
+    fn stored(bits: &ColumnMask) -> Vec<usize> {
         let mut v: Vec<usize> = bits.iter().collect();
         v.sort_unstable();
         v

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2331,12 +2331,6 @@ pub struct BTreeTable {
     pub root_page: i64,
     pub name: String,
     pub primary_key_columns: Vec<(String, SortOrder)>,
-    /// Prefer mutating through [`BTreeTable::columns_mut`], which invalidates
-    /// [`BTreeTable::cached_graph`]. `pub(crate)` so struct-literal callers
-    /// inside this crate can construct tables without a builder; external
-    /// crates (bindings, CLI) must go through the accessors. Internal
-    /// mutations must still route through `columns_mut()` to keep the cache
-    /// consistent.
     pub(crate) columns: Vec<Column>,
     pub has_rowid: bool,
     pub is_strict: bool,
@@ -2357,8 +2351,6 @@ impl BTreeTable {
         &self.columns
     }
 
-    /// Returns a mutable reference to the columns vector, invalidating the
-    /// cached dependency graph so it is rebuilt on the next query.
     pub fn columns_mut(&mut self) -> &mut Vec<Column> {
         self.column_dependencies.0 = OnceLock::new();
         &mut self.columns
@@ -2706,10 +2698,6 @@ impl BTreeTable {
     }
 
     pub fn prepare_generated_columns(&mut self) -> Result<()> {
-        // Any mutation of columns happened through `columns_mut()` upstream,
-        // which already reset the cache; rebuild here is lazy-on-next-access.
-        // Reset explicitly to cover callers that constructed this BTreeTable
-        // via struct literal and populated columns before calling us.
         self.column_dependencies.0 = OnceLock::new();
         self.has_virtual_columns = self.columns.iter().any(|c| c.is_virtual_generated());
         if !self.has_virtual_columns {
@@ -2722,7 +2710,6 @@ impl BTreeTable {
                 *self.columns[i].generated_expr_mut().unwrap() = expr;
             }
         }
-        // Force eager cache build so cycle errors surface at CREATE TABLE / ALTER time.
         self.column_graph()?;
         Ok(())
     }
@@ -3489,9 +3476,6 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     if referenced_cols.iter().any(|c| c == &current_col_name) {
                         bail_parse_error!("generated column \"{}\" cannot reference itself", name);
                     }
-                    // Transitive-cycle detection happens inside
-                    // `prepare_generated_columns()` via Kahn's algorithm when
-                    // `GeneratedColGraph::build` is forced.
                 }
 
                 if primary_key {
@@ -5366,8 +5350,6 @@ mod tests {
             .to_string()
             .contains("generated columns"));
     }
-
-    // --- generated-column dependency graph ---
 
     fn indices(mask: &ColumnMask) -> Vec<usize> {
         let mut v: Vec<usize> = mask.iter().collect();

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -176,7 +176,7 @@ fn emit_rename_sqlite_sequence_entry(
     program.mark_last_insn_constant();
 
     let affinity_str = sqlite_sequence
-        .columns
+        .columns()
         .iter()
         .map(|col| col.affinity().aff_mask())
         .collect::<String>();
@@ -426,10 +426,12 @@ fn emit_add_virtual_column_validation(
     })?;
 
     let mut original_table = table.clone();
-    original_table.columns.retain(|c| !c.is_virtual_generated());
+    original_table
+        .columns_mut()
+        .retain(|c| !c.is_virtual_generated());
     original_table.has_virtual_columns = false;
     original_table.logical_to_physical_map =
-        BTreeTable::build_logical_to_physical_map(&original_table.columns);
+        BTreeTable::build_logical_to_physical_map(original_table.columns());
     let original_table = Arc::new(original_table);
     let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(original_table.clone()));
     program.emit_insn(Insn::OpenRead {
@@ -454,7 +456,7 @@ fn emit_add_virtual_column_validation(
 
     let layout = resolved_table.column_layout();
     let base_dest_reg = program.alloc_registers(layout.column_count());
-    for (idx, table_column) in resolved_table.columns.iter().enumerate() {
+    for (idx, table_column) in resolved_table.columns().iter().enumerate() {
         if table_column.is_virtual_generated() || table_column.is_rowid_alias() {
             continue;
         }
@@ -467,8 +469,8 @@ fn emit_add_virtual_column_validation(
     }
 
     let dml_ctx =
-        DmlColumnContext::layout(&resolved_table.columns, base_dest_reg, rowid_reg, layout);
-    compute_virtual_columns(program, resolved_table.columns.iter(), &dml_ctx, resolver)?;
+        DmlColumnContext::layout(resolved_table.columns(), base_dest_reg, rowid_reg, layout);
+    compute_virtual_columns(program, resolved_table.columns().iter(), &dml_ctx, resolver)?;
     let result_reg = dml_ctx.to_column_reg(new_column_idx);
 
     if !check_constraints.is_empty() {
@@ -481,7 +483,7 @@ fn emit_add_virtual_column_validation(
             resolved_table.name.as_str(),
             rowid_reg,
             resolved_table
-                .columns
+                .columns()
                 .iter()
                 .enumerate()
                 .filter_map(|(idx, col)| {
@@ -707,9 +709,9 @@ pub fn translate_alter_table(
             let column_name = column_name.as_str();
 
             // Tables always have at least one column.
-            turso_assert_ne!(btree.columns.len(), 0);
+            turso_assert_ne!(btree.columns().len(), 0);
 
-            if btree.columns.len() == 1 {
+            if btree.columns().len() == 1 {
                 return Err(LimboError::ParseError(format!(
                     "cannot drop column \"{column_name}\": no other columns exist"
                 )));
@@ -861,7 +863,7 @@ pub fn translate_alter_table(
             // Must have at least one non-generated column after the drop
             {
                 let remaining_non_generated = btree
-                    .columns
+                    .columns()
                     .iter()
                     .enumerate()
                     .filter(|(idx, col)| *idx != dropped_index && !col.is_generated())
@@ -875,10 +877,9 @@ pub fn translate_alter_table(
 
             // Check if any virtual column depends on the dropped column
             {
-                let affected =
-                    crate::schema::columns_affected_by_update(&btree.columns, [dropped_index]);
+                let affected = btree.columns_affected_by_update([dropped_index])?;
                 for idx in &affected {
-                    if idx != dropped_index && btree.columns[idx].is_virtual_generated() {
+                    if idx != dropped_index && btree.columns()[idx].is_virtual_generated() {
                         return Err(LimboError::ParseError(format!(
                             "error in table {table_name} after drop column: no such column: {column_name}"
                         )));
@@ -895,7 +896,7 @@ pub fn translate_alter_table(
             // trigger execution time.
             let post_drop_btree = {
                 let mut t = btree.clone();
-                t.columns.remove(dropped_index);
+                t.columns_mut().remove(dropped_index);
                 t
             };
             let table_name_norm = normalize_ident(table_name);
@@ -940,7 +941,7 @@ pub fn translate_alter_table(
                 }
             }
 
-            btree.columns.remove(dropped_index);
+            btree.columns_mut().remove(dropped_index);
 
             let sql = escape_sql_string_literal(&btree.to_sql());
 
@@ -972,7 +973,7 @@ pub fn translate_alter_table(
                 |program| {
                     let table_name = btree.name.clone();
                     let source_column_by_schema_idx = btree
-                        .columns
+                        .columns()
                         .iter()
                         .enumerate()
                         .map(|(new_idx, column)| {
@@ -1110,7 +1111,7 @@ pub fn translate_alter_table(
             }
 
             // TODO: All quoted ids will be quoted with `[]`, we should store some info from the parsed AST
-            btree.columns.push(column.clone());
+            btree.columns_mut().push(column.clone());
 
             // Add foreign key constraints and CHECK constraints to the btree table
             for constraint in &constraints {
@@ -1170,7 +1171,7 @@ pub fn translate_alter_table(
                     }
                     ast::ColumnConstraint::Check(expr) => {
                         let column_names: Vec<&str> = btree
-                            .columns
+                            .columns()
                             .iter()
                             .filter_map(|c| c.name.as_deref())
                             .collect();
@@ -1383,7 +1384,7 @@ pub fn translate_alter_table(
             });
 
             program.cursor_loop(cursor_id, |program, rowid| {
-                let sqlite_schema_column_len = sqlite_schema.columns.len();
+                let sqlite_schema_column_len = sqlite_schema.columns().len();
                 turso_assert_eq!(sqlite_schema_column_len, 5);
 
                 let first_column = program.alloc_registers(sqlite_schema_column_len);
@@ -1570,7 +1571,7 @@ pub fn translate_alter_table(
                 true => (false, None),
                 false => {
                     let replacement_column = Column::try_from(&definition)?;
-                    let rewrites_physical_layout = !btree.columns[column_index].is_generated()
+                    let rewrites_physical_layout = !btree.columns()[column_index].is_generated()
                         && replacement_column.is_generated();
                     (rewrites_physical_layout, Some(replacement_column))
                 }
@@ -1604,7 +1605,7 @@ pub fn translate_alter_table(
                 }
 
                 let non_generated_count = btree
-                    .columns
+                    .columns()
                     .iter()
                     .enumerate()
                     .filter(|(idx, col)| *idx != column_index && !col.is_generated())
@@ -1619,11 +1620,11 @@ pub fn translate_alter_table(
 
             let rewritten_table = if rewrites_physical_layout {
                 let mut table = btree.clone();
-                table.columns[column_index] =
+                table.columns_mut()[column_index] =
                     replacement_column.expect("replacement_column must exist for ALTER COLUMN");
                 table.prepare_generated_columns()?;
                 table.logical_to_physical_map =
-                    BTreeTable::build_logical_to_physical_map(&table.columns);
+                    BTreeTable::build_logical_to_physical_map(table.columns());
                 Some(table)
             } else {
                 None
@@ -1775,7 +1776,7 @@ pub fn translate_alter_table(
             });
 
             program.cursor_loop(cursor_id, |program, rowid| {
-                let sqlite_schema_column_len = sqlite_schema.columns.len();
+                let sqlite_schema_column_len = sqlite_schema.columns().len();
                 turso_assert_eq!(sqlite_schema_column_len, 5);
 
                 let first_column = program.alloc_registers(sqlite_schema_column_len);
@@ -1921,7 +1922,7 @@ pub fn translate_alter_table(
                 emit_add_virtual_column_validation(
                     program,
                     &rewritten_table,
-                    &rewritten_table.columns[column_index],
+                    &rewritten_table.columns()[column_index],
                     &definition.constraints,
                     resolver,
                     connection,
@@ -1929,7 +1930,7 @@ pub fn translate_alter_table(
                 )?;
 
                 let source_column_by_schema_idx = rewritten_table
-                    .columns
+                    .columns()
                     .iter()
                     .enumerate()
                     .map(|(idx, column)| {
@@ -1984,7 +1985,7 @@ fn emit_rewrite_table_rows(
 ) {
     turso_assert_eq!(
         source_column_by_schema_idx.len(),
-        rewritten_table.columns.len()
+        rewritten_table.columns().len()
     );
 
     let layout = rewritten_table.column_layout();
@@ -2043,7 +2044,7 @@ fn emit_rewrite_table_rows(
 
 fn non_virtual_affinity_str(table: &BTreeTable) -> String {
     table
-        .columns
+        .columns()
         .iter()
         .filter(|col| !col.is_virtual_generated())
         .map(|col| col.affinity_with_strict(table.is_strict).aff_mask())
@@ -2087,7 +2088,7 @@ fn translate_rename_virtual_table(
     });
 
     program.cursor_loop(schema_cur, |program, rowid| {
-        let ncols = sqlite_schema.columns.len();
+        let ncols = sqlite_schema.columns().len();
         turso_assert_eq!(ncols, 5);
 
         let first_col = program.alloc_registers(ncols);
@@ -3658,7 +3659,7 @@ fn validate_trigger_columns_after_drop(
     {
         Some(
             post_drop_table
-                .columns
+                .columns()
                 .iter()
                 .filter_map(|c| c.name.as_deref().map(normalize_ident))
                 .collect(),
@@ -3667,7 +3668,7 @@ fn validate_trigger_columns_after_drop(
         resolver.with_schema(trigger_database_id, |s| {
             s.get_table(&trigger_table_norm).and_then(|t| {
                 t.btree().map(|bt| {
-                    bt.columns
+                    bt.columns()
                         .iter()
                         .filter_map(|c| c.name.as_deref().map(normalize_ident))
                         .collect()
@@ -5296,7 +5297,7 @@ fn get_table_columns(
     if lookup_database_id == altered_database_id && table_name_norm == altered_table_norm {
         Some(
             post_drop_table
-                .columns
+                .columns()
                 .iter()
                 .filter_map(|c| c.name.as_deref().map(normalize_ident))
                 .collect(),
@@ -5305,7 +5306,7 @@ fn get_table_columns(
         resolver.with_schema(lookup_database_id, |s| {
             s.get_table(table_name_norm).and_then(|t| {
                 t.btree().map(|bt| {
-                    bt.columns
+                    bt.columns()
                         .iter()
                         .filter_map(|c| c.name.as_deref().map(normalize_ident))
                         .collect()

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -536,6 +536,7 @@ mod tests {
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         }));
         table_references.add_joined_table(JoinedTable {
             op: Operation::Scan(Scan::BTreeTable {
@@ -598,6 +599,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             })),
             indexed: None,
         });
@@ -638,6 +640,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             })),
             indexed: None,
         });
@@ -693,6 +696,7 @@ mod tests {
                 rowid_alias_conflict_clause: None,
                 has_virtual_columns: false,
                 logical_to_physical_map,
+                column_dependencies: Default::default(),
             })),
         });
         table_references

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -19,7 +19,6 @@ use super::order_by::SortMetadata;
 use super::plan::{BitSet, HashJoinType, TableReferences};
 use crate::error::SQLITE_CONSTRAINT_CHECK;
 use crate::function::Func;
-use crate::schema::dependencies_of_columns;
 use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
 };
@@ -1634,18 +1633,17 @@ fn rewrite_where_for_update_registers(
 /// Emits  `target_columns`, plus the stored columns needed by `target_columns`, into compact
 /// registers. This takes into account stored columns, and any stored columns required
 /// by virtual columns in `target_columns`.
-#[must_use]
 pub(crate) fn emit_columns_and_dependencies(
     program: &mut ProgramBuilder,
     table: &BTreeTable,
     cursor_id: usize,
     rowid_reg: usize,
     target_columns: impl IntoIterator<Item = usize>,
-) -> DmlColumnContext {
-    let dependencies = dependencies_of_columns(&table.columns, target_columns);
+) -> Result<DmlColumnContext> {
+    let dependencies = table.dependencies_of_columns(target_columns)?;
     let base = program.alloc_registers(dependencies.count());
     let mut next_reg = base;
-    let pairs = table.columns.iter().enumerate().map(|(idx, col)| {
+    let pairs = table.columns().iter().enumerate().map(|(idx, col)| {
         let reg = if col.is_rowid_alias() {
             rowid_reg
         } else if dependencies.get(idx) {
@@ -1658,7 +1656,7 @@ pub(crate) fn emit_columns_and_dependencies(
         };
         (col, reg)
     });
-    DmlColumnContext::from_column_reg_mapping(pairs)
+    Ok(DmlColumnContext::from_column_reg_mapping(pairs))
 }
 
 /// Emit code to load the value of an IndexColumn from the OLD image of the row being updated.
@@ -1729,7 +1727,7 @@ fn generated_column(
         .cloned()
         .flat_map(|table| {
             table
-                .columns
+                .columns()
                 .get(idx_col.pos_in_table)
                 .filter(|col| col.is_virtual_generated())
                 .cloned()

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -464,6 +464,7 @@ fn emit_materialized_build_inputs(
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         });
         let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(ephemeral_table.clone()));
 

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1572,10 +1572,10 @@ fn emit_update_insns<'a>(
             if t_ctx.resolver.schema().has_child_fks(table_name) {
                 let rowid_new_reg = rowid_set_clause_reg.unwrap_or(beg);
                 let mut directly_and_indirectly_updated_columns = ColumnMask::default();
-                for (i, _) in set_clauses.iter() {
-                    directly_and_indirectly_updated_columns
-                        .union_with(&table_btree.columns_affected_by_update([*i])?);
-                }
+                directly_and_indirectly_updated_columns.union_with(
+                    &table_btree
+                        .columns_affected_by_update(set_clauses.iter().map(|(idx, _)| *idx))?,
+                );
 
                 emit_fk_child_update_counters(
                     program,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1,6 +1,6 @@
 use super::gencol::compute_virtual_columns;
 use super::TranslateCtx;
-use crate::schema::{columns_affected_by_update, ColumnLayout, GeneratedType, Table};
+use crate::schema::{ColumnLayout, GeneratedType, Table};
 use crate::translate::insert::halt_desc_and_on_error;
 use crate::translate::plan::ColumnMask;
 use crate::translate::stmt_journal::any_effective_replace;
@@ -469,10 +469,10 @@ fn emit_update_column_values<'a>(
         }
     }
     let target_table_columns = target_table.table.columns();
-    let affected_columns = columns_affected_by_update(
-        target_table_columns,
-        set_clauses.iter().map(|(idx, _)| *idx),
-    );
+    let affected_columns = match target_table.table.btree() {
+        Some(btree) => btree.columns_affected_by_update(set_clauses.iter().map(|(idx, _)| *idx))?,
+        None => set_clauses.iter().map(|(idx, _)| *idx).collect(),
+    };
 
     for (idx, table_column) in target_table_columns.iter().enumerate() {
         let target_reg = layout.to_register(start, idx);
@@ -1059,7 +1059,7 @@ fn emit_update_insns<'a>(
     if let Some(btree_table) = target_table.table.btree() {
         if !btree_table.is_strict {
             let affinity = btree_table
-                .columns
+                .columns()
                 .iter()
                 .filter(|c| !c.is_virtual_generated())
                 .map(|c| c.affinity());
@@ -1353,8 +1353,10 @@ fn emit_update_insns<'a>(
     for (idx, _) in set_clauses {
         set_clause_cols.set(*idx);
     }
-    let affected_columns =
-        columns_affected_by_update(target_table.table.columns(), &set_clause_cols);
+    let affected_columns = match target_table.table.btree() {
+        Some(btree) => btree.columns_affected_by_update(&set_clause_cols)?,
+        None => set_clause_cols.clone(),
+    };
     let update_affects_virtual_columns = affected_columns.count() > set_clause_cols.count();
     let has_returning = returning.as_ref().is_some_and(|r| !r.is_empty());
     let has_check_constraints = target_table
@@ -1484,7 +1486,7 @@ fn emit_update_insns<'a>(
             crate::translate::expr::emit_custom_type_encode_columns(
                 program,
                 &t_ctx.resolver,
-                &btree_table.columns,
+                btree_table.columns(),
                 start,
                 Some(&set_col_indices),
                 table_name,
@@ -1506,21 +1508,19 @@ fn emit_update_insns<'a>(
         if !btree_table.check_constraints.is_empty() {
             // SQLite only evaluates CHECK constraints that reference at least one
             // column in the SET clause. Build a set of updated column names to filter.
-            let mut updated_col_names: HashSet<String> = columns_affected_by_update(
-                &btree_table.columns,
-                set_clauses.iter().map(|(idx, _)| *idx),
-            )
-            .into_iter()
-            .filter_map(|col_idx| btree_table.columns.get(col_idx))
-            .filter_map(|col| col.name.as_deref())
-            .map(normalize_ident)
-            .collect();
+            let mut updated_col_names: HashSet<String> = btree_table
+                .columns_affected_by_update(set_clauses.iter().map(|(idx, _)| *idx))?
+                .into_iter()
+                .filter_map(|col_idx| btree_table.columns().get(col_idx))
+                .filter_map(|col| col.name.as_deref())
+                .map(normalize_ident)
+                .collect();
 
             // If the rowid is being updated (either directly via ROWID_SENTINEL or
             // through a rowid alias column), also include the rowid pseudo-column
             // names so that CHECK(rowid > 0) etc. are properly triggered.
             let rowid_updated = set_clauses.iter().any(|(idx, _)| *idx == ROWID_SENTINEL)
-                || btree_table.columns.iter().enumerate().any(|(i, c)| {
+                || btree_table.columns().iter().enumerate().any(|(i, c)| {
                     c.is_rowid_alias() && set_clauses.iter().any(|(idx, _)| *idx == i)
                 });
             if rowid_updated {
@@ -1545,7 +1545,7 @@ fn emit_update_insns<'a>(
                 &btree_table.name,
                 rowid_set_clause_reg.unwrap_or(beg),
                 btree_table
-                    .columns
+                    .columns()
                     .iter()
                     .enumerate()
                     .filter_map(|(idx, col)| {
@@ -1571,13 +1571,11 @@ fn emit_update_insns<'a>(
         if let Some(table_btree) = target_table.table.btree() {
             if t_ctx.resolver.schema().has_child_fks(table_name) {
                 let rowid_new_reg = rowid_set_clause_reg.unwrap_or(beg);
-                let directly_and_indirectly_updated_columns: ColumnMask = set_clauses
-                    .iter()
-                    .map(|(i, _)| *i)
-                    .flat_map(|col| {
-                        columns_affected_by_update(&table_btree.columns, [col].iter().cloned())
-                    })
-                    .collect();
+                let mut directly_and_indirectly_updated_columns = ColumnMask::default();
+                for (i, _) in set_clauses.iter() {
+                    directly_and_indirectly_updated_columns
+                        .union_with(&table_btree.columns_affected_by_update([*i])?);
+                }
 
                 emit_fk_child_update_counters(
                     program,

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -330,7 +330,7 @@ pub fn build_index_affinity_string(idx: &Index, table: &BTreeTable) -> String {
     idx.columns
         .iter()
         .map(|ic| {
-            table.columns[ic.pos_in_table]
+            table.columns()[ic.pos_in_table]
                 .affinity_with_strict(table.is_strict)
                 .aff_mask()
         })
@@ -459,26 +459,28 @@ pub fn emit_parent_index_key_change_checks(
     let some_idx_columns_are_virtual = index
         .columns
         .iter()
-        .any(|col| table_btree.columns[col.pos_in_table].is_virtual_generated());
+        .any(|col| table_btree.columns()[col.pos_in_table].is_virtual_generated());
 
     let old_key = program.alloc_registers(idx_len);
     let idx_target_cols = index.columns.iter().map(|c| c.pos_in_table);
-    let dml_ctx = some_idx_columns_are_virtual.then(|| {
-        emit_columns_and_dependencies(
-            program,
-            table_btree,
-            cursor_id,
-            old_rowid_reg,
-            idx_target_cols,
-        )
-    });
+    let dml_ctx = some_idx_columns_are_virtual
+        .then(|| {
+            emit_columns_and_dependencies(
+                program,
+                table_btree,
+                cursor_id,
+                old_rowid_reg,
+                idx_target_cols,
+            )
+        })
+        .transpose()?;
     for (i, index_col) in index.columns.iter().enumerate() {
         if let Some(ref ctx) = dml_ctx {
             emit_table_column_for_dml(
                 program,
                 cursor_id,
                 ctx.clone(),
-                &table_btree.columns[index_col.pos_in_table],
+                &table_btree.columns()[index_col.pos_in_table],
                 index_col.pos_in_table,
                 old_key + i,
                 resolver,
@@ -490,7 +492,7 @@ pub fn emit_parent_index_key_change_checks(
     let new_key = program.alloc_registers(idx_len);
     for (i, index_col) in index.columns.iter().enumerate() {
         let pos_in_table = index_col.pos_in_table;
-        let column = &table_btree.columns[pos_in_table];
+        let column = &table_btree.columns()[pos_in_table];
         let src = if column.is_rowid_alias() {
             new_rowid_reg
         } else {
@@ -707,15 +709,17 @@ fn build_parent_key(
     let fk_target_cols = parent_cols
         .iter()
         .filter_map(|pcol| parent_bt.get_column(pcol).map(|(pos, _)| pos));
-    let ctx = some_fk_cols_are_virtual.then(|| {
-        emit_columns_and_dependencies(
-            program,
-            parent_bt,
-            parent_cursor_id,
-            parent_rowid_reg,
-            fk_target_cols,
-        )
-    });
+    let ctx = some_fk_cols_are_virtual
+        .then(|| {
+            emit_columns_and_dependencies(
+                program,
+                parent_bt,
+                parent_cursor_id,
+                parent_rowid_reg,
+                fk_target_cols,
+            )
+        })
+        .transpose()?;
 
     for (i, pcol) in parent_cols.iter().enumerate() {
         let Some((pos, col)) = parent_bt.get_column(pcol) else {
@@ -1119,14 +1123,19 @@ pub fn emit_fk_update_parent_actions(
 ) -> Result<Vec<DeferredNewKeyProbePlan>> {
     let mut deferred_new_key_plans = Vec::new();
     let updated_positions: ColumnMask = set_clauses.iter().map(|(i, _)| *i).collect();
-    let check_fks: Vec<_> = resolver
-        .with_schema(database_id, |s| {
-            s.resolved_fks_referencing(&table_btree.name)
-        })?
-        .into_iter()
-        .filter(|fk| fk.parent_key_may_change(&updated_positions, table_btree))
-        .filter(|fk| matches!(fk.fk.on_update, RefAct::NoAction | RefAct::Restrict))
-        .collect();
+    let mut check_fks: Vec<_> = Vec::new();
+    let referencing = resolver.with_schema(database_id, |s| {
+        s.resolved_fks_referencing(&table_btree.name)
+    })?;
+    for fk in referencing {
+        if !fk.parent_key_may_change(&updated_positions, table_btree)? {
+            continue;
+        }
+        if !matches!(fk.fk.on_update, RefAct::NoAction | RefAct::Restrict) {
+            continue;
+        }
+        check_fks.push(fk);
+    }
     if check_fks.is_empty() {
         return Ok(deferred_new_key_plans);
     }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -136,7 +136,7 @@ pub fn translate_create_index(
     for col in &columns {
         if col.expr.is_none() {
             // Simple column reference (not expression index)
-            if let Some(column) = tbl.columns.get(col.pos_in_table) {
+            if let Some(column) = tbl.columns().get(col.pos_in_table) {
                 if let Some(type_def) = resolver
                     .schema()
                     .get_type_def(&column.ty_str, tbl.is_strict)
@@ -222,7 +222,7 @@ pub fn translate_create_index(
     );
     let sorter_cursor_id = program.alloc_cursor_id(CursorType::Sorter);
     let pseudo_cursor_id = program.alloc_cursor_id(CursorType::Pseudo(PseudoCursorType {
-        column_count: tbl.columns.len(),
+        column_count: tbl.columns().len(),
     }));
 
     let mut table_references = TableReferences::new(
@@ -680,7 +680,7 @@ fn validate_index_expression(expr: &Expr, table: &BTreeTable) -> bool {
     let has_col = |name: &str| {
         let n = normalize_ident(name);
         table
-            .columns
+            .columns()
             .iter()
             .any(|c| c.name.as_ref().is_some_and(|cn| normalize_ident(cn) == n))
     };
@@ -1030,7 +1030,7 @@ pub fn translate_drop_index(
         let before_record_reg = if program.capture_data_changes_info().has_before() {
             Some(emit_cdc_full_record(
                 program,
-                &sqlite_table.columns,
+                sqlite_table.columns(),
                 sqlite_schema_cursor_id,
                 row_id_reg,
                 sqlite_table.is_strict,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1510,15 +1510,15 @@ fn get_valid_sqlite_sequence_table(
         crate::bail_corrupt_error!("malformed sqlite_sequence: table must have rowid");
     }
 
-    if seq_table.columns.len() != 2 {
+    if seq_table.columns().len() != 2 {
         crate::bail_corrupt_error!(
             "malformed sqlite_sequence: expected 2 columns, got {}",
-            seq_table.columns.len()
+            seq_table.columns().len()
         );
     }
 
-    let col0_name = seq_table.columns[0].name.as_deref();
-    let col1_name = seq_table.columns[1].name.as_deref();
+    let col0_name = seq_table.columns()[0].name.as_deref();
+    let col1_name = seq_table.columns()[1].name.as_deref();
     if !matches!(col0_name, Some(name) if name.eq_ignore_ascii_case("name"))
         || !matches!(col1_name, Some(name) if name.eq_ignore_ascii_case("seq"))
     {
@@ -2107,7 +2107,7 @@ fn init_source_emission<'a>(
                     let record_reg = program.alloc_register();
                     let affinity_str = if columns.is_empty() {
                         ctx.table
-                            .columns
+                            .columns()
                             .iter()
                             .filter(|col| !col.hidden() && !col.is_generated())
                             .map(|col| col.affinity_with_strict(ctx.table.is_strict).aff_mask())
@@ -2881,7 +2881,7 @@ fn emit_unique_index_check(
             if ic.expr.is_some() {
                 Affinity::Blob.aff_mask()
             } else {
-                ctx.table.columns[ic.pos_in_table]
+                ctx.table.columns()[ic.pos_in_table]
                     .affinity_with_strict(ctx.table.is_strict)
                     .aff_mask()
             }
@@ -3236,7 +3236,7 @@ fn ensure_sequence_initialized(
     });
 
     let affinity_str = seq_table
-        .columns
+        .columns()
         .iter()
         .map(|c| c.affinity().aff_mask())
         .collect();
@@ -3586,7 +3586,7 @@ fn emit_update_sqlite_sequence(
 
     let seq_table = get_valid_sqlite_sequence_table(resolver, database_id)?;
     let affinity_str = seq_table
-        .columns
+        .columns()
         .iter()
         .map(|col| col.affinity().aff_mask())
         .collect::<String>();
@@ -3745,7 +3745,7 @@ fn emit_replace_delete_conflicting_row(
         let before_record_reg = if cdc_has_before {
             Some(emit_cdc_full_record(
                 program,
-                &table.columns,
+                table.columns(),
                 main_cursor_id,
                 ctx.conflict_rowid_reg,
                 table.is_strict,

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -268,7 +268,7 @@ fn translate_integrity_check_impl(
                         unique_nullable.push(true);
                     } else {
                         columns.push(BoundIndexColumn::Column(col.pos_in_table));
-                        unique_nullable.push(!btree_table.columns[col.pos_in_table].notnull());
+                        unique_nullable.push(!btree_table.columns()[col.pos_in_table].notnull());
                     }
                 }
 
@@ -293,7 +293,7 @@ fn translate_integrity_check_impl(
         }
 
         let not_null_columns: Vec<(BoundIndexColumn, String)> = btree_table
-            .columns
+            .columns()
             .iter()
             .enumerate()
             .filter(|(_, col)| col.notnull() && !col.is_rowid_alias())

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -2441,6 +2441,7 @@ mod tests {
             unique_sets: vec![],
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
         schema
             .add_btree_table(Arc::new(users_table))
@@ -2493,6 +2494,7 @@ mod tests {
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
         schema
             .add_btree_table(Arc::new(orders_table))
@@ -2545,6 +2547,7 @@ mod tests {
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         };
         schema
             .add_btree_table(Arc::new(products_table))

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -308,7 +308,7 @@ impl OpenLoop {
                                     };
                                     let num_seek_keys = seek_def.size(&seek_def.start);
                                     let table_columns = if let Table::BTree(btree) = &table.table {
-                                        Some(btree.columns.as_slice())
+                                        Some(btree.columns())
                                     } else {
                                         None
                                     };

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -575,7 +575,7 @@ pub(super) fn choose_best_in_seek_candidate(
 
             let affinity = if let Some(col_pos) = constraint.table_col_pos {
                 btree
-                    .columns
+                    .columns()
                     .get(col_pos)
                     .map(|col| col.affinity())
                     .unwrap_or(Affinity::Blob)

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -3218,6 +3218,7 @@ mod tests {
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         })
     }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -15,9 +15,7 @@ use crate::{
     function::{AggFunc, Deterministic},
     index_method::IndexMethodCostEstimate,
     numeric::Numeric,
-    schema::{
-        columns_affected_by_update, BTreeTable, Index, IndexColumn, Schema, Table, ROWID_SENTINEL,
-    },
+    schema::{BTreeTable, Index, IndexColumn, Schema, Table, ROWID_SENTINEL},
     translate::{
         insert::ROWID_COLUMN,
         optimizer::{
@@ -859,7 +857,7 @@ fn first_update_safety_reason(
 
         let Some(index) = table_ref.op.index() else {
             let rowid_alias_used = plan.set_clauses.iter().fold(false, |accum, (idx, _)| {
-                accum || (*idx != ROWID_SENTINEL && btree_table.columns[*idx].is_rowid_alias())
+                accum || (*idx != ROWID_SENTINEL && btree_table.columns()[*idx].is_rowid_alias())
             });
             if rowid_alias_used {
                 break 'requires Some(DmlSafetyReason::KeyMutation);
@@ -886,7 +884,7 @@ fn first_update_safety_reason(
             }
         }
 
-        let affected_cols = columns_affected_by_update(&btree_table.columns, &updated_cols);
+        let affected_cols = btree_table.columns_affected_by_update(&updated_cols)?;
         if index
             .columns
             .iter()
@@ -961,6 +959,7 @@ fn add_ephemeral_table_to_update_plan(
         rowid_alias_conflict_clause: None,
         has_virtual_columns: false,
         logical_to_physical_map,
+        column_dependencies: Default::default(),
     });
 
     let temp_cursor_id = program.alloc_cursor_id_keyed(

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -1179,6 +1179,7 @@ mod tests {
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         })
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1396,10 +1396,9 @@ impl ColumnMask {
         self.bitset.is_empty() && !self.has_rowid_sentinel
     }
 
-    /// Iterates over the real column indices in this mask. ROWID_SENTINEL,
-    /// if present, is not yielded.
     pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
-        self.bitset.iter()
+        let rowid_sentinel = self.has_rowid_sentinel.then_some(ROWID_SENTINEL);
+        self.bitset.iter().chain(rowid_sentinel)
     }
 
     pub fn union_with(&mut self, other: &ColumnMask) {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1395,6 +1395,17 @@ impl ColumnMask {
     pub fn is_empty(&self) -> bool {
         self.bitset.is_empty() && !self.has_rowid_sentinel
     }
+
+    /// Iterates over the real column indices in this mask. ROWID_SENTINEL,
+    /// if present, is not yielded.
+    pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
+        self.bitset.iter()
+    }
+
+    pub fn union_with(&mut self, other: &ColumnMask) {
+        self.bitset.union_with(&other.bitset);
+        self.has_rowid_sentinel |= other.has_rowid_sentinel;
+    }
 }
 
 impl FromIterator<usize> for ColumnMask {
@@ -1633,6 +1644,19 @@ impl BitSet {
                 *s &= !o;
             }
             self.trim_overflow();
+        }
+    }
+
+    pub fn union_with(&mut self, other: &Self) {
+        self.inline |= other.inline;
+        if let Some(other_ov) = &other.overflow {
+            let self_ov = self.overflow.get_or_insert_with(Vec::new);
+            if self_ov.len() < other_ov.len() {
+                self_ov.resize(other_ov.len(), 0);
+            }
+            for (s, &o) in self_ov.iter_mut().zip(other_ov.iter()) {
+                *s |= o;
+            }
         }
     }
 
@@ -2433,7 +2457,7 @@ impl JoinedTable {
                     // see `recomputeColumnsNotIndexed` in `build.c`. We might be able to improve this
                     // in the future, but for now we do this to ensure correctness.
                     !btree
-                        .columns
+                        .columns()
                         .get(c.pos_in_table)
                         .expect("column should be in table")
                         .is_virtual_generated()

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1072,6 +1072,7 @@ fn parse_table(
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         });
         drop(view_guard);
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -180,7 +180,7 @@ fn emit_table_list_rows_for_schema(
             program,
             &bt.name,
             "table",
-            bt.columns.len(),
+            bt.columns().len(),
             !bt.has_rowid,
             bt.is_strict,
         );

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1585,7 +1585,7 @@ pub fn translate_drop_table(
         let before_record_reg = if program.capture_data_changes_info().has_before() {
             Some(emit_cdc_full_record(
                 program,
-                &schema_table.columns,
+                schema_table.columns(),
                 sqlite_schema_cursor_id_0,
                 row_id_reg,
                 schema_table.is_strict,
@@ -1820,6 +1820,7 @@ pub fn translate_drop_table(
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         });
         // cursor id 2
         let ephemeral_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(simple_table_rc));

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -228,7 +228,7 @@ pub(crate) fn set_update_stmt_journal_flags(
             return false;
         }
         btree_table
-            .columns
+            .columns()
             .get(*col_idx)
             .is_some_and(|c| c.notnull() && !c.is_rowid_alias())
     });

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1543,6 +1543,7 @@ fn emit_materialized_subquery_table(
         rowid_alias_conflict_clause: None,
         has_virtual_columns: false,
         logical_to_physical_map,
+        column_dependencies: Default::default(),
     });
 
     let cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(ephemeral_table.clone()));

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -419,7 +419,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
             // Handle NEW.column references
             if ns.eq_ignore_ascii_case("new") {
                 if ctx.has_new {
-                    let num_cols = ctx.table.columns.len();
+                    let num_cols = ctx.table.columns().len();
                     if let Some((idx, col_def)) = ctx.table.get_column(&col) {
                         if col_def.is_rowid_alias() {
                             *e = variable_from_parameter_index(
@@ -457,7 +457,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
             // Handle OLD.column references
             if ns.eq_ignore_ascii_case("old") {
                 if ctx.has_old {
-                    let num_cols = ctx.table.columns.len();
+                    let num_cols = ctx.table.columns().len();
                     if let Some((idx, col_def)) = ctx.table.get_column(&col) {
                         if col_def.is_rowid_alias() {
                             *e = variable_from_parameter_index(
@@ -535,7 +535,7 @@ fn execute_trigger_commands(
 
     let has_new = ctx.new_registers.is_some();
     let has_old = ctx.old_registers.is_some();
-    let num_cols = ctx.table.columns.len();
+    let num_cols = ctx.table.columns().len();
 
     // Ordinary non-main triggers need unqualified DML targets rewritten into the
     // trigger's schema. Temp-backed triggers intentionally keep unqualified names
@@ -954,7 +954,7 @@ fn decode_trigger_registers(
         });
     }
 
-    let columns = &ctx.table.columns;
+    let columns = ctx.table.columns();
 
     let decoded_new = if ctx.new_encoded {
         if let Some(new_regs) = &ctx.new_registers {
@@ -1011,7 +1011,7 @@ fn populate_trigger_row_register_affinities(
         return;
     };
 
-    for (idx, column) in table.columns.iter().enumerate() {
+    for (idx, column) in table.columns().iter().enumerate() {
         let affinity = if column.is_rowid_alias() {
             Affinity::Integer
         } else {

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -1,7 +1,7 @@
 use crate::sync::Arc;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::schema::{columns_affected_by_update, ROWID_SENTINEL};
+use crate::schema::ROWID_SENTINEL;
 use crate::translate::emitter::Resolver;
 use crate::translate::expr::{bind_and_rewrite_expr, BindingBehavior};
 use crate::translate::expression_index::expression_index_column_usage;
@@ -449,10 +449,13 @@ pub fn prepare_update_plan(
     let rowid_alias_used = set_clauses
         .iter()
         .any(|(idx, _)| *idx == ROWID_SENTINEL || columns[*idx].is_rowid_alias());
-    let updated_cols = (!rowid_alias_used).then(|| set_clauses.iter().map(|(i, _)| *i).collect());
-    let affected_cols = updated_cols
-        .as_ref()
-        .map(|updated_cols: &ColumnMask| columns_affected_by_update(columns, updated_cols));
+    let updated_cols: Option<ColumnMask> =
+        (!rowid_alias_used).then(|| set_clauses.iter().map(|(i, _)| *i).collect());
+    let affected_cols = match (table.btree(), updated_cols.as_ref()) {
+        (Some(bt), Some(updated)) => Some(bt.columns_affected_by_update(updated)?),
+        (None, Some(updated)) => Some(updated.clone()),
+        _ => None,
+    };
     let mut indexes_to_update = Vec::new();
 
     for idx in indexes {

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -6,9 +6,7 @@ use turso_parser::ast::{self, TriggerEvent, TriggerTime, Upsert};
 
 use super::emitter::gencol::compute_virtual_columns;
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
-use crate::schema::{
-    columns_affected_by_update, BTreeTable, ColumnLayout, IndexColumn, ROWID_SENTINEL,
-};
+use crate::schema::{BTreeTable, ColumnLayout, IndexColumn, ROWID_SENTINEL};
 use crate::translate::emitter::{emit_check_constraints, emit_make_record, UpdateRowSource};
 use crate::translate::expr::{walk_expr, WalkControl};
 use crate::translate::fkeys::{
@@ -408,7 +406,7 @@ pub fn emit_upsert(
         src_reg: ctx.conflict_rowid_reg,
         target_pc: ctx.loop_labels.row_done,
     });
-    let num_cols = ctx.table.columns.len();
+    let num_cols = ctx.table.columns().len();
     let layout = ctx.table.column_layout();
 
     let table_ref_id = table_references
@@ -472,7 +470,7 @@ pub fn emit_upsert(
             crate::translate::expr::emit_custom_type_decode_columns(
                 program,
                 resolver,
-                &bt.columns,
+                bt.columns(),
                 decoded_current,
                 None,
                 &layout,
@@ -482,7 +480,7 @@ pub fn emit_upsert(
             crate::translate::expr::emit_custom_type_decode_columns(
                 program,
                 resolver,
-                &bt.columns,
+                bt.columns(),
                 new_start,
                 None,
                 &layout,
@@ -498,7 +496,7 @@ pub fn emit_upsert(
             crate::translate::expr::emit_custom_type_decode_columns(
                 program,
                 resolver,
-                &bt.columns,
+                bt.columns(),
                 decoded_excluded,
                 None,
                 &layout,
@@ -585,8 +583,8 @@ pub fn emit_upsert(
     if ctx.table.has_virtual_columns() {
         let rowid_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
         let dml_ctx =
-            DmlColumnContext::layout(&ctx.table.columns, new_start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, ctx.table.columns.iter(), &dml_ctx, resolver)?;
+            DmlColumnContext::layout(ctx.table.columns(), new_start, rowid_reg, layout.clone());
+        compute_virtual_columns(program, ctx.table.columns().iter(), &dml_ctx, resolver)?;
     }
 
     if let Some(bt) = table.btree() {
@@ -609,7 +607,7 @@ pub fn emit_upsert(
             crate::translate::expr::emit_custom_type_encode_columns(
                 program,
                 resolver,
-                &bt.columns,
+                bt.columns(),
                 new_start,
                 None,
                 &bt.name,
@@ -628,7 +626,7 @@ pub fn emit_upsert(
             // This must happen early so that both index records and the table record
             // use the converted values.
             let affinity = bt
-                .columns
+                .columns()
                 .iter()
                 .filter(|c| !c.is_virtual_generated())
                 .map(|c| c.affinity());
@@ -651,7 +649,7 @@ pub fn emit_upsert(
             resolver,
             &bt.name,
             new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg),
-            bt.columns.iter().enumerate().filter_map(|(idx, col)| {
+            bt.columns().iter().enumerate().filter_map(|(idx, col)| {
                 col.name
                     .as_deref()
                     .map(|n| (n, layout.to_register(new_start, idx)))
@@ -667,7 +665,7 @@ pub fn emit_upsert(
     // Expand to include virtual columns that transitively depend on SET columns,
     // so that indexes on virtual columns are correctly updated.
     let changed_cols = if ctx.table.has_virtual_columns() {
-        columns_affected_by_update(table.columns(), &changed_cols)
+        ctx.table.columns_affected_by_update(&changed_cols)?
     } else {
         changed_cols
     };
@@ -1282,8 +1280,8 @@ pub fn emit_upsert(
     if !returning.is_empty() && ctx.table.has_virtual_columns() {
         let rowid_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
         let dml_ctx =
-            DmlColumnContext::layout(&ctx.table.columns, new_start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, ctx.table.columns.iter(), &dml_ctx, resolver)?;
+            DmlColumnContext::layout(ctx.table.columns(), new_start, rowid_reg, layout.clone());
+        compute_virtual_columns(program, ctx.table.columns().iter(), &dml_ctx, resolver)?;
     }
 
     // RETURNING from NEW image + final rowid

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -109,6 +109,7 @@ pub fn translate_create_materialized_view(
         rowid_alias_conflict_clause: None,
         has_virtual_columns: false,
         logical_to_physical_map,
+        column_dependencies: Default::default(),
     });
 
     // Allocate a cursor for writing to the view's btree during population

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -558,6 +558,7 @@ impl EmitWindow {
             rowid_alias_conflict_clause: None,
             has_virtual_columns: false,
             logical_to_physical_map,
+            column_dependencies: Default::default(),
         });
         let cursor_buffer_read =
             program.alloc_cursor_id(CursorType::BTreeTable(buffer_table.clone()));

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -399,14 +399,14 @@ impl CursorType {
     pub fn get_explain_description(&self) -> String {
         let out = match self {
             CursorType::BTreeTable(btree_table) => {
-                let mut col_count = btree_table.columns.len();
+                let mut col_count = btree_table.columns().len();
                 if btree_table.get_rowid_alias_column().is_none() {
                     col_count += 1;
                 }
                 Some((
                     col_count,
                     btree_table
-                        .columns
+                        .columns()
                         .iter()
                         .map(|col| {
                             if let Some(coll) = col.collation_opt() {
@@ -1700,7 +1700,7 @@ impl ProgramBuilder {
         let (_, cursor_type) = self.cursor_ref.get(cursor_id).expect("cursor_id is valid");
         if let CursorType::BTreeTable(btree) = cursor_type {
             let column_def = btree
-                .columns
+                .columns()
                 .get(column)
                 .expect("column index out of bounds");
             if column_def.is_rowid_alias() {
@@ -1733,7 +1733,7 @@ impl ProgramBuilder {
 
         if let CursorType::BTreeTable(btree) = cursor_type {
             let column_def = btree
-                .columns
+                .columns()
                 .get(column)
                 .expect("column index out of bounds");
             turso_assert!(
@@ -1750,9 +1750,9 @@ impl ProgramBuilder {
 
         let default = 'value: {
             let default = match cursor_type {
-                CursorType::BTreeTable(btree) => &btree.columns[column].default,
+                CursorType::BTreeTable(btree) => &btree.columns()[column].default,
                 CursorType::BTreeIndex(index) => &index.columns[column].default,
-                CursorType::MaterializedView(btree, _) => &btree.columns[column].default,
+                CursorType::MaterializedView(btree, _) => &btree.columns()[column].default,
                 _ => break 'value None,
             };
 
@@ -1777,8 +1777,8 @@ impl ProgramBuilder {
             // pCol->affinity. This ensures e.g. ALTER TABLE ADD COLUMN c TEXT
             // DEFAULT 0 returns text "0" rather than integer 0 for pre-existing rows.
             let affinity = match cursor_type {
-                CursorType::BTreeTable(btree) => btree.columns[column].affinity(),
-                CursorType::MaterializedView(btree, _) => btree.columns[column].affinity(),
+                CursorType::BTreeTable(btree) => btree.columns()[column].affinity(),
+                CursorType::MaterializedView(btree, _) => btree.columns()[column].affinity(),
                 _ => Affinity::Blob,
             };
             if let Some(converted) = affinity.convert(&value) {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1114,9 +1114,9 @@ pub fn op_open_read(
     }
     let cursors = &mut state.cursors;
     let num_columns = match cursor_type {
-        CursorType::BTreeTable(table_rc) => table_rc.columns.len(),
+        CursorType::BTreeTable(table_rc) => table_rc.columns().len(),
         CursorType::BTreeIndex(index_arc) => index_arc.columns.len(),
-        CursorType::MaterializedView(table_rc, _) => table_rc.columns.len(),
+        CursorType::MaterializedView(table_rc, _) => table_rc.columns().len(),
         _ => unreachable!("This should not have happened"),
     };
 
@@ -1889,7 +1889,7 @@ pub fn op_type_check(
     assert!(table_reference.is_strict);
     state.registers[*start_reg..*start_reg + *count]
         .iter_mut()
-        .zip(table_reference.columns.iter())
+        .zip(table_reference.columns().iter())
         .try_for_each(|(reg, col)| {
             // INT PRIMARY KEY is not row_id_alias so we throw error if this col is NULL
             if !col.is_rowid_alias() && col.primary_key() && matches!(reg.get_value(), Value::Null)
@@ -10079,8 +10079,8 @@ pub fn op_open_write(
                 .replace(Cursor::new_btree(cursor));
         } else {
             let num_columns = match cursor_type {
-                CursorType::BTreeTable(table_rc) => table_rc.columns.len(),
-                CursorType::MaterializedView(table_rc, _) => table_rc.columns.len(),
+                CursorType::BTreeTable(table_rc) => table_rc.columns().len(),
+                CursorType::MaterializedView(table_rc, _) => table_rc.columns().len(),
                 _ => unreachable!(
                     "Expected BTreeTable or MaterializedView. This should not have happened."
                 ),
@@ -11540,7 +11540,7 @@ pub fn op_open_ephemeral(
                 .expect("cursor_id should exist in cursor_ref");
 
             let num_columns = match cursor_type {
-                CursorType::BTreeTable(table_rc) => table_rc.columns.len(),
+                CursorType::BTreeTable(table_rc) => table_rc.columns().len(),
                 CursorType::BTreeIndex(index_arc) => index_arc.columns.len(),
                 _ => unreachable!("This should not have happened"),
             };
@@ -11654,7 +11654,7 @@ pub fn op_open_dup(
             let cursor = Box::new(BTreeCursor::new_table(
                 pager,
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
-                table.columns.len(),
+                table.columns().len(),
             ));
             let cursor: Box<dyn CursorTrait> = if !is_ephemeral {
                 if let Some(tx_id) = program.connection.get_mv_tx_id() {
@@ -12326,9 +12326,9 @@ pub fn op_drop_column(
         };
 
         let btree = Arc::make_mut(btree);
-        btree.columns.remove(*column_index);
+        btree.columns_mut().remove(*column_index);
         btree.logical_to_physical_map =
-            crate::schema::BTreeTable::build_logical_to_physical_map(&btree.columns);
+            crate::schema::BTreeTable::build_logical_to_physical_map(btree.columns());
         // Remove column-level CHECK constraints for the dropped column
         let col_name = column_name.clone();
         btree.check_constraints.retain(|c| {
@@ -12337,7 +12337,7 @@ pub fn op_drop_column(
                 .is_none_or(|col| normalize_ident(col) != normalize_ident(&col_name))
         });
 
-        btree.has_virtual_columns = btree.columns.iter().any(|c| c.is_virtual_generated());
+        btree.has_virtual_columns = btree.columns().iter().any(|c| c.is_virtual_generated());
         btree.shift_generated_column_indices_after_drop(*column_index)?;
         Ok(())
     })?;
@@ -12424,9 +12424,9 @@ pub fn op_add_column(
         };
 
         let btree = Arc::make_mut(btree);
-        btree.columns.push((**column).clone());
+        btree.columns_mut().push((**column).clone());
         btree.logical_to_physical_map =
-            crate::schema::BTreeTable::build_logical_to_physical_map(&btree.columns);
+            crate::schema::BTreeTable::build_logical_to_physical_map(btree.columns());
         // Update CHECK constraints to include any constraints from the new column
         btree.check_constraints.clone_from(check_constraints);
         // Update foreign keys to include any FK constraints from the new column
@@ -12540,7 +12540,7 @@ pub fn op_alter_column(
         };
         let btree = Arc::make_mut(btree_arc);
         let existing_column_name = btree
-            .columns
+            .columns()
             .get(*column_index)
             .expect("column being ALTERed should be in schema");
         let existing_column_name = existing_column_name
@@ -12565,14 +12565,14 @@ pub fn op_alter_column(
             }
         }
         if *rename {
-            btree.columns[*column_index].name = Some(new_name.clone());
+            btree.columns_mut()[*column_index].name = Some(new_name.clone());
         } else {
-            btree.columns[*column_index] = new_column.clone();
+            btree.columns_mut()[*column_index] = new_column.clone();
         }
 
         btree.prepare_generated_columns()?;
         btree.logical_to_physical_map =
-            crate::schema::BTreeTable::build_logical_to_physical_map(&btree.columns);
+            crate::schema::BTreeTable::build_logical_to_physical_map(btree.columns());
 
         // Keep primary_key_columns consistent (names may change on rename)
         for (pk_name, _ord) in &mut btree.primary_key_columns {
@@ -12604,7 +12604,7 @@ pub fn op_alter_column(
         // Maintain rowid-alias bit after change/rename (INTEGER PRIMARY KEY)
         if !*rename {
             // recompute alias from `new_column`
-            btree.columns[*column_index].set_rowid_alias(new_column.is_rowid_alias());
+            btree.columns_mut()[*column_index].set_rowid_alias(new_column.is_rowid_alias());
         }
 
         // Update this table's OWN foreign keys

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -580,7 +580,7 @@ pub fn insn_to_row(
                 let cursor_type = &program.cursor_ref[*cursor_id].1;
                 let column_name: Option<&String> = match cursor_type {
                     CursorType::BTreeTable(table) => {
-                        let name = table.columns.get(*column).and_then(|v| v.name.as_ref());
+                        let name = table.columns().get(*column).and_then(|v| v.name.as_ref());
                         name
                     }
                     CursorType::BTreeIndex(index) => {
@@ -588,7 +588,7 @@ pub fn insn_to_row(
                         Some(name)
                     }
                     CursorType::MaterializedView(table, _) => {
-                        let name = table.columns.get(*column).and_then(|v| v.name.as_ref());
+                        let name = table.columns().get(*column).and_then(|v| v.name.as_ref());
                         name
                     }
                     CursorType::Pseudo(_) => None,

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -793,7 +793,7 @@ pub(crate) fn build_copy_sql(
     // Collect non-virtual-generated columns with their quoted names.
     let mut data_columns: Vec<String> = Vec::new();
     let mut rowid_alias_col_idx: Option<usize> = None;
-    for (i, col) in btree.columns.iter().enumerate() {
+    for (i, col) in btree.columns().iter().enumerate() {
         if col.is_virtual_generated() {
             continue;
         }
@@ -838,7 +838,7 @@ pub(crate) fn build_copy_sql(
             // Remove the rowid alias column from data_columns (it IS the rowid)
             let mut filtered: Vec<&str> = Vec::new();
             let mut col_physical_idx = 0;
-            for (i, col) in btree.columns.iter().enumerate() {
+            for (i, col) in btree.columns().iter().enumerate() {
                 if col.is_virtual_generated() {
                     continue;
                 }


### PR DESCRIPTION
## Description

Previously, `columns_affected_by_update` and `dependencies_of_columns` walked each generated column expression on every invocation. This was wasteful. Plus, at schema load, we walked the schema to verify that there weren't any cycles between generated columns. This PR computes everything upfront, and caches the results.

## Description of AI Usage

Claude Code, lots of iterations, and careful review