### PR TITLE
add some sqltests

### DIFF
--- a/testing/sqltests/tests/correlated-subquery-nested-exists.sqltest
+++ b/testing/sqltests/tests/correlated-subquery-nested-exists.sqltest
@@ -28,7 +28,9 @@ expect {
     1|10
 }
 
-@skip-if sqlite "sqlite parity intentionally skipped for this BETWEEN/subquery rewrite case"
+# Regression case from https://sqlite.org/forum/forumpost/0ab502f519
+# Broken in SQLite < 3.53 for multiple releases; fixed in SQLite 3.53+.
+@skip-if sqlite "CI SQLite is 3.51.x; upstream BETWEEN/subquery fix is in 3.53+"
 test update-between-subquery-equivalence {
     CREATE TABLE t(v INT);
     INSERT INTO t VALUES(1), (2);

--- a/testing/sqltests/tests/correlated-subquery-nested-exists.sqltest
+++ b/testing/sqltests/tests/correlated-subquery-nested-exists.sqltest
@@ -1,0 +1,72 @@
+@database :memory:
+
+test correlated-subquery-nested-exists-count-sum {
+    CREATE TABLE t1(b, c);
+    CREATE TABLE t2(x, y);
+    CREATE TABLE t3(p, q);
+
+    INSERT INTO t1 VALUES(7, 10);
+    INSERT INTO t2 VALUES(1, 1), (4, 7);
+    INSERT INTO t3 VALUES(4, 7);
+
+    CREATE INDEX t2_yx ON t2(y, x);
+    CREATE INDEX t3_pq ON t3(p, q);
+
+    SELECT count(*), sum(c)
+    FROM t1 AS A
+    WHERE EXISTS (
+        SELECT 1
+        FROM t2 AS B
+        WHERE EXISTS (
+            SELECT 1
+            FROM t3 AS C
+            WHERE C.p = B.x AND C.q = A.b
+        )
+    );
+}
+expect {
+    1|10
+}
+
+test update-between-subquery-equivalence {
+    CREATE TABLE t(v INT);
+    INSERT INTO t VALUES(1), (2);
+
+    BEGIN;
+    UPDATE t SET v = 100
+     WHERE v = 1 OR (1 BETWEEN 0 AND ((SELECT min(v) FROM t) >= v));
+    SELECT 'original', group_concat(v, '|') FROM (SELECT v FROM t ORDER BY v);
+    ROLLBACK;
+
+    UPDATE t SET v = 100
+     WHERE v = 1 OR ((1 >= 0) AND (1 <= ((SELECT min(v) FROM t) >= v)));
+    SELECT 'equivalent..?', group_concat(v, '|') FROM (SELECT v FROM t ORDER BY v);
+}
+expect {
+    original|2|100
+    equivalent..?|2|100
+}
+
+test correlated-exists-limit-offset-empty-after-offset {
+    CREATE TABLE t2(id INT, data INT);
+    CREATE TABLE t3(amount INT);
+
+    INSERT INTO t2 VALUES (1, 0), (2, 0);
+    INSERT INTO t3 VALUES (1), (1);
+
+    SELECT COUNT(*) AS matched
+    FROM t2
+    WHERE EXISTS (SELECT 1 FROM t3 WHERE t3.amount > t2.data);
+
+    SELECT COUNT(*) AS rows_out
+    FROM (
+      SELECT id
+      FROM t2
+      WHERE EXISTS (SELECT 1 FROM t3 WHERE t3.amount > t2.data)
+      LIMIT 2 OFFSET 3
+    );
+}
+expect {
+    2
+    0
+}

--- a/testing/sqltests/tests/correlated-subquery-nested-exists.sqltest
+++ b/testing/sqltests/tests/correlated-subquery-nested-exists.sqltest
@@ -28,6 +28,7 @@ expect {
     1|10
 }
 
+@skip-if sqlite "sqlite parity intentionally skipped for this BETWEEN/subquery rewrite case"
 test update-between-subquery-equivalence {
     CREATE TABLE t(v INT);
     INSERT INTO t VALUES(1), (2);


### PR DESCRIPTION
ran into these while working on https://github.com/tursodatabase/turso/pull/6474

our ci found a optimizer bug in upstream sqlite. and other 2 bugs were found while trying to add more tests. -all 3 bugs are fixed on sqlite trunk shortly after reporting.

We do not have these bugs right now since we are not doing those optimizations yet, but I think having these tests will help ensure we do not introduce them when we optimize later.

refer

https://sqlite.org/forum/forumpost/2c43f36255a630e39521d36df8ed79d848108b257ffee6b50ca13aebc5e82d90

https://sqlite.org/forum/forumpost/077c02e8ed

https://sqlite.org/forum/forumpost/0ab502f519