### PR TITLE
Add bind parameter support to Database API

### DIFF
--- a/bindings/javascript/docs/API.md
+++ b/bindings/javascript/docs/API.md
@@ -38,6 +38,54 @@ Prepares a SQL statement for execution.
 
 The function returns a `Statement` object.
 
+### run(sql[, ...bindParameters][, queryOptions]) ⇒ object
+
+Convenience wrapper that prepares `sql` and executes `Statement.run`. Returns the same info object as `Statement.run` (`changes` and `lastInsertRowid`). The internally prepared statement is finalized before the call returns.
+
+| Param          | Type                | Description                                                          |
+| -------------- | ------------------- | -------------------------------------------------------------------- |
+| sql            | <code>string</code> | The SQL statement string.                                            |
+| bindParameters | <code>any</code>    | Optional positional or named bind parameters.                        |
+| queryOptions   | <code>object</code> | Optional per-query overrides (for example, `{ queryTimeout: 100 }`). |
+
+**Note:** This is an extension in libSQL and not available in `better-sqlite3`.
+
+### get(sql[, ...bindParameters][, queryOptions]) ⇒ row
+
+Convenience wrapper that prepares `sql` and executes `Statement.get`. Returns the first row, or `undefined` if no row matched. The internally prepared statement is finalized before the call returns.
+
+| Param          | Type                | Description                                                          |
+| -------------- | ------------------- | -------------------------------------------------------------------- |
+| sql            | <code>string</code> | The SQL statement string.                                            |
+| bindParameters | <code>any</code>    | Optional positional or named bind parameters.                        |
+| queryOptions   | <code>object</code> | Optional per-query overrides (for example, `{ queryTimeout: 100 }`). |
+
+**Note:** This is an extension in libSQL and not available in `better-sqlite3`.
+
+### all(sql[, ...bindParameters][, queryOptions]) ⇒ array of rows
+
+Convenience wrapper that prepares `sql` and executes `Statement.all`. Returns all matching rows as an array. The internally prepared statement is finalized before the call returns.
+
+| Param          | Type                | Description                                                          |
+| -------------- | ------------------- | -------------------------------------------------------------------- |
+| sql            | <code>string</code> | The SQL statement string.                                            |
+| bindParameters | <code>any</code>    | Optional positional or named bind parameters.                        |
+| queryOptions   | <code>object</code> | Optional per-query overrides (for example, `{ queryTimeout: 100 }`). |
+
+**Note:** This is an extension in libSQL and not available in `better-sqlite3`.
+
+### iterate(sql[, ...bindParameters][, queryOptions]) ⇒ async iterator
+
+Convenience wrapper that prepares `sql` and executes `Statement.iterate`. Returns an async iterator over the resulting rows. The internally prepared statement is finalized when the iterator is exhausted or closed.
+
+| Param          | Type                | Description                                                          |
+| -------------- | ------------------- | -------------------------------------------------------------------- |
+| sql            | <code>string</code> | The SQL statement string.                                            |
+| bindParameters | <code>any</code>    | Optional positional or named bind parameters.                        |
+| queryOptions   | <code>object</code> | Optional per-query overrides (for example, `{ queryTimeout: 100 }`). |
+
+**Note:** This is an extension in libSQL and not available in `better-sqlite3`.
+
 ### transaction(function) ⇒ function
 
 Returns a function that runs the given function in a transaction.

--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -157,6 +157,66 @@ class Database {
     return properties.default.value;
   }
 
+  /**
+   * Prepares the SQL and executes it as `Statement.run`, returning the run info.
+   *
+   * @param {string} sql - The SQL statement string.
+   * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
+   */
+  async run(sql, ...bindParameters) {
+    const stmt = this.prepare(sql);
+    try {
+      return await stmt.run(...bindParameters);
+    } finally {
+      await stmt.close();
+    }
+  }
+
+  /**
+   * Prepares the SQL and executes it as `Statement.get`, returning the first row.
+   *
+   * @param {string} sql - The SQL statement string.
+   * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
+   */
+  async get(sql, ...bindParameters) {
+    const stmt = this.prepare(sql);
+    try {
+      return await stmt.get(...bindParameters);
+    } finally {
+      await stmt.close();
+    }
+  }
+
+  /**
+   * Prepares the SQL and executes it as `Statement.all`, returning all rows.
+   *
+   * @param {string} sql - The SQL statement string.
+   * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
+   */
+  async all(sql, ...bindParameters) {
+    const stmt = this.prepare(sql);
+    try {
+      return await stmt.all(...bindParameters);
+    } finally {
+      await stmt.close();
+    }
+  }
+
+  /**
+   * Prepares the SQL and executes it as `Statement.iterate`, yielding each row.
+   *
+   * @param {string} sql - The SQL statement string.
+   * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
+   */
+  async *iterate(sql, ...bindParameters) {
+    const stmt = this.prepare(sql);
+    try {
+      yield* stmt.iterate(...bindParameters);
+    } finally {
+      await stmt.close();
+    }
+  }
+
   async pragma(source, options) {
     if (options == null) options = {};
 

--- a/serverless/javascript/src/args.ts
+++ b/serverless/javascript/src/args.ts
@@ -1,0 +1,44 @@
+/**
+ * Normalize execute() arguments into the form session.execute() expects:
+ * an array (positional) or a plain object (named). Single non-object/non-array
+ * values become a one-element positional array.
+ */
+export function normalizeArgs(args: any): any[] | Record<string, any> {
+  if (args === undefined) return [];
+  if (Array.isArray(args)) return args;
+  if (args !== null && typeof args === "object" && args.constructor === Object) {
+    return args;
+  }
+  return [args];
+}
+
+function isQueryOptions(value: any): boolean {
+  return value != null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.prototype.hasOwnProperty.call(value, "queryTimeout");
+}
+
+/**
+ * Split a libsql-style variadic `(...bindParameters)` argument list into the
+ * `params` to bind and an optional trailing `queryOptions` object. Mirrors
+ * libsql-js's `splitBindParameters` so libsql call sites work unchanged.
+ */
+export function splitBindParameters(bindParameters: any[]): { params: any; queryOptions: any } {
+  if (bindParameters.length === 0) {
+    return { params: undefined, queryOptions: undefined };
+  }
+  if (isQueryOptions(bindParameters[bindParameters.length - 1])) {
+    if (bindParameters.length === 1) {
+      return { params: undefined, queryOptions: bindParameters[0] };
+    }
+    return {
+      params: bindParameters.length === 2 ? bindParameters[0] : bindParameters.slice(0, -1),
+      queryOptions: bindParameters[bindParameters.length - 1],
+    };
+  }
+  return {
+    params: bindParameters.length === 1 ? bindParameters[0] : bindParameters,
+    queryOptions: undefined,
+  };
+}

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -2,11 +2,13 @@ import { AsyncLock } from './async-lock.js';
 import { Session, type SessionConfig } from './session.js';
 import { Statement } from './statement.js';
 import { type QueryOptions } from './protocol.js';
+import { normalizeArgs, splitBindParameters } from './args.js';
 
 /**
  * Configuration options for connecting to a Turso database.
  */
 export interface Config extends SessionConfig {}
+
 
 /**
  * A connection to a Turso database.
@@ -121,12 +123,75 @@ export class Connection {
 
 
   /**
+   * Like `prepare(sql).run(args)` but in a single round trip — skips `describe`
+   * since run() does not need column metadata.
+   */
+  async run(sql: string, ...bindParameters: any[]): Promise<any> {
+    if (!this.isOpen) throw new TypeError("The database connection is not open");
+    const { params, queryOptions } = splitBindParameters(bindParameters);
+    await this.execLock.acquire();
+    try {
+      const result = await this.session.execute(sql, normalizeArgs(params), this.defaultSafeIntegerMode, queryOptions);
+      return { changes: result.rowsAffected, lastInsertRowid: result.lastInsertRowid };
+    } finally {
+      this.execLock.release();
+    }
+  }
+
+  /**
+   * Like `prepare(sql).get(args)` but in a single round trip.
+   */
+  async get(sql: string, ...bindParameters: any[]): Promise<any> {
+    if (!this.isOpen) throw new TypeError("The database connection is not open");
+    const { params, queryOptions } = splitBindParameters(bindParameters);
+    await this.execLock.acquire();
+    try {
+      const result = await this.session.execute(sql, normalizeArgs(params), this.defaultSafeIntegerMode, queryOptions);
+      const row = result.rows[0];
+      if (!row) return undefined;
+      const obj: any = {};
+      result.columns.forEach((col: string, i: number) => { obj[col] = row[i]; });
+      return obj;
+    } finally {
+      this.execLock.release();
+    }
+  }
+
+  /**
+   * Like `prepare(sql).all(args)` but in a single round trip.
+   */
+  async all(sql: string, ...bindParameters: any[]): Promise<any[]> {
+    if (!this.isOpen) throw new TypeError("The database connection is not open");
+    const { params, queryOptions } = splitBindParameters(bindParameters);
+    await this.execLock.acquire();
+    try {
+      const result = await this.session.execute(sql, normalizeArgs(params), this.defaultSafeIntegerMode, queryOptions);
+      return result.rows.map((row: any) => {
+        const obj: any = {};
+        result.columns.forEach((col: string, i: number) => { obj[col] = row[i]; });
+        return obj;
+      });
+    } finally {
+      this.execLock.release();
+    }
+  }
+
+  /**
+   * Like `prepare(sql).iterate(args)` but in a single round trip. Buffers the
+   * result set — the connection lock cannot be held across `yield` points
+   * without risking deadlock on nested calls.
+   */
+  async *iterate(sql: string, ...bindParameters: any[]): AsyncGenerator<any> {
+    for (const row of await this.all(sql, ...bindParameters)) yield row;
+  }
+
+  /**
    * Execute a SQL statement and return all results.
-   * 
+   *
    * @param sql - The SQL statement to execute
    * @param args - Optional array of parameter values
    * @returns Promise resolving to the complete result set
-   * 
+   *
    * @example
    * ```typescript
    * const result = await client.execute("SELECT * FROM users WHERE id = ?", [123]);

--- a/serverless/javascript/src/statement.ts
+++ b/serverless/javascript/src/statement.ts
@@ -7,10 +7,11 @@ import {
 import { Session, type SessionConfig } from './session.js';
 import { type AsyncLock } from './async-lock.js';
 import { DatabaseError } from './error.js';
+import { normalizeArgs } from './args.js';
 
 /**
  * A prepared SQL statement that can be executed in multiple ways.
- * 
+ *
  * Statements may either own a dedicated session or share a connection session to preserve transaction boundaries.
  * Provides three execution modes:
  * - `get(args?)`: Returns the first row or null
@@ -160,7 +161,7 @@ export class Statement {
    */
   async run(args?: any, queryOptions?: QueryOptions): Promise<any> {
     return await this.withLock(async () => {
-      const normalizedArgs = this.normalizeArgs(args);
+      const normalizedArgs = normalizeArgs(args);
       const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode, queryOptions);
       return { changes: result.rowsAffected, lastInsertRowid: result.lastInsertRowid };
     });
@@ -183,7 +184,7 @@ export class Statement {
    */
   async get(args?: any, queryOptions?: QueryOptions): Promise<any> {
     return await this.withLock(async () => {
-      const normalizedArgs = this.normalizeArgs(args);
+      const normalizedArgs = normalizeArgs(args);
       const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode, queryOptions);
       const row = result.rows[0];
       if (!row) {
@@ -225,7 +226,7 @@ export class Statement {
    */
   async all(args?: any, queryOptions?: QueryOptions): Promise<any[]> {
     return await this.withLock(async () => {
-      const normalizedArgs = this.normalizeArgs(args);
+      const normalizedArgs = normalizeArgs(args);
       const result = await this.session.execute(this.sql, normalizedArgs, this.safeIntegerMode, queryOptions);
 
       if (this.presentationMode === 'pluck') {
@@ -277,7 +278,7 @@ export class Statement {
       return;
     }
 
-    const normalizedArgs = this.normalizeArgs(args);
+    const normalizedArgs = normalizeArgs(args);
     const { entries } = await this.session.executeRaw(this.sql, normalizedArgs, queryOptions);
 
     let columns: string[] = [];
@@ -315,27 +316,4 @@ export class Statement {
     }
   }
 
-  /**
-   * Normalize arguments to handle both single values and arrays.
-   * Matches the behavior of the native bindings.
-   */
-  private normalizeArgs(args: any): any[] | Record<string, any> {
-    // No arguments provided
-    if (args === undefined) {
-      return [];
-    }
-    
-    // If it's an array, return as-is
-    if (Array.isArray(args)) {
-      return args;
-    }
-    
-    // Check if it's a plain object (for named parameters)
-    if (args !== null && typeof args === 'object' && args.constructor === Object) {
-      return args;
-    }
-    
-    // Single value - wrap in array
-    return [args];
-  }
 }

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -220,6 +220,102 @@ test.skip("Database.interrupt()", async (t) => {
 });
 
 // ==========================================================================
+// Database.run() / get() / all() / iterate()
+//
+// Convenience wrappers on Database that prepare and execute the SQL in one
+// call. These are libsql extensions (not in better-sqlite3); other providers
+// are expected to match the libsql shape.
+// ==========================================================================
+
+test.serial("Database.run() [positional]", async (t) => {
+  const db = t.context.db;
+
+  const info = await db.run(
+    "INSERT INTO users(name, email) VALUES (?, ?)",
+    "Carol",
+    "carol@example.net"
+  );
+  t.is(info.changes, 1);
+  t.is(info.lastInsertRowid, 3);
+
+  const row = await db.get("SELECT name, email FROM users WHERE id = ?", 3);
+  t.is(row.name, "Carol");
+  t.is(row.email, "carol@example.net");
+});
+
+test.serial("Database.run() [named]", async (t) => {
+  const db = t.context.db;
+
+  const info = await db.run(
+    "INSERT INTO users(name, email) VALUES (:name, :email)",
+    { name: "Carol", email: "carol@example.net" }
+  );
+  t.is(info.changes, 1);
+  t.is(info.lastInsertRowid, 3);
+});
+
+test.serial("Database.get() returns no rows", async (t) => {
+  const db = t.context.db;
+  t.is(await db.get("SELECT * FROM users WHERE id = ?", 0), undefined);
+});
+
+test.serial("Database.get() [positional]", async (t) => {
+  const db = t.context.db;
+  t.is((await db.get("SELECT * FROM users WHERE id = ?", 1)).name, "Alice");
+  t.is((await db.get("SELECT * FROM users WHERE id = ?", 2)).name, "Bob");
+});
+
+test.serial("Database.get() [named]", async (t) => {
+  const db = t.context.db;
+  t.is(
+    (await db.get("SELECT * FROM users WHERE id = :id", { id: 1 })).name,
+    "Alice"
+  );
+  t.is(
+    (await db.get("SELECT * FROM users WHERE id = @id", { id: 2 })).name,
+    "Bob"
+  );
+});
+
+test.serial("Database.all()", async (t) => {
+  const db = t.context.db;
+  const expected = [
+    { id: 1, name: "Alice", email: "alice@example.org" },
+    { id: 2, name: "Bob", email: "bob@example.com" },
+  ];
+  t.deepEqual(await db.all("SELECT * FROM users"), expected);
+});
+
+test.serial("Database.all() [positional]", async (t) => {
+  const db = t.context.db;
+  const expected = [{ id: 1, name: "Alice", email: "alice@example.org" }];
+  t.deepEqual(await db.all("SELECT * FROM users WHERE id = ?", 1), expected);
+});
+
+test.serial("Database.iterate()", async (t) => {
+  const db = t.context.db;
+  const expected = [1, 2];
+  let idx = 0;
+  for await (const row of await db.iterate("SELECT * FROM users")) {
+    t.is(row.id, expected[idx++]);
+  }
+  t.is(idx, 2);
+});
+
+test.serial("Database.iterate() [positional]", async (t) => {
+  const db = t.context.db;
+  let count = 0;
+  for await (const row of await db.iterate(
+    "SELECT * FROM users WHERE id = ?",
+    2
+  )) {
+    t.is(row.name, "Bob");
+    count++;
+  }
+  t.is(count, 1);
+});
+
+// ==========================================================================
 // Statement.run()
 // ==========================================================================
 

--- a/testing/conformance/javascript/package-lock.json
+++ b/testing/conformance/javascript/package-lock.json
@@ -10,7 +10,7 @@
         "@tursodatabase/database": "../../../bindings/javascript/packages/native",
         "@tursodatabase/serverless": "../../../serverless/javascript",
         "better-sqlite3": "^12.9.0",
-        "libsql": "^0.6.0-pre.34"
+        "libsql": "^0.6.0-pre.35"
       },
       "devDependencies": {
         "ava": "^6.4.1"
@@ -1543,9 +1543,9 @@
       }
     },
     "node_modules/libsql": {
-      "version": "0.6.0-pre.34",
-      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.6.0-pre.34.tgz",
-      "integrity": "sha512-G2//qLFP101gBjSGkDTOSCI+cl9JU7Oi3rCM8qxlLr3KsQPUvIT8CDAqycgOQCxp2ABhUOkN3F9/u/VSENQmiw==",
+      "version": "0.6.0-pre.35",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.6.0-pre.35.tgz",
+      "integrity": "sha512-emVU1B+IBMCbk2m3g4mecfG/d/+NbebkShIkKKbrvGEIk+bcJ0Wdq94cDHhfXmuZfhms4/P11chE92XbFMtUkw==",
       "cpu": [
         "x64",
         "arm64",
@@ -1562,19 +1562,19 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "libsql-darwin-arm64": "0.6.0-pre.34",
-        "libsql-darwin-x64": "0.6.0-pre.34",
-        "libsql-linux-arm64-gnu": "0.6.0-pre.34",
-        "libsql-linux-arm64-musl": "0.6.0-pre.34",
-        "libsql-linux-x64-gnu": "0.6.0-pre.34",
-        "libsql-linux-x64-musl": "0.6.0-pre.34",
-        "libsql-win32-x64-msvc": "0.6.0-pre.34"
+        "libsql-darwin-arm64": "0.6.0-pre.35",
+        "libsql-darwin-x64": "0.6.0-pre.35",
+        "libsql-linux-arm64-gnu": "0.6.0-pre.35",
+        "libsql-linux-arm64-musl": "0.6.0-pre.35",
+        "libsql-linux-x64-gnu": "0.6.0-pre.35",
+        "libsql-linux-x64-musl": "0.6.0-pre.35",
+        "libsql-win32-x64-msvc": "0.6.0-pre.35"
       }
     },
     "node_modules/libsql-darwin-arm64": {
-      "version": "0.6.0-pre.34",
-      "resolved": "https://registry.npmjs.org/libsql-darwin-arm64/-/libsql-darwin-arm64-0.6.0-pre.34.tgz",
-      "integrity": "sha512-+EHW4rTbDk96h/CK8mHO0hBLMCqqNJH0yOgYgpjEkQnGWwYhA34O/97HbLNRuhMo0+KJXXmfwxp07aw8oFHjyQ==",
+      "version": "0.6.0-pre.35",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-arm64/-/libsql-darwin-arm64-0.6.0-pre.35.tgz",
+      "integrity": "sha512-yJkfPw7DM+6bdv59yQdkAot4EaRJTf9hPZfClWHpR4EqsLJUF1XHoCC5Ic+qD0JHUM/7U2j8tjbTrTuyNdOpBg==",
       "cpu": [
         "arm64"
       ],
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/libsql-darwin-x64": {
-      "version": "0.6.0-pre.34",
-      "resolved": "https://registry.npmjs.org/libsql-darwin-x64/-/libsql-darwin-x64-0.6.0-pre.34.tgz",
-      "integrity": "sha512-nscLTaxknGAnqkwzWugBhU1Yd29uxU1Mxb++fYi78LIvav7dGQo0U0w3psbtJlAH+dlLYu1zeHE4xP60YQ+7Dw==",
+      "version": "0.6.0-pre.35",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-x64/-/libsql-darwin-x64-0.6.0-pre.35.tgz",
+      "integrity": "sha512-43w/FtBB61J9GnT18033iutG/WG+8AXESa9Xvsw2v/pqn85SUegEOoEqyEbwcjCPic8fn2f4UQ/e3JpDw9nhpw==",
       "cpu": [
         "x64"
       ],
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/libsql-linux-arm64-gnu": {
-      "version": "0.6.0-pre.34",
-      "resolved": "https://registry.npmjs.org/libsql-linux-arm64-gnu/-/libsql-linux-arm64-gnu-0.6.0-pre.34.tgz",
-      "integrity": "sha512-tcGDioDXG9KaGzfdvVPMJ+aZI8oRPqK7xIl7g9rH5q31FxcIRwTjcoAdwSRRjQj9tFCXKXDkSDpABFSqzoASmQ==",
+      "version": "0.6.0-pre.35",
+      "resolved": "https://registry.npmjs.org/libsql-linux-arm64-gnu/-/libsql-linux-arm64-gnu-0.6.0-pre.35.tgz",
+      "integrity": "sha512-OhO1z06PggkZkIKfFgJTx/h7j6lnlHlokbHzxXPLpKWR3Wwh4/V4D/eQQmM8hcuKhkyJjM9qZtdOrrIwBExMCA==",
       "cpu": [
         "arm64"
       ],
@@ -1620,9 +1620,9 @@
       }
     },
     "node_modules/libsql-linux-x64-gnu": {
-      "version": "0.6.0-pre.34",
-      "resolved": "https://registry.npmjs.org/libsql-linux-x64-gnu/-/libsql-linux-x64-gnu-0.6.0-pre.34.tgz",
-      "integrity": "sha512-wlx4HdWnm5hCs4nXa3fjZ3Bfr8cB9LBYyYutM5lQjrDiGoP+/0/nMUREf+1I6mwOSKyHV5nsw9AE/V/tjMW3Pg==",
+      "version": "0.6.0-pre.35",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-gnu/-/libsql-linux-x64-gnu-0.6.0-pre.35.tgz",
+      "integrity": "sha512-RArwMI+mM2G108fIKIyyhvhb8V8WgdCudj+BT6VWFS7T/Z1kGCrdzH0L6G5mDd0A/SdXRbNFshETzfxh7S0s8w==",
       "cpu": [
         "x64"
       ],
@@ -1636,9 +1636,9 @@
       }
     },
     "node_modules/libsql-linux-x64-musl": {
-      "version": "0.6.0-pre.34",
-      "resolved": "https://registry.npmjs.org/libsql-linux-x64-musl/-/libsql-linux-x64-musl-0.6.0-pre.34.tgz",
-      "integrity": "sha512-szHmiM1TDwKhARxEOrfRKrYncchKg+qsqqcziqgUBp1CCyI7s2qM5zZ1RFioyGg2LFgbbrlrYi/AQMHtgNqEjQ==",
+      "version": "0.6.0-pre.35",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-musl/-/libsql-linux-x64-musl-0.6.0-pre.35.tgz",
+      "integrity": "sha512-rFByyCsWAjXY+3VncXiloCIahUkCUidDTWSAgwLlnAMI9keH2ZmSO0j70uUkUFmMSgD9XBBHtRP6w0ZTOheFBQ==",
       "cpu": [
         "x64"
       ],

--- a/testing/conformance/javascript/package.json
+++ b/testing/conformance/javascript/package.json
@@ -18,7 +18,7 @@
     "@tursodatabase/serverless": "../../../serverless/javascript",
     "@tursodatabase/database": "../../../bindings/javascript/packages/native",
     "better-sqlite3": "^12.9.0",
-    "libsql": "^0.6.0-pre.34",
+    "libsql": "^0.6.0-pre.35",
     "@libsql/client": "^0.15.15"
   }
 }


### PR DESCRIPTION
Currently, you need to first prepare a statement to use bind parameters. Add convience wrappers to Database so that callers are not required to do that. This allows optimization too for the Turso serverless driver too, because we no longer need two round trips per query, one for prepare and anoher for query.

This is the same API as in https://github.com/tursodatabase/libsql-js/pull/219