### PR TITLE
execute: Use MVCC schema cookie during savepoint rollback

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6391,6 +6391,42 @@ fn test_savepoint_index_multiple_statements() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+/// issue #5936 hypothesis:
+/// rollback to a named savepoint inside BEGIN CONCURRENT invalidates schema
+/// state and then repopulates from the current global schema cookie instead of
+/// the transaction snapshot, making pre-existing tables disappear after
+/// concurrent DDL on another connection.
+#[test_log::test]
+fn test_rollback_to_savepoint_preserves_schema_during_concurrent_ddl() {
+    let db = MvccTestDbNoConn::new();
+    let conn0 = db.connect();
+    conn0.execute("CREATE TABLE t1(x INT)").unwrap();
+    conn0.execute("INSERT INTO t1 VALUES (1)").unwrap();
+
+    let conn1 = db.connect();
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+
+    let rows = get_rows(&conn1, "SELECT * FROM t1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+
+    conn1.execute("SAVEPOINT sp1").unwrap();
+    conn1.execute("INSERT INTO t1 VALUES (2)").unwrap();
+
+    conn0.execute("CREATE TABLE t2(a INT)").unwrap();
+    conn1.execute("ROLLBACK TO sp1").unwrap();
+
+    let rows = get_rows(&conn1, "SELECT * FROM t1");
+    assert_eq!(
+        rows.len(),
+        1,
+        "t1 should still be visible after savepoint rollback despite concurrent DDL"
+    );
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+
+    conn1.execute("ROLLBACK").unwrap();
+}
+
 /// Test INSERT followed by DELETE of same row, then another statement fails.
 /// The insert+delete should be preserved (row shouldn't exist).
 #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3893,29 +3893,73 @@ pub fn op_savepoint(
             // cached schema cookie and check if a schema reparse is needed.
             pager.set_schema_cookie(None);
             let in_memory_version = conn.schema.read().schema_version;
+            let mv_snapshot_cookie = mv_store.as_ref().and_then(|mv_store| {
+                conn.get_mv_tx_id().and_then(|tx_id| {
+                    mv_store
+                        .with_header(|h| h.schema_cookie.get(), Some(&tx_id))
+                        .ok()
+                })
+            });
             let pager_ref = conn.pager.load().clone();
-            match pager_ref
-                .io
-                .block(|| pager.with_header(|h| h.schema_cookie.get()))
-            {
+            let current_cookie = if let Some(cookie) = mv_snapshot_cookie {
+                Ok(cookie)
+            } else {
+                pager_ref
+                    .io
+                    .block(|| pager.with_header(|h| h.schema_cookie.get()))
+            };
+            match current_cookie {
                 Ok(on_disk_cookie) if in_memory_version != on_disk_cookie => {
+                    tracing::debug!(
+                        tx_state = ?conn.get_tx_state(),
+                        mv_tx_id = ?conn.get_mv_tx_id(),
+                        in_memory_version,
+                        pager_cookie = on_disk_cookie,
+                        mv_snapshot_cookie = ?mv_snapshot_cookie,
+                        "savepoint rollback: schema cookie mismatch, reparsing schema"
+                    );
                     // Schema was modified during the savepoint. Try to reparse
                     // from the restored database pages. If that fails (e.g. the
                     // database was empty at the savepoint), use an empty schema.
-                    if conn.reparse_schema().is_err() {
+                    if let Err(err) = conn.reparse_schema() {
+                        tracing::debug!(
+                            tx_state = ?conn.get_tx_state(),
+                            mv_tx_id = ?conn.get_mv_tx_id(),
+                            in_memory_version,
+                            pager_cookie = on_disk_cookie,
+                            mv_snapshot_cookie = ?mv_snapshot_cookie,
+                            error = %err,
+                            "savepoint rollback: reparse_schema failed, resetting schema to empty"
+                        );
                         conn.with_schema_mut(|schema| {
                             *schema = Schema::new();
                         });
                     }
                 }
                 Err(_) => {
+                    tracing::debug!(
+                        tx_state = ?conn.get_tx_state(),
+                        mv_tx_id = ?conn.get_mv_tx_id(),
+                        in_memory_version,
+                        mv_snapshot_cookie = ?mv_snapshot_cookie,
+                        "savepoint rollback: schema cookie unreadable, resetting schema to empty"
+                    );
                     // Header page is not readable (database empty after rollback).
                     // Reset to an empty schema.
                     conn.with_schema_mut(|schema| {
                         *schema = Schema::new();
                     });
                 }
-                _ => {} // Schema unchanged, nothing to do.
+                Ok(on_disk_cookie) => {
+                    tracing::debug!(
+                        tx_state = ?conn.get_tx_state(),
+                        mv_tx_id = ?conn.get_mv_tx_id(),
+                        in_memory_version,
+                        pager_cookie = on_disk_cookie,
+                        mv_snapshot_cookie = ?mv_snapshot_cookie,
+                        "savepoint rollback: schema cookie unchanged"
+                    );
+                }
             }
 
             state.pc += 1;


### PR DESCRIPTION
## Description

Fixes: #5936


## Motivation and context

In `SavepointOp::RollbackTo` we weren't using header from MVCC to read current cookie and instead using pager's cookie.

## Description of AI Usage

Codex helped finding out the hypothesis about the cookie and the I corrected it.