### PR TITLE
core/connection: consolidate usage of `is_memory_like` and `is_memory_path`

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2342,7 +2342,7 @@ impl Connection {
         //   file-based (important for simulator fault injection and WAL coordination)
         // - If the parent is :memory: (MemoryIO) but the attached DB is file-based,
         //   we need a file-capable IO layer since MemoryIO can't read real files
-        let is_memory_db = Database::is_memory_path(path);
+        let is_memory_db = is_memory_like(path);
         let io: Arc<dyn IO> = if is_memory_db {
             Arc::new(MemoryIO::new())
         } else if self.db.is_in_memory_db() {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -323,6 +323,10 @@ pub(crate) type MvStore = mvcc::MvStore<mvcc::MvccClock>;
 
 pub(crate) type MvCursor = mvcc::cursor::MvccLazyCursor<mvcc::MvccClock>;
 
+/// Returns true for in memory databases (i.e. databases backed by MemoryIO)
+///
+/// Turso treats every path with the `:memory:` prefix as a named
+/// in-memory database.
 fn is_memory_like(path: &str) -> bool {
     path.starts_with(":memory:") || path.starts_with("file::memory:") || path.is_empty()
 }
@@ -540,17 +544,9 @@ impl fmt::Debug for Database {
 }
 
 impl Database {
-    /// Returns true for database path forms backed by MemoryIO.
-    ///
-    /// Turso treats every path with the `:memory:` prefix as a named
-    /// in-memory database.
-    pub fn is_memory_path(path: &str) -> bool {
-        path.starts_with(util::MEMORY_PATH) || path.starts_with("file::memory:") || path.is_empty()
-    }
-
     /// Returns true if this database is backed by MemoryIO.
     pub fn is_in_memory_db(&self) -> bool {
-        Self::is_memory_path(&self.path)
+        is_memory_like(&self.path)
     }
 
     fn new(
@@ -796,7 +792,7 @@ impl Database {
         path: &str,
         encryption_opts: &Option<EncryptionOpts>,
     ) -> Result<Option<Arc<Database>>> {
-        if Self::is_memory_path(path) {
+        if is_memory_like(path) {
             return Ok(None);
         }
         let file_id = match io::get_file_id(path) {
@@ -985,7 +981,7 @@ impl Database {
         // in this case we need to bypass registry (as this is MemoryIO DB) but also preserve original distinction in names (e.g. :memory:-draft and :memory:-synced)
         // so, we bypass registry for all in memory dbs (i.e. db paths which starts with ":memory:")
 
-        if matches!(state.phase, OpenDbAsyncPhase::Init) && !Self::is_memory_path(path) {
+        if matches!(state.phase, OpenDbAsyncPhase::Init) && !is_memory_like(path) {
             // Briefly lock the registry to check/reserve — never hold across I/O yields.
             let mut registry = DATABASE_MANAGER.lock();
 
@@ -2211,7 +2207,7 @@ impl Database {
 
     #[cfg(feature = "fs")]
     pub fn io_for_path(path: &str) -> Result<Arc<dyn IO>> {
-        let io: Arc<dyn IO> = if Self::is_memory_path(path.trim()) {
+        let io: Arc<dyn IO> = if is_memory_like(path.trim()) {
             Arc::new(MemoryIO::new())
         } else {
             Arc::new(PlatformIO::new()?)
@@ -2632,16 +2628,16 @@ impl Iterator for QueryRunner<'_> {
 
 #[cfg(test)]
 mod database_tests {
-    use super::Database;
+    use super::{is_memory_like, Database};
 
     #[test]
     fn memory_path_classifies_named_memory_databases() {
-        assert!(Database::is_memory_path(":memory:"));
-        assert!(Database::is_memory_path(":memory:sync-draft"));
-        assert!(Database::is_memory_path("file::memory:?cache=shared"));
-        assert!(Database::is_memory_path(""));
-        assert!(!Database::is_memory_path("memory.db"));
-        assert!(!Database::is_memory_path("file:memory.db"));
+        assert!(is_memory_like(":memory:"));
+        assert!(is_memory_like(":memory:sync-draft"));
+        assert!(is_memory_like("file::memory:?cache=shared"));
+        assert!(is_memory_like(""));
+        assert!(!is_memory_like("memory.db"));
+        assert!(!is_memory_like("file:memory.db"));
     }
 
     #[cfg(feature = "fs")]


### PR DESCRIPTION
I didn't not realise we already have is_memory_like, so i removed is_memory_path.

follow up PR from: https://github.com/tursodatabase/turso/pull/6449
