### PR TITLE
fix: apply without rowid insert affinity in record order

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2712,23 +2712,58 @@ impl BTreeTable {
         ColumnsMut { table: self }
     }
 
+    fn storable_columns_in_register_order(table: &BTreeTable) -> Vec<(usize, Column)> {
+        let mut columns = table
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, col)| !col.is_virtual_generated())
+            .map(|(idx, col)| {
+                let physical_offset = table
+                    .logical_to_physical_map
+                    .get(idx)
+                    .copied()
+                    .unwrap_or(idx);
+                (idx, physical_offset, col.clone())
+            })
+            .collect::<Vec<_>>();
+        columns.sort_unstable_by_key(|(_, physical_offset, _)| *physical_offset);
+        columns
+            .into_iter()
+            .map(|(idx, _, col)| (idx, col))
+            .collect()
+    }
+
+    fn type_check_table_ref_needs_register_order(table: &BTreeTable) -> bool {
+        let columns = Self::storable_columns_in_register_order(table);
+        columns.len() != table.columns.len()
+            || columns
+                .iter()
+                .enumerate()
+                .any(|(register_offset, (logical_idx, _))| *logical_idx != register_offset)
+    }
+
     /// Create a table reference for TypeCheck where custom type columns have
     /// their `ty_str` replaced with the base type name, and where virtual columns
     /// are skipped. This ensures TypeCheck validates the encoded value against the
     /// correct base type (e.g., BLOB) rather than accepting any STRICT type via the wildcard arm.
     pub fn type_check_table_ref(table: &Arc<BTreeTable>, schema: &Schema) -> Arc<BTreeTable> {
-        let has_virtual = table.has_virtual_columns();
+        let needs_register_order = Self::type_check_table_ref_needs_register_order(table);
         let has_custom = table
             .columns
             .iter()
             .any(|c| c.is_array() || schema.get_type_def(&c.ty_str, table.is_strict).is_some());
-        if !has_custom && !has_virtual {
+        if !has_custom && !needs_register_order {
             return Arc::clone(table);
         }
         let mut modified = (**table).clone();
-        if has_virtual {
-            modified.columns.retain(|c| !c.is_virtual_generated());
+        if needs_register_order {
+            modified.columns = Self::storable_columns_in_register_order(table)
+                .into_iter()
+                .map(|(_, col)| col)
+                .collect();
             modified.has_virtual_columns = false;
+            modified.logical_to_physical_map = (0..modified.columns.len()).collect();
         }
         for col in &mut modified.columns {
             if col.is_array() {
@@ -2750,32 +2785,29 @@ impl BTreeTable {
         schema: &Schema,
         only_columns: Option<&ColumnMask>,
     ) -> Arc<BTreeTable> {
-        let has_virtual = table.has_virtual_columns();
+        let needs_register_order = Self::type_check_table_ref_needs_register_order(table);
         let has_custom = table
             .columns
             .iter()
             .any(|c| c.is_array() || schema.get_type_def(&c.ty_str, table.is_strict).is_some());
-        if !has_custom && !has_virtual {
+        if !has_custom && !needs_register_order {
             return Arc::clone(table);
         }
         let mut modified = (**table).clone();
-        let remapped_only_columns = if has_virtual {
+        let remapped_only_columns = if needs_register_order {
+            let columns = Self::storable_columns_in_register_order(table);
             let remapped = only_columns.map(|only| {
                 let mut new_set = ColumnMask::default();
-                let mut physical = 0usize;
-                for (orig, col) in modified.columns.iter().enumerate() {
-                    if col.is_virtual_generated() {
-                        continue;
+                for (register_offset, (logical_idx, _)) in columns.iter().enumerate() {
+                    if only.get(*logical_idx) {
+                        new_set.set(register_offset);
                     }
-                    if only.get(orig) {
-                        new_set.set(physical);
-                    }
-                    physical += 1;
                 }
                 new_set
             });
-            modified.columns.retain(|c| !c.is_virtual_generated());
+            modified.columns = columns.into_iter().map(|(_, col)| col).collect();
             modified.has_virtual_columns = false;
+            modified.logical_to_physical_map = (0..modified.columns.len()).collect();
             remapped
         } else {
             None

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -484,10 +484,9 @@ pub fn translate_insert(
     // trigger bodies see affinity-applied values. Affinity is idempotent, so
     // applying it here means we can skip the per-trigger Copy+Affinity in fire_trigger.
     if !ctx.table.is_strict {
-        let affinity = insertion
-            .col_mappings
+        let storable_mappings = storable_col_mappings_in_register_order(&insertion);
+        let affinity = storable_mappings
             .iter()
-            .filter(|cm| !cm.column.is_virtual_generated())
             .map(|col_mapping| col_mapping.column.affinity());
 
         // Only emit Affinity if there's meaningful affinity to apply
@@ -868,9 +867,10 @@ pub fn translate_insert(
     )?;
 
     // Create and insert the record
+    let storable_mappings = storable_col_mappings_in_register_order(&insertion);
     emit_make_record(
         program,
-        insertion.col_mappings.iter().map(|m| m.column),
+        storable_mappings.iter().map(|m| m.column),
         insertion.base_reg,
         insertion.record_register(),
         ctx.table.is_strict,
@@ -2390,6 +2390,18 @@ impl<'a> Insertion<'a> {
                 .is_some_and(|n| n.eq_ignore_ascii_case(name))
         })
     }
+}
+
+fn storable_col_mappings_in_register_order<'a, 'b>(
+    insertion: &'a Insertion<'b>,
+) -> Vec<&'a ColMapping<'b>> {
+    let mut mappings = insertion
+        .col_mappings
+        .iter()
+        .filter(|cm| !cm.column.is_virtual_generated())
+        .collect::<Vec<_>>();
+    mappings.sort_unstable_by_key(|cm| cm.register);
+    mappings
 }
 
 #[derive(Debug)]

--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -38,6 +38,8 @@ pub struct TableOpts {
     #[garde(range(min = 0.0, max = 1.0))]
     #[serde(alias = "rowid_style_prob")]
     pub rowid_alias_prob: f64,
+    #[garde(range(min = 0.0, max = 1.0))]
+    pub without_rowid_prob: f64,
     /// Range of numbers of columns to generate
     #[garde(custom(range_struct_min(1)))]
     pub column_range: Range<u32>,
@@ -48,6 +50,7 @@ impl Default for TableOpts {
         Self {
             large_table: Default::default(),
             rowid_alias_prob: 0.05,
+            without_rowid_prob: 0.0,
             // Up to 10 columns
             column_range: 1..11,
         }

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -361,7 +361,10 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
                 .iter()
                 .enumerate()
                 .map(|(col_idx, c)| {
-                    if integer_pk_idx == Some(col_idx) && rng.random_bool(INTEGER_PK_NULL_PROB) {
+                    if !table.without_rowid
+                        && integer_pk_idx == Some(col_idx)
+                        && rng.random_bool(INTEGER_PK_NULL_PROB)
+                    {
                         return SimValue::NULL;
                     }
                     if c.has_unique_or_pk() {

--- a/sql_generation/generation/table.rs
+++ b/sql_generation/generation/table.rs
@@ -50,6 +50,7 @@ impl Table {
             name,
             columns: Vec::from_iter(column_set),
             indexes: vec![],
+            without_rowid: false,
         }
     }
 }
@@ -57,6 +58,41 @@ impl Table {
 impl Arbitrary for Table {
     fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, context: &C) -> Self {
         let name = Name::arbitrary(rng, context).0;
+
+        let without_rowid = rng.random_bool(context.opts().table.without_rowid_prob);
+        if without_rowid {
+            let payload_name = Name::arbitrary(rng, context).0;
+            let pk_name = Name::arbitrary(rng, context).0;
+            let extra_name = Name::arbitrary(rng, context).0;
+
+            return Table {
+                rows: Vec::new(),
+                name,
+                columns: vec![
+                    Column {
+                        name: payload_name,
+                        column_type: ColumnType::Text,
+                        constraints: vec![],
+                    },
+                    Column {
+                        name: pk_name,
+                        column_type: ColumnType::Integer,
+                        constraints: vec![ColumnConstraint::PrimaryKey {
+                            order: None,
+                            conflict_clause: None,
+                            auto_increment: false,
+                        }],
+                    },
+                    Column {
+                        name: extra_name,
+                        column_type: ColumnType::Float,
+                        constraints: vec![],
+                    },
+                ],
+                indexes: vec![],
+                without_rowid: true,
+            };
+        }
 
         let rowid_alias = rng.random_bool(context.opts().table.rowid_alias_prob);
         if rowid_alias {
@@ -95,6 +131,7 @@ impl Arbitrary for Table {
                 name,
                 columns,
                 indexes: vec![],
+                without_rowid: false,
             }
         } else {
             Table::arbitrary_with_columns(rng, context, name, vec![])

--- a/sql_generation/model/query/create.rs
+++ b/sql_generation/model/query/create.rs
@@ -21,6 +21,10 @@ impl Display for Create {
             .map(|column| column.to_string())
             .join(", ");
 
-        write!(f, "{cols})")
+        write!(f, "{cols})")?;
+        if self.table.without_rowid {
+            write!(f, " WITHOUT ROWID")?;
+        }
+        Ok(())
     }
 }

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -47,6 +47,8 @@ pub struct Table {
     pub columns: Vec<Column>,
     pub rows: Vec<Vec<SimValue>>,
     pub indexes: Vec<Index>,
+    #[serde(default)]
+    pub without_rowid: bool,
 }
 
 impl Table {
@@ -56,6 +58,7 @@ impl Table {
             name: "".to_string(),
             columns: vec![],
             indexes: vec![],
+            without_rowid: false,
         }
     }
 

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -1225,6 +1225,7 @@ pub fn create_initial_schema(rng: &mut ChaCha8Rng) -> Vec<Create> {
             columns,
             rows: vec![],
             indexes: vec![],
+            without_rowid: false,
         };
 
         schema.push(Create { table });

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -210,15 +210,38 @@ fn validate_integer_pk_row_non_null(
     }
 }
 
+fn validate_without_rowid_primary_key_not_null(
+    table_name: &str,
+    columns: &[Column],
+    row: &[SimValue],
+) -> anyhow::Result<()> {
+    for (idx, column) in columns.iter().enumerate() {
+        if column.is_primary_key() && row[idx].0 == Value::Null {
+            return Err(anyhow::anyhow!(
+                "datatype mismatch: table '{}' PRIMARY KEY column '{}' cannot be NULL",
+                table_name,
+                column.name
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn prepare_insert_rows(
     table_name: &str,
     columns: &[Column],
+    without_rowid: bool,
     existing_rows: &[Vec<SimValue>],
     input_rows: &[Vec<SimValue>],
 ) -> anyhow::Result<Vec<Vec<SimValue>>> {
     let mut new_rows = input_rows.to_vec();
 
-    if let Some(pk_idx) = integer_pk_index(columns) {
+    if without_rowid {
+        for r in &new_rows {
+            ensure_row_width(table_name, columns, r)?;
+            validate_without_rowid_primary_key_not_null(table_name, columns, r)?;
+        }
+    } else if let Some(pk_idx) = integer_pk_index(columns) {
         let mut alloc = RowidAllocator::new(existing_rows, pk_idx);
         new_rows = new_rows
             .iter()
@@ -654,8 +677,14 @@ impl Shadow for Insert {
                     .ok_or_else(|| anyhow::anyhow!("Table {} does not exist", table_name))?;
 
                 let columns = tables[table_pos].columns.clone();
-                let rows =
-                    prepare_insert_rows(&table_name, &columns, &tables[table_pos].rows, &raw_rows)?;
+                let without_rowid = tables[table_pos].without_rowid;
+                let rows = prepare_insert_rows(
+                    &table_name,
+                    &columns,
+                    without_rowid,
+                    &tables[table_pos].rows,
+                    &raw_rows,
+                )?;
 
                 for row in &rows {
                     tables.record_insert(table_name.clone(), row.clone());
@@ -676,12 +705,14 @@ impl Shadow for Insert {
                     .ok_or_else(|| anyhow::anyhow!("Table {} does not exist", table_name))?;
 
                 let columns = tables[table_pos].columns.clone();
+                let without_rowid = tables[table_pos].without_rowid;
 
                 match on_conflict {
                     None => {
                         let new_rows = prepare_insert_rows(
                             &table_name,
                             &columns,
+                            without_rowid,
                             &tables[table_pos].rows,
                             values,
                         )?;

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -186,6 +186,59 @@ impl Profile {
         profile
     }
 
+    /// Profile that generates WITHOUT ROWID tables and checks typed row content
+    /// after inserts. This exercises b-tree record layout paths that differ from
+    /// ordinary rowid tables.
+    pub fn without_rowid() -> Self {
+        let profile = Profile {
+            io: IOProfile {
+                fault: FaultProfile {
+                    enable: false,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            query: QueryProfile {
+                gen_opts: Opts {
+                    table: TableOpts {
+                        rowid_alias_prob: 0.0,
+                        without_rowid_prob: 1.0,
+                        ..Default::default()
+                    },
+                    query: QueryOpts {
+                        select: SelectOpts {
+                            free_expr_size: 1,
+                            order_by_prob: 0.0,
+                            ..Default::default()
+                        },
+                        insert: InsertOpts {
+                            min_rows: NonZeroU32::new(1).unwrap(),
+                            max_rows: NonZeroU32::new(4).unwrap(),
+                            upsert_prob: 0.0,
+                        },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                select_weight: 20,
+                insert_weight: 70,
+                create_table_weight: 10,
+                update_weight: 0,
+                delete_weight: 0,
+                create_index_weight: 0,
+                drop_table_weight: 0,
+                alter_table_weight: 0,
+                drop_index: 0,
+                pragma_weight: 0,
+                ..Default::default()
+            },
+            max_connections: 1,
+            ..Default::default()
+        };
+        profile.validate().unwrap();
+        profile
+    }
+
     pub fn faultless() -> Self {
         let profile = Profile {
             io: IOProfile {
@@ -235,6 +288,7 @@ impl Profile {
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
             ProfileType::SavepointStress => Self::savepoint_stress(),
+            ProfileType::WithoutRowid => Self::without_rowid(),
             ProfileType::Custom(path) => {
                 Self::parse(path).with_context(|| "failed to parse JSON profile")?
             }
@@ -277,6 +331,7 @@ pub enum ProfileType {
     SimpleMvcc,
     WriteStress,
     SavepointStress,
+    WithoutRowid,
     #[strum(disabled)]
     Custom(PathBuf),
 }

--- a/testing/sqltests/turso-tests/without_rowid.sqltest
+++ b/testing/sqltests/turso-tests/without_rowid.sqltest
@@ -19,6 +19,15 @@ expect error {
     UNIQUE constraint failed
 }
 
+test without-rowid-insert-affinity-follows-record-order {
+    CREATE TABLE t(c TEXT, b INTEGER PRIMARY KEY, a REAL) WITHOUT ROWID;
+    INSERT INTO t VALUES ('x', 1, 2.5);
+    SELECT typeof(c), typeof(b), typeof(a) FROM t;
+}
+expect {
+    text|integer|real
+}
+
 test without-rowid-missing-primary-key-rejected {
     CREATE TABLE t(a INTEGER, b TEXT) WITHOUT ROWID;
 }

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -3,9 +3,10 @@ use crate::common::{
 };
 use crate::common::{compare_string, do_flush, TempDatabase};
 use log::debug;
-use rusqlite::types::Value as RValue;
+use rusqlite::{types::Value as RValue, Connection as SqliteConnection};
 use std::io::{Read, Seek, Write};
 use std::sync::Arc;
+use tempfile::TempDir;
 use turso_core::vdbe::StepResult;
 use turso_core::{CheckpointMode, Connection, LimboError, Numeric, Row, Statement, Value};
 
@@ -130,6 +131,114 @@ fn test_insert_without_rowid_table(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     do_flush(&conn, &tmp_db)?;
     rusqlite_integrity_check(tmp_db.path.as_path())?;
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_insert_without_rowid_applies_affinity_in_record_order(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE wr(c TEXT, b INTEGER PRIMARY KEY, a REAL) WITHOUT ROWID")?;
+    conn.execute("INSERT INTO wr VALUES('x', 1, 2.5)")?;
+    conn.execute("INSERT INTO wr(a, c, b) VALUES(3.5, 'y', 2)")?;
+    conn.execute("CREATE TABLE src(c TEXT, b INTEGER, a REAL)")?;
+    conn.execute("INSERT INTO src VALUES('z', 3, 4.5)")?;
+    conn.execute("INSERT INTO wr SELECT c, b, a FROM src")?;
+
+    let types: Vec<(String, String, String)> =
+        conn.exec_rows("SELECT typeof(c), typeof(b), typeof(a) FROM wr ORDER BY b");
+    assert_eq!(
+        types,
+        vec![
+            (
+                "text".to_string(),
+                "integer".to_string(),
+                "real".to_string()
+            ),
+            (
+                "text".to_string(),
+                "integer".to_string(),
+                "real".to_string()
+            ),
+            (
+                "text".to_string(),
+                "integer".to_string(),
+                "real".to_string()
+            ),
+        ]
+    );
+
+    let integer_pk_rows: Vec<(i64,)> =
+        conn.exec_rows("SELECT COUNT(*) FROM wr WHERE typeof(b) = 'integer'");
+    assert_eq!(integer_pk_rows, vec![(3,)]);
+
+    conn.execute(
+        "CREATE TABLE wd(c TEXT DEFAULT 7, b INTEGER PRIMARY KEY, a REAL DEFAULT '5.5') WITHOUT ROWID",
+    )?;
+    conn.execute("INSERT INTO wd(b) VALUES(4)")?;
+    let default_types: Vec<(String, String, String)> =
+        conn.exec_rows("SELECT typeof(c), typeof(b), typeof(a) FROM wd");
+    assert_eq!(
+        default_types,
+        vec![(
+            "text".to_string(),
+            "integer".to_string(),
+            "real".to_string()
+        )]
+    );
+
+    do_flush(&conn, &tmp_db)?;
+    rusqlite_integrity_check(tmp_db.path.as_path())?;
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_insert_existing_strict_without_rowid_applies_type_check_in_record_order(
+    _tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let db_path = temp_dir.path().join("strict_without_rowid.db");
+    {
+        let sqlite = SqliteConnection::open(&db_path)?;
+        sqlite.execute_batch(
+            "CREATE TABLE wr(c TEXT DEFAULT 'd', b INTEGER PRIMARY KEY, a REAL DEFAULT '5.5') STRICT, WITHOUT ROWID;",
+        )?;
+    }
+
+    let db = TempDatabase::new_with_existent(&db_path);
+    let conn = db.connect_limbo();
+
+    conn.execute("INSERT INTO wr VALUES('x', 1, 2.5)")?;
+    conn.execute("INSERT INTO wr(a, c, b) VALUES(3.5, 'y', 2)")?;
+    conn.execute("INSERT INTO wr(b) VALUES(3)")?;
+
+    let types: Vec<(String, String, String)> =
+        conn.exec_rows("SELECT typeof(c), typeof(b), typeof(a) FROM wr ORDER BY b");
+    assert_eq!(
+        types,
+        vec![
+            (
+                "text".to_string(),
+                "integer".to_string(),
+                "real".to_string()
+            ),
+            (
+                "text".to_string(),
+                "integer".to_string(),
+                "real".to_string()
+            ),
+            (
+                "text".to_string(),
+                "integer".to_string(),
+                "real".to_string()
+            ),
+        ]
+    );
+
+    do_flush(&conn, &db)?;
+    rusqlite_integrity_check(db.path.as_path())?;
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #6749.

This fixes inserts into `WITHOUT ROWID` tables when the primary-key column is not first in the schema.

The inserted value registers are laid out in b-tree record order, with primary-key columns first. The insert metadata was still using schema order for affinity and strict type checks, so the wrong affinity could be applied to a physical register.

Direct repro:

```sql
CREATE TABLE t(c TEXT, b INTEGER PRIMARY KEY, a REAL) WITHOUT ROWID;
INSERT INTO t VALUES ('x', '1', '2.5');
SELECT typeof(c), typeof(b), typeof(a) FROM t;
```

Current main: `text|text|real`
This PR: `text|integer|real`

The patch orders the insert metadata by register order and adds coverage in the sqltest file, integration tests, and a simulator `without_rowid` profile.

Checked locally:

```bash
cargo fmt --check
cargo test -q -p core_tester without_rowid --features turso_core/pure-rust-crypto -- --nocapture
cargo check -q -p sql_generation -p limbo_sim --features turso_core/pure-rust-crypto
cargo check -q -p turso_whopper --features turso_core/pure-rust-crypto
cargo run -q -p limbo_sim --features turso_core/pure-rust-crypto -- --profile without_rowid --io-backend memory --disable-bugbase --disable-integrity-check -n 80 -k 30 -t 120
```