### PR TITLE
Use correct statement origin for pragma vtab helpers

### DIFF
--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -427,7 +427,11 @@ impl PragmaVirtualTableCursor {
             sql.push_str(&format!("=\"{arg}\""));
         }
 
-        self.stmt = Some(self.conn.prepare(sql)?);
+        // Table-valued pragma helpers execute inside the parent statement's VM step.
+        // For example, UPDATE ... FROM pragma_table_info('dst') runs this helper while the
+        // outer UPDATE still has an active MVCC transaction and write cursor open on `dst`.
+        // The helper must stay nested so it does not disturb the parent's transaction state.
+        self.stmt = Some(self.conn.prepare_internal(sql)?);
 
         self.next()
     }


### PR DESCRIPTION
Extracted from #6427 

Table-valued pragma helpers (e.g. pragma_table_info) prepare and step a separate helper statement on the same connection during the parent statement's VM step. Using prepare() marks the helper as a Root statement, which is semantically wrong — it increments n_active_root_statements and skips the nestedness guard that tells op_transaction to preserve the parent's transaction state.

Switch to prepare_internal() (InternalHelper origin) so the helper is correctly identified as nested.

I could not find a clean repro for this that isn't UPDATE...FROM specific, so no regression test here, but there will be one in the UPDATE-FROM PR.