### PR TITLE
core/vdbe: propagate yield-completions across nested-statement IO yields

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -325,6 +325,9 @@ jobs:
           - name: in-process
             iterations: 100
             args: "--mode fast --reopen-probability 0.001"
+          - name: in-process-mvcc
+            iterations: 100
+            args: "--mode fast --reopen-probability 0.01 --enable-mvcc"
           - name: multiprocess
             iterations: 20
             args: "--mode fast --multiprocess --connections-per-process 4 --processes 4"

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11074,7 +11074,7 @@ fn op_parse_schema_step(
                 let io = inner
                     .stmt
                     .take_io_completions()
-                    .expect("IO returned but no completions");
+                    .unwrap_or_else(|| IOCompletions::Single(Completion::new_yield()));
                 return Ok(InsnFunctionStepResult::IO(io));
             }
             StepResult::Row => {
@@ -11333,7 +11333,7 @@ fn drive_init_cdc_version(
                 let io = inner
                     .stmt
                     .take_io_completions()
-                    .expect("IO returned but no completions");
+                    .unwrap_or_else(|| IOCompletions::Single(Completion::new_yield()));
                 return Ok(InsnFunctionStepResult::IO(io));
             }
             StepResult::Row => match &inner.phase {


### PR DESCRIPTION
This PR fixes a Whopper/MVCC panic:

```
SEED=42 cargo run -p turso_whopper -- --enable-mvcc --max-steps 2000

...

thread 'main' panicked at core/vdbe/execute.rs:11077:22:
IO returned but no completions
```

We never caught it, because Whopper wasn't running in MVCC mode in CI, so I added a CI configuration.

Closes #6644
