### PR TITLE
Add support for encryption parameters in VACUUM INTO

### DIFF
--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -105,6 +105,8 @@ fn extract_path_from_expr(expr: &Expr) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vdbe::builder::ProgramBuilderOpts;
+    use crate::QueryMode;
 
     #[test]
     fn test_extract_path_from_string_literal() {
@@ -131,5 +133,115 @@ mod tests {
     fn test_extract_path_empty_fails() {
         let expr = Expr::Literal(Literal::String("''".to_string()));
         assert!(extract_path_from_expr(&expr).is_err());
+    }
+
+    fn make_builder() -> ProgramBuilder {
+        ProgramBuilder::new(
+            QueryMode::Normal,
+            None,
+            ProgramBuilderOpts {
+                num_cursors: 0,
+                approx_num_insns: 4,
+                approx_num_labels: 0,
+            },
+        )
+    }
+
+    fn quoted_string_expr(s: &str) -> Expr {
+        Expr::Literal(Literal::String(format!("'{s}'")))
+    }
+
+    #[test]
+    fn test_translate_vacuum_into_plain_path_has_no_encryption() {
+        let mut program = make_builder();
+        let dest = quoted_string_expr("test.db");
+        translate_vacuum(&mut program, None, Some(&dest)).unwrap();
+
+        let insn = program
+            .insns
+            .iter()
+            .find_map(|(insn, _)| match insn {
+                Insn::VacuumInto {
+                    schema_name: _,
+                    dest_path,
+                    encryption_opts,
+                } => Some((dest_path.clone(), encryption_opts.clone())),
+                _ => None,
+            })
+            .expect("VacuumInto instruction was not emitted");
+
+        assert_eq!(insn.0, "test.db");
+        assert!(insn.1.is_none());
+    }
+
+    #[test]
+    fn test_translate_vacuum_into_uri_with_cipher_and_hexkey() {
+        let mut program = make_builder();
+        let dest = quoted_string_expr("file:test.db?cipher=aes256&hexkey=00112233");
+        translate_vacuum(&mut program, None, Some(&dest)).unwrap();
+
+        let (dest_path, encryption_opts) = program
+            .insns
+            .iter()
+            .find_map(|(insn, _)| match insn {
+                Insn::VacuumInto {
+                    schema_name: _,
+                    dest_path,
+                    encryption_opts,
+                } => Some((dest_path.clone(), encryption_opts.clone())),
+                _ => None,
+            })
+            .expect("VacuumInto instruction was not emitted");
+
+        // The URI scheme and query string are stripped from the destination path.
+        assert_eq!(dest_path, "test.db");
+        let opts = encryption_opts.expect("encryption_opts should be set");
+        assert_eq!(opts.cipher, "aes256");
+        assert_eq!(opts.hexkey, "00112233");
+    }
+
+    #[test]
+    fn test_translate_vacuum_into_uri_only_cipher_errors() {
+        let mut program = make_builder();
+        let dest = quoted_string_expr("file:test.db?cipher=aes256");
+        let err = translate_vacuum(&mut program, None, Some(&dest)).unwrap_err();
+        assert!(
+            err.to_string().contains("hexkey is required"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_translate_vacuum_into_uri_only_hexkey_errors() {
+        let mut program = make_builder();
+        let dest = quoted_string_expr("file:test.db?hexkey=00112233");
+        let err = translate_vacuum(&mut program, None, Some(&dest)).unwrap_err();
+        assert!(
+            err.to_string().contains("cipher is required"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_translate_vacuum_into_uri_without_encryption_params() {
+        let mut program = make_builder();
+        let dest = quoted_string_expr("file:test.db");
+        translate_vacuum(&mut program, None, Some(&dest)).unwrap();
+
+        let (dest_path, encryption_opts) = program
+            .insns
+            .iter()
+            .find_map(|(insn, _)| match insn {
+                Insn::VacuumInto {
+                    schema_name: _,
+                    dest_path,
+                    encryption_opts,
+                } => Some((dest_path.clone(), encryption_opts.clone())),
+                _ => None,
+            })
+            .expect("VacuumInto instruction was not emitted");
+
+        assert_eq!(dest_path, "test.db");
+        assert!(encryption_opts.is_none());
     }
 }

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -1,8 +1,9 @@
 //! Translation of VACUUM statements to VDBE bytecode.
 
+use crate::util::OpenOptions;
 use crate::vdbe::builder::ProgramBuilder;
 use crate::vdbe::insn::Insn;
-use crate::{bail_parse_error, Connection, Result};
+use crate::{bail_parse_error, Connection, EncryptionOpts, Result};
 use crate::{sync::Arc, LimboError};
 use turso_parser::ast::{Expr, Literal, Name};
 
@@ -28,11 +29,24 @@ pub fn translate_vacuum(
     match into {
         Some(dest_expr) => {
             // VACUUM INTO 'path' - create compacted copy at destination
-            let dest_path = extract_path_from_expr(dest_expr)?;
-            program.emit_insn(Insn::VacuumInto {
-                schema_name,
-                dest_path,
-            });
+            let dest = extract_path_from_expr(dest_expr)?;
+            let opts = OpenOptions::parse(dest.as_str())?;
+            // Do we need to throw error if nonsense options like mode=ro are passed?
+            match (opts.cipher, opts.hexkey) {
+                (Some(cipher), Some(hexkey)) => program.emit_insn(Insn::VacuumInto {
+                    schema_name,
+                    dest_path: opts.path,
+                    encryption_opts: Some(EncryptionOpts { cipher, hexkey }),
+                }),
+                (Some(_), None) => bail_parse_error!("hexkey is required when cipher is provided"),
+                (None, Some(_)) => bail_parse_error!("cipher is required when hexkey is provided"),
+                (None, None) => program.emit_insn(Insn::VacuumInto {
+                    schema_name,
+                    dest_path: opts.path,
+                    encryption_opts: None,
+                }),
+            }
+
             Ok(())
         }
         None => {

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -152,29 +152,6 @@ mod tests {
     }
 
     #[test]
-    fn test_translate_vacuum_into_plain_path_has_no_encryption() {
-        let mut program = make_builder();
-        let dest = quoted_string_expr("test.db");
-        translate_vacuum(&mut program, None, Some(&dest)).unwrap();
-
-        let insn = program
-            .insns
-            .iter()
-            .find_map(|(insn, _)| match insn {
-                Insn::VacuumInto {
-                    schema_name: _,
-                    dest_path,
-                    encryption_opts,
-                } => Some((dest_path.clone(), encryption_opts.clone())),
-                _ => None,
-            })
-            .expect("VacuumInto instruction was not emitted");
-
-        assert_eq!(insn.0, "test.db");
-        assert!(insn.1.is_none());
-    }
-
-    #[test]
     fn test_translate_vacuum_into_uri_with_cipher_and_hexkey() {
         let mut program = make_builder();
         let dest = quoted_string_expr("file:test.db?cipher=aes256&hexkey=00112233");

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -106,7 +106,7 @@ fn extract_path_from_expr(expr: &Expr) -> Result<String> {
 mod tests {
     use super::*;
     use crate::vdbe::builder::ProgramBuilderOpts;
-    use crate::QueryMode;
+    use crate::{DatabaseOpts, QueryMode};
 
     #[test]
     fn test_extract_path_from_string_literal() {
@@ -155,7 +155,9 @@ mod tests {
     fn test_translate_vacuum_into_uri_with_cipher_and_hexkey() {
         let mut program = make_builder();
         let dest = quoted_string_expr("file:test.db?cipher=aes256&hexkey=00112233");
-        translate_vacuum(&mut program, None, Some(&dest)).unwrap();
+        let (_, connection) = Connection::from_uri(":memory:", DatabaseOpts::new())
+            .expect("in-memory connection should succeed");
+        translate_vacuum(&mut program, None, Some(&dest), connection).unwrap();
 
         let (dest_path, encryption_opts) = program
             .insns
@@ -181,7 +183,9 @@ mod tests {
     fn test_translate_vacuum_into_uri_only_cipher_errors() {
         let mut program = make_builder();
         let dest = quoted_string_expr("file:test.db?cipher=aes256");
-        let err = translate_vacuum(&mut program, None, Some(&dest)).unwrap_err();
+        let (_, connection) = Connection::from_uri(":memory:", DatabaseOpts::new())
+            .expect("in-memory connection should succeed");
+        let err = translate_vacuum(&mut program, None, Some(&dest), connection).unwrap_err();
         assert!(
             err.to_string().contains("hexkey is required"),
             "unexpected error: {err}"
@@ -192,7 +196,9 @@ mod tests {
     fn test_translate_vacuum_into_uri_only_hexkey_errors() {
         let mut program = make_builder();
         let dest = quoted_string_expr("file:test.db?hexkey=00112233");
-        let err = translate_vacuum(&mut program, None, Some(&dest)).unwrap_err();
+        let (_, connection) = Connection::from_uri(":memory:", DatabaseOpts::new())
+            .expect("in-memory connection should succeed");
+        let err = translate_vacuum(&mut program, None, Some(&dest), connection).unwrap_err();
         assert!(
             err.to_string().contains("cipher is required"),
             "unexpected error: {err}"
@@ -203,7 +209,9 @@ mod tests {
     fn test_translate_vacuum_into_uri_without_encryption_params() {
         let mut program = make_builder();
         let dest = quoted_string_expr("file:test.db");
-        translate_vacuum(&mut program, None, Some(&dest)).unwrap();
+        let (_, connection) = Connection::from_uri(":memory:", DatabaseOpts::new())
+            .expect("in-memory connection should succeed");
+        translate_vacuum(&mut program, None, Some(&dest), connection).unwrap();
 
         let (dest_path, encryption_opts) = program
             .insns

--- a/core/translate/vacuum.rs
+++ b/core/translate/vacuum.rs
@@ -31,7 +31,8 @@ pub fn translate_vacuum(
             // VACUUM INTO 'path' - create compacted copy at destination
             let dest = extract_path_from_expr(dest_expr)?;
             let opts = OpenOptions::parse(dest.as_str())?;
-            // Do we need to throw error if nonsense options like mode=ro are passed?
+            // TODO: Handle all URI parameters, including throwing errors for nonsense ones like
+            // mode=ro
             match (opts.cipher, opts.hexkey) {
                 (Some(cipher), Some(hexkey)) => program.emit_insn(Insn::VacuumInto {
                     schema_name,
@@ -186,9 +187,9 @@ mod tests {
         let (_, connection) = Connection::from_uri(":memory:", DatabaseOpts::new())
             .expect("in-memory connection should succeed");
         let err = translate_vacuum(&mut program, None, Some(&dest), connection).unwrap_err();
-        assert!(
-            err.to_string().contains("hexkey is required"),
-            "unexpected error: {err}"
+        assert_eq!(
+            err.to_string(),
+            "Parse error: hexkey is required when cipher is provided"
         );
     }
 
@@ -199,9 +200,9 @@ mod tests {
         let (_, connection) = Connection::from_uri(":memory:", DatabaseOpts::new())
             .expect("in-memory connection should succeed");
         let err = translate_vacuum(&mut program, None, Some(&dest), connection).unwrap_err();
-        assert!(
-            err.to_string().contains("cipher is required"),
-            "unexpected error: {err}"
+        assert_eq!(
+            err.to_string(),
+            "Parse error: cipher is required when hexkey is provided"
         );
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -64,9 +64,9 @@ use crate::{
         builder::CursorType,
         insn::{IdxInsertFlags, Insn, SavepointOp},
     },
-    CaptureDataChangesInfo, CdcVersion, CheckpointMode, Completion, Connection, Database,
-    DatabaseStorage, IOExt, MvCursor, NonNan, OpenFlags, QueryMode, Statement, TransactionState,
-    ValueRef, WalAutoActions, MAIN_DB_ID, TEMP_DB_ID,
+    CaptureDataChangesInfo, CdcVersion, CheckpointMode, CipherMode, Completion, Connection,
+    Database, DatabaseStorage, EncryptionOpts, IOExt, MvCursor, NonNan, OpenFlags, QueryMode,
+    Statement, TransactionState, ValueRef, WalAutoActions, MAIN_DB_ID, TEMP_DB_ID,
 };
 use crate::{
     error::{
@@ -16396,7 +16396,8 @@ fn op_vacuum_into_inner(
     load_insn!(
         VacuumInto {
             schema_name,
-            dest_path
+            dest_path,
+            encryption_opts
         },
         insn
     );
@@ -16462,6 +16463,7 @@ fn op_vacuum_into_inner(
                 // BEGIN and pragma helpers here are blocking convenience wrappers;
                 // async work starts with the schema scan in vacuum_target_build_step.
                 let source_db = program.connection.get_source_database(source_db_id);
+
                 program.connection.execute("BEGIN")?;
                 state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                 let page_size: u32 = extract_pragma_int(
@@ -16510,6 +16512,8 @@ fn op_vacuum_into_inner(
                 // Mirror source feature flags to the output so schema replay
                 // can resolve custom types, generated columns, vtab modules, etc.
                 let output_opts = vacuum_target_opts_from_source(&source_db);
+                let output_opts = output_opts
+                    .with_encryption(output_opts.enable_encryption || encryption_opts.is_some());
 
                 // Always use PlatformIO for the output file, even if source
                 // is in-memory. This ensures VACUUM INTO writes to disk.
@@ -16519,14 +16523,21 @@ fn op_vacuum_into_inner(
                     dest_path,
                     OpenFlags::Create,
                     output_opts,
-                    None,
+                    encryption_opts.clone(),
                 )?;
                 let output_conn = output_db.connect()?;
                 output_conn.reset_page_size(page_size)?;
-                // set reserved_space on output to match source
-                // this is important for databases using encryption or checksums
-                // must be set before page 1 is allocated (before any schema operations)
-                output_conn.set_reserved_bytes(reserved_space)?;
+                // set reserved_space on destination to match source or use encryption parameters,
+                // if specified. This is important for databases using encryption or checksums.
+                // Must be set before page 1 is allocated (before any schema operations)
+                if let Some(EncryptionOpts { cipher, hexkey }) = encryption_opts {
+                    let cipher_mode = CipherMode::try_from(cipher.as_str())?;
+                    output_conn.execute(format!("PRAGMA cipher = '{cipher}'"))?;
+                    output_conn.execute(format!("PRAGMA hexkey = '{hexkey}'"))?;
+                    output_conn.set_reserved_bytes(cipher_mode.metadata_size() as u8)?;
+                } else {
+                    output_conn.set_reserved_bytes(reserved_space)?;
+                }
 
                 mirror_symbols(&program.connection, &output_conn);
                 let source_custom_types = capture_custom_types(&program.connection, source_db_id);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -137,7 +137,7 @@ use super::{make_record, Program, ProgramState, Register};
 
 #[cfg(feature = "fs")]
 use crate::connection::resolve_ext_path;
-use crate::{bail_constraint_error, must_be_btree_cursor, MvStore, Pager, Result};
+use crate::{bail_constraint_error, must_be_btree_cursor, EncryptionKey, MvStore, Pager, Result};
 
 type MvccCheckpointStateMachine = CheckpointStateMachine<MvccClock, DynAllocator>;
 
@@ -16525,19 +16525,22 @@ fn op_vacuum_into_inner(
                     output_opts,
                     encryption_opts.clone(),
                 )?;
-                let output_conn = output_db.connect()?;
-                output_conn.reset_page_size(page_size)?;
                 // set reserved_space on destination to match source or use encryption parameters,
                 // if specified. This is important for databases using encryption or checksums.
                 // Must be set before page 1 is allocated (before any schema operations)
-                if let Some(EncryptionOpts { cipher, hexkey }) = encryption_opts {
-                    let cipher_mode = CipherMode::try_from(cipher.as_str())?;
-                    output_conn.execute(format!("PRAGMA cipher = '{cipher}'"))?;
-                    output_conn.execute(format!("PRAGMA hexkey = '{hexkey}'"))?;
-                    output_conn.set_reserved_bytes(cipher_mode.metadata_size() as u8)?;
-                } else {
-                    output_conn.set_reserved_bytes(reserved_space)?;
-                }
+                let (encryption_key, reserved_bytes) =
+                    if let Some(EncryptionOpts { cipher, hexkey }) = encryption_opts {
+                        let cipher_mode = CipherMode::try_from(cipher.as_str())?;
+                        (
+                            Some(EncryptionKey::from_hex_string(hexkey)?),
+                            cipher_mode.metadata_size() as u8,
+                        )
+                    } else {
+                        (None, reserved_space)
+                    };
+                let output_conn = output_db.connect_with_encryption(encryption_key)?;
+                output_conn.reset_page_size(page_size)?;
+                output_conn.set_reserved_bytes(reserved_bytes)?;
 
                 mirror_symbols(&program.connection, &output_conn);
                 let source_custom_types = capture_custom_types(&program.connection, source_db_id);

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2554,7 +2554,7 @@ pub fn insn_to_row(
                 format!("hash_table_id={hash_table_id}"),
             )
         },
-        Insn::VacuumInto { schema_name, dest_path } => (
+        Insn::VacuumInto { schema_name, dest_path, .. } => (
             "VacuumInto",
             0,
             0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -16,7 +16,7 @@ use crate::{
     translate::{collate::CollationSeq, emitter::TransactionMode},
     types::KeyInfo,
     vdbe::affinity::Affinity,
-    PreparedProgram, Value,
+    EncryptionOpts, PreparedProgram, Value,
 };
 use strum::EnumCount;
 use strum_macros::{EnumDiscriminants, FromRepr, VariantArray};
@@ -1924,6 +1924,7 @@ pub enum Insn {
         schema_name: String,
         /// Destination file path for the vacuumed database
         dest_path: String,
+        encryption_opts: Option<EncryptionOpts>,
     },
 
     /// In-place VACUUM - compact the database (by writing to a temporary location and then copying

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -6242,6 +6242,12 @@ fn test_vacuum_into_encrypts_destination(tmp_db: TempDatabase) -> anyhow::Result
         "encrypted VACUUM INTO destination leaked plaintext sentinel"
     );
 
+    let integrity_result = run_integrity_check(&dest_conn);
+    assert_eq!(
+        integrity_result, "ok",
+        "Destination database with index should pass integrity check"
+    );
+
     Ok(())
 }
 

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -1,6 +1,7 @@
 use crate::common::{
     compute_dbhash, compute_dbhash_with_database_opts, compute_dbhash_with_options,
-    compute_dbhash_with_options_and_database_opts, do_flush, ExecRows, TempDatabase,
+    compute_dbhash_with_options_and_database_opts, do_flush, run_query_on_row, ExecRows,
+    TempDatabase,
 };
 use crate::queued_io::{QueuedIo, QueuedIoOpKind};
 use rusqlite::Connection as SqliteConnection;
@@ -6187,6 +6188,111 @@ fn test_vacuum_into_followed_by_writes_and_indexed_read() -> anyhow::Result<()> 
     assert_eq!(
         scalar_i64(&conn, "SELECT count(*) FROM t INDEXED BY i_c WHERE c >= ''"),
         55
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Encrypted VACUUM tests
+// ---------------------------------------------------------------------------
+
+const VACUUM_ENC_CIPHER: &str = "aegis256";
+const VACUUM_ENC_HEXKEY: &str = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+/// VACUUM INTO with cipher+hexkey produces an encrypted destination: the rows
+/// can be read back with the matching key, and the on-disk bytes do not contain
+/// the plaintext sentinel string.
+#[turso_macros::test]
+fn test_vacuum_into_encrypts_destination(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let conn = tmp_db.connect_limbo();
+
+    // unique sentinel that should never appear in ciphertext
+    let sentinel = "PLAINTEXT_SENTINEL_QWERTY_12345";
+    conn.execute("CREATE TABLE secrets (id INTEGER PRIMARY KEY, value TEXT)")?;
+    conn.execute(format!("INSERT INTO secrets (value) VALUES ('{sentinel}')"))?;
+    conn.execute("INSERT INTO secrets (value) VALUES ('another secret')")?;
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("encrypted_vacuumed.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!(
+        "VACUUM INTO 'file:{dest_path_str}?cipher={VACUUM_ENC_CIPHER}&hexkey={VACUUM_ENC_HEXKEY}'"
+    ))?;
+    assert!(dest_path.exists(), "destination file should exist");
+
+    // open destination with matching encryption params and verify rows
+    let uri = format!("file:{dest_path_str}?cipher={VACUUM_ENC_CIPHER}&hexkey={VACUUM_ENC_HEXKEY}");
+    let (_io, dest_conn) =
+        Connection::from_uri(&uri, turso_core::DatabaseOpts::new().with_encryption(true))?;
+    let rows: Vec<(i64, String)> = dest_conn.exec_rows("SELECT id, value FROM secrets ORDER BY id");
+    assert_eq!(
+        rows,
+        vec![(1, sentinel.to_string()), (2, "another secret".to_string()),]
+    );
+
+    // the raw on-disk bytes must not contain the plaintext sentinel
+    let bytes = std::fs::read(&dest_path)?;
+    let needle = sentinel.as_bytes();
+    let leaked = bytes.windows(needle.len()).any(|w| w == needle);
+    assert!(
+        !leaked,
+        "encrypted VACUUM INTO destination leaked plaintext sentinel"
+    );
+
+    Ok(())
+}
+
+/// VACUUM INTO destination encrypted with a given key cannot be decrypted with
+/// a different key, and cannot be read at all without the cipher/hexkey params.
+#[turso_macros::test]
+fn test_vacuum_into_encrypted_destination_rejects_wrong_key(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE secrets (id INTEGER PRIMARY KEY, value TEXT)")?;
+    conn.execute("INSERT INTO secrets (value) VALUES ('hidden')")?;
+
+    let dest_dir = TempDir::new()?;
+    let dest_path = dest_dir.path().join("encrypted_vacuumed.db");
+    let dest_path_str = dest_path.to_str().unwrap();
+
+    conn.execute(format!(
+        "VACUUM INTO 'file:{dest_path_str}?cipher={VACUUM_ENC_CIPHER}&hexkey={VACUUM_ENC_HEXKEY}'"
+    ))?;
+
+    // try_open returns Err either when from_uri itself rejects the file, or when
+    // a subsequent query fails to decrypt page 1.
+    let try_open = |uri: &str| -> Result<(), ()> {
+        match Connection::from_uri(uri, turso_core::DatabaseOpts::new().with_encryption(true)) {
+            Err(_) => Err(()),
+            Ok((_io, c)) => run_query_on_row(
+                &tmp_db,
+                &c,
+                "SELECT id, value FROM secrets",
+                |_row: &turso_core::Row| {},
+            )
+            .map_err(|_| ()),
+        }
+    };
+
+    // wrong hexkey (last two hex digits flipped from `27` to `77`)
+    let wrong_hexkey = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76377";
+    let wrong_uri =
+        format!("file:{dest_path_str}?cipher={VACUUM_ENC_CIPHER}&hexkey={wrong_hexkey}");
+    assert!(
+        try_open(&wrong_uri).is_err(),
+        "encrypted destination must not be readable with wrong hexkey"
+    );
+
+    // no encryption params at all
+    let bare_uri = format!("file:{dest_path_str}");
+    assert!(
+        try_open(&bare_uri).is_err(),
+        "encrypted destination must not be readable without encryption params"
     );
 
     Ok(())


### PR DESCRIPTION
## Description

Adds support for the `cipher` and `hexkey` parameters for `file:` URIs when using `VACUUM INTO`.

## Motivation and context

Addresses #5852

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
I used Claude Code to ask where to find the relevant files that would need to be edited to implement the feature. The actual implementation was done by hand. Then I had Claude write the tests as well.