### PR TITLE
core/vdbe: Fix string truncation for substr() and like

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -175,6 +175,14 @@ impl From<SeekOp> for ComparisonOp {
     }
 }
 
+#[inline]
+fn sqlite_text_prefix(s: &str) -> &str {
+    match s.find('\0') {
+        Some(idx) => &s[..idx],
+        None => s,
+    }
+}
+
 enum TrimType {
     All,
     Left,
@@ -190,12 +198,7 @@ impl Value {
     pub fn exec_length(&self) -> Self {
         match self {
             Value::Text(t) => {
-                let s = t.as_str();
-                let len_before_null = s.find('\0').map_or_else(
-                    || s.chars().count(),
-                    |null_pos| s[..null_pos].chars().count(),
-                );
-                Value::from_i64(len_before_null as i64)
+                Value::from_i64(sqlite_text_prefix(t.as_str()).chars().count() as i64)
             }
             Value::Numeric(_) => {
                 // For numbers, SQLite returns the length of the string representation
@@ -546,13 +549,13 @@ impl Value {
             }
             (value, Value::Numeric(Numeric::Integer(start))) => {
                 if let Some(text) = value.cast_text() {
+                    let s = sqlite_text_prefix(text.as_str());
                     // Use character count to accurately resolve negative offsets in UTF-8 strings
-                    let char_count = text.chars().count();
+                    let char_count = s.chars().count();
                     let (mut start, mut end) =
                         calculate_postions(start, char_count, length_value.as_ref());
 
                     // https://github.com/sqlite/sqlite/blob/a248d84f/src/func.c#L417
-                    let s = text.as_str();
                     let mut start_byte_idx = 0;
                     end -= start;
                     while start > 0 {
@@ -1179,6 +1182,8 @@ impl Value {
                 "LIKE or GLOB pattern too complex".to_string(),
             ));
         }
+        let pattern = sqlite_text_prefix(pattern);
+        let text = sqlite_text_prefix(text);
 
         let has_escape = escape.is_some_and(|e| pattern.contains(e));
 
@@ -1221,6 +1226,8 @@ impl Value {
                 "GLOB pattern too complex".to_string(),
             ));
         }
+        let pattern = sqlite_text_prefix(pattern);
+        let text = sqlite_text_prefix(text);
 
         // 1. Exact match (no wildcards)
         if !pattern.contains(GLOB_CHARS) {

--- a/testing/sqltests/tests/glob/memory.sqltest
+++ b/testing/sqltests/tests/glob/memory.sqltest
@@ -185,6 +185,12 @@ expect { 1 }
 test glob-57 { SELECT glob('[-c]', 'x'); }
 expect { 0 }
 
+test glob-embedded-nul-1 { SELECT 'a' || char(0) || 'b' GLOB 'a?b'; }
+expect { 0 }
+
+test glob-embedded-nul-2 { SELECT 'a' || char(0) || 'b' GLOB 'a??'; }
+expect { 0 }
+
 # Unenclosed bracket tests (unrolled from foreach loop)
 test glob-unenclosed-1 { SELECT glob('abc[', 'abc['); }
 expect { 0 }

--- a/testing/sqltests/tests/like.sqltest
+++ b/testing/sqltests/tests/like.sqltest
@@ -125,6 +125,15 @@ expect {
     0
 }
 
+test like-embedded-nul {
+    SELECT 'a' || char(0) || 'b' LIKE 'a_b';
+    SELECT 'a' || char(0) || 'b' LIKE 'a__';
+}
+expect {
+    0
+    0
+}
+
 test like-fn-esc-1 {
     SELECT like('abcX%', 'abc%' , 'X')
 }
@@ -377,4 +386,3 @@ test like-perf {
 expect {
    0
 }
-

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -1288,6 +1288,17 @@ expect {
     |null
 }
 
+test substr-embedded-nul {
+    SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 1, 2));
+    SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 2, 1));
+    SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 3, 1));
+}
+expect {
+    61
+
+
+}
+
 test typeof-null {
     SELECT typeof(null);
 }


### PR DESCRIPTION
Fixes #6305


```
$ sqlite3 ':memory:' <<'SQL'
  SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 1, 2));
  SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 2, 1));
  SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 3, 1));
  SELECT 'a' || char(0) || 'b' LIKE 'a_b';
  SELECT 'a' || char(0) || 'b' LIKE 'a__';
  SELECT length('a' || char(0) || 'b' || char(0) || 'c');
  SELECT 'a' || char(0) || 'b' GLOB 'a?b';
  SELECT 'a' || char(0) || 'b' GLOB 'a??';
  SQL
  61


  0
  0
  1
  0
  0

  $ ./target/debug/tursodb -m list -q ':memory:' <<'SQL'
  SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 1, 2));
  SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 2, 1));
  SELECT hex(substr('a' || char(0) || 'b' || char(0) || 'c', 3, 1));
  SELECT 'a' || char(0) || 'b' LIKE 'a_b';
  SELECT 'a' || char(0) || 'b' LIKE 'a__';
  SELECT length('a' || char(0) || 'b' || char(0) || 'c');
  SELECT 'a' || char(0) || 'b' GLOB 'a?b';
  SELECT 'a' || char(0) || 'b' GLOB 'a??';
  SQL
  61


  0
  0
  1
  0
  0
```
