### PR TITLE
fix correlated subquery inside aggregate with GROUP BY

### DIFF
--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -337,6 +337,12 @@ pub fn compute_group_by_sort_order(
 /// These are the base table columns that aggregate expressions depend on.
 /// By storing only these in the GROUP BY sorter (instead of pre-computed expression
 /// results), we reduce sorter record size and avoid redundant B-tree column reads.
+///
+/// Correlated subquery results (`SubqueryResult`) inside aggregate arguments are
+/// also collected as leaf expressions.  Their value is computed per-row during the
+/// scan loop, stored in the sorter, and read back during the sorter loop so that
+/// each sorted row sees the correct subquery result instead of a stale register
+/// value left over from the last scanned row.
 fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Result<Vec<ast::Expr>> {
     let mut leaf_columns: Vec<ast::Expr> = Vec::new();
     let mut collect = |expr: &ast::Expr| -> Result<WalkControl> {
@@ -346,6 +352,19 @@ fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Resu
                     .table_references
                     .find_joined_table_by_internal_id(*table)
                     .is_some()
+                    && !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr))
+                {
+                    leaf_columns.push(expr.clone());
+                }
+                Ok(WalkControl::SkipChildren)
+            }
+            ast::Expr::SubqueryResult { subquery_id, .. } => {
+                let is_correlated = plan
+                    .non_from_clause_subqueries
+                    .iter()
+                    .find(|s| s.internal_id == *subquery_id)
+                    .is_some_and(|s| s.correlated);
+                if is_correlated
                     && !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr))
                 {
                     leaf_columns.push(expr.clone());

--- a/testing/sqltests/tests/correlated-subquery-aggregate-groupby.sqltest
+++ b/testing/sqltests/tests/correlated-subquery-aggregate-groupby.sqltest
@@ -1,0 +1,53 @@
+@database :memory:
+
+# Regression test for #6485: correlated subquery inside aggregate
+# returns wrong grouped result. The subquery was evaluated during the
+# scan loop and its result register held the value from the LAST
+# scanned row by the time the sorter loop ran aggregation.
+
+setup schema {
+    CREATE TABLE t1(grp TEXT, val INTEGER);
+    CREATE TABLE t2(grp TEXT, factor INTEGER);
+    INSERT INTO t1 VALUES ('a',1),('a',2),('b',3),('b',4);
+    INSERT INTO t2 VALUES ('a',10),('b',20);
+}
+
+@setup schema
+@backend rust
+test correlated-subquery-in-sum-group-by {
+    SELECT grp, sum((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|20
+    b|40
+}
+
+@setup schema
+@backend rust
+test correlated-subquery-in-count-group-by {
+    SELECT grp, count((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|2
+    b|2
+}
+
+@setup schema
+@backend rust
+test correlated-subquery-in-avg-group-by {
+    SELECT grp, avg((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|10.0
+    b|20.0
+}
+
+@setup schema
+@backend rust
+test correlated-subquery-in-min-max-group-by {
+    SELECT grp, min((SELECT factor FROM t2 WHERE t2.grp = t1.grp)), max((SELECT factor FROM t2 WHERE t2.grp = t1.grp)) FROM t1 GROUP BY grp;
+}
+expect {
+    a|10|10
+    b|20|20
+}


### PR DESCRIPTION
collect correlated SubqueryResult expressions as leaf columns in the GROUP BY sorter so the sorter loop reads the per-row value instead of a stale register from the last scanned row.

fixes #6485

used Claude Code