### PR TITLE
core/translate: fix missing affinity for IN with compound subquery

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -311,6 +311,10 @@ fn emit_compound_select(
             }
             CompoundOperator::Union => {
                 let mut new_dedupe_index = false;
+                let affinity_str = match &right_most.query_destination {
+                    QueryDestination::EphemeralIndex { affinity_str, .. } => affinity_str.clone(),
+                    _ => None,
+                };
                 let dedupe_index = match &right_most.query_destination {
                     QueryDestination::EphemeralIndex {
                         cursor_id, index, ..
@@ -323,7 +327,7 @@ fn emit_compound_select(
                 plan.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: dedupe_index.0,
                     index: dedupe_index.1.clone(),
-                    affinity_str: None,
+                    affinity_str: affinity_str.clone(),
                     is_delete: false,
                 };
                 let compound_select = Plan::CompoundSelect {
@@ -346,7 +350,7 @@ fn emit_compound_select(
                 right_most.query_destination = QueryDestination::EphemeralIndex {
                     cursor_id: dedupe_index.0,
                     index: dedupe_index.1.clone(),
-                    affinity_str: None,
+                    affinity_str,
                     is_delete: false,
                 };
 

--- a/testing/sqltests/tests/affinity.sqltest
+++ b/testing/sqltests/tests/affinity.sqltest
@@ -221,6 +221,17 @@ expect {
 }
 
 @cross-check-integrity
+test affinity-in-subquery-union-text-rhs {
+    CREATE TABLE t (a INTEGER);
+    INSERT INTO t VALUES (1), (2), (3);
+    SELECT a FROM t WHERE a IN (SELECT '1' UNION SELECT '2') ORDER BY a;
+}
+expect {
+    1
+    2
+}
+
+@cross-check-integrity
 test affinity-scalar-subquery-text-comparison {
     CREATE TABLE t_text (a TEXT);
     CREATE TABLE t_real (b REAL);


### PR DESCRIPTION
Fixes #6409.

## Description

Preserve `IN (subquery)` affinity metadata across `UNION` materialization.

The `UNION` path was rebuilding the ephemeral index destination with `affinity_str: None`, which dropped the affinity metadata computed for `IN (SELECT ...)`.

This change keeps that affinity metadata when materializing compound RHS subqueries, and adds a regression test for:

```sql
CREATE TABLE t(a INTEGER);
INSERT INTO t VALUES(1),(2),(3);
SELECT * FROM t WHERE a IN (SELECT '1' UNION SELECT '2');
```

<img width="807" height="227" alt="image" src="https://github.com/user-attachments/assets/be5553e0-f2a6-4eb1-aca8-bc2b82fac333" />

## Description of AI Usage

Used AI to compare the generated EXPLAIN output between turso and sqlite, locate the IN (subquery) and compound UNION code paths, and identify where affinity_str was being dropped.