### PR TITLE
core/vdbe: bounds-check index column lookup for table-ordinal indices

### DIFF
--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1865,7 +1865,20 @@ impl ProgramBuilder {
         let default = 'value: {
             let default = match cursor_type {
                 CursorType::BTreeTable(btree) => &btree.columns()[column].default,
-                CursorType::BTreeIndex(index) => &index.columns[column].default,
+                CursorType::BTreeIndex(index) => {
+                    // `column` is a *table* ordinal; an index only stores a
+                    // subset of the table's columns, so the same ordinal may
+                    // exceed `index.columns.len()`. This happens when emitting
+                    // the OLD image of a DELETE that iterates via an index
+                    // covering a virtual generated column whose expression
+                    // depends on a non-indexed column (#6612). The non-indexed
+                    // dependency has no entry in the index, so it carries no
+                    // default from this cursor — fall through.
+                    let Some(col) = index.columns.get(column) else {
+                        break 'value None;
+                    };
+                    &col.default
+                }
                 CursorType::MaterializedView(btree, _) => &btree.columns()[column].default,
                 _ => break 'value None,
             };

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -584,8 +584,12 @@ pub fn insn_to_row(
                         name
                     }
                     CursorType::BTreeIndex(index) => {
-                        let name = &index.columns.get(*column).expect("column index out of bounds").name;
-                        Some(name)
+                        // `column` is a table ordinal; not every table column is in
+                        // the index. When EXPLAINing a DELETE that emits the OLD
+                        // image of a virtual generated column from an index cursor
+                        // (#6612), the dependency's table ordinal can exceed
+                        // `index.columns.len()`. Tolerate that and skip the name.
+                        index.columns.get(*column).map(|c| &c.name)
                     }
                     CursorType::MaterializedView(table, _) => {
                         let name = table.columns().get(*column).and_then(|v| v.name.as_ref());


### PR DESCRIPTION
Fixes #6612.

Two adjacent panics share a root cause: `emit_column` and `explain.rs` index into `index.columns[column]`, but `column` is a *table* ordinal. An index only stores a subset of the table's columns, so when `DELETE` (or `EXPLAIN DELETE`) emits the OLD image of a virtual generated column whose expression depends on a non-indexed column, the dependency's table ordinal can exceed `index.columns.len()` and the slice access panics.

Reproduces exactly as the issue describes:

```sql
CREATE TABLE t (c0 TEXT, c1 INTEGER AS (c2 + 1), c2 INTEGER);
CREATE INDEX i ON t (c1, c0);
DELETE FROM t WHERE c0 < 'X';  -- index out of bounds: the len is 2 but the index is 2
EXPLAIN DELETE FROM t WHERE c0 < 'X';  -- column index out of bounds at explain.rs:587
```

Switch both sites to `index.columns.get(column)` and fall through to `None` when the table ordinal isn't in the index. Verified against the issue's reproducer (compiles cleanly, deletes match the rows the WHERE selects, EXPLAIN prints the bytecode without panicking).