### PR TITLE
core/translate: Fix stale indexes on ALTER COLUMN on virtual generated columns

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1628,6 +1628,14 @@ pub fn translate_alter_table(
                     let old_column = &btree.columns()[column_index];
                     let becomes_generated =
                         !old_column.is_generated() && replacement_column.is_generated();
+                    // Toggling the virtual-generated bit changes whether the column
+                    // occupies a stored slot, so the on-disk row layout shifts even
+                    // if neither side is "becomes_generated" (e.g. virtual -> regular).
+                    // Without rewriting, post-ALTER reads use the new schema's column
+                    // indexes against rows that still hold the pre-ALTER layout, and
+                    // values land in the wrong logical columns. See issue #6624.
+                    let virtuality_changed = old_column.is_virtual_generated()
+                        != replacement_column.is_virtual_generated();
                     // A change of declared type can change the column's affinity, in
                     // which case existing on-disk values must be coerced to match the
                     // new affinity. Without this, the row payload retains the old
@@ -1636,7 +1644,8 @@ pub fn translate_alter_table(
                     // changing NUMERIC -> TEXT). See issue #3706.
                     let affinity_changed = old_column.affinity_with_strict(btree.is_strict)
                         != replacement_column.affinity_with_strict(btree.is_strict);
-                    let rewrites_physical_layout = becomes_generated || affinity_changed;
+                    let rewrites_physical_layout =
+                        becomes_generated || virtuality_changed || affinity_changed;
                     (rewrites_physical_layout, Some(replacement_column))
                 }
             };
@@ -1991,14 +2000,29 @@ pub fn translate_alter_table(
                     database_id,
                 )?;
 
+                let original_columns = original_btree.columns();
                 let source_column_by_schema_idx = rewritten_table
                     .columns()
                     .iter()
                     .enumerate()
                     .map(|(idx, column)| {
                         if column.is_virtual_generated() {
+                            // Virtual columns don't occupy a slot in the rewritten record.
+                            None
+                        } else if original_columns
+                            .get(idx)
+                            .is_some_and(|c| c.is_virtual_generated())
+                        {
+                            // Newly-stored slot (the original column was virtual): no
+                            // source value exists on the old row image — leave NULL.
                             None
                         } else {
+                            // The cursor is opened on the original btree, so the logical
+                            // index passed here is mapped to the original physical slot
+                            // by `emit_column_or_rowid` via the original's logical-to-
+                            // physical map. Schema order is preserved by ALTER COLUMN,
+                            // so the rewritten schema_idx also identifies the same
+                            // logical column in the original.
                             Some(idx)
                         }
                     })
@@ -2064,7 +2088,10 @@ fn emit_rewrite_table_rows(
     });
 
     program.cursor_loop(cursor_id, |program, rowid| {
-        let base_dest_reg = program.alloc_registers(non_virtual_column_count);
+        // Initialize all destination slots to NULL so that columns without a
+        // source value (e.g. when a virtual generated column becomes stored,
+        // there is no pre-existing value on the old row image) default to NULL.
+        let base_dest_reg = program.alloc_registers_and_init_w_null(non_virtual_column_count);
         for (schema_idx, source_column_idx) in source_column_by_schema_idx.iter().enumerate() {
             let Some(source_column_idx) = source_column_idx else {
                 continue;

--- a/testing/sqltests/turso-tests/alter_column.sqltest
+++ b/testing/sqltests/turso-tests/alter_column.sqltest
@@ -632,3 +632,88 @@ expect {
     integer|1
     integer|2
 }
+
+# Issue #6624: Turning a virtual generated column into a regular column shifts
+# the on-disk row layout (a new physical slot is added). Existing rows must be
+# rewritten so the new schema's column indexes align with stored data, and
+# secondary indexes must remain consistent with the rewritten table.
+test alter-column-virtual-to-regular-rewrites-rows {
+    CREATE TABLE core (
+        id TEXT UNIQUE,
+        x TEXT AS (id || ':' || row_rank),
+        row_rank TEXT UNIQUE
+    );
+    INSERT INTO core(id, row_rank) VALUES('i-001','A001'),('i-002','A002');
+    ALTER TABLE core ALTER COLUMN x TO x2 TEXT;
+    INSERT INTO core(x2, id, row_rank) VALUES('x3','i-003','A003');
+    SELECT id, row_rank, x2 FROM core NOT INDEXED ORDER BY rowid;
+    SELECT row_rank FROM core INDEXED BY sqlite_autoindex_core_2 ORDER BY row_rank;
+    PRAGMA integrity_check;
+}
+expect {
+    i-001|A001|
+    i-002|A002|
+    i-003|A003|x3
+    A001
+    A002
+    A003
+    ok
+}
+
+# Same scenario as above under MVCC mode.
+test alter-column-virtual-to-regular-rewrites-rows-mvcc {
+    PRAGMA journal_mode = 'mvcc';
+    CREATE TABLE core (
+        id TEXT UNIQUE,
+        x TEXT AS (id || ':' || row_rank),
+        row_rank TEXT UNIQUE
+    );
+    BEGIN;
+    INSERT INTO core(id, row_rank) VALUES('i-001','A001'),('i-002','A002');
+    COMMIT;
+    ALTER TABLE core ALTER COLUMN x TO x2 TEXT;
+    INSERT INTO core(x2, id, row_rank) VALUES('x3','i-003','A003');
+    SELECT id, row_rank, x2 FROM core NOT INDEXED ORDER BY rowid;
+    SELECT row_rank FROM core INDEXED BY sqlite_autoindex_core_2 ORDER BY row_rank;
+}
+expect {
+    mvcc
+    i-001|A001|
+    i-002|A002|
+    i-003|A003|x3
+    A001
+    A002
+    A003
+}
+
+# Rewriting must use the original physical layout when reading source columns.
+# With a virtual column at index 1, reading row_rank by its new logical index
+# (2) used to land on the wrong stored slot.
+test alter-column-virtual-to-regular-preserves-trailing-columns {
+    CREATE TABLE t (a TEXT, b TEXT AS (a || '_x'), c TEXT, d INTEGER);
+    INSERT INTO t(a, c, d) VALUES('aa','cc',1),('aaa','ccc',2);
+    ALTER TABLE t ALTER COLUMN b TO b2 TEXT;
+    SELECT a, b2, c, d FROM t ORDER BY rowid;
+    PRAGMA integrity_check;
+}
+expect {
+    aa||cc|1
+    aaa||ccc|2
+    ok
+}
+
+# Reverse direction: regular -> virtual generated. The column that previously
+# held a stored value must be removed from the row record, and trailing
+# columns must keep their values.
+test alter-column-regular-to-virtual-rewrites-rows {
+    CREATE TABLE t (a TEXT UNIQUE, b TEXT, c TEXT);
+    INSERT INTO t VALUES('a1','b1','c1'),('a2','b2','c2');
+    ALTER TABLE t ALTER COLUMN b TO b2 TEXT GENERATED ALWAYS AS (a || c) VIRTUAL;
+    SELECT a, b2, c FROM t ORDER BY rowid;
+    PRAGMA integrity_check;
+}
+expect {
+    a1|a1c1|c1
+    a2|a2c2|c2
+    ok
+}


### PR DESCRIPTION
Toggling the virtual-generated bit changes whether a column occupies a
stored slot, so the on-disk row layout shifts. The previous logic only
triggered a rewrite for `becomes_generated` (regular -> generated) and
affinity changes, missing the virtual <-> regular toggle. Pre-ALTER
rows kept their old layout while the new schema's column indexes
pointed at shifted slots, and integrity_check reported missing entries
in secondary indexes because table values no longer matched the index
keys.

Detect the layout shift via `is_virtual_generated()` differing between
old and new, and fix the rewrite's source mapping to honor the
*original* column layout (not the rewritten schema indexes). When a
virtual column becomes stored, the new physical slot has no source
value on the old row image, so initialize destination registers to
NULL.

Closes #6624