### PR TITLE
core/vdbe: Fix AVG() for text values with numeric prefixes

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5792,16 +5792,27 @@ fn update_agg_payload(
                 Value::Numeric(Numeric::Float(f)) => {
                     apply_kbn_step(sum_val, f64::from(f), &mut sum_state);
                 }
-                Value::Text(t) => match try_for_float(t.as_str().as_bytes()).1 {
-                    ParsedNumber::Integer(i) => apply_kbn_step_int(sum_val, i, &mut sum_state),
-                    ParsedNumber::Float(f) => apply_kbn_step(sum_val, f, &mut sum_state),
-                    ParsedNumber::None => apply_kbn_step(sum_val, 0.0, &mut sum_state),
-                },
-                Value::Blob(b) => match try_for_float(&b).1 {
-                    ParsedNumber::Integer(i) => apply_kbn_step_int(sum_val, i, &mut sum_state),
-                    ParsedNumber::Float(f) => apply_kbn_step(sum_val, f, &mut sum_state),
-                    ParsedNumber::None => apply_kbn_step(sum_val, 0.0, &mut sum_state),
-                },
+                Value::Text(t) => {
+                    let (parse_result, parsed_number) = try_for_float(t.as_str().as_bytes());
+                    match parsed_number {
+                        ParsedNumber::Integer(i) => {
+                            if matches!(parse_result, NumericParseResult::ValidPrefixOnly) {
+                                apply_kbn_step(sum_val, i as f64, &mut sum_state);
+                            } else {
+                                apply_kbn_step_int(sum_val, i, &mut sum_state);
+                            }
+                        }
+                        ParsedNumber::Float(f) => apply_kbn_step(sum_val, f, &mut sum_state),
+                        ParsedNumber::None => apply_kbn_step(sum_val, 0.0, &mut sum_state),
+                    }
+                }
+                Value::Blob(b) => {
+                    match try_for_float(&b).1 {
+                        ParsedNumber::Integer(i) => apply_kbn_step(sum_val, i as f64, &mut sum_state),
+                        ParsedNumber::Float(f) => apply_kbn_step(sum_val, f, &mut sum_state),
+                        ParsedNumber::None => apply_kbn_step(sum_val, 0.0, &mut sum_state),
+                    }
+                }
                 _ => unreachable!(),
             }
             *r_err_val = Value::from_f64(sum_state.r_err);

--- a/testing/sqltests/tests/agg-functions/avg-text-types.sqltest
+++ b/testing/sqltests/tests/agg-functions/avg-text-types.sqltest
@@ -1,0 +1,36 @@
+@database :memory:
+
+@cross-check-integrity
+test avg_partial_integer_text_rounds_like_sqlite {
+    SELECT typeof(avg(x)), avg(x)
+    FROM (
+      SELECT '9007199254740994abc' AS x
+      UNION ALL
+      SELECT '-9007199254740993abc'
+    );
+}
+expect {
+    real|1.0
+}
+expect @js {
+    real|1
+}
+
+@cross-check-integrity
+test avg_partial_integer_text_grouped {
+    WITH t(g, x) AS (
+      SELECT 1, '9007199254740994abc' UNION ALL
+      SELECT 1, '-9007199254740993abc' UNION ALL
+      SELECT 2, '10' UNION ALL
+      SELECT 2, '20'
+    )
+    SELECT g, typeof(avg(x)), avg(x) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    1|real|1.0
+    2|real|15.0
+}
+expect @js {
+    1|real|1
+    2|real|15
+}


### PR DESCRIPTION
Fix `AVG()` for text values with numeric prefixes so it matches SQLite.

This came up while validating the large-integer `AVG()` fix in #6648. Values like `'9007199254740994abc'` were still handled differently from SQLite.

In `core/vdbe/execute.rs`, `AVG()` now sends text values with numeric prefixes down the float path instead of the int path. Pure integer text still uses the int path.

This fixes cases such as:

  ```sql
  SELECT avg(x)
  FROM (
    SELECT '9007199254740994abc' AS x
    UNION ALL
    SELECT '-9007199254740993abc'
  );
```
-- SQLite: 1.0
-- Turso: 0.5 *before this change*

I've also added the original repro with a grouped variant of the same behavior as tests.

## Description of AI Usage

AI was used to inspect the AVG() and SUM() coercion paths, compare the behavior against SQLite, and help draft the fix and regression tests, and I've reviewed the resulting change myself before opening the PR.