### PR TITLE
add a tool to measure stack usage

### DIFF
--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -36,12 +36,17 @@ Useful options:
 ```bash
 --sql FILE|-             # SQL payload, or stdin with -
 --format human|json|csv  # output format
---top N                  # human output row limit
+--top N                  # heaviest span rows per statement in human output
 ```
 
-The report is sorted by lowest `remaining_stack`, so the first rows are the
-deepest observed stack points. JSON and CSV formats are deterministic and
-intended for comparing runs.
+The report is statement-oriented. For each SQL statement, it records the
+remaining stack before execution, the minimum remaining stack sampled while that
+statement ran, and `stack_used = baseline_remaining_stack - min_remaining_stack`.
+Statements are sorted by `stack_used` descending so the worst SQL statements are
+first. Within each statement, span rows are sorted by `stack_used` descending,
+with the original tracing emission sequence kept in the `trace_sequence` field
+(`seq` in human output). JSON and CSV formats are deterministic and intended for
+comparing runs.
 
 `stack-report` splits payloads with `turso_parser::parser::Parser::next_cmd()`.
 It then executes statements with no result columns, and queries and drains

--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -37,6 +37,8 @@ Useful options:
 --sql FILE|-             # SQL payload, or stdin with -
 --format human|json|csv  # output format
 --top N                  # aggregate/span rows per statement in human output
+--statement N[,N...]     # only include reports for 1-based statement indexes
+--sql-contains TEXT      # only include reports for statements containing TEXT, ASCII case-insensitive
 ```
 
 The report is statement-oriented. For each SQL statement, it records the
@@ -60,6 +62,11 @@ for ranking likely contributors, not for summing to statement total stack.
 JSON and CSV formats are deterministic and intended for comparing runs. CSV
 uses a `row_type` column with `global_aggregate`, `statement_aggregate`, `span`,
 and `statement` rows.
+
+Statement filters affect reporting only. The runner still executes the full SQL
+payload in order so schema/data setup and earlier statements remain visible to
+later selected statements. Multiple `--statement` and `--sql-contains` filters
+are allowed; when both are present, a statement must match both kinds.
 
 `stack-report` splits payloads with `turso_parser::parser::Parser::next_cmd()`.
 It then executes statements with no result columns, and queries and drains

--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -7,11 +7,51 @@ description: How to benchmark and analyze memory usage in Turso using the memory
 
 The `perf/memory` crate benchmarks memory usage of SQL workloads under WAL and MVCC journal modes. It uses `dhat` as the global allocator to track every heap allocation, and `memory-stats` for process-level RSS snapshots.
 
+It also contains a `stack-report` helper binary for stack-usage investigations.
+That binary runs a SQL payload with the `stacker` feature enabled and captures
+`turso_stack` tracing events in-process, aggregating structured tracing fields
+instead of parsing stderr log text.
+
 ## Location
 
 - Benchmark crate: `perf/memory/`
 - Analysis script: `perf/memory/analyze-dhat.py`
 - dhat output: `dhat-heap.json` (written to CWD after each run)
+
+## Running Stack Reports
+
+Use this when investigating stack usage from SQL translation/execution probes.
+Run stack reports in release mode with `--features stacker` when comparing
+against server logs or CI stack-size output. Debug builds can materially
+overstate stack deltas and should only be used for quick local iteration.
+
+```bash
+cargo run --release -q -p memory-benchmark --features stacker --bin stack-report -- \
+  --sql path/to/payload.sql \
+  --top 40
+```
+
+Useful options:
+
+```bash
+--sql FILE|-             # SQL payload, or stdin with -
+--format human|json|csv  # output format
+--top N                  # human output row limit
+```
+
+The report is sorted by lowest `remaining_stack`, so the first rows are the
+deepest observed stack points. JSON and CSV formats are deterministic and
+intended for comparing runs.
+
+`stack-report` splits payloads with `turso_parser::parser::Parser::next_cmd()`.
+It then executes statements with no result columns, and queries and drains
+row-producing statements. Do not change binding `execute_batch` semantics for
+stack reports.
+
+The runner currently uses a fixed in-memory database and enables generated
+columns, custom types, and materialized views internally. There are no stack
+report CLI flags for selecting the database path or toggling those experimental
+features.
 
 ## Running Benchmarks
 

--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -36,17 +36,30 @@ Useful options:
 ```bash
 --sql FILE|-             # SQL payload, or stdin with -
 --format human|json|csv  # output format
---top N                  # heaviest span rows per statement in human output
+--top N                  # aggregate/span rows per statement in human output
 ```
 
 The report is statement-oriented. For each SQL statement, it records the
 remaining stack before execution, the minimum remaining stack sampled while that
 statement ran, and `stack_used = baseline_remaining_stack - min_remaining_stack`.
 Statements are sorted by `stack_used` descending so the worst SQL statements are
-first. Within each statement, span rows are sorted by `stack_used` descending,
-with the original tracing emission sequence kept in the `trace_sequence` field
-(`seq` in human output). JSON and CSV formats are deterministic and intended for
-comparing runs.
+first. The human report also prints global and per-statement span aggregates
+sorted by `total_inclusive_stack_used` descending. These aggregate rows group by
+`label` plus `detail` and include call count, total/max self stack, total/max
+inclusive stack, max cumulative stack at span entry, and `peak_path_hits` for
+spans that were active at the statement's minimum remaining-stack sample.
+
+Within each statement, raw span rows are still sorted by `stack_used`
+descending, with the original tracing emission sequence kept in the
+`trace_sequence` field (`seq` in human output). Raw span rows include
+`inclusive_stack_used`, which is measured from the span's parent stack level down
+to the deepest sampled remaining stack while the span was active. This is an
+inclusive profiler-style metric, so nested spans intentionally overlap; use it
+for ranking likely contributors, not for summing to statement total stack.
+
+JSON and CSV formats are deterministic and intended for comparing runs. CSV
+uses a `row_type` column with `global_aggregate`, `statement_aggregate`, `span`,
+and `statement` rows.
 
 `stack-report` splits payloads with `turso_parser::parser::Parser::next_cmd()`.
 It then executes statements with no result columns, and queries and drains

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,8 +3428,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "turso",
+ "turso_parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,6 +3427,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_json",
+ "stacker",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,6 +6607,7 @@ dependencies = [
  "simsimd",
  "smallvec",
  "sorted-vec",
+ "stacker",
  "strum",
  "strum_macros",
  "tantivy",

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -17,6 +17,7 @@ default = ["mimalloc", "fts"]
 mimalloc = ["dep:mimalloc"]
 pure-rust-crypto = ["turso_sdk_kit/pure-rust-crypto", "turso_sync_sdk_kit/pure-rust-crypto"]
 fts = ["turso_sdk_kit/fts"]
+stacker = ["turso_core/stacker"]
 sync = [
     "dep:hyper",
     "dep:tokio",
@@ -60,4 +61,3 @@ rand_chacha = { workspace = true }
 anyhow.workspace = true
 reqwest = { version = "0.13.2", features = ["json"] }
 serde_json.workspace = true
-

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,6 +72,7 @@ tracing_release = ["turso_core/tracing_release"]
 mimalloc = ["dep:mimalloc"]
 fts = ["turso_core/fts"]
 mvcc_repl = []
+stacker = ["turso_core/stacker"]
 
 [build-dependencies]
 syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,6 +41,7 @@ nanosecond-bench = ["bench"]
 fts = ["dep:tantivy"]
 codspeed = ["bench"]
 optimizer_params = ["serde", "dep:serde_json"]
+stacker = ["dep:stacker"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61.2", features = [
@@ -115,6 +116,7 @@ crc32c = "0.6.8"
 bigdecimal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
+stacker = { version = "0.1", optional = true }
 
 [target.'cfg(not(any(target_family = "wasm", all(target_os = "windows", target_arch = "aarch64"))))'.dependencies]
 simsimd = "6.5.3"

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -661,6 +661,7 @@ impl Connection {
         cmd: Cmd,
         input: &str,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
+        let _stack = crate::stack::trace_scope("compile_cmd");
         self.maybe_update_schema();
         let syms = self.syms.read();
         let pager = self.pager.load().clone();
@@ -682,9 +683,13 @@ impl Connection {
                 // than cloning the original AST, which can overflow the stack
                 // on deeply nested expression trees.
                 drop(syms);
-                let mut parser = Parser::new(input.as_bytes());
-                let Some(cmd) = parser.next_cmd()? else {
-                    return Err(err);
+                let cmd = {
+                    let _stack = crate::stack::trace_scope("compile_cmd:schema_retry_parse");
+                    let mut parser = Parser::new(input.as_bytes());
+                    let Some(cmd) = parser.next_cmd()? else {
+                        return Err(err);
+                    };
+                    cmd
                 };
                 self.maybe_update_schema();
                 let syms = self.syms.read();
@@ -744,20 +749,26 @@ impl Connection {
         let result = (|| {
             let sql = sql.as_ref();
             tracing::debug!("Preparing: {}", sql);
-            let mut parser = Parser::new(sql.as_bytes());
-            let cmd = match parser.next_cmd()? {
-                Some(cmd) => cmd,
-                None => {
-                    return Err(LimboError::InvalidArgument(
-                        "The supplied SQL string contains no statements".to_string(),
-                    ));
-                }
+            let (cmd, byte_offset_end) = {
+                let _stack = crate::stack::trace_scope("prepare:parse");
+                let mut parser = Parser::new(sql.as_bytes());
+                let cmd = match parser.next_cmd()? {
+                    Some(cmd) => cmd,
+                    None => {
+                        return Err(LimboError::InvalidArgument(
+                            "The supplied SQL string contains no statements".to_string(),
+                        ));
+                    }
+                };
+                (cmd, parser.offset())
             };
-            let byte_offset_end = parser.offset();
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
+            let (program, pager, mode) = {
+                let _stack = crate::stack::trace_scope("prepare:compile");
+                self.compile_cmd(cmd, input)?
+            };
             Ok(Statement::new_with_origin(
                 program,
                 pager,
@@ -797,15 +808,18 @@ impl Connection {
             let pager = self.pager.load().clone();
             let mode = QueryMode::Normal;
             let schema = self.schema.read().clone();
-            let program = translate::translate(
-                &schema,
-                stmt,
-                pager.clone(),
-                self.clone(),
-                &syms,
-                mode,
-                "<ast>", // No SQL input string available
-            )?;
+            let program = {
+                let _stack = crate::stack::trace_scope("prepare_stmt:translate");
+                translate::translate(
+                    &schema,
+                    stmt,
+                    pager.clone(),
+                    self.clone(),
+                    &syms,
+                    mode,
+                    "<ast>", // No SQL input string available
+                )?
+            };
             Ok(Statement::new_with_origin(
                 program,
                 pager,
@@ -1127,8 +1141,14 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
-            Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
+            let (program, pager, mode) = {
+                let _stack = crate::stack::trace_scope("execute:compile");
+                self.compile_cmd(cmd, input)?
+            };
+            {
+                let _stack = crate::stack::trace_scope("execute:run");
+                Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
+            }
         }
         Ok(())
     }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -662,12 +662,27 @@ impl Connection {
         input: &str,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
         let _stack = crate::stack::trace_scope("compile_cmd");
-        self.maybe_update_schema();
-        let syms = self.syms.read();
-        let pager = self.pager.load().clone();
-        let mode = QueryMode::new(&cmd);
+        {
+            let _stack = crate::stack::trace_scope("compile_cmd:update_schema");
+            self.maybe_update_schema();
+        }
+        let syms = {
+            let _stack = crate::stack::trace_scope("compile_cmd:read_symbols");
+            self.syms.read()
+        };
+        let pager = {
+            let _stack = crate::stack::trace_scope("compile_cmd:load_pager");
+            self.pager.load().clone()
+        };
+        let mode = {
+            let _stack = crate::stack::trace_scope("compile_cmd:query_mode");
+            QueryMode::new(&cmd)
+        };
         let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-        let schema = self.schema.read().clone();
+        let schema = {
+            let _stack = crate::stack::trace_scope("compile_cmd:clone_schema");
+            self.schema.read().clone()
+        };
         match translate::translate(
             &schema,
             stmt,
@@ -691,12 +706,27 @@ impl Connection {
                     };
                     cmd
                 };
-                self.maybe_update_schema();
-                let syms = self.syms.read();
-                let pager = self.pager.load().clone();
-                let mode = QueryMode::new(&cmd);
+                {
+                    let _stack = crate::stack::trace_scope("compile_cmd:retry_update_schema");
+                    self.maybe_update_schema();
+                }
+                let syms = {
+                    let _stack = crate::stack::trace_scope("compile_cmd:retry_read_symbols");
+                    self.syms.read()
+                };
+                let pager = {
+                    let _stack = crate::stack::trace_scope("compile_cmd:retry_load_pager");
+                    self.pager.load().clone()
+                };
+                let mode = {
+                    let _stack = crate::stack::trace_scope("compile_cmd:retry_query_mode");
+                    QueryMode::new(&cmd)
+                };
                 let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-                let schema = self.schema.read().clone();
+                let schema = {
+                    let _stack = crate::stack::trace_scope("compile_cmd:retry_clone_schema");
+                    self.schema.read().clone()
+                };
                 translate::translate(
                     &schema,
                     stmt,
@@ -744,6 +774,7 @@ impl Connection {
 
         let needs_nested_guard = origin.needs_nested_guard();
         if needs_nested_guard {
+            let _stack = crate::stack::trace_scope("prepare:start_nested");
             self.start_nested();
         }
         let result = (|| {
@@ -769,16 +800,20 @@ impl Connection {
                 let _stack = crate::stack::trace_scope("prepare:compile");
                 self.compile_cmd(cmd, input)?
             };
-            Ok(Statement::new_with_origin(
-                program,
-                pager,
-                mode,
-                byte_offset_end,
-                origin,
-                needs_nested_guard,
-            ))
+            {
+                let _stack = crate::stack::trace_scope("prepare:statement_new");
+                Ok(Statement::new_with_origin(
+                    program,
+                    pager,
+                    mode,
+                    byte_offset_end,
+                    origin,
+                    needs_nested_guard,
+                ))
+            }
         })();
         if result.is_err() && needs_nested_guard {
+            let _stack = crate::stack::trace_scope("prepare:end_nested_on_error");
             self.end_nested();
         }
         result
@@ -800,14 +835,30 @@ impl Connection {
         }
         let needs_nested_guard = origin.needs_nested_guard();
         if needs_nested_guard {
+            let _stack = crate::stack::trace_scope("prepare_stmt:start_nested");
             self.start_nested();
         }
         let result = (|| {
-            self.maybe_update_schema();
-            let syms = self.syms.read();
-            let pager = self.pager.load().clone();
-            let mode = QueryMode::Normal;
-            let schema = self.schema.read().clone();
+            {
+                let _stack = crate::stack::trace_scope("prepare_stmt:update_schema");
+                self.maybe_update_schema();
+            }
+            let syms = {
+                let _stack = crate::stack::trace_scope("prepare_stmt:read_symbols");
+                self.syms.read()
+            };
+            let pager = {
+                let _stack = crate::stack::trace_scope("prepare_stmt:load_pager");
+                self.pager.load().clone()
+            };
+            let mode = {
+                let _stack = crate::stack::trace_scope("prepare_stmt:query_mode");
+                QueryMode::Normal
+            };
+            let schema = {
+                let _stack = crate::stack::trace_scope("prepare_stmt:clone_schema");
+                self.schema.read().clone()
+            };
             let program = {
                 let _stack = crate::stack::trace_scope("prepare_stmt:translate");
                 translate::translate(
@@ -820,16 +871,20 @@ impl Connection {
                     "<ast>", // No SQL input string available
                 )?
             };
-            Ok(Statement::new_with_origin(
-                program,
-                pager,
-                mode,
-                0,
-                origin,
-                needs_nested_guard,
-            ))
+            {
+                let _stack = crate::stack::trace_scope("prepare_stmt:statement_new");
+                Ok(Statement::new_with_origin(
+                    program,
+                    pager,
+                    mode,
+                    0,
+                    origin,
+                    needs_nested_guard,
+                ))
+            }
         })();
         if result.is_err() && needs_nested_guard {
+            let _stack = crate::stack::trace_scope("prepare_stmt:end_nested_on_error");
             self.end_nested();
         }
         result

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -663,24 +663,24 @@ impl Connection {
         input: &str,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
         {
-            let _stack = crate::stack::trace_scope("update_schema");
+            crate::stack::trace_stack!("update_schema");
             self.maybe_update_schema();
         }
         let syms = {
-            let _stack = crate::stack::trace_scope("read_symbols");
+            crate::stack::trace_stack!("read_symbols");
             self.syms.read()
         };
         let pager = {
-            let _stack = crate::stack::trace_scope("load_pager");
+            crate::stack::trace_stack!("load_pager");
             self.pager.load().clone()
         };
         let mode = {
-            let _stack = crate::stack::trace_scope("query_mode");
+            crate::stack::trace_stack!("query_mode");
             QueryMode::new(&cmd)
         };
         let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
         let schema = {
-            let _stack = crate::stack::trace_scope("clone_schema");
+            crate::stack::trace_stack!("clone_schema");
             self.schema.read().clone()
         };
         match translate::translate(
@@ -699,7 +699,7 @@ impl Connection {
                 // on deeply nested expression trees.
                 drop(syms);
                 let cmd = {
-                    let _stack = crate::stack::trace_scope("schema_retry_parse");
+                    crate::stack::trace_stack!("schema_retry_parse");
                     let mut parser = Parser::new(input.as_bytes());
                     let Some(cmd) = parser.next_cmd()? else {
                         return Err(err);
@@ -707,24 +707,24 @@ impl Connection {
                     cmd
                 };
                 {
-                    let _stack = crate::stack::trace_scope("retry_update_schema");
+                    crate::stack::trace_stack!("retry_update_schema");
                     self.maybe_update_schema();
                 }
                 let syms = {
-                    let _stack = crate::stack::trace_scope("retry_read_symbols");
+                    crate::stack::trace_stack!("retry_read_symbols");
                     self.syms.read()
                 };
                 let pager = {
-                    let _stack = crate::stack::trace_scope("retry_load_pager");
+                    crate::stack::trace_stack!("retry_load_pager");
                     self.pager.load().clone()
                 };
                 let mode = {
-                    let _stack = crate::stack::trace_scope("retry_query_mode");
+                    crate::stack::trace_stack!("retry_query_mode");
                     QueryMode::new(&cmd)
                 };
                 let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
                 let schema = {
-                    let _stack = crate::stack::trace_scope("retry_clone_schema");
+                    crate::stack::trace_stack!("retry_clone_schema");
                     self.schema.read().clone()
                 };
                 translate::translate(
@@ -758,6 +758,7 @@ impl Connection {
         self.prepare_with_origin(sql, StatementOrigin::Root)
     }
 
+    #[turso_macros::trace_stack]
     fn prepare_with_origin(
         self: &Arc<Connection>,
         sql: impl AsRef<str>,
@@ -774,14 +775,14 @@ impl Connection {
 
         let needs_nested_guard = origin.needs_nested_guard();
         if needs_nested_guard {
-            let _stack = crate::stack::trace_scope("prepare:start_nested");
+            crate::stack::trace_stack!("start_nested");
             self.start_nested();
         }
         let result = (|| {
             let sql = sql.as_ref();
             tracing::debug!("Preparing: {}", sql);
             let (cmd, byte_offset_end) = {
-                let _stack = crate::stack::trace_scope("prepare:parse");
+                crate::stack::trace_stack!("parse");
                 let mut parser = Parser::new(sql.as_bytes());
                 let cmd = match parser.next_cmd()? {
                     Some(cmd) => cmd,
@@ -797,11 +798,11 @@ impl Connection {
                 .unwrap()
                 .trim();
             let (program, pager, mode) = {
-                let _stack = crate::stack::trace_scope("prepare:compile");
+                crate::stack::trace_stack!("compile");
                 self.compile_cmd(cmd, input)?
             };
             {
-                let _stack = crate::stack::trace_scope("prepare:statement_new");
+                crate::stack::trace_stack!("statement_new");
                 Ok(Statement::new_with_origin(
                     program,
                     pager,
@@ -813,7 +814,7 @@ impl Connection {
             }
         })();
         if result.is_err() && needs_nested_guard {
-            let _stack = crate::stack::trace_scope("prepare:end_nested_on_error");
+            crate::stack::trace_stack!("end_nested_on_error");
             self.end_nested();
         }
         result
@@ -825,6 +826,7 @@ impl Connection {
         self.prepare_stmt_with_origin(stmt, StatementOrigin::Root)
     }
 
+    #[turso_macros::trace_stack]
     fn prepare_stmt_with_origin(
         self: &Arc<Connection>,
         stmt: ast::Stmt,
@@ -835,32 +837,32 @@ impl Connection {
         }
         let needs_nested_guard = origin.needs_nested_guard();
         if needs_nested_guard {
-            let _stack = crate::stack::trace_scope("prepare_stmt:start_nested");
+            crate::stack::trace_stack!("start_nested");
             self.start_nested();
         }
         let result = (|| {
             {
-                let _stack = crate::stack::trace_scope("prepare_stmt:update_schema");
+                crate::stack::trace_stack!("update_schema");
                 self.maybe_update_schema();
             }
             let syms = {
-                let _stack = crate::stack::trace_scope("prepare_stmt:read_symbols");
+                crate::stack::trace_stack!("read_symbols");
                 self.syms.read()
             };
             let pager = {
-                let _stack = crate::stack::trace_scope("prepare_stmt:load_pager");
+                crate::stack::trace_stack!("load_pager");
                 self.pager.load().clone()
             };
             let mode = {
-                let _stack = crate::stack::trace_scope("prepare_stmt:query_mode");
+                crate::stack::trace_stack!("query_mode");
                 QueryMode::Normal
             };
             let schema = {
-                let _stack = crate::stack::trace_scope("prepare_stmt:clone_schema");
+                crate::stack::trace_stack!("clone_schema");
                 self.schema.read().clone()
             };
             let program = {
-                let _stack = crate::stack::trace_scope("prepare_stmt:translate");
+                crate::stack::trace_stack!("translate");
                 translate::translate(
                     &schema,
                     stmt,
@@ -872,7 +874,7 @@ impl Connection {
                 )?
             };
             {
-                let _stack = crate::stack::trace_scope("prepare_stmt:statement_new");
+                crate::stack::trace_stack!("statement_new");
                 Ok(Statement::new_with_origin(
                     program,
                     pager,
@@ -884,7 +886,7 @@ impl Connection {
             }
         })();
         if result.is_err() && needs_nested_guard {
-            let _stack = crate::stack::trace_scope("prepare_stmt:end_nested_on_error");
+            crate::stack::trace_stack!("end_nested_on_error");
             self.end_nested();
         }
         result
@@ -1185,6 +1187,7 @@ impl Connection {
     /// Execute will run a query from start to finish taking ownership of I/O because it will run pending I/Os if it didn't finish.
     /// TODO: make this api async
     #[instrument(skip_all, level = Level::INFO)]
+    #[turso_macros::trace_stack]
     pub fn execute(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<()> {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
@@ -1197,11 +1200,11 @@ impl Connection {
                 .unwrap()
                 .trim();
             let (program, pager, mode) = {
-                let _stack = crate::stack::trace_scope("execute:compile");
+                crate::stack::trace_stack!("compile");
                 self.compile_cmd(cmd, input)?
             };
             {
-                let _stack = crate::stack::trace_scope("execute:run");
+                crate::stack::trace_stack!("run");
                 Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;
             }
         }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -662,27 +662,13 @@ impl Connection {
         cmd: Cmd,
         input: &str,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
-        {
-            crate::stack::trace_stack!("update_schema");
-            self.maybe_update_schema();
-        }
-        let syms = {
-            crate::stack::trace_stack!("read_symbols");
-            self.syms.read()
-        };
-        let pager = {
-            crate::stack::trace_stack!("load_pager");
-            self.pager.load().clone()
-        };
-        let mode = {
-            crate::stack::trace_stack!("query_mode");
-            QueryMode::new(&cmd)
-        };
+        self.maybe_update_schema();
+
+        let syms = self.syms.read();
+        let pager = self.pager.load().clone();
+        let mode = QueryMode::new(&cmd);
         let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-        let schema = {
-            crate::stack::trace_stack!("clone_schema");
-            self.schema.read().clone()
-        };
+        let schema = self.schema.read().clone();
         match translate::translate(
             &schema,
             stmt,
@@ -706,27 +692,12 @@ impl Connection {
                     };
                     cmd
                 };
-                {
-                    crate::stack::trace_stack!("retry_update_schema");
-                    self.maybe_update_schema();
-                }
-                let syms = {
-                    crate::stack::trace_stack!("retry_read_symbols");
-                    self.syms.read()
-                };
-                let pager = {
-                    crate::stack::trace_stack!("retry_load_pager");
-                    self.pager.load().clone()
-                };
-                let mode = {
-                    crate::stack::trace_stack!("retry_query_mode");
-                    QueryMode::new(&cmd)
-                };
+                self.maybe_update_schema();
+                let syms = self.syms.read();
+                let pager = self.pager.load().clone();
+                let mode = QueryMode::new(&cmd);
                 let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
-                let schema = {
-                    crate::stack::trace_stack!("retry_clone_schema");
-                    self.schema.read().clone()
-                };
+                let schema = self.schema.read().clone();
                 translate::translate(
                     &schema,
                     stmt,
@@ -775,7 +746,6 @@ impl Connection {
 
         let needs_nested_guard = origin.needs_nested_guard();
         if needs_nested_guard {
-            crate::stack::trace_stack!("start_nested");
             self.start_nested();
         }
         let result = (|| {
@@ -797,24 +767,18 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = {
-                crate::stack::trace_stack!("compile");
-                self.compile_cmd(cmd, input)?
-            };
-            {
-                crate::stack::trace_stack!("statement_new");
-                Ok(Statement::new_with_origin(
-                    program,
-                    pager,
-                    mode,
-                    byte_offset_end,
-                    origin,
-                    needs_nested_guard,
-                ))
-            }
+            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
+
+            Ok(Statement::new_with_origin(
+                program,
+                pager,
+                mode,
+                byte_offset_end,
+                origin,
+                needs_nested_guard,
+            ))
         })();
         if result.is_err() && needs_nested_guard {
-            crate::stack::trace_stack!("end_nested_on_error");
             self.end_nested();
         }
         result
@@ -837,56 +801,33 @@ impl Connection {
         }
         let needs_nested_guard = origin.needs_nested_guard();
         if needs_nested_guard {
-            crate::stack::trace_stack!("start_nested");
             self.start_nested();
         }
         let result = (|| {
-            {
-                crate::stack::trace_stack!("update_schema");
-                self.maybe_update_schema();
-            }
-            let syms = {
-                crate::stack::trace_stack!("read_symbols");
-                self.syms.read()
-            };
-            let pager = {
-                crate::stack::trace_stack!("load_pager");
-                self.pager.load().clone()
-            };
-            let mode = {
-                crate::stack::trace_stack!("query_mode");
-                QueryMode::Normal
-            };
-            let schema = {
-                crate::stack::trace_stack!("clone_schema");
-                self.schema.read().clone()
-            };
-            let program = {
-                crate::stack::trace_stack!("translate");
-                translate::translate(
-                    &schema,
-                    stmt,
-                    pager.clone(),
-                    self.clone(),
-                    &syms,
-                    mode,
-                    "<ast>", // No SQL input string available
-                )?
-            };
-            {
-                crate::stack::trace_stack!("statement_new");
-                Ok(Statement::new_with_origin(
-                    program,
-                    pager,
-                    mode,
-                    0,
-                    origin,
-                    needs_nested_guard,
-                ))
-            }
+            self.maybe_update_schema();
+            let syms = self.syms.read();
+            let pager = self.pager.load().clone();
+            let mode = QueryMode::Normal;
+            let schema = self.schema.read().clone();
+            let program = translate::translate(
+                &schema,
+                stmt,
+                pager.clone(),
+                self.clone(),
+                &syms,
+                mode,
+                "<ast>", // No SQL input string available
+            )?;
+            Ok(Statement::new_with_origin(
+                program,
+                pager,
+                mode,
+                0,
+                origin,
+                needs_nested_guard,
+            ))
         })();
         if result.is_err() && needs_nested_guard {
-            crate::stack::trace_stack!("end_nested_on_error");
             self.end_nested();
         }
         result
@@ -1199,10 +1140,7 @@ impl Connection {
             let input = str::from_utf8(&sql.as_bytes()[..byte_offset_end])
                 .unwrap()
                 .trim();
-            let (program, pager, mode) = {
-                crate::stack::trace_stack!("compile");
-                self.compile_cmd(cmd, input)?
-            };
+            let (program, pager, mode) = self.compile_cmd(cmd, input)?;
             {
                 crate::stack::trace_stack!("run");
                 Statement::new(program, pager.clone(), mode, 0).run_ignore_rows()?;

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -656,31 +656,31 @@ impl Connection {
         Ok(true)
     }
 
+    #[turso_macros::trace_stack]
     fn compile_cmd(
         self: &Arc<Connection>,
         cmd: Cmd,
         input: &str,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
-        let _stack = crate::stack::trace_scope("compile_cmd");
         {
-            let _stack = crate::stack::trace_scope("compile_cmd:update_schema");
+            let _stack = crate::stack::trace_scope("update_schema");
             self.maybe_update_schema();
         }
         let syms = {
-            let _stack = crate::stack::trace_scope("compile_cmd:read_symbols");
+            let _stack = crate::stack::trace_scope("read_symbols");
             self.syms.read()
         };
         let pager = {
-            let _stack = crate::stack::trace_scope("compile_cmd:load_pager");
+            let _stack = crate::stack::trace_scope("load_pager");
             self.pager.load().clone()
         };
         let mode = {
-            let _stack = crate::stack::trace_scope("compile_cmd:query_mode");
+            let _stack = crate::stack::trace_scope("query_mode");
             QueryMode::new(&cmd)
         };
         let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
         let schema = {
-            let _stack = crate::stack::trace_scope("compile_cmd:clone_schema");
+            let _stack = crate::stack::trace_scope("clone_schema");
             self.schema.read().clone()
         };
         match translate::translate(
@@ -699,7 +699,7 @@ impl Connection {
                 // on deeply nested expression trees.
                 drop(syms);
                 let cmd = {
-                    let _stack = crate::stack::trace_scope("compile_cmd:schema_retry_parse");
+                    let _stack = crate::stack::trace_scope("schema_retry_parse");
                     let mut parser = Parser::new(input.as_bytes());
                     let Some(cmd) = parser.next_cmd()? else {
                         return Err(err);
@@ -707,24 +707,24 @@ impl Connection {
                     cmd
                 };
                 {
-                    let _stack = crate::stack::trace_scope("compile_cmd:retry_update_schema");
+                    let _stack = crate::stack::trace_scope("retry_update_schema");
                     self.maybe_update_schema();
                 }
                 let syms = {
-                    let _stack = crate::stack::trace_scope("compile_cmd:retry_read_symbols");
+                    let _stack = crate::stack::trace_scope("retry_read_symbols");
                     self.syms.read()
                 };
                 let pager = {
-                    let _stack = crate::stack::trace_scope("compile_cmd:retry_load_pager");
+                    let _stack = crate::stack::trace_scope("retry_load_pager");
                     self.pager.load().clone()
                 };
                 let mode = {
-                    let _stack = crate::stack::trace_scope("compile_cmd:retry_query_mode");
+                    let _stack = crate::stack::trace_scope("retry_query_mode");
                     QueryMode::new(&cmd)
                 };
                 let (Cmd::Stmt(stmt) | Cmd::Explain(stmt) | Cmd::ExplainQueryPlan(stmt)) = cmd;
                 let schema = {
-                    let _stack = crate::stack::trace_scope("compile_cmd:retry_clone_schema");
+                    let _stack = crate::stack::trace_scope("retry_clone_schema");
                     self.schema.read().clone()
                 };
                 translate::translate(

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -51,6 +51,7 @@ mod pseudo;
 mod regexp;
 #[cfg(feature = "series")]
 mod series;
+mod stack;
 mod statement;
 mod stats;
 #[allow(dead_code)]

--- a/core/stack.rs
+++ b/core/stack.rs
@@ -1,6 +1,6 @@
 macro_rules! trace_stack {
     () => {
-        let _stack = $crate::stack::trace_scope(concat!(module_path!(), "::", line!()));
+        let _stack = $crate::stack::trace_scope(concat!("line:", line!()));
     };
     ($label:expr $(,)?) => {
         let _stack = $crate::stack::trace_scope($label);

--- a/core/stack.rs
+++ b/core/stack.rs
@@ -1,3 +1,16 @@
+macro_rules! trace_stack {
+    () => {
+        let _stack = $crate::stack::trace_scope(concat!(module_path!(), ":", line!()));
+    };
+    ($label:expr $(,)?) => {
+        let _stack = $crate::stack::trace_scope($label);
+    };
+    ($label:expr, $detail:expr $(,)?) => {
+        let _stack = $crate::stack::trace_scope_with_detail($label, $detail);
+    };
+}
+pub(crate) use trace_stack;
+
 #[cfg(feature = "stacker")]
 pub(crate) struct TraceGuard {
     label: &'static str,

--- a/core/stack.rs
+++ b/core/stack.rs
@@ -1,6 +1,6 @@
 macro_rules! trace_stack {
     () => {
-        let _stack = $crate::stack::trace_scope(concat!(module_path!(), ":", line!()));
+        let _stack = $crate::stack::trace_scope(concat!(module_path!(), "::", line!()));
     };
     ($label:expr $(,)?) => {
         let _stack = $crate::stack::trace_scope($label);

--- a/core/stack.rs
+++ b/core/stack.rs
@@ -1,0 +1,64 @@
+#[cfg(feature = "stacker")]
+pub(crate) struct TraceGuard {
+    label: &'static str,
+    detail: Option<&'static str>,
+}
+
+#[cfg(feature = "stacker")]
+impl Drop for TraceGuard {
+    fn drop(&mut self) {
+        if std::env::var_os("TURSO_TRACE_STACK").is_none() {
+            return;
+        }
+
+        tracing::debug!(
+            target: "turso_stack",
+            label = self.label,
+            detail = self.detail,
+            remaining_stack = stacker::remaining_stack(),
+            "stacker remaining stack"
+        );
+    }
+}
+
+#[cfg(feature = "stacker")]
+pub(crate) fn trace_scope(label: &'static str) -> TraceGuard {
+    TraceGuard {
+        label,
+        detail: None,
+    }
+}
+
+#[cfg(feature = "stacker")]
+pub(crate) fn trace_scope_with_detail(label: &'static str, detail: &'static str) -> TraceGuard {
+    TraceGuard {
+        label,
+        detail: Some(detail),
+    }
+}
+
+#[cfg(feature = "stacker")]
+pub(crate) fn trace_remaining(label: &'static str) {
+    if std::env::var_os("TURSO_TRACE_STACK").is_none() {
+        return;
+    }
+
+    tracing::debug!(
+        target: "turso_stack",
+        label,
+        remaining_stack = stacker::remaining_stack(),
+        "stacker remaining stack"
+    );
+}
+
+#[cfg(not(feature = "stacker"))]
+#[inline]
+pub(crate) fn trace_scope(_label: &'static str) {}
+
+#[cfg(not(feature = "stacker"))]
+#[inline]
+pub(crate) fn trace_scope_with_detail(_label: &'static str, _detail: &'static str) {}
+
+#[cfg(not(feature = "stacker"))]
+#[inline]
+pub(crate) fn trace_remaining(_label: &'static str) {}

--- a/core/stack.rs
+++ b/core/stack.rs
@@ -5,8 +5,8 @@ pub(crate) struct TraceGuard {
 }
 
 #[cfg(feature = "stacker")]
-impl Drop for TraceGuard {
-    fn drop(&mut self) {
+impl TraceGuard {
+    fn emit(&self, phase: &'static str) {
         if std::env::var_os("TURSO_TRACE_STACK").is_none() {
             return;
         }
@@ -15,6 +15,7 @@ impl Drop for TraceGuard {
             target: "turso_stack",
             label = self.label,
             detail = self.detail,
+            phase,
             remaining_stack = stacker::remaining_stack(),
             "stacker remaining stack"
         );
@@ -22,19 +23,30 @@ impl Drop for TraceGuard {
 }
 
 #[cfg(feature = "stacker")]
-pub(crate) fn trace_scope(label: &'static str) -> TraceGuard {
-    TraceGuard {
-        label,
-        detail: None,
+impl Drop for TraceGuard {
+    fn drop(&mut self) {
+        self.emit("exit");
     }
 }
 
 #[cfg(feature = "stacker")]
+pub(crate) fn trace_scope(label: &'static str) -> TraceGuard {
+    let guard = TraceGuard {
+        label,
+        detail: None,
+    };
+    guard.emit("enter");
+    guard
+}
+
+#[cfg(feature = "stacker")]
 pub(crate) fn trace_scope_with_detail(label: &'static str, detail: &'static str) -> TraceGuard {
-    TraceGuard {
+    let guard = TraceGuard {
         label,
         detail: Some(detail),
-    }
+    };
+    guard.emit("enter");
+    guard
 }
 
 #[cfg(feature = "stacker")]
@@ -46,6 +58,7 @@ pub(crate) fn trace_remaining(label: &'static str) {
     tracing::debug!(
         target: "turso_stack",
         label,
+        phase = "sample",
         remaining_stack = stacker::remaining_stack(),
         "stacker remaining stack"
     );

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -130,6 +130,7 @@ impl Statement {
         )
     }
 
+    #[turso_macros::trace_stack]
     pub(crate) fn new_with_origin(
         program: vdbe::Program,
         pager: Arc<Pager>,

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -93,32 +93,27 @@ pub fn translate_delete(
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
     program.begin_write_on_database(database_id, schema_cookie);
 
-    let mut delete_plan = {
-        crate::stack::trace_stack!("prepare_plan");
-        prepare_delete_plan(
-            program,
-            resolver,
-            tbl_name,
-            table,
-            where_clause,
-            limit,
-            returning,
-            indexed,
-            with,
-            connection,
-            database_id,
-        )?
-    };
+    let mut delete_plan = prepare_delete_plan(
+        program,
+        resolver,
+        tbl_name,
+        table,
+        where_clause,
+        limit,
+        returning,
+        indexed,
+        with,
+        connection,
+        database_id,
+    )?;
 
     // Plan subqueries in the WHERE clause
     if let Plan::Delete(ref mut delete_plan_inner) = delete_plan {
         if let Some(ref mut rowset_plan) = delete_plan_inner.rowset_plan {
             // When using rowset (triggers or subqueries present), subqueries are in the rowset_plan's WHERE
-            crate::stack::trace_stack!("plan_rowset_subqueries");
             plan_subqueries_from_select_plan(program, rowset_plan, resolver, connection)?;
         } else {
             // Normal path: subqueries are in the DELETE plan's WHERE
-            crate::stack::trace_stack!("plan_where_subqueries");
             plan_subqueries_from_where_clause(
                 program,
                 &mut delete_plan_inner.non_from_clause_subqueries,
@@ -130,10 +125,7 @@ pub fn translate_delete(
         }
     }
 
-    {
-        crate::stack::trace_stack!("optimize_plan");
-        optimize_plan(program, &mut delete_plan, resolver)?;
-    }
+    optimize_plan(program, &mut delete_plan, resolver)?;
     if let Plan::Delete(delete_plan_inner) = &mut delete_plan {
         // Re-check after optimization: chosen access paths can make "delete while scanning"
         // unsafe, so we may need to collect rowids first.
@@ -179,14 +171,12 @@ pub fn translate_delete(
     )?;
     let opts = ProgramBuilderOpts::new(1, estimate_num_instructions(delete), 0);
     program.extend(&opts);
-    {
-        crate::stack::trace_stack!("emit_program");
-        emit_program(connection, resolver, program, delete_plan, |_| {})?;
-    }
+    emit_program(connection, resolver, program, delete_plan, |_| {})?;
     Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
 pub fn prepare_delete_plan(
     program: &mut ProgramBuilder,
     resolver: &Resolver,

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -79,6 +79,7 @@ pub fn translate_delete(
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope("delete:translate");
     let database_id = resolver.resolve_existing_table_database_id_qualified(tbl_name)?;
     let normalized_table_name = normalize_ident(tbl_name.name.as_str());
     let table = validate_delete(
@@ -92,27 +93,32 @@ pub fn translate_delete(
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
     program.begin_write_on_database(database_id, schema_cookie);
 
-    let mut delete_plan = prepare_delete_plan(
-        program,
-        resolver,
-        tbl_name,
-        table,
-        where_clause,
-        limit,
-        returning,
-        indexed,
-        with,
-        connection,
-        database_id,
-    )?;
+    let mut delete_plan = {
+        let _stack = crate::stack::trace_scope("delete:prepare_plan");
+        prepare_delete_plan(
+            program,
+            resolver,
+            tbl_name,
+            table,
+            where_clause,
+            limit,
+            returning,
+            indexed,
+            with,
+            connection,
+            database_id,
+        )?
+    };
 
     // Plan subqueries in the WHERE clause
     if let Plan::Delete(ref mut delete_plan_inner) = delete_plan {
         if let Some(ref mut rowset_plan) = delete_plan_inner.rowset_plan {
             // When using rowset (triggers or subqueries present), subqueries are in the rowset_plan's WHERE
+            let _stack = crate::stack::trace_scope("delete:plan_rowset_subqueries");
             plan_subqueries_from_select_plan(program, rowset_plan, resolver, connection)?;
         } else {
             // Normal path: subqueries are in the DELETE plan's WHERE
+            let _stack = crate::stack::trace_scope("delete:plan_where_subqueries");
             plan_subqueries_from_where_clause(
                 program,
                 &mut delete_plan_inner.non_from_clause_subqueries,
@@ -124,7 +130,10 @@ pub fn translate_delete(
         }
     }
 
-    optimize_plan(program, &mut delete_plan, resolver)?;
+    {
+        let _stack = crate::stack::trace_scope("delete:optimize_plan");
+        optimize_plan(program, &mut delete_plan, resolver)?;
+    }
     if let Plan::Delete(delete_plan_inner) = &mut delete_plan {
         // Re-check after optimization: chosen access paths can make "delete while scanning"
         // unsafe, so we may need to collect rowids first.
@@ -170,7 +179,10 @@ pub fn translate_delete(
     )?;
     let opts = ProgramBuilderOpts::new(1, estimate_num_instructions(delete), 0);
     program.extend(&opts);
-    emit_program(connection, resolver, program, delete_plan, |_| {})?;
+    {
+        let _stack = crate::stack::trace_scope("delete:emit_program");
+        emit_program(connection, resolver, program, delete_plan, |_| {})?;
+    }
     Ok(())
 }
 

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -94,7 +94,7 @@ pub fn translate_delete(
     program.begin_write_on_database(database_id, schema_cookie);
 
     let mut delete_plan = {
-        let _stack = crate::stack::trace_scope("prepare_plan");
+        crate::stack::trace_stack!("prepare_plan");
         prepare_delete_plan(
             program,
             resolver,
@@ -114,11 +114,11 @@ pub fn translate_delete(
     if let Plan::Delete(ref mut delete_plan_inner) = delete_plan {
         if let Some(ref mut rowset_plan) = delete_plan_inner.rowset_plan {
             // When using rowset (triggers or subqueries present), subqueries are in the rowset_plan's WHERE
-            let _stack = crate::stack::trace_scope("plan_rowset_subqueries");
+            crate::stack::trace_stack!("plan_rowset_subqueries");
             plan_subqueries_from_select_plan(program, rowset_plan, resolver, connection)?;
         } else {
             // Normal path: subqueries are in the DELETE plan's WHERE
-            let _stack = crate::stack::trace_scope("plan_where_subqueries");
+            crate::stack::trace_stack!("plan_where_subqueries");
             plan_subqueries_from_where_clause(
                 program,
                 &mut delete_plan_inner.non_from_clause_subqueries,
@@ -131,7 +131,7 @@ pub fn translate_delete(
     }
 
     {
-        let _stack = crate::stack::trace_scope("optimize_plan");
+        crate::stack::trace_stack!("optimize_plan");
         optimize_plan(program, &mut delete_plan, resolver)?;
     }
     if let Plan::Delete(delete_plan_inner) = &mut delete_plan {
@@ -180,7 +180,7 @@ pub fn translate_delete(
     let opts = ProgramBuilderOpts::new(1, estimate_num_instructions(delete), 0);
     program.extend(&opts);
     {
-        let _stack = crate::stack::trace_scope("emit_program");
+        crate::stack::trace_stack!("emit_program");
         emit_program(connection, resolver, program, delete_plan, |_| {})?;
     }
     Ok(())

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -68,6 +68,7 @@ fn validate_delete(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
 pub fn translate_delete(
     tbl_name: &QualifiedName,
     resolver: &Resolver,
@@ -79,7 +80,6 @@ pub fn translate_delete(
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope("delete:translate");
     let database_id = resolver.resolve_existing_table_database_id_qualified(tbl_name)?;
     let normalized_table_name = normalize_ident(tbl_name.name.as_str());
     let table = validate_delete(
@@ -94,7 +94,7 @@ pub fn translate_delete(
     program.begin_write_on_database(database_id, schema_cookie);
 
     let mut delete_plan = {
-        let _stack = crate::stack::trace_scope("delete:prepare_plan");
+        let _stack = crate::stack::trace_scope("prepare_plan");
         prepare_delete_plan(
             program,
             resolver,
@@ -114,11 +114,11 @@ pub fn translate_delete(
     if let Plan::Delete(ref mut delete_plan_inner) = delete_plan {
         if let Some(ref mut rowset_plan) = delete_plan_inner.rowset_plan {
             // When using rowset (triggers or subqueries present), subqueries are in the rowset_plan's WHERE
-            let _stack = crate::stack::trace_scope("delete:plan_rowset_subqueries");
+            let _stack = crate::stack::trace_scope("plan_rowset_subqueries");
             plan_subqueries_from_select_plan(program, rowset_plan, resolver, connection)?;
         } else {
             // Normal path: subqueries are in the DELETE plan's WHERE
-            let _stack = crate::stack::trace_scope("delete:plan_where_subqueries");
+            let _stack = crate::stack::trace_scope("plan_where_subqueries");
             plan_subqueries_from_where_clause(
                 program,
                 &mut delete_plan_inner.non_from_clause_subqueries,
@@ -131,7 +131,7 @@ pub fn translate_delete(
     }
 
     {
-        let _stack = crate::stack::trace_scope("delete:optimize_plan");
+        let _stack = crate::stack::trace_scope("optimize_plan");
         optimize_plan(program, &mut delete_plan, resolver)?;
     }
     if let Plan::Delete(delete_plan_inner) = &mut delete_plan {
@@ -180,7 +180,7 @@ pub fn translate_delete(
     let opts = ProgramBuilderOpts::new(1, estimate_num_instructions(delete), 0);
     program.extend(&opts);
     {
-        let _stack = crate::stack::trace_scope("delete:emit_program");
+        let _stack = crate::stack::trace_scope("emit_program");
         emit_program(connection, resolver, program, delete_plan, |_| {})?;
     }
     Ok(())

--- a/core/translate/emitter/gencol.rs
+++ b/core/translate/emitter/gencol.rs
@@ -8,6 +8,7 @@ use turso_parser::ast;
 use super::{ProgramBuilder, Resolver};
 
 /// Emit bytecode to compute virtual generated columns for a row.
+#[turso_macros::trace_stack]
 pub fn compute_virtual_columns(
     program: &mut ProgramBuilder,
     columns: &ColumnsTopologicalSort<'_>,

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -913,6 +913,7 @@ pub enum TransactionMode {
 /// Main entry point for emitting bytecode for a SQL query
 /// Takes a query plan and generates the corresponding bytecode program
 #[instrument(skip_all, level = tracing::Level::DEBUG)]
+#[turso_macros::trace_stack]
 pub fn emit_program(
     connection: &Arc<Connection>,
     resolver: &Resolver,

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5888,7 +5888,7 @@ pub fn bind_and_rewrite_expr<'a>(
         &mut |expr: &mut ast::Expr| -> Result<WalkControl> {
             match expr {
                 Expr::Id(id) => {
-                    let _stack = crate::stack::trace_scope("bind_id");
+                    crate::stack::trace_stack!("bind_id");
                     let Some(referenced_tables) = &mut referenced_tables else {
                         if binding_behavior == BindingBehavior::AllowUnboundIdentifiers {
                             return Ok(WalkControl::Continue);
@@ -6047,7 +6047,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     }
                 }
                 Expr::Qualified(tbl, id) => {
-                    let _stack = crate::stack::trace_scope("bind_qualified");
+                    crate::stack::trace_stack!("bind_qualified");
                     // Resolve a `<tbl>.<id>` reference.
                     //
                     // Two-stage lookup with shadowing:
@@ -6070,11 +6070,11 @@ pub fn bind_and_rewrite_expr<'a>(
                         );
                     };
                     let normalized_table_name = {
-                        let _stack = crate::stack::trace_scope("qualified:normalize_table");
+                        crate::stack::trace_stack!("qualified:normalize_table");
                         normalize_ident(tbl.as_str())
                     };
                     let normalized_id = {
-                        let _stack = crate::stack::trace_scope("qualified:normalize_column");
+                        crate::stack::trace_stack!("qualified:normalize_column");
                         normalize_ident(id.as_str())
                     };
 
@@ -6095,7 +6095,7 @@ pub fn bind_and_rewrite_expr<'a>(
 
                     // --- Stage 1: search the current scope's FROM tables. ---
                     {
-                        let _stack = crate::stack::trace_scope("qualified:find_table");
+                        crate::stack::trace_stack!("qualified:find_table");
                         for joined_table in referenced_tables
                             .joined_tables()
                             .iter()
@@ -6143,7 +6143,6 @@ pub fn bind_and_rewrite_expr<'a>(
                     // CTE is consumed into a FROM, column resolution must go through the
                     // corresponding `joined_table`, not the definition-only ref.
                     if !identifier_matched {
-                        let _stack = crate::stack::trace_scope("qualified:find_outer_ref");
                         let nearest_outer_scope = referenced_tables
                             .outer_query_refs()
                             .iter()
@@ -6204,7 +6203,7 @@ pub fn bind_and_rewrite_expr<'a>(
                         // definition refs so any other future use of `cte_definition_only`
                         // still falls through to "no such table".
                         let is_definition_only_cte = {
-                            let _stack = crate::stack::trace_scope("qualified:outer_ref_check");
+                            crate::stack::trace_stack!("qualified:outer_ref_check");
                             referenced_tables
                                 .find_outer_query_ref_by_identifier(&normalized_table_name)
                                 .is_some_and(|outer_ref| {
@@ -6235,12 +6234,11 @@ pub fn bind_and_rewrite_expr<'a>(
                         // the combinatorial explosion (CREATE TYPE, CREATE TABLE, ALTER TABLE)
                         // makes that impractical. Deterministic precedence is sufficient.
                         let field_name = {
-                            let _stack = crate::stack::trace_scope("qualified:normalize_field");
+                            crate::stack::trace_stack!("qualified:normalize_field");
                             normalize_ident(id.as_str())
                         };
                         if let Some(m) = {
-                            let _stack =
-                                crate::stack::trace_scope("qualified:find_custom_type_column");
+                            crate::stack::trace_stack!("qualified:find_custom_type_column");
                             find_custom_type_column(
                                 referenced_tables,
                                 &normalized_table_name,
@@ -6248,8 +6246,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             )?
                         } {
                             {
-                                let _stack =
-                                    crate::stack::trace_scope("qualified:make_field_access");
+                                crate::stack::trace_stack!("qualified:make_field_access");
                                 *expr = make_field_access_expr(
                                     m.table_id,
                                     m.col_idx,
@@ -6259,8 +6256,7 @@ pub fn bind_and_rewrite_expr<'a>(
                                 );
                             }
                             {
-                                let _stack =
-                                    crate::stack::trace_scope("qualified:mark_column_used");
+                                crate::stack::trace_stack!("qualified:mark_column_used");
                                 referenced_tables.mark_column_used(m.table_id, m.col_idx);
                             }
                             return Ok(WalkControl::Continue);
@@ -6279,7 +6275,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             is_rowid_alias,
                         } => {
                             {
-                                let _stack = crate::stack::trace_scope("qualified:rewrite_column");
+                                crate::stack::trace_stack!("qualified:rewrite_column");
                                 *expr = Expr::Column {
                                     database: None, // TODO: support different databases
                                     table: tbl_id,
@@ -6289,14 +6285,13 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                             tracing::debug!("rewritten to column");
                             {
-                                let _stack =
-                                    crate::stack::trace_scope("qualified:mark_column_used");
+                                crate::stack::trace_stack!("qualified:mark_column_used");
                                 referenced_tables.mark_column_used(tbl_id, col_idx);
                             }
                         }
                         QualifiedMatch::RowId => {
                             {
-                                let _stack = crate::stack::trace_scope("qualified:rewrite_rowid");
+                                crate::stack::trace_stack!("qualified:rewrite_rowid");
                                 *expr = Expr::RowId {
                                     database: None, // TODO: support different databases
                                     table: tbl_id,
@@ -6304,7 +6299,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                             tracing::debug!("rewritten to rowid");
                             {
-                                let _stack = crate::stack::trace_scope("qualified:mark_rowid_used");
+                                crate::stack::trace_stack!("qualified:mark_rowid_used");
                                 referenced_tables.mark_rowid_referenced(tbl_id);
                             }
                         }
@@ -6312,7 +6307,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     return Ok(WalkControl::Continue);
                 }
                 Expr::DoublyQualified(db_name, tbl_name, col_name) => {
-                    let _stack = crate::stack::trace_scope("bind_doubly_qualified");
+                    crate::stack::trace_stack!("bind_doubly_qualified");
                     // Clone the names upfront so we can reassign *expr later
                     // without lifetime conflicts.
                     let db_name_str = db_name.as_str().to_string();

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5888,6 +5888,7 @@ pub fn bind_and_rewrite_expr<'a>(
         &mut |expr: &mut ast::Expr| -> Result<WalkControl> {
             match expr {
                 Expr::Id(id) => {
+                    let _stack = crate::stack::trace_scope("expr:bind_id");
                     let Some(referenced_tables) = &mut referenced_tables else {
                         if binding_behavior == BindingBehavior::AllowUnboundIdentifiers {
                             return Ok(WalkControl::Continue);
@@ -6046,6 +6047,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     }
                 }
                 Expr::Qualified(tbl, id) => {
+                    let _stack = crate::stack::trace_scope("expr:bind_qualified");
                     // Resolve a `<tbl>.<id>` reference.
                     //
                     // Two-stage lookup with shadowing:
@@ -6271,6 +6273,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     return Ok(WalkControl::Continue);
                 }
                 Expr::DoublyQualified(db_name, tbl_name, col_name) => {
+                    let _stack = crate::stack::trace_scope("expr:bind_doubly_qualified");
                     // Clone the names upfront so we can reassign *expr later
                     // without lifetime conflicts.
                     let db_name_str = db_name.as_str().to_string();

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5882,6 +5882,7 @@ pub fn bind_and_rewrite_expr<'a>(
     resolver: &Resolver<'_>,
     binding_behavior: BindingBehavior,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope("expr:bind_and_rewrite");
     walk_expr_mut(
         top_level_expr,
         &mut |expr: &mut ast::Expr| -> Result<WalkControl> {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1017,6 +1017,7 @@ pub fn resolve_expr(
 }
 
 /// Translate an expression into bytecode.
+#[turso_macros::trace_stack]
 pub fn translate_expr(
     program: &mut ProgramBuilder,
     referenced_tables: Option<&TableReferences>,
@@ -6069,14 +6070,8 @@ pub fn bind_and_rewrite_expr<'a>(
                             id.as_str()
                         );
                     };
-                    let normalized_table_name = {
-                        crate::stack::trace_stack!("qualified:normalize_table");
-                        normalize_ident(tbl.as_str())
-                    };
-                    let normalized_id = {
-                        crate::stack::trace_stack!("qualified:normalize_column");
-                        normalize_ident(id.as_str())
-                    };
+                    let normalized_table_name = normalize_ident(tbl.as_str());
+                    let normalized_id = normalize_ident(id.as_str());
 
                     // `resolved` holds the accepted binding (at most one).
                     // `identifier_matched` is true once *any* scope produced a table whose
@@ -6094,22 +6089,20 @@ pub fn bind_and_rewrite_expr<'a>(
                     };
 
                     // --- Stage 1: search the current scope's FROM tables. ---
+                    for joined_table in referenced_tables
+                        .joined_tables()
+                        .iter()
+                        .filter(|t| t.identifier == normalized_table_name)
                     {
-                        crate::stack::trace_stack!("qualified:find_table");
-                        for joined_table in referenced_tables
-                            .joined_tables()
-                            .iter()
-                            .filter(|t| t.identifier == normalized_table_name)
-                        {
-                            identifier_matched = true;
-                            let Some(candidate) = resolve_qualified_on_ref(
-                                &joined_table.table,
-                                joined_table.internal_id,
-                                &normalized_id,
-                            )?
-                            else {
-                                continue;
-                            };
+                        identifier_matched = true;
+                        let Some(candidate) = resolve_qualified_on_ref(
+                            &joined_table.table,
+                            joined_table.internal_id,
+                            &normalized_id,
+                        )?
+                        else {
+                            continue;
+                        };
 
                         // Multiple FROM tables share this identifier and both contain `id`.
                         // For column matches, a USING/NATURAL join on `id` lets the first
@@ -6128,6 +6121,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                             continue;
                         }
+                        resolved = Some((joined_table.internal_id, candidate));
                     }
                     // --- Stage 2: fall back to enclosing scopes ---
                     // Only attempted if no inner-scope table matched the identifier — an
@@ -6202,16 +6196,13 @@ pub fn bind_and_rewrite_expr<'a>(
                         // The `cte_id`/`cte_select` check restricts this to real CTE
                         // definition refs so any other future use of `cte_definition_only`
                         // still falls through to "no such table".
-                        let is_definition_only_cte = {
-                            crate::stack::trace_stack!("qualified:outer_ref_check");
-                            referenced_tables
-                                .find_outer_query_ref_by_identifier(&normalized_table_name)
-                                .is_some_and(|outer_ref| {
-                                    outer_ref.cte_definition_only
-                                        && (outer_ref.cte_id.is_some()
-                                            || outer_ref.cte_select.is_some())
-                                })
-                        };
+                        let is_definition_only_cte = referenced_tables
+                            .find_outer_query_ref_by_identifier(&normalized_table_name)
+                            .is_some_and(|outer_ref| {
+                                outer_ref.cte_definition_only
+                                    && (outer_ref.cte_id.is_some()
+                                        || outer_ref.cte_select.is_some())
+                            });
                         if is_definition_only_cte {
                             crate::bail_parse_error!(
                                 "no such column: {}.{}",
@@ -6233,32 +6224,20 @@ pub fn bind_and_rewrite_expr<'a>(
                         // We do NOT reject ambiguous schemas at CREATE TABLE time because
                         // the combinatorial explosion (CREATE TYPE, CREATE TABLE, ALTER TABLE)
                         // makes that impractical. Deterministic precedence is sufficient.
-                        let field_name = {
-                            crate::stack::trace_stack!("qualified:normalize_field");
-                            normalize_ident(id.as_str())
-                        };
-                        if let Some(m) = {
-                            crate::stack::trace_stack!("qualified:find_custom_type_column");
-                            find_custom_type_column(
-                                referenced_tables,
-                                &normalized_table_name,
-                                resolver,
-                            )?
-                        } {
-                            {
-                                crate::stack::trace_stack!("qualified:make_field_access");
-                                *expr = make_field_access_expr(
-                                    m.table_id,
-                                    m.col_idx,
-                                    m.is_rowid_alias,
-                                    &field_name,
-                                    m.type_def,
-                                );
-                            }
-                            {
-                                crate::stack::trace_stack!("qualified:mark_column_used");
-                                referenced_tables.mark_column_used(m.table_id, m.col_idx);
-                            }
+                        let field_name = normalize_ident(id.as_str());
+                        if let Some(m) = find_custom_type_column(
+                            referenced_tables,
+                            &normalized_table_name,
+                            resolver,
+                        )? {
+                            *expr = make_field_access_expr(
+                                m.table_id,
+                                m.col_idx,
+                                m.is_rowid_alias,
+                                &field_name,
+                                m.type_def,
+                            );
+                            referenced_tables.mark_column_used(m.table_id, m.col_idx);
                             return Ok(WalkControl::Continue);
                         }
                         crate::bail_parse_error!("no such table: {}", normalized_table_name);
@@ -6274,34 +6253,22 @@ pub fn bind_and_rewrite_expr<'a>(
                             col_idx,
                             is_rowid_alias,
                         } => {
-                            {
-                                crate::stack::trace_stack!("qualified:rewrite_column");
-                                *expr = Expr::Column {
-                                    database: None, // TODO: support different databases
-                                    table: tbl_id,
-                                    column: col_idx,
-                                    is_rowid_alias,
-                                };
-                            }
+                            *expr = Expr::Column {
+                                database: None, // TODO: support different databases
+                                table: tbl_id,
+                                column: col_idx,
+                                is_rowid_alias,
+                            };
                             tracing::debug!("rewritten to column");
-                            {
-                                crate::stack::trace_stack!("qualified:mark_column_used");
-                                referenced_tables.mark_column_used(tbl_id, col_idx);
-                            }
+                            referenced_tables.mark_column_used(tbl_id, col_idx);
                         }
                         QualifiedMatch::RowId => {
-                            {
-                                crate::stack::trace_stack!("qualified:rewrite_rowid");
-                                *expr = Expr::RowId {
-                                    database: None, // TODO: support different databases
-                                    table: tbl_id,
-                                };
-                            }
+                            *expr = Expr::RowId {
+                                database: None, // TODO: support different databases
+                                table: tbl_id,
+                            };
                             tracing::debug!("rewritten to rowid");
-                            {
-                                crate::stack::trace_stack!("qualified:mark_rowid_used");
-                                referenced_tables.mark_rowid_referenced(tbl_id);
-                            }
+                            referenced_tables.mark_rowid_referenced(tbl_id);
                         }
                     }
                     return Ok(WalkControl::Continue);
@@ -6658,6 +6625,7 @@ struct CustomTypeColumnMatch<'a> {
 
 /// Search all joined tables for a column named `col_name` with a struct/union type.
 /// Errors on ambiguity (>1 match). Returns `None` if no match.
+#[turso_macros::trace_stack]
 fn find_custom_type_column<'a>(
     referenced_tables: &TableReferences,
     col_name: &str,

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -6069,8 +6069,14 @@ pub fn bind_and_rewrite_expr<'a>(
                             id.as_str()
                         );
                     };
-                    let normalized_table_name = normalize_ident(tbl.as_str());
-                    let normalized_id = normalize_ident(id.as_str());
+                    let normalized_table_name = {
+                        let _stack = crate::stack::trace_scope("expr:qualified:normalize_table");
+                        normalize_ident(tbl.as_str())
+                    };
+                    let normalized_id = {
+                        let _stack = crate::stack::trace_scope("expr:qualified:normalize_column");
+                        normalize_ident(id.as_str())
+                    };
 
                     // `resolved` holds the accepted binding (at most one).
                     // `identifier_matched` is true once *any* scope produced a table whose
@@ -6088,20 +6094,22 @@ pub fn bind_and_rewrite_expr<'a>(
                     };
 
                     // --- Stage 1: search the current scope's FROM tables. ---
-                    for joined_table in referenced_tables
-                        .joined_tables()
-                        .iter()
-                        .filter(|t| t.identifier == normalized_table_name)
                     {
-                        identifier_matched = true;
-                        let Some(candidate) = resolve_qualified_on_ref(
-                            &joined_table.table,
-                            joined_table.internal_id,
-                            &normalized_id,
-                        )?
-                        else {
-                            continue;
-                        };
+                        let _stack = crate::stack::trace_scope("expr:qualified:find_table");
+                        for joined_table in referenced_tables
+                            .joined_tables()
+                            .iter()
+                            .filter(|t| t.identifier == normalized_table_name)
+                        {
+                            identifier_matched = true;
+                            let Some(candidate) = resolve_qualified_on_ref(
+                                &joined_table.table,
+                                joined_table.internal_id,
+                                &normalized_id,
+                            )?
+                            else {
+                                continue;
+                            };
 
                         // Multiple FROM tables share this identifier and both contain `id`.
                         // For column matches, a USING/NATURAL join on `id` lets the first
@@ -6120,7 +6128,6 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                             continue;
                         }
-                        resolved = Some((joined_table.internal_id, candidate));
                     }
                     // --- Stage 2: fall back to enclosing scopes ---
                     // Only attempted if no inner-scope table matched the identifier — an
@@ -6136,6 +6143,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     // CTE is consumed into a FROM, column resolution must go through the
                     // corresponding `joined_table`, not the definition-only ref.
                     if !identifier_matched {
+                        let _stack = crate::stack::trace_scope("expr:qualified:find_outer_ref");
                         let nearest_outer_scope = referenced_tables
                             .outer_query_refs()
                             .iter()
@@ -6195,14 +6203,18 @@ pub fn bind_and_rewrite_expr<'a>(
                         // The `cte_id`/`cte_select` check restricts this to real CTE
                         // definition refs so any other future use of `cte_definition_only`
                         // still falls through to "no such table".
-                        if referenced_tables
-                            .find_outer_query_ref_by_identifier(&normalized_table_name)
-                            .is_some_and(|outer_ref| {
-                                outer_ref.cte_definition_only
-                                    && (outer_ref.cte_id.is_some()
-                                        || outer_ref.cte_select.is_some())
-                            })
-                        {
+                        let is_definition_only_cte = {
+                            let _stack =
+                                crate::stack::trace_scope("expr:qualified:outer_ref_check");
+                            referenced_tables
+                                .find_outer_query_ref_by_identifier(&normalized_table_name)
+                                .is_some_and(|outer_ref| {
+                                    outer_ref.cte_definition_only
+                                        && (outer_ref.cte_id.is_some()
+                                            || outer_ref.cte_select.is_some())
+                                })
+                        };
+                        if is_definition_only_cte {
                             crate::bail_parse_error!(
                                 "no such column: {}.{}",
                                 tbl.as_str(),
@@ -6223,20 +6235,36 @@ pub fn bind_and_rewrite_expr<'a>(
                         // We do NOT reject ambiguous schemas at CREATE TABLE time because
                         // the combinatorial explosion (CREATE TYPE, CREATE TABLE, ALTER TABLE)
                         // makes that impractical. Deterministic precedence is sufficient.
-                        let field_name = normalize_ident(id.as_str());
-                        if let Some(m) = find_custom_type_column(
-                            referenced_tables,
-                            &normalized_table_name,
-                            resolver,
-                        )? {
-                            *expr = make_field_access_expr(
-                                m.table_id,
-                                m.col_idx,
-                                m.is_rowid_alias,
-                                &field_name,
-                                m.type_def,
-                            );
-                            referenced_tables.mark_column_used(m.table_id, m.col_idx);
+                        let field_name = {
+                            let _stack =
+                                crate::stack::trace_scope("expr:qualified:normalize_field");
+                            normalize_ident(id.as_str())
+                        };
+                        if let Some(m) = {
+                            let _stack =
+                                crate::stack::trace_scope("expr:qualified:find_custom_type_column");
+                            find_custom_type_column(
+                                referenced_tables,
+                                &normalized_table_name,
+                                resolver,
+                            )?
+                        } {
+                            {
+                                let _stack =
+                                    crate::stack::trace_scope("expr:qualified:make_field_access");
+                                *expr = make_field_access_expr(
+                                    m.table_id,
+                                    m.col_idx,
+                                    m.is_rowid_alias,
+                                    &field_name,
+                                    m.type_def,
+                                );
+                            }
+                            {
+                                let _stack =
+                                    crate::stack::trace_scope("expr:qualified:mark_column_used");
+                                referenced_tables.mark_column_used(m.table_id, m.col_idx);
+                            }
                             return Ok(WalkControl::Continue);
                         }
                         crate::bail_parse_error!("no such table: {}", normalized_table_name);
@@ -6252,22 +6280,38 @@ pub fn bind_and_rewrite_expr<'a>(
                             col_idx,
                             is_rowid_alias,
                         } => {
-                            *expr = Expr::Column {
-                                database: None, // TODO: support different databases
-                                table: tbl_id,
-                                column: col_idx,
-                                is_rowid_alias,
-                            };
+                            {
+                                let _stack =
+                                    crate::stack::trace_scope("expr:qualified:rewrite_column");
+                                *expr = Expr::Column {
+                                    database: None, // TODO: support different databases
+                                    table: tbl_id,
+                                    column: col_idx,
+                                    is_rowid_alias,
+                                };
+                            }
                             tracing::debug!("rewritten to column");
-                            referenced_tables.mark_column_used(tbl_id, col_idx);
+                            {
+                                let _stack =
+                                    crate::stack::trace_scope("expr:qualified:mark_column_used");
+                                referenced_tables.mark_column_used(tbl_id, col_idx);
+                            }
                         }
                         QualifiedMatch::RowId => {
-                            *expr = Expr::RowId {
-                                database: None, // TODO: support different databases
-                                table: tbl_id,
-                            };
+                            {
+                                let _stack =
+                                    crate::stack::trace_scope("expr:qualified:rewrite_rowid");
+                                *expr = Expr::RowId {
+                                    database: None, // TODO: support different databases
+                                    table: tbl_id,
+                                };
+                            }
                             tracing::debug!("rewritten to rowid");
-                            referenced_tables.mark_rowid_referenced(tbl_id);
+                            {
+                                let _stack =
+                                    crate::stack::trace_scope("expr:qualified:mark_rowid_used");
+                                referenced_tables.mark_rowid_referenced(tbl_id);
+                            }
                         }
                     }
                     return Ok(WalkControl::Continue);

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -5875,6 +5875,7 @@ fn resolve_qualified_on_ref(
 /// Rewrite ast::Expr in place, binding Column references/rewriting Expr::Id -> Expr::Column
 /// using the provided TableReferences, and replacing anonymous parameters with internal named
 /// ones
+#[turso_macros::trace_stack]
 pub fn bind_and_rewrite_expr<'a>(
     top_level_expr: &mut ast::Expr,
     mut referenced_tables: Option<&'a mut TableReferences>,
@@ -5882,13 +5883,12 @@ pub fn bind_and_rewrite_expr<'a>(
     resolver: &Resolver<'_>,
     binding_behavior: BindingBehavior,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope("expr:bind_and_rewrite");
     walk_expr_mut(
         top_level_expr,
         &mut |expr: &mut ast::Expr| -> Result<WalkControl> {
             match expr {
                 Expr::Id(id) => {
-                    let _stack = crate::stack::trace_scope("expr:bind_id");
+                    let _stack = crate::stack::trace_scope("bind_id");
                     let Some(referenced_tables) = &mut referenced_tables else {
                         if binding_behavior == BindingBehavior::AllowUnboundIdentifiers {
                             return Ok(WalkControl::Continue);
@@ -6047,7 +6047,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     }
                 }
                 Expr::Qualified(tbl, id) => {
-                    let _stack = crate::stack::trace_scope("expr:bind_qualified");
+                    let _stack = crate::stack::trace_scope("bind_qualified");
                     // Resolve a `<tbl>.<id>` reference.
                     //
                     // Two-stage lookup with shadowing:
@@ -6070,11 +6070,11 @@ pub fn bind_and_rewrite_expr<'a>(
                         );
                     };
                     let normalized_table_name = {
-                        let _stack = crate::stack::trace_scope("expr:qualified:normalize_table");
+                        let _stack = crate::stack::trace_scope("qualified:normalize_table");
                         normalize_ident(tbl.as_str())
                     };
                     let normalized_id = {
-                        let _stack = crate::stack::trace_scope("expr:qualified:normalize_column");
+                        let _stack = crate::stack::trace_scope("qualified:normalize_column");
                         normalize_ident(id.as_str())
                     };
 
@@ -6095,7 +6095,7 @@ pub fn bind_and_rewrite_expr<'a>(
 
                     // --- Stage 1: search the current scope's FROM tables. ---
                     {
-                        let _stack = crate::stack::trace_scope("expr:qualified:find_table");
+                        let _stack = crate::stack::trace_scope("qualified:find_table");
                         for joined_table in referenced_tables
                             .joined_tables()
                             .iter()
@@ -6143,7 +6143,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     // CTE is consumed into a FROM, column resolution must go through the
                     // corresponding `joined_table`, not the definition-only ref.
                     if !identifier_matched {
-                        let _stack = crate::stack::trace_scope("expr:qualified:find_outer_ref");
+                        let _stack = crate::stack::trace_scope("qualified:find_outer_ref");
                         let nearest_outer_scope = referenced_tables
                             .outer_query_refs()
                             .iter()
@@ -6204,8 +6204,7 @@ pub fn bind_and_rewrite_expr<'a>(
                         // definition refs so any other future use of `cte_definition_only`
                         // still falls through to "no such table".
                         let is_definition_only_cte = {
-                            let _stack =
-                                crate::stack::trace_scope("expr:qualified:outer_ref_check");
+                            let _stack = crate::stack::trace_scope("qualified:outer_ref_check");
                             referenced_tables
                                 .find_outer_query_ref_by_identifier(&normalized_table_name)
                                 .is_some_and(|outer_ref| {
@@ -6236,13 +6235,12 @@ pub fn bind_and_rewrite_expr<'a>(
                         // the combinatorial explosion (CREATE TYPE, CREATE TABLE, ALTER TABLE)
                         // makes that impractical. Deterministic precedence is sufficient.
                         let field_name = {
-                            let _stack =
-                                crate::stack::trace_scope("expr:qualified:normalize_field");
+                            let _stack = crate::stack::trace_scope("qualified:normalize_field");
                             normalize_ident(id.as_str())
                         };
                         if let Some(m) = {
                             let _stack =
-                                crate::stack::trace_scope("expr:qualified:find_custom_type_column");
+                                crate::stack::trace_scope("qualified:find_custom_type_column");
                             find_custom_type_column(
                                 referenced_tables,
                                 &normalized_table_name,
@@ -6251,7 +6249,7 @@ pub fn bind_and_rewrite_expr<'a>(
                         } {
                             {
                                 let _stack =
-                                    crate::stack::trace_scope("expr:qualified:make_field_access");
+                                    crate::stack::trace_scope("qualified:make_field_access");
                                 *expr = make_field_access_expr(
                                     m.table_id,
                                     m.col_idx,
@@ -6262,7 +6260,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                             {
                                 let _stack =
-                                    crate::stack::trace_scope("expr:qualified:mark_column_used");
+                                    crate::stack::trace_scope("qualified:mark_column_used");
                                 referenced_tables.mark_column_used(m.table_id, m.col_idx);
                             }
                             return Ok(WalkControl::Continue);
@@ -6281,8 +6279,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             is_rowid_alias,
                         } => {
                             {
-                                let _stack =
-                                    crate::stack::trace_scope("expr:qualified:rewrite_column");
+                                let _stack = crate::stack::trace_scope("qualified:rewrite_column");
                                 *expr = Expr::Column {
                                     database: None, // TODO: support different databases
                                     table: tbl_id,
@@ -6293,14 +6290,13 @@ pub fn bind_and_rewrite_expr<'a>(
                             tracing::debug!("rewritten to column");
                             {
                                 let _stack =
-                                    crate::stack::trace_scope("expr:qualified:mark_column_used");
+                                    crate::stack::trace_scope("qualified:mark_column_used");
                                 referenced_tables.mark_column_used(tbl_id, col_idx);
                             }
                         }
                         QualifiedMatch::RowId => {
                             {
-                                let _stack =
-                                    crate::stack::trace_scope("expr:qualified:rewrite_rowid");
+                                let _stack = crate::stack::trace_scope("qualified:rewrite_rowid");
                                 *expr = Expr::RowId {
                                     database: None, // TODO: support different databases
                                     table: tbl_id,
@@ -6308,8 +6304,7 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                             tracing::debug!("rewritten to rowid");
                             {
-                                let _stack =
-                                    crate::stack::trace_scope("expr:qualified:mark_rowid_used");
+                                let _stack = crate::stack::trace_scope("qualified:mark_rowid_used");
                                 referenced_tables.mark_rowid_referenced(tbl_id);
                             }
                         }
@@ -6317,7 +6312,7 @@ pub fn bind_and_rewrite_expr<'a>(
                     return Ok(WalkControl::Continue);
                 }
                 Expr::DoublyQualified(db_name, tbl_name, col_name) => {
-                    let _stack = crate::stack::trace_scope("expr:bind_doubly_qualified");
+                    let _stack = crate::stack::trace_scope("bind_doubly_qualified");
                     // Clone the names upfront so we can reassign *expr later
                     // without lifetime conflicts.
                     let db_name_str = db_name.as_str().to_string();

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -239,6 +239,7 @@ pub fn translate_insert(
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope("insert:translate");
     let opts = ProgramBuilderOpts::new(1, 30, 5);
     program.extend(&opts);
 
@@ -308,15 +309,18 @@ pub fn translate_insert(
         mut values,
         mut upsert_actions,
         inserting_multiple_rows,
-    } = bind_insert(
-        program,
-        resolver,
-        &table,
-        &columns,
-        &mut body,
-        on_conflict.unwrap_or(ResolveType::Abort),
-        database_id,
-    )?;
+    } = {
+        let _stack = crate::stack::trace_scope("insert:bind");
+        bind_insert(
+            program,
+            resolver,
+            &table,
+            &columns,
+            &mut body,
+            on_conflict.unwrap_or(ResolveType::Abort),
+            database_id,
+        )?
+    };
 
     if inserting_multiple_rows && btree_table.has_autoincrement {
         ensure_sequence_initialized(program, resolver, &btree_table, database_id)?;
@@ -348,25 +352,31 @@ pub fn translate_insert(
     );
 
     // Plan CTEs and add them as outer query references for RETURNING subquery resolution
-    plan_ctes_as_outer_refs(
-        with_for_returning,
-        resolver,
-        program,
-        &mut table_references,
-        connection,
-    )?;
+    {
+        let _stack = crate::stack::trace_scope("insert:plan_returning_ctes");
+        plan_ctes_as_outer_refs(
+            with_for_returning,
+            resolver,
+            program,
+            &mut table_references,
+            connection,
+        )?;
+    }
 
     // Plan subqueries in RETURNING expressions before processing
     // (so SubqueryResult nodes are cloned into result_columns)
     let mut returning_subqueries = vec![];
-    plan_subqueries_from_returning(
-        program,
-        &mut returning_subqueries,
-        &mut table_references,
-        &mut returning,
-        resolver,
-        connection,
-    )?;
+    {
+        let _stack = crate::stack::trace_scope("insert:plan_returning_subqueries");
+        plan_subqueries_from_returning(
+            program,
+            &mut returning_subqueries,
+            &mut table_references,
+            &mut returning,
+            resolver,
+            connection,
+        )?;
+    }
 
     // Process RETURNING clause using shared module
     let mut result_columns =
@@ -432,18 +442,21 @@ pub fn translate_insert(
         });
     }
 
-    init_source_emission(
-        program,
-        &table,
-        connection,
-        &mut ctx,
-        resolver,
-        &mut values,
-        body,
-        &columns,
-        &table_references,
-        database_id,
-    )?;
+    {
+        let _stack = crate::stack::trace_scope("insert:init_source_emission");
+        init_source_emission(
+            program,
+            &table,
+            connection,
+            &mut ctx,
+            resolver,
+            &mut values,
+            body,
+            &columns,
+            &table_references,
+            database_id,
+        )?;
+    }
     let has_upsert = !upsert_actions.is_empty();
 
     // Set up the program to return result columns if RETURNING is specified
@@ -452,14 +465,17 @@ pub fn translate_insert(
     }
     let insertion = build_insertion(program, &table, &columns, ctx.num_values)?;
 
-    translate_rows_and_open_tables(
-        program,
-        resolver,
-        &insertion,
-        &ctx,
-        &values,
-        inserting_multiple_rows,
-    )?;
+    {
+        let _stack = crate::stack::trace_scope("insert:translate_rows_open_tables");
+        translate_rows_and_open_tables(
+            program,
+            resolver,
+            &insertion,
+            &ctx,
+            &values,
+            inserting_multiple_rows,
+        )?;
+    }
 
     // Emit subqueries for RETURNING clause (uncorrelated subqueries are evaluated once)
     emit_non_from_clause_subqueries_for_eval_at(
@@ -527,6 +543,7 @@ pub fn translate_insert(
 
     let has_before_triggers = !relevant_before_triggers.is_empty();
     if has_before_triggers {
+        let _stack = crate::stack::trace_scope("insert:before_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,
@@ -939,6 +956,7 @@ pub fn translate_insert(
     );
     let has_after_triggers = !relevant_after_triggers.is_empty();
     if has_after_triggers {
+        let _stack = crate::stack::trace_scope("insert:after_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -309,18 +309,15 @@ pub fn translate_insert(
         mut values,
         mut upsert_actions,
         inserting_multiple_rows,
-    } = {
-        crate::stack::trace_stack!("bind");
-        bind_insert(
-            program,
-            resolver,
-            &table,
-            &columns,
-            &mut body,
-            on_conflict.unwrap_or(ResolveType::Abort),
-            database_id,
-        )?
-    };
+    } = bind_insert(
+        program,
+        resolver,
+        &table,
+        &columns,
+        &mut body,
+        on_conflict.unwrap_or(ResolveType::Abort),
+        database_id,
+    )?;
 
     if inserting_multiple_rows && btree_table.has_autoincrement {
         ensure_sequence_initialized(program, resolver, &btree_table, database_id)?;
@@ -352,31 +349,25 @@ pub fn translate_insert(
     );
 
     // Plan CTEs and add them as outer query references for RETURNING subquery resolution
-    {
-        crate::stack::trace_stack!("plan_returning_ctes");
-        plan_ctes_as_outer_refs(
-            with_for_returning,
-            resolver,
-            program,
-            &mut table_references,
-            connection,
-        )?;
-    }
+    plan_ctes_as_outer_refs(
+        with_for_returning,
+        resolver,
+        program,
+        &mut table_references,
+        connection,
+    )?;
 
     // Plan subqueries in RETURNING expressions before processing
     // (so SubqueryResult nodes are cloned into result_columns)
     let mut returning_subqueries = vec![];
-    {
-        crate::stack::trace_stack!("plan_returning_subqueries");
-        plan_subqueries_from_returning(
-            program,
-            &mut returning_subqueries,
-            &mut table_references,
-            &mut returning,
-            resolver,
-            connection,
-        )?;
-    }
+    plan_subqueries_from_returning(
+        program,
+        &mut returning_subqueries,
+        &mut table_references,
+        &mut returning,
+        resolver,
+        connection,
+    )?;
 
     // Process RETURNING clause using shared module
     let mut result_columns =
@@ -442,21 +433,18 @@ pub fn translate_insert(
         });
     }
 
-    {
-        crate::stack::trace_stack!("init_source_emission");
-        init_source_emission(
-            program,
-            &table,
-            connection,
-            &mut ctx,
-            resolver,
-            &mut values,
-            body,
-            &columns,
-            &table_references,
-            database_id,
-        )?;
-    }
+    init_source_emission(
+        program,
+        &table,
+        connection,
+        &mut ctx,
+        resolver,
+        &mut values,
+        body,
+        &columns,
+        &table_references,
+        database_id,
+    )?;
     let has_upsert = !upsert_actions.is_empty();
 
     // Set up the program to return result columns if RETURNING is specified
@@ -465,17 +453,14 @@ pub fn translate_insert(
     }
     let insertion = build_insertion(program, &table, &columns, ctx.num_values)?;
 
-    {
-        crate::stack::trace_stack!("translate_rows_open_tables");
-        translate_rows_and_open_tables(
-            program,
-            resolver,
-            &insertion,
-            &ctx,
-            &values,
-            inserting_multiple_rows,
-        )?;
-    }
+    translate_rows_and_open_tables(
+        program,
+        resolver,
+        &insertion,
+        &ctx,
+        &values,
+        inserting_multiple_rows,
+    )?;
 
     // Emit subqueries for RETURNING clause (uncorrelated subqueries are evaluated once)
     emit_non_from_clause_subqueries_for_eval_at(
@@ -543,7 +528,6 @@ pub fn translate_insert(
 
     let has_before_triggers = !relevant_before_triggers.is_empty();
     if has_before_triggers {
-        crate::stack::trace_stack!("before_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,
@@ -956,7 +940,6 @@ pub fn translate_insert(
     );
     let has_after_triggers = !relevant_after_triggers.is_empty();
     if has_after_triggers {
-        crate::stack::trace_stack!("after_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,
@@ -1405,6 +1388,7 @@ fn emit_commit_phase(
     Ok(())
 }
 
+#[turso_macros::trace_stack]
 fn translate_rows_and_open_tables(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
@@ -1898,6 +1882,7 @@ fn resolve_defaults_in_row(
     }
 }
 
+#[turso_macros::trace_stack]
 fn bind_insert(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
@@ -2070,6 +2055,7 @@ fn bind_insert(
 /// default expressions registered for the columns, or NULLs, so they can be translated into
 /// registers later.
 #[allow(clippy::too_many_arguments, clippy::vec_box)]
+#[turso_macros::trace_stack]
 fn init_source_emission<'a>(
     program: &mut ProgramBuilder,
     table: &Table,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -310,7 +310,7 @@ pub fn translate_insert(
         mut upsert_actions,
         inserting_multiple_rows,
     } = {
-        let _stack = crate::stack::trace_scope("bind");
+        crate::stack::trace_stack!("bind");
         bind_insert(
             program,
             resolver,
@@ -353,7 +353,7 @@ pub fn translate_insert(
 
     // Plan CTEs and add them as outer query references for RETURNING subquery resolution
     {
-        let _stack = crate::stack::trace_scope("plan_returning_ctes");
+        crate::stack::trace_stack!("plan_returning_ctes");
         plan_ctes_as_outer_refs(
             with_for_returning,
             resolver,
@@ -367,7 +367,7 @@ pub fn translate_insert(
     // (so SubqueryResult nodes are cloned into result_columns)
     let mut returning_subqueries = vec![];
     {
-        let _stack = crate::stack::trace_scope("plan_returning_subqueries");
+        crate::stack::trace_stack!("plan_returning_subqueries");
         plan_subqueries_from_returning(
             program,
             &mut returning_subqueries,
@@ -443,7 +443,7 @@ pub fn translate_insert(
     }
 
     {
-        let _stack = crate::stack::trace_scope("init_source_emission");
+        crate::stack::trace_stack!("init_source_emission");
         init_source_emission(
             program,
             &table,
@@ -466,7 +466,7 @@ pub fn translate_insert(
     let insertion = build_insertion(program, &table, &columns, ctx.num_values)?;
 
     {
-        let _stack = crate::stack::trace_scope("translate_rows_open_tables");
+        crate::stack::trace_stack!("translate_rows_open_tables");
         translate_rows_and_open_tables(
             program,
             resolver,
@@ -543,7 +543,7 @@ pub fn translate_insert(
 
     let has_before_triggers = !relevant_before_triggers.is_empty();
     if has_before_triggers {
-        let _stack = crate::stack::trace_scope("before_triggers");
+        crate::stack::trace_stack!("before_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,
@@ -956,7 +956,7 @@ pub fn translate_insert(
     );
     let has_after_triggers = !relevant_after_triggers.is_empty();
     if has_after_triggers {
-        let _stack = crate::stack::trace_scope("after_triggers");
+        crate::stack::trace_stack!("after_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -228,6 +228,7 @@ impl<'a> InsertEmitCtx<'a> {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
 pub fn translate_insert(
     resolver: &mut Resolver,
     on_conflict: Option<ResolveType>,
@@ -239,7 +240,6 @@ pub fn translate_insert(
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope("insert:translate");
     let opts = ProgramBuilderOpts::new(1, 30, 5);
     program.extend(&opts);
 
@@ -310,7 +310,7 @@ pub fn translate_insert(
         mut upsert_actions,
         inserting_multiple_rows,
     } = {
-        let _stack = crate::stack::trace_scope("insert:bind");
+        let _stack = crate::stack::trace_scope("bind");
         bind_insert(
             program,
             resolver,
@@ -353,7 +353,7 @@ pub fn translate_insert(
 
     // Plan CTEs and add them as outer query references for RETURNING subquery resolution
     {
-        let _stack = crate::stack::trace_scope("insert:plan_returning_ctes");
+        let _stack = crate::stack::trace_scope("plan_returning_ctes");
         plan_ctes_as_outer_refs(
             with_for_returning,
             resolver,
@@ -367,7 +367,7 @@ pub fn translate_insert(
     // (so SubqueryResult nodes are cloned into result_columns)
     let mut returning_subqueries = vec![];
     {
-        let _stack = crate::stack::trace_scope("insert:plan_returning_subqueries");
+        let _stack = crate::stack::trace_scope("plan_returning_subqueries");
         plan_subqueries_from_returning(
             program,
             &mut returning_subqueries,
@@ -443,7 +443,7 @@ pub fn translate_insert(
     }
 
     {
-        let _stack = crate::stack::trace_scope("insert:init_source_emission");
+        let _stack = crate::stack::trace_scope("init_source_emission");
         init_source_emission(
             program,
             &table,
@@ -466,7 +466,7 @@ pub fn translate_insert(
     let insertion = build_insertion(program, &table, &columns, ctx.num_values)?;
 
     {
-        let _stack = crate::stack::trace_scope("insert:translate_rows_open_tables");
+        let _stack = crate::stack::trace_scope("translate_rows_open_tables");
         translate_rows_and_open_tables(
             program,
             resolver,
@@ -543,7 +543,7 @@ pub fn translate_insert(
 
     let has_before_triggers = !relevant_before_triggers.is_empty();
     if has_before_triggers {
-        let _stack = crate::stack::trace_scope("insert:before_triggers");
+        let _stack = crate::stack::trace_scope("before_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,
@@ -956,7 +956,7 @@ pub fn translate_insert(
     );
     let has_after_triggers = !relevant_after_triggers.is_empty();
     if has_after_triggers {
-        let _stack = crate::stack::trace_scope("insert:after_triggers");
+        let _stack = crate::stack::trace_scope("after_triggers");
         compute_virtual_columns(
             program,
             &ctx.table.columns_topo_sort()?,

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -79,46 +79,61 @@ pub fn translate(
 ) -> Result<Program> {
     let _stack = crate::stack::trace_scope("translate");
     tracing::trace!("querying {}", input);
-    let change_cnt_on = matches!(
-        stmt,
-        ast::Stmt::CreateIndex { .. }
-            | ast::Stmt::Delete { .. }
-            | ast::Stmt::Insert { .. }
-            | ast::Stmt::Update { .. }
-    );
+    let change_cnt_on = {
+        let _stack = crate::stack::trace_scope("translate:change_count");
+        matches!(
+            stmt,
+            ast::Stmt::CreateIndex { .. }
+                | ast::Stmt::Delete { .. }
+                | ast::Stmt::Insert { .. }
+                | ast::Stmt::Update { .. }
+        )
+    };
 
     // Boxed so the ~800 B builder sits on the heap instead of the prepare frame.
-    let mut program = Box::new(ProgramBuilder::new(
-        query_mode,
-        connection.get_capture_data_changes_info().clone(),
-        // These options will be extended whithin each translate program
-        ProgramBuilderOpts::new(1, 32, 2),
-    ));
+    let mut program = {
+        let _stack = crate::stack::trace_scope("translate:program_builder_new");
+        Box::new(ProgramBuilder::new(
+            query_mode,
+            connection.get_capture_data_changes_info().clone(),
+            // These options will be extended whithin each translate program
+            ProgramBuilderOpts::new(1, 32, 2),
+        ))
+    };
 
-    program.prologue();
-    let mut resolver = Resolver::new(
-        schema,
-        connection.database_schemas(),
-        &connection.temp.database,
-        connection.attached_databases(),
-        syms,
-        connection.experimental_custom_types_enabled(),
-        connection.get_dqs_dml().into(),
-    );
+    {
+        let _stack = crate::stack::trace_scope("translate:prologue");
+        program.prologue();
+    }
+    let mut resolver = {
+        let _stack = crate::stack::trace_scope("translate:resolver_new");
+        Resolver::new(
+            schema,
+            connection.database_schemas(),
+            &connection.temp.database,
+            connection.attached_databases(),
+            syms,
+            connection.experimental_custom_types_enabled(),
+            connection.get_dqs_dml().into(),
+        )
+    };
 
-    match stmt {
-        // There can be no nesting with pragma, so lift it up here
-        ast::Stmt::Pragma { name, body } => {
-            pragma::translate_pragma(
-                &resolver,
-                &name,
-                body,
-                pager,
-                connection.clone(),
-                &mut program,
-            )?;
+    {
+        let _stack = crate::stack::trace_scope("translate:dispatch");
+        match stmt {
+            // There can be no nesting with pragma, so lift it up here
+            ast::Stmt::Pragma { name, body } => {
+                pragma::translate_pragma(
+                    &resolver,
+                    &name,
+                    body,
+                    pager,
+                    connection.clone(),
+                    &mut program,
+                )?;
+            }
+            stmt => translate_inner(stmt, &mut resolver, &mut program, &connection, input)?,
         }
-        stmt => translate_inner(stmt, &mut resolver, &mut program, &connection, input)?,
     };
 
     {
@@ -143,30 +158,36 @@ pub fn translate_inner(
     input: &str,
 ) -> Result<()> {
     let _stack = crate::stack::trace_scope_with_detail("translate_inner", stmt_kind(&stmt));
-    let is_write = matches!(
-        stmt,
-        ast::Stmt::AlterTable { .. }
-            | ast::Stmt::Analyze { .. }
-            | ast::Stmt::CreateIndex { .. }
-            | ast::Stmt::CreateTable { .. }
-            | ast::Stmt::CreateTrigger { .. }
-            | ast::Stmt::CreateView { .. }
-            | ast::Stmt::CreateMaterializedView { .. }
-            | ast::Stmt::CreateVirtualTable(..)
-            | ast::Stmt::CreateType { .. }
-            | ast::Stmt::CreateDomain { .. }
-            | ast::Stmt::Delete { .. }
-            | ast::Stmt::DropIndex { .. }
-            | ast::Stmt::DropTable { .. }
-            | ast::Stmt::DropType { .. }
-            | ast::Stmt::DropDomain { .. }
-            | ast::Stmt::DropView { .. }
-            | ast::Stmt::Reindex { .. }
-            | ast::Stmt::Optimize { .. }
-            | ast::Stmt::Update { .. }
-            | ast::Stmt::Insert { .. }
-    );
-    let is_vacuum = matches!(stmt, ast::Stmt::Vacuum { .. });
+    let is_write = {
+        let _stack = crate::stack::trace_scope("translate_inner:classify_write");
+        matches!(
+            stmt,
+            ast::Stmt::AlterTable { .. }
+                | ast::Stmt::Analyze { .. }
+                | ast::Stmt::CreateIndex { .. }
+                | ast::Stmt::CreateTable { .. }
+                | ast::Stmt::CreateTrigger { .. }
+                | ast::Stmt::CreateView { .. }
+                | ast::Stmt::CreateMaterializedView { .. }
+                | ast::Stmt::CreateVirtualTable(..)
+                | ast::Stmt::CreateType { .. }
+                | ast::Stmt::CreateDomain { .. }
+                | ast::Stmt::Delete { .. }
+                | ast::Stmt::DropIndex { .. }
+                | ast::Stmt::DropTable { .. }
+                | ast::Stmt::DropType { .. }
+                | ast::Stmt::DropDomain { .. }
+                | ast::Stmt::DropView { .. }
+                | ast::Stmt::Reindex { .. }
+                | ast::Stmt::Optimize { .. }
+                | ast::Stmt::Update { .. }
+                | ast::Stmt::Insert { .. }
+        )
+    };
+    let is_vacuum = {
+        let _stack = crate::stack::trace_scope("translate_inner:classify_vacuum");
+        matches!(stmt, ast::Stmt::Vacuum { .. })
+    };
 
     if is_vacuum && connection.get_query_only() {
         bail_parse_error!("Cannot execute VACUUM in query_only mode")
@@ -176,249 +197,264 @@ pub fn translate_inner(
         bail_parse_error!("Cannot execute write statement in query_only mode")
     }
 
-    let is_select = matches!(stmt, ast::Stmt::Select { .. });
+    let is_select = {
+        let _stack = crate::stack::trace_scope("translate_inner:classify_select");
+        matches!(stmt, ast::Stmt::Select { .. })
+    };
 
-    match stmt {
-        ast::Stmt::AlterTable(alter) => {
-            translate_alter_table(alter, resolver, program, connection, input)?;
-        }
-        ast::Stmt::Analyze { name } => translate_analyze(name, resolver, program)?,
-        ast::Stmt::Attach { expr, db_name, key } => {
-            attach::translate_attach(&expr, resolver, &db_name, &key, program, connection.clone())?;
-        }
-        ast::Stmt::Begin { typ, name } => translate_tx_begin(typ, name, resolver, program)?,
-        ast::Stmt::Commit { name } => {
-            translate_tx_commit(name, resolver.schema(), resolver, program)?
-        }
-        ast::Stmt::CreateIndex { .. } => {
-            translate_create_index(program, connection, resolver, stmt)?;
-        }
-        ast::Stmt::CreateTable {
-            temporary,
-            if_not_exists,
-            tbl_name,
-            body,
-        } => translate_create_table(
-            tbl_name,
-            resolver,
-            temporary,
-            if_not_exists,
-            body,
-            program,
-            connection,
-        )?,
-        ast::Stmt::CreateTrigger {
-            temporary,
-            if_not_exists,
-            trigger_name,
-            time,
-            event,
-            tbl_name,
-            for_each_row,
-            when_clause,
-            commands,
-        } => {
-            // Reconstruct SQL for storage
-            let sql = trigger::create_trigger_to_sql(
+    {
+        let _stack = crate::stack::trace_scope("translate_inner:dispatch");
+        match stmt {
+            ast::Stmt::AlterTable(alter) => {
+                translate_alter_table(alter, resolver, program, connection, input)?;
+            }
+            ast::Stmt::Analyze { name } => translate_analyze(name, resolver, program)?,
+            ast::Stmt::Attach { expr, db_name, key } => {
+                attach::translate_attach(
+                    &expr,
+                    resolver,
+                    &db_name,
+                    &key,
+                    program,
+                    connection.clone(),
+                )?;
+            }
+            ast::Stmt::Begin { typ, name } => translate_tx_begin(typ, name, resolver, program)?,
+            ast::Stmt::Commit { name } => {
+                translate_tx_commit(name, resolver.schema(), resolver, program)?
+            }
+            ast::Stmt::CreateIndex { .. } => {
+                translate_create_index(program, connection, resolver, stmt)?;
+            }
+            ast::Stmt::CreateTable {
                 temporary,
                 if_not_exists,
-                &trigger_name,
-                time,
-                &event,
-                &tbl_name,
-                for_each_row,
-                when_clause.as_deref(),
-                &commands,
-            );
-            trigger::translate_create_trigger(
-                trigger_name,
-                resolver,
-                temporary,
-                if_not_exists,
-                time,
                 tbl_name,
-                program,
-                sql,
-                &commands,
-                when_clause.as_deref(),
-            )?
-        }
-        ast::Stmt::CreateView {
-            view_name,
-            select,
-            columns,
-            ..
-        } => view::translate_create_view(&view_name, resolver, &select, &columns, program)?,
-        ast::Stmt::CreateMaterializedView {
-            view_name, select, ..
-        } => view::translate_create_materialized_view(
-            &view_name,
-            resolver,
-            &select,
-            connection.clone(),
-            program,
-        )?,
-        ast::Stmt::CreateVirtualTable(vtab) => {
-            translate_create_virtual_table(vtab, resolver, program, connection)?
-        }
-        ast::Stmt::Delete {
-            tbl_name,
-            where_clause,
-            limit,
-            returning,
-            indexed,
-            order_by,
-            with,
-        } => {
-            if !order_by.is_empty() {
-                bail_parse_error!("ORDER BY clause is not supported in DELETE");
-            }
-            if where_clause.is_none() && connection.get_dml_require_where() {
-                bail_parse_error!(
-                    "DELETE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
-                );
-            }
-            translate_delete(
-                &tbl_name,
+                body,
+            } => translate_create_table(
+                tbl_name,
                 resolver,
+                temporary,
+                if_not_exists,
+                body,
+                program,
+                connection,
+            )?,
+            ast::Stmt::CreateTrigger {
+                temporary,
+                if_not_exists,
+                trigger_name,
+                time,
+                event,
+                tbl_name,
+                for_each_row,
+                when_clause,
+                commands,
+            } => {
+                // Reconstruct SQL for storage
+                let sql = trigger::create_trigger_to_sql(
+                    temporary,
+                    if_not_exists,
+                    &trigger_name,
+                    time,
+                    &event,
+                    &tbl_name,
+                    for_each_row,
+                    when_clause.as_deref(),
+                    &commands,
+                );
+                trigger::translate_create_trigger(
+                    trigger_name,
+                    resolver,
+                    temporary,
+                    if_not_exists,
+                    time,
+                    tbl_name,
+                    program,
+                    sql,
+                    &commands,
+                    when_clause.as_deref(),
+                )?
+            }
+            ast::Stmt::CreateView {
+                view_name,
+                select,
+                columns,
+                ..
+            } => view::translate_create_view(&view_name, resolver, &select, &columns, program)?,
+            ast::Stmt::CreateMaterializedView {
+                view_name, select, ..
+            } => view::translate_create_materialized_view(
+                &view_name,
+                resolver,
+                &select,
+                connection.clone(),
+                program,
+            )?,
+            ast::Stmt::CreateVirtualTable(vtab) => {
+                translate_create_virtual_table(vtab, resolver, program, connection)?
+            }
+            ast::Stmt::Delete {
+                tbl_name,
                 where_clause,
                 limit,
                 returning,
                 indexed,
+                order_by,
+                with,
+            } => {
+                if !order_by.is_empty() {
+                    bail_parse_error!("ORDER BY clause is not supported in DELETE");
+                }
+                if where_clause.is_none() && connection.get_dml_require_where() {
+                    bail_parse_error!(
+                    "DELETE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
+                );
+                }
+                translate_delete(
+                    &tbl_name,
+                    resolver,
+                    where_clause,
+                    limit,
+                    returning,
+                    indexed,
+                    with,
+                    program,
+                    connection,
+                )?
+            }
+            ast::Stmt::Detach { name } => {
+                attach::translate_detach(&name, resolver, program, connection.clone())?
+            }
+            ast::Stmt::DropIndex {
+                if_exists,
+                idx_name,
+            } => translate_drop_index(&idx_name, resolver, if_exists, program)?,
+            ast::Stmt::DropTable {
+                if_exists,
+                tbl_name,
+            } => translate_drop_table(tbl_name, resolver, if_exists, program, connection)?,
+            ast::Stmt::DropTrigger {
+                if_exists,
+                trigger_name,
+            } => trigger::translate_drop_trigger(resolver, &trigger_name, if_exists, program)?,
+            ast::Stmt::DropView {
+                if_exists,
+                view_name,
+            } => view::translate_drop_view(resolver, &view_name, if_exists, program)?,
+            ast::Stmt::CreateType {
+                if_not_exists,
+                type_name,
+                body,
+            } => {
+                if !connection.experimental_custom_types_enabled() {
+                    bail_parse_error!("Custom types require --experimental-custom-types flag");
+                }
+                schema::translate_create_type(&type_name, &body, if_not_exists, resolver, program)?
+            }
+            ast::Stmt::CreateDomain {
+                if_not_exists,
+                domain_name,
+                base_type,
+                default,
+                not_null,
+                constraints,
+            } => {
+                if !connection.experimental_custom_types_enabled() {
+                    bail_parse_error!("Custom types require --experimental-custom-types flag");
+                }
+                schema::translate_create_domain(
+                    &domain_name,
+                    &base_type,
+                    not_null,
+                    &constraints,
+                    default,
+                    if_not_exists,
+                    resolver,
+                    program,
+                )?
+            }
+            ast::Stmt::DropType {
+                if_exists,
+                type_name,
+            } => {
+                if !connection.experimental_custom_types_enabled() {
+                    bail_parse_error!("Custom types require --experimental-custom-types flag");
+                }
+                schema::translate_drop_type(&type_name, if_exists, false, resolver, program)?
+            }
+            ast::Stmt::DropDomain {
+                if_exists,
+                domain_name,
+            } => {
+                if !connection.experimental_custom_types_enabled() {
+                    bail_parse_error!("Custom types require --experimental-custom-types flag");
+                }
+                schema::translate_drop_type(&domain_name, if_exists, true, resolver, program)?
+            }
+            ast::Stmt::Pragma { .. } => {
+                bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
+            }
+            ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
+            ast::Stmt::Optimize { idx_name } => {
+                translate_optimize(idx_name, resolver, program, connection)?
+            }
+            ast::Stmt::Release { name } => translate_release(program, name)?,
+            ast::Stmt::Rollback {
+                tx_name,
+                savepoint_name,
+            } => translate_rollback(program, tx_name, savepoint_name)?,
+            ast::Stmt::Savepoint { name } => translate_savepoint(program, name)?,
+            ast::Stmt::Select(select) => {
+                translate_select(
+                    select,
+                    resolver,
+                    program,
+                    plan::QueryDestination::ResultRows,
+                    connection,
+                )?;
+            }
+            ast::Stmt::Update(update) => {
+                if update.where_clause.is_none() && connection.get_dml_require_where() {
+                    bail_parse_error!(
+                    "UPDATE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
+                );
+                }
+                translate_update(update, resolver, program, connection)?
+            }
+            ast::Stmt::Vacuum { name, into } => {
+                vacuum::translate_vacuum(program, name.as_ref(), into.as_deref(), connection.clone())?
+            }
+            ast::Stmt::Insert {
+                with,
+                or_conflict,
+                tbl_name,
+                columns,
+                body,
+                returning,
+            } => translate_insert(
+                resolver,
+                or_conflict,
+                tbl_name,
+                columns,
+                body,
+                returning,
                 with,
                 program,
                 connection,
-            )?
-        }
-        ast::Stmt::Detach { name } => {
-            attach::translate_detach(&name, resolver, program, connection.clone())?
-        }
-        ast::Stmt::DropIndex {
-            if_exists,
-            idx_name,
-        } => translate_drop_index(&idx_name, resolver, if_exists, program)?,
-        ast::Stmt::DropTable {
-            if_exists,
-            tbl_name,
-        } => translate_drop_table(tbl_name, resolver, if_exists, program, connection)?,
-        ast::Stmt::DropTrigger {
-            if_exists,
-            trigger_name,
-        } => trigger::translate_drop_trigger(resolver, &trigger_name, if_exists, program)?,
-        ast::Stmt::DropView {
-            if_exists,
-            view_name,
-        } => view::translate_drop_view(resolver, &view_name, if_exists, program)?,
-        ast::Stmt::CreateType {
-            if_not_exists,
-            type_name,
-            body,
-        } => {
-            if !connection.experimental_custom_types_enabled() {
-                bail_parse_error!("Custom types require --experimental-custom-types flag");
-            }
-            schema::translate_create_type(&type_name, &body, if_not_exists, resolver, program)?
-        }
-        ast::Stmt::CreateDomain {
-            if_not_exists,
-            domain_name,
-            base_type,
-            default,
-            not_null,
-            constraints,
-        } => {
-            if !connection.experimental_custom_types_enabled() {
-                bail_parse_error!("Custom types require --experimental-custom-types flag");
-            }
-            schema::translate_create_domain(
-                &domain_name,
-                &base_type,
-                not_null,
-                &constraints,
-                default,
-                if_not_exists,
-                resolver,
-                program,
-            )?
-        }
-        ast::Stmt::DropType {
-            if_exists,
-            type_name,
-        } => {
-            if !connection.experimental_custom_types_enabled() {
-                bail_parse_error!("Custom types require --experimental-custom-types flag");
-            }
-            schema::translate_drop_type(&type_name, if_exists, false, resolver, program)?
-        }
-        ast::Stmt::DropDomain {
-            if_exists,
-            domain_name,
-        } => {
-            if !connection.experimental_custom_types_enabled() {
-                bail_parse_error!("Custom types require --experimental-custom-types flag");
-            }
-            schema::translate_drop_type(&domain_name, if_exists, true, resolver, program)?
-        }
-        ast::Stmt::Pragma { .. } => {
-            bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
-        }
-        ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
-        ast::Stmt::Optimize { idx_name } => {
-            translate_optimize(idx_name, resolver, program, connection)?
-        }
-        ast::Stmt::Release { name } => translate_release(program, name)?,
-        ast::Stmt::Rollback {
-            tx_name,
-            savepoint_name,
-        } => translate_rollback(program, tx_name, savepoint_name)?,
-        ast::Stmt::Savepoint { name } => translate_savepoint(program, name)?,
-        ast::Stmt::Select(select) => {
-            translate_select(
-                select,
-                resolver,
-                program,
-                plan::QueryDestination::ResultRows,
-                connection,
-            )?;
-        }
-        ast::Stmt::Update(update) => {
-            if update.where_clause.is_none() && connection.get_dml_require_where() {
-                bail_parse_error!(
-                    "UPDATE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
-                );
-            }
-            translate_update(update, resolver, program, connection)?
-        }
-        ast::Stmt::Vacuum { name, into } => {
-            vacuum::translate_vacuum(program, name.as_ref(), into.as_deref(), connection.clone())?
-        }
-        ast::Stmt::Insert {
-            with,
-            or_conflict,
-            tbl_name,
-            columns,
-            body,
-            returning,
-        } => translate_insert(
-            resolver,
-            or_conflict,
-            tbl_name,
-            columns,
-            body,
-            returning,
-            with,
-            program,
-            connection,
-        )?,
-    };
+            )?,
+        };
+    }
 
     // Indicate write operations so that in the epilogue we can emit the correct type of transaction
     if is_write {
+        let _stack = crate::stack::trace_scope("translate_inner:begin_write_operation");
         program.begin_write_operation();
     }
 
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction
     if is_select && !program.table_references.is_empty() {
+        let _stack = crate::stack::trace_scope("translate_inner:begin_read_operation");
         program.begin_read_operation();
     }
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -77,6 +77,7 @@ pub fn translate(
     query_mode: QueryMode,
     input: &str,
 ) -> Result<Program> {
+    let _stack = crate::stack::trace_scope("translate");
     tracing::trace!("querying {}", input);
     let change_cnt_on = matches!(
         stmt,
@@ -120,9 +121,15 @@ pub fn translate(
         stmt => translate_inner(stmt, &mut resolver, &mut program, &connection, input)?,
     };
 
-    program.epilogue(schema);
+    {
+        let _stack = crate::stack::trace_scope("translate:epilogue");
+        program.epilogue(schema);
+    }
 
-    program.build(connection, change_cnt_on, input)
+    {
+        let _stack = crate::stack::trace_scope("translate:build");
+        program.build(connection, change_cnt_on, input)
+    }
 }
 
 // TODO: for now leaving the return value as a Program. But ideally to support nested parsing of arbitraty
@@ -135,6 +142,7 @@ pub fn translate_inner(
     connection: &Arc<Connection>,
     input: &str,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope_with_detail("translate_inner", stmt_kind(&stmt));
     let is_write = matches!(
         stmt,
         ast::Stmt::AlterTable { .. }
@@ -415,6 +423,42 @@ pub fn translate_inner(
     }
 
     Ok(())
+}
+
+fn stmt_kind(stmt: &ast::Stmt) -> &'static str {
+    match stmt {
+        ast::Stmt::AlterTable(_) => "alter_table",
+        ast::Stmt::Analyze { .. } => "analyze",
+        ast::Stmt::Attach { .. } => "attach",
+        ast::Stmt::Begin { .. } => "begin",
+        ast::Stmt::Commit { .. } => "commit",
+        ast::Stmt::CreateIndex { .. } => "create_index",
+        ast::Stmt::CreateTable { .. } => "create_table",
+        ast::Stmt::CreateTrigger { .. } => "create_trigger",
+        ast::Stmt::CreateView { .. } => "create_view",
+        ast::Stmt::CreateMaterializedView { .. } => "create_materialized_view",
+        ast::Stmt::CreateVirtualTable(_) => "create_virtual_table",
+        ast::Stmt::CreateType { .. } => "create_type",
+        ast::Stmt::CreateDomain { .. } => "create_domain",
+        ast::Stmt::Delete { .. } => "delete",
+        ast::Stmt::Detach { .. } => "detach",
+        ast::Stmt::DropIndex { .. } => "drop_index",
+        ast::Stmt::DropTable { .. } => "drop_table",
+        ast::Stmt::DropType { .. } => "drop_type",
+        ast::Stmt::DropDomain { .. } => "drop_domain",
+        ast::Stmt::DropTrigger { .. } => "drop_trigger",
+        ast::Stmt::DropView { .. } => "drop_view",
+        ast::Stmt::Insert { .. } => "insert",
+        ast::Stmt::Pragma { .. } => "pragma",
+        ast::Stmt::Reindex { .. } => "reindex",
+        ast::Stmt::Release { .. } => "release",
+        ast::Stmt::Rollback { .. } => "rollback",
+        ast::Stmt::Savepoint { .. } => "savepoint",
+        ast::Stmt::Select { .. } => "select",
+        ast::Stmt::Update { .. } => "update",
+        ast::Stmt::Vacuum { .. } => "vacuum",
+        ast::Stmt::Optimize { .. } => "optimize",
+    }
 }
 
 #[cfg(test)]

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -68,6 +68,7 @@ use update::translate_update;
 
 #[instrument(skip_all, level = Level::DEBUG)]
 #[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
 pub fn translate(
     schema: &Schema,
     stmt: ast::Stmt,
@@ -77,10 +78,9 @@ pub fn translate(
     query_mode: QueryMode,
     input: &str,
 ) -> Result<Program> {
-    let _stack = crate::stack::trace_scope("translate");
     tracing::trace!("querying {}", input);
     let change_cnt_on = {
-        let _stack = crate::stack::trace_scope("translate:change_count");
+        let _stack = crate::stack::trace_scope("change_count");
         matches!(
             stmt,
             ast::Stmt::CreateIndex { .. }
@@ -92,7 +92,7 @@ pub fn translate(
 
     // Boxed so the ~800 B builder sits on the heap instead of the prepare frame.
     let mut program = {
-        let _stack = crate::stack::trace_scope("translate:program_builder_new");
+        let _stack = crate::stack::trace_scope("program_builder_new");
         Box::new(ProgramBuilder::new(
             query_mode,
             connection.get_capture_data_changes_info().clone(),
@@ -102,11 +102,11 @@ pub fn translate(
     };
 
     {
-        let _stack = crate::stack::trace_scope("translate:prologue");
+        let _stack = crate::stack::trace_scope("prologue");
         program.prologue();
     }
     let mut resolver = {
-        let _stack = crate::stack::trace_scope("translate:resolver_new");
+        let _stack = crate::stack::trace_scope("resolver_new");
         Resolver::new(
             schema,
             connection.database_schemas(),
@@ -119,7 +119,7 @@ pub fn translate(
     };
 
     {
-        let _stack = crate::stack::trace_scope("translate:dispatch");
+        let _stack = crate::stack::trace_scope("dispatch");
         match stmt {
             // There can be no nesting with pragma, so lift it up here
             ast::Stmt::Pragma { name, body } => {
@@ -137,12 +137,12 @@ pub fn translate(
     };
 
     {
-        let _stack = crate::stack::trace_scope("translate:epilogue");
+        let _stack = crate::stack::trace_scope("epilogue");
         program.epilogue(schema);
     }
 
     {
-        let _stack = crate::stack::trace_scope("translate:build");
+        let _stack = crate::stack::trace_scope("build");
         program.build(connection, change_cnt_on, input)
     }
 }
@@ -150,6 +150,7 @@ pub fn translate(
 // TODO: for now leaving the return value as a Program. But ideally to support nested parsing of arbitraty
 // statements, we would have to return a program builder instead
 /// Translate SQL statement into bytecode program.
+#[turso_macros::trace_stack(detail = stmt_kind(&stmt))]
 pub fn translate_inner(
     stmt: ast::Stmt,
     resolver: &mut Resolver,
@@ -157,9 +158,8 @@ pub fn translate_inner(
     connection: &Arc<Connection>,
     input: &str,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope_with_detail("translate_inner", stmt_kind(&stmt));
     let is_write = {
-        let _stack = crate::stack::trace_scope("translate_inner:classify_write");
+        let _stack = crate::stack::trace_scope("classify_write");
         matches!(
             stmt,
             ast::Stmt::AlterTable { .. }
@@ -185,7 +185,7 @@ pub fn translate_inner(
         )
     };
     let is_vacuum = {
-        let _stack = crate::stack::trace_scope("translate_inner:classify_vacuum");
+        let _stack = crate::stack::trace_scope("classify_vacuum");
         matches!(stmt, ast::Stmt::Vacuum { .. })
     };
 
@@ -198,12 +198,12 @@ pub fn translate_inner(
     }
 
     let is_select = {
-        let _stack = crate::stack::trace_scope("translate_inner:classify_select");
+        let _stack = crate::stack::trace_scope("classify_select");
         matches!(stmt, ast::Stmt::Select { .. })
     };
 
     {
-        let _stack = crate::stack::trace_scope("translate_inner:dispatch");
+        let _stack = crate::stack::trace_scope("dispatch");
         match stmt {
             ast::Stmt::AlterTable(alter) => {
                 translate_alter_table(alter, resolver, program, connection, input)?;
@@ -448,13 +448,13 @@ pub fn translate_inner(
 
     // Indicate write operations so that in the epilogue we can emit the correct type of transaction
     if is_write {
-        let _stack = crate::stack::trace_scope("translate_inner:begin_write_operation");
+        let _stack = crate::stack::trace_scope("begin_write_operation");
         program.begin_write_operation();
     }
 
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction
     if is_select && !program.table_references.is_empty() {
-        let _stack = crate::stack::trace_scope("translate_inner:begin_read_operation");
+        let _stack = crate::stack::trace_scope("begin_read_operation");
         program.begin_read_operation();
     }
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -79,72 +79,51 @@ pub fn translate(
     input: &str,
 ) -> Result<Program> {
     tracing::trace!("querying {}", input);
-    let change_cnt_on = {
-        crate::stack::trace_stack!("change_count");
-        matches!(
-            stmt,
-            ast::Stmt::CreateIndex { .. }
-                | ast::Stmt::Delete { .. }
-                | ast::Stmt::Insert { .. }
-                | ast::Stmt::Update { .. }
-        )
-    };
+    let change_cnt_on = matches!(
+        stmt,
+        ast::Stmt::CreateIndex { .. }
+            | ast::Stmt::Delete { .. }
+            | ast::Stmt::Insert { .. }
+            | ast::Stmt::Update { .. }
+    );
 
     // Boxed so the ~800 B builder sits on the heap instead of the prepare frame.
-    let mut program = {
-        crate::stack::trace_stack!("program_builder_new");
-        Box::new(ProgramBuilder::new(
-            query_mode,
-            connection.get_capture_data_changes_info().clone(),
-            // These options will be extended whithin each translate program
-            ProgramBuilderOpts::new(1, 32, 2),
-        ))
-    };
+    let mut program = Box::new(ProgramBuilder::new(
+        query_mode,
+        connection.get_capture_data_changes_info().clone(),
+        // These options will be extended whithin each translate program
+        ProgramBuilderOpts::new(1, 32, 2),
+    ));
 
-    {
-        crate::stack::trace_stack!("prologue");
-        program.prologue();
-    }
-    let mut resolver = {
-        crate::stack::trace_stack!("resolver_new");
-        Resolver::new(
-            schema,
-            connection.database_schemas(),
-            &connection.temp.database,
-            connection.attached_databases(),
-            syms,
-            connection.experimental_custom_types_enabled(),
-            connection.get_dqs_dml().into(),
-        )
-    };
+    program.prologue();
+    let mut resolver = Resolver::new(
+        schema,
+        connection.database_schemas(),
+        &connection.temp.database,
+        connection.attached_databases(),
+        syms,
+        connection.experimental_custom_types_enabled(),
+        connection.get_dqs_dml().into(),
+    );
 
-    {
-        crate::stack::trace_stack!("dispatch");
-        match stmt {
-            // There can be no nesting with pragma, so lift it up here
-            ast::Stmt::Pragma { name, body } => {
-                pragma::translate_pragma(
-                    &resolver,
-                    &name,
-                    body,
-                    pager,
-                    connection.clone(),
-                    &mut program,
-                )?;
-            }
-            stmt => translate_inner(stmt, &mut resolver, &mut program, &connection, input)?,
+    match stmt {
+        // There can be no nesting with pragma, so lift it up here
+        ast::Stmt::Pragma { name, body } => {
+            pragma::translate_pragma(
+                &resolver,
+                &name,
+                body,
+                pager,
+                connection.clone(),
+                &mut program,
+            )?;
         }
+        stmt => translate_inner(stmt, &mut resolver, &mut program, &connection, input)?,
     };
 
-    {
-        crate::stack::trace_stack!("epilogue");
-        program.epilogue(schema);
-    }
+    program.epilogue(schema);
 
-    {
-        crate::stack::trace_stack!("build");
-        program.build(connection, change_cnt_on, input)
-    }
+    program.build(connection, change_cnt_on, input)
 }
 
 // TODO: for now leaving the return value as a Program. But ideally to support nested parsing of arbitraty
@@ -158,36 +137,30 @@ pub fn translate_inner(
     connection: &Arc<Connection>,
     input: &str,
 ) -> Result<()> {
-    let is_write = {
-        crate::stack::trace_stack!("classify_write");
-        matches!(
-            stmt,
-            ast::Stmt::AlterTable { .. }
-                | ast::Stmt::Analyze { .. }
-                | ast::Stmt::CreateIndex { .. }
-                | ast::Stmt::CreateTable { .. }
-                | ast::Stmt::CreateTrigger { .. }
-                | ast::Stmt::CreateView { .. }
-                | ast::Stmt::CreateMaterializedView { .. }
-                | ast::Stmt::CreateVirtualTable(..)
-                | ast::Stmt::CreateType { .. }
-                | ast::Stmt::CreateDomain { .. }
-                | ast::Stmt::Delete { .. }
-                | ast::Stmt::DropIndex { .. }
-                | ast::Stmt::DropTable { .. }
-                | ast::Stmt::DropType { .. }
-                | ast::Stmt::DropDomain { .. }
-                | ast::Stmt::DropView { .. }
-                | ast::Stmt::Reindex { .. }
-                | ast::Stmt::Optimize { .. }
-                | ast::Stmt::Update { .. }
-                | ast::Stmt::Insert { .. }
-        )
-    };
-    let is_vacuum = {
-        crate::stack::trace_stack!("classify_vacuum");
-        matches!(stmt, ast::Stmt::Vacuum { .. })
-    };
+    let is_write = matches!(
+        stmt,
+        ast::Stmt::AlterTable { .. }
+            | ast::Stmt::Analyze { .. }
+            | ast::Stmt::CreateIndex { .. }
+            | ast::Stmt::CreateTable { .. }
+            | ast::Stmt::CreateTrigger { .. }
+            | ast::Stmt::CreateView { .. }
+            | ast::Stmt::CreateMaterializedView { .. }
+            | ast::Stmt::CreateVirtualTable(..)
+            | ast::Stmt::CreateType { .. }
+            | ast::Stmt::CreateDomain { .. }
+            | ast::Stmt::Delete { .. }
+            | ast::Stmt::DropIndex { .. }
+            | ast::Stmt::DropTable { .. }
+            | ast::Stmt::DropType { .. }
+            | ast::Stmt::DropDomain { .. }
+            | ast::Stmt::DropView { .. }
+            | ast::Stmt::Reindex { .. }
+            | ast::Stmt::Optimize { .. }
+            | ast::Stmt::Update { .. }
+            | ast::Stmt::Insert { .. }
+    );
+    let is_vacuum = matches!(stmt, ast::Stmt::Vacuum { .. });
 
     if is_vacuum && connection.get_query_only() {
         bail_parse_error!("Cannot execute VACUUM in query_only mode")
@@ -197,267 +170,249 @@ pub fn translate_inner(
         bail_parse_error!("Cannot execute write statement in query_only mode")
     }
 
-    let is_select = {
-        crate::stack::trace_stack!("classify_select");
-        matches!(stmt, ast::Stmt::Select { .. })
-    };
+    let is_select = matches!(stmt, ast::Stmt::Select { .. });
 
-    {
-        crate::stack::trace_stack!("dispatch");
-        match stmt {
-            ast::Stmt::AlterTable(alter) => {
-                translate_alter_table(alter, resolver, program, connection, input)?;
-            }
-            ast::Stmt::Analyze { name } => translate_analyze(name, resolver, program)?,
-            ast::Stmt::Attach { expr, db_name, key } => {
-                attach::translate_attach(
-                    &expr,
-                    resolver,
-                    &db_name,
-                    &key,
-                    program,
-                    connection.clone(),
-                )?;
-            }
-            ast::Stmt::Begin { typ, name } => translate_tx_begin(typ, name, resolver, program)?,
-            ast::Stmt::Commit { name } => {
-                translate_tx_commit(name, resolver.schema(), resolver, program)?
-            }
-            ast::Stmt::CreateIndex { .. } => {
-                translate_create_index(program, connection, resolver, stmt)?;
-            }
-            ast::Stmt::CreateTable {
+    match stmt {
+        ast::Stmt::AlterTable(alter) => {
+            translate_alter_table(alter, resolver, program, connection, input)?;
+        }
+        ast::Stmt::Analyze { name } => translate_analyze(name, resolver, program)?,
+        ast::Stmt::Attach { expr, db_name, key } => {
+            attach::translate_attach(&expr, resolver, &db_name, &key, program, connection.clone())?;
+        }
+        ast::Stmt::Begin { typ, name } => translate_tx_begin(typ, name, resolver, program)?,
+        ast::Stmt::Commit { name } => {
+            translate_tx_commit(name, resolver.schema(), resolver, program)?
+        }
+        ast::Stmt::CreateIndex { .. } => {
+            translate_create_index(program, connection, resolver, stmt)?;
+        }
+        ast::Stmt::CreateTable {
+            temporary,
+            if_not_exists,
+            tbl_name,
+            body,
+        } => translate_create_table(
+            tbl_name,
+            resolver,
+            temporary,
+            if_not_exists,
+            body,
+            program,
+            connection,
+        )?,
+        ast::Stmt::CreateTrigger {
+            temporary,
+            if_not_exists,
+            trigger_name,
+            time,
+            event,
+            tbl_name,
+            for_each_row,
+            when_clause,
+            commands,
+        } => {
+            // Reconstruct SQL for storage
+            let sql = trigger::create_trigger_to_sql(
                 temporary,
                 if_not_exists,
-                tbl_name,
-                body,
-            } => translate_create_table(
-                tbl_name,
-                resolver,
-                temporary,
-                if_not_exists,
-                body,
-                program,
-                connection,
-            )?,
-            ast::Stmt::CreateTrigger {
-                temporary,
-                if_not_exists,
-                trigger_name,
+                &trigger_name,
                 time,
-                event,
-                tbl_name,
+                &event,
+                &tbl_name,
                 for_each_row,
-                when_clause,
-                commands,
-            } => {
-                // Reconstruct SQL for storage
-                let sql = trigger::create_trigger_to_sql(
-                    temporary,
-                    if_not_exists,
-                    &trigger_name,
-                    time,
-                    &event,
-                    &tbl_name,
-                    for_each_row,
-                    when_clause.as_deref(),
-                    &commands,
-                );
-                trigger::translate_create_trigger(
-                    trigger_name,
-                    resolver,
-                    temporary,
-                    if_not_exists,
-                    time,
-                    tbl_name,
-                    program,
-                    sql,
-                    &commands,
-                    when_clause.as_deref(),
-                )?
-            }
-            ast::Stmt::CreateView {
-                view_name,
-                select,
-                columns,
-                ..
-            } => view::translate_create_view(&view_name, resolver, &select, &columns, program)?,
-            ast::Stmt::CreateMaterializedView {
-                view_name, select, ..
-            } => view::translate_create_materialized_view(
-                &view_name,
+                when_clause.as_deref(),
+                &commands,
+            );
+            trigger::translate_create_trigger(
+                trigger_name,
                 resolver,
-                &select,
-                connection.clone(),
-                program,
-            )?,
-            ast::Stmt::CreateVirtualTable(vtab) => {
-                translate_create_virtual_table(vtab, resolver, program, connection)?
-            }
-            ast::Stmt::Delete {
+                temporary,
+                if_not_exists,
+                time,
                 tbl_name,
+                program,
+                sql,
+                &commands,
+                when_clause.as_deref(),
+            )?
+        }
+        ast::Stmt::CreateView {
+            view_name,
+            select,
+            columns,
+            ..
+        } => view::translate_create_view(&view_name, resolver, &select, &columns, program)?,
+        ast::Stmt::CreateMaterializedView {
+            view_name, select, ..
+        } => view::translate_create_materialized_view(
+            &view_name,
+            resolver,
+            &select,
+            connection.clone(),
+            program,
+        )?,
+        ast::Stmt::CreateVirtualTable(vtab) => {
+            translate_create_virtual_table(vtab, resolver, program, connection)?
+        }
+        ast::Stmt::Delete {
+            tbl_name,
+            where_clause,
+            limit,
+            returning,
+            indexed,
+            order_by,
+            with,
+        } => {
+            if !order_by.is_empty() {
+                bail_parse_error!("ORDER BY clause is not supported in DELETE");
+            }
+            if where_clause.is_none() && connection.get_dml_require_where() {
+                bail_parse_error!(
+                    "DELETE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
+                );
+            }
+            translate_delete(
+                &tbl_name,
+                resolver,
                 where_clause,
                 limit,
                 returning,
                 indexed,
-                order_by,
-                with,
-            } => {
-                if !order_by.is_empty() {
-                    bail_parse_error!("ORDER BY clause is not supported in DELETE");
-                }
-                if where_clause.is_none() && connection.get_dml_require_where() {
-                    bail_parse_error!(
-                    "DELETE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
-                );
-                }
-                translate_delete(
-                    &tbl_name,
-                    resolver,
-                    where_clause,
-                    limit,
-                    returning,
-                    indexed,
-                    with,
-                    program,
-                    connection,
-                )?
-            }
-            ast::Stmt::Detach { name } => {
-                attach::translate_detach(&name, resolver, program, connection.clone())?
-            }
-            ast::Stmt::DropIndex {
-                if_exists,
-                idx_name,
-            } => translate_drop_index(&idx_name, resolver, if_exists, program)?,
-            ast::Stmt::DropTable {
-                if_exists,
-                tbl_name,
-            } => translate_drop_table(tbl_name, resolver, if_exists, program, connection)?,
-            ast::Stmt::DropTrigger {
-                if_exists,
-                trigger_name,
-            } => trigger::translate_drop_trigger(resolver, &trigger_name, if_exists, program)?,
-            ast::Stmt::DropView {
-                if_exists,
-                view_name,
-            } => view::translate_drop_view(resolver, &view_name, if_exists, program)?,
-            ast::Stmt::CreateType {
-                if_not_exists,
-                type_name,
-                body,
-            } => {
-                if !connection.experimental_custom_types_enabled() {
-                    bail_parse_error!("Custom types require --experimental-custom-types flag");
-                }
-                schema::translate_create_type(&type_name, &body, if_not_exists, resolver, program)?
-            }
-            ast::Stmt::CreateDomain {
-                if_not_exists,
-                domain_name,
-                base_type,
-                default,
-                not_null,
-                constraints,
-            } => {
-                if !connection.experimental_custom_types_enabled() {
-                    bail_parse_error!("Custom types require --experimental-custom-types flag");
-                }
-                schema::translate_create_domain(
-                    &domain_name,
-                    &base_type,
-                    not_null,
-                    &constraints,
-                    default,
-                    if_not_exists,
-                    resolver,
-                    program,
-                )?
-            }
-            ast::Stmt::DropType {
-                if_exists,
-                type_name,
-            } => {
-                if !connection.experimental_custom_types_enabled() {
-                    bail_parse_error!("Custom types require --experimental-custom-types flag");
-                }
-                schema::translate_drop_type(&type_name, if_exists, false, resolver, program)?
-            }
-            ast::Stmt::DropDomain {
-                if_exists,
-                domain_name,
-            } => {
-                if !connection.experimental_custom_types_enabled() {
-                    bail_parse_error!("Custom types require --experimental-custom-types flag");
-                }
-                schema::translate_drop_type(&domain_name, if_exists, true, resolver, program)?
-            }
-            ast::Stmt::Pragma { .. } => {
-                bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
-            }
-            ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
-            ast::Stmt::Optimize { idx_name } => {
-                translate_optimize(idx_name, resolver, program, connection)?
-            }
-            ast::Stmt::Release { name } => translate_release(program, name)?,
-            ast::Stmt::Rollback {
-                tx_name,
-                savepoint_name,
-            } => translate_rollback(program, tx_name, savepoint_name)?,
-            ast::Stmt::Savepoint { name } => translate_savepoint(program, name)?,
-            ast::Stmt::Select(select) => {
-                translate_select(
-                    select,
-                    resolver,
-                    program,
-                    plan::QueryDestination::ResultRows,
-                    connection,
-                )?;
-            }
-            ast::Stmt::Update(update) => {
-                if update.where_clause.is_none() && connection.get_dml_require_where() {
-                    bail_parse_error!(
-                    "UPDATE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
-                );
-                }
-                translate_update(update, resolver, program, connection)?
-            }
-            ast::Stmt::Vacuum { name, into } => vacuum::translate_vacuum(
-                program,
-                name.as_ref(),
-                into.as_deref(),
-                connection.clone(),
-            )?,
-            ast::Stmt::Insert {
-                with,
-                or_conflict,
-                tbl_name,
-                columns,
-                body,
-                returning,
-            } => translate_insert(
-                resolver,
-                or_conflict,
-                tbl_name,
-                columns,
-                body,
-                returning,
                 with,
                 program,
                 connection,
-            )?,
-        };
-    }
+            )?
+        }
+        ast::Stmt::Detach { name } => {
+            attach::translate_detach(&name, resolver, program, connection.clone())?
+        }
+        ast::Stmt::DropIndex {
+            if_exists,
+            idx_name,
+        } => translate_drop_index(&idx_name, resolver, if_exists, program)?,
+        ast::Stmt::DropTable {
+            if_exists,
+            tbl_name,
+        } => translate_drop_table(tbl_name, resolver, if_exists, program, connection)?,
+        ast::Stmt::DropTrigger {
+            if_exists,
+            trigger_name,
+        } => trigger::translate_drop_trigger(resolver, &trigger_name, if_exists, program)?,
+        ast::Stmt::DropView {
+            if_exists,
+            view_name,
+        } => view::translate_drop_view(resolver, &view_name, if_exists, program)?,
+        ast::Stmt::CreateType {
+            if_not_exists,
+            type_name,
+            body,
+        } => {
+            if !connection.experimental_custom_types_enabled() {
+                bail_parse_error!("Custom types require --experimental-custom-types flag");
+            }
+            schema::translate_create_type(&type_name, &body, if_not_exists, resolver, program)?
+        }
+        ast::Stmt::CreateDomain {
+            if_not_exists,
+            domain_name,
+            base_type,
+            default,
+            not_null,
+            constraints,
+        } => {
+            if !connection.experimental_custom_types_enabled() {
+                bail_parse_error!("Custom types require --experimental-custom-types flag");
+            }
+            schema::translate_create_domain(
+                &domain_name,
+                &base_type,
+                not_null,
+                &constraints,
+                default,
+                if_not_exists,
+                resolver,
+                program,
+            )?
+        }
+        ast::Stmt::DropType {
+            if_exists,
+            type_name,
+        } => {
+            if !connection.experimental_custom_types_enabled() {
+                bail_parse_error!("Custom types require --experimental-custom-types flag");
+            }
+            schema::translate_drop_type(&type_name, if_exists, false, resolver, program)?
+        }
+        ast::Stmt::DropDomain {
+            if_exists,
+            domain_name,
+        } => {
+            if !connection.experimental_custom_types_enabled() {
+                bail_parse_error!("Custom types require --experimental-custom-types flag");
+            }
+            schema::translate_drop_type(&domain_name, if_exists, true, resolver, program)?
+        }
+        ast::Stmt::Pragma { .. } => {
+            bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
+        }
+        ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
+        ast::Stmt::Optimize { idx_name } => {
+            translate_optimize(idx_name, resolver, program, connection)?
+        }
+        ast::Stmt::Release { name } => translate_release(program, name)?,
+        ast::Stmt::Rollback {
+            tx_name,
+            savepoint_name,
+        } => translate_rollback(program, tx_name, savepoint_name)?,
+        ast::Stmt::Savepoint { name } => translate_savepoint(program, name)?,
+        ast::Stmt::Select(select) => {
+            translate_select(
+                select,
+                resolver,
+                program,
+                plan::QueryDestination::ResultRows,
+                connection,
+            )?;
+        }
+        ast::Stmt::Update(update) => {
+            if update.where_clause.is_none() && connection.get_dml_require_where() {
+                bail_parse_error!(
+                    "UPDATE without a WHERE clause is not allowed when require_where (or i_am_a_dummy) is enabled"
+                );
+            }
+            translate_update(update, resolver, program, connection)?
+        }
+        ast::Stmt::Vacuum { name, into } => {
+            vacuum::translate_vacuum(program, name.as_ref(), into.as_deref(), connection.clone())?
+        }
+        ast::Stmt::Insert {
+            with,
+            or_conflict,
+            tbl_name,
+            columns,
+            body,
+            returning,
+        } => translate_insert(
+            resolver,
+            or_conflict,
+            tbl_name,
+            columns,
+            body,
+            returning,
+            with,
+            program,
+            connection,
+        )?,
+    };
 
     // Indicate write operations so that in the epilogue we can emit the correct type of transaction
     if is_write {
-        crate::stack::trace_stack!("begin_write_operation");
         program.begin_write_operation();
     }
 
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction
     if is_select && !program.table_references.is_empty() {
-        crate::stack::trace_stack!("begin_read_operation");
         program.begin_read_operation();
     }
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -80,7 +80,7 @@ pub fn translate(
 ) -> Result<Program> {
     tracing::trace!("querying {}", input);
     let change_cnt_on = {
-        let _stack = crate::stack::trace_scope("change_count");
+        crate::stack::trace_stack!("change_count");
         matches!(
             stmt,
             ast::Stmt::CreateIndex { .. }
@@ -92,7 +92,7 @@ pub fn translate(
 
     // Boxed so the ~800 B builder sits on the heap instead of the prepare frame.
     let mut program = {
-        let _stack = crate::stack::trace_scope("program_builder_new");
+        crate::stack::trace_stack!("program_builder_new");
         Box::new(ProgramBuilder::new(
             query_mode,
             connection.get_capture_data_changes_info().clone(),
@@ -102,11 +102,11 @@ pub fn translate(
     };
 
     {
-        let _stack = crate::stack::trace_scope("prologue");
+        crate::stack::trace_stack!("prologue");
         program.prologue();
     }
     let mut resolver = {
-        let _stack = crate::stack::trace_scope("resolver_new");
+        crate::stack::trace_stack!("resolver_new");
         Resolver::new(
             schema,
             connection.database_schemas(),
@@ -119,7 +119,7 @@ pub fn translate(
     };
 
     {
-        let _stack = crate::stack::trace_scope("dispatch");
+        crate::stack::trace_stack!("dispatch");
         match stmt {
             // There can be no nesting with pragma, so lift it up here
             ast::Stmt::Pragma { name, body } => {
@@ -137,12 +137,12 @@ pub fn translate(
     };
 
     {
-        let _stack = crate::stack::trace_scope("epilogue");
+        crate::stack::trace_stack!("epilogue");
         program.epilogue(schema);
     }
 
     {
-        let _stack = crate::stack::trace_scope("build");
+        crate::stack::trace_stack!("build");
         program.build(connection, change_cnt_on, input)
     }
 }
@@ -159,7 +159,7 @@ pub fn translate_inner(
     input: &str,
 ) -> Result<()> {
     let is_write = {
-        let _stack = crate::stack::trace_scope("classify_write");
+        crate::stack::trace_stack!("classify_write");
         matches!(
             stmt,
             ast::Stmt::AlterTable { .. }
@@ -185,7 +185,7 @@ pub fn translate_inner(
         )
     };
     let is_vacuum = {
-        let _stack = crate::stack::trace_scope("classify_vacuum");
+        crate::stack::trace_stack!("classify_vacuum");
         matches!(stmt, ast::Stmt::Vacuum { .. })
     };
 
@@ -198,12 +198,12 @@ pub fn translate_inner(
     }
 
     let is_select = {
-        let _stack = crate::stack::trace_scope("classify_select");
+        crate::stack::trace_stack!("classify_select");
         matches!(stmt, ast::Stmt::Select { .. })
     };
 
     {
-        let _stack = crate::stack::trace_scope("dispatch");
+        crate::stack::trace_stack!("dispatch");
         match stmt {
             ast::Stmt::AlterTable(alter) => {
                 translate_alter_table(alter, resolver, program, connection, input)?;
@@ -422,9 +422,12 @@ pub fn translate_inner(
                 }
                 translate_update(update, resolver, program, connection)?
             }
-            ast::Stmt::Vacuum { name, into } => {
-                vacuum::translate_vacuum(program, name.as_ref(), into.as_deref(), connection.clone())?
-            }
+            ast::Stmt::Vacuum { name, into } => vacuum::translate_vacuum(
+                program,
+                name.as_ref(),
+                into.as_deref(),
+                connection.clone(),
+            )?,
             ast::Stmt::Insert {
                 with,
                 or_conflict,
@@ -448,13 +451,13 @@ pub fn translate_inner(
 
     // Indicate write operations so that in the epilogue we can emit the correct type of transaction
     if is_write {
-        let _stack = crate::stack::trace_scope("begin_write_operation");
+        crate::stack::trace_stack!("begin_write_operation");
         program.begin_write_operation();
     }
 
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction
     if is_select && !program.table_references.is_empty() {
-        let _stack = crate::stack::trace_scope("begin_read_operation");
+        crate::stack::trace_stack!("begin_read_operation");
         program.begin_read_operation();
     }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -440,6 +440,7 @@ fn collect_index_method_candidates(
 }
 
 #[tracing::instrument(skip_all, level = tracing::Level::DEBUG)]
+#[turso_macros::trace_stack]
 pub fn optimize_plan(
     program: &mut ProgramBuilder,
     plan: &mut Plan,
@@ -637,6 +638,7 @@ struct OptimizeTableAccessResult {
  * TODO: these could probably be done in less passes,
  * but having them separate makes them easier to understand
  */
+#[turso_macros::trace_stack]
 pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
     // Transform MATCH expressions to fts_match() for FTS optimizer recognition
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1190,6 +1190,7 @@ fn base_outer_refs_for_cte_planning(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
 pub fn parse_from(
     from: Option<FromClause>,
     resolver: &Resolver,
@@ -1201,7 +1202,6 @@ pub fn parse_from(
     table_references: &mut TableReferences,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope("planner:parse_from");
     // Collect CTE definitions instead of planning them immediately.
     // Each CTE reference will be planned fresh when encountered, ensuring unique internal_ids.
     let mut cte_definitions: Vec<CteDefinition> = vec![];
@@ -1318,6 +1318,7 @@ pub fn parse_from(
     Ok(())
 }
 
+#[turso_macros::trace_stack]
 pub fn parse_where(
     where_clause: Option<&Expr>,
     table_references: &mut TableReferences,
@@ -1325,7 +1326,6 @@ pub fn parse_where(
     out_where_clause: &mut Vec<WhereTerm>,
     resolver: &Resolver,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope("planner:parse_where");
     if let Some(where_expr) = where_clause {
         let start_idx = out_where_clause.len();
         break_predicate_at_and_boundaries(where_expr, out_where_clause);

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1201,6 +1201,7 @@ pub fn parse_from(
     table_references: &mut TableReferences,
     connection: &Arc<crate::Connection>,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope("planner:parse_from");
     // Collect CTE definitions instead of planning them immediately.
     // Each CTE reference will be planned fresh when encountered, ensuring unique internal_ids.
     let mut cte_definitions: Vec<CteDefinition> = vec![];
@@ -1324,6 +1325,7 @@ pub fn parse_where(
     out_where_clause: &mut Vec<WhereTerm>,
     resolver: &Resolver,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope("planner:parse_where");
     if let Some(where_expr) = where_clause {
         let start_idx = out_where_clause.len();
         break_predicate_at_and_boundaries(where_expr, out_where_clause);

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -583,6 +583,7 @@ fn plan_cte(
 /// Plan CTEs from a WITH clause and add them as outer query references.
 /// This is used by DML statements (DELETE, UPDATE) to make CTEs available
 /// for subqueries in WHERE and SET clauses.
+#[turso_macros::trace_stack]
 pub fn plan_ctes_as_outer_refs(
     with: Option<With>,
     resolver: &Resolver,
@@ -1961,6 +1962,7 @@ where
 }
 
 #[allow(clippy::type_complexity)]
+#[turso_macros::trace_stack]
 pub fn parse_limit(
     mut limit: Limit,
     resolver: &Resolver,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -40,26 +40,20 @@ pub fn translate_select(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
-    let plan = {
-        trace_stack!("prepare_plan");
-        prepare_select_plan(
-            select,
-            resolver,
-            program,
-            &[],
-            query_destination,
-            connection,
-        )?
-    };
+    let plan = prepare_select_plan(
+        select,
+        resolver,
+        program,
+        &[],
+        query_destination,
+        connection,
+    )?;
     if program.trigger.is_some() {
         if let Some(virtual_table) = plan_first_virtual_table_name(&plan) {
             crate::bail_parse_error!("unsafe use of virtual table \"{}\"", virtual_table);
         }
     }
-    {
-        trace_stack!("emit_plan");
-        emit_select_plan(plan, resolver, program, connection)
-    }
+    emit_select_plan(plan, resolver, program, connection)
 }
 
 /// Optimize and emit bytecode for an already-prepared select plan.
@@ -70,10 +64,7 @@ pub fn emit_select_plan(
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
-    {
-        trace_stack!("optimize_plan");
-        optimize_plan(program, &mut plan, resolver)?;
-    }
+    optimize_plan(program, &mut plan, resolver)?;
     let num_result_cols;
     let opts = match &plan {
         Plan::Select(select) => {
@@ -112,10 +103,7 @@ pub fn emit_select_plan(
     };
 
     program.extend(&opts);
-    {
-        trace_stack!("emit_program");
-        emit_program(connection, resolver, program, plan, |_| {})?;
-    }
+    emit_program(connection, resolver, program, plan, |_| {})?;
     Ok(num_result_cols)
 }
 
@@ -313,7 +301,6 @@ fn prepare_one_select_plan(
                     limit.as_ref(),
                 );
             {
-                trace_stack!("parse_from");
                 parse_from(
                     from,
                     resolver,
@@ -544,13 +531,11 @@ fn prepare_one_select_plan(
             // Virtual table predicates may depend on column bindings from tables to the right in the join order,
             // so we must wait until the full set of references has been collected.
             {
-                trace_stack!("add_vtab_predicates");
                 add_vtab_predicates_to_where_clause(&mut vtab_predicates, &mut plan, resolver)?;
             }
 
             // Parse the actual WHERE clause and add its conditions to the plan WHERE clause that already contains the join conditions.
             {
-                trace_stack!("parse_where");
                 parse_where(
                     where_clause.as_deref(),
                     &mut plan.table_references,
@@ -738,20 +723,15 @@ fn prepare_one_select_plan(
 
             // Parse the LIMIT/OFFSET clause
             {
-                trace_stack!("parse_limit");
                 (plan.limit, plan.offset) =
                     limit.map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
             }
 
             if !windows.is_empty() {
-                trace_stack!("plan_windows");
                 plan_windows(program, &mut plan, resolver, connection, &mut windows)?;
             }
 
-            {
-                trace_stack!("plan_subqueries");
-                plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
-            }
+            plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
 
             {
                 trace_stack!("validate_plan");
@@ -1070,6 +1050,7 @@ fn reject_outer_scope_refs_inside_select_plan(
     Ok(())
 }
 
+#[turso_macros::trace_stack]
 fn add_vtab_predicates_to_where_clause(
     vtab_predicates: &mut Vec<Expr>,
     plan: &mut SelectPlan,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -4,6 +4,7 @@ use super::plan::{
     QueryDestination, Search, TableReferences, Window,
 };
 use crate::schema::Table;
+use crate::stack::trace_stack;
 use crate::sync::Arc;
 use crate::translate::emitter::{OperationMode, Resolver};
 use crate::translate::expr::{
@@ -31,6 +32,7 @@ use turso_parser::ast::{self, CompoundSelect, Expr};
 /// SQLite's default SQLITE_MAX_COLUMN is 2000, with a hard upper limit of 32767.
 const SQLITE_MAX_COLUMN: usize = 2000;
 
+#[turso_macros::trace_stack]
 pub fn translate_select(
     select: ast::Select,
     resolver: &Resolver,
@@ -38,9 +40,8 @@ pub fn translate_select(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
-    let _stack = crate::stack::trace_scope("select:translate");
     let plan = {
-        let _stack = crate::stack::trace_scope("select:prepare_plan");
+        trace_stack!("select:prepare_plan");
         prepare_select_plan(
             select,
             resolver,
@@ -56,21 +57,21 @@ pub fn translate_select(
         }
     }
     {
-        let _stack = crate::stack::trace_scope("select:emit_plan");
+        trace_stack!("select:emit_plan");
         emit_select_plan(plan, resolver, program, connection)
     }
 }
 
 /// Optimize and emit bytecode for an already-prepared select plan.
+#[turso_macros::trace_stack]
 pub fn emit_select_plan(
     mut plan: Plan,
     resolver: &Resolver,
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
-    let _stack = crate::stack::trace_scope("select:emit_select_plan");
     {
-        let _stack = crate::stack::trace_scope("select:optimize_plan");
+        trace_stack!("select:optimize_plan");
         optimize_plan(program, &mut plan, resolver)?;
     }
     let num_result_cols;
@@ -112,7 +113,7 @@ pub fn emit_select_plan(
 
     program.extend(&opts);
     {
-        let _stack = crate::stack::trace_scope("select:emit_program");
+        trace_stack!("select:emit_program");
         emit_program(connection, resolver, program, plan, |_| {})?;
     }
     Ok(num_result_cols)
@@ -157,6 +158,7 @@ fn select_plan_first_virtual_table_name(select_plan: &SelectPlan) -> Option<Stri
     None
 }
 
+#[turso_macros::trace_stack]
 pub fn prepare_select_plan(
     select: ast::Select,
     resolver: &Resolver,
@@ -165,7 +167,6 @@ pub fn prepare_select_plan(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<Plan> {
-    let _stack = crate::stack::trace_scope("select:prepare_select_plan");
     let compounds = select.body.compounds;
     match compounds.is_empty() {
         true => Ok(Plan::Select(Box::new(prepare_one_select_plan(
@@ -262,6 +263,7 @@ pub fn prepare_select_plan(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
 fn prepare_one_select_plan(
     select: ast::OneSelect,
     resolver: &Resolver,
@@ -273,7 +275,6 @@ fn prepare_one_select_plan(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<SelectPlan> {
-    let _stack = crate::stack::trace_scope("select:prepare_one_select_plan");
     match select {
         ast::OneSelect::Select {
             columns,
@@ -312,7 +313,7 @@ fn prepare_one_select_plan(
                     limit.as_ref(),
                 );
             {
-                let _stack = crate::stack::trace_scope("select:parse_from");
+                trace_stack!("select:parse_from");
                 parse_from(
                     from,
                     resolver,
@@ -382,7 +383,7 @@ fn prepare_one_select_plan(
 
             let mut windows = Vec::with_capacity(window_clause.len());
             {
-                let _stack = crate::stack::trace_scope("select:bind_windows");
+                trace_stack!("select:bind_windows");
                 for window_def in window_clause.iter() {
                     let name = normalize_ident(window_def.name.as_str());
                     let mut window = Window::new(Some(name), &window_def.window)?;
@@ -414,7 +415,7 @@ fn prepare_one_select_plan(
                 connection.get_full_column_names() && !connection.get_short_column_names();
             let mut aggregate_expressions = Vec::new();
             {
-                let _stack = crate::stack::trace_scope("select:bind_result_columns");
+                trace_stack!("select:bind_result_columns");
                 for column in columns.into_iter() {
                     match column {
                         ResultColumn::Star => {
@@ -543,13 +544,13 @@ fn prepare_one_select_plan(
             // Virtual table predicates may depend on column bindings from tables to the right in the join order,
             // so we must wait until the full set of references has been collected.
             {
-                let _stack = crate::stack::trace_scope("select:add_vtab_predicates");
+                trace_stack!("select:add_vtab_predicates");
                 add_vtab_predicates_to_where_clause(&mut vtab_predicates, &mut plan, resolver)?;
             }
 
             // Parse the actual WHERE clause and add its conditions to the plan WHERE clause that already contains the join conditions.
             {
-                let _stack = crate::stack::trace_scope("select:parse_where");
+                trace_stack!("select:parse_where");
                 parse_where(
                     where_clause.as_deref(),
                     &mut plan.table_references,
@@ -560,7 +561,7 @@ fn prepare_one_select_plan(
             }
 
             {
-                let _stack = crate::stack::trace_scope("select:process_group_by");
+                trace_stack!("select:process_group_by");
                 if let Some(mut group_by) = group_by {
                     // Process HAVING clause if present
                     let having_predicates = if let Some(having) = group_by.having {
@@ -633,7 +634,7 @@ fn prepare_one_select_plan(
                 .is_some_and(|gb| !gb.exprs.is_empty());
 
             {
-                let _stack = crate::stack::trace_scope("select:process_order_by");
+                trace_stack!("select:process_order_by");
                 for mut o in order_by {
                     replace_column_number_with_copy_of_column_expr(
                         &mut o.expr,
@@ -737,23 +738,23 @@ fn prepare_one_select_plan(
 
             // Parse the LIMIT/OFFSET clause
             {
-                let _stack = crate::stack::trace_scope("select:parse_limit");
+                trace_stack!("select:parse_limit");
                 (plan.limit, plan.offset) =
                     limit.map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
             }
 
             if !windows.is_empty() {
-                let _stack = crate::stack::trace_scope("select:plan_windows");
+                trace_stack!("select:plan_windows");
                 plan_windows(program, &mut plan, resolver, connection, &mut windows)?;
             }
 
             {
-                let _stack = crate::stack::trace_scope("select:plan_subqueries");
+                trace_stack!("select:plan_subqueries");
                 plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
             }
 
             {
-                let _stack = crate::stack::trace_scope("select:validate_plan");
+                trace_stack!("select:validate_plan");
                 validate_group_by_outer_scope_refs(&plan)?;
 
                 validate_expr_correct_column_counts(&plan)?;

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -38,20 +38,27 @@ pub fn translate_select(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
-    let plan = prepare_select_plan(
-        select,
-        resolver,
-        program,
-        &[],
-        query_destination,
-        connection,
-    )?;
+    let _stack = crate::stack::trace_scope("select:translate");
+    let plan = {
+        let _stack = crate::stack::trace_scope("select:prepare_plan");
+        prepare_select_plan(
+            select,
+            resolver,
+            program,
+            &[],
+            query_destination,
+            connection,
+        )?
+    };
     if program.trigger.is_some() {
         if let Some(virtual_table) = plan_first_virtual_table_name(&plan) {
             crate::bail_parse_error!("unsafe use of virtual table \"{}\"", virtual_table);
         }
     }
-    emit_select_plan(plan, resolver, program, connection)
+    {
+        let _stack = crate::stack::trace_scope("select:emit_plan");
+        emit_select_plan(plan, resolver, program, connection)
+    }
 }
 
 /// Optimize and emit bytecode for an already-prepared select plan.
@@ -61,7 +68,11 @@ pub fn emit_select_plan(
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
-    optimize_plan(program, &mut plan, resolver)?;
+    let _stack = crate::stack::trace_scope("select:emit_select_plan");
+    {
+        let _stack = crate::stack::trace_scope("select:optimize_plan");
+        optimize_plan(program, &mut plan, resolver)?;
+    }
     let num_result_cols;
     let opts = match &plan {
         Plan::Select(select) => {
@@ -100,7 +111,10 @@ pub fn emit_select_plan(
     };
 
     program.extend(&opts);
-    emit_program(connection, resolver, program, plan, |_| {})?;
+    {
+        let _stack = crate::stack::trace_scope("select:emit_program");
+        emit_program(connection, resolver, program, plan, |_| {})?;
+    }
     Ok(num_result_cols)
 }
 
@@ -151,6 +165,7 @@ pub fn prepare_select_plan(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<Plan> {
+    let _stack = crate::stack::trace_scope("select:prepare_select_plan");
     let compounds = select.body.compounds;
     match compounds.is_empty() {
         true => Ok(Plan::Select(Box::new(prepare_one_select_plan(
@@ -258,6 +273,7 @@ fn prepare_one_select_plan(
     query_destination: QueryDestination,
     connection: &Arc<crate::Connection>,
 ) -> Result<SelectPlan> {
+    let _stack = crate::stack::trace_scope("select:prepare_one_select_plan");
     match select {
         ast::OneSelect::Select {
             columns,
@@ -295,17 +311,20 @@ fn prepare_one_select_plan(
                     &order_by,
                     limit.as_ref(),
                 );
-            parse_from(
-                from,
-                resolver,
-                program,
-                with,
-                preplan_ctes_for_non_from_subqueries,
-                &mut where_predicates,
-                &mut vtab_predicates,
-                &mut table_references,
-                connection,
-            )?;
+            {
+                let _stack = crate::stack::trace_scope("select:parse_from");
+                parse_from(
+                    from,
+                    resolver,
+                    program,
+                    with,
+                    preplan_ctes_for_non_from_subqueries,
+                    &mut where_predicates,
+                    &mut vtab_predicates,
+                    &mut table_references,
+                    connection,
+                )?;
+            }
 
             // Preallocate space for the result columns
             let result_columns = Vec::with_capacity(
@@ -362,150 +381,156 @@ fn prepare_one_select_plan(
             };
 
             let mut windows = Vec::with_capacity(window_clause.len());
-            for window_def in window_clause.iter() {
-                let name = normalize_ident(window_def.name.as_str());
-                let mut window = Window::new(Some(name), &window_def.window)?;
+            {
+                let _stack = crate::stack::trace_scope("select:bind_windows");
+                for window_def in window_clause.iter() {
+                    let name = normalize_ident(window_def.name.as_str());
+                    let mut window = Window::new(Some(name), &window_def.window)?;
 
-                for expr in window.partition_by.iter_mut() {
-                    bind_and_rewrite_expr(
-                        expr,
-                        Some(&mut plan.table_references),
-                        None,
-                        resolver,
-                        BindingBehavior::ResultColumnsNotAllowed,
-                    )?;
-                }
-                for (expr, _, _) in window.order_by.iter_mut() {
-                    bind_and_rewrite_expr(
-                        expr,
-                        Some(&mut plan.table_references),
-                        None,
-                        resolver,
-                        BindingBehavior::ResultColumnsNotAllowed,
-                    )?;
-                }
-
-                windows.push(window);
-            }
-
-            let long_names =
-                connection.get_full_column_names() && !connection.get_short_column_names();
-            let mut aggregate_expressions = Vec::new();
-            for column in columns.into_iter() {
-                match column {
-                    ResultColumn::Star => {
-                        select_star(
-                            plan.table_references.joined_tables(),
-                            &mut plan.result_columns,
-                            plan.table_references.right_join_swapped(),
-                            long_names,
-                        )?;
-                        for table in plan.table_references.joined_tables_mut() {
-                            for idx in 0..table.columns().len() {
-                                let column = &table.columns()[idx];
-                                if column.hidden() {
-                                    continue;
-                                }
-                                table.mark_column_used(idx);
-                            }
-                        }
-                    }
-                    ResultColumn::TableStar(name) => {
-                        let name_normalized = normalize_ident(name.as_str());
-                        // If this table identifier appears more than once in the FROM
-                        // clause, `A.*` is ambiguous (matches SQLite behavior).
-                        let dup_count = plan
-                            .table_references
-                            .joined_tables()
-                            .iter()
-                            .filter(|t| t.identifier == name_normalized)
-                            .count();
-                        if dup_count > 1 {
-                            let first_tbl = plan
-                                .table_references
-                                .joined_tables()
-                                .iter()
-                                .find(|t| t.identifier == name_normalized)
-                                .unwrap(); // safe: dup_count > 1 guarantees a match
-                            let col_name = first_tbl
-                                .columns()
-                                .iter()
-                                .find(|c| !c.hidden())
-                                .and_then(|c| c.name.as_ref())
-                                .map(|n| n.as_str())
-                                .unwrap_or("?");
-                            crate::bail_parse_error!(
-                                "ambiguous column name: {}.{}",
-                                name.as_str(),
-                                col_name
-                            );
-                        }
-                        let referenced_table = plan
-                            .table_references
-                            .joined_tables_mut()
-                            .iter_mut()
-                            .find(|t| t.identifier == name_normalized);
-
-                        if referenced_table.is_none() {
-                            crate::bail_parse_error!("no such table: {}", name.as_str());
-                        }
-                        let table = referenced_table.unwrap();
-                        let num_columns = table.columns().len();
-                        for idx in 0..num_columns {
-                            let column = &table.columns()[idx];
-                            if column.hidden() {
-                                continue;
-                            }
-                            let alias = column.name.as_ref().map(|col_name| {
-                                if long_names {
-                                    format!("{}.{}", table.identifier, col_name)
-                                } else {
-                                    col_name.clone()
-                                }
-                            });
-                            plan.result_columns.push(ResultSetColumn {
-                                expr: ast::Expr::Column {
-                                    database: None, // TODO: support different databases
-                                    table: table.internal_id,
-                                    column: idx,
-                                    is_rowid_alias: column.is_rowid_alias(),
-                                },
-                                alias,
-                                implicit_column_name: None,
-                                contains_aggregates: false,
-                            });
-                            table.mark_column_used(idx);
-                        }
-                    }
-                    ResultColumn::Expr(mut expr, maybe_alias) => {
+                    for expr in window.partition_by.iter_mut() {
                         bind_and_rewrite_expr(
-                            &mut expr,
+                            expr,
                             Some(&mut plan.table_references),
                             None,
                             resolver,
                             BindingBehavior::ResultColumnsNotAllowed,
                         )?;
-                        let contains_aggregates = resolve_window_and_aggregate_functions(
-                            &expr,
+                    }
+                    for (expr, _, _) in window.order_by.iter_mut() {
+                        bind_and_rewrite_expr(
+                            expr,
+                            Some(&mut plan.table_references),
+                            None,
                             resolver,
-                            &mut aggregate_expressions,
-                            Some(&mut windows),
+                            BindingBehavior::ResultColumnsNotAllowed,
                         )?;
-                        let (alias, implicit_column_name) = match &maybe_alias {
-                            Some(ast::As::As(name)) | Some(ast::As::Elided(name)) => {
-                                (Some(name.as_str().to_string()), None)
+                    }
+
+                    windows.push(window);
+                }
+            }
+
+            let long_names =
+                connection.get_full_column_names() && !connection.get_short_column_names();
+            let mut aggregate_expressions = Vec::new();
+            {
+                let _stack = crate::stack::trace_scope("select:bind_result_columns");
+                for column in columns.into_iter() {
+                    match column {
+                        ResultColumn::Star => {
+                            select_star(
+                                plan.table_references.joined_tables(),
+                                &mut plan.result_columns,
+                                plan.table_references.right_join_swapped(),
+                                long_names,
+                            )?;
+                            for table in plan.table_references.joined_tables_mut() {
+                                for idx in 0..table.columns().len() {
+                                    let column = &table.columns()[idx];
+                                    if column.hidden() {
+                                        continue;
+                                    }
+                                    table.mark_column_used(idx);
+                                }
                             }
-                            Some(ast::As::ImplicitColumnName(name)) => {
-                                (None, Some(name.as_str().to_string()))
+                        }
+                        ResultColumn::TableStar(name) => {
+                            let name_normalized = normalize_ident(name.as_str());
+                            // If this table identifier appears more than once in the FROM
+                            // clause, `A.*` is ambiguous (matches SQLite behavior).
+                            let dup_count = plan
+                                .table_references
+                                .joined_tables()
+                                .iter()
+                                .filter(|t| t.identifier == name_normalized)
+                                .count();
+                            if dup_count > 1 {
+                                let first_tbl = plan
+                                    .table_references
+                                    .joined_tables()
+                                    .iter()
+                                    .find(|t| t.identifier == name_normalized)
+                                    .unwrap(); // safe: dup_count > 1 guarantees a match
+                                let col_name = first_tbl
+                                    .columns()
+                                    .iter()
+                                    .find(|c| !c.hidden())
+                                    .and_then(|c| c.name.as_ref())
+                                    .map(|n| n.as_str())
+                                    .unwrap_or("?");
+                                crate::bail_parse_error!(
+                                    "ambiguous column name: {}.{}",
+                                    name.as_str(),
+                                    col_name
+                                );
                             }
-                            None => (None, None),
-                        };
-                        plan.result_columns.push(ResultSetColumn {
-                            alias,
-                            implicit_column_name,
-                            expr: *expr,
-                            contains_aggregates,
-                        });
+                            let referenced_table = plan
+                                .table_references
+                                .joined_tables_mut()
+                                .iter_mut()
+                                .find(|t| t.identifier == name_normalized);
+
+                            if referenced_table.is_none() {
+                                crate::bail_parse_error!("no such table: {}", name.as_str());
+                            }
+                            let table = referenced_table.unwrap();
+                            let num_columns = table.columns().len();
+                            for idx in 0..num_columns {
+                                let column = &table.columns()[idx];
+                                if column.hidden() {
+                                    continue;
+                                }
+                                let alias = column.name.as_ref().map(|col_name| {
+                                    if long_names {
+                                        format!("{}.{}", table.identifier, col_name)
+                                    } else {
+                                        col_name.clone()
+                                    }
+                                });
+                                plan.result_columns.push(ResultSetColumn {
+                                    expr: ast::Expr::Column {
+                                        database: None, // TODO: support different databases
+                                        table: table.internal_id,
+                                        column: idx,
+                                        is_rowid_alias: column.is_rowid_alias(),
+                                    },
+                                    alias,
+                                    implicit_column_name: None,
+                                    contains_aggregates: false,
+                                });
+                                table.mark_column_used(idx);
+                            }
+                        }
+                        ResultColumn::Expr(mut expr, maybe_alias) => {
+                            bind_and_rewrite_expr(
+                                &mut expr,
+                                Some(&mut plan.table_references),
+                                None,
+                                resolver,
+                                BindingBehavior::ResultColumnsNotAllowed,
+                            )?;
+                            let contains_aggregates = resolve_window_and_aggregate_functions(
+                                &expr,
+                                resolver,
+                                &mut aggregate_expressions,
+                                Some(&mut windows),
+                            )?;
+                            let (alias, implicit_column_name) = match &maybe_alias {
+                                Some(ast::As::As(name)) | Some(ast::As::Elided(name)) => {
+                                    (Some(name.as_str().to_string()), None)
+                                }
+                                Some(ast::As::ImplicitColumnName(name)) => {
+                                    (None, Some(name.as_str().to_string()))
+                                }
+                                None => (None, None),
+                            };
+                            plan.result_columns.push(ResultSetColumn {
+                                alias,
+                                implicit_column_name,
+                                expr: *expr,
+                                contains_aggregates,
+                            });
+                        }
                     }
                 }
             }
@@ -517,64 +542,73 @@ fn prepare_one_select_plan(
             // This step can only be performed at this point, because all table references are now available.
             // Virtual table predicates may depend on column bindings from tables to the right in the join order,
             // so we must wait until the full set of references has been collected.
-            add_vtab_predicates_to_where_clause(&mut vtab_predicates, &mut plan, resolver)?;
+            {
+                let _stack = crate::stack::trace_scope("select:add_vtab_predicates");
+                add_vtab_predicates_to_where_clause(&mut vtab_predicates, &mut plan, resolver)?;
+            }
 
             // Parse the actual WHERE clause and add its conditions to the plan WHERE clause that already contains the join conditions.
-            parse_where(
-                where_clause.as_deref(),
-                &mut plan.table_references,
-                Some(&plan.result_columns),
-                &mut plan.where_clause,
-                resolver,
-            )?;
+            {
+                let _stack = crate::stack::trace_scope("select:parse_where");
+                parse_where(
+                    where_clause.as_deref(),
+                    &mut plan.table_references,
+                    Some(&plan.result_columns),
+                    &mut plan.where_clause,
+                    resolver,
+                )?;
+            }
 
-            if let Some(mut group_by) = group_by {
-                // Process HAVING clause if present
-                let having_predicates = if let Some(having) = group_by.having {
-                    Some(process_having_clause(
-                        having,
-                        &mut plan.table_references,
-                        &plan.result_columns,
-                        resolver,
-                        &mut aggregate_expressions,
-                    )?)
-                } else {
-                    None
-                };
-
-                if !group_by.exprs.is_empty() {
-                    // Normal GROUP BY with expressions
-                    for expr in group_by.exprs.iter_mut() {
-                        replace_column_number_with_copy_of_column_expr(
-                            expr,
+            {
+                let _stack = crate::stack::trace_scope("select:process_group_by");
+                if let Some(mut group_by) = group_by {
+                    // Process HAVING clause if present
+                    let having_predicates = if let Some(having) = group_by.having {
+                        Some(process_having_clause(
+                            having,
+                            &mut plan.table_references,
                             &plan.result_columns,
-                            "GROUP BY",
-                        )?;
-                        bind_and_rewrite_expr(
-                            expr,
-                            Some(&mut plan.table_references),
-                            Some(&plan.result_columns),
                             resolver,
-                            BindingBehavior::TryCanonicalColumnsFirst,
-                        )?;
-                    }
+                            &mut aggregate_expressions,
+                        )?)
+                    } else {
+                        None
+                    };
 
-                    plan.group_by = Some(GroupBy {
-                        sort_order: Vec::new(),
-                        nulls_order: Vec::new(),
-                        exprs: group_by.exprs.into_iter().map(|expr| *expr).collect(),
-                        sort_elided: false,
-                        having: having_predicates,
-                    });
-                } else {
-                    // HAVING without GROUP BY: treat as ungrouped aggregation with filter
-                    plan.group_by = Some(GroupBy {
-                        sort_order: Vec::new(),
-                        nulls_order: Vec::new(),
-                        sort_elided: false,
-                        exprs: vec![],
-                        having: having_predicates,
-                    });
+                    if !group_by.exprs.is_empty() {
+                        // Normal GROUP BY with expressions
+                        for expr in group_by.exprs.iter_mut() {
+                            replace_column_number_with_copy_of_column_expr(
+                                expr,
+                                &plan.result_columns,
+                                "GROUP BY",
+                            )?;
+                            bind_and_rewrite_expr(
+                                expr,
+                                Some(&mut plan.table_references),
+                                Some(&plan.result_columns),
+                                resolver,
+                                BindingBehavior::TryCanonicalColumnsFirst,
+                            )?;
+                        }
+
+                        plan.group_by = Some(GroupBy {
+                            sort_order: Vec::new(),
+                            nulls_order: Vec::new(),
+                            exprs: group_by.exprs.into_iter().map(|expr| *expr).collect(),
+                            sort_elided: false,
+                            having: having_predicates,
+                        });
+                    } else {
+                        // HAVING without GROUP BY: treat as ungrouped aggregation with filter
+                        plan.group_by = Some(GroupBy {
+                            sort_order: Vec::new(),
+                            nulls_order: Vec::new(),
+                            sort_elided: false,
+                            exprs: vec![],
+                            having: having_predicates,
+                        });
+                    }
                 }
             }
 
@@ -598,39 +632,42 @@ fn prepare_one_select_plan(
                 .as_ref()
                 .is_some_and(|gb| !gb.exprs.is_empty());
 
-            for mut o in order_by {
-                replace_column_number_with_copy_of_column_expr(
-                    &mut o.expr,
-                    &plan.result_columns,
-                    "ORDER BY",
-                )?;
+            {
+                let _stack = crate::stack::trace_scope("select:process_order_by");
+                for mut o in order_by {
+                    replace_column_number_with_copy_of_column_expr(
+                        &mut o.expr,
+                        &plan.result_columns,
+                        "ORDER BY",
+                    )?;
 
-                bind_and_rewrite_expr(
-                    &mut o.expr,
-                    Some(&mut plan.table_references),
-                    Some(&plan.result_columns),
-                    resolver,
-                    BindingBehavior::TryResultColumnsFirst,
-                )?;
-                let had_agg = resolve_window_and_aggregate_functions(
-                    &o.expr,
-                    resolver,
-                    &mut plan.aggregates,
-                    Some(&mut windows),
-                )?;
+                    bind_and_rewrite_expr(
+                        &mut o.expr,
+                        Some(&mut plan.table_references),
+                        Some(&plan.result_columns),
+                        resolver,
+                        BindingBehavior::TryResultColumnsFirst,
+                    )?;
+                    let had_agg = resolve_window_and_aggregate_functions(
+                        &o.expr,
+                        resolver,
+                        &mut plan.aggregates,
+                        Some(&mut windows),
+                    )?;
 
-                // SQLite rejects aggregate functions in ORDER BY when the query
-                // has a FROM clause and is not already an aggregate query (no
-                // GROUP BY and no aggregates in SELECT/HAVING).
-                // e.g. SELECT f1 FROM t ORDER BY min(f1);
-                // But SELECT 1 ORDER BY sum(1) is allowed (no FROM clause).
-                let has_from = !plan.table_references.joined_tables().is_empty();
-                if had_agg && has_from && !has_group_by && agg_count_before_order_by == 0 {
-                    let agg = &plan.aggregates[agg_count_before_order_by];
-                    crate::bail_parse_error!("misuse of aggregate: {}()", agg.func);
+                    // SQLite rejects aggregate functions in ORDER BY when the query
+                    // has a FROM clause and is not already an aggregate query (no
+                    // GROUP BY and no aggregates in SELECT/HAVING).
+                    // e.g. SELECT f1 FROM t ORDER BY min(f1);
+                    // But SELECT 1 ORDER BY sum(1) is allowed (no FROM clause).
+                    let has_from = !plan.table_references.joined_tables().is_empty();
+                    if had_agg && has_from && !has_group_by && agg_count_before_order_by == 0 {
+                        let agg = &plan.aggregates[agg_count_before_order_by];
+                        crate::bail_parse_error!("misuse of aggregate: {}()", agg.func);
+                    }
+
+                    key.push((o.expr, o.order.unwrap_or(ast::SortOrder::Asc), o.nulls));
                 }
-
-                key.push((o.expr, o.order.unwrap_or(ast::SortOrder::Asc), o.nulls));
             }
             // Remove duplicate ORDER BY expressions, keeping the first occurrence.
             // Duplicates are semantically redundant.
@@ -699,18 +736,28 @@ fn prepare_one_select_plan(
             }
 
             // Parse the LIMIT/OFFSET clause
-            (plan.limit, plan.offset) =
-                limit.map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
+            {
+                let _stack = crate::stack::trace_scope("select:parse_limit");
+                (plan.limit, plan.offset) =
+                    limit.map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
+            }
 
             if !windows.is_empty() {
+                let _stack = crate::stack::trace_scope("select:plan_windows");
                 plan_windows(program, &mut plan, resolver, connection, &mut windows)?;
             }
 
-            plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
+            {
+                let _stack = crate::stack::trace_scope("select:plan_subqueries");
+                plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
+            }
 
-            validate_group_by_outer_scope_refs(&plan)?;
+            {
+                let _stack = crate::stack::trace_scope("select:validate_plan");
+                validate_group_by_outer_scope_refs(&plan)?;
 
-            validate_expr_correct_column_counts(&plan)?;
+                validate_expr_correct_column_counts(&plan)?;
+            }
 
             // Return the unoptimized query plan
             Ok(plan)

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -41,7 +41,7 @@ pub fn translate_select(
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
     let plan = {
-        trace_stack!("select:prepare_plan");
+        trace_stack!("prepare_plan");
         prepare_select_plan(
             select,
             resolver,
@@ -57,7 +57,7 @@ pub fn translate_select(
         }
     }
     {
-        trace_stack!("select:emit_plan");
+        trace_stack!("emit_plan");
         emit_select_plan(plan, resolver, program, connection)
     }
 }
@@ -71,7 +71,7 @@ pub fn emit_select_plan(
     connection: &Arc<crate::Connection>,
 ) -> Result<usize> {
     {
-        trace_stack!("select:optimize_plan");
+        trace_stack!("optimize_plan");
         optimize_plan(program, &mut plan, resolver)?;
     }
     let num_result_cols;
@@ -113,7 +113,7 @@ pub fn emit_select_plan(
 
     program.extend(&opts);
     {
-        trace_stack!("select:emit_program");
+        trace_stack!("emit_program");
         emit_program(connection, resolver, program, plan, |_| {})?;
     }
     Ok(num_result_cols)
@@ -313,7 +313,7 @@ fn prepare_one_select_plan(
                     limit.as_ref(),
                 );
             {
-                trace_stack!("select:parse_from");
+                trace_stack!("parse_from");
                 parse_from(
                     from,
                     resolver,
@@ -383,7 +383,7 @@ fn prepare_one_select_plan(
 
             let mut windows = Vec::with_capacity(window_clause.len());
             {
-                trace_stack!("select:bind_windows");
+                trace_stack!("bind_windows");
                 for window_def in window_clause.iter() {
                     let name = normalize_ident(window_def.name.as_str());
                     let mut window = Window::new(Some(name), &window_def.window)?;
@@ -415,7 +415,7 @@ fn prepare_one_select_plan(
                 connection.get_full_column_names() && !connection.get_short_column_names();
             let mut aggregate_expressions = Vec::new();
             {
-                trace_stack!("select:bind_result_columns");
+                trace_stack!("bind_result_columns");
                 for column in columns.into_iter() {
                     match column {
                         ResultColumn::Star => {
@@ -544,13 +544,13 @@ fn prepare_one_select_plan(
             // Virtual table predicates may depend on column bindings from tables to the right in the join order,
             // so we must wait until the full set of references has been collected.
             {
-                trace_stack!("select:add_vtab_predicates");
+                trace_stack!("add_vtab_predicates");
                 add_vtab_predicates_to_where_clause(&mut vtab_predicates, &mut plan, resolver)?;
             }
 
             // Parse the actual WHERE clause and add its conditions to the plan WHERE clause that already contains the join conditions.
             {
-                trace_stack!("select:parse_where");
+                trace_stack!("parse_where");
                 parse_where(
                     where_clause.as_deref(),
                     &mut plan.table_references,
@@ -561,7 +561,7 @@ fn prepare_one_select_plan(
             }
 
             {
-                trace_stack!("select:process_group_by");
+                trace_stack!("process_group_by");
                 if let Some(mut group_by) = group_by {
                     // Process HAVING clause if present
                     let having_predicates = if let Some(having) = group_by.having {
@@ -634,7 +634,7 @@ fn prepare_one_select_plan(
                 .is_some_and(|gb| !gb.exprs.is_empty());
 
             {
-                trace_stack!("select:process_order_by");
+                trace_stack!("process_order_by");
                 for mut o in order_by {
                     replace_column_number_with_copy_of_column_expr(
                         &mut o.expr,
@@ -738,23 +738,23 @@ fn prepare_one_select_plan(
 
             // Parse the LIMIT/OFFSET clause
             {
-                trace_stack!("select:parse_limit");
+                trace_stack!("parse_limit");
                 (plan.limit, plan.offset) =
                     limit.map_or(Ok((None, None)), |l| parse_limit(l, resolver))?;
             }
 
             if !windows.is_empty() {
-                trace_stack!("select:plan_windows");
+                trace_stack!("plan_windows");
                 plan_windows(program, &mut plan, resolver, connection, &mut windows)?;
             }
 
             {
-                trace_stack!("select:plan_subqueries");
+                trace_stack!("plan_subqueries");
                 plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
             }
 
             {
-                trace_stack!("select:validate_plan");
+                trace_stack!("validate_plan");
                 validate_group_by_outer_scope_refs(&plan)?;
 
                 validate_expr_correct_column_counts(&plan)?;

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -225,6 +225,7 @@ pub fn plan_subqueries_from_select_plan(
     resolver: &Resolver,
     connection: &Arc<Connection>,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope("subquery:plan_from_select_plan");
     // WHERE
     plan_subqueries_with_outer_query_access(
         program,

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -227,32 +227,39 @@ pub fn plan_subqueries_from_select_plan(
 ) -> Result<()> {
     let _stack = crate::stack::trace_scope("subquery:plan_from_select_plan");
     // WHERE
-    plan_subqueries_with_outer_query_access(
-        program,
-        &mut plan.non_from_clause_subqueries,
-        &mut plan.table_references,
-        resolver,
-        plan.where_clause.iter_mut().map(|t| &mut t.expr),
-        connection,
-        SubqueryPosition::Where,
-        SubqueryOrigin::SelectWhere,
-        SubqueryPosition::Where.allow_correlated(),
-    )?;
-
-    // GROUP BY
-    if let Some(group_by) = &mut plan.group_by {
+    {
+        let _stack = crate::stack::trace_scope("subquery:select_where");
         plan_subqueries_with_outer_query_access(
             program,
             &mut plan.non_from_clause_subqueries,
             &mut plan.table_references,
             resolver,
-            group_by.exprs.iter_mut(),
+            plan.where_clause.iter_mut().map(|t| &mut t.expr),
             connection,
-            SubqueryPosition::GroupBy,
-            SubqueryOrigin::SelectGroupBy,
-            SubqueryPosition::GroupBy.allow_correlated(),
+            SubqueryPosition::Where,
+            SubqueryOrigin::SelectWhere,
+            SubqueryPosition::Where.allow_correlated(),
         )?;
+    }
+
+    // GROUP BY
+    if let Some(group_by) = &mut plan.group_by {
+        {
+            let _stack = crate::stack::trace_scope("subquery:select_group_by");
+            plan_subqueries_with_outer_query_access(
+                program,
+                &mut plan.non_from_clause_subqueries,
+                &mut plan.table_references,
+                resolver,
+                group_by.exprs.iter_mut(),
+                connection,
+                SubqueryPosition::GroupBy,
+                SubqueryOrigin::SelectGroupBy,
+                SubqueryPosition::GroupBy.allow_correlated(),
+            )?;
+        }
         if let Some(having) = group_by.having.as_mut() {
+            let _stack = crate::stack::trace_scope("subquery:select_having");
             plan_subqueries_with_outer_query_access(
                 program,
                 &mut plan.non_from_clause_subqueries,
@@ -268,30 +275,36 @@ pub fn plan_subqueries_from_select_plan(
     }
 
     // Result columns
-    plan_subqueries_with_outer_query_access(
-        program,
-        &mut plan.non_from_clause_subqueries,
-        &mut plan.table_references,
-        resolver,
-        plan.result_columns.iter_mut().map(|c| &mut c.expr),
-        connection,
-        SubqueryPosition::ResultColumn,
-        SubqueryOrigin::SelectList,
-        SubqueryPosition::ResultColumn.allow_correlated(),
-    )?;
+    {
+        let _stack = crate::stack::trace_scope("subquery:select_result_columns");
+        plan_subqueries_with_outer_query_access(
+            program,
+            &mut plan.non_from_clause_subqueries,
+            &mut plan.table_references,
+            resolver,
+            plan.result_columns.iter_mut().map(|c| &mut c.expr),
+            connection,
+            SubqueryPosition::ResultColumn,
+            SubqueryOrigin::SelectList,
+            SubqueryPosition::ResultColumn.allow_correlated(),
+        )?;
+    }
 
     // ORDER BY
-    plan_subqueries_with_outer_query_access(
-        program,
-        &mut plan.non_from_clause_subqueries,
-        &mut plan.table_references,
-        resolver,
-        plan.order_by.iter_mut().map(|(expr, _, _)| &mut **expr),
-        connection,
-        SubqueryPosition::OrderBy,
-        SubqueryOrigin::SelectOrderBy,
-        SubqueryPosition::OrderBy.allow_correlated(),
-    )?;
+    {
+        let _stack = crate::stack::trace_scope("subquery:select_order_by");
+        plan_subqueries_with_outer_query_access(
+            program,
+            &mut plan.non_from_clause_subqueries,
+            &mut plan.table_references,
+            resolver,
+            plan.order_by.iter_mut().map(|(expr, _, _)| &mut **expr),
+            connection,
+            SubqueryPosition::OrderBy,
+            SubqueryOrigin::SelectOrderBy,
+            SubqueryPosition::OrderBy.allow_correlated(),
+        )?;
+    }
 
     // LIMIT and OFFSET cannot reference columns from the outer query
     let get_outer_query_refs = |_: &TableReferences| vec![];
@@ -309,10 +322,12 @@ pub fn plan_subqueries_from_select_plan(
         );
         // Limit
         if let Some(limit) = &mut plan.limit {
+            let _stack = crate::stack::trace_scope("subquery:select_limit");
             walk_expr_mut(limit, &mut subquery_parser)?;
         }
         // Offset
         if let Some(offset) = &mut plan.offset {
+            let _stack = crate::stack::trace_scope("subquery:select_offset");
             walk_expr_mut(offset, &mut subquery_parser)?;
         }
     }
@@ -495,6 +510,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
     origin: SubqueryOrigin,
     allow_correlated: bool,
 ) -> Result<()> {
+    let _stack = crate::stack::trace_scope("subquery:walk_outer_query_access");
     // Most subqueries can reference columns from the outer query,
     // including nested cases where a subquery inside a subquery references columns from its parent's parent
     // and so on.
@@ -589,7 +605,10 @@ fn get_subquery_parser<'a>(
         match expr {
             ast::Expr::Exists(_) => {
                 let subquery_id = program.table_reference_counter.next();
-                let outer_query_refs = get_outer_query_refs(referenced_tables);
+                let outer_query_refs = {
+                    let _stack = crate::stack::trace_scope("subquery:get_outer_refs");
+                    get_outer_query_refs(referenced_tables)
+                };
 
                 let result_reg = program.alloc_register();
                 let subquery_type = SubqueryType::Exists { result_reg };
@@ -599,24 +618,33 @@ fn get_subquery_parser<'a>(
                     not_in: false,
                     query_type: subquery_type.clone(),
                 };
-                let ast::Expr::Exists(subselect) = std::mem::replace(expr, result_expr) else {
+                let ast::Expr::Exists(subselect) = ({
+                    let _stack = crate::stack::trace_scope("subquery:replace_exists_expr");
+                    std::mem::replace(expr, result_expr)
+                }) else {
                     unreachable!();
                 };
 
-                let plan = prepare_select_plan(
-                    subselect,
-                    resolver,
-                    program,
-                    &outer_query_refs,
-                    QueryDestination::ExistsSubqueryResult { result_reg },
-                    connection,
-                )?;
+                let plan = {
+                    let _stack = crate::stack::trace_scope("subquery:prepare_exists_plan");
+                    prepare_select_plan(
+                        subselect,
+                        resolver,
+                        program,
+                        &outer_query_refs,
+                        QueryDestination::ExistsSubqueryResult { result_reg },
+                        connection,
+                    )?
+                };
                 let Plan::Select(mut plan) = plan else {
                     crate::bail_parse_error!(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                optimize_select_plan(&mut plan, resolver.schema())?;
+                {
+                    let _stack = crate::stack::trace_scope("subquery:optimize_exists_plan");
+                    optimize_select_plan(&mut plan, resolver.schema())?;
+                }
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
                 out_subqueries.push(NonFromClauseSubquery {
@@ -633,7 +661,10 @@ fn get_subquery_parser<'a>(
             }
             ast::Expr::Subquery(_) => {
                 let subquery_id = program.table_reference_counter.next();
-                let outer_query_refs = get_outer_query_refs(referenced_tables);
+                let outer_query_refs = {
+                    let _stack = crate::stack::trace_scope("subquery:get_outer_refs");
+                    get_outer_query_refs(referenced_tables)
+                };
 
                 let result_expr = ast::Expr::SubqueryResult {
                     subquery_id,
@@ -646,23 +677,32 @@ fn get_subquery_parser<'a>(
                         num_regs: 0,
                     },
                 };
-                let ast::Expr::Subquery(subselect) = std::mem::replace(expr, result_expr) else {
+                let ast::Expr::Subquery(subselect) = ({
+                    let _stack = crate::stack::trace_scope("subquery:replace_scalar_expr");
+                    std::mem::replace(expr, result_expr)
+                }) else {
                     unreachable!();
                 };
-                let plan = prepare_select_plan(
-                    subselect,
-                    resolver,
-                    program,
-                    &outer_query_refs,
-                    QueryDestination::Unset,
-                    connection,
-                )?;
+                let plan = {
+                    let _stack = crate::stack::trace_scope("subquery:prepare_scalar_plan");
+                    prepare_select_plan(
+                        subselect,
+                        resolver,
+                        program,
+                        &outer_query_refs,
+                        QueryDestination::Unset,
+                        connection,
+                    )?
+                };
                 let Plan::Select(mut plan) = plan else {
                     crate::bail_parse_error!(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                optimize_select_plan(&mut plan, resolver.schema())?;
+                {
+                    let _stack = crate::stack::trace_scope("subquery:optimize_scalar_plan");
+                    optimize_select_plan(&mut plan, resolver.schema())?;
+                }
                 let reg_count = plan.result_columns.len();
                 let reg_start = program.alloc_registers(reg_count);
 
@@ -738,21 +778,31 @@ fn get_subquery_parser<'a>(
             }
             ast::Expr::InSelect { .. } => {
                 let subquery_id = program.table_reference_counter.next();
-                let outer_query_refs = get_outer_query_refs(referenced_tables);
+                let outer_query_refs = {
+                    let _stack = crate::stack::trace_scope("subquery:get_outer_refs");
+                    get_outer_query_refs(referenced_tables)
+                };
 
-                let ast::Expr::InSelect { lhs, not, rhs } = std::mem::take(expr) else {
+                let ast::Expr::InSelect { lhs, not, rhs } = ({
+                    let _stack = crate::stack::trace_scope("subquery:take_in_select_expr");
+                    std::mem::take(expr)
+                }) else {
                     unreachable!();
                 };
-                let plan = prepare_select_plan(
-                    rhs,
-                    resolver,
-                    program,
-                    &outer_query_refs,
-                    QueryDestination::Unset,
-                    connection,
-                )?;
+                let plan = {
+                    let _stack = crate::stack::trace_scope("subquery:prepare_in_select_plan");
+                    prepare_select_plan(
+                        rhs,
+                        resolver,
+                        program,
+                        &outer_query_refs,
+                        QueryDestination::Unset,
+                        connection,
+                    )?
+                };
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
+                        let _stack = crate::stack::trace_scope("subquery:optimize_in_select_plan");
                         optimize_select_plan(&mut select_plan, resolver.schema())?;
                         Plan::Select(select_plan)
                     }
@@ -763,6 +813,8 @@ fn get_subquery_parser<'a>(
                         offset,
                         order_by,
                     } => {
+                        let _stack =
+                            crate::stack::trace_scope("subquery:optimize_in_compound_plan");
                         optimize_select_plan(&mut right_most, resolver.schema())?;
                         for (select_plan, _) in left.iter_mut() {
                             optimize_select_plan(select_plan, resolver.schema())?;

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -228,7 +228,7 @@ pub fn plan_subqueries_from_select_plan(
 ) -> Result<()> {
     // WHERE
     {
-        let _stack = crate::stack::trace_scope("select_where");
+        crate::stack::trace_stack!("select_where");
         plan_subqueries_with_outer_query_access(
             program,
             &mut plan.non_from_clause_subqueries,
@@ -245,7 +245,7 @@ pub fn plan_subqueries_from_select_plan(
     // GROUP BY
     if let Some(group_by) = &mut plan.group_by {
         {
-            let _stack = crate::stack::trace_scope("select_group_by");
+            crate::stack::trace_stack!("select_group_by");
             plan_subqueries_with_outer_query_access(
                 program,
                 &mut plan.non_from_clause_subqueries,
@@ -259,7 +259,7 @@ pub fn plan_subqueries_from_select_plan(
             )?;
         }
         if let Some(having) = group_by.having.as_mut() {
-            let _stack = crate::stack::trace_scope("select_having");
+            crate::stack::trace_stack!("select_having");
             plan_subqueries_with_outer_query_access(
                 program,
                 &mut plan.non_from_clause_subqueries,
@@ -276,7 +276,7 @@ pub fn plan_subqueries_from_select_plan(
 
     // Result columns
     {
-        let _stack = crate::stack::trace_scope("select_result_columns");
+        crate::stack::trace_stack!("select_result_columns");
         plan_subqueries_with_outer_query_access(
             program,
             &mut plan.non_from_clause_subqueries,
@@ -292,7 +292,7 @@ pub fn plan_subqueries_from_select_plan(
 
     // ORDER BY
     {
-        let _stack = crate::stack::trace_scope("select_order_by");
+        crate::stack::trace_stack!("select_order_by");
         plan_subqueries_with_outer_query_access(
             program,
             &mut plan.non_from_clause_subqueries,
@@ -322,12 +322,12 @@ pub fn plan_subqueries_from_select_plan(
         );
         // Limit
         if let Some(limit) = &mut plan.limit {
-            let _stack = crate::stack::trace_scope("select_limit");
+            crate::stack::trace_stack!("select_limit");
             walk_expr_mut(limit, &mut subquery_parser)?;
         }
         // Offset
         if let Some(offset) = &mut plan.offset {
-            let _stack = crate::stack::trace_scope("select_offset");
+            crate::stack::trace_stack!("select_offset");
             walk_expr_mut(offset, &mut subquery_parser)?;
         }
     }
@@ -606,7 +606,7 @@ fn get_subquery_parser<'a>(
             ast::Expr::Exists(_) => {
                 let subquery_id = program.table_reference_counter.next();
                 let outer_query_refs = {
-                    let _stack = crate::stack::trace_scope("get_outer_refs");
+                    crate::stack::trace_stack!("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
                 };
 
@@ -619,14 +619,14 @@ fn get_subquery_parser<'a>(
                     query_type: subquery_type.clone(),
                 };
                 let ast::Expr::Exists(subselect) = ({
-                    let _stack = crate::stack::trace_scope("replace_exists_expr");
+                    crate::stack::trace_stack!("replace_exists_expr");
                     std::mem::replace(expr, result_expr)
                 }) else {
                     unreachable!();
                 };
 
                 let plan = {
-                    let _stack = crate::stack::trace_scope("prepare_exists_plan");
+                    crate::stack::trace_stack!("prepare_exists_plan");
                     prepare_select_plan(
                         subselect,
                         resolver,
@@ -642,7 +642,7 @@ fn get_subquery_parser<'a>(
                     );
                 };
                 {
-                    let _stack = crate::stack::trace_scope("optimize_exists_plan");
+                    crate::stack::trace_stack!("optimize_exists_plan");
                     optimize_select_plan(&mut plan, resolver.schema())?;
                 }
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
@@ -662,7 +662,7 @@ fn get_subquery_parser<'a>(
             ast::Expr::Subquery(_) => {
                 let subquery_id = program.table_reference_counter.next();
                 let outer_query_refs = {
-                    let _stack = crate::stack::trace_scope("get_outer_refs");
+                    crate::stack::trace_stack!("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
                 };
 
@@ -678,13 +678,13 @@ fn get_subquery_parser<'a>(
                     },
                 };
                 let ast::Expr::Subquery(subselect) = ({
-                    let _stack = crate::stack::trace_scope("replace_scalar_expr");
+                    crate::stack::trace_stack!("replace_scalar_expr");
                     std::mem::replace(expr, result_expr)
                 }) else {
                     unreachable!();
                 };
                 let plan = {
-                    let _stack = crate::stack::trace_scope("prepare_scalar_plan");
+                    crate::stack::trace_stack!("prepare_scalar_plan");
                     prepare_select_plan(
                         subselect,
                         resolver,
@@ -700,7 +700,7 @@ fn get_subquery_parser<'a>(
                     );
                 };
                 {
-                    let _stack = crate::stack::trace_scope("optimize_scalar_plan");
+                    crate::stack::trace_stack!("optimize_scalar_plan");
                     optimize_select_plan(&mut plan, resolver.schema())?;
                 }
                 let reg_count = plan.result_columns.len();
@@ -779,18 +779,18 @@ fn get_subquery_parser<'a>(
             ast::Expr::InSelect { .. } => {
                 let subquery_id = program.table_reference_counter.next();
                 let outer_query_refs = {
-                    let _stack = crate::stack::trace_scope("get_outer_refs");
+                    crate::stack::trace_stack!("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
                 };
 
                 let ast::Expr::InSelect { lhs, not, rhs } = ({
-                    let _stack = crate::stack::trace_scope("take_in_select_expr");
+                    crate::stack::trace_stack!("take_in_select_expr");
                     std::mem::take(expr)
                 }) else {
                     unreachable!();
                 };
                 let plan = {
-                    let _stack = crate::stack::trace_scope("prepare_in_select_plan");
+                    crate::stack::trace_stack!("prepare_in_select_plan");
                     prepare_select_plan(
                         rhs,
                         resolver,
@@ -802,7 +802,7 @@ fn get_subquery_parser<'a>(
                 };
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
-                        let _stack = crate::stack::trace_scope("optimize_in_select_plan");
+                        crate::stack::trace_stack!("optimize_in_select_plan");
                         optimize_select_plan(&mut select_plan, resolver.schema())?;
                         Plan::Select(select_plan)
                     }
@@ -813,7 +813,7 @@ fn get_subquery_parser<'a>(
                         offset,
                         order_by,
                     } => {
-                        let _stack = crate::stack::trace_scope("optimize_in_compound_plan");
+                        crate::stack::trace_stack!("optimize_in_compound_plan");
                         optimize_select_plan(&mut right_most, resolver.schema())?;
                         for (select_plan, _) in left.iter_mut() {
                             optimize_select_plan(select_plan, resolver.schema())?;

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -361,6 +361,7 @@ pub fn plan_subqueries_from_select_plan(
 /// This is used by DELETE and UPDATE statements which only have subqueries in the WHERE clause.
 /// Similar to [plan_subqueries_from_select_plan] but only handles the WHERE clause
 /// since these statements don't have GROUP BY, ORDER BY, or result column subqueries.
+#[turso_macros::trace_stack]
 pub fn plan_subqueries_from_where_clause(
     program: &mut ProgramBuilder,
     non_from_clause_subqueries: &mut Vec<NonFromClauseSubquery>,
@@ -443,6 +444,7 @@ pub fn plan_subqueries_from_update_sets(
 /// Compute query plans for subqueries in RETURNING expressions.
 /// This is used by INSERT, UPDATE, and DELETE statements with RETURNING clauses.
 /// RETURNING expressions may contain scalar subqueries that need to be planned.
+#[turso_macros::trace_stack]
 pub fn plan_subqueries_from_returning(
     program: &mut ProgramBuilder,
     non_from_clause_subqueries: &mut Vec<NonFromClauseSubquery>,
@@ -476,6 +478,7 @@ pub fn plan_subqueries_from_returning(
 /// Plan subqueries in a trigger WHEN clause expression.
 /// The WHEN clause has no FROM clause, so there are no outer query references.
 /// NEW/OLD references should already be rewritten to Expr::Register before calling this.
+#[turso_macros::trace_stack]
 pub fn plan_subqueries_from_trigger_when_clause(
     program: &mut ProgramBuilder,
     non_from_clause_subqueries: &mut Vec<NonFromClauseSubquery>,
@@ -625,26 +628,20 @@ fn get_subquery_parser<'a>(
                     unreachable!();
                 };
 
-                let plan = {
-                    crate::stack::trace_stack!("prepare_exists_plan");
-                    prepare_select_plan(
-                        subselect,
-                        resolver,
-                        program,
-                        &outer_query_refs,
-                        QueryDestination::ExistsSubqueryResult { result_reg },
-                        connection,
-                    )?
-                };
+                let plan = prepare_select_plan(
+                    subselect,
+                    resolver,
+                    program,
+                    &outer_query_refs,
+                    QueryDestination::ExistsSubqueryResult { result_reg },
+                    connection,
+                )?;
                 let Plan::Select(mut plan) = plan else {
                     crate::bail_parse_error!(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                {
-                    crate::stack::trace_stack!("optimize_exists_plan");
-                    optimize_select_plan(&mut plan, resolver.schema())?;
-                }
+                optimize_select_plan(&mut plan, resolver.schema())?;
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
                 out_subqueries.push(NonFromClauseSubquery {
@@ -683,26 +680,20 @@ fn get_subquery_parser<'a>(
                 }) else {
                     unreachable!();
                 };
-                let plan = {
-                    crate::stack::trace_stack!("prepare_scalar_plan");
-                    prepare_select_plan(
-                        subselect,
-                        resolver,
-                        program,
-                        &outer_query_refs,
-                        QueryDestination::Unset,
-                        connection,
-                    )?
-                };
+                let plan = prepare_select_plan(
+                    subselect,
+                    resolver,
+                    program,
+                    &outer_query_refs,
+                    QueryDestination::Unset,
+                    connection,
+                )?;
                 let Plan::Select(mut plan) = plan else {
                     crate::bail_parse_error!(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                {
-                    crate::stack::trace_stack!("optimize_scalar_plan");
-                    optimize_select_plan(&mut plan, resolver.schema())?;
-                }
+                optimize_select_plan(&mut plan, resolver.schema())?;
                 let reg_count = plan.result_columns.len();
                 let reg_start = program.alloc_registers(reg_count);
 
@@ -789,20 +780,16 @@ fn get_subquery_parser<'a>(
                 }) else {
                     unreachable!();
                 };
-                let plan = {
-                    crate::stack::trace_stack!("prepare_in_select_plan");
-                    prepare_select_plan(
-                        rhs,
-                        resolver,
-                        program,
-                        &outer_query_refs,
-                        QueryDestination::Unset,
-                        connection,
-                    )?
-                };
+                let plan = prepare_select_plan(
+                    rhs,
+                    resolver,
+                    program,
+                    &outer_query_refs,
+                    QueryDestination::Unset,
+                    connection,
+                )?;
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
-                        crate::stack::trace_stack!("optimize_in_select_plan");
                         optimize_select_plan(&mut select_plan, resolver.schema())?;
                         Plan::Select(select_plan)
                     }
@@ -813,7 +800,6 @@ fn get_subquery_parser<'a>(
                         offset,
                         order_by,
                     } => {
-                        crate::stack::trace_stack!("optimize_in_compound_plan");
                         optimize_select_plan(&mut right_most, resolver.schema())?;
                         for (select_plan, _) in left.iter_mut() {
                             optimize_select_plan(select_plan, resolver.schema())?;

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -219,16 +219,16 @@ pub(crate) fn mark_shared_cte_materialization_requirements(
 /// The appropriate time is determined by whether the subquery is correlated or uncorrelated;
 /// if it is uncorrelated, it can be evaluated as early as possible, but if it is correlated, it must be evaluated after all of its dependencies from the
 /// outer query are 'in scope', i.e. their cursors are open and rewound.
+#[turso_macros::trace_stack]
 pub fn plan_subqueries_from_select_plan(
     program: &mut ProgramBuilder,
     plan: &mut SelectPlan,
     resolver: &Resolver,
     connection: &Arc<Connection>,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope("subquery:plan_from_select_plan");
     // WHERE
     {
-        let _stack = crate::stack::trace_scope("subquery:select_where");
+        let _stack = crate::stack::trace_scope("select_where");
         plan_subqueries_with_outer_query_access(
             program,
             &mut plan.non_from_clause_subqueries,
@@ -245,7 +245,7 @@ pub fn plan_subqueries_from_select_plan(
     // GROUP BY
     if let Some(group_by) = &mut plan.group_by {
         {
-            let _stack = crate::stack::trace_scope("subquery:select_group_by");
+            let _stack = crate::stack::trace_scope("select_group_by");
             plan_subqueries_with_outer_query_access(
                 program,
                 &mut plan.non_from_clause_subqueries,
@@ -259,7 +259,7 @@ pub fn plan_subqueries_from_select_plan(
             )?;
         }
         if let Some(having) = group_by.having.as_mut() {
-            let _stack = crate::stack::trace_scope("subquery:select_having");
+            let _stack = crate::stack::trace_scope("select_having");
             plan_subqueries_with_outer_query_access(
                 program,
                 &mut plan.non_from_clause_subqueries,
@@ -276,7 +276,7 @@ pub fn plan_subqueries_from_select_plan(
 
     // Result columns
     {
-        let _stack = crate::stack::trace_scope("subquery:select_result_columns");
+        let _stack = crate::stack::trace_scope("select_result_columns");
         plan_subqueries_with_outer_query_access(
             program,
             &mut plan.non_from_clause_subqueries,
@@ -292,7 +292,7 @@ pub fn plan_subqueries_from_select_plan(
 
     // ORDER BY
     {
-        let _stack = crate::stack::trace_scope("subquery:select_order_by");
+        let _stack = crate::stack::trace_scope("select_order_by");
         plan_subqueries_with_outer_query_access(
             program,
             &mut plan.non_from_clause_subqueries,
@@ -322,12 +322,12 @@ pub fn plan_subqueries_from_select_plan(
         );
         // Limit
         if let Some(limit) = &mut plan.limit {
-            let _stack = crate::stack::trace_scope("subquery:select_limit");
+            let _stack = crate::stack::trace_scope("select_limit");
             walk_expr_mut(limit, &mut subquery_parser)?;
         }
         // Offset
         if let Some(offset) = &mut plan.offset {
-            let _stack = crate::stack::trace_scope("subquery:select_offset");
+            let _stack = crate::stack::trace_scope("select_offset");
             walk_expr_mut(offset, &mut subquery_parser)?;
         }
     }
@@ -499,6 +499,7 @@ pub fn plan_subqueries_from_trigger_when_clause(
 
 /// Compute query plans for subqueries in the WHERE clause and HAVING clause (both of which have access to the outer query scope)
 #[allow(clippy::too_many_arguments)]
+#[turso_macros::trace_stack]
 fn plan_subqueries_with_outer_query_access<'a>(
     program: &mut ProgramBuilder,
     out_subqueries: &mut Vec<NonFromClauseSubquery>,
@@ -510,7 +511,6 @@ fn plan_subqueries_with_outer_query_access<'a>(
     origin: SubqueryOrigin,
     allow_correlated: bool,
 ) -> Result<()> {
-    let _stack = crate::stack::trace_scope("subquery:walk_outer_query_access");
     // Most subqueries can reference columns from the outer query,
     // including nested cases where a subquery inside a subquery references columns from its parent's parent
     // and so on.
@@ -606,7 +606,7 @@ fn get_subquery_parser<'a>(
             ast::Expr::Exists(_) => {
                 let subquery_id = program.table_reference_counter.next();
                 let outer_query_refs = {
-                    let _stack = crate::stack::trace_scope("subquery:get_outer_refs");
+                    let _stack = crate::stack::trace_scope("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
                 };
 
@@ -619,14 +619,14 @@ fn get_subquery_parser<'a>(
                     query_type: subquery_type.clone(),
                 };
                 let ast::Expr::Exists(subselect) = ({
-                    let _stack = crate::stack::trace_scope("subquery:replace_exists_expr");
+                    let _stack = crate::stack::trace_scope("replace_exists_expr");
                     std::mem::replace(expr, result_expr)
                 }) else {
                     unreachable!();
                 };
 
                 let plan = {
-                    let _stack = crate::stack::trace_scope("subquery:prepare_exists_plan");
+                    let _stack = crate::stack::trace_scope("prepare_exists_plan");
                     prepare_select_plan(
                         subselect,
                         resolver,
@@ -642,7 +642,7 @@ fn get_subquery_parser<'a>(
                     );
                 };
                 {
-                    let _stack = crate::stack::trace_scope("subquery:optimize_exists_plan");
+                    let _stack = crate::stack::trace_scope("optimize_exists_plan");
                     optimize_select_plan(&mut plan, resolver.schema())?;
                 }
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
@@ -662,7 +662,7 @@ fn get_subquery_parser<'a>(
             ast::Expr::Subquery(_) => {
                 let subquery_id = program.table_reference_counter.next();
                 let outer_query_refs = {
-                    let _stack = crate::stack::trace_scope("subquery:get_outer_refs");
+                    let _stack = crate::stack::trace_scope("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
                 };
 
@@ -678,13 +678,13 @@ fn get_subquery_parser<'a>(
                     },
                 };
                 let ast::Expr::Subquery(subselect) = ({
-                    let _stack = crate::stack::trace_scope("subquery:replace_scalar_expr");
+                    let _stack = crate::stack::trace_scope("replace_scalar_expr");
                     std::mem::replace(expr, result_expr)
                 }) else {
                     unreachable!();
                 };
                 let plan = {
-                    let _stack = crate::stack::trace_scope("subquery:prepare_scalar_plan");
+                    let _stack = crate::stack::trace_scope("prepare_scalar_plan");
                     prepare_select_plan(
                         subselect,
                         resolver,
@@ -700,7 +700,7 @@ fn get_subquery_parser<'a>(
                     );
                 };
                 {
-                    let _stack = crate::stack::trace_scope("subquery:optimize_scalar_plan");
+                    let _stack = crate::stack::trace_scope("optimize_scalar_plan");
                     optimize_select_plan(&mut plan, resolver.schema())?;
                 }
                 let reg_count = plan.result_columns.len();
@@ -779,18 +779,18 @@ fn get_subquery_parser<'a>(
             ast::Expr::InSelect { .. } => {
                 let subquery_id = program.table_reference_counter.next();
                 let outer_query_refs = {
-                    let _stack = crate::stack::trace_scope("subquery:get_outer_refs");
+                    let _stack = crate::stack::trace_scope("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
                 };
 
                 let ast::Expr::InSelect { lhs, not, rhs } = ({
-                    let _stack = crate::stack::trace_scope("subquery:take_in_select_expr");
+                    let _stack = crate::stack::trace_scope("take_in_select_expr");
                     std::mem::take(expr)
                 }) else {
                     unreachable!();
                 };
                 let plan = {
-                    let _stack = crate::stack::trace_scope("subquery:prepare_in_select_plan");
+                    let _stack = crate::stack::trace_scope("prepare_in_select_plan");
                     prepare_select_plan(
                         rhs,
                         resolver,
@@ -802,7 +802,7 @@ fn get_subquery_parser<'a>(
                 };
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
-                        let _stack = crate::stack::trace_scope("subquery:optimize_in_select_plan");
+                        let _stack = crate::stack::trace_scope("optimize_in_select_plan");
                         optimize_select_plan(&mut select_plan, resolver.schema())?;
                         Plan::Select(select_plan)
                     }
@@ -813,8 +813,7 @@ fn get_subquery_parser<'a>(
                         offset,
                         order_by,
                     } => {
-                        let _stack =
-                            crate::stack::trace_scope("subquery:optimize_in_compound_plan");
+                        let _stack = crate::stack::trace_scope("optimize_in_compound_plan");
                         optimize_select_plan(&mut right_most, resolver.schema())?;
                         for (select_plan, _) in left.iter_mut() {
                             optimize_select_plan(select_plan, resolver.schema())?;

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -279,6 +279,7 @@ fn rewrite_upsert_exprs_for_subprogram(
 }
 
 /// Convert TriggerCmd to Stmt, rewriting NEW/OLD to Variable expressions (for subprogram compilation)
+#[turso_macros::trace_stack(detail = trigger_command_kind(cmd))]
 fn trigger_cmd_to_stmt_for_subprogram(
     cmd: &ast::TriggerCmd,
     subprogram_ctx: &TriggerSubprogramContext,
@@ -599,21 +600,15 @@ fn execute_trigger_commands(
     resolver.set_trigger_context(trigger_database_id, trigger.name.clone());
     let compile_result = (|| -> Result<()> {
         for command in trigger.commands.iter() {
-            let stmt = {
-                crate::stack::trace_stack!("rewrite_command", trigger_command_kind(command),);
-                trigger_cmd_to_stmt_for_subprogram(command, &subprogram_ctx)?
-            };
+            let stmt = trigger_cmd_to_stmt_for_subprogram(command, &subprogram_ctx)?;
             subprogram_builder.prologue();
-            {
-                crate::stack::trace_stack!("translate_command", trigger_command_kind(command),);
-                translate_inner(
-                    stmt,
-                    resolver,
-                    &mut subprogram_builder,
-                    connection,
-                    "trigger subprogram",
-                )?;
-            }
+            translate_inner(
+                stmt,
+                resolver,
+                &mut subprogram_builder,
+                connection,
+                "trigger subprogram",
+            )?;
             if matches!(
                 command,
                 ast::TriggerCmd::Insert { .. }
@@ -628,14 +623,9 @@ fn execute_trigger_commands(
     // Restore previous trigger context (supports nested triggers).
     resolver.trigger_context = prev_trigger_context;
     compile_result?;
-    {
-        crate::stack::trace_stack!("subprogram_epilogue");
-        subprogram_builder.epilogue(resolver.schema());
-    }
-    let built_subprogram = {
-        crate::stack::trace_stack!("subprogram_build");
-        subprogram_builder.build(connection.clone(), true, "trigger subprogram")?
-    };
+    subprogram_builder.epilogue(resolver.schema());
+    let built_subprogram =
+        subprogram_builder.build(connection.clone(), true, "trigger subprogram")?;
     let subprogram_prepared = built_subprogram.prepared();
 
     // Trigger subprograms do not emit Transaction opcodes, so the parent statement
@@ -895,24 +885,18 @@ pub fn fire_trigger(
         if let Some(mut when_expr) = trigger.when_clause.clone() {
             crate::stack::trace_stack!("when_clause");
             // Rewrite NEW/OLD references in WHEN clause to use registers
-            {
-                crate::stack::trace_stack!("rewrite_when");
-                rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
-            }
+            rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
 
             // Plan and emit any subqueries in the WHEN clause (e.g. IN (SELECT ...), EXISTS, scalar subqueries).
             // This transforms InSelect/Exists/Subquery nodes into SubqueryResult nodes that translate_expr can handle.
             let mut subqueries = Vec::new();
-            {
-                crate::stack::trace_stack!("plan_when_subqueries");
-                plan_subqueries_from_trigger_when_clause(
-                    program,
-                    &mut subqueries,
-                    &mut when_expr,
-                    resolver,
-                    connection,
-                )?;
-            }
+            plan_subqueries_from_trigger_when_clause(
+                program,
+                &mut subqueries,
+                &mut when_expr,
+                resolver,
+                connection,
+            )?;
             // Emit the planned subqueries so their results are available when we evaluate the WHEN expression.
             // Always treat these as correlated (no `Once` caching) because the WHEN clause is evaluated
             // per-row, and trigger bodies may modify the tables referenced by the subquery between evaluations.
@@ -929,10 +913,7 @@ pub fn fire_trigger(
             }
 
             let when_reg = program.alloc_register();
-            {
-                crate::stack::trace_stack!("translate_when_expr");
-                translate_expr(program, None, &when_expr, when_reg, resolver)?;
-            }
+            translate_expr(program, None, &when_expr, when_reg, resolver)?;
 
             let skip_label = program.allocate_label();
             program.emit_insn(Insn::IfNot {
@@ -942,34 +923,28 @@ pub fn fire_trigger(
             });
 
             // Execute trigger commands if WHEN clause is true
-            {
-                crate::stack::trace_stack!("execute_when_body");
-                execute_trigger_commands(
-                    program,
-                    resolver,
-                    &trigger,
-                    ctx,
-                    connection,
-                    database_id,
-                    ignore_jump_target,
-                )?;
-            }
+            execute_trigger_commands(
+                program,
+                resolver,
+                &trigger,
+                ctx,
+                connection,
+                database_id,
+                ignore_jump_target,
+            )?;
 
             program.preassign_label_to_next_insn(skip_label);
         } else {
             // No WHEN clause - always execute
-            {
-                crate::stack::trace_stack!("execute_body");
-                execute_trigger_commands(
-                    program,
-                    resolver,
-                    &trigger,
-                    ctx,
-                    connection,
-                    database_id,
-                    ignore_jump_target,
-                )?;
-            }
+            execute_trigger_commands(
+                program,
+                resolver,
+                &trigger,
+                ctx,
+                connection,
+                database_id,
+                ignore_jump_target,
+            )?;
         }
 
         Ok(())
@@ -1091,6 +1066,7 @@ fn populate_trigger_row_register_affinities(
 }
 
 /// Rewrite NEW/OLD references in WHEN clause expressions (uses Register expressions, not Variable)
+#[turso_macros::trace_stack]
 fn rewrite_trigger_expr_for_when_clause(
     expr: &mut ast::Expr,
     table: &BTreeTable,

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -600,18 +600,12 @@ fn execute_trigger_commands(
     let compile_result = (|| -> Result<()> {
         for command in trigger.commands.iter() {
             let stmt = {
-                let _stack = crate::stack::trace_scope_with_detail(
-                    "rewrite_command",
-                    trigger_command_kind(command),
-                );
+                crate::stack::trace_stack!("rewrite_command", trigger_command_kind(command),);
                 trigger_cmd_to_stmt_for_subprogram(command, &subprogram_ctx)?
             };
             subprogram_builder.prologue();
             {
-                let _stack = crate::stack::trace_scope_with_detail(
-                    "translate_command",
-                    trigger_command_kind(command),
-                );
+                crate::stack::trace_stack!("translate_command", trigger_command_kind(command),);
                 translate_inner(
                     stmt,
                     resolver,
@@ -635,11 +629,11 @@ fn execute_trigger_commands(
     resolver.trigger_context = prev_trigger_context;
     compile_result?;
     {
-        let _stack = crate::stack::trace_scope("subprogram_epilogue");
+        crate::stack::trace_stack!("subprogram_epilogue");
         subprogram_builder.epilogue(resolver.schema());
     }
     let built_subprogram = {
-        let _stack = crate::stack::trace_scope("subprogram_build");
+        crate::stack::trace_stack!("subprogram_build");
         subprogram_builder.build(connection.clone(), true, "trigger subprogram")?
     };
     let subprogram_prepared = built_subprogram.prepared();
@@ -899,10 +893,10 @@ pub fn fire_trigger(
     let result = (|| -> Result<()> {
         // Evaluate WHEN clause if present
         if let Some(mut when_expr) = trigger.when_clause.clone() {
-            let _stack = crate::stack::trace_scope("when_clause");
+            crate::stack::trace_stack!("when_clause");
             // Rewrite NEW/OLD references in WHEN clause to use registers
             {
-                let _stack = crate::stack::trace_scope("rewrite_when");
+                crate::stack::trace_stack!("rewrite_when");
                 rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
             }
 
@@ -910,7 +904,7 @@ pub fn fire_trigger(
             // This transforms InSelect/Exists/Subquery nodes into SubqueryResult nodes that translate_expr can handle.
             let mut subqueries = Vec::new();
             {
-                let _stack = crate::stack::trace_scope("plan_when_subqueries");
+                crate::stack::trace_stack!("plan_when_subqueries");
                 plan_subqueries_from_trigger_when_clause(
                     program,
                     &mut subqueries,
@@ -936,7 +930,7 @@ pub fn fire_trigger(
 
             let when_reg = program.alloc_register();
             {
-                let _stack = crate::stack::trace_scope("translate_when_expr");
+                crate::stack::trace_stack!("translate_when_expr");
                 translate_expr(program, None, &when_expr, when_reg, resolver)?;
             }
 
@@ -949,7 +943,7 @@ pub fn fire_trigger(
 
             // Execute trigger commands if WHEN clause is true
             {
-                let _stack = crate::stack::trace_scope("execute_when_body");
+                crate::stack::trace_stack!("execute_when_body");
                 execute_trigger_commands(
                     program,
                     resolver,
@@ -965,7 +959,7 @@ pub fn fire_trigger(
         } else {
             // No WHEN clause - always execute
             {
-                let _stack = crate::stack::trace_scope("execute_body");
+                crate::stack::trace_stack!("execute_body");
                 execute_trigger_commands(
                     program,
                     resolver,

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -532,6 +532,10 @@ fn execute_trigger_commands(
     database_id: usize,
     ignore_jump_target: BranchOffset,
 ) -> Result<bool> {
+    let _stack = crate::stack::trace_scope_with_detail(
+        "trigger:execute_commands",
+        trigger_event_kind(&trigger.event),
+    );
     struct TriggerCompilationGuard {
         connection: Arc<crate::Connection>,
     }
@@ -598,15 +602,27 @@ fn execute_trigger_commands(
     resolver.set_trigger_context(trigger_database_id, trigger.name.clone());
     let compile_result = (|| -> Result<()> {
         for command in trigger.commands.iter() {
-            let stmt = trigger_cmd_to_stmt_for_subprogram(command, &subprogram_ctx)?;
+            let stmt = {
+                let _stack = crate::stack::trace_scope_with_detail(
+                    "trigger:rewrite_command",
+                    trigger_command_kind(command),
+                );
+                trigger_cmd_to_stmt_for_subprogram(command, &subprogram_ctx)?
+            };
             subprogram_builder.prologue();
-            translate_inner(
-                stmt,
-                resolver,
-                &mut subprogram_builder,
-                connection,
-                "trigger subprogram",
-            )?;
+            {
+                let _stack = crate::stack::trace_scope_with_detail(
+                    "trigger:translate_command",
+                    trigger_command_kind(command),
+                );
+                translate_inner(
+                    stmt,
+                    resolver,
+                    &mut subprogram_builder,
+                    connection,
+                    "trigger subprogram",
+                )?;
+            }
             if matches!(
                 command,
                 ast::TriggerCmd::Insert { .. }
@@ -621,9 +637,14 @@ fn execute_trigger_commands(
     // Restore previous trigger context (supports nested triggers).
     resolver.trigger_context = prev_trigger_context;
     compile_result?;
-    subprogram_builder.epilogue(resolver.schema());
-    let built_subprogram =
-        subprogram_builder.build(connection.clone(), true, "trigger subprogram")?;
+    {
+        let _stack = crate::stack::trace_scope("trigger:subprogram_epilogue");
+        subprogram_builder.epilogue(resolver.schema());
+    }
+    let built_subprogram = {
+        let _stack = crate::stack::trace_scope("trigger:subprogram_build");
+        subprogram_builder.build(connection.clone(), true, "trigger subprogram")?
+    };
     let subprogram_prepared = built_subprogram.prepared();
 
     // Trigger subprograms do not emit Transaction opcodes, so the parent statement
@@ -864,6 +885,8 @@ pub fn fire_trigger(
     database_id: usize,
     ignore_jump_target: BranchOffset,
 ) -> Result<()> {
+    let _stack =
+        crate::stack::trace_scope_with_detail("trigger:fire", trigger_event_kind(&trigger.event));
     // Decode custom type registers so trigger bodies see user-facing values,
     // not raw encoded blobs from disk.
     // - OLD registers always come from cursor reads → always encoded → always decode
@@ -880,19 +903,26 @@ pub fn fire_trigger(
     let result = (|| -> Result<()> {
         // Evaluate WHEN clause if present
         if let Some(mut when_expr) = trigger.when_clause.clone() {
+            let _stack = crate::stack::trace_scope("trigger:when_clause");
             // Rewrite NEW/OLD references in WHEN clause to use registers
-            rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
+            {
+                let _stack = crate::stack::trace_scope("trigger:rewrite_when");
+                rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
+            }
 
             // Plan and emit any subqueries in the WHEN clause (e.g. IN (SELECT ...), EXISTS, scalar subqueries).
             // This transforms InSelect/Exists/Subquery nodes into SubqueryResult nodes that translate_expr can handle.
             let mut subqueries = Vec::new();
-            plan_subqueries_from_trigger_when_clause(
-                program,
-                &mut subqueries,
-                &mut when_expr,
-                resolver,
-                connection,
-            )?;
+            {
+                let _stack = crate::stack::trace_scope("trigger:plan_when_subqueries");
+                plan_subqueries_from_trigger_when_clause(
+                    program,
+                    &mut subqueries,
+                    &mut when_expr,
+                    resolver,
+                    connection,
+                )?;
+            }
             // Emit the planned subqueries so their results are available when we evaluate the WHEN expression.
             // Always treat these as correlated (no `Once` caching) because the WHEN clause is evaluated
             // per-row, and trigger bodies may modify the tables referenced by the subquery between evaluations.
@@ -909,7 +939,10 @@ pub fn fire_trigger(
             }
 
             let when_reg = program.alloc_register();
-            translate_expr(program, None, &when_expr, when_reg, resolver)?;
+            {
+                let _stack = crate::stack::trace_scope("trigger:translate_when_expr");
+                translate_expr(program, None, &when_expr, when_reg, resolver)?;
+            }
 
             let skip_label = program.allocate_label();
             program.emit_insn(Insn::IfNot {
@@ -919,34 +952,58 @@ pub fn fire_trigger(
             });
 
             // Execute trigger commands if WHEN clause is true
-            execute_trigger_commands(
-                program,
-                resolver,
-                &trigger,
-                ctx,
-                connection,
-                database_id,
-                ignore_jump_target,
-            )?;
+            {
+                let _stack = crate::stack::trace_scope("trigger:execute_when_body");
+                execute_trigger_commands(
+                    program,
+                    resolver,
+                    &trigger,
+                    ctx,
+                    connection,
+                    database_id,
+                    ignore_jump_target,
+                )?;
+            }
 
             program.preassign_label_to_next_insn(skip_label);
         } else {
             // No WHEN clause - always execute
-            execute_trigger_commands(
-                program,
-                resolver,
-                &trigger,
-                ctx,
-                connection,
-                database_id,
-                ignore_jump_target,
-            )?;
+            {
+                let _stack = crate::stack::trace_scope("trigger:execute_body");
+                execute_trigger_commands(
+                    program,
+                    resolver,
+                    &trigger,
+                    ctx,
+                    connection,
+                    database_id,
+                    ignore_jump_target,
+                )?;
+            }
         }
 
         Ok(())
     })();
     resolver.register_affinities = saved_register_affinities;
     result
+}
+
+fn trigger_event_kind(event: &TriggerEvent) -> &'static str {
+    match event {
+        TriggerEvent::Delete => "delete",
+        TriggerEvent::Insert => "insert",
+        TriggerEvent::Update => "update",
+        TriggerEvent::UpdateOf(_) => "update_of",
+    }
+}
+
+fn trigger_command_kind(command: &ast::TriggerCmd) -> &'static str {
+    match command {
+        ast::TriggerCmd::Insert { .. } => "insert",
+        ast::TriggerCmd::Update { .. } => "update",
+        ast::TriggerCmd::Delete { .. } => "delete",
+        ast::TriggerCmd::Select(_) => "select",
+    }
 }
 
 /// Decode encoded custom type registers in a TriggerContext.

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -523,6 +523,7 @@ fn rewrite_trigger_expr_single_for_subprogram(
 
 /// Execute trigger commands by compiling them as a subprogram and emitting Program instruction
 /// Returns true if there are triggers that will fire.
+#[turso_macros::trace_stack(detail = trigger_event_kind(&trigger.event))]
 fn execute_trigger_commands(
     program: &mut ProgramBuilder,
     resolver: &mut Resolver,
@@ -532,10 +533,6 @@ fn execute_trigger_commands(
     database_id: usize,
     ignore_jump_target: BranchOffset,
 ) -> Result<bool> {
-    let _stack = crate::stack::trace_scope_with_detail(
-        "trigger:execute_commands",
-        trigger_event_kind(&trigger.event),
-    );
     struct TriggerCompilationGuard {
         connection: Arc<crate::Connection>,
     }
@@ -604,7 +601,7 @@ fn execute_trigger_commands(
         for command in trigger.commands.iter() {
             let stmt = {
                 let _stack = crate::stack::trace_scope_with_detail(
-                    "trigger:rewrite_command",
+                    "rewrite_command",
                     trigger_command_kind(command),
                 );
                 trigger_cmd_to_stmt_for_subprogram(command, &subprogram_ctx)?
@@ -612,7 +609,7 @@ fn execute_trigger_commands(
             subprogram_builder.prologue();
             {
                 let _stack = crate::stack::trace_scope_with_detail(
-                    "trigger:translate_command",
+                    "translate_command",
                     trigger_command_kind(command),
                 );
                 translate_inner(
@@ -638,11 +635,11 @@ fn execute_trigger_commands(
     resolver.trigger_context = prev_trigger_context;
     compile_result?;
     {
-        let _stack = crate::stack::trace_scope("trigger:subprogram_epilogue");
+        let _stack = crate::stack::trace_scope("subprogram_epilogue");
         subprogram_builder.epilogue(resolver.schema());
     }
     let built_subprogram = {
-        let _stack = crate::stack::trace_scope("trigger:subprogram_build");
+        let _stack = crate::stack::trace_scope("subprogram_build");
         subprogram_builder.build(connection.clone(), true, "trigger subprogram")?
     };
     let subprogram_prepared = built_subprogram.prepared();
@@ -876,6 +873,7 @@ pub fn has_triggers_including_temp(
     false
 }
 
+#[turso_macros::trace_stack(detail = trigger_event_kind(&trigger.event))]
 pub fn fire_trigger(
     program: &mut ProgramBuilder,
     resolver: &mut Resolver,
@@ -885,8 +883,6 @@ pub fn fire_trigger(
     database_id: usize,
     ignore_jump_target: BranchOffset,
 ) -> Result<()> {
-    let _stack =
-        crate::stack::trace_scope_with_detail("trigger:fire", trigger_event_kind(&trigger.event));
     // Decode custom type registers so trigger bodies see user-facing values,
     // not raw encoded blobs from disk.
     // - OLD registers always come from cursor reads → always encoded → always decode
@@ -903,10 +899,10 @@ pub fn fire_trigger(
     let result = (|| -> Result<()> {
         // Evaluate WHEN clause if present
         if let Some(mut when_expr) = trigger.when_clause.clone() {
-            let _stack = crate::stack::trace_scope("trigger:when_clause");
+            let _stack = crate::stack::trace_scope("when_clause");
             // Rewrite NEW/OLD references in WHEN clause to use registers
             {
-                let _stack = crate::stack::trace_scope("trigger:rewrite_when");
+                let _stack = crate::stack::trace_scope("rewrite_when");
                 rewrite_trigger_expr_for_when_clause(&mut when_expr, &ctx.table, ctx)?;
             }
 
@@ -914,7 +910,7 @@ pub fn fire_trigger(
             // This transforms InSelect/Exists/Subquery nodes into SubqueryResult nodes that translate_expr can handle.
             let mut subqueries = Vec::new();
             {
-                let _stack = crate::stack::trace_scope("trigger:plan_when_subqueries");
+                let _stack = crate::stack::trace_scope("plan_when_subqueries");
                 plan_subqueries_from_trigger_when_clause(
                     program,
                     &mut subqueries,
@@ -940,7 +936,7 @@ pub fn fire_trigger(
 
             let when_reg = program.alloc_register();
             {
-                let _stack = crate::stack::trace_scope("trigger:translate_when_expr");
+                let _stack = crate::stack::trace_scope("translate_when_expr");
                 translate_expr(program, None, &when_expr, when_reg, resolver)?;
             }
 
@@ -953,7 +949,7 @@ pub fn fire_trigger(
 
             // Execute trigger commands if WHEN clause is true
             {
-                let _stack = crate::stack::trace_scope("trigger:execute_when_body");
+                let _stack = crate::stack::trace_scope("execute_when_body");
                 execute_trigger_commands(
                     program,
                     resolver,
@@ -969,7 +965,7 @@ pub fn fire_trigger(
         } else {
             // No WHEN clause - always execute
             {
-                let _stack = crate::stack::trace_scope("trigger:execute_body");
+                let _stack = crate::stack::trace_scope("execute_body");
                 execute_trigger_commands(
                     program,
                     resolver,

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -88,6 +88,7 @@ struct WindowSubqueryContext<'a> {
 ///     ORDER BY c, d
 /// );
 /// ```
+#[turso_macros::trace_stack]
 pub fn plan_windows(
     program: &mut ProgramBuilder,
     plan: &mut SelectPlan,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -641,6 +641,8 @@ impl ProgramBuilder {
     ) -> Self {
         ProgramBuilder::_new(query_mode, capture_data_changes_info, opts, None, true)
     }
+
+    #[turso_macros::trace_stack]
     fn _new(
         query_mode: QueryMode,
         capture_data_changes_info: Option<CaptureDataChangesInfo>,
@@ -1967,6 +1969,7 @@ impl ProgramBuilder {
         Ok(prepared)
     }
 
+    #[turso_macros::trace_stack]
     pub fn build(
         self,
         connection: Arc<Connection>,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1310,6 +1310,7 @@ impl Program {
         state.is_interrupted()
     }
 
+    #[turso_macros::trace_stack]
     pub fn step(
         &self,
         state: &mut ProgramState,
@@ -1317,7 +1318,6 @@ impl Program {
         query_mode: QueryMode,
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
-        let _stack = crate::stack::trace_scope("program_step");
         state.execution_state = ProgramExecutionState::Running;
         let result = match query_mode {
             QueryMode::Normal => self.normal_step(state, pager, waker),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1317,6 +1317,7 @@ impl Program {
         query_mode: QueryMode,
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
+        let _stack = crate::stack::trace_scope("program_step");
         state.execution_state = ProgramExecutionState::Running;
         let result = match query_mode {
             QueryMode::Normal => self.normal_step(state, pager, waker),
@@ -1536,6 +1537,7 @@ impl Program {
             let insn_function = insn.to_function();
             if enable_tracing {
                 trace_insn(self, state.pc as InsnReference, insn);
+                crate::stack::trace_remaining("program_step:opcode");
             }
             // Always increment VM steps for every loop iteration
             state.metrics.vm_steps = state.metrics.vm_steps.saturating_add(1);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -87,6 +87,8 @@ mod test;
 
 // Import assertion proc macro implementations
 mod assert;
+#[path = "trace_stack.rs"]
+mod trace_stack_impl;
 
 use assert::{
     comparison_auto_message, details_debug_check, details_format_args, details_json,
@@ -645,6 +647,24 @@ pub fn derive_atomic_enum(input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
     test::test_macro_attribute(args, input)
+}
+
+/// Wrap a function body in a stack trace guard and a `turso_stack` tracing span.
+///
+/// With no arguments, the label is inferred as `module_path!()::function_name`
+/// and the span name is the function name.
+/// A string literal argument overrides the label.
+///
+/// ```ignore
+/// #[turso_macros::trace_stack]
+/// fn prepare_select_plan(...) { ... }
+///
+/// #[turso_macros::trace_stack("select:translate")]
+/// fn translate_select(...) { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn trace_stack(attr: TokenStream, input: TokenStream) -> TokenStream {
+    trace_stack_impl::trace_stack_attribute(attr, input)
 }
 
 /// Controls the `#[cfg(not(antithesis))]` fallback in "always" comparison macros.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -661,6 +661,9 @@ pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// #[turso_macros::trace_stack("select:translate")]
 /// fn translate_select(...) { ... }
+///
+/// #[turso_macros::trace_stack(detail = stmt_kind(&stmt))]
+/// fn translate_inner(stmt: ast::Stmt, ...) { ... }
 /// ```
 #[proc_macro_attribute]
 pub fn trace_stack(attr: TokenStream, input: TokenStream) -> TokenStream {

--- a/macros/src/trace_stack.rs
+++ b/macros/src/trace_stack.rs
@@ -1,0 +1,61 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, ItemFn, LitStr, Token,
+};
+
+enum TraceStackArgs {
+    Inferred,
+    Label(LitStr),
+}
+
+impl Parse for TraceStackArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(Self::Inferred);
+        }
+
+        let label = input.parse()?;
+        if !input.is_empty() {
+            input.parse::<Token![,]>()?;
+        }
+        if !input.is_empty() {
+            return Err(input.error("expected at most one string literal label"));
+        }
+
+        Ok(Self::Label(label))
+    }
+}
+
+pub(crate) fn trace_stack_attribute(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as TraceStackArgs);
+    let mut function = parse_macro_input!(input as ItemFn);
+    let function_name = &function.sig.ident;
+    let inferred_span_name = LitStr::new(&function_name.to_string(), function_name.span());
+
+    let (span_name, guard) = match args {
+        TraceStackArgs::Inferred => {
+            let guard = quote! {
+                let _stack = crate::stack::trace_scope(concat!(module_path!(), "::", stringify!(#function_name)));
+            };
+            (inferred_span_name, guard)
+        }
+        TraceStackArgs::Label(label) => {
+            let guard = quote! {
+                let _stack = crate::stack::trace_scope(#label);
+            };
+            (label, guard)
+        }
+    };
+
+    let body = &function.block;
+    function.block = syn::parse_quote!({
+        #[cfg(feature = "stacker")]
+        let _stack_span = tracing::debug_span!(target: "turso_stack", #span_name).entered();
+        #guard
+        #body
+    });
+
+    quote!(#function).into()
+}

--- a/macros/src/trace_stack.rs
+++ b/macros/src/trace_stack.rs
@@ -2,12 +2,14 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
-    parse_macro_input, ItemFn, LitStr, Token,
+    Expr, Ident, ImplItemFn, ItemFn, LitStr, Token,
 };
 
 enum TraceStackArgs {
     Inferred,
+    InferredWithDetail(Expr),
     Label(LitStr),
+    LabelWithDetail(LitStr, Expr),
 }
 
 impl Parse for TraceStackArgs {
@@ -16,12 +18,39 @@ impl Parse for TraceStackArgs {
             return Ok(Self::Inferred);
         }
 
+        if input.peek(Ident) {
+            let ident: Ident = input.parse()?;
+            if ident != "detail" {
+                return Err(syn::Error::new_spanned(ident, "expected `detail`"));
+            }
+            input.parse::<Token![=]>()?;
+            let detail = input.parse()?;
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+            if !input.is_empty() {
+                return Err(input.error("expected a single detail expression"));
+            }
+            return Ok(Self::InferredWithDetail(detail));
+        }
+
         let label = input.parse()?;
+        if input.is_empty() {
+            return Ok(Self::Label(label));
+        }
+
+        input.parse::<Token![,]>()?;
         if !input.is_empty() {
+            let detail = input.parse()?;
+            if input.is_empty() {
+                return Ok(Self::LabelWithDetail(label, detail));
+            }
             input.parse::<Token![,]>()?;
         }
         if !input.is_empty() {
-            return Err(input.error("expected at most one string literal label"));
+            return Err(
+                input.error("expected a string literal label and optional detail expression")
+            );
         }
 
         Ok(Self::Label(label))
@@ -29,9 +58,38 @@ impl Parse for TraceStackArgs {
 }
 
 pub(crate) fn trace_stack_attribute(attr: TokenStream, input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(attr as TraceStackArgs);
-    let mut function = parse_macro_input!(input as ItemFn);
-    let function_name = &function.sig.ident;
+    let args = match syn::parse::<TraceStackArgs>(attr) {
+        Ok(args) => args,
+        Err(err) => return err.to_compile_error().into(),
+    };
+    let input: proc_macro2::TokenStream = input.into();
+
+    if let Ok(mut function) = syn::parse2::<ItemFn>(input.clone()) {
+        let guard = trace_guard(&args, &function.sig.ident);
+        let body = &function.block;
+        function.block = syn::parse_quote!({
+            #guard
+            #body
+        });
+        return quote!(#function).into();
+    }
+
+    if let Ok(mut function) = syn::parse2::<ImplItemFn>(input.clone()) {
+        let guard = trace_guard(&args, &function.sig.ident);
+        let body = &function.block;
+        function.block = syn::parse_quote!({
+            #guard
+            #body
+        });
+        return quote!(#function).into();
+    }
+
+    syn::Error::new_spanned(input, "trace_stack can only be applied to functions")
+        .to_compile_error()
+        .into()
+}
+
+fn trace_guard(args: &TraceStackArgs, function_name: &syn::Ident) -> proc_macro2::TokenStream {
     let inferred_span_name = LitStr::new(&function_name.to_string(), function_name.span());
 
     let (span_name, guard) = match args {
@@ -41,21 +99,29 @@ pub(crate) fn trace_stack_attribute(attr: TokenStream, input: TokenStream) -> To
             };
             (inferred_span_name, guard)
         }
+        TraceStackArgs::InferredWithDetail(detail) => {
+            let guard = quote! {
+                let _stack = crate::stack::trace_scope_with_detail(concat!(module_path!(), "::", stringify!(#function_name)), #detail);
+            };
+            (inferred_span_name, guard)
+        }
         TraceStackArgs::Label(label) => {
             let guard = quote! {
                 let _stack = crate::stack::trace_scope(#label);
             };
-            (label, guard)
+            (label.clone(), guard)
+        }
+        TraceStackArgs::LabelWithDetail(label, detail) => {
+            let guard = quote! {
+                let _stack = crate::stack::trace_scope_with_detail(#label, #detail);
+            };
+            (label.clone(), guard)
         }
     };
 
-    let body = &function.block;
-    function.block = syn::parse_quote!({
+    quote! {
         #[cfg(feature = "stacker")]
         let _stack_span = tracing::debug_span!(target: "turso_stack", #span_name).entered();
         #guard
-        #body
-    });
-
-    quote!(#function).into()
+    }
 }

--- a/macros/src/trace_stack.rs
+++ b/macros/src/trace_stack.rs
@@ -95,13 +95,13 @@ fn trace_guard(args: &TraceStackArgs, function_name: &syn::Ident) -> proc_macro2
     let (span_name, guard) = match args {
         TraceStackArgs::Inferred => {
             let guard = quote! {
-                crate::stack::trace_stack!(concat!(module_path!(), "::", stringify!(#function_name)));
+                crate::stack::trace_stack!(stringify!(#function_name));
             };
             (inferred_span_name, guard)
         }
         TraceStackArgs::InferredWithDetail(detail) => {
             let guard = quote! {
-                crate::stack::trace_stack!(concat!(module_path!(), "::", stringify!(#function_name)), #detail);
+                crate::stack::trace_stack!(stringify!(#function_name), #detail);
             };
             (inferred_span_name, guard)
         }
@@ -121,7 +121,7 @@ fn trace_guard(args: &TraceStackArgs, function_name: &syn::Ident) -> proc_macro2
 
     quote! {
         #[cfg(feature = "stacker")]
-        let _stack_span = tracing::debug_span!(target: "turso_stack", #span_name).entered();
+        let _stack_span = tracing::debug_span!(target: "turso_stack", #span_name, module_path = module_path!()).entered();
         #guard
     }
 }

--- a/macros/src/trace_stack.rs
+++ b/macros/src/trace_stack.rs
@@ -95,25 +95,25 @@ fn trace_guard(args: &TraceStackArgs, function_name: &syn::Ident) -> proc_macro2
     let (span_name, guard) = match args {
         TraceStackArgs::Inferred => {
             let guard = quote! {
-                let _stack = crate::stack::trace_scope(concat!(module_path!(), "::", stringify!(#function_name)));
+                crate::stack::trace_stack!(concat!(module_path!(), "::", stringify!(#function_name)));
             };
             (inferred_span_name, guard)
         }
         TraceStackArgs::InferredWithDetail(detail) => {
             let guard = quote! {
-                let _stack = crate::stack::trace_scope_with_detail(concat!(module_path!(), "::", stringify!(#function_name)), #detail);
+                crate::stack::trace_stack!(concat!(module_path!(), "::", stringify!(#function_name)), #detail);
             };
             (inferred_span_name, guard)
         }
         TraceStackArgs::Label(label) => {
             let guard = quote! {
-                let _stack = crate::stack::trace_scope(#label);
+                crate::stack::trace_stack!(#label);
             };
             (label.clone(), guard)
         }
         TraceStackArgs::LabelWithDetail(label, detail) => {
             let guard = quote! {
-                let _stack = crate::stack::trace_scope_with_detail(#label, #detail);
+                crate::stack::trace_stack!(#label, #detail);
             };
             (label.clone(), guard)
         }

--- a/perf/memory/Cargo.toml
+++ b/perf/memory/Cargo.toml
@@ -8,11 +8,20 @@ license.workspace = true
 name = "memory-benchmark"
 path = "src/main.rs"
 
+[[bin]]
+name = "stack-report"
+path = "src/stack_report.rs"
+
+[features]
+stacker = ["turso/stacker"]
+
 [dependencies]
 turso = { path = "../../bindings/rust", default-features = false }
+turso_parser = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, default-features = true, features = ["full"] }
 tracing-subscriber = { workspace = true }
+tracing = { workspace = true }
 memory-stats = "1.2.0"
 dhat = "0.3"
 serde = { workspace = true, features = ["derive"] }

--- a/perf/memory/Cargo.toml
+++ b/perf/memory/Cargo.toml
@@ -22,6 +22,7 @@ clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, default-features = true, features = ["full"] }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
+stacker = "0.1"
 memory-stats = "1.2.0"
 dhat = "0.3"
 serde = { workspace = true, features = ["derive"] }

--- a/perf/memory/src/stack_report.rs
+++ b/perf/memory/src/stack_report.rs
@@ -38,6 +38,14 @@ struct Args {
     /// Output format.
     #[arg(long = "format", default_value = "human")]
     format: OutputFormat,
+
+    /// Only include reports for these 1-based statement indexes. Can be repeated or comma-separated.
+    #[arg(long = "statement", value_delimiter = ',')]
+    statements: Vec<usize>,
+
+    /// Only include reports for statements whose SQL contains this substring. Can be repeated.
+    #[arg(long = "sql-contains")]
+    sql_contains: Vec<String>,
 }
 
 #[derive(Debug, Default)]
@@ -235,7 +243,7 @@ async fn main() -> Result<()> {
         .build()
         .await?;
     let conn = db.connect()?;
-    let mut statements = execute_sql_payload(&conn, &sql, Arc::clone(&collector)).await?;
+    let mut statements = execute_sql_payload(&conn, &sql, Arc::clone(&collector), &args).await?;
     statements.sort_by(|a, b| {
         b.stack_used
             .cmp(&a.stack_used)
@@ -272,6 +280,7 @@ async fn execute_sql_payload(
     conn: &turso::Connection,
     sql: &str,
     collector: Arc<StackCollector>,
+    args: &Args,
 ) -> Result<Vec<StatementReport>> {
     let mut reports = Vec::new();
 
@@ -305,15 +314,40 @@ async fn execute_sql_payload(
             {}
         }
 
-        let samples = collector.samples_from(start_sample);
-        reports.push(build_statement_report(
-            index + 1,
-            statement,
-            baseline_remaining_stack,
-            samples,
-        ));
+        let statement_index = index + 1;
+        if statement_matches_report_filters(statement_index, statement, args) {
+            let samples = collector.samples_from(start_sample);
+            reports.push(build_statement_report(
+                statement_index,
+                statement,
+                baseline_remaining_stack,
+                samples,
+            ));
+        }
     }
     Ok(reports)
+}
+
+fn statement_matches_report_filters(index: usize, sql: &str, args: &Args) -> bool {
+    if !args.statements.is_empty() && !args.statements.contains(&index) {
+        return false;
+    }
+    if !args.sql_contains.is_empty()
+        && !args
+            .sql_contains
+            .iter()
+            .any(|needle| contains_ignore_ascii_case(sql, needle))
+    {
+        return false;
+    }
+    true
+}
+
+fn contains_ignore_ascii_case(value: &str, needle: &str) -> bool {
+    value
+        .as_bytes()
+        .windows(needle.len())
+        .any(|candidate| candidate.eq_ignore_ascii_case(needle.as_bytes()))
 }
 
 fn split_sql_statements(sql: &str) -> Result<Vec<&str>> {
@@ -800,6 +834,54 @@ mod tests {
     use super::*;
 
     #[test]
+    fn statement_filter_matches_one_based_indexes() {
+        let args = args_with_filters(vec![2, 4], Vec::new());
+
+        assert!(!statement_matches_report_filters(1, "SELECT 1", &args));
+        assert!(statement_matches_report_filters(2, "SELECT 2", &args));
+        assert!(!statement_matches_report_filters(3, "SELECT 3", &args));
+        assert!(statement_matches_report_filters(4, "SELECT 4", &args));
+    }
+
+    #[test]
+    fn sql_contains_filter_matches_any_substring() {
+        let args = args_with_filters(Vec::new(), vec!["trigger", "GENERATED"]);
+
+        assert!(statement_matches_report_filters(
+            1,
+            "CREATE TRIGGER cleanup AFTER INSERT ON t BEGIN SELECT 1; END",
+            &args
+        ));
+        assert!(statement_matches_report_filters(
+            2,
+            "CREATE TABLE t(x INT GENERATED ALWAYS AS (1))",
+            &args
+        ));
+        assert!(!statement_matches_report_filters(
+            3,
+            "CREATE TABLE t(x)",
+            &args
+        ));
+    }
+
+    #[test]
+    fn combined_filters_require_index_and_sql_match() {
+        let args = args_with_filters(vec![3], vec!["trigger"]);
+
+        assert!(!statement_matches_report_filters(
+            2,
+            "CREATE TRIGGER cleanup AFTER INSERT ON t BEGIN SELECT 1; END",
+            &args
+        ));
+        assert!(!statement_matches_report_filters(3, "SELECT 1", &args));
+        assert!(statement_matches_report_filters(
+            3,
+            "CREATE TRIGGER cleanup AFTER INSERT ON t BEGIN SELECT 1; END",
+            &args
+        ));
+    }
+
+    #[test]
     fn statement_stack_used_is_peak_delta_not_sum() {
         let report = build_statement_report(
             1,
@@ -974,5 +1056,15 @@ mod tests {
         let buffer = [0_u8; 16 * 1024];
         std::hint::black_box(&buffer);
         stacker::remaining_stack().expect("remaining stack should be available")
+    }
+
+    fn args_with_filters(statements: Vec<usize>, sql_contains: Vec<&str>) -> Args {
+        Args {
+            sql: PathBuf::from("-"),
+            top: 40,
+            format: OutputFormat::Human,
+            statements,
+            sql_contains: sql_contains.into_iter().map(str::to_string).collect(),
+        }
     }
 }

--- a/perf/memory/src/stack_report.rs
+++ b/perf/memory/src/stack_report.rs
@@ -90,6 +90,7 @@ struct SpanReport {
     label: String,
     detail: Option<String>,
     remaining_stack: usize,
+    cumulative_stack_used: usize,
     stack_used: usize,
 }
 
@@ -321,18 +322,7 @@ fn build_statement_report(
         .map(|sample| sample.remaining_stack)
         .min()
         .unwrap_or(baseline_remaining_stack);
-    let mut spans = samples
-        .iter()
-        .enumerate()
-        .filter(|(_, sample)| matches!(sample.phase, StackPhase::Enter | StackPhase::Sample))
-        .map(|(trace_sequence, sample)| SpanReport {
-            trace_sequence: trace_sequence + 1,
-            label: sample.label.clone(),
-            detail: sample.detail.clone(),
-            remaining_stack: sample.remaining_stack,
-            stack_used: baseline_remaining_stack.saturating_sub(sample.remaining_stack),
-        })
-        .collect::<Vec<_>>();
+    let mut spans = build_span_reports(baseline_remaining_stack, &samples);
     spans.sort_by(|a, b| {
         b.stack_used
             .cmp(&a.stack_used)
@@ -348,6 +338,54 @@ fn build_statement_report(
         samples: spans.len(),
         spans,
     }
+}
+
+fn build_span_reports(baseline_remaining_stack: usize, samples: &[StackSample]) -> Vec<SpanReport> {
+    let mut active_stack = vec![baseline_remaining_stack];
+    let mut spans = Vec::new();
+
+    for (trace_sequence, sample) in samples.iter().enumerate() {
+        match sample.phase {
+            StackPhase::Enter => {
+                let parent_remaining = active_stack
+                    .last()
+                    .copied()
+                    .unwrap_or(baseline_remaining_stack);
+                spans.push(SpanReport {
+                    trace_sequence: trace_sequence + 1,
+                    label: sample.label.clone(),
+                    detail: sample.detail.clone(),
+                    remaining_stack: sample.remaining_stack,
+                    cumulative_stack_used: baseline_remaining_stack
+                        .saturating_sub(sample.remaining_stack),
+                    stack_used: parent_remaining.saturating_sub(sample.remaining_stack),
+                });
+                active_stack.push(sample.remaining_stack);
+            }
+            StackPhase::Exit => {
+                let _ = active_stack.pop();
+                if active_stack.is_empty() {
+                    active_stack.push(baseline_remaining_stack);
+                }
+            }
+            StackPhase::Sample => {
+                let parent_remaining = active_stack
+                    .last()
+                    .copied()
+                    .unwrap_or(baseline_remaining_stack);
+                spans.push(SpanReport {
+                    trace_sequence: trace_sequence + 1,
+                    label: sample.label.clone(),
+                    detail: sample.detail.clone(),
+                    remaining_stack: sample.remaining_stack,
+                    cumulative_stack_used: baseline_remaining_stack
+                        .saturating_sub(sample.remaining_stack),
+                    stack_used: parent_remaining.saturating_sub(sample.remaining_stack),
+                });
+            }
+        }
+    }
+    spans
 }
 
 fn print_human(report: &StackReport, top: usize) {
@@ -372,8 +410,8 @@ fn print_human(report: &StackReport, top: usize) {
             continue;
         }
         println!(
-            "  {:>5} {:>12} {:>12}  span",
-            "seq", "stack_used", "remaining"
+            "  {:>5} {:>12} {:>12} {:>12}  span",
+            "seq", "self_used", "cum_used", "remaining"
         );
         for span in statement.spans.iter().take(top) {
             let label = match &span.detail {
@@ -381,8 +419,12 @@ fn print_human(report: &StackReport, top: usize) {
                 None => span.label.clone(),
             };
             println!(
-                "  {:>5} {:>12} {:>12}  {}",
-                span.trace_sequence, span.stack_used, span.remaining_stack, label
+                "  {:>5} {:>12} {:>12} {:>12}  {}",
+                span.trace_sequence,
+                span.stack_used,
+                span.cumulative_stack_used,
+                span.remaining_stack,
+                label
             );
         }
         if statement.spans.len() > top {
@@ -394,7 +436,7 @@ fn print_human(report: &StackReport, top: usize) {
 
 fn print_csv(report: &StackReport) {
     println!(
-        "statement_index,statement_sql,statement_stack_used,statement_baseline_remaining_stack,statement_min_remaining_stack,statement_samples,span_trace_sequence,span_label,span_detail,span_stack_used,span_remaining_stack"
+        "statement_index,statement_sql,statement_stack_used,statement_baseline_remaining_stack,statement_min_remaining_stack,statement_samples,span_trace_sequence,span_label,span_detail,span_self_stack_used,span_cumulative_stack_used,span_remaining_stack"
     );
     for statement in &report.statements {
         if statement.spans.is_empty() {
@@ -411,7 +453,7 @@ fn print_csv(report: &StackReport) {
         }
         for span in &statement.spans {
             println!(
-                "{},{},{},{},{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{},{},{},{},{}",
                 statement.index,
                 csv_escape(&statement.sql),
                 statement.stack_used,
@@ -422,6 +464,7 @@ fn print_csv(report: &StackReport) {
                 csv_escape(&span.label),
                 csv_escape(span.detail.as_deref().unwrap_or("")),
                 span.stack_used,
+                span.cumulative_stack_used,
                 span.remaining_stack
             );
         }
@@ -492,6 +535,12 @@ mod tests {
                     remaining_stack: 7_500,
                 },
                 StackSample {
+                    label: "inner:end".to_string(),
+                    detail: None,
+                    phase: StackPhase::Exit,
+                    remaining_stack: 9_000,
+                },
+                StackSample {
                     label: "outer:end".to_string(),
                     detail: None,
                     phase: StackPhase::Exit,
@@ -503,14 +552,15 @@ mod tests {
         assert_eq!(report.stack_used, 2_500);
         assert_eq!(report.min_remaining_stack, 7_500);
         assert_eq!(report.spans[0].label, "inner");
-        assert_eq!(report.spans[0].stack_used, 2_500);
+        assert_eq!(report.spans[0].stack_used, 1_500);
+        assert_eq!(report.spans[0].cumulative_stack_used, 2_500);
         assert_eq!(
             report
                 .spans
                 .iter()
                 .map(|span| span.stack_used)
                 .sum::<usize>(),
-            3_500
+            2_500
         );
     }
 

--- a/perf/memory/src/stack_report.rs
+++ b/perf/memory/src/stack_report.rs
@@ -61,7 +61,16 @@ impl StackCollector {
 struct StackSample {
     label: String,
     detail: Option<String>,
+    phase: StackPhase,
     remaining_stack: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum StackPhase {
+    Enter,
+    Exit,
+    Sample,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -127,6 +136,7 @@ where
             .push(StackSample {
                 label,
                 detail: visitor.detail,
+                phase: visitor.phase.unwrap_or(StackPhase::Sample),
                 remaining_stack,
             });
     }
@@ -136,6 +146,7 @@ where
 struct StackEventVisitor {
     label: Option<String>,
     detail: Option<String>,
+    phase: Option<StackPhase>,
     remaining_stack: Option<usize>,
 }
 
@@ -150,6 +161,7 @@ impl Visit for StackEventVisitor {
                     self.detail = detail;
                 }
             }
+            "phase" => self.phase = parse_stack_phase(&unquote_debug_string(&rendered)),
             "remaining_stack" => {
                 self.remaining_stack = rendered.parse().ok();
             }
@@ -161,6 +173,7 @@ impl Visit for StackEventVisitor {
         match field.name() {
             "label" => self.label = Some(value.to_string()),
             "detail" if !value.is_empty() => self.detail = Some(value.to_string()),
+            "phase" => self.phase = parse_stack_phase(value),
             _ => {}
         }
     }
@@ -311,6 +324,7 @@ fn build_statement_report(
     let mut spans = samples
         .iter()
         .enumerate()
+        .filter(|(_, sample)| matches!(sample.phase, StackPhase::Enter | StackPhase::Sample))
         .map(|(trace_sequence, sample)| SpanReport {
             trace_sequence: trace_sequence + 1,
             label: sample.label.clone(),
@@ -437,10 +451,114 @@ fn parse_debug_option_string(value: &str) -> Option<String> {
         .or_else(|| Some(unquote_debug_string(value)))
 }
 
+fn parse_stack_phase(value: &str) -> Option<StackPhase> {
+    match value {
+        "enter" => Some(StackPhase::Enter),
+        "exit" => Some(StackPhase::Exit),
+        "sample" => Some(StackPhase::Sample),
+        _ => None,
+    }
+}
+
 fn csv_escape(value: &str) -> String {
     if value.contains(',') || value.contains('"') || value.contains('\n') {
         format!("\"{}\"", value.replace('"', "\"\""))
     } else {
         value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn statement_stack_used_is_peak_delta_not_sum() {
+        let report = build_statement_report(
+            1,
+            "SELECT 1",
+            10_000,
+            vec![
+                StackSample {
+                    label: "outer".to_string(),
+                    detail: None,
+                    phase: StackPhase::Enter,
+                    remaining_stack: 9_000,
+                },
+                StackSample {
+                    label: "inner".to_string(),
+                    detail: None,
+                    phase: StackPhase::Enter,
+                    remaining_stack: 7_500,
+                },
+                StackSample {
+                    label: "outer:end".to_string(),
+                    detail: None,
+                    phase: StackPhase::Exit,
+                    remaining_stack: 9_100,
+                },
+            ],
+        );
+
+        assert_eq!(report.stack_used, 2_500);
+        assert_eq!(report.min_remaining_stack, 7_500);
+        assert_eq!(report.spans[0].label, "inner");
+        assert_eq!(report.spans[0].stack_used, 2_500);
+        assert_eq!(
+            report
+                .spans
+                .iter()
+                .map(|span| span.stack_used)
+                .sum::<usize>(),
+            3_500
+        );
+    }
+
+    #[test]
+    fn span_sort_keeps_trace_sequence_for_ties() {
+        let report = build_statement_report(
+            1,
+            "SELECT 1",
+            10_000,
+            vec![
+                StackSample {
+                    label: "first".to_string(),
+                    detail: None,
+                    phase: StackPhase::Enter,
+                    remaining_stack: 8_000,
+                },
+                StackSample {
+                    label: "second".to_string(),
+                    detail: None,
+                    phase: StackPhase::Enter,
+                    remaining_stack: 8_000,
+                },
+            ],
+        );
+
+        assert_eq!(report.spans[0].trace_sequence, 1);
+        assert_eq!(report.spans[1].trace_sequence, 2);
+    }
+
+    #[test]
+    fn stacker_remaining_stack_tracks_real_stack_growth() {
+        let before = stacker::remaining_stack().expect("remaining stack should be available");
+        let inside = consume_stack_frame();
+        assert!(
+            before > inside,
+            "remaining stack should shrink inside a stack-consuming frame: before={before}, inside={inside}"
+        );
+        assert!(
+            before - inside >= 8 * 1024,
+            "expected at least an 8KiB observed stack delta, got {} bytes",
+            before - inside
+        );
+    }
+
+    #[inline(never)]
+    fn consume_stack_frame() -> usize {
+        let buffer = [0_u8; 16 * 1024];
+        std::hint::black_box(&buffer);
+        stacker::remaining_stack().expect("remaining stack should be available")
     }
 }

--- a/perf/memory/src/stack_report.rs
+++ b/perf/memory/src/stack_report.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::BTreeMap,
     fs,
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -31,7 +30,7 @@ struct Args {
     #[arg(long = "sql", short = 's')]
     sql: PathBuf,
 
-    /// Maximum number of lowest-stack labels to print in human output.
+    /// Maximum number of heaviest span samples to print per statement in human output.
     #[arg(long = "top", default_value = "40")]
     top: usize,
 
@@ -45,6 +44,19 @@ struct StackCollector {
     samples: Mutex<Vec<StackSample>>,
 }
 
+impl StackCollector {
+    fn sample_count(&self) -> usize {
+        self.samples
+            .lock()
+            .expect("stack collector mutex poisoned")
+            .len()
+    }
+
+    fn samples_from(&self, start: usize) -> Vec<StackSample> {
+        self.samples.lock().expect("stack collector mutex poisoned")[start..].to_vec()
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct StackSample {
     label: String,
@@ -53,13 +65,23 @@ struct StackSample {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct StackSummary {
+struct StatementReport {
+    index: usize,
+    sql: String,
+    baseline_remaining_stack: usize,
+    min_remaining_stack: usize,
+    stack_used: usize,
+    samples: usize,
+    spans: Vec<SpanReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SpanReport {
+    trace_sequence: usize,
     label: String,
     detail: Option<String>,
-    count: usize,
-    min_remaining_stack: usize,
-    max_remaining_stack: usize,
-    avg_remaining_stack: usize,
+    remaining_stack: usize,
+    stack_used: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -67,7 +89,7 @@ struct StackReport {
     sql: String,
     db: String,
     samples: usize,
-    summaries: Vec<StackSummary>,
+    statements: Vec<StatementReport>,
 }
 
 #[derive(Clone)]
@@ -174,25 +196,25 @@ async fn main() -> Result<()> {
 
     let sql = read_sql(&args.sql)?;
 
-    let db = turso::Builder::new_local(":memory")
+    let db = turso::Builder::new_local(":memory:")
         .experimental_generated_columns(true)
         .experimental_custom_types(true)
         .experimental_materialized_views(true)
         .build()
         .await?;
     let conn = db.connect()?;
-    execute_sql_payload(&conn, &sql).await?;
-
-    let samples = collector
-        .samples
-        .lock()
-        .expect("stack collector mutex poisoned")
-        .clone();
+    let mut statements = execute_sql_payload(&conn, &sql, Arc::clone(&collector)).await?;
+    statements.sort_by(|a, b| {
+        b.stack_used
+            .cmp(&a.stack_used)
+            .then_with(|| a.index.cmp(&b.index))
+    });
+    let samples = statements.iter().map(|statement| statement.samples).sum();
     let report = StackReport {
         sql: args.sql.display().to_string(),
-        db: "memory".to_string(),
-        samples: samples.len(),
-        summaries: summarize(samples),
+        db: ":memory:".to_string(),
+        samples,
+        statements,
     };
 
     match args.format {
@@ -212,13 +234,22 @@ fn read_sql(path: &PathBuf) -> Result<String> {
     }
 }
 
-async fn execute_sql_payload(conn: &turso::Connection, sql: &str) -> Result<()> {
-    for statement in split_sql_statements(sql)? {
+async fn execute_sql_payload(
+    conn: &turso::Connection,
+    sql: &str,
+    collector: Arc<StackCollector>,
+) -> Result<Vec<StatementReport>> {
+    let mut reports = Vec::new();
+
+    for (index, statement) in split_sql_statements(sql)?.into_iter().enumerate() {
         let statement = statement.trim();
         if statement.is_empty() {
             continue;
         }
 
+        let start_sample = collector.sample_count();
+        let baseline_remaining_stack =
+            stacker::remaining_stack().context("failed to read baseline remaining stack")?;
         let mut stmt = conn
             .prepare(statement)
             .await
@@ -239,8 +270,16 @@ async fn execute_sql_payload(conn: &turso::Connection, sql: &str) -> Result<()> 
                 .is_some()
             {}
         }
+
+        let samples = collector.samples_from(start_sample);
+        reports.push(build_statement_report(
+            index + 1,
+            statement,
+            baseline_remaining_stack,
+            samples,
+        ));
     }
-    Ok(())
+    Ok(reports)
 }
 
 fn split_sql_statements(sql: &str) -> Result<Vec<&str>> {
@@ -258,37 +297,43 @@ fn split_sql_statements(sql: &str) -> Result<Vec<&str>> {
     Ok(statements)
 }
 
-fn summarize(samples: Vec<StackSample>) -> Vec<StackSummary> {
-    let mut grouped: BTreeMap<(String, Option<String>), (usize, usize, usize, usize)> =
-        BTreeMap::new();
-
-    for sample in samples {
-        let key = (sample.label, sample.detail);
-        let entry = grouped.entry(key).or_insert((0, usize::MAX, 0, 0));
-        entry.0 += 1;
-        entry.1 = entry.1.min(sample.remaining_stack);
-        entry.2 = entry.2.max(sample.remaining_stack);
-        entry.3 += sample.remaining_stack;
-    }
-
-    let mut summaries = grouped
-        .into_iter()
-        .map(|((label, detail), (count, min, max, sum))| StackSummary {
-            label,
-            detail,
-            count,
-            min_remaining_stack: min,
-            max_remaining_stack: max,
-            avg_remaining_stack: sum / count,
+fn build_statement_report(
+    index: usize,
+    sql: &str,
+    baseline_remaining_stack: usize,
+    samples: Vec<StackSample>,
+) -> StatementReport {
+    let min_remaining_stack = samples
+        .iter()
+        .map(|sample| sample.remaining_stack)
+        .min()
+        .unwrap_or(baseline_remaining_stack);
+    let mut spans = samples
+        .iter()
+        .enumerate()
+        .map(|(trace_sequence, sample)| SpanReport {
+            trace_sequence: trace_sequence + 1,
+            label: sample.label.clone(),
+            detail: sample.detail.clone(),
+            remaining_stack: sample.remaining_stack,
+            stack_used: baseline_remaining_stack.saturating_sub(sample.remaining_stack),
         })
         .collect::<Vec<_>>();
-    summaries.sort_by(|a, b| {
-        a.min_remaining_stack
-            .cmp(&b.min_remaining_stack)
-            .then_with(|| a.label.cmp(&b.label))
-            .then_with(|| a.detail.cmp(&b.detail))
+    spans.sort_by(|a, b| {
+        b.stack_used
+            .cmp(&a.stack_used)
+            .then_with(|| a.trace_sequence.cmp(&b.trace_sequence))
     });
-    summaries
+
+    StatementReport {
+        index,
+        sql: single_line_sql(sql),
+        baseline_remaining_stack,
+        min_remaining_stack,
+        stack_used: baseline_remaining_stack.saturating_sub(min_remaining_stack),
+        samples: spans.len(),
+        spans,
+    }
 }
 
 fn print_human(report: &StackReport, top: usize) {
@@ -297,39 +342,80 @@ fn print_human(report: &StackReport, top: usize) {
     println!("DB:      {}", report.db);
     println!("Samples: {}", report.samples);
     println!();
-    println!(
-        "{:>8} {:>12} {:>12} {:>12}  label",
-        "count", "min", "max", "avg"
-    );
-    for summary in report.summaries.iter().take(top) {
-        let label = match &summary.detail {
-            Some(detail) => format!("{} detail={detail}", summary.label),
-            None => summary.label.clone(),
-        };
+
+    for statement in &report.statements {
         println!(
-            "{:>8} {:>12} {:>12} {:>12}  {}",
-            summary.count,
-            summary.min_remaining_stack,
-            summary.max_remaining_stack,
-            summary.avg_remaining_stack,
-            label
+            "statement #{:<4} stack_used={:<8} baseline={:<10} min_remaining={:<10} samples={:<6} {}",
+            statement.index,
+            statement.stack_used,
+            statement.baseline_remaining_stack,
+            statement.min_remaining_stack,
+            statement.samples,
+            statement.sql
         );
+        if statement.spans.is_empty() {
+            println!("  no stack samples");
+            continue;
+        }
+        println!(
+            "  {:>5} {:>12} {:>12}  span",
+            "seq", "stack_used", "remaining"
+        );
+        for span in statement.spans.iter().take(top) {
+            let label = match &span.detail {
+                Some(detail) => format!("{} detail={detail}", span.label),
+                None => span.label.clone(),
+            };
+            println!(
+                "  {:>5} {:>12} {:>12}  {}",
+                span.trace_sequence, span.stack_used, span.remaining_stack, label
+            );
+        }
+        if statement.spans.len() > top {
+            println!("  ... {} more spans", statement.spans.len() - top);
+        }
+        println!();
     }
 }
 
 fn print_csv(report: &StackReport) {
-    println!("label,detail,count,min_remaining_stack,max_remaining_stack,avg_remaining_stack");
-    for summary in &report.summaries {
-        println!(
-            "{},{},{},{},{},{}",
-            csv_escape(&summary.label),
-            csv_escape(summary.detail.as_deref().unwrap_or("")),
-            summary.count,
-            summary.min_remaining_stack,
-            summary.max_remaining_stack,
-            summary.avg_remaining_stack
-        );
+    println!(
+        "statement_index,statement_sql,statement_stack_used,statement_baseline_remaining_stack,statement_min_remaining_stack,statement_samples,span_trace_sequence,span_label,span_detail,span_stack_used,span_remaining_stack"
+    );
+    for statement in &report.statements {
+        if statement.spans.is_empty() {
+            println!(
+                "{},{},{},{},{},{},,,,,",
+                statement.index,
+                csv_escape(&statement.sql),
+                statement.stack_used,
+                statement.baseline_remaining_stack,
+                statement.min_remaining_stack,
+                statement.samples
+            );
+            continue;
+        }
+        for span in &statement.spans {
+            println!(
+                "{},{},{},{},{},{},{},{},{},{},{}",
+                statement.index,
+                csv_escape(&statement.sql),
+                statement.stack_used,
+                statement.baseline_remaining_stack,
+                statement.min_remaining_stack,
+                statement.samples,
+                span.trace_sequence,
+                csv_escape(&span.label),
+                csv_escape(span.detail.as_deref().unwrap_or("")),
+                span.stack_used,
+                span.remaining_stack
+            );
+        }
     }
+}
+
+fn single_line_sql(sql: &str) -> String {
+    sql.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn unquote_debug_string(value: &str) -> String {

--- a/perf/memory/src/stack_report.rs
+++ b/perf/memory/src/stack_report.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -81,6 +82,7 @@ struct StatementReport {
     min_remaining_stack: usize,
     stack_used: usize,
     samples: usize,
+    span_aggregates: Vec<SpanAggregateReport>,
     spans: Vec<SpanReport>,
 }
 
@@ -92,6 +94,21 @@ struct SpanReport {
     remaining_stack: usize,
     cumulative_stack_used: usize,
     stack_used: usize,
+    inclusive_stack_used: usize,
+    peak_path_hits: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct SpanAggregateReport {
+    label: String,
+    detail: Option<String>,
+    calls: usize,
+    total_self_stack_used: usize,
+    max_self_stack_used: usize,
+    total_inclusive_stack_used: usize,
+    max_inclusive_stack_used: usize,
+    max_cumulative_stack_used: usize,
+    peak_path_hits: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -99,6 +116,7 @@ struct StackReport {
     sql: String,
     db: String,
     samples: usize,
+    span_aggregates: Vec<SpanAggregateReport>,
     statements: Vec<StatementReport>,
 }
 
@@ -224,10 +242,12 @@ async fn main() -> Result<()> {
             .then_with(|| a.index.cmp(&b.index))
     });
     let samples = statements.iter().map(|statement| statement.samples).sum();
+    let span_aggregates = build_global_span_aggregates(&statements);
     let report = StackReport {
         sql: args.sql.display().to_string(),
         db: ":memory:".to_string(),
         samples,
+        span_aggregates,
         statements,
     };
 
@@ -322,7 +342,8 @@ fn build_statement_report(
         .map(|sample| sample.remaining_stack)
         .min()
         .unwrap_or(baseline_remaining_stack);
-    let mut spans = build_span_reports(baseline_remaining_stack, &samples);
+    let mut spans = build_span_reports(baseline_remaining_stack, min_remaining_stack, &samples);
+    let span_aggregates = aggregate_span_reports(&spans);
     spans.sort_by(|a, b| {
         b.stack_used
             .cmp(&a.stack_used)
@@ -336,21 +357,36 @@ fn build_statement_report(
         min_remaining_stack,
         stack_used: baseline_remaining_stack.saturating_sub(min_remaining_stack),
         samples: spans.len(),
+        span_aggregates,
         spans,
     }
 }
 
-fn build_span_reports(baseline_remaining_stack: usize, samples: &[StackSample]) -> Vec<SpanReport> {
-    let mut active_stack = vec![baseline_remaining_stack];
+#[derive(Debug)]
+struct ActiveSpan {
+    span_index: usize,
+    parent_remaining_stack: usize,
+    entry_remaining_stack: usize,
+    min_remaining_stack: usize,
+}
+
+fn build_span_reports(
+    baseline_remaining_stack: usize,
+    statement_min_remaining_stack: usize,
+    samples: &[StackSample],
+) -> Vec<SpanReport> {
+    let mut active_spans = Vec::<ActiveSpan>::new();
     let mut spans = Vec::new();
 
     for (trace_sequence, sample) in samples.iter().enumerate() {
         match sample.phase {
             StackPhase::Enter => {
-                let parent_remaining = active_stack
+                update_active_span_min(&mut active_spans, sample.remaining_stack);
+                let parent_remaining = active_spans
                     .last()
-                    .copied()
+                    .map(|span| span.entry_remaining_stack)
                     .unwrap_or(baseline_remaining_stack);
+                let span_index = spans.len();
                 spans.push(SpanReport {
                     trace_sequence: trace_sequence + 1,
                     label: sample.label.clone(),
@@ -359,20 +395,38 @@ fn build_span_reports(baseline_remaining_stack: usize, samples: &[StackSample]) 
                     cumulative_stack_used: baseline_remaining_stack
                         .saturating_sub(sample.remaining_stack),
                     stack_used: parent_remaining.saturating_sub(sample.remaining_stack),
+                    inclusive_stack_used: 0,
+                    peak_path_hits: 0,
                 });
-                active_stack.push(sample.remaining_stack);
+                active_spans.push(ActiveSpan {
+                    span_index,
+                    parent_remaining_stack: parent_remaining,
+                    entry_remaining_stack: sample.remaining_stack,
+                    min_remaining_stack: sample.remaining_stack,
+                });
+                if sample.remaining_stack == statement_min_remaining_stack {
+                    mark_peak_path(&active_spans, &mut spans);
+                }
             }
             StackPhase::Exit => {
-                let _ = active_stack.pop();
-                if active_stack.is_empty() {
-                    active_stack.push(baseline_remaining_stack);
+                update_active_span_min(&mut active_spans, sample.remaining_stack);
+                if sample.remaining_stack == statement_min_remaining_stack {
+                    mark_peak_path(&active_spans, &mut spans);
+                }
+                if let Some(active_span) = active_spans.pop() {
+                    finalize_active_span(active_span, &mut spans);
                 }
             }
             StackPhase::Sample => {
-                let parent_remaining = active_stack
+                update_active_span_min(&mut active_spans, sample.remaining_stack);
+                if sample.remaining_stack == statement_min_remaining_stack {
+                    mark_peak_path(&active_spans, &mut spans);
+                }
+                let parent_remaining = active_spans
                     .last()
-                    .copied()
+                    .map(|span| span.entry_remaining_stack)
                     .unwrap_or(baseline_remaining_stack);
+                let stack_used = parent_remaining.saturating_sub(sample.remaining_stack);
                 spans.push(SpanReport {
                     trace_sequence: trace_sequence + 1,
                     label: sample.label.clone(),
@@ -380,12 +434,95 @@ fn build_span_reports(baseline_remaining_stack: usize, samples: &[StackSample]) 
                     remaining_stack: sample.remaining_stack,
                     cumulative_stack_used: baseline_remaining_stack
                         .saturating_sub(sample.remaining_stack),
-                    stack_used: parent_remaining.saturating_sub(sample.remaining_stack),
+                    stack_used,
+                    inclusive_stack_used: stack_used,
+                    peak_path_hits: usize::from(
+                        sample.remaining_stack == statement_min_remaining_stack,
+                    ),
                 });
             }
         }
     }
+    while let Some(active_span) = active_spans.pop() {
+        finalize_active_span(active_span, &mut spans);
+    }
     spans
+}
+
+fn update_active_span_min(active_spans: &mut [ActiveSpan], remaining_stack: usize) {
+    for active_span in active_spans {
+        active_span.min_remaining_stack = active_span.min_remaining_stack.min(remaining_stack);
+    }
+}
+
+fn mark_peak_path(active_spans: &[ActiveSpan], spans: &mut [SpanReport]) {
+    for active_span in active_spans {
+        spans[active_span.span_index].peak_path_hits += 1;
+    }
+}
+
+fn finalize_active_span(active_span: ActiveSpan, spans: &mut [SpanReport]) {
+    spans[active_span.span_index].inclusive_stack_used = active_span
+        .parent_remaining_stack
+        .saturating_sub(active_span.min_remaining_stack);
+}
+
+fn build_global_span_aggregates(statements: &[StatementReport]) -> Vec<SpanAggregateReport> {
+    aggregate_span_reports(
+        statements
+            .iter()
+            .flat_map(|statement| statement.spans.iter()),
+    )
+}
+
+fn aggregate_span_reports<'a, I>(spans: I) -> Vec<SpanAggregateReport>
+where
+    I: IntoIterator<Item = &'a SpanReport>,
+{
+    let mut aggregates = BTreeMap::<(String, Option<String>), SpanAggregateReport>::new();
+    for span in spans {
+        let entry = aggregates
+            .entry((span.label.clone(), span.detail.clone()))
+            .or_insert_with(|| SpanAggregateReport {
+                label: span.label.clone(),
+                detail: span.detail.clone(),
+                calls: 0,
+                total_self_stack_used: 0,
+                max_self_stack_used: 0,
+                total_inclusive_stack_used: 0,
+                max_inclusive_stack_used: 0,
+                max_cumulative_stack_used: 0,
+                peak_path_hits: 0,
+            });
+        entry.calls += 1;
+        entry.total_self_stack_used += span.stack_used;
+        entry.max_self_stack_used = entry.max_self_stack_used.max(span.stack_used);
+        entry.total_inclusive_stack_used += span.inclusive_stack_used;
+        entry.max_inclusive_stack_used = entry
+            .max_inclusive_stack_used
+            .max(span.inclusive_stack_used);
+        entry.max_cumulative_stack_used = entry
+            .max_cumulative_stack_used
+            .max(span.cumulative_stack_used);
+        entry.peak_path_hits += span.peak_path_hits;
+    }
+
+    let mut aggregates = aggregates.into_values().collect::<Vec<_>>();
+    sort_span_aggregates(&mut aggregates);
+    aggregates
+}
+
+fn sort_span_aggregates(aggregates: &mut [SpanAggregateReport]) {
+    aggregates.sort_by(|a, b| {
+        b.total_inclusive_stack_used
+            .cmp(&a.total_inclusive_stack_used)
+            .then_with(|| b.max_inclusive_stack_used.cmp(&a.max_inclusive_stack_used))
+            .then_with(|| b.peak_path_hits.cmp(&a.peak_path_hits))
+            .then_with(|| b.calls.cmp(&a.calls))
+            .then_with(|| b.total_self_stack_used.cmp(&a.total_self_stack_used))
+            .then_with(|| a.label.cmp(&b.label))
+            .then_with(|| a.detail.cmp(&b.detail))
+    });
 }
 
 fn print_human(report: &StackReport, top: usize) {
@@ -394,6 +531,12 @@ fn print_human(report: &StackReport, top: usize) {
     println!("DB:      {}", report.db);
     println!("Samples: {}", report.samples);
     println!();
+
+    if !report.span_aggregates.is_empty() {
+        println!("global span aggregates:");
+        print_span_aggregate_rows(&report.span_aggregates, top, "  ");
+        println!();
+    }
 
     for statement in &report.statements {
         println!(
@@ -409,65 +552,206 @@ fn print_human(report: &StackReport, top: usize) {
             println!("  no stack samples");
             continue;
         }
+        println!("  aggregate spans:");
+        print_span_aggregate_rows(&statement.span_aggregates, top, "    ");
+        if statement.span_aggregates.len() > top {
+            println!(
+                "    ... {} more aggregate spans",
+                statement.span_aggregates.len() - top
+            );
+        }
+        println!("  span samples:");
         println!(
-            "  {:>5} {:>12} {:>12} {:>12}  span",
-            "seq", "self_used", "cum_used", "remaining"
+            "    {:>5} {:>12} {:>12} {:>12} {:>10} {:>12}  span",
+            "seq", "self_used", "incl_used", "cum_used", "peak_hits", "remaining"
         );
         for span in statement.spans.iter().take(top) {
-            let label = match &span.detail {
-                Some(detail) => format!("{} detail={detail}", span.label),
-                None => span.label.clone(),
-            };
+            let label = span_label(&span.label, span.detail.as_deref());
             println!(
-                "  {:>5} {:>12} {:>12} {:>12}  {}",
+                "    {:>5} {:>12} {:>12} {:>12} {:>10} {:>12}  {}",
                 span.trace_sequence,
                 span.stack_used,
+                span.inclusive_stack_used,
                 span.cumulative_stack_used,
+                span.peak_path_hits,
                 span.remaining_stack,
                 label
             );
         }
         if statement.spans.len() > top {
-            println!("  ... {} more spans", statement.spans.len() - top);
+            println!("    ... {} more spans", statement.spans.len() - top);
         }
         println!();
     }
 }
 
+fn print_span_aggregate_rows(aggregates: &[SpanAggregateReport], top: usize, indent: &str) {
+    println!(
+        "{indent}{:>7} {:>12} {:>12} {:>12} {:>12} {:>12} {:>10}  span",
+        "calls", "total_self", "max_self", "total_incl", "max_incl", "max_cum", "peak_hits"
+    );
+    for aggregate in aggregates.iter().take(top) {
+        let label = span_label(&aggregate.label, aggregate.detail.as_deref());
+        println!(
+            "{indent}{:>7} {:>12} {:>12} {:>12} {:>12} {:>12} {:>10}  {}",
+            aggregate.calls,
+            aggregate.total_self_stack_used,
+            aggregate.max_self_stack_used,
+            aggregate.total_inclusive_stack_used,
+            aggregate.max_inclusive_stack_used,
+            aggregate.max_cumulative_stack_used,
+            aggregate.peak_path_hits,
+            label
+        );
+    }
+}
+
 fn print_csv(report: &StackReport) {
     println!(
-        "statement_index,statement_sql,statement_stack_used,statement_baseline_remaining_stack,statement_min_remaining_stack,statement_samples,span_trace_sequence,span_label,span_detail,span_self_stack_used,span_cumulative_stack_used,span_remaining_stack"
+        "row_type,statement_index,statement_sql,statement_stack_used,statement_baseline_remaining_stack,statement_min_remaining_stack,statement_samples,span_trace_sequence,span_label,span_detail,span_self_stack_used,span_inclusive_stack_used,span_cumulative_stack_used,span_peak_path_hits,span_remaining_stack,aggregate_label,aggregate_detail,aggregate_calls,aggregate_total_self_stack_used,aggregate_max_self_stack_used,aggregate_total_inclusive_stack_used,aggregate_max_inclusive_stack_used,aggregate_max_cumulative_stack_used,aggregate_peak_path_hits"
     );
+    for aggregate in &report.span_aggregates {
+        print_csv_aggregate_row("global_aggregate", None, aggregate);
+    }
     for statement in &report.statements {
         if statement.spans.is_empty() {
-            println!(
-                "{},{},{},{},{},{},,,,,",
-                statement.index,
-                csv_escape(&statement.sql),
-                statement.stack_used,
-                statement.baseline_remaining_stack,
-                statement.min_remaining_stack,
-                statement.samples
-            );
+            print_csv_statement_row(statement);
             continue;
         }
-        for span in &statement.spans {
-            println!(
-                "{},{},{},{},{},{},{},{},{},{},{},{}",
-                statement.index,
-                csv_escape(&statement.sql),
-                statement.stack_used,
-                statement.baseline_remaining_stack,
-                statement.min_remaining_stack,
-                statement.samples,
-                span.trace_sequence,
-                csv_escape(&span.label),
-                csv_escape(span.detail.as_deref().unwrap_or("")),
-                span.stack_used,
-                span.cumulative_stack_used,
-                span.remaining_stack
-            );
+        for aggregate in &statement.span_aggregates {
+            print_csv_aggregate_row("statement_aggregate", Some(statement), aggregate);
         }
+        for span in &statement.spans {
+            print_csv_span_row(statement, span);
+        }
+    }
+}
+
+fn print_csv_statement_row(statement: &StatementReport) {
+    print_csv_row(vec![
+        "statement".to_string(),
+        statement.index.to_string(),
+        csv_escape(&statement.sql),
+        statement.stack_used.to_string(),
+        statement.baseline_remaining_stack.to_string(),
+        statement.min_remaining_stack.to_string(),
+        statement.samples.to_string(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+    ]);
+}
+
+fn print_csv_span_row(statement: &StatementReport, span: &SpanReport) {
+    print_csv_row(vec![
+        "span".to_string(),
+        statement.index.to_string(),
+        csv_escape(&statement.sql),
+        statement.stack_used.to_string(),
+        statement.baseline_remaining_stack.to_string(),
+        statement.min_remaining_stack.to_string(),
+        statement.samples.to_string(),
+        span.trace_sequence.to_string(),
+        csv_escape(&span.label),
+        csv_escape(span.detail.as_deref().unwrap_or("")),
+        span.stack_used.to_string(),
+        span.inclusive_stack_used.to_string(),
+        span.cumulative_stack_used.to_string(),
+        span.peak_path_hits.to_string(),
+        span.remaining_stack.to_string(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+    ]);
+}
+
+fn print_csv_aggregate_row(
+    row_type: &str,
+    statement: Option<&StatementReport>,
+    aggregate: &SpanAggregateReport,
+) {
+    let (
+        statement_index,
+        statement_sql,
+        statement_stack_used,
+        statement_baseline_remaining_stack,
+        statement_min_remaining_stack,
+        statement_samples,
+    ) = match statement {
+        Some(statement) => (
+            statement.index.to_string(),
+            csv_escape(&statement.sql),
+            statement.stack_used.to_string(),
+            statement.baseline_remaining_stack.to_string(),
+            statement.min_remaining_stack.to_string(),
+            statement.samples.to_string(),
+        ),
+        None => (
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ),
+    };
+
+    print_csv_row(vec![
+        row_type.to_string(),
+        statement_index,
+        statement_sql,
+        statement_stack_used,
+        statement_baseline_remaining_stack,
+        statement_min_remaining_stack,
+        statement_samples,
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+        csv_escape(&aggregate.label),
+        csv_escape(aggregate.detail.as_deref().unwrap_or("")),
+        aggregate.calls.to_string(),
+        aggregate.total_self_stack_used.to_string(),
+        aggregate.max_self_stack_used.to_string(),
+        aggregate.total_inclusive_stack_used.to_string(),
+        aggregate.max_inclusive_stack_used.to_string(),
+        aggregate.max_cumulative_stack_used.to_string(),
+        aggregate.peak_path_hits.to_string(),
+    ]);
+}
+
+fn print_csv_row(fields: Vec<String>) {
+    println!("{}", fields.join(","));
+}
+
+fn span_label(label: &str, detail: Option<&str>) -> String {
+    match detail {
+        Some(detail) => format!("{label} detail={detail}"),
+        None => label.to_string(),
     }
 }
 
@@ -553,7 +837,24 @@ mod tests {
         assert_eq!(report.min_remaining_stack, 7_500);
         assert_eq!(report.spans[0].label, "inner");
         assert_eq!(report.spans[0].stack_used, 1_500);
+        assert_eq!(report.spans[0].inclusive_stack_used, 1_500);
         assert_eq!(report.spans[0].cumulative_stack_used, 2_500);
+        let outer = report
+            .span_aggregates
+            .iter()
+            .find(|aggregate| aggregate.label == "outer")
+            .expect("outer aggregate should exist");
+        assert_eq!(outer.total_self_stack_used, 1_000);
+        assert_eq!(outer.total_inclusive_stack_used, 2_500);
+        assert_eq!(outer.peak_path_hits, 1);
+        let inner = report
+            .span_aggregates
+            .iter()
+            .find(|aggregate| aggregate.label == "inner")
+            .expect("inner aggregate should exist");
+        assert_eq!(inner.total_self_stack_used, 1_500);
+        assert_eq!(inner.total_inclusive_stack_used, 1_500);
+        assert_eq!(inner.peak_path_hits, 1);
         assert_eq!(
             report
                 .spans
@@ -574,13 +875,13 @@ mod tests {
                 StackSample {
                     label: "first".to_string(),
                     detail: None,
-                    phase: StackPhase::Enter,
+                    phase: StackPhase::Sample,
                     remaining_stack: 8_000,
                 },
                 StackSample {
                     label: "second".to_string(),
                     detail: None,
-                    phase: StackPhase::Enter,
+                    phase: StackPhase::Sample,
                     remaining_stack: 8_000,
                 },
             ],
@@ -588,6 +889,69 @@ mod tests {
 
         assert_eq!(report.spans[0].trace_sequence, 1);
         assert_eq!(report.spans[1].trace_sequence, 2);
+    }
+
+    #[test]
+    fn aggregate_spans_count_repeated_calls() {
+        let report = build_statement_report(
+            1,
+            "SELECT 1",
+            10_000,
+            vec![
+                StackSample {
+                    label: "leaf".to_string(),
+                    detail: Some("expr".to_string()),
+                    phase: StackPhase::Sample,
+                    remaining_stack: 9_000,
+                },
+                StackSample {
+                    label: "leaf".to_string(),
+                    detail: Some("expr".to_string()),
+                    phase: StackPhase::Sample,
+                    remaining_stack: 8_500,
+                },
+            ],
+        );
+
+        assert_eq!(report.span_aggregates.len(), 1);
+        let aggregate = &report.span_aggregates[0];
+        assert_eq!(aggregate.label, "leaf");
+        assert_eq!(aggregate.detail.as_deref(), Some("expr"));
+        assert_eq!(aggregate.calls, 2);
+        assert_eq!(aggregate.total_self_stack_used, 2_500);
+        assert_eq!(aggregate.max_self_stack_used, 1_500);
+        assert_eq!(aggregate.total_inclusive_stack_used, 2_500);
+        assert_eq!(aggregate.max_inclusive_stack_used, 1_500);
+        assert_eq!(aggregate.peak_path_hits, 1);
+    }
+
+    #[test]
+    fn exit_samples_contribute_to_active_span_inclusive_usage() {
+        let report = build_statement_report(
+            1,
+            "SELECT 1",
+            10_000,
+            vec![
+                StackSample {
+                    label: "scope".to_string(),
+                    detail: None,
+                    phase: StackPhase::Enter,
+                    remaining_stack: 9_500,
+                },
+                StackSample {
+                    label: "scope:end".to_string(),
+                    detail: None,
+                    phase: StackPhase::Exit,
+                    remaining_stack: 9_000,
+                },
+            ],
+        );
+
+        assert_eq!(report.stack_used, 1_000);
+        assert_eq!(report.spans.len(), 1);
+        assert_eq!(report.spans[0].stack_used, 500);
+        assert_eq!(report.spans[0].inclusive_stack_used, 1_000);
+        assert_eq!(report.spans[0].peak_path_hits, 1);
     }
 
     #[test]

--- a/perf/memory/src/stack_report.rs
+++ b/perf/memory/src/stack_report.rs
@@ -1,0 +1,360 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+use serde::Serialize;
+use tracing::{Event, Level, Subscriber, field::Visit};
+use tracing_subscriber::{
+    Layer,
+    layer::{Context as LayerContext, SubscriberExt},
+    registry::LookupSpan,
+};
+use turso_parser::parser::Parser as SqlParser;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum OutputFormat {
+    Human,
+    Json,
+    Csv,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "stack-report")]
+#[command(about = "Run a SQL payload and summarize turso stacker tracing samples")]
+struct Args {
+    /// SQL file to execute. Use '-' to read from stdin.
+    #[arg(long = "sql", short = 's')]
+    sql: PathBuf,
+
+    /// Maximum number of lowest-stack labels to print in human output.
+    #[arg(long = "top", default_value = "40")]
+    top: usize,
+
+    /// Output format.
+    #[arg(long = "format", default_value = "human")]
+    format: OutputFormat,
+}
+
+#[derive(Debug, Default)]
+struct StackCollector {
+    samples: Mutex<Vec<StackSample>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StackSample {
+    label: String,
+    detail: Option<String>,
+    remaining_stack: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StackSummary {
+    label: String,
+    detail: Option<String>,
+    count: usize,
+    min_remaining_stack: usize,
+    max_remaining_stack: usize,
+    avg_remaining_stack: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct StackReport {
+    sql: String,
+    db: String,
+    samples: usize,
+    summaries: Vec<StackSummary>,
+}
+
+#[derive(Clone)]
+struct StackLayer {
+    collector: Arc<StackCollector>,
+}
+
+impl<S> Layer<S> for StackLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, _ctx: LayerContext<'_, S>) -> bool {
+        metadata.target() == "turso_stack" && *metadata.level() <= Level::DEBUG
+    }
+
+    fn on_event(&self, event: &Event<'_>, _ctx: LayerContext<'_, S>) {
+        if event.metadata().target() != "turso_stack" {
+            return;
+        }
+
+        let mut visitor = StackEventVisitor::default();
+        event.record(&mut visitor);
+
+        let Some(label) = visitor.label else {
+            return;
+        };
+        let Some(remaining_stack) = visitor.remaining_stack else {
+            return;
+        };
+
+        self.collector
+            .samples
+            .lock()
+            .expect("stack collector mutex poisoned")
+            .push(StackSample {
+                label,
+                detail: visitor.detail,
+                remaining_stack,
+            });
+    }
+}
+
+#[derive(Default)]
+struct StackEventVisitor {
+    label: Option<String>,
+    detail: Option<String>,
+    remaining_stack: Option<usize>,
+}
+
+impl Visit for StackEventVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        let rendered = format!("{value:?}");
+        match field.name() {
+            "label" => self.label = Some(unquote_debug_string(&rendered)),
+            "detail" => {
+                let detail = parse_debug_option_string(&rendered);
+                if detail.as_deref().is_some_and(|value| !value.is_empty()) {
+                    self.detail = detail;
+                }
+            }
+            "remaining_stack" => {
+                self.remaining_stack = rendered.parse().ok();
+            }
+            _ => {}
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        match field.name() {
+            "label" => self.label = Some(value.to_string()),
+            "detail" if !value.is_empty() => self.detail = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "remaining_stack" {
+            self.remaining_stack = Some(value as usize);
+        }
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        if field.name() == "remaining_stack" {
+            self.remaining_stack = usize::try_from(value).ok();
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    // This single-threaded tool sets the flag before building the database
+    // objects, so stack guards consistently emit tracing events.
+    unsafe {
+        std::env::set_var("TURSO_TRACE_STACK", "1");
+    }
+
+    let collector = Arc::new(StackCollector::default());
+    let subscriber = tracing_subscriber::registry().with(StackLayer {
+        collector: Arc::clone(&collector),
+    });
+    tracing::subscriber::set_global_default(subscriber)
+        .context("failed to install stack tracing subscriber")?;
+
+    let sql = read_sql(&args.sql)?;
+
+    let db = turso::Builder::new_local(":memory")
+        .experimental_generated_columns(true)
+        .experimental_custom_types(true)
+        .experimental_materialized_views(true)
+        .build()
+        .await?;
+    let conn = db.connect()?;
+    execute_sql_payload(&conn, &sql).await?;
+
+    let samples = collector
+        .samples
+        .lock()
+        .expect("stack collector mutex poisoned")
+        .clone();
+    let report = StackReport {
+        sql: args.sql.display().to_string(),
+        db: "memory".to_string(),
+        samples: samples.len(),
+        summaries: summarize(samples),
+    };
+
+    match args.format {
+        OutputFormat::Human => print_human(&report, args.top),
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&report)?),
+        OutputFormat::Csv => print_csv(&report),
+    }
+
+    Ok(())
+}
+
+fn read_sql(path: &PathBuf) -> Result<String> {
+    if path.as_os_str() == "-" {
+        std::io::read_to_string(std::io::stdin()).context("failed to read SQL from stdin")
+    } else {
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))
+    }
+}
+
+async fn execute_sql_payload(conn: &turso::Connection, sql: &str) -> Result<()> {
+    for statement in split_sql_statements(sql)? {
+        let statement = statement.trim();
+        if statement.is_empty() {
+            continue;
+        }
+
+        let mut stmt = conn
+            .prepare(statement)
+            .await
+            .with_context(|| format!("failed to prepare statement: {statement}"))?;
+        if stmt.column_count() == 0 {
+            stmt.execute(())
+                .await
+                .with_context(|| format!("failed to execute statement: {statement}"))?;
+        } else {
+            let mut rows = stmt
+                .query(())
+                .await
+                .with_context(|| format!("failed to query statement: {statement}"))?;
+            while rows
+                .next()
+                .await
+                .with_context(|| format!("failed to drain statement rows: {statement}"))?
+                .is_some()
+            {}
+        }
+    }
+    Ok(())
+}
+
+fn split_sql_statements(sql: &str) -> Result<Vec<&str>> {
+    let mut statements = Vec::new();
+    let mut parser = SqlParser::new(sql.as_bytes());
+    let mut start = 0;
+    while parser.next_cmd()?.is_some() {
+        let end = parser.offset();
+        let statement = &sql[start..end];
+        if !statement.trim().is_empty() {
+            statements.push(statement);
+        }
+        start = end;
+    }
+    Ok(statements)
+}
+
+fn summarize(samples: Vec<StackSample>) -> Vec<StackSummary> {
+    let mut grouped: BTreeMap<(String, Option<String>), (usize, usize, usize, usize)> =
+        BTreeMap::new();
+
+    for sample in samples {
+        let key = (sample.label, sample.detail);
+        let entry = grouped.entry(key).or_insert((0, usize::MAX, 0, 0));
+        entry.0 += 1;
+        entry.1 = entry.1.min(sample.remaining_stack);
+        entry.2 = entry.2.max(sample.remaining_stack);
+        entry.3 += sample.remaining_stack;
+    }
+
+    let mut summaries = grouped
+        .into_iter()
+        .map(|((label, detail), (count, min, max, sum))| StackSummary {
+            label,
+            detail,
+            count,
+            min_remaining_stack: min,
+            max_remaining_stack: max,
+            avg_remaining_stack: sum / count,
+        })
+        .collect::<Vec<_>>();
+    summaries.sort_by(|a, b| {
+        a.min_remaining_stack
+            .cmp(&b.min_remaining_stack)
+            .then_with(|| a.label.cmp(&b.label))
+            .then_with(|| a.detail.cmp(&b.detail))
+    });
+    summaries
+}
+
+fn print_human(report: &StackReport, top: usize) {
+    println!("=== STACK USAGE REPORT ===");
+    println!("SQL:     {}", report.sql);
+    println!("DB:      {}", report.db);
+    println!("Samples: {}", report.samples);
+    println!();
+    println!(
+        "{:>8} {:>12} {:>12} {:>12}  label",
+        "count", "min", "max", "avg"
+    );
+    for summary in report.summaries.iter().take(top) {
+        let label = match &summary.detail {
+            Some(detail) => format!("{} detail={detail}", summary.label),
+            None => summary.label.clone(),
+        };
+        println!(
+            "{:>8} {:>12} {:>12} {:>12}  {}",
+            summary.count,
+            summary.min_remaining_stack,
+            summary.max_remaining_stack,
+            summary.avg_remaining_stack,
+            label
+        );
+    }
+}
+
+fn print_csv(report: &StackReport) {
+    println!("label,detail,count,min_remaining_stack,max_remaining_stack,avg_remaining_stack");
+    for summary in &report.summaries {
+        println!(
+            "{},{},{},{},{},{}",
+            csv_escape(&summary.label),
+            csv_escape(summary.detail.as_deref().unwrap_or("")),
+            summary.count,
+            summary.min_remaining_stack,
+            summary.max_remaining_stack,
+            summary.avg_remaining_stack
+        );
+    }
+}
+
+fn unquote_debug_string(value: &str) -> String {
+    value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(value)
+        .to_string()
+}
+
+fn parse_debug_option_string(value: &str) -> Option<String> {
+    if value == "None" {
+        return None;
+    }
+    value
+        .strip_prefix("Some(\"")
+        .and_then(|value| value.strip_suffix("\")"))
+        .map(str::to_string)
+        .or_else(|| Some(unquote_debug_string(value)))
+}
+
+fn csv_escape(value: &str) -> String {
+    if value.contains(',') || value.contains('"') || value.contains('\n') {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}

--- a/perf/memory/src/stack_report.rs
+++ b/perf/memory/src/stack_report.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use serde::Serialize;
-use tracing::{Event, Level, Subscriber, field::Visit};
+use tracing::{Event, Id, Level, Subscriber, field::Visit, span::Attributes};
 use tracing_subscriber::{
     Layer,
     layer::{Context as LayerContext, SubscriberExt},
@@ -141,7 +141,18 @@ where
         metadata.target() == "turso_stack" && *metadata.level() <= Level::DEBUG
     }
 
-    fn on_event(&self, event: &Event<'_>, _ctx: LayerContext<'_, S>) {
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: LayerContext<'_, S>) {
+        let mut visitor = StackSpanVisitor::default();
+        attrs.record(&mut visitor);
+
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(StackSpanFields {
+                module_path: visitor.module_path,
+            });
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: LayerContext<'_, S>) {
         if event.metadata().target() != "turso_stack" {
             return;
         }
@@ -155,6 +166,7 @@ where
         let Some(remaining_stack) = visitor.remaining_stack else {
             return;
         };
+        let label = scoped_stack_label(&ctx, event, &label);
 
         self.collector
             .samples
@@ -166,6 +178,30 @@ where
                 phase: visitor.phase.unwrap_or(StackPhase::Sample),
                 remaining_stack,
             });
+    }
+}
+
+#[derive(Debug)]
+struct StackSpanFields {
+    module_path: Option<String>,
+}
+
+#[derive(Default)]
+struct StackSpanVisitor {
+    module_path: Option<String>,
+}
+
+impl Visit for StackSpanVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "module_path" {
+            self.module_path = Some(unquote_debug_string(&format!("{value:?}")));
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "module_path" {
+            self.module_path = Some(value.to_string());
+        }
     }
 }
 
@@ -215,6 +251,107 @@ impl Visit for StackEventVisitor {
         if field.name() == "remaining_stack" {
             self.remaining_stack = usize::try_from(value).ok();
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StackPathSegment {
+    module_path: Option<String>,
+    name: String,
+}
+
+fn scoped_stack_label<S>(ctx: &LayerContext<'_, S>, event: &Event<'_>, label: &str) -> String
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    let event_segment = StackPathSegment {
+        module_path: None,
+        name: label.to_string(),
+    };
+    let Some(scope) = ctx.event_scope(event) else {
+        return format_stack_path(&[], &event_segment);
+    };
+
+    let scope_segments = scope
+        .from_root()
+        .filter(|span| span.metadata().target() == "turso_stack")
+        .map(|span| {
+            let module_path = span
+                .extensions()
+                .get::<StackSpanFields>()
+                .and_then(|fields| fields.module_path.clone());
+            StackPathSegment {
+                module_path,
+                name: span.metadata().name().to_string(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    format_stack_path(&scope_segments, &event_segment)
+}
+
+fn format_stack_path(scope_segments: &[StackPathSegment], event: &StackPathSegment) -> String {
+    let mut path = String::new();
+
+    for segment in scope_segments {
+        append_stack_path_segment(&mut path, segment);
+    }
+
+    if scope_segments
+        .last()
+        .is_some_and(|segment| stack_segments_match(segment, event))
+    {
+        return path;
+    }
+
+    append_stack_path_segment(&mut path, event);
+    path
+}
+
+fn stack_segments_match(
+    scope_segment: &StackPathSegment,
+    event_segment: &StackPathSegment,
+) -> bool {
+    scope_segment.name == event_segment.name
+        || event_segment
+            .name
+            .strip_prefix(scope_segment.module_path.as_deref().unwrap_or_default())
+            .is_some_and(|suffix| suffix == format!("::{}", scope_segment.name))
+}
+
+fn append_stack_path_segment(path: &mut String, segment: &StackPathSegment) {
+    let rendered = render_stack_path_segment(
+        segment.module_path.as_deref(),
+        &segment.name,
+        path.is_empty(),
+    );
+    if !path.is_empty() && !rendered.is_empty() {
+        path.push_str("::");
+    }
+    path.push_str(&rendered);
+}
+
+fn render_stack_path_segment(module_path: Option<&str>, name: &str, is_first: bool) -> String {
+    if let Some(module_path) = module_path {
+        if let Some(local_name) = name.strip_prefix(&format!("{module_path}::")) {
+            return if is_first {
+                format!("{module_path}::{local_name}")
+            } else {
+                local_name.to_string()
+            };
+        }
+
+        if name.contains("::") {
+            return name.to_string();
+        }
+
+        if is_first {
+            format!("{module_path}::{name}")
+        } else {
+            name.to_string()
+        }
+    } else {
+        name.to_string()
     }
 }
 
@@ -879,6 +1016,69 @@ mod tests {
             "CREATE TRIGGER cleanup AFTER INSERT ON t BEGIN SELECT 1; END",
             &args
         ));
+    }
+
+    #[test]
+    fn stack_path_does_not_repeat_same_module_for_nested_spans() {
+        let scope = vec![
+            StackPathSegment {
+                module_path: Some("turso_core::connection".to_string()),
+                name: "prepare_with_origin".to_string(),
+            },
+            StackPathSegment {
+                module_path: Some("turso_core::connection".to_string()),
+                name: "compile_cmd".to_string(),
+            },
+        ];
+        let event = StackPathSegment {
+            module_path: Some("turso_core::connection".to_string()),
+            name: "compile".to_string(),
+        };
+
+        assert_eq!(
+            format_stack_path(&scope, &event),
+            "turso_core::connection::prepare_with_origin::compile_cmd::compile"
+        );
+    }
+
+    #[test]
+    fn stack_path_does_not_append_event_when_it_matches_current_span() {
+        let scope = vec![StackPathSegment {
+            module_path: Some("turso_core::connection".to_string()),
+            name: "prepare_with_origin".to_string(),
+        }];
+        let event = StackPathSegment {
+            module_path: Some("turso_core::connection".to_string()),
+            name: "prepare_with_origin".to_string(),
+        };
+
+        assert_eq!(
+            format_stack_path(&scope, &event),
+            "turso_core::connection::prepare_with_origin"
+        );
+    }
+
+    #[test]
+    fn stack_path_uses_tracing_style_names_when_scope_moves_to_another_module() {
+        let scope = vec![
+            StackPathSegment {
+                module_path: Some("turso_core::connection".to_string()),
+                name: "prepare_with_origin".to_string(),
+            },
+            StackPathSegment {
+                module_path: Some("turso_core::translate".to_string()),
+                name: "translate".to_string(),
+            },
+        ];
+        let event = StackPathSegment {
+            module_path: Some("turso_core::translate".to_string()),
+            name: "dispatch".to_string(),
+        };
+
+        assert_eq!(
+            format_stack_path(&scope, &event),
+            "turso_core::connection::prepare_with_origin::translate::dispatch"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Use `stacker` crate to check the remaining stack space in the current function. Also adds for guard structs that emit tracing events to look at the remaining stack space. These events can then be collected with a custom tracing subscriber to produce a stack report in `perf/memory`

I think the overall output of what each field in the report is still a bit difficult to interpret here for a human, but I mainly want to use this with AI for it to distill the stack information and provide some summary for me to act on. It also helps for the AI to get reproducible results to compare the stack usage after some change. 

## Motivation and context
Want to investigate high stack usage in certain functions and this helps with instrumenting the code when needed to investigate with agents.


## Description of AI Usage
Codex helped me create the tool
