### PR TITLE
fix correlated subquery inside aggregate with GROUP BY

### DIFF
--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -337,6 +337,12 @@ pub fn compute_group_by_sort_order(
 /// These are the base table columns that aggregate expressions depend on.
 /// By storing only these in the GROUP BY sorter (instead of pre-computed expression
 /// results), we reduce sorter record size and avoid redundant B-tree column reads.
+///
+/// Correlated subquery results (`SubqueryResult`) inside aggregate arguments are
+/// also collected as leaf expressions.  Their value is computed per-row during the
+/// scan loop, stored in the sorter, and read back during the sorter loop so that
+/// each sorted row sees the correct subquery result instead of a stale register
+/// value left over from the last scanned row.
 fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Result<Vec<ast::Expr>> {
     let mut leaf_columns: Vec<ast::Expr> = Vec::new();
     for agg in aggregates {
@@ -352,6 +358,23 @@ fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Resu
                         {
                             leaf_columns.push(expr.clone());
                         }
+                        Ok(WalkControl::SkipChildren)
+                    }
+                    // Correlated subquery results must be materialized in the
+                    // sorter so the sorter loop reads the per-row value instead
+                    // of the stale last-scanned register.
+                    ast::Expr::SubqueryResult { subquery_id, .. } => {
+                        let is_correlated = plan
+                            .non_from_clause_subqueries
+                            .iter()
+                            .find(|s| s.internal_id == *subquery_id)
+                            .is_some_and(|s| s.correlated);
+                        if is_correlated
+                            && !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr))
+                        {
+                            leaf_columns.push(expr.clone());
+                        }
+                        // Skip children — the subquery is an opaque value here.
                         Ok(WalkControl::SkipChildren)
                     }
                     _ => Ok(WalkControl::Continue),

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -125,6 +125,7 @@ impl Arbitrary for SelectInner {
             from: Some(from),
             where_clause: Predicate::arbitrary_from(rng, env, &join_table),
             order_by,
+            group_by: None,
         }
     }
 }
@@ -237,6 +238,7 @@ impl Arbitrary for Select {
                     .collect(),
             },
             limit: None,
+            raw_sql_override: None,
         }
     }
 }
@@ -281,10 +283,12 @@ impl Arbitrary for Insert {
                             }),
                             where_clause: Predicate::true_(),
                             order_by: None,
+                            group_by: None,
                         }),
                         compounds: Vec::new(),
                     },
                     limit: None,
+                    raw_sql_override: None,
                 };
             }
 

--- a/sql_generation/model/query/select.rs
+++ b/sql_generation/model/query/select.rs
@@ -40,6 +40,12 @@ impl Display for ResultColumn {
 pub struct Select {
     pub body: SelectBody,
     pub limit: Option<usize>,
+    /// When set, this raw SQL string is used for Display instead of
+    /// generating from the AST. This allows properties to test SQL
+    /// patterns (like correlated subqueries with GROUP BY) that the
+    /// model's AST builder does not yet support.
+    #[serde(default)]
+    pub raw_sql_override: Option<String>,
 }
 
 impl Select {
@@ -62,10 +68,12 @@ impl Select {
                     from: None,
                     where_clause: Predicate::true_(),
                     order_by: None,
+                    group_by: None,
                 }),
                 compounds: Vec::new(),
             },
             limit: None,
+            raw_sql_override: None,
         }
     }
 
@@ -87,10 +95,12 @@ impl Select {
                     }),
                     where_clause,
                     order_by: None,
+                    group_by: None,
                 }),
                 compounds: Vec::new(),
             },
             limit,
+            raw_sql_override: None,
         }
     }
 
@@ -103,6 +113,31 @@ impl Select {
         Select {
             body,
             limit: left.limit.or(right.limit),
+            raw_sql_override: None,
+        }
+    }
+
+    /// Create a Select that outputs the given raw SQL string verbatim.
+    /// Used for SQL patterns the model AST cannot yet express (e.g.
+    /// correlated subqueries with GROUP BY and table aliases).
+    pub fn raw(sql: String, table_dependency: String) -> Self {
+        Select {
+            body: SelectBody {
+                select: Box::new(SelectInner {
+                    distinctness: Distinctness::All,
+                    columns: vec![ResultColumn::Star],
+                    from: Some(FromClause {
+                        table: SelectTable::Table(table_dependency),
+                        joins: Vec::new(),
+                    }),
+                    where_clause: Predicate::true_(),
+                    order_by: None,
+                    group_by: None,
+                }),
+                compounds: Vec::new(),
+            },
+            limit: None,
+            raw_sql_override: Some(sql),
         }
     }
 
@@ -156,6 +191,8 @@ pub struct SelectInner {
     pub where_clause: Predicate,
     /// `ORDER BY` clause
     pub order_by: Option<OrderBy>,
+    /// `GROUP BY` clause
+    pub group_by: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -342,7 +379,13 @@ impl Select {
                         .collect(),
                     from: self.body.select.from.as_ref().map(|f| f.to_sql_ast()),
                     where_clause: Some(self.body.select.where_clause.0.clone().into_boxed()),
-                    group_by: None,
+                    group_by: self.body.select.group_by.as_ref().map(|cols| ast::GroupBy {
+                        exprs: cols
+                            .iter()
+                            .map(|c| column_qualified_expr(c).into_boxed())
+                            .collect(),
+                        having: None,
+                    }),
                     window_clause: Vec::new(),
                 },
                 compounds: self
@@ -408,6 +451,9 @@ impl Select {
 
 impl Display for Select {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(raw) = &self.raw_sql_override {
+            return write!(f, "{raw}");
+        }
         self.to_sql_ast().displayer(&BlankContext).fmt(f)
     }
 }

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -239,7 +239,8 @@ impl Property {
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
             | Property::TableHasExpectedContent { .. }
-            | Property::AllTableHaveExpectedContent { .. } => {
+            | Property::AllTableHaveExpectedContent { .. }
+            | Property::CorrelatedSubqueryAggregate { .. } => {
                 unreachable!("No extensional queries")
             }
         }
@@ -928,6 +929,96 @@ impl Property {
                     InteractionBuilder::with_interaction(assertion),
                 ]
             }
+            Property::CorrelatedSubqueryAggregate {
+                table,
+                group_column,
+            } => {
+                let table_dependency = table.clone();
+                let assumption = InteractionType::Assumption(Assertion::new(
+                    format!("table {table} exists"),
+                    {
+                        let table = table.clone();
+                        move |_: &Vec<ResultSet>, env: &mut SimulatorEnv| {
+                            let conn_tables = env.get_conn_tables(connection_index);
+                            if conn_tables.iter().any(|t| t.name == table) {
+                                Ok(Ok(()))
+                            } else {
+                                Ok(Err(format!(
+                                    "table '{table}' not found for CorrelatedSubqueryAggregate"
+                                )))
+                            }
+                        }
+                    },
+                    vec![table_dependency.clone()],
+                ));
+
+                // Reference query: SELECT <col>, COUNT(*) FROM <table> GROUP BY <col> ORDER BY <col>
+                let ref_sql = format!(
+                    "SELECT \"{group_column}\", COUNT(*) FROM \"{table}\" GROUP BY \"{group_column}\" ORDER BY \"{group_column}\""
+                );
+                let select_ref = Select::raw(ref_sql, table.clone());
+                let select_ref_interaction = InteractionType::Query(Query::Select(select_ref));
+
+                // Correlated subquery query:
+                // SELECT <col>, COUNT((SELECT 1 FROM <table> AS t2 WHERE t2.<col> = t_outer.<col> LIMIT 1))
+                //   FROM <table> AS t_outer GROUP BY <col> ORDER BY <col>
+                // The subquery always returns 1 when there is at least one matching row (which is always
+                // true since t_outer's own row matches), so COUNT(...) == COUNT(*).
+                let corr_sql = format!(
+                    "SELECT t_outer.\"{group_column}\", COUNT((SELECT 1 FROM \"{table}\" AS t2 \
+                     WHERE t2.\"{group_column}\" = t_outer.\"{group_column}\" LIMIT 1)) \
+                     FROM \"{table}\" AS t_outer GROUP BY t_outer.\"{group_column}\" \
+                     ORDER BY t_outer.\"{group_column}\""
+                );
+                let select_corr = Select::raw(corr_sql, table.clone());
+                let select_corr_interaction = InteractionType::Query(Query::Select(select_corr));
+
+                let assertion = InteractionType::Assertion(Assertion::new(
+                    format!(
+                        "correlated subquery aggregate GROUP BY on {table}.{group_column} \
+                         should match plain COUNT(*) GROUP BY"
+                    ),
+                    move |stack: &Vec<ResultSet>, _| {
+                        let corr_result = stack.last().unwrap();
+                        let ref_result = stack.get(stack.len() - 2).unwrap();
+                        match (ref_result, corr_result) {
+                            (Ok(ref_rows), Ok(corr_rows)) => {
+                                if ref_rows.len() != corr_rows.len() {
+                                    return Ok(Err(format!(
+                                        "row count mismatch: reference={}, correlated={}",
+                                        ref_rows.len(),
+                                        corr_rows.len()
+                                    )));
+                                }
+                                for (i, (r, c)) in ref_rows.iter().zip(corr_rows.iter()).enumerate()
+                                {
+                                    if r != c {
+                                        return Ok(Err(format!(
+                                            "row {i} mismatch: reference={r:?}, correlated={c:?}"
+                                        )));
+                                    }
+                                }
+                                Ok(Ok(()))
+                            }
+                            (Err(e1), Err(e2)) => {
+                                tracing::debug!("Both queries errored: ref={}, corr={}", e1, e2);
+                                Ok(Ok(()))
+                            }
+                            (Err(e), _) | (_, Err(e)) => {
+                                Err(LimboError::InternalError(e.to_string()))
+                            }
+                        }
+                    },
+                    vec![table_dependency],
+                ));
+
+                vec![
+                    InteractionBuilder::with_interaction(assumption),
+                    InteractionBuilder::with_interaction(select_ref_interaction),
+                    InteractionBuilder::with_interaction(select_corr_interaction),
+                    InteractionBuilder::with_interaction(assertion),
+                ]
+            }
             Property::FsyncNoWait { query } => {
                 vec![InteractionBuilder::with_interaction(
                     InteractionType::FsyncQuery(query.clone()),
@@ -1033,6 +1124,7 @@ impl Property {
                             from: select.body.select.from.clone(),
                             where_clause: p_true,
                             order_by: None,
+                            group_by: None,
                         }),
                         compounds: vec![
                             CompoundSelect {
@@ -1043,6 +1135,7 @@ impl Property {
                                     from: select.body.select.from.clone(),
                                     where_clause: p_false,
                                     order_by: None,
+                                    group_by: None,
                                 }),
                             },
                             CompoundSelect {
@@ -1053,11 +1146,13 @@ impl Property {
                                     from: select.body.select.from.clone(),
                                     where_clause: p_null,
                                     order_by: None,
+                                    group_by: None,
                                 }),
                             },
                         ],
                     },
                     limit: None,
+                    raw_sql_override: None,
                 };
 
                 let select = InteractionType::Query(Query::Select(select.clone()));
@@ -1594,6 +1689,24 @@ fn property_faulty_query<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_correlated_subquery_aggregate<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    assert!(!ctx.tables().is_empty());
+    let table = pick(ctx.tables(), rng);
+    // Pick a random column to GROUP BY
+    let col_idx = pick_index(table.columns.len(), rng);
+    let group_column = table.columns[col_idx].name.clone();
+
+    Property::CorrelatedSubqueryAggregate {
+        table: table.name.clone(),
+        group_column,
+    }
+}
+
 type PropertyGenFunc<R, G> = fn(&mut R, &QueryDistribution, &G, bool) -> Property;
 
 impl PropertyDiscriminants {
@@ -1620,6 +1733,9 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
+            PropertyDiscriminants::CorrelatedSubqueryAggregate => {
+                property_correlated_subquery_aggregate
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
             }
@@ -1725,6 +1841,13 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::CorrelatedSubqueryAggregate => {
+                if !ctx.tables().is_empty() {
+                    remaining.select / 3
+                } else {
+                    0
+                }
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -1765,6 +1888,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
+            PropertyDiscriminants::CorrelatedSubqueryAggregate => QueryCapabilities::SELECT,
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -182,6 +182,23 @@ pub enum Property {
     FaultyQuery {
         query: Query,
     },
+    /// CorrelatedSubqueryAggregate tests that correlated subqueries inside
+    /// aggregate functions work correctly with GROUP BY.
+    /// This verifies the fix for bug #6485 where the subquery was evaluated
+    /// during the scan loop and its result register held the value from the
+    /// LAST scanned row by the time the sorter loop ran aggregation.
+    ///
+    /// Execution:
+    ///     SELECT col, COUNT(*) FROM t GROUP BY col ORDER BY col
+    ///     SELECT col, COUNT((SELECT 1 FROM t AS t2 WHERE t2.col = t_outer.col LIMIT 1))
+    ///         FROM t AS t_outer GROUP BY col ORDER BY col
+    ///
+    /// Assertion:
+    /// - Both queries must return the same results
+    CorrelatedSubqueryAggregate {
+        table: String,
+        group_column: String,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -228,7 +245,8 @@ impl Property {
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
             | Property::TableHasExpectedContent { .. }
-            | Property::AllTableHaveExpectedContent { .. } => None,
+            | Property::AllTableHaveExpectedContent { .. }
+            | Property::CorrelatedSubqueryAggregate { .. } => None,
         }
     }
 }

--- a/testing/sqltests/tests/correlated-subquery-aggregate-groupby.sqltest
+++ b/testing/sqltests/tests/correlated-subquery-aggregate-groupby.sqltest
@@ -1,0 +1,49 @@
+@database :memory:
+
+# Regression test for #6485: correlated subquery inside aggregate
+# returns wrong grouped result. The subquery was evaluated during the
+# scan loop and its result register held the value from the LAST
+# scanned row by the time the sorter loop ran aggregation.
+
+setup schema {
+    CREATE TABLE t1(grp TEXT, val INTEGER);
+    CREATE TABLE t2(grp TEXT, factor INTEGER);
+    INSERT INTO t1 VALUES ('a',1),('a',2),('b',3),('b',4);
+    INSERT INTO t2 VALUES ('a',10),('b',20);
+}
+
+@setup schema
+test correlated-subquery-in-sum-group-by {
+    SELECT grp, sum((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|20
+    b|40
+}
+
+@setup schema
+test correlated-subquery-in-count-group-by {
+    SELECT grp, count((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|2
+    b|2
+}
+
+@setup schema
+test correlated-subquery-in-avg-group-by {
+    SELECT grp, avg((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|10.0
+    b|20.0
+}
+
+@setup schema
+test correlated-subquery-in-min-max-group-by {
+    SELECT grp, min((SELECT factor FROM t2 WHERE t2.grp = t1.grp)), max((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|10|10
+    b|20|20
+}


### PR DESCRIPTION
Fix correlated subquery inside aggregate returning wrong grouped result.

The subquery result was evaluated during the scan loop but never stored
in the GROUP BY sorter, so the sorter loop used a stale register value
from the last scanned row.

Adds CorrelatedSubqueryAggregate simulator property to catch this pattern.

Motivation and context:
Fixes #6485

Description of AI Usage:
Used Claude Code for exploring the codebase and drafting the fix.
Reviewed and verified all changes manually.