### PR TITLE
core/vdbe: Fix panic in EXPLAIN on compound select with ORDER BY

### DIFF
--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -584,8 +584,8 @@ pub fn insn_to_row(
                         name
                     }
                     CursorType::BTreeIndex(index) => {
-                        let name = &index.columns.get(*column).expect("column index out of bounds").name;
-                        Some(name)
+                        let name = index.columns.get(*column).map(|c| &c.name);
+                        name
                     }
                     CursorType::MaterializedView(table, _) => {
                         let name = table.columns().get(*column).and_then(|v| v.name.as_ref());
@@ -594,7 +594,10 @@ pub fn insn_to_row(
                     CursorType::Pseudo(_) => None,
                     CursorType::Sorter => None,
                     CursorType::IndexMethod(..) => None,
-                    CursorType::VirtualTable(v) => v.columns.get(*column).expect("column index out of bounds").name.as_ref(),
+                    CursorType::VirtualTable(v) => {
+                        let name = v.columns.get(*column).and_then(|c| c.name.as_ref());
+                        name
+}
                 };
                 (
                     "Column",

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -597,7 +597,7 @@ pub fn insn_to_row(
                     CursorType::VirtualTable(v) => {
                         let name = v.columns.get(*column).and_then(|c| c.name.as_ref());
                         name
-}
+                    }
                 };
                 (
                     "Column",

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/setops.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/setops.sqltest
@@ -207,3 +207,8 @@ snapshot union-subquery-aggregation {
     GROUP BY department
     ORDER BY total_people DESC;
 }
+
+# UNION + ORDER BY on literals (EXPLAIN regression #6411)
+snapshot union-order-by-literals {
+    SELECT 1 UNION SELECT 2 ORDER BY 1;
+}

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-order-by-literals.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-order-by-literals.snap
@@ -1,0 +1,52 @@
+---
+source: setops.sqltest
+expression: SELECT 1 UNION SELECT 2 ORDER BY 1;
+info:
+  statement_type: SELECT
+  database: ':memory:'
+---
+QUERY PLAN
+|--COMPOUND QUERY
+|  |--LEFT-MOST SUBQUERY
+|  |  `--SCAN CONSTANT ROW
+|  `--UNION USING TEMP B-TREE
+|     `--SCAN CONSTANT ROW
+`--USE SORTER FOR ORDER BY
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4        p5  comment
+   0  Init             0  34   0             0  Start at 34
+   1  OpenEphemeral    0   0   0             0  cursor=0 is_table=false
+   2  OpenEphemeral    1   0   0             0  cursor=1 is_table=false
+   3  Integer          1   1   0             0  r[1]=1
+   4  MakeRecord       1   1   2             0  r[2]=mkrec(r[1..1]); for compound_dedupe
+   5  IdxInsert        1   2   0             8  key=r[2]
+   6  Integer          2   1   0             0  r[1]=2
+   7  MakeRecord       1   1   3             0  r[3]=mkrec(r[1..1]); for compound_dedupe
+   8  IdxInsert        1   3   0             8  key=r[3]
+   9  Rewind           1  15   0             0  Rewind  ephemeral(compound_dedupe)
+  10    Column         1   0   1             0  r[1]=ephemeral(compound_dedupe).2
+  11    Copy           1   5   0             0  r[5]=r[1]
+  12    Sequence       0   6   0             0
+  13    MakeRecord     5   2   4             0  r[4]=mkrec(r[5..6]); for compound_collection
+  14    IdxInsert      0   4   0             8  key=r[4]
+  15  Next             1  10   0             0
+  16  Close            1   0   0             0
+  17  SorterOpen       2   2   0  k(2,B,B)   0  cursor=2
+  18  Rewind           0  26   0             0  Rewind  ephemeral(compound_collection)
+  19    Column         0   0   7             0  r[7]=ephemeral(compound_collection).2
+  20    Column         0   1   8             0  r[8]=ephemeral(compound_collection).column 1
+  21    Copy           7   9   0             0  r[9]=r[7]
+  22    Copy           8  10   0             0  r[10]=r[8]
+  23    MakeRecord     9   2  11             0  r[11]=mkrec(r[9..10])
+  24    SorterInsert   2  11   0  0          0  key=r[11]
+  25  Next             0  19   0             0
+  26  Close            0   0   0             0
+  27  OpenPseudo       3  11   2             0  2 columns in r[11]
+  28  SorterSort       2  33   0             0
+  29    SorterData     2  11   3             0  r[11]=data
+  30    Column         3   0  12             0  r[12]=pseudo.column 0
+  31    ResultRow     12   1   0             0  output=r[12]
+  32  SorterNext       2  29   0             0
+  33  Halt             0   0   0             0
+  34  Goto             0   1   0             0


### PR DESCRIPTION


Fixes #6411

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

The EXPLAIN formatter panicked when encountering hidden sequence columns dynamically added to temporary indexes during UNION operations. Replaced strict .expect() checks with safe lookups so the formatter can fall back to generic name(e.g., column N)


## Motivation and context
The panic occurred because `core/vdbe/explain.rs` assumed every internal column being accessed by a `Column` opcode must exist within the target index's explicit schema.

This is particularly relevant due to the architectural differences between how Turso (Limbo) and original SQLite handle `UNION` operations:
* **SQLite:** Uses a highly optimized "Coroutine" approach (`InitCoroutine`, `Yield`), comparing rows from the left and right sides of the `UNION` on the fly without needing temporary storage.
 * **Turso:** Currently uses a "Gather and Sort" approach. It creates an ephemeral `compound_collection` index to store all rows before running them through a Sorter.
Because Turso builds this massive temporary index, it must dynamically append a hidden "sequence" column to ensure insertion order is preserved during sorting. This internal column is intentionally not part of the official
      `index.columns` definition.

When the `EXPLAIN` formatter encountered an instruction attempting to read this hidden sequence column, the `.expect()` instantly panicked. By making the formatter more defensive, `EXPLAIN` output is now safer and gracefully handles these Turso-specific internal structures.


## Description of AI Usage


I primarily used Gemini CLI to help understand the deeper architectural differences between Turso and SQLite when processing compound queries. By comparing the raw `EXPLAIN` outputs of both engines for `UNION` + `ORDER BY` statements, AI helped me map out how SQLite utilizes Coroutines (`InitCoroutine`, `Yield`) for on-the-fly merging, whereas Turso relies on ephemeral indexes (`OpenEphemeral`) and a "Gather and Sort" methodology.

 This comparison clarified *why* Turso was generating an internal sequence column in the first place, allowing us to confidently identify the root cause of the panic as a strictly-typed formatting error in `core/vdbe/explain.rs` rather than a bug in the query execution logic itself. AI then assisted in drafting the `.and_then()` fallback pattern