### PR TITLE
core/vdbe: Allow users specify vacuum temp dir path

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -404,7 +404,7 @@ impl Connection {
 
         #[cfg(not(target_family = "wasm"))]
         {
-            let temp_dir = tempfile::tempdir().map_err(|e| io_error(e, "tempdir"))?;
+            let temp_dir = self.create_tempdir()?;
             let temp_path = temp_dir.path().join("tursodb-temp.db");
             let temp_path_str = temp_path.to_str().ok_or_else(|| {
                 LimboError::InternalError("temp db path is not valid UTF-8".into())
@@ -2731,6 +2731,24 @@ impl Connection {
         self.reset_temp_database();
         self.temp_store.set(value);
         self.bump_prepare_context_generation();
+    }
+
+    /// Create a `TempDir` honoring `TURSO_TMPDIR` and `SQLITE_TMPDIR`,
+    /// falling back to the OS default (`env::temp_dir()`).
+    ///
+    /// `&self` is reserved for a future per-connection
+    /// `temp_store_directory` setting (e.g. `PRAGMA temp_store_directory`)
+    /// so call sites don't need to change when that lands.
+    #[cfg(not(target_family = "wasm"))]
+    pub(crate) fn create_tempdir(&self) -> Result<TempDir> {
+        let res = if let Some(d) = std::env::var_os("TURSO_TMPDIR") {
+            tempfile::tempdir_in(d)
+        } else if let Some(d) = std::env::var_os("SQLITE_TMPDIR") {
+            tempfile::tempdir_in(d)
+        } else {
+            tempfile::tempdir()
+        };
+        res.map_err(|e| io_error(e, "tempdir"))
     }
 
     pub fn get_data_sync_retry(&self) -> bool {

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -246,8 +246,7 @@ pub(crate) fn open_vacuum_temp_db(
     page_size: u32,
     reserved_space: u8,
 ) -> Result<VacuumTempDb> {
-    // todo: let users specify the temp dir path
-    let temp_dir = tempfile::tempdir().map_err(|e| crate::error::io_error(e, "tempdir"))?;
+    let temp_dir = source_conn.create_tempdir()?;
     let source_db_name = std::path::Path::new(&source_db.path)
         .file_name()
         .and_then(|name| name.to_str())


### PR DESCRIPTION
## Description

The vacuum machinery recreates the DB by writing to a temporary DB. This patch lets users specify the directory path where the temp DB should be created. SQLite has `SQLITE_TMPDIR`, so we support that as well as `TURSO_TMPDIR`.

Why do we need this? You typically want to vacuum when disk space is getting full. Without the ability to specify this temporary directory path, it defaults to the system's temp directory, which may not be what you want always. You can attach a disk just for vacuum, let it run, and then destroy it, without needing to increase the main disk size.