### PR TITLE
core/translate: Fix `GROUP BY` infinite loop

### DIFF
--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -1016,6 +1016,12 @@ pub fn group_by_emit_row_phase<'a>(
 
     t_ctx.resolver.enable_expr_to_reg_cache();
 
+    // Disable constant optimization within the GROUP BY output subroutine.
+    // Constants hoisted to the init section would cause the IfPos jump
+    // (targeting label_agg_final) to land in the init block, which ends
+    // with Goto back to the start of the program, creating an infinite loop.
+    let span_idx = program.constant_spans_next_idx();
+
     if let Some(having) = &group_by.having {
         emit_non_from_clause_subqueries_for_phase(
             program,
@@ -1046,11 +1052,6 @@ pub fn group_by_emit_row_phase<'a>(
         }
     }
 
-    // Disable constant optimization within the GROUP BY output subroutine.
-    // Constants hoisted to the init section would cause the IfPos jump
-    // (targeting label_agg_final) to land in the init block, which ends
-    // with Goto back to the start of the program, creating an infinite loop.
-    let span_idx = program.constant_spans_next_idx();
     emit_non_from_clause_subqueries_for_phase(
         program,
         &t_ctx.resolver,

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
@@ -27,12 +27,12 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                     p1  p2  p3  p4                  p5  comment
-   0          Init                0  53   0                       0  Start at 53
+   0          Init                0  54   0                       0  Start at 54
    1          SorterOpen          0   1   0  k(1,-B)              0  cursor=0
    2          Null                0  10  11                       0  r[10..11]=NULL
    3          Integer             0   7   0                       0  r[7]=0; clear group by abort flag
    4          Null                0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
-   5          Gosub              16  41   0                       0  ; go to clear accumulator subroutine
+   5          Gosub              16  42   0                       0  ; go to clear accumulator subroutine
    6          OpenRead            1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
    7          OpenRead            2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
    8          Rewind              2  25   0                       0  Rewind index idx_sales_category
@@ -44,8 +44,8 @@ addr  opcode                     p1  p2  p3  p4                  p5  comment
   14            Jump             15  19  15                       0  ; start new group if comparison is not equal
   15            Gosub             5  29   0                       0  ; check if ended group had data, and output if so
   16            Move             13   8   1                       0  r[8..8]=r[13..13]
-  17            IfPos             7  44   0                       0  r[7]>0 -> r[7]-=0, goto 44; check abort flag
-  18            Gosub            16  41   0                       0  ; goto clear accumulator subroutine
+  17            IfPos             7  45   0                       0  r[7]>0 -> r[7]-=0, goto 45; check abort flag
+  18            Gosub            16  42   0                       0  ; goto clear accumulator subroutine
   19            AggStep           0  14  10  sum                  0  accum=r[10] step(r[14])
   20            AggStep           0  15  11  avg                  0  accum=r[11] step(r[15])
   21            If                6  23   0                       0  if r[6] goto 23; don't emit group columns if continuing existing group
@@ -53,7 +53,7 @@ addr  opcode                     p1  p2  p3  p4                  p5  comment
   23            Integer           1   6   0                       0  r[6]=1; indicate data in accumulator
   24          Next                2   9   0                       0
   25          Gosub               5  29   0                       0  ; emit row for final group
-  26          Goto                0  44   0                       0  ; group by finished
+  26          Goto                0  45   0                       0  ; group by finished
   27          Integer             1   7   0                       0  r[7]=1
   28        Return                5   0   0                       0
   29        IfPos                 6  31   0                       0  r[6]>0 -> r[6]-=0, goto 31; output group by row subroutine start
@@ -61,25 +61,25 @@ addr  opcode                     p1  p2  p3  p4                  p5  comment
   31      AggFinal                0  10   0  sum                  0  accum=r[10]
   32      AggFinal                0  11   0  avg                  0  accum=r[11]
   33      Copy                   10  18   0                       0  r[18]=r[10]
-  34      Le                     18  19  30                       0  if r[18]<=r[19] goto 30
-  35      Copy                   10  20   0                       0  r[20]=r[10]
-  36      Copy                    9  21   0                       0  r[21]=r[9]
-  37      Copy                   11  22   0                       0  r[22]=r[11]
-  38      MakeRecord             20   3   4                       0  r[4]=mkrec(r[20..22])
-  39      SorterInsert            0   4   0  0                    0  key=r[4]
-  40    Return                    5   0   0                       0
-  41    Null                      0   9  11                       0  r[9..11]=NULL; clear accumulator subroutine start
-  42    Integer                   0   6   0                       0  r[6]=0
-  43  Return                     16   0   0                       0
-  44  OpenPseudo                  3   4   3                       0  3 columns in r[4]
-  45  SorterSort                  0  52   0                       0
-  46    SorterData                0   4   3                       0  r[4]=data
-  47    Column                    3   1   1                       0  r[1]=pseudo.column 1
-  48    Column                    3   0   2                       0  r[2]=pseudo.column 0
-  49    Column                    3   2   3                       0  r[3]=pseudo.column 2
-  50    ResultRow                 1   3   0                       0  output=r[1..3]
-  51  SorterNext                  0  46   0                       0
-  52  Halt                        0   0   0                       0
-  53  Transaction                 0   1   8                       0  iDb=0 tx_mode=Read
-  54  Integer                 10000  19   0                       0  r[19]=10000
+  34      Integer             10000  19   0                       0  r[19]=10000
+  35      Le                     18  19  30                       0  if r[18]<=r[19] goto 30
+  36      Copy                   10  20   0                       0  r[20]=r[10]
+  37      Copy                    9  21   0                       0  r[21]=r[9]
+  38      Copy                   11  22   0                       0  r[22]=r[11]
+  39      MakeRecord             20   3   4                       0  r[4]=mkrec(r[20..22])
+  40      SorterInsert            0   4   0  0                    0  key=r[4]
+  41    Return                    5   0   0                       0
+  42    Null                      0   9  11                       0  r[9..11]=NULL; clear accumulator subroutine start
+  43    Integer                   0   6   0                       0  r[6]=0
+  44  Return                     16   0   0                       0
+  45  OpenPseudo                  3   4   3                       0  3 columns in r[4]
+  46  SorterSort                  0  53   0                       0
+  47    SorterData                0   4   3                       0  r[4]=data
+  48    Column                    3   1   1                       0  r[1]=pseudo.column 1
+  49    Column                    3   0   2                       0  r[2]=pseudo.column 0
+  50    Column                    3   2   3                       0  r[3]=pseudo.column 2
+  51    ResultRow                 1   3   0                       0  output=r[1..3]
+  52  SorterNext                  0  47   0                       0
+  53  Halt                        0   0   0                       0
+  54  Transaction                 0   1   8                       0  iDb=0 tx_mode=Read
   55  Goto                        0   1   0                       0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
@@ -25,13 +25,13 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  52   0                 0  Start at 52
-   1          Once              41   0   0                 0  goto 41
+   0          Init               0  53   0                 0  Start at 53
+   1          Once              42   0   0                 0  goto 42
    2          OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
    3          Null               0   7   0                 0  r[7]=NULL
    4          Integer            0   4   0                 0  r[4]=0; clear group by abort flag
    5          Null               0   5   0                 0  r[5]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             11  38   0                 0  ; go to clear accumulator subroutine
+   6          Gosub             11  39   0                 0  ; go to clear accumulator subroutine
    7          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
    8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
@@ -43,40 +43,40 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   15            Jump            16  20  16                 0  ; start new group if comparison is not equal
   16            Gosub            2  29   0                 0  ; check if ended group had data, and output if so
   17            Move             9   5   1                 0  r[5..5]=r[9..9]
-  18            IfPos            4  41   0                 0  r[4]>0 -> r[4]-=0, goto 41; check abort flag
-  19            Gosub           11  38   0                 0  ; goto clear accumulator subroutine
+  18            IfPos            4  42   0                 0  r[4]>0 -> r[4]-=0, goto 42; check abort flag
+  19            Gosub           11  39   0                 0  ; goto clear accumulator subroutine
   20            AggStep          0  10   7  sum            0  accum=r[7] step(r[10])
   21            If               3  23   0                 0  if r[3] goto 23; don't emit group columns if continuing existing group
   22            Column           1   1   6                 0  r[6]=orders.customer_id
   23            Integer          1   3   0                 0  r[3]=1; indicate data in accumulator
   24          Next               2  10   0                 0
   25          Gosub              2  29   0                 0  ; emit row for final group
-  26          Goto               0  41   0                 0  ; group by finished
+  26          Goto               0  42   0                 0  ; group by finished
   27          Integer            1   4   0                 0  r[4]=1
   28        Return               2   0   0                 0
   29        IfPos                3  31   0                 0  r[3]>0 -> r[3]-=0, goto 31; output group by row subroutine start
   30      Return                 2   0   0                 0
   31      AggFinal               0   7   0  sum            0  accum=r[7]
   32      Copy                   7  13   0                 0  r[13]=r[7]
-  33      Le                    13  14  30                 0  if r[13]<=r[14] goto 30
-  34      Copy                   6   1   0                 0  r[1]=r[6]
-  35      MakeRecord             1   1  15                 0  r[15]=mkrec(r[1..1]); for ephemeral_index_where_sub_t2
-  36      IdxInsert              0  15   0                 8  key=r[15]
-  37    Return                   2   0   0                 0
-  38    Null                     0   6   7                 0  r[6..7]=NULL; clear accumulator subroutine start
-  39    Integer                  0   3   0                 0  r[3]=0
-  40  Return                    11   0   0                 0
-  41  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  42  NullRow                    0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  43  Rewind                     0  51   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
-  44    Column                   0   0  18                 0  r[18]=ephemeral(ephemeral_index_where_sub_t2).customer_id
-  45    IsNull                  18  50   0                 0  if (r[18]==NULL) goto 50
-  46    SeekRowid                3  18  50                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 50
-  47    RowId                    3  16   0                 0  r[16]=customers.rowid
-  48    Column                   3   1  17                 0  r[17]=customers.name
-  49    ResultRow               16   2   0                 0  output=r[16..17]
-  50  Next                       0  44   0                 0
-  51  Halt                       0   0   0                 0
-  52  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
-  53  Integer                 1000  14   0                 0  r[14]=1000
+  33      Integer             1000  14   0                 0  r[14]=1000
+  34      Le                    13  14  30                 0  if r[13]<=r[14] goto 30
+  35      Copy                   6   1   0                 0  r[1]=r[6]
+  36      MakeRecord             1   1  15                 0  r[15]=mkrec(r[1..1]); for ephemeral_index_where_sub_t2
+  37      IdxInsert              0  15   0                 8  key=r[15]
+  38    Return                   2   0   0                 0
+  39    Null                     0   6   7                 0  r[6..7]=NULL; clear accumulator subroutine start
+  40    Integer                  0   3   0                 0  r[3]=0
+  41  Return                    11   0   0                 0
+  42  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  43  NullRow                    0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  44  Rewind                     0  52   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
+  45    Column                   0   0  18                 0  r[18]=ephemeral(ephemeral_index_where_sub_t2).customer_id
+  46    IsNull                  18  51   0                 0  if (r[18]==NULL) goto 51
+  47    SeekRowid                3  18  51                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 51
+  48    RowId                    3  16   0                 0  r[16]=customers.rowid
+  49    Column                   3   1  17                 0  r[17]=customers.name
+  50    ResultRow               16   2   0                 0  output=r[16..17]
+  51  Next                       0  45   0                 0
+  52  Halt                       0   0   0                 0
+  53  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
   54  Goto                       0   1   0                 0

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
@@ -48,12 +48,12 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4                  p5  comment
-   0            Init             0  85   0                       0  Start at 85
+   0            Init             0  87   0                       0  Start at 87
    1            SorterOpen       0   1   0  k(1,-B)              0  cursor=0
    2            Null             0  10   0                       0  r[10]=NULL
    3            Integer          0   7   0                       0  r[7]=0; clear group by abort flag
    4            Null             0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  74   0                       0  ; go to clear accumulator subroutine
+   5            Gosub           14  76   0                       0  ; go to clear accumulator subroutine
    6            OpenRead         1   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
    7            OpenRead         2   7   0  k(3,B,B)             0  index=sqlite_autoindex_partsupp_1, root=7, iDb=0
    8            OpenRead         3   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
@@ -74,67 +74,67 @@ addr  opcode                    p1  p2  p3  p4                  p5  comment
   23              Jump          24  28  24                       0  ; start new group if comparison is not equal
   24              Gosub          5  37   0                       0  ; check if ended group had data, and output if so
   25              Move          12   8   1                       0  r[8..8]=r[12..12]
-  26              IfPos          7  77   0                       0  r[7]>0 -> r[7]-=0, goto 77; check abort flag
-  27              Gosub         14  74   0                       0  ; goto clear accumulator subroutine
+  26              IfPos          7  79   0                       0  r[7]>0 -> r[7]-=0, goto 79; check abort flag
+  27              Gosub         14  76   0                       0  ; goto clear accumulator subroutine
   28              AggStep        0  13  10  sum                  0  accum=r[10] step(r[13])
   29              If             6  31   0                       0  if r[6] goto 31; don't emit group columns if continuing existing group
   30              Column         1   0   9                       0  r[9]=partsupp.PS_PARTKEY
   31              Integer        1   6   0                       0  r[6]=1; indicate data in accumulator
   32            Next             2  11   0                       0
   33            Gosub            5  37   0                       0  ; emit row for final group
-  34            Goto             0  77   0                       0  ; group by finished
+  34            Goto             0  79   0                       0  ; group by finished
   35            Integer          1   7   0                       0  r[7]=1
   36          Return             5   0   0                       0
   37          IfPos              6  39   0                       0  r[6]>0 -> r[6]-=0, goto 39; output group by row subroutine start
   38        Return               5   0   0                       0
   39        AggFinal             0  10   0  sum                  0  accum=r[10]
-  40        Once                66   0   0                       0  goto 66
+  40        Once                68   0   0                       0  goto 68
   41        BeginSubrtn         22   0   0                       0  r[22]=NULL
   42        Null                 0   1   0                       0  r[1]=NULL
   43        Null                 0  24   0                       0  r[24]=NULL
   44        Integer              1  25   0                       0  r[25]=1; LIMIT counter
-  45        IfNot               25  61   0                       0  if !r[25] goto 61
+  45        IfNot               25  62   0                       0  if !r[25] goto 62
   46        OpenRead             5   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
   47        OpenRead             6   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
   48        OpenRead             7   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
-  49        Rewind               5  61   0                       0  Rewind table partsupp
+  49        Rewind               5  62   0                       0  Rewind table partsupp
   50          Column             5   1  26                       0  r[26]=partsupp.PS_SUPPKEY
-  51          SeekRowid          6  26  60                       0  if (r[26]!=cursor 6 for table supplier.rowid) goto 60
+  51          SeekRowid          6  26  61                       0  if (r[26]!=cursor 6 for table supplier.rowid) goto 61
   52          Column             6   3  27                       0  r[27]=supplier.S_NATIONKEY
-  53          SeekRowid          7  27  60                       0  if (r[27]!=cursor 7 for table nation.rowid) goto 60
+  53          SeekRowid          7  27  61                       0  if (r[27]!=cursor 7 for table nation.rowid) goto 61
   54          Column             7   1  29                       0  r[29]=nation.N_NAME
-  55          Ne                29  30  60  Binary               0  if r[29]!=r[30] goto 60
-  56          Column             5   3  32                       0  r[32]=partsupp.PS_SUPPLYCOST
-  57          Column             5   2  33                       0  r[33]=partsupp.PS_AVAILQTY
-  58          Multiply          32  33  31                       0  r[31]=r[32]*r[33]
-  59          AggStep            0  31  24  sum                  0  accum=r[24] step(r[31])
-  60        Next                 5  50   0                       0
-  61        AggFinal             0  24   0  sum                  0  accum=r[24]
-  62        Copy                24  34   0                       0  r[34]=r[24]
-  63        Multiply            34  35  23                       0  r[23]=r[34]*r[35]
-  64        Copy                23   1   0                       0  r[1]=r[23]
-  65      Return                22   0   1                       0
-  66      Copy                  10  37   0                       0  r[37]=r[10]
-  67      Copy                   1  38   0                       0  r[38]=r[1]
-  68      Le                    37  38  38                       0  if r[37]<=r[38] goto 38
-  69      Copy                  10  39   0                       0  r[39]=r[10]
-  70      Copy                   9  40   0                       0  r[40]=r[9]
-  71      MakeRecord            39   2   4                       0  r[4]=mkrec(r[39..40])
-  72      SorterInsert           0   4   0  0                    0  key=r[4]
-  73    Return                   5   0   0                       0
-  74    Null                     0   9  10                       0  r[9..10]=NULL; clear accumulator subroutine start
-  75    Integer                  0   6   0                       0  r[6]=0
-  76  Return                    14   0   0                       0
-  77  OpenPseudo                 8   4   2                       0  2 columns in r[4]
-  78  SorterSort                 0  84   0                       0
-  79    SorterData               0   4   8                       0  r[4]=data
-  80    Column                   8   1   2                       0  r[2]=pseudo.column 1
-  81    Column                   8   0   3                       0  r[3]=pseudo.column 0
-  82    ResultRow                2   2   0                       0  output=r[2..3]
-  83  SorterNext                 0  79   0                       0
-  84  Halt                       0   0   0                       0
-  85  Transaction                0   1   8                       0  iDb=0 tx_mode=Read
-  86  String8                    0  19   0  ARGENTINA            0  r[19]='ARGENTINA'
-  87  String8                    0  30   0  ARGENTINA            0  r[30]='ARGENTINA'
-  88  Real                       0  35   0  0.0001               0  r[35]=0.0001
+  55          String8            0  30   0  ARGENTINA            0  r[30]='ARGENTINA'
+  56          Ne                29  30  61  Binary               0  if r[29]!=r[30] goto 61
+  57          Column             5   3  32                       0  r[32]=partsupp.PS_SUPPLYCOST
+  58          Column             5   2  33                       0  r[33]=partsupp.PS_AVAILQTY
+  59          Multiply          32  33  31                       0  r[31]=r[32]*r[33]
+  60          AggStep            0  31  24  sum                  0  accum=r[24] step(r[31])
+  61        Next                 5  50   0                       0
+  62        AggFinal             0  24   0  sum                  0  accum=r[24]
+  63        Copy                24  34   0                       0  r[34]=r[24]
+  64        Real                 0  35   0  0.0001               0  r[35]=0.0001
+  65        Multiply            34  35  23                       0  r[23]=r[34]*r[35]
+  66        Copy                23   1   0                       0  r[1]=r[23]
+  67      Return                22   0   1                       0
+  68      Copy                  10  37   0                       0  r[37]=r[10]
+  69      Copy                   1  38   0                       0  r[38]=r[1]
+  70      Le                    37  38  38                       0  if r[37]<=r[38] goto 38
+  71      Copy                  10  39   0                       0  r[39]=r[10]
+  72      Copy                   9  40   0                       0  r[40]=r[9]
+  73      MakeRecord            39   2   4                       0  r[4]=mkrec(r[39..40])
+  74      SorterInsert           0   4   0  0                    0  key=r[4]
+  75    Return                   5   0   0                       0
+  76    Null                     0   9  10                       0  r[9..10]=NULL; clear accumulator subroutine start
+  77    Integer                  0   6   0                       0  r[6]=0
+  78  Return                    14   0   0                       0
+  79  OpenPseudo                 8   4   2                       0  2 columns in r[4]
+  80  SorterSort                 0  86   0                       0
+  81    SorterData               0   4   8                       0  r[4]=data
+  82    Column                   8   1   2                       0  r[2]=pseudo.column 1
+  83    Column                   8   0   3                       0  r[3]=pseudo.column 0
+  84    ResultRow                2   2   0                       0  output=r[2..3]
+  85  SorterNext                 0  81   0                       0
+  86  Halt                       0   0   0                       0
+  87  Transaction                0   1   8                       0  iDb=0 tx_mode=Read
+  88  String8                    0  19   0  ARGENTINA            0  r[19]='ARGENTINA'
   89  Goto                       0   1   0                       0

--- a/testing/sqltests/turso-tests/group-by-having-infinite-loop.sqltest
+++ b/testing/sqltests/turso-tests/group-by-having-infinite-loop.sqltest
@@ -1,0 +1,28 @@
+@database :memory:
+
+test group-by-literal-having-truthy {
+    SELECT 1 AS x GROUP BY 1 HAVING 1;
+}
+expect {
+    1
+}
+
+test group-by-literal-having-falsy {
+    SELECT 1 AS x GROUP BY 1 HAVING 0;
+}
+expect {
+}
+
+test group-by-literal-having-value {
+    SELECT 42 GROUP BY 1 HAVING 1;
+}
+expect {
+    42
+}
+
+test group-by-literal-having-no-alias {
+    SELECT 1 GROUP BY 1 HAVING 1;
+}
+expect {
+    1
+}


### PR DESCRIPTION
## Description
When GROUP BY uses a literal with HAVING, the constant gets hoisted to the init block. The IfPos jump targeting label_agg_final follows it there, and the init block ends with Goto back to program start. This creates an infinite loop. There's comment now on line 1019 of group_by.rs describing this exact scenario.

The fix moves constant_spans_next_idx() above the HAVING block to prevent the constant from being hoisted. Snapshot tests updated and minimum reproducer tests added.


## Motivation and context

Closes #6412

## Description of AI Usage

Claude Code was used for codebase exploration and writing minimum reproducer tests.