### PR TITLE
Fix npm publish workflow asset name mismatch

### DIFF
--- a/.github/workflows/publish-cli-npm.yml
+++ b/.github/workflows/publish-cli-npm.yml
@@ -71,28 +71,28 @@ jobs:
 
           # Download all platform archives
           gh release download "$TAG" \
-            --pattern "tursodb-aarch64-apple-darwin.tar.xz" \
-            --pattern "tursodb-x86_64-apple-darwin.tar.xz" \
-            --pattern "tursodb-aarch64-unknown-linux-gnu.tar.xz" \
-            --pattern "tursodb-x86_64-unknown-linux-gnu.tar.xz" \
-            --pattern "tursodb-x86_64-pc-windows-msvc.zip" \
+            --pattern "turso_cli-aarch64-apple-darwin.tar.xz" \
+            --pattern "turso_cli-x86_64-apple-darwin.tar.xz" \
+            --pattern "turso_cli-aarch64-unknown-linux-gnu.tar.xz" \
+            --pattern "turso_cli-x86_64-unknown-linux-gnu.tar.xz" \
+            --pattern "turso_cli-x86_64-pc-windows-msvc.zip" \
             --dir "$TMPDIR"
 
           # Extract each binary into the corresponding npm package directory
-          tar -xf "$TMPDIR/tursodb-aarch64-apple-darwin.tar.xz" -C "$TMPDIR"
-          cp "$TMPDIR/tursodb-aarch64-apple-darwin/tursodb" packages/turso-cli/npm/darwin-arm64/tursodb
+          tar -xf "$TMPDIR/turso_cli-aarch64-apple-darwin.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/turso_cli-aarch64-apple-darwin/tursodb" packages/turso-cli/npm/darwin-arm64/tursodb
 
-          tar -xf "$TMPDIR/tursodb-x86_64-apple-darwin.tar.xz" -C "$TMPDIR"
-          cp "$TMPDIR/tursodb-x86_64-apple-darwin/tursodb" packages/turso-cli/npm/darwin-x64/tursodb
+          tar -xf "$TMPDIR/turso_cli-x86_64-apple-darwin.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/turso_cli-x86_64-apple-darwin/tursodb" packages/turso-cli/npm/darwin-x64/tursodb
 
-          tar -xf "$TMPDIR/tursodb-aarch64-unknown-linux-gnu.tar.xz" -C "$TMPDIR"
-          cp "$TMPDIR/tursodb-aarch64-unknown-linux-gnu/tursodb" packages/turso-cli/npm/linux-arm64-gnu/tursodb
+          tar -xf "$TMPDIR/turso_cli-aarch64-unknown-linux-gnu.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/turso_cli-aarch64-unknown-linux-gnu/tursodb" packages/turso-cli/npm/linux-arm64-gnu/tursodb
 
-          tar -xf "$TMPDIR/tursodb-x86_64-unknown-linux-gnu.tar.xz" -C "$TMPDIR"
-          cp "$TMPDIR/tursodb-x86_64-unknown-linux-gnu/tursodb" packages/turso-cli/npm/linux-x64-gnu/tursodb
+          tar -xf "$TMPDIR/turso_cli-x86_64-unknown-linux-gnu.tar.xz" -C "$TMPDIR"
+          cp "$TMPDIR/turso_cli-x86_64-unknown-linux-gnu/tursodb" packages/turso-cli/npm/linux-x64-gnu/tursodb
 
-          unzip -o "$TMPDIR/tursodb-x86_64-pc-windows-msvc.zip" -d "$TMPDIR/tursodb-x86_64-pc-windows-msvc"
-          cp "$TMPDIR/tursodb-x86_64-pc-windows-msvc/tursodb.exe" packages/turso-cli/npm/win32-x64-msvc/tursodb.exe
+          unzip -o "$TMPDIR/turso_cli-x86_64-pc-windows-msvc.zip" -d "$TMPDIR/turso_cli-x86_64-pc-windows-msvc"
+          cp "$TMPDIR/turso_cli-x86_64-pc-windows-msvc/tursodb.exe" packages/turso-cli/npm/win32-x64-msvc/tursodb.exe
 
           # Set executable permissions
           chmod +x packages/turso-cli/npm/darwin-arm64/tursodb


### PR DESCRIPTION
## Summary
- cargo-dist names release archives after the Cargo package name (turso_cli), not the binary name (tursodb)
- The npm publish workflow was downloading tursodb-{target}.* assets which don't exist, causing every run to fail with 'no assets match the file pattern'
- Updated all archive filename and extracted directory references from tursodb- to turso_cli-

## Test plan
- Verified locally: gh release download v0.6.0-pre.19 --pattern 'turso_cli-*' succeeds, --pattern 'tursodb-*' fails
- The binary name inside archives is still tursodb — npm packages and CLI name are unaffected