### PR TITLE
never overwrite virtual columns with NULL

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1,6 +1,5 @@
-use crate::schema::{ColumnLayout, GeneratedType};
+use crate::schema::ColumnLayout;
 use crate::translate::emitter::{emit_index_column_value_old_image, gencol};
-use crate::translate::optimizer::Optimizable;
 use crate::turso_debug_assert;
 use crate::{
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
@@ -2648,16 +2647,9 @@ fn translate_column(
         program.emit_insn(Insn::SoftNull {
             reg: column_register,
         });
-    } else if matches!(
-        column.generated_type(),
-        GeneratedType::Virtual { expr, .. } if expr.is_constant(resolver)
-    ) {
-        // Constant virtual generated columns are hoisted to the program init
-        // section by translate_expr in compute_virtual_columns. Emitting NULL
-        // here would clobber the hoisted value before constraint checks
-        // (e.g. NOT NULL) and triggers read it.
-    } else if column.hidden() || column.is_virtual_generated() {
-        // Emit NULL for not-explicitly-mentioned hidden or virtual columns, even ignoring DEFAULT.
+    } else if column.is_virtual_generated() {
+        // virtual columns are computed in a separate pass in compute_virtual_columns
+    } else if column.hidden() {
         program.emit_insn(Insn::Null {
             dest: column_register,
             dest_end: None,

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4534,3 +4534,12 @@ test integrity-check-unique-virtual-column {
 } expect {
     ok
 }
+
+@cross-check-integrity
+test insert-transitive-unique-index {
+    CREATE TABLE t (a UNIQUE AS (b), b AS ('x'), c);
+    INSERT INTO t(c) VALUES (1);
+    INSERT INTO t(c) VALUES (2);
+} expect error {
+    UNIQUE constraint failed: t.a
+}


### PR DESCRIPTION
## Description

There was a bug where a unique index in a virtual column that depended on a virtual column wasn't correctly enforced.

The reason was that `translate_column` first emitted stored columns AND non-constant virtual columns, and then `compute_virtual_column` filled in the rest, hoisting constant expressions whenever possible. The problem is the `expression.is_constant()` check that `translate_column` relied on can return `false` even when the expression is hoisted when fully translated. This is because `is_column()` relies on a syntactic check, so a column `a as (b)` would be treated as non-constant, even though when evaluating it in the context of `a as (b), b as ('x')`, it would be treated as a constant and its evaluation hoisted.

`translate_column` had a check to avoid overwriting with `null` registers with hoisted expression computations, but it was imperfect, for the reason stated above. The solution was to stop overwriting any virtual column in `translate_column`.

Closes #6492

## Description of AI Usage

50/50
