### PR TITLE
core/translate: fix UNION ALL dropping result columns when IN subquery present

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -164,10 +164,11 @@ pub fn emit_program_for_compound_select(
 
     emit_explain!(program, true, "COMPOUND QUERY".to_owned());
 
-    // This is inefficient, but emit_compound_select() takes ownership of 'plan' and we
-    // must set the result columns to the leftmost subselect's result columns to be compatible
-    // with SQLite.
-    program.result_columns.clone_from(&left[0].0.result_columns);
+    // The compound query's result columns are the leftmost subselect's result columns
+    // (per SQLite semantics). Save them so we can install them on `program` after
+    // `emit_compound_select` finishes — emission of nested subqueries (e.g. IN-subqueries)
+    // calls `emit_program_for_select`, which clobbers `program.result_columns`.
+    let leftmost_result_columns = left[0].0.result_columns.clone();
 
     // These must also be set because we make the decision to start a transaction based on whether
     // any tables are actually touched by the query. Previously this only used the rightmost subselect's
@@ -199,6 +200,13 @@ pub fn emit_program_for_compound_select(
         )
     })?;
     program.pop_current_parent_explain();
+
+    // Install the compound query's result columns. Emission of nested subqueries above may
+    // have overwritten `program.result_columns` (each `emit_program_for_select` call sets
+    // it to the inner plan's result columns). Restore to the leftmost subselect's columns
+    // so `column_count`/column metadata reflect the compound query, and so that the
+    // ORDER BY emitter below sees the correct columns.
+    program.result_columns = leftmost_result_columns;
 
     // When ORDER BY is present, sort the collected results and emit to the real destination.
     if let (Some(order_by), Some(collection_cursor_id), Some(collection_idx)) =

--- a/testing/sqltests/tests/union_all.sqltest
+++ b/testing/sqltests/tests/union_all.sqltest
@@ -1,0 +1,58 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t1 (id TEXT PRIMARY KEY, val TEXT);
+    CREATE TABLE t2 (id TEXT PRIMARY KEY, val TEXT);
+    INSERT INTO t1 VALUES ('1','apple'),('2','banana');
+    INSERT INTO t2 VALUES ('3','xenon'),('4','yam');
+}
+
+@setup schema
+test union-all-no-in-subquery {
+    SELECT 'A' AS dim, val FROM t1
+    UNION ALL
+    SELECT 'B' AS dim, val FROM t2;
+}
+expect {
+    A|apple
+    A|banana
+    B|xenon
+    B|yam
+}
+
+@setup schema
+test union-all-where-literal {
+    SELECT 'A' AS dim, val FROM t1 WHERE val = 'apple'
+    UNION ALL
+    SELECT 'B' AS dim, val FROM t2 WHERE val = 'xenon';
+}
+expect {
+    A|apple
+    B|xenon
+}
+
+@setup schema
+test union-all-with-in-subquery-two-cols {
+    SELECT 'A' AS dim, val FROM t1
+    WHERE id IN (SELECT id FROM t1 WHERE val = 'apple')
+    UNION ALL
+    SELECT 'B' AS dim, val FROM t2
+    WHERE id IN (SELECT id FROM t2 WHERE val = 'xenon');
+}
+expect {
+    A|apple
+    B|xenon
+}
+
+@setup schema
+test union-all-with-in-subquery-three-cols {
+    SELECT 'A' AS dim, val, 1 AS n FROM t1
+    WHERE id IN (SELECT id FROM t1 WHERE val = 'apple')
+    UNION ALL
+    SELECT 'B' AS dim, val, 2 AS n FROM t2
+    WHERE id IN (SELECT id FROM t2 WHERE val = 'xenon');
+}
+expect {
+    A|apple|1
+    B|xenon|2
+}


### PR DESCRIPTION
Previously a UNION ALL query with an IN (subquery...), the subquery would clobber the result columns and we would silently drop all result columns from `1..=N`. 

This only manifested in the Rust bindings (`bindings/rust/src/rows.rs:61`): `Rows::new()` latches `column_count()` up front, then on every `step()` reads exactly that many values from the row. So if `result_columns.len()` was clobbered to 1 by the IN-subquery during compile, every row gets truncated to 1 value and they are silently dropped before they ever reach the user.


again, thanks to @wadamek65 for reporting this bug.

