### PR TITLE
Refactor ` ProgramState` opcode state into single enum + Box commit state machines

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3518,16 +3518,16 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         tx_id: TxID,
         connection: &Arc<Connection>,
-    ) -> Result<StateMachine<CommitStateMachine<Clock>>> {
-        let state_machine: StateMachine<CommitStateMachine<Clock>> =
-            StateMachine::<CommitStateMachine<Clock>>::new(CommitStateMachine::new(
-                CommitState::Initial,
-                tx_id,
-                connection.clone(),
-                self.commit_coordinator.clone(),
-                self.global_header.clone(),
-                connection.get_sync_mode(),
-            ));
+    ) -> Result<StateMachine<Box<CommitStateMachine<Clock>>>> {
+        let state = Box::new(CommitStateMachine::new(
+            CommitState::Initial,
+            tx_id,
+            connection.clone(),
+            self.commit_coordinator.clone(),
+            self.global_header.clone(),
+            connection.get_sync_mode(),
+        ));
+        let state_machine = StateMachine::new(state);
         Ok(state_machine)
     }
 

--- a/core/state_machine.rs
+++ b/core/state_machine.rs
@@ -36,6 +36,23 @@ pub struct StateMachine<State: StateTransition> {
     is_finalized: bool,
 }
 
+impl<State: StateTransition> StateTransition for Box<State> {
+    type Context = State::Context;
+    type SMResult = State::SMResult;
+
+    fn step(&mut self, context: &Self::Context) -> Result<TransitionResult<Self::SMResult>> {
+        self.as_mut().step(context)
+    }
+
+    fn finalize(&mut self, context: &Self::Context) -> Result<()> {
+        self.as_mut().finalize(context)
+    }
+
+    fn is_finalized(&self) -> bool {
+        self.as_ref().is_finalized()
+    }
+}
+
 /// A generic state machine that loops calling `transition` until it returns `TransitionResult::Done` or `TransitionResult::Io`.
 impl<State: StateTransition> StateMachine<State> {
     pub fn new(state: State) -> Self {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13918,7 +13918,7 @@ pub struct OpJournalModeState {
     /// The new journal mode we're changing to
     pub new_mode: Option<journal_mode::JournalMode>,
     /// Checkpoint state machine for MVCC mode
-    pub checkpoint_sm: Option<StateMachine<CheckpointStateMachine<MvccClock>>>,
+    pub checkpoint_sm: Option<StateMachine<Box<CheckpointStateMachine<MvccClock>>>>,
     /// Page reference for writing header
     pub page_ref: Option<PageRef>,
 }
@@ -14026,13 +14026,13 @@ fn op_journal_mode_inner(
                     // MVCC checkpoint using state machine
                     if state.active_op_state.journal_mode().checkpoint_sm.is_none() {
                         state.active_op_state.journal_mode().checkpoint_sm =
-                            Some(StateMachine::new(CheckpointStateMachine::new(
+                            Some(StateMachine::new(Box::new(CheckpointStateMachine::new(
                                 pager.clone(),
                                 mv_store.clone(),
                                 program.connection.clone(),
                                 true,
                                 program.connection.get_sync_mode(),
-                            )));
+                            ))));
                     }
 
                     let ckpt_sm = state

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1671,15 +1671,15 @@ pub fn op_column(
         insn
     );
     'outer: loop {
-        match state.op_column_state {
+        match *state.active_op_state.column() {
             OpColumnState::Start => {
                 if let Some(deferred) = state.deferred_seeks[*cursor_id].take() {
-                    state.op_column_state = OpColumnState::Rowid {
+                    *state.active_op_state.column() = OpColumnState::Rowid {
                         index_cursor_id: deferred.index_cursor_id,
                         table_cursor_id: deferred.table_cursor_id,
                     };
                 } else {
-                    state.op_column_state = OpColumnState::GetColumn;
+                    *state.active_op_state.column() = OpColumnState::GetColumn;
                 }
             }
             OpColumnState::Rowid {
@@ -1697,7 +1697,7 @@ pub fn op_column(
                     state.registers[*dest].set_null();
                     break 'outer;
                 };
-                state.op_column_state = OpColumnState::Seek {
+                *state.active_op_state.column() = OpColumnState::Seek {
                     rowid,
                     table_cursor_id,
                 };
@@ -1726,7 +1726,7 @@ pub fn op_column(
                 }
                 state.metrics.btree_seeks = state.metrics.btree_seeks.saturating_add(1);
                 state.metrics.search_count = state.metrics.search_count.saturating_add(1);
-                state.op_column_state = OpColumnState::GetColumn;
+                *state.active_op_state.column() = OpColumnState::GetColumn;
             }
             OpColumnState::GetColumn => {
                 let (active_cursor_id, active_column) = (*cursor_id, *column);
@@ -1861,7 +1861,7 @@ pub fn op_column(
         }
     }
 
-    state.op_column_state = OpColumnState::Start;
+    state.active_op_state.clear();
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -2927,13 +2927,13 @@ pub fn op_transaction(
     let result = op_transaction_inner(program, state, insn, pager);
     tracing::debug!(
         "op_transaction: end: state={:?}, tx_state={:?}",
-        state.op_transaction_state,
+        *state.active_op_state.transaction(),
         program.connection.get_tx_state()
     );
     match result {
         Ok(result) => Ok(result),
         Err(err) => {
-            state.op_transaction_state = OpTransactionState::Start;
+            state.active_op_state.clear();
             Err(err)
         }
     }
@@ -3118,7 +3118,7 @@ pub fn op_transaction_inner(
     // Get the MvStore for the specific database (main or attached).
     let mv_store = program.connection.mv_store_for_db(*db);
     loop {
-        match state.op_transaction_state {
+        match *state.active_op_state.transaction() {
             OpTransactionState::Start => {
                 let conn = program.connection.clone();
                 let write = matches!(tx_mode, TransactionMode::Write);
@@ -3332,11 +3332,12 @@ pub fn op_transaction_inner(
                             if matches!(tx_mode, TransactionMode::Write)
                                 && !pager.holds_write_lock()
                             {
-                                state.op_transaction_state =
+                                *state.active_op_state.transaction() =
                                     OpTransactionState::AttachedBeginWriteTx;
                                 continue;
                             }
-                            state.op_transaction_state = OpTransactionState::CheckSchemaCookie;
+                            *state.active_op_state.transaction() =
+                                OpTransactionState::CheckSchemaCookie;
                             continue;
                         }
                         pager.begin_read_tx()?;
@@ -3346,10 +3347,10 @@ pub fn op_transaction_inner(
                             // separately, so if it returns IO we don't re-call begin_read_tx
                             // on re-entry.
                             if conn.with_named_savepoints(|savepoints| savepoints.is_empty()) {
-                                state.op_transaction_state =
+                                *state.active_op_state.transaction() =
                                     OpTransactionState::AttachedBeginWriteTx;
                             } else {
-                                state.op_transaction_state =
+                                *state.active_op_state.transaction() =
                                     OpTransactionState::BeginNamedSavepoints;
                             }
                             continue;
@@ -3417,10 +3418,10 @@ pub fn op_transaction_inner(
                     && started_secondary_tx
                     && !conn.with_named_savepoints(|s| s.is_empty())
                 {
-                    state.op_transaction_state = OpTransactionState::BeginNamedSavepoints;
+                    *state.active_op_state.transaction() = OpTransactionState::BeginNamedSavepoints;
                     continue;
                 }
-                state.op_transaction_state = OpTransactionState::CheckSchemaCookie;
+                *state.active_op_state.transaction() = OpTransactionState::CheckSchemaCookie;
                 continue;
             }
             // 3b. For attached databases, begin the write transaction after
@@ -3430,7 +3431,7 @@ pub fn op_transaction_inner(
                 if let IOResult::IO(io) = res {
                     return Ok(InsnFunctionStepResult::IO(io));
                 }
-                state.op_transaction_state = OpTransactionState::CheckSchemaCookie;
+                *state.active_op_state.transaction() = OpTransactionState::CheckSchemaCookie;
                 continue;
             }
             OpTransactionState::BeginNamedSavepoints => {
@@ -3441,9 +3442,11 @@ pub fn op_transaction_inner(
                             && matches!(tx_mode, TransactionMode::Write)
                             && !pager.holds_write_lock()
                         {
-                            state.op_transaction_state = OpTransactionState::AttachedBeginWriteTx;
+                            *state.active_op_state.transaction() =
+                                OpTransactionState::AttachedBeginWriteTx;
                         } else {
-                            state.op_transaction_state = OpTransactionState::CheckSchemaCookie;
+                            *state.active_op_state.transaction() =
+                                OpTransactionState::CheckSchemaCookie;
                         }
                         continue;
                     }
@@ -3474,7 +3477,7 @@ pub fn op_transaction_inner(
                     }
                 }
 
-                state.op_transaction_state = OpTransactionState::BeginStatement;
+                *state.active_op_state.transaction() = OpTransactionState::BeginStatement;
             }
             OpTransactionState::BeginStatement => {
                 let needs_stmt_journal = program.needs_stmt_subtransactions.load(Ordering::Relaxed);
@@ -3536,7 +3539,7 @@ pub fn op_transaction_inner(
                     state.is_active_write = true;
                 }
                 state.pc += 1;
-                state.op_transaction_state = OpTransactionState::Start;
+                state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
         }
@@ -4048,6 +4051,12 @@ pub enum OpProgramState {
     },
 }
 
+impl Default for OpProgramState {
+    fn default() -> Self {
+        Self::Start
+    }
+}
+
 fn finish_subprogram(
     program: &Program,
     statement: &Statement,
@@ -4112,7 +4121,7 @@ pub fn op_program(
         insn
     );
     loop {
-        match std::mem::replace(&mut state.op_program_state, OpProgramState::Start) {
+        match std::mem::take(state.active_op_state.program()) {
             OpProgramState::Start => {
                 // Try to reuse a cached statement for this PC, otherwise create a new one.
                 // When we have triggers or fk-actions with multi-row inserts, we can re-use
@@ -4155,7 +4164,7 @@ pub fn op_program(
                     statement.bind_at(param_index, value);
                 }
 
-                state.op_program_state = OpProgramState::Step {
+                *state.active_op_state.program() = OpProgramState::Step {
                     is_trigger,
                     statement,
                     saved_last_insert_rowid,
@@ -4182,7 +4191,7 @@ pub fn op_program(
                                 let io = statement.take_io_completions().unwrap_or_else(|| {
                                     IOCompletions::Single(Completion::new_yield())
                                 });
-                                state.op_program_state = OpProgramState::Step {
+                                *state.active_op_state.program() = OpProgramState::Step {
                                     is_trigger,
                                     statement,
                                     saved_last_insert_rowid,
@@ -4192,7 +4201,7 @@ pub fn op_program(
                             }
                             StepResult::Row => continue,
                             StepResult::Interrupt | StepResult::Busy => {
-                                state.op_program_state = OpProgramState::Step {
+                                *state.active_op_state.program() = OpProgramState::Step {
                                     is_trigger,
                                     statement,
                                     saved_last_insert_rowid,
@@ -4259,6 +4268,7 @@ pub fn op_program(
                 } else {
                     state.pc += 1;
                 }
+                state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
         }
@@ -4369,15 +4379,15 @@ pub fn op_row_id(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(RowId { cursor_id, dest }, insn);
     loop {
-        match state.op_row_id_state {
+        match *state.active_op_state.row_id() {
             OpRowIdState::Start => {
                 if let Some(deferred) = state.deferred_seeks[*cursor_id].take() {
-                    state.op_row_id_state = OpRowIdState::Record {
+                    *state.active_op_state.row_id() = OpRowIdState::Record {
                         index_cursor_id: deferred.index_cursor_id,
                         table_cursor_id: deferred.table_cursor_id,
                     };
                 } else {
-                    state.op_row_id_state = OpRowIdState::GetRowid;
+                    *state.active_op_state.row_id() = OpRowIdState::GetRowid;
                 }
             }
             OpRowIdState::Record {
@@ -4406,7 +4416,7 @@ pub fn op_row_id(
                         _ => panic!("unexpected cursor type"),
                     }
                 };
-                state.op_row_id_state = OpRowIdState::Seek {
+                *state.active_op_state.row_id() = OpRowIdState::Seek {
                     rowid,
                     table_cursor_id,
                 }
@@ -4422,7 +4432,7 @@ pub fn op_row_id(
                         table_cursor.seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })
                     );
                 }
-                state.op_row_id_state = OpRowIdState::GetRowid;
+                *state.active_op_state.row_id() = OpRowIdState::GetRowid;
             }
             OpRowIdState::GetRowid => {
                 let cursors = &mut state.cursors;
@@ -4479,7 +4489,7 @@ pub fn op_row_id(
         }
     }
 
-    state.op_row_id_state = OpRowIdState::Start;
+    state.active_op_state.clear();
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -8765,7 +8775,7 @@ pub struct OpInsertState {
     pub is_noop_update: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum OpInsertSubState {
     /// If this insert overwrites a record, capture the old record for incremental view maintenance.
     /// If cursor is already positioned (no REQUIRE_SEEK), capture directly.
@@ -8811,7 +8821,7 @@ pub fn op_insert(
     );
 
     loop {
-        match &state.op_insert_state.sub_state {
+        match state.active_op_state.insert().sub_state {
             OpInsertSubState::MaybeCaptureRecord => {
                 let has_dependent_views = {
                     let schema = program.connection.schema.read();
@@ -8827,11 +8837,11 @@ pub fn op_insert(
                     has_dependent_views && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE);
 
                 if flag.has(InsertFlags::REQUIRE_SEEK) {
-                    state.op_insert_state.sub_state = OpInsertSubState::Seek;
+                    state.active_op_state.insert().sub_state = OpInsertSubState::Seek;
                 } else if needs_capture {
-                    state.op_insert_state.sub_state = OpInsertSubState::CaptureRecord;
+                    state.active_op_state.insert().sub_state = OpInsertSubState::CaptureRecord;
                 } else {
-                    state.op_insert_state.sub_state = OpInsertSubState::NoopCheck;
+                    state.active_op_state.insert().sub_state = OpInsertSubState::NoopCheck;
                 }
                 continue;
             }
@@ -8859,9 +8869,9 @@ pub fn op_insert(
                 let needs_capture =
                     has_dependent_views && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE);
                 if needs_capture {
-                    state.op_insert_state.sub_state = OpInsertSubState::CaptureRecord;
+                    state.active_op_state.insert().sub_state = OpInsertSubState::CaptureRecord;
                 } else {
-                    state.op_insert_state.sub_state = OpInsertSubState::NoopCheck;
+                    state.active_op_state.insert().sub_state = OpInsertSubState::NoopCheck;
                 }
                 continue;
             }
@@ -8897,8 +8907,8 @@ pub fn op_insert(
                 } else {
                     None
                 };
-                state.op_insert_state.old_record = old_record;
-                state.op_insert_state.sub_state = OpInsertSubState::NoopCheck;
+                state.active_op_state.insert().old_record = old_record;
+                state.active_op_state.insert().sub_state = OpInsertSubState::NoopCheck;
                 continue;
             }
             // TODO: add some InsertFlags that allows us to skip this check when we know for
@@ -8914,7 +8924,7 @@ pub fn op_insert(
                 // still appear physically intact, MVCC-store rows become invisible).
                 // The noop check is fundamentally incompatible with the MVCC
                 // Delete+Insert update pattern.
-                state.op_insert_state.is_noop_update = false;
+                state.active_op_state.insert().is_noop_update = false;
                 let is_mvcc = {
                     let cursor_ref = get_cursor!(state, *cursor_id);
                     cursor_ref.as_btree_mut().is_mvcc()
@@ -8944,15 +8954,15 @@ pub fn op_insert(
                         };
                         let existing_record = return_if_io!(cursor.record());
                         if existing_record.is_some_and(|r| r == record.as_ref()) {
-                            state.op_insert_state.is_noop_update = true;
+                            state.active_op_state.insert().is_noop_update = true;
                         }
                     }
                 }
-                state.op_insert_state.sub_state = OpInsertSubState::Insert;
+                state.active_op_state.insert().sub_state = OpInsertSubState::Insert;
                 continue;
             }
             OpInsertSubState::Insert => {
-                if !state.op_insert_state.is_noop_update {
+                if !state.active_op_state.insert().is_noop_update {
                     let key = match &state.registers[*key_reg].get_value() {
                         Value::Numeric(Numeric::Integer(i)) => *i,
                         _ => unreachable!("expected integer key"),
@@ -8983,7 +8993,7 @@ pub fn op_insert(
                     && table_name != SQLITE_SEQUENCE_TABLE_NAME
                     && !flag.has(InsertFlags::EPHEMERAL_TABLE_INSERT)
                 {
-                    state.op_insert_state.sub_state = OpInsertSubState::UpdateLastRowid;
+                    state.active_op_state.insert().sub_state = OpInsertSubState::UpdateLastRowid;
                 } else {
                     // Schema table writes (sqlite_master, sqlite_sequence, ephemeral)
                     // must not produce view deltas. The p4 table_name on these inserts
@@ -8991,7 +9001,7 @@ pub fn op_insert(
                     // actually being written to. Tracking deltas here would feed the
                     // sqlite_master record into the DBSP circuit as if it were data
                     // from the named table, corrupting the materialized view.
-                    state.op_insert_state.old_record = None;
+                    state.active_op_state.insert().old_record = None;
                     break;
                 }
             }
@@ -9012,7 +9022,7 @@ pub fn op_insert(
                 let schema = program.connection.schema.read();
                 let dependent_views = schema.get_dependent_materialized_views(table_name);
                 if !dependent_views.is_empty() {
-                    state.op_insert_state.sub_state = OpInsertSubState::ApplyViewChange;
+                    state.active_op_state.insert().sub_state = OpInsertSubState::ApplyViewChange;
                     continue;
                 }
                 break;
@@ -9056,7 +9066,7 @@ pub fn op_insert(
                     (key, new_values)
                 };
 
-                if let Some((key, values)) = state.op_insert_state.old_record.take() {
+                if let Some((key, values)) = state.active_op_state.insert().old_record.take() {
                     for view_name in dependent_views.iter() {
                         let tx_state = program
                             .connection
@@ -9079,8 +9089,7 @@ pub fn op_insert(
         }
     }
 
-    state.op_insert_state.sub_state = OpInsertSubState::MaybeCaptureRecord;
-    state.op_insert_state.is_noop_update = false;
+    state.active_op_state.clear();
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -9110,6 +9119,7 @@ pub struct OpDeleteState {
     pub deleted_record: Option<(i64, Vec<Value>)>,
 }
 
+#[derive(Clone, Copy)]
 pub enum OpDeleteSubState {
     /// Capture the record before deletion, if the are dependent views.
     MaybeCaptureRecord,
@@ -9135,12 +9145,12 @@ pub fn op_delete(
     );
 
     loop {
-        match &state.op_delete_state.sub_state {
+        match state.active_op_state.delete().sub_state {
             OpDeleteSubState::MaybeCaptureRecord => {
                 let schema = program.connection.schema.read();
                 let dependent_views = schema.get_dependent_materialized_views(table_name);
                 if dependent_views.is_empty() {
-                    state.op_delete_state.sub_state = OpDeleteSubState::Delete;
+                    state.active_op_state.delete().sub_state = OpDeleteSubState::Delete;
                     continue;
                 }
 
@@ -9170,8 +9180,8 @@ pub fn op_delete(
                         None
                     }
                 };
-                state.op_delete_state.deleted_record = deleted_record;
-                state.op_delete_state.sub_state = OpDeleteSubState::Delete;
+                state.active_op_state.delete().deleted_record = deleted_record;
+                state.active_op_state.delete().sub_state = OpDeleteSubState::Delete;
                 continue;
             }
             OpDeleteSubState::Delete => {
@@ -9187,14 +9197,14 @@ pub fn op_delete(
                 if dependent_views.is_empty() {
                     break;
                 }
-                state.op_delete_state.sub_state = OpDeleteSubState::ApplyViewChange;
+                state.active_op_state.delete().sub_state = OpDeleteSubState::ApplyViewChange;
                 continue;
             }
             OpDeleteSubState::ApplyViewChange => {
                 let schema = program.connection.schema.read();
                 let dependent_views = schema.get_dependent_materialized_views(table_name);
                 assert!(!dependent_views.is_empty());
-                let maybe_deleted_record = state.op_delete_state.deleted_record.take();
+                let maybe_deleted_record = state.active_op_state.delete().deleted_record.take();
                 if let Some((key, values)) = maybe_deleted_record {
                     for view_name in dependent_views {
                         let tx_state = program
@@ -9209,7 +9219,7 @@ pub fn op_delete(
         }
     }
 
-    state.op_delete_state.sub_state = OpDeleteSubState::MaybeCaptureRecord;
+    state.active_op_state.clear();
     if !is_part_of_update {
         // DELETEs do not count towards the total changes if they are part of an UPDATE statement,
         // i.e. the DELETE and subsequent INSERT of a row are the same "change".
@@ -9258,9 +9268,9 @@ pub fn op_idx_delete(
             start_reg,
             num_regs,
             state.get_cursor(*cursor_id).as_btree_mut().root_page(),
-            state.op_idx_delete_state
+            state.active_op_state.idx_delete()
         );
-        match &state.op_idx_delete_state {
+        match state.active_op_state.idx_delete() {
             Some(OpIdxDeleteState::Seeking) => {
                 let found = match seek_internal(
                     program,
@@ -9292,10 +9302,10 @@ pub fn op_idx_delete(
                         )));
                     }
                     state.pc += 1;
-                    state.op_idx_delete_state = None;
+                    state.active_op_state.clear();
                     return Ok(InsnFunctionStepResult::Step);
                 }
-                state.op_idx_delete_state = Some(OpIdxDeleteState::Verifying);
+                *state.active_op_state.idx_delete() = Some(OpIdxDeleteState::Verifying);
             }
             Some(OpIdxDeleteState::Verifying) => {
                 let rowid = {
@@ -9312,7 +9322,7 @@ pub fn op_idx_delete(
                         "IdxDelete: no matching index entry found for key while verifying: {reg_values:?}"
                     )));
                 }
-                state.op_idx_delete_state = Some(OpIdxDeleteState::Deleting);
+                *state.active_op_state.idx_delete() = Some(OpIdxDeleteState::Deleting);
             }
             Some(OpIdxDeleteState::Deleting) => {
                 {
@@ -9323,11 +9333,11 @@ pub fn op_idx_delete(
                 // Increment metrics for index write (delete is a write operation)
                 state.record_rows_written(1);
                 state.pc += 1;
-                state.op_idx_delete_state = None;
+                state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
             None => {
-                state.op_idx_delete_state = Some(OpIdxDeleteState::Seeking);
+                *state.active_op_state.idx_delete() = Some(OpIdxDeleteState::Seeking);
             }
         }
     }
@@ -9387,7 +9397,7 @@ pub fn op_idx_insert(
         }
     };
 
-    match state.op_idx_insert_state {
+    match *state.active_op_state.idx_insert() {
         OpIdxInsertState::MaybeSeek => {
             let (_, cursor_type) = program
                 .cursor_ref
@@ -9404,7 +9414,7 @@ pub fn op_idx_insert(
             // HOWEVER: If the record contains NULLs, NoConflict skips the seek entirely
             // (since NULLs can't conflict), so we must fall back to seeking here.
             if flags.has(IdxInsertFlags::USE_SEEK) && !record_to_insert.contains_null()? {
-                state.op_idx_insert_state = OpIdxInsertState::Insert;
+                *state.active_op_state.idx_insert() = OpIdxInsertState::Insert;
                 return Ok(InsnFunctionStepResult::Step);
                 // Fall through to do the seek since NoConflict skipped it due to NULLs
             }
@@ -9419,7 +9429,7 @@ pub fn op_idx_insert(
                 SeekOp::GE { eq_only: true },
             )? {
                 SeekInternalResult::Found => {
-                    state.op_idx_insert_state = if index_meta.unique {
+                    *state.active_op_state.idx_insert() = if index_meta.unique {
                         OpIdxInsertState::UniqueConstraintCheck
                     } else {
                         OpIdxInsertState::Insert
@@ -9427,7 +9437,7 @@ pub fn op_idx_insert(
                     Ok(InsnFunctionStepResult::Step)
                 }
                 SeekInternalResult::NotFound => {
-                    state.op_idx_insert_state = OpIdxInsertState::Insert;
+                    *state.active_op_state.idx_insert() = OpIdxInsertState::Insert;
                     Ok(InsnFunctionStepResult::Step)
                 }
                 SeekInternalResult::IO(io) => Ok(InsnFunctionStepResult::IO(io)),
@@ -9471,13 +9481,14 @@ pub fn op_idx_insert(
 
                 false
             };
-            state.op_idx_insert_state = if ignore_conflict {
+            if ignore_conflict {
                 state.pc += 1;
-                OpIdxInsertState::MaybeSeek
+                state.active_op_state.clear();
+                Ok(InsnFunctionStepResult::Step)
             } else {
-                OpIdxInsertState::Insert
-            };
-            Ok(InsnFunctionStepResult::Step)
+                *state.active_op_state.idx_insert() = OpIdxInsertState::Insert;
+                Ok(InsnFunctionStepResult::Step)
+            }
         }
         OpIdxInsertState::Insert => {
             {
@@ -9488,7 +9499,7 @@ pub fn op_idx_insert(
             if flags.has(IdxInsertFlags::NCHANGE) {
                 state.record_rows_written(1);
             }
-            state.op_idx_insert_state = OpIdxInsertState::MaybeSeek;
+            state.active_op_state.clear();
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
@@ -9561,7 +9572,7 @@ fn new_rowid_inner(
     const MAX_ATTEMPTS: u32 = 100;
     let mv_store = program.connection.mv_store();
     loop {
-        match state.op_new_rowid_state {
+        match *state.active_op_state.new_rowid() {
             OpNewRowidState::Start => {
                 if mv_store.is_some() {
                     let cursor = state.get_cursor(*cursor);
@@ -9569,9 +9580,10 @@ fn new_rowid_inner(
                     if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
                         match return_if_io!(mvcc_cursor.start_new_rowid()) {
                             NextRowidResult::Uninitialized => {
-                                state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
-                                    mvcc_already_initialized: false,
-                                };
+                                *state.active_op_state.new_rowid() =
+                                    OpNewRowidState::SeekingToLast {
+                                        mvcc_already_initialized: false,
+                                    };
                             }
                             NextRowidResult::Next {
                                 new_rowid,
@@ -9584,13 +9596,14 @@ fn new_rowid_inner(
                                     state.registers[*prev_largest_reg]
                                         .set_int(prev_rowid.unwrap_or(0));
                                 }
-                                state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
-                                    mvcc_already_initialized: true,
-                                };
+                                *state.active_op_state.new_rowid() =
+                                    OpNewRowidState::SeekingToLast {
+                                        mvcc_already_initialized: true,
+                                    };
                             }
                             NextRowidResult::FindRandom => {
                                 mvcc_cursor.end_new_rowid();
-                                state.op_new_rowid_state =
+                                *state.active_op_state.new_rowid() =
                                     OpNewRowidState::GeneratingRandom { attempts: 0 };
                             }
                         }
@@ -9602,12 +9615,12 @@ fn new_rowid_inner(
                             cursor.downcast_ref::<BTreeCursor>().is_some(),
                             "Expected MvCursor or BTreeCursor in op_new_rowid"
                         );
-                        state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
+                        *state.active_op_state.new_rowid() = OpNewRowidState::SeekingToLast {
                             mvcc_already_initialized: false,
                         };
                     }
                 } else {
-                    state.op_new_rowid_state = OpNewRowidState::SeekingToLast {
+                    *state.active_op_state.new_rowid() = OpNewRowidState::SeekingToLast {
                         mvcc_already_initialized: false,
                     };
                 }
@@ -9626,9 +9639,9 @@ fn new_rowid_inner(
                     return_if_io!(cursor.seek_to_last(always_seek));
                 }
                 if mvcc_already_initialized {
-                    state.op_new_rowid_state = OpNewRowidState::GoNext;
+                    *state.active_op_state.new_rowid() = OpNewRowidState::GoNext;
                 } else {
-                    state.op_new_rowid_state = OpNewRowidState::ReadingMaxRowid;
+                    *state.active_op_state.new_rowid() = OpNewRowidState::ReadingMaxRowid;
                 }
             }
 
@@ -9656,12 +9669,12 @@ fn new_rowid_inner(
                                         .set_int(prev_rowid.unwrap_or(0));
                                 }
                                 tracing::trace!("new_rowid={}", new_rowid);
-                                state.op_new_rowid_state = OpNewRowidState::GoNext;
+                                *state.active_op_state.new_rowid() = OpNewRowidState::GoNext;
                                 continue;
                             }
                             None => {
                                 // At i64::MAX — fall back to random
-                                state.op_new_rowid_state =
+                                *state.active_op_state.new_rowid() =
                                     OpNewRowidState::GeneratingRandom { attempts: 0 };
                                 continue;
                             }
@@ -9677,17 +9690,17 @@ fn new_rowid_inner(
                     Some(rowid) if rowid < MAX_ROWID => {
                         state.registers[*rowid_reg].set_int(rowid + 1);
                         tracing::trace!("new_rowid={}", rowid + 1);
-                        state.op_new_rowid_state = OpNewRowidState::GoNext;
+                        *state.active_op_state.new_rowid() = OpNewRowidState::GoNext;
                         continue;
                     }
                     Some(_) => {
-                        state.op_new_rowid_state =
+                        *state.active_op_state.new_rowid() =
                             OpNewRowidState::GeneratingRandom { attempts: 0 };
                     }
                     None => {
                         tracing::trace!("new_rowid=1");
                         state.registers[*rowid_reg].set_int(1);
-                        state.op_new_rowid_state = OpNewRowidState::GoNext;
+                        *state.active_op_state.new_rowid() = OpNewRowidState::GoNext;
                         continue;
                     }
                 }
@@ -9705,7 +9718,7 @@ fn new_rowid_inner(
                 random_rowid &= MAX_ROWID >> 1; // Mask to keep value in range [0, MAX_ROWID/2]
                 random_rowid += 1; // Ensure positive
 
-                state.op_new_rowid_state = OpNewRowidState::VerifyingCandidate {
+                *state.active_op_state.new_rowid() = OpNewRowidState::VerifyingCandidate {
                     attempts,
                     candidate: random_rowid,
                 };
@@ -9727,7 +9740,7 @@ fn new_rowid_inner(
                 if !exists {
                     // Found unused rowid!
                     state.registers[*rowid_reg].set_int(candidate);
-                    state.op_new_rowid_state = OpNewRowidState::Start;
+                    state.active_op_state.clear();
                     state.pc += 1;
 
                     if mv_store.is_some() {
@@ -9741,7 +9754,7 @@ fn new_rowid_inner(
                     return Ok(InsnFunctionStepResult::Step);
                 } else {
                     // Collision, try again
-                    state.op_new_rowid_state = OpNewRowidState::GeneratingRandom {
+                    *state.active_op_state.new_rowid() = OpNewRowidState::GeneratingRandom {
                         attempts: attempts + 1,
                     };
                 }
@@ -9752,7 +9765,7 @@ fn new_rowid_inner(
                     let cursor = cursor.as_btree_mut();
                     return_if_io!(cursor.next());
                 }
-                state.op_new_rowid_state = OpNewRowidState::Start;
+                state.active_op_state.clear();
                 state.pc += 1;
 
                 if mv_store.is_some() {
@@ -9835,7 +9848,7 @@ pub fn op_no_conflict(
     );
 
     loop {
-        match state.op_no_conflict_state {
+        match *state.active_op_state.no_conflict() {
             OpNoConflictState::Start => {
                 let record_source = if *num_regs == 0 {
                     RecordSource::Packed {
@@ -9871,10 +9884,11 @@ pub fn op_no_conflict(
 
                 if contains_nulls {
                     state.pc = target_pc.as_offset_int();
-                    state.op_no_conflict_state = OpNoConflictState::Start;
+                    state.active_op_state.clear();
                     return Ok(InsnFunctionStepResult::Step);
                 } else {
-                    state.op_no_conflict_state = OpNoConflictState::Seeking(record_source);
+                    *state.active_op_state.no_conflict() =
+                        OpNoConflictState::Seeking(record_source);
                 }
             }
             OpNoConflictState::Seeking(record_source) => {
@@ -9889,12 +9903,12 @@ pub fn op_no_conflict(
                 )? {
                     SeekInternalResult::Found => {
                         state.pc += 1;
-                        state.op_no_conflict_state = OpNoConflictState::Start;
+                        state.active_op_state.clear();
                         Ok(InsnFunctionStepResult::Step)
                     }
                     SeekInternalResult::NotFound => {
                         state.pc = target_pc.as_offset_int();
-                        state.op_no_conflict_state = OpNoConflictState::Start;
+                        state.active_op_state.clear();
                         Ok(InsnFunctionStepResult::Step)
                     }
                     SeekInternalResult::IO(io) => Ok(InsnFunctionStepResult::IO(io)),
@@ -10328,19 +10342,19 @@ pub fn op_destroy(
     };
 
     loop {
-        match state.op_destroy_state {
+        match state.active_op_state.destroy() {
             OpDestroyState::CreateCursor => {
                 // Destroy doesn't do anything meaningful with the table/index distinction so we can just use a
                 // table btree cursor for both.
                 let cursor = BTreeCursor::new(destroy_pager.clone(), *root, 0);
-                state.op_destroy_state =
+                *state.active_op_state.destroy() =
                     OpDestroyState::DestroyBtree(Arc::new(RwLock::new(cursor)));
             }
             OpDestroyState::DestroyBtree(ref mut cursor) => {
                 let maybe_former_root_page = return_if_io!(cursor.write().btree_destroy());
                 state.registers[*former_root_reg]
                     .set_int(maybe_former_root_page.unwrap_or(0) as i64);
-                state.op_destroy_state = OpDestroyState::CreateCursor;
+                state.active_op_state.clear();
                 state.pc += 1;
                 return Ok(InsnFunctionStepResult::Step);
             }
@@ -10597,7 +10611,7 @@ pub fn op_page_count(
 }
 
 /// State for the async ParseSchema instruction state machine.
-/// Stored in `ProgramState::op_parse_schema_state` so that when the inner
+/// Stored in the active opcode state slot so that when the inner
 /// schema query yields IO, we can return control to the outer caller and
 /// resume later without losing intermediate parsing state.
 pub struct OpParseSchemaInner {
@@ -10625,7 +10639,7 @@ pub fn op_parse_schema(
     let conn = program.connection.clone();
 
     // If we have in-progress state, resume stepping through schema rows.
-    if state.op_parse_schema_state.is_some() {
+    if state.active_op_state.parse_schema().is_some() {
         return op_parse_schema_step(state, &conn);
     }
 
@@ -10696,7 +10710,7 @@ pub fn op_parse_schema(
     stmt.set_mv_tx(mv_tx);
 
     // Store state for resumption across IO boundaries
-    state.op_parse_schema_state = Some(Box::new(OpParseSchemaInner {
+    *state.active_op_state.parse_schema() = Some(Box::new(OpParseSchemaInner {
         stmt,
         schema_arc,
         from_sql_indexes: Vec::with_capacity(10),
@@ -10720,7 +10734,7 @@ fn op_parse_schema_step(
     conn: &Arc<Connection>,
 ) -> Result<InsnFunctionStepResult> {
     loop {
-        let inner = state.op_parse_schema_state.as_mut().unwrap();
+        let inner = state.active_op_state.parse_schema().as_mut().unwrap();
         match inner.stmt.step()? {
             StepResult::IO => {
                 let io = inner
@@ -10731,7 +10745,8 @@ fn op_parse_schema_step(
             }
             StepResult::Row => {
                 let inner = state
-                    .op_parse_schema_state
+                    .active_op_state
+                    .parse_schema()
                     .as_mut()
                     .expect("parse schema state should exist");
                 let row = inner.stmt.row().expect("row should be present");
@@ -10777,7 +10792,8 @@ fn op_parse_schema_step(
                     db,
                     previous_auto_commit,
                 } = *state
-                    .op_parse_schema_state
+                    .active_op_state
+                    .parse_schema()
                     .take()
                     .expect("parse schema state should exist");
                 let schema = Arc::make_mut(&mut schema_arc);
@@ -10825,6 +10841,7 @@ fn op_parse_schema_step(
                 let _ = (res1?, res2?);
 
                 state.pc += 1;
+                state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
             StepResult::Interrupt => {
@@ -10833,7 +10850,8 @@ fn op_parse_schema_step(
                     previous_auto_commit,
                     ..
                 } = *state
-                    .op_parse_schema_state
+                    .active_op_state
+                    .parse_schema()
                     .take()
                     .expect("parse schema state should exist");
                 drop(stmt);
@@ -10847,7 +10865,8 @@ fn op_parse_schema_step(
                     previous_auto_commit,
                     ..
                 } = *state
-                    .op_parse_schema_state
+                    .active_op_state
+                    .parse_schema()
                     .take()
                     .expect("parse schema state should exist");
                 drop(stmt);
@@ -11451,14 +11470,14 @@ pub fn op_open_ephemeral(
         _ => unreachable!("unexpected Insn {:?}", insn),
     };
     let mv_store = program.connection.mv_store();
-    match &mut state.op_open_ephemeral_state {
+    match state.active_op_state.open_ephemeral() {
         OpOpenEphemeralState::Start => {
             tracing::trace!("Start");
             // Fast path: if cursor already has an ephemeral btree, just clear it instead of
             // recreating the entire pager/file/btree. This is important for performance when
             // OpenEphemeral is called repeatedly during statement execution.
             if state.cursors[cursor_id].is_some() {
-                state.op_open_ephemeral_state = OpOpenEphemeralState::ClearExisting;
+                *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::ClearExisting;
                 return Ok(InsnFunctionStepResult::Step);
             }
             // Ephemeral tables always use the main DB's page size (db index 0)
@@ -11496,7 +11515,7 @@ pub fn op_open_ephemeral(
 
             pager.set_page_size(page_size);
 
-            state.op_open_ephemeral_state = OpOpenEphemeralState::StartingTxn {
+            *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::StartingTxn {
                 pager,
                 temp_file: Some(temp_file),
             };
@@ -11518,7 +11537,7 @@ pub fn op_open_ephemeral(
                     }
                 }
             }
-            state.op_open_ephemeral_state = OpOpenEphemeralState::RewindExisting;
+            *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::RewindExisting;
         }
         OpOpenEphemeralState::RewindExisting => {
             tracing::trace!("RewindExisting");
@@ -11528,7 +11547,7 @@ pub fn op_open_ephemeral(
             let btree_cursor = cursor.as_btree_mut();
             return_if_io!(btree_cursor.rewind());
             state.pc += 1;
-            state.op_open_ephemeral_state = OpOpenEphemeralState::Start;
+            state.active_op_state.clear();
         }
         OpOpenEphemeralState::StartingTxn { pager, temp_file } => {
             tracing::trace!("StartingTxn");
@@ -11536,7 +11555,7 @@ pub fn op_open_ephemeral(
                 .begin_read_tx() // we have to begin a read tx before beginning a write
                 .expect("Failed to start read transaction");
             return_if_io!(pager.begin_write_tx());
-            state.op_open_ephemeral_state = OpOpenEphemeralState::CreateBtree {
+            *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::CreateBtree {
                 pager: pager.clone(),
                 temp_file: temp_file.take(),
             };
@@ -11567,7 +11586,7 @@ pub fn op_open_ephemeral(
             } else {
                 BTreeCursor::new_table(pager.clone(), root_page, num_columns)
             };
-            state.op_open_ephemeral_state = OpOpenEphemeralState::Rewind {
+            *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::Rewind {
                 cursor: Box::new(cursor),
                 temp_file: temp_file.take(),
             };
@@ -11586,7 +11605,7 @@ pub fn op_open_ephemeral(
                 .expect("cursor_id should exist in cursor_ref");
 
             let OpOpenEphemeralState::Rewind { cursor, temp_file } =
-                std::mem::take(&mut state.op_open_ephemeral_state)
+                std::mem::take(state.active_op_state.open_ephemeral())
             else {
                 unreachable!()
             };
@@ -11626,7 +11645,7 @@ pub fn op_open_ephemeral(
             }
 
             state.pc += 1;
-            state.op_open_ephemeral_state = OpOpenEphemeralState::Start;
+            state.active_op_state.clear();
         }
     }
 
@@ -11930,7 +11949,7 @@ pub fn op_integrity_check(
     } else {
         program.get_pager_from_database_index(db)?
     };
-    match &mut state.op_integrity_check_state {
+    match state.active_op_state.integrity_check() {
         OpIntegrityCheckState::Start => {
             let (freelist_trunk_page, db_size) = return_if_io!(with_header(
                 &target_pager,
@@ -11962,11 +11981,12 @@ pub fn op_integrity_check(
                 current_root_idx += 1;
             }
 
-            state.op_integrity_check_state = OpIntegrityCheckState::CheckingBTreeStructure {
-                errors,
-                state: integrity_check_state,
-                current_root_idx,
-            };
+            *state.active_op_state.integrity_check() =
+                OpIntegrityCheckState::CheckingBTreeStructure {
+                    errors,
+                    state: integrity_check_state,
+                    current_root_idx,
+                };
         }
         OpIntegrityCheckState::CheckingBTreeStructure {
             errors,
@@ -11987,7 +12007,7 @@ pub fn op_integrity_check(
                     Some(msg) => state.registers[*message_register].set_text(Text::new(msg)),
                     None => state.registers[*message_register].set_null(),
                 };
-                state.op_integrity_check_state = OpIntegrityCheckState::Start;
+                state.active_op_state.clear();
                 state.pc += 1;
                 return Ok(InsnFunctionStepResult::Step);
             }
@@ -12045,7 +12065,7 @@ pub fn op_integrity_check(
                 Some(msg) => state.registers[*message_register].set_text(Text::new(msg)),
                 None => state.registers[*message_register].set_null(),
             };
-            state.op_integrity_check_state = OpIntegrityCheckState::Start;
+            state.active_op_state.clear();
             state.pc += 1;
         }
     }
@@ -12913,7 +12933,8 @@ pub fn op_hash_build(
     load_insn!(HashBuild { data }, insn);
 
     let mut op_state = state
-        .op_hash_build_state
+        .active_op_state
+        .hash_build()
         .take()
         .filter(|s| {
             s.hash_table_id == data.hash_table_id
@@ -12986,11 +13007,11 @@ pub fn op_hash_build(
                 let rowid_opt = match btree_cursor.rowid() {
                     Ok(IOResult::Done(v)) => v,
                     Ok(IOResult::IO(io)) => {
-                        state.op_hash_build_state = Some(op_state);
+                        *state.active_op_state.hash_build() = Some(op_state);
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
                     Err(e) => {
-                        state.op_hash_build_state = Some(op_state);
+                        *state.active_op_state.hash_build() = Some(op_state);
                         return Err(e);
                     }
                 };
@@ -13020,13 +13041,13 @@ pub fn op_hash_build(
             HashInsertResult::IO { io, pending } => {
                 op_state.key_values = pending.key_values;
                 op_state.payload_values = pending.payload_values;
-                state.op_hash_build_state = Some(op_state);
+                *state.active_op_state.hash_build() = Some(op_state);
                 return Ok(InsnFunctionStepResult::IO(io));
             }
         }
     }
 
-    state.op_hash_build_state = None;
+    state.active_op_state.clear();
     state.record_rows_read(1);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13147,7 +13168,7 @@ pub fn op_hash_probe(
     let num_payload = *num_payload as usize;
     let probe_rowid_reg = probe_rowid_reg.map(|r| r as usize);
     let (probe_keys, partition_idx, probe_buffered) =
-        if let Some(op_state) = state.op_hash_probe_state.take() {
+        if let Some(op_state) = state.active_op_state.hash_probe().take() {
             if op_state.hash_table_id == hash_table_id {
                 (
                     op_state.probe_keys,
@@ -13175,7 +13196,7 @@ pub fn op_hash_probe(
 
     let Some(hash_table) = state.hash_tables.get_mut(&hash_table_id) else {
         // Empty build side: treat as no match and jump to target.
-        state.op_hash_probe_state = None;
+        state.active_op_state.clear();
         state.pc = target_pc.as_offset_int();
         return Ok(InsnFunctionStepResult::Step);
     };
@@ -13190,6 +13211,7 @@ pub fn op_hash_probe(
         if let Some(rowid_reg) = probe_rowid_reg {
             if probe_buffered {
                 state.pc = target_pc.as_offset_int();
+                state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
             if !hash_table.is_partition_loaded(partition_idx) {
@@ -13205,7 +13227,7 @@ pub fn op_hash_probe(
                 )? {
                     IOResult::Done(()) => {}
                     IOResult::IO(io) => {
-                        state.op_hash_probe_state = Some(OpHashProbeState {
+                        *state.active_op_state.hash_probe() = Some(OpHashProbeState {
                             probe_keys: Vec::new(), // keys consumed
                             hash_table_id,
                             partition_idx,
@@ -13216,6 +13238,7 @@ pub fn op_hash_probe(
                 }
                 // Jump to target_pc: this row is deferred to grace processing.
                 state.pc = target_pc.as_offset_int();
+                state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
             // Partition is in memory: probe immediately (fast path)
@@ -13244,10 +13267,12 @@ pub fn op_hash_probe(
                     payload_dest_reg,
                     num_payload,
                 );
+                state.active_op_state.clear();
                 state.pc += 1;
                 Ok(InsnFunctionStepResult::Step)
             }
             None => {
+                state.active_op_state.clear();
                 state.pc = target_pc.as_offset_int();
                 Ok(InsnFunctionStepResult::Step)
             }
@@ -13263,10 +13288,12 @@ pub fn op_hash_probe(
                     payload_dest_reg,
                     num_payload,
                 );
+                state.active_op_state.clear();
                 state.pc += 1;
                 Ok(InsnFunctionStepResult::Step)
             }
             None => {
+                state.active_op_state.clear();
                 state.pc = target_pc.as_offset_int();
                 Ok(InsnFunctionStepResult::Step)
             }
@@ -13906,13 +13933,13 @@ pub fn op_journal_mode(
         Ok(result) => {
             if !matches!(result, InsnFunctionStepResult::IO(_)) {
                 // Reset state if we are done with this instruction
-                state.op_journal_mode_state = Default::default();
+                state.active_op_state.clear();
             }
             Ok(result)
         }
         Err(err) => {
             // Reset state on error
-            state.op_journal_mode_state = Default::default();
+            state.active_op_state.clear();
             Err(err)
         }
     }
@@ -13931,7 +13958,7 @@ fn op_journal_mode_inner(
     let pager = &pager;
 
     loop {
-        match state.op_journal_mode_state.sub_state {
+        match state.active_op_state.journal_mode().sub_state {
             OpJournalModeSubState::Start => {
                 // Read header to get current mode
                 let mv_store = program.connection.mv_store_for_db(*db);
@@ -13946,7 +13973,7 @@ fn op_journal_mode_inner(
                     .map_err(|val| LimboError::Corrupt(format!("Invalid read_version: {val}")))?;
 
                 let prev_mode = journal_mode::JournalMode::from(prev_mode_version);
-                state.op_journal_mode_state.prev_mode = Some(prev_mode);
+                state.active_op_state.journal_mode().prev_mode = Some(prev_mode);
 
                 // If no new mode specified, just return current mode
                 let Some(mode_str) = new_mode else {
@@ -13988,8 +14015,8 @@ fn op_journal_mode_inner(
                     return Err(LimboError::ReadOnly);
                 }
 
-                state.op_journal_mode_state.new_mode = Some(new_mode);
-                state.op_journal_mode_state.sub_state = OpJournalModeSubState::Checkpoint;
+                state.active_op_state.journal_mode().new_mode = Some(new_mode);
+                state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Checkpoint;
             }
 
             OpJournalModeSubState::Checkpoint => {
@@ -13997,8 +14024,8 @@ fn op_journal_mode_inner(
                 let mv_store = program.connection.mv_store_for_db(*db);
                 if let Some(mv_store) = mv_store.as_ref() {
                     // MVCC checkpoint using state machine
-                    if state.op_journal_mode_state.checkpoint_sm.is_none() {
-                        state.op_journal_mode_state.checkpoint_sm =
+                    if state.active_op_state.journal_mode().checkpoint_sm.is_none() {
+                        state.active_op_state.journal_mode().checkpoint_sm =
                             Some(StateMachine::new(CheckpointStateMachine::new(
                                 pager.clone(),
                                 mv_store.clone(),
@@ -14008,10 +14035,16 @@ fn op_journal_mode_inner(
                             )));
                     }
 
-                    let ckpt_sm = state.op_journal_mode_state.checkpoint_sm.as_mut().unwrap();
+                    let ckpt_sm = state
+                        .active_op_state
+                        .journal_mode()
+                        .checkpoint_sm
+                        .as_mut()
+                        .unwrap();
                     return_if_io!(ckpt_sm.step(&()));
-                    state.op_journal_mode_state.checkpoint_sm = None;
-                    state.op_journal_mode_state.sub_state = OpJournalModeSubState::UpdateHeader;
+                    state.active_op_state.journal_mode().checkpoint_sm = None;
+                    state.active_op_state.journal_mode().sub_state =
+                        OpJournalModeSubState::UpdateHeader;
                 } else {
                     // WAL checkpoint
                     let checkpoint_result = pager.checkpoint(
@@ -14022,13 +14055,15 @@ fn op_journal_mode_inner(
                         false, // Don't clear cache yet, we'll do it in Finalize
                     );
                     return_if_io!(checkpoint_result);
-                    state.op_journal_mode_state.sub_state = OpJournalModeSubState::UpdateHeader;
+                    state.active_op_state.journal_mode().sub_state =
+                        OpJournalModeSubState::UpdateHeader;
                 }
             }
 
             OpJournalModeSubState::UpdateHeader => {
                 let new_mode = state
-                    .op_journal_mode_state
+                    .active_op_state
+                    .journal_mode()
                     .new_mode
                     .expect("new_mode should be set");
                 let new_version = new_mode
@@ -14049,20 +14084,21 @@ fn op_journal_mode_inner(
                 }
 
                 // Save the page reference for writing
-                state.op_journal_mode_state.page_ref = Some(header_ref.page().clone());
+                state.active_op_state.journal_mode().page_ref = Some(header_ref.page().clone());
                 // Skip ReadPage and go directly to WritePage
-                state.op_journal_mode_state.sub_state = OpJournalModeSubState::WritePage;
+                state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::WritePage;
             }
 
             OpJournalModeSubState::WritePage => {
                 // Write page 1 to disk to flush the header
                 let page = state
-                    .op_journal_mode_state
+                    .active_op_state
+                    .journal_mode()
                     .page_ref
                     .as_ref()
                     .expect("page_ref should be set");
                 let completion = begin_write_btree_page(pager, page)?;
-                state.op_journal_mode_state.sub_state = OpJournalModeSubState::Finalize;
+                state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Finalize;
                 return Ok(InsnFunctionStepResult::IO(IOCompletions::Single(
                     completion,
                 )));
@@ -14070,7 +14106,8 @@ fn op_journal_mode_inner(
 
             OpJournalModeSubState::Finalize => {
                 let new_mode = state
-                    .op_journal_mode_state
+                    .active_op_state
+                    .journal_mode()
                     .new_mode
                     .expect("new_mode should be set");
 
@@ -14259,7 +14296,7 @@ pub fn op_vacuum_into(
     match op_vacuum_into_inner(program, state, insn) {
         Ok(InsnFunctionStepResult::Step) => {
             // Instruction complete, reset state
-            state.op_vacuum_into_state = None;
+            state.active_op_state.clear();
             Ok(InsnFunctionStepResult::Step)
         }
         Ok(InsnFunctionStepResult::IO(io)) => {
@@ -14271,7 +14308,7 @@ pub fn op_vacuum_into(
         }
         Err(err) => {
             // Reset state on error
-            state.op_vacuum_into_state = None;
+            state.active_op_state.clear();
             Err(err)
         }
     }
@@ -14292,7 +14329,7 @@ fn op_vacuum_into_inner(
         insn
     );
 
-    if state.op_vacuum_into_state.is_none() {
+    if state.active_op_state.vacuum_into().is_none() {
         let database_id = program.connection.get_database_id_by_name(schema_name)?;
 
         // Matches sqlite that treats VACUUM temp INTO as a no-op (no file created)
@@ -14301,14 +14338,14 @@ fn op_vacuum_into_inner(
             return Ok(InsnFunctionStepResult::Step);
         }
 
-        state.op_vacuum_into_state = Some(OpVacuumIntoState {
+        *state.active_op_state.vacuum_into() = Some(OpVacuumIntoState {
             escaped_schema_name: schema_name.replace('"', "\"\""),
             database_id,
             ..Default::default()
         });
     }
 
-    let vacuum_state = state.op_vacuum_into_state.as_mut().unwrap();
+    let vacuum_state = state.active_op_state.vacuum_into().as_mut().unwrap();
     let escaped_schema_name = &vacuum_state.escaped_schema_name;
     let database_id = vacuum_state.database_id;
 
@@ -14632,7 +14669,7 @@ mod tests {
         );
         assert_eq!(state.pc, 0, "pc should not advance on invariant violation");
         assert!(
-            state.op_hash_probe_state.is_none(),
+            matches!(state.active_op_state.hash_probe(), None),
             "HashProbe should not stash resumable state for the removed fallback path"
         );
     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -50,8 +50,8 @@ use crate::{
         execute::{
             OpColumnState, OpDeleteState, OpDeleteSubState, OpDestroyState, OpIdxInsertState,
             OpInsertState, OpInsertSubState, OpJournalModeState, OpNewRowidState,
-            OpNoConflictState, OpProgramState, OpRowIdState, OpSeekState, OpTransactionState,
-            OpVacuumIntoState,
+            OpNoConflictState, OpParseSchemaState, OpProgramState, OpRowIdState, OpSeekState,
+            OpTransactionState, OpVacuumIntoState,
         },
         hash_table::HashTable,
         metrics::StatementMetrics,
@@ -419,6 +419,153 @@ pub struct OpHashProbeState {
     pub probe_buffered: bool,
 }
 
+enum ActiveOpState {
+    None,
+    Delete(OpDeleteState),
+    Destroy(OpDestroyState),
+    IdxDelete(Option<OpIdxDeleteState>),
+    IntegrityCheck(OpIntegrityCheckState),
+    OpenEphemeral(OpOpenEphemeralState),
+    Program(OpProgramState),
+    NewRowid(OpNewRowidState),
+    IdxInsert(OpIdxInsertState),
+    Insert(OpInsertState),
+    NoConflict(OpNoConflictState),
+    Column(OpColumnState),
+    RowId(OpRowIdState),
+    Transaction(OpTransactionState),
+    JournalMode(OpJournalModeState),
+    VacuumInto(Option<OpVacuumIntoState>),
+    ParseSchema(OpParseSchemaState),
+    HashBuild(Option<OpHashBuildState>),
+    HashProbe(Option<OpHashProbeState>),
+}
+
+#[derive(Default)]
+struct ActiveOpStateSlot {
+    state: ActiveOpState,
+}
+
+macro_rules! active_state_accessor {
+    ($name:ident, $variant:ident, $ty:ty, $init:expr) => {
+        fn $name(&mut self) -> &mut $ty {
+            if matches!(self.state, ActiveOpState::None) {
+                self.state = ActiveOpState::$variant($init);
+            }
+            match &mut self.state {
+                ActiveOpState::$variant(state) => state,
+                _ => unreachable!(
+                    "active opcode state mismatch: expected {}",
+                    stringify!($variant)
+                ),
+            }
+        }
+    };
+}
+
+impl Default for ActiveOpState {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl ActiveOpStateSlot {
+    fn clear(&mut self) {
+        self.state = ActiveOpState::None;
+    }
+
+    active_state_accessor!(
+        delete,
+        Delete,
+        OpDeleteState,
+        OpDeleteState {
+            sub_state: OpDeleteSubState::MaybeCaptureRecord,
+            deleted_record: None,
+        }
+    );
+    active_state_accessor!(
+        destroy,
+        Destroy,
+        OpDestroyState,
+        OpDestroyState::CreateCursor
+    );
+    active_state_accessor!(idx_delete, IdxDelete, Option<OpIdxDeleteState>, None);
+    active_state_accessor!(
+        integrity_check,
+        IntegrityCheck,
+        OpIntegrityCheckState,
+        OpIntegrityCheckState::Start
+    );
+    active_state_accessor!(
+        open_ephemeral,
+        OpenEphemeral,
+        OpOpenEphemeralState,
+        OpOpenEphemeralState::Start
+    );
+    active_state_accessor!(program, Program, OpProgramState, OpProgramState::Start);
+    active_state_accessor!(new_rowid, NewRowid, OpNewRowidState, OpNewRowidState::Start);
+    active_state_accessor!(
+        idx_insert,
+        IdxInsert,
+        OpIdxInsertState,
+        OpIdxInsertState::MaybeSeek
+    );
+    active_state_accessor!(
+        insert,
+        Insert,
+        OpInsertState,
+        OpInsertState {
+            sub_state: OpInsertSubState::MaybeCaptureRecord,
+            old_record: None,
+            is_noop_update: false,
+        }
+    );
+    active_state_accessor!(
+        no_conflict,
+        NoConflict,
+        OpNoConflictState,
+        OpNoConflictState::Start
+    );
+    active_state_accessor!(column, Column, OpColumnState, OpColumnState::Start);
+    active_state_accessor!(row_id, RowId, OpRowIdState, OpRowIdState::Start);
+    active_state_accessor!(
+        transaction,
+        Transaction,
+        OpTransactionState,
+        OpTransactionState::Start
+    );
+    active_state_accessor!(
+        journal_mode,
+        JournalMode,
+        OpJournalModeState,
+        OpJournalModeState::default()
+    );
+    active_state_accessor!(vacuum_into, VacuumInto, Option<OpVacuumIntoState>, None);
+    active_state_accessor!(parse_schema, ParseSchema, OpParseSchemaState, None);
+    active_state_accessor!(hash_build, HashBuild, Option<OpHashBuildState>, None);
+    active_state_accessor!(hash_probe, HashProbe, Option<OpHashProbeState>, None);
+
+    fn program_ref(&self) -> Option<&OpProgramState> {
+        match &self.state {
+            ActiveOpState::Program(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    fn program_mut(&mut self) -> Option<&mut OpProgramState> {
+        match &mut self.state {
+            ActiveOpState::Program(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    fn reset_vacuum_into(&mut self) {
+        if matches!(self.state, ActiveOpState::VacuumInto(_)) {
+            self.clear();
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct DeferredSeekState {
     pub index_cursor_id: CursorID,
@@ -448,26 +595,12 @@ pub struct ProgramState {
     commit_state: CommitState,
     #[cfg(feature = "json")]
     json_cache: JsonCacheCell,
-    op_delete_state: OpDeleteState,
-    op_destroy_state: OpDestroyState,
-    op_idx_delete_state: Option<OpIdxDeleteState>,
-    op_integrity_check_state: OpIntegrityCheckState,
+    active_op_state: ActiveOpStateSlot,
+    seek_state: OpSeekState,
     /// Metrics collected for the lifetime of this prepared statement.
     pub metrics: StatementMetrics,
-    op_open_ephemeral_state: OpOpenEphemeralState,
-    op_program_state: OpProgramState,
-    op_new_rowid_state: OpNewRowidState,
-    op_idx_insert_state: OpIdxInsertState,
-    op_insert_state: OpInsertState,
-    op_no_conflict_state: OpNoConflictState,
-    seek_state: OpSeekState,
     /// Current collation sequence set by OP_CollSeq instruction
     current_collation: Option<CollationSeq>,
-    op_column_state: OpColumnState,
-    op_row_id_state: OpRowIdState,
-    op_transaction_state: OpTransactionState,
-    op_journal_mode_state: OpJournalModeState,
-    op_vacuum_into_state: Option<OpVacuumIntoState>,
     /// State machine for committing view deltas with I/O handling
     view_delta_state: ViewDeltaCommitState,
     /// Marker which tells about auto transaction cleanup necessary for that connection in case of reset
@@ -493,7 +626,6 @@ pub struct ProgramState {
     /// capture_data_changes has type Option<CaptureDataChangesInfo> (off mode is None)
     /// so, for pending_cdc_info we wrap it in one more Option<...> layer to represent if mode changed during program execution
     pub(crate) pending_cdc_info: Option<Option<CaptureDataChangesInfo>>,
-    pub(crate) op_parse_schema_state: execute::OpParseSchemaState,
     /// Cached subprogram Statements keyed by the PC of the Program instruction.
     /// Avoids re-allocating ProgramState on each trigger/FK-action fire.
     pub(crate) subprogram_stmt_cache: HashMap<usize, Box<Statement>>,
@@ -502,8 +634,6 @@ pub struct ProgramState {
     /// Bloom filters stored by cursor ID for probabilistic set membership testing
     /// Used to avoid unnecessary seeks on ephemeral indexes and hash tables
     pub(crate) bloom_filters: HashMap<usize, BloomFilter>,
-    op_hash_build_state: Option<OpHashBuildState>,
-    op_hash_probe_state: Option<OpHashProbeState>,
     /// Number of deferred foreign key violations when the statement started.
     /// When a statement subtransaction rolls back, the connection's deferred foreign key violations counter
     /// is reset to this value.
@@ -556,34 +686,11 @@ impl ProgramState {
             commit_state: CommitState::Ready,
             #[cfg(feature = "json")]
             json_cache: JsonCacheCell::new(),
-            op_delete_state: OpDeleteState {
-                sub_state: OpDeleteSubState::MaybeCaptureRecord,
-                deleted_record: None,
-            },
-            op_destroy_state: OpDestroyState::CreateCursor,
-            op_idx_delete_state: None,
-            op_integrity_check_state: OpIntegrityCheckState::Start,
-            metrics: StatementMetrics::new(),
-            op_open_ephemeral_state: OpOpenEphemeralState::Start,
-            op_program_state: OpProgramState::Start,
-            op_new_rowid_state: OpNewRowidState::Start,
-            op_idx_insert_state: OpIdxInsertState::MaybeSeek,
-            op_insert_state: OpInsertState {
-                sub_state: OpInsertSubState::MaybeCaptureRecord,
-                old_record: None,
-                is_noop_update: false,
-            },
-            op_no_conflict_state: OpNoConflictState::Start,
-            op_hash_build_state: None,
-            op_hash_probe_state: None,
-            distinct_key_values: Vec::new(),
+            active_op_state: ActiveOpStateSlot::default(),
             seek_state: OpSeekState::Start,
+            metrics: StatementMetrics::new(),
+            distinct_key_values: Vec::new(),
             current_collation: None,
-            op_column_state: OpColumnState::Start,
-            op_row_id_state: OpRowIdState::Start,
-            op_transaction_state: OpTransactionState::Start,
-            op_journal_mode_state: OpJournalModeState::default(),
-            op_vacuum_into_state: None,
             view_delta_state: ViewDeltaCommitState::NotStarted,
             auto_txn_cleanup: TxnCleanup::None,
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),
@@ -600,7 +707,6 @@ impl ProgramState {
             explain_state: RwLock::new(ExplainState::default()),
             pending_fail_error: None,
             pending_cdc_info: None,
-            op_parse_schema_state: None,
             subprogram_stmt_cache: HashMap::default(),
         }
     }
@@ -696,31 +802,10 @@ impl ProgramState {
         self.json_cache.clear();
 
         // Reset state machines
-        self.op_delete_state = OpDeleteState {
-            sub_state: OpDeleteSubState::MaybeCaptureRecord,
-            deleted_record: None,
-        };
-        self.op_idx_delete_state = None;
-        self.op_integrity_check_state = OpIntegrityCheckState::Start;
-        self.op_open_ephemeral_state = OpOpenEphemeralState::Start;
-        self.op_new_rowid_state = OpNewRowidState::Start;
-        self.op_idx_insert_state = OpIdxInsertState::MaybeSeek;
-        self.op_insert_state = OpInsertState {
-            sub_state: OpInsertSubState::MaybeCaptureRecord,
-            old_record: None,
-            is_noop_update: false,
-        };
-        self.op_no_conflict_state = OpNoConflictState::Start;
+        self.active_op_state.clear();
         self.seek_state = OpSeekState::Start;
         self.current_collation = None;
-        self.op_column_state = OpColumnState::Start;
-        self.op_row_id_state = OpRowIdState::Start;
         self.commit_state = CommitState::Ready;
-        self.op_destroy_state = OpDestroyState::CreateCursor;
-        self.op_program_state = OpProgramState::Start;
-        self.op_transaction_state = OpTransactionState::Start;
-        self.op_journal_mode_state = OpJournalModeState::default();
-        self.op_vacuum_into_state = None;
         self.view_delta_state = ViewDeltaCommitState::NotStarted;
         self.auto_txn_cleanup = TxnCleanup::None;
         self.fk_immediate_violations_during_stmt
@@ -731,8 +816,6 @@ impl ProgramState {
         self.bloom_filters.clear();
         self.hash_tables.clear();
         self.ephemeral_temp_files.clear();
-        self.op_hash_build_state = None;
-        self.op_hash_probe_state = None;
         self.uses_subjournal = false;
         self.is_active_write = false;
         self.has_stmt_transaction = false;
@@ -757,7 +840,7 @@ impl ProgramState {
 
     pub(crate) fn metrics(&self) -> StatementMetrics {
         let mut metrics = self.metrics.clone();
-        if let OpProgramState::Step { statement, .. } = &self.op_program_state {
+        if let Some(OpProgramState::Step { statement, .. }) = self.active_op_state.program_ref() {
             metrics.merge(&statement.metrics());
         }
         for statement in self.subprogram_stmt_cache.values() {
@@ -768,7 +851,7 @@ impl ProgramState {
 
     pub(crate) fn reset_metrics(&mut self) {
         self.metrics.reset();
-        if let OpProgramState::Step { statement, .. } = &mut self.op_program_state {
+        if let Some(OpProgramState::Step { statement, .. }) = self.active_op_state.program_mut() {
             statement.reset_metrics();
         }
         for statement in self.subprogram_stmt_cache.values_mut() {
@@ -787,7 +870,7 @@ impl ProgramState {
             crate::statement::StatementStatusCounter::RowsRead => self.metrics.rows_read = 0,
             crate::statement::StatementStatusCounter::RowsWritten => self.metrics.rows_written = 0,
         }
-        if let OpProgramState::Step { statement, .. } = &mut self.op_program_state {
+        if let Some(OpProgramState::Step { statement, .. }) = self.active_op_state.program_mut() {
             statement.reset_stmt_status(counter);
         }
         for statement in self.subprogram_stmt_cache.values_mut() {
@@ -2073,7 +2156,7 @@ impl Program {
         // VACUUM INTO state can own internal helper statements whose drop path
         // releases nested guards. Drop them before checking whether this program
         // is itself nested; otherwise abort could skip top-level cleanup.
-        state.op_vacuum_into_state = None;
+        state.active_op_state.reset_vacuum_into();
 
         // Only end trigger execution if the subprogram was actually running.
         // Cached (pooled) statements may be dropped after their trigger execution
@@ -2605,6 +2688,56 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
         }
 
         Some(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    #[test]
+    fn active_opcode_helpers_initialize_defaults() {
+        let mut state = ProgramState::new(1, 0);
+
+        assert!(matches!(state.active_op_state.state, ActiveOpState::None));
+        assert!(matches!(
+            state.active_op_state.column(),
+            OpColumnState::Start
+        ));
+        state.active_op_state.clear();
+        assert!(state.active_op_state.vacuum_into().is_none());
+        state.active_op_state.clear();
+        assert!(state.active_op_state.parse_schema().is_none());
+    }
+
+    #[test]
+    fn active_opcode_helpers_reject_mismatched_resumes() {
+        let mut state = ProgramState::new(1, 0);
+        *state.active_op_state.column() = OpColumnState::GetColumn;
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = state.active_op_state.vacuum_into();
+        }));
+        assert!(panic.is_err(), "mismatched opcode resume should panic");
+    }
+
+    #[test]
+    fn seek_state_is_independent_from_active_opcode_slot() {
+        let mut state = ProgramState::new(1, 0);
+
+        *state.active_op_state.insert() = OpInsertState {
+            sub_state: OpInsertSubState::Seek,
+            old_record: None,
+            is_noop_update: false,
+        };
+        state.seek_state = OpSeekState::MoveLast;
+
+        assert!(matches!(
+            state.active_op_state.insert().sub_state,
+            OpInsertSubState::Seek
+        ));
+        assert!(matches!(state.seek_state, OpSeekState::MoveLast));
     }
 }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -219,11 +219,11 @@ enum CommitState {
     /// Committing attached database pagers after main pager commit is done.
     CommittingAttached,
     CommittingMvcc {
-        state_machine: StateMachine<CommitStateMachine<MvccClock>>,
+        state_machine: StateMachine<Box<CommitStateMachine<MvccClock>>>,
     },
     /// Committing MVCC transactions on attached databases after main MVCC commit is done.
     CommittingAttachedMvcc {
-        state_machine: StateMachine<CommitStateMachine<MvccClock>>,
+        state_machine: StateMachine<Box<CommitStateMachine<MvccClock>>>,
         db_id: usize,
         mv_store: Arc<MvStore>,
     },
@@ -2125,7 +2125,7 @@ impl Program {
     #[instrument(skip(self, commit_state, mv_store), level = Level::DEBUG)]
     fn step_end_mvcc_txn(
         &self,
-        commit_state: &mut StateMachine<CommitStateMachine<MvccClock>>,
+        commit_state: &mut StateMachine<Box<CommitStateMachine<MvccClock>>>,
         mv_store: &Arc<MvStore>,
     ) -> Result<IOResult<()>> {
         commit_state.step(mv_store)


### PR DESCRIPTION
## Description
Only 1 INSN can be active at any given time. But we always had all of the state machines allocated on the stack, even when not in use. 

Also Boxes `CommitStateMachine<MvccClock>` overall reducing the size of `ProgramState` in half

## Motivation and context
Reduce stack usage


## Description of AI Usage
Codex did it. I reviewed it.
