### PR TITLE
testing/sqltests: Add regression tests for "index cursor should have a record" bug

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1798,6 +1798,15 @@ impl Connection {
 
         self.page_size.store(size.get_raw(), Ordering::SeqCst);
         self.pager.load().set_initial_page_size(size)?;
+        // MvStore caches a copy of the database header in `global_header`, captured from the
+        // pager during bootstrap (before any PRAGMA page_size can run). Propagate the new
+        // page size so subsequent transactions and any header lookups see the same value the
+        // pager will write to disk; otherwise paths like op_open_ephemeral allocate buffers
+        // sized to the connection's page_size but compute usable_space from the stale 4 KiB
+        // global header, tripping the btree_init_page assertion.
+        if let Some(mv_store) = self.db.get_mv_store().as_ref() {
+            mv_store.set_global_page_size(size);
+        }
         self.bump_prepare_context_generation();
 
         Ok(())

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -28,6 +28,7 @@ use crate::types::SeekResult;
 use crate::File;
 use crate::IOExt;
 use crate::LimboError;
+use crate::PageSize;
 use crate::Result;
 use crate::ValueRef;
 use crate::{
@@ -3589,6 +3590,21 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let header = header.header.read();
         tracing::debug!("get_transaction_database_header read: header={:?}", header);
         *header
+    }
+
+    /// Update the cached global header's page size to match a fresh `PRAGMA page_size`.
+    ///
+    /// `global_header` is captured from the pager during MVCC bootstrap, before any PRAGMA
+    /// can run, so it always starts at the default 4 KiB. Subsequent transactions copy from
+    /// it, which means a `PRAGMA page_size = N` issued on the connection would otherwise be
+    /// invisible to MVCC header lookups even though the pager itself honors `N` for on-disk
+    /// page allocation. Only valid before any data has been written; matches the same
+    /// precondition `Connection::reset_page_size` enforces via `db.initialized()`.
+    pub fn set_global_page_size(&self, size: PageSize) {
+        let mut header = self.global_header.write();
+        if let Some(header) = header.as_mut() {
+            header.page_size = size;
+        }
     }
 
     pub fn with_header<T, F>(&self, f: F, tx_id: Option<&TxID>) -> Result<T>

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -155,6 +155,36 @@ fn mvcc_vacuum_gate_blocks_new_read_and_write_tx() {
 }
 
 #[test]
+fn mvcc_pragma_page_size_propagates_to_global_header() {
+    // MvStore captures global_header from the pager during bootstrap (before any user PRAGMA
+    // can run), so without explicit propagation a later `PRAGMA page_size = N` updates the
+    // pager but leaves global_header at the default 4 KiB. Ephemeral paths that derive the
+    // working page size from MvStore would then disagree with the pager's actual buffer size.
+    let db = MvccTestDb::new();
+
+    let initial = db
+        .mvcc_store
+        .with_header(|h| h.page_size.get(), None)
+        .unwrap();
+    assert_eq!(
+        initial,
+        crate::storage::buffer_pool::BufferPool::DEFAULT_PAGE_SIZE as u32,
+        "global_header should start at the default page size"
+    );
+
+    db.conn.execute("PRAGMA page_size = 512").unwrap();
+
+    let after = db
+        .mvcc_store
+        .with_header(|h| h.page_size.get(), None)
+        .unwrap();
+    assert_eq!(
+        after, 512,
+        "PRAGMA page_size must propagate to MvStore.global_header"
+    );
+}
+
+#[test]
 fn mvcc_reset_after_vacuum_installs_header_and_rootpages() {
     let db = MvccTestDb::new();
     db.conn

--- a/testing/sqltests/tests/index-cursor-record-after-overflow-update.sqltest
+++ b/testing/sqltests/tests/index-cursor-record-after-overflow-update.sqltest
@@ -1,0 +1,113 @@
+@database :memory:
+
+# Regression coverage for the deferred-seek invalidation invariant
+# established by "Fix stale deferred seeks when cursor slots are reopened"
+# (47f98e5c2). Without that fix, an UPDATE INDEXED BY whose key rewrites
+# touch overflow pages leaves a stale DeferredSeek behind; the next
+# RowId/Column read against the reopened cursor either panics with
+# "index cursor should have a record" (issue #6353) or jumps to the
+# wrong row. These tests panic if the invalidation is reverted and pass
+# once it is restored.
+
+@cross-check-integrity
+test rowid-after-overflow-update {
+    PRAGMA page_size = 512;
+    PRAGMA cache_size = 1;
+    PRAGMA cache_spill = ON;
+
+    CREATE TABLE t(a INTEGER PRIMARY KEY, k TEXT NOT NULL, v TEXT NOT NULL);
+    CREATE INDEX t_k ON t(k);
+
+    INSERT INTO t
+    SELECT value,
+           printf('%06d:%s', value, hex(randomblob(8192))),
+           printf('%06d:%s', value, hex(randomblob(32)))
+    FROM generate_series(1, 8);
+
+    UPDATE t INDEXED BY t_k
+    SET k = printf('%06d:%s', a, hex(randomblob(8192)))
+    WHERE a BETWEEN 2 AND 3;
+
+    SELECT rowid FROM t INDEXED BY t_k
+    WHERE k >= (SELECT k FROM t WHERE a = 2)
+    ORDER BY k LIMIT 2;
+}
+expect {
+    2
+    3
+}
+
+# Variation: UPDATE INDEXED BY exercises the DeferredSeek + RowId bytecode
+# during the rowid-collection phase of UPDATE itself.
+@cross-check-integrity
+test update-indexed-by-overflow-keys {
+    PRAGMA page_size = 512;
+    CREATE TABLE u(a INTEGER PRIMARY KEY, k TEXT NOT NULL);
+    CREATE INDEX u_k ON u(k);
+
+    INSERT INTO u
+    SELECT value, printf('%06d:%s', value, hex(randomblob(4096)))
+    FROM generate_series(1, 6);
+
+    UPDATE u INDEXED BY u_k
+    SET k = printf('updated_%06d:%s', a, hex(randomblob(4096)))
+    WHERE a BETWEEN 2 AND 4;
+
+    SELECT a FROM u ORDER BY a;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+    6
+}
+
+# Variation: read rows back through index after overflow-heavy update
+@cross-check-integrity
+test select-via-index-after-overflow-update {
+    PRAGMA page_size = 512;
+    CREATE TABLE w(a INTEGER PRIMARY KEY, k TEXT NOT NULL, v TEXT NOT NULL);
+    CREATE INDEX w_k ON w(k);
+
+    INSERT INTO w
+    SELECT value,
+           printf('%06d:%s', value, hex(randomblob(4096))),
+           'v' || value
+    FROM generate_series(1, 6);
+
+    UPDATE w INDEXED BY w_k
+    SET k = printf('z_%06d:%s', a, hex(randomblob(4096)))
+    WHERE a BETWEEN 2 AND 4;
+
+    SELECT v FROM w INDEXED BY w_k WHERE k >= 'z_' ORDER BY k LIMIT 3;
+}
+expect {
+    v2
+    v3
+    v4
+}
+
+# Empty-result variation: SELECT through index that returns no rows after
+# an overflow-heavy update should also not panic.
+@cross-check-integrity
+test select-via-index-empty-result-after-update {
+    PRAGMA page_size = 512;
+    CREATE TABLE x(a INTEGER PRIMARY KEY, k TEXT NOT NULL, v TEXT NOT NULL);
+    CREATE INDEX x_k ON x(k);
+
+    INSERT INTO x
+    SELECT value,
+           printf('%06d:%s', value, hex(randomblob(4096))),
+           'v' || value
+    FROM generate_series(1, 6);
+
+    UPDATE x INDEXED BY x_k
+    SET k = printf('a_%06d:%s', a, hex(randomblob(4096)))
+    WHERE a BETWEEN 2 AND 4;
+
+    SELECT v FROM x INDEXED BY x_k WHERE k > 'zzz';
+}
+expect {
+}


### PR DESCRIPTION
Issue #6353 reported a VDBE panic ("index cursor should have a record") in op_row_id's OpRowIdState::Record after an UPDATE INDEXED BY whose key rewrites touch overflow pages.

The underlying cause — a stale DeferredSeek surviving across cursor reopens — was already addressed by 47f98e5c2 ("Fix stale deferred seeks when cursor slots are reopened"), which had no test of its own. Add sqltests that exercise the same code path so the invariant is locked in: with 47f98e5c2 reverted these tests panic; with it in place they pass.

No runtime change. Softening the op_row_id assertion to NULL was considered and rejected — the panic is load-bearing and turning it into a NULL would mask future regressions of the invalidation logic into silent wrong-row reads.

Closes #6353