### PR TITLE
serverless/javascript: preserve zero lastInsertRowid

### DIFF
--- a/serverless/javascript/integration-tests/compat.test.mjs
+++ b/serverless/javascript/integration-tests/compat.test.mjs
@@ -64,3 +64,23 @@ test.serial('createClient works with basic libSQL API', async t => {
   client.close();
   t.true(client.closed);
 });
+
+test.serial('compat execute preserves lastInsertRowid of 0', async t => {
+  const client = createClient({
+    url: 'http://localhost:0',
+  });
+
+  client.session.execute = async () => ({
+    columns: [],
+    columnTypes: [],
+    rows: [],
+    rowsAffected: 1,
+    lastInsertRowid: 0,
+  });
+
+  const result = await client.execute('INSERT INTO users DEFAULT VALUES');
+  t.is(result.lastInsertRowid, 0n);
+  t.is(typeof result.lastInsertRowid, 'bigint');
+
+  client.close();
+});

--- a/serverless/javascript/src/compat.ts
+++ b/serverless/javascript/src/compat.ts
@@ -231,7 +231,7 @@ class LibSQLClient implements Client {
       columnTypes: result.columnTypes || [],
       rows: result.rows || [],
       rowsAffected: result.rowsAffected || 0,
-      lastInsertRowid: result.lastInsertRowid ? BigInt(result.lastInsertRowid) : undefined,
+      lastInsertRowid: result.lastInsertRowid != null ? BigInt(result.lastInsertRowid) : undefined,
       toJSON() {
         return {
           columns: this.columns,


### PR DESCRIPTION
<!-- # NOTICE: -->
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description
Fix compat layer handling of `lastInsertRowid: 0` so it is preserved as `0n` instead of being dropped as falsy `undefined`.

## Motivation and context
The compat wrapper used a truthy check when converting `lastInsertRowid`, which treated `0` as missing. This is a separate issue from large-rowid precision handling.


## Description of AI Usage

AI was used to draft and edit this PR description and to review the scope of the compat-layer fix.
