### PR TITLE
Fix encryption cipher mapping in promise API and add tests

### DIFF
--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -270,6 +270,45 @@ test('blobs', async () => {
     expect(rows).toEqual([{ x: Buffer.from([16, 32]) }])
 })
 
+test('encryption', async () => {
+    const path = `test-encryption-${(Math.random() * 10000) | 0}.db`;
+    const hexkey = 'b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';
+    const wrongKey = 'aaaaaaa4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327';
+    try {
+        const db = await connect(path, {
+            encryption: { cipher: 'aegis256', hexkey }
+        });
+        await db.exec("CREATE TABLE t(x)");
+        await db.exec("INSERT INTO t SELECT 'secret' FROM generate_series(1, 1024)");
+        await db.exec("PRAGMA wal_checkpoint(truncate)");
+        db.close();
+
+        // Re-open with the same key - should work
+        const db2 = await connect(path, {
+            encryption: { cipher: 'aegis256', hexkey }
+        });
+        const rows = await db2.prepare("SELECT COUNT(*) as cnt FROM t").all();
+        expect(rows).toEqual([{ cnt: 1024 }]);
+        db2.close();
+
+        // Opening with wrong key MUST fail
+        await expect(async () => {
+            const db3 = await connect(path, {
+                encryption: { cipher: 'aegis256', hexkey: wrongKey }
+            });
+            await db3.prepare("SELECT * FROM t").all();
+        }).rejects.toThrow();
+
+        // Opening without encryption MUST fail
+        await expect(async () => {
+            const db4 = await connect(path);
+            await db4.prepare("SELECT * FROM t").all();
+        }).rejects.toThrow();
+    } finally {
+        unlinkSync(path);
+    }
+})
+
 
 test('example-1', async () => {
     const db = await connect(':memory:');

--- a/bindings/javascript/packages/native/promise.ts
+++ b/bindings/javascript/packages/native/promise.ts
@@ -1,9 +1,33 @@
-import { DatabasePromise, NativeDatabase, SqliteError, DatabaseOpts } from "@tursodatabase/database-common"
-import { Database as NativeDB } from "#index";
+import { DatabasePromise, NativeDatabase, SqliteError, DatabaseOpts, EncryptionCipher } from "@tursodatabase/database-common"
+import { Database as NativeDB, EncryptionCipher as NativeEncryptionCipher } from "#index";
+
+// Map string cipher names to native enum values (lazy to avoid errors if native module lacks encryption)
+function getCipherValue(cipher: EncryptionCipher): number {
+    if (!NativeEncryptionCipher) {
+        throw new Error('Encryption is not supported in this build');
+    }
+    const cipherMap: Record<EncryptionCipher, number> = {
+        'aes128gcm': NativeEncryptionCipher.Aes128Gcm,
+        'aes256gcm': NativeEncryptionCipher.Aes256Gcm,
+        'aegis256': NativeEncryptionCipher.Aegis256,
+        'aegis256x2': NativeEncryptionCipher.Aegis256x2,
+        'aegis128l': NativeEncryptionCipher.Aegis128l,
+        'aegis128x2': NativeEncryptionCipher.Aegis128x2,
+        'aegis128x4': NativeEncryptionCipher.Aegis128x4,
+    };
+    return cipherMap[cipher];
+}
 
 class Database extends DatabasePromise {
     constructor(path: string, opts: DatabaseOpts = {}) {
-        super(new NativeDB(path, opts) as unknown as NativeDatabase)
+        const nativeOpts: any = { ...opts };
+        if (opts.encryption) {
+            nativeOpts.encryption = {
+                cipher: getCipherValue(opts.encryption.cipher),
+                hexkey: opts.encryption.hexkey,
+            };
+        }
+        super(new NativeDB(path, nativeOpts) as unknown as NativeDatabase)
     }
 }
 


### PR DESCRIPTION
The promise.ts wrapper was passing string cipher names directly to the native NAPI module, which expects numeric enum values. Map string cipher names (e.g. 'aegis256') to native EncryptionCipher enum values, matching the existing fix in compat.ts. Add encryption test to promise.test.ts.

