### PR TITLE
core: Fix various gencol affinity test failures

### DIFF
--- a/core/translate/emitter/gencol.rs
+++ b/core/translate/emitter/gencol.rs
@@ -20,19 +20,19 @@ pub fn compute_virtual_columns(
         dml_ctx: dml_ctx.clone(),
         table: Arc::clone(table),
     };
-    for (idx, column) in columns.iter() {
-        let GeneratedType::Virtual { expr, .. } = column.generated_type() else {
-            continue;
-        };
-        let target_reg = dml_ctx.to_column_reg(idx);
-        program.with_self_table_context(Some(&ctx), |program, _| {
-            translate_expr(program, None, expr, target_reg, resolver)
-        })?;
-        if column.affinity() != Affinity::Blob {
-            program.emit_column_affinity(target_reg, column.affinity());
+    resolver.with_self_table_context(program, Some(&ctx), |program, _| {
+        for (idx, column) in columns.iter() {
+            let GeneratedType::Virtual { expr, .. } = column.generated_type() else {
+                continue;
+            };
+            let target_reg = dml_ctx.to_column_reg(idx);
+            translate_expr(program, None, expr, target_reg, resolver)?;
+            if column.affinity() != Affinity::Blob {
+                program.emit_column_affinity(target_reg, column.affinity());
+            }
         }
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Emit bytecode to compute a single virtual generated column expression.
@@ -52,7 +52,7 @@ pub(crate) fn emit_gencol_expr_from_registers(
         dml_ctx: DmlColumnContext::layout(columns, registers_start, rowid_reg, layout.clone()),
         table: Arc::clone(table),
     };
-    program.with_self_table_context(Some(&ctx), |program, _| {
+    resolver.with_self_table_context(program, Some(&ctx), |program, _| {
         translate_expr(program, None, expr, target_reg, resolver)?;
         Ok(())
     })?;

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -150,15 +150,13 @@ pub struct Resolver<'a> {
     /// mechanism, but operates as a side-channel since limbo rewrites the AST rather
     /// than redirecting column reads at codegen time.
     pub register_affinities: HashMap<usize, Affinity>,
-    /// Column affinities for the SELF_TABLE context (DML expression index evaluation).
-    /// Indexed by table column position. Populated alongside `register_affinities`
-    /// so that `get_expr_affinity_info` can resolve `Expr::Column { SELF_TABLE }`
-    /// affinities when `referenced_tables` is `None`.
-    pub self_table_column_affinities: Vec<Affinity>,
     /// Affinity metadata for planned scalar subqueries keyed by their internal ID.
     /// This lets comparison affinity follow SQLite rules for expressions like
     /// `(SELECT text_col FROM ...) > some_numeric_expr`.
     pub(crate) subquery_affinities: RefCell<HashMap<TableInternalId, ExprAffinityInfo>>,
+    /// Context and metadata for resolving Expr::Column values that use
+    /// [TableInternalId::SELF_TABLE] as a placeholder.
+    self_table_scope: RefCell<Option<SelfTableScope>>,
     pub enable_custom_types: bool,
     /// Controls whether unresolved double-quoted identifiers fall back to string
     /// literals (SQLite's DQS misfeature) in DML statements.
@@ -180,6 +178,50 @@ pub struct Resolver<'a> {
     /// (e.g. via a nested sub-program), update this field on that
     /// path or switch to a live read.
     has_temp_schema: bool,
+}
+
+#[derive(Clone)]
+struct SelfTableScope {
+    context: SelfTableContext,
+    affinities: Option<Arc<[Affinity]>>,
+}
+
+impl SelfTableScope {
+    fn new(context: SelfTableContext) -> Self {
+        let affinities = match &context {
+            SelfTableContext::ForDML { table, .. } => Some(
+                table
+                    .columns()
+                    .iter()
+                    .map(|c| c.affinity_with_strict(table.is_strict))
+                    .collect(),
+            ),
+            SelfTableContext::ForSelect {
+                table_ref_id,
+                referenced_tables,
+            } => referenced_tables
+                .find_table_by_internal_id(*table_ref_id)
+                .and_then(|(_, table_ref)| table_ref.btree())
+                .map(|btree| {
+                    btree
+                        .columns()
+                        .iter()
+                        .map(|c| c.affinity_with_strict(btree.is_strict))
+                        .collect()
+                }),
+        };
+
+        Self {
+            context,
+            affinities,
+        }
+    }
+
+    fn affinity(&self, column: usize) -> Option<Affinity> {
+        self.affinities
+            .as_ref()
+            .and_then(|affinities| affinities.get(column).copied())
+    }
 }
 
 /// Context for restricting table resolution during trigger subprogram compilation.
@@ -221,8 +263,8 @@ impl<'a> Resolver<'a> {
             expr_to_reg_cache_enabled: false,
             expr_to_reg_cache: Vec::new(),
             register_affinities: HashMap::default(),
-            self_table_column_affinities: Vec::new(),
             subquery_affinities: RefCell::new(HashMap::default()),
+            self_table_scope: RefCell::new(None),
             enable_custom_types,
             dqs_dml,
             trigger_context: None,
@@ -249,8 +291,8 @@ impl<'a> Resolver<'a> {
             expr_to_reg_cache_enabled: false,
             expr_to_reg_cache: Vec::new(),
             register_affinities: HashMap::default(),
-            self_table_column_affinities: Vec::new(),
             subquery_affinities: RefCell::new(self.subquery_affinities.borrow().clone()),
+            self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
             trigger_context: self.trigger_context.clone(),
@@ -269,8 +311,8 @@ impl<'a> Resolver<'a> {
             expr_to_reg_cache_enabled: self.expr_to_reg_cache_enabled,
             expr_to_reg_cache: self.expr_to_reg_cache.clone(),
             register_affinities: self.register_affinities.clone(),
-            self_table_column_affinities: self.self_table_column_affinities.clone(),
             subquery_affinities: RefCell::new(self.subquery_affinities.borrow().clone()),
+            self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
             trigger_context: self.trigger_context.clone(),
@@ -283,6 +325,50 @@ impl<'a> Resolver<'a> {
             crate::bail_parse_error!("{} require --experimental-custom-types flag", feature);
         }
         Ok(())
+    }
+
+    pub(crate) fn with_self_table_context<T>(
+        &self,
+        program: &mut ProgramBuilder,
+        ctx: Option<&SelfTableContext>,
+        f: impl FnOnce(&mut ProgramBuilder, Option<&SelfTableContext>) -> Result<T>,
+    ) -> Result<T> {
+        match ctx {
+            Some(ctx) => {
+                let scope = SelfTableScope::new(ctx.clone());
+                let prev = self.self_table_scope.borrow_mut().replace(scope);
+                let result = f(program, Some(ctx));
+                *self.self_table_scope.borrow_mut() = prev;
+                result
+            }
+            None => f(program, None),
+        }
+    }
+
+    pub(crate) fn with_existing_self_table_context<T>(
+        &self,
+        f: impl FnOnce(Option<&SelfTableContext>) -> Result<T>,
+    ) -> Result<T> {
+        let ctx = self
+            .self_table_scope
+            .borrow()
+            .as_ref()
+            .map(|scope| scope.context.clone());
+        f(ctx.as_ref())
+    }
+
+    pub(crate) fn self_table_context(&self) -> Option<SelfTableContext> {
+        self.self_table_scope
+            .borrow()
+            .as_ref()
+            .map(|scope| scope.context.clone())
+    }
+
+    pub(crate) fn self_table_affinity(&self, column: usize) -> Option<Affinity> {
+        self.self_table_scope
+            .borrow()
+            .as_ref()
+            .and_then(|scope| scope.affinity(column))
     }
 
     fn cached_non_main_schema(&self, database_id: usize) -> Arc<Schema> {
@@ -1691,7 +1777,7 @@ pub(crate) fn emit_index_column_value_old_image(
             table_ref_id: table_internal_id,
             referenced_tables: table_references.clone(),
         };
-        program.with_self_table_context(Some(&self_table_context), |program, _| {
+        resolver.with_self_table_context(program, Some(&self_table_context), |program, _| {
             translate_expr_no_constant_opt(
                 program,
                 Some(table_references),

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -222,6 +222,21 @@ impl SelfTableScope {
             .as_ref()
             .and_then(|affinities| affinities.get(column).copied())
     }
+
+    fn column_type_str(&self, column: usize) -> Option<String> {
+        match &self.context {
+            SelfTableContext::ForDML { table, .. } => {
+                table.columns().get(column).map(|c| c.ty_str.clone())
+            }
+            SelfTableContext::ForSelect {
+                table_ref_id,
+                referenced_tables,
+            } => referenced_tables
+                .find_table_by_internal_id(*table_ref_id)
+                .and_then(|(_, table_ref)| table_ref.columns().get(column))
+                .map(|c| c.ty_str.clone()),
+        }
+    }
 }
 
 /// Context for restricting table resolution during trigger subprogram compilation.
@@ -357,18 +372,18 @@ impl<'a> Resolver<'a> {
         f(ctx.as_ref())
     }
 
-    pub(crate) fn self_table_context(&self) -> Option<SelfTableContext> {
-        self.self_table_scope
-            .borrow()
-            .as_ref()
-            .map(|scope| scope.context.clone())
-    }
-
     pub(crate) fn self_table_affinity(&self, column: usize) -> Option<Affinity> {
         self.self_table_scope
             .borrow()
             .as_ref()
             .and_then(|scope| scope.affinity(column))
+    }
+
+    pub(crate) fn self_table_column_type_str(&self, column: usize) -> Option<String> {
+        self.self_table_scope
+            .borrow()
+            .as_ref()
+            .and_then(|scope| scope.column_type_str(column))
     }
 
     fn cached_non_main_schema(&self, database_id: usize) -> Arc<Schema> {

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -833,7 +833,8 @@ fn emit_update_column_values<'a>(
                         GeneratedType::NotGenerated => None,
                     };
 
-                    program.with_self_table_context(
+                    t_ctx.resolver.with_self_table_context(
+                        program,
                         self_table_context.as_ref(),
                         |program, _| {
                             // Save/restore target_union_type so union_value() resolves tags
@@ -1537,8 +1538,6 @@ fn emit_update_insns<'a>(
     // the end of the function.
     {
         let columns = target_table.table.columns();
-        t_ctx.resolver.self_table_column_affinities =
-            columns.iter().map(|c| c.affinity()).collect();
         for (idx, col) in columns.iter().enumerate() {
             t_ctx
                 .resolver
@@ -2568,6 +2567,5 @@ fn emit_update_insns<'a>(
     program.preassign_label_to_next_insn(trigger_ignore_jump_label);
 
     t_ctx.resolver.register_affinities.clear();
-    t_ctx.resolver.self_table_column_affinities.clear();
     Ok(())
 }

--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -29,6 +29,13 @@ pub(crate) fn get_expr_affinity_info(
 ) -> ExprAffinityInfo {
     match expr {
         ast::Expr::Column { table, column, .. } => {
+            if table.is_self_table() {
+                if let Some(resolver) = resolver {
+                    if let Some(aff) = resolver.self_table_affinity(*column) {
+                        return ExprAffinityInfo::with_affinity(aff);
+                    }
+                }
+            }
             if let Some(tables) = referenced_tables {
                 if let Some((_, table_ref)) = tables.find_table_by_internal_id(*table) {
                     if let Some(col) = table_ref.get_column_at(*column) {
@@ -38,16 +45,6 @@ pub(crate) fn get_expr_affinity_info(
                             );
                         }
                         return ExprAffinityInfo::with_affinity(col.affinity());
-                    }
-                }
-            }
-            // SELF_TABLE fallback: during DML expression index evaluation,
-            // referenced_tables is None but column affinities are available
-            // via the resolver's self_table_column_affinities.
-            if table.is_self_table() {
-                if let Some(resolver) = resolver {
-                    if let Some(aff) = resolver.self_table_column_affinities.get(*column) {
-                        return ExprAffinityInfo::with_affinity(*aff);
                     }
                 }
             }

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -707,7 +707,7 @@ pub(super) fn extract_string_literal(expr: &ast::Expr) -> crate::Result<String> 
 ///
 /// In the DML index-maintenance path (INSERT with expression indexes),
 /// `referenced_tables` is `None` and columns use `SELF_TABLE`. We fall back
-/// to the ProgramBuilder's `SelfTableContext::ForDML` to obtain column metadata.
+/// to the Resolver's `SelfTableContext::ForDML` to obtain column metadata.
 /// Resolve the TypeDef for a column expression (Column or DML self-table column).
 pub(super) fn resolve_typedef_from_column(
     expr: &ast::Expr,
@@ -797,8 +797,8 @@ pub(super) fn resolve_column_type_str(
     table: ast::TableInternalId,
     column: usize,
     referenced_tables: Option<&TableReferences>,
-    _resolver: &Resolver,
-    program: &ProgramBuilder,
+    resolver: &Resolver,
+    _program: &ProgramBuilder,
 ) -> Option<String> {
     if let Some(rt) = referenced_tables {
         if let Some((_, tbl)) = rt.find_table_by_internal_id(table) {
@@ -806,7 +806,7 @@ pub(super) fn resolve_column_type_str(
         }
     }
     if table.is_self_table() {
-        if let Some(SelfTableContext::ForDML { table, .. }) = program.current_self_table_context() {
+        if let Some(SelfTableContext::ForDML { table, .. }) = resolver.self_table_context() {
             return Some(table.columns().get(column)?.ty_str.clone());
         }
     }

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -713,11 +713,10 @@ pub(super) fn resolve_typedef_from_column(
     expr: &ast::Expr,
     referenced_tables: Option<&TableReferences>,
     resolver: &Resolver,
-    program: &ProgramBuilder,
 ) -> Option<Arc<TypeDef>> {
     let ty_str = match expr {
         ast::Expr::Column { table, column, .. } => {
-            resolve_column_type_str(*table, *column, referenced_tables, resolver, program)?
+            resolve_column_type_str(*table, *column, referenced_tables, resolver)?
         }
         ast::Expr::Variable(var) => var.col_type.as_ref()?.to_string(),
         _ => return None,
@@ -730,10 +729,8 @@ pub(super) fn resolve_union_from_column(
     expr: &ast::Expr,
     referenced_tables: Option<&TableReferences>,
     resolver: &Resolver,
-    program: &ProgramBuilder,
 ) -> Option<Arc<TypeDef>> {
-    resolve_typedef_from_column(expr, referenced_tables, resolver, program)
-        .filter(|td| td.is_union())
+    resolve_typedef_from_column(expr, referenced_tables, resolver).filter(|td| td.is_union())
 }
 
 /// Resolve the struct TypeDef that an expression evaluates to.
@@ -745,13 +742,10 @@ pub(super) fn resolve_struct_from_expr(
     expr: &ast::Expr,
     referenced_tables: Option<&TableReferences>,
     resolver: &Resolver,
-    program: &ProgramBuilder,
 ) -> Option<Arc<TypeDef>> {
     match expr {
-        ast::Expr::Column { .. } => {
-            resolve_typedef_from_column(expr, referenced_tables, resolver, program)
-                .filter(|td| td.is_struct())
-        }
+        ast::Expr::Column { .. } => resolve_typedef_from_column(expr, referenced_tables, resolver)
+            .filter(|td| td.is_struct()),
         ast::Expr::FunctionCall { name, args, .. } => {
             let normalized = crate::util::normalize_ident(name.as_str());
             match normalized.as_str() {
@@ -759,7 +753,7 @@ pub(super) fn resolve_struct_from_expr(
                 "union_extract" if args.len() == 2 => {
                     let tag_name = extract_string_literal(&args[1]).ok()?;
                     let union_td =
-                        resolve_union_from_column(&args[0], referenced_tables, resolver, program)?;
+                        resolve_union_from_column(&args[0], referenced_tables, resolver)?;
                     let (_, variant) = union_td.find_union_variant(&tag_name)?;
                     let struct_td = resolver
                         .schema()
@@ -774,7 +768,7 @@ pub(super) fn resolve_struct_from_expr(
                 "struct_extract" if args.len() == 2 => {
                     let field_name = extract_string_literal(&args[1]).ok()?;
                     let parent_td =
-                        resolve_struct_from_expr(&args[0], referenced_tables, resolver, program)?;
+                        resolve_struct_from_expr(&args[0], referenced_tables, resolver)?;
                     let (_, field_def) = parent_td.find_struct_field(&field_name)?;
                     let field_td = resolver
                         .schema()
@@ -792,13 +786,12 @@ pub(super) fn resolve_struct_from_expr(
     }
 }
 
-/// Get the type string for a column, handling both referenced_tables and self-table context.
+/// Get the type string for a column
 pub(super) fn resolve_column_type_str(
     table: ast::TableInternalId,
     column: usize,
     referenced_tables: Option<&TableReferences>,
     resolver: &Resolver,
-    _program: &ProgramBuilder,
 ) -> Option<String> {
     if let Some(rt) = referenced_tables {
         if let Some((_, tbl)) = rt.find_table_by_internal_id(table) {

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -792,7 +792,7 @@ pub(super) fn resolve_struct_from_expr(
     }
 }
 
-/// Get the type string for a column, handling both referenced_tables and DML context.
+/// Get the type string for a column, handling both referenced_tables and self-table context.
 pub(super) fn resolve_column_type_str(
     table: ast::TableInternalId,
     column: usize,
@@ -806,9 +806,7 @@ pub(super) fn resolve_column_type_str(
         }
     }
     if table.is_self_table() {
-        if let Some(SelfTableContext::ForDML { table, .. }) = resolver.self_table_context() {
-            return Some(table.columns().get(column)?.ty_str.clone());
-        }
+        return resolver.self_table_column_type_str(column);
     }
     None
 }

--- a/core/translate/expr/columns.rs
+++ b/core/translate/expr/columns.rs
@@ -71,7 +71,7 @@ pub(super) fn do_emit_table_column(
 ) -> Result<()> {
     match column.generated_type() {
         GeneratedType::Virtual { expr, .. } => {
-            program.with_self_table_context(Some(self_table_context), |program, _| {
+            resolver.with_self_table_context(program, Some(self_table_context), |program, _| {
                 translate_expr(program, referenced_tables, expr, target_register, resolver)?;
                 Ok(())
             })?;

--- a/core/translate/expr/custom_types.rs
+++ b/core/translate/expr/custom_types.rs
@@ -362,7 +362,7 @@ pub(crate) fn emit_dml_expr_index_value(
         dml_ctx: DmlColumnContext::from_column_reg_mapping(pairs),
         table: Arc::clone(table),
     };
-    program.with_self_table_context(Some(&ctx), |program, _| {
+    resolver.with_self_table_context(program, Some(&ctx), |program, _| {
         translate_expr(program, None, &expr, dest_reg, resolver)?;
         Ok(())
     })?;

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -1898,12 +1898,8 @@ pub fn translate_expr(
                         ScalarFunc::UnionTagFunc => {
                             // union_tag(col): resolve col's union type for index→name lookup.
                             let args = expect_arguments_exact!(args, 1, srf);
-                            let td = resolve_union_from_column(
-                                &*args[0],
-                                referenced_tables,
-                                resolver,
-                                program,
-                            );
+                            let td =
+                                resolve_union_from_column(&*args[0], referenced_tables, resolver);
                             let tag_names = td
                                 .as_ref()
                                 .and_then(|td| td.union_def())
@@ -1917,12 +1913,8 @@ pub fn translate_expr(
                             let args = expect_arguments_exact!(args, 2, srf);
                             let tag_name = extract_string_literal(&*args[1])?;
                             // union_extract(col, 'tag'): resolve col's union type for name→index.
-                            let td = resolve_union_from_column(
-                                &*args[0],
-                                referenced_tables,
-                                resolver,
-                                program,
-                            );
+                            let td =
+                                resolve_union_from_column(&*args[0], referenced_tables, resolver);
                             let tag_index = td
                                 .as_ref()
                                 .and_then(|td| td.resolve_union_tag_index(&tag_name))
@@ -1938,12 +1930,8 @@ pub fn translate_expr(
                         ScalarFunc::StructExtractFunc => {
                             let args = expect_arguments_exact!(args, 2, srf);
                             let field_name = extract_string_literal(&*args[1])?;
-                            let td = resolve_struct_from_expr(
-                                &*args[0],
-                                referenced_tables,
-                                resolver,
-                                program,
-                            );
+                            let td =
+                                resolve_struct_from_expr(&*args[0], referenced_tables, resolver);
                             let (field_index, _) = td
                                 .as_ref()
                                 .and_then(|td| td.find_struct_field(&field_name))
@@ -2403,13 +2391,12 @@ pub fn translate_expr(
                             // if we're reading from an index that contains this virtual column,
                             // the index already has the computed value, so read it from the index
                             GeneratedType::Virtual { expr, .. } if !read_from_index => {
-                                let self_ctx = SelfTableContext::ForSelect {
-                                    table_ref_id: *table_ref_id,
-                                    referenced_tables: referenced_tables.unwrap().clone(),
-                                };
                                 resolver.with_self_table_context(
                                     program,
-                                    Some(&self_ctx),
+                                    Some(&SelfTableContext::ForSelect {
+                                        table_ref_id: *table_ref_id,
+                                        referenced_tables: referenced_tables.unwrap().clone(),
+                                    }),
                                     |program, _| {
                                         translate_expr(
                                             program,

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2191,7 +2191,7 @@ pub fn translate_expr(
         } if table_ref_id.is_self_table() => {
             // the table is a SELF_TABLE placeholder (used for generated columns), so we now have
             // to resolve it to the actual reference id using the SelfTableContext.
-            return program.with_existing_self_table_context(|program, self_table_context| {
+            return resolver.with_existing_self_table_context(|self_table_context| {
                 match self_table_context {
                     Some(SelfTableContext::ForSelect {
                         table_ref_id: real_id,
@@ -2221,7 +2221,7 @@ pub fn translate_expr(
                         Ok(target_register)
                     }
                     None => {
-                        // This error means that a program.with_self_table_context() was missing
+                        // This error means that a resolver.with_self_table_context() scope was missing
                         // somewhere in the call stack.
                         crate::bail_parse_error!(
                             "SELF_TABLE column reference outside of generated column context"
@@ -2403,11 +2403,13 @@ pub fn translate_expr(
                             // if we're reading from an index that contains this virtual column,
                             // the index already has the computed value, so read it from the index
                             GeneratedType::Virtual { expr, .. } if !read_from_index => {
-                                program.with_self_table_context(
-                                    Some(&SelfTableContext::ForSelect {
-                                        table_ref_id: *table_ref_id,
-                                        referenced_tables: referenced_tables.unwrap().clone(),
-                                    }),
+                                let self_ctx = SelfTableContext::ForSelect {
+                                    table_ref_id: *table_ref_id,
+                                    referenced_tables: referenced_tables.unwrap().clone(),
+                                };
+                                resolver.with_self_table_context(
+                                    program,
+                                    Some(&self_ctx),
                                     |program, _| {
                                         translate_expr(
                                             program,

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2959,10 +2959,9 @@ pub fn translate_expr(
                 }
                 ResolveType::Replace => {
                     crate::bail_parse_error!("REPLACE is not valid for RAISE");
-                }
-                // If the custom type requires parameters but the CAST
-                // doesn't provide them (e.g. CAST(x AS NUMERIC) vs
-                // CAST(x AS numeric(10,2))), fall through to regular CAST.
+                } // If the custom type requires parameters but the CAST
+                  // doesn't provide them (e.g. CAST(x AS NUMERIC) vs
+                  // CAST(x AS numeric(10,2))), fall through to regular CAST.
             }
             Ok(target_register)
         }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -873,7 +873,7 @@ fn emit_index_column_value_from_cursor(
                     table_ref_id: jt.internal_id,
                     referenced_tables: table_references.clone(),
                 });
-        program.with_self_table_context(self_table_context.as_ref(), |program, _| {
+        resolver.with_self_table_context(program, self_table_context.as_ref(), |program, _| {
             translate_expr(program, Some(table_references), &expr, dest_reg, resolver)?;
             Ok(())
         })?;

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -835,14 +835,11 @@ pub fn translate_insert(
     // while the table row gets the default value, causing integrity_check failures.
     emit_notnulls(program, &ctx, &insertion, resolver)?;
 
-    // Populate register-to-affinity and column-to-affinity maps so that
-    // partial index WHERE clauses and expression index expressions get
+    // Populate register-to-affinity map so partial index WHERE clauses get
     // correct column affinity during INSERT.
     //
     // Partial index WHEREs use rewrite_partial_index_where which converts
     // column refs to Expr::Register — register_affinities handles those.
-    // Expression index values use SelfTableContext::ForDML which keeps
-    // Expr::Column { SELF_TABLE } — self_table_column_affinities handles those.
     //
     // Without this, comparisons like `integer_col < '2'` lose their
     // INTEGER affinity and evaluate under type-ordering rules, producing
@@ -855,8 +852,6 @@ pub fn translate_insert(
     resolver
         .register_affinities
         .insert(insertion.key_register(), Affinity::Integer);
-    resolver.self_table_column_affinities =
-        ctx.table.columns().iter().map(|c| c.affinity()).collect();
 
     emit_preflight_constraint_checks(
         program,
@@ -911,7 +906,6 @@ pub fn translate_insert(
     }
 
     resolver.register_affinities.clear();
-    resolver.self_table_column_affinities.clear();
 
     let mut insert_flags = InsertFlags::new();
 

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -347,7 +347,8 @@ fn translate_integrity_check_impl(
                             referenced_tables: table_references.clone(),
                         }
                     });
-                    program.with_self_table_context(
+                    resolver.with_self_table_context(
+                        program,
                         self_table_context.as_ref(),
                         |program, _| {
                             translate_expr_no_constant_opt(
@@ -460,7 +461,8 @@ fn translate_integrity_check_impl(
                                 }
                             });
 
-                        program.with_self_table_context(
+                        resolver.with_self_table_context(
+                            program,
                             self_table_context.as_ref(),
                             |program, _| {
                                 translate_expr_no_constant_opt(

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -422,11 +422,13 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
                     .map(|c| c.generated_type())
                 {
                     Some(GeneratedType::Virtual { expr, .. }) if !config.use_materialized_keys => {
-                        planner.program.with_self_table_context(
-                            Some(&SelfTableContext::ForSelect {
-                                table_ref_id: build_table.internal_id,
-                                referenced_tables: planner.table_references.clone(),
-                            }),
+                        let self_ctx = SelfTableContext::ForSelect {
+                            table_ref_id: build_table.internal_id,
+                            referenced_tables: planner.table_references.clone(),
+                        };
+                        planner.t_ctx.resolver.with_self_table_context(
+                            planner.program,
+                            Some(&self_ctx),
                             |program, _| -> Result<()> {
                                 translate_expr(
                                     program,

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -422,13 +422,12 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
                     .map(|c| c.generated_type())
                 {
                     Some(GeneratedType::Virtual { expr, .. }) if !config.use_materialized_keys => {
-                        let self_ctx = SelfTableContext::ForSelect {
-                            table_ref_id: build_table.internal_id,
-                            referenced_tables: planner.table_references.clone(),
-                        };
                         planner.t_ctx.resolver.with_self_table_context(
                             planner.program,
-                            Some(&self_ctx),
+                            Some(&SelfTableContext::ForSelect {
+                                table_ref_id: build_table.internal_id,
+                                referenced_tables: planner.table_references.clone(),
+                            }),
                             |program, _| -> Result<()> {
                                 translate_expr(
                                     program,

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -1048,13 +1048,13 @@ fn populate_trigger_row_register_affinities(
     };
 
     for (idx, column) in table.columns().iter().enumerate() {
-        let affinity = if column.is_rowid_alias() {
-            Affinity::Integer
-        } else {
-            column.affinity_with_strict(table.is_strict)
-        };
+        if !column.is_rowid_alias() {
+            continue;
+        }
         if let Some(&register) = registers.get(idx) {
-            resolver.register_affinities.insert(register, affinity);
+            resolver
+                .register_affinities
+                .insert(register, Affinity::Integer);
         }
     }
 

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -1038,6 +1038,8 @@ fn populate_trigger_register_affinities(resolver: &mut Resolver, ctx: &TriggerCo
     populate_trigger_row_register_affinities(resolver, &ctx.table, ctx.old_registers.as_deref());
 }
 
+// NEW/OLD columns don't have affinities, except for rowids and rowid aliases,
+// which have INTEGER affinity. See https://www.sqlite.org/forum/forumpost/819f2d6627
 fn populate_trigger_row_register_affinities(
     resolver: &mut Resolver,
     table: &BTreeTable,

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -403,10 +403,6 @@ pub fn emit_upsert(
     connection: &Arc<Connection>,
     table_references: &mut TableReferences,
 ) -> crate::Result<()> {
-    // Populate SELF_TABLE column affinities so expression index evaluation
-    // can resolve affinity for column references (matches UPDATE path).
-    resolver.self_table_column_affinities = table.columns().iter().map(|c| c.affinity()).collect();
-
     // Seek & snapshot CURRENT
     program.emit_insn(Insn::SeekRowid {
         cursor_id: ctx.cursor_id,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -248,8 +248,6 @@ pub struct ProgramBuilder {
     /// Maps table internal_id to result_columns_start_reg for FROM clause subqueries.
     /// Used when nested subqueries need to reference columns from outer query subqueries.
     subquery_result_regs: HashMap<TableInternalId, usize>,
-    /// Context for resolving an Expr::Column that has a [TableInternalId::SELF_TABLE] placeholder.
-    self_table_context: Option<SelfTableContext>,
     /// The mode in which the query is being executed.
     query_mode: QueryMode,
     pub flags: ProgramBuilderFlags,
@@ -283,7 +281,7 @@ pub struct ProgramBuilder {
     /// the target column, so the type must come from the INSERT/UPDATE/UPSERT context.
     ///
     /// This follows the same save/restore pattern as `id_register_overrides`
-    /// (ENCODE/DECODE context) and `self_table_context` (DML column resolution).
+    /// (ENCODE/DECODE context).
     /// Callers must save with `.take()`, set the new value, translate the expression,
     /// then restore the saved value. For nested unions (union-in-union), the
     /// `UnionValueFunc` handler in expr.rs saves/restores this to the inner union
@@ -686,7 +684,6 @@ impl ProgramBuilder {
             hash_build_signatures: HashMap::default(),
             hash_tables_to_keep_open: BitSet::default(),
             subquery_result_regs: HashMap::default(),
-            self_table_context: None,
             next_cte_id: 0,
             materialized_ctes: HashMap::default(),
             ctes_being_defined: Vec::new(),
@@ -1979,33 +1976,5 @@ impl ProgramBuilder {
         let prepare_context = PrepareContext::from_connection(&connection);
         let prepared = self.build_prepared_program(prepare_context, change_cnt_on, sql)?;
         Ok(Program::from_prepared(Arc::new(prepared), connection))
-    }
-
-    pub fn with_existing_self_table_context<T>(
-        &mut self,
-        f: impl FnOnce(&mut ProgramBuilder, Option<&SelfTableContext>) -> crate::Result<T>,
-    ) -> crate::Result<T> {
-        let result = f(self, self.self_table_context.clone().as_ref())?;
-        Ok(result)
-    }
-
-    pub fn with_self_table_context<T>(
-        &mut self,
-        ctx: Option<&SelfTableContext>,
-        f: impl FnOnce(&mut ProgramBuilder, Option<&SelfTableContext>) -> crate::Result<T>,
-    ) -> crate::Result<T> {
-        if ctx.is_none() {
-            return f(self, ctx);
-        }
-
-        let prev = self.self_table_context.take();
-        self.self_table_context = ctx.cloned();
-        let result = f(self, ctx);
-        self.self_table_context = prev;
-        result
-    }
-
-    pub fn current_self_table_context(&self) -> Option<&SelfTableContext> {
-        self.self_table_context.as_ref()
     }
 }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -145,7 +145,6 @@ expect {
 }
 
 # TEXT column uses text comparison: '10' > '5' is false (lexicographic)
-@skip "TODO needs virtual column affinity handling"
 test gencol_comparison_affinity_text_integer {
     CREATE TABLE t1(a TEXT, b INTEGER AS (a > 5));
     INSERT INTO t1(a) VALUES('10'), ('3'), ('7');
@@ -157,7 +156,6 @@ expect {
     7|1
 }
 
-@skip "TODO needs virtual column affinity handling"
 test gencol_comparison_affinity_equals {
     CREATE TABLE t1(a TEXT, b INTEGER AS (a = 10));
     INSERT INTO t1(a) VALUES('10'), ('5');
@@ -168,7 +166,6 @@ expect {
     5|0
 }
 
-@skip "TODO needs virtual column affinity handling"
 test gencol_comparison_affinity_null {
     CREATE TABLE t1(a TEXT, b INTEGER AS (a > 5));
     INSERT INTO t1(a) VALUES(NULL), ('10');
@@ -179,7 +176,6 @@ expect {
     10|0
 }
 
-@skip "TODO needs virtual column affinity handling"
 test gencol_comparison_affinity_negative {
     CREATE TABLE t1(a TEXT, b INTEGER AS (a > -5));
     INSERT INTO t1(a) VALUES('-3'), ('-7'), ('0');
@@ -191,7 +187,6 @@ expect {
     0|1
 }
 
-@skip "TODO needs virtual column affinity handling"
 test gencol_comparison_affinity_real {
     CREATE TABLE t1(a TEXT, b INTEGER AS (a > 5.5));
     INSERT INTO t1(a) VALUES('6'), ('5'), ('5.5');
@@ -201,6 +196,156 @@ expect {
     6|1
     5|0
     5.5|0
+}
+
+test gencol_self_table_affinity_update_not_null {
+    CREATE TABLE t(a TEXT, g AS (CASE WHEN a=10 THEN NULL ELSE 1 END) NOT NULL);
+    INSERT INTO t(a) VALUES('x');
+    UPDATE t SET a='10';
+}
+expect error {
+    NOT NULL constraint failed: t.g
+}
+
+test gencol_self_table_affinity_create_index_population {
+    CREATE TABLE t(a TEXT, g INT GENERATED ALWAYS AS (a >= 10) VIRTUAL);
+    INSERT INTO t(a) VALUES('0');
+    CREATE INDEX idx_g ON t(g);
+    SELECT 'g1', a, g FROM t INDEXED BY idx_g WHERE g=1;
+    SELECT 'g0', a, g FROM t INDEXED BY idx_g WHERE g=0;
+}
+expect {
+    g0|0|0
+}
+
+test gencol_self_table_affinity_delete_index_maintenance {
+    CREATE TABLE t(a TEXT, v AS (a = 10) VIRTUAL);
+    CREATE INDEX i ON t(v);
+    INSERT INTO t(a) VALUES('10');
+    DELETE FROM t;
+    SELECT count(*) FROM t;
+    PRAGMA integrity_check;
+}
+expect {
+    0
+    ok
+}
+
+test gencol_self_table_affinity_hash_join_payload {
+    CREATE TABLE b(k INT, a TEXT, g INT GENERATED ALWAYS AS (a = 5) VIRTUAL);
+    CREATE TABLE p(k INT);
+    INSERT INTO b VALUES(1, '5');
+    INSERT INTO p VALUES(1);
+    SELECT 'plain', g FROM b;
+    SELECT 'hash', b.g FROM b FULL OUTER JOIN p ON b.k = p.k;
+}
+expect {
+    plain|1
+    hash|1
+}
+
+test gencol_self_table_affinity_integrity_check_not_null {
+    CREATE TABLE t(
+        a TEXT,
+        b INT GENERATED ALWAYS AS (CASE WHEN a < 40 THEN 1 END) VIRTUAL NOT NULL
+    );
+    INSERT INTO t(a) VALUES('10');
+    SELECT a, b, typeof(b), a < 40 FROM t;
+    PRAGMA integrity_check;
+}
+expect {
+    10|1|integer|1
+    ok
+}
+
+test gencol_self_table_affinity_integrity_check_index {
+    CREATE TABLE t(a TEXT, g INT GENERATED ALWAYS AS (a < 2) VIRTUAL);
+    CREATE INDEX i ON t(g);
+    INSERT INTO t(a) VALUES('10');
+    SELECT a, g, typeof(g) FROM t;
+    PRAGMA integrity_check;
+}
+expect {
+    10|1|integer
+    ok
+}
+
+test gencol_self_table_affinity_update_returning_not_null {
+    CREATE TABLE t(a TEXT, g INT AS (CASE WHEN a=10 THEN 1 END) VIRTUAL NOT NULL);
+    INSERT INTO t(a) VALUES('10');
+    UPDATE t SET a='10' RETURNING a, g, typeof(g);
+}
+expect {
+    10|1|integer
+}
+
+test gencol_self_table_affinity_indexed_update_returning {
+    CREATE TABLE t(a TEXT, g INT AS (a = 10) VIRTUAL);
+    INSERT INTO t(a) VALUES('10'), ('5');
+    CREATE INDEX idx_g ON t(g);
+    UPDATE t INDEXED BY idx_g SET a='11' WHERE g=1 RETURNING a, g, typeof(g);
+    SELECT 'all', a, g FROM t ORDER BY a;
+    PRAGMA integrity_check;
+}
+expect {
+    11|0|integer
+    all|11|0
+    all|5|0
+    ok
+}
+
+test gencol_self_table_affinity_indexed_delete_returning {
+    CREATE TABLE t(a TEXT, g INT AS (a = 10) VIRTUAL);
+    INSERT INTO t(a) VALUES('10'), ('5');
+    CREATE INDEX idx_g ON t(g);
+    DELETE FROM t INDEXED BY idx_g WHERE g=0 RETURNING a, g, typeof(g);
+    SELECT 'left', a, g FROM t;
+    PRAGMA integrity_check;
+}
+expect {
+    5|0|integer
+    left|10|1
+    ok
+}
+
+test gencol_self_table_affinity_insert_returning_index_integrity {
+    CREATE TABLE t(a TEXT, g INT AS (a = 10) VIRTUAL);
+    CREATE INDEX idx_g ON t(g);
+    INSERT INTO t(a) VALUES('10'), ('5') RETURNING a, g, typeof(g);
+    SELECT 'idx1', a, g FROM t INDEXED BY idx_g WHERE g=1;
+    SELECT 'idx0', a, g FROM t INDEXED BY idx_g WHERE g=0;
+    PRAGMA integrity_check;
+}
+expect {
+    10|1|integer
+    5|0|integer
+    idx1|10|1
+    idx0|5|0
+    ok
+}
+
+test gencol_trigger_when_generated_text_affinity {
+    CREATE TABLE t(a TEXT, g TEXT AS (a > 5) VIRTUAL);
+    CREATE TABLE log(ev TEXT, val TEXT);
+
+    CREATE TRIGGER bi BEFORE INSERT ON t WHEN NEW.g = 0 BEGIN INSERT INTO log VALUES('BI:new', NEW.g || ':' || typeof(NEW.g)); END;
+    CREATE TRIGGER ai AFTER INSERT ON t WHEN NEW.g = 0 BEGIN INSERT INTO log VALUES('AI:new', NEW.g || ':' || typeof(NEW.g)); END;
+    INSERT INTO t(a) VALUES('10');
+
+    CREATE TRIGGER bu_old BEFORE UPDATE ON t WHEN OLD.g = 0 BEGIN INSERT INTO log VALUES('BU:old', OLD.g || ':' || typeof(OLD.g)); END;
+    CREATE TRIGGER bu_new BEFORE UPDATE ON t WHEN NEW.g = 0 BEGIN INSERT INTO log VALUES('BU:new', NEW.g || ':' || typeof(NEW.g)); END;
+    CREATE TRIGGER au_old AFTER UPDATE ON t WHEN OLD.g = 0 BEGIN INSERT INTO log VALUES('AU:old', OLD.g || ':' || typeof(OLD.g)); END;
+    CREATE TRIGGER au_new AFTER UPDATE ON t WHEN NEW.g = 0 BEGIN INSERT INTO log VALUES('AU:new', NEW.g || ':' || typeof(NEW.g)); END;
+    UPDATE t SET a='10';
+
+    CREATE TRIGGER bd BEFORE DELETE ON t WHEN OLD.g = 0 BEGIN INSERT INTO log VALUES('BD:old', OLD.g || ':' || typeof(OLD.g)); END;
+    CREATE TRIGGER ad AFTER DELETE ON t WHEN OLD.g = 0 BEGIN INSERT INTO log VALUES('AD:old', OLD.g || ':' || typeof(OLD.g)); END;
+    DELETE FROM t;
+
+    SELECT COALESCE(group_concat(ev || '=' || val, ','), 'EMPTY') FROM log;
+}
+expect {
+    EMPTY
 }
 
 # --- Unary operators ---

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4816,6 +4816,23 @@ test update-virtual-column-index-via-single-column-unique-index-scan {
 } expect {
 }
 
+@skip-if sqlite "SQLite doesn't support custom types"
+@requires custom_types "uses custom types"
+test gencol-virtual-union-tag-select-resolves-self-table-type {
+    CREATE TYPE number AS UNION(i INT, f REAL);
+    CREATE TABLE tagged(
+        id INT,
+        val number,
+        tag TEXT GENERATED ALWAYS AS (union_tag(val)) VIRTUAL
+    ) STRICT;
+    INSERT INTO tagged(id, val) VALUES (1, union_value('i', 42));
+    INSERT INTO tagged(id, val) VALUES (2, union_value('f', 3.5));
+    SELECT id, tag FROM tagged ORDER BY id;
+} expect {
+    1|i
+    2|f
+}
+
 @cross-check-integrity
 test update-covering-index-chained-virtual-gencol {
     CREATE TABLE t (a, c, e AS (a), d AS (e));

--- a/testing/sqltests/tests/trigger-before-insert-affinity.sqltest
+++ b/testing/sqltests/tests/trigger-before-insert-affinity.sqltest
@@ -141,3 +141,101 @@ test after-trigger-affinity {
 expect {
     real
 }
+
+
+# see https://www.sqlite.org/forum/forumpost/819f2d6627
+test new-columns-have-no-affinity {
+    CREATE TABLE t(a TEXT);
+    CREATE TABLE log(msg);
+
+    CREATE TRIGGER tr_when AFTER INSERT ON t WHEN NEW.a = 5
+      BEGIN INSERT INTO log VALUES('when_fired'); END;
+
+    CREATE TRIGGER tr_where AFTER INSERT ON t
+      BEGIN INSERT INTO log SELECT 'body_where_fired' WHERE NEW.a = 5; END;
+
+    CREATE TRIGGER tr_having AFTER INSERT ON t
+      BEGIN
+        INSERT INTO log SELECT 'body_having_fired'
+        FROM (SELECT 1 AS x) GROUP BY x HAVING NEW.a = 5;
+      END;
+
+    INSERT INTO t VALUES('5');
+
+    SELECT 'where_match', count(*) FROM t WHERE a = 5
+    UNION ALL
+    SELECT 'when_fired', count(*) FROM log WHERE msg = 'when_fired'
+    UNION ALL
+    SELECT 'body_where_fired', count(*) FROM log WHERE msg = 'body_where_fired'
+    UNION ALL
+    SELECT 'body_having_fired', count(*) FROM log WHERE msg = 'body_having_fired';
+}
+expect {
+    where_match|1
+    when_fired|0
+    body_where_fired|0
+    body_having_fired|0
+}
+
+# see https://www.sqlite.org/forum/forumpost/819f2d6627
+test old-columns-have-no-affinity {
+    CREATE TABLE t(a TEXT);
+    CREATE TABLE log(msg);
+    INSERT INTO t VALUES('5');
+
+    CREATE TRIGGER tr_when AFTER UPDATE ON t WHEN OLD.a = 5
+      BEGIN INSERT INTO log VALUES('when_fired'); END;
+
+    CREATE TRIGGER tr_where AFTER UPDATE ON t
+      BEGIN INSERT INTO log SELECT 'body_where_fired' WHERE OLD.a = 5; END;
+
+    CREATE TRIGGER tr_having AFTER UPDATE ON t
+      BEGIN
+        INSERT INTO log SELECT 'body_having_fired'
+        FROM (SELECT 1 AS x) GROUP BY x HAVING OLD.a = 5;
+      END;
+
+    UPDATE t SET a = a;
+
+    SELECT 'where_match', count(*) FROM t WHERE a = 5
+    UNION ALL
+    SELECT 'when_fired', count(*) FROM log WHERE msg = 'when_fired'
+    UNION ALL
+    SELECT 'body_where_fired', count(*) FROM log WHERE msg = 'body_where_fired'
+    UNION ALL
+    SELECT 'body_having_fired', count(*) FROM log WHERE msg = 'body_having_fired';
+}
+expect {
+    where_match|1
+    when_fired|0
+    body_where_fired|0
+    body_having_fired|0
+}
+
+test when-rowid-alias-keeps-integer-affinity {
+    CREATE TABLE t12(id INTEGER PRIMARY KEY, v);
+    CREATE TABLE log12(msg);
+    CREATE TRIGGER tr12 AFTER INSERT ON t12 WHEN NEW.id = '1'
+      BEGIN
+        INSERT INTO log12 VALUES('fired');
+      END;
+    INSERT INTO t12 VALUES(1, 'x');
+    SELECT * FROM log12;
+}
+expect {
+    fired
+}
+
+test rowid-keeps-integer-affinity {
+    CREATE TABLE t12(id);
+    CREATE TABLE log12(msg);
+    CREATE TRIGGER tr12 AFTER INSERT ON t12 WHEN NEW.rowid = '1'
+      BEGIN
+        INSERT INTO log12 VALUES('fired');
+      END;
+    INSERT INTO t12 VALUES('x');
+    SELECT * FROM log12;
+}
+expect {
+    fired
+}


### PR DESCRIPTION
## Description

Correctly handle missing affinity cases
- moved the `self_table` machinery from `ProgramBuilder` to `Resolver`
- introduced a `SelfTableScope` type to group self_table things
- removed an old `self_table_column_affinities` since it was now unused

## Description of AI Usage

Codex