### PR TITLE
testing: Add recovery-heavy MVCC profile in Whopper

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -328,6 +328,9 @@ jobs:
           - name: in-process-mvcc
             iterations: 100
             args: "--mode fast --reopen-probability 0.01 --enable-mvcc"
+          - name: recovery-heavy-mvcc
+            iterations: 100
+            args: "--mode recovery-heavy --enable-mvcc"
           - name: multiprocess
             iterations: 20
             args: "--mode fast --multiprocess --connections-per-process 4 --processes 4"

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1351,29 +1351,54 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
         };
 
+        // Returns Some(row_version) if our tx contributed to it and if we must therefore log it.
+        let our_committed_image = |row_version: &RowVersion| -> Option<RowVersion> {
+            let our_begin = matches!(
+                row_version.begin,
+                Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+            );
+            let our_end = matches!(
+                row_version.end,
+                Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+            );
+            if !our_begin && !our_end {
+                // row_version belongs to another tx
+                return None;
+            }
+            let mut committed = row_version.clone();
+            if our_begin {
+                // New version is valid STARTING FROM the committing
+                // transaction's end timestamp. See Hekaton page 299.
+                committed.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+
+                if !our_end {
+                    // A version row_version we inserted may have row_version.end == tx_b.tx_id,
+                    // where tx_b is a concurrent tx. This is because when a tx transitions to
+                    // Preparing, its row_version becomes *speculatively updatable*, and a tx tx_b
+                    // is allowed to change row_version.end from None to tx_b.tx_id to delete it
+                    // (see the Hekaton paper, §3.1, heading "check updatability").
+                    //
+                    // That deletion is tx_b's contribution, and tx_b will log it on its own commit.
+                    // Our log record must capture our own contribution, but if the `end` field is
+                    // set, it will be serialized as a OP_DELETE_* in the logical log, so we unset
+                    // it so that it will be serialized as an OP_UPSERT_*. tx_b will take care of
+                    // logging the deletion.
+                    committed.end = None;
+                }
+            }
+            if our_end {
+                // Old version is valid UNTIL the committing
+                // transaction's end timestamp. See Hekaton page 299.
+                committed.end = Some(TxTimestampOrID::Timestamp(end_ts));
+            }
+            Some(committed)
+        };
+
         let collect_versions = |id: &RowID, log_record: &mut LogRecord| {
             if let Some(row_versions) = mvcc_store.rows.get(id) {
                 let row_versions = row_versions.value().read();
                 for row_version in row_versions.iter() {
-                    let mut committed_version = row_version.clone();
-                    let mut changed = false;
-                    if let Some(TxTimestampOrID::TxID(vid)) = committed_version.begin {
-                        if vid == self.tx_id {
-                            // New version is valid STARTING FROM the committing
-                            // transaction's end timestamp. See Hekaton page 299.
-                            committed_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
-                            changed = true;
-                        }
-                    }
-                    if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
-                        if vid == self.tx_id {
-                            // Old version is valid UNTIL the committing
-                            // transaction's end timestamp. See Hekaton page 299.
-                            committed_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
-                            changed = true;
-                        }
-                    }
-                    if changed {
+                    if let Some(mut committed_version) = our_committed_image(row_version) {
                         canonicalize_table_id(&mut committed_version);
                         mvcc_store
                             .insert_version_raw(&mut log_record.row_versions, committed_version);
@@ -1389,25 +1414,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 if let Some(row_versions) = index.get(index_key) {
                     let row_versions = row_versions.value().read();
                     for row_version in row_versions.iter() {
-                        let mut committed_version = row_version.clone();
-                        let mut changed = false;
-                        if let Some(TxTimestampOrID::TxID(vid)) = committed_version.begin {
-                            if vid == self.tx_id {
-                                // New version is valid STARTING FROM the committing
-                                // transaction's end timestamp. See Hekaton page 299.
-                                committed_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
-                                changed = true;
-                            }
-                        }
-                        if let Some(TxTimestampOrID::TxID(vid)) = committed_version.end {
-                            if vid == self.tx_id {
-                                // Old version is valid UNTIL the committing
-                                // transaction's end timestamp. See Hekaton page 299.
-                                committed_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
-                                changed = true;
-                            }
-                        }
-                        if changed {
+                        if let Some(mut committed_version) = our_committed_image(row_version) {
                             canonicalize_table_id(&mut committed_version);
                             mvcc_store.insert_version_raw(
                                 &mut log_record.row_versions,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1136,6 +1136,88 @@ fn test_restart_preserves_autoindex_to_column_mapping() {
     assert_eq!(b_rows[0][0].to_string(), "bb");
 }
 
+/// What this test checks: when transaction A updates a row and a concurrent
+/// transaction B (later begin_ts) speculatively tombstones that row while A
+/// is in `Preparing`, A's commit must serialize its OWN writes — not the
+/// DELETEs that B's tombstone TxID, still pinned to the versions' `end`
+/// fields, would imply.
+///
+/// References: Hekaton paper (https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf)
+/// §2.5 Table 1 (speculative read of preparing writer), §2.7 (commit deps).
+#[test]
+fn test_concurrent_update_then_delete_serializes_correctly_across_restart() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+            .unwrap();
+        conn.execute("INSERT INTO t(id, v) VALUES (1, 'initial')")
+            .unwrap();
+        conn.close().unwrap();
+    }
+
+    {
+        let conn_a = db.connect();
+        let conn_b = db.connect();
+
+        conn_a.execute("BEGIN CONCURRENT").unwrap();
+        conn_a
+            .execute("UPDATE t SET v = 'a_value' WHERE id = 1")
+            .unwrap();
+
+        conn_a.set_yield_injector(Some(FixedYieldInjector::new([
+            CommitYieldPoint::CommitValidation.point(),
+        ])));
+
+        let mut commit_stmt = conn_a.prepare("COMMIT").unwrap();
+        let mut yielded = false;
+        for _ in 0..100 {
+            match commit_stmt.step().unwrap() {
+                StepResult::IO => {
+                    yielded = true;
+                    break;
+                }
+                StepResult::Done => break,
+                _ => {}
+            }
+        }
+        assert!(
+            yielded,
+            "tx_a's COMMIT should yield at CommitYieldPoint::CommitValidation"
+        );
+
+        // tx_b begins *after* tx_a's prepare so tx_b.begin_ts > tx_a's
+        // prepared end_ts; its DELETE plants a speculative tombstone whose
+        // TxID(tx_b) lands in the `end` field of tx_a's new versions.
+        conn_b.execute("BEGIN CONCURRENT").unwrap();
+        conn_b.execute("DELETE FROM t WHERE id = 1").unwrap();
+
+        commit_stmt.run_collect_rows().unwrap();
+        drop(commit_stmt);
+
+        let rows = get_rows(&conn_a, "SELECT id, v FROM t");
+        assert_eq!(rows.len(), 1);
+
+        conn_b.execute("ROLLBACK").unwrap();
+
+        conn_a.close().unwrap();
+        conn_b.close().unwrap();
+    }
+
+    db.restart();
+
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT id, v FROM t");
+    assert_eq!(
+        rows.len(),
+        1,
+        "tx_a's committed row must survive recovery, got {rows:?}"
+    );
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "a_value");
+}
+
 /// What this test checks: MVCC restart handles sqlite_schema rows with rootpage=0 (triggers).
 /// Why this matters: Trigger definitions are stored without btrees and should not break recovery.
 #[test]


### PR DESCRIPTION
## Description

This adds a `recovery-heavy` profile in whopper that would have caught the bug from https://github.com/tursodatabase/turso/pull/6628. I/Claude also found and fixed another bug while I was working on this.

Shout-out to @avinassh and his yield injection machinery, without which the bug probably wouldn't have appeared.

## Description of AI Usage

A lot of Claude Code, and then some manual cleanup.