### PR TITLE
Fix infinite loop on INSERT with two partial indexes

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1354,7 +1354,7 @@ fn emit_commit_phase(
         });
 
         if let Some(lbl) = commit_skip_label {
-            program.resolve_label(lbl, program.offset());
+            program.preassign_label_to_next_insn(lbl);
         }
     }
     Ok(())
@@ -2884,7 +2884,7 @@ fn emit_index_uniqueness_check(
 
     // Close the partial-index skip (preflight)
     if let Some(lbl) = maybe_skip_probe_label {
-        program.resolve_label(lbl, program.offset());
+        program.preassign_label_to_next_insn(lbl);
     }
     Ok(())
 }

--- a/testing/sqltests/tests/insert.sqltest
+++ b/testing/sqltests/tests/insert.sqltest
@@ -2202,3 +2202,22 @@ test insert-column-count-mismatch-select {
 expect error {
     table t1 has 1 columns but 7 values were supplied
 }
+
+# Regression: used to infinite-loop on INSERT when two partial UNIQUE
+# indexes coexist and one of them has an expression key. The skip-this-
+# index label was resolved via `resolve_label` instead of
+# `preassign_label_to_next_insn`, so when a compile-time constant emitted
+# later got hoisted, the label followed it and the skip jumped somewhere
+# that looped back to the start of the program. Discovered by fuzz test
+# `partial_index_mutation_and_upsert_fuzz`.
+@cross-check-integrity
+test insert-two-partial-unique-indexes-expr-key-no-hang {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, k TEXT, c0 INT);
+    CREATE UNIQUE INDEX idx_a ON t(k, c0) WHERE 1;
+    CREATE UNIQUE INDEX idx_b ON t(upper(c0)) WHERE c0 BETWEEN -6 AND -6;
+    INSERT INTO t VALUES (NULL, 'B', NULL);
+    SELECT id, k, c0 FROM t;
+}
+expect {
+    1|B|
+}


### PR DESCRIPTION
`resolve_label()` vs `preassign_label_to_next_insn()` footgun strikes again.

---

`emit_partial_index_check` returns a label the caller must resolve after the index's code so that if the partial predicate is false, the rest of the index's work is skipped. Both the preflight (`emit_index_uniqueness_check`) and commit (`emit_commit_phase`) call sites resolved this label with `resolve_label(lbl, program.offset())`, which pins the label to the exact instruction index reported by `program.offset()` at that moment.

If the very next instruction turns out to be a compile-time constant, `emit_constant_insns` later moves it to the one-time setup phase at the end of the program, and the label's resolved offset gets remapped to the new location. The skip jump then lands inside that setup block, which ends with an unconditional jump back to the start of the program — and every attempted INSERT where the predicate is false loops there forever.

Use `preassign_label_to_next_insn` at both call sites instead.