### PR TITLE
core/storage: Reset syncing flag when sync submission fails

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -753,11 +753,16 @@ pub fn begin_sync(
 ) -> Result<Completion> {
     turso_assert!(!syncing.load(Ordering::SeqCst));
     syncing.store(true, Ordering::SeqCst);
-    let completion = Completion::new_sync(move |_| {
-        syncing.store(false, Ordering::SeqCst);
+    let completion = Completion::new_sync({
+        let syncing = syncing.clone();
+        move |_| {
+            syncing.store(false, Ordering::SeqCst);
+        }
     });
     #[allow(clippy::arc_with_non_send_sync)]
-    db_file.sync(completion, sync_type)
+    db_file.sync(completion, sync_type).inspect_err(|_| {
+        syncing.store(false, Ordering::SeqCst);
+    })
 }
 
 #[allow(clippy::enum_variant_names)]


### PR DESCRIPTION
begin_sync() sets `syncing` to `true`, then passed a completion whose callback resets it back to false to `db_file.sync()`. However, when `sync()` returns an error synchronously (e.g. the kernel rejected the fsync submission), the completion was dropped without ever being completed/errored/aborted, so the reset callback never ran and `syncing` stayed stuck at `true`. The next `begin_sync()` then tripped over its `!syncing.load(...)` assertion.

Spotted by Antithesis with `unreliable-libc` workload.