### PR TITLE
Handle cases where FK cascade triggers can write back to target mid-scan.

### DIFF
--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -16,7 +16,7 @@ use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::util::normalize_ident;
 use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts};
 use crate::Result;
-use turso_parser::ast::{Expr, Limit, QualifiedName, ResultColumn, TriggerEvent, With};
+use turso_parser::ast::{Expr, Limit, QualifiedName, RefAct, ResultColumn, TriggerEvent, With};
 
 use super::plan::{ColumnUsedMask, JoinedTable, TableReferences, WhereTerm};
 
@@ -258,9 +258,17 @@ pub fn prepare_delete_plan(
         })
         .unwrap_or(false);
 
+    let has_fk_cascade_triggers = btree_table_for_triggers
+        .as_ref()
+        .map(|bt| table_has_fk_cascade_triggers(resolver, database_id, &bt.name, &mut vec![]))
+        .unwrap_or(false);
+
     let mut safety = DmlSafety::default();
     if has_delete_triggers {
         safety.require(DmlSafetyReason::Trigger);
+    }
+    if has_fk_cascade_triggers {
+        safety.require(DmlSafetyReason::FkCascade);
     }
     if where_clause_has_subquery(&where_predicates) {
         safety.require(DmlSafetyReason::SubqueryInWhere);
@@ -286,6 +294,54 @@ pub fn prepare_delete_plan(
     }
 
     Ok(Plan::Delete(Box::new(delete_plan)))
+}
+
+/// Returns true if any FK referencing `table_name` (transitively, following CASCADE chains)
+/// has triggers on the child table side, which could write back to `table_name` and
+/// invalidate a live DELETE scan iterator.
+fn table_has_fk_cascade_triggers(
+    resolver: &crate::translate::emitter::Resolver,
+    database_id: usize,
+    table_name: &str,
+    visited: &mut Vec<String>,
+) -> bool {
+    let normalized = crate::util::normalize_ident(table_name);
+    if visited.iter().any(|v| v == &normalized) {
+        return false;
+    }
+    visited.push(normalized.clone());
+
+    let referencing_fks =
+        resolver.with_schema(database_id, |s| s.resolved_fks_referencing(&normalized));
+    let referencing_fks = match referencing_fks {
+        Ok(fks) => fks,
+        Err(_) => return false,
+    };
+
+    for fk_ref in &referencing_fks {
+        if matches!(fk_ref.fk.on_delete, RefAct::NoAction | RefAct::Restrict) {
+            continue;
+        }
+        let child_name = &fk_ref.child_table.name;
+        let has_triggers = resolver.with_schema(database_id, |s| {
+            s.get_triggers_for_table(child_name).next().is_some()
+        });
+        if has_triggers {
+            return true;
+        }
+        if database_id != crate::TEMP_DB_ID && resolver.has_temp_database() {
+            let has_temp = resolver.with_schema(crate::TEMP_DB_ID, |s| {
+                s.get_triggers_for_table(child_name).next().is_some()
+            });
+            if has_temp {
+                return true;
+            }
+        }
+        if table_has_fk_cascade_triggers(resolver, database_id, child_name, visited) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Check if any WHERE predicate contains a subquery (Subquery, InSelect, or Exists).

--- a/testing/sqltests/tests/trigger_fk_cascade.sqltest
+++ b/testing/sqltests/tests/trigger_fk_cascade.sqltest
@@ -124,3 +124,106 @@ expect {
     2|p2
     3|2|c3
 }
+
+# The trigger mutates the target mid-scan; without pre-materialisation rows are skipped.
+@cross-check-integrity
+test fk-cascade-delete-writeback-trigger-no-rows-skipped {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT, active INTEGER);
+    CREATE TABLE sessions(id INTEGER PRIMARY KEY,
+                         user_id INTEGER REFERENCES users(id) ON DELETE CASCADE);
+    CREATE TRIGGER t AFTER DELETE ON sessions BEGIN
+        UPDATE users SET active = 0;
+    END;
+    INSERT INTO users    VALUES (1,'alice',0),(2,'bob',1),(3,'carol',1),(4,'dave',1),(5,'eve',1);
+    INSERT INTO sessions VALUES (100,1);
+    DELETE FROM users WHERE active = 0;
+    SELECT COUNT(*) FROM users;
+}
+expect {
+    4
+}
+
+# Trigger-inserted rows must not be consumed by the same DELETE statement.
+@cross-check-integrity
+test fk-cascade-delete-trigger-inserted-rows-not-consumed {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       pid INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+    CREATE TRIGGER tr AFTER DELETE ON child BEGIN
+        INSERT INTO parent VALUES (OLD.id + 1000, 9999);
+    END;
+    INSERT INTO parent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    DELETE FROM parent;
+    SELECT * FROM parent ORDER BY id;
+}
+expect {
+    1010|9999
+    1020|9999
+    1030|9999
+}
+
+@cross-check-integrity
+test fk-cascade-delete-two-hop-trigger-no-rows-skipped {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, t_id INTEGER REFERENCES t(id) ON DELETE CASCADE);
+    CREATE TABLE bridge(a INTEGER);
+    CREATE TRIGGER tr1 AFTER DELETE ON c      BEGIN INSERT INTO bridge VALUES (OLD.id); END;
+    CREATE TRIGGER tr2 AFTER INSERT ON bridge BEGIN UPDATE t SET x = 0 WHERE id > 0; END;
+    INSERT INTO t VALUES (1,100),(2,200),(3,300);
+    INSERT INTO c VALUES (10,1),(20,2),(30,3);
+    DELETE FROM t WHERE x > 150;
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|0
+}
+
+@cross-check-integrity
+test fk-cascade-delete-grandchild-writeback-trigger-no-rows-skipped {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE grandparent(id INTEGER PRIMARY KEY, active INTEGER);
+    CREATE TABLE parent(id INTEGER PRIMARY KEY,
+                        gp_id INTEGER REFERENCES grandparent(id) ON DELETE CASCADE);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       p_id INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+    CREATE TRIGGER tr AFTER DELETE ON child BEGIN
+        UPDATE grandparent SET active = 0 WHERE id > 0;
+    END;
+    -- Only id=1 starts inactive; deleting it cascades through parent→child, then the
+    -- trigger zeros out the rest.  Only id=1 should be deleted.
+    INSERT INTO grandparent VALUES (1,0),(2,1),(3,1),(4,1),(5,1);
+    INSERT INTO parent VALUES (100,1);
+    INSERT INTO child  VALUES (1000,100);
+    DELETE FROM grandparent WHERE active = 0;
+    SELECT COUNT(*) FROM grandparent;
+}
+expect {
+    4
+}
+
+@cross-check-integrity
+test fk-cascade-delete-grandchild-trigger-inserted-rows-not-consumed {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE grandparent(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE TABLE parent(id INTEGER PRIMARY KEY,
+                        gp_id INTEGER REFERENCES grandparent(id) ON DELETE CASCADE);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       p_id INTEGER REFERENCES parent(id) ON DELETE CASCADE);
+    CREATE TRIGGER tr AFTER DELETE ON child BEGIN
+        INSERT INTO grandparent VALUES (OLD.p_id + 1000, 9999);
+    END;
+    INSERT INTO grandparent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO parent VALUES (10,1),(20,2),(30,3);
+    INSERT INTO child  VALUES (100,10),(200,20),(300,30);
+    DELETE FROM grandparent;
+    SELECT * FROM grandparent ORDER BY id;
+}
+expect {
+    1010|9999
+    1020|9999
+    1030|9999
+}


### PR DESCRIPTION
Fixes #6459.

When an FK ON DELETE cascade fires a trigger on a child table that writes back to the parent, the parent's DELETE scan was still live, causing rows to be skipped or re-evaluated against a mutated state.

I added a check at plan time to force rowset materialization before any writes in these cases.