### PR TITLE
add checkpoint flag for `perf/memory`

### DIFF
--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -24,6 +24,9 @@ cargo run --release -p memory-benchmark -- --mode wal --workload insert-heavy -i
 # MVCC with concurrent connections
 cargo run --release -p memory-benchmark -- --mode mvcc --workload mixed -i 100 -b 100 --connections 4
 
+# Run a final checkpoint after the workload
+cargo run --release -p memory-benchmark -- --mode wal --workload read-heavy --checkpoint
+
 # All CLI options
 cargo run --release -p memory-benchmark -- \
   --mode wal|mvcc \
@@ -31,6 +34,7 @@ cargo run --release -p memory-benchmark -- \
   -i <iterations> \
   -b <batch-size> \
   --connections <N> \
+  --checkpoint \
   --timeout <ms> \
   --cache-size <pages> \
   --format human|json|csv
@@ -146,6 +150,7 @@ When investigating memory usage or a suspected regression:
 When `--connections > 1`:
 - Setup phase (schema creation, seeding) always runs on a single connection sequentially
 - Run phase spawns one tokio task per connection, each executing its batch concurrently
+- `--checkpoint` adds a final single-connection `PRAGMA wal_checkpoint(TRUNCATE)` phase after the run phase
 - Each connection gets `busy_timeout` set (default 30s, configurable via `--timeout`)
 - WAL mode uses `BEGIN`, MVCC uses `BEGIN CONCURRENT`
 - The `Profile` trait's `next_batch(connections)` returns one batch per connection with non-overlapping row IDs

--- a/perf/memory/src/main.rs
+++ b/perf/memory/src/main.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use profile::{
-    Phase, Profile, WorkItem, insert::InsertHeavy, mixed::Mixed, read::ReadHeavy, scan::ScanHeavy,
-    series_blob::SeriesBlob,
+    Phase, Profile, WorkItem, checkpoint::Checkpoint, insert::InsertHeavy, mixed::Mixed,
+    read::ReadHeavy, scan::ScanHeavy, series_blob::SeriesBlob,
 };
 use turso::Connection;
 use turso::params::Params;
@@ -95,6 +95,10 @@ struct Args {
     /// Output format
     #[arg(long = "format", default_value = "human")]
     format: OutputFormat,
+
+    /// Run a final checkpoint after the workload completes
+    #[arg(long)]
+    checkpoint: bool,
 }
 
 fn main() -> Result<()> {
@@ -117,7 +121,12 @@ async fn async_main(args: Args) -> Result<()> {
     let db_path = "memory_benchmark.db";
     clean_db_files(db_path);
 
-    let mut profile = create_profile(args.workload, args.iterations, args.batch_size);
+    let mut profile = create_profile(
+        args.workload,
+        args.iterations,
+        args.batch_size,
+        args.checkpoint,
+    );
     let timeout = Duration::from_millis(args.timeout);
 
     let start = Instant::now();
@@ -164,6 +173,7 @@ async fn async_main(args: Args) -> Result<()> {
             let label = match phase {
                 Phase::Setup => "setup",
                 Phase::Run => "run-start",
+                Phase::Checkpoint => "checkpoint",
                 Phase::Done => unreachable!(),
             };
             snapshots.push(take_snapshot(start, label));
@@ -174,34 +184,44 @@ async fn async_main(args: Args) -> Result<()> {
             continue;
         }
 
-        if phase == Phase::Setup {
-            // Setup runs sequentially on a single connection
-            let items = batches.into_iter().next().unwrap_or_default();
-            if !items.is_empty() {
-                setup_conn.execute("BEGIN", ()).await?;
-                execute_items(&setup_conn, items).await?;
-                setup_conn.execute("COMMIT", ()).await?;
-            }
-        } else {
-            // Run phase: dispatch batches concurrently across connections
-            let mut handles = Vec::with_capacity(batches.len());
-            for items in batches {
-                if items.is_empty() {
-                    continue;
+        match phase {
+            Phase::Setup => {
+                // Setup runs sequentially on a single connection.
+                let items = batches.into_iter().next().unwrap_or_default();
+                if !items.is_empty() {
+                    setup_conn.execute("BEGIN", ()).await?;
+                    execute_items(&setup_conn, items).await?;
+                    setup_conn.execute("COMMIT", ()).await?;
                 }
-                let conn = db.connect()?;
-                conn.busy_timeout(timeout)?;
-                let begin = begin_stmt.to_string();
-                handles.push(tokio::spawn(async move {
-                    conn.execute(&begin, ()).await?;
-                    execute_items(&conn, items).await?;
-                    conn.execute("COMMIT", ()).await?;
-                    Ok::<_, turso::Error>(())
-                }));
             }
-            for handle in handles {
-                handle.await??;
+            Phase::Run => {
+                // Run phase: dispatch batches concurrently across connections.
+                let mut handles = Vec::with_capacity(batches.len());
+                for items in batches {
+                    if items.is_empty() {
+                        continue;
+                    }
+                    let conn = db.connect()?;
+                    conn.busy_timeout(timeout)?;
+                    let begin = begin_stmt.to_string();
+                    handles.push(tokio::spawn(async move {
+                        conn.execute(&begin, ()).await?;
+                        execute_items(&conn, items).await?;
+                        conn.execute("COMMIT", ()).await?;
+                        Ok::<_, turso::Error>(())
+                    }));
+                }
+                for handle in handles {
+                    handle.await??;
+                }
             }
+            Phase::Checkpoint => {
+                let items = batches.into_iter().next().unwrap_or_default();
+                if !items.is_empty() {
+                    execute_checkpoint_items(&setup_conn, items).await?;
+                }
+            }
+            Phase::Done => unreachable!(),
         }
 
         // Track peak
@@ -284,14 +304,34 @@ fn create_profile(
     workload: WorkloadProfile,
     iterations: usize,
     batch_size: usize,
+    checkpoint: bool,
 ) -> Box<dyn Profile> {
-    match workload {
+    let profile: Box<dyn Profile> = match workload {
         WorkloadProfile::InsertHeavy => Box::new(InsertHeavy::new(iterations, batch_size)),
         WorkloadProfile::ReadHeavy => Box::new(ReadHeavy::new(iterations, batch_size)),
         WorkloadProfile::Mixed => Box::new(Mixed::new(iterations, batch_size)),
         WorkloadProfile::ScanHeavy => Box::new(ScanHeavy::new(iterations, batch_size)),
         WorkloadProfile::SeriesBlob => Box::new(SeriesBlob::new(iterations, batch_size)),
+    };
+
+    if checkpoint {
+        Box::new(Checkpoint::new(profile))
+    } else {
+        profile
     }
+}
+
+async fn execute_checkpoint_items(
+    conn: &Connection,
+    items: Vec<WorkItem>,
+) -> Result<(), turso::Error> {
+    for item in items {
+        let mut rows = conn
+            .query(&item.sql, Params::Positional(item.params))
+            .await?;
+        while rows.next().await?.is_some() {}
+    }
+    Ok(())
 }
 
 fn clean_db_files(db_path: &str) {

--- a/perf/memory/src/profile/checkpoint.rs
+++ b/perf/memory/src/profile/checkpoint.rs
@@ -1,0 +1,120 @@
+use super::{Phase, Profile, WorkItem};
+
+pub struct Checkpoint {
+    inner: Box<dyn Profile>,
+    name: String,
+    needs_checkpoint: bool,
+}
+
+impl Checkpoint {
+    pub fn new(inner: Box<dyn Profile>) -> Self {
+        let name = format!("{}+checkpoint", inner.name());
+        Self {
+            inner,
+            name,
+            needs_checkpoint: true,
+        }
+    }
+}
+
+impl Profile for Checkpoint {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn next_batch(&mut self, connections: usize) -> (Phase, Vec<Vec<WorkItem>>) {
+        if !self.needs_checkpoint {
+            return (Phase::Done, vec![]);
+        }
+
+        let (phase, batches) = self.inner.next_batch(connections);
+        if phase != Phase::Done {
+            return (phase, batches);
+        }
+
+        self.needs_checkpoint = false;
+        (
+            Phase::Checkpoint,
+            vec![vec![WorkItem {
+                sql: "PRAGMA wal_checkpoint(TRUNCATE)".to_string(),
+                params: vec![],
+            }]],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ScriptedProfile {
+        name: &'static str,
+        steps: std::vec::IntoIter<(Phase, Vec<Vec<WorkItem>>)>,
+    }
+
+    impl ScriptedProfile {
+        fn new(steps: Vec<(Phase, Vec<Vec<WorkItem>>)>) -> Self {
+            Self {
+                name: "scripted",
+                steps: steps.into_iter(),
+            }
+        }
+    }
+
+    impl Profile for ScriptedProfile {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn next_batch(&mut self, _connections: usize) -> (Phase, Vec<Vec<WorkItem>>) {
+            self.steps.next().unwrap_or((Phase::Done, vec![]))
+        }
+    }
+
+    #[test]
+    fn checkpoint_profile_runs_after_inner_profile_completes() {
+        let setup = WorkItem {
+            sql: "CREATE TABLE bench(id INTEGER PRIMARY KEY)".to_string(),
+            params: vec![],
+        };
+        let run = WorkItem {
+            sql: "SELECT * FROM bench".to_string(),
+            params: vec![],
+        };
+
+        let inner = Box::new(ScriptedProfile::new(vec![
+            (Phase::Setup, vec![vec![setup]]),
+            (Phase::Run, vec![vec![run]]),
+            (Phase::Done, vec![]),
+        ]));
+        let mut profile = Checkpoint::new(inner);
+
+        assert_eq!(profile.name(), "scripted+checkpoint");
+
+        let (phase, batches) = profile.next_batch(1);
+        assert_eq!(phase, Phase::Setup);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(
+            batches[0][0].sql,
+            "CREATE TABLE bench(id INTEGER PRIMARY KEY)"
+        );
+
+        let (phase, batches) = profile.next_batch(1);
+        assert_eq!(phase, Phase::Run);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(batches[0][0].sql, "SELECT * FROM bench");
+
+        let (phase, batches) = profile.next_batch(1);
+        assert_eq!(phase, Phase::Checkpoint);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(batches[0][0].sql, "PRAGMA wal_checkpoint(TRUNCATE)");
+        assert!(batches[0][0].params.is_empty());
+
+        let (phase, batches) = profile.next_batch(1);
+        assert_eq!(phase, Phase::Done);
+        assert!(batches.is_empty());
+    }
+}

--- a/perf/memory/src/profile/mod.rs
+++ b/perf/memory/src/profile/mod.rs
@@ -1,3 +1,4 @@
+pub mod checkpoint;
 pub mod insert;
 pub mod mixed;
 pub mod read;
@@ -11,6 +12,8 @@ pub enum Phase {
     Setup,
     /// The measured workload
     Run,
+    /// A final checkpoint pass after the measured workload completes
+    Checkpoint,
     /// No more work
     Done,
 }


### PR DESCRIPTION
## Description
Adds a wrapper Profile that adds a checkpoint step at the end of the run

## Motivation and context
Check for MVCC mem usage before and after checkpoint


## Description of AI Usage
Added the necessary changes
