### PR TITLE
Fix stack overflow on self-referential FK ON UPDATE CASCADE

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2297,6 +2297,7 @@ fn emit_update_insns<'a>(
                     new_rowid_reg,
                     connection,
                     update_database_id,
+                    &updated_column_indices,
                 )?;
             }
 

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -1882,6 +1882,7 @@ pub fn fire_fk_update_actions(
     new_rowid_reg: usize,
     connection: &Arc<Connection>,
     database_id: usize,
+    updated_positions: &ColumnMask,
 ) -> Result<()> {
     let parent_bt = resolver
         .with_schema(database_id, |s| s.get_btree_table(parent_table_name))
@@ -1890,6 +1891,16 @@ pub fn fire_fk_update_actions(
     for fk_ref in resolver.with_schema(database_id, |s| {
         s.resolved_fks_referencing(parent_table_name)
     })? {
+        // Skip FKs whose referenced parent-key column isn't in this UPDATE's
+        // SET list. Without this filter a self-referential ON UPDATE CASCADE
+        // recurses at translate-time: the cascade UPDATE on the child (same
+        // table) re-enters this function for its own FKs and emits another
+        // cascade subprogram, until the host stack overflows. Runtime skips
+        // via `emit_key_change_check` don't help because the recursion is
+        // during subprogram code generation.
+        if !fk_ref.parent_key_may_change(updated_positions, &parent_bt)? {
+            continue;
+        }
         let parent_cols: &[String] = &fk_ref.parent_cols;
         let ncols = parent_cols.len();
 

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -1143,6 +1143,7 @@ pub fn emit_upsert(
                 new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg), // new_rowid_reg
                 connection,
                 upsert_database_id,
+                &updated_positions,
             )?;
         }
     }

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -3188,3 +3188,53 @@ test fk-alter-table-add-column-rejects-missing {
 }
 expect error {
 }
+
+# Regression: self-referential FK ON UPDATE CASCADE used to blow the host
+# stack at translate-time. Emitting the cascade UPDATE on the child (same
+# table) recursively entered FK emission again for the same table, without
+# checking whether the cascade's SET list touched the parent key. Even the
+# minimal single-row no-child case crashed.
+@cross-check-integrity
+test fk-self-referential-cascade-on-update-single-row {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON UPDATE CASCADE);
+    INSERT INTO t VALUES(1, NULL);
+    UPDATE t SET id = 100 WHERE id = 1;
+    SELECT * FROM t;
+}
+expect {
+    100|
+}
+
+# Self-referential cascade with real child references: both child rows
+# should follow the parent key mutation.
+@cross-check-integrity
+test fk-self-referential-cascade-on-update-with-children {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON UPDATE CASCADE);
+    INSERT INTO t VALUES(1, NULL),(2, 1),(3, 1);
+    UPDATE t SET id = 100 WHERE id = 1;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    2|100
+    3|100
+    100|
+}
+
+# Updating a non-referenced column on a self-FK table must not emit any
+# cascade and must not trip the compile-time recursion either. Children
+# retain their pid values since the referenced parent key didn't change.
+@cross-check-integrity
+test fk-self-referential-update-non-referenced-column {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON UPDATE CASCADE, extra TEXT);
+    INSERT INTO t VALUES(1, NULL, 'a'),(2, 1, 'b'),(3, 1, 'c');
+    UPDATE t SET extra = 'zzz' WHERE id = 1;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1||zzz
+    2|1|b
+    3|1|c
+}


### PR DESCRIPTION
TODO: I discovered this on the `update-from` branch (#6427 ) so i'll wait until thats green and merged

---

`fire_fk_update_actions` iterated every FK referencing the parent table and emitted a cascade subprogram unconditionally. For a self-referential `REFERENCES t(id) ON UPDATE CASCADE`, compiling that cascade UPDATE re-entered FK emission for the same table (since the cascade UPDATE also targets t), which emitted another cascade subprogram, and so on — overflowing the host stack at translate time even for a minimal single-row no-child case. Runtime skips via `emit_key_change_check` don't help because the recursion is during code generation, not execution.

Thread the UPDATE's `updated_positions` through
`fire_fk_update_actions` and skip FKs whose referenced parent key cannot change for this SET list (matching what
`emit_fk_update_parent_actions` already does via
`parent_key_may_change`). The self-referential cascade UPDATE only assigns the child column, so the check returns false on the second pass and the recursion terminates.