### PR TITLE
core/translate: Fix out of bounds caused by spurious covering index

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2966,7 +2966,9 @@ pub(crate) struct ColumnsTopologicalSort<'a> {
 
 impl<'a> ColumnsTopologicalSort<'a> {
     pub fn iter(&self) -> impl Iterator<Item = (usize, &'a Column)> + '_ {
-        self.topological_sort.iter().map(|&idx| (idx, &self.columns[idx]))
+        self.topological_sort
+            .iter()
+            .map(|&idx| (idx, &self.columns[idx]))
     }
 }
 

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -25,7 +25,7 @@ use super::{
 };
 use crate::instrument;
 use crate::schema::{
-    BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
+    BTreeTable, CheckConstraint, Column, ColumnLayout, IndexColumn, Schema, Table,
 };
 use crate::translate::plan::ColumnMask;
 use crate::vdbe::{

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -1,7 +1,7 @@
 use crate::sync::Arc;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::schema::ROWID_SENTINEL;
+use crate::schema::{EXPR_INDEX_SENTINEL, ROWID_SENTINEL};
 use crate::translate::emitter::Resolver;
 use crate::translate::expr::{bind_and_rewrite_expr, BindingBehavior};
 use crate::translate::expression_index::expression_index_column_usage;
@@ -491,8 +491,22 @@ pub fn prepare_update_plan(
         }
 
         if must_update {
+            // mark as used dependencies of expression indexes
             for col_idx in expression_cols_used.iter() {
                 table_references.mark_column_used(target_table_internal_id, col_idx);
+            }
+            // mark as used dependencies of virtual columns
+            if let Some(btree) = target_table_ref.table.btree() {
+                let virtual_cols_in_index = idx
+                    .columns
+                    .iter()
+                    .filter(|c| c.pos_in_table != EXPR_INDEX_SENTINEL)
+                    .map(|c| c.pos_in_table)
+                    .filter(|&pos| btree.columns()[pos].is_virtual_generated());
+                let deps = btree.dependencies_of_columns(virtual_cols_in_index)?;
+                for dep_idx in deps.iter() {
+                    table_references.mark_column_used(target_table_internal_id, dep_idx);
+                }
             }
             indexes_to_update.push(idx);
         }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4543,3 +4543,10 @@ test insert-transitive-unique-index {
 } expect error {
     UNIQUE constraint failed: t.a
 }
+
+@cross-check-integrity
+test update-virtual-column-index-via-single-column-unique-index-scan {
+    CREATE TABLE t (a, b, c UNIQUE, f UNIQUE AS (b));
+    UPDATE t SET b = 42 WHERE c = 'x';
+} expect {
+}


### PR DESCRIPTION
## Description

Claude explains better:


For `UPDATE t SET b = 42 WHERE c = 'x' on CREATE TABLE t (a, b, c UNIQUE, f UNIQUE AS (b)):`

1. The query planner picks the UNIQUE index on c to scan (fast lookup for c = 'x').
2. The UPDATE also has to update the UNIQUE index on f because f depends on b, and b is being changed.
3. To delete the OLD index entry for f, we need the OLD value of f, which means reading OLD b from the row.
4. In translate_update, when deciding which columns are "used" (col_used_mask), only columns referenced in the query text got marked — i.e. c from the WHERE. The dependencies needed to recompute OLD virtual
columns for indexes-being-updated were not marked.
5. With col_used_mask = {c}, utilizes_covering_index() decided the index on c was a covering index for the scan.
6. Down in translate_expr, "covering index" meant table_cursor_id = None. When reading b (to evaluate f's defining expression), it fell through to the index cursor on c. b's table position is 1, but that
index has 1 column — index.columns[1] panics in emit_column (builder.rs:1807).

The fix

core/translate/update.rs: when marking an index as must-update, also mark as used the dependencies of any virtual generated columns referenced by the index (using the existing dependencies_of_columns). That
makes col_used_mask honest about what the OLD-image reads actually need, so utilizes_covering_index returns false and translate_expr opens the table cursor.

Closes #6493


## Description of AI Usage

Claude fixed it, I tweaked it a bit