### PR TITLE
translate/refactor: remove resolve_label() footgun

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -171,7 +171,7 @@ pub fn emit_ungrouped_aggregation<'a>(
         program.preassign_label_to_next_insn(distinct_ctx.label_on_conflict);
     }
 
-    program.resolve_label(end_label, program.offset());
+    program.preassign_label_to_next_insn(end_label);
 
     Ok(())
 }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -240,7 +240,7 @@ fn emit_rename_sqlite_sequence_entry(
             table_name: crate::schema::SQLITE_SEQUENCE_TABLE_NAME.to_string(),
         });
 
-        program.resolve_label(continue_loop_label, program.offset());
+        program.preassign_label_to_next_insn(continue_loop_label);
     });
 }
 
@@ -376,7 +376,7 @@ fn emit_add_column_default_type_validation(
         description_reg: None,
     });
 
-    program.resolve_label(skip_check_label, program.offset());
+    program.preassign_label_to_next_insn(skip_check_label);
     Ok(())
 }
 
@@ -514,7 +514,7 @@ fn emit_add_virtual_column_validation(
             on_error: None,
             description_reg: None,
         });
-        program.resolve_label(notnull_passed, program.offset());
+        program.preassign_label_to_next_insn(notnull_passed);
     }
 
     program.emit_insn(Insn::Next {
@@ -522,7 +522,7 @@ fn emit_add_virtual_column_validation(
         pc_if_next: loop_start,
     });
 
-    program.resolve_label(skip_label, program.offset());
+    program.preassign_label_to_next_insn(skip_label);
     Ok(())
 }
 
@@ -661,7 +661,7 @@ fn emit_add_column_check_validation(
         program.preassign_label_to_next_insn(check_passed_label);
     }
 
-    program.resolve_label(skip_check_label, program.offset());
+    program.preassign_label_to_next_insn(skip_check_label);
     Ok(())
 }
 
@@ -1312,7 +1312,7 @@ pub fn translate_alter_table(
                         description_reg: None,
                     });
 
-                    program.resolve_label(skip_error_label, program.offset());
+                    program.preassign_label_to_next_insn(skip_error_label);
                 }
 
                 if default_type_mismatch {

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1066,7 +1066,7 @@ fn emit_compound_order_by(
         });
     }
 
-    program.resolve_label(sort_loop_next, program.offset());
+    program.preassign_label_to_next_insn(sort_loop_next);
     program.emit_insn(Insn::SorterNext {
         cursor_id: sort_cursor,
         pc_if_next: sort_loop_start,

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -751,7 +751,7 @@ fn emit_delete_row_common(
                 raise_error_if_no_matching_entry: index.where_clause.is_none(),
             });
             if let Some(label) = skip_delete_label {
-                program.resolve_label(label, program.offset());
+                program.preassign_label_to_next_insn(label);
             }
         }
 

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1484,7 +1484,7 @@ pub fn emit_cdc_autocommit_commit(
 
         emit_cdc_commit_insns(program, resolver, cdc_cursor_id)?;
 
-        program.resolve_label(skip_label, program.offset());
+        program.preassign_label_to_next_insn(skip_label);
     }
 
     Ok(())

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2154,7 +2154,7 @@ fn emit_update_insns<'a>(
         });
 
         if let Some(label) = skip_delete_label {
-            program.resolve_label(label, program.offset());
+            program.preassign_label_to_next_insn(label);
         }
     }
 
@@ -2180,7 +2180,7 @@ fn emit_update_insns<'a>(
         });
 
         if let Some(label) = skip_insert_label {
-            program.resolve_label(label, program.offset());
+            program.preassign_label_to_next_insn(label);
         }
     }
 

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -831,13 +831,13 @@ pub fn translate_condition_expr(
 
             if *not {
                 // When IN is TRUE (match found), NOT IN should be FALSE
-                program.resolve_label(not_true_label.unwrap(), program.offset());
+                program.preassign_label_to_next_insn(not_true_label.unwrap());
                 program.emit_insn(Insn::Goto {
                     target_pc: jump_target_when_false,
                 });
 
                 // When IN is FALSE (no match), NOT IN should be TRUE
-                program.resolve_label(not_false_label.unwrap(), program.offset());
+                program.preassign_label_to_next_insn(not_false_label.unwrap());
                 program.emit_insn(Insn::Goto {
                     target_pc: jump_target_when_true,
                 });
@@ -2052,7 +2052,7 @@ pub fn translate_expr(
                                 resolver,
                                 NoConstantOptReason::RegisterReuse,
                             )?;
-                            program.resolve_label(before_copy_label, program.offset());
+                            program.preassign_label_to_next_insn(before_copy_label);
                             program.emit_insn(Insn::Copy {
                                 src_reg: temp_reg,
                                 dst_reg: target_register,
@@ -3663,7 +3663,7 @@ pub fn translate_expr(
             });
 
             // False path: set result to 0
-            program.resolve_label(dest_if_false, program.offset());
+            program.preassign_label_to_next_insn(dest_if_false);
 
             // Force integer conversion with AddImm 0
             program.emit_insn(Insn::AddImm {
@@ -3677,7 +3677,7 @@ pub fn translate_expr(
                     dest: tmp,
                 });
             }
-            program.resolve_label(dest_if_null, program.offset());
+            program.preassign_label_to_next_insn(dest_if_null);
             program.emit_insn(Insn::Copy {
                 src_reg: tmp,
                 dst_reg: result_reg,

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -669,7 +669,7 @@ pub fn group_by_process_single_group(
         program.offset(),
         "check if ended group had data, and output if so",
     );
-    program.resolve_label(label_jump_after_comparison, program.offset());
+    program.preassign_label_to_next_insn(label_jump_after_comparison);
     program.emit_insn(Insn::Gosub {
         target_pc: labels.label_subrtn_acc_output,
         return_reg: registers.reg_subrtn_acc_output_return_offset,
@@ -891,7 +891,7 @@ pub fn group_by_process_single_group(
     }
 
     // Mark that we've stored data for this group
-    program.resolve_label(labels.label_acc_indicator_set_flag_true, program.offset());
+    program.preassign_label_to_next_insn(labels.label_acc_indicator_set_flag_true);
     program.add_comment(program.offset(), "indicate data in accumulator");
     program.emit_insn(Insn::Integer {
         value: 1,
@@ -972,7 +972,7 @@ pub fn group_by_emit_row_phase<'a>(
         can_fallthrough: false,
     });
 
-    program.resolve_label(labels.label_subrtn_acc_output, program.offset());
+    program.preassign_label_to_next_insn(labels.label_subrtn_acc_output);
 
     // Only output a row if there's data in the accumulator
     program.add_comment(program.offset(), "output group by row subroutine start");
@@ -983,14 +983,11 @@ pub fn group_by_emit_row_phase<'a>(
     });
 
     // If no data, return without outputting a row
-    program.resolve_label(
-        labels.label_group_by_end_without_emitting_row,
-        program.offset(),
-    );
+    program.preassign_label_to_next_insn(labels.label_group_by_end_without_emitting_row);
     // SELECT DISTINCT also jumps here if there is a duplicate.
     if let Distinctness::Distinct { ctx } = &plan.distinctness {
         let distinct_ctx = ctx.as_ref().expect("distinct context must exist");
-        program.resolve_label(distinct_ctx.label_on_conflict, program.offset());
+        program.preassign_label_to_next_insn(distinct_ctx.label_on_conflict);
     }
     program.emit_insn(Insn::Return {
         return_reg: registers.reg_subrtn_acc_output_return_offset,
@@ -998,7 +995,7 @@ pub fn group_by_emit_row_phase<'a>(
     });
 
     // Resolve the label for the start of the group by output row subroutine
-    program.resolve_label(labels.label_agg_final, program.offset());
+    program.preassign_label_to_next_insn(labels.label_agg_final);
     // Finalize aggregate values for output
     for (i, agg) in plan.aggregates.iter().enumerate() {
         let agg_start_reg = t_ctx
@@ -1091,7 +1088,7 @@ pub fn group_by_emit_row_phase<'a>(
 
     // Subroutine to clear accumulators for a new group
     program.add_comment(program.offset(), "clear accumulator subroutine start");
-    program.resolve_label(labels.label_subrtn_acc_clear, program.offset());
+    program.preassign_label_to_next_insn(labels.label_subrtn_acc_clear);
     let start_reg = registers.reg_non_aggregate_exprs_acc;
 
     // Reset all accumulator registers to NULL

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -389,7 +389,7 @@ pub fn translate_create_index(
         });
 
         if let Some(skip_row_label) = skip_row_label {
-            program.resolve_label(skip_row_label, program.offset());
+            program.preassign_label_to_next_insn(skip_row_label);
         }
         program.emit_insn(Insn::Next {
             cursor_id: table_cursor_id,
@@ -487,7 +487,7 @@ pub fn translate_create_index(
         });
 
         if let Some(skip_row_label) = skip_row_label {
-            program.resolve_label(skip_row_label, program.offset());
+            program.preassign_label_to_next_insn(skip_row_label);
         }
         program.emit_insn(Insn::Next {
             cursor_id: table_cursor_id,
@@ -519,7 +519,7 @@ pub fn translate_create_index(
             // we fall through to Halt with a unique constraint violation error.
             let goto_label = program.allocate_label();
             let label_after_sorter_compare = program.allocate_label();
-            program.resolve_label(goto_label, program.offset());
+            program.preassign_label_to_next_insn(goto_label);
             program.emit_insn(Insn::Goto {
                 target_pc: label_after_sorter_compare,
             });
@@ -1003,7 +1003,7 @@ pub fn translate_drop_index(
         cursor_id: sqlite_schema_cursor_id,
         pc_if_empty: loop_end_label,
     });
-    program.resolve_label(loop_start_label, program.offset());
+    program.preassign_label_to_next_insn(loop_start_label);
 
     // Read sqlite_schema.name into dest_reg
     let dest_reg = program.alloc_register();
@@ -1041,7 +1041,7 @@ pub fn translate_drop_index(
     program.emit_insn(Insn::Once {
         target_pc_when_reentered: label_once_end,
     });
-    program.resolve_label(label_once_end, program.offset());
+    program.preassign_label_to_next_insn(label_once_end);
 
     if let Some((cdc_cursor_id, _)) = cdc_table {
         let before_record_reg = if program.capture_data_changes_info().has_before() {
@@ -1074,13 +1074,13 @@ pub fn translate_drop_index(
         is_part_of_update: false,
     });
 
-    program.resolve_label(next_label, program.offset());
+    program.preassign_label_to_next_insn(next_label);
     program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: loop_start_label,
     });
 
-    program.resolve_label(loop_end_label, program.offset());
+    program.preassign_label_to_next_insn(loop_end_label);
     if let Some((cdc_cursor_id, _)) = cdc_table {
         emit_cdc_autocommit_commit(program, resolver, cdc_cursor_id)?;
     }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1213,7 +1213,7 @@ fn emit_epilogue(
 ) -> Result<()> {
     if inserting_multiple_rows {
         if let Some(temp_table_ctx) = &ctx.temp_table_ctx {
-            program.resolve_label(ctx.loop_labels.row_done, program.offset());
+            program.preassign_label_to_next_insn(ctx.loop_labels.row_done);
 
             program.emit_insn(Insn::Next {
                 cursor_id: temp_table_ctx.cursor_id,
@@ -1229,7 +1229,7 @@ fn emit_epilogue(
             });
         } else {
             // For multiple rows which not require a temp table, loop back
-            program.resolve_label(ctx.loop_labels.row_done, program.offset());
+            program.preassign_label_to_next_insn(ctx.loop_labels.row_done);
             program.emit_insn(Insn::Goto {
                 target_pc: ctx.loop_labels.loop_start,
             });
@@ -1241,7 +1241,7 @@ fn emit_epilogue(
             }
         }
     } else {
-        program.resolve_label(ctx.loop_labels.row_done, program.offset());
+        program.preassign_label_to_next_insn(ctx.loop_labels.row_done);
         // single-row falls through to epilogue
         program.emit_insn(Insn::Goto {
             target_pc: ctx.loop_labels.stmt_epilogue,
@@ -1259,7 +1259,7 @@ fn emit_epilogue(
         program.emit_insn(Insn::FkCheck { deferred: false });
         emit_returning_scan_back(program, buf);
     }
-    program.resolve_label(ctx.halt_label, program.offset());
+    program.preassign_label_to_next_insn(ctx.halt_label);
     Ok(())
 }
 
@@ -3288,7 +3288,7 @@ fn translate_virtual_table_insert(
     program.emit_insn(Insn::Close { cursor_id });
 
     let halt_label = program.allocate_label();
-    program.resolve_label(halt_label, program.offset());
+    program.preassign_label_to_next_insn(halt_label);
 
     Ok(())
 }
@@ -3797,7 +3797,7 @@ fn emit_replace_delete_conflicting_row(
         });
 
         if let Some(label) = skip_delete_label {
-            program.resolve_label(label, program.offset());
+            program.preassign_label_to_next_insn(label);
         }
     }
 
@@ -4180,10 +4180,10 @@ pub fn emit_parent_side_fk_decrement_on_insert(
             program.emit_insn(Insn::Goto { target_pc: skip });
 
             // Found: guarded counter decrement
-            program.resolve_label(found, program.offset());
+            program.preassign_label_to_next_insn(found);
             program.emit_insn(Insn::Close { cursor_id: icur });
             emit_guarded_fk_decrement(program, skip, pref.fk.deferred);
-            program.resolve_label(skip, program.offset());
+            program.preassign_label_to_next_insn(skip);
         } else {
             // fallback scan :(
             let ccur = open_read_table(program, child_tbl, database_id);
@@ -4194,7 +4194,7 @@ pub fn emit_parent_side_fk_decrement_on_insert(
             });
             let loop_top = program.allocate_label();
             let next_row = program.allocate_label();
-            program.resolve_label(loop_top, program.offset());
+            program.preassign_label_to_next_insn(loop_top);
 
             for (i, child_name) in child_cols.iter().enumerate() {
                 let (pos, _) = child_tbl.get_column(child_name).ok_or_else(|| {
@@ -4224,16 +4224,16 @@ pub fn emit_parent_side_fk_decrement_on_insert(
                 program.emit_insn(Insn::Goto {
                     target_pc: next_row,
                 });
-                program.resolve_label(cont, program.offset());
+                program.preassign_label_to_next_insn(cont);
             }
             // Matched one child row: guarded decrement of counter
             emit_guarded_fk_decrement(program, next_row, pref.fk.deferred);
-            program.resolve_label(next_row, program.offset());
+            program.preassign_label_to_next_insn(next_row);
             program.emit_insn(Insn::Next {
                 cursor_id: ccur,
                 pc_if_next: loop_top,
             });
-            program.resolve_label(done, program.offset());
+            program.preassign_label_to_next_insn(done);
             program.emit_insn(Insn::Close { cursor_id: ccur });
         }
     }

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -399,7 +399,7 @@ fn emit_loop_source<'a>(
             }
 
             if let Some(label) = label_emit_nonagg_only_once {
-                program.resolve_label(label, program.offset());
+                program.preassign_label_to_next_insn(label);
                 let flag = t_ctx.reg_nonagg_emit_once_flag.unwrap();
                 program.emit_int(1, flag);
             }

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -55,15 +55,14 @@ impl CloseLoop {
 
             let (table_cursor_id, index_cursor_id) =
                 table.resolve_cursors(program, mode.clone())?;
-            // Track the "next iteration" offset for semi/anti-join label resolution.
-            // For most operations this equals the loop_labels.next resolution offset;
-            // HashJoin overrides it to point at the Gosub Return or HashNext instead.
-            let mut semi_anti_next_pc = None;
-            // Helper: resolve loop_labels.next and record its offset for semi/anti-join.
+            // Track the "next iteration" anchor label for semi/anti-join label resolution.
+            // For most operations this is loop_labels.next itself;
+            // HashJoin overrides it to anchor at the Gosub Return or HashNext instead.
+            let mut semi_anti_next_anchor: Option<BranchOffset> = None;
+            // Helper: preassign loop_labels.next and record it as the semi/anti anchor.
             let mut resolve_next = |program: &mut ProgramBuilder| {
-                let pc = program.offset();
-                program.resolve_label(loop_labels.next, pc);
-                semi_anti_next_pc = Some(pc);
+                program.preassign_label_to_next_insn(loop_labels.next);
+                semi_anti_next_anchor = Some(loop_labels.next);
             };
             match &table.op {
                 Operation::Scan(scan) => {
@@ -215,7 +214,7 @@ impl CloseLoop {
 
                             // Once the current key is exhausted (or a seek found nothing),
                             // advance the outer ephemeral cursor and restart the equality seek.
-                            program.resolve_label(next_val_label, program.offset());
+                            program.preassign_label_to_next_insn(next_val_label);
                             program.emit_insn(Insn::Next {
                                 cursor_id: ephemeral_cursor_id,
                                 pc_if_next: outer_loop_start,
@@ -239,7 +238,7 @@ impl CloseLoop {
                         .cloned()
                     {
                         // Emit the close-loop teardown for a hash-join probe table.
-                        semi_anti_next_pc = HashProbeCloseEmitter::new(
+                        semi_anti_next_anchor = HashProbeCloseEmitter::new(
                             program,
                             t_ctx,
                             hash_join_op,
@@ -248,11 +247,11 @@ impl CloseLoop {
                             table_index,
                         )
                         .emit()?
-                        .semi_anti_next_pc;
+                        .semi_anti_next_anchor;
                     }
 
                     // Advance probe cursor.
-                    program.resolve_label(loop_labels.next, program.offset());
+                    program.preassign_label_to_next_insn(loop_labels.next);
                     let probe_cursor_id = table_cursor_id.expect("Probe table must have a cursor");
                     program.emit_insn(Insn::Next {
                         cursor_id: probe_cursor_id,
@@ -319,10 +318,10 @@ impl CloseLoop {
             }
 
             // Resolve any semi/anti-join "outer next" labels targeting this table.
-            if let Some(pc) = semi_anti_next_pc {
+            if let Some(anchor) = semi_anti_next_anchor {
                 for meta in t_ctx.meta_semi_anti_joins.iter().flatten() {
                     if meta.outer_table_idx == table_index {
-                        program.resolve_label(meta.label_next_outer, pc);
+                        program.link_label_to_other_label(meta.label_next_outer, anchor);
                     }
                 }
             }
@@ -365,7 +364,7 @@ impl CloseLoop {
                     // (e.g. SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a).
                     // If the left join match flag has been set to 1, we jump to the next row on the outer table,
                     // i.e. continue to the next row of t1 in our example.
-                    program.resolve_label(lj_meta.label_match_flag_check_value, program.offset());
+                    program.preassign_label_to_next_insn(lj_meta.label_match_flag_check_value);
                     let label_when_right_table_notnull = program.allocate_label();
                     program.emit_insn(Insn::IfPos {
                         reg: lj_meta.reg_match_flag,

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -903,12 +903,15 @@ impl<'a, 'plan> HashProbeSetupEmitter<'a, 'plan> {
 
 struct ProbeCloseState {
     label_next_probe_row: BranchOffset,
-    semi_anti_next_pc: Option<BranchOffset>,
+    semi_anti_next_anchor: Option<BranchOffset>,
 }
 
 /// Result of emitting hash-join probe teardown.
 pub(super) struct HashProbeCloseOutcome {
-    pub semi_anti_next_pc: Option<BranchOffset>,
+    /// Preassigned label anchored at the point semi/anti-join `label_next_outer`
+    /// labels should target. Callers link their labels to it via
+    /// `ProgramBuilder::link_label_to_other_label`.
+    pub semi_anti_next_anchor: Option<BranchOffset>,
 }
 
 /// Close-loop path of a hash-join probe.
@@ -957,10 +960,12 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
         let inner_loop_gosub_reg = self.hash_ctx.inner_loop_gosub_reg;
         let inner_loop_skip_label = self.hash_ctx.labels.inner_loop_skip;
         let label_next_probe_row = self.program.allocate_label();
-        let mut semi_anti_next_pc = None;
+        let mut semi_anti_next_anchor: Option<BranchOffset> = None;
 
         if let Some(gosub_reg) = inner_loop_gosub_reg {
-            semi_anti_next_pc = Some(self.program.offset());
+            let return_anchor = self.program.allocate_label();
+            self.program.preassign_label_to_next_insn(return_anchor);
+            semi_anti_next_anchor = Some(return_anchor);
             self.program.emit_insn(Insn::Return {
                 return_reg: gosub_reg,
                 can_fallthrough: false,
@@ -976,11 +981,10 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
             label_next_probe_row
         };
 
-        if semi_anti_next_pc.is_none() {
-            semi_anti_next_pc = Some(self.program.offset());
+        self.program.preassign_label_to_next_insn(hash_next_label);
+        if semi_anti_next_anchor.is_none() {
+            semi_anti_next_anchor = Some(hash_next_label);
         }
-        self.program
-            .resolve_label(hash_next_label, self.program.offset());
 
         // Grace dispatch: if grace_flag_reg > 0, jump to the grace loop's own
         // HashNext (which has a different miss target). This lets the inner body
@@ -1012,7 +1016,7 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
 
         Ok(ProbeCloseState {
             label_next_probe_row,
-            semi_anti_next_pc,
+            semi_anti_next_anchor,
         })
     }
 
@@ -1020,7 +1024,7 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
     fn emit_probe_miss_rows(&mut self, state: ProbeCloseState) -> Result<ProbeCloseState> {
         let ProbeCloseState {
             label_next_probe_row,
-            semi_anti_next_pc,
+            semi_anti_next_anchor,
         } = state;
 
         if matches!(self.hash_ctx.join_type, HashJoinType::FullOuter) {
@@ -1031,11 +1035,10 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
             let reg_match_flag = lj_meta.reg_match_flag;
 
             if let Some(check_outer_label) = self.hash_ctx.labels.check_outer {
-                self.program
-                    .resolve_label(check_outer_label, self.program.offset());
+                self.program.preassign_label_to_next_insn(check_outer_label);
             }
             self.program
-                .resolve_label(lj_meta.label_match_flag_check_value, self.program.offset());
+                .preassign_label_to_next_insn(lj_meta.label_match_flag_check_value);
 
             self.program.emit_insn(Insn::IfPos {
                 reg: reg_match_flag,
@@ -1074,7 +1077,7 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
 
         Ok(ProbeCloseState {
             label_next_probe_row,
-            semi_anti_next_pc,
+            semi_anti_next_anchor,
         })
     }
 
@@ -1082,13 +1085,15 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
     fn finish(&mut self, state: ProbeCloseState) -> HashProbeCloseOutcome {
         let ProbeCloseState {
             label_next_probe_row,
-            semi_anti_next_pc,
+            semi_anti_next_anchor,
         } = state;
 
         self.program
             .preassign_label_to_next_insn(label_next_probe_row);
 
-        HashProbeCloseOutcome { semi_anti_next_pc }
+        HashProbeCloseOutcome {
+            semi_anti_next_anchor,
+        }
     }
 
     pub(super) fn emit(mut self) -> Result<HashProbeCloseOutcome> {
@@ -1161,7 +1166,7 @@ pub(super) fn emit_hash_join_unmatched_build_rows<'a>(
             .zip(hash_ctx.labels.inner_loop_gosub),
     )?;
 
-    program.resolve_label(label_next_unmatched, program.offset());
+    program.preassign_label_to_next_insn(label_next_unmatched);
     program.emit_insn(Insn::HashNextUnmatched {
         hash_table_id: hash_table_reg,
         dest_reg: match_reg,
@@ -1292,7 +1297,7 @@ impl GraceHashLoop {
         // grace_hash_next: the grace loop's own HashNext, reached via IfPos dispatch
         // from the shared body.
         if let Some(grace_hash_next_label) = hash_ctx.labels.grace_hash_next {
-            program.resolve_label(grace_hash_next_label, program.offset());
+            program.preassign_label_to_next_insn(grace_hash_next_label);
         }
 
         // For FULL OUTER, HashNext miss goes to outer check (unmatched probe row).
@@ -1312,7 +1317,7 @@ impl GraceHashLoop {
         // FULL OUTER: unmatched probe row path.
         // If match_flag is still 0, emit the probe row with NULL build columns.
         if is_full_outer {
-            program.resolve_label(grace_outer_check, program.offset());
+            program.preassign_label_to_next_insn(grace_outer_check);
 
             let probe_table_idx = hash_join_op.probe_table_idx;
             if let Some(lj_meta) = t_ctx.meta_left_joins[probe_table_idx].as_ref() {
@@ -1361,7 +1366,7 @@ impl GraceHashLoop {
         }
 
         // grace_advance: probe entries exhausted for this partition.
-        program.resolve_label(grace_advance, program.offset());
+        program.preassign_label_to_next_insn(grace_advance);
 
         // LEFT/FULL OUTER: emit unmatched build rows for this partition BEFORE evicting.
         // After eviction, matched_bits are lost, so the global unmatched scan can't
@@ -1410,7 +1415,7 @@ impl GraceHashLoop {
                         .zip(hash_ctx.labels.inner_loop_gosub),
                 )?;
 
-                program.resolve_label(grace_next_unmatched, program.offset());
+                program.preassign_label_to_next_insn(grace_next_unmatched);
                 program.emit_insn(Insn::HashNextUnmatched {
                     hash_table_id: hash_table_reg,
                     dest_reg: match_reg,
@@ -1435,7 +1440,7 @@ impl GraceHashLoop {
         });
 
         // grace_cleanup: clear grace mode flag
-        program.resolve_label(grace_cleanup, program.offset());
+        program.preassign_label_to_next_insn(grace_cleanup);
         program.emit_insn(Insn::Integer {
             value: 0,
             dest: grace_flag_reg,

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -83,7 +83,7 @@ impl OpenLoop {
                 if prev_is_anti {
                     if let Some(prev_sa_meta) = t_ctx.meta_semi_anti_joins[prev_table_idx].as_ref()
                     {
-                        program.resolve_label(prev_sa_meta.label_body, program.offset());
+                        program.preassign_label_to_next_insn(prev_sa_meta.label_body);
                     }
                 }
             }
@@ -593,7 +593,7 @@ impl OpenLoop {
             if let Some(join_info) = table.join_info.as_ref() {
                 if join_info.is_outer() && !is_outer_hj_probe {
                     let lj_meta = t_ctx.meta_left_joins[joined_table_index].as_ref().unwrap();
-                    program.resolve_label(lj_meta.label_match_flag_set_true, program.offset());
+                    program.preassign_label_to_next_insn(lj_meta.label_match_flag_set_true);
                     program.emit_insn(Insn::Integer {
                         value: 1,
                         dest: lj_meta.reg_match_flag,
@@ -615,8 +615,7 @@ impl OpenLoop {
                     if matches!(hj.join_type, HashJoinType::FullOuter) {
                         let probe_idx = hj.probe_table_idx;
                         if let Some(lj_meta) = t_ctx.meta_left_joins[probe_idx].as_ref() {
-                            program
-                                .resolve_label(lj_meta.label_match_flag_set_true, program.offset());
+                            program.preassign_label_to_next_insn(lj_meta.label_match_flag_set_true);
                             program.emit_insn(Insn::Integer {
                                 value: 1,
                                 dest: lj_meta.reg_match_flag,

--- a/core/translate/main_loop/seek.rs
+++ b/core/translate/main_loop/seek.rs
@@ -88,7 +88,7 @@ fn encode_seek_keys_for_custom_types(
             type_def,
             resolver,
         )?;
-        program.resolve_label(skip_label, program.offset());
+        program.preassign_label_to_next_insn(skip_label);
     }
     Ok(())
 }

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -413,7 +413,7 @@ impl EmitOrderBy {
                             &type_def,
                             &t_ctx.resolver,
                         )?;
-                        program.resolve_label(skip_label, program.offset());
+                        program.preassign_label_to_next_insn(skip_label);
                     }
                 }
             }
@@ -440,7 +440,7 @@ impl EmitOrderBy {
             },
         )?;
 
-        program.resolve_label(sort_loop_next_label, program.offset());
+        program.preassign_label_to_next_insn(sort_loop_next_label);
         if !use_heap_sort {
             program.emit_insn(Insn::SorterNext {
                 cursor_id: sort_cursor,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -564,7 +564,7 @@ fn update_pragma(
                 on_error: None,
                 description_reg: None,
             });
-            program.resolve_label(set_cookie_label, program.offset());
+            program.preassign_label_to_next_insn(set_cookie_label);
             program.emit_insn(Insn::SetCookie {
                 db: database_id,
                 cookie: Cookie::IncrementalVacuum,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1241,7 +1241,7 @@ pub fn translate_create_table(
         value: 1,
         p5: 0,
     });
-    program.resolve_label(create_btree_label, program.offset());
+    program.preassign_label_to_next_insn(create_btree_label);
 
     let created_sequence_table = if has_autoincrement
         && resolver.with_schema(database_id, |s| {
@@ -1381,7 +1381,7 @@ pub fn translate_create_table(
         }
     }
 
-    program.resolve_label(parse_schema_label, program.offset());
+    program.preassign_label_to_next_insn(parse_schema_label);
     let schema_version = resolver.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
         db: database_id,
@@ -1883,7 +1883,7 @@ pub fn translate_drop_table(
             None,
             SQLITE_TABLEID,
         )?;
-        program.resolve_label(skip_cdc_label, program.offset());
+        program.preassign_label_to_next_insn(skip_cdc_label);
     }
     program.emit_insn(Insn::Delete {
         cursor_id: sqlite_schema_cursor_id_0,
@@ -1891,7 +1891,7 @@ pub fn translate_drop_table(
         is_part_of_update: false,
     });
 
-    program.resolve_label(next_label, program.offset());
+    program.preassign_label_to_next_insn(next_label);
     program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id_0,
         pc_if_next: metadata_loop,
@@ -1994,13 +1994,13 @@ pub fn translate_drop_table(
                 program.emit_insn(Insn::Goto {
                     target_pc: temp_next_label,
                 });
-                program.resolve_label(temp_delete_label, program.offset());
+                program.preassign_label_to_next_insn(temp_delete_label);
                 program.emit_insn(Insn::Delete {
                     cursor_id: temp_cursor,
                     table_name: SQLITE_TABLEID.to_string(),
                     is_part_of_update: false,
                 });
-                program.resolve_label(temp_next_label, program.offset());
+                program.preassign_label_to_next_insn(temp_next_label);
                 program.emit_insn(Insn::Next {
                     cursor_id: temp_cursor,
                     pc_if_next: temp_loop_label,
@@ -2153,7 +2153,7 @@ pub fn translate_drop_table(
             table_name: "scratch_table".to_string(),
         });
 
-        program.resolve_label(next_label, program.offset());
+        program.preassign_label_to_next_insn(next_label);
         program.emit_insn(Insn::Next {
             cursor_id: sqlite_schema_cursor_id_1,
             pc_if_next: copy_schema_to_temp_table_loop,
@@ -2161,7 +2161,7 @@ pub fn translate_drop_table(
         program.preassign_label_to_next_insn(copy_schema_to_temp_table_loop_end_label);
         // End loop to copy over row id's from the schema table for rows that have the same root page as the one that was moved
 
-        program.resolve_label(if_not_label, program.offset());
+        program.preassign_label_to_next_insn(if_not_label);
 
         // 5. Open a write cursor to the schema table and re-insert the records placed in the ephemeral table but insert the correct root page now
         program.emit_insn(Insn::OpenWrite {
@@ -2219,7 +2219,7 @@ pub fn translate_drop_table(
             table_name: SQLITE_TABLEID.to_string(),
         });
 
-        program.resolve_label(next_label, program.offset());
+        program.preassign_label_to_next_insn(next_label);
         program.emit_insn(Insn::Next {
             cursor_id: ephemeral_cursor_id,
             pc_if_next: copy_temp_table_to_schema_loop,
@@ -2273,7 +2273,7 @@ pub fn translate_drop_table(
             is_part_of_update: false,
         });
 
-        program.resolve_label(continue_loop_label, program.offset());
+        program.preassign_label_to_next_insn(continue_loop_label);
         program.emit_insn(Insn::Next {
             cursor_id: seq_cursor_id,
             pc_if_next: loop_start_label,
@@ -2327,7 +2327,7 @@ pub fn translate_drop_table(
             is_part_of_update: false,
         });
 
-        program.resolve_label(continue_ver_label, program.offset());
+        program.preassign_label_to_next_insn(continue_ver_label);
         program.emit_insn(Insn::Next {
             cursor_id: ver_cursor_id,
             pc_if_next: ver_loop_start_label,
@@ -2850,7 +2850,7 @@ pub fn translate_drop_type(
         is_part_of_update: false,
     });
 
-    program.resolve_label(skip_delete_label, program.offset());
+    program.preassign_label_to_next_insn(skip_delete_label);
 
     program.emit_insn(Insn::Next {
         cursor_id: types_cursor_id,

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -923,7 +923,7 @@ pub fn emit_upsert(
                 raise_error_if_no_matching_entry: false,
             });
             if let Some(label) = maybe_skip_del {
-                program.resolve_label(label, program.offset());
+                program.preassign_label_to_next_insn(label);
             }
 
             // Skip insert if NEW predicate false/NULL
@@ -1040,7 +1040,7 @@ pub fn emit_upsert(
             });
 
             if let Some(lbl) = maybe_skip_ins {
-                program.resolve_label(lbl, program.offset());
+                program.preassign_label_to_next_insn(lbl);
             }
         }
     }

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -536,7 +536,7 @@ pub fn translate_drop_view(
         is_part_of_update: false,
     });
 
-    program.resolve_label(skip_delete_label, program.offset());
+    program.preassign_label_to_next_insn(skip_delete_label);
 
     // Move to next row
     program.emit_insn(Insn::Next {
@@ -651,7 +651,7 @@ pub fn translate_drop_view(
             is_part_of_update: false,
         });
 
-        program.resolve_label(dbsp_skip_delete_label, program.offset());
+        program.preassign_label_to_next_insn(dbsp_skip_delete_label);
 
         // Move to next row
         program.emit_insn(Insn::Next {

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -791,7 +791,7 @@ fn emit_flush_buffer_if_new_partition(
             target_pc_gt: new_partition_label,
         });
 
-        program.resolve_label(new_partition_label, program.offset());
+        program.preassign_label_to_next_insn(new_partition_label);
         program.add_comment(program.offset(), "detected new partition");
         program.emit_insn(Insn::Gosub {
             target_pc: labels.flush_buffer,
@@ -808,7 +808,7 @@ fn emit_flush_buffer_if_new_partition(
             extra_amount: partition_by_len - 1,
         });
 
-        program.resolve_label(same_partition_label, program.offset());
+        program.preassign_label_to_next_insn(same_partition_label);
     }
 
     Ok(())
@@ -901,7 +901,7 @@ fn emit_flush_buffer_if_not_peer(
             target_pc_gt: label_not_peer,
         });
 
-        program.resolve_label(label_not_peer, program.offset());
+        program.preassign_label_to_next_insn(label_not_peer);
         program.add_comment(program.offset(), "detected non-peer row");
         program.emit_insn(Insn::Gosub {
             target_pc: labels.flush_buffer,
@@ -913,7 +913,7 @@ fn emit_flush_buffer_if_not_peer(
             extra_amount: order_by_len - 1,
         });
 
-        program.resolve_label(label_peer, program.offset());
+        program.preassign_label_to_next_insn(label_peer);
     }
 
     Ok(())
@@ -1055,7 +1055,7 @@ pub fn emit_window_results(
 
     emit_return_buffered_rows(program, window, t_ctx, plan)?;
 
-    program.resolve_label(label_empty, program.offset());
+    program.preassign_label_to_next_insn(label_empty);
 
     program.emit_insn(Insn::ResetSorter {
         cursor_id: cursor_buffer_read,
@@ -1146,7 +1146,7 @@ fn emit_return_buffered_rows(
         }
     }
 
-    program.resolve_label(label_skip_returning_row, program.offset());
+    program.preassign_label_to_next_insn(label_skip_returning_row);
 
     if let Distinctness::Distinct { ctx } = &plan.distinctness {
         let distinct_ctx = ctx.as_ref().expect("distinct context must exist");

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -39,7 +39,7 @@ impl TableRefIdCounter {
 }
 
 use super::{
-    affinity::Affinity, BranchOffset, CursorID, Insn, InsnReference, JumpTarget, PrepareContext,
+    affinity::Affinity, BranchOffset, CursorID, Insn, InsnReference, PrepareContext,
     PreparedProgram, Program,
 };
 use crate::translate::plan::BitSet;
@@ -200,7 +200,11 @@ pub struct ProgramBuilder {
     /// again. Hence, the key is optional.
     pub cursor_ref: Vec<(Option<CursorKey>, CursorType)>,
     /// A vector where index=label number, value=resolved offset. Resolved in build().
-    label_to_resolved_offset: Vec<Option<(InsnReference, JumpTarget)>>,
+    /// For each allocated label, the offset of the instruction emitted *just
+    /// before* the label's logical "next-insn" anchor. The label resolves to
+    /// `anchor_offset + 1` so it tracks whichever instruction ends up at that
+    /// position, even after `emit_constant_insns` reorders the program.
+    label_to_resolved_offset: Vec<Option<InsnReference>>,
     // map of instruction index to manual comment (used in EXPLAIN only)
     comments: Vec<(InsnReference, &'static str)>,
     pub parameters: Parameters,
@@ -1165,8 +1169,8 @@ impl ProgramBuilder {
         }
 
         for resolved_offset in self.label_to_resolved_offset.iter_mut() {
-            if let Some((old_offset, target)) = resolved_offset {
-                *resolved_offset = Some((old_to_new[*old_offset as usize] as u32, *target));
+            if let Some(old_offset) = resolved_offset {
+                *resolved_offset = Some(old_to_new[*old_offset as usize] as u32);
             }
         }
 
@@ -1218,29 +1222,35 @@ impl ProgramBuilder {
     /// reordering the emitted instructions.
     #[inline]
     pub fn preassign_label_to_next_insn(&mut self, label: BranchOffset) {
-        turso_assert!(label.is_label(), "BranchOffset should be a label", { "label": label });
-        self._resolve_label(label, self.offset().sub(1u32), JumpTarget::AfterThisInsn);
-    }
-
-    /// Resolve a label to exactly the instruction that was last emitted.
-    ///
-    /// Use this when your use case is: "the program should jump to the exact instruction
-    /// that was last emitted", and you don't care WHERE exactly that ends up being
-    /// once the order of the bytecode of the program is finalized. Examples include
-    /// "jump to the Halt instruction", or "jump to the Next instruction of a loop".
-    #[inline]
-    pub fn resolve_label(&mut self, label: BranchOffset, to_offset: BranchOffset) {
-        self._resolve_label(label, to_offset, JumpTarget::ExactlyThisInsn);
-    }
-
-    fn _resolve_label(&mut self, label: BranchOffset, to_offset: BranchOffset, target: JumpTarget) {
-        turso_assert!(matches!(label, BranchOffset::Label(_)));
-        turso_assert!(matches!(to_offset, BranchOffset::Offset(_)));
         let BranchOffset::Label(label_number) = label else {
-            unreachable!("Label is not a label");
+            unreachable!("preassign_label_to_next_insn requires a Label, got {label:?}");
         };
-        self.label_to_resolved_offset[label_number as usize] =
-            Some((to_offset.as_offset_int(), target));
+        let anchor = self.offset().as_offset_int().saturating_sub(1);
+        self.label_to_resolved_offset[label_number as usize] = Some(anchor);
+    }
+
+    /// Resolve `dest` so that it ends up pointing at the same final offset as
+    /// `anchor`. `anchor` must already be preassigned. Use when several labels
+    /// have to target the same logical program point but the point was
+    /// anchored earlier (or in a different function) and
+    /// `preassign_label_to_next_insn` cannot be called again at that moment.
+    ///
+    /// Using this helper (instead of capturing a raw `BranchOffset::Offset`
+    /// from `program.offset()` and passing it to multiple resolutions) keeps
+    /// all the linked labels correctly remapped when `emit_constant_insns`
+    /// hoists compile-time constants — raw offsets don't get remapped, but
+    /// label resolutions do.
+    #[inline]
+    pub fn link_label_to_other_label(&mut self, dest: BranchOffset, anchor: BranchOffset) {
+        let BranchOffset::Label(dest_n) = dest else {
+            unreachable!("link_label_to_other_label dest must be a Label, got {dest:?}");
+        };
+        let BranchOffset::Label(anchor_n) = anchor else {
+            unreachable!("link_label_to_other_label anchor must be a Label, got {anchor:?}");
+        };
+        let resolution = self.label_to_resolved_offset[anchor_n as usize]
+            .expect("anchor label must already be preassigned/resolved");
+        self.label_to_resolved_offset[dest_n as usize] = Some(resolution);
     }
 
     /// Resolve unresolved labels to a specific offset in the instruction list.
@@ -1251,21 +1261,12 @@ impl ProgramBuilder {
     pub fn resolve_labels(&mut self) -> crate::Result<()> {
         let resolve = |pc: &mut BranchOffset, insn_name: &str| -> crate::Result<()> {
             if let BranchOffset::Label(label) = pc {
-                let Some(Some((to_offset, target))) =
-                    self.label_to_resolved_offset.get(*label as usize)
-                else {
+                let Some(Some(anchor)) = self.label_to_resolved_offset.get(*label as usize) else {
                     crate::bail_corrupt_error!(
                         "Reference to undefined or unresolved label in {insn_name}: {label}"
                     );
                 };
-                *pc = BranchOffset::Offset(
-                    to_offset
-                        + if *target == JumpTarget::ExactlyThisInsn {
-                            0
-                        } else {
-                            1
-                        },
-                );
+                *pc = BranchOffset::Offset(anchor + 1);
             }
             Ok(())
         };

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -108,34 +108,14 @@ pub enum ViewDeltaCommitState {
     Done,
 }
 
-/// We use labels to indicate that we want to jump to whatever the instruction offset
-/// will be at runtime, because the offset cannot always be determined when the jump
-/// instruction is created.
-///
-/// In some cases, we want to jump to EXACTLY a specific instruction.
-/// - Example: a condition is not met, so we want to jump to wherever Halt is.
-///
-/// In other cases, we don't care what the exact instruction is, but we know that we
-/// want to jump to whatever comes AFTER a certain instruction.
-/// - Example: a Next instruction will want to jump to "whatever the start of the loop is",
-///   but it doesn't care what instruction that is.
-///
-/// The reason this distinction is important is that we might reorder instructions that are
-/// constant at compile time, and when we do that, we need to change the offsets of any impacted
-/// jump instructions, so the instruction that comes immediately after "next Insn" might have changed during the reordering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum JumpTarget {
-    ExactlyThisInsn,
-    AfterThisInsn,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Represents a target for a jump instruction.
 /// Stores 32-bit ints to keep the enum word-sized.
 pub enum BranchOffset {
     /// A label is a named location in the program.
     /// If there are references to it, it must always be resolved to an Offset
-    /// via program.resolve_label().
+    /// via `ProgramBuilder::preassign_label_to_next_insn` or
+    /// `ProgramBuilder::link_label_to_other_label`.
     Label(u32),
     /// An offset is a direct index into the instruction list.
     Offset(InsnReference),
@@ -145,11 +125,6 @@ pub enum BranchOffset {
 }
 
 impl BranchOffset {
-    /// Returns true if the branch offset is a label.
-    pub fn is_label(&self) -> bool {
-        matches!(self, BranchOffset::Label(_))
-    }
-
     /// Returns true if the branch offset is an offset.
     pub fn is_offset(&self) -> bool {
         matches!(self, BranchOffset::Offset(_))
@@ -173,19 +148,6 @@ impl BranchOffset {
             BranchOffset::Offset(v) => *v as i32,
             BranchOffset::Placeholder => i32::MAX,
         }
-    }
-
-    /// Adds an integer value to the branch offset.
-    /// Returns a new branch offset.
-    /// Panics if the branch offset is a label or placeholder.
-    #[allow(clippy::should_implement_trait)]
-    pub fn add<N: Into<u32>>(self, n: N) -> BranchOffset {
-        BranchOffset::Offset(self.as_offset_int() + n.into())
-    }
-
-    #[allow(clippy::should_implement_trait)]
-    pub fn sub<N: Into<u32>>(self, n: N) -> BranchOffset {
-        BranchOffset::Offset(self.as_offset_int() - n.into())
     }
 }
 


### PR DESCRIPTION
## TLDR

Remove `resolve_label()` entirely, it's never needed, and is only a continuous source of bugs where hoisting constant instructions for bytecode optimization causes incorrect jumps which are often the cause of infinite loops -> hangs

`preassign_label_to_next_insn()` is always what's needed. the only exceptions are cases that need to link to one label _via another label_, so add a dedicated method `link_label_to_other_label()` for it.

Mass-migrate all ~90 call sites to preassign_label_to_next_insn.