### PR TITLE
Fix DELETE panic for indexed virtual generated columns

### DIFF
--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2283,7 +2283,6 @@ pub fn translate_expr(
 
             // If we are reading a column from a table, we find the cursor that corresponds to
             // the table and read the column from the cursor.
-            // If we have a covering index, we don't have an open table cursor so we read from the index cursor.
             match &table {
                 Table::BTree(_) => {
                     let (table_cursor_id, index_cursor_id) = if is_from_outer_query_scope {
@@ -2302,8 +2301,16 @@ pub fn translate_expr(
                             )
                         }
                     } else {
-                        let table_cursor_id = if use_covering_index || use_index_method.is_some() {
+                        let table_cursor_id = if use_index_method.is_some() {
                             None
+                        } else if use_covering_index {
+                            // If we have a covering index, we don't have an open table cursor so we
+                            // read from the index cursor, but the requested column might
+                            // legitimately not be in the index if it's a dependency of a generated
+                            // column.
+                            // Example: CREATE TABLE t(c0, c1 AS (c2 + 1), c2);
+                            // CREATE INDEX i ON t(c1, c0); DELETE FROM t WHERE c0 < 'X';
+                            program.resolve_cursor_id_safe(&CursorKey::table(*table_ref_id))
                         } else {
                             Some(program.resolve_cursor_id(&CursorKey::table(*table_ref_id)))
                         };

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4584,6 +4584,16 @@ test delete-using-indexed-virtual-column {
 } expect {
 }
 
+@cross-check-integrity
+test delete-indexed-virtual-generated-column-old-image {
+    CREATE TABLE t (c0 TEXT, c1 INTEGER AS (c2 + 1), c2 INTEGER);
+    CREATE INDEX i ON t (c1, c0);
+    DELETE FROM t WHERE c0 < 'X';
+    SELECT count(*) FROM t;
+} expect {
+    0
+}
+
 test update-with-virtual-column-before-pk {
     PRAGMA foreign_keys = ON;
     CREATE TABLE t(a AS (1), b, c, PRIMARY KEY (b));


### PR DESCRIPTION
Fixes https://github.com/tursodatabase/turso/issues/6612.

## Summary

- Fix DELETE codegen when an index covers a virtual generated column.
- Read generated-column dependencies from the table cursor when DML has one open.
- Add a gencol sqltest regression for the prepare-time panic.

## Testing

- `cargo run -p test-runner -- run testing/sqltests/tests/gencol.sqltest --backend rust --filter delete-indexed-virtual-generated-column-old-image`
- `cargo run -p test-runner -- run testing/sqltests/tests/gencol.sqltest --backend rust`