### PR TITLE
Fix CTE sharing decisions for correlated subqueries

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2985,8 +2985,8 @@ pub struct FromClauseSubquery {
 pub struct FromClauseSubqueryCteMetadata {
     /// Identity shared by all references to the same CTE definition.
     pub id: usize,
-    /// True when this CTE is referenced more than once inside the enclosing
-    /// query tree and therefore must be materialized once and shared.
+    /// True when more than one read in the same query tree can reuse one
+    /// materialized result for this CTE.
     pub shared_materialization: bool,
     /// True for explicit WITH ... AS MATERIALIZED.
     pub materialize_hint: bool,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3087,6 +3087,83 @@ pub fn plan_is_correlated(plan: &Plan) -> bool {
     }
 }
 
+fn select_plan_has_outer_scope_dependency_with_tables(
+    plan: &SelectPlan,
+    accessible_table_ids: &mut Vec<TableInternalId>,
+) -> bool {
+    let outer_scope_base_len = accessible_table_ids.len();
+    accessible_table_ids.extend(
+        plan.table_references
+            .joined_tables()
+            .iter()
+            .map(|table| table.internal_id),
+    );
+
+    let has_outer_scope_dependency =
+        plan.table_references
+            .outer_query_refs()
+            .iter()
+            .any(|outer_ref| {
+                outer_ref.is_used() && !accessible_table_ids.contains(&outer_ref.internal_id)
+            })
+            || plan
+                .non_from_clause_subqueries
+                .iter()
+                .any(|subquery| match &subquery.state {
+                    SubqueryState::Unevaluated {
+                        plan: Some(subquery_plan),
+                    } => plan_has_outer_scope_dependency_with_tables(
+                        subquery_plan,
+                        accessible_table_ids,
+                    ),
+                    SubqueryState::Unevaluated { plan: None } => false,
+                    SubqueryState::Evaluated { outer_ref_ids, .. } => outer_ref_ids
+                        .iter()
+                        .any(|outer_ref_id| !accessible_table_ids.contains(outer_ref_id)),
+                })
+            || plan
+                .table_references
+                .joined_tables()
+                .iter()
+                .any(|table| match &table.table {
+                    Table::FromClauseSubquery(subquery) => {
+                        plan_has_outer_scope_dependency_with_tables(
+                            subquery.plan.as_ref(),
+                            accessible_table_ids,
+                        )
+                    }
+                    _ => false,
+                });
+
+    accessible_table_ids.truncate(outer_scope_base_len);
+    has_outer_scope_dependency
+}
+
+fn plan_has_outer_scope_dependency_with_tables(
+    plan: &Plan,
+    accessible_table_ids: &mut Vec<TableInternalId>,
+) -> bool {
+    match plan {
+        Plan::Select(select_plan) => {
+            select_plan_has_outer_scope_dependency_with_tables(select_plan, accessible_table_ids)
+        }
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            left.iter().any(|(select_plan, _)| {
+                select_plan_has_outer_scope_dependency_with_tables(
+                    select_plan,
+                    accessible_table_ids,
+                )
+            }) || select_plan_has_outer_scope_dependency_with_tables(
+                right_most,
+                accessible_table_ids,
+            )
+        }
+        Plan::Delete(_) | Plan::Update(_) => false,
+    }
+}
+
 /// Returns true when evaluating this plan depends on table values from an
 /// enclosing query scope outside the plan itself.
 ///
@@ -3095,78 +3172,11 @@ pub fn plan_is_correlated(plan: &Plan) -> bool {
 /// references another table in the same CTE) without depending on an enclosing
 /// query row. Those plans are still safe to materialize once and reuse.
 pub fn plan_has_outer_scope_dependency(plan: &Plan) -> bool {
-    fn select_plan_has_outer_scope_dependency(
-        plan: &SelectPlan,
-        accessible_table_ids: &mut Vec<TableInternalId>,
-    ) -> bool {
-        let outer_scope_base_len = accessible_table_ids.len();
-        accessible_table_ids.extend(
-            plan.table_references
-                .joined_tables()
-                .iter()
-                .map(|table| table.internal_id),
-        );
-
-        let has_outer_scope_dependency =
-            plan.table_references
-                .outer_query_refs()
-                .iter()
-                .any(|outer_ref| {
-                    outer_ref.is_used() && !accessible_table_ids.contains(&outer_ref.internal_id)
-                })
-                || plan
-                    .non_from_clause_subqueries
-                    .iter()
-                    .any(|subquery| match &subquery.state {
-                        SubqueryState::Unevaluated {
-                            plan: Some(subquery_plan),
-                        } => plan_has_outer_scope_dependency_with_tables(
-                            subquery_plan,
-                            accessible_table_ids,
-                        ),
-                        SubqueryState::Unevaluated { plan: None } => false,
-                        SubqueryState::Evaluated { outer_ref_ids, .. } => outer_ref_ids
-                            .iter()
-                            .any(|outer_ref_id| !accessible_table_ids.contains(outer_ref_id)),
-                    })
-                || plan
-                    .table_references
-                    .joined_tables()
-                    .iter()
-                    .any(|table| match &table.table {
-                        Table::FromClauseSubquery(subquery) => {
-                            plan_has_outer_scope_dependency_with_tables(
-                                subquery.plan.as_ref(),
-                                accessible_table_ids,
-                            )
-                        }
-                        _ => false,
-                    });
-
-        accessible_table_ids.truncate(outer_scope_base_len);
-        has_outer_scope_dependency
-    }
-
-    fn plan_has_outer_scope_dependency_with_tables(
-        plan: &Plan,
-        accessible_table_ids: &mut Vec<TableInternalId>,
-    ) -> bool {
-        match plan {
-            Plan::Select(select_plan) => {
-                select_plan_has_outer_scope_dependency(select_plan, accessible_table_ids)
-            }
-            Plan::CompoundSelect {
-                left, right_most, ..
-            } => {
-                left.iter().any(|(select_plan, _)| {
-                    select_plan_has_outer_scope_dependency(select_plan, accessible_table_ids)
-                }) || select_plan_has_outer_scope_dependency(right_most, accessible_table_ids)
-            }
-            Plan::Delete(_) | Plan::Update(_) => false,
-        }
-    }
-
     plan_has_outer_scope_dependency_with_tables(plan, &mut Vec::new())
+}
+
+pub fn select_plan_has_outer_scope_dependency(plan: &SelectPlan) -> bool {
+    select_plan_has_outer_scope_dependency_with_tables(plan, &mut Vec::new())
 }
 
 /// Determine when a SELECT plan can be evaluated, including nested non-FROM and FROM-clause subqueries.

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -455,22 +455,6 @@ fn add_aggregate_if_not_exists(
 /// multiple references to the same CTE get independent cursor IDs,
 /// yield registers and so on.
 ///
-/// `count_reference`: Controls whether this call increments the CTE reference count.
-///
-/// **Reference counting determines materialization strategy:**
-/// - ref_count = 1: CTE can use efficient coroutine (no materialization needed)
-/// - ref_count > 1: CTE must be materialized into ephemeral table for sharing
-///
-/// **When to count (true):**
-/// - CTE appears in a FROM/JOIN clause (actual usage site)
-/// - CTE is referenced via outer_query_refs (e.g., in scalar subqueries)
-///
-/// **When NOT to count (false):**
-/// - Pre-planning CTEs for outer_query_refs visibility (making CTEs available
-///   for potential use by nested subqueries - not actual usage)
-/// - Recursively planning CTE dependencies (CTE A references CTE B internally -
-///   B needs to be visible to A's planning, but this isn't a usage from the
-///   main query's perspective)
 #[allow(clippy::too_many_arguments)]
 fn plan_cte(
     cte_idx: usize,
@@ -479,7 +463,7 @@ fn plan_cte(
     resolver: &Resolver,
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
-    count_reference: bool,
+    actual_reference: bool,
 ) -> Result<JoinedTable> {
     let cte_def = &cte_definitions[cte_idx];
 
@@ -499,8 +483,8 @@ fn plan_cte(
         }
         // Recursively plan the referenced CTE so it's visible within this CTE's body.
         // Example: WITH a AS (...), b AS (SELECT * FROM a) - when planning b, we need
-        // a to be in scope. But this internal dependency doesn't count as a "reference"
-        // for materialization purposes - only actual usage in the main query counts.
+        // a to be in scope. This visibility-only copy is not itself a read that can
+        // share a materialized result, so it must not be treated as one here.
         let referenced_table = plan_cte(
             ref_idx,
             cte_definitions,
@@ -549,14 +533,9 @@ fn plan_cte(
         Some(cte_def.explicit_columns.as_slice())
     };
 
-    // Track CTE reference count globally for materialization decisions during emission.
-    // Multi-ref CTEs should be materialized; single-ref CTEs can use coroutine.
-    // Only count actual references (FROM/JOIN usage), not pre-planning or recursive deps.
-    if count_reference {
-        program.increment_cte_reference(cte_def.cte_id);
-
-        // Validate explicit column count only on actual references (matching SQLite behavior,
-        // which defers this check until the CTE is used).
+    // SQLite defers explicit column-count validation until the CTE is actually
+    // referenced, so preplanned visibility-only copies must not raise here.
+    if actual_reference {
         if let Some(cols) = explicit_cols {
             let result_col_count = cte_plan.select_result_columns().len();
             if cols.len() != result_col_count {
@@ -657,7 +636,7 @@ pub fn plan_ctes_as_outer_refs(
                 None,
                 program.table_reference_counter.next(),
                 explicit_cols,
-                None, // CTEs in DML don't share materialized data (TODO: implement if needed)
+                None, // DML CTEs don't share materialized data (TODO: implement if needed)
                 materialize_hint,
             )?,
             Plan::Delete(_) | Plan::Update(_) => {
@@ -867,11 +846,6 @@ fn parse_table(
     if let Some(outer_ref) =
         table_references.find_outer_query_ref_by_identifier(&normalized_qualified_name)
     {
-        // If this is a CTE reference (via outer_query_refs), count it for materialization decisions.
-        // This handles scalar subqueries that reference CTEs.
-        if let Some(cte_id) = outer_ref.cte_id {
-            program.increment_cte_reference(cte_id);
-        }
         let alias = maybe_alias.map(|a| normalize_ident(a.name().as_str()));
         // Clone fields we need before dropping the borrow on table_references.
         let cte_select = outer_ref.cte_select.clone();

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -17,10 +17,10 @@ use crate::{
         },
         optimizer::optimize_select_plan,
         plan::{
-            plan_has_outer_scope_dependency, plan_is_correlated, ColumnUsedMask, EvalAt,
-            JoinOrderMember, NonFromClauseSubquery, OuterQueryReference, Plan, SetOperation,
-            SubqueryEvalPhase, SubqueryOrigin, SubqueryPosition, SubqueryState, TableReferences,
-            WhereTerm,
+            plan_has_outer_scope_dependency, plan_is_correlated,
+            select_plan_has_outer_scope_dependency, ColumnUsedMask, EvalAt, JoinOrderMember,
+            NonFromClauseSubquery, OuterQueryReference, Plan, SetOperation, SubqueryEvalPhase,
+            SubqueryOrigin, SubqueryPosition, SubqueryState, TableReferences, WhereTerm,
         },
         select::prepare_select_plan,
     },
@@ -72,41 +72,121 @@ pub(crate) fn materialized_from_clause_subquery_storage(
     }
 }
 
+// Count the CTE reads in this query tree that can share one materialized
+// result.
+//
+// Reads from correlated post-write RETURNING subqueries are skipped because
+// they run once per updated row instead of once for the statement.
+fn count_shared_cte_references(
+    counts: &mut HashMap<usize, usize>,
+    table_references: &TableReferences,
+    non_from_clause_subqueries: &[NonFromClauseSubquery],
+) {
+    for table in table_references.joined_tables() {
+        if let Table::FromClauseSubquery(from_clause_subquery) = &table.table {
+            if let Some(cte_id) = from_clause_subquery.cte_id() {
+                *counts.entry(cte_id).or_default() += 1;
+                continue;
+            }
+            count_shared_cte_references_in_plan(counts, from_clause_subquery.plan.as_ref());
+        }
+    }
+
+    for subquery in non_from_clause_subqueries {
+        let SubqueryState::Unevaluated {
+            plan: Some(subquery_plan),
+        } = &subquery.state
+        else {
+            continue;
+        };
+        // A correlated RETURNING subquery runs after each updated row is
+        // written, so its CTE reads must not be counted as part of the shared
+        // pre-write snapshot used by earlier readers in the same statement.
+        if subquery.origin.is_post_write_returning()
+            && plan_has_outer_scope_dependency(subquery_plan)
+        {
+            continue;
+        }
+        count_shared_cte_references_in_plan(counts, subquery_plan);
+    }
+}
+
+fn count_shared_cte_references_in_plan(counts: &mut HashMap<usize, usize>, plan: &Plan) {
+    match plan {
+        Plan::Select(select_plan) => count_shared_cte_references(
+            counts,
+            &select_plan.table_references,
+            &select_plan.non_from_clause_subqueries,
+        ),
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            for (select_plan, _) in left {
+                count_shared_cte_references(
+                    counts,
+                    &select_plan.table_references,
+                    &select_plan.non_from_clause_subqueries,
+                );
+            }
+            count_shared_cte_references(
+                counts,
+                &right_most.table_references,
+                &right_most.non_from_clause_subqueries,
+            );
+        }
+        Plan::Delete(_) | Plan::Update(_) => {}
+    }
+}
+
 /// Mark CTE references that must be materialized once and shared across
 /// multiple reads of the same query tree.
-///
-/// Correlated plans are explicitly excluded: they must re-run for each outer
-/// row, so sharing a single materialized result would be semantically wrong.
-fn mark_shared_cte_materialization_requirements(program: &ProgramBuilder, plan: &mut SelectPlan) {
-    fn annotate_plan(program: &ProgramBuilder, plan: &mut Plan) {
+pub(crate) fn mark_shared_cte_materialization_requirements(
+    table_references: &mut TableReferences,
+    non_from_clause_subqueries: &mut [NonFromClauseSubquery],
+) {
+    fn annotate_plan(plan: &mut Plan) {
         match plan {
-            Plan::Select(select_plan) => {
-                mark_shared_cte_materialization_requirements(program, select_plan)
-            }
+            Plan::Select(select_plan) => mark_shared_cte_materialization_requirements(
+                &mut select_plan.table_references,
+                &mut select_plan.non_from_clause_subqueries,
+            ),
             Plan::CompoundSelect {
                 left, right_most, ..
             } => {
                 for (select_plan, _) in left.iter_mut() {
-                    mark_shared_cte_materialization_requirements(program, select_plan);
+                    mark_shared_cte_materialization_requirements(
+                        &mut select_plan.table_references,
+                        &mut select_plan.non_from_clause_subqueries,
+                    );
                 }
-                mark_shared_cte_materialization_requirements(program, right_most);
+                mark_shared_cte_materialization_requirements(
+                    &mut right_most.table_references,
+                    &mut right_most.non_from_clause_subqueries,
+                );
             }
-            Plan::Delete(_) | Plan::Update(_) => unreachable!("DML plans cannot be subqueries"),
+            Plan::Delete(_) | Plan::Update(_) => {}
         }
     }
 
-    for table in plan.table_references.joined_tables_mut().iter_mut() {
+    let mut shared_ref_counts = HashMap::default();
+    count_shared_cte_references(
+        &mut shared_ref_counts,
+        table_references,
+        non_from_clause_subqueries,
+    );
+
+    for table in table_references.joined_tables_mut().iter_mut() {
         if let Table::FromClauseSubquery(from_clause_subquery) = &mut table.table {
             let from_clause_subquery = Arc::make_mut(from_clause_subquery);
             let shared_materialization = from_clause_subquery.cte_id().is_some_and(|cte_id| {
-                program.get_cte_reference_count(cte_id) > 1
+                shared_ref_counts.get(&cte_id).copied().unwrap_or_default() > 1
                     && !plan_has_outer_scope_dependency(&from_clause_subquery.plan)
             });
             from_clause_subquery.set_shared_materialization(shared_materialization);
             if let Some(cte_id) = from_clause_subquery.cte_id() {
                 tracing::trace!(
                     cte_id,
-                    reference_count = program.get_cte_reference_count(cte_id),
+                    shared_ref_count = shared_ref_counts.get(&cte_id).copied().unwrap_or_default(),
                     shared_materialization,
                     outer_scope_dependency = plan_has_outer_scope_dependency(
                         &from_clause_subquery.plan,
@@ -116,18 +196,18 @@ fn mark_shared_cte_materialization_requirements(program: &ProgramBuilder, plan: 
                     "annotated CTE materialization requirements"
                 );
             }
-            annotate_plan(program, from_clause_subquery.plan.as_mut());
+            annotate_plan(from_clause_subquery.plan.as_mut());
         }
     }
 
-    for subquery in plan.non_from_clause_subqueries.iter_mut() {
+    for subquery in non_from_clause_subqueries.iter_mut() {
         let SubqueryState::Unevaluated {
             plan: Some(subquery_plan),
         } = &mut subquery.state
         else {
             continue;
         };
-        annotate_plan(program, subquery_plan);
+        annotate_plan(subquery_plan);
     }
 }
 
@@ -249,7 +329,10 @@ pub fn plan_subqueries_from_select_plan(
     }
 
     assign_select_subquery_eval_phases(plan);
-    mark_shared_cte_materialization_requirements(program, plan);
+    mark_shared_cte_materialization_requirements(
+        &mut plan.table_references,
+        &mut plan.non_from_clause_subqueries,
+    );
 
     update_column_used_masks(
         &mut plan.table_references,
@@ -531,7 +614,7 @@ fn get_subquery_parser<'a>(
                     );
                 };
                 optimize_select_plan(&mut plan, resolver.schema())?;
-                let correlated = plan.is_correlated();
+                let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
                 out_subqueries.push(NonFromClauseSubquery {
                     internal_id: subquery_id,
@@ -632,7 +715,7 @@ fn get_subquery_parser<'a>(
                 *result_reg_start = reg_start;
                 *num_regs = reg_count;
 
-                let correlated = plan.is_correlated();
+                let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
 
                 out_subqueries.push(NonFromClauseSubquery {
@@ -780,7 +863,7 @@ fn get_subquery_parser<'a>(
                     },
                 };
 
-                let correlated = plan_is_correlated(&plan);
+                let correlated = plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
 
                 out_subqueries.push(NonFromClauseSubquery {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -247,9 +247,6 @@ pub struct ProgramBuilder {
     /// Registry of materialized CTEs, keyed by cte_id.
     /// Used to share materialized data across multiple CTE references via OpenDup.
     materialized_ctes: HashMap<usize, MaterializedCteInfo>,
-    /// Global count of references to each CTE across the entire query.
-    /// Used to determine whether a CTE should be materialized (multi-ref) or use coroutine (single-ref).
-    cte_reference_counts: HashMap<usize, usize>,
     /// Stack of CTE names currently being planned. Used to detect circular
     /// references in non-recursive CTEs and to prevent fallthrough to schema
     /// resolution for same-named tables/views.
@@ -693,7 +690,6 @@ impl ProgramBuilder {
             self_table_context: None,
             next_cte_id: 0,
             materialized_ctes: HashMap::default(),
-            cte_reference_counts: HashMap::default(),
             ctes_being_defined: Vec::new(),
             next_subquery_eqp_id: 1,
         }
@@ -731,18 +727,6 @@ impl ProgramBuilder {
     /// Register a materialized CTE so that subsequent references can share it via OpenDup.
     pub fn register_materialized_cte(&mut self, cte_id: usize, info: MaterializedCteInfo) {
         self.materialized_ctes.insert(cte_id, info);
-    }
-
-    /// Increment the global reference count for a CTE.
-    /// Called during planning when a CTE reference is created.
-    pub fn increment_cte_reference(&mut self, cte_id: usize) {
-        *self.cte_reference_counts.entry(cte_id).or_insert(0) += 1;
-    }
-
-    /// Get the global reference count for a CTE.
-    /// Used during emission to decide whether to materialize (multi-ref) or use coroutine (single-ref).
-    pub fn get_cte_reference_count(&self, cte_id: usize) -> usize {
-        self.cte_reference_counts.get(&cte_id).copied().unwrap_or(0)
     }
 
     /// Mark a CTE name as currently being planned. While on the stack,

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-correlated-range-probe.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-correlated-range-probe.snap
@@ -34,4 +34,4 @@ QUERY PLAN
 `--SCAN previous_points
    |--SCAN ordered_points AS p1
    `--CORRELATED SCALAR SUBQUERY 1
-      `--SCAN ordered_points AS p2
+      `--SEARCH p2 USING INDEX ephemeral_subquery_t5 (point_key<?)

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -24,95 +24,132 @@ info:
 ---
 QUERY PLAN
 |--SCALAR SUBQUERY 1
-|  |--SCAN products USING INDEX idx_products_category
 |  `--SCAN category_avg
+|     `--SCAN products USING INDEX idx_products_category
+|--SCAN products USING INDEX idx_products_category
 |--SCAN category_avg AS ca
 `--SEARCH p USING INDEX idx_products_category (category_id=?)
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  82   0                   0  Start at 82
-   1            Once            57   0   0                   0  goto 57
-   2            BeginSubrtn      2   0   0                   0  r[2]=NULL
-   3            Null             0   1   0                   0  r[1]=NULL
-   4            OpenEphemeral    0   1   0                   0  cursor=0 is_table=true
-   5            Null             0  12   0                   0  r[12]=NULL
-   6            Integer          0   9   0                   0  r[9]=0; clear group by abort flag
-   7            Null             0  10   0                   0  r[10]=NULL; initialize group by comparison registers to NULL
-   8            Gosub           16  40   0                   0  ; go to clear accumulator subroutine
-   9            OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  10            OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  11            Rewind           2  27   0                   0  Rewind index idx_products_category
-  12              DeferredSeek   2   1   0                   0
-  13              Column         1   2  14                   0  r[14]=products.category_id
-  14              Column         1   3  15                   0  r[15]=products.price
-  15              RealAffinity  15   0   0                   0
-  16              Compare       10  14   1  k(1, Binary)     0  r[10..10]==r[14..14]
-  17              Jump          18  22  18                   0  ; start new group if comparison is not equal
-  18              Gosub          7  31   0                   0  ; check if ended group had data, and output if so
-  19              Move          14  10   1                   0  r[10..10]=r[14..14]
-  20              IfPos          9  43   0                   0  r[9]>0 -> r[9]-=0, goto 43; check abort flag
-  21              Gosub         16  40   0                   0  ; goto clear accumulator subroutine
-  22              AggStep        0  15  12  avg              0  accum=r[12] step(r[15])
-  23              If             8  25   0                   0  if r[8] goto 25; don't emit group columns if continuing existing group
-  24              Column         1   2  11                   0  r[11]=products.category_id
-  25              Integer        1   8   0                   0  r[8]=1; indicate data in accumulator
-  26            Next             2  12   0                   0
-  27            Gosub            7  31   0                   0  ; emit row for final group
-  28            Goto             0  43   0                   0  ; group by finished
-  29            Integer          1   9   0                   0  r[9]=1
-  30          Return             7   0   0                   0
-  31          IfPos              8  33   0                   0  r[8]>0 -> r[8]-=0, goto 33; output group by row subroutine start
-  32        Return               7   0   0                   0
-  33        AggFinal             0  12   0  avg              0  accum=r[12]
-  34        Copy                11   5   0                   0  r[5]=r[11]
-  35        Copy                12   6   0                   0  r[6]=r[12]
-  36        MakeRecord           5   2  17                   0  r[17]=mkrec(r[5..6]); for
-  37        NewRowid             0  18   0                   0  r[18]=rowid
-  38        Insert               0  17  18                   4  intkey=r[18] data=r[17]
-  39      Return                 7   0   0                   0
-  40      Null                   0  11  12                   0  r[11..12]=NULL; clear accumulator subroutine start
-  41      Integer                0   8   0                   0  r[8]=0
-  42    Return                  16   0   0                   0
-  43    Null                     0  20   0                   0  r[20]=NULL
-  44    Integer                  1  21   0                   0  r[21]=1; LIMIT counter
-  45    IfNot                   21  53   0                   0  if !r[21] goto 53
-  46    Rewind                   0  53   0                   0  Rewind  ephemeral()
-  47      Column                 0   0   3                   0  r[3]=ephemeral().category_id
-  48      Column                 0   1   4                   0  r[4]=ephemeral().avg_price
-  49      Copy                   4  22   0                   0  r[22]=r[4]
-  50      CollSeq                0   0   0  Binary           0  collation=Binary
-  51      AggStep                0  22  20  max              0  accum=r[20] step(r[22])
-  52    Next                     0  47   0                   0
-  53    AggFinal                 0  20   0  max              0  accum=r[20]
-  54    Copy                    20  19   0                   0  r[19]=r[20]
-  55    Copy                    19   1   0                   0  r[1]=r[19]
-  56  Return                     2   0   1                   0
-  57  OpenDup                    3   0   0                   0  new_cursor=3, original_cursor=0
-  58  OpenRead                   4   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  59  OpenRead                   5   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  60  Rewind                     3  81   0                   0  Rewind  ephemeral()
-  61    Column                   3   0  23                   0  r[23]=ephemeral().category_id
-  62    Column                   3   1  24                   0  r[24]=ephemeral().avg_price
-  63    Copy                    23  28   0                   0  r[28]=r[23]
-  64    IsNull                  28  80   0                   0  if (r[28]==NULL) goto 80
-  65    Affinity                28   1   0                   0  r[28..29] = D
-  66    SeekGE                   5  80  28                   0  key=[28..28]
-  67      IdxGT                  5  80  28                   0  key=[28..28]
-  68      DeferredSeek           5   4   0                   0
-  69      Column                 4   3  30                   0  r[30]=products.price
-  70      RealAffinity          30   0   0                   0
-  71      Copy                   1  32   0                   0  r[32]=r[1]
-  72      Multiply              32  33  31                   0  r[31]=r[32]*r[33]
-  73      Le                    30  31  79  Binary           0  if r[30]<=r[31] goto 79
-  74      Column                 4   1  25                   0  r[25]=products.name
-  75      Column                 4   3  26                   0  r[26]=products.price
-  76      RealAffinity          26   0   0                   0
-  77      Copy                  24  27   0                   0  r[27]=r[24]
-  78      ResultRow             25   3   0                   0  output=r[25..27]
-  79    Next                     5  67   0                   0
-  80  Next                       3  61   0                   0
-  81  Halt                       0   0   0                   0
-  82  Transaction                0   1  11                   0  iDb=0 tx_mode=Read
-  83  Real                       0  33   0  0.8              0  r[33]=0.8
-  84  Goto                       0   1   0                   0
+addr  opcode                            p1   p2   p3  p4              p5  comment
+   0                    Init             0  118    0                   0  Start at 118
+   1                    Once            55    0    0                   0  goto 55
+   2                    BeginSubrtn      2    0    0                   0  r[2]=NULL
+   3                    Null             0    1    0                   0  r[1]=NULL
+   4                    InitCoroutine    3   42    5                   0
+   5                    Null             0   11    0                   0  r[11]=NULL
+   6                    Integer          0    8    0                   0  r[8]=0; clear group by abort flag
+   7                    Null             0    9    0                   0  r[9]=NULL; initialize group by comparison registers to NULL
+   8                    Gosub           15   38    0                   0  ; go to clear accumulator subroutine
+   9                    OpenRead         0    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  10                    OpenRead         1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  11                    Rewind           1   27    0                   0  Rewind index idx_products_category
+  12                      DeferredSeek   1    0    0                   0
+  13                      Column         0    2   13                   0  r[13]=products.category_id
+  14                      Column         0    3   14                   0  r[14]=products.price
+  15                      RealAffinity  14    0    0                   0
+  16                      Compare        9   13    1  k(1, Binary)     0  r[9..9]==r[13..13]
+  17                      Jump          18   22   18                   0  ; start new group if comparison is not equal
+  18                      Gosub          6   31    0                   0  ; check if ended group had data, and output if so
+  19                      Move          13    9    1                   0  r[9..9]=r[13..13]
+  20                      IfPos          8   41    0                   0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
+  21                      Gosub         15   38    0                   0  ; goto clear accumulator subroutine
+  22                      AggStep        0   14   11  avg              0  accum=r[11] step(r[14])
+  23                      If             7   25    0                   0  if r[7] goto 25; don't emit group columns if continuing existing group
+  24                      Column         0    2   10                   0  r[10]=products.category_id
+  25                      Integer        1    7    0                   0  r[7]=1; indicate data in accumulator
+  26                    Next             1   12    0                   0
+  27                    Gosub            6   31    0                   0  ; emit row for final group
+  28                    Goto             0   41    0                   0  ; group by finished
+  29                    Integer          1    8    0                   0  r[8]=1
+  30                  Return             6    0    0                   0
+  31                  IfPos              7   33    0                   0  r[7]>0 -> r[7]-=0, goto 33; output group by row subroutine start
+  32                Return               6    0    0                   0
+  33                AggFinal             0   11    0  avg              0  accum=r[11]
+  34                Copy                10    4    0                   0  r[4]=r[10]
+  35                Copy                11    5    0                   0  r[5]=r[11]
+  36                Yield                3    0    0                   0
+  37              Return                 6    0    0                   0
+  38              Null                   0   10   11                   0  r[10..11]=NULL; clear accumulator subroutine start
+  39              Integer                0    7    0                   0  r[7]=0
+  40            Return                  15    0    0                   0
+  41            EndCoroutine             3    0    0                   0
+  42            Null                     0   17    0                   0  r[17]=NULL
+  43            Integer                  1   18    0                   0  r[18]=1; LIMIT counter
+  44            IfNot                   18   51    0                   0  if !r[18] goto 51
+  45            InitCoroutine            3    0    5                   0
+  46              Yield                  3   51    0                   0
+  47              Copy                   5   19    0                   0  r[19]=r[5]
+  48              CollSeq                0    0    0  Binary           0  collation=Binary
+  49              AggStep                0   19   17  max              0  accum=r[17] step(r[19])
+  50            Goto                     0   46    0                   0
+  51            AggFinal                 0   17    0  max              0  accum=r[17]
+  52            Copy                    17   16    0                   0  r[16]=r[17]
+  53            Copy                    16    1    0                   0  r[1]=r[16]
+  54          Return                     2    0    1                   0
+  55          OpenEphemeral              2    1    0                   0  cursor=2 is_table=true
+  56          Null                       0   29    0                   0  r[29]=NULL
+  57          Integer                    0   26    0                   0  r[26]=0; clear group by abort flag
+  58          Null                       0   27    0                   0  r[27]=NULL; initialize group by comparison registers to NULL
+  59          Gosub                     33   91    0                   0  ; go to clear accumulator subroutine
+  60          OpenRead                   3    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  61          OpenRead                   4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  62          Rewind                     4   78    0                   0  Rewind index idx_products_category
+  63            DeferredSeek             4    3    0                   0
+  64            Column                   3    2   31                   0  r[31]=products.category_id
+  65            Column                   3    3   32                   0  r[32]=products.price
+  66            RealAffinity            32    0    0                   0
+  67            Compare                 27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
+  68            Jump                    69   73   69                   0  ; start new group if comparison is not equal
+  69            Gosub                   24   82    0                   0  ; check if ended group had data, and output if so
+  70            Move                    31   27    1                   0  r[27..27]=r[31..31]
+  71            IfPos                   26   94    0                   0  r[26]>0 -> r[26]-=0, goto 94; check abort flag
+  72            Gosub                   33   91    0                   0  ; goto clear accumulator subroutine
+  73            AggStep                  0   32   29  avg              0  accum=r[29] step(r[32])
+  74            If                      25   76    0                   0  if r[25] goto 76; don't emit group columns if continuing existing group
+  75            Column                   3    2   28                   0  r[28]=products.category_id
+  76            Integer                  1   25    0                   0  r[25]=1; indicate data in accumulator
+  77          Next                       4   63    0                   0
+  78          Gosub                     24   82    0                   0  ; emit row for final group
+  79          Goto                       0   94    0                   0  ; group by finished
+  80          Integer                    1   26    0                   0  r[26]=1
+  81        Return                      24    0    0                   0
+  82        IfPos                       25   84    0                   0  r[25]>0 -> r[25]-=0, goto 84; output group by row subroutine start
+  83      Return                        24    0    0                   0
+  84      AggFinal                       0   29    0  avg              0  accum=r[29]
+  85      Copy                          28   22    0                   0  r[22]=r[28]
+  86      Copy                          29   23    0                   0  r[23]=r[29]
+  87      MakeRecord                    22    2   34                   0  r[34]=mkrec(r[22..23]); for
+  88      NewRowid                       2   35    0                   0  r[35]=rowid
+  89      Insert                         2   34   35                   4  intkey=r[35] data=r[34]
+  90    Return                          24    0    0                   0
+  91    Null                             0   28   29                   0  r[28..29]=NULL; clear accumulator subroutine start
+  92    Integer                          0   25    0                   0  r[25]=0
+  93  Return                            33    0    0                   0
+  94  OpenRead                           5    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  95  OpenRead                           6    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  96  Rewind                             2  117    0                   0  Rewind  ephemeral()
+  97    Column                           2    0   20                   0  r[20]=ephemeral().category_id
+  98    Column                           2    1   21                   0  r[21]=ephemeral().avg_price
+  99    Copy                            20   39    0                   0  r[39]=r[20]
+ 100    IsNull                          39  116    0                   0  if (r[39]==NULL) goto 116
+ 101    Affinity                        39    1    0                   0  r[39..40] = D
+ 102    SeekGE                           6  116   39                   0  key=[39..39]
+ 103      IdxGT                          6  116   39                   0  key=[39..39]
+ 104      DeferredSeek                   6    5    0                   0
+ 105      Column                         5    3   41                   0  r[41]=products.price
+ 106      RealAffinity                  41    0    0                   0
+ 107      Copy                           1   43    0                   0  r[43]=r[1]
+ 108      Multiply                      43   44   42                   0  r[42]=r[43]*r[44]
+ 109      Le                            41   42  115  Binary           0  if r[41]<=r[42] goto 115
+ 110      Column                         5    1   36                   0  r[36]=products.name
+ 111      Column                         5    3   37                   0  r[37]=products.price
+ 112      RealAffinity                  37    0    0                   0
+ 113      Copy                          21   38    0                   0  r[38]=r[21]
+ 114      ResultRow                     36    3    0                   0  output=r[36..38]
+ 115    Next                             6  103    0                   0
+ 116  Next                               2   97    0                   0
+ 117  Halt                               0    0    0                   0
+ 118  Transaction                        0    1   11                   0  iDb=0 tx_mode=Read
+ 119  Real                               0   44    0  0.8              0  r[44]=0.8
+ 120  Goto                               0    1    0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-materialized-scalar-probe.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-materialized-scalar-probe.snap
@@ -61,19 +61,28 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--CORRELATED SCALAR SUBQUERY 1
+|--SCALAR SUBQUERY 1
 |  |--SCALAR SUBQUERY 2
-|  |  |--SCAN sample_points
-|  |  |--USE HASH TABLE FOR DISTINCT
-|  |  |--USE SORTER FOR ORDER BY
 |  |  `--SCAN ordered_points
-|  |--SCAN ordered_points AS p1
-|  |--CORRELATED SCALAR SUBQUERY 3
-|  |  `--SCAN ordered_points AS p2
-|  |--SCAN previous_points
-|  |--SCAN window_subquery_0
-|  |  `--SCAN run_markers
-|  `--SEARCH run_ids USING INDEX ephemeral_subquery_t63 (point_key=?)
+|  |     |--SCAN sample_points
+|  |     |--USE HASH TABLE FOR DISTINCT
+|  |     `--USE SORTER FOR ORDER BY
+|  |--SCAN sample_points
+|  |--USE HASH TABLE FOR DISTINCT
+|  |--USE SORTER FOR ORDER BY
+|  `--SCAN run_ids
+|     `--SCAN window_subquery_0
+|        `--SCAN run_markers
+|           `--SCAN previous_points
+|              |--SCAN ordered_points AS p1
+|              `--CORRELATED SCALAR SUBQUERY 3
+|                 `--SEARCH p2 USING INDEX ephemeral_subquery_t59 (point_key<?)
 `--SCAN run_lengths
    |--SCAN run_ids
+   |  `--SCAN window_subquery_0
+   |     `--SCAN run_markers
+   |        `--SCAN previous_points
+   |           |--SCAN ordered_points AS p1
+   |           `--CORRELATED SCALAR SUBQUERY 4
+   |              `--SEARCH p2 USING INDEX ephemeral_subquery_t45 (point_key<?)
    `--USE SORTER FOR GROUP BY

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -34,83 +34,85 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN orders
 |--SCAN vip_customers AS v
 |  |--LIST SUBQUERY 1
 |  |  `--SCAN large_orders
+|  |     `--SCAN orders
 |  `--SEARCH customers USING INTEGER PRIMARY KEY (rowid=?)
 `--SEARCH l USING INDEX ephemeral_subquery_t8 (customer_id=?)
+   `--SCAN orders
 
 BYTECODE
 addr  opcode              p1  p2  p3  p4            p5  comment
    0  Init                 0  68   0                 0  Start at 68
-   1  OpenEphemeral        1   1   0                 0  cursor=1 is_table=true
-   2  OpenRead             2   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   3  Rewind               2  15   0                 0  Rewind table orders
-   4    Column             2   3   8                 0  r[8]=orders.total_amount
-   5    RealAffinity       8   0   0                 0
-   6    Le                 8   9  14  Binary         0  if r[8]<=r[9] goto 14
-   7    RowId              2   4   0                 0  r[4]=orders.rowid
-   8    Column             2   1   5                 0  r[5]=orders.customer_id
-   9    Column             2   3   6                 0  r[6]=orders.total_amount
-  10    RealAffinity       6   0   0                 0
-  11    MakeRecord         4   3  10                 0  r[10]=mkrec(r[4..6]); for
-  12    NewRowid           1  11   0                 0  r[11]=rowid
-  13    Insert             1  10  11                 4  intkey=r[11] data=r[10]
-  14  Next                 2   4   0                 0
-  15  InitCoroutine       12  37  16                 0
-  16  Once                26   0   0                 0  goto 26
-  17  OpenEphemeral        0   0   0                 0  cursor=0 is_table=false
-  18  Rewind               1  26   0                 0  Rewind  ephemeral()
-  19    Column             1   0   1                 0  r[1]=ephemeral().id
-  20    Column             1   1   2                 0  r[2]=ephemeral().customer_id
-  21    Column             1   2   3                 0  r[3]=ephemeral().total_amount
-  22    Copy               2  13   0                 0  r[13]=r[2]
-  23    MakeRecord        13   1  14                 0  r[14]=mkrec(r[13..13]); for ephemeral_index_where_sub_t4
-  24    IdxInsert          0  14   0                 8  key=r[14]
-  25  Next                 1  19   0                 0
-  26  OpenRead             3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  27  NullRow              0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  28  Rewind               0  36   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
-  29    Column             0   0  17                 0  r[17]=ephemeral(ephemeral_index_where_sub_t4).customer_id
-  30    IsNull            17  35   0                 0  if (r[17]==NULL) goto 35
-  31    SeekRowid          3  17  35                 0  if (r[17]!=cursor 3 for table customers.rowid) goto 35
-  32    RowId              3  15   0                 0  r[15]=customers.rowid
-  33    Column             3   1  16                 0  r[16]=customers.name
-  34    Yield             12   0   0                 0
-  35  Next                 0  29   0                 0
-  36  EndCoroutine        12   0   0                 0
-  37  OpenDup              4   1   0                 0  new_cursor=4, original_cursor=1
-  38  InitCoroutine       12   0  16                 0
-  39    Yield             12  67   0                 0
-  40    Once              51   0   0                 0  goto 51
-  41    OpenAutoindex      5   0   0                 0  cursor=5
-  42    Rewind             4  43   0                 0  Rewind  ephemeral()
-  43      Column           4   1  23                 0  r[23]=ephemeral().customer_id
-  44      Column           4   0  24                 0  r[24]=ephemeral().id
-  45      Column           4   2  25                 0  r[25]=ephemeral().total_amount
-  46      RowId            4  26   0                 0  r[26]=ephemeral().rowid
-  47      MakeRecord      23   4  27                 0  r[27]=mkrec(r[23..26]); for ephemeral_subquery_t8
-  48      FilterAdd        5  23   1                 0  bloom_filter_add(r[23..24])
-  49      IdxInsert        5  27  23                 0  key=r[27]
-  50    Next               4  43   0                 0
-  51    Copy              15  28   0                 0  r[28]=r[15]
-  52    IsNull            28  66   0                 0  if (r[28]==NULL) goto 66
-  53    Affinity          28   1   0                 0  r[28..29] = D
-  54    Filter             5  66  28                 1  if !bloom_filter(r[28..29]) goto 66
-  55    SeekGE             5  66  28                 0  key=[28..28]
-  56      IdxGT            5  66  28                 0  key=[28..28]
-  57      DeferredSeek     5   4   0                 0
-  58      Column           4   0  18                 0  r[18]=ephemeral().id
-  59      Column           4   1  19                 0  r[19]=ephemeral().customer_id
-  60      Column           4   2  20                 0  r[20]=ephemeral().total_amount
-  61      Copy            16  21   0                 0  r[21]=r[16]
-  62      Column           5   2  22                 0  r[22]=ephemeral(ephemeral_subquery_t8).total_amount
-  63      RealAffinity    22   0   0                 0
-  64      ResultRow       21   2   0                 0  output=r[21..22]
-  65    Next               5  56   0                 0
-  66  Goto                 0  39   0                 0
+   1  InitCoroutine        1  34   2                 0
+   2  Once                23   0   0                 0  goto 23
+   3  OpenEphemeral        0   0   0                 0  cursor=0 is_table=false
+   4  InitCoroutine        2  17   5                 0
+   5  OpenRead             1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   6  Rewind               1  16   0                 0  Rewind table orders
+   7    Column             1   3   7                 0  r[7]=orders.total_amount
+   8    RealAffinity       7   0   0                 0
+   9    Le                 7   8  15  Binary         0  if r[7]<=r[8] goto 15
+  10    RowId              1   3   0                 0  r[3]=orders.rowid
+  11    Column             1   1   4                 0  r[4]=orders.customer_id
+  12    Column             1   3   5                 0  r[5]=orders.total_amount
+  13    RealAffinity       5   0   0                 0
+  14    Yield              2   0   0                 0
+  15  Next                 1   7   0                 0
+  16  EndCoroutine         2   0   0                 0
+  17  InitCoroutine        2   0   5                 0
+  18    Yield              2  23   0                 0
+  19    Copy               4   9   0                 0  r[9]=r[4]
+  20    MakeRecord         9   1  10                 0  r[10]=mkrec(r[9..9]); for ephemeral_index_where_sub_t4
+  21    IdxInsert          0  10   0                 8  key=r[10]
+  22  Goto                 0  18   0                 0
+  23  OpenRead             2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  24  NullRow              0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  25  Rewind               0  33   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
+  26    Column             0   0  13                 0  r[13]=ephemeral(ephemeral_index_where_sub_t4).customer_id
+  27    IsNull            13  32   0                 0  if (r[13]==NULL) goto 32
+  28    SeekRowid          2  13  32                 0  if (r[13]!=cursor 2 for table customers.rowid) goto 32
+  29    RowId              2  11   0                 0  r[11]=customers.rowid
+  30    Column             2   1  12                 0  r[12]=customers.name
+  31    Yield              1   0   0                 0
+  32  Next                 0  26   0                 0
+  33  EndCoroutine         1   0   0                 0
+  34  OpenEphemeral        3   0   0                 0  cursor=3 is_table=false
+  35  OpenRead             4   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  36  Rewind               4  51   0                 0  Rewind table orders
+  37    Column             4   3  21                 0  r[21]=orders.total_amount
+  38    RealAffinity      21   0   0                 0
+  39    Le                21  22  50  Binary         0  if r[21]<=r[22] goto 50
+  40    RowId              4  17   0                 0  r[17]=orders.rowid
+  41    Column             4   1  18                 0  r[18]=orders.customer_id
+  42    Column             4   3  19                 0  r[19]=orders.total_amount
+  43    RealAffinity      19   0   0                 0
+  44    Copy              18  24   0                 0  r[24]=r[18]
+  45    Copy              17  25   0                 0  r[25]=r[17]
+  46    Copy              19  26   0                 0  r[26]=r[19]
+  47    Sequence           3  27   0                 0
+  48    MakeRecord        24   4  23                 0  r[23]=mkrec(r[24..27]); for ephemeral_subquery_t8
+  49    IdxInsert          3  23   0                 8  key=r[23]
+  50  Next                 4  37   0                 0
+  51  InitCoroutine        1   0   2                 0
+  52    Yield              1  67   0                 0
+  53    Copy              11  30   0                 0  r[30]=r[11]
+  54    IsNull            30  66   0                 0  if (r[30]==NULL) goto 66
+  55    Affinity          30   1   0                 0  r[30..31] = D
+  56    SeekGE             3  66  30                 0  key=[30..30]
+  57      IdxGT            3  66  30                 0  key=[30..30]
+  58      Column           3   1  14                 0  r[14]=ephemeral(ephemeral_subquery_t8).id
+  59      Column           3   0  15                 0  r[15]=ephemeral(ephemeral_subquery_t8).customer_id
+  60      Column           3   2  16                 0  r[16]=ephemeral(ephemeral_subquery_t8).total_amount
+  61      Copy            12  28   0                 0  r[28]=r[12]
+  62      Column           3   2  29                 0  r[29]=ephemeral(ephemeral_subquery_t8).total_amount
+  63      RealAffinity    29   0   0                 0
+  64      ResultRow       28   2   0                 0  output=r[28..29]
+  65    Next               3  57   0                 0
+  66  Goto                 0  52   0                 0
   67  Halt                 0   0   0                 0
   68  Transaction          0   1  11                 0  iDb=0 tx_mode=Read
-  69  Integer           1000   9   0                 0  r[9]=1000
-  70  Goto                 0   1   0                 0
+  69  Integer           1000   8   0                 0  r[8]=1000
+  70  Integer           1000  22   0                 0  r[22]=1000
+  71  Goto                 0   1   0                 0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
@@ -26,103 +26,177 @@ info:
 ---
 QUERY PLAN
 |--SCALAR SUBQUERY 1
-|  |--SCAN orders USING INDEX idx_orders_customer
 |  `--SCAN order_totals
+|     `--SCAN orders USING INDEX idx_orders_customer
 |--SCALAR SUBQUERY 2
 |  `--SCAN order_totals
+|     `--SCAN orders USING INDEX idx_orders_customer
+|--SCAN orders USING INDEX idx_orders_customer
 |--SCAN order_totals AS ot
 `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode                      p1  p2  p3  p4            p5  comment
-   0              Init             0  89   0                 0  Start at 89
-   1              Once            56   0   0                 0  goto 56
-   2              BeginSubrtn      3   0   0                 0  r[3]=NULL
-   3              Null             0   1   0                 0  r[1]=NULL
-   4              OpenEphemeral    0   1   0                 0  cursor=0 is_table=true
-   5              Null             0  13   0                 0  r[13]=NULL
-   6              Integer          0  10   0                 0  r[10]=0; clear group by abort flag
-   7              Null             0  11   0                 0  r[11]=NULL; initialize group by comparison registers to NULL
-   8              Gosub           17  40   0                 0  ; go to clear accumulator subroutine
-   9              OpenRead         1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  10              OpenRead         2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-  11              Rewind           2  27   0                 0  Rewind index idx_orders_customer
-  12                DeferredSeek   2   1   0                 0
-  13                Column         1   1  15                 0  r[15]=orders.customer_id
-  14                Column         1   3  16                 0  r[16]=orders.total_amount
-  15                RealAffinity  16   0   0                 0
-  16                Compare       11  15   1  k(1, Binary)   0  r[11..11]==r[15..15]
-  17                Jump          18  22  18                 0  ; start new group if comparison is not equal
-  18                Gosub          8  31   0                 0  ; check if ended group had data, and output if so
-  19                Move          15  11   1                 0  r[11..11]=r[15..15]
-  20                IfPos         10  43   0                 0  r[10]>0 -> r[10]-=0, goto 43; check abort flag
-  21                Gosub         17  40   0                 0  ; goto clear accumulator subroutine
-  22                AggStep        0  16  13  sum            0  accum=r[13] step(r[16])
-  23                If             9  25   0                 0  if r[9] goto 25; don't emit group columns if continuing existing group
-  24                Column         1   1  12                 0  r[12]=orders.customer_id
-  25                Integer        1   9   0                 0  r[9]=1; indicate data in accumulator
-  26              Next             2  12   0                 0
-  27              Gosub            8  31   0                 0  ; emit row for final group
-  28              Goto             0  43   0                 0  ; group by finished
-  29              Integer          1  10   0                 0  r[10]=1
-  30            Return             8   0   0                 0
-  31            IfPos              9  33   0                 0  r[9]>0 -> r[9]-=0, goto 33; output group by row subroutine start
-  32          Return               8   0   0                 0
-  33          AggFinal             0  13   0  sum            0  accum=r[13]
-  34          Copy                12   6   0                 0  r[6]=r[12]
-  35          Copy                13   7   0                 0  r[7]=r[13]
-  36          MakeRecord           6   2  18                 0  r[18]=mkrec(r[6..7]); for
-  37          NewRowid             0  19   0                 0  r[19]=rowid
-  38          Insert               0  18  19                 4  intkey=r[19] data=r[18]
-  39        Return                 8   0   0                 0
-  40        Null                   0  12  13                 0  r[12..13]=NULL; clear accumulator subroutine start
-  41        Integer                0   9   0                 0  r[9]=0
-  42      Return                  17   0   0                 0
-  43      Null                     0  21   0                 0  r[21]=NULL
-  44      Integer                  1  22   0                 0  r[22]=1; LIMIT counter
-  45      IfNot                   22  52   0                 0  if !r[22] goto 52
-  46      Rewind                   0  52   0                 0  Rewind  ephemeral()
-  47        Column                 0   0   4                 0  r[4]=ephemeral().customer_id
-  48        Column                 0   1   5                 0  r[5]=ephemeral().total
-  49        Copy                   5  23   0                 0  r[23]=r[5]
-  50        AggStep                0  23  21  avg            0  accum=r[21] step(r[23])
-  51      Next                     0  47   0                 0
-  52      AggFinal                 0  21   0  avg            0  accum=r[21]
-  53      Copy                    21  20   0                 0  r[20]=r[21]
-  54      Copy                    20   1   0                 0  r[1]=r[20]
-  55    Return                     3   0   1                 0
-  56    Once                      73   0   0                 0  goto 73
-  57    BeginSubrtn               24   0   0                 0  r[24]=NULL
-  58    Null                       0   2   0                 0  r[2]=NULL
-  59    OpenDup                    3   0   0                 0  new_cursor=3, original_cursor=0
-  60    Null                       0  28   0                 0  r[28]=NULL
-  61    Integer                    1  29   0                 0  r[29]=1; LIMIT counter
-  62    IfNot                     29  69   0                 0  if !r[29] goto 69
-  63    Rewind                     3  69   0                 0  Rewind  ephemeral()
-  64      Column                   3   0  25                 0  r[25]=ephemeral().customer_id
-  65      Column                   3   1  26                 0  r[26]=ephemeral().total
-  66      Copy                    26  30   0                 0  r[30]=r[26]
-  67      AggStep                  0  30  28  avg            0  accum=r[28] step(r[30])
-  68    Next                       3  64   0                 0
-  69    AggFinal                   0  28   0  avg            0  accum=r[28]
-  70    Copy                      28  27   0                 0  r[27]=r[28]
-  71    Copy                      27   2   0                 0  r[2]=r[27]
-  72  Return                      24   0   1                 0
-  73  OpenDup                      4   0   0                 0  new_cursor=4, original_cursor=0
-  74  OpenRead                     5   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  75  Rewind                       4  88   0                 0  Rewind  ephemeral()
-  76    Column                     4   0  31                 0  r[31]=ephemeral().customer_id
-  77    Column                     4   1  32                 0  r[32]=ephemeral().total
-  78    Copy                      32  37   0                 0  r[37]=r[32]
-  79    Copy                       1  38   0                 0  r[38]=r[1]
-  80    Le                        37  38  87  Binary         0  if r[37]<=r[38] goto 87
-  81    Copy                      31  39   0                 0  r[39]=r[31]
-  82    SeekRowid                  5  39  87                 0  if (r[39]!=cursor 5 for table customers.rowid) goto 87
-  83    Column                     5   1  33                 0  r[33]=customers.name
-  84    Copy                      32  34   0                 0  r[34]=r[32]
-  85    Copy                       2  35   0                 0  r[35]=r[2]
-  86    ResultRow                 33   3   0                 0  output=r[33..35]
-  87  Next                         4  76   0                 0
-  88  Halt                         0   0   0                 0
-  89  Transaction                  0   1  11                 0  iDb=0 tx_mode=Read
-  90  Goto                         0   1   0                 0
+addr  opcode                                       p1   p2   p3  p4            p5  comment
+   0                              Init              0  161    0                 0  Start at 161
+   1                              Once             54    0    0                 0  goto 54
+   2                              BeginSubrtn       3    0    0                 0  r[3]=NULL
+   3                              Null              0    1    0                 0  r[1]=NULL
+   4                              InitCoroutine     4   42    5                 0
+   5                              Null              0   12    0                 0  r[12]=NULL
+   6                              Integer           0    9    0                 0  r[9]=0; clear group by abort flag
+   7                              Null              0   10    0                 0  r[10]=NULL; initialize group by comparison registers to NULL
+   8                              Gosub            16   38    0                 0  ; go to clear accumulator subroutine
+   9                              OpenRead          0    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  10                              OpenRead          1    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  11                              Rewind            1   27    0                 0  Rewind index idx_orders_customer
+  12                                DeferredSeek    1    0    0                 0
+  13                                Column          0    1   14                 0  r[14]=orders.customer_id
+  14                                Column          0    3   15                 0  r[15]=orders.total_amount
+  15                                RealAffinity   15    0    0                 0
+  16                                Compare        10   14    1  k(1, Binary)   0  r[10..10]==r[14..14]
+  17                                Jump           18   22   18                 0  ; start new group if comparison is not equal
+  18                                Gosub           7   31    0                 0  ; check if ended group had data, and output if so
+  19                                Move           14   10    1                 0  r[10..10]=r[14..14]
+  20                                IfPos           9   41    0                 0  r[9]>0 -> r[9]-=0, goto 41; check abort flag
+  21                                Gosub          16   38    0                 0  ; goto clear accumulator subroutine
+  22                                AggStep         0   15   12  sum            0  accum=r[12] step(r[15])
+  23                                If              8   25    0                 0  if r[8] goto 25; don't emit group columns if continuing existing group
+  24                                Column          0    1   11                 0  r[11]=orders.customer_id
+  25                                Integer         1    8    0                 0  r[8]=1; indicate data in accumulator
+  26                              Next              1   12    0                 0
+  27                              Gosub             7   31    0                 0  ; emit row for final group
+  28                              Goto              0   41    0                 0  ; group by finished
+  29                              Integer           1    9    0                 0  r[9]=1
+  30                            Return              7    0    0                 0
+  31                            IfPos               8   33    0                 0  r[8]>0 -> r[8]-=0, goto 33; output group by row subroutine start
+  32                          Return                7    0    0                 0
+  33                          AggFinal              0   12    0  sum            0  accum=r[12]
+  34                          Copy                 11    5    0                 0  r[5]=r[11]
+  35                          Copy                 12    6    0                 0  r[6]=r[12]
+  36                          Yield                 4    0    0                 0
+  37                        Return                  7    0    0                 0
+  38                        Null                    0   11   12                 0  r[11..12]=NULL; clear accumulator subroutine start
+  39                        Integer                 0    8    0                 0  r[8]=0
+  40                      Return                   16    0    0                 0
+  41                      EndCoroutine              4    0    0                 0
+  42                      Null                      0   18    0                 0  r[18]=NULL
+  43                      Integer                   1   19    0                 0  r[19]=1; LIMIT counter
+  44                      IfNot                    19   50    0                 0  if !r[19] goto 50
+  45                      InitCoroutine             4    0    5                 0
+  46                        Yield                   4   50    0                 0
+  47                        Copy                    6   20    0                 0  r[20]=r[6]
+  48                        AggStep                 0   20   18  avg            0  accum=r[18] step(r[20])
+  49                      Goto                      0   46    0                 0
+  50                      AggFinal                  0   18    0  avg            0  accum=r[18]
+  51                      Copy                     18   17    0                 0  r[17]=r[18]
+  52                      Copy                     17    1    0                 0  r[1]=r[17]
+  53                    Return                      3    0    1                 0
+  54                    Once                      107    0    0                 0  goto 107
+  55                    BeginSubrtn                21    0    0                 0  r[21]=NULL
+  56                    Null                        0    2    0                 0  r[2]=NULL
+  57                    InitCoroutine              22   95   58                 0
+  58                    Null                        0   30    0                 0  r[30]=NULL
+  59                    Integer                     0   27    0                 0  r[27]=0; clear group by abort flag
+  60                    Null                        0   28    0                 0  r[28]=NULL; initialize group by comparison registers to NULL
+  61                    Gosub                      34   91    0                 0  ; go to clear accumulator subroutine
+  62                    OpenRead                    2    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  63                    OpenRead                    3    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  64                    Rewind                      3   80    0                 0  Rewind index idx_orders_customer
+  65                      DeferredSeek              3    2    0                 0
+  66                      Column                    2    1   32                 0  r[32]=orders.customer_id
+  67                      Column                    2    3   33                 0  r[33]=orders.total_amount
+  68                      RealAffinity             33    0    0                 0
+  69                      Compare                  28   32    1  k(1, Binary)   0  r[28..28]==r[32..32]
+  70                      Jump                     71   75   71                 0  ; start new group if comparison is not equal
+  71                      Gosub                    25   84    0                 0  ; check if ended group had data, and output if so
+  72                      Move                     32   28    1                 0  r[28..28]=r[32..32]
+  73                      IfPos                    27   94    0                 0  r[27]>0 -> r[27]-=0, goto 94; check abort flag
+  74                      Gosub                    34   91    0                 0  ; goto clear accumulator subroutine
+  75                      AggStep                   0   33   30  sum            0  accum=r[30] step(r[33])
+  76                      If                       26   78    0                 0  if r[26] goto 78; don't emit group columns if continuing existing group
+  77                      Column                    2    1   29                 0  r[29]=orders.customer_id
+  78                      Integer                   1   26    0                 0  r[26]=1; indicate data in accumulator
+  79                    Next                        3   65    0                 0
+  80                    Gosub                      25   84    0                 0  ; emit row for final group
+  81                    Goto                        0   94    0                 0  ; group by finished
+  82                    Integer                     1   27    0                 0  r[27]=1
+  83                  Return                       25    0    0                 0
+  84                  IfPos                        26   86    0                 0  r[26]>0 -> r[26]-=0, goto 86; output group by row subroutine start
+  85                Return                         25    0    0                 0
+  86                AggFinal                        0   30    0  sum            0  accum=r[30]
+  87                Copy                           29   23    0                 0  r[23]=r[29]
+  88                Copy                           30   24    0                 0  r[24]=r[30]
+  89                Yield                          22    0    0                 0
+  90              Return                           25    0    0                 0
+  91              Null                              0   29   30                 0  r[29..30]=NULL; clear accumulator subroutine start
+  92              Integer                           0   26    0                 0  r[26]=0
+  93            Return                             34    0    0                 0
+  94            EndCoroutine                       22    0    0                 0
+  95            Null                                0   36    0                 0  r[36]=NULL
+  96            Integer                             1   37    0                 0  r[37]=1; LIMIT counter
+  97            IfNot                              37  103    0                 0  if !r[37] goto 103
+  98            InitCoroutine                      22    0   58                 0
+  99              Yield                            22  103    0                 0
+ 100              Copy                             24   38    0                 0  r[38]=r[24]
+ 101              AggStep                           0   38   36  avg            0  accum=r[36] step(r[38])
+ 102            Goto                                0   99    0                 0
+ 103            AggFinal                            0   36    0  avg            0  accum=r[36]
+ 104            Copy                               36   35    0                 0  r[35]=r[36]
+ 105            Copy                               35    2    0                 0  r[2]=r[35]
+ 106          Return                               21    0    1                 0
+ 107          OpenEphemeral                         4    1    0                 0  cursor=4 is_table=true
+ 108          Null                                  0   48    0                 0  r[48]=NULL
+ 109          Integer                               0   45    0                 0  r[45]=0; clear group by abort flag
+ 110          Null                                  0   46    0                 0  r[46]=NULL; initialize group by comparison registers to NULL
+ 111          Gosub                                52  143    0                 0  ; go to clear accumulator subroutine
+ 112          OpenRead                              5    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+ 113          OpenRead                              6    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+ 114          Rewind                                6  130    0                 0  Rewind index idx_orders_customer
+ 115            DeferredSeek                        6    5    0                 0
+ 116            Column                              5    1   50                 0  r[50]=orders.customer_id
+ 117            Column                              5    3   51                 0  r[51]=orders.total_amount
+ 118            RealAffinity                       51    0    0                 0
+ 119            Compare                            46   50    1  k(1, Binary)   0  r[46..46]==r[50..50]
+ 120            Jump                              121  125  121                 0  ; start new group if comparison is not equal
+ 121            Gosub                              43  134    0                 0  ; check if ended group had data, and output if so
+ 122            Move                               50   46    1                 0  r[46..46]=r[50..50]
+ 123            IfPos                              45  146    0                 0  r[45]>0 -> r[45]-=0, goto 146; check abort flag
+ 124            Gosub                              52  143    0                 0  ; goto clear accumulator subroutine
+ 125            AggStep                             0   51   48  sum            0  accum=r[48] step(r[51])
+ 126            If                                 44  128    0                 0  if r[44] goto 128; don't emit group columns if continuing existing group
+ 127            Column                              5    1   47                 0  r[47]=orders.customer_id
+ 128            Integer                             1   44    0                 0  r[44]=1; indicate data in accumulator
+ 129          Next                                  6  115    0                 0
+ 130          Gosub                                43  134    0                 0  ; emit row for final group
+ 131          Goto                                  0  146    0                 0  ; group by finished
+ 132          Integer                               1   45    0                 0  r[45]=1
+ 133        Return                                 43    0    0                 0
+ 134        IfPos                                  44  136    0                 0  r[44]>0 -> r[44]-=0, goto 136; output group by row subroutine start
+ 135      Return                                   43    0    0                 0
+ 136      AggFinal                                  0   48    0  sum            0  accum=r[48]
+ 137      Copy                                     47   41    0                 0  r[41]=r[47]
+ 138      Copy                                     48   42    0                 0  r[42]=r[48]
+ 139      MakeRecord                               41    2   53                 0  r[53]=mkrec(r[41..42]); for
+ 140      NewRowid                                  4   54    0                 0  r[54]=rowid
+ 141      Insert                                    4   53   54                 4  intkey=r[54] data=r[53]
+ 142    Return                                     43    0    0                 0
+ 143    Null                                        0   47   48                 0  r[47..48]=NULL; clear accumulator subroutine start
+ 144    Integer                                     0   44    0                 0  r[44]=0
+ 145  Return                                       52    0    0                 0
+ 146  OpenRead                                      7    6    0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+ 147  Rewind                                        4  160    0                 0  Rewind  ephemeral()
+ 148    Column                                      4    0   39                 0  r[39]=ephemeral().customer_id
+ 149    Column                                      4    1   40                 0  r[40]=ephemeral().total
+ 150    Copy                                       40   59    0                 0  r[59]=r[40]
+ 151    Copy                                        1   60    0                 0  r[60]=r[1]
+ 152    Le                                         59   60  159  Binary         0  if r[59]<=r[60] goto 159
+ 153    Copy                                       39   61    0                 0  r[61]=r[39]
+ 154    SeekRowid                                   7   61  159                 0  if (r[61]!=cursor 7 for table customers.rowid) goto 159
+ 155    Column                                      7    1   55                 0  r[55]=customers.name
+ 156    Copy                                       40   56    0                 0  r[56]=r[40]
+ 157    Copy                                        2   57    0                 0  r[57]=r[2]
+ 158    ResultRow                                  55    3    0                 0  output=r[55..57]
+ 159  Next                                          4  148    0                 0
+ 160  Halt                                          0    0    0                 0
+ 161  Transaction                                   0    1   11                 0  iDb=0 tx_mode=Read
+ 162  Goto                                          0    1    0                 0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-current-window.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-current-window.snap
@@ -77,32 +77,54 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--CORRELATED SCALAR SUBQUERY 1
+|--SCALAR SUBQUERY 1
 |  |--SCALAR SUBQUERY 2
-|  |  |--SCAN (subquery-0)
-|  |  |  `--COMPOUND QUERY
-|  |  |     |--LEFT-MOST SUBQUERY
-|  |  |     |  `--SCAN user_messages
-|  |  |     |--UNION ALL
-|  |  |     |  `--SCAN session_starts
-|  |  |     |--UNION ALL
-|  |  |     |  `--SCAN observed_items
-|  |  |     |--UNION ALL
-|  |  |     |  `--SCAN observed_items
-|  |  |     |--UNION ALL
-|  |  |     |  `--SCAN observed_items
-|  |  |     `--UNION ALL
-|  |  |        `--SCAN journal_entries
-|  |  |--USE HASH TABLE FOR DISTINCT
-|  |  |--USE SORTER FOR ORDER BY
 |  |  `--SCAN signal_days
-|  |--SCAN signal_days AS d1
-|  |--CORRELATED SCALAR SUBQUERY 3
-|  |  `--SCAN signal_days AS d2
-|  |--SCAN prior_days
-|  |--SCAN window_subquery_0
-|  |  `--SCAN run_boundaries
-|  `--SEARCH run_ids USING INDEX ephemeral_subquery_t111 (signal_day=?)
+|  |     |--SCAN (subquery-0)
+|  |     |  `--COMPOUND QUERY
+|  |     |     |--LEFT-MOST SUBQUERY
+|  |     |     |  `--SCAN user_messages
+|  |     |     |--UNION ALL
+|  |     |     |  `--SCAN session_starts
+|  |     |     |--UNION ALL
+|  |     |     |  `--SCAN observed_items
+|  |     |     |--UNION ALL
+|  |     |     |  `--SCAN observed_items
+|  |     |     |--UNION ALL
+|  |     |     |  `--SCAN observed_items
+|  |     |     `--UNION ALL
+|  |     |        `--SCAN journal_entries
+|  |     |--USE HASH TABLE FOR DISTINCT
+|  |     `--USE SORTER FOR ORDER BY
+|  |--SCAN (subquery-0)
+|  |  `--COMPOUND QUERY
+|  |     |--LEFT-MOST SUBQUERY
+|  |     |  `--SCAN user_messages
+|  |     |--UNION ALL
+|  |     |  `--SCAN session_starts
+|  |     |--UNION ALL
+|  |     |  `--SCAN observed_items
+|  |     |--UNION ALL
+|  |     |  `--SCAN observed_items
+|  |     |--UNION ALL
+|  |     |  `--SCAN observed_items
+|  |     `--UNION ALL
+|  |        `--SCAN journal_entries
+|  |--USE HASH TABLE FOR DISTINCT
+|  |--USE SORTER FOR ORDER BY
+|  `--SCAN run_ids
+|     `--SCAN window_subquery_0
+|        `--SCAN run_boundaries
+|           `--SCAN prior_days
+|              |--SCAN signal_days AS d1
+|              `--CORRELATED SCALAR SUBQUERY 3
+|                 `--SEARCH d2 USING INDEX ephemeral_subquery_t107 (signal_day<?)
 `--SCAN run_lengths
    |--SCAN run_ids
+   |  `--SCAN window_subquery_0
+   |     `--SCAN run_boundaries
+   |        `--SCAN prior_days
+   |           |--SCAN signal_days AS d1
+   |           `--CORRELATED SCALAR SUBQUERY 4
+   |              `--SEARCH d2 USING INDEX ephemeral_subquery_t81 (signal_day<?)
    `--USE SORTER FOR GROUP BY

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-longest-window.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__run-length-longest-window.snap
@@ -94,6 +94,6 @@ QUERY PLAN
 |  |        `--SCAN prior_days
 |  |           |--SCAN signal_days AS d1
 |  |           `--CORRELATED SCALAR SUBQUERY 1
-|  |              `--SCAN signal_days AS d2
+|  |              `--SEARCH d2 USING INDEX ephemeral_subquery_t11 (signal_day<?)
 |  `--USE SORTER FOR GROUP BY
 `--USE SORTER FOR ORDER BY

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
@@ -50,12 +50,12 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--CORRELATED LIST SUBQUERY 1
+|--LIST SUBQUERY 1
 |  |--LIST SUBQUERY 2
 |  |  `--SCAN part
 |  |--SEARCH partsupp USING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
 |  `--CORRELATED SCALAR SUBQUERY 3
 |     `--SCAN lineitem
-|--SCAN supplier
+|--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 `--USE SORTER FOR ORDER BY


### PR DESCRIPTION
Extracted from #6427 

Replace the global CTE reference counter on ProgramBuilder with a tree-walk approach that counts shareable reads per query tree. The old approach double-counted CTE references from correlated subqueries and visibility-only pre-planning copies, leading to incorrect materialization decisions.

- Remove cte_reference_counts from ProgramBuilder
- Add count_shared_cte_references() tree-walk in subquery.rs
- mark_shared_cte_materialization_requirements now takes TableReferences instead of ProgramBuilder
- Extract select_plan_has_outer_scope_dependency() as public
- Remove count_reference parameter from plan_cte()
- Correlated RETURNING subqueries excluded from shared CTE counting