### PR TITLE
github: Switch macOS runners to Blacksmith

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -18,12 +18,12 @@ jobs:
           artifact-name: linux64
           target: x86_64-unknown-linux-gnu
 
-        - os: macos-latest
+        - os: blacksmith-6vcpu-macos-latest
           make-target: build-rust-macos64
           artifact-name: macos64
           target: x86_64-apple-darwin
 
-        - os: macos-latest
+        - os: blacksmith-6vcpu-macos-latest
           make-target: build-rust-macosarm64
           target: aarch64-apple-darwin
           artifact-name: macosarm64

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         os:
           - blacksmith-4vcpu-ubuntu-2404
-          - macos-latest
+          - blacksmith-6vcpu-macos-latest
           - windows-latest
     env:
       CARGO_TERM_COLOR: always

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -17,11 +17,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             make-target: linux_x86
             artifact-name: linux-x86_64
-          - os: macos-latest
+          - os: blacksmith-6vcpu-macos-latest
             target: x86_64-apple-darwin
             make-target: macos_x86
             artifact-name: macos-x86_64
-          - os: macos-latest
+          - os: blacksmith-6vcpu-macos-latest
             target: aarch64-apple-darwin
             make-target: macos_arm64
             artifact-name: macos-arm64

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -51,11 +51,11 @@ jobs:
             artifact: sync-bindings-x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: yarn workspace @tursodatabase/sync napi-build --target x86_64-unknown-linux-gnu
-          - host: macos-latest
+          - host: blacksmith-6vcpu-macos-latest
             target: aarch64-apple-darwin
             artifact: db-bindings-aarch64-apple-darwin
             build: yarn workspace @tursodatabase/database napi-build --target aarch64-apple-darwin
-          - host: macos-latest
+          - host: blacksmith-6vcpu-macos-latest
             target: aarch64-apple-darwin
             artifact: sync-bindings-aarch64-apple-darwin
             build: yarn workspace @tursodatabase/sync napi-build --target aarch64-apple-darwin

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os:
           - blacksmith-4vcpu-ubuntu-2404
-          - macos-latest
+          - blacksmith-6vcpu-macos-latest
           - windows-latest
         python-version: ${{ fromJson(needs.configure-strategy.outputs.python-versions) }}
     runs-on: ${{ matrix.os }}
@@ -171,7 +171,7 @@ jobs:
           path: bindings/python/dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/react-native.yml
+++ b/.github/workflows/react-native.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build-ios:
     name: Build iOS libraries
-    runs-on: macos-latest
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
 
   build-example-ios:
     name: Build example app (iOS)
-    runs-on: macos-latest
+    runs-on: blacksmith-6vcpu-macos-latest
     timeout-minutes: 45
     needs:
       - build-ios

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: ${{ matrix.os == 'windows-latest' && 120 || 30 }}
     strategy:
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2404, macos-latest, windows-latest]
+        os: [blacksmith-4vcpu-ubuntu-2404, blacksmith-6vcpu-macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Replace `macos-latest` with `blacksmith-6vcpu-macos-latest` across all workflows to match the Blacksmith Linux runners already in use.