### PR TITLE
core/storage: Fix savepoint rollback overflow spill

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -205,7 +205,7 @@ jobs:
         run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim yarn workspace @tursodatabase/database test
   test-db-wasm-binding:
     name: Test DB bindings on browser@${{ matrix.node }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs:
       - build
     strategy:
@@ -227,7 +227,7 @@ jobs:
       - name: Build wasm-common
         run: yarn workspace @tursodatabase/database-wasm-common build
       - name: Install playwright with deps
-        run: yarn workspace @tursodatabase/database-wasm playwright install --with-deps
+        run: yarn workspace @tursodatabase/database-wasm playwright install --with-deps chromium firefox
       - name: Download all DB artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -295,7 +295,7 @@ jobs:
         run: yarn workspace @tursodatabase/sync test
   test-sync-wasm-binding:
     name: Test sync bindings on browser@${{ matrix.node }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs:
       - build
     strategy:
@@ -331,7 +331,7 @@ jobs:
       - name: Build sync common
         run: yarn workspace @tursodatabase/sync-common build
       - name: Install playwright with deps
-        run: yarn workspace @tursodatabase/sync-wasm playwright install --with-deps
+        run: yarn workspace @tursodatabase/sync-wasm playwright install --with-deps chromium
       - name: Download all DB artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -139,11 +139,12 @@ jobs:
         run: uvx ruff check
 
   linux:
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: ${{ env.working-directory }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64
@@ -156,6 +157,19 @@ jobs:
       - uses: useblacksmith/setup-python@v6
         with:
           python-version: '3.10'
+      - name: Pre-pull manylinux image
+        shell: bash
+        run: |
+          image="quay.io/pypa/manylinux2014_${{ matrix.target }}:latest"
+          for attempt in 1 2 3; do
+            if docker pull "$image"; then
+              exit 0
+            fi
+            if [ "$attempt" = "3" ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -191,6 +191,8 @@ pub struct InsertOpts {
     pub max_rows: NonZeroU32,
     #[garde(range(min = 0.0, max = 1.0))]
     pub upsert_prob: f64,
+    #[garde(skip)]
+    pub padding_size: Option<usize>,
 }
 
 impl Default for InsertOpts {
@@ -199,6 +201,7 @@ impl Default for InsertOpts {
             min_rows: NonZero::new(1).unwrap(),
             max_rows: NonZero::new(10).unwrap(),
             upsert_prob: 0.15,
+            padding_size: None,
         }
     }
 }

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -369,7 +369,13 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
                             base_offset + (col_idx as i64 * UNIQUE_COL_STRIDE) + row_idx as i64;
                         SimValue::unique_for_type(&c.column_type, offset)
                     } else {
-                        SimValue::arbitrary_from(rng, env, &c.column_type)
+                        padded_insert_value(
+                            insert_opts.padding_size,
+                            row_idx,
+                            col_idx,
+                            &c.column_type,
+                        )
+                        .unwrap_or_else(|| SimValue::arbitrary_from(rng, env, &c.column_type))
                     }
                 })
                 .collect()
@@ -381,6 +387,26 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
         values,
         on_conflict: None,
     })
+}
+
+fn padded_insert_value(
+    padding_size: Option<usize>,
+    row_idx: u32,
+    col_idx: usize,
+    column_type: &ColumnType,
+) -> Option<SimValue> {
+    let size = padding_size?;
+    let mut bytes = Vec::with_capacity(size);
+    let prefix = format!("p{row_idx}_{col_idx}:");
+    bytes.extend_from_slice(prefix.as_bytes());
+    bytes.resize(size, b'X');
+    match column_type {
+        ColumnType::Text => Some(SimValue(turso_core::Value::build_text(
+            String::from_utf8(bytes).unwrap(),
+        ))),
+        ColumnType::Blob => Some(SimValue(turso_core::Value::Blob(bytes))),
+        ColumnType::Integer | ColumnType::Float => None,
+    }
 }
 
 fn gen_insert_upsert_values<R: Rng + ?Sized, C: GenerationContext>(

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -35,8 +35,10 @@ pub struct Profile {
     pub io: IOProfile,
     #[garde(dive)]
     pub query: QueryProfile,
-    #[garde(range(min = 200, max = 2000))]
+    #[garde(range(min = 1, max = 2000))]
     pub cache_size_pages: Option<usize>,
+    #[garde(skip)]
+    pub page_size: Option<usize>,
 }
 
 impl Default for Profile {
@@ -47,6 +49,7 @@ impl Default for Profile {
             io: Default::default(),
             query: Default::default(),
             cache_size_pages: Some(2000),
+            page_size: None,
         }
     }
 }
@@ -186,6 +189,67 @@ impl Profile {
         profile
     }
 
+    /// Profile that biases savepoint rollback toward overflow pages and very
+    /// small cache sizes. This targets page restoration bugs involving large
+    /// table/index payloads.
+    pub fn savepoint_overflow_stress() -> Self {
+        let profile = Profile {
+            io: IOProfile {
+                fault: FaultProfile {
+                    enable: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            cache_size_pages: Some(8),
+            page_size: Some(512),
+            query: QueryProfile {
+                gen_opts: Opts {
+                    table: TableOpts {
+                        rowid_alias_prob: 0.75,
+                        column_range: 3..7,
+                        large_table: LargeTableOpts {
+                            large_table_prob: 0.0,
+                            ..Default::default()
+                        },
+                    },
+                    query: QueryOpts {
+                        select: SelectOpts {
+                            free_expr_size: 1,
+                            ..Default::default()
+                        },
+                        insert: InsertOpts {
+                            min_rows: NonZeroU32::new(12).unwrap(),
+                            max_rows: NonZeroU32::new(16).unwrap(),
+                            padding_size: Some(10_000),
+                            ..Default::default()
+                        },
+                        update: UpdateOpts {
+                            padding_size: Some(14_000),
+                            force_late_failure: true,
+                        },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                select_weight: 0,
+                insert_weight: 40,
+                update_weight: 35,
+                delete_weight: 10,
+                create_index_weight: 15,
+                create_table_weight: 6,
+                drop_table_weight: 0,
+                alter_table_weight: 0,
+                drop_index: 0,
+                pragma_weight: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        profile.validate().unwrap();
+        profile
+    }
+
     pub fn faultless() -> Self {
         let profile = Profile {
             io: IOProfile {
@@ -221,6 +285,7 @@ impl Profile {
             mvcc: true,
             max_connections: 2,
             cache_size_pages: Some(2000),
+            page_size: None,
         };
         profile.validate().unwrap();
         profile
@@ -235,6 +300,7 @@ impl Profile {
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
             ProfileType::SavepointStress => Self::savepoint_stress(),
+            ProfileType::SavepointOverflowStress => Self::savepoint_overflow_stress(),
             ProfileType::Custom(path) => {
                 Self::parse(path).with_context(|| "failed to parse JSON profile")?
             }
@@ -277,6 +343,7 @@ pub enum ProfileType {
     SimpleMvcc,
     WriteStress,
     SavepointStress,
+    SavepointOverflowStress,
     #[strum(disabled)]
     Custom(PathBuf),
 }

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1107,7 +1107,7 @@ impl SimulatorEnv {
             disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
-            page_size: 4096, // TODO: randomize this too
+            page_size: profile.page_size.unwrap_or(4096),
             max_interactions: rng.random_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_time_simulation: cli_opts.maximum_time,
             disable_reopen_database: cli_opts.disable_reopen_database,
@@ -1271,6 +1271,10 @@ impl SimulatorEnv {
                     .expect("db to be Some")
                     .connect()
                     .expect("Failed to connect to Limbo database");
+                if self.opts.page_size != 4096 {
+                    conn.execute(format!("PRAGMA page_size = {}", self.opts.page_size))
+                        .expect("set pragma page_size");
+                }
                 if self.opts.cache_size != DEFAULT_CACHE_SIZE {
                     conn.execute(format!("PRAGMA cache_size = {}", self.opts.cache_size))
                         .expect("set pragma cache_size");
@@ -1278,10 +1282,17 @@ impl SimulatorEnv {
                 self.connections[connection_index] = SimConnection::LimboConnection(conn);
             }
             SimulationType::Differential => {
-                self.connections[connection_index] = SimConnection::SQLiteConnection(
-                    rusqlite::Connection::open(self.get_db_path())
-                        .expect("Failed to open SQLite connection"),
-                );
+                let conn = rusqlite::Connection::open(self.get_db_path())
+                    .expect("Failed to open SQLite connection");
+                if self.opts.page_size != 4096 {
+                    conn.execute(&format!("PRAGMA page_size = {}", self.opts.page_size), [])
+                        .expect("set sqlite pragma page_size");
+                }
+                if self.opts.cache_size != DEFAULT_CACHE_SIZE {
+                    conn.execute(&format!("PRAGMA cache_size = {}", self.opts.cache_size), [])
+                        .expect("set sqlite pragma cache_size");
+                }
+                self.connections[connection_index] = SimConnection::SQLiteConnection(conn);
             }
         };
 

--- a/testing/simulator/runner/memory/statement_abandon.rs
+++ b/testing/simulator/runner/memory/statement_abandon.rs
@@ -22,8 +22,12 @@ fn make_two_conns(seed: u64) -> Result<(Arc<Connection>, Arc<Connection>, Arc<Me
 }
 
 fn make_io(seed: u64) -> Arc<MemorySimIO> {
+    make_io_with_page_size(seed, 4096)
+}
+
+fn make_io_with_page_size(seed: u64, page_size: usize) -> Arc<MemorySimIO> {
     Arc::new(MemorySimIO::new(
-        seed, 4096, 100, // Always schedule operations asynchronously.
+        seed, page_size, 100, // Always schedule operations asynchronously.
         1, 5,
     ))
 }
@@ -54,16 +58,36 @@ fn open_two_conns(io: Arc<MemorySimIO>, path: &str) -> Result<(Arc<Connection>, 
 }
 
 fn query_count(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<i64> {
-    let mut stmt = conn.prepare("SELECT COUNT(*) FROM t")?;
+    query_one_i64(conn, io, "SELECT COUNT(*) FROM t")
+}
+
+fn query_one_i64(conn: &Arc<Connection>, io: &MemorySimIO, sql: &str) -> Result<i64> {
+    let mut stmt = conn.prepare(sql)?;
     loop {
         match stmt.step()? {
             StepResult::IO => io.step()?,
             StepResult::Row => {
-                let row = stmt.row().expect("row should exist for count query");
-                let count = row.get::<i64>(0).expect("count column should exist");
-                return Ok(count);
+                let row = stmt.row().expect("row should exist for scalar query");
+                let value = row.get::<i64>(0).expect("i64 column should exist");
+                return Ok(value);
             }
-            StepResult::Done => panic!("count query ended without a row"),
+            StepResult::Done => panic!("scalar query ended without a row"),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+fn query_one_string(conn: &Arc<Connection>, io: &MemorySimIO, sql: &str) -> Result<String> {
+    let mut stmt = conn.prepare(sql)?;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist for scalar query");
+                let value = row.get::<String>(0).expect("text column should exist");
+                return Ok(value);
+            }
+            StepResult::Done => panic!("scalar query ended without a row"),
             other => panic!("unexpected step result: {other:?}"),
         }
     }
@@ -86,6 +110,148 @@ fn query_rows(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<Vec<(i64, Stri
             other => panic!("unexpected step result: {other:?}"),
         }
     }
+}
+
+#[test]
+fn sim_statement_rollback_restores_overflow_pages_when_cache_spills() -> Result<()> {
+    let io = make_io_with_page_size(9, 512);
+    let conn = open_conn(io.clone(), "sim_stmt_overflow_rollback_spill.db")?;
+
+    conn.execute("PRAGMA page_size=512")?;
+    conn.execute("PRAGMA cache_size=200")?;
+    conn.execute(
+        "CREATE TABLE t(
+            id INTEGER PRIMARY KEY,
+            v TEXT,
+            unique_text TEXT UNIQUE,
+            r REAL,
+            unique_int INTEGER UNIQUE
+        )",
+    )?;
+
+    let values = (0..8)
+        .map(|i| {
+            let id = if i == 0 {
+                "NULL".to_string()
+            } else {
+                (1000 + i).to_string()
+            };
+            let prefix = format!("p{i}:");
+            let payload = format!("{prefix}{}", "X".repeat(12_000 - prefix.len()));
+            format!("({id}, '{payload}', 'u{i}', 0, {})", 2000 + i)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    conn.execute(format!("INSERT INTO t VALUES {values}"))?;
+    conn.execute("SAVEPOINT sp")?;
+    conn.execute("INSERT INTO t VALUES (999999, 'small', 'ufail', 0, 999999)")?;
+
+    let update_payload = "Y".repeat(16_000);
+    let failed_update = conn.execute(format!(
+        "UPDATE t
+            SET v = '{update_payload}',
+                id = CASE WHEN id = 999999 THEN 1 ELSE id END
+          WHERE TRUE"
+    ));
+    assert!(
+        failed_update.is_err(),
+        "update should fail with a duplicate rowid"
+    );
+
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT COUNT(*) FROM t")?,
+        9
+    );
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT sum(length(v)) FROM t")?,
+        8 * 12_000 + 5
+    );
+    assert_eq!(
+        query_one_string(&conn, io.as_ref(), "PRAGMA integrity_check")?,
+        "ok"
+    );
+
+    conn.execute("ROLLBACK TO sp")?;
+    conn.execute("RELEASE sp")?;
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT COUNT(*) FROM t")?,
+        8
+    );
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT sum(length(v)) FROM t")?,
+        8 * 12_000
+    );
+    Ok(())
+}
+
+#[test]
+fn sim_statement_rollback_spill_does_not_pollute_parent_savepoint() -> Result<()> {
+    let io = make_io_with_page_size(10, 512);
+    let conn = open_conn(io.clone(), "sim_stmt_nested_rollback_spill.db")?;
+
+    conn.execute("PRAGMA page_size=512")?;
+    conn.execute("PRAGMA journal_mode=WAL")?;
+    conn.execute("PRAGMA cache_size=8")?;
+    conn.execute(
+        "CREATE TABLE t(
+            id INTEGER PRIMARY KEY,
+            v TEXT,
+            unique_text TEXT UNIQUE,
+            unique_int INTEGER UNIQUE
+        )",
+    )?;
+
+    let values = (1..=30)
+        .map(|i| {
+            let payload = "X".repeat(12_000);
+            format!("({i}, '{payload}', 'u{i}', {i})")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    conn.execute(format!("INSERT INTO t VALUES {values}"))?;
+
+    conn.execute("SAVEPOINT outer")?;
+    let update_payload = "Y".repeat(16_000);
+    let failed_update = conn.execute(format!(
+        "UPDATE t
+            SET v = '{update_payload}',
+                id = CASE WHEN id = 30 THEN 1 ELSE id END
+          WHERE TRUE"
+    ));
+    assert!(
+        failed_update.is_err(),
+        "update should fail with a duplicate rowid"
+    );
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT sum(length(v)) FROM t")?,
+        30 * 12_000
+    );
+    assert_eq!(
+        query_one_string(&conn, io.as_ref(), "PRAGMA integrity_check")?,
+        "ok"
+    );
+
+    conn.execute("UPDATE t SET v = 'changed' WHERE id = 1")?;
+    conn.execute("ROLLBACK TO outer")?;
+    conn.execute("RELEASE outer")?;
+
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT count(*) FROM t")?,
+        30
+    );
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT sum(length(v)) FROM t")?,
+        30 * 12_000
+    );
+    assert_eq!(
+        query_one_i64(&conn, io.as_ref(), "SELECT length(v) FROM t WHERE id = 1")?,
+        12_000
+    );
+    assert_eq!(
+        query_one_string(&conn, io.as_ref(), "PRAGMA integrity_check")?,
+        "ok"
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
This fixes a savepoint rollback issue I found while stress testing large overflow payloads.

When a multi-row UPDATE inside a SAVEPOINT writes large TEXT values and then fails late on a UNIQUE constraint, statement rollback has to restore many before-images from the subjournal. If the page cache fills during that restore, Turso could spill pages before the rollback was fully restored, leaving an inconsistent overflow chain.

The fix makes rollback read the subjournal before-images first, roll back the WAL state, discard pages allocated after the savepoint, restore resident cached pages first, and only then allow missing restored pages to be inserted/spilled safely.

I also added a simulator regression test and a savepoint_overflow_stress profile to keep covering this case.

Tested locally:
- cargo fmt --check
- cargo test -p limbo_sim -- --nocapture
- target/debug/limbo_sim --profile savepoint_overflow_stress --seed 1 -n 40 -k 20 -t 10 --disable-bugbase --differential --io-backend memory --keep-files
