### PR TITLE
fix(update): populate chained virtual gen col registers before index rebuild

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -8,7 +8,10 @@ use crate::vdbe::builder::SelfTableContext;
 use crate::{
     ast, emit_explain,
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
-    schema::{BTreeTable, CheckConstraint, Index, EXPR_INDEX_SENTINEL, ROWID_SENTINEL},
+    schema::{
+        collect_column_dependencies_of_expr, BTreeTable, CheckConstraint, Index,
+        EXPR_INDEX_SENTINEL, ROWID_SENTINEL,
+    },
     sync::Arc,
     translate::{
         display::format_eqp_detail,
@@ -1552,13 +1555,28 @@ fn emit_update_insns<'a>(
     let has_returning = returning.as_ref().is_some_and(|r| !r.is_empty());
     if let Table::BTree(ref btree) = target_table.table {
         let has_check_constraints = !btree.check_constraints.is_empty();
-        let index_references_virtual_column = indexes_to_update
+        let cols = btree.columns();
+        let virtual_col_names: HashSet<String> = cols
             .iter()
-            .flat_map(|idx| idx.columns.iter())
-            .any(|col| {
-                col.pos_in_table != EXPR_INDEX_SENTINEL
-                    && btree.columns()[col.pos_in_table].is_virtual_generated()
-            });
+            .filter(|c| c.is_virtual_generated())
+            .filter_map(|c| c.name.as_ref().map(|n| normalize_ident(n)))
+            .collect();
+        let expr_references_virtual = |expr: &ast::Expr| {
+            !virtual_col_names.is_empty()
+                && !collect_column_dependencies_of_expr(expr, cols).is_disjoint(&virtual_col_names)
+        };
+        let index_references_virtual_column = indexes_to_update.iter().any(|idx| {
+            idx.columns.iter().any(|col| {
+                if col.pos_in_table != EXPR_INDEX_SENTINEL {
+                    cols[col.pos_in_table].is_virtual_generated()
+                } else {
+                    col.expr.as_deref().is_some_and(&expr_references_virtual)
+                }
+            }) || idx
+                .where_clause
+                .as_deref()
+                .is_some_and(&expr_references_virtual)
+        });
 
         if update_affects_virtual_columns
             || has_before_triggers

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -8,7 +8,7 @@ use crate::vdbe::builder::SelfTableContext;
 use crate::{
     ast, emit_explain,
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
-    schema::{BTreeTable, CheckConstraint, Index, ROWID_SENTINEL},
+    schema::{BTreeTable, CheckConstraint, Index, EXPR_INDEX_SENTINEL, ROWID_SENTINEL},
     sync::Arc,
     translate::{
         display::format_eqp_detail,
@@ -1552,12 +1552,20 @@ fn emit_update_insns<'a>(
     let has_returning = returning.as_ref().is_some_and(|r| !r.is_empty());
     if let Table::BTree(ref btree) = target_table.table {
         let has_check_constraints = !btree.check_constraints.is_empty();
+        let index_references_virtual_column = indexes_to_update
+            .iter()
+            .flat_map(|idx| idx.columns.iter())
+            .any(|col| {
+                col.pos_in_table != EXPR_INDEX_SENTINEL
+                    && btree.columns()[col.pos_in_table].is_virtual_generated()
+            });
 
         if update_affects_virtual_columns
             || has_before_triggers
             || has_after_triggers
             || has_returning
             || has_check_constraints
+            || index_references_virtual_column
         {
             let columns = target_table.table.columns();
 

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4563,3 +4563,29 @@ test update-covering-index-chained-virtual-gencol {
     1|bbb
     ok
 }
+
+@cross-check-integrity
+test update-partial-index-where-references-virtual-gencol {
+    CREATE TABLE t (a, c, e AS (a));
+    INSERT INTO t (a, c) VALUES (1, 'aaa'), (-1, 'xxx');
+    CREATE INDEX idx_t ON t (c) WHERE e > 0;
+    UPDATE t SET c = c || c;
+    SELECT a, c FROM t INDEXED BY idx_t WHERE e > 0;
+    PRAGMA integrity_check;
+} expect {
+    1|aaaaaa
+    ok
+}
+
+@cross-check-integrity
+test update-expression-index-references-virtual-gencol {
+    CREATE TABLE t (a, c, e AS (a));
+    INSERT INTO t (a, c) VALUES (1, 'aaa'), (2, 'xxx');
+    CREATE INDEX idx_t ON t (e+0, c);
+    UPDATE t SET c = c || c;
+    SELECT a, c FROM t INDEXED BY idx_t WHERE e+0 = 1;
+    PRAGMA integrity_check;
+} expect {
+    1|aaaaaa
+    ok
+}

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4550,3 +4550,16 @@ test update-virtual-column-index-via-single-column-unique-index-scan {
     UPDATE t SET b = 42 WHERE c = 'x';
 } expect {
 }
+
+@cross-check-integrity
+test update-covering-index-chained-virtual-gencol {
+    CREATE TABLE t (a, c, e AS (a), d AS (e));
+    INSERT INTO t (a, c) VALUES (1, 'aaa');
+    CREATE INDEX idx_t ON t (d, c);
+    UPDATE t SET c = 'bbb';
+    SELECT d, c FROM t INDEXED BY idx_t WHERE d = 1;
+    PRAGMA integrity_check;
+} expect {
+    1|bbb
+    ok
+}


### PR DESCRIPTION
Fixes #6613.

UPDATE codegen rebuilds the new index entry for a virtual generated
column by translating the column's expression against the post-update
register layout. When the expression references *another* virtual
generated column (`d AS (e)` where `e AS (a)`), `translate_expr`
resolves `e` to its layout register slot — but that slot is only
populated by `compute_virtual_columns`, which the UPDATE path skipped
when no SET clause transitively touched the chain. The IdxInsert key
then carried whatever happened to be left in the register, leaving the
row missing from the index.

`compute_virtual_columns` now also runs when any index being rebuilt
contains a virtual generated column, so chained registers are filled
before index keys are constructed. INSERT (which always populates
virtual columns when the table has any) and DELETE (which uses the
old-image path that recursively expands gen col expressions) are unaffected.
