### PR TITLE
core/translate: Rewrite row payload when ALTER COLUMN changes affinity

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1618,8 +1618,18 @@ pub fn translate_alter_table(
                 true => (false, None),
                 false => {
                     let replacement_column = Column::try_from(&definition)?;
-                    let rewrites_physical_layout = !btree.columns()[column_index].is_generated()
-                        && replacement_column.is_generated();
+                    let old_column = &btree.columns()[column_index];
+                    let becomes_generated =
+                        !old_column.is_generated() && replacement_column.is_generated();
+                    // A change of declared type can change the column's affinity, in
+                    // which case existing on-disk values must be coerced to match the
+                    // new affinity. Without this, the row payload retains the old
+                    // serial type and SQLite's `PRAGMA integrity_check` reports the
+                    // file as corrupt (e.g. "NUMERIC value in <table>.<col>" when
+                    // changing NUMERIC -> TEXT). See issue #3706.
+                    let affinity_changed = old_column.affinity_with_strict(btree.is_strict)
+                        != replacement_column.affinity_with_strict(btree.is_strict);
+                    let rewrites_physical_layout = becomes_generated || affinity_changed;
                     (rewrites_physical_layout, Some(replacement_column))
                 }
             };

--- a/testing/sqltests/turso-tests/alter_column.sqltest
+++ b/testing/sqltests/turso-tests/alter_column.sqltest
@@ -596,3 +596,39 @@ test alter-table-add-parens-default {
 expect {
     1|123|-456
 }
+
+# Existing rows must be rewritten when ALTER COLUMN changes affinity, so the
+# stored serial type matches the new declared type (issue #3706).
+test alter-column-numeric-to-text-coerces-existing-rows {
+    CREATE TABLE t (x NUMERIC);
+    INSERT INTO t VALUES (1), (2.5), ('abc');
+    ALTER TABLE t ALTER COLUMN x TO y TEXT;
+    SELECT typeof(y), y FROM t ORDER BY rowid;
+}
+expect {
+    text|1
+    text|2.5
+    text|abc
+}
+
+test alter-column-text-to-integer-coerces-existing-rows {
+    CREATE TABLE t (x TEXT);
+    INSERT INTO t VALUES ('42'), ('abc');
+    ALTER TABLE t ALTER COLUMN x TO y INTEGER;
+    SELECT typeof(y), y FROM t ORDER BY rowid;
+}
+expect {
+    integer|42
+    text|abc
+}
+
+test alter-column-same-affinity-keeps-existing-rows {
+    CREATE TABLE t (x INTEGER);
+    INSERT INTO t VALUES (1), (2);
+    ALTER TABLE t ALTER COLUMN x TO y INTEGER;
+    SELECT typeof(y), y FROM t ORDER BY rowid;
+}
+expect {
+    integer|1
+    integer|2
+}


### PR DESCRIPTION
Previously `ALTER TABLE ... ALTER COLUMN` only updated the schema and
left existing row data untouched. When the new declared type implied a
different affinity (e.g. NUMERIC -> TEXT), the on-disk serial types no
longer matched the column, and SQLite's `PRAGMA integrity_check`
flagged the file as corrupt with messages like "NUMERIC value in t.y".

Detect an affinity change between the old and replacement columns and
treat it the same as a physical-layout change so the row data is
rewritten through the new affinity. Add sqltest coverage for
NUMERIC -> TEXT, TEXT -> INTEGER, and a same-affinity no-op case.

Fixes #3706.
