### PR TITLE
Fix MVCC integrity_check false positives when stale dropped-root bookkeeping overlaps with live schema rootpages

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4749,6 +4749,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 }
                                 self.insert_table_id_to_rootpage(table_id, None);
                             } else {
+                                dropped_root_pages.remove(&root_page);
+                                // later schema upsert makes this root page non-dropped again, so remove from dropped_root_pages
+                                // set if it was previously added by an earlier schema row
                                 let table_id = self.get_table_id_from_root_page(root_page);
                                 let Some(entry) = self.table_id_to_rootpage.get(&table_id) else {
                                     panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4749,10 +4749,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 }
                                 self.insert_table_id_to_rootpage(table_id, None);
                             } else {
-                                turso_assert!(
-                                     !dropped_root_pages.contains(&root_page),
-                                     "logical log contains root page reference {root_page} that was already dropped in this recovery run"
-                                );
+                                dropped_root_pages.remove(&root_page);
                                 let table_id = self.get_table_id_from_root_page(root_page);
                                 let Some(entry) = self.table_id_to_rootpage.get(&table_id) else {
                                     panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4749,9 +4749,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 }
                                 self.insert_table_id_to_rootpage(table_id, None);
                             } else {
-                                dropped_root_pages.remove(&root_page);
-                                // later schema upsert makes this root page non-dropped again, so remove from dropped_root_pages
-                                // set if it was previously added by an earlier schema row
                                 let table_id = self.get_table_id_from_root_page(root_page);
                                 let Some(entry) = self.table_id_to_rootpage.get(&table_id) else {
                                     panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4749,6 +4749,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 }
                                 self.insert_table_id_to_rootpage(table_id, None);
                             } else {
+                                turso_assert!(
+                                     !dropped_root_pages.contains(&root_page),
+                                     "logical log contains root page reference {root_page} that was already dropped in this recovery run"
+                                );
                                 let table_id = self.get_table_id_from_root_page(root_page);
                                 let Some(entry) = self.table_id_to_rootpage.get(&table_id) else {
                                     panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9101,3 +9101,35 @@ fn test_create_type_visible_to_second_connection_under_mvcc() {
     assert_eq!(rows[0][0].to_string(), "my_uint(value any)");
     conn2.close().unwrap();
 }
+
+#[test]
+fn test_integrity_check_ignores_dropped_root_that_is_live_after_recovery() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'x')").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+
+    let conn = db.connect();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = 't'",
+    );
+    let root_page = rows[0][0].as_int().unwrap();
+    assert!(root_page > 0);
+
+    conn.with_schema_mut(|schema| {
+        schema.dropped_root_pages.insert(root_page);
+    });
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6020,7 +6020,7 @@ pub fn integrity_check(
             ..
         }) = state.page_stack.last().cloned()
         else {
-            panic!("Page stack is empty on integrity_check start");
+            return Ok(IOResult::Done(()));
         };
         if root_page < 0 {
             let table_id = mv_store.get_table_id_from_root_page(root_page);

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -13,6 +13,7 @@ use crate::{
         builder::{CursorKey, CursorType, ProgramBuilder},
         insn::{CmpInsFlags, Insn},
     },
+    HashSet,
 };
 use turso_parser::ast;
 
@@ -138,6 +139,7 @@ fn translate_integrity_check_impl(
     // SQLite's OP_IntegrityCk front-pass and can already emit corruption errors
     // before any row-by-row semantic checks run.
     let mut root_pages = Vec::with_capacity(schema.tables.len() + schema.indexes.len());
+    let mut live_root_pages = HashSet::default();
 
     for table in schema.tables.values() {
         if let Table::BTree(btree_table) = table.as_ref() {
@@ -145,10 +147,12 @@ fn translate_integrity_check_impl(
                 continue;
             }
             root_pages.push(btree_table.root_page);
+            live_root_pages.insert(btree_table.root_page);
             if let Some(indexes) = schema.indexes.get(btree_table.name.as_str()) {
                 for index in indexes {
                     if index.root_page > 0 {
                         root_pages.push(index.root_page);
+                        live_root_pages.insert(index.root_page);
                     }
                 }
             }
@@ -156,7 +160,9 @@ fn translate_integrity_check_impl(
     }
 
     for &dropped_root in &schema.dropped_root_pages {
-        root_pages.push(dropped_root);
+        if !live_root_pages.contains(&dropped_root) {
+            root_pages.push(dropped_root);
+        }
     }
 
     let remaining_errors_reg = program.alloc_register();


### PR DESCRIPTION
Ran into this issue while running the MVCC sync fuzzer against a remote tursodb database (turso-server): after the bootstrap convergence, the remote `PRAGMA integrity_check` failed with `Page 5106 referenced multiple times`, even though querying `sqlite_schema` showed no duplicate live root pages.

This pointed to stale MVCC dropped-root bookkeeping being included in the integrity walk alongside the live schema root.