### PR TITLE
sim: verify table contents after REOPEN_DATABASE fault

### DIFF
--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -301,7 +301,14 @@ impl Interactions {
         match &self.interactions {
             InteractionsType::Property(property) => property.check_tables(),
             InteractionsType::Query(query) => query.is_dml(),
-            InteractionsType::Fault(..) => false,
+            // REOPEN_DATABASE tears down all connections and re-opens the
+            // database, which exercises the on-disk recovery path (WAL replay,
+            // header re-read, schema reload). Any committed row must still be
+            // visible afterwards, so we verify it using the shared
+            // `AllTableHaveExpectedContent` check. DISCONNECT only affects a
+            // single in-memory connection and doesn't touch persistence, so
+            // we don't follow it with a check.
+            InteractionsType::Fault(fault) => matches!(fault, Fault::ReopenDatabase),
         }
     }
 


### PR DESCRIPTION
## sim: verify table contents after REOPEN_DATABASE fault

The simulator already injects a `REOPEN_DATABASE` fault (see
[`testing/simulator/model/interactions.rs`](https://github.com/tursodatabase/turso/blob/main/testing/simulator/model/interactions.rs))
that closes every connection **without** the default checkpoint-on-close
behaviour and then re-opens the database. That path exercises WAL
replay, header re-read and schema reload, which is exactly where
durability/recovery regressions tend to sneak in.

However, `Interactions::check_tables()` returns `false` for every
`InteractionsType::Fault`, so the existing "append an
`AllTableHaveExpectedContent` property after interactions that mutate
state" machinery never runs after a reopen. In practice this means:

* A bug that silently **drops rows** across an open/close cycle will
  only fail the simulator on the *next* DML property, which makes it
  much harder to localise.
* A bug that introduces **phantom rows** (e.g. a replay that applies
  frames twice) will never be caught if the test plan happens to stop
  generating DML after the reopen — the integrity check at the end of
  the simulation only verifies schema/cell layout, not content.

This PR flips `check_tables()` for `Fault::ReopenDatabase` to `true` so
the plan generator automatically emits an `AllTableHaveExpectedContent`
property after every reopen. The property selects every committed
table and compares the result set to the shadow model, catching both
missing and phantom rows immediately at the point they are introduced.

`Fault::Disconnect` is intentionally left as `false`: it only tears
down a single in-memory connection and doesn't touch any on-disk
state, so following it with a check is pointless (and would read from
a connection that no longer exists).

### Scope

* No new public API.
* Eight lines changed, in a single file (`testing/simulator/model/interactions.rs`).
* The generated `AllTableHaveExpectedContent` property already exists
  (`Property::AllTableHaveExpectedContent`) and is used today after
  `FsyncNoWait` / `FaultyQuery`, so we simply reuse the same assertion
  text and shadow-comparison code path.

### Verification

Built and ran the simulator locally (`cargo run --bin limbo_sim --release`).
With the change, a 2 000-interaction run of the `write_heavy` profile
triggers ~68 `REOPEN_DATABASE` events and ~9 000
`AllTableHaveExpectedContent` table comparisons, so the new coverage is
exercised on every run where a reopen is generated. Multiple seeds
across `default`, `write_heavy`, `write_stress` passed with the
additional assertions enabled, confirming no regressions in today's WAL
recovery path.
