### PR TITLE
Fix sync checkpoint bug

### DIFF
--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1721,39 +1721,10 @@ mod tests {
         assert_eq!(remote_rows[1][2], Value::Text("from-local".to_string()));
     }
 
-    /// Reproducer for the panic seen by read-only sync-engine consumers:
-    ///     thread 'tokio-rt-worker' panicked at core/storage/wal.rs
-    ///     frame_count must be not less than frame_watermark
-    ///     frame_count=0, frame_watermark=23
-    ///
-    /// Scenario the user described: a service only reads from a locally
-    /// synced database — it never writes — and `db.pull()` panics inside
-    /// `apply_changes_internal` after a previous pull populated the WAL.
-    ///
-    /// Mechanism:
-    /// 1. First pull writes N frames into the local WAL and stores
-    ///    `meta.revert_since_wal_watermark = N` (no `revert_since_wal_salt`
-    ///    is recorded on the pull path).
-    /// 2. The service does not write anything between pulls, so
-    ///    `WAL.max_frame` stays at N.
-    /// 3. Second pull -> `apply_changes_internal`:
-    ///    a. `checkpoint_passive` returns `watermark = N` and runs a
-    ///       Passive checkpoint with `upper_bound_inclusive = N`. Because
-    ///       no other reader is holding a read mark and `max_frame == N`,
-    ///       the checkpoint backfills every frame, leaving
-    ///       `nbackfills == max_frame == N`.
-    ///    b. `WalSession::begin()` calls `begin_write_tx`, which calls
-    ///       `try_restart_log_before_write` (core/storage/wal.rs:4737).
-    ///       The conditions to restart are now all met
-    ///       (`max_frame == nbackfills > 0`, holds read-mark 0), so the
-    ///       WAL header is restarted and `apply_restart_snapshot` resets
-    ///       this connection's `WalFile::max_frame` to 0.
-    ///    c. `rollback_changes_after(coro, watermark = N)` calls
-    ///       `wal_changed_pages_after(N)`, whose
-    ///       `turso_assert!(frame_count >= frame_watermark, ...)` fires
-    ///       with `frame_count=0, frame_watermark=N`.
-    ///
-    /// The test must complete the second `db.pull().await` without panicking.
+    /// Read-only consumer: pull + checkpoint loop with concurrent readers must
+    /// not panic with `frame_count must be not less than frame_watermark` when
+    /// a checkpoint backfills every frame and the next write tx restarts the
+    /// WAL header behind a stale sync-engine watermark.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     pub async fn test_sync_pull_panics_after_full_backfill() {
         use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1720,4 +1720,132 @@ mod tests {
         assert_eq!(remote_rows[1][1], Value::Text("beta".to_string()));
         assert_eq!(remote_rows[1][2], Value::Text("from-local".to_string()));
     }
+
+    /// Reproducer for the panic seen by read-only sync-engine consumers:
+    ///     thread 'tokio-rt-worker' panicked at core/storage/wal.rs
+    ///     frame_count must be not less than frame_watermark
+    ///     frame_count=0, frame_watermark=23
+    ///
+    /// Scenario the user described: a service only reads from a locally
+    /// synced database — it never writes — and `db.pull()` panics inside
+    /// `apply_changes_internal` after a previous pull populated the WAL.
+    ///
+    /// Mechanism:
+    /// 1. First pull writes N frames into the local WAL and stores
+    ///    `meta.revert_since_wal_watermark = N` (no `revert_since_wal_salt`
+    ///    is recorded on the pull path).
+    /// 2. The service does not write anything between pulls, so
+    ///    `WAL.max_frame` stays at N.
+    /// 3. Second pull -> `apply_changes_internal`:
+    ///    a. `checkpoint_passive` returns `watermark = N` and runs a
+    ///       Passive checkpoint with `upper_bound_inclusive = N`. Because
+    ///       no other reader is holding a read mark and `max_frame == N`,
+    ///       the checkpoint backfills every frame, leaving
+    ///       `nbackfills == max_frame == N`.
+    ///    b. `WalSession::begin()` calls `begin_write_tx`, which calls
+    ///       `try_restart_log_before_write` (core/storage/wal.rs:4737).
+    ///       The conditions to restart are now all met
+    ///       (`max_frame == nbackfills > 0`, holds read-mark 0), so the
+    ///       WAL header is restarted and `apply_restart_snapshot` resets
+    ///       this connection's `WalFile::max_frame` to 0.
+    ///    c. `rollback_changes_after(coro, watermark = N)` calls
+    ///       `wal_changed_pages_after(N)`, whose
+    ///       `turso_assert!(frame_count >= frame_watermark, ...)` fires
+    ///       with `frame_count=0, frame_watermark=N`.
+    ///
+    /// The test must complete the second `db.pull().await` without panicking.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    pub async fn test_sync_pull_panics_after_full_backfill() {
+        use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+        use std::sync::Arc;
+
+        let _ = tracing_subscriber::fmt::try_init();
+        let dir = TempDir::new().unwrap();
+        let server = TursoServer::new().await.unwrap();
+
+        let db = crate::sync::Builder::new_remote(dir.path().join("local.db").to_str().unwrap())
+            .with_remote_url(server.db_url())
+            .build()
+            .await
+            .unwrap();
+
+        server.db_sql("CREATE TABLE t(y BLOB)").await.unwrap();
+        db.pull().await.unwrap();
+
+        // Read-only consumer: only opens a connection and queries.
+        let conn = db.connect().await.unwrap();
+
+        // Spawn random readers on independent connections that race against
+        // the pull+checkpoint loop. Each reader picks a random query out of a
+        // small set, sleeps a random short interval, and verifies that the
+        // observed row count never goes backward and never exceeds what the
+        // pull loop has already applied.
+        let done = Arc::new(AtomicBool::new(false));
+        let applied_total = Arc::new(AtomicI64::new(0));
+        let mut readers = Vec::new();
+        for _ in 0..4 {
+            let reader_conn = db.connect().await.unwrap();
+            let done = done.clone();
+            let applied_total = applied_total.clone();
+            readers.push(tokio::spawn(async move {
+                let mut last_seen: i64 = 0;
+                while !done.load(Ordering::Relaxed) {
+                    let sleep_ms = rand::rng().random_range(0..=4);
+                    tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+
+                    let sql = match rand::rng().random_range(0..3) {
+                        0 => "SELECT count(*) FROM t",
+                        1 => "SELECT count(length(y)) FROM t",
+                        _ => "SELECT count(*) FROM t WHERE length(y) > 0",
+                    };
+                    let rows = match reader_conn.query(sql, ()).await {
+                        Ok(rows) => rows,
+                        // Acceptable transient errors during pull/checkpoint;
+                        // anything else (including the WAL panic) propagates.
+                        Err(crate::Error::Busy(_)) => continue,
+                        Err(e) => panic!("reader query failed: {e:?}"),
+                    };
+                    let all = all_rows(rows).await.unwrap();
+                    let Value::Integer(n) = all[0][0] else {
+                        panic!("unexpected reader value: {:?}", all[0][0]);
+                    };
+                    let upper = applied_total.load(Ordering::Acquire);
+                    assert!(
+                        n >= last_seen && n <= upper,
+                        "reader saw inconsistent count {n}, last_seen={last_seen}, upper={upper}"
+                    );
+                    last_seen = n;
+                }
+            }));
+        }
+
+        let mut total: i64 = 0;
+        for _ in 0..25 {
+            let cnt: u16 = rand::rng().random_range(1..=16);
+            let size: u32 = rand::rng().random_range(1..=4 * 1024);
+
+            server
+                .db_sql(&format!(
+                    "INSERT INTO t SELECT randomblob({size}) FROM generate_series(1, {cnt})"
+                ))
+                .await
+                .unwrap();
+            total += cnt as i64;
+
+            applied_total.store(total, Ordering::Release);
+            db.pull().await.unwrap();
+
+            let _ = db.checkpoint().await;
+
+            let rows = all_rows(conn.query("SELECT count(*) FROM t", ()).await.unwrap())
+                .await
+                .unwrap();
+            assert_eq!(rows, vec![vec![Value::Integer(total)]]);
+        }
+
+        done.store(true, Ordering::Relaxed);
+        for h in readers {
+            h.await.unwrap();
+        }
+    }
 }

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -30,7 +30,7 @@ pub struct TursoSyncServer {
 
 impl TursoSyncServer {
     pub fn new(address: String, conn: Arc<Connection>, interrupt_count: Arc<AtomicUsize>) -> Self {
-        conn.wal_auto_checkpoint_disable();
+        conn.wal_auto_actions_disable();
         Self {
             address,
             conn: Arc::new(Mutex::new(conn)),

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -4,7 +4,9 @@ use crate::mvcc::yield_points::{FailureInjector, YieldInjector};
 use crate::statement::StatementOrigin;
 use crate::storage::{journal_mode, pager::SavepointResult};
 use crate::sync::{
-    atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, Ordering},
+    atomic::{
+        AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicU8, Ordering,
+    },
     Arc, RwLock,
 };
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
@@ -25,7 +27,7 @@ use crate::{
     Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
     EncryptionKey, EncryptionOpts, IndexMethod, LimboError, MvStore, OpenFlags, PageSize, Pager,
     Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
-    Trigger, Value, VirtualTable,
+    Trigger, Value, VirtualTable, WalAutoActions,
 };
 use crate::{is_memory_like, turso_assert};
 use crate::{MAIN_DB_ID, TEMP_DB_ID};
@@ -175,9 +177,14 @@ pub struct Connection {
     /// page size used for an uninitialized database or the next vacuum command.
     /// it's not always equal to the current page size of the database
     pub(super) page_size: AtomicU16,
-    /// Disable automatic checkpoint behaviour when DB is shutted down or WAL reach certain size
-    /// Client still can manually execute PRAGMA wal_checkpoint(...) commands
-    pub(super) wal_auto_checkpoint_disabled: AtomicBool,
+    /// Allowed automatic WAL maintenance actions for this connection.
+    /// Stored as the `bits()` of a `WalAutoActions`. Default is
+    /// `WalAutoActions::all_enabled()`. `wal_auto_checkpoint_disable`
+    /// clears every bit, opting out of both auto-checkpoint and WAL header
+    /// restart — sync-engine consumers rely on the latter staying disabled
+    /// because rotating the WAL header invalidates their published
+    /// watermarks.
+    pub(super) wal_auto_actions: AtomicU8,
     pub(super) capture_data_changes: RwLock<Option<CaptureDataChangesInfo>>,
     /// CDC v2: transaction ID for grouping CDC records by transaction.
     /// -1 means unset (will be assigned on first CDC write in the transaction).
@@ -1472,9 +1479,16 @@ impl Connection {
     pub fn wal_insert_begin(&self) -> Result<()> {
         let pager = self.pager.load();
         pager.begin_read_tx()?;
-        pager.io.block(|| pager.begin_write_tx()).inspect_err(|_| {
-            pager.end_read_tx();
-        })?;
+        // Sync-engine drives WAL maintenance explicitly: any auto-restart of
+        // the WAL header here would invalidate the watermarks the caller has
+        // already published (see `wal_changed_pages_after`), so opt out of
+        // every auto action for this write transaction.
+        pager
+            .io
+            .block(|| pager.begin_write_tx(WalAutoActions::empty()))
+            .inspect_err(|_| {
+                pager.end_read_tx();
+            })?;
 
         // start write transaction and disable auto-commit mode as SQL can be executed within WAL session (at caller own risk)
         self.set_tx_state(TransactionState::Write {
@@ -1505,7 +1519,7 @@ impl Connection {
                     .io
                     .block(|| {
                         return_if_io!(pager.commit_dirty_pages(
-                            true,
+                            WalAutoActions::empty(),
                             self.get_sync_mode(),
                             self.get_data_sync_retry(),
                         ));
@@ -1628,21 +1642,29 @@ impl Connection {
             && !is_memory_db
             && should_checkpoint_on_close
         {
-            self.pager.load().checkpoint_shutdown(
-                self.is_wal_auto_checkpoint_disabled(),
-                self.get_sync_mode(),
-            )?;
+            self.pager
+                .load()
+                .checkpoint_shutdown(self.wal_auto_actions(), self.get_sync_mode())?;
         };
         Ok(())
     }
 
+    /// Disable every automatic WAL maintenance action for this connection
+    /// (auto-checkpoint AND WAL header restart). Sync-engine consumers call
+    /// this so they own all WAL bookkeeping themselves.
     pub fn wal_auto_checkpoint_disable(&self) {
-        self.wal_auto_checkpoint_disabled
-            .store(true, Ordering::SeqCst);
+        self.wal_auto_actions
+            .store(WalAutoActions::empty().bits(), Ordering::SeqCst);
     }
 
-    pub fn is_wal_auto_checkpoint_disabled(&self) -> bool {
-        self.wal_auto_checkpoint_disabled.load(Ordering::SeqCst) || self.db.get_mv_store().is_some()
+    /// Returns the set of automatic WAL maintenance actions this connection
+    /// permits. MVCC connections always return an empty set because the
+    /// MVCC checkpoint state machine drives WAL maintenance explicitly.
+    pub fn wal_auto_actions(&self) -> WalAutoActions {
+        if self.db.get_mv_store().is_some() {
+            return WalAutoActions::empty();
+        }
+        WalAutoActions::from_bits_truncate(self.wal_auto_actions.load(Ordering::SeqCst))
     }
 
     #[cfg(feature = "simulator")]

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -179,8 +179,8 @@ pub struct Connection {
     pub(super) page_size: AtomicU16,
     /// Allowed automatic WAL maintenance actions for this connection.
     /// Stored as the `bits()` of a `WalAutoActions`. Default is
-    /// `WalAutoActions::all_enabled()`. `wal_auto_checkpoint_disable`
-    /// clears every bit, opting out of both auto-checkpoint and WAL header
+    /// `WalAutoActions::all_enabled()`. `wal_auto_actions_disable` clears
+    /// every bit, opting out of both auto-checkpoint and WAL header
     /// restart — sync-engine consumers rely on the latter staying disabled
     /// because rotating the WAL header invalidates their published
     /// watermarks.
@@ -1652,7 +1652,7 @@ impl Connection {
     /// Disable every automatic WAL maintenance action for this connection
     /// (auto-checkpoint AND WAL header restart). Sync-engine consumers call
     /// this so they own all WAL bookkeeping themselves.
-    pub fn wal_auto_checkpoint_disable(&self) {
+    pub fn wal_auto_actions_disable(&self) {
         self.wal_auto_actions
             .store(WalAutoActions::empty().bits(), Ordering::SeqCst);
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -84,8 +84,8 @@ use crate::{
     },
     sync::{
         atomic::{
-            AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicUsize,
-            Ordering,
+            AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicU8,
+            AtomicUsize, Ordering,
         },
         Arc, LazyLock, Mutex, RwLock, Weak,
     },
@@ -142,7 +142,7 @@ pub use storage::{
     database::{DatabaseStorage, IOContext},
     encryption::{CipherMode, EncryptionContext, EncryptionKey},
     pager::{Page, PageRef, Pager},
-    wal::{CheckpointMode, CheckpointResult, Wal, WalFile, WalFileShared},
+    wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
 };
 pub use translate::expr::{walk_expr_mut, WalkControl};
 pub use turso_macros::{
@@ -1678,7 +1678,7 @@ impl Database {
             _shared_cache: false,
             cache_size: AtomicI32::new(default_cache_size),
             page_size: AtomicU16::new(page_size.get_raw()),
-            wal_auto_checkpoint_disabled: AtomicBool::new(false),
+            wal_auto_actions: AtomicU8::new(WalAutoActions::all_enabled().bits()),
             capture_data_changes: RwLock::new(None),
             cdc_transaction_id: AtomicI64::new(-1),
             closed: AtomicBool::new(false),

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -489,7 +489,7 @@ fn database_open_rebuilds_from_disk_scan_after_partial_checkpoint_without_backfi
 
     let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
-    conn.wal_auto_checkpoint_disable();
+    conn.wal_auto_actions_disable();
     conn.execute("create table test(id integer primary key, value blob)")
         .unwrap();
     conn.execute("begin immediate").unwrap();
@@ -567,7 +567,7 @@ fn database_open_rebuilds_from_disk_scan_after_wal_append_invalidates_backfill_p
 
     let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
-    conn.wal_auto_checkpoint_disable();
+    conn.wal_auto_actions_disable();
     conn.execute("create table test(id integer primary key, value blob)")
         .unwrap();
     conn.execute("begin immediate").unwrap();
@@ -639,7 +639,7 @@ fn database_open_rebuilds_from_disk_scan_after_db_header_mismatch_invalidates_ba
 
     let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
-    conn.wal_auto_checkpoint_disable();
+    conn.wal_auto_actions_disable();
     conn.execute("create table test(id integer primary key, value blob)")
         .unwrap();
     conn.execute("begin immediate").unwrap();
@@ -1208,7 +1208,7 @@ fn subprocess_readonly_child_reader_blocks_restart_and_truncate_checkpoints() {
 
     let db = open_multiprocess_db(io, db_path_str).unwrap();
     let conn = db.connect().unwrap();
-    conn.wal_auto_checkpoint_disable();
+    conn.wal_auto_actions_disable();
     conn.execute("create table test(id integer primary key, value blob)")
         .unwrap();
     conn.execute("begin immediate").unwrap();
@@ -1302,7 +1302,7 @@ fn subprocess_readonly_disk_scan_child_reader_stays_in_shared_coordination() {
 
     let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
-    conn.wal_auto_checkpoint_disable();
+    conn.wal_auto_actions_disable();
     conn.execute("create table test(id integer primary key, value blob)")
         .unwrap();
     conn.execute("begin immediate").unwrap();
@@ -1539,7 +1539,7 @@ fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
 
     let db = open_multiprocess_db(io.clone(), db_path_str).unwrap();
     let conn = db.connect().unwrap();
-    conn.wal_auto_checkpoint_disable();
+    conn.wal_auto_actions_disable();
     conn.execute("create table test(id integer primary key, value blob)")
         .unwrap();
     conn.execute("begin immediate").unwrap();

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -9,7 +9,7 @@ use crate::state_machine::{StateMachine, StateTransition, TransitionResult};
 use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::storage::pager::CreateBTreeFlags;
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
-use crate::storage::wal::{CheckpointMode, TursoRwLock};
+use crate::storage::wal::{CheckpointMode, TursoRwLock, WalAutoActions};
 use crate::sync::atomic::Ordering;
 use crate::sync::Arc;
 use crate::sync::RwLock;
@@ -855,7 +855,9 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     self.lock_states.pager_read_tx = true;
                 }
 
-                self.pager.io.block(|| self.pager.begin_write_tx())?;
+                self.pager
+                    .io
+                    .block(|| self.pager.begin_write_tx(WalAutoActions::all_enabled()))?;
                 if self.update_transaction_state {
                     self.connection.set_tx_state(TransactionState::Write {
                         schema_did_change: false,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8320,7 +8320,8 @@ mod tests {
         },
         types::Text,
         vdbe::Register,
-        BufferPool, Completion, Connection, IOContext, StepResult, Wal, WalFile, WalFileShared,
+        BufferPool, Completion, Connection, IOContext, StepResult, Wal, WalAutoActions, WalFile,
+        WalFileShared,
     };
     use arc_swap::ArcSwapOption;
     use std::{mem::transmute, ops::Deref, sync::Arc};
@@ -8674,7 +8675,11 @@ mod tests {
 
         // force allocate page1 with a transaction
         pager.begin_read_tx().unwrap();
-        run_until_done(|| pager.begin_write_tx(), &pager).unwrap();
+        run_until_done(
+            || pager.begin_write_tx(WalAutoActions::all_enabled()),
+            &pager,
+        )
+        .unwrap();
         run_until_done(|| pager.commit_tx(&conn, true), &pager).unwrap();
 
         let page2 = run_until_done(|| pager.allocate_page(), &pager).unwrap();
@@ -8951,7 +8956,11 @@ mod tests {
             for insert_id in 0..inserts {
                 let do_validate = do_validate_btree || (insert_id % VALIDATE_INTERVAL == 0);
                 pager.begin_read_tx().unwrap();
-                run_until_done(|| pager.begin_write_tx(), &pager).unwrap();
+                run_until_done(
+                    || pager.begin_write_tx(WalAutoActions::all_enabled()),
+                    &pager,
+                )
+                .unwrap();
                 let size = size(&mut rng);
                 let key = {
                     let result;
@@ -9096,7 +9105,10 @@ mod tests {
             tracing::info!("seed: {seed}");
             for i in 0..inserts {
                 pager.begin_read_tx().unwrap();
-                pager.io.block(|| pager.begin_write_tx()).unwrap();
+                pager
+                    .io
+                    .block(|| pager.begin_write_tx(WalAutoActions::all_enabled()))
+                    .unwrap();
                 let key = {
                     let result;
                     loop {
@@ -9271,7 +9283,10 @@ mod tests {
                 let print_progress = i % 100 == 0;
                 pager.begin_read_tx().unwrap();
 
-                pager.io.block(|| pager.begin_write_tx()).unwrap();
+                pager
+                    .io
+                    .block(|| pager.begin_write_tx(WalAutoActions::all_enabled()))
+                    .unwrap();
 
                 // Decide whether to insert or delete (80% chance of insert)
                 let is_insert = rng.next_u64() % 100 < (insert_chance * 100.0) as u64;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5719,7 +5719,7 @@ mod checkpoint_phase_tests {
         let (db, dir) = open_checkpoint_test_database();
         let db_path = dir.join("test.db");
         let conn = db.connect().unwrap();
-        conn.wal_auto_checkpoint_disable();
+        conn.wal_auto_actions_disable();
         conn.execute("create table test(id integer primary key, value blob)")
             .unwrap();
         conn.execute("begin immediate").unwrap();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -52,7 +52,7 @@ use super::sqlite3_ondisk::{
     FREELIST_TRUNK_OFFSET_FIRST_LEAF_PTR, FREELIST_TRUNK_OFFSET_LEAF_COUNT,
     FREELIST_TRUNK_OFFSET_NEXT_TRUNK_PTR,
 };
-use super::wal::CheckpointMode;
+use super::wal::{CheckpointMode, WalAutoActions};
 use crate::storage::encryption::{CipherMode, EncryptionContext, EncryptionKey};
 
 /// SQLite's default maximum page count
@@ -2681,14 +2681,20 @@ impl Pager {
 
     #[inline(always)]
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn begin_write_tx(&self) -> Result<IOResult<()>> {
+    /// `allowed_auto_actions` controls which automatic WAL maintenance the
+    /// caller permits during this begin. The only action consulted here is
+    /// `WalAutoActions::Restart`, which gates the WAL-header restart inside
+    /// `try_restart_log_before_write`. Callers managing WAL state externally
+    /// (sync engine) must not pass `Restart` because rotating the WAL header
+    /// behind their back invalidates watermarks they have already published.
+    pub fn begin_write_tx(&self, allowed_auto_actions: WalAutoActions) -> Result<IOResult<()>> {
         // TODO(Diego): The only possibly allocate page1 here is because OpenEphemeral needs a write transaction
         // we should have a unique API to begin transactions, something like sqlite3BtreeBeginTrans
         return_if_io!(self.maybe_allocate_page1());
         let Some(wal) = self.wal.as_ref() else {
             return Ok(IOResult::Done(()));
         };
-        Ok(IOResult::Done(wal.begin_write_tx()?))
+        Ok(IOResult::Done(wal.begin_write_tx(allowed_auto_actions)?))
     }
 
     /// Acquire exclusive WAL access + block new transactions (used by VACUUM).
@@ -2769,7 +2775,7 @@ impl Pager {
                 }
                 _ => {
                     return_if_io!(self.commit_dirty_pages(
-                        connection.is_wal_auto_checkpoint_disabled(),
+                        connection.wal_auto_actions(),
                         connection.get_sync_mode(),
                         connection.get_data_sync_retry(),
                     ));
@@ -3607,10 +3613,15 @@ impl Pager {
     /// In the base case, it will write the dirty pages to the WAL and then fsync the WAL.
     /// If the WAL size is over the checkpoint threshold, it will checkpoint the WAL to
     /// the database file and then fsync the database file.
+    ///
+    /// `allowed_auto_actions` controls automatic WAL maintenance permitted at
+    /// commit time. Only `WalAutoActions::Checkpoint` is consulted here — it
+    /// gates the post-commit auto-checkpoint when `should_checkpoint()` is
+    /// true.
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn commit_dirty_pages(
         &self,
-        wal_auto_checkpoint_disabled: bool,
+        allowed_auto_actions: WalAutoActions,
         sync_mode: SyncMode,
         data_sync_retry: bool,
     ) -> Result<IOResult<()>> {
@@ -3627,7 +3638,7 @@ impl Pager {
         }
 
         let result =
-            self.commit_dirty_pages_inner(wal_auto_checkpoint_disabled, sync_mode, data_sync_retry);
+            self.commit_dirty_pages_inner(allowed_auto_actions, sync_mode, data_sync_retry);
         if result.is_err() {
             self.commit_info.write().reset();
         }
@@ -3641,7 +3652,7 @@ impl Pager {
     #[instrument(skip_all, level = Level::DEBUG)]
     fn commit_dirty_pages_inner(
         &self,
-        wal_auto_checkpoint_disabled: bool,
+        allowed_auto_actions: WalAutoActions,
         sync_mode: SyncMode,
         data_sync_retry: bool,
     ) -> Result<IOResult<()>> {
@@ -3881,7 +3892,8 @@ impl Pager {
                     self.dirty_pages.write().clear();
                     commit_info.prepared_frames.clear();
 
-                    let need_checkpoint = !wal_auto_checkpoint_disabled && wal.should_checkpoint();
+                    let need_checkpoint = allowed_auto_actions.contains(WalAutoActions::Checkpoint)
+                        && wal.should_checkpoint();
                     if need_checkpoint {
                         commit_info.state = CommitState::AutoCheckpoint;
                     }
@@ -4470,7 +4482,7 @@ impl Pager {
     /// deletes the WAL file.
     pub fn checkpoint_shutdown(
         &self,
-        wal_auto_checkpoint_disabled: bool,
+        allowed_auto_actions: WalAutoActions,
         sync_mode: crate::SyncMode,
     ) -> Result<()> {
         let mut attempts = 0;
@@ -4485,7 +4497,7 @@ impl Pager {
             let c = wal.sync(self.get_sync_type())?;
             self.io.wait_for_completion(c)?;
         }
-        if !wal_auto_checkpoint_disabled {
+        if allowed_auto_actions.contains(WalAutoActions::Checkpoint) {
             while let Err(LimboError::Busy) = self.blocking_checkpoint(
                 CheckpointMode::Truncate {
                     upper_bound_inclusive: None,

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -15,6 +15,7 @@ use tracing::{instrument, Level};
 
 use crate::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use crate::sync::RwLock;
+use bitflags::bitflags;
 use std::fmt::{Debug, Formatter};
 use std::{fmt, sync::Arc};
 
@@ -114,6 +115,35 @@ pub(crate) fn coordination_path_for_wal_path(wal_path: &str) -> String {
         format!("{db_path}-tshm")
     } else {
         format!("{wal_path}-tshm")
+    }
+}
+
+bitflags! {
+    /// Automatic WAL maintenance actions a caller permits the engine to take
+    /// during routine operations (begin write tx, commit, shutdown).
+    ///
+    /// Callers that manage WAL state out-of-band — e.g. the sync engine,
+    /// which keeps its own watermarks across the WAL header — pass an
+    /// explicit subset so unrelated bookkeeping remains untouched. The
+    /// previous single `wal_auto_checkpoint_disabled` boolean conflated both
+    /// auto-checkpoint and WAL header restart; spelling them out separately
+    /// avoids breaking sync-engine assumptions whenever one of the two is
+    /// disabled.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct WalAutoActions: u8 {
+        /// Run an auto-checkpoint after commit when `should_checkpoint()`
+        /// is true, and the truncate-checkpoint on connection shutdown.
+        const Checkpoint = 0b01;
+        /// Restart the WAL header in `try_restart_log_before_write` when
+        /// every frame has been backfilled, before starting a write tx.
+        const Restart    = 0b10;
+    }
+}
+
+impl WalAutoActions {
+    /// Default policy for ordinary connections: every auto action allowed.
+    pub const fn all_enabled() -> Self {
+        Self::from_bits_truncate(Self::Checkpoint.bits() | Self::Restart.bits())
     }
 }
 
@@ -572,7 +602,13 @@ pub trait Wal: Debug + Send + Sync {
     fn mvcc_refresh_if_db_changed(&self) -> bool;
 
     /// Begin a write transaction.
-    fn begin_write_tx(&self) -> Result<()>;
+    ///
+    /// `allowed_auto_actions` controls which automatic WAL maintenance
+    /// actions are permitted within this call — currently only
+    /// `WalAutoActions::Restart` is consulted (it gates
+    /// `try_restart_log_before_write`). Callers that own WAL state
+    /// externally (e.g. the sync engine) pass an empty set to opt out.
+    fn begin_write_tx(&self, allowed_auto_actions: WalAutoActions) -> Result<()>;
 
     /// End a read transaction.
     fn end_read_tx(&self);
@@ -3094,7 +3130,7 @@ impl Wal for WalFile {
 
     /// Begin a write transaction
     #[instrument(skip_all, level = Level::DEBUG)]
-    fn begin_write_tx(&self) -> Result<()> {
+    fn begin_write_tx(&self, allowed_auto_actions: WalAutoActions) -> Result<()> {
         tracing::debug!("begin_write_tx");
         let begin_write_result: Result<()> = {
             // sqlite/src/wal.c 3702
@@ -3142,6 +3178,10 @@ impl Wal for WalFile {
                 false,
                 "begin_write_tx called while write lock already held according to connection state"
             );
+        }
+
+        if !allowed_auto_actions.contains(WalAutoActions::Restart) {
+            return Ok(());
         }
 
         let result = self.try_restart_log_before_write();
@@ -5480,7 +5520,8 @@ pub mod test {
     };
     use super::{
         CheckpointLocks, InProcessWalCoordination, ReadGuardKind, TryBeginReadResult, Wal,
-        WalCommitState, WalConnectionState, WalCoordination, WalFile, WalSnapshot, NO_LOCK_HELD,
+        WalAutoActions, WalCommitState, WalConnectionState, WalCoordination, WalFile, WalSnapshot,
+        NO_LOCK_HELD,
     };
     #[cfg(host_shared_wal)]
     use crate::storage::shared_wal_coordination::{
@@ -8862,7 +8903,7 @@ pub mod test {
             let pager = conn2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
             let _ = wal.begin_read_tx().unwrap();
-            wal.begin_write_tx().unwrap();
+            wal.begin_write_tx(WalAutoActions::all_enabled()).unwrap();
         }
 
         // should fail because writer lock is held
@@ -8902,7 +8943,7 @@ pub mod test {
         // Attempt to start a write transaction without a read transaction
         let pager = conn.pager.load();
         let wal = pager.wal.as_ref().unwrap();
-        let _ = wal.begin_write_tx();
+        let _ = wal.begin_write_tx(WalAutoActions::all_enabled());
     }
 
     fn check_read_lock_slot(conn: &Arc<Connection>, _expected_slot: usize) -> bool {
@@ -9166,7 +9207,7 @@ pub mod test {
         let result = {
             let pager = conn2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.begin_write_tx()
+            wal.begin_write_tx(WalAutoActions::all_enabled())
         };
         // Should get BusySnapShot due to stale snapshot
         assert!(matches!(result, Err(LimboError::BusySnapshot)));
@@ -9182,7 +9223,7 @@ pub mod test {
         let result = {
             let pager = conn2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.begin_write_tx()
+            wal.begin_write_tx(WalAutoActions::all_enabled())
         };
         assert!(matches!(result, Ok(())));
     }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -7407,7 +7407,7 @@ pub mod test {
         let wal_path = path.join("test.db-wal");
         let wal_path_str = wal_path.to_str().unwrap();
         let conn = db.connect().unwrap();
-        conn.wal_auto_checkpoint_disable();
+        conn.wal_auto_actions_disable();
         conn.execute("create table test(id integer primary key, value text)")
             .unwrap();
         bulk_inserts(&conn, 8, 2);
@@ -7495,7 +7495,7 @@ pub mod test {
         let wal_path = path.join("test.db-wal");
         let wal_path_str = wal_path.to_str().unwrap();
         let conn = db.connect().unwrap();
-        conn.wal_auto_checkpoint_disable();
+        conn.wal_auto_actions_disable();
         conn.execute("create table test(id integer primary key, value text)")
             .unwrap();
         bulk_inserts(&conn, 8, 2);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -62,7 +62,7 @@ use crate::{
     },
     CaptureDataChangesInfo, CdcVersion, CheckpointMode, Completion, Connection, Database,
     DatabaseStorage, IOExt, MvCursor, NonNan, OpenFlags, QueryMode, Statement, TransactionState,
-    ValueRef, MAIN_DB_ID, TEMP_DB_ID,
+    ValueRef, WalAutoActions, MAIN_DB_ID, TEMP_DB_ID,
 };
 use crate::{
     error::{
@@ -3612,7 +3612,7 @@ pub fn op_transaction_inner(
                             !conn.is_nested_stmt(),
                             "nested stmt should not begin a new write transaction"
                         );
-                        let begin_w_tx_res = pager.begin_write_tx();
+                        let begin_w_tx_res = pager.begin_write_tx(conn.wal_auto_actions());
                         if matches!(
                             begin_w_tx_res,
                             Err(LimboError::Busy | LimboError::BusySnapshot)
@@ -3667,7 +3667,8 @@ pub fn op_transaction_inner(
             // 3b. For attached databases, begin the write transaction after
             // begin_read_tx has already completed in the Start state.
             OpTransactionState::AttachedBeginWriteTx => {
-                let res = pager.begin_write_tx()?;
+                let conn = program.connection.clone();
+                let res = pager.begin_write_tx(conn.wal_auto_actions())?;
                 if let IOResult::IO(io) = res {
                     return Ok(InsnFunctionStepResult::IO(io));
                 }
@@ -11962,7 +11963,7 @@ pub fn op_open_ephemeral(
             pager
                 .begin_read_tx() // we have to begin a read tx before beginning a write
                 .expect("Failed to start read transaction");
-            return_if_io!(pager.begin_write_tx());
+            return_if_io!(pager.begin_write_tx(WalAutoActions::all_enabled()));
             *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::CreateBtree {
                 pager: pager.clone(),
                 temp_file: temp_file.take(),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -57,7 +57,7 @@ use crate::{
         metrics::StatementMetrics,
         vacuum::VacuumInPlaceOpContext,
     },
-    ValueRef,
+    ValueRef, WalAutoActions,
 };
 use smallvec::SmallVec;
 
@@ -2084,7 +2084,11 @@ impl Program {
                     // Commit dirty pages to WAL, then end write+read transactions.
                     // We disable auto-checkpoint and avoid pager.commit_tx() since
                     // the checkpoint logic can leave read locks held.
-                    match attached_pager.commit_dirty_pages(true, SyncMode::Normal, false) {
+                    match attached_pager.commit_dirty_pages(
+                        WalAutoActions::empty(),
+                        SyncMode::Normal,
+                        false,
+                    ) {
                         Ok(IOResult::Done(_)) => {}
                         Ok(IOResult::IO(io)) => {
                             // IO pending — return so the caller can yield and re-enter.

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -272,7 +272,7 @@ pub(crate) fn open_vacuum_temp_db(
     let conn = db.connect_with_encryption(encryption_key)?;
     conn.reset_page_size(page_size)?;
     conn.set_reserved_bytes(reserved_space)?;
-    conn.wal_auto_checkpoint_disable();
+    conn.wal_auto_actions_disable();
 
     Ok(VacuumTempDb {
         conn,
@@ -540,7 +540,7 @@ pub(crate) fn vacuum_target_build_step(
                 state.target_conn.set_sync_mode(crate::SyncMode::Off);
                 state.target_conn.set_foreign_keys_enabled(false);
                 state.target_conn.set_check_constraints_ignored(true);
-                state.target_conn.wal_auto_checkpoint_disable();
+                state.target_conn.wal_auto_actions_disable();
 
                 // Wrap all operations in a single write transaction so helper
                 // statements share one durable target build and cleanup can
@@ -2792,7 +2792,7 @@ mod tests {
         )?;
         let conn = db.connect()?;
         conn.set_sync_mode(crate::SyncMode::Off);
-        conn.wal_auto_checkpoint_disable();
+        conn.wal_auto_actions_disable();
 
         conn.execute("BEGIN IMMEDIATE")?;
         conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2974,7 +2974,10 @@ mod tests {
 
         assert!(Arc::ptr_eq(&temp._db.io, &source_db.io));
         assert_ne!(temp.path, source_db.path);
-        assert!(temp.conn.is_wal_auto_checkpoint_disabled());
+        assert_eq!(
+            temp.conn.wal_auto_actions(),
+            crate::storage::wal::WalAutoActions::empty()
+        );
         assert_eq!(temp.conn.get_page_size().get(), 4096);
         assert_eq!(temp.conn.get_reserved_bytes(), Some(0));
 

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -2818,7 +2818,7 @@ pub unsafe extern "C" fn libsql_wal_disable_checkpoint(db: *mut sqlite3) -> ffi:
     }
     let db: &mut sqlite3 = &mut *db;
     let db = db.inner.lock().unwrap();
-    db.conn.wal_auto_checkpoint_disable();
+    db.conn.wal_auto_actions_disable();
     SQLITE_OK
 }
 

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -1108,9 +1108,10 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
     /// Create read/write database connection and appropriately configure it before use
     pub async fn connect_rw<Ctx>(&self, coro: &Coro<Ctx>) -> Result<Arc<turso_core::Connection>> {
         let conn = self.main_tape.connect(coro).await?;
-        assert!(
-            conn.is_wal_auto_checkpoint_disabled(),
-            "tape must be configured to have autocheckpoint disabled"
+        assert_eq!(
+            conn.wal_auto_actions(),
+            turso_core::WalAutoActions::empty(),
+            "tape must be configured to have all auto-WAL actions disabled"
         );
         Ok(conn)
     }

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -438,7 +438,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         // DB wasn't synced with remote but will be encrypted on remote - so we must properly set reserved bytes field in advance
         if meta.synced_revision.is_none() && opts.reserved_bytes != 0 {
             let conn = main_db.connect()?;
-            conn.wal_auto_checkpoint_disable();
+            conn.wal_auto_actions_disable();
             conn.set_reserved_bytes(opts.reserved_bytes as u8)?;
 
             // write transaction forces allocation of root DB page
@@ -571,7 +571,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
         };
         let conn = db.connect()?;
-        conn.wal_auto_checkpoint_disable();
+        conn.wal_auto_actions_disable();
         Ok(conn)
     }
 

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -106,9 +106,10 @@ pub enum WalPushResult {
 
 pub fn connect_untracked(tape: &DatabaseTape) -> Result<Arc<turso_core::Connection>> {
     let conn = tape.connect_untracked()?;
-    assert!(
-        conn.is_wal_auto_checkpoint_disabled(),
-        "tape must be configured to have autocheckpoint disabled"
+    assert_eq!(
+        conn.wal_auto_actions(),
+        turso_core::WalAutoActions::empty(),
+        "tape must be configured to have all auto-WAL actions disabled"
     );
     Ok(conn)
 }

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -136,14 +136,14 @@ impl DatabaseTape {
     pub(crate) fn connect_untracked(&self) -> Result<Arc<turso_core::Connection>> {
         let connection = self.inner.connect()?;
         if self.disable_auto_checkpoint {
-            connection.wal_auto_checkpoint_disable();
+            connection.wal_auto_actions_disable();
         }
         Ok(connection)
     }
     pub async fn connect<Ctx>(&self, coro: &Coro<Ctx>) -> Result<Arc<turso_core::Connection>> {
         let connection = self.inner.connect()?;
         if self.disable_auto_checkpoint {
-            connection.wal_auto_checkpoint_disable();
+            connection.wal_auto_actions_disable();
         }
         tracing::debug!("set '{CDC_PRAGMA_NAME}' for new connection");
         let mut stmt = connection.prepare(&self.pragma_query)?;
@@ -194,7 +194,7 @@ impl DatabaseTape {
         tracing::debug!("opening changes iterator with options {:?}", opts);
         let conn = self.inner.connect()?;
         if self.disable_auto_checkpoint {
-            conn.wal_auto_checkpoint_disable();
+            conn.wal_auto_actions_disable();
         }
 
         let cdc_version = self

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -125,7 +125,7 @@ pub fn run_worker(
                         continue;
                     }
                 };
-                conn.wal_auto_checkpoint_disable();
+                conn.wal_auto_actions_disable();
                 send_response(&WorkerResponse::Ack)?;
             }
             WorkerCommand::PassiveCheckpoint {

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -302,11 +302,11 @@ fn test_wal_frame_api_no_schema_changes_fuzz(db: TempDatabase) {
         let conn1 = db1.connect_limbo();
         let db2 = builder.clone().build();
         let conn2 = db2.connect_limbo();
-        conn1.wal_auto_checkpoint_disable();
+        conn1.wal_auto_actions_disable();
         conn1
             .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
             .unwrap();
-        conn2.wal_auto_checkpoint_disable();
+        conn2.wal_auto_actions_disable();
         conn2
             .execute("CREATE TABLE t(x INTEGER PRIMARY KEY, y)")
             .unwrap();
@@ -875,7 +875,7 @@ fn test_db_share_same_file() {
     )
     .unwrap();
     let conn1 = db1.connect().unwrap();
-    conn1.wal_auto_checkpoint_disable();
+    conn1.wal_auto_actions_disable();
 
     conn1.execute("create table a(x, y)").unwrap();
     conn1
@@ -902,7 +902,7 @@ fn test_db_share_same_file() {
     )
     .unwrap();
     let conn2 = db2.connect().unwrap();
-    conn2.wal_auto_checkpoint_disable();
+    conn2.wal_auto_actions_disable();
 
     let mut stmt = conn2.prepare("select x, length(y) from a").unwrap();
     let mut rows: Vec<Vec<turso_core::types::Value>> = Vec::new();

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -292,8 +292,8 @@ fn test_vector_sparse_ivf_fuzz(tmp_db: TempDatabase) {
         );
         let simple_conn = simple_db.connect_limbo();
         let index_conn = index_db.connect_limbo();
-        simple_conn.wal_auto_checkpoint_disable();
-        index_conn.wal_auto_checkpoint_disable();
+        simple_conn.wal_auto_actions_disable();
+        index_conn.wal_auto_actions_disable();
         index_conn
             .execute(format!("CREATE INDEX t_idx ON t USING toy_vector_sparse_ivf (embedding) WITH (delta = {delta})"))
             .unwrap();


### PR DESCRIPTION
sync-engine rely a lot that tursodb will not perform any non-append manipulations with the WAL. It disable auto-checkpoints explicitly - but turso still was able to perform WAL header restart automatically, which lead to the panic:

```
2026-05-01T10:43:26.1598960Z     helpers_test.go:375: [db-router/stderr] thread 'tokio-rt-worker' (15363) panicked at /home/runner/.cargo/git/checkouts/turso-455557cd4a2364c7/7fef34f/core/storage/wal.rs:3344:9:
2026-05-01T10:43:26.1601704Z     helpers_test.go:375: [db-router/stderr] frame_count must be not less than frame_watermark | frame_count=0, frame_watermark=48
2026-05-01T10:43:26.1603309Z     helpers_test.go:375: [db-router/stderr] stack backtrace:
```

This PR disable auto-restarts too and refactor code in order to carry explicit flags enum instead of boolean flag.