### PR TITLE
core/translate: fix hash joins emitting incorrect cross products

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1,7 +1,10 @@
 use crate::schema::{Index, IndexColumn, PseudoCursorType};
 use crate::sync::Arc;
 use crate::translate::collate::get_collseq_from_expr;
-use crate::translate::emitter::{select::emit_query, LimitCtx, Resolver, TranslateCtx};
+use crate::translate::emitter::{
+    select::{emit_materialized_build_inputs, emit_query},
+    LimitCtx, Resolver, TranslateCtx,
+};
 use crate::translate::expr::translate_expr;
 use crate::translate::order_by::{custom_type_comparator, sorter_insert};
 use crate::translate::plan::{Plan, QueryDestination, SelectPlan};
@@ -305,6 +308,11 @@ fn emit_compound_select(
                 }
 
                 emit_explain!(program, true, "UNION ALL".to_owned());
+                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
+                    program,
+                    &right_most_ctx.resolver,
+                    &mut right_most,
+                )?;
                 emit_query(program, &mut right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
                 program.preassign_label_to_next_insn(label_next_select);
@@ -355,6 +363,11 @@ fn emit_compound_select(
                 };
 
                 emit_explain!(program, true, "UNION USING TEMP B-TREE".to_owned());
+                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
+                    program,
+                    &right_most_ctx.resolver,
+                    &mut right_most,
+                )?;
                 emit_query(program, &mut right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
 
@@ -411,6 +424,11 @@ fn emit_compound_select(
                 )?;
 
                 emit_explain!(program, true, "INTERSECT USING TEMP B-TREE".to_owned());
+                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
+                    program,
+                    &right_most_ctx.resolver,
+                    &mut right_most,
+                )?;
                 emit_query(program, &mut right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
                 read_intersect_rows(
@@ -464,6 +482,11 @@ fn emit_compound_select(
                     is_delete: true,
                 };
                 emit_explain!(program, true, "EXCEPT USING TEMP B-TREE".to_owned());
+                right_most_ctx.materialized_build_inputs = emit_materialized_build_inputs(
+                    program,
+                    &right_most_ctx.resolver,
+                    &mut right_most,
+                )?;
                 emit_query(program, &mut right_most, &mut right_most_ctx)?;
                 program.pop_current_parent_explain();
                 if new_index {
@@ -489,6 +512,8 @@ fn emit_compound_select(
                 right_most_ctx.reg_offset = offset_reg;
             }
             emit_explain!(program, true, "LEFT-MOST SUBQUERY".to_owned());
+            right_most_ctx.materialized_build_inputs =
+                emit_materialized_build_inputs(program, &right_most_ctx.resolver, &mut right_most)?;
             emit_query(program, &mut right_most, &mut right_most_ctx)?;
             program.pop_current_parent_explain();
         }

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -319,7 +319,7 @@ struct MaterializationSpec {
 /// For probe->build chaining we store join keys and payload columns directly
 /// in the ephemeral table; otherwise we only store rowids and `SeekRowid`
 /// during probing when needed.
-fn emit_materialized_build_inputs(
+pub(crate) fn emit_materialized_build_inputs(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     plan: &mut SelectPlan,
@@ -496,12 +496,21 @@ fn emit_materialized_build_inputs(
         });
         program.nested(|program| -> Result<()> {
             program.set_hash_tables_to_keep_open(&hash_tables_to_keep_open);
+            // emit_program_for_select_with_inputs unconditionally overwrites
+            // program.result_columns and extends program.table_references with
+            // the materialize subplan's columns/refs. In a nested context (e.g.
+            // a compound branch or CTE) those belong to the *outer* SELECT, so
+            // save and restore them around the nested emission.
+            let saved_result_columns = std::mem::take(&mut program.result_columns);
+            let saved_table_references = std::mem::take(&mut program.table_references);
             emit_program_for_select_with_inputs(
                 program,
                 resolver,
                 materialize_plan,
                 build_inputs.clone(),
             )?;
+            program.result_columns = saved_result_columns;
+            program.table_references = saved_table_references;
             program.clear_hash_tables_to_keep_open();
             Ok(())
         })?;

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -10,7 +10,8 @@ use crate::{
         collate::get_collseq_from_expr,
         compound_select::emit_program_for_compound_select,
         emitter::select::{
-            emit_program_for_select, emit_program_for_select_with_resolver, emit_query,
+            emit_materialized_build_inputs, emit_program_for_select,
+            emit_program_for_select_with_resolver, emit_query,
         },
         expr::{
             compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr_mut, WalkControl,
@@ -1552,6 +1553,8 @@ pub fn emit_from_clause_subquery(
                 hash_table_contexts: HashMap::default(),
                 unsafe_testing: t_ctx.unsafe_testing,
             });
+            metadata.materialized_build_inputs =
+                emit_materialized_build_inputs(program, &metadata.resolver, select_plan)?;
             emit_query(program, select_plan, &mut metadata)?
         }
         Plan::CompoundSelect { .. } => {
@@ -1638,6 +1641,8 @@ fn emit_indexed_materialized_subquery(
                 hash_table_contexts: HashMap::default(),
                 unsafe_testing: t_ctx.unsafe_testing,
             });
+            metadata.materialized_build_inputs =
+                emit_materialized_build_inputs(program, &metadata.resolver, select_plan)?;
             emit_query(program, select_plan, &mut metadata)?;
         }
         Plan::CompoundSelect { .. } => {
@@ -1731,6 +1736,8 @@ fn emit_materialized_subquery_table(
                 hash_table_contexts: HashMap::default(),
                 unsafe_testing: t_ctx.unsafe_testing,
             });
+            metadata.materialized_build_inputs =
+                emit_materialized_build_inputs(program, &metadata.resolver, select_plan)?;
             emit_query(program, select_plan, &mut metadata)?;
         }
         Plan::CompoundSelect { .. } => {

--- a/testing/sqltests/tests/hash-join-three-table-nested.sqltest
+++ b/testing/sqltests/tests/hash-join-three-table-nested.sqltest
@@ -1,0 +1,132 @@
+@database :memory:
+
+# Regression tests for a 3+ table hash join producing a cross product when
+# the SELECT is wrapped inside a compound (UNION/INTERSECT/EXCEPT), a CTE,
+# or a VIEW. The chained hash build needs the prior join to be materialized
+# into an ephemeral table; the compound/CTE/view emit paths previously
+# bypassed `emit_materialized_build_inputs`, so the second hash build was
+# emitted nested inside the first probe loop without preserving the
+# correlation between the outer probe row and the build it feeds.
+#
+# Without the fix, each of these queries returns rows from the un-joined
+# middle table instead of the single matching row.
+
+setup schema {
+    CREATE TABLE t1(x INT);
+    CREATE TABLE t2(y INT);
+    CREATE TABLE t3(z INT);
+    INSERT INTO t1 VALUES (1),(2),(3);
+    INSERT INTO t2 VALUES (2),(3);
+    INSERT INTO t3 VALUES (3);
+}
+
+@setup schema
+test three-table-hash-join-in-union-all {
+    SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z
+    UNION ALL
+    SELECT 0;
+}
+expect {
+    3
+    0
+}
+
+@setup schema
+test three-table-hash-join-in-union {
+    SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z
+    UNION
+    SELECT 0
+    ORDER BY 1;
+}
+expect {
+    0
+    3
+}
+
+@setup schema
+test three-table-hash-join-in-intersect {
+    SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z
+    INTERSECT
+    SELECT 3;
+}
+expect {
+    3
+}
+
+@setup schema
+test three-table-hash-join-in-except {
+    SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z
+    EXCEPT
+    SELECT 1;
+}
+expect {
+    3
+}
+
+@setup schema
+test three-table-hash-join-in-cte {
+    WITH cte AS (
+        SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z
+    )
+    SELECT * FROM cte;
+}
+expect {
+    3
+}
+
+@setup schema
+test three-table-hash-join-in-view {
+    CREATE VIEW v AS
+        SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z;
+    SELECT * FROM v;
+}
+expect {
+    3
+}
+
+# Top-level (non-wrapped) variant for parity — already worked before the fix
+# but pin it down so a future regression in the materialization path is caught
+# both wrapped and unwrapped.
+@setup schema
+test three-table-hash-join-top-level {
+    SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z;
+}
+expect {
+    3
+}
+
+# Schema with more rows on each side so a regression that emits a cross
+# product is unmistakable in the diff.
+setup schema-wide {
+    CREATE TABLE t1(x INT);
+    CREATE TABLE t2(y INT);
+    CREATE TABLE t3(z INT);
+    INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+    INSERT INTO t2 VALUES (2),(3),(4),(5);
+    INSERT INTO t3 VALUES (3),(5);
+}
+
+@setup schema-wide
+test three-table-hash-join-wide-cte {
+    WITH cte AS (
+        SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z
+    )
+    SELECT x FROM cte ORDER BY x;
+}
+expect {
+    3
+    5
+}
+
+@setup schema-wide
+test three-table-hash-join-wide-union-all {
+    SELECT t1.x FROM t1 JOIN t2 ON t1.x=t2.y JOIN t3 ON t2.y=t3.z
+    UNION ALL
+    SELECT 0
+    ORDER BY 1;
+}
+expect {
+    0
+    3
+    5
+}


### PR DESCRIPTION
closes https://github.com/tursodatabase/turso/issues/6406

For chained hash joins to be correct, the optimizer marks the second build with `materialize_build_input=true`. The emitter is supposed to first materialize the partial join into an ephemeral table, then build `hash[t2]` from that.

The top-level path (`emit_program_for_select_with_resolver`) calls `emit_materialized_build_inputs`. But the compound and subquery paths invoke `emit_query` directly with `materialized_build_inputs` with an empty hash map, skipping materialization. The hash-join emitter then falls back to a buggy nested probe-then-build, where the inner `hash[t2]` is built from all rows of `t2` with no link to the outer `t2` row that produced the `t1` match, which yields a cross product.