### PR TITLE
Fix UPDATE Halloween bug for mutable index scans

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -905,43 +905,36 @@ fn update_write_set_reason(
             break 'requires Some(DmlSafetyReason::ReplaceMode);
         }
 
+        let rowid_alias_used = plan.set_clauses.iter().any(|set_clause| {
+            set_clause.column_index != ROWID_SENTINEL
+                && btree_table.columns()[set_clause.column_index].is_rowid_alias()
+        });
+        let direct_rowid_update = plan
+            .set_clauses
+            .iter()
+            .any(|set_clause| set_clause.column_index == ROWID_SENTINEL);
+        if rowid_alias_used || direct_rowid_update {
+            break 'requires Some(DmlSafetyReason::KeyMutation);
+        }
+
         let Some(index) = table_ref.op.index() else {
-            let rowid_alias_used = plan.set_clauses.iter().any(|set_clause| {
-                set_clause.column_index != ROWID_SENTINEL
-                    && btree_table.columns()[set_clause.column_index].is_rowid_alias()
-            });
-            if rowid_alias_used {
-                break 'requires Some(DmlSafetyReason::KeyMutation);
-            }
-            let direct_rowid_update = plan
-                .set_clauses
-                .iter()
-                .any(|set_clause| set_clause.column_index == ROWID_SENTINEL);
-            if direct_rowid_update {
-                break 'requires Some(DmlSafetyReason::KeyMutation);
-            }
             break 'requires None;
         };
 
-        for set_clause in plan.set_clauses.iter() {
-            for c in index.columns.iter() {
-                if let Some(ref expr) = c.expr {
-                    let expr_idx_cols_mask =
-                        expression_index_column_usage(expr.as_ref(), table_ref, resolver)?;
-                    if expr_idx_cols_mask.get(set_clause.column_index) {
-                        break 'requires Some(DmlSafetyReason::KeyMutation);
-                    }
-                }
-            }
-        }
-
         let affected_cols = btree_table.columns_affected_by_update(&updated_cols)?;
-        if index
-            .columns
-            .iter()
-            .any(|c| affected_cols.get(c.pos_in_table))
-        {
-            break 'requires Some(DmlSafetyReason::KeyMutation);
+        for c in index.columns.iter() {
+            if let Some(ref expr) = c.expr {
+                let expr_idx_cols_mask =
+                    expression_index_column_usage(expr.as_ref(), table_ref, resolver)?;
+                if expr_idx_cols_mask
+                    .iter()
+                    .any(|cidx| affected_cols.get(cidx))
+                {
+                    break 'requires Some(DmlSafetyReason::KeyMutation);
+                }
+            } else if affected_cols.get(c.pos_in_table) {
+                break 'requires Some(DmlSafetyReason::KeyMutation);
+            }
         }
         break 'requires None;
     };

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -2335,6 +2335,40 @@ expect {
 
 @cross-check-integrity
 @skip-if mvcc "Expression indexes are not supported with MVCC"
+test gencol_expr_index_virtual_update_returning_halloween {
+    CREATE TABLE t1(a INTEGER, g INT AS (a = 10) VIRTUAL);
+    CREATE INDEX idx_expr ON t1(g + 0);
+    INSERT INTO t1(a) VALUES(10), (5);
+    UPDATE t1 SET a = 11 WHERE g + 0 = 1 RETURNING a, g, g + 0;
+    SELECT 'all', a, g FROM t1 ORDER BY a;
+    PRAGMA integrity_check;
+}
+expect {
+    11|0|0
+    all|5|0
+    all|11|0
+    ok
+}
+
+@cross-check-integrity
+@skip-if mvcc "Expression indexes are not supported with MVCC"
+test gencol_expr_index_virtual_update_transitive_halloween {
+    CREATE TABLE t1(a INTEGER, g INT AS (a = 10) VIRTUAL, h INT AS (g + 0) VIRTUAL);
+    CREATE INDEX idx_expr ON t1(h + 0);
+    INSERT INTO t1(a) VALUES(10), (5);
+    UPDATE t1 SET a = 11 WHERE h + 0 = 1 RETURNING a, g, h, h + 0;
+    SELECT 'all', a, g, h FROM t1 ORDER BY a;
+    PRAGMA integrity_check;
+}
+expect {
+    11|0|0|0
+    all|5|0|0
+    all|11|0|0
+    ok
+}
+
+@cross-check-integrity
+@skip-if mvcc "Expression indexes are not supported with MVCC"
 test gencol_expr_index_virtual_delete {
     CREATE TABLE t1(a INTEGER, b AS (a * 2));
     CREATE INDEX idx1 ON t1(b + 10);

--- a/testing/sqltests/tests/update_or_replace_rowid_secondary_index.sqltest
+++ b/testing/sqltests/tests/update_or_replace_rowid_secondary_index.sqltest
@@ -4,6 +4,29 @@
 # conflict is resolved via REPLACE.
 
 @cross-check-integrity
+test update-rowid-through-secondary-index-scan {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, payload TEXT);
+    CREATE INDEX idx_a ON t(a);
+    INSERT INTO t VALUES(1, 1, 'x'), (2, 1, 'y'), (3, 2, 'z');
+
+    UPDATE t
+       SET id = id + 10
+     WHERE a = 1
+     RETURNING id, a, payload;
+
+    SELECT id, a, payload FROM t ORDER BY id;
+    PRAGMA integrity_check;
+}
+expect {
+    11|1|x
+    12|1|y
+    3|2|z
+    11|1|x
+    12|1|y
+    ok
+}
+
+@cross-check-integrity
 test update-or-replace-rowid-conflict-preserves-secondary-index {
     CREATE TABLE t(id INTEGER PRIMARY KEY, c TEXT, payload TEXT);
     CREATE INDEX idx_c ON t(c);


### PR DESCRIPTION
## Summary
- materialize UPDATE write sets when a scanned index key is affected through virtual generated column dependencies
- materialize rowid-changing UPDATEs while scanning secondary indexes
- add sqltests for the generated-column UPDATE regression and rowid secondary-index scan

Fixes #6599

