### PR TITLE
serverless/javascript: Fix empty blob decoding returning `null`

### DIFF
--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -33,6 +33,13 @@ test('decodeValue decodes empty base64 blob as empty Buffer', t => {
   t.is(result.length, 0);
 });
 
+test('decodeValue decodes blob without base64 key as empty Buffer', t => {
+  const result = decodeValue({ type: 'blob' });
+  t.truthy(result, 'blob without base64 key should not decode to null');
+  t.true(Buffer.isBuffer(result), 'should be a Buffer');
+  t.is(result.length, 0);
+});
+
 test('decodeValue decodes unpadded base64 blob', t => {
   // 'aGVsbG8' is 'hello' without trailing '=' padding
   const result = decodeValue({ type: 'blob', base64: 'aGVsbG8' });

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -156,7 +156,7 @@ export function decodeValue(value: Value, safeIntegers: boolean = false): any {
         }
         return Buffer.from(bytes);
       }
-      return null;
+      return Buffer.alloc(0);
     default:
       return null;
   }


### PR DESCRIPTION
decodeValue() returned null for blobs without a base64 field (e.g. {"type":"blob"} with no base64 key). Now returns Buffer.alloc(0), matching the turso NAPI driver behavior.

