### PR TITLE
iterate schema rows in order in recovery

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4665,7 +4665,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let syms = connection.syms.read();
                 let mv_store = connection.db.get_mv_store().clone();
 
-                for record in schema_rows.values() {
+                let mut sorted_rowids: Vec<i64> = schema_rows.keys().copied().collect();
+                sorted_rowids.sort_unstable();
+                for rowid in &sorted_rowids {
+                    let record = &schema_rows[rowid];
                     let ty = match record.get_value_opt(0) {
                         Some(ValueRef::Text(v)) => v.as_str(),
                         _ => {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1083,6 +1083,35 @@ fn test_recovery_checkpoint_then_more_writes() {
     assert_eq!(rows[2][1].to_string(), "c");
 }
 
+/// This test checks that after MVCC restart, the auto-indexes for PRIMARY KEY and UNIQUE
+/// constraints stay associated with the columns they were created for.
+#[test]
+fn test_restart_preserves_autoindex_to_column_mapping() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+    {
+        let conn = db.connect();
+        // The dummy table exposes the bug because of the implementation of the HashMap used to
+        // store schema rows. This test is not perfect, because it may not catch a regression if
+        // the implementation changes. But until we patch the simulator to reproduce the bug,
+        // this'll do.
+        conn.execute("CREATE TABLE dummy(x)").unwrap();
+        conn.execute("CREATE TABLE t(a TEXT PRIMARY KEY, b TEXT UNIQUE)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES('aa', 'bb')").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+
+    let conn = db.connect();
+    let a_rows = get_rows(&conn, "SELECT a FROM t");
+    assert_eq!(a_rows.len(), 1);
+    assert_eq!(a_rows[0][0].to_string(), "aa");
+    let b_rows = get_rows(&conn, "SELECT b FROM t");
+    assert_eq!(b_rows.len(), 1);
+    assert_eq!(b_rows[0][0].to_string(), "bb");
+}
+
 /// What this test checks: MVCC restart handles sqlite_schema rows with rootpage=0 (triggers).
 /// Why this matters: Trigger definitions are stored without btrees and should not break recovery.
 #[test]


### PR DESCRIPTION
## Motivation and context

Previously, during MVCC recovery, we read `schema_rows` in the iteration order of the `HashMap`, so sometimes, schema rows were inverted. If two autoindexes belonging to the same table were inverted in the map's iteration order, we built a schema with the indexes swapped (`Schema::populate_indices` assumes that it receives autoindexes in definition order). This could lead selects to swap the data from the two columns, if they relied on index scans of the swapped indexes.

To occur, this bug needs:
* MVCC
* a restart triggering a recovery of the logical log
* a table with 2+ autoindexes
* a schema configuration for which the `HashMap` used to store schema rows produced an iteration order where the two autoindexes were inverted
* a query that uses one of the indexes

The simulator didn't catch it because we don't have properties that use covering indexes across faults (like restarts). I'm working on a property that will catch correctness issues in index scans.

## Description of AI Usage

I iterated with a few dozen concurrent Claude Code and Codex agents, with the SQL dump and the `EXPLAIN`s from an affected DB, and they finally identified the issue.