### PR TITLE
core/vdbe: Make scalar function edge cases SQLite compatible

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -219,7 +219,8 @@ fn parse_date_or_time(value: &str, p: &mut DateTime) -> Result<()> {
         set_to_current(p);
         return Ok(());
     }
-    if let Ok(val) = value.parse::<f64>() {
+    let numeric_value = value.trim_matches(|c: char| c.is_ascii_whitespace());
+    if let Ok(val) = numeric_value.parse::<f64>() {
         p.s = val;
         p.raw_s = true;
         if (0.0..5373484.5).contains(&val) {
@@ -2575,6 +2576,21 @@ mod tests {
 
         let result = exec_unixepoch(vec![Value::from_f64(2440587.5)]);
         assert_eq!(result, Value::from_i64(0));
+    }
+
+    #[test]
+    fn test_numeric_datetime_accepts_ascii_whitespace() {
+        let expected = Value::from_i64(-210866328000);
+        for input in ["5 ", " 5", " 5 ", "\t5\n"] {
+            let result = exec_unixepoch(vec![Value::build_text(input.to_string())]);
+            assert_eq!(result, expected, "input {input:?}");
+        }
+
+        let result = exec_julianday(vec![Value::build_text("5 ".to_string())]);
+        assert_eq!(result, Value::from_f64(5.0));
+
+        let result = exec_unixepoch(vec![Value::build_text("5 trailing".to_string())]);
+        assert_eq!(result, Value::Null);
     }
 
     #[test]

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -506,7 +506,11 @@ impl Value {
             if p1 < 0 {
                 p1 = p1.wrapping_add(len);
                 if p1 < 0 {
-                    p2 = p2.wrapping_add(p1);
+                    if p2 < 0 {
+                        p2 = 0;
+                    } else {
+                        p2 += p1;
+                    }
                     p1 = 0;
                 }
             } else if p1 > 0 {
@@ -2815,6 +2819,15 @@ mod tests {
         let start_value = Value::from_i64(10);
         let length_value = Value::Null;
         let expected_val = Value::Null;
+        assert_eq!(
+            Value::exec_substring(&str_value, &start_value, Some(&length_value)),
+            expected_val
+        );
+
+        let str_value = Value::build_text("limbo");
+        let start_value = Value::from_i64(-7_096_519_388_852_014_892);
+        let length_value = Value::from_i64(-4_829_175_794_346_763_833);
+        let expected_val = Value::build_text("");
         assert_eq!(
             Value::exec_substring(&str_value, &start_value, Some(&length_value)),
             expected_val

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -1155,6 +1155,24 @@ test substr-large-float-clamp {
 expect {
 }
 
+test substr-extreme-negative-start-and-length {
+    SELECT length(substr('limbo', -7096519388852014892, -4829175794346763833)), substr('limbo', -7096519388852014892, -4829175794346763833) = '';
+}
+expect {
+    0|1
+}
+
+test datetime-numeric-string-whitespace {
+    SELECT unixepoch('5 '), unixepoch(' 5'), unixepoch(' 5 '), unixepoch(char(9) || '5' || char(10));
+    SELECT julianday('5 ') = 5.0, typeof(julianday('5 '));
+    SELECT unixepoch('5 trailing') IS NULL;
+}
+expect {
+    -210866328000|-210866328000|-210866328000|-210866328000
+    1|real
+    1
+}
+
 test cast-real-overflow-clamp {
     SELECT CAST(9223372036854775808 AS INTEGER);
 }


### PR DESCRIPTION
## What changed
- Accept ASCII whitespace around numeric date/time strings, matching SQLite behavior for inputs like `unixepoch('5 ')`.
- Fix `substr()` handling for extreme negative start and negative length values so it returns the same empty result as SQLite.
- Add core unit coverage and SQL regression tests for both cases.

## Why
Numeric date/time parsing went straight through `parse::<f64>()`, which rejects leading or trailing whitespace. `substr()` also used wrapping arithmetic after a negative start moved before the beginning of the string, which could turn a negative length into a large positive range.

## Testing
- `cargo test -q -p turso_core test_numeric_datetime_accepts_ascii_whitespace --features pure-rust-crypto -- --nocapture`
- `cargo test -q -p turso_core test_substring --features pure-rust-crypto -- --nocapture`
- `cargo run -q -p test-runner --bin test-runner -- run testing/sqltests/tests/scalar-functions.sqltest --filter substr-extreme-negative-start-and-length --snapshot-mode no`
- `cargo run -q -p test-runner --bin test-runner -- run testing/sqltests/tests/scalar-functions.sqltest --filter datetime-numeric-string-whitespace --snapshot-mode no`
- Same two SQL tests with `--backend cli`