### PR TITLE
core/translate: UPDATE OR REPLACE conflict delete should not increment changes()

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -723,7 +723,7 @@ fn emit_replace_delete<'a>(
     program.emit_insn(Insn::Delete {
         cursor_id: target_table_cursor_id,
         table_name: table_name.to_string(),
-        is_part_of_update: false,
+        is_part_of_update: true,
     });
 
     prepared_fk_actions.fire_prepared_fk_delete_actions(

--- a/testing/sqltests/tests/update_or_replace_rowid_secondary_index.sqltest
+++ b/testing/sqltests/tests/update_or_replace_rowid_secondary_index.sqltest
@@ -27,6 +27,16 @@ expect {
     ok
 }
 
+test update-or-replace-conflict-delete-changes-count {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b INT UNIQUE);
+    INSERT INTO t VALUES(1,10),(2,20),(3,30);
+    UPDATE OR REPLACE t SET b = 10 WHERE a = 3;
+    SELECT changes();
+}
+expect {
+    1
+}
+
 test update-or-replace-rowid-no-conflict-preserves-secondary-index {
     CREATE TABLE t(id INTEGER PRIMARY KEY, c TEXT, payload TEXT);
     CREATE INDEX idx_c ON t(c);


### PR DESCRIPTION
Fixes #6482.

Pretty small fix here. Delete conflicting rows in an update or replace query as part of the update so changes isn't incremented again.