### PR TITLE
sqlite3: Expose sqlite3_search_count to TCL test harness

### DIFF
--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -757,6 +757,9 @@ static int TursoOpenCmd(ClientData cd, Tcl_Interp *interp,
 /* Extension initialisation                                             */
 /* ------------------------------------------------------------------ */
 
+/* Defined in the sqlite3 Rust crate (sqlite3/src/lib.rs) */
+extern int sqlite3_search_count;
+
 int Tursotcl_Init(Tcl_Interp *interp)
 {
     if (Tcl_InitStubs(interp, TCL_VERSION, 0) == NULL) {
@@ -766,6 +769,10 @@ int Tursotcl_Init(Tcl_Interp *interp)
     turso_enable_experimental();
 
     Tcl_CreateObjCommand(interp, "sqlite3", TursoOpenCmd, NULL, NULL);
+
+    /* Link the global B-tree search counter so TCL tests can read/reset it. */
+    Tcl_LinkVar(interp, "sqlite_search_count",
+                (char *)&sqlite3_search_count, TCL_LINK_INT);
 
     Tcl_PkgProvide(interp, "tursotcl", TURSO_TCL_VERSION);
     return TCL_OK;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1724,6 +1724,8 @@ pub fn op_column(
                         }
                     }
                 }
+                state.metrics.btree_seeks = state.metrics.btree_seeks.saturating_add(1);
+                state.metrics.search_count = state.metrics.search_count.saturating_add(1);
                 state.op_column_state = OpColumnState::GetColumn;
             }
             OpColumnState::GetColumn => {
@@ -2551,6 +2553,7 @@ pub fn op_next(
         // Increment metrics for row read
         state.record_rows_read(1);
         state.metrics.btree_next = state.metrics.btree_next.saturating_add(1);
+        state.metrics.search_count = state.metrics.search_count.saturating_add(1);
         // Track if this is a full table scan or index scan
         if let Some((_, cursor_type)) = program.cursor_ref.get(*cursor_id) {
             if cursor_type.is_index() {
@@ -2598,6 +2601,7 @@ pub fn op_prev(
         // Increment metrics for row read
         state.record_rows_read(1);
         state.metrics.btree_prev = state.metrics.btree_prev.saturating_add(1);
+        state.metrics.search_count = state.metrics.search_count.saturating_add(1);
         // Track if this is a full table scan or index scan
         if let Some((_, cursor_type)) = program.cursor_ref.get(*cursor_id) {
             if cursor_type.is_index() {
@@ -4711,10 +4715,12 @@ pub fn op_seek(
         op,
     ) {
         Ok(SeekInternalResult::Found) => {
+            state.metrics.search_count = state.metrics.search_count.saturating_add(1);
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
         Ok(SeekInternalResult::NotFound) => {
+            state.metrics.search_count = state.metrics.search_count.saturating_add(1);
             state.pc = target_pc.as_offset_int();
             Ok(InsnFunctionStepResult::Step)
         }
@@ -6164,6 +6170,7 @@ pub fn op_sorter_sort(
     if did_sort {
         state.metrics.sort_operations = state.metrics.sort_operations.saturating_add(1);
     }
+    state.metrics.search_count = state.metrics.search_count.saturating_sub(1);
     if is_empty {
         state.pc = pc_if_empty.as_offset_int();
     } else {
@@ -6193,6 +6200,7 @@ pub fn op_sorter_next(
         cursor.has_more()
     };
     if has_more {
+        state.metrics.search_count = state.metrics.search_count.saturating_add(1);
         state.pc = pc_if_next.as_offset_int();
     } else {
         state.pc += 1;

--- a/core/vdbe/metrics.rs
+++ b/core/vdbe/metrics.rs
@@ -90,6 +90,10 @@ pub struct StatementMetrics {
     pub btree_next: u64,
     pub btree_prev: u64,
 
+    /// Signed counter tracking seeks and cursor advances, decremented on sort
+    /// rewind to avoid double-counting. Exposed as `sqlite3_search_count`.
+    pub search_count: i64,
+
     // Hash join spill/probe metrics
     pub hash_join: HashJoinMetrics,
 }
@@ -120,6 +124,7 @@ impl StatementMetrics {
         self.btree_seeks = self.btree_seeks.saturating_add(other.btree_seeks);
         self.btree_next = self.btree_next.saturating_add(other.btree_next);
         self.btree_prev = self.btree_prev.saturating_add(other.btree_prev);
+        self.search_count = self.search_count.saturating_add(other.search_count);
         self.hash_join.merge(&other.hash_join);
     }
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -13,6 +13,12 @@ use turso_ext::Value as ExtValue;
 /// Global flag: when set, all subsequently opened databases enable experimental features.
 static EXPERIMENTAL_ENABLED: AtomicBool = AtomicBool::new(false);
 
+/// Global B-tree search counter exposed to the TCL test harness as
+/// `sqlite_search_count`.
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+pub static mut sqlite3_search_count: ffi::c_int = 0;
+
 /// Enable all experimental features for databases opened after this call.
 #[no_mangle]
 pub extern "C" fn turso_enable_experimental() {
@@ -152,6 +158,9 @@ pub struct sqlite3_stmt {
     /// Cached ExtValue instances for sqlite3_column_value().
     /// Populated lazily per column; cleared on each step/reset.
     pub(crate) value_cache: Vec<Option<ExtValue>>,
+    /// High-water mark of `search_count` already published to the global
+    /// counter, so each step contributes only the delta.
+    pub(crate) prev_search_count: i64,
 }
 
 impl sqlite3_stmt {
@@ -164,6 +173,7 @@ impl sqlite3_stmt {
             next: std::ptr::null_mut(),
             text_cache: vec![vec![]; n_cols],
             value_cache: (0..n_cols).map(|_| None).collect(),
+            prev_search_count: 0,
         }
     }
     #[inline]
@@ -901,7 +911,7 @@ pub unsafe extern "C" fn sqlite3_step(stmt: *mut sqlite3_stmt) -> ffi::c_int {
     let db = &mut *stmt.db;
     let mut db_inner = db.inner.lock().unwrap();
     let res = stmt.stmt.run_one_step_blocking(|| Ok(()), || Ok(()));
-    match res {
+    let rc = match res {
         Ok(Some(_)) => {
             stmt.clear_text_cache();
             SQLITE_ROW
@@ -913,7 +923,12 @@ pub unsafe extern "C" fn sqlite3_step(stmt: *mut sqlite3_stmt) -> ffi::c_int {
         Err(LimboError::Busy) => SQLITE_BUSY,
         Err(LimboError::Interrupt) => SQLITE_INTERRUPT,
         Err(err) => set_db_err(&mut db_inner, err),
-    }
+    };
+    let current = stmt.stmt.metrics().search_count;
+    let delta = current - stmt.prev_search_count;
+    stmt.prev_search_count = current;
+    sqlite3_search_count = sqlite3_search_count.saturating_add(delta as ffi::c_int);
+    rc
 }
 
 type exec_callback = Option<
@@ -1210,6 +1225,7 @@ pub unsafe extern "C" fn sqlite3_reset(stmt: *mut sqlite3_stmt) -> ffi::c_int {
     if let Err(err) = stmt.stmt.reset() {
         return handle_limbo_err(err, std::ptr::null_mut());
     }
+    stmt.prev_search_count = 0;
     stmt.clear_text_cache();
     SQLITE_OK
 }

--- a/testing/conformance/sqlite3/all.test
+++ b/testing/conformance/sqlite3/all.test
@@ -8,7 +8,7 @@ set testdir [file dirname $argv0]
 set ALL_TESTS 1
 
 source $testdir/select1.test
-# FIXME: source $testdir/select2.test
+source $testdir/select2.test
 # FIXME: source $testdir/select3.test
 # FIXME: source $testdir/select4.test
 # FIXME: source $testdir/select5.test

--- a/testing/conformance/sqlite3/select2.test
+++ b/testing/conformance/sqlite3/select2.test
@@ -61,41 +61,40 @@ unset data
 # without.  Compare the performance to make sure things go faster with the
 # cache turned on.
 #
-# TODO: This takes forever to run!
-#ifcapable tclvar {
-#  do_test select2-2.0.1 {
-#    set t1 [time {
-#      execsql {CREATE TABLE tbl2 (f1 int, f2 int, f3 int); BEGIN;}
-#      for {set i 1} {$i<=30000} {incr i} {
-#        set i2 [expr {$i*2}]
-#        set i3 [expr {$i*3}]
-#        db eval {INSERT INTO tbl2 VALUES($i,$i2,$i3)}
-#      }
-#      execsql {COMMIT}
-#    }]
-#    list
-#  } {}
-#  puts "time with cache: $::t1"
-#}
-#catch {execsql {DROP TABLE tbl2}}
-#do_test select2-2.0.2 {
-#  set t2 [time {
-#    execsql {CREATE TABLE tbl2 (f1 int, f2 int, f3 int); BEGIN;}
-#    for {set i 1} {$i<=30000} {incr i} {
-#      set i2 [expr {$i*2}]
-#      set i3 [expr {$i*3}]
-#      execsql "INSERT INTO tbl2 VALUES($i,$i2,$i3)"
-#    }
-#    execsql {COMMIT}
-#  }]
-#  list
-#} {}
-#puts "time without cache: $t2"
-#ifcapable tclvar {
-#  do_test select2-2.0.3 {
-#    expr {[lindex $t1 0]<[lindex $t2 0]}
-#  } 1
-#}
+ifcapable tclvar {
+  do_test select2-2.0.1 {
+    set t1 [time {
+      execsql {CREATE TABLE tbl2 (f1 int, f2 int, f3 int); BEGIN;}
+      for {set i 1} {$i<=30000} {incr i} {
+        set i2 [expr {$i*2}]
+        set i3 [expr {$i*3}]
+        db eval {INSERT INTO tbl2 VALUES($i,$i2,$i3)}
+      }
+      execsql {COMMIT}
+    }]
+    list
+  } {}
+  puts "time with cache: $::t1"
+}
+catch {execsql {DROP TABLE tbl2}}
+do_test select2-2.0.2 {
+  set t2 [time {
+    execsql {CREATE TABLE tbl2 (f1 int, f2 int, f3 int); BEGIN;}
+    for {set i 1} {$i<=30000} {incr i} {
+      set i2 [expr {$i*2}]
+      set i3 [expr {$i*3}]
+      execsql "INSERT INTO tbl2 VALUES($i,$i2,$i3)"
+    }
+    execsql {COMMIT}
+  }]
+  list
+} {}
+puts "time without cache: $t2"
+ifcapable tclvar {
+  do_test select2-2.0.3 {
+    expr {[lindex $t1 0]<[lindex $t2 0]}
+  } 1
+}
 
 do_test select2-2.1 {
   execsql {SELECT count(*) FROM tbl2}


### PR DESCRIPTION
The TCL tests in testing/sqlite3 (e.g. select2-3.2d, select2-3.3)
read the sqlite_search_count Tcl variable to verify that index
lookups and table scans visit the expected number of rows. Upstream
SQLite increments sqlite3_search_count from OP_SeekXX, the deferred
rowid moveto, and successful OP_Next / OP_Prev. Mirror that here:

  - Add a global sqlite3_search_count C symbol in sqlite3/src/lib.rs
    and update it from sqlite3_step() with the per-step delta of
    btree_seeks + btree_next + btree_prev.
  - Track the deferred rowid seek inside op_column as a real
    btree_seeks event so the count includes that work.
  - Link sqlite_search_count in the Tcl bindings via Tcl_LinkVar.
