### PR TITLE
bindings/javascript: Make Database.prepare() return a promise

### DIFF
--- a/bindings/javascript/packages/native/index.d.ts
+++ b/bindings/javascript/packages/native/index.d.ts
@@ -41,9 +41,9 @@ export declare class Database {
    *
    * # Returns
    *
-   * A `Statement` instance.
+   * A promise resolving to a `Statement` instance.
    */
-  prepare(sql: string): Statement
+  prepare(sql: string): Promise<Statement>
   executor(sql: string, queryOptions?: QueryOptions | undefined | null): BatchExecutor
   /**
    * Returns the rowid of the last row inserted.

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -452,8 +452,8 @@ impl Database {
     ///
     /// # Returns
     ///
-    /// A `Statement` instance.
-    #[napi]
+    /// A promise resolving to a `Statement` instance.
+    #[napi(ts_return_type = "Promise<Statement>")]
     pub fn prepare(&self, sql: String) -> napi::Result<Statement> {
         let inner = self.inner()?;
         let stmt = self


### PR DESCRIPTION
Make the prepare() method signature the same as libSQL and serverless one.