### PR TITLE
core/connection: Prevent DETACH on databases with active transactions

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2434,6 +2434,13 @@ impl Connection {
         let pager = self
             .get_pager_from_database_index(&database_id)
             .expect("attached database should always have a pager");
+
+        if pager.holds_read_lock() || pager.holds_write_lock() {
+            return Err(LimboError::InvalidArgument(format!(
+                "database {alias} is locked"
+            )));
+        }
+
         if let Some((tx_id, _mode)) = self.get_mv_tx_for_db(database_id) {
             if let Some(mv_store) = self.mv_store_for_db(database_id) {
                 mv_store.rollback_tx(tx_id, pager.clone(), self, database_id);

--- a/testing/sqltests/tests/detach/transaction.sqltest
+++ b/testing/sqltests/tests/detach/transaction.sqltest
@@ -1,0 +1,34 @@
+@database :memory:
+
+test detach-fails-with-active-read-transaction {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t2(y);
+    BEGIN;
+    SELECT * FROM aux.t2;
+    DETACH aux;
+}
+expect error {
+    .*database aux is locked.*
+}
+
+test detach-fails-with-active-write-transaction {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t2(y);
+    BEGIN;
+    INSERT INTO aux.t2 VALUES (1);
+    DETACH aux;
+}
+expect error {
+    .*database aux is locked.*
+}
+
+test detach-succeeds-after-commit {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t2(y);
+    BEGIN;
+    INSERT INTO aux.t2 VALUES (1);
+    COMMIT;
+    DETACH aux;
+}
+expect {
+}


### PR DESCRIPTION
This PR prevents DETACH operations on databases that have an active read or write transaction.

### Changes:
- Modified core/connection.rs to check for active locks on the pager before detaching.
- Added a new SQL test 	esting/sqltests/tests/detach/transaction.sqltest to verify the fix for both read and write transactions.

This is a surgical fix that addresses the issue without unrelated changes.