### PR TITLE
core/mvcc: clear connection's mvcc tx id on commit

### DIFF
--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -57,7 +57,9 @@ fn bench(c: &mut Criterion) {
             let conn = &db.conn;
             let tx_id = db.mvcc_store.begin_tx(conn.get_pager()).unwrap();
             let mv_store = &db.mvcc_store;
-            let mut sm = mv_store.commit_tx(tx_id, conn).unwrap();
+            let mut sm = mv_store
+                .commit_tx(tx_id, conn, turso_core::MAIN_DB_ID)
+                .unwrap();
             // TODO: sync IO hack
             loop {
                 let res = sm.step(mv_store).unwrap();
@@ -84,7 +86,9 @@ fn bench(c: &mut Criterion) {
                 )
                 .unwrap();
             let mv_store = &db.mvcc_store;
-            let mut sm = mv_store.commit_tx(tx_id, conn).unwrap();
+            let mut sm = mv_store
+                .commit_tx(tx_id, conn, turso_core::MAIN_DB_ID)
+                .unwrap();
             // TODO: sync IO hack
             loop {
                 let res = sm.step(mv_store).unwrap();
@@ -114,7 +118,9 @@ fn bench(c: &mut Criterion) {
                 )
                 .unwrap();
             let mv_store = &db.mvcc_store;
-            let mut sm = mv_store.commit_tx(tx_id, conn).unwrap();
+            let mut sm = mv_store
+                .commit_tx(tx_id, conn, turso_core::MAIN_DB_ID)
+                .unwrap();
             // TODO: sync IO hack
             loop {
                 let res = sm.step(mv_store).unwrap();

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1,6 +1,6 @@
 use crate::error::io_error;
 #[cfg(any(test, injected_yields))]
-use crate::mvcc::yield_points::YieldInjector;
+use crate::mvcc::yield_points::{FailureInjector, YieldInjector};
 use crate::statement::StatementOrigin;
 use crate::storage::{journal_mode, pager::SavepointResult};
 use crate::sync::{
@@ -205,6 +205,8 @@ pub struct Connection {
         RwLock<HashMap<usize, (crate::mvcc::database::TxID, TransactionMode)>>,
     #[cfg(any(test, injected_yields))]
     pub(super) yield_injector: RwLock<Option<Arc<dyn YieldInjector>>>,
+    #[cfg(any(test, injected_yields))]
+    pub(super) failure_injector: RwLock<Option<Arc<dyn FailureInjector>>>,
     #[cfg(any(test, injected_yields))]
     pub(super) yield_instance_id_counter: AtomicU64,
 
@@ -2004,6 +2006,32 @@ impl Connection {
     #[cfg(any(test, injected_yields))]
     pub(crate) fn yield_injector(&self) -> Option<Arc<dyn YieldInjector>> {
         self.yield_injector.read().clone()
+    }
+
+    #[cfg(any(test, injected_yields))]
+    pub fn set_failure_injector(&self, injector: Option<Arc<dyn FailureInjector>>) {
+        let mut slot = self.failure_injector.write();
+        match injector {
+            Some(injector) => {
+                turso_assert!(
+                    slot.is_none(),
+                    "failure injector should be empty before installing a new one"
+                );
+                *slot = Some(injector);
+            }
+            None => {
+                turso_assert!(
+                    slot.is_some(),
+                    "failure injector should be installed before it is cleared"
+                );
+                *slot = None;
+            }
+        }
+    }
+
+    #[cfg(any(test, injected_yields))]
+    pub(crate) fn failure_injector(&self) -> Option<Arc<dyn FailureInjector>> {
+        self.failure_injector.read().clone()
     }
 
     #[cfg(any(test, injected_yields))]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1691,6 +1691,8 @@ impl Database {
             #[cfg(any(test, injected_yields))]
             yield_injector: RwLock::new(None),
             #[cfg(any(test, injected_yields))]
+            failure_injector: RwLock::new(None),
+            #[cfg(any(test, injected_yields))]
             yield_instance_id_counter: AtomicU64::new(1),
             view_transaction_states: AllViewsTxState::new(),
             metrics: RwLock::new(ConnectionMetrics::new()),

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -136,6 +136,7 @@ impl<Clock: LogicalClock + 'static> ProvidesYieldContext for MvccLazyCursor<Cloc
     fn yield_context(&self) -> YieldContext {
         YieldContext::new(
             self.connection.yield_injector(),
+            self.connection.failure_injector(),
             self.yield_instance_id,
             cursor_yield_key(self.tx_id, self.table_id),
         )

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2,7 +2,7 @@ use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
-use crate::mvcc::yield_points::inject_transition_yield;
+use crate::mvcc::yield_points::{inject_transition_failure, inject_transition_yield};
 use crate::schema::{Schema, Table};
 use crate::state_machine::StateMachine;
 use crate::state_machine::StateTransition;
@@ -926,10 +926,14 @@ impl CommitCoordinator {
 #[cfg(any(test, injected_yields))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumCount)]
 #[repr(u8)]
-enum CommitYieldPoint {
+pub(crate) enum CommitYieldPoint {
     CommitValidation,
     WaitForDependencies,
     LogRecordPrepared,
+    /// Boundary right after `remove_tx` runs but before the connection cache
+    /// is cleared by the caller at vdbe/mod.rs. Used for failure injection
+    /// to reproduce divergence between `mv_store.txs` and `connection.mv_tx_id`.
+    AfterRemoveTx,
 }
 
 #[cfg(any(test, injected_yields))]
@@ -953,6 +957,7 @@ impl<Clock: LogicalClock> ProvidesYieldContext for CommitStateMachine<Clock> {
     fn yield_context(&self) -> YieldContext {
         YieldContext::new(
             self.connection.yield_injector(),
+            self.connection.failure_injector(),
             self.yield_instance_id,
             commit_yield_key(self.tx_id),
         )
@@ -1679,6 +1684,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     }
                     mvcc_store.unlock_commit_lock_if_held(tx);
                     mvcc_store.remove_tx(self.tx_id);
+                    inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
                 }
@@ -1763,6 +1769,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         self.commit_coordinator.pager_commit_lock.unlock();
                     }
                     mvcc_store.remove_tx(self.tx_id);
+                    inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
                 }
@@ -1931,6 +1938,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // transaction ID to a timestamp and can, therefore, remove the
                 // transaction.
                 mvcc_store.remove_tx(self.tx_id);
+                inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
 
                 if mvcc_store.is_exclusive_tx(&self.tx_id) {
                     mvcc_store.release_exclusive_tx(&self.tx_id);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -972,6 +972,10 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     did_commit_schema_change: bool,
     tx_id: TxID,
     connection: Arc<Connection>,
+    /// Database index this commit is for (`MAIN_DB_ID` or an attached-db id).
+    /// Threaded through so that `finish_committed_tx` can clear the matching
+    /// connection-level mv_tx slot atomically with `remove_tx`.
+    db_id: usize,
     /// Write set sorted by table id and row id
     write_set: Vec<RowID>,
     commit_coordinator: Arc<CommitCoordinator>,
@@ -1024,6 +1028,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         state: CommitState<Clock>,
         tx_id: TxID,
         connection: Arc<Connection>,
+        db_id: usize,
         commit_coordinator: Arc<CommitCoordinator>,
         header: Arc<RwLock<Option<DatabaseHeader>>>,
         sync_mode: SyncMode,
@@ -1048,6 +1053,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             did_commit_schema_change: schema_did_change_from_tx,
             tx_id,
             connection,
+            db_id,
             write_set: Vec::new(),
             commit_coordinator,
             pager,
@@ -1683,7 +1689,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         mvcc_store.release_exclusive_tx(&self.tx_id);
                     }
                     mvcc_store.unlock_commit_lock_if_held(tx);
-                    mvcc_store.remove_tx(self.tx_id);
+                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
@@ -1768,7 +1774,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         mvcc_store.release_exclusive_tx(&self.tx_id);
                         self.commit_coordinator.pager_commit_lock.unlock();
                     }
-                    mvcc_store.remove_tx(self.tx_id);
+                    mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;
                     return Ok(TransitionResult::Done(()));
@@ -1936,8 +1942,10 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
 
                 // We have now updated all the versions with a reference to the
                 // transaction ID to a timestamp and can, therefore, remove the
-                // transaction.
-                mvcc_store.remove_tx(self.tx_id);
+                // transaction. Pair removal with the connection cache clear so
+                // an IO yield + abandon during the upcoming checkpoint cannot
+                // strand `conn.mv_tx_id` referencing a tx that's gone from `txs`.
+                mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
 
                 if mvcc_store.is_exclusive_tx(&self.tx_id) {
@@ -3523,6 +3531,23 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         self.blocking_checkpoint_lock.unlock();
     }
 
+    /// Atomically retire a committed tx: clear the connection's mv_tx_id cache
+    /// for `db_id`, then remove the tx from `txs`. Pairs the two mutations so
+    /// no concurrent observer (or in-flight statement) can see the divergent
+    /// `(cache=Some, txs=None)` state — the production-panic shape from
+    /// `release_named_savepoint` and `NoSuchTransactionID` read-path errors.
+    ///
+    /// Order matches `rollback_tx` (cache cleared before `remove_tx`) so the
+    /// commit and rollback paths are symmetric.
+    ///
+    /// Use this anywhere the commit state machine would otherwise call
+    /// `remove_tx` directly. Other call sites that don't have a connection
+    /// context (e.g. tests poking internal state) keep using `remove_tx`.
+    pub fn finish_committed_tx(&self, tx_id: TxID, conn: &Connection, db_id: usize) {
+        conn.set_mv_tx_for_db(db_id, None);
+        self.remove_tx(tx_id);
+    }
+
     fn get_new_transaction_database_header(&self, pager: &Arc<Pager>) -> DatabaseHeader {
         if self.global_header.read().is_none() {
             pager
@@ -3628,11 +3653,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         tx_id: TxID,
         connection: &Arc<Connection>,
+        db_id: usize,
     ) -> Result<StateMachine<Box<CommitStateMachine<Clock>>>> {
         let state = Box::new(CommitStateMachine::new(
             CommitState::Initial,
             tx_id,
             connection.clone(),
+            db_id,
             self.commit_coordinator.clone(),
             self.global_header.clone(),
             connection.get_sync_mode(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8,7 +8,7 @@ use crate::mvcc::persistent_storage::logical_log::{
     ENCRYPTED_PAYLOAD_CHUNK_SIZE, FRAME_MAGIC, LOG_HDR_SIZE,
 };
 use crate::mvcc::yield_hooks::YieldPointMarker;
-use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
+use crate::mvcc::yield_points::{FailureInjector, YieldInjector, YieldPoint};
 use crate::state_machine::{StateTransition, TransitionResult};
 use crate::storage::sqlite3_ondisk::{
     checksum_wal, read_varint, write_varint, DatabaseHeader, WalHeader, WAL_FRAME_HEADER_SIZE,
@@ -55,6 +55,30 @@ impl FixedYieldInjector {
 
 impl YieldInjector for FixedYieldInjector {
     fn should_yield(&self, _instance_id: u64, _selection_key: u64, point: YieldPoint) -> bool {
+        self.remaining.lock().remove(&point)
+    }
+}
+
+#[derive(Debug)]
+struct FixedFailureInjector {
+    remaining: Mutex<rustc_hash::FxHashMap<YieldPoint, LimboError>>,
+}
+
+impl FixedFailureInjector {
+    fn new(points: impl IntoIterator<Item = (YieldPoint, LimboError)>) -> Arc<Self> {
+        Arc::new(Self {
+            remaining: Mutex::new(points.into_iter().collect()),
+        })
+    }
+}
+
+impl FailureInjector for FixedFailureInjector {
+    fn should_fail(
+        &self,
+        _instance_id: u64,
+        _selection_key: u64,
+        point: YieldPoint,
+    ) -> Option<LimboError> {
         self.remaining.lock().remove(&point)
     }
 }
@@ -7217,6 +7241,79 @@ fn test_abandoned_commit_rolls_back_insert_with_injected_yield() {
         "row from abandoned INSERT commit remained visible: {rows:?}",
     );
     observer.close().unwrap();
+}
+
+/// Reproduces the divergence between `mv_store.txs` and `connection.mv_tx_id` that
+/// caused production panics like `Transaction <id> not found while releasing savepoint`
+/// (Antithesis Limbo run, 2026-04-27).
+///
+/// The bug: `CommitStateMachine` calls `mvcc_store.remove_tx(tx_id)` *before* a fallible
+/// step. If that later step returns Err, the state machine's caller at vdbe/mod.rs:1889
+/// uses `?` and short-circuits past `conn.set_mv_tx(None)`. The downstream abort handler
+/// at vdbe/mod.rs:2202 catches *most* error classes via `rollback_current_txn`, which
+/// clears the cache as a side effect — but it explicitly *skips* rollback for
+/// `TxError`, `TableLocked`, `Busy`, `BusySnapshot`, and `SchemaUpdated` (lines 2204-2216).
+/// For any of those error classes, the cache stays stranded.
+///
+/// We pick `TxError` to drive the failure: it's in the no-rollback list, and the
+/// real-world panic was preceded by a logical-log flush failure that surfaces as a
+/// related error type.
+///
+/// We simulate "fallible step after remove_tx" via the `FailureInjector` at the new
+/// `CommitYieldPoint::AfterRemoveTx` boundary, with no real I/O fault required.
+///
+/// On unfixed code: the "tx removed" assertion passes, the "cache cleared" assertion
+/// fails. When the divergence fix lands, both pass — drop the `#[ignore]` then.
+///
+/// Run manually: `cargo test -p turso_core --lib \
+/// test_commit_failure_after_remove_tx_does_not_strand_conn_cache -- --ignored`
+#[test]
+#[ignore = "reproduces unfixed mv_tx_id divergence; remove ignore when fix lands"]
+fn test_commit_failure_after_remove_tx_does_not_strand_conn_cache() {
+    let db = MvccTestDbNoConn::new();
+    let conn = db.connect();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'new')").unwrap();
+
+    let tx_id = conn.get_mv_tx_id().expect("tx should be open after BEGIN");
+    let mv_store = db.get_mvcc_store();
+    assert!(
+        mv_store.txs.get(&tx_id).is_some(),
+        "precondition: tx must be live in txs before COMMIT"
+    );
+
+    conn.set_failure_injector(Some(FixedFailureInjector::new([(
+        CommitYieldPoint::AfterRemoveTx.point(),
+        // TxError is in the no-rollback list at vdbe/mod.rs:2204, so the abort
+        // handler will NOT call rollback_current_txn and will NOT incidentally
+        // clear conn.mv_tx_id. This is the path that produces the production panic.
+        LimboError::TxError("synthetic post-remove_tx failure".to_string()),
+    )])));
+
+    let commit_err = conn
+        .execute("COMMIT")
+        .expect_err("commit must fail at the injected boundary");
+    tracing::info!("injected commit failure: {commit_err}");
+
+    // assert!(
+    //     mv_store.txs.get(&tx_id).is_none(),
+    //     "remove_tx ran before the injected failure; tx must be gone from txs"
+    // );
+    // assert_eq!(
+    //     conn.get_mv_tx_id(),
+    //     None,
+    //     "BUG: connection mv_tx cache still references the removed tx — a follow-up \
+    //      savepoint / rollback statement would now panic in release_named_savepoint / \
+    //      rollback_tx looking for a tx that no longer exists. The fix must keep \
+    //      `conn.set_mv_tx(None)` in sync with `mv_store.remove_tx` even on the Err path."
+    // );
+    conn.execute("select * from t")
+        .expect("select after abandoned commit should succeed");
+
+    conn.close().unwrap();
 }
 
 /// if a txn made some inserts, then aborted (or abandoned due to some IO issue), then those

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2996,7 +2996,7 @@ pub(crate) fn commit_tx(
     conn: &Arc<Connection>,
     tx_id: u64,
 ) -> Result<()> {
-    let mut sm = mv_store.commit_tx(tx_id, conn).unwrap();
+    let mut sm = mv_store.commit_tx(tx_id, conn, crate::MAIN_DB_ID).unwrap();
     // TODO: sync IO hack
     loop {
         let res = sm.step(&mv_store)?;
@@ -3017,7 +3017,7 @@ pub(crate) fn commit_tx_no_conn(
     conn: &Arc<Connection>,
 ) -> Result<(), LimboError> {
     let mv_store = db.get_mvcc_store();
-    let mut sm = mv_store.commit_tx(tx_id, conn).unwrap();
+    let mut sm = mv_store.commit_tx(tx_id, conn, crate::MAIN_DB_ID).unwrap();
     // TODO: sync IO hack
     loop {
         let res = sm.step(&mv_store)?;
@@ -7243,32 +7243,36 @@ fn test_abandoned_commit_rolls_back_insert_with_injected_yield() {
     observer.close().unwrap();
 }
 
-/// Reproduces the divergence between `mv_store.txs` and `connection.mv_tx_id` that
-/// caused production panics like `Transaction <id> not found while releasing savepoint`
-/// (Antithesis Limbo run, 2026-04-27).
+/// Regression guard for the `mv_store.txs` ↔ `connection.mv_tx_id` divergence
+/// originally observed in production as `Transaction <id> not found while
+/// releasing savepoint` (panic) and `NoSuchTransactionID(<id>)` (read-path
+/// error) — see Antithesis Limbo run, 2026-04-27.
 ///
-/// The bug: `CommitStateMachine` calls `mvcc_store.remove_tx(tx_id)` *before* a fallible
-/// step. If that later step returns Err, the state machine's caller at vdbe/mod.rs:1889
-/// uses `?` and short-circuits past `conn.set_mv_tx(None)`. The downstream abort handler
-/// at vdbe/mod.rs:2202 catches *most* error classes via `rollback_current_txn`, which
-/// clears the cache as a side effect — but it explicitly *skips* rollback for
-/// `TxError`, `TableLocked`, `Busy`, `BusySnapshot`, and `SchemaUpdated` (lines 2204-2216).
-/// For any of those error classes, the cache stays stranded.
+/// **Bug shape (pre-fix):** `CommitStateMachine` called `mvcc_store.remove_tx(tx_id)`
+/// directly. The connection-cache clear (`conn.set_mv_tx(None)`) lived at the
+/// caller (vdbe/mod.rs:1898) and only ran on the success path. If anything
+/// between `remove_tx` and that caller-side clear failed or yielded I/O and
+/// then the runtime abandoned the task before re-entering, the cache was
+/// stranded pointing at a tx that was already gone from `txs`. The natural
+/// trigger in production was an IO yield from `CheckpointStateMachine::step`
+/// (called after `remove_tx` at the EndCommitLogicalLog site) followed by
+/// task abandonment under network partition.
 ///
-/// We pick `TxError` to drive the failure: it's in the no-rollback list, and the
-/// real-world panic was preceded by a logical-log flush failure that surfaces as a
-/// related error type.
+/// **Fix:** `MvStore::finish_committed_tx(tx_id, conn, db_id)` clears the
+/// connection's mv_tx cache and removes the tx from `txs` together,
+/// atomically. All three commit sites that previously called `remove_tx`
+/// directly now call `finish_committed_tx`. After this, no in-flight state
+/// (Err propagation, IO yield + abandon, success) can produce the divergent
+/// `(cache=Some, txs=None)` pair — they're mutated as a single act.
 ///
-/// We simulate "fallible step after remove_tx" via the `FailureInjector` at the new
-/// `CommitYieldPoint::AfterRemoveTx` boundary, with no real I/O fault required.
-///
-/// On unfixed code: the "tx removed" assertion passes, the "cache cleared" assertion
-/// fails. When the divergence fix lands, both pass — drop the `#[ignore]` then.
-///
-/// Run manually: `cargo test -p turso_core --lib \
-/// test_commit_failure_after_remove_tx_does_not_strand_conn_cache -- --ignored`
+/// **What this test exercises:** we inject a `TxError` at the historical
+/// post-`remove_tx` boundary (`CommitYieldPoint::AfterRemoveTx`). The abort
+/// handler at vdbe/mod.rs:2204 explicitly skips rollback for `TxError`, so
+/// pre-fix nothing else would have cleared the cache — the divergence would
+/// surface. Post-fix, `finish_committed_tx` already cleared the cache before
+/// the injection point fires, so both stores are gone in lock-step and a
+/// follow-up read on the connection sees a clean state.
 #[test]
-#[ignore = "reproduces unfixed mv_tx_id divergence; remove ignore when fix lands"]
 fn test_commit_failure_after_remove_tx_does_not_strand_conn_cache() {
     let db = MvccTestDbNoConn::new();
     let conn = db.connect();
@@ -7287,9 +7291,9 @@ fn test_commit_failure_after_remove_tx_does_not_strand_conn_cache() {
 
     conn.set_failure_injector(Some(FixedFailureInjector::new([(
         CommitYieldPoint::AfterRemoveTx.point(),
-        // TxError is in the no-rollback list at vdbe/mod.rs:2204, so the abort
-        // handler will NOT call rollback_current_txn and will NOT incidentally
-        // clear conn.mv_tx_id. This is the path that produces the production panic.
+        // `TxError` is in the no-rollback list at vdbe/mod.rs:2204, so the abort
+        // handler will not rescue stranded state on its own — the only thing
+        // keeping the connection coherent here is `finish_committed_tx`.
         LimboError::TxError("synthetic post-remove_tx failure".to_string()),
     )])));
 
@@ -7298,20 +7302,30 @@ fn test_commit_failure_after_remove_tx_does_not_strand_conn_cache() {
         .expect_err("commit must fail at the injected boundary");
     tracing::info!("injected commit failure: {commit_err}");
 
-    // assert!(
-    //     mv_store.txs.get(&tx_id).is_none(),
-    //     "remove_tx ran before the injected failure; tx must be gone from txs"
-    // );
-    // assert_eq!(
-    //     conn.get_mv_tx_id(),
-    //     None,
-    //     "BUG: connection mv_tx cache still references the removed tx — a follow-up \
-    //      savepoint / rollback statement would now panic in release_named_savepoint / \
-    //      rollback_tx looking for a tx that no longer exists. The fix must keep \
-    //      `conn.set_mv_tx(None)` in sync with `mv_store.remove_tx` even on the Err path."
-    // );
-    conn.execute("select * from t")
-        .expect("select after abandoned commit should succeed");
+    // The pairing invariant: `finish_committed_tx` clears both atomically, so
+    // after the injected Err we see them gone together — no half-state.
+    assert!(
+        mv_store.txs.get(&tx_id).is_none(),
+        "fix: tx must be gone from txs (finish_committed_tx ran before the \
+         injection point)"
+    );
+    assert_eq!(
+        conn.get_mv_tx_id(),
+        None,
+        "fix: connection mv_tx cache must be cleared in lock-step with the \
+         txs removal — pre-fix this stranded the cache"
+    );
+
+    // NOTE: we deliberately do not assert anything about the *visibility* of
+    // the failed-commit's INSERT here. By the time the injection fires at
+    // `AfterRemoveTx`, the commit pipeline has already published
+    // `tx.state = Committed(end_ts)` and timestamp-rewritten live versions
+    // (mod.rs:1901-1903) — so the row IS visible to subsequent readers. That's
+    // a separate "Err on COMMIT but data is durable" semantic concern that
+    // predates this fix and applies equally to the production network-partition
+    // scenario; it's not what this regression test is guarding. This test
+    // verifies only the pairing invariant: `mv_store.txs` and
+    // `conn.mv_tx_id` mutate in lock-step, leaving the connection reusable.
 
     conn.close().unwrap();
 }

--- a/core/mvcc/yield_hooks.rs
+++ b/core/mvcc/yield_hooks.rs
@@ -1,11 +1,12 @@
 use std::fmt::Debug;
 
-use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
+use crate::mvcc::yield_points::{FailureInjector, YieldInjector, YieldPoint};
 use crate::state_machine::TransitionResult;
 use crate::sync::Arc;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
 use crate::Completion;
+use crate::LimboError;
 
 pub(crate) trait YieldPointMarker: Copy + Debug {
     const POINT_COUNT: u8;
@@ -28,6 +29,7 @@ impl YieldPoint {
 
 pub(crate) struct YieldContext {
     pub(crate) injector: Option<Arc<dyn YieldInjector>>,
+    pub(crate) failure_injector: Option<Arc<dyn FailureInjector>>,
     pub(crate) instance_id: u64,
     pub(crate) selection_key: u64,
 }
@@ -35,11 +37,13 @@ pub(crate) struct YieldContext {
 impl YieldContext {
     pub(crate) fn new(
         injector: Option<Arc<dyn YieldInjector>>,
+        failure_injector: Option<Arc<dyn FailureInjector>>,
         instance_id: u64,
         selection_key: u64,
     ) -> Self {
         Self {
             injector,
+            failure_injector,
             instance_id,
             selection_key,
         }
@@ -80,4 +84,18 @@ pub(crate) fn maybe_inject_io_yield<T, P: YieldPointMarker>(
         return Some(IOResult::IO(IOCompletions::Single(Completion::new_yield())));
     }
     None
+}
+
+pub(crate) fn maybe_inject_transition_failure<P: YieldPointMarker>(
+    injector: Option<&Arc<dyn FailureInjector>>,
+    instance_id: u64,
+    selection_key: u64,
+    point: P,
+) -> Option<LimboError> {
+    let err = injector
+        .and_then(|injector| injector.should_fail(instance_id, selection_key, point.point()));
+    if let Some(ref err) = err {
+        tracing::debug!(?point, %err, "injecting MVCC failure");
+    }
+    err
 }

--- a/core/mvcc/yield_points.rs
+++ b/core/mvcc/yield_points.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use crate::LimboError;
+
 /// YieldPoint is a descriptor for one safe yield boundary in a state machine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct YieldPoint {
@@ -14,6 +16,21 @@ pub trait YieldInjector: Debug + Send + Sync {
     /// `instance_id` distinguishes one live state machine/cursor from another so
     /// they do not share yield bookkeeping.
     fn should_yield(&self, instance_id: u64, selection_key: u64, point: YieldPoint) -> bool;
+}
+
+/// External hook consulted at safe state machine boundaries to decide whether to synthesize
+/// an error return. Mirrors `YieldInjector` but produces an `Err` instead of a yield, so tests
+/// can reproduce mid-state-machine failures (e.g. an I/O error after `remove_tx` ran but before
+/// the connection cache was cleared) without requiring a real fault in the I/O layer.
+pub trait FailureInjector: Debug + Send + Sync {
+    /// Returns `Some(err)` if the state machine should synthetically fail at this point.
+    /// Same selection_key / instance_id semantics as `YieldInjector`.
+    fn should_fail(
+        &self,
+        instance_id: u64,
+        selection_key: u64,
+        point: YieldPoint,
+    ) -> Option<LimboError>;
 }
 
 // At a safe resumable boundary, ask the active yield injector whether this
@@ -59,3 +76,26 @@ macro_rules! inject_io_yield {
 }
 
 pub(crate) use inject_io_yield;
+
+// At a safe resumable boundary, ask the active failure injector whether this
+// state machine should return Err here. Used to reproduce mid-commit failures
+// in tests without requiring a real I/O fault.
+macro_rules! inject_transition_failure {
+    ($state_machine:expr, $point:expr) => {{
+        #[cfg(any(test, injected_yields))]
+        {
+            use $crate::mvcc::yield_hooks::ProvidesYieldContext;
+            let yield_context = $state_machine.yield_context();
+            if let Some(err) = crate::mvcc::yield_hooks::maybe_inject_transition_failure(
+                yield_context.failure_injector.as_ref(),
+                yield_context.instance_id,
+                yield_context.selection_key,
+                $point,
+            ) {
+                return Err(err);
+            }
+        }
+    }};
+}
+
+pub(crate) use inject_transition_failure;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1870,7 +1870,7 @@ impl Program {
         // Phase 1: Commit main DB MVCC transaction
         if matches!(program_state.commit_state, CommitState::Ready) {
             if let Some(tx_id) = conn.get_mv_tx_id() {
-                let state_machine = mv_store.commit_tx(tx_id, &conn)?;
+                let state_machine = mv_store.commit_tx(tx_id, &conn, crate::MAIN_DB_ID)?;
                 program_state.commit_state = CommitState::CommittingMvcc { state_machine };
             }
             // If no main MVCC tx, commit_state stays Ready and we fall
@@ -1939,7 +1939,7 @@ impl Program {
                 conn.set_mv_tx_for_db(db_id, None);
                 continue;
             };
-            let mut state_machine = match attached_mv_store.commit_tx(tx_id, &conn) {
+            let mut state_machine = match attached_mv_store.commit_tx(tx_id, &conn, db_id) {
                 Ok(sm) => sm,
                 Err(e) => {
                     tracing::error!(


### PR DESCRIPTION
## Description

On commit, if a checkpoint failed it could end up in a situation where the connections tx id we store is mismatched with the txn map in MVCC where we already delete it. So when we rollback statement because we see tx id is not found in txn map because we already deleted it before checkpoint happened!

Furthermore, I added few injection entrypoints with Claude to be enabled under testing explicitly.


## Description of AI Usage

Claude helped me with comments, investigation and injection testing.
