### PR TITLE
core/translate: reduce stack usage by boxing

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -274,7 +274,7 @@ fn emit_compound_select(
                 }
                 let compound_select = Plan::CompoundSelect {
                     left,
-                    right_most: plan,
+                    right_most: Box::new(plan),
                     limit: limit.clone(),
                     offset: offset.clone(),
                     order_by,
@@ -328,7 +328,7 @@ fn emit_compound_select(
                 };
                 let compound_select = Plan::CompoundSelect {
                     left,
-                    right_most: plan,
+                    right_most: Box::new(plan),
                     limit,
                     offset,
                     order_by,
@@ -391,7 +391,7 @@ fn emit_compound_select(
                 };
                 let compound_select = Plan::CompoundSelect {
                     left,
-                    right_most: plan,
+                    right_most: Box::new(plan),
                     limit,
                     offset,
                     order_by,
@@ -439,7 +439,7 @@ fn emit_compound_select(
                 };
                 let compound_select = Plan::CompoundSelect {
                     left,
-                    right_most: plan,
+                    right_most: Box::new(plan),
                     limit,
                     offset,
                     order_by,

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -46,12 +46,12 @@ pub fn emit_program_for_compound_select(
     let Plan::CompoundSelect { ref left, .. } = plan else {
         unreachable!()
     };
-    let right_most_ctx = TranslateCtx::new(
+    let right_most_ctx = Box::new(TranslateCtx::new(
         program,
         resolver.fork(),
         right_plan.table_references.joined_tables().len(),
         false,
-    );
+    ));
 
     // Each subselect shares the same limit_ctx and offset, because the LIMIT, OFFSET applies to
     // the entire compound select, not just a single subselect.
@@ -254,12 +254,12 @@ fn emit_compound_select(
             jump_if_null: false,
         });
     }
-    let mut right_most_ctx = TranslateCtx::new(
+    let mut right_most_ctx = Box::new(TranslateCtx::new(
         program,
         resolver.fork(),
         right_most.table_references.joined_tables().len(),
         false,
-    );
+    ));
     right_most_ctx.reg_result_cols_start = reg_result_cols_start;
     match left.pop() {
         Some((mut plan, operator)) => match operator {

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -280,7 +280,7 @@ pub fn prepare_delete_plan(
         ensure_delete_uses_rowset(program, &mut delete_plan);
     }
 
-    Ok(Plan::Delete(delete_plan))
+    Ok(Plan::Delete(Box::new(delete_plan)))
 }
 
 /// Check if any WHERE predicate contains a subquery (Subquery, InSelect, or Exists).

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -44,12 +44,12 @@ pub fn emit_program_for_delete(
     program: &mut ProgramBuilder,
     mut plan: DeletePlan,
 ) -> Result<()> {
-    let mut t_ctx = TranslateCtx::new(
+    let mut t_ctx = Box::new(TranslateCtx::new(
         program,
         resolver.fork(),
         plan.table_references.joined_tables().len(),
         connection.db.opts.unsafe_testing,
-    );
+    ));
 
     let after_main_loop_label = program.allocate_label();
     t_ctx.label_main_loop_end = Some(after_main_loop_label);

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -908,9 +908,9 @@ pub fn emit_program(
     after: impl FnOnce(&mut ProgramBuilder),
 ) -> Result<()> {
     match plan {
-        Plan::Select(plan) => emit_program_for_select(program, resolver, plan),
-        Plan::Delete(plan) => emit_program_for_delete(connection, resolver, program, plan),
-        Plan::Update(plan) => emit_program_for_update(connection, resolver, program, plan, after),
+        Plan::Select(plan) => emit_program_for_select(program, resolver, *plan),
+        Plan::Delete(plan) => emit_program_for_delete(connection, resolver, program, *plan),
+        Plan::Update(plan) => emit_program_for_update(connection, resolver, program, *plan, after),
         Plan::CompoundSelect { .. } => {
             emit_program_for_compound_select(program, resolver, plan).map(|_| ())
         }

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -56,12 +56,13 @@ fn emit_program_for_select_with_inputs(
     materialized_build_inputs: HashMap<usize, MaterializedBuildInput>,
 ) -> Result<()> {
     let result_cols_start = program.with_scoped_result_cols_start(|program| {
-        let mut t_ctx = TranslateCtx::new(
+        // Boxed to keep ~960 B off the prepare-path stack; see TranslateCtx size.
+        let mut t_ctx = Box::new(TranslateCtx::new(
             program,
             resolver.fork_with_expr_cache(),
             plan.table_references.joined_tables().len(),
             false,
-        );
+        ));
         t_ctx.materialized_build_inputs = materialized_build_inputs;
         emit_query(program, &mut plan, &mut t_ctx)
     })?;

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -71,12 +71,12 @@ pub fn emit_program_for_update(
         .flags
         .set_has_statement_conflict(plan.or_conflict.is_some());
 
-    let mut t_ctx = TranslateCtx::new(
+    let mut t_ctx = Box::new(TranslateCtx::new(
         program,
         resolver.fork(),
         plan.table_references.joined_tables().len(),
         connection.db.opts.unsafe_testing,
-    );
+    ));
 
     let after_main_loop_label = program.allocate_label();
     t_ctx.label_main_loop_end = Some(after_main_loop_label);

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -86,12 +86,13 @@ pub fn translate(
             | ast::Stmt::Update { .. }
     );
 
-    let mut program = ProgramBuilder::new(
+    // Boxed so the ~800 B builder sits on the heap instead of the prepare frame.
+    let mut program = Box::new(ProgramBuilder::new(
         query_mode,
         connection.get_capture_data_changes_info().clone(),
         // These options will be extended whithin each translate program
         ProgramBuilderOpts::new(1, 32, 2),
-    );
+    ));
 
     program.prologue();
     let mut resolver = Resolver::new(

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -315,20 +315,23 @@ impl SubqueryOrigin {
 }
 
 /// A query plan is either a SELECT or a DELETE (for now)
+/// Variants are boxed so that moving a `Plan` around the prepare path
+/// (returns from plan builders, argument to emitters) costs a pointer
+/// move rather than ~880 B on the stack.
 #[derive(Debug, Clone)]
 pub enum Plan {
-    Select(SelectPlan),
+    Select(Box<SelectPlan>),
     CompoundSelect {
         left: Vec<(SelectPlan, ast::CompoundOperator)>,
-        right_most: SelectPlan,
+        right_most: Box<SelectPlan>,
         limit: Option<Box<Expr>>,
         offset: Option<Box<Expr>>,
         /// ORDER BY for compound selects. Each entry is (result_column_index, sort_order, nulls_order).
         /// The column index is 0-based into the result set.
         order_by: Option<Vec<(usize, SortOrder, Option<ast::NullsOrder>)>>,
     },
-    Delete(DeletePlan),
-    Update(UpdatePlan),
+    Delete(Box<DeletePlan>),
+    Update(Box<UpdatePlan>),
 }
 
 impl Plan {
@@ -2188,7 +2191,7 @@ impl JoinedTable {
 
         let table = Table::FromClauseSubquery(Arc::new(FromClauseSubquery {
             name: identifier.clone(),
-            plan: Box::new(Plan::Select(plan)),
+            plan: Box::new(Plan::Select(Box::new(plan))),
             columns,
             result_columns_start_reg: None,
             materialized_cursor_id: None,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -153,7 +153,7 @@ pub fn prepare_select_plan(
 ) -> Result<Plan> {
     let compounds = select.body.compounds;
     match compounds.is_empty() {
-        true => Ok(Plan::Select(prepare_one_select_plan(
+        true => Ok(Plan::Select(Box::new(prepare_one_select_plan(
             select.body.select,
             resolver,
             program,
@@ -163,7 +163,7 @@ pub fn prepare_select_plan(
             outer_query_refs,
             query_destination,
             connection,
-        )?)),
+        )?))),
         false => {
             // For compound SELECTs, the WITH clause applies to all parts.
             // We clone the WITH clause for each SELECT in the compound so that
@@ -237,7 +237,7 @@ pub fn prepare_select_plan(
 
             Ok(Plan::CompoundSelect {
                 left,
-                right_most: last,
+                right_most: Box::new(last),
                 limit,
                 offset,
                 order_by,

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1469,7 +1469,7 @@ pub fn emit_from_clause_subquery(
 
     let result_column_start_reg = match plan {
         Plan::Select(select_plan) => {
-            let mut metadata = TranslateCtx {
+            let mut metadata = Box::new(TranslateCtx {
                 labels_main_loop: (0..select_plan.joined_tables().len())
                     .map(|_| LoopLabels::new(program))
                     .collect(),
@@ -1499,7 +1499,7 @@ pub fn emit_from_clause_subquery(
                 materialized_build_inputs: HashMap::default(),
                 hash_table_contexts: HashMap::default(),
                 unsafe_testing: t_ctx.unsafe_testing,
-            };
+            });
             emit_query(program, select_plan, &mut metadata)?
         }
         Plan::CompoundSelect { .. } => {
@@ -1555,7 +1555,7 @@ fn emit_indexed_materialized_subquery(
 
     match plan {
         Plan::Select(select_plan) => {
-            let mut metadata = TranslateCtx {
+            let mut metadata = Box::new(TranslateCtx {
                 labels_main_loop: (0..select_plan.joined_tables().len())
                     .map(|_| LoopLabels::new(program))
                     .collect(),
@@ -1585,7 +1585,7 @@ fn emit_indexed_materialized_subquery(
                 materialized_build_inputs: HashMap::default(),
                 hash_table_contexts: HashMap::default(),
                 unsafe_testing: t_ctx.unsafe_testing,
-            };
+            });
             emit_query(program, select_plan, &mut metadata)?;
         }
         Plan::CompoundSelect { .. } => {
@@ -1648,7 +1648,7 @@ fn emit_materialized_subquery_table(
     // Emit the subquery - it will insert rows into the ephemeral table
     match plan {
         Plan::Select(select_plan) => {
-            let mut metadata = TranslateCtx {
+            let mut metadata = Box::new(TranslateCtx {
                 labels_main_loop: (0..select_plan.joined_tables().len())
                     .map(|_| LoopLabels::new(program))
                     .collect(),
@@ -1678,7 +1678,7 @@ fn emit_materialized_subquery_table(
                 materialized_build_inputs: HashMap::default(),
                 hash_table_contexts: HashMap::default(),
                 unsafe_testing: t_ctx.unsafe_testing,
-            };
+            });
             emit_query(program, select_plan, &mut metadata)?;
         }
         Plan::CompoundSelect { .. } => {

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1761,10 +1761,10 @@ pub fn emit_non_from_clause_subquery(
                         emit_program_for_select_with_resolver(
                             program,
                             resolver.fork_with_expr_cache(),
-                            select_plan,
+                            *select_plan,
                         )
                     } else {
-                        emit_program_for_select(program, resolver, select_plan)
+                        emit_program_for_select(program, resolver, *select_plan)
                     }
                 }
                 compound @ Plan::CompoundSelect { .. } => {

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -512,7 +512,7 @@ pub fn prepare_update_plan(
         }
     }
 
-    Ok(Plan::Update(UpdatePlan {
+    Ok(Plan::Update(Box::new(UpdatePlan {
         table_references,
         or_conflict,
         set_clauses,
@@ -531,7 +531,7 @@ pub fn prepare_update_plan(
         cdc_update_alter_statement: None,
         non_from_clause_subqueries,
         safety: DmlSafety::default(),
-    }))
+    })))
 }
 
 fn build_scan_op(table: &Table, iter_dir: IterationDirection) -> Operation {


### PR DESCRIPTION
## Description

* TranslateCtx is ~960 B per instance
* Plan enum ~880 B (max variant)
* ProgramBuilder is ~800 B




## Description of AI Usage
Let codex identify and fix high stack usage structs from the translation path.
