### PR TITLE
feat: REINDEX

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -107,7 +107,7 @@ ongoing work to pass the full SQLite TCL test suite.
 | INSERT                    | ✅ Yes     |                                                                                   |
 | INSERT ... ON CONFLICT (UPSERT) | ✅ Yes |                                                                                   |
 | ON CONFLICT clause        | ✅ Yes     |                                                                                   |
-| REINDEX                   | ❌ No      |                                                                                   |
+| REINDEX                   | ✅ Yes      |                                                                                   |
 | RELEASE SAVEPOINT         | ✅ Yes     |                                                                                   |
 | REPLACE                   | ✅ Yes     |                                                                                   |
 | RETURNING clause          | ✅ Yes     |                                                                                   |

--- a/bindings/javascript/packages/native/compat.test.ts
+++ b/bindings/javascript/packages/native/compat.test.ts
@@ -1,6 +1,24 @@
 import { unlinkSync } from "node:fs";
 import { expect, test } from 'vitest'
 import { Database } from './compat.js'
+import { Database as NativeDatabase } from '#index'
+
+test('classifySql treats reindex as write', () => {
+    const db = new NativeDatabase(':memory:');
+    db.connectSync();
+    try {
+        expect(db.classifySql('SELECT 1')).toEqual('read');
+        expect(db.classifySql('BEGIN')).toEqual('begin');
+        expect(db.classifySql('COMMIT')).toEqual('commit');
+        expect(db.classifySql('ROLLBACK')).toEqual('rollback');
+
+        expect(db.classifySql('REINDEX')).toEqual('write');
+        expect(db.classifySql('REINDEX idx')).toEqual('write');
+        expect(db.classifySql('REINDEX main.idx')).toEqual('write');
+    } finally {
+        db.close();
+    }
+})
 
 test('insert returning test', () => {
     const db = new Database(':memory:');

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -609,8 +609,7 @@ impl Database {
                     Stmt::Select(..)
                     | Stmt::Pragma { .. }
                     | Stmt::Attach { .. }
-                    | Stmt::Detach { .. }
-                    | Stmt::Reindex { .. } => "read",
+                    | Stmt::Detach { .. } => "read",
                     Stmt::Begin { .. } | Stmt::Savepoint { .. } => "begin",
                     Stmt::Commit { .. } | Stmt::Release { .. } => "commit",
                     Stmt::Rollback { .. } => "rollback",

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -170,9 +170,17 @@ impl CollationSeq {
 
     #[inline(always)]
     fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
-        let nocase_lhs = uncased::UncasedStr::new(lhs);
-        let nocase_rhs = uncased::UncasedStr::new(rhs);
-        nocase_lhs.cmp(nocase_rhs)
+        for (left, right) in lhs.bytes().zip(rhs.bytes()) {
+            let left = left.to_ascii_lowercase();
+            let right = right.to_ascii_lowercase();
+            if left != right {
+                return left.cmp(&right);
+            }
+            if left == 0 {
+                return lhs.len().cmp(&rhs.len());
+            }
+        }
+        lhs.len().cmp(&rhs.len())
     }
 
     #[inline(always)]

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -21,7 +21,7 @@ use crate::vdbe::builder::{CursorKey, ProgramBuilderOpts, SelfTableContext};
 use crate::vdbe::insn::{to_u16, CmpInsFlags, Cookie};
 use crate::{bail_parse_error, CaptureDataChangesExt, LimboError, MAIN_DB_ID, TEMP_DB_ID};
 use crate::{
-    schema::{BTreeTable, Index, IndexColumn, PseudoCursorType},
+    schema::{BTreeTable, Index, IndexColumn, PseudoCursorType, SchemaObjectType},
     storage::pager::CreateBTreeFlags,
     util::{escape_sql_string_literal, normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
     vdbe::{
@@ -626,6 +626,9 @@ pub fn translate_reindex(
     if targets.is_empty() {
         return Ok(());
     }
+    if connection.get_query_only() {
+        bail_parse_error!("Cannot execute write statement in query_only mode");
+    }
 
     let mut write_databases = Vec::new();
     for (database_id, _, _) in &targets {
@@ -776,15 +779,24 @@ fn find_reindex_table(
 
 /// Returns all indexes belonging to `table_name` inside a single database.
 ///
-/// A table without indexes is still a valid REINDEX target, so this returns an
-/// empty vector wrapped in `Some` when the table exists.
+/// A table or view without indexes is still a valid REINDEX target, so this
+/// returns an empty vector wrapped in `Some` when the object exists.
 fn find_reindex_table_in_db(
     table_name: &str,
     database_id: usize,
     resolver: &Resolver,
 ) -> Option<Vec<ReindexTarget>> {
     resolver.with_schema(database_id, |schema| {
-        let table = schema.get_btree_table(table_name)?;
+        let object_type = schema.get_object_type(table_name)?;
+        if object_type == SchemaObjectType::View {
+            return Some(Vec::new());
+        }
+        let SchemaObjectType::Table = object_type else {
+            return None;
+        };
+        let Some(table) = schema.get_btree_table(table_name) else {
+            return Some(Vec::new());
+        };
         let targets = schema
             .indexes
             .get(&normalize_ident(table.name.as_str()))

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -929,18 +929,25 @@ fn extract_collation<'a>(
 ) -> crate::Result<(Option<CollationSeq>, &'a Expr)> {
     let mut current = expr;
     let mut coll = None;
-    while let Expr::Collate(inner, seq) = current {
-        let collation = match resolver {
-            Some(resolver) => resolver.resolve_collation(seq.as_str())?,
-            None => CollationSeq::new(seq.as_str())?,
-        };
-        if collation.is_custom() {
-            crate::bail_parse_error!("custom collations are not supported in indexes");
+    loop {
+        current = unwrap_parens(current)?;
+        match current {
+            Expr::Collate(inner, seq) => {
+                if coll.is_none() {
+                    let collation = match resolver {
+                        Some(resolver) => resolver.resolve_collation(seq.as_str())?,
+                        None => CollationSeq::new(seq.as_str())?,
+                    };
+                    if collation.is_custom() {
+                        crate::bail_parse_error!("custom collations are not supported in indexes");
+                    }
+                    coll = Some(collation);
+                }
+                current = inner.as_ref();
+            }
+            _ => return Ok((coll, current)),
         }
-        coll = Some(collation);
-        current = inner.as_ref();
     }
-    Ok((coll, current))
 }
 
 /// For a given Index Expression, attempts to resolve it to a column position in the table.

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -19,7 +19,7 @@ use crate::translate::{
 };
 use crate::vdbe::builder::{CursorKey, ProgramBuilderOpts, SelfTableContext};
 use crate::vdbe::insn::{to_u16, CmpInsFlags, Cookie};
-use crate::{bail_parse_error, CaptureDataChangesExt, LimboError, MAIN_DB_ID};
+use crate::{bail_parse_error, CaptureDataChangesExt, LimboError, MAIN_DB_ID, TEMP_DB_ID};
 use crate::{
     schema::{BTreeTable, Index, IndexColumn, PseudoCursorType},
     storage::pager::CreateBTreeFlags,
@@ -204,7 +204,7 @@ pub fn translate_create_index(
         name: idx_name.clone(),
         table_name: tbl.name.clone(),
         root_page: 0, //  we dont have access till its created, after we parse the schema table
-        columns: columns.clone(),
+        columns,
         unique,
         ephemeral: false,
         has_rowid: tbl.has_rowid,
@@ -225,49 +225,13 @@ pub fn translate_create_index(
         );
     }
 
-    // Allocate the necessary cursors:
-    //
-    // 1. sqlite_schema_cursor_id - sqlite_schema table
-    // 2. index_cursor_id         - new index cursor
-    // 3. table_cursor_id         - table we are creating the index on
-    // 4. sorter_cursor_id        - sorter
-    // 5. pseudo_cursor_id        - pseudo table to store the sorted index values
     let sqlite_table = resolver.schema().get_btree_table(SQLITE_TABLEID).unwrap();
     let sqlite_schema_cursor_id =
         program.alloc_cursor_id(CursorType::BTreeTable(sqlite_table.clone()));
-    let table_ref = program.table_reference_counter.next();
-    let index_cursor_id = program.alloc_cursor_index(None, &idx)?;
-    let table_cursor_id = program.alloc_cursor_id_keyed(
-        CursorKey::table(table_ref),
-        CursorType::BTreeTable(tbl.clone()),
-    );
-    let sorter_cursor_id = program.alloc_cursor_id(CursorType::Sorter);
-    let pseudo_cursor_id = program.alloc_cursor_id(CursorType::Pseudo(PseudoCursorType {
-        column_count: tbl.columns().len(),
-    }));
-
-    let mut table_references = TableReferences::new(
-        vec![JoinedTable {
-            op: Operation::Scan(Scan::BTreeTable {
-                iter_dir: IterationDirection::Forwards,
-                index: None,
-            }),
-            table: Table::BTree(tbl.clone()),
-            identifier: tbl_name.clone(),
-            internal_id: table_ref,
-            join_info: None,
-            col_used_mask: ColumnUsedMask::default(),
-            column_use_counts: Vec::new(),
-            expression_index_usages: Vec::new(),
-            database_id: MAIN_DB_ID,
-            indexed: None,
-        }],
-        vec![],
-    );
-    let where_clause = idx.bind_where_expr(Some(&mut table_references), resolver);
 
     // Create a new B-Tree and store the root page index in a register
     let root_page_reg = program.alloc_register();
+    let index_cursor_id = program.alloc_cursor_index(None, &idx)?;
     if idx.index_method.is_some() && !idx.is_backing_btree_index() {
         program.emit_insn(Insn::IndexMethodCreate {
             db: database_id,
@@ -302,276 +266,16 @@ pub fn translate_create_index(
         Some(sql),
     )?;
 
-    if index_method
-        .as_ref()
-        .is_some_and(|m| !m.definition().backing_btree)
-    {
-        // open the table we are creating the index on for reading
-        program.emit_insn(Insn::OpenRead {
-            cursor_id: table_cursor_id,
-            root_page: tbl.root_page,
-            db: database_id,
-        });
-
-        // Open the index btree we created for writing to insert the
-        // newly sorted index records.
-        program.emit_insn(Insn::OpenWrite {
-            cursor_id: index_cursor_id,
-            root_page: RegisterOrLiteral::Register(root_page_reg),
-            db: database_id,
-        });
-
-        let loop_start_label = program.allocate_label();
-        let loop_end_label = program.allocate_label();
-        program.emit_insn(Insn::Rewind {
-            cursor_id: table_cursor_id,
-            pc_if_empty: loop_end_label,
-        });
-        program.preassign_label_to_next_insn(loop_start_label);
-
-        // Loop start:
-        // Collect index values into start_reg..rowid_reg
-        // emit MakeRecord (index key + rowid) into record_reg.
-        //
-        // Then insert the record into the sorter
-        let mut skip_row_label = None;
-        if let Some(where_clause) = where_clause {
-            let label = program.allocate_label();
-            let condition_true_label = program.allocate_label();
-            translate_condition_expr(
-                program,
-                &table_references,
-                &where_clause,
-                ConditionMetadata {
-                    jump_if_condition_is_true: false,
-                    jump_target_when_false: label,
-                    jump_target_when_true: condition_true_label,
-                    jump_target_when_null: label,
-                },
-                resolver,
-            )?;
-            program.preassign_label_to_next_insn(condition_true_label);
-            skip_row_label = Some(label);
-        }
-
-        let start_reg = program.alloc_registers(columns.len() + 1);
-        for (i, col) in columns.iter().enumerate() {
-            emit_index_column_value_from_cursor(
-                program,
-                resolver,
-                &mut table_references,
-                table_cursor_id,
-                &tbl,
-                col,
-                start_reg + i,
-            )?;
-        }
-        let rowid_reg = start_reg + columns.len();
-        program.emit_insn(Insn::RowId {
-            cursor_id: table_cursor_id,
-            dest: rowid_reg,
-        });
-        let record_reg = program.alloc_register();
-        program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(start_reg),
-            count: to_u16(columns.len() + 1),
-            dest_reg: to_u16(record_reg),
-            index_name: Some(idx_name.clone()),
-            affinity_str: None,
-        });
-
-        // insert new index record
-        program.emit_insn(Insn::IdxInsert {
-            cursor_id: index_cursor_id,
-            record_reg,
-            unpacked_start: Some(start_reg),
-            unpacked_count: Some((columns.len() + 1) as u16),
-            flags: IdxInsertFlags::new().use_seek(false),
-        });
-
-        if let Some(skip_row_label) = skip_row_label {
-            program.preassign_label_to_next_insn(skip_row_label);
-        }
-        program.emit_insn(Insn::Next {
-            cursor_id: table_cursor_id,
-            pc_if_next: loop_start_label,
-        });
-        program.preassign_label_to_next_insn(loop_end_label);
-    } else if index_method.is_none() {
-        // determine the order, collation, and nulls ordering of the columns in the index for the sorter
-        let order_collations_nulls = idx
-            .columns
-            .iter()
-            .map(|c| (c.order, c.collation, None))
-            .collect();
-        // open the sorter and the pseudo table
-        program.emit_insn(Insn::SorterOpen {
-            cursor_id: sorter_cursor_id,
-            columns: columns.len(),
-            order_collations_nulls,
-            comparators: vec![],
-        });
-        let content_reg = program.alloc_register();
-        program.emit_insn(Insn::OpenPseudo {
-            cursor_id: pseudo_cursor_id,
-            content_reg,
-            num_fields: columns.len() + 1,
-        });
-
-        // open the table we are creating the index on for reading
-        program.emit_insn(Insn::OpenRead {
-            cursor_id: table_cursor_id,
-            root_page: tbl.root_page,
-            db: database_id,
-        });
-
-        let loop_start_label = program.allocate_label();
-        let loop_end_label = program.allocate_label();
-        program.emit_insn(Insn::Rewind {
-            cursor_id: table_cursor_id,
-            pc_if_empty: loop_end_label,
-        });
-        program.preassign_label_to_next_insn(loop_start_label);
-
-        // Loop start:
-        // Collect index values into start_reg..rowid_reg
-        // emit MakeRecord (index key + rowid) into record_reg.
-        //
-        // Then insert the record into the sorter
-        let mut skip_row_label = None;
-        if let Some(where_clause) = where_clause {
-            let label = program.allocate_label();
-            let condition_true_label = program.allocate_label();
-            translate_condition_expr(
-                program,
-                &table_references,
-                &where_clause,
-                ConditionMetadata {
-                    jump_if_condition_is_true: false,
-                    jump_target_when_false: label,
-                    jump_target_when_true: condition_true_label,
-                    jump_target_when_null: label,
-                },
-                resolver,
-            )?;
-            program.preassign_label_to_next_insn(condition_true_label);
-            skip_row_label = Some(label);
-        }
-
-        let start_reg = program.alloc_registers(columns.len() + 1);
-        for (i, col) in columns.iter().enumerate() {
-            emit_index_column_value_from_cursor(
-                program,
-                resolver,
-                &mut table_references,
-                table_cursor_id,
-                &tbl,
-                col,
-                start_reg + i,
-            )?;
-        }
-        let rowid_reg = start_reg + columns.len();
-        program.emit_insn(Insn::RowId {
-            cursor_id: table_cursor_id,
-            dest: rowid_reg,
-        });
-        let record_reg = program.alloc_register();
-        program.emit_insn(Insn::MakeRecord {
-            start_reg: to_u16(start_reg),
-            count: to_u16(columns.len() + 1),
-            dest_reg: to_u16(record_reg),
-            index_name: Some(idx_name.clone()),
-            affinity_str: None,
-        });
-        program.emit_insn(Insn::SorterInsert {
-            cursor_id: sorter_cursor_id,
-            record_reg,
-        });
-
-        if let Some(skip_row_label) = skip_row_label {
-            program.preassign_label_to_next_insn(skip_row_label);
-        }
-        program.emit_insn(Insn::Next {
-            cursor_id: table_cursor_id,
-            pc_if_next: loop_start_label,
-        });
-        program.preassign_label_to_next_insn(loop_end_label);
-
-        // Open the index btree we created for writing to insert the
-        // newly sorted index records.
-        program.emit_insn(Insn::OpenWrite {
-            cursor_id: index_cursor_id,
-            root_page: RegisterOrLiteral::Register(root_page_reg),
-            db: database_id,
-        });
-
-        let sorted_loop_start = program.allocate_label();
-        let sorted_loop_end = program.allocate_label();
-
-        // Sort the index records in the sorter
-        program.emit_insn(Insn::SorterSort {
-            cursor_id: sorter_cursor_id,
-            pc_if_empty: sorted_loop_end,
-        });
-
-        let sorted_record_reg = program.alloc_register();
-
-        if unique {
-            // Since the records to be inserted are sorted, we can compare prev with current and if they are equal,
-            // we fall through to Halt with a unique constraint violation error.
-            let goto_label = program.allocate_label();
-            let label_after_sorter_compare = program.allocate_label();
-            program.preassign_label_to_next_insn(goto_label);
-            program.emit_insn(Insn::Goto {
-                target_pc: label_after_sorter_compare,
-            });
-            program.preassign_label_to_next_insn(sorted_loop_start);
-            program.emit_insn(Insn::SorterCompare {
-                cursor_id: sorter_cursor_id,
-                sorted_record_reg,
-                num_regs: columns.len(),
-                pc_when_nonequal: goto_label,
-            });
-            program.emit_insn(Insn::Halt {
-                err_code: SQLITE_CONSTRAINT_UNIQUE,
-                description: format_unique_violation_desc(tbl_name.as_str(), &idx),
-                on_error: None,
-                description_reg: None,
-            });
-            program.preassign_label_to_next_insn(label_after_sorter_compare);
-        } else {
-            program.preassign_label_to_next_insn(sorted_loop_start);
-        }
-
-        program.emit_insn(Insn::SorterData {
-            pseudo_cursor: pseudo_cursor_id,
-            cursor_id: sorter_cursor_id,
-            dest_reg: sorted_record_reg,
-        });
-
-        // seek to the end of the index btree to position the cursor for appending
-        program.emit_insn(Insn::SeekEnd {
-            cursor_id: index_cursor_id,
-        });
-        // insert new index record
-        program.emit_insn(Insn::IdxInsert {
-            cursor_id: index_cursor_id,
-            record_reg: sorted_record_reg,
-            unpacked_start: None, // TODO: optimize with these to avoid decoding record twice
-            unpacked_count: None,
-            flags: IdxInsertFlags::new().use_seek(false),
-        });
-        program.emit_insn(Insn::SorterNext {
-            cursor_id: sorter_cursor_id,
-            pc_if_next: sorted_loop_start,
-        });
-        program.preassign_label_to_next_insn(sorted_loop_end);
-    }
-
-    // End of the outer loop
-    //
-    // Keep schema table open to emit ParseSchema, close the other cursors.
-    program.close_cursors(&[sorter_cursor_id, table_cursor_id, index_cursor_id]);
+    emit_refill_index(
+        program,
+        resolver,
+        database_id,
+        &tbl,
+        &idx,
+        index_cursor_id,
+        RegisterOrLiteral::Register(root_page_reg),
+        None,
+    )?;
 
     let current_schema_version = resolver.with_schema(database_id, |s| s.schema_version);
     program.emit_insn(Insn::SetCookie {
@@ -593,6 +297,566 @@ pub fn translate_create_index(
     });
 
     Ok(())
+}
+
+/// Emits the bytecode that rebuilds `idx` from a full scan of `tbl`.
+///
+/// `CREATE INDEX` calls this with a newly allocated root page. `REINDEX` calls it with
+/// `clear_existing_root` so the existing b-tree is emptied only after all replacement
+/// records have been collected and sorted. Statement journaling is therefore required
+/// around REINDEX callers so any later refill error restores the original index b-tree.
+#[allow(clippy::too_many_arguments)]
+fn emit_refill_index(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    database_id: usize,
+    tbl: &Arc<BTreeTable>,
+    idx: &Arc<Index>,
+    index_cursor_id: usize,
+    index_root_page: RegisterOrLiteral<i64>,
+    clear_existing_root: Option<i64>,
+) -> crate::Result<()> {
+    let table_ref = program.table_reference_counter.next();
+    let table_cursor_id = program.alloc_cursor_id_keyed(
+        CursorKey::table(table_ref),
+        CursorType::BTreeTable(tbl.clone()),
+    );
+    let sorter_cursor_id = program.alloc_cursor_id(CursorType::Sorter);
+    let pseudo_cursor_id = program.alloc_cursor_id(CursorType::Pseudo(PseudoCursorType {
+        column_count: tbl.columns().len(),
+    }));
+    let columns = &idx.columns;
+    let tbl_name = normalize_ident(tbl.name.as_str());
+
+    let mut table_references = TableReferences::new(
+        vec![JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            table: Table::BTree(tbl.clone()),
+            identifier: tbl_name.clone(),
+            internal_id: table_ref,
+            join_info: None,
+            col_used_mask: ColumnUsedMask::default(),
+            column_use_counts: Vec::new(),
+            expression_index_usages: Vec::new(),
+            database_id,
+            indexed: None,
+        }],
+        vec![],
+    );
+    let where_clause = idx.bind_where_expr(Some(&mut table_references), resolver);
+
+    if idx
+        .index_method
+        .as_ref()
+        .is_some_and(|m| !m.definition().backing_btree)
+    {
+        program.emit_insn(Insn::OpenRead {
+            cursor_id: table_cursor_id,
+            root_page: tbl.root_page,
+            db: database_id,
+        });
+
+        program.emit_insn(Insn::OpenWrite {
+            cursor_id: index_cursor_id,
+            root_page: index_root_page,
+            db: database_id,
+        });
+
+        let loop_start_label = program.allocate_label();
+        let loop_end_label = program.allocate_label();
+        program.emit_insn(Insn::Rewind {
+            cursor_id: table_cursor_id,
+            pc_if_empty: loop_end_label,
+        });
+        program.preassign_label_to_next_insn(loop_start_label);
+
+        let mut skip_row_label = None;
+        if let Some(where_clause) = where_clause {
+            let label = program.allocate_label();
+            let condition_true_label = program.allocate_label();
+            translate_condition_expr(
+                program,
+                &table_references,
+                &where_clause,
+                ConditionMetadata {
+                    jump_if_condition_is_true: false,
+                    jump_target_when_false: label,
+                    jump_target_when_true: condition_true_label,
+                    jump_target_when_null: label,
+                },
+                resolver,
+            )?;
+            program.preassign_label_to_next_insn(condition_true_label);
+            skip_row_label = Some(label);
+        }
+
+        let start_reg = program.alloc_registers(columns.len() + 1);
+        for (i, col) in columns.iter().enumerate() {
+            emit_index_column_value_from_cursor(
+                program,
+                resolver,
+                &mut table_references,
+                table_cursor_id,
+                tbl,
+                col,
+                start_reg + i,
+            )?;
+        }
+        let rowid_reg = start_reg + columns.len();
+        program.emit_insn(Insn::RowId {
+            cursor_id: table_cursor_id,
+            dest: rowid_reg,
+        });
+        let record_reg = program.alloc_register();
+        program.emit_insn(Insn::MakeRecord {
+            start_reg: to_u16(start_reg),
+            count: to_u16(columns.len() + 1),
+            dest_reg: to_u16(record_reg),
+            index_name: Some(idx.name.clone()),
+            affinity_str: None,
+        });
+
+        program.emit_insn(Insn::IdxInsert {
+            cursor_id: index_cursor_id,
+            record_reg,
+            unpacked_start: Some(start_reg),
+            unpacked_count: Some((columns.len() + 1) as u16),
+            flags: IdxInsertFlags::new().use_seek(false),
+        });
+
+        if let Some(skip_row_label) = skip_row_label {
+            program.preassign_label_to_next_insn(skip_row_label);
+        }
+        program.emit_insn(Insn::Next {
+            cursor_id: table_cursor_id,
+            pc_if_next: loop_start_label,
+        });
+        program.preassign_label_to_next_insn(loop_end_label);
+    } else {
+        let order_collations_nulls = idx
+            .columns
+            .iter()
+            .map(|c| (c.order, c.collation, None))
+            .collect();
+        program.emit_insn(Insn::SorterOpen {
+            cursor_id: sorter_cursor_id,
+            columns: columns.len(),
+            order_collations_nulls,
+            comparators: vec![],
+        });
+        let content_reg = program.alloc_register();
+        program.emit_insn(Insn::OpenPseudo {
+            cursor_id: pseudo_cursor_id,
+            content_reg,
+            num_fields: columns.len() + 1,
+        });
+
+        program.emit_insn(Insn::OpenRead {
+            cursor_id: table_cursor_id,
+            root_page: tbl.root_page,
+            db: database_id,
+        });
+
+        let loop_start_label = program.allocate_label();
+        let loop_end_label = program.allocate_label();
+        program.emit_insn(Insn::Rewind {
+            cursor_id: table_cursor_id,
+            pc_if_empty: loop_end_label,
+        });
+        program.preassign_label_to_next_insn(loop_start_label);
+
+        let mut skip_row_label = None;
+        if let Some(where_clause) = where_clause {
+            let label = program.allocate_label();
+            let condition_true_label = program.allocate_label();
+            translate_condition_expr(
+                program,
+                &table_references,
+                &where_clause,
+                ConditionMetadata {
+                    jump_if_condition_is_true: false,
+                    jump_target_when_false: label,
+                    jump_target_when_true: condition_true_label,
+                    jump_target_when_null: label,
+                },
+                resolver,
+            )?;
+            program.preassign_label_to_next_insn(condition_true_label);
+            skip_row_label = Some(label);
+        }
+
+        let start_reg = program.alloc_registers(columns.len() + 1);
+        for (i, col) in columns.iter().enumerate() {
+            emit_index_column_value_from_cursor(
+                program,
+                resolver,
+                &mut table_references,
+                table_cursor_id,
+                tbl,
+                col,
+                start_reg + i,
+            )?;
+        }
+        let rowid_reg = start_reg + columns.len();
+        program.emit_insn(Insn::RowId {
+            cursor_id: table_cursor_id,
+            dest: rowid_reg,
+        });
+        let record_reg = program.alloc_register();
+        program.emit_insn(Insn::MakeRecord {
+            start_reg: to_u16(start_reg),
+            count: to_u16(columns.len() + 1),
+            dest_reg: to_u16(record_reg),
+            index_name: Some(idx.name.clone()),
+            affinity_str: None,
+        });
+        program.emit_insn(Insn::SorterInsert {
+            cursor_id: sorter_cursor_id,
+            record_reg,
+        });
+
+        if let Some(skip_row_label) = skip_row_label {
+            program.preassign_label_to_next_insn(skip_row_label);
+        }
+        program.emit_insn(Insn::Next {
+            cursor_id: table_cursor_id,
+            pc_if_next: loop_start_label,
+        });
+        program.preassign_label_to_next_insn(loop_end_label);
+
+        if let Some(root) = clear_existing_root {
+            program.emit_insn(Insn::ClearBtree {
+                db: database_id,
+                root,
+            });
+        }
+        program.emit_insn(Insn::OpenWrite {
+            cursor_id: index_cursor_id,
+            root_page: index_root_page,
+            db: database_id,
+        });
+
+        let sorted_loop_start = program.allocate_label();
+        let sorted_loop_end = program.allocate_label();
+
+        program.emit_insn(Insn::SorterSort {
+            cursor_id: sorter_cursor_id,
+            pc_if_empty: sorted_loop_end,
+        });
+
+        let sorted_record_reg = program.alloc_register();
+
+        if idx.unique {
+            let goto_label = program.allocate_label();
+            let label_after_sorter_compare = program.allocate_label();
+            program.preassign_label_to_next_insn(goto_label);
+            program.emit_insn(Insn::Goto {
+                target_pc: label_after_sorter_compare,
+            });
+            program.preassign_label_to_next_insn(sorted_loop_start);
+            program.emit_insn(Insn::SorterCompare {
+                cursor_id: sorter_cursor_id,
+                sorted_record_reg,
+                num_regs: columns.len(),
+                pc_when_nonequal: goto_label,
+            });
+            program.emit_insn(Insn::Halt {
+                err_code: SQLITE_CONSTRAINT_UNIQUE,
+                description: format_unique_violation_desc(tbl_name.as_str(), idx),
+                on_error: None,
+                description_reg: None,
+            });
+            program.preassign_label_to_next_insn(label_after_sorter_compare);
+        } else {
+            program.preassign_label_to_next_insn(sorted_loop_start);
+        }
+
+        program.emit_insn(Insn::SorterData {
+            pseudo_cursor: pseudo_cursor_id,
+            cursor_id: sorter_cursor_id,
+            dest_reg: sorted_record_reg,
+        });
+
+        program.emit_insn(Insn::SeekEnd {
+            cursor_id: index_cursor_id,
+        });
+        program.emit_insn(Insn::IdxInsert {
+            cursor_id: index_cursor_id,
+            record_reg: sorted_record_reg,
+            unpacked_start: None,
+            unpacked_count: None,
+            flags: IdxInsertFlags::new().use_seek(false),
+        });
+        program.emit_insn(Insn::SorterNext {
+            cursor_id: sorter_cursor_id,
+            pc_if_next: sorted_loop_start,
+        });
+        program.preassign_label_to_next_insn(sorted_loop_end);
+    }
+
+    program.close_cursors(&[sorter_cursor_id, table_cursor_id, index_cursor_id]);
+    Ok(())
+}
+
+type ReindexTarget = (usize, Arc<BTreeTable>, Arc<Index>);
+
+/// Translates a SQLite-compatible `REINDEX` statement into bytecode.
+///
+/// The supported scope is rowid b-tree indexes in non-MVCC mode. Target
+/// resolution accepts SQLite's all-index, collation-name, table-name, and
+/// index-name forms, then emits a destructive clear-plus-refill program for
+/// each resolved index.
+pub fn translate_reindex(
+    name: Option<QualifiedName>,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    connection: &Arc<crate::Connection>,
+) -> crate::Result<()> {
+    if connection.mvcc_enabled() {
+        bail_parse_error!("REINDEX is not supported in MVCC mode");
+    }
+
+    let opts = ProgramBuilderOpts::new(5, 40, 5);
+    program.extend(&opts);
+
+    let targets = resolve_reindex_targets(name.as_ref(), resolver, connection)?;
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let mut write_databases = Vec::new();
+    for (database_id, _, _) in &targets {
+        if !write_databases.contains(database_id) {
+            let schema_cookie = resolver.with_schema(*database_id, |s| s.schema_version);
+            program.begin_write_on_database(*database_id, schema_cookie)?;
+            write_databases.push(*database_id);
+        }
+    }
+
+    for (database_id, table, index) in targets {
+        if index
+            .index_method
+            .as_ref()
+            .is_some_and(|m| !m.definition().backing_btree)
+        {
+            bail_parse_error!(
+                "REINDEX is not supported for custom index methods without a backing btree"
+            );
+        }
+        if !table.has_rowid {
+            bail_parse_error!("REINDEX on WITHOUT ROWID tables is not supported");
+        }
+        let index_cursor_id = program.alloc_cursor_index(None, &index)?;
+        emit_refill_index(
+            program,
+            resolver,
+            database_id,
+            &table,
+            &index,
+            index_cursor_id,
+            RegisterOrLiteral::Literal(index.root_page),
+            Some(index.root_page),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Resolves the optional `REINDEX` target name to concrete `(database, table, index)` triples.
+///
+/// SQLite resolves unqualified targets as collation, then table, then index. Qualified
+/// names are schema-local and can only refer to a table or index in that database.
+fn resolve_reindex_targets(
+    name: Option<&QualifiedName>,
+    resolver: &Resolver,
+    connection: &Arc<crate::Connection>,
+) -> crate::Result<Vec<ReindexTarget>> {
+    let Some(name) = name else {
+        return Ok(collect_all_reindex_targets(resolver, connection));
+    };
+
+    let normalized_name = normalize_ident(name.name.as_str());
+    if name.db_name.is_none() {
+        if let Ok(collation) = CollationSeq::new(&normalized_name) {
+            return Ok(collect_reindex_targets_by_collation(
+                resolver, connection, collation,
+            ));
+        }
+        if let Some(targets) = find_reindex_table(&normalized_name, resolver, connection) {
+            return Ok(targets);
+        }
+        if let Some(target) = find_reindex_index(&normalized_name, resolver, connection) {
+            return Ok(vec![target]);
+        }
+        bail_parse_error!("unable to identify the object to be reindexed");
+    }
+
+    let database_id = resolver.resolve_database_id(name)?;
+    if let Some(targets) = find_reindex_table_in_db(&normalized_name, database_id, resolver) {
+        return Ok(targets);
+    }
+    if let Some(target) = find_reindex_index_in_db(&normalized_name, database_id, resolver) {
+        return Ok(vec![target]);
+    }
+    bail_parse_error!("unable to identify the object to be reindexed");
+}
+
+/// Returns every reindexable index across temp, main, and attached databases.
+fn collect_all_reindex_targets(
+    resolver: &Resolver,
+    connection: &Arc<crate::Connection>,
+) -> Vec<ReindexTarget> {
+    let mut targets = Vec::new();
+    for (database_id, _, _) in connection.list_all_databases() {
+        targets.extend(collect_all_reindex_targets_in_db(database_id, resolver));
+    }
+    targets
+}
+
+/// Returns every index across all schemas that contains at least one column using `collation`.
+fn collect_reindex_targets_by_collation(
+    resolver: &Resolver,
+    connection: &Arc<crate::Connection>,
+    collation: CollationSeq,
+) -> Vec<ReindexTarget> {
+    let mut targets = Vec::new();
+    for (database_id, _, _) in connection.list_all_databases() {
+        targets.extend(
+            collect_all_reindex_targets_in_db(database_id, resolver)
+                .into_iter()
+                .filter(|(_, _, index)| index_matches_collation(index, collation)),
+        );
+    }
+    targets
+}
+
+/// Returns every reindexable index in one schema database.
+fn collect_all_reindex_targets_in_db(
+    database_id: usize,
+    resolver: &Resolver,
+) -> Vec<ReindexTarget> {
+    resolver.with_schema(database_id, |schema| {
+        schema
+            .indexes
+            .iter()
+            .filter_map(|(table_name, indexes)| {
+                schema
+                    .get_btree_table(table_name)
+                    .map(|table| (table, indexes))
+            })
+            .flat_map(|(table, indexes)| {
+                indexes
+                    .iter()
+                    .cloned()
+                    .map(move |index| (database_id, table.clone(), index))
+            })
+            .collect()
+    })
+}
+
+/// Finds the first table matching an unqualified `REINDEX table_name` target.
+///
+/// Search order follows SQLite name resolution for unqualified schema objects:
+/// temp first, main second, then attached databases by numeric database id.
+fn find_reindex_table(
+    table_name: &str,
+    resolver: &Resolver,
+    connection: &Arc<crate::Connection>,
+) -> Option<Vec<ReindexTarget>> {
+    for database_id in reindex_unqualified_search_database_ids(connection) {
+        if let Some(targets) = find_reindex_table_in_db(table_name, database_id, resolver) {
+            return Some(targets);
+        }
+    }
+    None
+}
+
+/// Returns all indexes belonging to `table_name` inside a single database.
+///
+/// A table without indexes is still a valid REINDEX target, so this returns an
+/// empty vector wrapped in `Some` when the table exists.
+fn find_reindex_table_in_db(
+    table_name: &str,
+    database_id: usize,
+    resolver: &Resolver,
+) -> Option<Vec<ReindexTarget>> {
+    resolver.with_schema(database_id, |schema| {
+        let table = schema.get_btree_table(table_name)?;
+        let targets = schema
+            .indexes
+            .get(&normalize_ident(table.name.as_str()))
+            .map(|indexes| {
+                indexes
+                    .iter()
+                    .cloned()
+                    .map(|index| (database_id, table.clone(), index))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Some(targets)
+    })
+}
+
+/// Finds the first index matching an unqualified `REINDEX index_name` target.
+///
+/// This is tried only after collation and table lookup fail.
+fn find_reindex_index(
+    index_name: &str,
+    resolver: &Resolver,
+    connection: &Arc<crate::Connection>,
+) -> Option<ReindexTarget> {
+    for database_id in reindex_unqualified_search_database_ids(connection) {
+        if let Some(target) = find_reindex_index_in_db(index_name, database_id, resolver) {
+            return Some(target);
+        }
+    }
+    None
+}
+
+/// Finds one index by name inside a single database and returns its owning table.
+fn find_reindex_index_in_db(
+    index_name: &str,
+    database_id: usize,
+    resolver: &Resolver,
+) -> Option<ReindexTarget> {
+    resolver.with_schema(database_id, |schema| {
+        for (table_name, indexes) in &schema.indexes {
+            if let Some(index) = indexes
+                .iter()
+                .find(|index| index.name.eq_ignore_ascii_case(index_name))
+            {
+                let table = schema.get_btree_table(table_name)?;
+                return Some((database_id, table, index.clone()));
+            }
+        }
+        None
+    })
+}
+
+/// Returns database ids in SQLite's unqualified REINDEX search order.
+fn reindex_unqualified_search_database_ids(connection: &Arc<crate::Connection>) -> Vec<usize> {
+    let mut database_ids: Vec<_> = connection
+        .list_all_databases()
+        .into_iter()
+        .map(|(database_id, _, _)| database_id)
+        .collect();
+    database_ids.sort_by_key(|database_id| match *database_id {
+        TEMP_DB_ID => 0,
+        MAIN_DB_ID => 1,
+        _ => *database_id,
+    });
+    database_ids
+}
+
+/// Returns whether any indexed term explicitly uses `collation`.
+fn index_matches_collation(index: &Index, collation: CollationSeq) -> bool {
+    index
+        .columns
+        .iter()
+        .any(|column| column.collation.unwrap_or_default() == collation)
 }
 
 pub fn resolve_sorted_columns(

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -155,7 +155,6 @@ pub fn translate_inner(
             | ast::Stmt::DropType { .. }
             | ast::Stmt::DropDomain { .. }
             | ast::Stmt::DropView { .. }
-            | ast::Stmt::Reindex { .. }
             | ast::Stmt::Optimize { .. }
             | ast::Stmt::Update { .. }
             | ast::Stmt::Insert { .. }

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -56,7 +56,7 @@ use crate::vdbe::Program;
 use crate::{bail_parse_error, Connection, Result, SymbolTable};
 use alter::translate_alter_table;
 use analyze::translate_analyze;
-use index::{translate_create_index, translate_drop_index, translate_optimize};
+use index::{translate_create_index, translate_drop_index, translate_optimize, translate_reindex};
 use insert::translate_insert;
 use rollback::{translate_release, translate_rollback, translate_savepoint};
 use schema::{translate_create_table, translate_create_virtual_table, translate_drop_table};
@@ -356,7 +356,7 @@ pub fn translate_inner(
         ast::Stmt::Pragma { .. } => {
             bail_parse_error!("PRAGMA statement cannot be evaluated in a nested context")
         }
-        ast::Stmt::Reindex { .. } => bail_parse_error!("REINDEX not supported yet"),
+        ast::Stmt::Reindex { name } => translate_reindex(name, resolver, program, connection)?,
         ast::Stmt::Optimize { idx_name } => {
             translate_optimize(idx_name, resolver, program, connection)?
         }

--- a/core/util.rs
+++ b/core/util.rs
@@ -120,8 +120,8 @@ const QUOTE_PAIRS: &[(char, char)] = &[
 
 pub fn normalize_ident(identifier: &str) -> String {
     // quotes normalization already happened in the parser layer (see Name ast node implementation)
-    // so, we only need to convert identifier string to lowercase
-    identifier.to_lowercase()
+    // so, we only need to apply SQLite's ASCII-only identifier case folding.
+    identifier.to_ascii_lowercase()
 }
 
 /// Escape a SQL string literal payload for safe interpolation inside single quotes.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11142,6 +11142,15 @@ pub enum OpDestroyState {
     DestroyBtree(Arc<RwLock<BTreeCursor>>),
 }
 
+/// State carried across asynchronous steps while clearing an existing b-tree.
+pub enum OpClearBtreeState {
+    CreateCursor,
+    ClearBtree {
+        pager: Arc<Pager>,
+        cursor: Arc<RwLock<BTreeCursor>>,
+    },
+}
+
 pub fn op_destroy(
     program: &Program,
     state: &mut ProgramState,
@@ -11183,6 +11192,76 @@ pub fn op_destroy(
                 let maybe_former_root_page = return_if_io!(cursor.write().btree_destroy());
                 state.registers[*former_root_reg]
                     .set_int(maybe_former_root_page.unwrap_or(0) as i64);
+                state.active_op_state.clear();
+                state.pc += 1;
+                return Ok(InsnFunctionStepResult::Step);
+            }
+        }
+    }
+}
+
+/// Executes `ClearBtree` by deleting all cells from a persistent b-tree root.
+///
+/// REINDEX uses this after sorting all replacement index records and before
+/// refilling the existing root page. The operation invalidates other b-tree
+/// cursors on the same pager because page contents and cursor positions may no
+/// longer be valid after the clear.
+pub fn op_clear_btree(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    match op_clear_btree_inner(program, state, insn, pager) {
+        Ok(result) => Ok(result),
+        Err(err) => {
+            if !matches!(err, LimboError::Busy | LimboError::BusySnapshot) {
+                state.active_op_state.clear();
+            }
+            Err(err)
+        }
+    }
+}
+
+fn op_clear_btree_inner(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(ClearBtree { db, root }, insn);
+
+    let mv_store = program.connection.mv_store_for_db(*db);
+    if mv_store.is_some() {
+        return Err(LimboError::InternalError(
+            "ClearBtree is not supported in MVCC mode".to_string(),
+        ));
+    }
+
+    let clear_pager = if *db != MAIN_DB_ID {
+        program.get_pager_from_database_index(db)?
+    } else {
+        pager.clone()
+    };
+
+    loop {
+        match state.active_op_state.clear_btree() {
+            OpClearBtreeState::CreateCursor => {
+                let cursor = BTreeCursor::new(clear_pager.clone(), *root, 0);
+                *state.active_op_state.clear_btree() = OpClearBtreeState::ClearBtree {
+                    pager: clear_pager.clone(),
+                    cursor: Arc::new(RwLock::new(cursor)),
+                };
+            }
+            OpClearBtreeState::ClearBtree { pager, cursor } => {
+                return_if_io!(cursor.write().clear_btree());
+                for other_cursor_opt in state.cursors.iter_mut().flatten() {
+                    if let Cursor::BTree(ref mut btree_cursor) = other_cursor_opt {
+                        if Arc::ptr_eq(&btree_cursor.get_pager(), pager) {
+                            btree_cursor.invalidate_btree_cache();
+                        }
+                    }
+                }
                 state.active_op_state.clear();
                 state.pc += 1;
                 return Ok(InsnFunctionStepResult::Step);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13598,12 +13598,15 @@ pub fn op_alter_column(
             .expect("btree column should be named")
             .clone();
 
-        // Update indexes on THIS table that name the old column (you already had this)
+        // Update this table's indexes that reference the old column.
         if let Some(idxs) = schema.indexes.get_mut(&normalized_table_name) {
             for idx in idxs {
                 let idx = Arc::make_mut(idx);
                 for ic in &mut idx.columns {
-                    if ic.name.eq_ignore_ascii_case(&existing_column_name) {
+                    if let Some(expr) = &mut ic.expr {
+                        rename_identifiers(expr.as_mut(), &old_column_name, &new_name);
+                        ic.name = expr.to_string();
+                    } else if ic.name.eq_ignore_ascii_case(&existing_column_name) {
                         ic.name.clone_from(&new_name);
                     }
                 }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1645,6 +1645,15 @@ pub fn insn_to_row(
                 0,
                 "".to_string()
             ),
+            Insn::ClearBtree { db, root } => (
+                "ClearBtree",
+                *root,
+                *db as i64,
+                0,
+                Value::build_text(""),
+                0,
+                format!("root={root} iDb={db}"),
+            ),
             Insn::Destroy {
                 db,
                 root,

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -45,8 +45,12 @@ const BLOB_HASH: u8 = 4;
 /// Hash text case-insensitively without allocation (ASCII-only for SQLite NOCASE).
 /// SQLite's NOCASE collation only considers ASCII case, so to_ascii_lowercase() is correct.
 fn hash_text_nocase(hasher: &mut impl Hasher, text: &str) {
+    hasher.write_usize(text.len());
     for byte in text.bytes() {
         hasher.write_u8(byte.to_ascii_lowercase());
+        if byte == 0 {
+            break;
+        }
     }
 }
 
@@ -86,7 +90,7 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
                         hash_text_nocase(&mut hasher, text.as_str());
                     }
                     CollationSeq::Rtrim => {
-                        let trimmed = text.as_str().trim_end();
+                        let trimmed = text.as_str().trim_end_matches(' ');
                         hasher.write(trimmed.as_bytes());
                     }
                     CollationSeq::Binary | CollationSeq::Unset => {
@@ -3864,6 +3868,28 @@ mod hashtests {
         assert_ne!(
             h1, h2,
             "non-ASCII chars should not be case-folded by NOCASE"
+        );
+    }
+
+    #[test]
+    fn test_hash_nocase_embedded_nul_matches_equality() {
+        use crate::types::{TextRef, TextSubtype};
+
+        let nocase_coll = vec![CollationSeq::NoCase];
+        let keys1 = vec![ValueRef::Text(TextRef::new("A\0x", TextSubtype::Text))];
+        let keys2 = vec![ValueRef::Text(TextRef::new("a\0y", TextSubtype::Text))];
+        let keys3 = vec![ValueRef::Text(TextRef::new("a\0yz", TextSubtype::Text))];
+
+        assert!(values_equal(keys1[0], keys2[0], CollationSeq::NoCase));
+        assert_eq!(
+            hash_join_key(&keys1, &nocase_coll),
+            hash_join_key(&keys2, &nocase_coll)
+        );
+
+        assert!(!values_equal(keys1[0], keys3[0], CollationSeq::NoCase));
+        assert_ne!(
+            hash_join_key(&keys1, &nocase_coll),
+            hash_join_key(&keys3, &nocase_coll)
         );
     }
 

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1292,6 +1292,12 @@ pub enum Insn {
         pc_if_empty: BranchOffset,
     },
 
+    /// Delete all contents from a persistent table or index b-tree while keeping its root page.
+    ClearBtree {
+        db: usize,
+        root: i64,
+    },
+
     /// Deletes an entire database table or index whose root page in the database file is given by P1.
     Destroy {
         /// The database index (0 = main, 1 = temp, 2+ = attached)
@@ -1977,6 +1983,7 @@ impl InsnVariants {
             InsnVariants::IndexMethodDestroy => execute::op_index_method_destroy,
             InsnVariants::IndexMethodOptimize => execute::op_index_method_optimize,
             InsnVariants::IndexMethodQuery => execute::op_index_method_query,
+            InsnVariants::ClearBtree => execute::op_clear_btree,
             InsnVariants::Destroy => execute::op_destroy,
             InsnVariants::ResetSorter => execute::op_reset_sorter,
             InsnVariants::DropTable => execute::op_drop_table,
@@ -2088,6 +2095,7 @@ impl Insn {
             | Self::IndexMethodCreate { .. }
             | Self::IndexMethodDestroy { .. }
             | Self::IndexMethodOptimize { .. }
+            | Self::ClearBtree { .. }
             | Self::Destroy { .. }
             | Self::DropTable { .. }
             | Self::DropView { .. }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -48,10 +48,10 @@ use crate::{
     types::{IOCompletions, IOResult},
     vdbe::{
         execute::{
-            OpColumnState, OpDeleteState, OpDeleteSubState, OpDestroyState, OpIdxInsertState,
-            OpInitCdcVersionState, OpInsertState, OpInsertSubState, OpJournalModeState,
-            OpNewRowidState, OpNoConflictState, OpParseSchemaState, OpProgramState, OpRowIdState,
-            OpSeekState, OpTransactionState, VacuumIntoOpContext,
+            OpClearBtreeState, OpColumnState, OpDeleteState, OpDeleteSubState, OpDestroyState,
+            OpIdxInsertState, OpInitCdcVersionState, OpInsertState, OpInsertSubState,
+            OpJournalModeState, OpNewRowidState, OpNoConflictState, OpParseSchemaState,
+            OpProgramState, OpRowIdState, OpSeekState, OpTransactionState, VacuumIntoOpContext,
         },
         hash_table::HashTable,
         metrics::StatementMetrics,
@@ -429,6 +429,7 @@ pub struct OpHashProbeState {
 
 enum ActiveOpState {
     None,
+    ClearBtree(OpClearBtreeState),
     Delete(OpDeleteState),
     Destroy(OpDestroyState),
     IdxDelete(OpIdxDeleteState),
@@ -453,6 +454,7 @@ impl std::fmt::Debug for ActiveOpState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
             ActiveOpState::None => "None",
+            ActiveOpState::ClearBtree(_) => "ClearBtree",
             ActiveOpState::Delete(_) => "Delete",
             ActiveOpState::Destroy(_) => "Destroy",
             ActiveOpState::IdxDelete(_) => "IdxDelete",
@@ -518,6 +520,12 @@ impl ActiveOpStateSlot {
             sub_state: OpDeleteSubState::MaybeCaptureRecord,
             deleted_record: None,
         }
+    );
+    active_state_accessor!(
+        clear_btree,
+        ClearBtree,
+        OpClearBtreeState,
+        OpClearBtreeState::CreateCursor
     );
     active_state_accessor!(
         destroy,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1071,6 +1071,67 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn parse_reindex_fullname(&mut self) -> Result<QualifiedName> {
+        let first_name = self.parse_reindex_nm()?;
+
+        let second_name = if let Some(tok) = self.peek()? {
+            if tok.token_type == TK_DOT {
+                eat_assert!(self, TK_DOT);
+                Some(self.parse_reindex_nm()?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(second_name) = second_name {
+            Ok(QualifiedName {
+                db_name: Some(first_name),
+                name: second_name,
+                alias: None,
+            })
+        } else {
+            Ok(QualifiedName {
+                db_name: None,
+                name: first_name,
+                alias: None,
+            })
+        }
+    }
+
+    fn parse_reindex_nm(&mut self) -> Result<Name> {
+        let offset = self.offset();
+        let token = self.peek_no_eof()?;
+        if Self::is_reindex_compound_operator_name(token) {
+            let token_len = token.value.len();
+            let token_text = token.to_utf8();
+            return Err(Error::ParseUnexpectedToken {
+                parsed_offset: (offset, token_len).into(),
+                expected: &[TK_ID, TK_STRING, TK_INDEXED, TK_JOIN_KW, TK_LBRACKET],
+                got: token.token_type,
+                token_text,
+                offset,
+                expected_display: crate::token::TokenType::format_expected_tokens(&[
+                    TK_ID,
+                    TK_STRING,
+                    TK_INDEXED,
+                    TK_JOIN_KW,
+                    TK_LBRACKET,
+                ]),
+            });
+        }
+        self.parse_nm()
+    }
+
+    fn is_reindex_compound_operator_name(token: &Token<'_>) -> bool {
+        matches!(token.token_type, TK_UNION | TK_EXCEPT | TK_INTERSECT)
+            || matches!(token.token_type, TK_ID)
+                && (token.as_bytes().eq_ignore_ascii_case(b"union")
+                    || token.as_bytes().eq_ignore_ascii_case(b"except")
+                    || token.as_bytes().eq_ignore_ascii_case(b"intersect"))
+    }
+
     fn parse_signed(&mut self) -> Result<Box<Expr>> {
         peek_expect!(self, TK_FLOAT, TK_INTEGER, TK_PLUS, TK_MINUS);
 
@@ -4897,8 +4958,8 @@ impl<'a> Parser<'a> {
         eat_assert!(self, TK_REINDEX);
         match self.peek()? {
             Some(tok) => match tok.token_type.fallback_id_if_ok() {
-                TK_ID | TK_STRING | TK_JOIN_KW | TK_INDEXED => Ok(Stmt::Reindex {
-                    name: Some(self.parse_fullname(false)?),
+                TK_ID | TK_STRING | TK_JOIN_KW | TK_INDEXED | TK_LBRACKET => Ok(Stmt::Reindex {
+                    name: Some(self.parse_reindex_fullname()?),
                 }),
                 _ => Ok(Stmt::Reindex { name: None }),
             },

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -64,6 +64,13 @@ expect {
     1
 }
 
+test collate_nocase_embedded_nul {
+    SELECT CAST(X'410078' AS TEXT) = CAST(X'410079' AS TEXT) COLLATE NOCASE;
+}
+expect {
+    1
+}
+
 
 
 @cross-check-integrity

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -316,6 +316,16 @@ expect error {
     unable to identify the object to be reindexed
 }
 
+test reindex-non-ascii-identifiers-use-ascii-case-folding {
+    CREATE TABLE Café_reindex(a INT);
+    CREATE INDEX idx_cafe_reindex ON Café_reindex(a);
+    INSERT INTO Café_reindex VALUES(1);
+    REINDEX CAFÉ_reindex;
+}
+expect error {
+    unable to identify the object to be reindexed
+}
+
 test reindex-unknown-target {
     REINDEX missing_reindex_target;
 }

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -291,6 +291,18 @@ expect {
     ok
 }
 
+test reindex-view-is-noop {
+    CREATE TABLE t_reindex_view(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_reindex_view_a ON t_reindex_view(a);
+    INSERT INTO t_reindex_view VALUES (1, 'view-ok');
+    CREATE VIEW v_reindex_view AS SELECT * FROM t_reindex_view;
+    REINDEX v_reindex_view;
+    SELECT id, a FROM t_reindex_view ORDER BY id;
+}
+expect {
+    1|view-ok
+}
+
 test reindex-bracket-quoted-target {
     CREATE TABLE [t_reindex_bracket](a);
     CREATE INDEX [idx_reindex_bracket] ON [t_reindex_bracket](a);

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -314,6 +314,18 @@ expect {
     1
 }
 
+test reindex-expression-index-after-rename-column {
+    CREATE TABLE t_reindex_rename_expr(a, b);
+    CREATE INDEX idx_reindex_rename_expr ON t_reindex_rename_expr(a + b);
+    INSERT INTO t_reindex_rename_expr VALUES (1, 2), (3, 4);
+    ALTER TABLE t_reindex_rename_expr RENAME COLUMN a TO aa;
+    REINDEX idx_reindex_rename_expr;
+    SELECT * FROM t_reindex_rename_expr WHERE aa + b = 3;
+}
+expect {
+    1|2
+}
+
 test reindex-expression-index-explicit-collate {
     CREATE TABLE t_reindex_expr_collate(a TEXT);
     CREATE INDEX idx_reindex_expr_collate ON t_reindex_expr_collate((a COLLATE NOCASE));

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -1,0 +1,299 @@
+@database :memory:
+
+@skip-file-if mvcc "not supported in MVCC mode"
+
+test reindex-all {
+    CREATE TABLE t_all(id INTEGER PRIMARY KEY, a TEXT, b TEXT);
+    CREATE INDEX idx_all_a ON t_all(a);
+    CREATE INDEX idx_all_b ON t_all(b);
+    INSERT INTO t_all VALUES
+        (1, 'one', 'two'),
+        (2, 'three', 'four'),
+        (3, 'five', 'six');
+    REINDEX;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-table {
+    CREATE TABLE t_table(id INTEGER PRIMARY KEY, a TEXT, b TEXT);
+    CREATE INDEX idx_table_a ON t_table(a);
+    CREATE INDEX idx_table_b ON t_table(b);
+    INSERT INTO t_table VALUES
+        (1, 'a', 'x'),
+        (2, 'b', 'y'),
+        (3, 'c', 'z');
+    REINDEX t_table;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-index {
+    CREATE TABLE t_index(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_index_a ON t_index(a);
+    INSERT INTO t_index VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    REINDEX idx_index_a;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-table-without-indexes {
+    CREATE TABLE t_without_indexes(id INTEGER PRIMARY KEY, a TEXT);
+    INSERT INTO t_without_indexes VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    REINDEX t_without_indexes;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-qualified-table {
+    CREATE TABLE t_qualified_table(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_qualified_table_a ON t_qualified_table(a);
+    INSERT INTO t_qualified_table VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    REINDEX main.t_qualified_table;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-qualified-index {
+    CREATE TABLE t_qualified_index(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_qualified_index_a ON t_qualified_index(a);
+    INSERT INTO t_qualified_index VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    REINDEX main.idx_qualified_index_a;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-collation-nocase {
+    CREATE TABLE t_nocase(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_nocase_a ON t_nocase(a COLLATE NOCASE);
+    INSERT INTO t_nocase VALUES (1, 'a'), (2, 'B'), (3, 'c');
+    REINDEX nocase;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-collation-binary {
+    CREATE TABLE t_binary(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_binary_a ON t_binary(a COLLATE BINARY);
+    INSERT INTO t_binary VALUES (1, 'a'), (2, 'B'), (3, 'c');
+    REINDEX binary;
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+test reindex-partial-expression-index {
+    CREATE TABLE t_partial_expr(id INTEGER PRIMARY KEY, a TEXT, b INT);
+    CREATE INDEX idx_partial_expr ON t_partial_expr(lower(a)) WHERE b > 0;
+    INSERT INTO t_partial_expr VALUES
+        (1, 'Alpha', 1),
+        (2, 'beta', 2),
+        (3, 'Gamma', 0),
+        (4, 'ALPHA', -1),
+        (5, 'delta', 3);
+    REINDEX idx_partial_expr;
+    SELECT id, a FROM t_partial_expr INDEXED BY idx_partial_expr
+        WHERE lower(a) >= 'a' AND b > 0
+        ORDER BY lower(a), id;
+    PRAGMA integrity_check;
+}
+expect {
+    1|Alpha
+    2|beta
+    5|delta
+    ok
+}
+
+test reindex-composite-desc-index {
+    CREATE TABLE t_composite(id INTEGER PRIMARY KEY, a TEXT, b INT, c TEXT);
+    CREATE INDEX idx_composite ON t_composite(a COLLATE NOCASE DESC, b ASC, c DESC);
+    INSERT INTO t_composite VALUES
+        (1, 'alpha', 2, 'x'),
+        (2, 'Beta', 1, 'z'),
+        (3, 'beta', 1, 'a'),
+        (4, 'gamma', 3, 'm'),
+        (5, 'Alpha', 1, 'q');
+    REINDEX idx_composite;
+    SELECT id, a, b, c FROM t_composite INDEXED BY idx_composite
+        WHERE a >= ''
+        ORDER BY a COLLATE NOCASE DESC, b ASC, c DESC;
+    PRAGMA integrity_check;
+}
+expect {
+    4|gamma|3|m
+    2|Beta|1|z
+    3|beta|1|a
+    5|Alpha|1|q
+    1|alpha|2|x
+    ok
+}
+
+test reindex-rtrim-and-implicit-column-collation {
+    CREATE TABLE t_collations(
+        id INTEGER PRIMARY KEY,
+        a TEXT COLLATE NOCASE,
+        b TEXT
+    );
+    CREATE INDEX idx_implicit_nocase ON t_collations(a);
+    CREATE INDEX idx_rtrim ON t_collations(b COLLATE RTRIM);
+    INSERT INTO t_collations VALUES
+        (1, 'bravo', 'x   '),
+        (2, 'Alpha', 'x'),
+        (3, 'charlie', 'w  '),
+        (4, 'alpha', 'w');
+    REINDEX nocase;
+    REINDEX rtrim;
+    SELECT id, a FROM t_collations INDEXED BY idx_implicit_nocase
+        WHERE a >= ''
+        ORDER BY a, id;
+    SELECT id, quote(b) FROM t_collations INDEXED BY idx_rtrim
+        WHERE b >= ''
+        ORDER BY b COLLATE RTRIM, id;
+    PRAGMA integrity_check;
+}
+expect {
+    2|Alpha
+    4|alpha
+    1|bravo
+    3|charlie
+    3|'w  '
+    4|'w'
+    1|'x   '
+    2|'x'
+    ok
+}
+
+test reindex-unique-autoindex-and-null-keys {
+    CREATE TABLE t_unique(
+        id INTEGER PRIMARY KEY,
+        a TEXT,
+        b INT,
+        UNIQUE(a, b)
+    );
+    INSERT INTO t_unique VALUES
+        (1, 'a', 1),
+        (2, 'b', 2),
+        (3, NULL, 1),
+        (4, NULL, 1),
+        (5, 'c', NULL),
+        (6, 'c', NULL);
+    REINDEX t_unique;
+    SELECT id, a, b FROM t_unique
+        WHERE a IS NULL OR b IS NULL
+        ORDER BY id;
+    PRAGMA integrity_check;
+}
+expect {
+    3||1
+    4||1
+    5|c|
+    6|c|
+    ok
+}
+
+test reindex-table-with-multiple-index-types {
+    CREATE TABLE t_mixed(id INTEGER PRIMARY KEY, a TEXT, b INT, c TEXT);
+    CREATE INDEX idx_mixed_a ON t_mixed(a COLLATE NOCASE);
+    CREATE INDEX idx_mixed_partial ON t_mixed(b) WHERE b % 2 = 0;
+    CREATE INDEX idx_mixed_expr ON t_mixed(substr(c, 1, 1), id DESC);
+    INSERT INTO t_mixed VALUES
+        (1, 'Zulu', 2, 'ant'),
+        (2, 'alpha', 3, 'bee'),
+        (3, 'Echo', 4, 'ape'),
+        (4, 'bravo', 6, 'bat');
+    REINDEX t_mixed;
+    SELECT id FROM t_mixed INDEXED BY idx_mixed_a
+        WHERE a >= ''
+        ORDER BY a COLLATE NOCASE;
+    SELECT id, b FROM t_mixed INDEXED BY idx_mixed_partial
+        WHERE b >= 0 AND b % 2 = 0
+        ORDER BY b;
+    SELECT id, c FROM t_mixed INDEXED BY idx_mixed_expr
+        WHERE substr(c, 1, 1) >= ''
+        ORDER BY substr(c, 1, 1), id DESC;
+    PRAGMA integrity_check;
+}
+expect {
+    2
+    4
+    3
+    1
+    1|2
+    3|4
+    4|6
+    3|ape
+    1|ant
+    4|bat
+    2|bee
+    ok
+}
+
+test reindex-attached-qualified-targets {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t(id INTEGER PRIMARY KEY, a TEXT, b INT);
+    CREATE INDEX aux.idx_aux_a ON t(a COLLATE NOCASE);
+    CREATE INDEX aux.idx_aux_expr ON t(abs(b));
+    INSERT INTO aux.t VALUES (1, 'b', -2), (2, 'A', 1), (3, 'c', -1);
+    REINDEX aux.t;
+    REINDEX aux.idx_aux_a;
+    SELECT id, a FROM aux.t INDEXED BY idx_aux_a
+        WHERE a >= ''
+        ORDER BY a COLLATE NOCASE;
+    SELECT id, b FROM aux.t INDEXED BY idx_aux_expr
+        WHERE abs(b) >= 0
+        ORDER BY abs(b), id;
+}
+expect {
+    2|A
+    1|b
+    3|c
+    2|1
+    3|-1
+    1|-2
+}
+
+test reindex-temp-shadows-main-unqualified {
+    CREATE TABLE t_shadow(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_shadow_main ON t_shadow(a);
+    INSERT INTO t_shadow VALUES (1, 'main-b'), (2, 'main-a');
+    CREATE TEMP TABLE t_shadow(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_shadow_temp ON t_shadow(a);
+    INSERT INTO temp.t_shadow VALUES (1, 'temp-b'), (2, 'temp-a');
+    REINDEX t_shadow;
+    SELECT id, a FROM temp.t_shadow INDEXED BY idx_shadow_temp
+        WHERE a >= ''
+        ORDER BY a;
+    SELECT id, a FROM main.t_shadow INDEXED BY idx_shadow_main
+        WHERE a >= ''
+        ORDER BY a;
+    PRAGMA integrity_check;
+}
+expect {
+    2|temp-a
+    1|temp-b
+    2|main-a
+    1|main-b
+    ok
+}
+
+test reindex-unknown-target {
+    REINDEX missing_reindex_target;
+}
+expect error {
+    unable to identify the object to be reindexed
+}

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -291,6 +291,16 @@ expect {
     ok
 }
 
+test reindex-unset-is-not-a-collation {
+    CREATE TABLE t_reindex_unset(id INTEGER PRIMARY KEY, a TEXT);
+    CREATE INDEX idx_reindex_unset ON t_reindex_unset(a);
+    INSERT INTO t_reindex_unset VALUES (1, 'x');
+    REINDEX UNSET;
+}
+expect error {
+    unable to identify the object to be reindexed
+}
+
 test reindex-unknown-target {
     REINDEX missing_reindex_target;
 }

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -291,6 +291,21 @@ expect {
     ok
 }
 
+test reindex-nocase-embedded-nul {
+    CREATE TABLE t_reindex_nul(a);
+    CREATE INDEX idx_reindex_nul ON t_reindex_nul(a COLLATE NOCASE);
+    INSERT INTO t_reindex_nul VALUES(CAST(X'410078' AS TEXT));
+    INSERT INTO t_reindex_nul VALUES(CAST(X'410079' AS TEXT));
+    REINDEX idx_reindex_nul;
+    SELECT hex(a) FROM t_reindex_nul
+        WHERE a = CAST(X'410078' AS TEXT) COLLATE NOCASE
+        ORDER BY rowid;
+}
+expect {
+    410078
+    410079
+}
+
 test reindex-unset-is-not-a-collation {
     CREATE TABLE t_reindex_unset(id INTEGER PRIMARY KEY, a TEXT);
     CREATE INDEX idx_reindex_unset ON t_reindex_unset(a);

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -314,6 +314,32 @@ expect {
     1
 }
 
+test reindex-expression-index-explicit-collate {
+    CREATE TABLE t_reindex_expr_collate(a TEXT);
+    CREATE INDEX idx_reindex_expr_collate ON t_reindex_expr_collate((a COLLATE NOCASE));
+    INSERT INTO t_reindex_expr_collate VALUES('alpha'),('ALPHA'),('AlPhA'),('beta'),('BETA');
+    REINDEX idx_reindex_expr_collate;
+    SELECT quote(a) FROM t_reindex_expr_collate
+        WHERE (a COLLATE NOCASE) = 'alpha'
+        ORDER BY rowid;
+}
+expect {
+    'alpha'
+    'ALPHA'
+    'AlPhA'
+}
+
+test reindex-expression-index-outer-collate-target {
+    CREATE TABLE t_reindex_outer_collate(a TEXT);
+    CREATE INDEX idx_reindex_outer_collate ON t_reindex_outer_collate(((a COLLATE NOCASE) COLLATE RTRIM));
+    REINDEX rtrim;
+    PRAGMA index_xinfo('idx_reindex_outer_collate');
+}
+expect {
+    0|0|a|0|RTRIM|1
+    1|-1||0|BINARY|0
+}
+
 test reindex-nocase-embedded-nul {
     CREATE TABLE t_reindex_nul(a);
     CREATE INDEX idx_reindex_nul ON t_reindex_nul(a COLLATE NOCASE);

--- a/testing/sqltests/tests/reindex.sqltest
+++ b/testing/sqltests/tests/reindex.sqltest
@@ -291,6 +291,17 @@ expect {
     ok
 }
 
+test reindex-bracket-quoted-target {
+    CREATE TABLE [t_reindex_bracket](a);
+    CREATE INDEX [idx_reindex_bracket] ON [t_reindex_bracket](a);
+    INSERT INTO [t_reindex_bracket] VALUES(1);
+    REINDEX [t_reindex_bracket];
+    SELECT a FROM [t_reindex_bracket];
+}
+expect {
+    1
+}
+
 test reindex-nocase-embedded-nul {
     CREATE TABLE t_reindex_nul(a);
     CREATE INDEX idx_reindex_nul ON t_reindex_nul(a COLLATE NOCASE);
@@ -324,6 +335,15 @@ test reindex-non-ascii-identifiers-use-ascii-case-folding {
 }
 expect error {
     unable to identify the object to be reindexed
+}
+
+test reindex-unquoted-compound-keyword-target-rejected {
+    CREATE TABLE [union](a);
+    CREATE INDEX idx_reindex_union_keyword ON [union](a);
+    INSERT INTO [union] VALUES(1);
+    REINDEX union;
+}
+expect error {
 }
 
 test reindex-unknown-target {

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -8,6 +8,7 @@ pub mod journal_mode;
 pub mod mvcc_rowid_allocator;
 pub mod orderby_collation;
 pub mod raise;
+pub mod reindex;
 pub mod rowid_alias;
 pub mod savepoint;
 pub mod subjournal;

--- a/tests/fuzz/reindex.rs
+++ b/tests/fuzz/reindex.rs
@@ -1,0 +1,489 @@
+#[cfg(test)]
+mod reindex_fuzz_tests {
+    use crate::helpers;
+    use core_tester::common::TempDatabase;
+    use rand::seq::IndexedRandom;
+    use rand::Rng;
+    use rand_chacha::ChaCha8Rng;
+    use rusqlite::params;
+    use std::sync::Arc;
+
+    const COLLATIONS: &[&str] = &["BINARY", "NOCASE", "RTRIM"];
+    const DIRECTIONS: &[&str] = &["ASC", "DESC"];
+
+    #[derive(Clone, Copy)]
+    struct ExprSpec {
+        sql: &'static str,
+        where_sql: &'static str,
+        order_sql: &'static str,
+    }
+
+    const EXPRESSIONS: &[ExprSpec] = &[
+        ExprSpec {
+            sql: "abs(e)",
+            where_sql: "abs(e) IS NOT NULL",
+            order_sql: "abs(e), id DESC",
+        },
+        ExprSpec {
+            sql: "coalesce(a, 0) + coalesce(b, 0)",
+            where_sql: "coalesce(a, 0) + coalesce(b, 0) IS NOT NULL",
+            order_sql: "coalesce(a, 0) + coalesce(b, 0), id DESC",
+        },
+        ExprSpec {
+            sql: "length(c)",
+            where_sql: "length(c) IS NOT NULL",
+            order_sql: "length(c), id DESC",
+        },
+        ExprSpec {
+            sql: "lower(c)",
+            where_sql: "lower(c) IS NOT NULL",
+            order_sql: "lower(c), id DESC",
+        },
+        ExprSpec {
+            sql: "substr(d, 1, 1)",
+            where_sql: "substr(d, 1, 1) IS NOT NULL",
+            order_sql: "substr(d, 1, 1), id DESC",
+        },
+    ];
+
+    const PARTIAL_PREDICATES: &[&str] = &[
+        "b IS NOT NULL AND a IS NOT NULL",
+        "c IS NOT NULL",
+        "e BETWEEN -10 AND 10",
+        "d IS NOT NULL AND b >= 0",
+    ];
+
+    struct Scenario {
+        name: String,
+        schema: Vec<String>,
+        reindex_targets: Vec<String>,
+        verify_queries: Vec<(String, String)>,
+        a_order: String,
+        b_order: String,
+        c_collation: String,
+        c_order: String,
+        d_collation: String,
+        d_order: String,
+        expr: ExprSpec,
+        partial_predicate: String,
+    }
+
+    fn build_scenario(rng: &mut ChaCha8Rng, scenario_num: usize) -> Scenario {
+        let implicit_c_collation = choose_str(rng, COLLATIONS);
+        let implicit_d_collation = choose_str(rng, COLLATIONS);
+        let c_collation = choose_str(rng, COLLATIONS);
+        let d_collation = choose_str(rng, COLLATIONS);
+        let a_order = choose_str(rng, DIRECTIONS);
+        let b_order = choose_str(rng, DIRECTIONS);
+        let c_order = choose_str(rng, DIRECTIONS);
+        let d_order = choose_str(rng, DIRECTIONS);
+        let expr = *EXPRESSIONS.choose(rng).unwrap();
+        let partial_predicate = choose_str(rng, PARTIAL_PREDICATES);
+
+        let schema = vec![
+            format!(
+                "CREATE TABLE t(
+                    id INTEGER PRIMARY KEY,
+                    a INTEGER,
+                    b INTEGER,
+                    c TEXT COLLATE {implicit_c_collation},
+                    d TEXT COLLATE {implicit_d_collation},
+                    e INTEGER
+                )"
+            ),
+            format!("CREATE INDEX idx_a ON t(a {a_order}, id ASC)"),
+            format!("CREATE INDEX idx_b ON t(b {b_order}, id ASC)"),
+            format!("CREATE INDEX idx_c_text ON t(c COLLATE {c_collation} {c_order}, id ASC)"),
+            format!("CREATE INDEX idx_d_text ON t(d COLLATE {d_collation} {d_order}, id ASC)"),
+            format!("CREATE INDEX idx_expr ON t({}, id DESC)", expr.sql),
+            format!(
+                "CREATE INDEX idx_partial ON t(a {a_order}, c COLLATE {c_collation}, id) WHERE {partial_predicate}"
+            ),
+            format!("CREATE UNIQUE INDEX idx_unique_c_id ON t(c COLLATE {c_collation}, id)"),
+        ];
+
+        let verify_queries = vec![
+            (
+                "table".to_string(),
+                "SELECT id, a, b, c, quote(d), e FROM t ORDER BY id".to_string(),
+            ),
+            (
+                "idx_a".to_string(),
+                format!(
+                    "SELECT id, a FROM t INDEXED BY idx_a
+                        WHERE a IS NOT NULL
+                        ORDER BY a {a_order}, id
+                        LIMIT 40"
+                ),
+            ),
+            (
+                "idx_b".to_string(),
+                format!(
+                    "SELECT id, b FROM t INDEXED BY idx_b
+                        WHERE b IS NOT NULL
+                        ORDER BY b {b_order}, id
+                        LIMIT 40"
+                ),
+            ),
+            (
+                "idx_c_text".to_string(),
+                format!(
+                    "SELECT id, c FROM t INDEXED BY idx_c_text
+                        WHERE c COLLATE {c_collation} >= ''
+                        ORDER BY c COLLATE {c_collation} {c_order}, id
+                        LIMIT 40"
+                ),
+            ),
+            (
+                "idx_d_text".to_string(),
+                format!(
+                    "SELECT id, quote(d) FROM t INDEXED BY idx_d_text
+                        WHERE d COLLATE {d_collation} >= ''
+                        ORDER BY d COLLATE {d_collation} {d_order}, id
+                        LIMIT 40"
+                ),
+            ),
+            (
+                "idx_expr".to_string(),
+                format!(
+                    "SELECT id, a, b, c, quote(d), e FROM t INDEXED BY idx_expr
+                        WHERE {}
+                        ORDER BY {}
+                        LIMIT 40",
+                    expr.where_sql, expr.order_sql
+                ),
+            ),
+            (
+                "idx_partial".to_string(),
+                format!(
+                    "SELECT id, a, c FROM t INDEXED BY idx_partial
+                        WHERE {partial_predicate}
+                        ORDER BY a {a_order}, c COLLATE {c_collation}, id
+                        LIMIT 40"
+                ),
+            ),
+            (
+                "idx_unique_c_id".to_string(),
+                format!(
+                    "SELECT id, c FROM t INDEXED BY idx_unique_c_id
+                        WHERE c IS NOT NULL
+                        ORDER BY c COLLATE {c_collation}, id
+                        LIMIT 40"
+                ),
+            ),
+        ];
+
+        Scenario {
+            name: format!(
+                "scenario {scenario_num}: c={implicit_c_collation}/{c_collation} {c_order}, d={implicit_d_collation}/{d_collation} {d_order}, expr={}",
+                expr.sql
+            ),
+            schema,
+            reindex_targets: vec![
+                "REINDEX".to_string(),
+                "REINDEX t".to_string(),
+                "REINDEX main.t".to_string(),
+                "REINDEX idx_a".to_string(),
+                "REINDEX main.idx_a".to_string(),
+                "REINDEX idx_b".to_string(),
+                "REINDEX idx_c_text".to_string(),
+                "REINDEX idx_d_text".to_string(),
+                "REINDEX idx_expr".to_string(),
+                "REINDEX idx_partial".to_string(),
+                "REINDEX idx_unique_c_id".to_string(),
+                format!("REINDEX {c_collation}"),
+                format!("REINDEX {d_collation}"),
+                "REINDEX BINARY".to_string(),
+                "REINDEX NOCASE".to_string(),
+                "REINDEX RTRIM".to_string(),
+            ],
+            verify_queries,
+            a_order: a_order.to_string(),
+            b_order: b_order.to_string(),
+            c_collation: c_collation.to_string(),
+            c_order: c_order.to_string(),
+            d_collation: d_collation.to_string(),
+            d_order: d_order.to_string(),
+            expr,
+            partial_predicate: partial_predicate.to_string(),
+        }
+    }
+
+    fn choose_str(rng: &mut ChaCha8Rng, values: &'static [&'static str]) -> &'static str {
+        values.choose(rng).unwrap()
+    }
+
+    fn int_or_null(rng: &mut ChaCha8Rng) -> String {
+        helpers::random_nullable_int(rng, -30..=30, 0.18)
+    }
+
+    fn text_or_null(rng: &mut ChaCha8Rng, allow_trailing_spaces: bool) -> String {
+        if rng.random_bool(0.18) {
+            return "NULL".to_string();
+        }
+
+        let mut text = helpers::generate_random_text(rng, 8);
+        if allow_trailing_spaces {
+            for _ in 0..rng.random_range(0..=3) {
+                text.push(' ');
+            }
+        }
+        format!("'{text}'")
+    }
+
+    fn text_literal(rng: &mut ChaCha8Rng) -> String {
+        format!("'{}'", helpers::generate_random_text(rng, 4))
+    }
+
+    fn insert_stmt(rng: &mut ChaCha8Rng, next_id: &mut i64) -> String {
+        let id = *next_id;
+        *next_id += 1;
+        format!(
+            "INSERT INTO t(id, a, b, c, d, e) VALUES ({}, {}, {}, {}, {}, {})",
+            id,
+            int_or_null(rng),
+            int_or_null(rng),
+            text_or_null(rng, false),
+            text_or_null(rng, true),
+            int_or_null(rng)
+        )
+    }
+
+    fn insert_or_replace_stmt(rng: &mut ChaCha8Rng, max_id: i64) -> String {
+        let id = rng.random_range(1..=max_id.max(1));
+        format!(
+            "INSERT OR REPLACE INTO t(id, a, b, c, d, e) VALUES ({}, {}, {}, {}, {}, {})",
+            id,
+            int_or_null(rng),
+            int_or_null(rng),
+            text_or_null(rng, false),
+            text_or_null(rng, true),
+            int_or_null(rng)
+        )
+    }
+
+    fn update_stmt(rng: &mut ChaCha8Rng, max_id: i64) -> String {
+        let column = *["a", "b", "c", "d", "e"].choose(rng).unwrap();
+        let value = match column {
+            "c" => text_or_null(rng, false),
+            "d" => text_or_null(rng, true),
+            _ => int_or_null(rng),
+        };
+        format!(
+            "UPDATE t SET {column} = {value} {}",
+            where_clause(rng, max_id)
+        )
+    }
+
+    fn delete_stmt(rng: &mut ChaCha8Rng, max_id: i64) -> String {
+        format!("DELETE FROM t {}", where_clause(rng, max_id))
+    }
+
+    fn where_clause(rng: &mut ChaCha8Rng, max_id: i64) -> String {
+        match rng.random_range(0..6) {
+            0 => format!("WHERE id = {}", rng.random_range(1..=max_id.max(1))),
+            1 => format!("WHERE id <= {}", rng.random_range(1..=max_id.max(1))),
+            2 => format!("WHERE a = {}", rng.random_range(-30..=30)),
+            3 => "WHERE b IS NOT NULL".to_string(),
+            4 => "WHERE c IS NOT NULL".to_string(),
+            5 => "WHERE d IS NULL OR e IS NULL".to_string(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn random_probe_query(rng: &mut ChaCha8Rng, scenario: &Scenario) -> (String, String) {
+        let limit = rng.random_range(1..=25);
+        match rng.random_range(0..7) {
+            0 => (
+                "probe_idx_a".to_string(),
+                format!(
+                    "SELECT id, a, b FROM t INDEXED BY idx_a
+                        WHERE a {} {}
+                        ORDER BY a {}, id
+                        LIMIT {limit}",
+                    choose_str(rng, &["=", "<=", ">="]),
+                    rng.random_range(-30..=30),
+                    scenario.a_order
+                ),
+            ),
+            1 => (
+                "probe_idx_b".to_string(),
+                format!(
+                    "SELECT id, a, b FROM t INDEXED BY idx_b
+                        WHERE b {} {}
+                        ORDER BY b {}, id
+                        LIMIT {limit}",
+                    choose_str(rng, &["=", "<=", ">="]),
+                    rng.random_range(-30..=30),
+                    scenario.b_order
+                ),
+            ),
+            2 => (
+                "probe_idx_c_text".to_string(),
+                format!(
+                    "SELECT id, c FROM t INDEXED BY idx_c_text
+                        WHERE c COLLATE {} >= {}
+                        ORDER BY c COLLATE {} {}, id
+                        LIMIT {limit}",
+                    scenario.c_collation,
+                    text_literal(rng),
+                    scenario.c_collation,
+                    scenario.c_order
+                ),
+            ),
+            3 => (
+                "probe_idx_d_text".to_string(),
+                format!(
+                    "SELECT id, quote(d) FROM t INDEXED BY idx_d_text
+                        WHERE d COLLATE {} <= {}
+                        ORDER BY d COLLATE {} {}, id
+                        LIMIT {limit}",
+                    scenario.d_collation,
+                    text_literal(rng),
+                    scenario.d_collation,
+                    scenario.d_order
+                ),
+            ),
+            4 => (
+                "probe_idx_expr".to_string(),
+                format!(
+                    "SELECT id, a, b, c, quote(d), e FROM t INDEXED BY idx_expr
+                        WHERE {}
+                        ORDER BY {}
+                        LIMIT {limit}",
+                    scenario.expr.where_sql, scenario.expr.order_sql
+                ),
+            ),
+            5 => (
+                "probe_idx_partial".to_string(),
+                format!(
+                    "SELECT id, a, c FROM t INDEXED BY idx_partial
+                        WHERE ({}) AND a >= {}
+                        ORDER BY a {}, c COLLATE {}, id
+                        LIMIT {limit}",
+                    scenario.partial_predicate,
+                    rng.random_range(-30..=30),
+                    scenario.a_order,
+                    scenario.c_collation
+                ),
+            ),
+            6 => {
+                let lo = rng.random_range(1..=60);
+                let hi = lo + rng.random_range(0..=50);
+                (
+                    "probe_idx_unique_c_id".to_string(),
+                    format!(
+                        "SELECT id, c FROM t INDEXED BY idx_unique_c_id
+                            WHERE id BETWEEN {lo} AND {hi}
+                            ORDER BY c COLLATE {}, id
+                            LIMIT {limit}",
+                        scenario.c_collation
+                    ),
+                )
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn execute_on_both(
+        limbo_conn: &Arc<turso_core::Connection>,
+        sqlite_conn: &rusqlite::Connection,
+        stmt: &str,
+        context: &str,
+    ) {
+        if let Err(err) = sqlite_conn.execute(stmt, params![]) {
+            panic!("SQLite execution failed\n{context}\nstmt: {stmt}\nerror: {err}");
+        }
+        if let Err(err) = limbo_conn.execute(stmt) {
+            panic!("Limbo execution failed\n{context}\nstmt: {stmt}\nerror: {err}");
+        }
+    }
+
+    fn verify_reindex_state(
+        limbo_conn: &Arc<turso_core::Connection>,
+        sqlite_conn: &rusqlite::Connection,
+        scenario: &Scenario,
+        rng: &mut ChaCha8Rng,
+        context: &str,
+    ) {
+        for (label, query) in &scenario.verify_queries {
+            helpers::assert_differential(
+                limbo_conn,
+                sqlite_conn,
+                query,
+                &format!("{label} verification\n{context}"),
+            );
+        }
+        for _ in 0..4 {
+            let (label, query) = random_probe_query(rng, scenario);
+            helpers::assert_differential(
+                limbo_conn,
+                sqlite_conn,
+                &query,
+                &format!("{label} verification\n{context}"),
+            );
+        }
+        helpers::assert_differential(limbo_conn, sqlite_conn, "PRAGMA integrity_check", context);
+    }
+
+    #[turso_macros::test]
+    pub fn reindex_differential_fuzz(db: TempDatabase) {
+        let (mut rng, seed) = helpers::init_fuzz_test("reindex_differential_fuzz");
+        let limbo_conn = db.connect_limbo();
+        let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        let scenario_count = helpers::fuzz_iterations(6);
+        let iterations = helpers::fuzz_iterations(80);
+        for scenario_num in 0..scenario_count {
+            let scenario = build_scenario(&mut rng, scenario_num);
+            println!("reindex_differential_fuzz {}", scenario.name);
+
+            for ddl in &scenario.schema {
+                execute_on_both(&limbo_conn, &sqlite_conn, ddl, &scenario.name);
+            }
+
+            let mut next_id = 1;
+            let mut history = Vec::new();
+            for _ in 0..60 {
+                let stmt = insert_stmt(&mut rng, &mut next_id);
+                history.push(stmt.clone());
+                execute_on_both(&limbo_conn, &sqlite_conn, &stmt, "seed rows");
+            }
+
+            for iter in 0..iterations {
+                helpers::log_progress("reindex_differential_fuzz", iter, iterations, 10);
+
+                let action = rng.random_range(0..100);
+                let stmt = match action {
+                    0..=29 => insert_stmt(&mut rng, &mut next_id),
+                    30..=44 => insert_or_replace_stmt(&mut rng, next_id - 1),
+                    45..=69 => update_stmt(&mut rng, next_id - 1),
+                    70..=84 => delete_stmt(&mut rng, next_id - 1),
+                    85..=99 => scenario.reindex_targets.choose(&mut rng).unwrap().clone(),
+                    _ => unreachable!(),
+                };
+
+                history.push(stmt.clone());
+                let context = format!(
+                    "{}\nseed: {seed}\nscenario: {scenario_num}\niteration: {iter}\nhistory:\n{}",
+                    scenario.name,
+                    helpers::history_tail(&history, 40)
+                );
+                execute_on_both(&limbo_conn, &sqlite_conn, &stmt, &context);
+
+                if stmt.starts_with("REINDEX") || iter % 20 == 0 {
+                    verify_reindex_state(&limbo_conn, &sqlite_conn, &scenario, &mut rng, &context);
+                }
+            }
+
+            let context = format!(
+                "final verification\n{}\nseed: {seed}\nscenario: {scenario_num}\nhistory:\n{}",
+                scenario.name,
+                helpers::history_tail(&history, 60)
+            );
+            verify_reindex_state(&limbo_conn, &sqlite_conn, &scenario, &mut rng, &context);
+
+            execute_on_both(&limbo_conn, &sqlite_conn, "DROP TABLE t", &context);
+        }
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -14,6 +14,7 @@ mod pragma;
 mod query_processing;
 mod query_timeout;
 mod queued_io;
+mod reindex;
 mod statement_reset;
 mod stmt_journal;
 mod stmt_readonly;

--- a/tests/integration/queued_io.rs
+++ b/tests/integration/queued_io.rs
@@ -1,11 +1,13 @@
 use std::{
     collections::VecDeque,
+    io::ErrorKind,
     sync::{Arc, Mutex},
 };
 
 use turso_core::{
     io::{FileId, FileSyncType},
-    Buffer, Clock, Completion, File, MonotonicInstant, OpenFlags, WallClockInstant, IO,
+    Buffer, Clock, Completion, CompletionError, File, MonotonicInstant, OpenFlags,
+    WallClockInstant, IO,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -73,6 +75,30 @@ impl QueuedIo {
         (op.action)()?;
         self.state.history.lock().unwrap().push(event.clone());
         Ok(Some(event))
+    }
+
+    /// Injects an I/O error after `allowed_successes` matching queued operations.
+    ///
+    /// REINDEX rollback tests use this to fail the destructive refill path at a
+    /// deterministic write boundary while still exercising the normal queued I/O
+    /// completion machinery.
+    pub(crate) fn fault_after(
+        &self,
+        path_suffix: impl Into<String>,
+        kind: QueuedIoOpKind,
+        allowed_successes: usize,
+    ) {
+        *self.state.fault.lock().unwrap() = Some(QueuedIoFault {
+            path_suffix: path_suffix.into(),
+            kind,
+            allowed_successes,
+            seen: 0,
+        });
+    }
+
+    /// Removes the active queued-I/O fault so cleanup and integrity checks can run normally.
+    pub(crate) fn clear_fault(&self) {
+        *self.state.fault.lock().unwrap() = None;
     }
 }
 
@@ -172,7 +198,7 @@ impl QueuedFile {
         let queued_completion = completion.clone();
         let queued_action: Box<dyn FnOnce() -> turso_core::Result<()> + Send> = if fault_this_op {
             Box::new(move || {
-                queued_completion.abort();
+                queued_completion.error(CompletionError::IOError(ErrorKind::Other, "queued_io"));
                 Ok(())
             })
         } else {

--- a/tests/integration/reindex.rs
+++ b/tests/integration/reindex.rs
@@ -91,6 +91,21 @@ fn reindex_requires_stmt_journal_for_all_target_forms(
     Ok(())
 }
 
+/// SQLite allows REINDEX under query_only when target resolution finds no
+/// indexes to rebuild, because no write is attempted.
+#[turso_macros::test]
+fn reindex_query_only_allows_empty_work(tmp_db: crate::common::TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t_without_indexes(a)")?;
+
+    conn.execute("PRAGMA query_only = 1")?;
+    conn.execute("REINDEX")?;
+    conn.execute("REINDEX t_without_indexes")?;
+    conn.execute("PRAGMA query_only = 0")?;
+
+    Ok(())
+}
+
 /// Resetting a REINDEX statement while writes are pending must roll back the
 /// partially executed statement instead of leaving the target index empty.
 #[test]

--- a/tests/integration/reindex.rs
+++ b/tests/integration/reindex.rs
@@ -1,0 +1,143 @@
+use crate::queued_io::{QueuedIo, QueuedIoOpKind};
+use std::sync::{atomic::Ordering, Arc};
+use turso_core::{Connection, Database, DatabaseOpts, OpenFlags, StepResult};
+
+/// Opens a database on `QueuedIo` so tests can control when pending writes complete.
+fn open_queued_db(io: Arc<QueuedIo>, path: &str) -> anyhow::Result<Arc<Database>> {
+    Ok(Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?)
+}
+
+/// Executes a query and renders rows as pipe-separated values for compact assertions.
+fn query_rows(conn: &Arc<Connection>, sql: &str) -> anyhow::Result<Vec<String>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        let values: Vec<String> = row.get_values().map(|value| format!("{value}")).collect();
+        rows.push(values.join("|"));
+        Ok(())
+    })?;
+    Ok(rows)
+}
+
+/// Returns whether compiling `sql` marked the program as needing statement rollback.
+fn needs_stmt_journal(conn: &Arc<Connection>, sql: &str) -> bool {
+    let stmt = conn.prepare(sql).unwrap();
+    stmt.get_program()
+        .prepared()
+        .needs_stmt_subtransactions
+        .load(Ordering::Relaxed)
+}
+
+/// Creates a table with enough indexed data to force REINDEX through sorter and pager I/O.
+fn populate_reindex_fixture(conn: &Arc<Connection>, rows: usize) -> anyhow::Result<()> {
+    conn.execute("PRAGMA page_size = 512")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b INT, c TEXT)")?;
+    conn.execute("CREATE INDEX idx_a ON t(a COLLATE NOCASE)")?;
+    conn.execute("CREATE INDEX idx_b_partial ON t(b) WHERE b % 2 = 0")?;
+    conn.execute("CREATE INDEX idx_expr ON t(substr(c, 1, 2), id DESC)")?;
+    for i in 0..rows {
+        let rev = rows - i;
+        let a = format!("value{rev:04}");
+        let b = (i % 97) as i64 - 48;
+        let c = format!("payload{i:04}");
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{a}', {b}, '{c}')"))?;
+    }
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    Ok(())
+}
+
+/// Verifies indexed lookups and full integrity after an interrupted or failed REINDEX.
+fn assert_reindex_fixture_intact(conn: &Arc<Connection>, rows: usize) -> anyhow::Result<()> {
+    assert_eq!(
+        query_rows(conn, "SELECT COUNT(*) FROM t")?,
+        vec![rows.to_string()]
+    );
+    assert_eq!(
+        query_rows(
+            conn,
+            "SELECT id, a FROM t INDEXED BY idx_a WHERE a >= '' ORDER BY a COLLATE NOCASE LIMIT 3"
+        )?,
+        vec![
+            format!("{}|value0001", rows - 1),
+            format!("{}|value0002", rows - 2),
+            format!("{}|value0003", rows - 3),
+        ]
+    );
+    assert_eq!(query_rows(conn, "PRAGMA integrity_check")?, vec!["ok"]);
+    Ok(())
+}
+
+/// REINDEX clears and refills existing index roots, so every target form must
+/// run under statement subtransactions when compiled in write mode.
+#[turso_macros::test]
+fn reindex_requires_stmt_journal_for_all_target_forms(
+    tmp_db: crate::common::TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT COLLATE NOCASE, b INT)")?;
+    conn.execute("CREATE INDEX idx_a ON t(a)")?;
+    conn.execute("CREATE INDEX idx_b ON t(b)")?;
+
+    assert!(needs_stmt_journal(&conn, "REINDEX"));
+    assert!(needs_stmt_journal(&conn, "REINDEX t"));
+    assert!(needs_stmt_journal(&conn, "REINDEX idx_a"));
+    assert!(needs_stmt_journal(&conn, "REINDEX nocase"));
+    Ok(())
+}
+
+/// Resetting a REINDEX statement while writes are pending must roll back the
+/// partially executed statement instead of leaving the target index empty.
+#[test]
+fn reindex_reset_during_pending_io_preserves_original_indexes() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let db = open_queued_db(io.clone(), "queued-reindex-reset.db")?;
+    let conn = db.connect()?;
+    let rows = 700;
+    populate_reindex_fixture(&conn, rows)?;
+
+    conn.execute("BEGIN")?;
+    let mut stmt = conn.prepare("REINDEX idx_a")?;
+    loop {
+        match stmt.step()? {
+            StepResult::Done => anyhow::bail!("REINDEX finished before yielding I/O"),
+            StepResult::Row => continue,
+            StepResult::Busy | StepResult::Interrupt => {
+                anyhow::bail!("unexpected REINDEX step result before reset")
+            }
+            StepResult::IO => break,
+        }
+    }
+
+    stmt.reset()?;
+    assert_reindex_fixture_intact(&conn, rows)?;
+    Ok(())
+}
+
+/// A write fault during the clear-plus-refill phase must preserve the original index contents.
+#[test]
+fn reindex_write_fault_rolls_back_without_emptying_index() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let db_path = "queued-reindex-fault.db";
+    let wal_path = format!("{db_path}-wal");
+    let db = open_queued_db(io.clone(), db_path)?;
+    let conn = db.connect()?;
+    let rows = 700;
+    populate_reindex_fixture(&conn, rows)?;
+
+    io.fault_after(wal_path, QueuedIoOpKind::Pwritev, 0);
+    let reindex_result = conn.execute("REINDEX idx_a");
+    assert!(
+        reindex_result.is_err(),
+        "REINDEX should fail under injected WAL write fault"
+    );
+    io.clear_fault();
+
+    assert_reindex_fixture_intact(&conn, rows)?;
+    Ok(())
+}


### PR DESCRIPTION
Implements `REINDEX` to repopulate an index or indexes.

`REINDEX;` - repopulates all indexes

`REINDEX table_name;` - repopulates all indexes of `table_name`, including when it doesn't have any

`REINDEX index_name;` - repopulates this specific index

`REINDEX nocase;` - repopulates all indexes using `COLLATE nocase`

Note - sqlite added `REINDEX EXPRESSIONS` last month (April 2026), which recomputes and repopulates all expression indexes, but we don't add that here yet, simply because our CI tooling etc aren't up to date


Stacked on #6690