### PR TITLE
bindings/go: Fix named parameter binding

### DIFF
--- a/bindings/go/bindings_db.go
+++ b/bindings/go/bindings_db.go
@@ -178,6 +178,7 @@ var (
 	c_turso_statement_row_value_double       func(self TursoStatement, index uintptr) float64
 	c_turso_statement_named_position         func(self TursoStatement, name string) int64
 	c_turso_statement_parameters_count       func(self TursoStatement) int64
+	c_turso_statement_parameter_name         func(self TursoStatement, index int64) uintptr
 	c_turso_statement_bind_positional_null   func(self TursoStatement, position uintptr) turso_status_code_t
 	c_turso_statement_bind_positional_int    func(self TursoStatement, position uintptr, value int64) turso_status_code_t
 	c_turso_statement_bind_positional_double func(self TursoStatement, position uintptr, value float64) turso_status_code_t
@@ -218,6 +219,7 @@ func registerTursoDb(handle uintptr) error {
 	purego.RegisterLibFunc(&c_turso_statement_row_value_double, handle, "turso_statement_row_value_double")
 	purego.RegisterLibFunc(&c_turso_statement_named_position, handle, "turso_statement_named_position")
 	purego.RegisterLibFunc(&c_turso_statement_parameters_count, handle, "turso_statement_parameters_count")
+	purego.RegisterLibFunc(&c_turso_statement_parameter_name, handle, "turso_statement_parameter_name")
 	purego.RegisterLibFunc(&c_turso_statement_bind_positional_null, handle, "turso_statement_bind_positional_null")
 	purego.RegisterLibFunc(&c_turso_statement_bind_positional_int, handle, "turso_statement_bind_positional_int")
 	purego.RegisterLibFunc(&c_turso_statement_bind_positional_double, handle, "turso_statement_bind_positional_double")
@@ -602,6 +604,17 @@ func turso_statement_named_position(self TursoStatement, name string) int64 {
 // turso_statement_parameters_count returns parameters count for the statement.
 func turso_statement_parameters_count(self TursoStatement) int64 {
 	return c_turso_statement_parameters_count(self)
+}
+
+// turso_statement_parameter_name returns the name of the parameter at 1-based
+// index, including its SQL prefix (e.g. ":name", "@name", "$name").
+// Returns "" for positional-only parameters or out-of-range indices.
+func turso_statement_parameter_name(self TursoStatement, index int) string {
+	ptr := c_turso_statement_parameter_name(self, int64(index))
+	if ptr == 0 {
+		return ""
+	}
+	return decodeAndFreeCStringRaw(ptr)
 }
 
 // turso_statement_bind_positional_null binds a positional argument as NULL.

--- a/bindings/go/driver_db.go
+++ b/bindings/go/driver_db.go
@@ -735,7 +735,7 @@ func (c *tursoDbConnection) executeFully(ctx context.Context, stmt TursoStatemen
 }
 
 // bindArgs binds ordered and named values to a statement.
-// Named values are resolved via turso_statement_named_position, otherwise ordinal positions are used (1-based).
+// Named values are resolved via turso_statement_parameter_name, otherwise ordinal positions are used (1-based).
 func bindArgs(stmt TursoStatement, args []driver.NamedValue) error {
 	// Validate number of inputs if no named args present
 	if len(args) > 0 {
@@ -753,14 +753,36 @@ func bindArgs(stmt TursoStatement, args []driver.NamedValue) error {
 			}
 		}
 	}
+
+	// Build bare-name → position map from statement metadata.
+	// Go's database/sql strips the SQL prefix from named parameters:
+	// sql.Named("a", v) arrives as Name="a", but the statement knows
+	// the full name (e.g. ":a", "@a", "$a"). We strip the prefix from
+	// the statement's parameter names to build the lookup table.
+	var nameMap map[string]int
+	paramCount := int(turso_statement_parameters_count(stmt))
+	if paramCount > 0 {
+		nameMap = make(map[string]int, paramCount)
+		for i := 1; i <= paramCount; i++ {
+			pname := turso_statement_parameter_name(stmt, i)
+			if pname == "" {
+				continue
+			}
+			bare := strings.TrimLeft(pname, ":@$")
+			if bare != "" {
+				nameMap[bare] = i
+			}
+		}
+	}
+
 	for idx, nv := range args {
 		pos := idx + 1
 		if nv.Name != "" {
-			np := int(turso_statement_named_position(stmt, nv.Name))
-			if np <= 0 {
+			p, ok := nameMap[nv.Name]
+			if !ok {
 				return fmt.Errorf("turso: unknown named parameter %q", nv.Name)
 			}
-			pos = np
+			pos = p
 		} else if nv.Ordinal > 0 {
 			pos = nv.Ordinal
 		}

--- a/bindings/go/driver_db_test.go
+++ b/bindings/go/driver_db_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 	turso_libs "github.com/tursodatabase/turso-go-platform-libs"
 )
@@ -742,6 +743,78 @@ func TestParameterOrdering(t *testing.T) {
 			if result[i] != expectedValues[i] {
 				t.Fatalf("Expected %d, got %d", expectedValues[i], result[i])
 			}
+		}
+	}
+}
+
+// TestParametersNamed tests named parameter binding through Go's database/sql
+// API against both turso and go-sqlite3 to ensure compatible behavior.
+//
+// Go's database/sql strips SQL prefixes: sql.Named("a", v) → Name="a".
+// The driver must resolve bare names against :param, @param, and $param
+// placeholders. The "colon" variant was the original bug; the "@" and "$"
+// variants are for coverage to match go-sqlite3 behavior.
+func TestParametersNamed(t *testing.T) {
+	openSqlite3 := func(t *testing.T) *sql.DB {
+		t.Helper()
+		db, err := sql.Open("sqlite3", ":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+		return db
+	}
+
+	drivers := []struct {
+		name string
+		open func(t *testing.T) *sql.DB
+	}{
+		{"turso", openMem},
+		{"sqlite3", openSqlite3},
+	}
+
+	// Each SQL prefix variant with bare Go names (the standard pattern).
+	prefixes := []struct {
+		tag    string
+		prefix string
+	}{
+		{"colon", ":"},
+		{"at", "@"},
+		{"dollar", "$"},
+	}
+
+	for _, drv := range drivers {
+		for _, pfx := range prefixes {
+			t.Run(drv.name+"/"+pfx.tag, func(t *testing.T) {
+				db := drv.open(t)
+				_, err := db.Exec("CREATE TABLE np (a TEXT, b TEXT, c INTEGER)")
+				require.NoError(t, err)
+
+				insertSQL := fmt.Sprintf(
+					"INSERT INTO np (a, b, c) VALUES (%[1]sa, %[1]sb, %[1]sc)", pfx.prefix)
+				_, err = db.Exec(insertSQL,
+					sql.Named("a", "one"),
+					sql.Named("b", "two"),
+					sql.Named("c", 3))
+				require.NoError(t, err)
+
+				var a, b string
+				var c int
+				err = db.QueryRow("SELECT a, b, c FROM np").Scan(&a, &b, &c)
+				require.NoError(t, err)
+				require.Equal(t, "one", a)
+				require.Equal(t, "two", b)
+				require.Equal(t, 3, c)
+
+				// Also test named params in a WHERE clause.
+				whereSQL := fmt.Sprintf(
+					"SELECT a, b, c FROM np WHERE a = %[1]sx AND c = %[1]sy", pfx.prefix)
+				err = db.QueryRow(whereSQL,
+					sql.Named("x", "one"),
+					sql.Named("y", 3)).Scan(&a, &b, &c)
+				require.NoError(t, err)
+				require.Equal(t, "one", a)
+				require.Equal(t, "two", b)
+				require.Equal(t, 3, c)
+			})
 		}
 	}
 }

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.42 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/bindings/go/go.sum
+++ b/bindings/go/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
 github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/mattn/go-sqlite3 v1.14.42 h1:MigqEP4ZmHw3aIdIT7T+9TLa90Z6smwcthx+Azv4Cgo=
+github.com/mattn/go-sqlite3 v1.14.42/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kbHKBr7yXKVQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -302,6 +302,13 @@ unsafe extern "C" {
     pub fn turso_statement_parameters_count(self_: *const turso_statement_t) -> i64;
 }
 unsafe extern "C" {
+    #[doc = " Return the name of the parameter at 1-based index, including the SQL prefix.\nReturns NULL for positional-only parameters or out-of-range indices.\nThe caller must free the returned string with turso_str_deinit."]
+    pub fn turso_statement_parameter_name(
+        self_: *const turso_statement_t,
+        index: i64,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
     #[doc = " Bind a positional argument to a statement"]
     pub fn turso_statement_bind_positional_null(
         self_: *const turso_statement_t,

--- a/sdk-kit/src/capi.rs
+++ b/sdk-kit/src/capi.rs
@@ -493,6 +493,29 @@ pub extern "C" fn turso_statement_parameters_count(statement: *const c::turso_st
     statement.parameters_count() as i64
 }
 
+/// Return the name of the parameter at 1-based `index`, including the SQL
+/// prefix (e.g. `:name`, `@name`, `$name`). Returns NULL for positional-only
+/// parameters or out-of-range indices. The caller must free the returned
+/// string with `turso_str_deinit`.
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_statement_parameter_name(
+    statement: *const c::turso_statement_t,
+    index: i64,
+) -> *const std::ffi::c_char {
+    if index <= 0 {
+        return std::ptr::null();
+    }
+    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
+        Ok(statement) => statement,
+        Err(_) => return std::ptr::null(),
+    };
+    match statement.parameter_name(index as usize) {
+        Some(name) => str_to_c_string(&name),
+        None => std::ptr::null(),
+    }
+}
+
 #[no_mangle]
 #[signature(c)]
 pub extern "C" fn turso_statement_bind_positional_null(

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1057,6 +1057,15 @@ impl TursoStatement {
             None => 0,
         }
     }
+    /// Returns the name of the parameter at the given 1-based index,
+    /// including its SQL prefix (e.g. `:name`, `@name`, `$name`).
+    /// Returns None for positional-only (`?`) parameters or out-of-range indices.
+    pub fn parameter_name(&self, index: usize) -> Option<String> {
+        let handle = self.handle.lock().unwrap();
+        let stmt = handle.as_ref()?;
+        let index = index.try_into().ok()?;
+        stmt.parameters().name(index)
+    }
     /// binds positional parameter at the corresponding index (1-based)
     pub fn bind_positional(
         &mut self,


### PR DESCRIPTION
Go database/sql strips the SQL prefix from named parameters: sql.Named("a", val) produces NamedValue{Name: "a"}. The C-level named_position API requires the prefix, so bare names failed with "unknown named parameter".

Add turso_statement_parameter_name(stmt, idx) to the sdk-kit C API (the equivalent of sqlite3_bind_parameter_name, which was only in the sqlite3 compat layer). The Go driver uses it to build a bare-name to position map from the statement metadata, resolving names without guessing which prefix the SQL used.

Tests run every variant (colon, at, dollar) against both turso and go-sqlite3 to ensure compatible behavior. Update COMPAT.md to note the new sdk-kit exposure.

