### PR TITLE
concurrent-simulator: Add a coverage runner config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,13 @@ test-multiprocess:
 	cargo run --release -p turso_whopper -- --mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01
 .PHONY: test-multiprocess
 
+WHOPPER_ARGS ?=
+WHOPPER_RUNS ?=
+
+whopper-coverage:
+	./testing/concurrent-simulator/bin/coverage "$(WHOPPER_RUNS)" $(WHOPPER_ARGS)
+.PHONY: whopper-coverage
+
 bench-vfs: uv-sync-test build-release
 	RUST_LOG=$(RUST_LOG) uv run --project limbo_test bench-vfs "$(SQL)" "$(N)"
 

--- a/testing/concurrent-simulator/README.md
+++ b/testing/concurrent-simulator/README.md
@@ -2,6 +2,26 @@
 
 Deterministic concurrent simulator for Turso.
 
+## Coverage
+
+To collect line coverage from actual Whopper execution:
+
+```bash
+make whopper-coverage WHOPPER_RUNS=10
+```
+
+Pass regular Whopper CLI flags through `WHOPPER_ARGS`:
+
+```bash
+make whopper-coverage WHOPPER_RUNS=10 \
+  WHOPPER_ARGS="--mode fast --max-steps 10000 --multiprocess --processes 2 --connections-per-process 2"
+```
+
+Reports are written to:
+
+- `.coverage/whopper/report.txt`
+- `.coverage/whopper/html/index.html`
+
 ## Running Elle Locally (macOS)
 
 ### One-time setup

--- a/testing/concurrent-simulator/bin/coverage
+++ b/testing/concurrent-simulator/bin/coverage
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+runs="${1:-}"
+shift || true
+
+if [ -z "${runs}" ]; then
+    runs=10
+fi
+
+case "${runs}" in
+    ''|*[!0-9]*)
+        echo "WHOPPER_RUNS must be a positive integer" >&2
+        exit 1
+        ;;
+esac
+
+if [ "${runs}" -eq 0 ]; then
+    echo "WHOPPER_RUNS must be > 0" >&2
+    exit 1
+fi
+
+features=()
+args=()
+checksum_enabled=false
+encryption_enabled=false
+
+for arg in "$@"; do
+    if [[ "${arg}" == "--enable-checksums" ]]; then
+        features=(--features checksum)
+        checksum_enabled=true
+    elif [[ "${arg}" == "--enable-encryption" ]]; then
+        encryption_enabled=true
+        args+=("${arg}")
+    else
+        args+=("${arg}")
+    fi
+done
+
+if [[ "${checksum_enabled}" == true && "${encryption_enabled}" == true ]]; then
+    echo "Error: --enable-checksums and --enable-encryption are not compatible with each other" >&2
+    exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+coverage_dir="${repo_root}/.coverage/whopper"
+profiles_dir="${coverage_dir}/profiles"
+target_dir="${coverage_dir}/target"
+binary_path="${target_dir}/debug/turso_whopper"
+profdata_path="${coverage_dir}/turso_whopper.profdata"
+text_report_path="${coverage_dir}/report.txt"
+html_report_dir="${coverage_dir}/html"
+
+toolchain_bin_dir="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/^host: //p')/bin"
+llvm_profdata="${toolchain_bin_dir}/llvm-profdata"
+llvm_cov="${toolchain_bin_dir}/llvm-cov"
+
+if [ ! -x "${llvm_profdata}" ] || [ ! -x "${llvm_cov}" ]; then
+    echo "llvm coverage tools are missing" >&2
+    echo "install them with: rustup component add llvm-tools-preview" >&2
+    exit 1
+fi
+
+mkdir -p "${profiles_dir}" "${html_report_dir}"
+rm -f "${profiles_dir}"/*.profraw "${profdata_path}" "${text_report_path}"
+
+export CARGO_TARGET_DIR="${target_dir}"
+export RUSTFLAGS="-Cinstrument-coverage"
+
+cargo build "${features[@]}" -p turso_whopper
+
+for run in $(seq 1 "${runs}"); do
+    echo "coverage run ${run}/${runs}"
+    LLVM_PROFILE_FILE="${profiles_dir}/turso_whopper-${run}-%p-%m.profraw" \
+        RUST_BACKTRACE=full \
+        "${binary_path}" "${args[@]}"
+done
+
+"${llvm_profdata}" merge -sparse "${profiles_dir}"/*.profraw -o "${profdata_path}"
+"${llvm_cov}" report "${binary_path}" \
+    --instr-profile "${profdata_path}" \
+    --ignore-filename-regex='\.cargo|rustc|/usr/'
+"${llvm_cov}" show "${binary_path}" \
+    --instr-profile "${profdata_path}" \
+    --show-line-counts-or-regions \
+    --ignore-filename-regex='\.cargo|rustc|/usr/' \
+    > "${text_report_path}"
+"${llvm_cov}" show "${binary_path}" \
+    --instr-profile "${profdata_path}" \
+    --format html \
+    --output-dir "${html_report_dir}" \
+    --ignore-filename-regex='\.cargo|rustc|/usr/'
+
+echo
+echo "text report: ${text_report_path}"
+echo "html report: ${html_report_dir}/index.html"


### PR DESCRIPTION
This adds a concurrent simulator config that captures code coverage of a
simulator run. There's a new top-level `make whopper-coverage` command
to run it. The coverage files are stored in `.coverage/whopper`
directory.
