### PR TITLE
Use iterative DFS for expression walkers

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -32,6 +32,7 @@ use crate::vdbe::{
     BranchOffset, CursorID,
 };
 use crate::{LimboError, Numeric, Result, Value};
+use smallvec::SmallVec;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ConditionMetadata {
@@ -5580,180 +5581,176 @@ pub enum WalkControl {
     SkipChildren, // Skip children but continue walking siblings
 }
 
-/// Recursively walks an immutable expression, applying a function to each sub-expression.
+/// Walks an immutable expression in pre-order, applying a function to each sub-expression.
 pub fn walk_expr<'a, F>(expr: &'a ast::Expr, func: &mut F) -> Result<WalkControl>
 where
     F: FnMut(&'a ast::Expr) -> Result<WalkControl>,
 {
-    match func(expr)? {
-        WalkControl::Continue => {
-            match expr {
-                ast::Expr::SubqueryResult { lhs, .. } => {
-                    if let Some(lhs) = lhs {
-                        walk_expr(lhs, func)?;
-                    }
-                }
-                ast::Expr::Between {
-                    lhs, start, end, ..
-                } => {
-                    walk_expr(lhs, func)?;
-                    walk_expr(start, func)?;
-                    walk_expr(end, func)?;
-                }
-                ast::Expr::Binary(lhs, _, rhs) => {
-                    walk_expr(lhs, func)?;
-                    walk_expr(rhs, func)?;
-                }
-                ast::Expr::Case {
-                    base,
-                    when_then_pairs,
-                    else_expr,
-                } => {
-                    if let Some(base_expr) = base {
-                        walk_expr(base_expr, func)?;
-                    }
-                    for (when_expr, then_expr) in when_then_pairs {
-                        walk_expr(when_expr, func)?;
-                        walk_expr(then_expr, func)?;
-                    }
-                    if let Some(else_expr) = else_expr {
-                        walk_expr(else_expr, func)?;
-                    }
-                }
-                ast::Expr::Cast { expr, .. } => {
-                    walk_expr(expr, func)?;
-                }
-                ast::Expr::Collate(expr, _) => {
-                    walk_expr(expr, func)?;
-                }
-                ast::Expr::Exists(_select) | ast::Expr::Subquery(_select) => {
-                    // TODO: Walk through select statements if needed
-                }
-                ast::Expr::FunctionCall {
-                    args,
-                    order_by,
-                    filter_over,
-                    ..
-                } => {
-                    for arg in args {
-                        walk_expr(arg, func)?;
-                    }
-                    for sort_col in order_by {
-                        walk_expr(&sort_col.expr, func)?;
-                    }
-                    if let Some(filter_clause) = &filter_over.filter_clause {
-                        walk_expr(filter_clause, func)?;
-                    }
-                    if let Some(over_clause) = &filter_over.over_clause {
-                        match over_clause {
-                            ast::Over::Window(window) => {
-                                for part_expr in &window.partition_by {
-                                    walk_expr(part_expr, func)?;
-                                }
-                                for sort_col in &window.order_by {
-                                    walk_expr(&sort_col.expr, func)?;
-                                }
-                                if let Some(frame_clause) = &window.frame_clause {
-                                    walk_expr_frame_bound(&frame_clause.start, func)?;
-                                    if let Some(end_bound) = &frame_clause.end {
-                                        walk_expr_frame_bound(end_bound, func)?;
-                                    }
-                                }
-                            }
-                            ast::Over::Name(_) => {}
-                        }
-                    }
-                }
-                ast::Expr::FunctionCallStar { filter_over, .. } => {
-                    if let Some(filter_clause) = &filter_over.filter_clause {
-                        walk_expr(filter_clause, func)?;
-                    }
-                    if let Some(over_clause) = &filter_over.over_clause {
-                        match over_clause {
-                            ast::Over::Window(window) => {
-                                for part_expr in &window.partition_by {
-                                    walk_expr(part_expr, func)?;
-                                }
-                                for sort_col in &window.order_by {
-                                    walk_expr(&sort_col.expr, func)?;
-                                }
-                                if let Some(frame_clause) = &window.frame_clause {
-                                    walk_expr_frame_bound(&frame_clause.start, func)?;
-                                    if let Some(end_bound) = &frame_clause.end {
-                                        walk_expr_frame_bound(end_bound, func)?;
-                                    }
-                                }
-                            }
-                            ast::Over::Name(_) => {}
-                        }
-                    }
-                }
-                ast::Expr::InList { lhs, rhs, .. } => {
-                    walk_expr(lhs, func)?;
-                    for expr in rhs {
-                        walk_expr(expr, func)?;
-                    }
-                }
-                ast::Expr::InSelect { lhs, rhs: _, .. } => {
-                    walk_expr(lhs, func)?;
-                    // TODO: Walk through select statements if needed
-                }
-                ast::Expr::InTable { lhs, args, .. } => {
-                    walk_expr(lhs, func)?;
-                    for expr in args {
-                        walk_expr(expr, func)?;
-                    }
-                }
-                ast::Expr::IsNull(expr) | ast::Expr::NotNull(expr) => {
-                    walk_expr(expr, func)?;
-                }
-                ast::Expr::Like {
-                    lhs, rhs, escape, ..
-                } => {
-                    walk_expr(lhs, func)?;
-                    walk_expr(rhs, func)?;
-                    if let Some(esc_expr) = escape {
-                        walk_expr(esc_expr, func)?;
-                    }
-                }
-                ast::Expr::Parenthesized(exprs) => {
-                    for expr in exprs {
-                        walk_expr(expr, func)?;
-                    }
-                }
-                ast::Expr::Raise(_, expr) => {
-                    if let Some(raise_expr) = expr {
-                        walk_expr(raise_expr, func)?;
-                    }
-                }
-                ast::Expr::Unary(_, expr) => {
-                    walk_expr(expr, func)?;
-                }
-                ast::Expr::Array { .. } | ast::Expr::Subscript { .. } => {
-                    unreachable!(
-                        "Array and Subscript are desugared into function calls by the parser"
-                    )
-                }
-                ast::Expr::Id(_)
-                | ast::Expr::Column { .. }
-                | ast::Expr::RowId { .. }
-                | ast::Expr::Literal(_)
-                | ast::Expr::DoublyQualified(..)
-                | ast::Expr::Name(_)
-                | ast::Expr::Qualified(..)
-                | ast::Expr::Variable(_)
-                | ast::Expr::Register(_)
-                | ast::Expr::Default => {
-                    // No nested expressions
-                }
-                ast::Expr::FieldAccess { base, .. } => {
-                    walk_expr(base, func)?;
-                }
+    let mut stack = SmallVec::<[&'a ast::Expr; 16]>::new();
+    stack.push(expr);
+
+    while let Some(expr) = stack.pop() {
+        if matches!(func(expr)?, WalkControl::Continue) {
+            push_expr_children(expr, &mut stack);
+        }
+    }
+
+    Ok(WalkControl::Continue)
+}
+
+fn push_expr_children<'a>(expr: &'a ast::Expr, stack: &mut SmallVec<[&'a ast::Expr; 16]>) {
+    match expr {
+        ast::Expr::SubqueryResult { lhs, .. } => {
+            if let Some(lhs) = lhs {
+                stack.push(lhs);
             }
         }
-        WalkControl::SkipChildren => return Ok(WalkControl::Continue),
-    };
-    Ok(WalkControl::Continue)
+        ast::Expr::Between {
+            lhs, start, end, ..
+        } => {
+            stack.push(end);
+            stack.push(start);
+            stack.push(lhs);
+        }
+        ast::Expr::Binary(lhs, _, rhs) => {
+            stack.push(rhs);
+            stack.push(lhs);
+        }
+        ast::Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            if let Some(else_expr) = else_expr {
+                stack.push(else_expr);
+            }
+            for (when_expr, then_expr) in when_then_pairs.iter().rev() {
+                stack.push(then_expr);
+                stack.push(when_expr);
+            }
+            if let Some(base_expr) = base {
+                stack.push(base_expr);
+            }
+        }
+        ast::Expr::Cast { expr, .. }
+        | ast::Expr::Collate(expr, _)
+        | ast::Expr::IsNull(expr)
+        | ast::Expr::NotNull(expr)
+        | ast::Expr::Unary(_, expr)
+        | ast::Expr::FieldAccess { base: expr, .. } => {
+            stack.push(expr);
+        }
+        ast::Expr::Exists(_select) | ast::Expr::Subquery(_select) => {
+            // TODO: Walk through select statements if needed
+        }
+        ast::Expr::FunctionCall {
+            args,
+            order_by,
+            filter_over,
+            ..
+        } => {
+            push_over_clause_exprs(filter_over.over_clause.as_ref(), stack);
+            if let Some(filter_clause) = &filter_over.filter_clause {
+                stack.push(filter_clause);
+            }
+            for sort_col in order_by.iter().rev() {
+                stack.push(&sort_col.expr);
+            }
+            for arg in args.iter().rev() {
+                stack.push(arg);
+            }
+        }
+        ast::Expr::FunctionCallStar { filter_over, .. } => {
+            push_over_clause_exprs(filter_over.over_clause.as_ref(), stack);
+            if let Some(filter_clause) = &filter_over.filter_clause {
+                stack.push(filter_clause);
+            }
+        }
+        ast::Expr::InList { lhs, rhs, .. } => {
+            for expr in rhs.iter().rev() {
+                stack.push(expr);
+            }
+            stack.push(lhs);
+        }
+        ast::Expr::InSelect { lhs, rhs: _, .. } => {
+            // TODO: Walk through select statements if needed
+            stack.push(lhs);
+        }
+        ast::Expr::InTable { lhs, args, .. } => {
+            for expr in args.iter().rev() {
+                stack.push(expr);
+            }
+            stack.push(lhs);
+        }
+        ast::Expr::Like {
+            lhs, rhs, escape, ..
+        } => {
+            if let Some(esc_expr) = escape {
+                stack.push(esc_expr);
+            }
+            stack.push(rhs);
+            stack.push(lhs);
+        }
+        ast::Expr::Parenthesized(exprs) => {
+            for expr in exprs.iter().rev() {
+                stack.push(expr);
+            }
+        }
+        ast::Expr::Raise(_, expr) => {
+            if let Some(raise_expr) = expr {
+                stack.push(raise_expr);
+            }
+        }
+        ast::Expr::Array { .. } | ast::Expr::Subscript { .. } => {
+            unreachable!("Array and Subscript are desugared into function calls by the parser")
+        }
+        ast::Expr::Id(_)
+        | ast::Expr::Column { .. }
+        | ast::Expr::RowId { .. }
+        | ast::Expr::Literal(_)
+        | ast::Expr::DoublyQualified(..)
+        | ast::Expr::Name(_)
+        | ast::Expr::Qualified(..)
+        | ast::Expr::Variable(_)
+        | ast::Expr::Register(_)
+        | ast::Expr::Default => {
+            // No nested expressions
+        }
+    }
+}
+
+fn push_over_clause_exprs<'a>(
+    over_clause: Option<&'a ast::Over>,
+    stack: &mut SmallVec<[&'a ast::Expr; 16]>,
+) {
+    if let Some(ast::Over::Window(window)) = over_clause {
+        if let Some(frame_clause) = &window.frame_clause {
+            if let Some(end_bound) = &frame_clause.end {
+                push_frame_bound_expr(end_bound, stack);
+            }
+            push_frame_bound_expr(&frame_clause.start, stack);
+        }
+        for sort_col in window.order_by.iter().rev() {
+            stack.push(&sort_col.expr);
+        }
+        for part_expr in window.partition_by.iter().rev() {
+            stack.push(part_expr);
+        }
+    }
+}
+
+fn push_frame_bound_expr<'a>(
+    bound: &'a ast::FrameBound,
+    stack: &mut SmallVec<[&'a ast::Expr; 16]>,
+) {
+    match bound {
+        ast::FrameBound::Following(expr) | ast::FrameBound::Preceding(expr) => {
+            stack.push(expr);
+        }
+        ast::FrameBound::CurrentRow
+        | ast::FrameBound::UnboundedFollowing
+        | ast::FrameBound::UnboundedPreceding => {}
+    }
 }
 
 pub fn expr_references_subquery_id(expr: &ast::Expr, subquery_id: TableInternalId) -> bool {
@@ -5783,22 +5780,6 @@ pub fn expr_references_any_subquery(expr: &ast::Expr) -> bool {
         Ok(WalkControl::Continue)
     });
     found
-}
-
-fn walk_expr_frame_bound<'a, F>(bound: &'a ast::FrameBound, func: &mut F) -> Result<WalkControl>
-where
-    F: FnMut(&'a ast::Expr) -> Result<WalkControl>,
-{
-    match bound {
-        ast::FrameBound::Following(expr) | ast::FrameBound::Preceding(expr) => {
-            walk_expr(expr, func)?;
-        }
-        ast::FrameBound::CurrentRow
-        | ast::FrameBound::UnboundedFollowing
-        | ast::FrameBound::UnboundedPreceding => {}
-    }
-
-    Ok(WalkControl::Continue)
 }
 
 /// The precedence of binding identifiers to columns.
@@ -6879,196 +6860,240 @@ fn validate_custom_type_function_call(
     Ok(())
 }
 
-/// Recursively walks a mutable expression, applying a function to each sub-expression.
+/// Walks a mutable expression in pre-order, applying a function to each sub-expression.
 pub fn walk_expr_mut<F>(expr: &mut ast::Expr, func: &mut F) -> Result<WalkControl>
 where
     F: FnMut(&mut ast::Expr) -> Result<WalkControl>,
 {
-    match func(expr)? {
-        WalkControl::Continue => {
-            match expr {
-                ast::Expr::SubqueryResult { lhs, .. } => {
-                    if let Some(lhs) = lhs {
-                        walk_expr_mut(lhs, func)?;
-                    }
-                }
-                ast::Expr::Between {
-                    lhs, start, end, ..
-                } => {
-                    walk_expr_mut(lhs, func)?;
-                    walk_expr_mut(start, func)?;
-                    walk_expr_mut(end, func)?;
-                }
-                ast::Expr::Binary(lhs, _, rhs) => {
-                    walk_expr_mut(lhs, func)?;
-                    walk_expr_mut(rhs, func)?;
-                }
-                ast::Expr::Case {
-                    base,
-                    when_then_pairs,
-                    else_expr,
-                } => {
-                    if let Some(base_expr) = base {
-                        walk_expr_mut(base_expr, func)?;
-                    }
-                    for (when_expr, then_expr) in when_then_pairs {
-                        walk_expr_mut(when_expr, func)?;
-                        walk_expr_mut(then_expr, func)?;
-                    }
-                    if let Some(else_expr) = else_expr {
-                        walk_expr_mut(else_expr, func)?;
-                    }
-                }
-                ast::Expr::Cast { expr, .. } => {
-                    walk_expr_mut(expr, func)?;
-                }
-                ast::Expr::Collate(expr, _) => {
-                    walk_expr_mut(expr, func)?;
-                }
-                ast::Expr::Exists(_) | ast::Expr::Subquery(_) => {
-                    // TODO: Walk through select statements if needed
-                }
-                ast::Expr::FunctionCall {
-                    args,
-                    order_by,
-                    filter_over,
-                    ..
-                } => {
-                    for arg in args {
-                        walk_expr_mut(arg, func)?;
-                    }
-                    for sort_col in order_by {
-                        walk_expr_mut(&mut sort_col.expr, func)?;
-                    }
-                    if let Some(filter_clause) = &mut filter_over.filter_clause {
-                        walk_expr_mut(filter_clause, func)?;
-                    }
-                    if let Some(over_clause) = &mut filter_over.over_clause {
-                        match over_clause {
-                            ast::Over::Window(window) => {
-                                for part_expr in &mut window.partition_by {
-                                    walk_expr_mut(part_expr, func)?;
-                                }
-                                for sort_col in &mut window.order_by {
-                                    walk_expr_mut(&mut sort_col.expr, func)?;
-                                }
-                                if let Some(frame_clause) = &mut window.frame_clause {
-                                    walk_expr_mut_frame_bound(&mut frame_clause.start, func)?;
-                                    if let Some(end_bound) = &mut frame_clause.end {
-                                        walk_expr_mut_frame_bound(end_bound, func)?;
-                                    }
-                                }
-                            }
-                            ast::Over::Name(_) => {}
-                        }
-                    }
-                }
-                ast::Expr::FunctionCallStar { filter_over, .. } => {
-                    if let Some(ref mut filter_clause) = filter_over.filter_clause {
-                        walk_expr_mut(filter_clause, func)?;
-                    }
-                    if let Some(ref mut over_clause) = filter_over.over_clause {
-                        match over_clause {
-                            ast::Over::Window(window) => {
-                                for part_expr in &mut window.partition_by {
-                                    walk_expr_mut(part_expr, func)?;
-                                }
-                                for sort_col in &mut window.order_by {
-                                    walk_expr_mut(&mut sort_col.expr, func)?;
-                                }
-                                if let Some(frame_clause) = &mut window.frame_clause {
-                                    walk_expr_mut_frame_bound(&mut frame_clause.start, func)?;
-                                    if let Some(end_bound) = &mut frame_clause.end {
-                                        walk_expr_mut_frame_bound(end_bound, func)?;
-                                    }
-                                }
-                            }
-                            ast::Over::Name(_) => {}
-                        }
-                    }
-                }
-                ast::Expr::InList { lhs, rhs, .. } => {
-                    walk_expr_mut(lhs, func)?;
-                    for expr in rhs {
-                        walk_expr_mut(expr, func)?;
-                    }
-                }
-                ast::Expr::InSelect { lhs, rhs: _, .. } => {
-                    walk_expr_mut(lhs, func)?;
-                    // TODO: Walk through select statements if needed
-                }
-                ast::Expr::InTable { lhs, args, .. } => {
-                    walk_expr_mut(lhs, func)?;
-                    for expr in args {
-                        walk_expr_mut(expr, func)?;
-                    }
-                }
-                ast::Expr::IsNull(expr) | ast::Expr::NotNull(expr) => {
-                    walk_expr_mut(expr, func)?;
-                }
-                ast::Expr::Like {
-                    lhs, rhs, escape, ..
-                } => {
-                    walk_expr_mut(lhs, func)?;
-                    walk_expr_mut(rhs, func)?;
-                    if let Some(esc_expr) = escape {
-                        walk_expr_mut(esc_expr, func)?;
-                    }
-                }
-                ast::Expr::Parenthesized(exprs) => {
-                    for expr in exprs {
-                        walk_expr_mut(expr, func)?;
-                    }
-                }
-                ast::Expr::Raise(_, expr) => {
-                    if let Some(raise_expr) = expr {
-                        walk_expr_mut(raise_expr, func)?;
-                    }
-                }
-                ast::Expr::Unary(_, expr) => {
-                    walk_expr_mut(expr, func)?;
-                }
-                ast::Expr::Array { .. } | ast::Expr::Subscript { .. } => {
-                    unreachable!(
-                        "Array and Subscript are desugared into function calls by the parser"
-                    )
-                }
-                ast::Expr::Id(_)
-                | ast::Expr::Column { .. }
-                | ast::Expr::RowId { .. }
-                | ast::Expr::Literal(_)
-                | ast::Expr::DoublyQualified(..)
-                | ast::Expr::Name(_)
-                | ast::Expr::Qualified(..)
-                | ast::Expr::Variable(_)
-                | ast::Expr::Register(_)
-                | ast::Expr::Default => {
-                    // No nested expressions
-                }
-                ast::Expr::FieldAccess { base, .. } => {
-                    walk_expr_mut(base, func)?;
-                }
-            }
+    let mut stack = SmallVec::<[*mut ast::Expr; 16]>::new();
+    stack.push(expr);
+
+    while let Some(expr_ptr) = stack.pop() {
+        // SAFETY: Pointers pushed onto the stack are derived from the unique
+        // mutable borrow of the root expression. The walker visits each node at
+        // most once and never mutates ancestor containers after child pointers
+        // have been pushed.
+        let expr = unsafe { &mut *expr_ptr };
+        if matches!(func(expr)?, WalkControl::Continue) {
+            push_expr_children_mut(expr, &mut stack);
         }
-        WalkControl::SkipChildren => return Ok(WalkControl::Continue),
-    };
+    }
+
     Ok(WalkControl::Continue)
 }
 
-fn walk_expr_mut_frame_bound<F>(bound: &mut ast::FrameBound, func: &mut F) -> Result<WalkControl>
-where
-    F: FnMut(&mut ast::Expr) -> Result<WalkControl>,
-{
+fn push_expr_children_mut(expr: &mut ast::Expr, stack: &mut SmallVec<[*mut ast::Expr; 16]>) {
+    match expr {
+        ast::Expr::SubqueryResult { lhs, .. } => {
+            if let Some(lhs) = lhs {
+                stack.push(&mut **lhs);
+            }
+        }
+        ast::Expr::Between {
+            lhs, start, end, ..
+        } => {
+            stack.push(&mut **end);
+            stack.push(&mut **start);
+            stack.push(&mut **lhs);
+        }
+        ast::Expr::Binary(lhs, _, rhs) => {
+            stack.push(&mut **rhs);
+            stack.push(&mut **lhs);
+        }
+        ast::Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            if let Some(else_expr) = else_expr {
+                stack.push(&mut **else_expr);
+            }
+            for (when_expr, then_expr) in when_then_pairs.iter_mut().rev() {
+                stack.push(&mut **then_expr);
+                stack.push(&mut **when_expr);
+            }
+            if let Some(base_expr) = base {
+                stack.push(&mut **base_expr);
+            }
+        }
+        ast::Expr::Cast { expr, .. }
+        | ast::Expr::Collate(expr, _)
+        | ast::Expr::IsNull(expr)
+        | ast::Expr::NotNull(expr)
+        | ast::Expr::Unary(_, expr)
+        | ast::Expr::FieldAccess { base: expr, .. } => {
+            stack.push(&mut **expr);
+        }
+        ast::Expr::Exists(_) | ast::Expr::Subquery(_) => {
+            // TODO: Walk through select statements if needed
+        }
+        ast::Expr::FunctionCall {
+            args,
+            order_by,
+            filter_over,
+            ..
+        } => {
+            push_over_clause_exprs_mut(filter_over.over_clause.as_mut(), stack);
+            if let Some(filter_clause) = &mut filter_over.filter_clause {
+                stack.push(&mut **filter_clause);
+            }
+            for sort_col in order_by.iter_mut().rev() {
+                stack.push(&mut *sort_col.expr);
+            }
+            for arg in args.iter_mut().rev() {
+                stack.push(&mut **arg);
+            }
+        }
+        ast::Expr::FunctionCallStar { filter_over, .. } => {
+            push_over_clause_exprs_mut(filter_over.over_clause.as_mut(), stack);
+            if let Some(filter_clause) = &mut filter_over.filter_clause {
+                stack.push(&mut **filter_clause);
+            }
+        }
+        ast::Expr::InList { lhs, rhs, .. } => {
+            for expr in rhs.iter_mut().rev() {
+                stack.push(&mut **expr);
+            }
+            stack.push(&mut **lhs);
+        }
+        ast::Expr::InSelect { lhs, rhs: _, .. } => {
+            // TODO: Walk through select statements if needed
+            stack.push(&mut **lhs);
+        }
+        ast::Expr::InTable { lhs, args, .. } => {
+            for expr in args.iter_mut().rev() {
+                stack.push(&mut **expr);
+            }
+            stack.push(&mut **lhs);
+        }
+        ast::Expr::Like {
+            lhs, rhs, escape, ..
+        } => {
+            if let Some(esc_expr) = escape {
+                stack.push(&mut **esc_expr);
+            }
+            stack.push(&mut **rhs);
+            stack.push(&mut **lhs);
+        }
+        ast::Expr::Parenthesized(exprs) => {
+            for expr in exprs.iter_mut().rev() {
+                stack.push(&mut **expr);
+            }
+        }
+        ast::Expr::Raise(_, expr) => {
+            if let Some(raise_expr) = expr {
+                stack.push(&mut **raise_expr);
+            }
+        }
+        ast::Expr::Array { .. } | ast::Expr::Subscript { .. } => {
+            unreachable!("Array and Subscript are desugared into function calls by the parser")
+        }
+        ast::Expr::Id(_)
+        | ast::Expr::Column { .. }
+        | ast::Expr::RowId { .. }
+        | ast::Expr::Literal(_)
+        | ast::Expr::DoublyQualified(..)
+        | ast::Expr::Name(_)
+        | ast::Expr::Qualified(..)
+        | ast::Expr::Variable(_)
+        | ast::Expr::Register(_)
+        | ast::Expr::Default => {
+            // No nested expressions
+        }
+    }
+}
+
+fn push_over_clause_exprs_mut(
+    over_clause: Option<&mut ast::Over>,
+    stack: &mut SmallVec<[*mut ast::Expr; 16]>,
+) {
+    if let Some(ast::Over::Window(window)) = over_clause {
+        if let Some(frame_clause) = &mut window.frame_clause {
+            if let Some(end_bound) = &mut frame_clause.end {
+                push_frame_bound_expr_mut(end_bound, stack);
+            }
+            push_frame_bound_expr_mut(&mut frame_clause.start, stack);
+        }
+        for sort_col in window.order_by.iter_mut().rev() {
+            stack.push(&mut *sort_col.expr);
+        }
+        for part_expr in window.partition_by.iter_mut().rev() {
+            stack.push(&mut **part_expr);
+        }
+    }
+}
+
+fn push_frame_bound_expr_mut(
+    bound: &mut ast::FrameBound,
+    stack: &mut SmallVec<[*mut ast::Expr; 16]>,
+) {
     match bound {
         ast::FrameBound::Following(expr) | ast::FrameBound::Preceding(expr) => {
-            walk_expr_mut(expr, func)?;
+            stack.push(&mut **expr);
         }
         ast::FrameBound::CurrentRow
         | ast::FrameBound::UnboundedFollowing
         | ast::FrameBound::UnboundedPreceding => {}
     }
+}
 
-    Ok(WalkControl::Continue)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use turso_parser::ast::{Literal, Operator};
+
+    fn numeric(value: &str) -> ast::Expr {
+        ast::Expr::Literal(Literal::Numeric(value.to_string()))
+    }
+
+    fn describe_expr(expr: &ast::Expr) -> String {
+        match expr {
+            ast::Expr::Between { .. } => "between".to_string(),
+            ast::Expr::Binary(_, op, _) => format!("binary:{op:?}"),
+            ast::Expr::Id(name) => format!("id:{}", name.as_str()),
+            ast::Expr::Literal(Literal::Numeric(value)) => format!("num:{value}"),
+            other => format!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn walk_expr_visits_nodes_in_preorder() {
+        let expr = ast::Expr::between(
+            ast::Expr::binary(numeric("1"), Operator::Add, numeric("2")),
+            false,
+            numeric("3"),
+            numeric("4"),
+        );
+        let mut visited = Vec::new();
+
+        walk_expr(&expr, &mut |expr| {
+            visited.push(describe_expr(expr));
+            Ok(WalkControl::Continue)
+        })
+        .unwrap();
+
+        assert_eq!(
+            visited,
+            ["between", "binary:Add", "num:1", "num:2", "num:3", "num:4"]
+        );
+    }
+
+    #[test]
+    fn walk_expr_mut_visits_children_added_by_callback() {
+        let mut expr = ast::Expr::Id(ast::Name::from_bytes(b"root"));
+        let mut visited = Vec::new();
+
+        walk_expr_mut(&mut expr, &mut |expr| {
+            visited.push(describe_expr(expr));
+            if matches!(expr, ast::Expr::Id(_)) {
+                *expr = ast::Expr::binary(numeric("1"), Operator::Add, numeric("2"));
+            }
+            Ok(WalkControl::Continue)
+        })
+        .unwrap();
+
+        assert_eq!(visited, ["id:root", "num:1", "num:2"]);
+    }
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Description
Refactors `walk_expr` and `walk_expr_mut` to be iterative instead of recursive. There is some unsafe around the `walk_expr_mut`, but in this case here we are just copying the same traversal logic as is done in the recursive case, so it should be safe. 

## Motivation and context
Reduce stack usage and prevent possible overflows of really deeply nested expressions. 


## Description of AI Usage
Codex with me
