### PR TITLE
Compute virtual columns in topological order to avoid double-evaluation

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2277,6 +2277,8 @@ pub(crate) struct GeneratedColGraph {
     dependencies: Vec<ColumnMask>,
     /// `dependents[i]` = columns that transitively read from `i` (excludes `i`).
     dependents: Vec<ColumnMask>,
+    /// Column indices in topological (dependency) order. Contains all columns.
+    topological_sort: Vec<usize>,
 }
 
 impl GeneratedColGraph {
@@ -2309,10 +2311,10 @@ impl GeneratedColGraph {
         }
 
         // Kahn's algorithm (topological sort) over direct_deps.
-        let mut topo: Vec<usize> = Vec::with_capacity(n);
+        let mut topological_sort: Vec<usize> = Vec::with_capacity(n);
         let mut ready: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
         while let Some(i) = ready.pop() {
-            topo.push(i);
+            topological_sort.push(i);
             for j in direct_dependents[i].iter() {
                 in_degree[j] -= 1;
                 if in_degree[j] == 0 {
@@ -2322,7 +2324,7 @@ impl GeneratedColGraph {
         }
 
         // see if there's cycles in the graph
-        if topo.len() != n {
+        if topological_sort.len() != n {
             let cycle_names: Vec<&str> = (0..n)
                 .filter(|i| in_degree[*i] > 0)
                 .filter_map(|i| columns[i].name.as_deref())
@@ -2335,7 +2337,7 @@ impl GeneratedColGraph {
 
         // compute transitive closures.
         let mut dependencies = vec![ColumnMask::default(); n];
-        for &j in &topo {
+        for &j in &topological_sort {
             dependencies[j] = direct_deps[j].clone();
             for i in direct_deps[j].iter() {
                 let snapshot = dependencies[i].clone();
@@ -2345,7 +2347,7 @@ impl GeneratedColGraph {
 
         // compute transitive closures of the transpose graph (dependents)
         let mut dependents = vec![ColumnMask::default(); n];
-        for &i in topo.iter().rev() {
+        for &i in topological_sort.iter().rev() {
             dependents[i] = direct_dependents[i].clone();
             for j in direct_dependents[i].iter() {
                 let snapshot = dependents[j].clone();
@@ -2356,6 +2358,7 @@ impl GeneratedColGraph {
         Ok(Self {
             dependencies,
             dependents,
+            topological_sort,
         })
     }
 }
@@ -2901,6 +2904,17 @@ impl BTreeTable {
             .expect("column_dependencies was just initialized"))
     }
 
+    /// Returns an iterator over columns in topological (dependency) order. Processing
+    /// columns in this order guarantees that all dependencies of generated columns are computed
+    /// before the columns that reference them.
+    pub(crate) fn columns_topo_sort(&self) -> Result<ColumnsTopologicalSort<'_>> {
+        let topo = self.column_graph()?.topological_sort.to_vec();
+        Ok(ColumnsTopologicalSort {
+            columns: &self.columns,
+            topological_sort: topo,
+        })
+    }
+
     #[cfg(test)]
     pub(crate) fn peek_column_dependencies(&self) -> Option<&GeneratedColGraph> {
         self.column_dependencies.0.get()
@@ -2940,6 +2954,19 @@ impl BTreeTable {
             }
         }
         Ok(deps)
+    }
+}
+
+/// Topologically sorted generated columns, yielding `(column_index, &Column)`.
+pub(crate) struct ColumnsTopologicalSort<'a> {
+    columns: &'a [Column],
+    /// indices of `columns`
+    topological_sort: Vec<usize>,
+}
+
+impl<'a> ColumnsTopologicalSort<'a> {
+    pub fn iter(&self) -> impl Iterator<Item = (usize, &'a Column)> + '_ {
+        self.topological_sort.iter().map(|&idx| (idx, &self.columns[idx]))
     }
 }
 

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -467,7 +467,12 @@ fn emit_add_virtual_column_validation(
 
     let dml_ctx =
         DmlColumnContext::layout(resolved_table.columns(), base_dest_reg, rowid_reg, layout);
-    compute_virtual_columns(program, resolved_table.columns().iter(), &dml_ctx, resolver)?;
+    compute_virtual_columns(
+        program,
+        &resolved_table.columns_topo_sort()?,
+        &dml_ctx,
+        resolver,
+    )?;
     let result_reg = dml_ctx.to_column_reg(new_column_idx);
 
     if !check_constraints.is_empty() {

--- a/core/translate/emitter/gencol.rs
+++ b/core/translate/emitter/gencol.rs
@@ -1,21 +1,20 @@
-use crate::schema::{Column, ColumnLayout, GeneratedType};
+use crate::schema::{ColumnsTopologicalSort, GeneratedType};
 use crate::translate::expr::translate_expr;
 use crate::vdbe::affinity::Affinity;
 use crate::vdbe::builder::{DmlColumnContext, SelfTableContext};
 use crate::Result;
-use turso_parser::ast;
 
 use super::{ProgramBuilder, Resolver};
 
-/// Emit bytecode to compute all virtual generated columns for a row.
-pub fn compute_virtual_columns<'a>(
+/// Emit bytecode to compute virtual generated columns for a row.
+pub fn compute_virtual_columns(
     program: &mut ProgramBuilder,
-    columns: impl Iterator<Item = &'a Column>,
+    columns: &ColumnsTopologicalSort<'_>,
     dml_ctx: &DmlColumnContext,
     resolver: &Resolver,
 ) -> Result<()> {
     let ctx = SelfTableContext::ForDML(dml_ctx.clone());
-    for (idx, column) in columns.enumerate() {
+    for (idx, column) in columns.iter() {
         let GeneratedType::Virtual { expr, .. } = column.generated_type() else {
             continue;
         };
@@ -27,31 +26,5 @@ pub fn compute_virtual_columns<'a>(
             program.emit_column_affinity(target_reg, column.affinity());
         }
     }
-    Ok(())
-}
-
-/// Emit bytecode to compute a single virtual generated column expression.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn emit_gencol_expr_from_registers(
-    program: &mut ProgramBuilder,
-    expr: &ast::Expr,
-    target_reg: usize,
-    registers_start: usize,
-    columns: &[crate::schema::Column],
-    resolver: &Resolver,
-    rowid_reg: usize,
-    layout: &ColumnLayout,
-) -> Result<()> {
-    let ctx = SelfTableContext::ForDML(DmlColumnContext::layout(
-        columns,
-        registers_start,
-        rowid_reg,
-        layout.clone(),
-    ));
-    program.with_self_table_context(Some(&ctx), |program, _| {
-        translate_expr(program, None, expr, target_reg, resolver)?;
-        Ok(())
-    })?;
-
     Ok(())
 }

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1653,6 +1653,7 @@ pub(crate) fn emit_columns_and_dependencies(
     cursor_id: usize,
     rowid_reg: usize,
     target_columns: impl IntoIterator<Item = usize>,
+    resolver: &Resolver,
 ) -> Result<DmlColumnContext> {
     let targets: Vec<usize> = target_columns.into_iter().collect();
     let dependencies = table.dependencies_of_columns(targets.iter().copied())?;
@@ -1696,6 +1697,9 @@ pub(crate) fn emit_columns_and_dependencies(
     debug_assert!(targets
         .windows(2)
         .all(|w| { dml_ctx.to_column_reg(w[1]) == dml_ctx.to_column_reg(w[0]) + 1 }));
+
+    gencol::compute_virtual_columns(program, &table.columns_topo_sort()?, &dml_ctx, resolver)?;
+
     Ok(dml_ctx)
 }
 
@@ -1833,33 +1837,16 @@ fn emit_index_column_value_new_image(
         let col_in_table = columns
             .get(idx_col.pos_in_table)
             .expect("column index out of bounds");
-        match col_in_table.generated_type() {
-            GeneratedType::Virtual { ref expr, .. } => {
-                gencol::emit_gencol_expr_from_registers(
-                    program,
-                    expr,
-                    dest_reg,
-                    columns_start_reg,
-                    columns,
-                    resolver,
-                    rowid_reg,
-                    layout,
-                )?;
-                program.emit_column_affinity(dest_reg, col_in_table.affinity());
-            }
-            GeneratedType::NotGenerated => {
-                let src_reg = if col_in_table.is_rowid_alias() {
-                    rowid_reg
-                } else {
-                    layout.to_register(columns_start_reg, idx_col.pos_in_table)
-                };
-                program.emit_insn(Insn::Copy {
-                    src_reg,
-                    dst_reg: dest_reg,
-                    extra_amount: 0,
-                });
-            }
-        }
+        let src_reg = if col_in_table.is_rowid_alias() {
+            rowid_reg
+        } else {
+            layout.to_register(columns_start_reg, idx_col.pos_in_table)
+        };
+        program.emit_insn(Insn::Copy {
+            src_reg,
+            dst_reg: dest_reg,
+            extra_amount: 0,
+        });
     }
     Ok(())
 }

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1145,8 +1145,16 @@ fn emit_update_insns<'a>(
 
             // Compute virtual columns for NEW values
             //TODO only emit required virtual columns
-            let new_ctx = DmlColumnContext::layout(columns, start, new_rowid_reg, layout.clone());
-            compute_virtual_columns(program, columns.iter(), &new_ctx, &t_ctx.resolver)?;
+            if let Table::BTree(ref btree) = target_table.table {
+                let new_ctx =
+                    DmlColumnContext::layout(columns, start, new_rowid_reg, layout.clone());
+                compute_virtual_columns(
+                    program,
+                    &btree.columns_topo_sort()?,
+                    &new_ctx,
+                    &t_ctx.resolver,
+                )?;
+            }
 
             let new_registers = (0..col_len)
                 .map(|i| layout.to_register(start, i))
@@ -1361,22 +1369,27 @@ fn emit_update_insns<'a>(
     };
     let update_affects_virtual_columns = affected_columns.count() > set_clause_cols.count();
     let has_returning = returning.as_ref().is_some_and(|r| !r.is_empty());
-    let has_check_constraints = target_table
-        .table
-        .btree()
-        .is_some_and(|bt| !bt.check_constraints.is_empty());
-    if update_affects_virtual_columns
-        || has_before_triggers
-        || has_after_triggers
-        || has_returning
-        || has_check_constraints
-    {
-        let columns = target_table.table.columns();
-        let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
+    if let Table::BTree(ref btree) = target_table.table {
+        let has_check_constraints = !btree.check_constraints.is_empty();
 
-        //TODO don't emit all virtual columns
-        let dml_ctx = DmlColumnContext::layout(columns, start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, columns.iter(), &dml_ctx, &t_ctx.resolver)?;
+        if update_affects_virtual_columns
+            || has_before_triggers
+            || has_after_triggers
+            || has_returning
+            || has_check_constraints
+        {
+            let columns = target_table.table.columns();
+            let rowid_reg = rowid_set_clause_reg.unwrap_or(beg);
+
+            //TODO don't emit all virtual columns
+            let dml_ctx = DmlColumnContext::layout(columns, start, rowid_reg, layout.clone());
+            compute_virtual_columns(
+                program,
+                &btree.columns_topo_sort()?,
+                &dml_ctx,
+                &t_ctx.resolver,
+            )?;
+        }
     }
 
     let target_is_strict = target_table
@@ -2278,7 +2291,12 @@ fn emit_update_insns<'a>(
                     // Compute VIRTUAL columns for NEW values
                     //TODO only emit required virtual columns
                     let new_ctx = DmlColumnContext::layout(columns, start, beg, layout.clone());
-                    compute_virtual_columns(program, columns.iter(), &new_ctx, &t_ctx.resolver)?;
+                    compute_virtual_columns(
+                        program,
+                        &btree_table.columns_topo_sort()?,
+                        &new_ctx,
+                        &t_ctx.resolver,
+                    )?;
 
                     // Compute VIRTUAL columns for OLD values if we have preserved OLD registers
                     if let Some(ref old_regs) = preserved_old_registers {
@@ -2287,7 +2305,7 @@ fn emit_update_insns<'a>(
                         let old_ctx = DmlColumnContext::from_column_reg_mapping(pairs);
                         compute_virtual_columns(
                             program,
-                            columns.iter(),
+                            &btree_table.columns_topo_sort()?,
                             &old_ctx,
                             &t_ctx.resolver,
                         )?;

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -3035,21 +3035,13 @@ pub fn translate_expr(
                         )
                     }
                     Some(SelfTableContext::ForDML(dml_ctx)) => {
-                        if let Some((resolved, affinity)) = dml_ctx.virtual_column_info(*column) {
-                            translate_expr(program, None, resolved, target_register, resolver)?;
-                            if affinity != Affinity::Blob {
-                                program.emit_column_affinity(target_register, affinity);
-                            }
-                            Ok(target_register)
-                        } else {
-                            let src_reg = dml_ctx.to_column_reg(*column);
-                            program.emit_insn(Insn::Copy {
-                                src_reg,
-                                dst_reg: target_register,
-                                extra_amount: 0,
-                            });
-                            Ok(target_register)
-                        }
+                        let src_reg = dml_ctx.to_column_reg(*column);
+                        program.emit_insn(Insn::Copy {
+                            src_reg,
+                            dst_reg: target_register,
+                            extra_amount: 0,
+                        });
+                        Ok(target_register)
                     }
                     None => {
                         // This error means that a program.with_self_table_context() was missing

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -468,6 +468,7 @@ pub fn emit_parent_index_key_change_checks(
                 cursor_id,
                 old_rowid_reg,
                 idx_target_cols,
+                resolver,
             )
         })
         .transpose()?;
@@ -714,6 +715,7 @@ fn build_parent_key(
                 parent_cursor_id,
                 parent_rowid_reg,
                 fk_target_cols,
+                resolver,
             )
         })
         .transpose()?;
@@ -794,6 +796,7 @@ pub fn emit_fk_child_update_counters(
             child_cursor_id,
             old_rowid_reg,
             fk_col_positions.clone(),
+            resolver,
         )?;
 
         for &pos in &fk_col_positions {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -507,12 +507,7 @@ pub fn translate_insert(
 
     let has_before_triggers = !relevant_before_triggers.is_empty();
     if has_before_triggers {
-        compute_virtual_columns(
-            program,
-            insertion.col_mappings.iter().map(|cm| cm.column),
-            &dml_ctx,
-            resolver,
-        )?;
+        compute_virtual_columns(program, &ctx.table.columns_topo_sort()?, &dml_ctx, resolver)?;
 
         // In SQLite, NEW.<rowid_alias> returns -1 in BEFORE INSERT triggers when the rowid
         // hasn't been assigned yet (i.e., it's NULL). We need to temporarily set the key
@@ -727,12 +722,7 @@ pub fn translate_insert(
     // Make computed virtual columns accessible to CHECK and NOT NULL constraint evaluation
     if insertion.has_virtual_columns() {
         //TODO only compute the necessary virtual columns for CHECK and NOT NULL evaluation
-        compute_virtual_columns(
-            program,
-            insertion.col_mappings.iter().map(|cm| cm.column),
-            &dml_ctx,
-            resolver,
-        )?;
+        compute_virtual_columns(program, &ctx.table.columns_topo_sort()?, &dml_ctx, resolver)?;
     }
 
     // Evaluate CHECK constraints after type affinity/TypeCheck but before other constraints
@@ -888,12 +878,7 @@ pub fn translate_insert(
     );
     let has_after_triggers = !relevant_after_triggers.is_empty();
     if has_after_triggers {
-        compute_virtual_columns(
-            program,
-            insertion.col_mappings.iter().map(|cm| cm.column),
-            &dml_ctx,
-            resolver,
-        )?;
+        compute_virtual_columns(program, &ctx.table.columns_topo_sort()?, &dml_ctx, resolver)?;
 
         // Build raw NEW registers for AFTER triggers. Values are encoded at this point;
         // fire_trigger will decode them via decode_trigger_registers.

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -588,7 +588,7 @@ pub fn emit_upsert(
         let rowid_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
         let dml_ctx =
             DmlColumnContext::layout(ctx.table.columns(), new_start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, ctx.table.columns().iter(), &dml_ctx, resolver)?;
+        compute_virtual_columns(program, &ctx.table.columns_topo_sort()?, &dml_ctx, resolver)?;
     }
 
     if let Some(bt) = table.btree() {
@@ -1306,7 +1306,7 @@ pub fn emit_upsert(
         let rowid_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
         let dml_ctx =
             DmlColumnContext::layout(ctx.table.columns(), new_start, rowid_reg, layout.clone());
-        compute_virtual_columns(program, ctx.table.columns().iter(), &dml_ctx, resolver)?;
+        compute_virtual_columns(program, &ctx.table.columns_topo_sort()?, &dml_ctx, resolver)?;
     }
 
     // RETURNING from NEW image + final rowid

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,15 +1,12 @@
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert};
 use rustc_hash::FxHashMap as HashMap;
 use tracing::{instrument, Level};
-use turso_parser::ast::{self, Expr, ResolveType, SortOrder, TableInternalId};
+use turso_parser::ast::{self, ResolveType, SortOrder, TableInternalId};
 
 use crate::{
     index_method::IndexMethodAttachment,
     parameters::Parameters,
-    schema::{
-        BTreeTable, Column, ColumnLayout, GeneratedType, Index, PseudoCursorType, Schema, Table,
-        Trigger,
-    },
+    schema::{BTreeTable, Column, ColumnLayout, Index, PseudoCursorType, Schema, Table, Trigger},
     translate::{
         collate::CollationSeq,
         emitter::{MaterializedColumnRef, TransactionMode},
@@ -135,10 +132,6 @@ enum DmlColumnRegisters {
 pub struct DmlColumnContext {
     registers: DmlColumnRegisters,
     rowid_alias_col: Option<usize>,
-    /// Bitset marking which columns are virtual generated.
-    virtual_mask: BitSet,
-    /// rank-indexed by `virtual_mask`.
-    virtual_data: Vec<(Box<Expr>, Affinity)>,
 }
 
 impl DmlColumnContext {
@@ -148,19 +141,7 @@ impl DmlColumnContext {
         rowid_reg: usize,
         layout: ColumnLayout,
     ) -> Self {
-        let mut rowid_alias_col = None;
-        let mut virtual_mask = BitSet::default();
-        let mut virtual_data = Vec::new();
-
-        for (idx, col) in columns.iter().enumerate() {
-            if col.is_rowid_alias() {
-                rowid_alias_col = Some(idx);
-            }
-            if let GeneratedType::Virtual { expr: resolved, .. } = col.generated_type() {
-                virtual_mask.set(idx);
-                virtual_data.push((resolved.clone(), col.affinity()));
-            }
-        }
+        let rowid_alias_col = columns.iter().position(|c| c.is_rowid_alias());
 
         Self {
             registers: DmlColumnRegisters::Layout {
@@ -169,43 +150,22 @@ impl DmlColumnContext {
                 layout,
             },
             rowid_alias_col,
-            virtual_mask,
-            virtual_data,
         }
     }
 
     pub fn from_column_reg_mapping<'a>(pairs: impl Iterator<Item = (&'a Column, usize)>) -> Self {
         let mut rowid_alias_col = None;
-        let mut virtual_mask = BitSet::default();
-        let mut virtual_data = Vec::new();
         let mut column_regs = Vec::new();
         for (idx, (col, reg)) in pairs.enumerate() {
             column_regs.push(reg);
             if col.is_rowid_alias() {
                 rowid_alias_col = Some(idx);
             }
-            if let GeneratedType::Virtual { expr, .. } = col.generated_type() {
-                virtual_mask.set(idx);
-                virtual_data.push((expr.clone(), col.affinity()));
-            }
         }
         Self {
             registers: DmlColumnRegisters::Indexed { column_regs },
             rowid_alias_col,
-            virtual_mask,
-            virtual_data,
         }
-    }
-
-    /// returns the expression and affinity of a virtual column, if the column index points to a
-    /// virtual column
-    pub(crate) fn virtual_column_info(&self, col_idx: usize) -> Option<(&Expr, Affinity)> {
-        if !self.virtual_mask.get(col_idx) {
-            return None;
-        }
-        let rank = self.virtual_mask.rank(col_idx);
-        let (ref expr, affinity) = self.virtual_data[rank];
-        Some((expr, affinity))
     }
 
     pub fn to_column_reg(&self, col_idx: usize) -> usize {


### PR DESCRIPTION
## Description

Previously, we were recomputing some virtual columns when they had forward references. For example, on main:

```
turso> CREATE TABLE t (a UNIQUE AS (b), b AS ('x'), c);
EXPLAIN INSERT INTO t(c) VALUES (1);
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     20    0                    0   Start at 20

...

20    Transaction        0     2     1                    0   iDb=0 tx_mode=Write
21    String8            0     4     0     x              0   r[4]='x'
22    String8            0     5     0     x              0   r[5]='x'
23    Goto               0     1     0                    0   
```

On this branch:

```
turso> CREATE TABLE t (a UNIQUE AS (b), b AS ('x'), c);
EXPLAIN INSERT INTO t(c) VALUES (1);
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     20    0                    0   Start at 20

...

20    Transaction        0     2     1                    0   iDb=0 tx_mode=Write
21    String8            0     5     0     x              0   r[5]='x'
22    Goto               0     1     0                    0   
```

## Description of AI Usage

50/50