### PR TITLE
parser: Fix parameter column names to match SQLite behavior

### DIFF
--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -838,9 +838,8 @@ impl<'a> Lexer<'a> {
             b'?' => {
                 self.eat_while(|b| b.is_ascii_digit());
 
-                // do not include '? in the value
                 Ok(Token::new(
-                    &self.input[start + 1..self.offset],
+                    &self.input[start..self.offset],
                     TokenType::TK_VARIABLE,
                 ))
             }
@@ -1049,8 +1048,9 @@ mod tests {
             (b"]".as_slice(), Token::new(b"]", TokenType::TK_RBRACKET)),
             (
                 b"?123".as_slice(),
-                Token::new(b"123", TokenType::TK_VARIABLE), // '?' omitted from value
+                Token::new(b"?123", TokenType::TK_VARIABLE),
             ),
+            (b"?".as_slice(), Token::new(b"?", TokenType::TK_VARIABLE)),
             (
                 b"$var_name".as_slice(),
                 Token::new(b"$var_name", TokenType::TK_VARIABLE),

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -182,26 +182,14 @@ impl<'a> Parser<'a> {
     }
 
     fn create_variable(&mut self, token: &'a [u8]) -> Result<Expr> {
-        if token.is_empty() {
+        debug_assert!(!token.is_empty());
+        if token == b"?" {
             // Rewrite anonymous variables in encounter order
             self.last_variable_id += 1;
             let index = NonZeroU32::new(self.last_variable_id).unwrap();
             Ok(Expr::Variable(Variable::indexed(index)))
-        } else if matches!(token[0], b':' | b'@' | b'$') {
-            let index = if let Some(index) = self.named_variables.get(token).copied() {
-                index
-            } else {
-                self.last_variable_id += 1;
-                let index = NonZeroU32::new(self.last_variable_id).unwrap();
-                self.named_variables.insert(token, index);
-                index
-            };
-            Ok(Expr::Variable(Variable::named(
-                from_bytes_as_str(token),
-                index,
-            )))
-        } else {
-            let variable_str = std::str::from_utf8(token)
+        } else if token[0] == b'?' {
+            let variable_str = std::str::from_utf8(&token[1..])
                 .map_err(|e| Error::Custom(format!("non-utf8 positional variable id: {e}")))?;
             let variable_id = variable_str
                 .parse::<u32>()
@@ -219,6 +207,20 @@ impl<'a> Parser<'a> {
             self.last_variable_id = self.last_variable_id.max(variable_id);
             let index = NonZeroU32::new(variable_id).unwrap();
             Ok(Expr::Variable(Variable::indexed(index)))
+        } else {
+            debug_assert!(matches!(token[0], b':' | b'@' | b'$'));
+            let index = if let Some(index) = self.named_variables.get(token).copied() {
+                index
+            } else {
+                self.last_variable_id += 1;
+                let index = NonZeroU32::new(self.last_variable_id).unwrap();
+                self.named_variables.insert(token, index);
+                index
+            };
+            Ok(Expr::Variable(Variable::named(
+                from_bytes_as_str(token),
+                index,
+            )))
         }
     }
 

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -988,3 +988,41 @@ fn test_bind_in_exists_subquery(tmp_db: TempDatabase) -> anyhow::Result<()> {
     assert_eq!(turso_rows[0], Value::from_i64(42));
     Ok(())
 }
+
+/// Column names for bound parameters must match SQLite:
+///   bare `?` → "?", explicit `?NNN` → "?NNN", named → verbatim text.
+#[turso_macros::test(mvcc)]
+fn test_parameter_column_names(tmp_db: TempDatabase) {
+    let cases: &[(&str, &[&str])] = &[
+        ("SELECT ?, ?", &["?", "?"]),
+        ("SELECT ?1, ?2", &["?1", "?2"]),
+        ("SELECT ?999", &["?999"]),
+        ("SELECT :foo", &[":foo"]),
+        ("SELECT @bar", &["@bar"]),
+        ("SELECT $baz", &["$baz"]),
+        (
+            "SELECT ?, ?1, :foo, @bar, $baz",
+            &["?", "?1", ":foo", "@bar", "$baz"],
+        ),
+        ("SELECT ? AS alias", &["alias"]),
+    ];
+
+    // Verify expected values against rusqlite (bundled SQLite)
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    for (sql, expected) in cases {
+        let stmt = sqlite_conn.prepare(sql).unwrap();
+        let names: Vec<&str> = stmt.column_names();
+        assert_eq!(names, *expected, "SQLite column names mismatch for: {sql}");
+    }
+
+    // Verify Turso matches
+    let conn = tmp_db.connect_limbo();
+    for (sql, expected) in cases {
+        let stmt = conn.prepare(sql).unwrap();
+        let names: Vec<String> = (0..stmt.num_columns())
+            .map(|i| stmt.get_column_name(i).to_string())
+            .collect();
+        let expected: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+        assert_eq!(names, expected, "Turso column names mismatch for: {sql}");
+    }
+}


### PR DESCRIPTION
The lexer strips the `?` prefix from ?-style variable tokens (bare `?` and explicit `?NNN`), so the source span used to derive implicit column names was either empty or missing the prefix. This caused `SELECT ?, ?` to report columns `["?1", "?2"]` and `SELECT ?1` to report `["1"]` instead of matching SQLite's `["?", "?"]` and `["?1"]` respectively.
