### PR TITLE
conformance/sqlite3: Fix TCL for func7 and func8

### DIFF
--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -192,18 +192,31 @@ static void tcl_scalar_bridge(void *ctx, int argc, void **argv)
     Tcl_Interp  *interp = func->interp;
     int          i, rc;
 
-    /* Bind argument variables in the calling scope. */
-    for (i = 0; i < argc && i < func->n_args; i++) {
-        Tcl_Obj *val = value_to_obj(argv[i]);
-        if (Tcl_ObjSetVar2(interp, func->arg_names[i], NULL, val,
-                           TCL_LEAVE_ERR_MSG) == NULL) {
-            sqlite3_result_error(ctx, Tcl_GetString(Tcl_GetObjResult(interp)), -1);
-            return;
+    if (func->n_args > 0) {
+        /* Custom Turso behavior: Bind argument variables in the calling scope. */
+        for (i = 0; i < argc && i < func->n_args; i++) {
+            Tcl_Obj *val = value_to_obj(argv[i]);
+            if (Tcl_ObjSetVar2(interp, func->arg_names[i], NULL, val,
+                               TCL_LEAVE_ERR_MSG) == NULL) {
+                sqlite3_result_error(ctx, Tcl_GetString(Tcl_GetObjResult(interp)), -1);
+                return;
+            }
         }
-    }
 
-    /* Evaluate the script body. */
-    rc = Tcl_EvalObjEx(interp, func->script, 0);
+        /* Evaluate the script body. */
+        rc = Tcl_EvalObjEx(interp, func->script, 0);
+    } else {
+        /* Standard SQLite behavior: Append SQL arguments to the script prefix. */
+        Tcl_Obj *cmd = Tcl_DuplicateObj(func->script);
+        Tcl_IncrRefCount(cmd);
+
+        for (i = 0; i < argc; i++) {
+            Tcl_ListObjAppendElement(interp, cmd, value_to_obj(argv[i]));
+        }
+
+        rc = Tcl_EvalObjEx(interp, cmd, TCL_EVAL_DIRECT);
+        Tcl_DecrRefCount(cmd);
+    }
 
     if (rc == TCL_ERROR) {
         const char *err = Tcl_GetString(Tcl_GetObjResult(interp));

--- a/testing/conformance/sqlite3/all.test
+++ b/testing/conformance/sqlite3/all.test
@@ -59,8 +59,8 @@ source $testdir/func2.test
 # FIXME: source $testdir/func4.test
 # FIXME: source $testdir/func5.test
 # FIXME: source $testdir/func6.test
-# FIXME: source $testdir/func7.test
-# FIXME: source $testdir/func8.test
+source $testdir/func7.test
+source $testdir/func8.test
 source $testdir/func9.test
 
 # Print aggregate summary and exit non-zero if any test failed.

--- a/testing/conformance/sqlite3/tester.tcl
+++ b/testing/conformance/sqlite3/tester.tcl
@@ -146,17 +146,44 @@ proc do_test {name cmd expected} {
     # Regular expression match
     set pattern [string range $expected 1 end-1]
     set ok [regexp $pattern $result]
-  } elseif {[string match "*" $expected]} {
-    # Glob pattern match
+  } elseif {[string first "*" $expected] != -1} {
+    # Glob pattern match (only if expected string contains a literal '*')
     set ok [string match $expected $result]
   } else {
-    # Exact match - handle both list and string formats
+    # Exact match - handle both list and string formats with true mathematical fallback
     if {[llength $expected] > 1 || [llength $result] > 1} {
       # List comparison
-      set ok [expr {$result eq $expected}]
+      set ok [expr {[llength $result] == [llength $expected]}]
+      if {$ok} {
+        for {set i 0} {$i < [llength $result]} {incr i} {
+          set r [lindex $result $i]
+          set e [lindex $expected $i]
+          if {$r ne $e} {
+            if {[string is double -strict $r] && [string is double -strict $e]} {
+              # True mathematical comparison for floating point noise
+              if {[expr {abs($r - $e) > 1e-12}]} {
+                set ok 0; break
+              }
+            } else {
+              set ok 0; break
+            }
+          }
+        }
+      }
     } else {
       # String comparison
-      set ok [expr {[string trim $result] eq [string trim $expected]}]
+      set r [string trim $result]
+      set e [string trim $expected]
+      if {$r ne $e} {
+        if {[string is double -strict $r] && [string is double -strict $e]} {
+          # True mathematical comparison for floating point noise
+          set ok [expr {abs($r - $e) < 1e-12}]
+        } else {
+          set ok 0
+        }
+      } else {
+        set ok 1
+      }
     }
   }
 

--- a/testing/sqltests/tests/scalar-functions-printf.sqltest
+++ b/testing/sqltests/tests/scalar-functions-printf.sqltest
@@ -1374,3 +1374,17 @@ test printf-blob-s-nul {
 expect {
     1
 }
+
+test func7-pg-301 {
+   SELECT format('%f',degrees(acos(0.5)));
+} 
+expect {
+    60.000000
+}
+
+test func7-pg-311 {
+   SELECT format('%f',degrees( asin(0.5) ));
+} 
+expect {
+    30.000000
+}

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -2463,3 +2463,27 @@ test func9-160 {
 expect error {
     wrong number of arguments to function concat_ws()
 }
+
+test func7-pg-180 {
+    SELECT log10(1000.0);
+}
+expect {
+    3.0
+}
+expect @js {
+    3
+}
+
+test func7-pg-401 {
+   SELECT cos( radians(60.0) );
+} 
+expect {
+    0.5
+}
+
+test func7-pg-411 {
+   SELECT sin( radians(30) );
+} 
+expect {
+    0.5
+}


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description
More closely aligns how sqlite runs tcl tests and enables func7 and func8.

## Motivation and context
It seems like tcl handles floating point different than the database so sqlite has a fuzzy comparison logic.
I copied the failing func7 tests to sqltests to verify that its properly outputting.


## Description of AI Usage
Fed turso files, sqlite files, and an explanation of the error into the ai.
