### PR TITLE
core/translate: Fix panic in window-to-subquery rewrite with multiple window functions

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3031,8 +3031,15 @@ pub struct WindowFunction {
     /// The resolved function. Aggregate window functions and specialized window
     /// functions such as ROW_NUMBER() are supported.
     pub func: WindowFunctionKind,
-    /// The expression from which the function was resolved.
+    /// The expression from which the function was resolved. Used as the lookup
+    /// key when locating this function during window-to-subquery rewriting.
     pub original_expr: Expr,
+    /// The rewritten form of `original_expr`, with arguments and the OVER clause
+    /// remapped to reference the window's input subquery. Set the first time
+    /// `rewrite_terminal_expr` matches this function. Subsequent occurrences of
+    /// the same `original_expr` reuse this cached rewrite so they end up pointing
+    /// at the same registers as the first occurrence.
+    pub rewritten_expr: Option<Expr>,
 }
 
 #[derive(Debug, Clone)]

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -406,9 +406,21 @@ fn link_with_window(
     expr_vector_size(expr)?;
     if let Some(windows) = windows {
         let window = resolve_window(windows, over_clause)?;
+        // Dedup: if an equivalent window function expression is already linked to
+        // this window, skip adding it again. Multiple occurrences of the same
+        // window function should share a single entry so the rewrite + emit code
+        // can rely on each entry being rewritten exactly once.
+        if window
+            .functions
+            .iter()
+            .any(|f| exprs_are_equivalent(&f.original_expr, expr))
+        {
+            return Ok(());
+        }
         window.functions.push(WindowFunction {
             func,
             original_expr: expr.clone(),
+            rewritten_expr: None,
         });
     } else {
         let func_name = match &func {

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -319,16 +319,26 @@ fn rewrite_terminal_expr(
                         // If the expression is a window function tied to the current window,
                         // do not push it to the subquery. Instead, rewrite it so its child
                         // expressions reference the subquery where needed.
-                        rewrite_expr_referencing_current_window(
-                            aggregates,
-                            current_window
-                                .name
-                                .clone()
-                                .expect("current_window must always have a name here"),
-                            ctx,
-                            expr,
-                        )?;
-                        window_function.original_expr = expr.clone();
+                        //
+                        // The same window function expression may appear in multiple places
+                        // (e.g. both in result columns and in ORDER BY, or twice in result
+                        // columns). The first occurrence performs the rewrite and caches the
+                        // result in `rewritten_expr`; subsequent occurrences just clone the
+                        // cached form so every reference points at the same window output.
+                        if let Some(rewritten) = &window_function.rewritten_expr {
+                            *expr = rewritten.clone();
+                        } else {
+                            rewrite_expr_referencing_current_window(
+                                aggregates,
+                                current_window
+                                    .name
+                                    .clone()
+                                    .expect("current_window must always have a name here"),
+                                ctx,
+                                expr,
+                            )?;
+                            window_function.rewritten_expr = Some(expr.clone());
+                        }
 
                         // At this point, the expression and all its children now reference the subquery,
                         // so further traversal is unnecessary.
@@ -576,8 +586,12 @@ impl EmitWindow {
         let reg_acc_start = program.alloc_registers(window_function_count);
         let reg_acc_result_start = program.alloc_registers(window_function_count);
         for (i, func) in window.functions.iter().enumerate() {
+            // Cache by the rewritten form (when available) so lookups against the
+            // result-column / ORDER-BY expressions — which were rewritten to
+            // reference this window's subquery — find the cached register.
+            let cache_expr = func.rewritten_expr.as_ref().unwrap_or(&func.original_expr);
             t_ctx.resolver.cache_expr_reg(
-                std::borrow::Cow::Borrowed(&func.original_expr),
+                std::borrow::Cow::Borrowed(cache_expr),
                 reg_acc_result_start + i,
                 false,
                 None,
@@ -988,7 +1002,10 @@ fn emit_aggregation_step(
         // The aggregation step is performed incrementally as each row from the subquery is
         // processed. Therefore, we don’t need to access the buffer table and can obtain argument
         // values directly by evaluating the expressions that reference the subquery result columns.
-        let args = match &func.original_expr {
+        // Use the rewritten form when available so the args reference the subquery
+        // rather than the (no-longer-visible) original tables.
+        let func_expr = func.rewritten_expr.as_ref().unwrap_or(&func.original_expr);
+        let args = match func_expr {
             Expr::FunctionCall { args, .. } => args.iter().map(|a| (**a).clone()).collect(),
             Expr::FunctionCallStar { .. } => vec![],
             _ => unreachable!(

--- a/testing/runner/tests/window/memory.sqltest
+++ b/testing/runner/tests/window/memory.sqltest
@@ -130,3 +130,121 @@ expect {
     3
 }
 
+# Regression test for #5763: a window function expression that appears multiple
+# times (here `SUM(amount) OVER ()` in two result columns) used to leave the
+# second occurrence un-rewritten, panicking the translator.
+@cross-check-integrity
+test window-same-window-fn-used-multiple-times {
+    CREATE TABLE sales(id INTEGER PRIMARY KEY, product TEXT, amount REAL);
+    INSERT INTO sales VALUES (1,'A',100),(2,'B',200),(3,'A',150),(4,'B',50),(5,'A',300);
+    SELECT id, product, amount,
+        SUM(amount) OVER (PARTITION BY product) AS product_total,
+        SUM(amount) OVER () AS grand_total,
+        amount * 100.0 / SUM(amount) OVER () AS pct_of_total
+    FROM sales ORDER BY id;
+}
+expect {
+    1|A|100.0|550.0|800.0|12.5
+    2|B|200.0|250.0|800.0|25.0
+    3|A|150.0|550.0|800.0|18.75
+    4|B|50.0|250.0|800.0|6.25
+    5|A|300.0|550.0|800.0|37.5
+}
+
+# Regression test for #5763: `ORDER BY 2` resolves to a clone of result column 2,
+# which is itself a window function. The cloned form needs to be rewritten the
+# same way as the in-result-column occurrence so the inner window's args don't
+# point at the no-longer-visible base table.
+@cross-check-integrity
+test window-order-by-position-references-window-fn {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES (3), (1), (2);
+    SELECT count(t.a) OVER (ORDER BY 2), count(t.a) OVER (ORDER BY t.a) FROM t ORDER BY 2;
+}
+expect {
+    3|1
+    3|2
+    3|3
+}
+
+# Variation: same window function referenced 3 times — once standalone and twice
+# inside arithmetic expressions.
+@cross-check-integrity
+test window-same-window-fn-used-three-times {
+    CREATE TABLE t(id INTEGER, val INTEGER);
+    INSERT INTO t VALUES (1,10),(2,20),(3,30);
+    SELECT id,
+        SUM(val) OVER () AS total,
+        val + SUM(val) OVER () AS plus_total,
+        val - SUM(val) OVER () AS minus_total
+    FROM t ORDER BY id;
+}
+expect {
+    1|60|70|-50
+    2|60|80|-40
+    3|60|90|-30
+}
+
+# Variation: same window function nested inside a function call.
+@cross-check-integrity
+test window-same-window-fn-inside-coalesce {
+    CREATE TABLE t(id INTEGER, val INTEGER);
+    INSERT INTO t VALUES (1,10),(2,NULL),(3,30);
+    SELECT id,
+        SUM(val) OVER () AS s,
+        COALESCE(val, SUM(val) OVER ()) AS c
+    FROM t ORDER BY id;
+}
+expect {
+    1|40|10
+    2|40|40
+    3|40|30
+}
+
+# Variation: same FunctionCallStar window function used twice.
+@cross-check-integrity
+test window-same-star-window-fn-twice {
+    CREATE TABLE t(id INTEGER);
+    INSERT INTO t VALUES (1),(2),(3);
+    SELECT count(*) OVER () AS c1, count(*) OVER () AS c2 FROM t ORDER BY id;
+}
+expect {
+    3|3
+    3|3
+    3|3
+}
+
+# Variation: same ROW_NUMBER window function used twice.
+@cross-check-integrity
+test window-same-row-number-twice {
+    CREATE TABLE t(id INTEGER);
+    INSERT INTO t VALUES (10),(20),(30);
+    SELECT ROW_NUMBER() OVER (ORDER BY id) AS r1,
+           ROW_NUMBER() OVER (ORDER BY id) AS r2
+    FROM t ORDER BY id;
+}
+expect {
+    1|1
+    2|2
+    3|3
+}
+
+# Variation: named window referenced multiple times by the same function.
+@cross-check-integrity
+test window-named-window-same-fn-multiple-references {
+    CREATE TABLE t(grp INTEGER, val INTEGER);
+    INSERT INTO t VALUES (1,10),(1,20),(2,30),(2,40);
+    SELECT grp,
+        sum(val) OVER w AS s1,
+        sum(val) OVER w + 1 AS s2
+    FROM t
+    WINDOW w AS (PARTITION BY grp)
+    ORDER BY grp, val;
+}
+expect {
+    1|30|31
+    1|30|31
+    2|70|71
+    2|70|71
+}
+


### PR DESCRIPTION
When the same window function expression appeared more than once in a SELECT (in two result columns, or once in a result column and once in ORDER BY after `ORDER BY <int>` resolution clones the result-column expression), only the first occurrence was rewritten to reference the window's input subquery. The other occurrences kept arguments pointing at the original base table, panicking the translator at expr.rs:3197 ("table reference should be found").

Two interacting causes:

* `link_with_window` pushed one entry to `Window.functions` per source occurrence, so the same function could appear multiple times. The rewrite walk only updated the first matching entry, leaving the others' `original_expr` referring to the no-longer-visible base table.
* `rewrite_terminal_expr` overwrote `original_expr` with the rewritten form, which broke the equivalence check used to match later clones of the original expression encountered in other result columns or ORDER BY.

Fix:

* Dedup in `link_with_window` so each unique window-function expression maps to a single `WindowFunction` entry.
* Add `WindowFunction.rewritten_expr: Option<Expr>` and update `rewrite_terminal_expr` to match by the immutable `original_expr`, performing the rewrite once and caching it. Subsequent occurrences clone the cached rewritten form. Consumers (`EmitWindow::init`'s cache_expr_reg and `emit_aggregation_step`'s arg extraction) prefer `rewritten_expr` when present.

Adds .sqltest cases covering both reproducers from the issue plus variations: same window function used three times, nested inside COALESCE, count(*) OVER () twice, ROW_NUMBER duplicated, and a named window referenced multiple times.

Closes #5763