### PR TITLE
Add savepoint rollback DST coverage and fix rollback cache invalidation

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -718,6 +718,32 @@ impl PageCache {
         Ok(())
     }
 
+    /// Removes clean cached pages that were read from WAL frames newer than a
+    /// rollback target. Dirty pages are preserved because they may contain
+    /// restored transaction-local state that still needs to be committed or
+    /// rolled back by an outer savepoint.
+    pub fn delete_clean_pages_after_wal_frame(&mut self, max_frame: u64) -> Result<(), CacheError> {
+        for key in self
+            .map
+            .iter()
+            .filter_map(|(key, &entry_ptr)| {
+                let entry = unsafe { &*entry_ptr };
+                let page = &entry.page;
+                if !page.is_dirty() && page.has_wal_tag() {
+                    let (frame, _) = page.wal_tag_pair();
+                    if frame > max_frame {
+                        return Some(*key);
+                    }
+                }
+                None
+            })
+            .collect::<Vec<_>>()
+        {
+            self.delete(key)?;
+        }
+        Ok(())
+    }
+
     pub fn print(&self) {
         tracing::debug!("page_cache_len={}", self.map.len());
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2001,7 +2001,13 @@ impl Pager {
             turso_assert!(c.succeeded(), "memory IO should complete immediately");
             current_offset += page_size;
             rollback_bitset.insert(page_id);
-            self.upsert_page_in_cache(page_id as usize, page, false)?;
+            // The restored image is the transaction-visible state at the
+            // savepoint, not necessarily durable state. Keep it dirty so cache
+            // eviction cannot drop uncommitted changes that predate the
+            // rolled-back savepoint/statement.
+            page.set_dirty();
+            dirty_pages.insert(page_id);
+            self.upsert_page_in_cache(page_id as usize, page, true)?;
         }
 
         let truncate_completion = subjournal.truncate(journal_start_offset)?;
@@ -2031,6 +2037,14 @@ impl Pager {
                 frame: savepoint.wal_max_frame,
                 checksum: savepoint.wal_checksum,
             }));
+            self.page_cache
+                .write()
+                .delete_clean_pages_after_wal_frame(savepoint.wal_max_frame)
+                .map_err(|e| {
+                    LimboError::InternalError(format!(
+                        "failed to invalidate rolled-back WAL pages: {e:?}"
+                    ))
+                })?;
         }
 
         Ok(())

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3995,6 +3995,12 @@ pub fn op_savepoint(
                         deferred_fk_violations,
                     );
                 } else {
+                    if !pager.holds_read_lock() {
+                        pager.begin_read_tx()?;
+                    }
+                    if matches!(conn.get_tx_state(), TransactionState::None) {
+                        conn.set_tx_state(TransactionState::Read);
+                    }
                     pager.open_subjournal()?;
                     let db_size =
                         return_if_io!(pager.with_header(|header| header.database_size.get()));
@@ -11356,12 +11362,12 @@ fn drive_init_cdc_version(
                             "CREATE TABLE IF NOT EXISTS {cdc_table_name} (change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_txn_id INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
                         ),
                     };
-                    inner.stmt = prepare_cdc_internal(&conn, create_sql)?;
+                    inner.stmt = prepare_cdc_internal(conn, create_sql)?;
                     inner.phase = OpInitCdcVersionPhase::CreateCdcTable;
                 }
                 OpInitCdcVersionPhase::CreateCdcTable => {
                     inner.stmt = prepare_cdc_internal(
-                        &conn,
+                        conn,
                         format!(
                             "CREATE TABLE IF NOT EXISTS {TURSO_CDC_VERSION_TABLE_NAME} (table_name TEXT PRIMARY KEY, version TEXT NOT NULL)",
                         ),
@@ -11378,7 +11384,7 @@ fn drive_init_cdc_version(
                         *version
                     };
                     inner.stmt = prepare_cdc_internal(
-                        &conn,
+                        conn,
                         format!(
                             "INSERT OR IGNORE INTO {TURSO_CDC_VERSION_TABLE_NAME} (table_name, version) VALUES ('{escaped_cdc_table_name}', '{version_to_insert}')",
                         ),
@@ -11387,7 +11393,7 @@ fn drive_init_cdc_version(
                 }
                 OpInitCdcVersionPhase::InsertVersion => {
                     inner.stmt = prepare_cdc_internal(
-                        &conn,
+                        conn,
                         format!(
                             "SELECT version FROM {TURSO_CDC_VERSION_TABLE_NAME} WHERE table_name = '{escaped_cdc_table_name}'",
                         ),
@@ -15428,7 +15434,7 @@ mod tests {
         );
         assert_eq!(state.pc, 0, "pc should not advance on invariant violation");
         assert!(
-            matches!(state.active_op_state.hash_probe(), None),
+            state.active_op_state.hash_probe().is_none(),
             "HashProbe should not stash resumable state for the removed fallback path"
         );
     }

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -99,6 +99,8 @@ pub struct QueryOpts {
 pub struct SelectOpts {
     #[garde(range(min = 0.0, max = 1.0))]
     pub order_by_prob: f64,
+    #[garde(range(min = 1, max = 64))]
+    pub free_expr_size: u32,
     #[garde(length(min = 1))]
     pub compound_selects: Vec<CompoundSelectWeight>,
 }
@@ -107,6 +109,7 @@ impl Default for SelectOpts {
     fn default() -> Self {
         Self {
             order_by_prob: 0.3,
+            free_expr_size: 8,
             compound_selects: vec![
                 CompoundSelectWeight {
                     num_compound_selects: 0,

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -192,7 +192,8 @@ pub struct SelectFree(pub Select);
 
 impl Arbitrary for SelectFree {
     fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, env: &C) -> Self {
-        let expr = Predicate(Expr::arbitrary_sized(rng, env, 8));
+        let expr_size = env.opts().query.select.free_expr_size as usize;
+        let expr = Predicate(Expr::arbitrary_sized(rng, env, expr_size));
         let select = Select::expr(expr);
         Self(select)
     }

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -53,11 +53,12 @@ simulator covers and tests.
 | INSERT                    | Partial | TODO                                                                              |
 | ON CONFLICT clause        | No      |                                                                                   |
 | REINDEX                   | No      |                                                                                   |
-| RELEASE SAVEPOINT         | No      |                                                                                   |
+| RELEASE SAVEPOINT         | Partial | Covered by SavepointRollback property.                                            |
 | REPLACE                   | No      |                                                                                   |
 | RETURNING clause          | No      | TODO                                                                              |
 | ROLLBACK TRANSACTION      | Partial | TODO                                                                              |
-| SAVEPOINT                 | No      |                                                                                   |
+| ROLLBACK TO SAVEPOINT     | Partial | Covered by SavepointRollback property.                                            |
+| SAVEPOINT                 | Partial | Covered by SavepointRollback property.                                            |
 | SELECT                    | Partial | TODO                                                                              |
 | SELECT ... WHERE          | Partial | TODO                                                                              |
 | SELECT ... WHERE ... LIKE | No      |                                                                                   |

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -19,7 +19,7 @@ use sql_generation::{
             transaction::{Begin, Commit, Rollback},
             update::{SetValue, Update},
         },
-        table::SimValue,
+        table::{ColumnType, SimValue, Table},
     },
 };
 use strum::IntoEnumIterator;
@@ -30,7 +30,8 @@ use crate::{
     common::print_diff,
     generation::{Shadow, WeightedDistribution, query::QueryDistribution},
     model::{
-        Query, QueryCapabilities, QueryDiscriminants, ResultSet,
+        Query, QueryCapabilities, QueryDiscriminants, ReleaseSavepoint, ResultSet,
+        RollbackToSavepoint, Savepoint,
         interactions::{
             Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
         },
@@ -225,6 +226,14 @@ impl Property {
                         }
                         _ => Some(query),
                     }
+                }
+            }
+            Property::SavepointRollback { .. } => {
+                |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
+                    let Property::SavepointRollback { write_kinds, .. } = property else {
+                        unreachable!()
+                    };
+                    random_main_table_write(rng, ctx, write_kinds)
                 }
             }
             Property::Queries { .. } => {
@@ -1197,6 +1206,33 @@ impl Property {
                 .into_iter()
                 .map(|query| InteractionBuilder::with_interaction(InteractionType::Query(query)))
                 .collect(),
+            Property::SavepointRollback {
+                queries, tables, ..
+            } => {
+                let savepoint_name = format!("sim_sp_{}", id.get());
+                let mut interactions = Vec::with_capacity(queries.len() + 4 + tables.len() * 2);
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Savepoint(Savepoint {
+                        name: savepoint_name.clone(),
+                    })),
+                ));
+                interactions.extend(queries.clone().into_iter().map(|query| {
+                    InteractionBuilder::with_interaction(InteractionType::Query(query))
+                }));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::RollbackToSavepoint(RollbackToSavepoint {
+                        name: savepoint_name.clone(),
+                    })),
+                ));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::ReleaseSavepoint(ReleaseSavepoint {
+                        name: savepoint_name,
+                    })),
+                ));
+                interactions.extend(assert_all_table_values(tables, connection_index));
+                interactions.push(assert_integrity_check(tables, connection_index));
+                interactions
+            }
         };
 
         assert!(!interactions.is_empty());
@@ -1211,6 +1247,230 @@ impl Property {
                 builder.build().unwrap()
             })
             .collect()
+    }
+}
+
+fn random_main_table_write<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    ctx: &impl GenerationContext,
+    write_kinds: &[QueryDiscriminants],
+) -> Option<Query> {
+    let tables = ctx
+        .tables()
+        .iter()
+        .filter(|table| !table.name.contains('.'))
+        .collect::<Vec<_>>();
+
+    if tables.is_empty() {
+        return None;
+    }
+
+    let table = *pick(&tables, rng);
+    let write_kind = pick(write_kinds, rng);
+
+    match write_kind {
+        QueryDiscriminants::Insert => Some(random_main_table_insert(rng, ctx, table)),
+        QueryDiscriminants::Update => Some(random_main_table_update(rng, ctx, table)),
+        QueryDiscriminants::Delete => Some(random_main_table_delete(rng, table)),
+        _ => None,
+    }
+}
+
+fn random_main_table_insert<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    ctx: &impl GenerationContext,
+    table: &Table,
+) -> Query {
+    const UNIQUE_BASE_OFFSET_RANGE: std::ops::Range<i64> = 3_000_000_000..4_000_000_000;
+    const UNIQUE_COL_STRIDE: i64 = 10_000_000;
+
+    let num_rows = rng.random_range(1..=5);
+    let base_offset: i64 = rng.random_range(UNIQUE_BASE_OFFSET_RANGE);
+    let values = (0..num_rows)
+        .map(|row_idx| {
+            table
+                .columns
+                .iter()
+                .enumerate()
+                .map(|(col_idx, column)| {
+                    if column.has_unique_or_pk() {
+                        let offset =
+                            base_offset + (col_idx as i64 * UNIQUE_COL_STRIDE) + row_idx as i64;
+                        SimValue::unique_for_type(&column.column_type, offset)
+                    } else {
+                        SimValue::arbitrary_from(rng, ctx, &column.column_type)
+                    }
+                })
+                .collect()
+        })
+        .collect();
+
+    Query::Insert(Insert::Values {
+        table: table.name.clone(),
+        values,
+        on_conflict: None,
+    })
+}
+
+fn random_main_table_update<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    ctx: &impl GenerationContext,
+    table: &Table,
+) -> Query {
+    let update_opts = &ctx.opts().query.update;
+    let unique_columns = table
+        .columns
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| {
+            column.has_unique_or_pk() && !matches!(column.column_type, ColumnType::Blob)
+        })
+        .collect::<Vec<_>>();
+    let non_unique_columns = table
+        .columns
+        .iter()
+        .filter(|column| !column.has_unique_or_pk())
+        .collect::<Vec<_>>();
+
+    let last_row_idx = table.rows.len().saturating_sub(1);
+    let conflict_capable_columns = if table.rows.len() >= 2 {
+        unique_columns
+            .iter()
+            .filter(|(col_idx, _)| table.rows[0][*col_idx] != table.rows[last_row_idx][*col_idx])
+            .copied()
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    if update_opts.force_late_failure
+        && !conflict_capable_columns.is_empty()
+        && !non_unique_columns.is_empty()
+    {
+        let (col_idx, unique_col) = *pick(&conflict_capable_columns, rng);
+        let marker_col = *pick(&non_unique_columns, rng);
+        let first_val = table.rows[0][col_idx].clone();
+        let last_val = table.rows[last_row_idx][col_idx].clone();
+        let marker_value = match update_opts.padding_size {
+            Some(size) if matches!(marker_col.column_type, ColumnType::Blob) => {
+                SimValue(turso_core::Value::Blob(vec![b'X'; size]))
+            }
+            Some(size) => SimValue(turso_core::Value::Text("X".repeat(size).into())),
+            None => SimValue::arbitrary_from(rng, ctx, &marker_col.column_type),
+        };
+
+        return Query::Update(Update {
+            table: table.name.clone(),
+            set_values: vec![
+                (marker_col.name.clone(), SetValue::Simple(marker_value)),
+                (
+                    unique_col.name.clone(),
+                    SetValue::CaseWhen {
+                        condition: Box::new(Predicate::eq(
+                            Predicate::column(unique_col.name.clone()),
+                            Predicate::value(last_val),
+                        )),
+                        then_value: first_val,
+                        else_column: unique_col.name.clone(),
+                    },
+                ),
+            ],
+            predicate: Predicate::true_(),
+        });
+    }
+
+    let column = if non_unique_columns.is_empty() {
+        pick(&table.columns, rng)
+    } else {
+        *pick(&non_unique_columns, rng)
+    };
+    let value = match (update_opts.padding_size, &column.column_type) {
+        (Some(size), ColumnType::Blob) => SimValue(turso_core::Value::Blob(vec![b'X'; size])),
+        (Some(size), ColumnType::Text) => {
+            SimValue(turso_core::Value::Text("X".repeat(size).into()))
+        }
+        _ => SimValue::arbitrary_from(rng, ctx, &column.column_type),
+    };
+
+    Query::Update(Update {
+        table: table.name.clone(),
+        set_values: vec![(column.name.clone(), SetValue::Simple(value))],
+        predicate: if rng.random_bool(0.8) {
+            Predicate::true_()
+        } else {
+            Predicate::false_()
+        },
+    })
+}
+
+fn random_main_table_delete<R: rand::Rng + ?Sized>(rng: &mut R, table: &Table) -> Query {
+    Query::Delete(Delete {
+        table: table.name.clone(),
+        predicate: if rng.random_bool(0.5) {
+            Predicate::true_()
+        } else {
+            Predicate::false_()
+        },
+    })
+}
+
+fn assert_integrity_check(tables: &[String], connection_index: usize) -> InteractionBuilder {
+    let tables = tables.to_vec();
+    InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
+        "PRAGMA integrity_check should be ok after savepoint rollback".to_string(),
+        move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
+            let result = run_integrity_check(env, connection_index)?;
+            if result == "ok" {
+                Ok(Ok(()))
+            } else {
+                Ok(Err(format!("integrity_check returned {result:?}")))
+            }
+        },
+        tables,
+    )))
+}
+
+fn run_integrity_check(
+    env: &mut SimulatorEnv,
+    connection_index: usize,
+) -> turso_core::Result<String> {
+    match &mut env.connections[connection_index] {
+        crate::runner::env::SimConnection::LimboConnection(conn) => {
+            let mut rows = conn.query("PRAGMA integrity_check")?.ok_or_else(|| {
+                LimboError::InternalError("integrity_check returned no rows".into())
+            })?;
+            let mut result = Vec::new();
+            rows.run_with_row_callback(|row| {
+                let value = row
+                    .get_value(0)
+                    .to_text()
+                    .ok_or_else(|| {
+                        LimboError::InternalError(
+                            "integrity_check returned a non-text value".to_string(),
+                        )
+                    })?
+                    .to_string();
+                result.push(value);
+                Ok(())
+            })?;
+            Ok(result.join("\n"))
+        }
+        crate::runner::env::SimConnection::SQLiteConnection(conn) => {
+            let mut stmt = conn
+                .prepare("PRAGMA integrity_check")
+                .map_err(|e| LimboError::InternalError(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|e| LimboError::InternalError(e.to_string()))?;
+            let mut result = Vec::new();
+            for row in rows {
+                result.push(row.map_err(|e| LimboError::InternalError(e.to_string()))?);
+            }
+            Ok(result.join("\n"))
+        }
+        crate::runner::env::SimConnection::Disconnected => Err(LimboError::InternalError(
+            "connection is disconnected during integrity_check assertion".into(),
+        )),
     }
 }
 
@@ -1382,6 +1642,39 @@ fn property_read_your_updates_back<R: rand::Rng + ?Sized>(
         update,
         select_before: select.clone(),
         select_after: select,
+    }
+}
+
+fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let tables = ctx
+        .tables()
+        .iter()
+        .filter(|table| !table.name.contains('.'))
+        .map(|table| table.name.clone())
+        .collect::<Vec<_>>();
+    assert!(!tables.is_empty());
+    let write_kinds = query_distr
+        .positive_items()
+        .filter(|query| {
+            matches!(
+                query,
+                QueryDiscriminants::Insert
+                    | QueryDiscriminants::Update
+                    | QueryDiscriminants::Delete
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(!write_kinds.is_empty());
+    let amount = rng.random_range(1..=5);
+    Property::SavepointRollback {
+        queries: std::iter::repeat_n(Query::Placeholder, amount).collect(),
+        tables,
+        write_kinds,
     }
 }
 
@@ -1605,6 +1898,7 @@ impl PropertyDiscriminants {
         match self {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
+            PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
@@ -1637,7 +1931,7 @@ impl PropertyDiscriminants {
                 if !env.opts.disable_insert_values_select && !ctx.tables().is_empty() {
                     let has_non_unique_table =
                         ctx.tables().iter().any(|t| !t.has_any_unique_column());
-                    if has_non_unique_table {
+                    if has_non_unique_table && remaining.select > 0 && remaining.insert > 0 {
                         u32::min(remaining.select, remaining.insert).max(1)
                     } else {
                         0 // all tables have UNIQUE columns, skip this property
@@ -1648,7 +1942,21 @@ impl PropertyDiscriminants {
             }
 
             PropertyDiscriminants::ReadYourUpdatesBack => {
-                u32::min(remaining.select, remaining.insert).max(1)
+                if remaining.select > 0 && remaining.update > 0 {
+                    u32::min(remaining.select, remaining.update).max(1)
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::SavepointRollback => {
+                if !env.opts.disable_savepoint_rollback
+                    && !env.profile.mvcc
+                    && ctx.tables().iter().any(|table| !table.name.contains('.'))
+                {
+                    remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
             }
             PropertyDiscriminants::TableHasExpectedContent => {
                 if !ctx.tables().is_empty() {
@@ -1750,6 +2058,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::ReadYourUpdatesBack => {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
+            PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -147,7 +147,10 @@ impl QueryDiscriminants {
             QueryDiscriminants::DropIndex => random_drop_index,
             QueryDiscriminants::Begin
             | QueryDiscriminants::Commit
-            | QueryDiscriminants::Rollback => {
+            | QueryDiscriminants::Rollback
+            | QueryDiscriminants::Savepoint
+            | QueryDiscriminants::RollbackToSavepoint
+            | QueryDiscriminants::ReleaseSavepoint => {
                 unreachable!("transactional queries should not be generated")
             }
             QueryDiscriminants::Placeholder => {
@@ -172,7 +175,10 @@ impl QueryDiscriminants {
             QueryDiscriminants::DropIndex => remaining.drop_index,
             QueryDiscriminants::Begin
             | QueryDiscriminants::Commit
-            | QueryDiscriminants::Rollback => {
+            | QueryDiscriminants::Rollback
+            | QueryDiscriminants::Savepoint
+            | QueryDiscriminants::RollbackToSavepoint
+            | QueryDiscriminants::ReleaseSavepoint => {
                 unreachable!("transactional queries should not be generated")
             }
             QueryDiscriminants::Placeholder => {
@@ -186,17 +192,30 @@ impl QueryDiscriminants {
 #[derive(Debug)]
 pub(super) struct QueryDistribution {
     queries: &'static [QueryDiscriminants],
+    query_weights: Vec<u32>,
     weights: WeightedIndex<u32>,
 }
 
 impl QueryDistribution {
     pub fn new(queries: &'static [QueryDiscriminants], remaining: &Remaining) -> Self {
-        let query_weights =
-            WeightedIndex::new(queries.iter().map(|query| query.weight(remaining))).unwrap();
+        let query_weights = queries
+            .iter()
+            .map(|query| query.weight(remaining))
+            .collect::<Vec<_>>();
+        let weights = WeightedIndex::new(query_weights.iter().copied()).unwrap();
         Self {
             queries,
-            weights: query_weights,
+            query_weights,
+            weights,
         }
+    }
+
+    pub(super) fn positive_items(&self) -> impl Iterator<Item = QueryDiscriminants> + '_ {
+        self.queries
+            .iter()
+            .zip(self.query_weights.iter())
+            .filter(|(_, weight)| **weight > 0)
+            .map(|(query, _)| *query)
     }
 }
 

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -145,6 +145,9 @@ impl InteractionStats {
             Query::Begin(_) => self.begin_count += 1,
             Query::Commit(_) => self.commit_count += 1,
             Query::Rollback(_) => self.rollback_count += 1,
+            Query::Savepoint(_) => self.begin_count += 1,
+            Query::RollbackToSavepoint(_) => self.rollback_count += 1,
+            Query::ReleaseSavepoint(_) => self.commit_count += 1,
             Query::AlterTable(_) => self.alter_table_count += 1,
             Query::DropIndex(_) => self.drop_index_count += 1,
             Query::Placeholder => {}

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -240,8 +240,42 @@ pub mod property;
 
 pub(crate) type ResultSet = turso_core::Result<Vec<Vec<SimValue>>>;
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Savepoint {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RollbackToSavepoint {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleaseSavepoint {
+    pub name: String,
+}
+
+impl Display for Savepoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SAVEPOINT {}", self.name)
+    }
+}
+
+impl Display for RollbackToSavepoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ROLLBACK TO {}", self.name)
+    }
+}
+
+impl Display for ReleaseSavepoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RELEASE {}", self.name)
+    }
+}
+
 // This type represents the potential queries on the database.
 #[derive(Debug, Clone, Serialize, Deserialize, strum::EnumDiscriminants)]
+#[strum_discriminants(derive(Serialize, Deserialize))]
 pub enum Query {
     Create(Create),
     Select(Select),
@@ -255,6 +289,9 @@ pub enum Query {
     Begin(Begin),
     Commit(Commit),
     Rollback(Rollback),
+    Savepoint(Savepoint),
+    RollbackToSavepoint(RollbackToSavepoint),
+    ReleaseSavepoint(ReleaseSavepoint),
     Pragma(Pragma),
     /// Placeholder query that still needs to be generated
     Placeholder,
@@ -306,6 +343,9 @@ impl Query {
             Query::Begin(_)
             | Query::Commit(_)
             | Query::Rollback(_)
+            | Query::Savepoint(_)
+            | Query::RollbackToSavepoint(_)
+            | Query::ReleaseSavepoint(_)
             | Query::Placeholder
             | Query::Pragma(_) => IndexSet::new(),
         }
@@ -331,6 +371,9 @@ impl Query {
                 table_name: table, ..
             }) => vec![table.clone()],
             Query::Begin(..) | Query::Commit(..) | Query::Rollback(..) => vec![],
+            Query::Savepoint(..) | Query::RollbackToSavepoint(..) | Query::ReleaseSavepoint(..) => {
+                vec![]
+            }
             Query::Placeholder => vec![],
             Query::Pragma(_) => vec![],
         }
@@ -340,7 +383,12 @@ impl Query {
     pub fn is_transaction(&self) -> bool {
         matches!(
             self,
-            Self::Begin(..) | Self::Commit(..) | Self::Rollback(..)
+            Self::Begin(..)
+                | Self::Commit(..)
+                | Self::Rollback(..)
+                | Self::Savepoint(..)
+                | Self::RollbackToSavepoint(..)
+                | Self::ReleaseSavepoint(..)
         )
     }
 
@@ -387,6 +435,9 @@ impl Display for Query {
             Self::Begin(begin) => write!(f, "{begin}"),
             Self::Commit(commit) => write!(f, "{commit}"),
             Self::Rollback(rollback) => write!(f, "{rollback}"),
+            Self::Savepoint(savepoint) => write!(f, "{savepoint}"),
+            Self::RollbackToSavepoint(rollback_to) => write!(f, "{rollback_to}"),
+            Self::ReleaseSavepoint(release) => write!(f, "{release}"),
             Self::Placeholder => Ok(()),
             Query::Pragma(pragma) => write!(f, "{pragma}"),
         }
@@ -413,6 +464,9 @@ impl Shadow for Query {
             Query::Begin(begin) => Ok(begin.shadow(env)),
             Query::Commit(commit) => Ok(commit.shadow(env)),
             Query::Rollback(rollback) => Ok(rollback.shadow(env)),
+            Query::Savepoint(savepoint) => Ok(savepoint.shadow(env)),
+            Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
+            Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
             Query::Pragma(Pragma::AutoVacuumMode(_)) => Ok(vec![]),
         }
@@ -463,7 +517,10 @@ impl From<QueryDiscriminants> for QueryCapabilities {
             QueryDiscriminants::DropIndex => Self::DROP_INDEX,
             QueryDiscriminants::Begin
             | QueryDiscriminants::Commit
-            | QueryDiscriminants::Rollback => {
+            | QueryDiscriminants::Rollback
+            | QueryDiscriminants::Savepoint
+            | QueryDiscriminants::RollbackToSavepoint
+            | QueryDiscriminants::ReleaseSavepoint => {
                 unreachable!("QueryCapabilities do not apply to transaction queries")
             }
             QueryDiscriminants::Placeholder => {
@@ -992,6 +1049,30 @@ impl Shadow for Rollback {
     fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
         tables.delete_snapshot();
         vec![]
+    }
+}
+
+impl Shadow for Savepoint {
+    type Result = Vec<Vec<SimValue>>;
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
+        tables.savepoint(self.name.clone());
+        vec![]
+    }
+}
+
+impl Shadow for RollbackToSavepoint {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
+        tables.rollback_to_savepoint(&self.name)?;
+        Ok(vec![])
+    }
+}
+
+impl Shadow for ReleaseSavepoint {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+    fn shadow(&self, tables: &mut ShadowTablesMut) -> Self::Result {
+        tables.release_savepoint(&self.name)?;
+        Ok(vec![])
     }
 }
 

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sql_generation::model::query::{Create, Insert, Select, predicate::Predicate, update::Update};
 
-use crate::model::Query;
+use crate::model::{Query, QueryDiscriminants};
 
 /// Properties are representations of executable specifications
 /// about the database behavior.
@@ -182,6 +182,15 @@ pub enum Property {
     FaultyQuery {
         query: Query,
     },
+    /// SavepointRollback wraps random write interactions in a named savepoint,
+    /// rolls them back, then checks that the database still matches the shadow
+    /// model. This targets pager/WAL/cache-spill bugs where rolled-back page
+    /// contents remain visible.
+    SavepointRollback {
+        queries: Vec<Query>,
+        tables: Vec<String>,
+        write_kinds: Vec<QueryDiscriminants>,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -210,6 +219,7 @@ impl Property {
                 | Property::DoubleCreateFailure { .. }
                 | Property::DeleteSelect { .. }
                 | Property::DropSelect { .. }
+                | Property::SavepointRollback { .. }
                 | Property::Queries { .. }
         )
     }
@@ -220,6 +230,7 @@ impl Property {
             | Property::DoubleCreateFailure { queries, .. }
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
+            | Property::SavepointRollback { queries, .. }
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -11,7 +11,7 @@ use garde::Validate;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sql_generation::generation::{
-    InsertOpts, LargeTableOpts, Opts, QueryOpts, TableOpts, UpdateOpts,
+    InsertOpts, LargeTableOpts, Opts, QueryOpts, SelectOpts, TableOpts, UpdateOpts,
 };
 use strum::EnumString;
 
@@ -129,6 +129,63 @@ impl Profile {
         profile
     }
 
+    /// Profile that biases generation toward named savepoint rollback under
+    /// cache pressure, where WAL spill and page restoration bugs tend to hide.
+    pub fn savepoint_stress() -> Self {
+        let profile = Profile {
+            io: IOProfile {
+                fault: FaultProfile {
+                    enable: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            cache_size_pages: Some(200),
+            query: QueryProfile {
+                gen_opts: Opts {
+                    table: TableOpts {
+                        large_table: LargeTableOpts {
+                            large_table_prob: 0.15,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    query: QueryOpts {
+                        select: SelectOpts {
+                            free_expr_size: 1,
+                            ..Default::default()
+                        },
+                        insert: InsertOpts {
+                            min_rows: NonZeroU32::new(5).unwrap(),
+                            max_rows: NonZeroU32::new(20).unwrap(),
+                            ..Default::default()
+                        },
+                        update: UpdateOpts {
+                            padding_size: Some(4_000),
+                            force_late_failure: true,
+                        },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                select_weight: 0,
+                insert_weight: 35,
+                update_weight: 35,
+                delete_weight: 5,
+                create_index_weight: 15,
+                create_table_weight: 8,
+                drop_table_weight: 0,
+                alter_table_weight: 0,
+                drop_index: 0,
+                pragma_weight: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        profile.validate().unwrap();
+        profile
+    }
+
     pub fn faultless() -> Self {
         let profile = Profile {
             io: IOProfile {
@@ -177,6 +234,7 @@ impl Profile {
             ProfileType::Faultless => Self::faultless(),
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
+            ProfileType::SavepointStress => Self::savepoint_stress(),
             ProfileType::Custom(path) => {
                 Self::parse(path).with_context(|| "failed to parse JSON profile")?
             }
@@ -218,6 +276,7 @@ pub enum ProfileType {
     Faultless,
     SimpleMvcc,
     WriteStress,
+    SavepointStress,
     #[strum(disabled)]
     Custom(PathBuf),
 }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -145,6 +145,12 @@ pub struct SimulatorCLI {
         default_value_t = false
     )]
     pub disable_union_all_preserves_cardinality: bool,
+    #[clap(
+        long,
+        help = "disable Savepoint-Rollback Property",
+        default_value_t = false
+    )]
+    pub disable_savepoint_rollback: bool,
     #[clap(long, help = "disable FsyncNoWait Property", default_value_t = true)]
     pub disable_fsync_no_wait: bool,
     #[clap(long, help = "disable FaultyQuery Property")]

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -129,6 +129,8 @@ pub struct Snapshot {
     current_tables: Vec<Table>,
     /// Operations recorded during this transaction, in order
     operations: Vec<TxOperation>,
+    /// Named savepoint snapshots in this transaction.
+    savepoints: Vec<ShadowSavepoint>,
 
     transaction_mode: TransactionMode,
 }
@@ -138,6 +140,14 @@ impl Snapshot {
     fn set_transaction_mode(&mut self, transaction_mode: TransactionMode) {
         self.transaction_mode = transaction_mode;
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct ShadowSavepoint {
+    name: String,
+    current_tables: Vec<Table>,
+    operation_len: usize,
+    starts_transaction: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -445,6 +455,66 @@ where
         }
     }
 
+    pub fn savepoint(&mut self, name: String) {
+        let starts_transaction = self.transaction_tables.is_none();
+        if starts_transaction
+            || matches!(
+                self.transaction_tables.as_ref(),
+                Some(TransactionTables::Deferred)
+            )
+        {
+            self.create_snapshot(TransactionMode::Write);
+        }
+
+        let snapshot = self
+            .transaction_tables
+            .as_mut()
+            .expect("savepoint should create a transaction snapshot")
+            .expect_snapshot_mut();
+        snapshot.savepoints.push(ShadowSavepoint {
+            name,
+            current_tables: snapshot.current_tables.clone(),
+            operation_len: snapshot.operations.len(),
+            starts_transaction,
+        });
+    }
+
+    pub fn rollback_to_savepoint(&mut self, name: &str) -> anyhow::Result<()> {
+        let Some(txn) = self.transaction_tables.as_mut() else {
+            return Err(anyhow::anyhow!(
+                "cannot rollback to savepoint {name}: no active transaction"
+            ));
+        };
+        let snapshot = txn.expect_snapshot_mut();
+        let Some(savepoint_idx) = snapshot.savepoints.iter().rposition(|sp| sp.name == name) else {
+            return Err(anyhow::anyhow!("no such savepoint: {name}"));
+        };
+        let savepoint = snapshot.savepoints[savepoint_idx].clone();
+        snapshot.current_tables = savepoint.current_tables;
+        snapshot.operations.truncate(savepoint.operation_len);
+        // ROLLBACK TO keeps the target savepoint active and discards nested ones.
+        snapshot.savepoints.truncate(savepoint_idx + 1);
+        Ok(())
+    }
+
+    pub fn release_savepoint(&mut self, name: &str) -> anyhow::Result<()> {
+        let Some(txn) = self.transaction_tables.as_mut() else {
+            return Err(anyhow::anyhow!(
+                "cannot release savepoint {name}: no active transaction"
+            ));
+        };
+        let snapshot = txn.expect_snapshot_mut();
+        let Some(savepoint_idx) = snapshot.savepoints.iter().rposition(|sp| sp.name == name) else {
+            return Err(anyhow::anyhow!("no such savepoint: {name}"));
+        };
+        let starts_transaction = snapshot.savepoints[savepoint_idx].starts_transaction;
+        snapshot.savepoints.truncate(savepoint_idx);
+        if starts_transaction {
+            self.apply_snapshot();
+        }
+        Ok(())
+    }
+
     /// Tries to upgrade the Transaction Mode
     #[inline]
     pub fn upgrade_transaction(&mut self, query: &Query) {
@@ -489,6 +559,7 @@ where
         *self.transaction_tables = Some(TransactionTables::Snapshot(Snapshot {
             current_tables: self.commited_tables.clone(),
             operations: Vec::new(),
+            savepoints: Vec::new(),
             transaction_mode,
         }));
     }
@@ -733,6 +804,89 @@ impl<'a> DerefMut for ShadowTablesMut<'a> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shadow_tables_mut<'a>(
+        commited_tables: &'a mut Vec<Table>,
+        transaction_tables: &'a mut Option<TransactionTables>,
+    ) -> ShadowTablesMut<'a> {
+        ShadowTablesMut {
+            commited_tables,
+            transaction_tables,
+        }
+    }
+
+    #[test]
+    fn savepoint_outside_transaction_commits_on_release() {
+        let mut commited_tables = Vec::new();
+        let mut transaction_tables = None;
+
+        {
+            let mut tables = shadow_tables_mut(&mut commited_tables, &mut transaction_tables);
+            tables.savepoint("sp".to_string());
+            let snapshot = tables
+                .transaction_tables
+                .as_ref()
+                .expect("savepoint should create a transaction")
+                .expect_snaphot();
+            assert_eq!(snapshot.savepoints.len(), 1);
+            assert!(snapshot.savepoints[0].starts_transaction);
+
+            tables.release_savepoint("sp").unwrap();
+        }
+
+        assert!(transaction_tables.is_none());
+    }
+
+    #[test]
+    fn rollback_to_savepoint_keeps_target_active() {
+        let mut commited_tables = Vec::new();
+        let mut transaction_tables = None;
+
+        let mut tables = shadow_tables_mut(&mut commited_tables, &mut transaction_tables);
+        tables.create_snapshot(TransactionMode::Write);
+        tables.savepoint("sp".to_string());
+        tables.record_insert("table_0".to_string(), vec![]);
+
+        tables.rollback_to_savepoint("sp").unwrap();
+        let snapshot = tables
+            .transaction_tables
+            .as_ref()
+            .expect("rollback target transaction should exist")
+            .expect_snaphot();
+        assert!(snapshot.operations.is_empty());
+        assert_eq!(snapshot.savepoints.len(), 1);
+        assert_eq!(snapshot.savepoints[0].name, "sp");
+    }
+
+    #[test]
+    fn savepoint_inside_deferred_transaction_stays_open_on_release() {
+        let mut commited_tables = Vec::new();
+        let mut transaction_tables = Some(TransactionTables::Deferred);
+
+        let mut tables = shadow_tables_mut(&mut commited_tables, &mut transaction_tables);
+        tables.savepoint("sp".to_string());
+        let snapshot = tables
+            .transaction_tables
+            .as_ref()
+            .expect("deferred transaction should materialize")
+            .expect_snaphot();
+        assert_eq!(snapshot.transaction_mode, TransactionMode::Write);
+        assert_eq!(snapshot.savepoints.len(), 1);
+        assert!(!snapshot.savepoints[0].starts_transaction);
+
+        tables.release_savepoint("sp").unwrap();
+        let snapshot = tables
+            .transaction_tables
+            .as_ref()
+            .expect("outer transaction should remain open")
+            .expect_snaphot();
+        assert!(snapshot.savepoints.is_empty());
+    }
+}
+
 pub(crate) struct SimulatorEnv {
     pub(crate) opts: SimulatorOpts,
     pub profile: Profile,
@@ -950,6 +1104,7 @@ impl SimulatorEnv {
             disable_where_true_false_null: cli_opts.disable_where_true_false_null,
             disable_union_all_preserves_cardinality: cli_opts
                 .disable_union_all_preserves_cardinality,
+            disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
             page_size: 4096, // TODO: randomize this too
@@ -1198,7 +1353,12 @@ impl SimulatorEnv {
         let value = query.is_some_and(|query| {
             matches!(
                 query,
-                Query::Begin(..) | Query::Commit(..) | Query::Rollback(..)
+                Query::Begin(..)
+                    | Query::Commit(..)
+                    | Query::Rollback(..)
+                    | Query::Savepoint(..)
+                    | Query::RollbackToSavepoint(..)
+                    | Query::ReleaseSavepoint(..)
             )
         });
         self.connection_last_query.set(conn_index, value);
@@ -1282,6 +1442,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_drop_select: bool,
     pub(crate) disable_where_true_false_null: bool,
     pub(crate) disable_union_all_preserves_cardinality: bool,
+    pub(crate) disable_savepoint_rollback: bool,
     pub(crate) disable_fsync_no_wait: bool,
     pub(crate) disable_faulty_query: bool,
     pub(crate) disable_reopen_database: bool,

--- a/testing/simulator/shrink/plan.rs
+++ b/testing/simulator/shrink/plan.rs
@@ -227,6 +227,9 @@ impl InteractionPlan {
                         InteractionType::Query(Query::Begin(..))
                             | InteractionType::Query(Query::Commit(..))
                             | InteractionType::Query(Query::Rollback(..))
+                            | InteractionType::Query(Query::Savepoint(..))
+                            | InteractionType::Query(Query::RollbackToSavepoint(..))
+                            | InteractionType::Query(Query::ReleaseSavepoint(..))
                     );
                     let is_pragma = matches!(
                         &interaction.interaction,
@@ -284,13 +287,15 @@ impl InteractionPlan {
 
         for (idx, interaction) in self.interactions_list().iter().enumerate() {
             match &interaction.interaction {
-                InteractionType::Query(Query::Begin(..)) => {
+                InteractionType::Query(Query::Begin(..))
+                | InteractionType::Query(Query::Savepoint(..)) => {
                     begin_idx
                         .entry(interaction.connection_index)
                         .or_insert_with(|| vec![idx]);
                 }
                 InteractionType::Query(Query::Commit(..))
-                | InteractionType::Query(Query::Rollback(..)) => {
+                | InteractionType::Query(Query::Rollback(..))
+                | InteractionType::Query(Query::ReleaseSavepoint(..)) => {
                     let last_begin = begin_idx
                         .get(&interaction.connection_index)
                         .and_then(|list| list.last())

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1327,6 +1327,42 @@ pub fn test_conflict_inside_txn(limbo: TempDatabase) {
     );
 }
 
+#[turso_macros::test]
+pub fn test_savepoint_rollback_uses_current_wal_snapshot(
+    limbo: TempDatabase,
+) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let conn1 = limbo.db.connect()?;
+    let conn2 = limbo.db.connect()?;
+
+    conn1.execute("CREATE TABLE t (u1 TEXT UNIQUE, u2 INTEGER UNIQUE, payload TEXT)")?;
+    for i in 1..=8 {
+        conn1.execute(format!("INSERT INTO t VALUES ('u{i}', {i}, 'base')"))?;
+    }
+
+    // Leave conn1's local WAL snapshot behind the committed frames added by conn2.
+    for i in 9..=20 {
+        conn2.execute(format!("INSERT INTO t VALUES ('u{i}', {i}, 'from_conn2')"))?;
+    }
+
+    conn1.execute("SAVEPOINT sp")?;
+    let payload = "X".repeat(4000);
+    assert!(matches!(
+        conn1.execute(format!(
+            "UPDATE t SET payload = '{payload}', u2 = CASE WHEN u2 = 20 THEN 1 ELSE u2 END WHERE TRUE"
+        )),
+        Err(LimboError::Constraint(_))
+    ));
+    conn1.execute("ROLLBACK TO sp")?;
+    conn1.execute("RELEASE sp")?;
+
+    let count: Vec<(i64,)> = conn1.exec_rows("SELECT COUNT(*) FROM t");
+    assert_eq!(count, vec![(20,)]);
+    let integrity: Vec<(String,)> = conn1.exec_rows("PRAGMA integrity_check");
+    assert_eq!(integrity, vec![("ok".to_string(),)]);
+    Ok(())
+}
+
 #[test]
 pub fn test_reopen_database_wal_restart() {
     let _ = env_logger::try_init();


### PR DESCRIPTION
## Summary
- extend the deterministic simulator with a `SavepointRollback` property that exercises `SAVEPOINT`, `ROLLBACK TO`, and `RELEASE`
- add a `savepoint_stress` profile that increases cache pressure and generates late-failing updates
- fix non-MVCC savepoint rollback so restored subjournal pages stay dirty and clean cache entries newer than the rolled-back WAL frame are invalidated
- add an integration regression test for stale WAL snapshot rollback behavior
- keep the workspace green with the warning cleanups required by `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`

## Root Cause
Before the fix, non-MVCC savepoint rollback could leave cache state inconsistent with the rolled-back WAL snapshot.

Pages restored from the subjournal were reinserted as clean, so later cache handling could discard transaction-visible state. At the same time, clean cache entries loaded from WAL frames newer than the rollback target could survive `ROLLBACK TO`, so later reads and `PRAGMA integrity_check` could observe stale page state instead of the rolled-back snapshot.

## Reproduction
Using seed `15876822065443495175` with:

```bash
cargo run -p limbo_sim -- --profile savepoint_stress --seed 15876822065443495175 -n 200 -k 50 -t 30 --disable-bugbase --differential --io-backend memory --keep-files
```

in a clean `HEAD` worktree with only the simulator/DST changes applied, the simulator fails with:
- `Assertion 'PRAGMA integrity_check should be ok after savepoint rollback'`
- `short read on page 5: expected 4096 bytes, got 0`

The same seed succeeds with this patch.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`
- `cargo test -p limbo_sim savepoint -- --nocapture`
- `cargo test -p core_tester --test integration_tests test_savepoint_rollback_uses_current_wal_snapshot -- --nocapture`
- `cargo run -p limbo_sim -- --profile savepoint_stress --seed 15876822065443495175 -n 200 -k 50 -t 30 --disable-bugbase --differential --io-backend memory --keep-files`
