### PR TITLE
Fix column-vs-column comparison collation precedence

### DIFF
--- a/cli/input.rs
+++ b/cli/input.rs
@@ -194,7 +194,7 @@ pub fn get_io(db_location: DbLocation, io_choice: &str) -> anyhow::Result<Arc<dy
 
 #[cfg(all(test, target_os = "windows", feature = "experimental_win_iocp"))]
 mod tests {
-    use super::{DbLocation, get_io};
+    use super::{get_io, DbLocation};
 
     #[test]
     fn experimental_win_iocp_backend_is_available_for_path_databases() {

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -200,8 +200,14 @@ fn get_collseq_parts_from_expr(
                 let column = table_ref
                     .get_column_at(*column)
                     .ok_or_else(|| crate::LimboError::ParseError("column not found".to_string()))?;
+                // Per SQLite rule 2, "if either operand is a column, then
+                // the collating function of that column is used", so a
+                // defaulted (BINARY) column must still register a column
+                // collation — otherwise a defaulted LHS column would
+                // incorrectly yield to a NOCASE RHS column in
+                // `resolve_comparison_collseq`.
                 if maybe_column_collseq.is_none() {
-                    maybe_column_collseq = column.collation_opt();
+                    maybe_column_collseq = Some(column.collation());
                 }
                 return Ok(WalkControl::Continue);
             }
@@ -212,7 +218,7 @@ fn get_collseq_parts_from_expr(
                 if let Some(btree) = table_ref.btree() {
                     if let Some((_, rowid_alias_col)) = btree.get_rowid_alias_column() {
                         if maybe_column_collseq.is_none() {
-                            maybe_column_collseq = rowid_alias_col.collation_opt();
+                            maybe_column_collseq = Some(rowid_alias_col.collation());
                         }
                     }
                 }
@@ -241,15 +247,19 @@ mod tests {
 
     #[test]
     fn test_get_collseq_from_expr_single_table_single_column() {
-        // plain column
-        for collation in [
-            None,
-            Some(CollationSeq::Binary),
-            Some(CollationSeq::NoCase),
-            Some(CollationSeq::Rtrim),
+        // Plain column. A column without an explicit COLLATE clause still
+        // has the default BINARY collation per SQLite semantics — rule 2 of
+        // comparison collation says "if either operand is a column, the
+        // collating function of that column is used", so we must report the
+        // defaulted BINARY rather than None.
+        for (input, expected) in [
+            (None, Some(CollationSeq::Binary)),
+            (Some(CollationSeq::Binary), Some(CollationSeq::Binary)),
+            (Some(CollationSeq::NoCase), Some(CollationSeq::NoCase)),
+            (Some(CollationSeq::Rtrim), Some(CollationSeq::Rtrim)),
         ] {
             let table_references =
-                get_table_references_single_table_single_column_with_collation(collation);
+                get_table_references_single_table_single_column_with_collation(input);
             let expr = Expr::Column {
                 database: None,
                 table: TableInternalId::from(1),
@@ -257,7 +267,7 @@ mod tests {
                 is_rowid_alias: false,
             };
             let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
-            assert_eq!(collseq, collation);
+            assert_eq!(collseq, expected);
         }
     }
 
@@ -429,7 +439,9 @@ mod tests {
 
     #[test]
     fn test_resolve_comparison_collseq_nocase_column_vs_binary_default() {
-        // LHS has NOCASE column, RHS has no collation → NOCASE
+        // Both sides are columns, so per SQLite rule 2 the LHS column's
+        // collation wins regardless of whether it was declared explicitly
+        // or defaults to BINARY.
         let table_refs = get_table_references_two_tables_single_column_with_collations(
             Some(CollationSeq::NoCase),
             None,
@@ -446,14 +458,15 @@ mod tests {
             column: 0,
             is_rowid_alias: false,
         };
+        // LHS is NOCASE column → NOCASE.
         assert_eq!(
             resolve_comparison_collseq(&lhs, &rhs, &table_refs).unwrap(),
             CollationSeq::NoCase
         );
-        // Swapped: RHS has NOCASE, LHS has no collation → still NOCASE
+        // Swapped: LHS is a BINARY (default) column → BINARY (not NOCASE).
         assert_eq!(
             resolve_comparison_collseq(&rhs, &lhs, &table_refs).unwrap(),
-            CollationSeq::NoCase
+            CollationSeq::Binary
         );
     }
 

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1,3 +1,4 @@
+use crate::translate::collate::CollationSeq;
 use crate::vdbe::{builder::CursorType, insn::RegisterOrLiteral};
 use crate::HashSet;
 use turso_parser::ast::{ResolveType, SortOrder};
@@ -1250,10 +1251,13 @@ pub fn insn_to_row(
                             SortOrder::Asc => "",
                             SortOrder::Desc => "-",
                         };
-                        let coll_str = if let Some(coll) = collation {
-                            format!("{sign}{coll}")
-                        } else {
-                            format!("{sign}B")
+                        // Match SQLite: print `B` as the shorthand for
+                        // BINARY, whether it came from an explicit
+                        // `COLLATE BINARY` clause or was the default for a
+                        // column without a COLLATE clause.
+                        let coll_str = match collation {
+                            Some(CollationSeq::Binary) | None => format!("{sign}B"),
+                            Some(coll) => format!("{sign}{coll}"),
                         };
                         match nulls {
                             Some(turso_parser::ast::NullsOrder::First) => format!("{coll_str} NF"),

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -113,7 +113,12 @@ fn test_concurrent_commit_no_yield_spin() {
         match stmt.step().expect("step") {
             turso_core::StepResult::Row => {
                 if let Some(row) = stmt.row() {
-                    count = row.get_values().next().expect("count value").as_int().expect("count int");
+                    count = row
+                        .get_values()
+                        .next()
+                        .expect("count value")
+                        .as_int()
+                        .expect("count int");
                 }
             }
             turso_core::StepResult::Done => break,

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -1327,3 +1327,61 @@ test agg_collate_no_leak_with_count {
 expect {
     a|a|2
 }
+
+# SQLite rule 2 for binary-comparison collation: "If either operand is a
+# column, then the collating function of that column is used with precedence
+# to the left operand." A column always has a collation — BINARY by default.
+# A defaulted-BINARY LHS column must therefore beat a NOCASE RHS column,
+# not silently inherit the RHS collation.
+test collate_lhs_default_binary_beats_rhs_nocase_column {
+    CREATE TABLE coll_t(v TEXT);
+    CREATE TABLE coll_s(name TEXT COLLATE NOCASE);
+    INSERT INTO coll_t VALUES('a'),('A');
+    INSERT INTO coll_s VALUES('A');
+    SELECT coll_t.v FROM coll_t, coll_s WHERE coll_t.v = coll_s.name;
+}
+expect {
+    A
+}
+
+# Swapped operands: the same rule with LHS precedence means the NOCASE
+# column now drives the comparison, so both rows match.
+test collate_lhs_nocase_column_beats_rhs_default_binary {
+    CREATE TABLE coll_t2(v TEXT);
+    CREATE TABLE coll_s2(name TEXT COLLATE NOCASE);
+    INSERT INTO coll_t2 VALUES('a'),('A');
+    INSERT INTO coll_s2 VALUES('A');
+    SELECT coll_t2.v FROM coll_t2, coll_s2 WHERE coll_s2.name = coll_t2.v ORDER BY coll_t2.v;
+}
+expect {
+    A
+    a
+}
+
+# Same LHS-precedence rule applies to IN against a subquery: the LHS
+# operand's column collation drives comparison with the subquery result
+# (previously a latent bug: NOCASE from the RHS subquery column leaked in).
+test collate_in_subquery_uses_lhs_column_collation {
+    CREATE TABLE coll_t3(v TEXT);
+    CREATE TABLE coll_s3(name TEXT COLLATE NOCASE);
+    INSERT INTO coll_t3 VALUES('a'),('A'),('B');
+    INSERT INTO coll_s3 VALUES('A');
+    SELECT coll_t3.v FROM coll_t3 WHERE coll_t3.v IN (SELECT name FROM coll_s3);
+}
+expect {
+    A
+}
+
+# Sanity check: explicit COLLATE on either side still wins over column
+# collations, regardless of LHS/RHS position.
+test collate_explicit_on_rhs_beats_lhs_column {
+    CREATE TABLE coll_t4(v TEXT);
+    CREATE TABLE coll_s4(name TEXT COLLATE NOCASE);
+    INSERT INTO coll_t4 VALUES('a'),('A');
+    INSERT INTO coll_s4 VALUES('A');
+    SELECT coll_t4.v FROM coll_t4, coll_s4 WHERE coll_t4.v = coll_s4.name COLLATE NOCASE ORDER BY coll_t4.v;
+}
+expect {
+    A
+    a
+}

--- a/testing/sqltests/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
+++ b/testing/sqltests/tests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
@@ -32,7 +32,7 @@ QUERY PLAN
 BYTECODE
 addr  opcode                    p1  p2  p3  p4                    p5  comment
    0          Init               0  80   0                         0  Start at 80
-   1          SorterOpen         0   2   0  k(2,-B,Binary)         0  cursor=0
+   1          SorterOpen         0   2   0  k(2,-B,B)              0  cursor=0
    2          Null               0  13  14                         0  r[13..14]=NULL
    3          SorterOpen         1   4   0  k(2,B,B)               0  cursor=1
    4          Integer            0   8   0                         0  r[8]=0; clear group by abort flag

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -24,75 +24,75 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  69   0                   0  Start at 69
-   1            SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
-   2            Null             0  10   0                   0  r[10]=NULL
-   3            Integer          0   7   0                   0  r[7]=0; clear group by abort flag
-   4            Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  58   0                   0  ; go to clear accumulator subroutine
-   6            OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-   7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-   8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
-   9              DeferredSeek   2   1   0                   0
-  10              Column         1   0  12                   0  r[12]=grouped_values.grp
-  11              Column         1   1  13                   0  r[13]=grouped_values.val
-  12              Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
-  13              Jump          14  18  14                   0  ; start new group if comparison is not equal
-  14              Gosub          5  27   0                   0  ; check if ended group had data, and output if so
-  15              Move          12   8   1                   0  r[8..8]=r[12..12]
-  16              IfPos          7  61   0                   0  r[7]>0 -> r[7]-=0, goto 61; check abort flag
-  17              Gosub         14  58   0                   0  ; goto clear accumulator subroutine
-  18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
-  19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
-  20              Column         1   0   9                   0  r[9]=grouped_values.grp
-  21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
-  22            Next             2   9   0                   0
-  23            Gosub            5  27   0                   0  ; emit row for final group
-  24            Goto             0  61   0                   0  ; group by finished
-  25            Integer          1   7   0                   0  r[7]=1
-  26          Return             5   0   0                   0
-  27          IfPos              6  29   0                   0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
-  28        Return               5   0   0                   0
-  29        AggFinal             0  10   0  sum              0  accum=r[10]
-  30        BeginSubrtn         15   0   0                   0  r[15]=NULL
-  31        Null                 0   1   0                   0  r[1]=NULL
-  32        Null                 0  17   0                   0  r[17]=NULL
-  33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
-  34        IfNot               18  47   0                   0  if !r[18] goto 47
-  35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-  36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-  37        Copy                 9  19   0                   0  r[19]=r[9]
-  38        IsNull              19  47   0                   0  if (r[19]==NULL) goto 47
-  39        Affinity            19   1   0                   0  r[19..20] = B
-  40        SeekGE               4  47  19                   0  key=[19..19]
-  41          IdxGT              4  47  19                   0  key=[19..19]
-  42          DeferredSeek       4   3   0                   0
-  43          Column             3   1  20                   0  r[20]=grouped_values.val
-  44          CollSeq            0   0   0  Binary           0  collation=Binary
-  45          AggStep            0  20  17  max              0  accum=r[17] step(r[20])
-  46        Next                 4  41   0                   0
-  47        AggFinal             0  17   0  max              0  accum=r[17]
-  48        Copy                17  16   0                   0  r[16]=r[17]
-  49        Copy                16   1   0                   0  r[1]=r[16]
-  50      Return                15   0   1                   0
-  51      Copy                   1  21   0                   0  r[21]=r[1]
-  52      Sequence               0  22   0                   0
-  53      Copy                   9  23   0                   0  r[23]=r[9]
-  54      Copy                  10  24   0                   0  r[24]=r[10]
-  55      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
-  56      SorterInsert           0   4   0  0                0  key=r[4]
-  57    Return                   5   0   0                   0
-  58    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  59    Integer                  0   6   0                   0  r[6]=0
-  60  Return                    14   0   0                   0
-  61  OpenPseudo                 5   4   4                   0  4 columns in r[4]
-  62  SorterSort                 0  68   0                   0
-  63    SorterData               0   4   5                   0  r[4]=data
-  64    Column                   5   2   2                   0  r[2]=pseudo.column 2
-  65    Column                   5   3   3                   0  r[3]=pseudo.column 3
-  66    ResultRow                2   2   0                   0  output=r[2..3]
-  67  SorterNext                 0  63   0                   0
-  68  Halt                       0   0   0                   0
-  69  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
-  70  Goto                       0   1   0                   0
+addr  opcode                    p1  p2  p3  p4            p5  comment
+   0            Init             0  69   0                 0  Start at 69
+   1            SorterOpen       0   2   0  k(2,-B,B)      0  cursor=0
+   2            Null             0  10   0                 0  r[10]=NULL
+   3            Integer          0   7   0                 0  r[7]=0; clear group by abort flag
+   4            Null             0   8   0                 0  r[8]=NULL; initialize group by comparison registers to NULL
+   5            Gosub           14  58   0                 0  ; go to clear accumulator subroutine
+   6            OpenRead         1   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+   7            OpenRead         2   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+   8            Rewind           2  23   0                 0  Rewind index idx_grouped_values_grp
+   9              DeferredSeek   2   1   0                 0
+  10              Column         1   0  12                 0  r[12]=grouped_values.grp
+  11              Column         1   1  13                 0  r[13]=grouped_values.val
+  12              Compare        8  12   1  k(1, Binary)   0  r[8..8]==r[12..12]
+  13              Jump          14  18  14                 0  ; start new group if comparison is not equal
+  14              Gosub          5  27   0                 0  ; check if ended group had data, and output if so
+  15              Move          12   8   1                 0  r[8..8]=r[12..12]
+  16              IfPos          7  61   0                 0  r[7]>0 -> r[7]-=0, goto 61; check abort flag
+  17              Gosub         14  58   0                 0  ; goto clear accumulator subroutine
+  18              AggStep        0  13  10  sum            0  accum=r[10] step(r[13])
+  19              If             6  21   0                 0  if r[6] goto 21; don't emit group columns if continuing existing group
+  20              Column         1   0   9                 0  r[9]=grouped_values.grp
+  21              Integer        1   6   0                 0  r[6]=1; indicate data in accumulator
+  22            Next             2   9   0                 0
+  23            Gosub            5  27   0                 0  ; emit row for final group
+  24            Goto             0  61   0                 0  ; group by finished
+  25            Integer          1   7   0                 0  r[7]=1
+  26          Return             5   0   0                 0
+  27          IfPos              6  29   0                 0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
+  28        Return               5   0   0                 0
+  29        AggFinal             0  10   0  sum            0  accum=r[10]
+  30        BeginSubrtn         15   0   0                 0  r[15]=NULL
+  31        Null                 0   1   0                 0  r[1]=NULL
+  32        Null                 0  17   0                 0  r[17]=NULL
+  33        Integer              1  18   0                 0  r[18]=1; LIMIT counter
+  34        IfNot               18  47   0                 0  if !r[18] goto 47
+  35        OpenRead             3   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+  36        OpenRead             4   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+  37        Copy                 9  19   0                 0  r[19]=r[9]
+  38        IsNull              19  47   0                 0  if (r[19]==NULL) goto 47
+  39        Affinity            19   1   0                 0  r[19..20] = B
+  40        SeekGE               4  47  19                 0  key=[19..19]
+  41          IdxGT              4  47  19                 0  key=[19..19]
+  42          DeferredSeek       4   3   0                 0
+  43          Column             3   1  20                 0  r[20]=grouped_values.val
+  44          CollSeq            0   0   0  Binary         0  collation=Binary
+  45          AggStep            0  20  17  max            0  accum=r[17] step(r[20])
+  46        Next                 4  41   0                 0
+  47        AggFinal             0  17   0  max            0  accum=r[17]
+  48        Copy                17  16   0                 0  r[16]=r[17]
+  49        Copy                16   1   0                 0  r[1]=r[16]
+  50      Return                15   0   1                 0
+  51      Copy                   1  21   0                 0  r[21]=r[1]
+  52      Sequence               0  22   0                 0
+  53      Copy                   9  23   0                 0  r[23]=r[9]
+  54      Copy                  10  24   0                 0  r[24]=r[10]
+  55      MakeRecord            21   4   4                 0  r[4]=mkrec(r[21..24])
+  56      SorterInsert           0   4   0  0              0  key=r[4]
+  57    Return                   5   0   0                 0
+  58    Null                     0   9  10                 0  r[9..10]=NULL; clear accumulator subroutine start
+  59    Integer                  0   6   0                 0  r[6]=0
+  60  Return                    14   0   0                 0
+  61  OpenPseudo                 5   4   4                 0  4 columns in r[4]
+  62  SorterSort                 0  68   0                 0
+  63    SorterData               0   4   5                 0  r[4]=data
+  64    Column                   5   2   2                 0  r[2]=pseudo.column 2
+  65    Column                   5   3   3                 0  r[3]=pseudo.column 3
+  66    ResultRow                2   2   0                 0  output=r[2..3]
+  67  SorterNext                 0  63   0                 0
+  68  Halt                       0   0   0                 0
+  69  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
+  70  Goto                       0   1   0                 0

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q13-customer-distribution.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q13-customer-distribution.snap
@@ -138,7 +138,7 @@ addr  opcode                                p1   p2   p3  p4                    
   94            Integer                      0    5    0                                               0  r[5]=0
   95          Return                        13    0    0                                               0
   96          EndCoroutine                   1    0    0                                               0
-  97          SorterOpen                     5    3    0  k(3,-B,-B,Binary)                            0  cursor=5
+  97          SorterOpen                     5    3    0  k(3,-B,-B,B)                                 0  cursor=5
   98          Null                           0   36    0                                               0  r[36]=NULL
   99          SorterOpen                     6    1    0  k(1,-B)                                      0  cursor=6
  100          Integer                        0   33    0                                               0  r[33]=0; clear group by abort flag


### PR DESCRIPTION
`get_collseq_parts_from_expr` used `column.collation_opt()`, which returns None for a column without an explicit COLLATE clause. Per SQLite rule 2 a column always has a collation (BINARY by default), so a defaulted LHS column would silently yield to a NOCASE RHS column in `resolve_comparison_collseq` instead of taking precedence. This also affected `IN (SELECT ...)` resolution, where the LHS column's default collation was discarded in favor of the subquery column's NOCASE.

Record `Some(column.collation())` instead. All downstream callers of `get_collseq_from_expr` (GROUP BY, window, IN) already `.unwrap_or_default()` the result, so Some(Binary) and None are equivalent there; the only behavior change is the one required by the spec.