### PR TITLE
Add CREATE DOMAIN / DROP DOMAIN support

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -998,12 +998,23 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         sync_mode: SyncMode,
     ) -> Self {
         let pager = connection.pager.load().clone();
+        // Use the connection's tx-level schema_did_change flag as the
+        // single source of truth.  This flag is set by SetCookie(SchemaVersion)
+        // which every DDL emits, so it covers all schema-changing operations
+        // including ones that don't write to sqlite_schema (e.g. AddType
+        // writing to __turso_internal_types for custom types).
+        let schema_did_change_from_tx = matches!(
+            connection.get_tx_state(),
+            crate::connection::TransactionState::Write {
+                schema_did_change: true
+            }
+        );
         Self {
             state,
             is_finalized: false,
             #[cfg(any(test, injected_yields))]
             yield_instance_id: connection.next_yield_instance_id(),
-            did_commit_schema_change: false,
+            did_commit_schema_change: schema_did_change_from_tx,
             tx_id,
             connection,
             write_set: Vec::new(),
@@ -1303,9 +1314,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
         };
 
-        let collect_versions = |id: &RowID,
-                                log_record: &mut LogRecord,
-                                did_commit_schema: &mut bool| {
+        let collect_versions = |id: &RowID, log_record: &mut LogRecord| {
             if let Some(row_versions) = mvcc_store.rows.get(id) {
                 let row_versions = row_versions.value().read();
                 for row_version in row_versions.iter() {
@@ -1317,9 +1326,6 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                             // transaction's end timestamp. See Hekaton page 299.
                             committed_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                             changed = true;
-                            if committed_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                                *did_commit_schema = true;
-                            }
                         }
                     }
                     if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
@@ -1328,9 +1334,6 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                             // transaction's end timestamp. See Hekaton page 299.
                             committed_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                             changed = true;
-                            if committed_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                                *did_commit_schema = true;
-                            }
                         }
                     }
                     if changed {
@@ -1379,16 +1382,16 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
         };
 
-        // First pass: schema rows only
+        // First pass: schema rows only (ordering matters for recovery)
         for id in &self.write_set {
             if id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(id, &mut log_record, &mut self.did_commit_schema_change);
+                collect_versions(id, &mut log_record);
             }
         }
         // Second pass: all non-schema rows
         for id in &self.write_set {
             if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(id, &mut log_record, &mut self.did_commit_schema_change);
+                collect_versions(id, &mut log_record);
             }
         }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9073,3 +9073,31 @@ fn test_drop_recreate_indexed_table_many_inserts_restart() {
         }
     }
 }
+
+/// What this test checks: CREATE TYPE (which writes to __turso_internal_types,
+/// not sqlite_schema) is visible to a second connection under MVCC.
+/// Why this matters: The commit phase must detect schema changes even when no
+/// rows are written to sqlite_schema. Without the fix, did_commit_schema_change
+/// stayed false and the second connection never reloaded the schema.
+#[test]
+fn test_create_type_visible_to_second_connection_under_mvcc() {
+    let db =
+        MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new().with_custom_types(true));
+
+    // conn1: define a custom type
+    let conn1 = db.connect();
+    conn1
+        .execute("CREATE TYPE my_uint(value any) BASE text ENCODE my_uint_enc(value) DECODE my_uint_dec(value)")
+        .unwrap();
+    conn1.close().unwrap();
+
+    // conn2: the type should be visible without reopening the database
+    let conn2 = db.connect();
+    let rows = get_rows(
+        &conn2,
+        "SELECT name FROM sqlite_turso_types WHERE name LIKE 'my_uint%'",
+    );
+    assert_eq!(rows.len(), 1, "CREATE TYPE should be visible to conn2");
+    assert_eq!(rows[0][0].to_string(), "my_uint(value any)");
+    conn2.close().unwrap();
+}

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -179,13 +179,50 @@ pub const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
 
 use crate::util::quote_identifier as quote_ident;
 
-/// Escape a string literal for SQL single-quote context.
-/// The value goes inside the surrounding quotes already present in the format string.
-fn quote_string_literal(s: &str) -> String {
-    s.replace('\'', "''")
+/// Recursively rewrite `Expr::Id("value")` (case-insensitive) to `Expr::Id(col_name)`.
+fn rewrite_value_to_column(expr: &ast::Expr, col_name: &str) -> Box<ast::Expr> {
+    let mut cloned = expr.clone();
+    let _ = walk_expr_mut(&mut cloned, &mut |e| {
+        if let ast::Expr::Id(name) = e {
+            if name.as_str().eq_ignore_ascii_case("value") {
+                *e = ast::Expr::Id(ast::Name::exact(col_name.to_string()));
+            }
+        }
+        Ok(WalkControl::Continue)
+    });
+    Box::new(cloned)
 }
 
 /// Custom type definition, loaded from sqlite_turso_types
+#[derive(Debug, Clone)]
+/// A fully-resolved custom type: the chain of TypeDefs from the named type
+/// up to the ultimate primitive, plus the primitive name itself.
+pub struct ResolvedType {
+    /// The ultimate primitive type name (e.g., "integer", "text", "blob").
+    pub primitive: String,
+    /// TypeDefs from child (the named type) to ancestor (closest to primitive).
+    pub chain: Vec<Arc<TypeDef>>,
+}
+
+impl ResolvedType {
+    /// The leaf (directly named) type definition.
+    pub fn leaf(&self) -> &TypeDef {
+        &self.chain[0]
+    }
+
+    /// Whether the leaf type is a domain.
+    pub fn is_domain(&self) -> bool {
+        self.chain[0].is_domain
+    }
+
+    /// Find the first DEFAULT expression in the type chain (child first, then ancestors).
+    /// Matches PostgreSQL: a child domain inherits the parent's DEFAULT when it
+    /// doesn't declare its own.
+    pub fn default_expr(&self) -> Option<&ast::Expr> {
+        self.chain.iter().find_map(|td| td.default.as_deref())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TypeDef {
     pub name: String,
@@ -196,11 +233,24 @@ pub struct TypeDef {
     pub operators: Vec<TypeOperator>,
     pub default: Option<Box<ast::Expr>>,
     pub is_builtin: bool,
+    pub not_null: bool,
+    /// Whether this is a domain (CREATE DOMAIN) vs a custom type (CREATE TYPE).
+    pub is_domain: bool,
+    /// Original SQL for round-trip persistence. Stored verbatim from creation.
+    pub sql: String,
+    /// CHECK constraints from CREATE DOMAIN, stored as first-class data.
+    /// Empty for regular CREATE TYPE definitions.
+    pub domain_checks: Vec<ast::DomainConstraint>,
 }
 
 impl TypeDef {
     /// Construct a TypeDef from a parsed CREATE TYPE statement.
-    pub fn from_create_type(type_name: &str, body: &ast::CreateTypeBody, is_builtin: bool) -> Self {
+    pub fn from_create_type(
+        type_name: &str,
+        body: &ast::CreateTypeBody,
+        is_builtin: bool,
+        sql: String,
+    ) -> Self {
         Self {
             name: type_name.to_string(),
             params: body.params.clone(),
@@ -210,6 +260,36 @@ impl TypeDef {
             operators: body.operators.clone(),
             default: body.default.clone(),
             is_builtin,
+            not_null: false,
+            is_domain: false,
+            sql,
+            domain_checks: Vec::new(),
+        }
+    }
+
+    /// Construct a TypeDef from a parsed CREATE DOMAIN statement.
+    /// Stores constraints as first-class data for propagation to table CHECK constraints.
+    pub fn from_domain(
+        domain_name: &str,
+        base_type: &str,
+        not_null: bool,
+        constraints: &[ast::DomainConstraint],
+        default: Option<Box<ast::Expr>>,
+        sql: String,
+    ) -> Self {
+        Self {
+            name: domain_name.to_string(),
+            params: Vec::new(),
+            base: base_type.to_string(),
+            encode: None,
+            decode: None,
+            operators: Vec::new(),
+            default,
+            is_builtin: false,
+            not_null,
+            is_domain: true,
+            sql,
+            domain_checks: constraints.to_vec(),
         }
     }
 
@@ -232,50 +312,9 @@ impl TypeDef {
             .filter(|p| !p.name.eq_ignore_ascii_case("value"))
     }
 
-    /// Reconstruct the CREATE TYPE SQL string from this definition.
-    pub fn to_sql(&self) -> String {
-        let mut sql = if self.params.is_empty() {
-            format!(
-                "CREATE TYPE {} BASE {}",
-                quote_ident(&self.name),
-                quote_ident(&self.base)
-            )
-        } else {
-            let params: Vec<String> = self
-                .params
-                .iter()
-                .map(|p| match &p.ty {
-                    Some(ty) => format!("{} {}", quote_ident(&p.name), ty),
-                    None => quote_ident(&p.name),
-                })
-                .collect();
-            format!(
-                "CREATE TYPE {}({}) BASE {}",
-                quote_ident(&self.name),
-                params.join(", "),
-                quote_ident(&self.base)
-            )
-        };
-        if let Some(ref encode) = self.encode {
-            sql.push_str(&format!(" ENCODE {encode}"));
-        }
-        if let Some(ref decode) = self.decode {
-            sql.push_str(&format!(" DECODE {decode}"));
-        }
-        if let Some(ref default) = self.default {
-            sql.push_str(&format!(" DEFAULT {default}"));
-        }
-        for op in &self.operators {
-            match &op.func_name {
-                Some(func_name) => sql.push_str(&format!(
-                    " OPERATOR '{}' {}",
-                    quote_string_literal(&op.op),
-                    quote_ident(func_name)
-                )),
-                None => sql.push_str(&format!(" OPERATOR '{}'", quote_string_literal(&op.op),)),
-            }
-        }
-        sql
+    /// Returns the original SQL used to create this type or domain.
+    pub fn to_sql(&self) -> &str {
+        &self.sql
     }
 }
 
@@ -445,7 +484,7 @@ fn bootstrap_builtin_types(registry: &mut HashMap<String, Arc<TypeDef>>) {
             panic!("Failed to parse built-in type SQL: {sql}");
         };
 
-        let type_def = TypeDef::from_create_type(&type_name, &body, true);
+        let type_def = TypeDef::from_create_type(&type_name, &body, true, sql.to_string());
         registry.insert(type_name.to_lowercase(), Arc::new(type_def));
     }
 
@@ -543,8 +582,64 @@ impl Schema {
         self.type_registry.get(&type_name.to_lowercase())
     }
 
+    /// Resolve a custom type fully: look it up (with strictness gate) and chase
+    /// the base-type chain to the ultimate primitive.
+    /// Returns `Ok(None)` if the type is not registered (or the table isn't strict).
+    pub fn resolve_type(
+        &self,
+        type_name: &str,
+        is_strict: bool,
+    ) -> crate::Result<Option<ResolvedType>> {
+        if !is_strict {
+            return Ok(None);
+        }
+        self.resolve_type_unchecked(type_name)
+    }
+
+    /// Resolve a custom type fully without a strictness check.
+    /// Returns `Ok(None)` if the type is not in the registry.
+    pub fn resolve_type_unchecked(&self, type_name: &str) -> crate::Result<Option<ResolvedType>> {
+        let key = type_name.to_lowercase();
+        if !self.type_registry.contains_key(&key) {
+            return Ok(None);
+        }
+        let (primitive, chain) = self.resolve_base_type_chain(type_name)?;
+        Ok(Some(ResolvedType { primitive, chain }))
+    }
+
     pub fn remove_type(&mut self, type_name: &str) {
         self.type_registry.remove(&type_name.to_lowercase());
+    }
+
+    /// Chase the base type chain: domain_a → domain_b → integer
+    /// Returns (ultimate_primitive, ordered_chain_of_TypeDefs)
+    /// The chain is ordered from child to ancestor.
+    /// Errors on cycles or missing intermediate types.
+    pub fn resolve_base_type_chain(
+        &self,
+        type_name: &str,
+    ) -> crate::Result<(String, Vec<Arc<TypeDef>>)> {
+        let mut chain = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+        let mut current = type_name.to_lowercase();
+
+        loop {
+            if !visited.insert(current.clone()) {
+                return Err(crate::LimboError::ParseError(format!(
+                    "circular type dependency detected: {current}"
+                )));
+            }
+            match self.type_registry.get(&current) {
+                Some(td) => {
+                    chain.push(Arc::clone(td));
+                    current = td.base.to_lowercase();
+                }
+                None => {
+                    // current is not in the registry — it's a primitive
+                    return Ok((current, chain));
+                }
+            }
+        }
     }
 
     /// Parse a CREATE TYPE SQL string and add the type to the in-memory registry.
@@ -553,18 +648,40 @@ impl Schema {
         use turso_parser::parser::Parser;
 
         let mut parser = Parser::new(sql.as_bytes());
-        let Ok(Some(Cmd::Stmt(Stmt::CreateType {
-            type_name, body, ..
-        }))) = parser.next_cmd()
-        else {
-            return Err(crate::LimboError::ParseError(format!(
-                "invalid type sql: {sql}"
-            )));
-        };
-
-        let type_def = TypeDef::from_create_type(&type_name, &body, false);
-        self.type_registry
-            .insert(type_name.to_lowercase(), Arc::new(type_def));
+        let cmd = parser.next_cmd();
+        match cmd {
+            Ok(Some(Cmd::Stmt(Stmt::CreateType {
+                type_name, body, ..
+            }))) => {
+                let type_def = TypeDef::from_create_type(&type_name, &body, false, sql.to_string());
+                self.type_registry
+                    .insert(type_name.to_lowercase(), Arc::new(type_def));
+            }
+            Ok(Some(Cmd::Stmt(Stmt::CreateDomain {
+                domain_name,
+                base_type,
+                default,
+                not_null,
+                constraints,
+                ..
+            }))) => {
+                let type_def = TypeDef::from_domain(
+                    &domain_name,
+                    &base_type,
+                    not_null,
+                    &constraints,
+                    default,
+                    sql.to_string(),
+                );
+                self.type_registry
+                    .insert(domain_name.to_lowercase(), Arc::new(type_def));
+            }
+            _ => {
+                return Err(crate::LimboError::ParseError(format!(
+                    "invalid type sql: {sql}"
+                )));
+            }
+        }
         Ok(())
     }
 
@@ -595,6 +712,7 @@ impl Schema {
             let bt = table.btree().expect("checked btree table");
             let mut modified = (*bt).clone();
             modified.resolve_custom_type_affinities(self);
+            modified.propagate_domain_constraints(self);
             tables.push((name.clone(), Arc::new(Table::BTree(Arc::new(modified)))));
         }
         for (name, table) in tables {
@@ -1411,6 +1529,7 @@ impl Schema {
 
                     let mut table = table;
                     table.resolve_custom_type_affinities(self);
+                    table.propagate_domain_constraints(self);
                     self.add_btree_table(Arc::new(table))?;
                 }
             }
@@ -2279,8 +2398,8 @@ impl BTreeTable {
             if col.is_array() {
                 // Arrays are stored as record-format blobs.
                 col.ty_str = "BLOB".to_string();
-            } else if let Some(type_def) = schema.get_type_def(&col.ty_str, table.is_strict) {
-                col.ty_str = type_def.base.to_uppercase();
+            } else if let Ok(Some(resolved)) = schema.resolve_type(&col.ty_str, table.is_strict) {
+                col.ty_str = resolved.primitive.to_uppercase();
             }
         }
         Arc::new(modified)
@@ -2359,12 +2478,58 @@ impl BTreeTable {
                 col.set_base_affinity(Affinity::Blob);
                 continue;
             }
-            if let Some(type_def) = schema.get_type_def_unchecked(&col.ty_str) {
-                let (base_ty, _) = type_from_name(&type_def.base);
+            if let Ok(Some(resolved)) = schema.resolve_type_unchecked(&col.ty_str) {
+                let (base_ty, _) = type_from_name(&resolved.primitive);
                 col.set_ty(base_ty);
-                col.set_base_affinity(Affinity::affinity(&type_def.base));
+                col.set_base_affinity(Affinity::affinity(&resolved.primitive));
             }
         }
+    }
+
+    /// Propagate domain NOT NULL and CHECK constraints to table columns.
+    /// For each column whose type resolves to a domain, this:
+    /// - Sets the column's NOT NULL flag if any domain in the chain has NOT NULL
+    /// - Adds domain CHECK constraints (with `value` rewritten to the column name)
+    ///   to the table's check_constraints list
+    pub fn propagate_domain_constraints(&mut self, schema: &Schema) {
+        if !self.is_strict {
+            return;
+        }
+        // Collect new constraints and notnull flags to avoid borrowing issues
+        let mut new_checks = Vec::new();
+        let mut notnull_cols = Vec::new();
+
+        for (col_idx, col) in self.columns.iter().enumerate() {
+            let Ok(Some(resolved)) = schema.resolve_type_unchecked(&col.ty_str) else {
+                continue;
+            };
+            if !resolved.is_domain() {
+                continue;
+            }
+            let col_name = col.name.as_deref().unwrap_or("").to_string();
+            for td in &resolved.chain {
+                if td.not_null {
+                    notnull_cols.push(col_idx);
+                }
+                for (i, dc) in td.domain_checks.iter().enumerate() {
+                    let rewritten = rewrite_value_to_column(&dc.check, &col_name);
+                    let name = dc
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| format!("{}_{}", td.name, i));
+                    new_checks.push(CheckConstraint {
+                        name: Some(name),
+                        expr: *rewritten,
+                        column: Some(col_name.clone()),
+                    });
+                }
+            }
+        }
+
+        for col_idx in notnull_cols {
+            self.columns[col_idx].set_notnull(true);
+        }
+        self.check_constraints.extend(new_checks);
     }
 
     pub fn get_rowid_alias_column(&self) -> Option<(usize, &Column)> {

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1053,14 +1053,14 @@ pub fn translate_alter_table(
                 ));
             }
 
-            let new_column_name = column.name.as_ref().ok_or_else(|| {
+            let new_column_name = column.name.clone().ok_or_else(|| {
                 LimboError::ParseError(
                     "column name is missing in ALTER TABLE ADD COLUMN".to_string(),
                 )
             })?;
-            if btree.get_column(new_column_name).is_some() {
+            if btree.get_column(&new_column_name).is_some() {
                 return Err(LimboError::ParseError(
-                    "duplicate column name: ".to_string() + new_column_name,
+                    "duplicate column name: ".to_string() + &new_column_name,
                 ));
             }
 
@@ -1079,10 +1079,22 @@ pub fn translate_alter_table(
                     || ty.eq_ignore_ascii_case("TEXT")
                     || ty.eq_ignore_ascii_case("BLOB")
                     || ty.eq_ignore_ascii_case("ANY");
+                // Domain types require STRICT tables because domain constraints
+                // (CHECK, NOT NULL, DEFAULT) are only enforced on STRICT tables.
+                if !is_builtin && !btree.is_strict {
+                    let type_def = resolver
+                        .schema()
+                        .get_type_def_unchecked(&normalize_ident(ty));
+                    if let Some(td) = type_def {
+                        if td.is_domain {
+                            return Err(LimboError::ParseError(format!(
+                                "domain type columns require STRICT tables: {table_name}.{new_column_name}"
+                            )));
+                        }
+                    }
+                }
+
                 if !is_builtin && btree.is_strict {
-                    // On non-STRICT tables any type name is allowed and is
-                    // treated as a plain affinity hint (no encode/decode).
-                    // Custom type validation only applies to STRICT tables.
                     let type_def = resolver
                         .schema()
                         .get_type_def_unchecked(&normalize_ident(ty));
@@ -1100,12 +1112,12 @@ pub fn translate_alter_table(
             // one, propagate the type-level DEFAULT to the column so that
             // existing rows get the type default instead of NULL.
             if column.default.is_none() {
-                if let Some(type_def) = resolver
+                if let Ok(Some(resolved)) = resolver
                     .schema()
-                    .get_type_def(&column.ty_str, btree.is_strict)
+                    .resolve_type(&column.ty_str, btree.is_strict)
                 {
-                    if let Some(ref type_default) = type_def.default {
-                        column.default = Some(type_default.clone());
+                    if let Some(type_default) = resolved.default_expr() {
+                        column.default = Some(Box::new(type_default.clone()));
                     }
                 }
             }
@@ -1180,7 +1192,7 @@ pub fn translate_alter_table(
                         btree.check_constraints.push(CheckConstraint::new(
                             constraint.name.as_ref(),
                             expr,
-                            Some(new_column_name),
+                            Some(&new_column_name),
                         ));
                     }
                     _ => {
@@ -1188,6 +1200,16 @@ pub fn translate_alter_table(
                     }
                 }
             }
+
+            // Propagate domain CHECK and NOT NULL constraints to the newly
+            // added column. Without this, columns typed with a domain would
+            // silently skip domain-level enforcement after ALTER TABLE.
+            resolver.with_schema(database_id, |schema| {
+                btree.propagate_domain_constraints(schema);
+            });
+            // Refresh local `column` from btree so that domain NOT NULL is
+            // visible to the empty-table check below.
+            column = btree.columns().last().unwrap().clone();
 
             let escaped = escape_sql_string_literal(&btree.to_sql());
             let escaped_table_name = escape_sql_string_literal(table_name);
@@ -1221,15 +1243,15 @@ pub fn translate_alter_table(
                 )?;
             } else {
                 // Check if we need to verify the table is empty at runtime.
-                let effective_default = column.default.as_ref().or_else(|| {
-                    resolver
-                        .schema()
-                        .get_type_def(&column.ty_str, btree.is_strict)
-                        .and_then(|td| td.default.as_ref())
-                });
+                let type_default = resolver
+                    .schema()
+                    .resolve_type(&column.ty_str, btree.is_strict)
+                    .ok()
+                    .flatten()
+                    .and_then(|r| r.default_expr().cloned());
+                let effective_default = column.default.as_deref().or(type_default.as_ref());
                 let needs_notnull_check = column.notnull()
-                    && effective_default
-                        .is_none_or(|default| crate::util::expr_contains_null(default));
+                    && effective_default.is_none_or(crate::util::expr_contains_null);
 
                 let needs_nondeterministic_check = column
                     .default
@@ -1277,7 +1299,7 @@ pub fn translate_alter_table(
                     program,
                     &btree,
                     &original_btree,
-                    new_column_name,
+                    &new_column_name,
                     &column,
                     &constraints,
                     resolver,

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1423,7 +1423,7 @@ pub fn translate_expr(
 
             // Check if casting to a custom type
             if let Some(ref tn) = type_name {
-                if let Some(type_def) = resolver.schema().get_type_def_unchecked(&tn.name) {
+                if let Some(resolved) = resolver.schema().resolve_type_unchecked(&tn.name)? {
                     // Build ty_params from AST TypeSize so parametric types
                     // (e.g. numeric(10,2)) get their parameters passed through.
                     let ty_params: Vec<Box<ast::Expr>> = match &tn.size {
@@ -1434,6 +1434,44 @@ pub fn translate_expr(
                         None => Vec::new(),
                     };
 
+                    // Domains: apply parent encode chain, then validate constraints
+                    // on the encoded value (domain CHECK sees the stored representation).
+                    if resolved.is_domain() {
+                        // Apply encode from parent custom types (domain itself has encode: None)
+                        let cast_col = Column::new(
+                            None,
+                            tn.name.clone(),
+                            None,
+                            None,
+                            Type::Null,
+                            None,
+                            ColDef::default(),
+                        );
+                        for td in &resolved.chain {
+                            if let Some(ref encode_expr) = td.encode {
+                                emit_type_expr(
+                                    program,
+                                    encode_expr,
+                                    target_register,
+                                    target_register,
+                                    &cast_col,
+                                    td,
+                                    resolver,
+                                )?;
+                            }
+                        }
+
+                        // Validate domain constraints on the encoded value
+                        emit_domain_cast_constraints(
+                            program,
+                            &resolved.chain,
+                            target_register,
+                            resolver,
+                        )?;
+                        return Ok(target_register);
+                    }
+
+                    let type_def = resolved.leaf();
                     // If the custom type requires parameters but the CAST
                     // doesn't provide them (e.g. CAST(x AS NUMERIC) vs
                     // CAST(x AS numeric(10,2))), fall through to regular CAST.
@@ -3231,20 +3269,27 @@ pub fn translate_expr(
                                     *column
                                 };
 
-                                // For custom type columns with a default, suppress the
-                                // default in the Column instruction so we can encode it
-                                // ourselves. Without this, pre-existing rows (from before
-                                // ALTER TABLE ADD COLUMN) would get the raw un-encoded
-                                // default, causing decode to fail.
+                                // For custom type columns with ENCODE/DECODE and a
+                                // default, suppress the default in the Column
+                                // instruction so we can encode it ourselves.  Without
+                                // this, pre-existing rows (from before ALTER TABLE ADD
+                                // COLUMN) would get the raw un-encoded default, causing
+                                // decode to fail.  Pure domain types (CREATE DOMAIN)
+                                // have no encoding, so their defaults must NOT be
+                                // suppressed.  Check the full type chain because a
+                                // domain built on top of a custom type inherits its
+                                // ENCODE/DECODE.
                                 let col_ref = table.get_column_at(column);
                                 if let Some(col) = col_ref {
-                                    if col.default.is_some()
-                                        && resolver
+                                    if col.default.is_some() {
+                                        if let Ok(Some(resolved)) = resolver
                                             .schema()
-                                            .get_type_def(&col.ty_str, table.is_strict())
-                                            .is_some()
-                                    {
-                                        program.flags.set_suppress_column_default(true);
+                                            .resolve_type(&col.ty_str, table.is_strict())
+                                        {
+                                            if resolved.chain.iter().any(|td| td.encode.is_some()) {
+                                                program.flags.set_suppress_column_default(true);
+                                            }
+                                        }
                                     }
                                 }
                                 program.emit_column_or_rowid(read_cursor, column, target_register);
@@ -7273,24 +7318,29 @@ pub(crate) fn emit_user_facing_column_value(
     if column.is_array() {
         return Ok(());
     }
-    if let Some(type_def) = resolver.schema().get_type_def(&column.ty_str, is_strict) {
-        if let Some(ref decode_expr) = type_def.decode {
-            let skip_label = program.allocate_label();
-            program.emit_insn(Insn::IsNull {
-                reg: dest_reg,
-                target_pc: skip_label,
-            });
-            emit_type_expr(
-                program,
-                decode_expr,
-                dest_reg,
-                dest_reg,
-                column,
-                type_def,
-                resolver,
-            )?;
-            program.preassign_label_to_next_insn(skip_label);
+    if let Ok(Some(resolved)) = resolver.schema().resolve_type(&column.ty_str, is_strict) {
+        let skip_label = program.allocate_label();
+        program.emit_insn(Insn::IsNull {
+            reg: dest_reg,
+            target_pc: skip_label,
+        });
+
+        // Apply decode in reverse order (parent/ancestor first, then child)
+        for td in resolved.chain.iter().rev() {
+            if let Some(ref decode_expr) = td.decode {
+                emit_type_expr(
+                    program,
+                    decode_expr,
+                    dest_reg,
+                    dest_reg,
+                    column,
+                    td,
+                    resolver,
+                )?;
+            }
         }
+
+        program.preassign_label_to_next_insn(skip_label);
     }
     Ok(())
 }
@@ -7349,6 +7399,76 @@ pub(crate) fn decode_custom_type_registers_in_expr(
         }
         Ok(WalkControl::Continue)
     })?;
+    Ok(())
+}
+
+/// Emit domain constraint checks for CAST(expr AS domain).
+/// Validates NOT NULL and CHECK constraints from the domain type chain.
+fn emit_domain_cast_constraints(
+    program: &mut ProgramBuilder,
+    chain: &[crate::sync::Arc<TypeDef>],
+    reg: usize,
+    resolver: &Resolver,
+) -> Result<()> {
+    use crate::error::{SQLITE_CONSTRAINT_CHECK, SQLITE_CONSTRAINT_NOTNULL};
+
+    let any_not_null = chain.iter().any(|td| td.not_null);
+
+    if any_not_null {
+        program.emit_insn(Insn::HaltIfNull {
+            target_reg: reg,
+            err_code: SQLITE_CONSTRAINT_NOTNULL,
+            description: format!(
+                "domain {} does not allow null values",
+                chain.first().map(|td| td.name.as_str()).unwrap_or("?")
+            ),
+        });
+    }
+
+    for td in chain {
+        for (i, dc) in td.domain_checks.iter().enumerate() {
+            let constraint_name = dc
+                .name
+                .clone()
+                .unwrap_or_else(|| format!("{}_{}", td.name, i));
+
+            // Bind `value` → reg, translate check expr, verify truthy
+            program
+                .id_register_overrides
+                .insert("value".to_string(), reg);
+
+            let expr_result_reg = program.alloc_register();
+            translate_expr(program, None, &dc.check, expr_result_reg, resolver)?;
+
+            program.id_register_overrides.remove("value");
+
+            let passed_label = program.allocate_label();
+
+            // NULL result passes CHECK constraints (SQLite semantics)
+            program.emit_insn(Insn::IsNull {
+                reg: expr_result_reg,
+                target_pc: passed_label,
+            });
+
+            program.emit_insn(Insn::If {
+                reg: expr_result_reg,
+                target_pc: passed_label,
+                jump_if_null: false,
+            });
+
+            program.emit_insn(Insn::Halt {
+                err_code: SQLITE_CONSTRAINT_CHECK,
+                description: format!(
+                    "value for domain {} violates check constraint \"{}\"",
+                    td.name, constraint_name
+                ),
+                on_error: None,
+                description_reg: None,
+            });
+
+            program.preassign_label_to_next_insn(passed_label);
+        }
+    }
     Ok(())
 }
 
@@ -7693,23 +7813,35 @@ pub(crate) fn emit_custom_type_encode_columns(
         if type_name.is_empty() {
             continue;
         }
-        let Some(type_def) = resolver.schema().get_type_def_unchecked(type_name) else {
-            continue;
-        };
-        let Some(ref encode_expr) = type_def.encode else {
+        let Ok(Some(resolved)) = resolver.schema().resolve_type_unchecked(type_name) else {
             continue;
         };
 
-        // Skip NULL values: jump over encode if NULL
-        let skip_label = program.allocate_label();
-        program.emit_insn(Insn::IsNull {
-            reg,
-            target_pc: skip_label,
-        });
+        // Check if any type in the chain has not_null — if so, don't skip NULLs
+        let any_not_null = resolved.chain.iter().any(|td| td.not_null);
 
-        emit_type_expr(program, encode_expr, reg, reg, col, type_def, resolver)?;
+        let skip_label = if !any_not_null {
+            // Skip NULL values: jump over encode if NULL
+            let label = program.allocate_label();
+            program.emit_insn(Insn::IsNull {
+                reg,
+                target_pc: label,
+            });
+            Some(label)
+        } else {
+            None
+        };
 
-        program.preassign_label_to_next_insn(skip_label);
+        // Apply encode for each type in the chain (child first, then parent)
+        for td in &resolved.chain {
+            if let Some(ref encode_expr) = td.encode {
+                emit_type_expr(program, encode_expr, reg, reg, col, td, resolver)?;
+            }
+        }
+
+        if let Some(label) = skip_label {
+            program.preassign_label_to_next_insn(label);
+        }
     }
     Ok(())
 }
@@ -7752,10 +7884,7 @@ pub(crate) fn emit_custom_type_decode_columns(
         if type_name.is_empty() {
             continue;
         }
-        let Some(type_def) = resolver.schema().get_type_def_unchecked(type_name) else {
-            continue;
-        };
-        let Some(ref decode_expr) = type_def.decode else {
+        let Ok(Some(resolved)) = resolver.schema().resolve_type_unchecked(type_name) else {
             continue;
         };
 
@@ -7766,7 +7895,12 @@ pub(crate) fn emit_custom_type_decode_columns(
             target_pc: skip_label,
         });
 
-        emit_type_expr(program, decode_expr, reg, reg, col, type_def, resolver)?;
+        // Apply decode in reverse order (parent/ancestor first, then child)
+        for td in resolved.chain.iter().rev() {
+            if let Some(ref decode_expr) = td.decode {
+                emit_type_expr(program, decode_expr, reg, reg, col, td, resolver)?;
+            }
+        }
 
         program.preassign_label_to_next_insn(skip_label);
     }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1799,9 +1799,9 @@ fn resolve_defaults_in_row(
         };
         *expr = match col {
             Some(col) => col.default.clone().unwrap_or_else(|| {
-                if let Some(type_def) = resolver.schema().get_type_def(&col.ty_str, is_strict) {
-                    if let Some(ref default_expr) = type_def.default {
-                        return default_expr.clone();
+                if let Ok(Some(resolved)) = resolver.schema().resolve_type(&col.ty_str, is_strict) {
+                    if let Some(default_expr) = resolved.default_expr() {
+                        return Box::new(default_expr.clone());
                     }
                 }
                 Box::new(ast::Expr::Literal(ast::Literal::Null))
@@ -1835,10 +1835,11 @@ fn bind_insert(
                 .filter(|c| !c.hidden() && !c.is_generated())
                 .map(|c| {
                     c.default.clone().unwrap_or_else(|| {
-                        if let Some(type_def) = resolver.schema().get_type_def(&c.ty_str, is_strict)
+                        if let Ok(Some(resolved)) =
+                            resolver.schema().resolve_type(&c.ty_str, is_strict)
                         {
-                            if let Some(ref default_expr) = type_def.default {
-                                return default_expr.clone();
+                            if let Some(default_expr) = resolved.default_expr() {
+                                return Box::new(default_expr.clone());
                             }
                         }
                         Box::new(ast::Expr::Literal(ast::Literal::Null))
@@ -2206,9 +2207,10 @@ fn init_source_emission<'a>(
             let is_strict = table.is_strict();
             values.extend(storable_columns.iter().map(|c| {
                 c.default.clone().unwrap_or_else(|| {
-                    if let Some(type_def) = resolver.schema().get_type_def(&c.ty_str, is_strict) {
-                        if let Some(ref default_expr) = type_def.default {
-                            return default_expr.clone();
+                    if let Ok(Some(resolved)) = resolver.schema().resolve_type(&c.ty_str, is_strict)
+                    {
+                        if let Some(default_expr) = resolved.default_expr() {
+                            return Box::new(default_expr.clone());
                         }
                     }
                     Box::new(ast::Expr::Literal(ast::Literal::Null))
@@ -2662,8 +2664,8 @@ fn translate_column(
         });
     } else if let Some(default_expr) = column.default.as_ref() {
         translate_expr(program, None, default_expr, column_register, resolver)?;
-    } else if let Some(type_def) = resolver.schema().get_type_def(&column.ty_str, is_strict) {
-        if let Some(ref default_expr) = type_def.default {
+    } else if let Ok(Some(resolved)) = resolver.schema().resolve_type(&column.ty_str, is_strict) {
+        if let Some(default_expr) = resolved.default_expr() {
             translate_expr(program, None, default_expr, column_register, resolver)?;
         } else {
             program.emit_insn(Insn::Null {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -145,10 +145,12 @@ pub fn translate_inner(
             | ast::Stmt::CreateMaterializedView { .. }
             | ast::Stmt::CreateVirtualTable(..)
             | ast::Stmt::CreateType { .. }
+            | ast::Stmt::CreateDomain { .. }
             | ast::Stmt::Delete { .. }
             | ast::Stmt::DropIndex { .. }
             | ast::Stmt::DropTable { .. }
             | ast::Stmt::DropType { .. }
+            | ast::Stmt::DropDomain { .. }
             | ast::Stmt::DropView { .. }
             | ast::Stmt::Reindex { .. }
             | ast::Stmt::Optimize { .. }
@@ -308,6 +310,28 @@ pub fn translate_inner(
             }
             schema::translate_create_type(&type_name, &body, if_not_exists, resolver, program)?
         }
+        ast::Stmt::CreateDomain {
+            if_not_exists,
+            domain_name,
+            base_type,
+            default,
+            not_null,
+            constraints,
+        } => {
+            if !connection.experimental_custom_types_enabled() {
+                bail_parse_error!("Custom types require --experimental-custom-types flag");
+            }
+            schema::translate_create_domain(
+                &domain_name,
+                &base_type,
+                not_null,
+                &constraints,
+                default,
+                if_not_exists,
+                resolver,
+                program,
+            )?
+        }
         ast::Stmt::DropType {
             if_exists,
             type_name,
@@ -315,7 +339,16 @@ pub fn translate_inner(
             if !connection.experimental_custom_types_enabled() {
                 bail_parse_error!("Custom types require --experimental-custom-types flag");
             }
-            schema::translate_drop_type(&type_name, if_exists, resolver, program)?
+            schema::translate_drop_type(&type_name, if_exists, false, resolver, program)?
+        }
+        ast::Stmt::DropDomain {
+            if_exists,
+            domain_name,
+        } => {
+            if !connection.experimental_custom_types_enabled() {
+                bail_parse_error!("Custom types require --experimental-custom-types flag");
+            }
+            schema::translate_drop_type(&domain_name, if_exists, true, resolver, program)?
         }
         ast::Stmt::Pragma { .. } => {
             bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -601,11 +601,12 @@ fn resolve_type_name(type_name: &str, resolver: &Resolver) -> Result<CheckExprTy
         return Ok(ty);
     }
     // Check if it's a known custom type
-    if resolver
-        .schema()
-        .get_type_def_unchecked(type_name)
-        .is_some()
-    {
+    if let Ok(Some(resolved)) = resolver.schema().resolve_type_unchecked(type_name) {
+        // Domains are transparent wrappers — resolve to the base primitive type
+        // so CHECK constraint type checking compares primitives, not domain names.
+        if resolved.is_domain() {
+            return resolve_type_name(&resolved.primitive, resolver);
+        }
         return Ok(CheckExprType::CustomType(type_name.to_lowercase()));
     }
     bail_parse_error!("unknown type '{}' in CHECK constraint", type_name);
@@ -793,10 +794,22 @@ fn validate(
                     );
                 }
 
+                // Domain types require STRICT tables because domain constraints
+                // (CHECK, NOT NULL, DEFAULT) are only enforced on STRICT tables.
+                if !is_builtin && !is_strict {
+                    let type_def = resolver.schema().get_type_def_unchecked(type_name);
+                    if let Some(td) = type_def {
+                        if td.is_domain {
+                            bail_parse_error!(
+                                "domain type columns require STRICT tables: {}.{}",
+                                table_name,
+                                c.col_name
+                            );
+                        }
+                    }
+                }
+
                 if !is_builtin && is_strict {
-                    // On non-STRICT tables any type name is allowed and is
-                    // treated as a plain affinity hint (no encode/decode).
-                    // Custom type validation only applies to STRICT tables.
                     let type_def = resolver.schema().get_type_def_unchecked(type_name);
                     {
                         match type_def {
@@ -2370,50 +2383,14 @@ fn validate_type_expr(expr: &ast::Expr, kind: &str, resolver: &Resolver) -> Resu
     Ok(())
 }
 
-pub fn translate_create_type(
-    type_name: &str,
-    body: &ast::CreateTypeBody,
-    if_not_exists: bool,
+/// Shared persistence logic for CREATE TYPE / CREATE DOMAIN.
+/// Persists the type SQL into __turso_internal_types and registers it in memory.
+fn persist_type_definition(
+    normalized_name: String,
+    sql: String,
     resolver: &Resolver,
     program: &mut ProgramBuilder,
 ) -> Result<()> {
-    let normalized_name = normalize_ident(type_name);
-
-    // Reject names that shadow SQLite base types — these are not in the
-    // type_registry but are handled by the column type system. Allowing
-    // them would create confusion and undropable types.
-    let is_base_type = turso_macros::match_ignore_ascii_case!(match normalized_name.as_bytes() {
-        b"INT" | b"INTEGER" | b"REAL" | b"TEXT" | b"BLOB" | b"ANY" => true,
-        _ => false,
-    });
-    if is_base_type {
-        bail_parse_error!("cannot create type \"{normalized_name}\": name is a built-in type");
-    }
-
-    // Check if type already exists
-    if resolver
-        .schema()
-        .get_type_def_unchecked(&normalized_name)
-        .is_some()
-    {
-        if if_not_exists {
-            return Ok(());
-        }
-        bail_parse_error!("type {normalized_name} already exists");
-    }
-
-    // Validate encode/decode expressions for safety
-    if let Some(ref encode) = body.encode {
-        validate_type_expr(encode, "ENCODE", resolver)?;
-    }
-    if let Some(ref decode) = body.decode {
-        validate_type_expr(decode, "DECODE", resolver)?;
-    }
-
-    // Reconstruct the SQL string (without IF NOT EXISTS) using TypeDef::to_sql()
-    let type_def = crate::schema::TypeDef::from_create_type(&normalized_name, body, false);
-    let sql = type_def.to_sql();
-
     // Ensure sqlite_turso_types table exists (lazy creation)
     let types_table: Arc<BTreeTable>;
     let types_root_page: RegisterOrLiteral<i64>;
@@ -2512,13 +2489,195 @@ pub fn translate_create_type(
     Ok(())
 }
 
-pub fn translate_drop_type(
+pub fn translate_create_type(
     type_name: &str,
-    if_exists: bool,
+    body: &ast::CreateTypeBody,
+    if_not_exists: bool,
     resolver: &Resolver,
     program: &mut ProgramBuilder,
 ) -> Result<()> {
     let normalized_name = normalize_ident(type_name);
+
+    // Reject names that shadow SQLite base types
+    let is_base_type = turso_macros::match_ignore_ascii_case!(match normalized_name.as_bytes() {
+        b"INT" | b"INTEGER" | b"REAL" | b"TEXT" | b"BLOB" | b"ANY" => true,
+        _ => false,
+    });
+    if is_base_type {
+        bail_parse_error!("cannot create type \"{normalized_name}\": name is a built-in type");
+    }
+
+    // Check if type already exists
+    if resolver
+        .schema()
+        .get_type_def_unchecked(&normalized_name)
+        .is_some()
+    {
+        if if_not_exists {
+            return Ok(());
+        }
+        bail_parse_error!("type {normalized_name} already exists");
+    }
+
+    // Validate encode/decode expressions for safety
+    if let Some(ref encode) = body.encode {
+        validate_type_expr(encode, "ENCODE", resolver)?;
+    }
+    if let Some(ref decode) = body.decode {
+        validate_type_expr(decode, "DECODE", resolver)?;
+    }
+
+    // Build canonical SQL (without IF NOT EXISTS) for persistence
+    let sql = build_create_type_sql(&normalized_name, body);
+
+    persist_type_definition(normalized_name, sql, resolver, program)
+}
+
+/// Build canonical CREATE TYPE SQL from a normalized name and parsed body.
+fn build_create_type_sql(name: &str, body: &ast::CreateTypeBody) -> String {
+    use crate::util::quote_identifier as quote_ident;
+    fn quote_string_literal(s: &str) -> String {
+        s.replace('\'', "''")
+    }
+
+    let mut sql = if body.params.is_empty() {
+        format!(
+            "CREATE TYPE {} BASE {}",
+            quote_ident(name),
+            quote_ident(&body.base)
+        )
+    } else {
+        let params: Vec<String> = body
+            .params
+            .iter()
+            .map(|p| match &p.ty {
+                Some(ty) => format!("{} {}", quote_ident(&p.name), ty),
+                None => quote_ident(&p.name),
+            })
+            .collect();
+        format!(
+            "CREATE TYPE {}({}) BASE {}",
+            quote_ident(name),
+            params.join(", "),
+            quote_ident(&body.base)
+        )
+    };
+    if let Some(ref encode) = body.encode {
+        sql.push_str(&format!(" ENCODE {encode}"));
+    }
+    if let Some(ref decode) = body.decode {
+        sql.push_str(&format!(" DECODE {decode}"));
+    }
+    if let Some(ref default) = body.default {
+        sql.push_str(&format!(" DEFAULT {default}"));
+    }
+    for op in &body.operators {
+        match &op.func_name {
+            Some(func_name) => sql.push_str(&format!(
+                " OPERATOR '{}' {}",
+                quote_string_literal(&op.op),
+                quote_ident(func_name)
+            )),
+            None => sql.push_str(&format!(" OPERATOR '{}'", quote_string_literal(&op.op),)),
+        }
+    }
+    sql
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn translate_create_domain(
+    domain_name: &str,
+    base_type: &str,
+    not_null: bool,
+    constraints: &[ast::DomainConstraint],
+    default: Option<Box<ast::Expr>>,
+    if_not_exists: bool,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+) -> Result<()> {
+    let normalized_name = normalize_ident(domain_name);
+
+    // Reject names that shadow SQLite base types
+    let is_base_type = turso_macros::match_ignore_ascii_case!(match normalized_name.as_bytes() {
+        b"INT" | b"INTEGER" | b"REAL" | b"TEXT" | b"BLOB" | b"ANY" => true,
+        _ => false,
+    });
+    if is_base_type {
+        bail_parse_error!("cannot create domain \"{normalized_name}\": name is a built-in type");
+    }
+
+    // Check if type/domain already exists
+    if resolver
+        .schema()
+        .get_type_def_unchecked(&normalized_name)
+        .is_some()
+    {
+        if if_not_exists {
+            return Ok(());
+        }
+        bail_parse_error!("type {normalized_name} already exists");
+    }
+
+    // Validate base type exists — must be a primitive or a registered type
+    let base_normalized = normalize_ident(base_type);
+    let is_primitive = turso_macros::match_ignore_ascii_case!(match base_normalized.as_bytes() {
+        b"INT" | b"INTEGER" | b"REAL" | b"TEXT" | b"BLOB" => true,
+        _ => false,
+    });
+    if !is_primitive
+        && resolver
+            .schema()
+            .get_type_def_unchecked(&base_normalized)
+            .is_none()
+    {
+        bail_parse_error!("base type \"{base_type}\" does not exist");
+    }
+
+    // Validate no cycles — check if base type chain is acyclic
+    if !is_primitive {
+        resolver
+            .schema()
+            .resolve_base_type_chain(&base_normalized)?;
+    }
+
+    // Validate CHECK and DEFAULT expressions (reject subqueries, aggregates, etc.)
+    for c in constraints {
+        validate_type_expr(&c.check, "domain CHECK", resolver)?;
+    }
+    if let Some(ref def) = default {
+        validate_type_expr(def, "domain DEFAULT", resolver)?;
+    }
+
+    // Build the CREATE DOMAIN SQL for persistence
+    let sql = {
+        let mut s = format!("CREATE DOMAIN {normalized_name} AS {base_type}");
+        if let Some(ref def) = default {
+            s.push_str(&format!(" DEFAULT {def}"));
+        }
+        if not_null {
+            s.push_str(" NOT NULL");
+        }
+        for c in constraints {
+            if let Some(ref name) = c.name {
+                s.push_str(&format!(" CONSTRAINT {name}"));
+            }
+            s.push_str(&format!(" CHECK ({})", c.check));
+        }
+        s
+    };
+
+    persist_type_definition(normalized_name, sql, resolver, program)
+}
+
+pub fn translate_drop_type(
+    type_name: &str,
+    if_exists: bool,
+    is_domain_drop: bool,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+) -> Result<()> {
+    let normalized_name = normalize_ident(type_name);
+    let kind = if is_domain_drop { "domain" } else { "type" };
 
     // Check if type exists
     let type_def = resolver.schema().get_type_def_unchecked(&normalized_name);
@@ -2526,11 +2685,22 @@ pub fn translate_drop_type(
         if if_exists {
             return Ok(());
         }
-        bail_parse_error!("no such type: {normalized_name}");
+        bail_parse_error!("no such {kind}: {normalized_name}");
+    }
+
+    let type_def = type_def.unwrap();
+
+    // Validate that DROP TYPE targets a type and DROP DOMAIN targets a domain
+    let target_is_domain = type_def.is_domain;
+    if is_domain_drop && !target_is_domain {
+        bail_parse_error!("{normalized_name} is a type, not a domain. Use DROP TYPE instead");
+    }
+    if !is_domain_drop && target_is_domain {
+        bail_parse_error!("{normalized_name} is a domain, not a type. Use DROP DOMAIN instead");
     }
 
     // Check if built-in type
-    if type_def.unwrap().is_builtin {
+    if type_def.is_builtin {
         bail_parse_error!("cannot drop built-in type: {normalized_name}");
     }
 
@@ -2544,6 +2714,17 @@ pub fn translate_drop_type(
                     table.get_name()
                 );
             }
+        }
+    }
+
+    // Check if any other type/domain depends on this type
+    for (name, td) in resolver.schema().type_registry.iter() {
+        if normalize_ident(&td.base) == normalized_name {
+            bail_parse_error!(
+                "cannot drop type {}: type {} depends on it",
+                normalized_name,
+                name
+            );
         }
     }
 

--- a/core/turso_types_vtab.rs
+++ b/core/turso_types_vtab.rs
@@ -99,7 +99,7 @@ impl TursoTypesCursor {
                         .collect();
                     format!("{}({})", td.name, params.join(", "))
                 };
-                self.entries.push((display_name, td.to_sql()));
+                self.entries.push((display_name, td.to_sql().to_string()));
             }
         });
     }

--- a/docs/sql-reference/experimental-features.mdx
+++ b/docs/sql-reference/experimental-features.mdx
@@ -13,7 +13,7 @@ Some Turso features are still experimental and must be explicitly enabled before
 | Feature | Flag | Description |
 |---------|------|-------------|
 | Views | `views` | [CREATE VIEW](/docs/sql-reference/statements/create-view) and [CREATE MATERIALIZED VIEW](/docs/sql-reference/statements/create-materialized-view) |
-| Custom Types | `custom_types` | [CREATE TYPE](/docs/sql-reference/statements/create-type) and [DROP TYPE](/docs/sql-reference/statements/drop-type) for STRICT tables |
+| Custom Types | `custom_types` | [CREATE TYPE](/docs/sql-reference/statements/create-type), [DROP TYPE](/docs/sql-reference/statements/drop-type), [CREATE DOMAIN](/docs/sql-reference/statements/create-domain), and [DROP DOMAIN](/docs/sql-reference/statements/drop-domain) for STRICT tables |
 | Triggers | `triggers` | [CREATE TRIGGER](/docs/sql-reference/statements/create-trigger) and [DROP TRIGGER](/docs/sql-reference/statements/drop-trigger) |
 | Encryption | `encryption` | At-rest encryption via [PRAGMA cipher / hexkey](/docs/sql-reference/pragmas#encryption) |
 | Index Methods | `index_method` | [CREATE INDEX ... USING](/docs/sql-reference/statements/create-index#using-clause) for FTS and custom index types |

--- a/docs/sql-reference/preview.sh
+++ b/docs/sql-reference/preview.sh
@@ -84,6 +84,8 @@ cat > src/SUMMARY.md << 'EOF'
 - [CREATE VIRTUAL TABLE](statements/create-virtual-table.md)
 - [CREATE TYPE](statements/create-type.md)
 - [DROP TYPE](statements/drop-type.md)
+- [CREATE DOMAIN](statements/create-domain.md)
+- [DROP DOMAIN](statements/drop-domain.md)
 - [Transactions](statements/transactions.md)
 - [ATTACH DATABASE](statements/attach-database.md)
 - [DETACH DATABASE](statements/detach-database.md)

--- a/docs/sql-reference/statements/create-domain.mdx
+++ b/docs/sql-reference/statements/create-domain.mdx
@@ -280,8 +280,12 @@ DROP DOMAIN my_domain;
 
 ## Restrictions
 
-- **STRICT tables only**: Domain names are ignored in non-STRICT tables.
+- **STRICT tables only**: Using a domain type on a non-STRICT table is rejected at CREATE TABLE and ALTER TABLE ADD COLUMN time. Non-STRICT tables allow arbitrary type names as affinity hints, but domain constraints (CHECK, NOT NULL, DEFAULT) are only enforced on STRICT tables, so permitting them would be misleading.
 - **Cannot drop while in use**: A domain cannot be dropped while any table column or another domain references it.
+
+<Note>
+If a non-STRICT table was created with a type name that did not exist at the time (e.g., `CREATE TABLE t(x mydom)`), and a domain with that name is created afterwards (`CREATE DOMAIN mydom AS ...`), the domain constraints will **not** be retroactively enforced on the existing table. This is not a bug: non-STRICT tables treat all type names as plain affinity hints regardless of whether a matching domain exists. STRICT tables prevent this scenario because they reject unknown type names at CREATE TABLE time.
+</Note>
 - **No UNIQUE, PRIMARY KEY, or REFERENCES**: These constraints are not supported in domain definitions. Use table-level constraints instead.
 - **No duplicate clauses**: Multiple DEFAULT or NOT NULL clauses in the same definition are rejected. Conflicting NULL and NOT NULL clauses are also rejected.
 

--- a/docs/sql-reference/statements/create-domain.mdx
+++ b/docs/sql-reference/statements/create-domain.mdx
@@ -1,0 +1,293 @@
+---
+title: CREATE DOMAIN
+description: Define a named constraint wrapper over a base type for use in STRICT tables
+sidebarTitle: CREATE DOMAIN
+---
+
+# CREATE DOMAIN
+
+<Info>
+**Turso Extension**: CREATE DOMAIN is a Turso-specific statement not available in standard SQLite. Domains require STRICT tables and the custom types experimental feature. This feature must be [enabled before use](/docs/sql-reference/experimental-features).
+</Info>
+
+The CREATE DOMAIN statement defines a named type alias with optional constraints. Unlike [CREATE TYPE](/docs/sql-reference/statements/create-type), a domain does not specify custom ENCODE/DECODE logic or OPERATORs. Instead, a domain adds NOT NULL and CHECK constraints on top of a base type, and values are stored using the base type's native storage format.
+
+## Syntax
+
+```sql
+CREATE DOMAIN [IF NOT EXISTS] domain-name AS base-type
+    [DEFAULT default-expr]
+    [NOT NULL]
+    [[CONSTRAINT constraint-name] CHECK (expr)]
+    ...;
+```
+
+## Description
+
+A domain wraps a base type with validation constraints. When a value is written to a column of a domain type, the CHECK constraints and NOT NULL restriction (if any) are verified. If validation passes, the value is stored using the base type's native format. When a value is read, it is returned unchanged.
+
+Domains are transparent to the query engine for operations like ORDER BY, indexing, arithmetic, and aggregation. A domain column behaves exactly like a column of its base type, with the addition of input validation.
+
+Domains work only with STRICT tables. Using a domain name in a non-STRICT table has no effect.
+
+## Clauses
+
+### IF NOT EXISTS
+
+Suppresses the error that would occur if a domain with the same name already exists. The existing domain is left unchanged.
+
+```sql
+CREATE DOMAIN IF NOT EXISTS positive_int AS integer CHECK (value > 0);
+```
+
+### AS base-type
+
+Specifies the underlying type. The base type can be a primitive type (`integer`, `real`, `text`, `blob`) or another domain, allowing domains to be layered.
+
+```sql
+CREATE DOMAIN percentage AS integer
+    CHECK (value >= 0)
+    CHECK (value <= 100);
+```
+
+### DEFAULT
+
+Sets a default value for columns of this domain type. A column-level DEFAULT overrides the domain-level DEFAULT.
+
+```sql
+CREATE DOMAIN status AS text DEFAULT 'active';
+
+CREATE TABLE accounts (
+    id INTEGER PRIMARY KEY,
+    state status
+) STRICT;
+
+INSERT INTO accounts(id) VALUES (1);
+SELECT state FROM accounts;
+-- active
+```
+
+### NOT NULL
+
+Adds a NOT NULL constraint to the domain. Any attempt to insert or update a NULL value into a column of this domain type will fail, even if the column definition does not specify NOT NULL.
+
+```sql
+CREATE DOMAIN required_text AS text NOT NULL;
+
+CREATE TABLE contacts (
+    id INTEGER PRIMARY KEY,
+    name required_text
+) STRICT;
+
+INSERT INTO contacts VALUES (1, 'Alice');
+-- OK
+
+INSERT INTO contacts VALUES (2, NULL);
+-- Error: domain required_text does not allow null values
+```
+
+A column-level NULL declaration does not override the domain's NOT NULL constraint.
+
+### CHECK
+
+Adds a validation constraint. The expression can reference `value` to refer to the input value being checked. Multiple CHECK constraints can be specified and all must pass.
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+CREATE TABLE measurements (
+    id INTEGER PRIMARY KEY,
+    reading positive_int
+) STRICT;
+
+INSERT INTO measurements VALUES (1, 42);
+-- OK
+
+INSERT INTO measurements VALUES (2, -5);
+-- Error: domain positive_int constraint violation
+```
+
+### CONSTRAINT name CHECK
+
+CHECK constraints can optionally be given a name for documentation purposes.
+
+```sql
+CREATE DOMAIN valid_score AS integer
+    CONSTRAINT non_negative CHECK (value >= 0)
+    CONSTRAINT max_hundred CHECK (value <= 100);
+```
+
+## Domain Chaining
+
+A domain can use another domain as its base type. When domains are chained, all constraints in the chain are enforced from child to ancestor.
+
+```sql
+CREATE DOMAIN base_amount AS integer CHECK (value > 0);
+CREATE DOMAIN small_amount AS base_amount CHECK (value < 1000);
+
+CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    quantity small_amount
+) STRICT;
+
+INSERT INTO orders VALUES (1, 50);
+-- OK: passes both value > 0 and value < 1000
+
+INSERT INTO orders VALUES (2, -1);
+-- Error: fails base_amount's CHECK (value > 0)
+
+INSERT INTO orders VALUES (3, 5000);
+-- Error: fails small_amount's CHECK (value < 1000)
+```
+
+Three or more levels of chaining are supported:
+
+```sql
+CREATE DOMAIN text_val AS text;
+CREATE DOMAIN nonempty AS text_val CHECK (length(value) > 0);
+CREATE DOMAIN short_text AS nonempty CHECK (length(value) < 50);
+
+CREATE TABLE labels (
+    id INTEGER PRIMARY KEY,
+    name short_text
+) STRICT;
+
+INSERT INTO labels VALUES (1, 'OK');
+-- OK
+
+INSERT INTO labels VALUES (2, '');
+-- Error: fails nonempty's CHECK (length(value) > 0)
+```
+
+## UPDATE Enforcement
+
+Domain constraints are enforced on UPDATE as well as INSERT.
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+CREATE TABLE items (
+    id INTEGER PRIMARY KEY,
+    stock positive_int
+) STRICT;
+
+INSERT INTO items VALUES (1, 10);
+UPDATE items SET stock = 20 WHERE id = 1;
+SELECT stock FROM items;
+-- 20
+
+UPDATE items SET stock = -1 WHERE id = 1;
+-- Error: domain positive_int constraint violation
+```
+
+## CAST Support
+
+CAST applies the domain's validation constraints:
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+SELECT CAST(42 AS positive_int);
+-- 42
+
+SELECT CAST(-1 AS positive_int);
+-- Error: domain positive_int constraint violation
+```
+
+Casting NULL to a NOT NULL domain is rejected:
+
+```sql
+CREATE DOMAIN notnull_int AS integer NOT NULL;
+
+SELECT CAST(NULL AS notnull_int);
+-- Error: domain notnull_int does not allow null values
+```
+
+## CHECK Constraints with Table-Level Checks
+
+Domain CHECK constraints and table-level CHECK constraints both apply. The domain constraint is checked during encoding and the table CHECK is checked separately.
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+
+CREATE TABLE bounded (
+    id INTEGER PRIMARY KEY,
+    val positive_int CHECK (val < 100)
+) STRICT;
+
+INSERT INTO bounded VALUES (1, 50);
+-- OK: passes domain CHECK (> 0) and table CHECK (< 100)
+
+INSERT INTO bounded VALUES (2, -1);
+-- Error: fails domain CHECK
+
+INSERT INTO bounded VALUES (3, 200);
+-- Error: fails table CHECK
+```
+
+## Operations on Domain Columns
+
+Domain columns support the same operations as their base type: arithmetic, comparisons, ordering, and aggregation.
+
+```sql
+CREATE DOMAIN myint AS integer;
+
+CREATE TABLE data (
+    id INTEGER PRIMARY KEY,
+    a myint,
+    b myint
+) STRICT;
+
+INSERT INTO data VALUES (1, 10, 3);
+SELECT a + b, a - b, a * b FROM data;
+-- 13|7|30
+```
+
+```sql
+CREATE DOMAIN myint AS integer;
+
+CREATE TABLE scores (
+    id INTEGER PRIMARY KEY,
+    val myint
+) STRICT;
+
+INSERT INTO scores VALUES (1, 30);
+INSERT INTO scores VALUES (2, 10);
+INSERT INTO scores VALUES (3, 20);
+SELECT val FROM scores ORDER BY val;
+-- 10
+-- 20
+-- 30
+```
+
+## Dropping Domains
+
+Domains are dropped with [DROP DOMAIN](/docs/sql-reference/statements/drop-domain), not DROP TYPE. Attempting to use DROP TYPE on a domain (or DROP DOMAIN on a type) results in an error.
+
+A domain cannot be dropped while any table column or another domain references it.
+
+```sql
+CREATE DOMAIN my_domain AS integer;
+CREATE TABLE t(x my_domain) STRICT;
+
+DROP DOMAIN my_domain;
+-- Error: type 'my_domain' is in use
+
+DROP TABLE t;
+DROP DOMAIN my_domain;
+-- OK
+```
+
+## Restrictions
+
+- **STRICT tables only**: Domain names are ignored in non-STRICT tables.
+- **Cannot drop while in use**: A domain cannot be dropped while any table column or another domain references it.
+- **No UNIQUE, PRIMARY KEY, or REFERENCES**: These constraints are not supported in domain definitions. Use table-level constraints instead.
+- **No duplicate clauses**: Multiple DEFAULT or NOT NULL clauses in the same definition are rejected. Conflicting NULL and NOT NULL clauses are also rejected.
+
+## See Also
+
+- [DROP DOMAIN](/docs/sql-reference/statements/drop-domain) for removing domains
+- [CREATE TYPE](/docs/sql-reference/statements/create-type) for defining custom types with ENCODE/DECODE logic
+- [Data Types](/docs/sql-reference/data-types) for an overview of the type system
+- [CREATE TABLE](/docs/sql-reference/statements/create-table) for STRICT table definitions

--- a/docs/sql-reference/statements/create-type.mdx
+++ b/docs/sql-reference/statements/create-type.mdx
@@ -385,5 +385,6 @@ SELECT amount + tax FROM transactions;
 ## See Also
 
 - [DROP TYPE](/docs/sql-reference/statements/drop-type) for removing custom types
+- [CREATE DOMAIN](/docs/sql-reference/statements/create-domain) for defining constrained type aliases without ENCODE/DECODE logic
 - [Data Types](/docs/sql-reference/data-types) for an overview of the type system and type affinity
 - [CREATE TABLE](/docs/sql-reference/statements/create-table) for STRICT table definitions

--- a/docs/sql-reference/statements/create-type.mdx
+++ b/docs/sql-reference/statements/create-type.mdx
@@ -283,6 +283,10 @@ The `uuid`, `json`, and `jsonb` types require their respective extensions to be 
 
 - **STRICT tables only**: Custom type names are ignored in non-STRICT tables. The column uses standard type affinity rules instead.
 - **Cannot drop while in use**: A type cannot be dropped with DROP TYPE while any table has a column of that type.
+
+<Note>
+If a non-STRICT table was created with a type name that did not exist at the time (e.g., `CREATE TABLE t(x mytype)`), and a custom type with that name is created afterwards (`CREATE TYPE mytype ...`), the type's ENCODE/DECODE logic will **not** be retroactively applied to the existing table. This is not a bug: non-STRICT tables treat all type names as plain affinity hints regardless of whether a matching custom type exists. STRICT tables prevent this scenario because they reject unknown type names at CREATE TABLE time.
+</Note>
 - **No subqueries in expressions**: The ENCODE, DECODE, and DEFAULT expressions cannot contain subqueries, aggregate functions, or window functions.
 
 ## Examples

--- a/docs/sql-reference/statements/drop-domain.mdx
+++ b/docs/sql-reference/statements/drop-domain.mdx
@@ -1,0 +1,95 @@
+---
+title: DROP DOMAIN
+description: Remove a user-defined domain from the database
+sidebarTitle: DROP DOMAIN
+---
+
+# DROP DOMAIN
+
+<Info>
+**Turso Extension**: DROP DOMAIN is a Turso-specific statement not available in standard SQLite. This feature is experimental and must be [enabled before use](/docs/sql-reference/experimental-features).
+</Info>
+
+The DROP DOMAIN statement removes a user-defined domain from the database. Once dropped, the domain name can no longer be used in new column definitions.
+
+## Syntax
+
+```sql
+DROP DOMAIN [IF EXISTS] domain-name;
+```
+
+## Description
+
+DROP DOMAIN removes the named domain from the database. The domain must exist unless the `IF EXISTS` clause is specified.
+
+### Clauses
+
+| Clause | Description |
+|--------|-------------|
+| `IF EXISTS` | Suppresses the error that would occur if the domain does not exist. The statement is a no-op when the domain is not found. |
+| `domain-name` | The name of the domain to remove. |
+
+### Restrictions
+
+A domain cannot be dropped while any table column uses it or while another domain references it as a base type. Remove all dependents before dropping.
+
+```sql
+CREATE DOMAIN base_d AS integer;
+CREATE DOMAIN child_d AS base_d CHECK (value > 0);
+
+-- Fails: child_d depends on base_d
+DROP DOMAIN base_d;
+
+-- Drop child first, then base
+DROP DOMAIN child_d;
+DROP DOMAIN base_d;
+```
+
+### DROP DOMAIN vs DROP TYPE
+
+DROP DOMAIN can only remove domains created with CREATE DOMAIN. Attempting to use DROP DOMAIN on a type created with CREATE TYPE results in an error, and vice versa.
+
+```sql
+CREATE TYPE my_type BASE integer ENCODE value DECODE value;
+DROP DOMAIN my_type;
+-- Error: 'my_type' is a type, not a domain. Use DROP TYPE instead
+
+CREATE DOMAIN my_domain AS integer;
+DROP TYPE my_domain;
+-- Error: 'my_domain' is a domain, not a type. Use DROP DOMAIN instead
+```
+
+## Examples
+
+### Drop a Domain
+
+```sql
+CREATE DOMAIN positive_int AS integer CHECK (value > 0);
+DROP DOMAIN positive_int;
+```
+
+### Drop with IF EXISTS
+
+```sql
+-- Safe to run even if the domain does not exist
+DROP DOMAIN IF EXISTS nonexistent_domain;
+```
+
+### Drop After Removing Table Dependency
+
+```sql
+CREATE DOMAIN score AS integer CHECK (value >= 0);
+CREATE TABLE results (id INTEGER PRIMARY KEY, val score) STRICT;
+
+-- Fails: table 'results' uses domain 'score'
+-- DROP DOMAIN score;
+
+DROP TABLE results;
+DROP DOMAIN score;
+-- OK
+```
+
+## See Also
+
+- [CREATE DOMAIN](/docs/sql-reference/statements/create-domain) for defining domains
+- [DROP TYPE](/docs/sql-reference/statements/drop-type) for removing custom types

--- a/docs/sql-reference/statements/drop-type.mdx
+++ b/docs/sql-reference/statements/drop-type.mdx
@@ -72,4 +72,5 @@ DROP TYPE IF EXISTS reversed_text;
 ## See Also
 
 - [CREATE TYPE](/docs/sql-reference/statements/create-type) for defining custom types
+- [DROP DOMAIN](/docs/sql-reference/statements/drop-domain) for removing domains
 - [Data Types](/docs/sql-reference/data-types) for an overview of the type system

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -194,6 +194,21 @@ pub enum Stmt {
         /// type body
         body: CreateTypeBody,
     },
+    /// `CREATE DOMAIN`
+    CreateDomain {
+        /// `IF NOT EXISTS`
+        if_not_exists: bool,
+        /// domain name
+        domain_name: String,
+        /// base type (primitive or another domain/custom type)
+        base_type: String,
+        /// default expression
+        default: Option<Box<Expr>>,
+        /// NOT NULL constraint
+        not_null: bool,
+        /// CHECK constraints
+        constraints: Vec<DomainConstraint>,
+    },
     /// `DELETE`
     Delete {
         /// CTE
@@ -250,6 +265,13 @@ pub enum Stmt {
         if_exists: bool,
         /// type name
         type_name: String,
+    },
+    /// `DROP DOMAIN`
+    DropDomain {
+        /// `IF EXISTS`
+        if_exists: bool,
+        /// domain name
+        domain_name: String,
     },
     /// `INSERT`
     Insert {
@@ -1278,6 +1300,16 @@ pub struct TypeParam {
     pub name: String,
     /// Type annotation. None means untyped (backward compat).
     pub ty: Option<String>,
+}
+
+/// A single named CHECK constraint on a domain
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DomainConstraint {
+    /// CONSTRAINT name (optional)
+    pub name: Option<String>,
+    /// CHECK expression using `value` placeholder
+    pub check: Box<Expr>,
 }
 
 /// Body of a `CREATE TYPE` statement

--- a/parser/src/ast/fmt.rs
+++ b/parser/src/ast/fmt.rs
@@ -759,6 +759,44 @@ impl ToTokens for Stmt {
                 }
                 Ok(())
             }
+            Self::CreateDomain {
+                if_not_exists,
+                domain_name,
+                base_type,
+                default,
+                not_null,
+                constraints,
+            } => {
+                s.append(TK_CREATE, None)?;
+                s.append(TK_ID, Some("DOMAIN"))?;
+                if *if_not_exists {
+                    s.append(TK_IF, None)?;
+                    s.append(TK_NOT, None)?;
+                    s.append(TK_EXISTS, None)?;
+                }
+                s.append(TK_ID, Some(domain_name))?;
+                s.append(TK_AS, None)?;
+                s.append(TK_ID, Some(base_type))?;
+                if let Some(ref def) = default {
+                    s.append(TK_DEFAULT, None)?;
+                    def.to_tokens(s, context)?;
+                }
+                if *not_null {
+                    s.append(TK_NOT, None)?;
+                    s.append(TK_NULL, None)?;
+                }
+                for c in constraints {
+                    if let Some(ref name) = c.name {
+                        s.append(TK_CONSTRAINT, None)?;
+                        s.append(TK_ID, Some(name))?;
+                    }
+                    s.append(TK_CHECK, None)?;
+                    s.append(TK_LP, None)?;
+                    c.check.to_tokens(s, context)?;
+                    s.append(TK_RP, None)?;
+                }
+                Ok(())
+            }
             Self::DropType {
                 if_exists,
                 type_name,
@@ -770,6 +808,19 @@ impl ToTokens for Stmt {
                     s.append(TK_EXISTS, None)?;
                 }
                 s.append(TK_ID, Some(type_name))?;
+                Ok(())
+            }
+            Self::DropDomain {
+                if_exists,
+                domain_name,
+            } => {
+                s.append(TK_DROP, None)?;
+                s.append(TK_ID, Some("DOMAIN"))?;
+                if *if_exists {
+                    s.append(TK_IF, None)?;
+                    s.append(TK_EXISTS, None)?;
+                }
+                s.append(TK_ID, Some(domain_name))?;
                 Ok(())
             }
         }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,15 +1,16 @@
 use crate::ast::{
     check::ColumnCount, AlterTable, AlterTableBody, As, Cmd, ColumnConstraint, ColumnDefinition,
     CommonTableExpr, CompoundOperator, CompoundSelect, CreateTableBody, CreateTypeBody,
-    CreateVirtualTable, DeferSubclause, Distinctness, Expr, ForeignKeyClause, FrameBound,
-    FrameClause, FrameExclude, FrameMode, FromClause, FunctionTail, GeneratedColumnType, GroupBy,
-    Indexed, IndexedColumn, InitDeferredPred, InsertBody, JoinConstraint, JoinOperator, JoinType,
-    JoinedSelectTable, LikeOperator, Limit, Literal, Materialized, Name, NamedColumnConstraint,
-    NamedTableConstraint, NullsOrder, OneSelect, Operator, Over, PragmaBody, PragmaValue,
-    QualifiedName, RefAct, RefArg, ResolveType, ResultColumn, Select, SelectBody, SelectTable, Set,
-    SortOrder, SortedColumn, Stmt, TableConstraint, TableOptions, TransactionType, TriggerCmd,
-    TriggerEvent, TriggerTime, Type, TypeOperator, TypeParam, TypeSize, UnaryOperator, Update,
-    Upsert, UpsertDo, UpsertIndex, Variable, Window, WindowDef, With,
+    CreateVirtualTable, DeferSubclause, Distinctness, DomainConstraint, Expr, ForeignKeyClause,
+    FrameBound, FrameClause, FrameExclude, FrameMode, FromClause, FunctionTail,
+    GeneratedColumnType, GroupBy, Indexed, IndexedColumn, InitDeferredPred, InsertBody,
+    JoinConstraint, JoinOperator, JoinType, JoinedSelectTable, LikeOperator, Limit, Literal,
+    Materialized, Name, NamedColumnConstraint, NamedTableConstraint, NullsOrder, OneSelect,
+    Operator, Over, PragmaBody, PragmaValue, QualifiedName, RefAct, RefArg, ResolveType,
+    ResultColumn, Select, SelectBody, SelectTable, Set, SortOrder, SortedColumn, Stmt,
+    TableConstraint, TableOptions, TransactionType, TriggerCmd, TriggerEvent, TriggerTime, Type,
+    TypeOperator, TypeParam, TypeSize, UnaryOperator, Update, Upsert, UpsertDo, UpsertIndex,
+    Variable, Window, WindowDef, With,
 };
 use crate::error::Error;
 use crate::lexer::{Lexer, Token};
@@ -941,7 +942,8 @@ impl<'a> Parser<'a> {
             TK_UNIQUE,
             TK_TRIGGER,
             TK_MATERIALIZED,
-            TK_TYPE
+            TK_TYPE,
+            TK_ID
         );
         let mut temp = false;
         if first_tok.token_type == TK_TEMP {
@@ -958,7 +960,13 @@ impl<'a> Parser<'a> {
             TK_VIRTUAL => self.parse_create_virtual(),
             TK_INDEX | TK_UNIQUE => self.parse_create_index(),
             TK_TYPE => self.parse_create_type(),
-            _ => unreachable!(),
+            TK_ID if first_tok.to_utf8().eq_ignore_ascii_case("DOMAIN") => {
+                self.parse_create_domain()
+            }
+            _ => Err(Error::ParseError(format!(
+                "unexpected token: {}",
+                first_tok.to_utf8()
+            )))?,
         }
     }
 
@@ -4467,9 +4475,119 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// Parse `CREATE DOMAIN [IF NOT EXISTS] name AS base_type
+    ///     [DEFAULT expr]
+    ///     [NOT NULL | NULL]
+    ///     [[CONSTRAINT name] CHECK (expr)]...`
+    fn parse_create_domain(&mut self) -> Result<Stmt> {
+        // Eat 'DOMAIN' (which is TK_ID)
+        eat_assert!(self, TK_ID);
+        let if_not_exists = self.parse_if_not_exists()?;
+
+        // Parse domain name
+        let name_tok = self.eat()?;
+        let domain_name = match name_tok {
+            Some(tok) if tok.token_type == TK_ID => from_bytes(tok.as_bytes()),
+            _ => return Err(Error::ParseError("expected domain name".to_owned())),
+        };
+
+        // Eat AS keyword
+        eat_expect!(self, TK_AS);
+
+        // Parse base type name (any identifier — primitive, custom type, or another domain)
+        let base_tok = self.eat()?;
+        let base_type = match base_tok {
+            Some(tok) if tok.token_type == TK_ID => from_bytes(tok.as_bytes()),
+            _ => return Err(Error::ParseError("expected base type name".to_owned())),
+        };
+
+        let mut default = None;
+        let mut not_null = false;
+        let mut has_null = false;
+        let mut has_default = false;
+        let mut constraints = Vec::new();
+
+        // Parse optional clauses: DEFAULT, NOT NULL, NULL, CONSTRAINT/CHECK
+        loop {
+            match self.peek()? {
+                Some(tok) if tok.token_type == TK_DEFAULT => {
+                    eat_assert!(self, TK_DEFAULT);
+                    if has_default {
+                        return Err(Error::ParseError(
+                            "multiple DEFAULT clauses in domain definition".to_owned(),
+                        ));
+                    }
+                    let expr = self.parse_expr(0)?;
+                    default = Some(expr);
+                    has_default = true;
+                }
+                Some(tok) if tok.token_type == TK_NOT => {
+                    eat_assert!(self, TK_NOT);
+                    eat_expect!(self, TK_NULL);
+                    if has_null {
+                        return Err(Error::ParseError(
+                            "conflicting NULL/NOT NULL clauses in domain definition".to_owned(),
+                        ));
+                    }
+                    if not_null {
+                        return Err(Error::ParseError(
+                            "duplicate NOT NULL clause in domain definition".to_owned(),
+                        ));
+                    }
+                    not_null = true;
+                }
+                Some(tok) if tok.token_type == TK_NULL => {
+                    eat_assert!(self, TK_NULL);
+                    if not_null {
+                        return Err(Error::ParseError(
+                            "conflicting NULL/NOT NULL clauses in domain definition".to_owned(),
+                        ));
+                    }
+                    has_null = true;
+                }
+                Some(tok) if tok.token_type == TK_CONSTRAINT => {
+                    eat_assert!(self, TK_CONSTRAINT);
+                    let cname_tok = self.eat()?;
+                    let cname = match cname_tok {
+                        Some(t) if t.token_type == TK_ID => from_bytes(t.as_bytes()),
+                        _ => return Err(Error::ParseError("expected constraint name".to_owned())),
+                    };
+                    eat_expect!(self, TK_CHECK);
+                    eat_expect!(self, TK_LP);
+                    let check_expr = self.parse_expr(0)?;
+                    eat_expect!(self, TK_RP);
+                    constraints.push(DomainConstraint {
+                        name: Some(cname),
+                        check: check_expr,
+                    });
+                }
+                Some(tok) if tok.token_type == TK_CHECK => {
+                    eat_assert!(self, TK_CHECK);
+                    eat_expect!(self, TK_LP);
+                    let check_expr = self.parse_expr(0)?;
+                    eat_expect!(self, TK_RP);
+                    constraints.push(DomainConstraint {
+                        name: None,
+                        check: check_expr,
+                    });
+                }
+                _ => break,
+            }
+        }
+
+        Ok(Stmt::CreateDomain {
+            if_not_exists,
+            domain_name,
+            base_type,
+            default,
+            not_null,
+            constraints,
+        })
+    }
+
     fn parse_drop_stmt(&mut self) -> Result<Stmt> {
         eat_assert!(self, TK_DROP);
-        let tok = peek_expect!(self, TK_TABLE, TK_INDEX, TK_TRIGGER, TK_VIEW, TK_TYPE);
+        let tok = peek_expect!(self, TK_TABLE, TK_INDEX, TK_TRIGGER, TK_VIEW, TK_TYPE, TK_ID);
 
         match tok.token_type {
             TK_TABLE => {
@@ -4521,7 +4639,23 @@ impl<'a> Parser<'a> {
                     type_name,
                 })
             }
-            _ => unreachable!(),
+            TK_ID if tok.to_utf8().eq_ignore_ascii_case("DOMAIN") => {
+                eat_assert!(self, TK_ID);
+                let if_exists = self.parse_if_exists()?;
+                let name_tok = self.eat()?;
+                let domain_name = match name_tok {
+                    Some(tok) if tok.token_type == TK_ID => from_bytes(tok.as_bytes()),
+                    _ => return Err(Error::ParseError("expected domain name".to_owned())),
+                };
+                Ok(Stmt::DropDomain {
+                    if_exists,
+                    domain_name,
+                })
+            }
+            _ => Err(Error::ParseError(format!(
+                "unexpected token: {}",
+                tok.to_utf8()
+            )))?,
         }
     }
 

--- a/testing/sqltests/turso-tests/domain.sqltest
+++ b/testing/sqltests/turso-tests/domain.sqltest
@@ -1,0 +1,1575 @@
+@database :memory:
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-basic-integer {
+    CREATE DOMAIN domainint AS integer;
+    CREATE TABLE t1(a domainint) STRICT;
+    INSERT INTO t1 VALUES (1);
+    INSERT INTO t1 VALUES (42);
+    SELECT * FROM t1;
+}
+expect {
+    1
+    42
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-basic-text {
+    CREATE DOMAIN domaintext AS text;
+    CREATE TABLE t1(a domaintext) STRICT;
+    INSERT INTO t1 VALUES ('hello');
+    INSERT INTO t1 VALUES ('world');
+    SELECT * FROM t1;
+}
+expect {
+    hello
+    world
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-pass {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint) STRICT;
+    INSERT INTO t1 VALUES (5);
+    INSERT INTO t1 VALUES (100);
+    SELECT * FROM t1;
+}
+expect {
+    5
+    100
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-fail-negative {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-fail-zero {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint) STRICT;
+    INSERT INTO t1 VALUES (0);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-not-null-pass {
+    CREATE DOMAIN notnull_int AS integer NOT NULL;
+    CREATE TABLE t1(a notnull_int) STRICT;
+    INSERT INTO t1 VALUES (1);
+    SELECT * FROM t1;
+}
+expect {
+    1
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-not-null-fail {
+    CREATE DOMAIN notnull_int AS integer NOT NULL;
+    CREATE TABLE t1(a notnull_int) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default {
+    CREATE DOMAIN defint AS integer DEFAULT 42;
+    CREATE TABLE t1(a defint) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT a FROM t1;
+}
+expect {
+    42
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-column-override {
+    CREATE DOMAIN defint2 AS integer DEFAULT 10;
+    CREATE TABLE t1(a defint2 DEFAULT 99) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT a FROM t1;
+}
+expect {
+    99
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-inherited {
+    CREATE DOMAIN d1 AS integer DEFAULT 10;
+    CREATE DOMAIN d2 AS d1;
+    CREATE TABLE t1(a d2) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT a FROM t1;
+}
+expect {
+    10
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-child-overrides-parent {
+    CREATE DOMAIN d1 AS integer DEFAULT 10;
+    CREATE DOMAIN d2 AS d1 DEFAULT 20;
+    CREATE TABLE t1(a d2) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT a FROM t1;
+}
+expect {
+    20
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-column-overrides-inherited {
+    CREATE DOMAIN d1 AS integer DEFAULT 10;
+    CREATE DOMAIN d2 AS d1;
+    CREATE TABLE t1(a d2 DEFAULT 99) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT a FROM t1;
+}
+expect {
+    99
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-three-level-inherited {
+    CREATE DOMAIN d1 AS integer DEFAULT 5;
+    CREATE DOMAIN d2 AS d1;
+    CREATE DOMAIN d3 AS d2;
+    CREATE TABLE t1(a d3) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT a FROM t1;
+}
+expect {
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-three-level-middle-overrides {
+    CREATE DOMAIN d1 AS integer DEFAULT 5;
+    CREATE DOMAIN d2 AS d1 DEFAULT 50;
+    CREATE DOMAIN d3 AS d2;
+    CREATE TABLE t1(a d3) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT a FROM t1;
+}
+expect {
+    50
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-recursive-pass {
+    CREATE DOMAIN base_d AS integer CHECK (value > 0);
+    CREATE DOMAIN child_d AS base_d CHECK (value < 100);
+    CREATE TABLE t1(x child_d) STRICT;
+    INSERT INTO t1 VALUES (50);
+    SELECT * FROM t1;
+}
+expect {
+    50
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-recursive-fail-base {
+    CREATE DOMAIN base_d AS integer CHECK (value > 0);
+    CREATE DOMAIN child_d AS base_d CHECK (value < 100);
+    CREATE TABLE t1(x child_d) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-recursive-fail-child {
+    CREATE DOMAIN base_d AS integer CHECK (value > 0);
+    CREATE DOMAIN child_d AS base_d CHECK (value < 100);
+    CREATE TABLE t1(x child_d) STRICT;
+    INSERT INTO t1 VALUES (200);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-three-level-pass {
+    CREATE DOMAIN d1 AS text;
+    CREATE DOMAIN d2 AS d1 CHECK (length(value) > 0);
+    CREATE DOMAIN d3 AS d2 CHECK (length(value) < 10);
+    CREATE TABLE t1(x d3) STRICT;
+    INSERT INTO t1 VALUES ('hello');
+    SELECT * FROM t1;
+}
+expect {
+    hello
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-three-level-fail-d2 {
+    CREATE DOMAIN d1 AS text;
+    CREATE DOMAIN d2 AS d1 CHECK (length(value) > 0);
+    CREATE DOMAIN d3 AS d2 CHECK (length(value) < 10);
+    CREATE TABLE t1(x d3) STRICT;
+    INSERT INTO t1 VALUES ('');
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-three-level-fail-d3 {
+    CREATE DOMAIN d1 AS text;
+    CREATE DOMAIN d2 AS d1 CHECK (length(value) > 0);
+    CREATE DOMAIN d3 AS d2 CHECK (length(value) < 10);
+    CREATE TABLE t1(x d3) STRICT;
+    INSERT INTO t1 VALUES ('toolongstring');
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-dependent-fail {
+    CREATE DOMAIN drop_base AS integer;
+    CREATE DOMAIN drop_child AS drop_base;
+    DROP DOMAIN drop_base;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-dependent-chain {
+    CREATE DOMAIN drop_base AS integer;
+    CREATE DOMAIN drop_child AS drop_base;
+    DROP DOMAIN drop_child;
+    DROP DOMAIN drop_base;
+}
+expect {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-table-dep-fail {
+    CREATE DOMAIN drop_d AS integer;
+    CREATE TABLE t1(x drop_d) STRICT;
+    DROP DOMAIN drop_d;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-table-dep-ok {
+    CREATE DOMAIN drop_d AS integer;
+    CREATE TABLE t1(x drop_d) STRICT;
+    DROP TABLE t1;
+    DROP DOMAIN drop_d;
+}
+expect {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-type-on-domain-error {
+    CREATE DOMAIN my_domain AS integer;
+    DROP TYPE my_domain;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-domain-on-type-error {
+    CREATE TYPE my_type BASE integer ENCODE value DECODE value;
+    DROP DOMAIN my_type;
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-check-pass {
+    CREATE DOMAIN multi_check AS integer
+        CHECK (value > 0)
+        CHECK (value < 1000);
+    CREATE TABLE t1(x multi_check) STRICT;
+    INSERT INTO t1 VALUES (500);
+    SELECT * FROM t1;
+}
+expect {
+    500
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-check-fail-lower {
+    CREATE DOMAIN multi_check AS integer
+        CHECK (value > 0)
+        CHECK (value < 1000);
+    CREATE TABLE t1(x multi_check) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-check-fail-upper {
+    CREATE DOMAIN multi_check AS integer
+        CHECK (value > 0)
+        CHECK (value < 1000);
+    CREATE TABLE t1(x multi_check) STRICT;
+    INSERT INTO t1 VALUES (1001);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-named-check-pass {
+    CREATE DOMAIN named_d AS integer
+        CONSTRAINT positive CHECK (value > 0)
+        CONSTRAINT small CHECK (value < 100);
+    CREATE TABLE t1(x named_d) STRICT;
+    INSERT INTO t1 VALUES (50);
+    SELECT * FROM t1;
+}
+expect {
+    50
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-named-check-fail-positive {
+    CREATE DOMAIN named_d AS integer
+        CONSTRAINT positive CHECK (value > 0)
+        CONSTRAINT small CHECK (value < 100);
+    CREATE TABLE t1(x named_d) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-named-check-fail-small {
+    CREATE DOMAIN named_d AS integer
+        CONSTRAINT positive CHECK (value > 0)
+        CONSTRAINT small CHECK (value < 100);
+    CREATE TABLE t1(x named_d) STRICT;
+    INSERT INTO t1 VALUES (200);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-bad-base-type {
+    CREATE DOMAIN bad AS nonexistent_type;
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-duplicate-error {
+    CREATE DOMAIN d AS integer;
+    CREATE DOMAIN d AS integer;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-if-not-exists {
+    CREATE DOMAIN d AS integer;
+    CREATE DOMAIN IF NOT EXISTS d AS integer;
+}
+expect {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-if-exists {
+    DROP DOMAIN IF EXISTS nonexistent;
+}
+expect {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-nonexistent-error {
+    DROP DOMAIN nonexistent;
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-check-pass {
+    CREATE DOMAIN strict_pos AS integer NOT NULL CHECK (value > 0);
+    CREATE TABLE t1(x strict_pos) STRICT;
+    INSERT INTO t1 VALUES (5);
+    SELECT * FROM t1;
+}
+expect {
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-check-fail-null {
+    CREATE DOMAIN strict_pos AS integer NOT NULL CHECK (value > 0);
+    CREATE TABLE t1(x strict_pos) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-check-fail-negative {
+    CREATE DOMAIN strict_pos AS integer NOT NULL CHECK (value > 0);
+    CREATE TABLE t1(x strict_pos) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-null-allowed {
+    CREATE DOMAIN nullable_d AS integer CHECK (value > 0);
+    CREATE TABLE t1(x nullable_d) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+    SELECT x FROM t1;
+}
+expect {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-reject-unique {
+    CREATE DOMAIN d AS integer UNIQUE;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-reject-primary-key {
+    CREATE DOMAIN d AS integer PRIMARY KEY;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-reject-references {
+    CREATE DOMAIN d AS integer REFERENCES other_table(id);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-conflicting-null-notnull {
+    CREATE DOMAIN d AS integer NOT NULL NULL;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-duplicate-default {
+    CREATE DOMAIN d AS integer DEFAULT 3 DEFAULT 5;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-duplicate-notnull {
+    CREATE DOMAIN d AS integer NOT NULL NOT NULL;
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-column-cannot-override {
+    CREATE DOMAIN dnn AS integer NOT NULL;
+    CREATE TABLE t1(x dnn) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-column-explicit-null {
+    CREATE DOMAIN dnn AS integer NOT NULL;
+    CREATE TABLE t1(x dnn NULL) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-update-check-pass {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint) STRICT;
+    INSERT INTO t1 VALUES (5);
+    UPDATE t1 SET x = 10;
+    SELECT x FROM t1;
+}
+expect {
+    10
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-update-check-fail {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint) STRICT;
+    INSERT INTO t1 VALUES (5);
+    UPDATE t1 SET x = -1;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-update-notnull-fail {
+    CREATE DOMAIN notnull_d AS integer NOT NULL;
+    CREATE TABLE t1(x notnull_d) STRICT;
+    INSERT INTO t1 VALUES (5);
+    UPDATE t1 SET x = NULL;
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-cast-pass {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    SELECT CAST(42 AS posint);
+}
+expect {
+    42
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-cast-fail {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    SELECT CAST(-1 AS posint);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-cast-null-to-notnull {
+    CREATE DOMAIN notnull_d AS integer NOT NULL;
+    SELECT CAST(NULL AS notnull_d);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-cast-null-to-nullable {
+    CREATE DOMAIN nullable_d AS integer CHECK (value > 0);
+    SELECT CAST(NULL AS nullable_d);
+}
+expect {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-plus-table-check-pass {
+    CREATE DOMAIN dcheck AS integer CHECK (value > 0);
+    CREATE TABLE t1(x dcheck CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (50);
+    SELECT x FROM t1;
+}
+expect {
+    50
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-plus-table-check-fail-domain {
+    CREATE DOMAIN dcheck AS integer CHECK (value > 0);
+    CREATE TABLE t1(x dcheck CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-plus-table-check-fail-table {
+    CREATE DOMAIN dcheck AS integer CHECK (value > 0);
+    CREATE TABLE t1(x dcheck CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (200);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-arithmetic {
+    CREATE DOMAIN myint AS integer;
+    CREATE TABLE t1(a myint, b myint) STRICT;
+    INSERT INTO t1 VALUES (10, 3);
+    SELECT a + b, a - b, a * b FROM t1;
+}
+expect {
+    13|7|30
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-comparison {
+    CREATE DOMAIN myint AS integer;
+    CREATE TABLE t1(a myint) STRICT;
+    INSERT INTO t1 VALUES (1);
+    INSERT INTO t1 VALUES (2);
+    INSERT INTO t1 VALUES (3);
+    SELECT a FROM t1 WHERE a > 1 ORDER BY a;
+}
+expect {
+    2
+    3
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-aggregation {
+    CREATE DOMAIN myint AS integer;
+    CREATE TABLE t1(a myint) STRICT;
+    INSERT INTO t1 VALUES (10);
+    INSERT INTO t1 VALUES (20);
+    INSERT INTO t1 VALUES (30);
+    SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t1;
+}
+expect {
+    60|20.0|10|30
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-check-update-pass {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (50);
+    UPDATE t1 SET x = 75;
+    SELECT x FROM t1;
+}
+expect {
+    75
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-check-update-fail-domain {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (50);
+    UPDATE t1 SET x = -1;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-check-update-fail-col {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (50);
+    UPDATE t1 SET x = 200;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-col-check-pass {
+    CREATE DOMAIN nn_int AS integer NOT NULL;
+    CREATE TABLE t1(x nn_int CHECK (x > 0)) STRICT;
+    INSERT INTO t1 VALUES (5);
+    SELECT x FROM t1;
+}
+expect {
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-col-check-fail-null {
+    CREATE DOMAIN nn_int AS integer NOT NULL;
+    CREATE TABLE t1(x nn_int CHECK (x > 0)) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-col-check-fail-check {
+    CREATE DOMAIN nn_int AS integer NOT NULL;
+    CREATE TABLE t1(x nn_int CHECK (x > 0)) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-notnull-pass {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint NOT NULL) STRICT;
+    INSERT INTO t1 VALUES (5);
+    SELECT x FROM t1;
+}
+expect {
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-notnull-fail-null {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint NOT NULL) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-notnull-fail-check {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(x posint NOT NULL) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-chained-check-col-check-pass {
+    CREATE DOMAIN base_d AS integer CHECK (value > 0);
+    CREATE DOMAIN child_d AS base_d CHECK (value < 1000);
+    CREATE TABLE t1(x child_d CHECK (x != 500)) STRICT;
+    INSERT INTO t1 VALUES (50);
+    SELECT x FROM t1;
+}
+expect {
+    50
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-chained-check-col-check-fail-base {
+    CREATE DOMAIN base_d AS integer CHECK (value > 0);
+    CREATE DOMAIN child_d AS base_d CHECK (value < 1000);
+    CREATE TABLE t1(x child_d CHECK (x != 500)) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-chained-check-col-check-fail-child {
+    CREATE DOMAIN base_d AS integer CHECK (value > 0);
+    CREATE DOMAIN child_d AS base_d CHECK (value < 1000);
+    CREATE TABLE t1(x child_d CHECK (x != 500)) STRICT;
+    INSERT INTO t1 VALUES (2000);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-chained-check-col-check-fail-col {
+    CREATE DOMAIN base_d AS integer CHECK (value > 0);
+    CREATE DOMAIN child_d AS base_d CHECK (value < 1000);
+    CREATE TABLE t1(x child_d CHECK (x != 500)) STRICT;
+    INSERT INTO t1 VALUES (500);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-check-upsert-pass {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(id integer PRIMARY KEY, x posint CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (1, 50);
+    INSERT INTO t1 VALUES (1, 60) ON CONFLICT(id) DO UPDATE SET x = 75;
+    SELECT id, x FROM t1;
+}
+expect {
+    1|75
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-check-upsert-fail-domain {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(id integer PRIMARY KEY, x posint CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (1, 50);
+    INSERT INTO t1 VALUES (1, 60) ON CONFLICT(id) DO UPDATE SET x = -1;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-col-check-upsert-fail-col {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(id integer PRIMARY KEY, x posint CHECK (x < 100)) STRICT;
+    INSERT INTO t1 VALUES (1, 50);
+    INSERT INTO t1 VALUES (1, 60) ON CONFLICT(id) DO UPDATE SET x = 200;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-default-col-pass {
+    CREATE DOMAIN nn_int AS integer NOT NULL;
+    CREATE TABLE t1(x nn_int DEFAULT 42) STRICT;
+    INSERT INTO t1(rowid) VALUES (1);
+    SELECT x FROM t1;
+}
+expect {
+    42
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-notnull-default-col-fail-explicit-null {
+    CREATE DOMAIN nn_int AS integer NOT NULL;
+    CREATE TABLE t1(x nn_int DEFAULT 42) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-col-same-domain {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(a posint, b posint) STRICT;
+    INSERT INTO t1 VALUES (1, 2);
+    SELECT a, b FROM t1;
+}
+expect {
+    1|2
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-col-same-domain-fail-first {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(a posint, b posint) STRICT;
+    INSERT INTO t1 VALUES (-1, 2);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-col-same-domain-fail-second {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(a posint, b posint) STRICT;
+    INSERT INTO t1 VALUES (1, -2);
+}
+expect error {
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-index {
+    CREATE DOMAIN posint AS integer CHECK (value > 0);
+    CREATE TABLE t1(a posint) STRICT;
+    INSERT INTO t1 VALUES (3);
+    INSERT INTO t1 VALUES (1);
+    INSERT INTO t1 VALUES (5);
+    INSERT INTO t1 VALUES (2);
+    INSERT INTO t1 VALUES (4);
+    CREATE INDEX idx_a ON t1(a);
+    SELECT a FROM t1 WHERE a >= 3 ORDER BY a;
+}
+expect {
+    3
+    4
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-group-by {
+    CREATE DOMAIN category AS text CHECK (length(value) > 0);
+    CREATE TABLE t1(cat category, val integer) STRICT;
+    INSERT INTO t1 VALUES ('a', 10);
+    INSERT INTO t1 VALUES ('b', 20);
+    INSERT INTO t1 VALUES ('a', 30);
+    INSERT INTO t1 VALUES ('b', 40);
+    SELECT cat, SUM(val) FROM t1 GROUP BY cat ORDER BY cat;
+}
+expect {
+    a|40
+    b|60
+}
+
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-insert-pass {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    CREATE TABLE t1(x positive_cents) STRICT;
+    INSERT INTO t1 VALUES (5);
+    SELECT x FROM t1;
+}
+expect {
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-insert-fail {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    CREATE TABLE t1(x positive_cents) STRICT;
+    INSERT INTO t1 VALUES (-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-update-pass {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    CREATE TABLE t1(x positive_cents) STRICT;
+    INSERT INTO t1 VALUES (5);
+    UPDATE t1 SET x = 10;
+    SELECT x FROM t1;
+}
+expect {
+    10
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-update-fail {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    CREATE TABLE t1(x positive_cents) STRICT;
+    INSERT INTO t1 VALUES (5);
+    UPDATE t1 SET x = -1;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-cast-pass {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    SELECT CAST(5 AS positive_cents);
+}
+expect {
+    500
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-cast-fail {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    SELECT CAST(-1 AS positive_cents);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-notnull {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN notnull_cents AS cents NOT NULL;
+    CREATE TABLE t1(x notnull_cents) STRICT;
+    INSERT INTO t1 VALUES (NULL);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-order-by {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    CREATE TABLE t1(x positive_cents) STRICT;
+    INSERT INTO t1 VALUES (3);
+    INSERT INTO t1 VALUES (1);
+    INSERT INTO t1 VALUES (2);
+    SELECT x FROM t1 ORDER BY x;
+}
+expect {
+    1
+    2
+    3
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-over-custom-type-multi-col {
+    CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100;
+    CREATE DOMAIN positive_cents AS cents CHECK (value > 0);
+    CREATE TABLE t1(a positive_cents, b positive_cents) STRICT;
+    INSERT INTO t1 VALUES (5, 10);
+    SELECT a, b FROM t1;
+}
+expect {
+    5|10
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: parser / name handling
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-quoted-name {
+    CREATE DOMAIN "my domain" AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x "my domain") STRICT;
+    INSERT INTO t VALUES(5);
+    SELECT x FROM t;
+}
+expect {
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-quoted-name-check-fail {
+    CREATE DOMAIN "my domain" AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x "my domain") STRICT;
+    INSERT INTO t VALUES(-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-value-uppercase {
+    CREATE DOMAIN d AS INTEGER CHECK (VALUE > 0);
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-value-mixed-case {
+    CREATE DOMAIN d AS INTEGER CHECK (Value > 0);
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(5);
+    SELECT x FROM t;
+}
+expect {
+    5
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-column-named-value {
+    CREATE DOMAIN posint AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(value posint) STRICT;
+    INSERT INTO t VALUES(5);
+    INSERT INTO t VALUES(-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-column-named-value-pass {
+    CREATE DOMAIN posint AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(value posint) STRICT;
+    INSERT INTO t VALUES(7);
+    SELECT value FROM t;
+}
+expect {
+    7
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-name-case-insensitive {
+    CREATE DOMAIN MyDomain AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x mydomain) STRICT;
+    INSERT INTO t VALUES(-1);
+}
+expect error {
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: CHECK expression validation at CREATE time
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-aggregate-rejected {
+    CREATE DOMAIN d AS INTEGER CHECK (COUNT(value) > 0);
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-window-rejected {
+    CREATE DOMAIN d AS INTEGER CHECK (value > ROW_NUMBER() OVER ());
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-subquery-rejected-at-create {
+    CREATE DOMAIN d AS INTEGER CHECK (value > (SELECT 0));
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-subquery-rejected-on-insert {
+    CREATE DOMAIN d AS INTEGER CHECK (value > (SELECT 0));
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-random-rejected-at-create {
+    CREATE DOMAIN d AS INTEGER CHECK (value + RANDOM() > value - 1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-current-timestamp-accepted-at-create {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0 OR CURRENT_TIMESTAMP IS NOT NULL);
+    SELECT 1;
+}
+expect {
+    1
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: DEFAULT validation at CREATE time
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-subquery-rejected-at-create {
+    CREATE DOMAIN d AS INTEGER DEFAULT (SELECT 1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-subquery-rejected-on-default-insert {
+    CREATE DOMAIN d AS INTEGER DEFAULT (SELECT 1);
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t DEFAULT VALUES;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-default-column-ref-fails-at-insert {
+    CREATE DOMAIN d AS INTEGER DEFAULT some_col;
+    CREATE TABLE t(some_col INTEGER, x d) STRICT;
+    INSERT INTO t(some_col) VALUES(7);
+}
+expect error {
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: STRICT vs non-STRICT enforcement
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-non-strict-check-not-enforced {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x d);
+}
+expect error {
+    domain type columns require STRICT tables: t.x
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-non-strict-notnull-not-enforced {
+    CREATE DOMAIN d AS INTEGER NOT NULL;
+    CREATE TABLE t(x d);
+}
+expect error {
+    domain type columns require STRICT tables: t.x
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: ALTER TABLE ADD COLUMN with a domain type
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-alter-add-column-strict-enforces-check {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x INTEGER) STRICT;
+    ALTER TABLE t ADD COLUMN y d;
+    INSERT INTO t(x, y) VALUES(1, -5);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-alter-add-column-strict-enforces-notnull {
+    CREATE DOMAIN d AS INTEGER NOT NULL;
+    CREATE TABLE t(x INTEGER) STRICT;
+    ALTER TABLE t ADD COLUMN y d DEFAULT 1;
+    INSERT INTO t(x, y) VALUES(1, NULL);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-alter-add-column-update-enforces-check {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x INTEGER) STRICT;
+    INSERT INTO t(x) VALUES(1);
+    ALTER TABLE t ADD COLUMN y d;
+    UPDATE t SET y = -5;
+}
+expect error {
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: statement atomicity and ON CONFLICT paths
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-row-values-atomic {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(1), (-2), (3);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-multi-row-values-atomic-no-partial {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(1);
+    INSERT INTO t VALUES(2), (-3), (4);
+    SELECT x FROM t ORDER BY x;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-insert-select-atomic {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE src(x INTEGER);
+    INSERT INTO src VALUES(1), (2), (-3);
+    CREATE TABLE dst(y d) STRICT;
+    INSERT INTO dst SELECT x FROM src;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-insert-or-ignore-skips-violations {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x d) STRICT;
+    INSERT OR IGNORE INTO t VALUES(5), (-1), (10);
+    SELECT x FROM t ORDER BY x;
+}
+expect {
+    5
+    10
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-upsert-do-update-enforces-check {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(id INTEGER PRIMARY KEY, x d) STRICT;
+    INSERT INTO t VALUES(1, 5);
+    INSERT INTO t(id, x) VALUES(1, 10) ON CONFLICT(id) DO UPDATE SET x = -99;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-insert-or-replace-enforces-check {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(id INTEGER PRIMARY KEY, x d) STRICT;
+    INSERT INTO t VALUES(1, 5);
+    INSERT OR REPLACE INTO t VALUES(1, -1);
+}
+expect error {
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: triggers propagate domain enforcement
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-trigger-insert-enforces-check {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE src(x INTEGER) STRICT;
+    CREATE TABLE dst(y d) STRICT;
+    CREATE TRIGGER tr AFTER INSERT ON src BEGIN INSERT INTO dst VALUES(NEW.x); END;
+    INSERT INTO src VALUES(-1);
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-trigger-insert-pass {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE src(x INTEGER) STRICT;
+    CREATE TABLE dst(y d) STRICT;
+    CREATE TRIGGER tr AFTER INSERT ON src BEGIN INSERT INTO dst VALUES(NEW.x); END;
+    INSERT INTO src VALUES(7);
+    SELECT y FROM dst;
+}
+expect {
+    7
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: transactional DDL (ROLLBACK)
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-rollback-create-removes-domain {
+    BEGIN;
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    ROLLBACK;
+    CREATE TABLE t(x d) STRICT;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-rollback-drop-restores-domain {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    BEGIN;
+    DROP DOMAIN d;
+    ROLLBACK;
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(-1);
+}
+expect error {
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: DROP path and namespace rules
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-double-error {
+    CREATE DOMAIN d AS INTEGER;
+    DROP DOMAIN d;
+    DROP DOMAIN d;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-type-on-domain-errors {
+    CREATE DOMAIN d AS INTEGER;
+    DROP TYPE d;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-domain-on-type-errors {
+    CREATE TYPE mytype BASE INTEGER;
+    DROP DOMAIN mytype;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-mid-chain-rejected {
+    CREATE DOMAIN d1 AS INTEGER;
+    CREATE DOMAIN d2 AS d1;
+    CREATE DOMAIN d3 AS d2;
+    DROP DOMAIN d2;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-leaf-chain-ok {
+    CREATE DOMAIN d1 AS INTEGER;
+    CREATE DOMAIN d2 AS d1;
+    CREATE DOMAIN d3 AS d2;
+    DROP DOMAIN d3;
+    DROP DOMAIN d2;
+    DROP DOMAIN d1;
+    SELECT 'ok';
+}
+expect {
+    ok
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: base type and cycle handling
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-base-any-rejected {
+    CREATE DOMAIN d AS ANY;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-base-nonexistent-rejected {
+    CREATE DOMAIN d AS no_such_type;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-chain-five-levels-pass {
+    CREATE DOMAIN d1 AS INTEGER CHECK (value > 0);
+    CREATE DOMAIN d2 AS d1 CHECK (value < 1000);
+    CREATE DOMAIN d3 AS d2 CHECK (value % 2 = 0);
+    CREATE DOMAIN d4 AS d3 CHECK (value > 10);
+    CREATE DOMAIN d5 AS d4;
+    CREATE TABLE t(x d5) STRICT;
+    INSERT INTO t VALUES(50);
+    SELECT x FROM t;
+}
+expect {
+    50
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-chain-five-levels-fail-leaf-check {
+    CREATE DOMAIN d1 AS INTEGER CHECK (value > 0);
+    CREATE DOMAIN d2 AS d1 CHECK (value < 1000);
+    CREATE DOMAIN d3 AS d2 CHECK (value % 2 = 0);
+    CREATE DOMAIN d4 AS d3 CHECK (value > 10);
+    CREATE DOMAIN d5 AS d4;
+    CREATE TABLE t(x d5) STRICT;
+    INSERT INTO t VALUES(5);
+}
+expect error {
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: IF NOT EXISTS silently keeps old definition
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-if-not-exists-keeps-old-def {
+    CREATE DOMAIN d AS INTEGER DEFAULT 5;
+    CREATE DOMAIN IF NOT EXISTS d AS TEXT DEFAULT 'x';
+    CREATE TABLE t(a d) STRICT;
+    INSERT INTO t DEFAULT VALUES;
+    SELECT a, typeof(a) FROM t;
+}
+expect {
+    5|integer
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: schema_version cookie bumps
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-create-bumps-schema-version {
+    PRAGMA schema_version = 0;
+    CREATE DOMAIN d AS INTEGER;
+    SELECT schema_version > 0 FROM pragma_schema_version();
+}
+expect {
+    1
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-drop-bumps-schema-version {
+    CREATE DOMAIN d AS INTEGER;
+    PRAGMA schema_version;
+    DROP DOMAIN d;
+}
+expect {
+    1
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: persisted SQL round-trip
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-persist-check-parens-roundtrip {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0 AND (value < 100 OR value = 200)) DEFAULT 42;
+    SELECT sql FROM __turso_internal_types WHERE name = 'd';
+}
+expect {
+    CREATE DOMAIN d AS INTEGER DEFAULT 42 CHECK (value > 0 AND (value < 100 OR value = 200))
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-persist-named-check-roundtrip {
+    CREATE DOMAIN d AS INTEGER CONSTRAINT positive CHECK (value > 0) CONSTRAINT bounded CHECK (value < 100);
+    SELECT sql FROM __turso_internal_types WHERE name = 'd';
+}
+expect {
+    CREATE DOMAIN d AS INTEGER CONSTRAINT positive CHECK (value > 0) CONSTRAINT bounded CHECK (value < 100)
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: NULL semantics under CHECK + NOT NULL combinations
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-check-null-passes-when-nullable {
+    CREATE DOMAIN posint AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x posint) STRICT;
+    INSERT INTO t VALUES(NULL);
+    SELECT count(*) FROM t WHERE x IS NULL;
+}
+expect {
+    1
+}
+
+
+# ------------------------------------------------------------------------------
+# Adversarial tests: index / delete / update paths on domain columns
+# ------------------------------------------------------------------------------
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-delete-preserves-check {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x d) STRICT;
+    INSERT INTO t VALUES(1), (2), (3);
+    DELETE FROM t WHERE x = 2;
+    SELECT x FROM t ORDER BY x;
+}
+expect {
+    1
+    3
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-indexed-column-update-check-fail {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x d) STRICT;
+    CREATE INDEX i ON t(x);
+    INSERT INTO t VALUES(5);
+    UPDATE t SET x = -1;
+}
+expect error {
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-indexed-column-update-pass {
+    CREATE DOMAIN d AS INTEGER CHECK (value > 0);
+    CREATE TABLE t(x d) STRICT;
+    CREATE INDEX i ON t(x);
+    INSERT INTO t VALUES(5);
+    UPDATE t SET x = 7;
+    SELECT x FROM t;
+}
+expect {
+    7
+}
+
+@requires custom_types "uses CREATE DOMAIN"
+test domain-alter-add-column-inherits-default {
+    CREATE DOMAIN defint AS INTEGER DEFAULT 42;
+    CREATE TABLE t(x INTEGER) STRICT;
+    INSERT INTO t VALUES(1);
+    INSERT INTO t VALUES(2);
+    ALTER TABLE t ADD COLUMN y defint;
+    SELECT x, y FROM t ORDER BY x;
+}
+expect {
+    1|42
+    2|42
+}


### PR DESCRIPTION
This is also present in Postgres and is part of the type system. It will make a great addition to what we do.

Domains are much lighter than types: they are just normal types that encode properties (like default, not null, and checks).

This is also dependent on the experimental flag for custom types.

