### PR TITLE
Add regression tests for pager panic after savepoint rollback with overflow

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3711,6 +3711,18 @@ impl Pager {
                         } else {
                             let (page, completion) =
                                 self.read_page_no_cache(page_id as i64, None, false)?;
+                            // If the read completed synchronously with an error,
+                            // surface it now. Otherwise we would silently drop the
+                            // failure (the completion is "finished" so we'd skip
+                            // pushing it into the wait list) and later trip the
+                            // page-buffer-not-loaded panic in prepare_frames when
+                            // it tries to read content from the evicted page.
+                            if completion.finished() && !completion.succeeded() {
+                                let err = completion.get_error().unwrap_or(
+                                    CompletionError::IOError(std::io::ErrorKind::Other, "read"),
+                                );
+                                return Err(LimboError::CompletionError(err));
+                            }
                             commit_info.page_sources.push(PageSource::Evicted(page));
                             if !completion.finished() {
                                 commit_info.completions.push(completion);
@@ -3777,6 +3789,17 @@ impl Pager {
                             }
                             PageSource::Evicted(page) => page.clone(),
                         };
+                        // Defensive check: prepare_frames will read page contents,
+                        // which panics if the buffer is not loaded. If we got here
+                        // with an unloaded page (e.g. an evicted dirty page whose
+                        // backing WAL frame was truncated by a savepoint rollback),
+                        // surface an internal error instead of panicking.
+                        if !page.is_loaded() {
+                            return Err(LimboError::InternalError(format!(
+                                "dirty page {} has no buffer loaded at commit time",
+                                page.get().id
+                            )));
+                        }
                         commit_info.page_source_cursor += 1;
                         commit_info.collected_pages.push(page);
 

--- a/testing/sqltests/tests/savepoint.sqltest
+++ b/testing/sqltests/tests/savepoint.sqltest
@@ -350,3 +350,105 @@ test savepoint-rollback-to-temp-table-unreachable {
 expect error {
     no such table
 }
+
+# Regression test for #6352: savepoint rollback over a transaction that
+# touches lots of overflow pages under cache pressure must not leave the
+# pager with dirty entries whose buffers cannot be loaded at commit time.
+@cross-check-integrity
+test savepoint-rollback-overflow-issue-6352 {
+    PRAGMA page_size = 2048;
+    PRAGMA cache_size = 8;
+    CREATE TABLE t6352(id INTEGER PRIMARY KEY, x BLOB);
+    BEGIN;
+    INSERT INTO t6352 VALUES(1, zeroblob(1720000));
+    SAVEPOINT s1;
+    UPDATE t6352 SET x = zeroblob(215000) WHERE id = 1;
+    ROLLBACK TO s1;
+    RELEASE s1;
+    INSERT INTO t6352 VALUES(2, zeroblob(860000));
+    COMMIT;
+    SELECT id, length(x) FROM t6352 ORDER BY id;
+}
+expect {
+    1|1720000
+    2|860000
+}
+
+# Same scenario but with nested savepoints — the inner savepoint is
+# released, and only the outer one is rolled back. Exercises the
+# subjournal entry coalescing across nested savepoints.
+@cross-check-integrity
+test savepoint-rollback-overflow-nested-issue-6352 {
+    PRAGMA page_size = 2048;
+    PRAGMA cache_size = 4;
+    CREATE TABLE t6352n(id INTEGER PRIMARY KEY, x BLOB);
+    BEGIN;
+    INSERT INTO t6352n VALUES(1, zeroblob(1720000));
+    SAVEPOINT s1;
+    UPDATE t6352n SET x = zeroblob(215000) WHERE id = 1;
+    SAVEPOINT s2;
+    UPDATE t6352n SET x = zeroblob(50000) WHERE id = 1;
+    ROLLBACK TO s2;
+    RELEASE s2;
+    ROLLBACK TO s1;
+    RELEASE s1;
+    INSERT INTO t6352n VALUES(2, zeroblob(860000));
+    COMMIT;
+    SELECT id, length(x) FROM t6352n ORDER BY id;
+}
+expect {
+    1|1720000
+    2|860000
+}
+
+# Repeated rollback of the same savepoint within a transaction. Each cycle
+# must produce a clean state for the surrounding outer transaction.
+@cross-check-integrity
+test savepoint-rollback-overflow-repeated-issue-6352 {
+    PRAGMA page_size = 2048;
+    PRAGMA cache_size = 8;
+    CREATE TABLE t6352r(id INTEGER PRIMARY KEY, x BLOB);
+    INSERT INTO t6352r VALUES(0, zeroblob(900000));
+    BEGIN;
+    SAVEPOINT a;
+    UPDATE t6352r SET x = zeroblob(50000) WHERE id = 0;
+    ROLLBACK TO a;
+    RELEASE a;
+    SAVEPOINT b;
+    UPDATE t6352r SET x = zeroblob(100000) WHERE id = 0;
+    ROLLBACK TO b;
+    RELEASE b;
+    SAVEPOINT c;
+    UPDATE t6352r SET x = zeroblob(150000) WHERE id = 0;
+    ROLLBACK TO c;
+    RELEASE c;
+    COMMIT;
+    SELECT id, length(x) FROM t6352r ORDER BY id;
+}
+expect {
+    0|900000
+}
+
+# Rollback after an UPDATE that grows the blob (additional overflow pages
+# allocated within the savepoint and then thrown away). The rollback must
+# truncate dirty page state and the database size cleanly so a follow-up
+# INSERT can append fresh overflow chains.
+@cross-check-integrity
+test savepoint-rollback-overflow-grow-issue-6352 {
+    PRAGMA page_size = 2048;
+    PRAGMA cache_size = 8;
+    CREATE TABLE t6352g(id INTEGER PRIMARY KEY, x BLOB);
+    BEGIN;
+    INSERT INTO t6352g VALUES(1, zeroblob(100000));
+    SAVEPOINT s1;
+    UPDATE t6352g SET x = zeroblob(2000000) WHERE id = 1;
+    ROLLBACK TO s1;
+    RELEASE s1;
+    INSERT INTO t6352g VALUES(2, zeroblob(500000));
+    COMMIT;
+    SELECT id, length(x) FROM t6352g ORDER BY id;
+}
+expect {
+    1|100000
+    2|500000
+}


### PR DESCRIPTION
After a savepoint rollback that touched overflow pages under cache pressure,
`commit_dirty_pages_inner` could reach `prepare_frames` with an evicted
dirty page whose buffer was never loaded — short-read errors from
`begin_read_page` were being silently dropped, then `get_contents()` would
panic asserting `inner.buffer.is_some()` at pager.rs:766.

Two defensive fixes in `commit_dirty_pages_inner`:

1. `ScanAndIssueReads`: when re-reading an evicted dirty page via
   `read_page_no_cache`, the existing code only pushed the completion to
   the wait list if it had not finished. A completion that finished
   synchronously with an error (e.g. `ShortRead` from a page that no
   longer exists in the WAL after a savepoint rollback) was silently
   dropped, mirroring the failure check that already exists in
   `WaitBatchedReads`. Surface the error inline instead.

2. `PrepareFrames`: add an `is_loaded()` guard on the page before
   collecting it for frame preparation. If a page reaches commit
   without a loaded buffer, return `LimboError::InternalError` rather than
   tripping the unchecked `get_contents()` panic in `prepare_frames`.

Also adds four sqltest regression cases (cache_size=8 / page_size=2048
with multi-page overflow blobs) covering: the issue's exact reproducer,
nested savepoints, repeated savepoint cycles, and an UPDATE that grows
the blob within a savepoint.

Closes https://github.com/tursodatabase/turso/issues/6352