### PR TITLE
core/vdbe: Fix AVG() function precision for large integers

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5780,35 +5780,30 @@ fn update_agg_payload(
                     "Avg: payload[2] is not an integer".to_string(),
                 ));
             };
-            let val = match arg {
-                Value::Numeric(Numeric::Integer(i)) => i as f64,
-                Value::Numeric(Numeric::Float(f)) => f64::from(f),
+            let mut sum_state = SumAggState {
+                r_err,
+                ..Default::default()
+            };
+            match arg {
+                Value::Numeric(Numeric::Integer(i)) => {
+                    apply_kbn_step_int(sum_val, i, &mut sum_state);
+                }
+                Value::Numeric(Numeric::Float(f)) => {
+                    apply_kbn_step(sum_val, f64::from(f), &mut sum_state);
+                }
                 Value::Text(t) => match try_for_float(t.as_str().as_bytes()).1 {
-                    ParsedNumber::Integer(i) => i as f64,
-                    ParsedNumber::Float(f) => f,
-                    ParsedNumber::None => 0.0,
+                    ParsedNumber::Integer(i) => apply_kbn_step_int(sum_val, i, &mut sum_state),
+                    ParsedNumber::Float(f) => apply_kbn_step(sum_val, f, &mut sum_state),
+                    ParsedNumber::None => apply_kbn_step(sum_val, 0.0, &mut sum_state),
                 },
                 Value::Blob(b) => match try_for_float(&b).1 {
-                    ParsedNumber::Integer(i) => i as f64,
-                    ParsedNumber::Float(f) => f,
-                    ParsedNumber::None => 0.0,
+                    ParsedNumber::Integer(i) => apply_kbn_step_int(sum_val, i, &mut sum_state),
+                    ParsedNumber::Float(f) => apply_kbn_step(sum_val, f, &mut sum_state),
+                    ParsedNumber::None => apply_kbn_step(sum_val, 0.0, &mut sum_state),
                 },
                 _ => unreachable!(),
-            };
-            // Use Kahan-Babuška-Neumaier compensation for better floating-point precision
-            let s = sum_val.to_float_or_zero();
-            let t = s + val;
-            // When t is infinite, the KBN correction computes inf - inf = NaN,
-            // which is meaningless. Skip compensation in that case.
-            if t.is_finite() {
-                let correction = if s.abs() > val.abs() {
-                    (s - t) + val
-                } else {
-                    (val - t) + s
-                };
-                *r_err_val = Value::from_f64(r_err + correction);
             }
-            *sum_val = Value::from_f64(t);
+            *r_err_val = Value::from_f64(sum_state.r_err);
             *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
         }
         AggFunc::Sum | AggFunc::Total => {
@@ -15814,6 +15809,37 @@ mod tests {
         ];
         let result = finalize_agg_payload(&AggFunc::Avg, &payload).unwrap();
         assert_eq!(result, Value::Null);
+    }
+
+    #[test]
+    fn test_finalize_avg_large_integers() {
+        let mut payload = vec![
+            Value::from_f64(0.0),
+            Value::from_f64(0.0),
+            Value::from_i64(0),
+        ];
+
+        update_agg_payload(
+            &AggFunc::Avg,
+            Value::from_i64(9007199254740994),
+            None,
+            &mut payload,
+            CollationSeq::Binary,
+            &None,
+        )
+        .unwrap();
+        update_agg_payload(
+            &AggFunc::Avg,
+            Value::from_i64(-9007199254740993),
+            None,
+            &mut payload,
+            CollationSeq::Binary,
+            &None,
+        )
+        .unwrap();
+
+        let result = finalize_agg_payload(&AggFunc::Avg, &payload).unwrap();
+        assert_eq!(result, Value::from_f64(0.5));
     }
 
     #[test]

--- a/testing/sqltests/tests/agg-functions/avg-large-integers.sqltest
+++ b/testing/sqltests/tests/agg-functions/avg-large-integers.sqltest
@@ -66,6 +66,9 @@ test avg_large_integer_mixed_with_real {
 expect {
     1.0
 }
+expect @js {
+    1
+}
 
 @cross-check-integrity
 test avg_large_integers_grouped {
@@ -80,6 +83,10 @@ test avg_large_integers_grouped {
 expect {
     1|0.5
     2|15.0
+}
+expect @js {
+    1|0.5
+    2|15
 }
 
 @cross-check-integrity

--- a/testing/sqltests/tests/agg-functions/avg-large-integers.sqltest
+++ b/testing/sqltests/tests/agg-functions/avg-large-integers.sqltest
@@ -1,0 +1,96 @@
+@database :memory:
+
+@cross-check-integrity
+test avg_large_integers_rounds_like_sqlite {
+    SELECT avg(x)
+    FROM (
+      SELECT 9007199254740994 AS x
+      UNION ALL
+      SELECT -9007199254740993
+    );
+}
+expect {
+    0.5
+}
+
+@cross-check-integrity
+test avg_large_integers_ignore_nulls {
+    SELECT avg(x)
+    FROM (
+      SELECT 9007199254740994 AS x
+      UNION ALL
+      SELECT NULL
+      UNION ALL
+      SELECT -9007199254740993
+    );
+}
+expect {
+    0.5
+}
+
+@cross-check-integrity
+test avg_i64_edge_pair_positive {
+    SELECT avg(x)
+    FROM (
+      SELECT 9223372036854775807 AS x
+      UNION ALL
+      SELECT -9223372036854775806
+    );
+}
+expect {
+    0.5
+}
+
+@cross-check-integrity
+test avg_i64_edge_pair_negative {
+    SELECT avg(x)
+    FROM (
+      SELECT -9223372036854775808 AS x
+      UNION ALL
+      SELECT 9223372036854775807
+    );
+}
+expect {
+    -0.5
+}
+
+@cross-check-integrity
+test avg_large_integer_mixed_with_real {
+    SELECT avg(x)
+    FROM (
+      SELECT 9007199254740994 AS x
+      UNION ALL
+      SELECT -9007199254740993.0
+    );
+}
+expect {
+    1.0
+}
+
+@cross-check-integrity
+test avg_large_integers_grouped {
+    WITH t(g, x) AS (
+      SELECT 1, 9007199254740994 UNION ALL
+      SELECT 1, -9007199254740993 UNION ALL
+      SELECT 2, 10 UNION ALL
+      SELECT 2, 20
+    )
+    SELECT g, avg(x) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    1|0.5
+    2|15.0
+}
+
+@cross-check-integrity
+test avg_infinite_cancellation_returns_null {
+    SELECT typeof(avg(x)), avg(x)
+    FROM (
+      SELECT '1e999' AS x
+      UNION ALL
+      SELECT '-1e999'
+    );
+}
+expect {
+    null|
+}


### PR DESCRIPTION
Fixes #6452.

Fix `AVG()` precision for large integer inputs by routing integer values through the existing KBN accumulation path instead of converting them directly to `f64`.

In `core/vdbe/execute.rs`, `AVG` now uses `apply_kbn_step_int()` for integer inputs and `apply_kbn_step()` for floating-point inputs, rather than doing an inline KBN update on a pre-converted `f64`. This preserves low-bit precision for integers above the exact `f64` range and fixes cases such as:

I also added a set of edge-case SQLite compatibility tests in the .sqltest suite covering:

 - the original repro
 - NULL handling
 - near-i64 boundary pairs
 - mixed integer/real inputs
 - grouped aggregation
 - Inf + (-Inf) cancellation to NULL
 
 Note: I also found a separate SQLite mismatch for text values with numeric prefixes:

  ```sql
  SELECT avg(x)
  FROM (
    SELECT '9007199254740994abc' AS x
    UNION ALL
    SELECT '-9007199254740993abc'
  );
```

SQLite returns 1.0, while Turso currently returns 0.5. Should this be fixed in another issue? or another commit in this PR?

## Description of AI Usage

AI was used to inspect the AVG and SUM code paths, summarize git history around the aggregate refactor, and help draft the regression fix, and I'v reviewed the resulting change myself and verified the fix locally before opening the PR.