### PR TITLE
Fix INSERT OR IGNORE incorrectly rejecting omitted NOT NULL column

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -2651,17 +2651,6 @@ fn translate_column(
             });
         }
     } else {
-        let nullable = !column.notnull() && !column.is_rowid_alias();
-        if !nullable {
-            crate::bail_parse_error!(
-                "column {} is not nullable",
-                column
-                    .name
-                    .as_ref()
-                    .expect("column name must be present")
-                    .as_str()
-            );
-        }
         program.emit_insn(Insn::Null {
             dest: column_register,
             dest_end: None,

--- a/testing/sqltests/tests/on_conflict.sqltest
+++ b/testing/sqltests/tests/on_conflict.sqltest
@@ -111,6 +111,35 @@ expect {
     2|two
 }
 
+@cross-check-integrity
+test insert-or-ignore-omitted-notnull-no-default {
+    CREATE TABLE t0 (c0 INT, c1 INT NOT NULL);
+    INSERT OR IGNORE INTO t0(c0) VALUES (1);
+    SELECT COUNT(*) FROM t0;
+}
+expect {
+    0
+}
+
+@cross-check-integrity
+test insert-or-ignore-omitted-notnull-continues {
+    CREATE TABLE t0 (c0 INT, c1 INT NOT NULL);
+    INSERT OR IGNORE INTO t0(c0) VALUES (1);
+    INSERT INTO t0 VALUES (2, 99);
+    SELECT COUNT(*) FROM t0;
+}
+expect {
+    1
+}
+
+@cross-check-integrity
+test insert-omitted-notnull-no-default {
+    CREATE TABLE t0 (c0 INT, c1 INT NOT NULL);
+    INSERT INTO t0(c0) VALUES (1);
+}
+expect error {
+}
+
 # =============================================================================
 # INSERT OR REPLACE tests
 # =============================================================================


### PR DESCRIPTION
Fixes #6481.

`translate_column` was raising a `bail_parse_error!` at translation time for any omitted column that is `NOT NULL` and has no default. This happened before `emit_notnulls` ever ran, so the statement's conflict policy was never consulted.

Fixed this by removing the early bail and unconditionally emit Null for omitted columns with no default (the else branch at the bottom of translate_column). `emit_notnulls` already emits `IsNull -> jump to row_done` at runtime.

Also noting here that now insert statements omitting a notnull column now raises `SQLITE_CONSTRAINT_NOTNULL`, which does match SQLite's behavior. Also added some regression unit tests :)