### PR TITLE
Avoid preparing a new Statement when reading `sqlite_schema` rows

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1901,62 +1901,17 @@ impl Connection {
 
         let syms = self.syms.read();
         self.with_schema_mut(|schema| -> Result<()> {
-            // Incremental re-parse after extension loading. The schema already has
-            // tables/indices/views from initial parse. We only need to pick up
-            // entries that previously failed (e.g. virtual tables whose module
-            // wasn't loaded yet). "Already exists" errors are expected and skipped.
-            let mut from_sql_indexes = Vec::new();
-            let mut automatic_indices = HashMap::default();
-            let mut dbsp_state_roots = HashMap::default();
-            let mut dbsp_state_index_roots = HashMap::default();
-            let mut materialized_view_info = HashMap::default();
-
             let attached_resolver = |name: &str| -> Option<usize> {
                 self.attached_databases
                     .read()
                     .get_database_by_name(&crate::util::normalize_ident(name))
                     .map(|(idx, _)| idx)
             };
+            let mut parser = SchemaTableParser::default();
             for row in &rows_data {
-                match schema.handle_schema_row(
-                    row.ty,
-                    &row.name,
-                    &row.table_name,
-                    row.root_page,
-                    row.sql.as_deref(),
-                    &syms,
-                    &mut from_sql_indexes,
-                    &mut automatic_indices,
-                    &mut dbsp_state_roots,
-                    &mut dbsp_state_index_roots,
-                    &mut materialized_view_info,
-                    &attached_resolver,
-                ) {
-                    Ok(()) => {}
-                    Err(LimboError::ParseError(msg)) if msg.contains("already exists") => {}
-                    Err(LimboError::ExtensionError(msg)) => {
-                        eprintln!("Warning: {msg}");
-                    }
-                    Err(e) => return Err(e),
-                }
+                parser.parse_extension_load_row(schema, row, &syms, &attached_resolver)?;
             }
-
-            match schema.populate_indices(&syms, from_sql_indexes, automatic_indices, false) {
-                Ok(()) => {}
-                Err(LimboError::ParseError(msg)) if msg.contains("already exists") => {}
-                Err(LimboError::ExtensionError(msg)) => eprintln!("Warning: {msg}"),
-                Err(e) => return Err(e),
-            }
-            match schema.populate_materialized_views(
-                materialized_view_info,
-                dbsp_state_roots,
-                dbsp_state_index_roots,
-            ) {
-                Ok(()) => {}
-                Err(LimboError::ExtensionError(msg)) => eprintln!("Warning: {msg}"),
-                Err(e) => return Err(e),
-            }
-            Ok(())
+            parser.finish_extension_load(schema, &syms)
         })
     }
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1,6 +1,7 @@
 use crate::error::io_error;
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_points::YieldInjector;
+use crate::schema_parser::SchemaTableType;
 use crate::statement::StatementOrigin;
 use crate::storage::{journal_mode, pager::SavepointResult};
 use crate::sync::{
@@ -1824,13 +1825,18 @@ impl Connection {
         // before taking the schema write lock. This prevents a deadlock in MVCC
         // mode where Statement::drop -> abort -> rollback_tx -> schema.read()
         // would deadlock against the schema write lock.
-        let mut rows_data: Vec<(String, String, String, i64, Option<String>)> = Vec::new();
+        let mut rows_data: Vec<(SchemaTableType, String, String, i64, Option<String>)> = Vec::new();
         {
             let mut rows = self
                 .query("SELECT * FROM sqlite_schema")?
                 .expect("query must be parsed to statement");
             rows.run_with_row_callback(|row| {
-                let ty = row.get::<&str>(0)?.to_string();
+                let ty_text = row.get::<&str>(0)?;
+                let ty = ty_text.parse::<SchemaTableType>().map_err(|_| {
+                    LimboError::ConversionError(format!(
+                        "Invalid sqlite_schema.type value: {ty_text}"
+                    ))
+                })?;
                 let name = row.get::<&str>(1)?.to_string();
                 let table_name = row.get::<&str>(2)?.to_string();
                 let root_page = row.get::<i64>(3)?;
@@ -1860,7 +1866,7 @@ impl Connection {
             };
             for (ty, name, table_name, root_page, sql) in &rows_data {
                 match schema.handle_schema_row(
-                    ty,
+                    *ty,
                     name,
                     table_name,
                     *root_page,

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1,8 +1,12 @@
 use crate::error::io_error;
+use crate::mvcc::cursor::MvccCursorType;
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_points::YieldInjector;
-use crate::schema_parser::SchemaTableType;
+use crate::schema_parser::{
+    SchemaTableCursor, SchemaTableDecodeErrorKind, SchemaTableParser, SchemaTableRow,
+};
 use crate::statement::StatementOrigin;
+use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::storage::{journal_mode, pager::SavepointResult};
 use crate::sync::{
     atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, Ordering},
@@ -17,16 +21,15 @@ use crate::Page;
 use crate::{
     ast, function,
     io::{MemoryIO, IO},
-    parse_schema_rows,
     progress::{ProgressHandler, ProgressHandlerCallback},
     refresh_analyze_stats, translate,
     util::IOExt,
     vdbe, AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
     Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
-    EncryptionKey, EncryptionOpts, IndexMethod, LimboError, MvStore, OpenFlags, PageSize, Pager,
-    Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
-    Trigger, Value, VirtualTable,
+    EncryptionKey, EncryptionOpts, IndexMethod, LimboError, MvCursor, MvStore, OpenFlags, PageSize,
+    Pager, Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode,
+    TransactionMode, Trigger, Value, VirtualTable,
 };
 use crate::{is_memory_like, turso_assert};
 use crate::{MAIN_DB_ID, TEMP_DB_ID};
@@ -41,6 +44,13 @@ use std::path::Path;
 use tempfile::TempDir;
 use tracing::{instrument, Level};
 use turso_macros::{turso_assert_ne, AtomicEnum};
+
+fn maybe_transform_root_page_to_positive(mv_store: Option<&Arc<MvStore>>, root_page: i64) -> i64 {
+    match mv_store {
+        Some(mv_store) if root_page < 0 => mv_store.get_real_table_id(root_page),
+        _ => root_page,
+    }
+}
 
 #[cfg(feature = "simulator")]
 fn db_identity_for_testing(db_path: &Path) -> Result<(u32, u32)> {
@@ -961,17 +971,6 @@ impl Connection {
             })
             .collect();
 
-        // TODO: this is hack to avoid a cyclical problem with schema reprepare
-        // The problem here is that we prepare a statement here, but when the statement tries
-        // to execute it, it first checks the schema cookie to see if it needs to reprepare the statement.
-        // But in this occasion it will always reprepare, and we get an error. So we trick the statement by swapping our schema
-        // with a new clean schema that has the same header cookie.
-        self.with_schema_mut(|schema| {
-            *schema = fresh.clone();
-        });
-
-        let stmt = self.prepare("SELECT * FROM sqlite_schema")?;
-
         // MVCC bootstrap connection gets the "baseline" from the DB file and ignores anything in MV store
         let mv_tx = if self.is_mvcc_bootstrap_connection() {
             None
@@ -986,14 +985,7 @@ impl Connection {
                 .get_database_by_name(&crate::util::normalize_ident(name))
                 .map(|(idx, _)| idx)
         };
-        // TODO: This function below is synchronous, make it async
-        parse_schema_rows(
-            stmt,
-            &mut fresh,
-            &self.syms.read(),
-            mv_tx,
-            &attached_resolver,
-        )?;
+        self.parse_schema_table_into(&mut fresh, mv_tx, &attached_resolver)?;
 
         // Rehydrate built-in table-valued functions that were captured above.
         for vtab in &table_valued_functions {
@@ -1038,6 +1030,85 @@ impl Connection {
             *schema = fresh;
         });
         Result::Ok(())
+    }
+
+    fn parse_schema_table_into(
+        self: &Arc<Connection>,
+        schema: &mut Schema,
+        mv_tx: Option<(u64, TransactionMode)>,
+        resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
+    ) -> Result<()> {
+        let rows = self.collect_schema_table_rows(mv_tx)?;
+        let syms = self.syms.read();
+        let mut parser = SchemaTableParser::default();
+        for row in &rows {
+            parser.parse_row(schema, row, &syms, resolve_attached_db)?;
+        }
+        parser.finish(schema, &syms, self.mv_store_for_db(MAIN_DB_ID).is_some())
+    }
+
+    fn collect_schema_table_rows(
+        self: &Arc<Connection>,
+        mv_tx: Option<(u64, TransactionMode)>,
+    ) -> Result<Vec<SchemaTableRow>> {
+        let pager = self.get_pager_from_database_index(&MAIN_DB_ID)?;
+        let opened_read_tx = self.get_tx_state() == TransactionState::None;
+        if opened_read_tx {
+            pager.begin_read_tx()?;
+            self.set_tx_state(TransactionState::Read);
+        }
+
+        let result = (|| {
+            let mut cursor = self.schema_table_cursor(mv_tx)?;
+            let mut rows = Vec::new();
+            while let Some(row) = pager.io.block(|| cursor.next_row())? {
+                rows.push(row);
+            }
+            Ok(rows)
+        })();
+
+        if opened_read_tx {
+            let previous = self.transaction_state.swap(TransactionState::None);
+            turso_assert!(
+                previous == TransactionState::Read,
+                "unexpected schema table scan transaction state"
+            );
+            pager.end_read_tx();
+        }
+
+        result
+    }
+
+    fn schema_table_cursor(
+        self: &Arc<Connection>,
+        mv_tx: Option<(u64, TransactionMode)>,
+    ) -> Result<SchemaTableCursor> {
+        let pager = self.get_pager_from_database_index(&MAIN_DB_ID)?;
+        let mv_store = self.mv_store_for_db(MAIN_DB_ID);
+        let root_page = maybe_transform_root_page_to_positive(mv_store.as_ref(), 1);
+        let btree_cursor: Box<dyn CursorTrait> =
+            Box::new(BTreeCursor::new_table(pager, root_page, 5));
+        let cursor: Box<dyn CursorTrait> = if let Some((tx_id, _)) = mv_tx {
+            let mv_store = mv_store
+                .as_ref()
+                .expect("mv_store should be Some when MVCC transaction is active")
+                .clone();
+            Box::new(MvCursor::new(
+                mv_store,
+                self,
+                tx_id,
+                1,
+                MvccCursorType::Table,
+                btree_cursor,
+            )?)
+        } else {
+            btree_cursor
+        };
+
+        Ok(SchemaTableCursor::new(
+            cursor,
+            SchemaTableDecodeErrorKind::Conversion,
+        ))
     }
 
     pub(crate) fn read_current_schema_cookie(&self) -> Result<u32> {
@@ -1821,30 +1892,12 @@ impl Connection {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        // Collect row data from the Statement first, then drop the Statement
-        // before taking the schema write lock. This prevents a deadlock in MVCC
-        // mode where Statement::drop -> abort -> rollback_tx -> schema.read()
-        // would deadlock against the schema write lock.
-        let mut rows_data: Vec<(SchemaTableType, String, String, i64, Option<String>)> = Vec::new();
-        {
-            let mut rows = self
-                .query("SELECT * FROM sqlite_schema")?
-                .expect("query must be parsed to statement");
-            rows.run_with_row_callback(|row| {
-                let ty_text = row.get::<&str>(0)?;
-                let ty = ty_text.parse::<SchemaTableType>().map_err(|_| {
-                    LimboError::ConversionError(format!(
-                        "Invalid sqlite_schema.type value: {ty_text}"
-                    ))
-                })?;
-                let name = row.get::<&str>(1)?.to_string();
-                let table_name = row.get::<&str>(2)?.to_string();
-                let root_page = row.get::<i64>(3)?;
-                let sql = row.get::<&str>(4).ok().map(|s| s.to_string());
-                rows_data.push((ty, name, table_name, root_page, sql));
-                Ok(())
-            })?;
-        } // Statement dropped here, before schema write lock
+        let mv_tx = if self.is_mvcc_bootstrap_connection() {
+            None
+        } else {
+            self.get_mv_tx()
+        };
+        let rows_data = self.collect_schema_table_rows(mv_tx)?;
 
         let syms = self.syms.read();
         self.with_schema_mut(|schema| -> Result<()> {
@@ -1864,13 +1917,13 @@ impl Connection {
                     .get_database_by_name(&crate::util::normalize_ident(name))
                     .map(|(idx, _)| idx)
             };
-            for (ty, name, table_name, root_page, sql) in &rows_data {
+            for row in &rows_data {
                 match schema.handle_schema_row(
-                    *ty,
-                    name,
-                    table_name,
-                    *root_page,
-                    sql.as_deref(),
+                    row.ty,
+                    &row.name,
+                    &row.table_name,
+                    row.root_page,
+                    row.sql.as_deref(),
                     &syms,
                     &mut from_sql_indexes,
                     &mut automatic_indices,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -18,6 +18,7 @@ pub mod mvcc;
 #[cfg(any(feature = "fuzz", feature = "bench"))]
 pub mod numeric;
 pub mod schema;
+mod schema_parser;
 pub mod state_machine;
 pub mod storage;
 pub mod types;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -114,7 +114,6 @@ use storage::{page_cache::PageCache, sqlite3_ondisk::PageSize};
 use tracing::{instrument, Level};
 use turso_macros::{match_ignore_ascii_case, AtomicEnum};
 use turso_parser::{ast, ast::Cmd, parser::Parser};
-use util::parse_schema_rows;
 
 pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4,6 +4,7 @@ use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
 use crate::mvcc::yield_points::inject_transition_yield;
 use crate::schema::{Schema, Table};
+use crate::schema_parser::{SchemaTableDecodeErrorKind, SchemaTableParser, SchemaTableRow};
 use crate::state_machine::StateMachine;
 use crate::state_machine::StateTransition;
 use crate::state_machine::TransitionResult;
@@ -25,17 +26,15 @@ use crate::types::IOResult;
 use crate::types::ImmutableRecord;
 use crate::types::IndexInfo;
 use crate::types::SeekResult;
+use crate::Completion;
 use crate::File;
 use crate::IOExt;
 use crate::LimboError;
+#[cfg(test)]
+use crate::Numeric;
 use crate::Result;
 use crate::ValueRef;
-use crate::{
-    contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case, Completion,
-};
-use crate::{
-    turso_assert, turso_assert_eq, turso_assert_less_than, turso_assert_reachable, Numeric,
-};
+use crate::{turso_assert, turso_assert_eq, turso_assert_less_than, turso_assert_reachable};
 use crate::{Connection, Pager, SyncMode};
 use crossbeam_skiplist::map::Entry;
 use crossbeam_skiplist::{SkipMap, SkipSet};
@@ -4639,112 +4638,48 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // Cell is used so the get_index_info closure can flush the pending rebuild.
         let needs_schema_rebuild = std::cell::Cell::new(false);
 
-        let rebuild_schema =
-            |connection: &Arc<Connection>, schema_rows: &HashMap<i64, ImmutableRecord>| {
-                let pager = connection.pager.load().clone();
-                let cookie = self
-                    .global_header
-                    .read()
-                    .as_ref()
-                    .map(|header| header.schema_cookie.get())
-                    .unwrap_or(
-                        pager
-                            .io
-                            .block(|| pager.with_header(|header| header.schema_cookie))?
-                            .get(),
-                    );
-                let mut fresh = Schema::new();
-                fresh.generated_columns_enabled =
-                    connection.db.experimental_generated_columns_enabled();
-                fresh.schema_version = cookie;
-                let mut from_sql_indexes = Vec::with_capacity(10);
-                let mut automatic_indices: HashMap<String, Vec<(String, i64)>> = HashMap::default();
-                let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
-                let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();
-                let mut materialized_view_info: HashMap<String, (String, i64)> = HashMap::default();
-                let syms = connection.syms.read();
-                let mv_store = connection.db.get_mv_store().clone();
-
-                for record in schema_rows.values() {
-                    let ty = match record.get_value_opt(0) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema type must be text".to_string(),
-                            ))
-                        }
-                    };
-                    let name = match record.get_value_opt(1) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema name must be text".to_string(),
-                            ))
-                        }
-                    };
-                    let table_name = match record.get_value_opt(2) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema tbl_name must be text".to_string(),
-                            ))
-                        }
-                    };
-                    let root_page = match record.get_value_opt(3) {
-                        Some(ValueRef::Numeric(Numeric::Integer(v))) => v,
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema root_page must be integer".to_string(),
-                            ))
-                        }
-                    };
-                    let sql = match record.get_value_opt(4) {
-                        Some(ValueRef::Text(v)) => Some(v.as_str()),
-                        _ => None,
-                    };
-                    let attached_resolver = |alias: &str| -> Option<usize> {
-                        connection
-                            .attached_databases()
-                            .read()
-                            .get_database_by_name(&crate::util::normalize_ident(alias))
-                            .map(|(idx, _)| idx)
-                    };
-                    fresh.handle_schema_row(
-                        ty,
-                        name,
-                        table_name,
-                        root_page,
-                        sql,
-                        &syms,
-                        &mut from_sql_indexes,
-                        &mut automatic_indices,
-                        &mut dbsp_state_roots,
-                        &mut dbsp_state_index_roots,
-                        &mut materialized_view_info,
-                        &attached_resolver,
-                    )?;
-                }
-                fresh.populate_indices(
-                    &syms,
-                    from_sql_indexes,
-                    automatic_indices,
-                    mv_store.is_some(),
-                )?;
-                fresh.populate_materialized_views(
-                    materialized_view_info,
-                    dbsp_state_roots,
-                    dbsp_state_index_roots,
-                )?;
-                Self::rehydrate_table_valued_functions(
-                    &mut fresh,
-                    &preserved_table_valued_functions,
+        let rebuild_schema = |connection: &Arc<Connection>,
+                              schema_rows: &HashMap<i64, ImmutableRecord>|
+         -> Result<()> {
+            let pager = connection.pager.load().clone();
+            let cookie = self
+                .global_header
+                .read()
+                .as_ref()
+                .map(|header| header.schema_cookie.get())
+                .unwrap_or(
+                    pager
+                        .io
+                        .block(|| pager.with_header(|header| header.schema_cookie))?
+                        .get(),
                 );
+            let mut fresh = Schema::new();
+            fresh.generated_columns_enabled =
+                connection.db.experimental_generated_columns_enabled();
+            fresh.schema_version = cookie;
+            let mut parser = SchemaTableParser::default();
+            let syms = connection.syms.read();
+            let mv_store = connection.db.get_mv_store().clone();
 
-                let fresh = Arc::new(fresh);
-                *connection.schema.write() = fresh.clone();
-                *connection.db.schema.lock() = fresh;
-                Ok(())
-            };
+            for record in schema_rows.values() {
+                let row = SchemaTableRow::from_record(record, SchemaTableDecodeErrorKind::Corrupt)?;
+                let attached_resolver = |alias: &str| -> Option<usize> {
+                    connection
+                        .attached_databases()
+                        .read()
+                        .get_database_by_name(&crate::util::normalize_ident(alias))
+                        .map(|(idx, _)| idx)
+                };
+                parser.parse_row(&mut fresh, &row, &syms, &attached_resolver)?;
+            }
+            parser.finish(&mut fresh, &syms, mv_store.is_some())?;
+            Self::rehydrate_table_valued_functions(&mut fresh, &preserved_table_valued_functions);
+
+            let fresh = Arc::new(fresh);
+            *connection.schema.write() = fresh.clone();
+            *connection.db.schema.lock() = fresh;
+            Ok(())
+        };
 
         loop {
             let mut get_index_info = |index_id: MVTableId| -> Result<Arc<IndexInfo>> {
@@ -4799,72 +4734,46 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     if is_schema_row {
                         let row_data = row.payload().to_vec();
                         let record = ImmutableRecord::from_bin_record(row_data);
-                        if record.column_count() < 5 {
-                            return Err(LimboError::Corrupt(format!(
-                                "sqlite_schema row must have at least 5 columns, got {}",
-                                record.column_count()
-                            )));
-                        }
-                        let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema type must be text".to_string(),
-                            ));
-                        };
-                        let row_type = row_type.as_str();
-                        let val = match record.get_value_opt(3) {
-                            Some(v) => v,
-                            None => {
-                                return Err(LimboError::InternalError(
-                                    "Expected at least 5 columns in sqlite_schema".to_string(),
-                                ));
-                            }
-                        };
-                        let ValueRef::Numeric(crate::numeric::Numeric::Integer(root_page)) = val
-                        else {
-                            panic!("Expected integer value for root page, got {val:?}");
-                        };
-                        let sql = match record.get_value_opt(4) {
-                            Some(ValueRef::Text(v)) => Some(v.as_str()),
-                            _ => None,
-                        };
-                        let is_virtual_table = row_type == "table"
-                            && sql.is_some_and(|sql| {
-                                contains_ignore_ascii_case!(sql.as_bytes(), b"create virtual")
-                            });
-                        let has_btree = match row_type {
-                            "index" => true,
-                            "table" => !is_virtual_table,
-                            _ => false,
-                        };
-                        if has_btree {
-                            if root_page == 0 {
+                        {
+                            let schema_row = SchemaTableRow::from_record(
+                                &record,
+                                SchemaTableDecodeErrorKind::Corrupt,
+                            )?;
+                            if schema_row.has_btree() {
+                                if schema_row.root_page == 0 {
+                                    return Err(LimboError::Corrupt(format!(
+                                        "sqlite_schema root_page=0 for btree {}",
+                                        schema_row.ty
+                                    )));
+                                }
+                                if schema_row.root_page < 0 {
+                                    let table_id =
+                                        self.get_table_id_from_root_page(schema_row.root_page);
+                                    if let Some(entry) = self.table_id_to_rootpage.get(&table_id) {
+                                        if let Some(value) = *entry.value() {
+                                            panic!("Logical log contains an insertion of a sqlite_schema record that has both a negative root page and a positive root page: {} & {value}", schema_row.root_page);
+                                        }
+                                    }
+                                    self.insert_table_id_to_rootpage(table_id, None);
+                                } else {
+                                    dropped_root_pages.remove(&schema_row.root_page);
+                                    let table_id =
+                                        self.get_table_id_from_root_page(schema_row.root_page);
+                                    let Some(entry) = self.table_id_to_rootpage.get(&table_id)
+                                    else {
+                                        panic!("Logical log contains root page reference {} that does not exist in the table_id_to_rootpage map", schema_row.root_page);
+                                    };
+                                    let Some(value) = *entry.value() else {
+                                        panic!("Logical log contains root page reference {} that does not have a root page in the table_id_to_rootpage map", schema_row.root_page);
+                                    };
+                                    turso_assert_eq!(value, schema_row.root_page as u64, "logical log root page does not match table_id_to_rootpage map", { "root_page": schema_row.root_page, "map_value": value });
+                                }
+                            } else if schema_row.root_page != 0 {
                                 return Err(LimboError::Corrupt(format!(
-                                    "sqlite_schema root_page=0 for btree {row_type}"
+                                    "sqlite_schema root_page must be 0 for {}, got {}",
+                                    schema_row.ty, schema_row.root_page
                                 )));
                             }
-                            if root_page < 0 {
-                                let table_id = self.get_table_id_from_root_page(root_page);
-                                if let Some(entry) = self.table_id_to_rootpage.get(&table_id) {
-                                    if let Some(value) = *entry.value() {
-                                        panic!("Logical log contains an insertion of a sqlite_schema record that has both a negative root page and a positive root page: {root_page} & {value}");
-                                    }
-                                }
-                                self.insert_table_id_to_rootpage(table_id, None);
-                            } else {
-                                dropped_root_pages.remove(&root_page);
-                                let table_id = self.get_table_id_from_root_page(root_page);
-                                let Some(entry) = self.table_id_to_rootpage.get(&table_id) else {
-                                    panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");
-                                };
-                                let Some(value) = *entry.value() else {
-                                    panic!("Logical log contains root page reference {root_page} that does not have a root page in the table_id_to_rootpage map");
-                                };
-                                turso_assert_eq!(value, root_page as u64, "logical log root page does not match table_id_to_rootpage map", { "root_page": root_page, "map_value": value });
-                            }
-                        } else if root_page != 0 {
-                            return Err(LimboError::Corrupt(format!(
-                                "sqlite_schema root_page must be 0 for {row_type}, got {root_page}"
-                            )));
                         }
                         let rowid_int = rowid.row_id.to_int_or_panic();
                         schema_rows.insert(rowid_int, record);
@@ -4971,27 +4880,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             // deleted in the same transaction (ex: a CREATE TABLE followed by a DROP TABLE)
                             continue;
                         };
-                        if record.column_count() < 5 {
-                            return Err(LimboError::Corrupt(format!(
-                                "sqlite_schema row must have at least 5 columns, got {}",
-                                record.column_count()
-                            )));
-                        }
-                        let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema type must be text".to_string(),
-                            ));
-                        };
-                        let row_type = row_type.as_str();
-                        let Some(ValueRef::Numeric(Numeric::Integer(root_page))) =
-                            record.get_value_opt(3)
-                        else {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema root_page must be integer".to_string(),
-                            ));
-                        };
-                        if (row_type == "table" || row_type == "index") && root_page > 0 {
-                            dropped_root_pages.insert(root_page);
+                        let schema_row = SchemaTableRow::from_record(
+                            record,
+                            SchemaTableDecodeErrorKind::Corrupt,
+                        )?;
+                        if schema_row.has_btree() && schema_row.root_page > 0 {
+                            dropped_root_pages.insert(schema_row.root_page);
                         }
                         schema_rows.remove(&rowid_int);
                         needs_schema_rebuild.set(true);

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -140,7 +140,9 @@ impl Trigger {
     }
 }
 
-use crate::schema_parser::{SchemaTableCursor, SchemaTableDecodeErrorKind, SchemaTableParser};
+use crate::schema_parser::{
+    SchemaTableCursor, SchemaTableDecodeErrorKind, SchemaTableParser, SchemaTableType,
+};
 use crate::storage::btree::BTreeCursor;
 use crate::sync::Arc;
 use crate::sync::Mutex;
@@ -1582,7 +1584,7 @@ impl Schema {
     #[allow(clippy::too_many_arguments)]
     pub fn handle_schema_row(
         &mut self,
-        ty: &str,
+        ty: SchemaTableType,
         name: &str,
         table_name: &str,
         root_page: i64,
@@ -1603,7 +1605,7 @@ impl Schema {
         resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
     ) -> Result<()> {
         match ty {
-            "table" => {
+            SchemaTableType::Table => {
                 let sql = maybe_sql.expect("sql should be present for table");
                 let sql_bytes = sql.as_bytes();
                 if root_page == 0 && contains_ignore_ascii_case!(sql_bytes, b"create virtual") {
@@ -1667,7 +1669,7 @@ impl Schema {
                     self.add_btree_table(Arc::new(table))?;
                 }
             }
-            "index" => {
+            SchemaTableType::Index => {
                 match maybe_sql {
                     Some(sql) => {
                         from_sql_indexes.push(UnparsedFromSqlIndex {
@@ -1714,7 +1716,7 @@ impl Schema {
                     }
                 }
             }
-            "view" => {
+            SchemaTableType::View => {
                 use crate::schema::View;
                 use turso_parser::ast::{Cmd, Stmt};
                 use turso_parser::parser::Parser;
@@ -1768,7 +1770,7 @@ impl Schema {
                     }
                 }
             }
-            "trigger" => {
+            SchemaTableType::Trigger => {
                 use turso_parser::ast::{Cmd, Stmt};
                 use turso_parser::parser::Parser;
 
@@ -1828,8 +1830,6 @@ impl Schema {
                     tbl_name.name.as_str(),
                 )?;
             }
-            // Types are stored in sqlite_turso_types, not sqlite_schema
-            _ => {}
         };
 
         Ok(())
@@ -5763,7 +5763,7 @@ mod tests {
         schema.generated_columns_enabled = false;
 
         let result = schema.handle_schema_row(
-            "table",
+            SchemaTableType::Table,
             "t1",
             "t1",
             2,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -140,7 +140,8 @@ impl Trigger {
     }
 }
 
-use crate::storage::btree::{BTreeCursor, CursorTrait};
+use crate::schema_parser::{SchemaTableCursor, SchemaTableDecodeErrorKind, SchemaTableParser};
+use crate::storage::btree::BTreeCursor;
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::translate::collate::CollationSeq;
@@ -151,11 +152,11 @@ use crate::util::{
 use crate::Result;
 use crate::{
     bail_parse_error, contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case,
-    LimboError, MvCursor, Pager, SymbolTable, ValueRef, VirtualTable,
+    LimboError, MvCursor, Pager, SymbolTable, VirtualTable,
 };
 use bitflags::bitflags;
 use core::fmt;
-use rustc_hash::{FxBuildHasher, FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::VecDeque;
 use std::ops::Deref;
 use std::sync::OnceLock;
@@ -529,34 +530,20 @@ impl TypeDef {
     }
 }
 
-/// Accumulators for schema loading - kept separate to avoid moving through state variants
-struct MakeFromBtreeAccumulators {
-    from_sql_indexes: Vec<UnparsedFromSqlIndex>,
-    automatic_indices: HashMap<String, Vec<(String, i64)>>,
-    /// Store DBSP state table root pages: view_name -> dbsp_state_root_page
-    dbsp_state_roots: HashMap<String, i64>,
-    /// Store DBSP state table index root pages: view_name -> dbsp_state_index_root_page
-    dbsp_state_index_roots: HashMap<String, i64>,
-    /// Store materialized view info (SQL and root page) for later creation
-    materialized_view_info: HashMap<String, (String, i64)>,
-}
-
 /// Phase tracking for async schema loading
 #[derive(Default, Debug)]
 pub enum MakeFromBtreePhase {
     #[default]
     Init,
-    Rewinding,
-    FetchingRecord,
-    Advancing,
+    Scanning,
     Done,
 }
 
 /// State machine for async schema loading - passed by caller, not stored on Schema
 pub struct MakeFromBtreeState {
     phase: MakeFromBtreePhase,
-    cursor: Option<BTreeCursor>,
-    accumulators: Option<MakeFromBtreeAccumulators>,
+    cursor: Option<SchemaTableCursor>,
+    parser: Option<SchemaTableParser>,
     read_tx_active: bool,
 }
 
@@ -571,7 +558,7 @@ impl MakeFromBtreeState {
         Self {
             phase: MakeFromBtreePhase::Init,
             cursor: None,
-            accumulators: None,
+            parser: None,
             read_tx_active: false,
         }
     }
@@ -583,7 +570,7 @@ impl MakeFromBtreeState {
             self.read_tx_active = false;
         }
         self.cursor = None;
-        self.accumulators = None;
+        self.parser = None;
     }
 }
 
@@ -1331,123 +1318,51 @@ impl Schema {
                         ));
                     }
 
-                    state.cursor = Some(BTreeCursor::new_table(Arc::clone(pager), 1, 10));
+                    state.cursor = Some(SchemaTableCursor::new(
+                        Box::new(BTreeCursor::new_table(Arc::clone(pager), 1, 10)),
+                        SchemaTableDecodeErrorKind::Conversion,
+                    ));
                     pager.begin_read_tx()?;
                     state.read_tx_active = true;
 
-                    state.accumulators = Some(MakeFromBtreeAccumulators {
-                        from_sql_indexes: Vec::with_capacity(10),
-                        automatic_indices: HashMap::with_capacity_and_hasher(10, FxBuildHasher),
-                        dbsp_state_roots: HashMap::default(),
-                        dbsp_state_index_roots: HashMap::default(),
-                        materialized_view_info: HashMap::default(),
-                    });
+                    state.parser = Some(SchemaTableParser::default());
 
-                    state.phase = MakeFromBtreePhase::Rewinding;
+                    state.phase = MakeFromBtreePhase::Scanning;
                 }
 
-                MakeFromBtreePhase::Rewinding => {
+                MakeFromBtreePhase::Scanning => {
                     let cursor = state
                         .cursor
                         .as_mut()
                         .expect("cursor must be initialized in Init phase");
-                    return_if_io!(cursor.rewind());
-                    state.phase = MakeFromBtreePhase::FetchingRecord;
-                }
-
-                MakeFromBtreePhase::FetchingRecord => {
-                    let cursor = state
-                        .cursor
-                        .as_mut()
-                        .expect("cursor must be initialized in Init phase");
-                    let row = return_if_io!(cursor.record());
+                    let row = return_if_io!(cursor.next_row());
 
                     let Some(row) = row else {
                         // EOF - finalize
                         pager.end_read_tx();
                         state.read_tx_active = false;
 
-                        let acc = state
-                            .accumulators
+                        let parser = state
+                            .parser
                             .take()
-                            .expect("accumulators must be initialized in Init phase");
-                        self.populate_indices(
-                            syms,
-                            acc.from_sql_indexes,
-                            acc.automatic_indices,
-                            mv_cursor.is_some(),
-                        )?;
-                        self.populate_materialized_views(
-                            acc.materialized_view_info,
-                            acc.dbsp_state_roots,
-                            acc.dbsp_state_index_roots,
-                        )?;
+                            .expect("schema parser must be initialized in Init phase");
+                        parser.finish(self, syms, mv_cursor.is_some())?;
 
                         state.cursor = None;
                         state.phase = MakeFromBtreePhase::Done;
                         return Ok(IOResult::Done(()));
                     };
 
-                    // Process the row (no IO - CPU only)
-                    // sqlite schema table has 5 columns: type, name, tbl_name, rootpage, sql
-                    let ty_value = row.get_value(0)?;
-                    let ValueRef::Text(ty) = ty_value else {
-                        return Err(LimboError::ConversionError("Expected text value".into()));
-                    };
-                    let ValueRef::Text(name) = row.get_value(1)? else {
-                        return Err(LimboError::ConversionError("Expected text value".into()));
-                    };
-                    let table_name_value = row.get_value(2)?;
-                    let ValueRef::Text(table_name) = table_name_value else {
-                        return Err(LimboError::ConversionError("Expected text value".into()));
-                    };
-                    let root_page_value = row.get_value(3)?;
-                    let ValueRef::Numeric(crate::numeric::Numeric::Integer(root_page)) =
-                        root_page_value
-                    else {
-                        return Err(LimboError::ConversionError("Expected integer value".into()));
-                    };
-                    let sql_value = row.get_value(4)?;
-                    let sql_textref = match sql_value {
-                        ValueRef::Text(sql) => Some(sql),
-                        _ => None,
-                    };
-                    let sql = sql_textref.map(|s| s.as_str());
-
-                    let acc = state
-                        .accumulators
+                    let parser = state
+                        .parser
                         .as_mut()
-                        .expect("accumulators must be initialized in Init phase");
+                        .expect("schema parser must be initialized in Init phase");
                     // `make_from_btree` is called during database open before
                     // any connection exists, so there is no attached catalog
                     // to consult. Any `CREATE TEMP TRIGGER ... ON aux.x` row
                     // maps to `Some(INVALID_DB_ID)` until a connection-scoped
                     // reparse runs with a real resolver.
-                    self.handle_schema_row(
-                        &ty,
-                        &name,
-                        &table_name,
-                        root_page,
-                        sql,
-                        syms,
-                        &mut acc.from_sql_indexes,
-                        &mut acc.automatic_indices,
-                        &mut acc.dbsp_state_roots,
-                        &mut acc.dbsp_state_index_roots,
-                        &mut acc.materialized_view_info,
-                        &|_| None,
-                    )?;
-
-                    state.phase = MakeFromBtreePhase::Advancing;
-                }
-
-                MakeFromBtreePhase::Advancing => {
-                    let cursor = state
-                        .cursor
-                        .as_mut()
-                        .expect("cursor must be initialized in Init phase");
-                    return_if_io!(cursor.next());
-                    state.phase = MakeFromBtreePhase::FetchingRecord;
+                    parser.parse_row(self, &row, syms, &|_| None)?;
                 }
 
                 MakeFromBtreePhase::Done => {

--- a/core/schema_parser.rs
+++ b/core/schema_parser.rs
@@ -318,6 +318,25 @@ impl SchemaTableParser {
         )
     }
 
+    pub(crate) fn parse_extension_load_row(
+        &mut self,
+        schema: &mut Schema,
+        row: &SchemaTableRow,
+        syms: &SymbolTable,
+        resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
+    ) -> Result<()> {
+        // Incremental re-parse after extension loading. The schema already has
+        // tables/indices/views from initial parse. We only need to pick up
+        // entries that previously failed (e.g. virtual tables whose module
+        // wasn't loaded yet). "Already exists" errors are expected and skipped.
+        Self::ignore_expected_extension_load_error(self.parse_row(
+            schema,
+            row,
+            syms,
+            resolve_attached_db,
+        ))
+    }
+
     pub(crate) fn finish(
         self,
         schema: &mut Schema,
@@ -335,5 +354,35 @@ impl SchemaTableParser {
             self.dbsp_state_roots,
             self.dbsp_state_index_roots,
         )
+    }
+
+    pub(crate) fn finish_extension_load(
+        self,
+        schema: &mut Schema,
+        syms: &SymbolTable,
+    ) -> Result<()> {
+        Self::ignore_expected_extension_load_error(schema.populate_indices(
+            syms,
+            self.from_sql_indexes,
+            self.automatic_indices,
+            false,
+        ))?;
+        Self::ignore_expected_extension_load_error(schema.populate_materialized_views(
+            self.materialized_view_info,
+            self.dbsp_state_roots,
+            self.dbsp_state_index_roots,
+        ))
+    }
+
+    fn ignore_expected_extension_load_error(result: Result<()>) -> Result<()> {
+        match result {
+            Ok(()) => Ok(()),
+            Err(LimboError::ParseError(msg)) if msg.contains("already exists") => Ok(()),
+            Err(LimboError::ExtensionError(msg)) => {
+                eprintln!("Warning: {msg}");
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 }

--- a/core/schema_parser.rs
+++ b/core/schema_parser.rs
@@ -1,0 +1,305 @@
+use crate::numeric::Numeric;
+use crate::schema::Schema;
+use crate::storage::btree::CursorTrait;
+use crate::types::IOResult;
+use crate::types::ImmutableRecord;
+use crate::util::UnparsedFromSqlIndex;
+use crate::{LimboError, Result, SymbolTable, ValueRef};
+use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
+
+#[derive(Debug, Clone)]
+pub enum ParseSchemaFilter {
+    All,
+    TableNameNotTrigger { table_names: Vec<String> },
+    Name { names: Vec<String> },
+    NameAndType { name: String, ty: String },
+}
+
+impl ParseSchemaFilter {
+    pub fn matches(&self, ty: &str, name: &str, table_name: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::TableNameNotTrigger { table_names } => {
+                ty != "trigger" && table_names.iter().any(|candidate| candidate == table_name)
+            }
+            Self::Name { names } => names.iter().any(|candidate| candidate == name),
+            Self::NameAndType {
+                name: candidate,
+                ty: candidate_ty,
+            } => candidate == name && candidate_ty == ty,
+        }
+    }
+
+    pub(crate) fn matches_row(&self, row: &SchemaTableRow) -> bool {
+        self.matches(&row.ty, &row.name, &row.table_name)
+    }
+
+    pub fn explain(&self) -> String {
+        match self {
+            Self::All => "ALL".to_string(),
+            Self::TableNameNotTrigger { table_names } => table_names
+                .iter()
+                .map(|table_name| {
+                    format!(
+                        "tbl_name = {} AND type != 'trigger'",
+                        quote_schema_value(table_name)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" OR "),
+            Self::Name { names } => names
+                .iter()
+                .map(|name| format!("name = {}", quote_schema_value(name)))
+                .collect::<Vec<_>>()
+                .join(" OR "),
+            Self::NameAndType { name, ty } => format!(
+                "name = {} AND type = {}",
+                quote_schema_value(name),
+                quote_schema_value(ty)
+            ),
+        }
+    }
+}
+
+fn quote_schema_value(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SchemaTableDecodeErrorKind {
+    Conversion,
+    Corrupt,
+}
+
+pub(crate) struct SchemaTableRow {
+    pub ty: String,
+    pub name: String,
+    pub table_name: String,
+    pub root_page: i64,
+    pub sql: Option<String>,
+}
+
+impl SchemaTableRow {
+    pub(crate) fn from_record(
+        record: &ImmutableRecord,
+        error_kind: SchemaTableDecodeErrorKind,
+    ) -> Result<Self> {
+        if record.column_count() < 5 {
+            return Err(schema_table_error(
+                error_kind,
+                format!(
+                    "sqlite_schema row must have at least 5 columns, got {}",
+                    record.column_count()
+                ),
+                "Expected at least 5 columns in sqlite_schema".to_string(),
+            ));
+        }
+
+        let ty = text_column(record, 0, "type", error_kind)?;
+        let name = text_column(record, 1, "name", error_kind)?;
+        let table_name = text_column(record, 2, "tbl_name", error_kind)?;
+        let root_page = integer_column(record, 3, "rootpage", error_kind)?;
+        let sql = match record.get_value_opt(4) {
+            Some(ValueRef::Text(sql)) => Some(sql.as_str()),
+            _ => None,
+        };
+
+        Ok(Self {
+            ty: ty.to_string(),
+            name: name.to_string(),
+            table_name: table_name.to_string(),
+            root_page,
+            sql: sql.map(ToString::to_string),
+        })
+    }
+
+    pub(crate) fn has_btree(&self) -> bool {
+        match self.ty.as_str() {
+            "index" => true,
+            "table" => !self.is_virtual_table(),
+            _ => false,
+        }
+    }
+
+    fn is_virtual_table(&self) -> bool {
+        self.sql
+            .as_deref()
+            .is_some_and(|sql| contains_ignore_ascii_case(sql.as_bytes(), b"create virtual"))
+    }
+}
+
+fn contains_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window.eq_ignore_ascii_case(needle))
+}
+
+#[derive(Debug)]
+enum SchemaTableCursorPhase {
+    Rewinding,
+    FetchingRecord,
+    Advancing,
+    Done,
+}
+
+pub(crate) struct SchemaTableCursor {
+    cursor: Box<dyn CursorTrait>,
+    phase: SchemaTableCursorPhase,
+    error_kind: SchemaTableDecodeErrorKind,
+}
+
+impl SchemaTableCursor {
+    pub(crate) fn new(
+        cursor: Box<dyn CursorTrait>,
+        error_kind: SchemaTableDecodeErrorKind,
+    ) -> Self {
+        Self {
+            cursor,
+            phase: SchemaTableCursorPhase::Rewinding,
+            error_kind,
+        }
+    }
+
+    pub(crate) fn next_row(&mut self) -> Result<IOResult<Option<SchemaTableRow>>> {
+        loop {
+            match self.phase {
+                SchemaTableCursorPhase::Rewinding => match self.cursor.rewind()? {
+                    IOResult::Done(()) => self.phase = SchemaTableCursorPhase::FetchingRecord,
+                    IOResult::IO(io) => return Ok(IOResult::IO(io)),
+                },
+                SchemaTableCursorPhase::FetchingRecord => {
+                    let record = match self.cursor.record()? {
+                        IOResult::Done(record) => record,
+                        IOResult::IO(io) => return Ok(IOResult::IO(io)),
+                    };
+                    let Some(record) = record else {
+                        self.phase = SchemaTableCursorPhase::Done;
+                        return Ok(IOResult::Done(None));
+                    };
+                    let row = SchemaTableRow::from_record(record, self.error_kind)?;
+                    self.phase = SchemaTableCursorPhase::Advancing;
+                    return Ok(IOResult::Done(Some(row)));
+                }
+                SchemaTableCursorPhase::Advancing => match self.cursor.next()? {
+                    IOResult::Done(()) => {
+                        self.phase = if self.cursor.has_record() {
+                            SchemaTableCursorPhase::FetchingRecord
+                        } else {
+                            SchemaTableCursorPhase::Done
+                        };
+                    }
+                    IOResult::IO(io) => return Ok(IOResult::IO(io)),
+                },
+                SchemaTableCursorPhase::Done => return Ok(IOResult::Done(None)),
+            }
+        }
+    }
+}
+
+fn text_column<'a>(
+    record: &'a ImmutableRecord,
+    column: usize,
+    column_name: &str,
+    error_kind: SchemaTableDecodeErrorKind,
+) -> Result<&'a str> {
+    match record.get_value_opt(column) {
+        Some(ValueRef::Text(value)) => Ok(value.as_str()),
+        _ => Err(schema_table_error(
+            error_kind,
+            format!("sqlite_schema {column_name} must be text"),
+            format!("Expected text value for sqlite_schema.{column_name}"),
+        )),
+    }
+}
+
+fn integer_column(
+    record: &ImmutableRecord,
+    column: usize,
+    column_name: &str,
+    error_kind: SchemaTableDecodeErrorKind,
+) -> Result<i64> {
+    match record.get_value_opt(column) {
+        Some(ValueRef::Numeric(Numeric::Integer(value))) => Ok(value),
+        _ => Err(schema_table_error(
+            error_kind,
+            format!("sqlite_schema {column_name} must be integer"),
+            format!("Expected integer value for sqlite_schema.{column_name}"),
+        )),
+    }
+}
+
+fn schema_table_error(
+    error_kind: SchemaTableDecodeErrorKind,
+    corrupt_message: String,
+    conversion_message: String,
+) -> LimboError {
+    match error_kind {
+        SchemaTableDecodeErrorKind::Conversion => LimboError::ConversionError(conversion_message),
+        SchemaTableDecodeErrorKind::Corrupt => LimboError::Corrupt(corrupt_message),
+    }
+}
+
+/// Accumulates schema rows whose final objects depend on entries parsed later in sqlite_schema.
+pub(crate) struct SchemaTableParser {
+    from_sql_indexes: Vec<UnparsedFromSqlIndex>,
+    automatic_indices: HashMap<String, Vec<(String, i64)>>,
+    dbsp_state_roots: HashMap<String, i64>,
+    dbsp_state_index_roots: HashMap<String, i64>,
+    materialized_view_info: HashMap<String, (String, i64)>,
+}
+
+impl Default for SchemaTableParser {
+    fn default() -> Self {
+        Self {
+            from_sql_indexes: Vec::with_capacity(10),
+            automatic_indices: HashMap::with_capacity_and_hasher(10, FxBuildHasher),
+            dbsp_state_roots: HashMap::default(),
+            dbsp_state_index_roots: HashMap::default(),
+            materialized_view_info: HashMap::default(),
+        }
+    }
+}
+
+impl SchemaTableParser {
+    pub(crate) fn parse_row(
+        &mut self,
+        schema: &mut Schema,
+        row: &SchemaTableRow,
+        syms: &SymbolTable,
+        resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
+    ) -> Result<()> {
+        schema.handle_schema_row(
+            &row.ty,
+            &row.name,
+            &row.table_name,
+            row.root_page,
+            row.sql.as_deref(),
+            syms,
+            &mut self.from_sql_indexes,
+            &mut self.automatic_indices,
+            &mut self.dbsp_state_roots,
+            &mut self.dbsp_state_index_roots,
+            &mut self.materialized_view_info,
+            resolve_attached_db,
+        )
+    }
+
+    pub(crate) fn finish(
+        self,
+        schema: &mut Schema,
+        syms: &SymbolTable,
+        mvcc_enabled: bool,
+    ) -> Result<()> {
+        schema.populate_indices(
+            syms,
+            self.from_sql_indexes,
+            self.automatic_indices,
+            mvcc_enabled,
+        )?;
+        schema.populate_materialized_views(
+            self.materialized_view_info,
+            self.dbsp_state_roots,
+            self.dbsp_state_index_roots,
+        )
+    }
+}

--- a/core/schema_parser.rs
+++ b/core/schema_parser.rs
@@ -6,32 +6,52 @@ use crate::types::ImmutableRecord;
 use crate::util::UnparsedFromSqlIndex;
 use crate::{LimboError, Result, SymbolTable, ValueRef};
 use rustc_hash::{FxBuildHasher, FxHashMap as HashMap};
+use std::str::FromStr;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::IntoStaticStr,
+)]
+#[strum(ascii_case_insensitive, serialize_all = "snake_case")]
+pub enum SchemaTableType {
+    Table,
+    Index,
+    View,
+    Trigger,
+}
 
 #[derive(Debug, Clone)]
 pub enum ParseSchemaFilter {
     All,
     TableNameNotTrigger { table_names: Vec<String> },
     Name { names: Vec<String> },
-    NameAndType { name: String, ty: String },
+    NameAndType { name: String, ty: SchemaTableType },
 }
 
 impl ParseSchemaFilter {
-    pub fn matches(&self, ty: &str, name: &str, table_name: &str) -> bool {
+    pub(crate) fn matches(&self, ty: SchemaTableType, name: &str, table_name: &str) -> bool {
         match self {
             Self::All => true,
             Self::TableNameNotTrigger { table_names } => {
-                ty != "trigger" && table_names.iter().any(|candidate| candidate == table_name)
+                ty != SchemaTableType::Trigger
+                    && table_names.iter().any(|candidate| candidate == table_name)
             }
             Self::Name { names } => names.iter().any(|candidate| candidate == name),
             Self::NameAndType {
                 name: candidate,
                 ty: candidate_ty,
-            } => candidate == name && candidate_ty == ty,
+            } => candidate == name && *candidate_ty == ty,
         }
     }
 
     pub(crate) fn matches_row(&self, row: &SchemaTableRow) -> bool {
-        self.matches(&row.ty, &row.name, &row.table_name)
+        self.matches(row.ty, &row.name, &row.table_name)
     }
 
     pub fn explain(&self) -> String {
@@ -55,7 +75,7 @@ impl ParseSchemaFilter {
             Self::NameAndType { name, ty } => format!(
                 "name = {} AND type = {}",
                 quote_schema_value(name),
-                quote_schema_value(ty)
+                quote_schema_value((*ty).into())
             ),
         }
     }
@@ -72,7 +92,7 @@ pub(crate) enum SchemaTableDecodeErrorKind {
 }
 
 pub(crate) struct SchemaTableRow {
-    pub ty: String,
+    pub ty: SchemaTableType,
     pub name: String,
     pub table_name: String,
     pub root_page: i64,
@@ -95,7 +115,7 @@ impl SchemaTableRow {
             ));
         }
 
-        let ty = text_column(record, 0, "type", error_kind)?;
+        let ty = schema_type_column(record, error_kind)?;
         let name = text_column(record, 1, "name", error_kind)?;
         let table_name = text_column(record, 2, "tbl_name", error_kind)?;
         let root_page = integer_column(record, 3, "rootpage", error_kind)?;
@@ -105,7 +125,7 @@ impl SchemaTableRow {
         };
 
         Ok(Self {
-            ty: ty.to_string(),
+            ty,
             name: name.to_string(),
             table_name: table_name.to_string(),
             root_page,
@@ -114,10 +134,10 @@ impl SchemaTableRow {
     }
 
     pub(crate) fn has_btree(&self) -> bool {
-        match self.ty.as_str() {
-            "index" => true,
-            "table" => !self.is_virtual_table(),
-            _ => false,
+        match self.ty {
+            SchemaTableType::Index => true,
+            SchemaTableType::Table => !self.is_virtual_table(),
+            SchemaTableType::View | SchemaTableType::Trigger => false,
         }
     }
 
@@ -132,6 +152,20 @@ fn contains_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> bool {
     haystack
         .windows(needle.len())
         .any(|window| window.eq_ignore_ascii_case(needle))
+}
+
+fn schema_type_column(
+    record: &ImmutableRecord,
+    error_kind: SchemaTableDecodeErrorKind,
+) -> Result<SchemaTableType> {
+    let value = text_column(record, 0, "type", error_kind)?;
+    SchemaTableType::from_str(value).map_err(|_| {
+        schema_table_error(
+            error_kind,
+            format!("sqlite_schema type is invalid: {value}"),
+            format!("Invalid sqlite_schema.type value: {value}"),
+        )
+    })
 }
 
 #[derive(Debug)]
@@ -269,7 +303,7 @@ impl SchemaTableParser {
         resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
     ) -> Result<()> {
         schema.handle_schema_row(
-            &row.ty,
+            row.ty,
             &row.name,
             &row.table_name,
             row.root_page,

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -220,11 +220,11 @@ pub fn translate_analyze(
             Some(sql.to_string()),
         )?;
 
-        let parse_schema_where_clause =
-            "tbl_name = 'sqlite_stat1' AND type != 'trigger'".to_string();
         program.emit_insn(Insn::ParseSchema {
             db: database_id,
-            where_clause: Some(parse_schema_where_clause),
+            filter: crate::vdbe::insn::ParseSchemaFilter::TableNameNotTrigger {
+                table_names: vec!["sqlite_stat1".to_string()],
+            },
         });
 
         // Bump schema cookie so subsequent statements reparse schema.

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -583,7 +583,7 @@ pub fn translate_create_index(
         db: database_id,
         filter: crate::vdbe::insn::ParseSchemaFilter::NameAndType {
             name: idx_name.clone(),
-            ty: "index".to_string(),
+            ty: crate::schema_parser::SchemaTableType::Index,
         },
     });
     // Close the final sqlite_schema cursor

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -23,7 +23,7 @@ use crate::{bail_parse_error, CaptureDataChangesExt, LimboError, MAIN_DB_ID};
 use crate::{
     schema::{BTreeTable, Index, IndexColumn, PseudoCursorType},
     storage::pager::CreateBTreeFlags,
-    util::{escape_sql_string_literal, normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
+    util::{normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
     vdbe::{
         builder::{CursorType, ProgramBuilder},
         insn::{IdxInsertFlags, Insn, RegisterOrLiteral},
@@ -579,11 +579,12 @@ pub fn translate_create_index(
         p5: 0,
     });
     // Parse the schema table to get the index root page and add new index to Schema
-    let escaped_idx_name = escape_sql_string_literal(&idx_name);
-    let parse_schema_where_clause = format!("name = '{escaped_idx_name}' AND type = 'index'");
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
-        where_clause: Some(parse_schema_where_clause),
+        filter: crate::vdbe::insn::ParseSchemaFilter::NameAndType {
+            name: idx_name.clone(),
+            ty: "index".to_string(),
+        },
     });
     // Close the final sqlite_schema cursor
     program.emit_insn(Insn::Close {

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -20,10 +20,7 @@ use crate::translate::plan::{Plan, QueryDestination};
 use crate::translate::planner::ROWID_STRS;
 use crate::translate::select::{emit_select_plan, prepare_select_plan};
 use crate::translate::{ProgramBuilder, ProgramBuilderOpts};
-use crate::util::{
-    escape_sql_string_literal, normalize_ident, quote_identifier,
-    PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX,
-};
+use crate::util::{normalize_ident, quote_identifier, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX};
 use crate::vdbe::builder::CursorType;
 use crate::vdbe::insn::{
     to_u16, {CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral},
@@ -1390,17 +1387,16 @@ pub fn translate_create_table(
         p5: 0,
     });
 
-    // TODO: remove format, it sucks for performance but is convenient
-    let escaped_tbl_name = escape_sql_string_literal(&normalized_tbl_name);
-    let mut parse_schema_where_clause =
-        format!("tbl_name = '{escaped_tbl_name}' AND type != 'trigger'");
+    let mut parse_schema_table_names = vec![normalized_tbl_name.clone()];
     if created_sequence_table {
-        parse_schema_where_clause.push_str(" OR tbl_name = 'sqlite_sequence'");
+        parse_schema_table_names.push("sqlite_sequence".to_string());
     }
 
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
-        where_clause: Some(parse_schema_where_clause),
+        filter: crate::vdbe::insn::ParseSchemaFilter::TableNameNotTrigger {
+            table_names: parse_schema_table_names,
+        },
     });
 
     // For CTAS, emit bytecode to populate the new table from the SELECT
@@ -1733,12 +1729,11 @@ pub fn translate_create_virtual_table(
         value: resolver.schema().schema_version as i32 + 1,
         p5: 0,
     });
-    let escaped_table_name = escape_sql_string_literal(&table_name);
-    let parse_schema_where_clause =
-        format!("tbl_name = '{escaped_table_name}' AND type != 'trigger'");
     program.emit_insn(Insn::ParseSchema {
-        db: sqlite_schema_cursor_id,
-        where_clause: Some(parse_schema_where_clause),
+        db: crate::MAIN_DB_ID,
+        filter: crate::vdbe::insn::ParseSchemaFilter::TableNameNotTrigger {
+            table_names: vec![table_name],
+        },
     });
 
     Ok(())
@@ -2454,10 +2449,10 @@ fn persist_type_definition(
 
         // Parse schema to register the new table in-memory
         program.emit_insn(Insn::ParseSchema {
-            db: schema_cursor_id,
-            where_clause: Some(format!(
-                "tbl_name = '{TURSO_TYPES_TABLE_NAME}' AND type != 'trigger'"
-            )),
+            db: MAIN_DB_ID,
+            filter: crate::vdbe::insn::ParseSchemaFilter::TableNameNotTrigger {
+                table_names: vec![TURSO_TYPES_TABLE_NAME.to_string()],
+            },
         });
     }
 

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -2,7 +2,7 @@ use crate::translate::emitter::Resolver;
 use crate::translate::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
 use crate::translate::ProgramBuilder;
 use crate::translate::ProgramBuilderOpts;
-use crate::util::{escape_sql_string_literal, normalize_ident};
+use crate::util::normalize_ident;
 use crate::vdbe::builder::CursorType;
 use crate::vdbe::insn::{Cookie, Insn};
 use crate::{bail_parse_error, Result, MAIN_DB_ID};
@@ -209,12 +209,12 @@ pub fn translate_create_trigger(
     });
 
     // Parse schema to load the new trigger
-    let escaped_trigger_name = escape_sql_string_literal(&normalized_trigger_name);
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
-        where_clause: Some(format!(
-            "name = '{escaped_trigger_name}' AND type = 'trigger'"
-        )),
+        filter: crate::vdbe::insn::ParseSchemaFilter::NameAndType {
+            name: normalized_trigger_name,
+            ty: "trigger".to_string(),
+        },
     });
 
     Ok(())

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -213,7 +213,7 @@ pub fn translate_create_trigger(
         db: database_id,
         filter: crate::vdbe::insn::ParseSchemaFilter::NameAndType {
             name: normalized_trigger_name,
-            ty: "trigger".to_string(),
+            ty: crate::schema_parser::SchemaTableType::Trigger,
         },
     });
 

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -8,9 +8,7 @@ use crate::translate::{
     emitter::Resolver,
     schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID},
 };
-use crate::util::{
-    escape_sql_string_literal, normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX,
-};
+use crate::util::{normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX};
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::{CmpInsFlags, Cookie, Insn, RegisterOrLiteral};
 use crate::{bail_parse_error, Connection, Result, MAIN_DB_ID};
@@ -234,14 +232,15 @@ pub fn translate_create_materialized_view(
     )?;
 
     // Parse schema to load the new view and DBSP state table
-    let escaped_view_name = escape_sql_string_literal(&normalized_view_name);
-    let escaped_dbsp_table_name = escape_sql_string_literal(dbsp_table_name.as_str());
-    let escaped_dbsp_index_name = escape_sql_string_literal(&dbsp_index_name);
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
-        where_clause: Some(format!(
-            "name = '{escaped_view_name}' OR name = '{escaped_dbsp_table_name}' OR name = '{escaped_dbsp_index_name}'"
-        )),
+        filter: crate::vdbe::insn::ParseSchemaFilter::Name {
+            names: vec![
+                normalized_view_name.clone(),
+                dbsp_table_name.as_str().to_string(),
+                dbsp_index_name,
+            ],
+        },
     });
 
     let schema_version = resolver.with_schema(database_id, |s| s.schema_version);
@@ -344,10 +343,11 @@ pub fn translate_create_view(
     )?;
 
     // Parse schema to load the new view
-    let escaped_view_name = escape_sql_string_literal(&normalized_view_name);
     program.emit_insn(Insn::ParseSchema {
         db: database_id,
-        where_clause: Some(format!("name = '{escaped_view_name}'")),
+        filter: crate::vdbe::insn::ParseSchemaFilter::Name {
+            names: vec![normalized_view_name],
+        },
     });
 
     let schema_version = resolver.with_schema(database_id, |s| s.schema_version);

--- a/core/util.rs
+++ b/core/util.rs
@@ -1,7 +1,5 @@
 use crate::numeric::StrToF64;
 use crate::schema::ColDef;
-use crate::schema_parser::{SchemaTableParser, SchemaTableRow, SchemaTableType};
-use crate::translate::emitter::TransactionMode;
 use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
 use crate::translate::plan::{BitSet, JoinedTable, TableReferences};
 use crate::translate::planner::{parse_row_id, TableMask};
@@ -10,12 +8,11 @@ use crate::IO;
 use crate::{
     schema::{Column, Schema, Table, Type},
     types::{Value, ValueType},
-    LimboError, OpenFlags, Result, Statement, SymbolTable,
+    LimboError, OpenFlags, Result,
 };
 use either::Either;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::future::Future;
-use tracing::{instrument, Level};
 use turso_macros::match_ignore_ascii_case;
 use turso_parser::ast::{self, CreateTableBody, Expr, Literal, UnaryOperator};
 use turso_parser::parser::Parser;
@@ -154,47 +151,6 @@ pub struct UnparsedFromSqlIndex {
     pub table_name: String,
     pub root_page: i64,
     pub sql: String,
-}
-
-#[instrument(skip_all, level = Level::INFO)]
-pub fn parse_schema_rows(
-    mut rows: Statement,
-    schema: &mut Schema,
-    syms: &SymbolTable,
-    mv_tx: Option<(u64, TransactionMode)>,
-    resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
-) -> Result<()> {
-    rows.set_mv_tx(mv_tx);
-    let mvcc_enabled = rows.mv_store().is_some();
-    let mut parser = SchemaTableParser::default();
-
-    // TODO: How do we ensure that the I/O we submitted to
-    // read the schema is actually complete?
-    rows.run_with_row_callback(|row| {
-        let ty = row.get::<&str>(0)?;
-        let name = row.get::<&str>(1)?;
-        let table_name = row.get::<&str>(2)?;
-        let root_page = row.get::<i64>(3)?;
-        let sql = row.get::<&str>(4).ok();
-        parser.parse_row(
-            schema,
-            &SchemaTableRow {
-                ty: ty.parse::<SchemaTableType>().map_err(|_| {
-                    LimboError::ConversionError(format!("Invalid sqlite_schema.type value: {ty}"))
-                })?,
-                name: name.to_string(),
-                table_name: table_name.to_string(),
-                root_page,
-                sql: sql.map(ToString::to_string),
-            },
-            syms,
-            resolve_attached_db,
-        )
-    })?;
-
-    parser.finish(schema, syms, mvcc_enabled)?;
-
-    Ok(())
 }
 
 fn cmp_numeric_strings(num_str: &str, other: &str) -> bool {

--- a/core/util.rs
+++ b/core/util.rs
@@ -1,6 +1,6 @@
 use crate::numeric::StrToF64;
 use crate::schema::ColDef;
-use crate::schema_parser::{SchemaTableParser, SchemaTableRow};
+use crate::schema_parser::{SchemaTableParser, SchemaTableRow, SchemaTableType};
 use crate::translate::emitter::TransactionMode;
 use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
 use crate::translate::plan::{BitSet, JoinedTable, TableReferences};
@@ -179,7 +179,9 @@ pub fn parse_schema_rows(
         parser.parse_row(
             schema,
             &SchemaTableRow {
-                ty: ty.to_string(),
+                ty: ty.parse::<SchemaTableType>().map_err(|_| {
+                    LimboError::ConversionError(format!("Invalid sqlite_schema.type value: {ty}"))
+                })?,
                 name: name.to_string(),
                 table_name: table_name.to_string(),
                 root_page,

--- a/core/util.rs
+++ b/core/util.rs
@@ -1,5 +1,6 @@
 use crate::numeric::StrToF64;
 use crate::schema::ColDef;
+use crate::schema_parser::{SchemaTableParser, SchemaTableRow};
 use crate::translate::emitter::TransactionMode;
 use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
 use crate::translate::plan::{BitSet, JoinedTable, TableReferences};
@@ -164,18 +165,8 @@ pub fn parse_schema_rows(
     resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
 ) -> Result<()> {
     rows.set_mv_tx(mv_tx);
-    let mv_store = rows.mv_store().clone();
-    // TODO: if we IO, this unparsed indexes is lost. Will probably need some state between
-    // IO runs
-    let mut from_sql_indexes = Vec::with_capacity(10);
-    let mut automatic_indices = HashMap::with_capacity_and_hasher(10, Default::default());
-
-    // Store DBSP state table root pages: view_name -> dbsp_state_root_page
-    let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
-    // Store DBSP state table index root pages: view_name -> dbsp_state_index_root_page
-    let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();
-    // Store materialized view info (SQL and root page) for later creation
-    let mut materialized_view_info: HashMap<String, (String, i64)> = HashMap::default();
+    let mvcc_enabled = rows.mv_store().is_some();
+    let mut parser = SchemaTableParser::default();
 
     // TODO: How do we ensure that the I/O we submitted to
     // read the schema is actually complete?
@@ -185,33 +176,21 @@ pub fn parse_schema_rows(
         let table_name = row.get::<&str>(2)?;
         let root_page = row.get::<i64>(3)?;
         let sql = row.get::<&str>(4).ok();
-        schema.handle_schema_row(
-            ty,
-            name,
-            table_name,
-            root_page,
-            sql,
+        parser.parse_row(
+            schema,
+            &SchemaTableRow {
+                ty: ty.to_string(),
+                name: name.to_string(),
+                table_name: table_name.to_string(),
+                root_page,
+                sql: sql.map(ToString::to_string),
+            },
             syms,
-            &mut from_sql_indexes,
-            &mut automatic_indices,
-            &mut dbsp_state_roots,
-            &mut dbsp_state_index_roots,
-            &mut materialized_view_info,
             resolve_attached_db,
         )
     })?;
 
-    schema.populate_indices(
-        syms,
-        from_sql_indexes,
-        automatic_indices,
-        mv_store.is_some(),
-    )?;
-    schema.populate_materialized_views(
-        materialized_view_info,
-        dbsp_state_roots,
-        dbsp_state_index_roots,
-    )?;
+    parser.finish(schema, syms, mvcc_enabled)?;
 
     Ok(())
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6,6 +6,7 @@ use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{Schema, Table, SQLITE_SEQUENCE_TABLE_NAME};
+use crate::schema_parser::{SchemaTableCursor, SchemaTableDecodeErrorKind, SchemaTableParser};
 use crate::state_machine::StateMachine;
 use crate::storage::btree::{
     integrity_check, CursorTrait, IntegrityCheckError, IntegrityCheckState, PageCategory,
@@ -10943,26 +10944,14 @@ pub fn op_page_count(
 /// schema cursor yields IO, we can return control to the outer caller and
 /// resume later without losing intermediate parsing state.
 pub struct OpParseSchemaInner {
-    cursor: Box<dyn CursorTrait>,
+    cursor: SchemaTableCursor,
     schema_arc: Arc<Schema>,
-    from_sql_indexes: Vec<crate::util::UnparsedFromSqlIndex>,
-    automatic_indices: crate::HashMap<String, Vec<(String, i64)>>,
-    dbsp_state_roots: crate::HashMap<String, i64>,
-    dbsp_state_index_roots: crate::HashMap<String, i64>,
-    materialized_view_info: crate::HashMap<String, (String, i64)>,
+    parser: SchemaTableParser,
     filter: crate::vdbe::insn::ParseSchemaFilter,
     db: usize,
-    phase: OpParseSchemaPhase,
 }
 
 pub type OpParseSchemaState = Option<Box<OpParseSchemaInner>>;
-
-#[derive(Debug)]
-enum OpParseSchemaPhase {
-    Rewinding,
-    FetchingRecord,
-    Advancing,
-}
 
 pub fn op_parse_schema(
     program: &Program,
@@ -11012,16 +11001,11 @@ pub fn op_parse_schema(
 
     // Store state for resumption across IO boundaries
     *state.active_op_state.parse_schema() = Some(Box::new(OpParseSchemaInner {
-        cursor,
+        cursor: SchemaTableCursor::new(cursor, SchemaTableDecodeErrorKind::Conversion),
         schema_arc,
-        from_sql_indexes: Vec::with_capacity(10),
-        automatic_indices: Default::default(),
-        dbsp_state_roots: Default::default(),
-        dbsp_state_index_roots: Default::default(),
-        materialized_view_info: Default::default(),
+        parser: SchemaTableParser::default(),
         filter: filter.clone(),
         db: *db,
-        phase: OpParseSchemaPhase::Rewinding,
     }));
 
     // Now begin stepping through the schema rows
@@ -11064,61 +11048,23 @@ fn op_parse_schema_step(
 ) -> Result<InsnFunctionStepResult> {
     loop {
         let inner = state.active_op_state.parse_schema().as_mut().unwrap();
-        match inner.phase {
-            OpParseSchemaPhase::Rewinding => {
-                return_if_io!(inner.cursor.rewind());
-                inner.phase = OpParseSchemaPhase::FetchingRecord;
-            }
-            OpParseSchemaPhase::FetchingRecord => {
-                let row = return_if_io!(inner.cursor.record());
-                let Some(row) = row else {
-                    return finish_parse_schema(state, conn);
-                };
+        let row = return_if_io!(inner.cursor.next_row());
+        let Some(row) = row else {
+            return finish_parse_schema(state, conn);
+        };
 
-                let ty = schema_text_column(row, 0, "type")?.to_string();
-                let name = schema_text_column(row, 1, "name")?.to_string();
-                let table_name = schema_text_column(row, 2, "tbl_name")?.to_string();
-                let root_page = schema_integer_column(row, 3, "rootpage")?;
-                let sql = match row.get_value(4)? {
-                    ValueRef::Text(sql) => Some(sql.as_str().to_string()),
-                    _ => None,
-                };
-
-                if inner.filter.matches(&ty, &name, &table_name) {
-                    let schema = Arc::make_mut(&mut inner.schema_arc);
-                    let syms = conn.syms.read();
-                    let attached_resolver = |alias: &str| -> Option<usize> {
-                        conn.attached_databases()
-                            .read()
-                            .get_database_by_name(&crate::util::normalize_ident(alias))
-                            .map(|(idx, _)| idx)
-                    };
-                    schema.handle_schema_row(
-                        &ty,
-                        &name,
-                        &table_name,
-                        root_page,
-                        sql.as_deref(),
-                        &syms,
-                        &mut inner.from_sql_indexes,
-                        &mut inner.automatic_indices,
-                        &mut inner.dbsp_state_roots,
-                        &mut inner.dbsp_state_index_roots,
-                        &mut inner.materialized_view_info,
-                        &attached_resolver,
-                    )?;
-                }
-
-                inner.phase = OpParseSchemaPhase::Advancing;
-            }
-            OpParseSchemaPhase::Advancing => {
-                return_if_io!(inner.cursor.next());
-                if inner.cursor.has_record() {
-                    inner.phase = OpParseSchemaPhase::FetchingRecord;
-                    continue;
-                }
-                return finish_parse_schema(state, conn);
-            }
+        if inner.filter.matches_row(&row) {
+            let schema = Arc::make_mut(&mut inner.schema_arc);
+            let syms = conn.syms.read();
+            let attached_resolver = |alias: &str| -> Option<usize> {
+                conn.attached_databases()
+                    .read()
+                    .get_database_by_name(&crate::util::normalize_ident(alias))
+                    .map(|(idx, _)| idx)
+            };
+            inner
+                .parser
+                .parse_row(schema, &row, &syms, &attached_resolver)?;
         }
     }
 }
@@ -11129,11 +11075,7 @@ fn finish_parse_schema(
 ) -> Result<InsnFunctionStepResult> {
     let OpParseSchemaInner {
         mut schema_arc,
-        from_sql_indexes,
-        automatic_indices,
-        dbsp_state_roots,
-        dbsp_state_index_roots,
-        materialized_view_info,
+        parser,
         db,
         ..
     } = *state
@@ -11145,17 +11087,7 @@ fn finish_parse_schema(
     let mv_store = conn.mv_store_for_db(db);
     let syms = conn.syms.read();
 
-    let res1 = schema.populate_indices(
-        &syms,
-        from_sql_indexes,
-        automatic_indices,
-        mv_store.is_some(),
-    );
-    let res2 = schema.populate_materialized_views(
-        materialized_view_info,
-        dbsp_state_roots,
-        dbsp_state_index_roots,
-    );
+    let res = parser.finish(schema, &syms, mv_store.is_some());
 
     // Store the modified schema back
     if db == crate::TEMP_DB_ID {
@@ -11181,33 +11113,11 @@ fn finish_parse_schema(
         *conn.schema.write() = schema_arc;
     }
     conn.bump_prepare_context_generation();
-    let _ = (res1?, res2?);
+    res?;
 
     state.pc += 1;
     state.active_op_state.clear();
     Ok(InsnFunctionStepResult::Step)
-}
-
-fn schema_text_column<'a>(
-    row: &'a ImmutableRecord,
-    column: usize,
-    column_name: &str,
-) -> Result<&'a str> {
-    let ValueRef::Text(value) = row.get_value(column)? else {
-        return Err(LimboError::ConversionError(format!(
-            "Expected text value for sqlite_schema.{column_name}"
-        )));
-    };
-    Ok(value.as_str())
-}
-
-fn schema_integer_column(row: &ImmutableRecord, column: usize, column_name: &str) -> Result<i64> {
-    let ValueRef::Numeric(Numeric::Integer(value)) = row.get_value(column)? else {
-        return Err(LimboError::ConversionError(format!(
-            "Expected integer value for sqlite_schema.{column_name}"
-        )));
-    };
-    Ok(value)
 }
 
 /// Phases of the multi-statement state machine driven by [`op_init_cdc_version`].

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5,7 +5,7 @@ use crate::mvcc::cursor::{MvccCursorType, NextRowidResult};
 use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
-use crate::schema::{Schema, Table, SCHEMA_TABLE_NAME, SQLITE_SEQUENCE_TABLE_NAME};
+use crate::schema::{Schema, Table, SQLITE_SEQUENCE_TABLE_NAME};
 use crate::state_machine::StateMachine;
 use crate::storage::btree::{
     integrity_check, CursorTrait, IntegrityCheckError, IntegrityCheckState, PageCategory,
@@ -10940,21 +10940,29 @@ pub fn op_page_count(
 
 /// State for the async ParseSchema instruction state machine.
 /// Stored in the active opcode state slot so that when the inner
-/// schema query yields IO, we can return control to the outer caller and
+/// schema cursor yields IO, we can return control to the outer caller and
 /// resume later without losing intermediate parsing state.
 pub struct OpParseSchemaInner {
-    stmt: crate::Statement,
+    cursor: Box<dyn CursorTrait>,
     schema_arc: Arc<Schema>,
     from_sql_indexes: Vec<crate::util::UnparsedFromSqlIndex>,
     automatic_indices: crate::HashMap<String, Vec<(String, i64)>>,
     dbsp_state_roots: crate::HashMap<String, i64>,
     dbsp_state_index_roots: crate::HashMap<String, i64>,
     materialized_view_info: crate::HashMap<String, (String, i64)>,
+    filter: crate::vdbe::insn::ParseSchemaFilter,
     db: usize,
-    previous_auto_commit: bool,
+    phase: OpParseSchemaPhase,
 }
 
 pub type OpParseSchemaState = Option<Box<OpParseSchemaInner>>;
+
+#[derive(Debug)]
+enum OpParseSchemaPhase {
+    Rewinding,
+    FetchingRecord,
+    Advancing,
+}
 
 pub fn op_parse_schema(
     program: &Program,
@@ -10962,7 +10970,7 @@ pub fn op_parse_schema(
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(ParseSchema { db, where_clause }, insn);
+    load_insn!(ParseSchema { db, filter }, insn);
 
     let conn = program.connection.clone();
 
@@ -10971,40 +10979,11 @@ pub fn op_parse_schema(
         return op_parse_schema_step(state, &conn);
     }
 
-    // set auto commit to false in order for parse schema to not commit changes as transaction state is stored in connection,
-    // and we use the same connection for nested query.
-    let previous_auto_commit = conn.auto_commit.load(Ordering::SeqCst);
-    conn.auto_commit.store(false, Ordering::SeqCst);
-
-    // For attached databases, qualify the sqlite_schema table with the database name
-    let schema_table = if *db != crate::MAIN_DB_ID {
-        let db_name = conn
-            .get_database_name_by_index(*db)
-            .unwrap_or_else(|| "main".to_string());
-        format!("{db_name}.sqlite_schema")
-    } else {
-        SCHEMA_TABLE_NAME.to_string()
-    };
-    let sql = if let Some(where_clause) = where_clause {
-        format!("SELECT * FROM {schema_table} WHERE {where_clause}")
-    } else {
-        format!("SELECT * FROM {schema_table}")
-    };
-    let mut stmt = conn.prepare_internal(sql)?;
-    // ParseSchema runs as a nested helper statement inside the parent schema
-    // mutation. It only reads sqlite_schema, so a statement subtransaction is
-    // unnecessary and can contend with the parent's subjournal on temp/attached
-    // pagers, surfacing as SQLITE_BUSY during temp DDL.
-    stmt.program
-        .prepared
-        .needs_stmt_subtransactions
-        .store(false, Ordering::Relaxed);
+    let cursor = parse_schema_cursor(&conn, *db)?;
 
     // Get a mutable schema clone *without* holding the schema lock during
-    // nested statement execution.  The nested Statement may call reprepare()
-    // which also acquires the schema / database_schemas write lock, so holding
-    // it here would deadlock on the same thread (parking_lot RwLock is not
-    // re-entrant).
+    // schema table scanning.  Schema row handling reparses SQL and may need
+    // connection-scoped metadata, so avoid holding schema locks across the scan.
     let schema_arc = if *db == crate::TEMP_DB_ID {
         // TEMP: single source of truth is `temp_db.db.schema`. Skip
         // `database_schemas` staging entirely — it would only go stale.
@@ -11018,8 +10997,6 @@ pub fn op_parse_schema(
         let fallback_schema = {
             let attached_dbs = conn.attached_databases.read();
             let Some((db_inst, _pager)) = attached_dbs.index_to_data.get(db) else {
-                conn.auto_commit
-                    .store(previous_auto_commit, Ordering::SeqCst);
                 return Err(LimboError::InternalError(format!(
                     "stale reference to detached database (index {db})"
                 )));
@@ -11033,29 +11010,53 @@ pub fn op_parse_schema(
         conn.schema.read().clone()
     };
 
-    // Set up MVCC transaction for the nested statement
-    let mv_tx = program.connection.get_mv_tx();
-    stmt.set_mv_tx(mv_tx);
-
     // Store state for resumption across IO boundaries
     *state.active_op_state.parse_schema() = Some(Box::new(OpParseSchemaInner {
-        stmt,
+        cursor,
         schema_arc,
         from_sql_indexes: Vec::with_capacity(10),
         automatic_indices: Default::default(),
         dbsp_state_roots: Default::default(),
         dbsp_state_index_roots: Default::default(),
         materialized_view_info: Default::default(),
+        filter: filter.clone(),
         db: *db,
-        previous_auto_commit,
+        phase: OpParseSchemaPhase::Rewinding,
     }));
 
     // Now begin stepping through the schema rows
     op_parse_schema_step(state, &conn)
 }
 
-/// Drive the inner schema statement one step at a time.
-/// Returns IO to the outer VDBE loop when the inner statement needs it,
+fn parse_schema_cursor(conn: &Arc<Connection>, db: usize) -> Result<Box<dyn CursorTrait>> {
+    let pager = conn.get_pager_from_database_index(&db)?;
+    let mv_store = conn.mv_store_for_db(db);
+    let btree_cursor: Box<dyn CursorTrait> = Box::new(BTreeCursor::new_table(
+        pager,
+        maybe_transform_root_page_to_positive(mv_store.as_ref(), 1),
+        5,
+    ));
+
+    if let Some(tx_id) = conn.get_mv_tx_id_for_db(db) {
+        let mv_store = mv_store
+            .as_ref()
+            .expect("mv_store should be Some when MVCC transaction is active")
+            .clone();
+        Ok(Box::new(MvCursor::new(
+            mv_store,
+            conn,
+            tx_id,
+            1,
+            MvccCursorType::Table,
+            btree_cursor,
+        )?))
+    } else {
+        Ok(btree_cursor)
+    }
+}
+
+/// Drive the schema table cursor one step at a time.
+/// Returns IO to the outer VDBE loop when the schema cursor needs it,
 /// preserving all intermediate parsing state for resumption.
 fn op_parse_schema_step(
     state: &mut ProgramState,
@@ -11063,147 +11064,150 @@ fn op_parse_schema_step(
 ) -> Result<InsnFunctionStepResult> {
     loop {
         let inner = state.active_op_state.parse_schema().as_mut().unwrap();
-        match inner.stmt.step()? {
-            StepResult::IO => {
-                let io = inner
-                    .stmt
-                    .take_io_completions()
-                    .expect("IO returned but no completions");
-                return Ok(InsnFunctionStepResult::IO(io));
+        match inner.phase {
+            OpParseSchemaPhase::Rewinding => {
+                return_if_io!(inner.cursor.rewind());
+                inner.phase = OpParseSchemaPhase::FetchingRecord;
             }
-            StepResult::Row => {
-                let inner = state
-                    .active_op_state
-                    .parse_schema()
-                    .as_mut()
-                    .expect("parse schema state should exist");
-                let row = inner.stmt.row().expect("row should be present");
-                let ty = row.get::<&str>(0)?;
-                let name = row.get::<&str>(1)?;
-                let table_name = row.get::<&str>(2)?;
-                let root_page = row.get::<i64>(3)?;
-                let sql = row.get::<&str>(4).ok();
-                let schema = Arc::make_mut(&mut inner.schema_arc);
-                let syms = conn.syms.read();
-                let attached_resolver = |alias: &str| -> Option<usize> {
-                    conn.attached_databases()
-                        .read()
-                        .get_database_by_name(&crate::util::normalize_ident(alias))
-                        .map(|(idx, _)| idx)
+            OpParseSchemaPhase::FetchingRecord => {
+                let row = return_if_io!(inner.cursor.record());
+                let Some(row) = row else {
+                    return finish_parse_schema(state, conn);
                 };
-                schema.handle_schema_row(
-                    ty,
-                    name,
-                    table_name,
-                    root_page,
-                    sql,
-                    &syms,
-                    &mut inner.from_sql_indexes,
-                    &mut inner.automatic_indices,
-                    &mut inner.dbsp_state_roots,
-                    &mut inner.dbsp_state_index_roots,
-                    &mut inner.materialized_view_info,
-                    &attached_resolver,
-                )?;
-                continue;
-            }
-            StepResult::Done => {
-                // Take the state to finalize
-                let OpParseSchemaInner {
-                    stmt,
-                    mut schema_arc,
-                    from_sql_indexes,
-                    automatic_indices,
-                    dbsp_state_roots,
-                    dbsp_state_index_roots,
-                    materialized_view_info,
-                    db,
-                    previous_auto_commit,
-                } = *state
-                    .active_op_state
-                    .parse_schema()
-                    .take()
-                    .expect("parse schema state should exist");
-                let schema = Arc::make_mut(&mut schema_arc);
-                let mv_store = stmt.mv_store();
-                let syms = conn.syms.read();
 
-                let res1 = schema.populate_indices(
-                    &syms,
-                    from_sql_indexes,
-                    automatic_indices,
-                    mv_store.is_some(),
-                );
-                let res2 = schema.populate_materialized_views(
-                    materialized_view_info,
-                    dbsp_state_roots,
-                    dbsp_state_index_roots,
-                );
+                let ty = schema_text_column(row, 0, "type")?.to_string();
+                let name = schema_text_column(row, 1, "name")?.to_string();
+                let table_name = schema_text_column(row, 2, "tbl_name")?.to_string();
+                let root_page = schema_integer_column(row, 3, "rootpage")?;
+                let sql = match row.get_value(4)? {
+                    ValueRef::Text(sql) => Some(sql.as_str().to_string()),
+                    _ => None,
+                };
 
-                // Store the modified schema back
-                if db == crate::TEMP_DB_ID {
-                    // TEMP: write directly to `temp_db.db.schema` — the single
-                    // source of truth; never stage in `database_schemas`.
-                    //
-                    // Refresh schema_version from the pager header first. At
-                    // this point SetCookie has already run for the current
-                    // DDL, so the header cookie is authoritative; without this
-                    // the cached version can drift on subsequent temp DDLs in
-                    // the same transaction and trigger a spurious
-                    // SchemaUpdated -> reprepare -> rollback_attached() loop
-                    // that wipes in-flight dirty pages.
-                    if let Some(temp_db) = conn.temp.database.read().as_ref() {
-                        if let Some(cookie) = temp_db.pager.get_schema_cookie_cached() {
-                            schema.schema_version = cookie;
-                        }
-                        *temp_db.db.schema.lock() = schema_arc;
-                    }
-                } else if db != crate::MAIN_DB_ID {
-                    conn.database_schemas().write().insert(db, schema_arc);
-                } else {
-                    *conn.schema.write() = schema_arc;
+                if inner.filter.matches(&ty, &name, &table_name) {
+                    let schema = Arc::make_mut(&mut inner.schema_arc);
+                    let syms = conn.syms.read();
+                    let attached_resolver = |alias: &str| -> Option<usize> {
+                        conn.attached_databases()
+                            .read()
+                            .get_database_by_name(&crate::util::normalize_ident(alias))
+                            .map(|(idx, _)| idx)
+                    };
+                    schema.handle_schema_row(
+                        &ty,
+                        &name,
+                        &table_name,
+                        root_page,
+                        sql.as_deref(),
+                        &syms,
+                        &mut inner.from_sql_indexes,
+                        &mut inner.automatic_indices,
+                        &mut inner.dbsp_state_roots,
+                        &mut inner.dbsp_state_index_roots,
+                        &mut inner.materialized_view_info,
+                        &attached_resolver,
+                    )?;
                 }
-                drop(stmt);
-                conn.auto_commit
-                    .store(previous_auto_commit, Ordering::SeqCst);
-                let _ = (res1?, res2?);
 
-                state.pc += 1;
-                state.active_op_state.clear();
-                return Ok(InsnFunctionStepResult::Step);
+                inner.phase = OpParseSchemaPhase::Advancing;
             }
-            StepResult::Interrupt => {
-                let OpParseSchemaInner {
-                    stmt,
-                    previous_auto_commit,
-                    ..
-                } = *state
-                    .active_op_state
-                    .parse_schema()
-                    .take()
-                    .expect("parse schema state should exist");
-                drop(stmt);
-                conn.auto_commit
-                    .store(previous_auto_commit, Ordering::SeqCst);
-                return Err(LimboError::Interrupt);
-            }
-            StepResult::Busy => {
-                let OpParseSchemaInner {
-                    stmt,
-                    previous_auto_commit,
-                    ..
-                } = *state
-                    .active_op_state
-                    .parse_schema()
-                    .take()
-                    .expect("parse schema state should exist");
-                drop(stmt);
-                conn.auto_commit
-                    .store(previous_auto_commit, Ordering::SeqCst);
-                return Err(LimboError::Busy);
+            OpParseSchemaPhase::Advancing => {
+                return_if_io!(inner.cursor.next());
+                if inner.cursor.has_record() {
+                    inner.phase = OpParseSchemaPhase::FetchingRecord;
+                    continue;
+                }
+                return finish_parse_schema(state, conn);
             }
         }
     }
+}
+
+fn finish_parse_schema(
+    state: &mut ProgramState,
+    conn: &Arc<Connection>,
+) -> Result<InsnFunctionStepResult> {
+    let OpParseSchemaInner {
+        mut schema_arc,
+        from_sql_indexes,
+        automatic_indices,
+        dbsp_state_roots,
+        dbsp_state_index_roots,
+        materialized_view_info,
+        db,
+        ..
+    } = *state
+        .active_op_state
+        .parse_schema()
+        .take()
+        .expect("parse schema state should exist");
+    let schema = Arc::make_mut(&mut schema_arc);
+    let mv_store = conn.mv_store_for_db(db);
+    let syms = conn.syms.read();
+
+    let res1 = schema.populate_indices(
+        &syms,
+        from_sql_indexes,
+        automatic_indices,
+        mv_store.is_some(),
+    );
+    let res2 = schema.populate_materialized_views(
+        materialized_view_info,
+        dbsp_state_roots,
+        dbsp_state_index_roots,
+    );
+
+    // Store the modified schema back
+    if db == crate::TEMP_DB_ID {
+        // TEMP: write directly to `temp_db.db.schema` — the single
+        // source of truth; never stage in `database_schemas`.
+        //
+        // Refresh schema_version from the pager header first. At
+        // this point SetCookie has already run for the current
+        // DDL, so the header cookie is authoritative; without this
+        // the cached version can drift on subsequent temp DDLs in
+        // the same transaction and trigger a spurious
+        // SchemaUpdated -> reprepare -> rollback_attached() loop
+        // that wipes in-flight dirty pages.
+        if let Some(temp_db) = conn.temp.database.read().as_ref() {
+            if let Some(cookie) = temp_db.pager.get_schema_cookie_cached() {
+                schema.schema_version = cookie;
+            }
+            *temp_db.db.schema.lock() = schema_arc;
+        }
+    } else if db != crate::MAIN_DB_ID {
+        conn.database_schemas().write().insert(db, schema_arc);
+    } else {
+        *conn.schema.write() = schema_arc;
+    }
+    conn.bump_prepare_context_generation();
+    let _ = (res1?, res2?);
+
+    state.pc += 1;
+    state.active_op_state.clear();
+    Ok(InsnFunctionStepResult::Step)
+}
+
+fn schema_text_column<'a>(
+    row: &'a ImmutableRecord,
+    column: usize,
+    column_name: &str,
+) -> Result<&'a str> {
+    let ValueRef::Text(value) = row.get_value(column)? else {
+        return Err(LimboError::ConversionError(format!(
+            "Expected text value for sqlite_schema.{column_name}"
+        )));
+    };
+    Ok(value.as_str())
+}
+
+fn schema_integer_column(row: &ImmutableRecord, column: usize, column_name: &str) -> Result<i64> {
+    let ValueRef::Numeric(Numeric::Integer(value)) = row.get_value(column)? else {
+        return Err(LimboError::ConversionError(format!(
+            "Expected integer value for sqlite_schema.{column_name}"
+        )));
+    };
+    Ok(value)
 }
 
 /// Phases of the multi-statement state machine driven by [`op_init_cdc_version`].

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1748,14 +1748,14 @@ pub fn insn_to_row(
                 0,
                 format!("if (r[{}]==NULL) goto {}", reg, target_pc.as_debug_int()),
             ),
-            Insn::ParseSchema { db, where_clause } => (
+            Insn::ParseSchema { db, filter } => (
                 "ParseSchema",
                 *db as i64,
                 0,
                 0,
-                Value::build_text(where_clause.clone().unwrap_or_else(|| "NULL".to_string())),
+                Value::build_text(filter.explain()),
                 0,
-                where_clause.clone().unwrap_or_else(|| "NULL".to_string()),
+                filter.explain(),
             ),
             Insn::PopulateMaterializedViews { cursors } => (
                 "PopulateMaterializedViews",

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -24,6 +24,8 @@ use strum_macros::{EnumDiscriminants, FromRepr, VariantArray};
 use turso_macros::Description;
 use turso_parser::ast::{ResolveType, SortOrder};
 
+pub use crate::schema_parser::ParseSchemaFilter;
+
 /// Known custom type comparator functions for sorting and MIN/MAX aggregates.
 /// These replace heap-allocated String names with a compact enum.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -32,60 +34,6 @@ pub enum SortComparatorType {
     StringReverse,
     TestUintLt,
     ArrayLt,
-}
-
-#[derive(Debug, Clone)]
-pub enum ParseSchemaFilter {
-    All,
-    TableNameNotTrigger { table_names: Vec<String> },
-    Name { names: Vec<String> },
-    NameAndType { name: String, ty: String },
-}
-
-impl ParseSchemaFilter {
-    pub fn matches(&self, ty: &str, name: &str, table_name: &str) -> bool {
-        match self {
-            Self::All => true,
-            Self::TableNameNotTrigger { table_names } => {
-                ty != "trigger" && table_names.iter().any(|candidate| candidate == table_name)
-            }
-            Self::Name { names } => names.iter().any(|candidate| candidate == name),
-            Self::NameAndType {
-                name: candidate,
-                ty: candidate_ty,
-            } => candidate == name && candidate_ty == ty,
-        }
-    }
-
-    pub fn explain(&self) -> String {
-        match self {
-            Self::All => "ALL".to_string(),
-            Self::TableNameNotTrigger { table_names } => table_names
-                .iter()
-                .map(|table_name| {
-                    format!(
-                        "tbl_name = {} AND type != 'trigger'",
-                        quote_schema_value(table_name)
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(" OR "),
-            Self::Name { names } => names
-                .iter()
-                .map(|name| format!("name = {}", quote_schema_value(name)))
-                .collect::<Vec<_>>()
-                .join(" OR "),
-            Self::NameAndType { name, ty } => format!(
-                "name = {} AND type = {}",
-                quote_schema_value(name),
-                quote_schema_value(ty)
-            ),
-        }
-    }
-}
-
-fn quote_schema_value(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
 }
 
 /// Flags provided to comparison instructions (e.g. Eq, Ne) which determine behavior related to NULL values.

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -34,6 +34,60 @@ pub enum SortComparatorType {
     ArrayLt,
 }
 
+#[derive(Debug, Clone)]
+pub enum ParseSchemaFilter {
+    All,
+    TableNameNotTrigger { table_names: Vec<String> },
+    Name { names: Vec<String> },
+    NameAndType { name: String, ty: String },
+}
+
+impl ParseSchemaFilter {
+    pub fn matches(&self, ty: &str, name: &str, table_name: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::TableNameNotTrigger { table_names } => {
+                ty != "trigger" && table_names.iter().any(|candidate| candidate == table_name)
+            }
+            Self::Name { names } => names.iter().any(|candidate| candidate == name),
+            Self::NameAndType {
+                name: candidate,
+                ty: candidate_ty,
+            } => candidate == name && candidate_ty == ty,
+        }
+    }
+
+    pub fn explain(&self) -> String {
+        match self {
+            Self::All => "ALL".to_string(),
+            Self::TableNameNotTrigger { table_names } => table_names
+                .iter()
+                .map(|table_name| {
+                    format!(
+                        "tbl_name = {} AND type != 'trigger'",
+                        quote_schema_value(table_name)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" OR "),
+            Self::Name { names } => names
+                .iter()
+                .map(|name| format!("name = {}", quote_schema_value(name)))
+                .collect::<Vec<_>>()
+                .join(" OR "),
+            Self::NameAndType { name, ty } => format!(
+                "name = {} AND type = {}",
+                quote_schema_value(name),
+                quote_schema_value(ty)
+            ),
+        }
+    }
+}
+
+fn quote_schema_value(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
 /// Flags provided to comparison instructions (e.g. Eq, Ne) which determine behavior related to NULL values.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct CmpInsFlags(usize);
@@ -1347,7 +1401,7 @@ pub enum Insn {
     },
     ParseSchema {
         db: usize,
-        where_clause: Option<String>,
+        filter: ParseSchemaFilter,
     },
 
     /// Populate all materialized views after schema parsing


### PR DESCRIPTION
## Description
Avoid preparing a new Statement when reading `sqlite_schema` rows, and centralize all of the logic in one place `SchemaTableParser` and `SchemaTableCursor`. Essentially we are just avoiding the entire prepare phase and just directly reading from `table` with a cursor. We already did this in some places like in `MVCC`, but the logic was repeated all over the codebase, so I consolidated it. This also most likely makes us faster as well. 

Changes in stack usage captured using https://github.com/tursodatabase/turso/pull/6575:

```
- vdbe:op_parse_schema: 29,152 B -> 26,656 B inclusive, -2,496 B
- vdbe:op_parse_schema_step: 19,568 B -> 17,104 B inclusive, -2,464 B; self stack 4,096 B -> 1,424 B, -2,672 B
- vdbe:finish_parse_schema: 1,824 B -> 1,312 B, -512 B
```

## Motivation and context
From my testing in the server, this reduces a lot the stack usage when using ddl statements as we avoid having to prepare and store a `Statement` (which uses a lot stack). 


## Description of AI Usage
Codex basically did as I instructed and I corrected it
