### PR TITLE
Update compatibility status for unistr() and unistr_quote()

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -307,7 +307,8 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | unicode(X)                   | ✅ Yes     |                                                      |
 | unlikely(X)                  | ✅ Yes     |                                                      |
 | upper(X)                     | ✅ Yes     |                                                      |
-| unistr(X)                    | ❌ No      |                                                      |
+| unistr(X)                    | ✅ Yes     |                                                      |
+| unistr_quote(X)              | ✅ Yes     |                                                      |
 | zeroblob(N)                  | ✅ Yes     |                                                      |
 
 #### Mathematical functions


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description
Update compat.md to correctly shows unistr() and unistr_quote() are now supported.

## Motivation and context
These prs added support or unistr() and unistr_quote():
https://github.com/tursodatabase/turso/pull/6132
https://github.com/tursodatabase/turso/pull/6216


## Description of AI Usage
None
