### PR TITLE
Compute virtual columns when checking deferred FKs

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1645,7 +1645,9 @@ fn rewrite_where_for_update_registers(
 ///
 /// The following postcondition holds:
 ///
-///     dml_ctx.to_column_reg(target_columns[i]) == dml_ctx.to_column_reg(target_columns[0]) + i
+/// ```text
+/// dml_ctx.to_column_reg(target_columns[i]) == dml_ctx.to_column_reg(target_columns[0]) + i
+/// ```
 ///
 /// This way, target_columns[0] can be used as a base for opcodes that require unpacked records.
 pub(crate) fn emit_columns_and_dependencies(
@@ -1693,7 +1695,11 @@ pub(crate) fn emit_columns_and_dependencies(
         };
         (col, reg)
     });
-    Ok(DmlColumnContext::from_column_reg_mapping(pairs))
+    let dml_ctx = DmlColumnContext::from_column_reg_mapping(pairs);
+    debug_assert!(targets
+        .windows(2)
+        .all(|w| { dml_ctx.to_column_reg(w[1]) == dml_ctx.to_column_reg(w[0]) + 1 }));
+    Ok(dml_ctx)
 }
 
 /// Emit code to load the value of an IndexColumn from the OLD image of the row being updated.

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -27,6 +27,7 @@ use crate::instrument;
 use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
 };
+use crate::translate::plan::ColumnMask;
 use crate::vdbe::{
     affinity::Affinity,
     builder::{CursorType, DmlColumnContext, ProgramBuilder, SelfTableContext},
@@ -1637,6 +1638,16 @@ fn rewrite_where_for_update_registers(
 /// Emits  `target_columns`, plus the stored columns needed by `target_columns`, into compact
 /// registers. This takes into account stored columns, and any stored columns required
 /// by virtual columns in `target_columns`.
+///
+/// Target columns are guaranteed to be in a contiguous block, in the given order, at the start of
+/// registers
+/// Load column values from cursor into registers, handling virtual generated columns.
+///
+/// The following postcondition holds:
+///
+///     dml_ctx.to_column_reg(target_columns[i]) == dml_ctx.to_column_reg(target_columns[0]) + i
+///
+/// This way, target_columns[0] can be used as a base for opcodes that require unpacked records.
 pub(crate) fn emit_columns_and_dependencies(
     program: &mut ProgramBuilder,
     table: &BTreeTable,
@@ -1644,16 +1655,38 @@ pub(crate) fn emit_columns_and_dependencies(
     rowid_reg: usize,
     target_columns: impl IntoIterator<Item = usize>,
 ) -> Result<DmlColumnContext> {
-    let dependencies = table.dependencies_of_columns(target_columns)?;
-    let base = program.alloc_registers(dependencies.count());
-    let mut next_reg = base;
+    let targets: Vec<usize> = target_columns.into_iter().collect();
+    let dependencies = table.dependencies_of_columns(targets.iter().copied())?;
+
+    let target_base = program.alloc_registers(targets.len());
+    let extra_base = {
+        let mut dependencies_not_in_targets: ColumnMask = dependencies.clone();
+        let target_mask = targets.iter().copied().collect();
+        dependencies_not_in_targets -= &target_mask;
+
+        let extra_count = dependencies_not_in_targets.count();
+
+        if extra_count > 0 {
+            program.alloc_registers(extra_count)
+        } else {
+            0
+        }
+    };
+
+    let mut extra_idx = 0;
     let pairs = table.columns().iter().enumerate().map(|(idx, col)| {
         let reg = if col.is_rowid_alias() {
             rowid_reg
+        } else if let Some(pos) = targets.iter().position(|&t| t == idx) {
+            let reg = target_base + pos;
+            if !col.is_virtual_generated() {
+                program.emit_column_or_rowid(cursor_id, idx, reg);
+            }
+            reg
         } else if dependencies.get(idx) {
-            let reg = next_reg;
+            let reg = extra_base + extra_idx;
             program.emit_column_or_rowid(cursor_id, idx, reg);
-            next_reg += 1;
+            extra_idx += 1;
             reg
         } else {
             0

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1640,10 +1640,7 @@ fn rewrite_where_for_update_registers(
 /// by virtual columns in `target_columns`.
 ///
 /// Target columns are guaranteed to be in a contiguous block, in the given order, at the start of
-/// registers
-/// Load column values from cursor into registers, handling virtual generated columns.
-///
-/// The following postcondition holds:
+/// registers. The following postcondition holds:
 ///
 /// ```text
 /// dml_ctx.to_column_reg(target_columns[i]) == dml_ctx.to_column_reg(target_columns[0]) + i

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -785,12 +785,7 @@ pub fn emit_fk_child_update_counters(
 
         let fk_col_positions: Vec<usize> = fk_cols
             .iter()
-            .filter_map(|col_name| {
-                match child_tbl.get_column(col_name) {
-                    Some((pos, _)) => Some(pos),
-                    None => None, //TODO I think this is impossible
-                }
-            })
+            .filter_map(|col_name| child_tbl.get_column(col_name).map(|(pos, _)| pos))
             .collect();
 
         let dml_ctx = emit_columns_and_dependencies(
@@ -873,21 +868,10 @@ pub fn emit_fk_child_update_counters(
                         .expect("parent unique index required");
                     let icur = open_read_index(program, idx, database_id);
 
-                    // index_probe emits opcode Found, which needs an unpacked record (with
-                    // contiguous registers), so we copy the potentially unordered registers.
-                    // We might be able to avoid this copy if we modify emit_columns_and_dependencies
-                    // to guarantee that its target_columns parameter is stored contiguously in
-                    // the first registers.
-                    let probe_start = program.alloc_registers(ncols);
-                    for (i, &pos) in fk_col_positions.iter().enumerate() {
-                        program.emit_insn(Insn::Copy {
-                            src_reg: dml_ctx.to_column_reg(pos),
-                            dst_reg: probe_start + i,
-                            extra_amount: 0,
-                        });
-                    }
-                    // Apply parent index affinities
-                    let probe = copy_with_affinity(program, probe_start, ncols, idx, &parent_tbl);
+                    // this is safe because emit_columns_and_dependencies
+                    // guarantees target columns are contiguous.
+                    let old_start = dml_ctx.to_column_reg(fk_col_positions[0]);
+                    let probe = copy_with_affinity(program, old_start, ncols, idx, &parent_tbl);
                     // Found: nothing; Not found: guarded decrement
                     index_probe(
                         program,

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -9,7 +9,7 @@ use crate::{
     schema::{BTreeTable, ColumnLayout, ForeignKey, Index, ResolvedFkRef, ROWID_SENTINEL},
     translate::{collate::CollationSeq, emitter::Resolver, planner::ROWID_STRS},
     vdbe::{
-        builder::{CursorType, QueryMode},
+        builder::{CursorType, DmlColumnContext, QueryMode},
         insn::{CmpInsFlags, Insn},
         BranchOffset,
     },
@@ -768,31 +768,47 @@ pub fn emit_fk_child_update_counters(
     resolver: &Resolver,
     layout: &ColumnLayout,
 ) -> Result<()> {
-    // Helper: materialize OLD tuple for this FK; returns (start_reg, ncols, null_skip_label).
+    // Helper: materialize OLD FK column values.
+    // Returns (dml_ctx, fk_col_positions, null_skip_label).
     // The null_skip_label is unresolved and must be resolved by the caller after the FK check
     // block, so that when any OLD column is NULL the entire FK check is skipped.
-    let load_old_tuple = |program: &mut ProgramBuilder,
-                          fk_cols: &[String]|
-     -> Option<(usize, usize, BranchOffset)> {
-        let n = fk_cols.len();
-        let start = program.alloc_registers(n);
-        let null_jmp = program.allocate_label();
+    let load_old_fk_values = |program: &mut ProgramBuilder,
+                              fk_cols: &[String]|
+     -> Result<Option<(DmlColumnContext, Vec<usize>, BranchOffset)>> {
+        let null_skip_label = program.allocate_label();
 
-        for (k, cname) in fk_cols.iter().enumerate() {
-            let (pos, _col) = match child_tbl.get_column(cname) {
-                Some(v) => v,
-                None => {
-                    return None;
+        let old_rowid_reg = program.alloc_register();
+        program.emit_insn(Insn::RowId {
+            cursor_id: child_cursor_id,
+            dest: old_rowid_reg,
+        });
+
+        let fk_col_positions: Vec<usize> = fk_cols
+            .iter()
+            .filter_map(|col_name| {
+                match child_tbl.get_column(col_name) {
+                    Some((pos, _)) => Some(pos),
+                    None => None, //TODO I think this is impossible
                 }
-            };
-            program.emit_column_or_rowid(child_cursor_id, pos, start + k);
+            })
+            .collect();
+
+        let dml_ctx = emit_columns_and_dependencies(
+            program,
+            child_tbl,
+            child_cursor_id,
+            old_rowid_reg,
+            fk_col_positions.clone(),
+        )?;
+
+        for &pos in &fk_col_positions {
             program.emit_insn(Insn::IsNull {
-                reg: start + k,
-                target_pc: null_jmp,
+                reg: dml_ctx.to_column_reg(pos),
+                target_pc: null_skip_label,
             });
         }
 
-        Some((start, n, null_jmp))
+        Ok(Some((dml_ctx, fk_col_positions, null_skip_label)))
     };
 
     for fk_ref in
@@ -807,8 +823,8 @@ pub fn emit_fk_child_update_counters(
 
         // Pass 1: OLD tuple handling only for deferred FKs
         if fk_ref.fk.deferred {
-            if let Some((old_start, _, null_skip)) =
-                load_old_tuple(program, &fk_ref.fk.child_columns)
+            if let Some((dml_ctx, fk_col_positions, null_skip)) =
+                load_old_fk_values(program, &fk_ref.fk.child_columns)?
             {
                 if fk_ref.parent_uses_rowid {
                     // Parent key is rowid: probe parent table by rowid
@@ -820,7 +836,7 @@ pub fn emit_fk_child_update_counters(
                     // first FK col is the rowid value
                     let rid = program.alloc_register();
                     program.emit_insn(Insn::Copy {
-                        src_reg: old_start,
+                        src_reg: dml_ctx.to_column_reg(fk_col_positions[0]),
                         dst_reg: rid,
                         extra_amount: 0,
                     });
@@ -847,7 +863,7 @@ pub fn emit_fk_child_update_counters(
 
                     program.preassign_label_to_next_insn(join);
                 } else {
-                    // Parent key is a unique index: use index probe and guarded decrement on NOT FOUND
+                    // Parent key is a unique index: use index probe
                     let parent_tbl = resolver
                         .with_schema(database_id, |s| s.get_btree_table(&fk_ref.fk.parent_table))
                         .expect("parent btree");
@@ -857,8 +873,21 @@ pub fn emit_fk_child_update_counters(
                         .expect("parent unique index required");
                     let icur = open_read_index(program, idx, database_id);
 
-                    // Copy OLD tuple and apply parent index affinities
-                    let probe = copy_with_affinity(program, old_start, ncols, idx, &parent_tbl);
+                    // index_probe emits opcode Found, which needs an unpacked record (with
+                    // contiguous registers), so we copy the potentially unordered registers.
+                    // We might be able to avoid this copy if we modify emit_columns_and_dependencies
+                    // to guarantee that its target_columns parameter is stored contiguously in
+                    // the first registers.
+                    let probe_start = program.alloc_registers(ncols);
+                    for (i, &pos) in fk_col_positions.iter().enumerate() {
+                        program.emit_insn(Insn::Copy {
+                            src_reg: dml_ctx.to_column_reg(pos),
+                            dst_reg: probe_start + i,
+                            extra_amount: 0,
+                        });
+                    }
+                    // Apply parent index affinities
+                    let probe = copy_with_affinity(program, probe_start, ncols, idx, &parent_tbl);
                     // Found: nothing; Not found: guarded decrement
                     index_probe(
                         program,

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -1,3 +1,4 @@
+use crate::translate::expr::emit_table_column;
 use crate::vdbe::builder::SelfTableContext;
 use crate::{
     schema::{GeneratedType, Index, Schema, Table},
@@ -433,7 +434,16 @@ fn translate_integrity_check_impl(
                 let target = key_start_reg + i;
                 match col {
                     BoundIndexColumn::Column(pos) => {
-                        program.emit_column_or_rowid(table_cursor_id, *pos, target);
+                        emit_table_column(
+                            program,
+                            table_cursor_id,
+                            table_ref_id,
+                            &table_references,
+                            &btree_table.columns()[*pos],
+                            *pos,
+                            target,
+                            resolver,
+                        )?;
                     }
                     BoundIndexColumn::Expr(expr) => {
                         let self_table_context =

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1438,6 +1438,13 @@ impl ColumnMask {
     }
 }
 
+impl std::ops::SubAssign<&Self> for ColumnMask {
+    fn sub_assign(&mut self, rhs: &Self) {
+        self.bitset -= &rhs.bitset;
+        self.has_rowid_sentinel &= !rhs.has_rowid_sentinel;
+    }
+}
+
 impl FromIterator<usize> for ColumnMask {
     fn from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Self {
         let mut mask = ColumnMask::default();
@@ -1787,6 +1794,15 @@ where
                 self.overflow = None;
             }
         }
+    }
+}
+
+impl<T: From<usize>> std::ops::SubAssign<&Self> for BitSet<T>
+where
+    usize: From<T>,
+{
+    fn sub_assign(&mut self, rhs: &Self) {
+        self.subtract(rhs);
     }
 }
 
@@ -3839,9 +3855,9 @@ mod tests {
                     );
                 }
                 11 => {
-                    // Subtract
+                    // SubAssign (delegates to subtract)
                     let (other_mask, other_ref) = sample_other(&mut rng, max_index);
-                    mask.subtract(&other_mask);
+                    mask -= &other_mask;
                     for i in &other_ref {
                         reference.remove(i);
                     }
@@ -3933,5 +3949,25 @@ mod tests {
         // FromIterator<TableInternalId> works.
         let rebuilt: BitSet<TableInternalId> = [a, c].into_iter().collect();
         assert_eq!(rebuilt, mask);
+    }
+
+    #[test]
+    fn test_column_mask_sub_assign() {
+        let mut a: ColumnMask = [1, 3, ROWID_SENTINEL].into_iter().collect();
+        let b: ColumnMask = [3, ROWID_SENTINEL].into_iter().collect();
+        a -= &b;
+        assert!(a.get(1));
+        assert!(!a.get(3));
+        assert!(!a.get(ROWID_SENTINEL));
+        assert_eq!(a.count(), 1);
+
+        // Subtracting without rowid sentinel leaves it intact
+        let mut a: ColumnMask = [2, 4, ROWID_SENTINEL].into_iter().collect();
+        let b: ColumnMask = [2].into_iter().collect();
+        a -= &b;
+        assert!(!a.get(2));
+        assert!(a.get(4));
+        assert!(a.get(ROWID_SENTINEL));
+        assert_eq!(a.count(), 2);
     }
 }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4525,5 +4525,5 @@ test update-deferred-fk-on-child-virtual-column {
   INSERT INTO c VALUES (1);
   UPDATE c SET a=2;
 } expect error {
-    deferred foreign key constraint failed
+    (FOREIGN KEY|deferred foreign key) constraint failed
 }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4527,3 +4527,10 @@ test update-deferred-fk-on-child-virtual-column {
 } expect error {
     deferred foreign key constraint failed
 }
+
+test integrity-check-unique-virtual-column {
+    CREATE TABLE t (x INTEGER, a BLOB UNIQUE AS (X'aa'));
+    PRAGMA integrity_check;
+} expect {
+    ok
+}

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4516,3 +4516,14 @@ test upsert-unique-virtual-column-ipk {
 } expect error {
     UNIQUE constraint failed: t.c
 }
+
+test update-deferred-fk-on-child-virtual-column {
+  PRAGMA foreign_keys=on;
+  CREATE TABLE p(x PRIMARY KEY);
+  CREATE TABLE c(a, b AS (a), FOREIGN KEY(b) REFERENCES p DEFERRABLE INITIALLY DEFERRED);
+  INSERT INTO p VALUES (1);
+  INSERT INTO c VALUES (1);
+  UPDATE c SET a=2;
+} expect error {
+    deferred foreign key constraint failed
+}


### PR DESCRIPTION
## Description

Virtual columns weren't computed when emitting the old images for deferred FK checks.

Closes https://github.com/tursodatabase/turso/issues/6415 

## Description of AI Usage

50/50
