### PR TITLE
core/vdbe: Transform root_page in MVCC for open read index

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1182,7 +1182,7 @@ pub fn op_open_read(
         CursorType::BTreeIndex(index) => {
             let btree_cursor = Box::new(BTreeCursor::new_index(
                 pager,
-                *root_page,
+                maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 index.as_ref(),
                 num_columns,
             ));


### PR DESCRIPTION

## Description

Noticed we didn't transform root page in `op_open_read` for indexes. Not sure if this fixes anything due to how dual cursor should skip reading from btree anyways.

## Description of AI Usage
nil
