### PR TITLE
sim: generate BETWEEN predicates

### DIFF
--- a/sql_generation/generation/predicate/binary.rs
+++ b/sql_generation/generation/predicate/binary.rs
@@ -127,6 +127,27 @@ impl Predicate {
                         })
                     }),
                 ),
+                (
+                    1,
+                    Box::new(|rng| {
+                        // column BETWEEN lt AND gt — always true since lt < column ≤ gt.
+                        // Skip when the column value is NULL: BETWEEN with a NULL operand
+                        // evaluates to NULL, which is not truthy.
+                        if value.is_null() {
+                            return None;
+                        }
+                        let lt_value =
+                            LTValue::arbitrary_from(rng, context, (value, column.column_type)).0;
+                        let gt_value =
+                            GTValue::arbitrary_from(rng, context, (value, column.column_type)).0;
+                        Some(Expr::Between {
+                            lhs: Box::new(qualified_column_expr(&table_name, &column.name)),
+                            not: false,
+                            start: Box::new(Expr::Literal(lt_value.into())),
+                            end: Box::new(Expr::Literal(gt_value.into())),
+                        })
+                    }),
+                ),
             ],
             rng,
         );
@@ -204,6 +225,33 @@ impl Predicate {
             ],
             rng,
         );
+        // Inject BETWEEN-based false predicates 30% of the time. Two flavours, both
+        // historically bug-prone in BETWEEN implementations:
+        //   * NOT BETWEEN [lt, gt] — column sits inside, NOT inverts to false.
+        //   * BETWEEN [gt, lt]     — reversed bounds (start > end); always false per SQL semantics.
+        let expr = if !value.is_null() && rng.random_bool(0.3) {
+            let lt_value = LTValue::arbitrary_from(rng, context, (value, column.column_type)).0;
+            let gt_value = GTValue::arbitrary_from(rng, context, (value, column.column_type)).0;
+            if rng.random_bool(0.5) {
+                // NOT BETWEEN around the value.
+                Expr::Between {
+                    lhs: Box::new(qualified_column_expr(&table_name, &column.name)),
+                    not: true,
+                    start: Box::new(Expr::Literal(lt_value.into())),
+                    end: Box::new(Expr::Literal(gt_value.into())),
+                }
+            } else {
+                // Reversed bounds — start > end, always false in SQL.
+                Expr::Between {
+                    lhs: Box::new(qualified_column_expr(&table_name, &column.name)),
+                    not: false,
+                    start: Box::new(Expr::Literal(gt_value.into())),
+                    end: Box::new(Expr::Literal(lt_value.into())),
+                }
+            }
+        } else {
+            expr
+        };
         Predicate(expr)
     }
 }
@@ -265,6 +313,22 @@ impl SimplePredicate {
             ],
             rng,
         );
+        // 20% chance to wrap in BETWEEN: column BETWEEN lt AND gt — true since lt < column ≤ gt.
+        // Skip when column_value is NULL (BETWEEN evaluates to NULL).
+        let expr = if !column_value.is_null() && rng.random_bool(0.2) {
+            let lt_value =
+                LTValue::arbitrary_from(rng, context, (column_value, column.column.column_type)).0;
+            let gt_value =
+                GTValue::arbitrary_from(rng, context, (column_value, column.column.column_type)).0;
+            Expr::Between {
+                lhs: Box::new(qualified_column_expr(table_name, &column.column.name)),
+                not: false,
+                start: Box::new(Expr::Literal(lt_value.into())),
+                end: Box::new(Expr::Literal(gt_value.into())),
+            }
+        } else {
+            expr
+        };
         SimplePredicate(Predicate(expr))
     }
 
@@ -324,6 +388,22 @@ impl SimplePredicate {
             ],
             rng,
         );
+        // 20% chance to use NOT BETWEEN: false because column always sits in [lt, gt].
+        // Skip on NULL columns where the result is NULL, not falsy.
+        let expr = if !column_value.is_null() && rng.random_bool(0.2) {
+            let lt_value =
+                LTValue::arbitrary_from(rng, context, (column_value, column.column.column_type)).0;
+            let gt_value =
+                GTValue::arbitrary_from(rng, context, (column_value, column.column.column_type)).0;
+            Expr::Between {
+                lhs: Box::new(qualified_column_expr(table_name, &column.column.name)),
+                not: true,
+                start: Box::new(Expr::Literal(lt_value.into())),
+                end: Box::new(Expr::Literal(gt_value.into())),
+            }
+        } else {
+            expr
+        };
         SimplePredicate(Predicate(expr))
     }
 }

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -148,6 +148,27 @@ pub fn expr_to_value<T: TableContext>(
             assert_eq!(exprs.len(), 1);
             expr_to_value(&exprs[0], row, table)
         }
+        ast::Expr::Between {
+            lhs,
+            not,
+            start,
+            end,
+        } => {
+            // x BETWEEN a AND b is exactly x >= a AND x <= b. NULL semantics propagate
+            // through the underlying binary comparisons (Greater/Less/And), so we can
+            // delegate without special-casing NULL here.
+            let lhs_v = expr_to_value(lhs, row, table)?;
+            let start_v = expr_to_value(start, row, table)?;
+            let end_v = expr_to_value(end, row, table)?;
+            let ge = lhs_v.binary_compare(&start_v, ast::Operator::GreaterEquals);
+            let le = lhs_v.binary_compare(&end_v, ast::Operator::LessEquals);
+            let in_range = ge.binary_compare(&le, ast::Operator::And);
+            Some(if *not {
+                in_range.unary_exec(ast::UnaryOperator::Not)
+            } else {
+                in_range
+            })
+        }
         _ => unreachable!("{:?}", expr),
     }
 }

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -219,7 +219,7 @@ impl SimValue {
     }
 
     #[inline]
-    fn is_null(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         matches!(self.0, types::Value::Null)
     }
 


### PR DESCRIPTION
## Summary

Adds generation of `BETWEEN` and `NOT BETWEEN` predicates to the deterministic simulator, covering a gap in the binary predicate generators where `BETWEEN` was the only SQLite range operator that was never emitted.

The new generators cover three semantically distinct cases:

* `column BETWEEN lt AND gt` (in-range, true)
* `NOT (column BETWEEN lt AND gt)` (in-range, NOT-inverted, false)
* `column BETWEEN gt AND lt` (reversed bounds, always false per SQL semantics)

Each is gated on the column value being non-NULL: `BETWEEN` with a NULL operand evaluates to NULL, which is neither truthy nor falsy and would invalidate the property assertion.

`expr_to_value` in `sql_generation/model/query/predicate.rs` previously panicked on `Expr::Between`. It now reduces to the equivalent `lhs >= start AND lhs <= end` using the existing `binary_compare`, so NULL semantics propagate correctly.

## Test plan

- [x] Existing predicate fuzz tests still pass (10,000 random tables each, with BETWEEN injection at 30%)
- [x] \`cargo build\` succeeds cleanly on \`limbo_sim\`
- [x] \`cargo fmt\` applied
- [x] \`cargo clippy -p sql_generation\` produces no new warnings in changed files
- [x] ~150 simulator runs across property and differential modes against SQLite, all green
- [x] \`BETWEEN\` is now generated heavily in WHERE clauses across SELECT, INSERT, UPDATE, UNION, and joined queries (verified via debug logging)

## Notes

This is foundational coverage. A natural follow-up is generating non-column LHS values (subqueries, function calls) which would target the known left-side-evaluated-twice issue at \`core/translate/expr.rs:4025-4048\` — see #5152.

## Description of AI Usage

Used Claude Code to explore the simulator codebase, draft the BETWEEN generators, and run regression tests against many seeds.