### PR TITLE
fix: enforce WAL checksum verification to prevent silent B-Tree corruption

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -144,6 +144,14 @@ pub enum CompletionError {
         expected: usize,
         actual: usize,
     },
+    #[error("WAL checksum mismatch for frame {frame_id}")]
+    WalChecksumMismatch {
+        frame_id: u64,
+        expected_1: u32,
+        expected_2: u32,
+        actual_1: u32,
+        actual_2: u32,
+    },
     #[error("Checksum mismatch on page {page_id}: expected {expected}, got {actual}")]
     ChecksumMismatch {
         page_id: usize,

--- a/core/error.rs
+++ b/core/error.rs
@@ -144,7 +144,7 @@ pub enum CompletionError {
         expected: usize,
         actual: usize,
     },
-    #[error("WAL checksum mismatch for frame {frame_id}")]
+    #[error("WAL checksum mismatch for frame {frame_id}: expected ({expected_1}, {expected_2}), got ({actual_1}, {actual_2})")]
     WalChecksumMismatch {
         frame_id: u64,
         expected_1: u32,

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -43,7 +43,7 @@
 
 #![allow(clippy::arc_with_non_send_sync)]
 
-use crate::{turso_assert, turso_assert_eq, turso_assert_greater_than};
+use crate::{turso_assert, turso_assert_eq};
 use branches::{mark_unlikely, unlikely};
 use bytemuck::{Pod, Zeroable};
 use pack1::{I32BE, U16BE, U32BE};
@@ -1516,6 +1516,7 @@ struct StreamingState {
     last_valid_checksum: (u32, u32),
     last_valid_frame: u64,
     pending_frames: FxHashMap<u64, Vec<u64>>,
+    pending_checksums: FxHashMap<u64, (u32, u32)>,
     page_size: usize,
     use_native_endian: bool,
     header_valid: bool,
@@ -1542,6 +1543,7 @@ impl StreamingWalReader {
                 last_valid_checksum: (0, 0),
                 last_valid_frame: 0,
                 pending_frames: FxHashMap::default(),
+                pending_checksums: FxHashMap::default(),
                 page_size: 0,
                 use_native_endian: false,
                 header_valid: false,
@@ -1744,6 +1746,7 @@ impl StreamingWalReader {
                 .entry(page_no as u64)
                 .or_default()
                 .push(frame_idx);
+            st.pending_checksums.insert(frame_idx, calc);
 
             if db_size > 0 {
                 st.last_valid_frame = st.frame_idx;
@@ -1769,11 +1772,17 @@ impl StreamingWalReader {
         let wfs = self.wal_shared.read();
         {
             let mut frame_cache = wfs.runtime.frame_cache.lock();
+            let mut checksum_cache = wfs.frame_checksums.lock();
             for (page, mut frames) in state.pending_frames.drain() {
                 // Only include frames up to last valid commit
                 frames.retain(|&f| f <= state.last_valid_frame);
                 if !frames.is_empty() {
                     frame_cache.entry(page).or_default().extend(frames);
+                }
+            }
+            for (frame, checksum) in state.pending_checksums.drain() {
+                if frame <= state.last_valid_frame {
+                    checksum_cache.insert(frame, checksum);
                 }
             }
         }
@@ -1796,10 +1805,12 @@ impl StreamingWalReader {
         let max_frame = st.last_valid_frame;
         if max_frame > 0 {
             let mut frame_cache = wfs.runtime.frame_cache.lock();
+            let mut checksum_cache = wfs.frame_checksums.lock();
             for frames in frame_cache.values_mut() {
                 frames.retain(|&f| f <= max_frame);
             }
             frame_cache.retain(|_, frames| !frames.is_empty());
+            checksum_cache.retain(|&f, _| f <= max_frame);
             let header = wfs.metadata.wal_header.lock();
             wfs.runtime.overflow_fallback_coverage.lock().record(
                 header.checkpoint_seq,
@@ -1842,6 +1853,7 @@ pub fn begin_read_wal_frame_raw<F: File + ?Sized>(
     Ok(c)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn begin_read_wal_frame<F: File + ?Sized>(
     io: &F,
     offset: u64,
@@ -1849,84 +1861,95 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
     complete: Box<ReadComplete>,
     page_idx: usize,
     io_ctx: &IOContext,
+    expected_checksum: Option<(u32, u32)>,
+    frame_id: u64,
 ) -> Result<Completion> {
     tracing::trace!(
         "begin_read_wal_frame(offset={}, page_idx={})",
         offset,
         page_idx
     );
-    let buf = buffer_pool.get_page();
-    let buf = Arc::new(buf);
+    let wal_buf = Arc::new(buffer_pool.get_wal_frame());
 
-    match io_ctx.encryption_or_checksum() {
+    let original_complete = complete;
+    let wrapper_complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+        let Ok((buf, bytes_read)) = res else {
+            return original_complete(res);
+        };
+        if bytes_read <= WAL_FRAME_HEADER_SIZE as i32 {
+            return original_complete(Ok((buf, bytes_read)));
+        }
+
+        let frame_slice = &buf.as_slice()[..bytes_read as usize];
+        let (header, raw_page) = parse_wal_frame_header(frame_slice);
+
+        if let Some((c1, c2)) = expected_checksum {
+            if header.checksum_1 != c1 || header.checksum_2 != c2 {
+                tracing::error!("WAL checksum mismatch for frame {frame_id}");
+                return original_complete(Err(CompletionError::WalChecksumMismatch {
+                    frame_id,
+                    expected_1: c1,
+                    expected_2: c2,
+                    actual_1: header.checksum_1,
+                    actual_2: header.checksum_2,
+                }));
+            }
+        }
+
+        let payload_len = raw_page.len();
+        let payload_buf = buffer_pool.get_page();
+        let payload_buf = Arc::new(payload_buf);
+        unsafe {
+            std::ptr::copy_nonoverlapping(raw_page.as_ptr(), payload_buf.as_mut_ptr(), payload_len);
+        }
+        original_complete(Ok((payload_buf, payload_len as i32)))
+    });
+
+    let new_complete: Box<ReadComplete> = match io_ctx.encryption_or_checksum() {
         EncryptionOrChecksum::Encryption(ctx) => {
             let encryption_ctx = ctx.clone();
-            let original_complete = complete;
-
-            let decrypt_complete =
-                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
-                    let Ok((encrypted_buf, bytes_read)) = res else {
-                        return original_complete(res);
-                    };
-                    turso_assert_greater_than!(
-                        bytes_read, 0,
-                        "expected to read data for encrypted page",
-                        { "page_idx": page_idx }
-                    );
-                    match encryption_ctx.decrypt_page(encrypted_buf.as_slice(), page_idx) {
-                        Ok(decrypted_data) => {
-                            encrypted_buf
-                                .as_mut_slice()
-                                .copy_from_slice(&decrypted_data);
-                            original_complete(Ok((encrypted_buf, bytes_read)))
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to decrypt WAL frame data for page_idx={page_idx}: {e}"
-                            );
-                            let err = CompletionError::DecryptionError { page_idx };
-                            original_complete(Err(err));
-                            Some(err)
-                        }
+            Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                let Ok((payload_buf, bytes_read)) = res else {
+                    return wrapper_complete(res);
+                };
+                match encryption_ctx
+                    .decrypt_page(&payload_buf.as_slice()[..bytes_read as usize], page_idx)
+                {
+                    Ok(decrypted_data) => {
+                        payload_buf.as_mut_slice().copy_from_slice(&decrypted_data);
+                        wrapper_complete(Ok((payload_buf, bytes_read)))
                     }
-                });
-
-            let new_completion = Completion::new_read(buf, decrypt_complete);
-            io.pread(offset, new_completion)
+                    Err(_e) => {
+                        let err = CompletionError::DecryptionError { page_idx };
+                        wrapper_complete(Err(err));
+                        Some(err)
+                    }
+                }
+            })
         }
         EncryptionOrChecksum::Checksum(ctx) => {
             let checksum_ctx = ctx.clone();
-            let original_c = complete;
-            let verify_complete =
-                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
-                    let Ok((buf, bytes_read)) = res else {
-                        return original_c(res);
-                    };
-                    if bytes_read <= 0 {
-                        tracing::trace!("Read page {page_idx} with {} bytes", bytes_read);
-                        return original_c(Ok((buf, bytes_read)));
+            Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                let Ok((payload_buf, bytes_read)) = res else {
+                    return wrapper_complete(res);
+                };
+                match checksum_ctx.verify_checksum(
+                    &mut payload_buf.as_mut_slice()[..bytes_read as usize],
+                    page_idx,
+                ) {
+                    Ok(_) => wrapper_complete(Ok((payload_buf, bytes_read))),
+                    Err(e) => {
+                        wrapper_complete(Err(e));
+                        Some(e)
                     }
+                }
+            })
+        }
+        EncryptionOrChecksum::None => wrapper_complete,
+    };
 
-                    match checksum_ctx.verify_checksum(buf.as_mut_slice(), page_idx) {
-                        Ok(_) => original_c(Ok((buf, bytes_read))),
-                        Err(e) => {
-                            mark_unlikely();
-                            tracing::error!(
-                                "Failed to verify checksum for page_id={page_idx}: {e}"
-                            );
-                            original_c(Err(e));
-                            Some(e)
-                        }
-                    }
-                });
-            let c = Completion::new_read(buf, verify_complete);
-            io.pread(offset, c)
-        }
-        EncryptionOrChecksum::None => {
-            let c = Completion::new_read(buf, complete);
-            io.pread(offset, c)
-        }
-    }
+    let c = Completion::new_read(wal_buf, new_complete);
+    io.pread(offset, c)
 }
 
 pub fn parse_wal_frame_header(frame: &[u8]) -> (WalFrameHeader, &[u8]) {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1452,6 +1452,7 @@ pub fn build_shared_wal(
                 SpinLock::new(OverflowFallbackCoverage::default()),
             ),
         },
+        frame_checksums: SpinLock::new(FxHashMap::default()),
     }));
 
     if size < WAL_HEADER_SIZE as u64 {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -532,6 +532,14 @@ trait WalCoordination: Debug + Send + Sync {
     /// Record a newly appended frame in the backend's page-to-frame lookup state.
     fn cache_frame(&self, page_id: u64, frame_id: u64);
 
+    /// Record a verified checksum for a newly appended frame.
+    fn cache_frame_checksum(&self, _frame_id: u64, _checksums: (u32, u32)) {}
+
+    /// Retrieve the verified checksum for a frame if available.
+    fn get_frame_checksum(&self, _frame_id: u64) -> Option<(u32, u32)> {
+        None
+    }
+
     /// Drop any cached frame mappings newer than `max_frame`.
     fn rollback_cache(&self, max_frame: u64);
 
@@ -1123,6 +1131,23 @@ impl WalCoordination for InProcessWalCoordination {
                 frame_cache.insert(page_id, vec![frame_id]);
             }
         }
+    }
+
+    fn cache_frame_checksum(&self, frame_id: u64, checksums: (u32, u32)) {
+        self.shared
+            .read()
+            .frame_checksums
+            .lock()
+            .insert(frame_id, checksums);
+    }
+
+    fn get_frame_checksum(&self, frame_id: u64) -> Option<(u32, u32)> {
+        self.shared
+            .read()
+            .frame_checksums
+            .lock()
+            .get(&frame_id)
+            .copied()
     }
 
     fn rollback_cache(&self, max_frame: u64) {
@@ -2530,7 +2555,6 @@ pub struct WalSharedRuntime {
 pub struct WalFileShared {
     pub metadata: WalSharedMetadata,
     pub runtime: WalSharedRuntime,
-    // Maps Frame ID -> (checksum_1, checksum_2)
     pub frame_checksums: SpinLock<FxHashMap<u64, (u32, u32)>>,
 }
 
@@ -3024,6 +3048,7 @@ impl Wal for WalFile {
                     actual: bytes_read as usize,
                 });
             }
+
             let cloned = frame.clone();
             finish_read_page(page.get().id, buf, cloned);
             frame.set_wal_tag(frame_id, epoch_at_issue);
@@ -3032,13 +3057,17 @@ impl Wal for WalFile {
         // important not to hold shared state locks beyond this point to avoid deadlock with
         // completions that re-enter WAL state while a writer is waiting.
         let file = self.coordination.wal_file()?;
+        let expected_checksum = self.coordination.get_frame_checksum(frame_id);
+
         begin_read_wal_frame(
             file.as_ref(),
-            offset + WAL_FRAME_HEADER_SIZE as u64,
+            offset,
             buffer_pool,
             complete,
             page_idx,
             &self.io_ctx.read(),
+            expected_checksum,
+            frame_id,
         )
     }
 
@@ -3057,6 +3086,7 @@ impl Wal for WalFile {
             let io_ctx = self.io_ctx.read();
             io_ctx.encryption_context().cloned()
         };
+        let expected_checksum = self.coordination.get_frame_checksum(frame_id);
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
                 return None; // IO error already captured in completion
@@ -3084,6 +3114,19 @@ impl Wal for WalFile {
 
             // Now parse the header from the freshly-copied data
             let (header, raw_page) = sqlite3_ondisk::parse_wal_frame_header(frame_ref);
+
+            if let Some((c1, c2)) = expected_checksum {
+                if header.checksum_1 != c1 || header.checksum_2 != c2 {
+                    tracing::error!("WAL checksum mismatch for frame {frame_id}");
+                    return Some(CompletionError::WalChecksumMismatch {
+                        frame_id,
+                        expected_1: c1,
+                        expected_2: c2,
+                        actual_1: header.checksum_1,
+                        actual_2: header.checksum_2,
+                    });
+                }
+            }
 
             if let Some(ctx) = encryption_ctx.clone() {
                 match ctx.decrypt_page(raw_page, header.page_number as usize) {
@@ -3176,11 +3219,13 @@ impl Wal for WalFile {
             let file = self.coordination.wal_file()?;
             let c = begin_read_wal_frame(
                 file.as_ref(),
-                offset + WAL_FRAME_HEADER_SIZE as u64,
+                offset,
                 buffer_pool,
                 complete,
                 page_id as usize,
                 &self.io_ctx.read(),
+                None,
+                frame_id,
             )?;
             self.io.wait_for_completion(c)?;
             return if *conflict.lock() {
@@ -3830,6 +3875,7 @@ impl WalFile {
         *self.last_checksum.write() = checksums;
         self.max_frame.store(frame_id, Ordering::Release);
         self.coordination.cache_frame(page_id, frame_id);
+        self.coordination.cache_frame_checksum(frame_id, checksums);
     }
 
     /// Reset connection-private WAL state.
@@ -4009,8 +4055,12 @@ impl WalFile {
                         }
                         // Issue read if page wasn't found in the page cache or doesnt meet
                         // the frame requirements
-                        let inflight =
-                            self.issue_wal_read_into_buffer(page_id as usize, target_frame)?;
+                        let checksums = self.coordination.get_frame_checksum(target_frame);
+                        let inflight = self.issue_wal_read_into_buffer(
+                            page_id as usize,
+                            target_frame,
+                            checksums,
+                        )?;
                         group.add(&inflight.completion);
                         nr_completions += 1;
                         ongoing_chkpt.inflight_reads.push(inflight);
@@ -4318,7 +4368,12 @@ impl WalFile {
         Ok(())
     }
 
-    fn issue_wal_read_into_buffer(&self, page_id: usize, frame_id: u64) -> Result<InflightRead> {
+    fn issue_wal_read_into_buffer(
+        &self,
+        page_id: usize,
+        frame_id: u64,
+        expected_checksum: Option<(u32, u32)>,
+    ) -> Result<InflightRead> {
         let offset = self.frame_offset(frame_id);
         let buf_slot = Arc::new(SpinLock::new(None));
         tracing::debug!(
@@ -4348,11 +4403,13 @@ impl WalFile {
         let file = self.coordination.wal_file()?;
         let c = begin_read_wal_frame(
             file.as_ref(),
-            offset + WAL_FRAME_HEADER_SIZE as u64,
+            offset,
             self.buffer_pool.clone(),
             complete,
             page_id,
             &self.io_ctx.read(),
+            expected_checksum,
+            frame_id,
         )?;
 
         Ok(InflightRead {
@@ -4752,6 +4809,7 @@ impl WalFileShared {
                     OverflowFallbackCoverage::default(),
                 )),
             },
+            frame_checksums: SpinLock::new(FxHashMap::default()),
         };
         Ok(Arc::new(RwLock::new(shared)))
     }
@@ -4819,6 +4877,7 @@ impl WalFileShared {
                     OverflowFallbackCoverage::default(),
                 )),
             },
+            frame_checksums: SpinLock::new(FxHashMap::default()),
         };
         Arc::new(RwLock::new(shared))
     }
@@ -4859,6 +4918,7 @@ impl WalFileShared {
                     OverflowFallbackCoverage::default(),
                 )),
             },
+            frame_checksums: SpinLock::new(FxHashMap::default()),
         };
         Ok(Arc::new(RwLock::new(shared)))
     }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2530,6 +2530,8 @@ pub struct WalSharedRuntime {
 pub struct WalFileShared {
     pub metadata: WalSharedMetadata,
     pub runtime: WalSharedRuntime,
+    // Maps Frame ID -> (checksum_1, checksum_2)
+    pub frame_checksums: SpinLock<FxHashMap<u64, (u32, u32)>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]


### PR DESCRIPTION
# NOTICE:
## Description

This PR implements mandatory WAL checksum validation to prevent silent data corruption. 

**Changes included:**
* Added thread-safe `frame_checksums` map to `WalFileShared` to track verified checksums.
* Configured `StreamingWalReader::process_frames` and `WalFile::complete_append_frame` to populate the trusted checksums during boot recovery and appends.
* Implemented checksum validation in `WalFile::read_frame` and `WalFile::read_frame_raw`.
* Created `CompletionError::WalChecksumMismatch` to gracefully halt operations on checksum mismatch.
* Added `Shock::BitFlip` to `testing/simulator/runner/file.rs` to deterministically catch this vulnerability in the DST environment.

Closes #6517 

## Motivation and context

Previously, Limbo correctly calculated and wrote checksums (`checksum_1` and `checksum_2`) when appending new frames to the `.db-wal` file, but lacked a validation step when reading them back into memory. 

Because the checksums were ignored on read operations, disk-level bit-flips could silently poison the Page Cache. Furthermore, during a checkpoint, the Checkpointer would read the corrupted WAL frame and permanently write the corrupted data into the main B-Tree file. This PR stops that propagation at the IO boundary.

## Description of AI Usage

AI was used to help draft and format the issue report and this pull request description.