### PR TITLE
core/translate: Fix integrity check panic

### DIFF
--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -1,3 +1,4 @@
+use crate::translate::expr::emit_table_column;
 use crate::vdbe::builder::SelfTableContext;
 use crate::{
     schema::{GeneratedType, Index, Schema, Table},
@@ -433,7 +434,16 @@ fn translate_integrity_check_impl(
                 let target = key_start_reg + i;
                 match col {
                     BoundIndexColumn::Column(pos) => {
-                        program.emit_column_or_rowid(table_cursor_id, *pos, target);
+                        emit_table_column(
+                            program,
+                            table_cursor_id,
+                            table_ref_id,
+                            &table_references,
+                            &btree_table.columns()[*pos],
+                            *pos,
+                            target,
+                            resolver,
+                        )?;
                     }
                     BoundIndexColumn::Expr(expr) => {
                         let self_table_context =

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4527,3 +4527,10 @@ test update-deferred-fk-on-child-virtual-column {
 } expect error {
     deferred foreign key constraint failed
 }
+
+test integrity-check-unique-virtual-column {
+    CREATE TABLE t (x INTEGER, a BLOB UNIQUE AS (X'aa'));
+    PRAGMA integrity_check;
+} expect {
+    ok
+}


### PR DESCRIPTION
## Description

Integrity check was panicking when checking indexed virtual columns. See the added test.

## Description of AI Usage

Claude Code