### PR TITLE
bindings/python: Add SQLAlchemy asyncio dialect

### DIFF
--- a/bindings/python/SQLALCHEMY_DIALECT.md
+++ b/bindings/python/SQLALCHEMY_DIALECT.md
@@ -4,8 +4,9 @@ This document describes the SQLAlchemy dialect implementation for pyturso.
 
 ## Status: Implemented
 
-The SQLAlchemy dialect is fully implemented with two dialects:
+The SQLAlchemy dialect is fully implemented with three dialects:
 - `sqlite+turso://` - Basic local database connections
+- `sqlite+aioturso://` - Basic local database connections for SQLAlchemy async engines
 - `sqlite+turso_sync://` - Sync-enabled connections with remote database support
 
 ## Installation
@@ -71,6 +72,25 @@ with engine.connect() as conn:
     sync.push()  # Push changes to remote
 ```
 
+### Async Local Connection
+
+```python
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+async with engine.begin() as conn:
+    await conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)"))
+    await conn.execute(text("INSERT INTO users (name) VALUES ('Alice')"))
+
+async with AsyncSession(engine) as session:
+    result = await session.execute(text("SELECT name FROM users ORDER BY id"))
+    print(result.scalars().all())
+
+await engine.dispose()
+```
+
 ### ORM Usage
 
 ```python
@@ -102,6 +122,18 @@ with Session(engine) as session:
 sqlite+turso:///path/to/database.db
 sqlite+turso:///:memory:
 sqlite+turso:///db.db?isolation_level=IMMEDIATE
+```
+
+Query parameters:
+- `isolation_level` - Transaction isolation level (DEFERRED, IMMEDIATE, EXCLUSIVE, AUTOCOMMIT)
+- `experimental_features` - Comma-separated feature flags
+
+### Async Local Dialect (`sqlite+aioturso://`)
+
+```
+sqlite+aioturso:///path/to/database.db
+sqlite+aioturso:///:memory:
+sqlite+aioturso:///db.db?isolation_level=IMMEDIATE
 ```
 
 Query parameters:
@@ -168,13 +200,18 @@ _TursoDialectMixin (reflection overrides)
         │       ├── uses turso.connect()
         │       └── pool: SingletonThreadPool (:memory:) / QueuePool (file)
         │
+        ├── AioTursoDialect (sqlite+aioturso://)
+        │       ├── uses turso.aio.connect()
+        │       ├── adapts turso.aio to SQLAlchemy's DBAPI-shaped async contract
+        │       └── pool: StaticPool (:memory:) / AsyncAdaptedQueuePool (file)
+        │
         └── TursoSyncDialect (sqlite+turso_sync://)
                 ├── uses turso.sync.connect()
                 ├── pool: SingletonThreadPool (:memory:) / QueuePool (file)
                 └── get_sync_connection() → ConnectionSync (pull/push/checkpoint/stats)
 ```
 
-Both dialects use Python MRO: `_TursoDialectMixin` provides PRAGMA-related overrides, `SQLiteDialect_pysqlite` provides core SQLite dialect behavior.
+The sync dialects use Python MRO: `_TursoDialectMixin` provides PRAGMA-related overrides, `SQLiteDialect_pysqlite` provides core SQLite dialect behavior. The async dialect uses `SQLiteDialect_aiosqlite` with the same Turso-specific mixin and an adapter that maps `turso.aio` into SQLAlchemy's async DBAPI wrapper.
 
 ## What Pyturso Provides
 
@@ -192,9 +229,11 @@ Both dialects use Python MRO: `_TursoDialectMixin` provides PRAGMA-related overr
 
 Both `turso` and `turso.sync` modules expose the full DB-API 2.0 interface including exception hierarchy (`Warning`, `Error`, `InterfaceError`, `DatabaseError`, `DataError`, `OperationalError`, `IntegrityError`, `InternalError`, `ProgrammingError`, `NotSupportedError`).
 
+`turso.aio` exposes coroutine connection and cursor APIs, but it does not expose the DB-API module metadata and exception hierarchy directly. `sqlite+aioturso://` uses an internal adapter to mirror those DB-API module attributes from `turso` and to provide SQLite constants such as `PARSE_DECLTYPES`, `PARSE_COLNAMES`, and `Binary`.
+
 ## Dialect Overrides
 
-Both dialects share these overrides via `_TursoDialectMixin` and direct method implementations:
+All dialects share these overrides via `_TursoDialectMixin` and direct method implementations:
 
 ### Class Attributes
 
@@ -203,12 +242,12 @@ Both dialects share these overrides via `_TursoDialectMixin` and direct method i
 
 ### Method Overrides
 
-- `import_dbapi()` - Returns `turso` or `turso.sync` module
+- `import_dbapi()` - Returns `turso`, `turso.sync`, or the async adapter for `turso.aio`
 - `create_connect_args()` - Parses URL to connection arguments
 - `on_connect()` - Returns `None` (skips REGEXP function setup that pysqlite does, since turso doesn't support `create_function`)
 - `get_isolation_level()` - Returns `SERIALIZABLE` (turso doesn't support `PRAGMA read_uncommitted`)
 - `set_isolation_level()` - No-op (isolation set at connection time via `isolation_level` param)
-- `get_pool_class()` - Returns `SingletonThreadPool` for `:memory:`, `QueuePool` for file databases
+- `get_pool_class()` - Returns `SingletonThreadPool` for sync `:memory:`, `QueuePool` for sync file databases, `StaticPool` for async `:memory:`, and `AsyncAdaptedQueuePool` for async file databases
 
 ### Reflection Overrides (via `_TursoDialectMixin`)
 
@@ -249,6 +288,10 @@ This doesn't affect normal usage including:
 
 `supports_native_datetime` is set to `False`. Datetime columns should use `String` type and store ISO format strings. SQLAlchemy's `DateTime` type will still work but values are stored/retrieved as strings.
 
+### Async Scope
+
+`sqlite+aioturso://` supports local databases through `turso.aio`. Remote sync for SQLAlchemy async engines is not implemented by this dialect; use `sqlite+turso_sync://` with synchronous SQLAlchemy engines for remote sync operations.
+
 ## Entry Points
 
 Dialects are registered via `pyproject.toml` entry points:
@@ -256,14 +299,16 @@ Dialects are registered via `pyproject.toml` entry points:
 ```toml
 [project.entry-points."sqlalchemy.dialects"]
 "sqlite.turso" = "turso.sqlalchemy:TursoDialect"
+"sqlite.aioturso" = "turso.sqlalchemy:AioTursoDialect"
 "sqlite.turso_sync" = "turso.sqlalchemy:TursoSyncDialect"
 ```
 
 ## Files
 
-- `turso/sqlalchemy/__init__.py` - Module exports (`TursoDialect`, `TursoSyncDialect`, `get_sync_connection`)
-- `turso/sqlalchemy/dialect.py` - Dialect implementations and `_TursoDialectMixin`
-- `tests/test_sqlalchemy.py` - Tests (28 tests across 8 test classes)
+- `turso/sqlalchemy/__init__.py` - Module exports (`TursoDialect`, `AioTursoDialect`, `TursoSyncDialect`, `get_sync_connection`)
+- `turso/sqlalchemy/dialect.py` - Dialect implementations, async DBAPI adapter, and `_TursoDialectMixin`
+- `tests/test_sqlalchemy.py` - Sync SQLAlchemy dialect tests
+- `tests/test_sqlalchemy_async.py` - Async SQLAlchemy dialect tests
 
 ## References
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -48,6 +48,7 @@ Source = "https://github.com/tursodatabase/turso"
 
 [project.entry-points."sqlalchemy.dialects"]
 "sqlite.turso" = "turso.sqlalchemy:TursoDialect"
+"sqlite.aioturso" = "turso.sqlalchemy:AioTursoDialect"
 "sqlite.turso_sync" = "turso.sqlalchemy:TursoSyncDialect"
 
 [tool.maturin]

--- a/bindings/python/tests/test_sqlalchemy_async.py
+++ b/bindings/python/tests/test_sqlalchemy_async.py
@@ -1,0 +1,277 @@
+"""Tests for the async SQLAlchemy dialect."""
+
+import pytest
+
+# Skip all tests if SQLAlchemy is not installed
+sqlalchemy = pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import text  # noqa: E402
+from sqlalchemy.engine import URL  # noqa: E402
+from sqlalchemy.exc import DatabaseError as SADatabaseError  # noqa: E402
+from sqlalchemy.exc import IntegrityError as SAIntegrityError  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine  # noqa: E402
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column  # noqa: E402
+from turso.sqlalchemy import AioTursoDialect  # noqa: E402
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users_async"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+
+
+def test_import_dbapi():
+    """The async dialect exposes a DBAPI-shaped adapter for SQLAlchemy."""
+    dbapi = AioTursoDialect.import_dbapi()
+    assert hasattr(dbapi, "connect")
+    assert dbapi.apilevel == "2.0"
+    assert dbapi.paramstyle == "qmark"
+
+
+def test_dialect_attributes():
+    """The async dialect uses the sqlite+aioturso driver name."""
+    assert AioTursoDialect.name == "sqlite"
+    assert AioTursoDialect.driver == "aioturso"
+
+
+def test_memory_database_url_parsing():
+    """In-memory async URLs map to a single database argument."""
+    dialect = AioTursoDialect()
+    url = URL.create("sqlite+aioturso", database=":memory:")
+
+    args, kwargs = dialect.create_connect_args(url)
+
+    assert args == [":memory:"]
+    assert kwargs == {}
+
+
+def test_file_database_url_parsing():
+    """File async URLs map to the file path database argument."""
+    dialect = AioTursoDialect()
+    url = URL.create("sqlite+aioturso", database="/path/to/db.db")
+
+    args, kwargs = dialect.create_connect_args(url)
+
+    assert args == ["/path/to/db.db"]
+    assert kwargs == {}
+
+
+def test_isolation_level_param():
+    """The async dialect accepts isolation_level query parameters."""
+    dialect = AioTursoDialect()
+    url = URL.create(
+        "sqlite+aioturso",
+        database="test.db",
+        query={"isolation_level": "IMMEDIATE"},
+    )
+
+    args, kwargs = dialect.create_connect_args(url)
+
+    assert args == ["test.db"]
+    assert kwargs["isolation_level"] == "IMMEDIATE"
+
+
+def test_autocommit_isolation_level():
+    """AUTOCOMMIT isolation maps to None, matching the sync local dialect."""
+    dialect = AioTursoDialect()
+    url = URL.create(
+        "sqlite+aioturso",
+        database="test.db",
+        query={"isolation_level": "AUTOCOMMIT"},
+    )
+
+    _, kwargs = dialect.create_connect_args(url)
+
+    assert kwargs["isolation_level"] is None
+
+
+def test_memory_uses_static_pool():
+    """Async :memory: databases use StaticPool."""
+    from sqlalchemy import pool
+
+    dialect = AioTursoDialect()
+    url = URL.create("sqlite+aioturso", database=":memory:")
+
+    pool_class = dialect.get_pool_class(url)
+
+    assert pool_class is pool.StaticPool
+
+
+def test_file_uses_async_adapted_queue_pool():
+    """Async file databases use AsyncAdaptedQueuePool."""
+    from sqlalchemy import pool
+
+    dialect = AioTursoDialect()
+    url = URL.create("sqlite+aioturso", database="test.db")
+
+    pool_class = dialect.get_pool_class(url)
+
+    assert pool_class is pool.AsyncAdaptedQueuePool
+
+
+def test_local_async_url_is_registered():
+    """The async local dialect should resolve through the entry point."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+    assert engine.dialect.driver == "aioturso"
+    assert engine.dialect.is_async is True
+
+
+@pytest.mark.asyncio
+async def test_local_async_core_crud():
+    """Core async CRUD works for local Turso."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)"))
+        await conn.execute(text("INSERT INTO items (name) VALUES ('alice')"))
+
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT name FROM items"))
+        assert result.scalar() == "alice"
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_local_async_orm():
+    """AsyncSession ORM flow works for local Turso."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with AsyncSession(engine) as session:
+        session.add(User(name="bob"))
+        await session.commit()
+
+    async with AsyncSession(engine) as session:
+        rows = (await session.execute(text("SELECT name FROM users_async ORDER BY id"))).scalars().all()
+        assert rows == ["bob"]
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_transaction_commit_rollback():
+    """Explicit commit and rollback work through the async dialect."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+    async with engine.connect() as conn:
+        await conn.execute(text("CREATE TABLE txn_test (id INTEGER, val TEXT)"))
+        await conn.commit()
+
+        await conn.execute(text("INSERT INTO txn_test VALUES (1, 'should_vanish')"))
+        await conn.rollback()
+
+        result = await conn.execute(text("SELECT COUNT(*) FROM txn_test"))
+        assert result.scalar() == 0
+
+        await conn.execute(text("INSERT INTO txn_test VALUES (2, 'should_stay')"))
+        await conn.commit()
+
+        result = await conn.execute(text("SELECT val FROM txn_test WHERE id = 2"))
+        assert result.scalar() == "should_stay"
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_null_handling():
+    """NULL values round-trip correctly through the async dialect."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE nullable (id INTEGER, val TEXT)"))
+        await conn.execute(text("INSERT INTO nullable VALUES (1, NULL)"))
+
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT val FROM nullable WHERE id = 1"))
+        assert result.scalar() is None
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unicode_data():
+    """Unicode strings round-trip correctly through the async dialect."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE uni (id INTEGER, val TEXT)"))
+        await conn.execute(text("INSERT INTO uni VALUES (1, '日本語テスト')"))
+        await conn.execute(text("INSERT INTO uni VALUES (2, '🚀🎉')"))
+
+    async with engine.connect() as conn:
+        rows = (await conn.execute(text("SELECT val FROM uni ORDER BY id"))).fetchall()
+        assert rows[0][0] == "日本語テスト"
+        assert rows[1][0] == "🚀🎉"
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sql_syntax_error():
+    """SQL errors propagate through SQLAlchemy's async error wrappers."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+    async with engine.connect() as conn:
+        with pytest.raises(SADatabaseError):
+            await conn.execute(text("SELEKT * FORM nonexistent"))
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_integrity_error_propagation():
+    """Unique constraint violations raise SQLAlchemy IntegrityError."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE uniq (id INTEGER PRIMARY KEY, email TEXT UNIQUE)"))
+        await conn.execute(text("INSERT INTO uniq VALUES (1, 'a@b.com')"))
+
+    async with engine.connect() as conn:
+        with pytest.raises(SAIntegrityError):
+            await conn.execute(text("INSERT INTO uniq VALUES (2, 'a@b.com')"))
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_multiple_connections_same_engine():
+    """Async engine handles multiple sequential connections."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE multi (id INTEGER)"))
+        await conn.execute(text("INSERT INTO multi VALUES (1)"))
+
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT * FROM multi"))
+        assert result.fetchall() == [(1,)]
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_large_text_data():
+    """Large text values round-trip correctly through the async dialect."""
+    engine = create_async_engine("sqlite+aioturso:///:memory:")
+    large = "x" * 100_000
+
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE TABLE big (id INTEGER, content TEXT)"))
+        await conn.execute(
+            text("INSERT INTO big VALUES (1, :content)"),
+            {"content": large},
+        )
+
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT content FROM big WHERE id = 1"))
+        assert result.scalar() == large
+
+    await engine.dispose()

--- a/bindings/python/turso/sqlalchemy/__init__.py
+++ b/bindings/python/turso/sqlalchemy/__init__.py
@@ -2,6 +2,7 @@
 
 This module provides SQLAlchemy integration for pyturso:
 - TursoDialect: Basic local database connections (sqlite+turso://)
+- AioTursoDialect: Basic local database connections for async engines (sqlite+aioturso://)
 - TursoSyncDialect: Sync-enabled connections with remote support (sqlite+turso_sync://)
 - get_sync_connection: Helper to access sync methods from SQLAlchemy connections
 
@@ -29,9 +30,10 @@ Usage:
         sync.push()  # Push local changes
 """
 
-from .dialect import TursoDialect, TursoSyncDialect, get_sync_connection
+from .dialect import AioTursoDialect, TursoDialect, TursoSyncDialect, get_sync_connection
 
 __all__ = [
+    "AioTursoDialect",
     "TursoDialect",
     "TursoSyncDialect",
     "get_sync_connection",

--- a/bindings/python/turso/sqlalchemy/dialect.py
+++ b/bindings/python/turso/sqlalchemy/dialect.py
@@ -1,7 +1,8 @@
 """SQLAlchemy dialects for pyturso.
 
-This module provides two SQLAlchemy dialects:
+This module provides SQLAlchemy dialects:
 - TursoDialect: Basic local database connections (sqlite+turso://)
+- AioTursoDialect: Basic local asyncio connections (sqlite+aioturso://)
 - TursoSyncDialect: Sync-enabled connections with remote support (sqlite+turso_sync://)
 """
 
@@ -11,9 +12,15 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from sqlalchemy import pool
+from sqlalchemy.connectors.asyncio import (
+    AsyncAdapt_dbapi_connection,
+    AsyncAdapt_dbapi_module,
+)
+from sqlalchemy.dialects.sqlite.aiosqlite import SQLiteDialect_aiosqlite
 from sqlalchemy.dialects.sqlite.pysqlite import SQLiteDialect_pysqlite
 from sqlalchemy.engine import URL
 from sqlalchemy.engine.reflection import ObjectKind
+from sqlalchemy.util.concurrency import await_only
 
 if TYPE_CHECKING:
     from sqlalchemy.engine.interfaces import ConnectArgsType, ReflectedForeignKeyConstraint, ReflectedIndex
@@ -290,6 +297,177 @@ class TursoDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):
         if url.database == ":memory:":
             return pool.SingletonThreadPool
         return pool.QueuePool
+
+
+class AsyncAdapt_turso_dbapi(AsyncAdapt_dbapi_module):
+    """Bridge turso.aio (coroutine API) to SQLAlchemy's DBAPI-shaped async adapter contract.
+
+    SQLAlchemy's async engine still drives execution through DBAPI-style
+    connection/cursor semantics internally. turso.aio exposes awaitable
+    operations, so we provide this adapter layer to map turso.aio connections
+    into SQLAlchemy's AsyncAdapt_dbapi_connection while exposing DBAPI module
+    attributes/exceptions (paramstyle, Error hierarchy, sqlite version info).
+    """
+
+    def __init__(self, turso_aio_module, turso_module):
+        # Match SQLAlchemy 2.0.x adapter style (same approach as aiosqlite).
+        self.turso_aio = turso_aio_module
+        self.turso = turso_module
+        self.paramstyle = "qmark"
+        self._init_dbapi_attributes()
+
+    def _init_dbapi_attributes(self) -> None:
+        """Populate DBAPI-shaped module attributes expected by SQLAlchemy.
+
+        turso.aio focuses on coroutine connection APIs and does not expose the
+        full DBAPI module surface directly. We mirror DBAPI exceptions/metadata
+        from turso (sync module) here so SQLAlchemy sees the expected interface.
+
+        Current support shape:
+        - turso.aio exposes async connection/cursor APIs (e.g. connect()).
+        - turso.aio does not expose DBAPI module attributes/exceptions like
+          apilevel/paramstyle/sqlite_version/Error hierarchy.
+        - turso (sync module) exposes that DBAPI metadata and exceptions.
+        """
+        for name in (
+            "Error",
+            "InterfaceError",
+            "DatabaseError",
+            "DataError",
+            "OperationalError",
+            "IntegrityError",
+            "InternalError",
+            "ProgrammingError",
+            "Warning",
+            "NotSupportedError",
+            "apilevel",
+            "threadsafety",
+            "sqlite_version",
+            "sqlite_version_info",
+        ):
+            setattr(self, name, getattr(self.turso, name))
+
+        # Preserve sqlite constants/types expected by SQLite dialect helpers.
+        import sqlite3
+
+        for name in ("PARSE_COLNAMES", "PARSE_DECLTYPES", "Binary"):
+            setattr(self, name, getattr(sqlite3, name))
+
+    def connect(self, *arg: Any, **kw: Any) -> AsyncAdapt_dbapi_connection:
+        creator_fn = kw.pop("async_creator_fn", None)
+
+        if creator_fn:
+            connection = creator_fn(*arg, **kw)
+        else:
+            connection = self.turso_aio.connect(*arg, **kw)
+
+        return AsyncAdapt_dbapi_connection(self, await_only(connection))
+
+
+class AioTursoDialect(_TursoDialectMixin, SQLiteDialect_aiosqlite):
+    """
+    SQLAlchemy asyncio dialect for pyturso local database connections.
+
+    Naming:
+        SQLAlchemy URLs use dialect+driver://. The driver is named
+        "aioturso" to mirror SQLAlchemy's built-in "sqlite+aiosqlite://"
+        naming. The "aio" prefix identifies the asyncio driver; "turso_sync"
+        remains reserved for Turso remote sync support.
+
+    Async model:
+        Like aiosqlite, turso.aio exposes an asyncio interface by running the
+        underlying blocking local connection on a worker thread. This integrates
+        with event loops and avoids blocking application code, but it is not
+        engine-level async I/O and should not be treated as a query performance
+        optimization.
+
+    References:
+        SQLAlchemy aiosqlite dialect:
+        https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/dialects/sqlite/aiosqlite.py
+        aioturso worker-thread implementation:
+        turso/lib_aio.py and turso/worker.py.
+
+    Usage:
+        from sqlalchemy.ext.asyncio import create_async_engine
+        engine = create_async_engine("sqlite+aioturso:///:memory:")
+    """
+
+    name = "sqlite"
+    driver = "aioturso"
+
+    # Enable statement caching for better performance
+    supports_statement_cache = True
+    # Disable native_datetime since turso handles datetime differently
+    supports_native_datetime = False
+
+    @classmethod
+    def import_dbapi(cls):
+        """Import turso.aio as async DBAPI with SQLAlchemy adapter."""
+        import turso
+        import turso.aio
+
+        return AsyncAdapt_turso_dbapi(turso.aio, turso)
+
+    def on_connect(self):
+        """Skip pysqlite REGEXP function setup (unsupported by turso)."""
+        return None
+
+    def get_isolation_level(self, dbapi_connection):
+        """Turso does not use PRAGMA read_uncommitted; always SERIALIZABLE."""
+        return "SERIALIZABLE"
+
+    def set_isolation_level(self, dbapi_connection, level):
+        """No-op: isolation level is set at connect time."""
+        pass
+
+    def create_connect_args(self, url: URL) -> ConnectArgsType:
+        """
+        Create connection arguments from SQLAlchemy URL.
+
+        The URL format is:
+            sqlite+aioturso:///path/to/database.db
+
+        Query parameters supported:
+            - isolation_level: Transaction isolation level
+            - experimental_features: Comma-separated feature flags
+        """
+        opts = url.translate_connect_args()
+
+        # 'database' key becomes the positional argument
+        database = opts.pop("database", ":memory:")
+
+        # Remove unsupported URL components
+        opts.pop("username", None)
+        opts.pop("password", None)
+        opts.pop("host", None)
+        opts.pop("port", None)
+
+        # Extract query parameters
+        query_params = dict(url.query)
+
+        kwargs: Dict[str, Any] = {}
+
+        # Handle isolation_level
+        isolation_level = query_params.pop("isolation_level", None)
+        if isolation_level:
+            if isolation_level.upper() == "AUTOCOMMIT":
+                kwargs["isolation_level"] = None
+            else:
+                kwargs["isolation_level"] = isolation_level
+
+        # Handle experimental_features
+        experimental_features = query_params.pop("experimental_features", None)
+        if experimental_features:
+            kwargs["experimental_features"] = experimental_features
+
+        return ([database], kwargs)
+
+    @classmethod
+    def get_pool_class(cls, url: URL) -> type[pool.Pool]:
+        """Match SQLAlchemy async SQLite pool behavior."""
+        if cls._is_url_file_db(url):
+            return pool.AsyncAdaptedQueuePool
+        return pool.StaticPool
 
 
 class TursoSyncDialect(_TursoDialectMixin, SQLiteDialect_pysqlite):


### PR DESCRIPTION
## Description

Add a local SQLAlchemy asyncio dialect for the Python bindings.

- Register `sqlite+aioturso://` as a SQLAlchemy dialect entry point
- Add `AioTursoDialect`, backed by `turso.aio`
- Adapt `turso.aio` to SQLAlchemy's DBAPI-shaped async adapter contract
- Document the local asyncio dialect and its scope

## Motivation and context

Related to #6296.

This covers local async SQLAlchemy usage only. Remote sync support for SQLAlchemy async engines is intentionally left out of scope to keep the PR focused and easier to review.

`aioturso` follows SQLAlchemy's `dialect+driver://` naming convention and mirrors the `sqlite+aiosqlite://` style. Like `aiosqlite`, `turso.aio` exposes an asyncio API over a worker-thread-backed local connection; this is for event-loop integration, not engine-level async I/O or query performance optimization.

## Description of AI Usage

AI was used as an implementation assistant, not as an autonomous author. I reviewed the SQLAlchemy implementation, checked the generated changes, and manually directed the refactoring and naming decisions.

How AI was used:
- implementation support
- test coverage suggestions
- documentation wording
