### PR TITLE
fix: UPDATE skips rows when an FK cascade trigger mutates the target table mid-statement

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -64,6 +64,7 @@ use order::{
 use rustc_hash::FxHashMap as HashMap;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintUsage};
+use turso_parser::ast::RefAct;
 use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TriggerEvent};
 
 pub(crate) mod access_method;
@@ -896,6 +897,25 @@ fn update_write_set_reason(
             btree_table,
         ) {
             break 'requires Some(DmlSafetyReason::Trigger);
+        }
+
+        // FK cascading actions on the target's parent key may fire writes on
+        // other tables (CASCADE / SET NULL / SET DEFAULT). Those writes can in
+        // turn fire triggers that mutate the target table while the UPDATE
+        // scan is still iterating it, causing rows to be skipped or visited
+        // twice. Self-referential cascades likewise rewrite rows in the
+        // target during the scan. Materialize target rowids first to keep
+        // the write set stable. (See issue #6460.)
+        let referencing_fks = resolver.with_schema(database_id, |s| {
+            s.resolved_fks_referencing(&btree_table.name)
+        })?;
+        for fk in &referencing_fks {
+            if matches!(fk.fk.on_update, RefAct::NoAction | RefAct::Restrict) {
+                continue;
+            }
+            if fk.parent_key_may_change(&updated_cols, btree_table)? {
+                break 'requires Some(DmlSafetyReason::FkCascade);
+            }
         }
 
         // REPLACE mode requires ephemeral table because REPLACE deletes conflicting rows,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -734,6 +734,11 @@ pub enum DmlSafetyReason {
     /// The index method cursor does not materialize results up front,
     /// so writes could invalidate the live iterator.
     IndexMethodNotMaterialized,
+    /// The UPDATE changes a column referenced by an FK with a cascading
+    /// action (CASCADE / SET NULL / SET DEFAULT). The cascade can fire
+    /// triggers on referencing tables that write back to the target,
+    /// which would invalidate the live scan iterator.
+    FkCascade,
 }
 
 /// Safety decisions made while planning UPDATE/DELETE.

--- a/testing/sqltests/tests/update-fk-cascade-trigger-skips-rows.sqltest
+++ b/testing/sqltests/tests/update-fk-cascade-trigger-skips-rows.sqltest
@@ -1,0 +1,217 @@
+@database :memory:
+
+# Issue #6460: UPDATE on a parent table must materialize its target rowids
+# when the parent's key is referenced by an FK with a cascading action.
+# Without materialization, the cascade can fire triggers on the child
+# that mutate the parent table mid-scan, causing later rows to be
+# skipped or visited twice.
+
+@cross-check-integrity
+test update-fk-cascade-trigger-mutates-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(key INTEGER UNIQUE, x INTEGER);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       pkey INTEGER REFERENCES parent(key) ON UPDATE CASCADE);
+    CREATE TRIGGER tr AFTER UPDATE ON child BEGIN
+      UPDATE parent SET x = 0 WHERE rowid > 0;
+    END;
+    INSERT INTO parent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    UPDATE parent SET key = key + 10 WHERE x > 150;
+    SELECT key, x FROM parent ORDER BY rowid;
+    SELECT 'sep';
+    SELECT id, pkey FROM child ORDER BY id;
+}
+expect {
+    1|0
+    12|0
+    13|0
+    sep
+    10|1
+    20|12
+    30|13
+}
+
+@cross-check-integrity
+test update-fk-set-null-trigger-mutates-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(key INTEGER UNIQUE, x INTEGER);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       pkey INTEGER REFERENCES parent(key) ON UPDATE SET NULL);
+    CREATE TRIGGER tr AFTER UPDATE ON child BEGIN
+      UPDATE parent SET x = 0 WHERE rowid > 0;
+    END;
+    INSERT INTO parent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    UPDATE parent SET key = key + 10 WHERE x > 150;
+    SELECT key, x FROM parent ORDER BY rowid;
+    SELECT 'sep';
+    SELECT id, pkey FROM child ORDER BY id;
+}
+expect {
+    1|0
+    12|0
+    13|0
+    sep
+    10|1
+    20|
+    30|
+}
+
+@cross-check-integrity
+test update-fk-set-default-trigger-mutates-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(key INTEGER UNIQUE, x INTEGER);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       pkey INTEGER DEFAULT 0 REFERENCES parent(key) ON UPDATE SET DEFAULT);
+    INSERT INTO parent VALUES (0,0),(1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    CREATE TRIGGER tr AFTER UPDATE ON child BEGIN
+      UPDATE parent SET x = 0 WHERE key <> 0;
+    END;
+    UPDATE parent SET key = key + 10 WHERE x > 150;
+    SELECT key, x FROM parent ORDER BY rowid;
+    SELECT 'sep';
+    SELECT id, pkey FROM child ORDER BY id;
+}
+expect {
+    0|0
+    1|0
+    12|0
+    13|0
+    sep
+    10|1
+    20|0
+    30|0
+}
+
+# AFTER UPDATE trigger on the child mutates the parent (matches the
+# second variant in the issue): SET NULL action with an UPDATE trigger
+# on child writing back to parent.
+@cross-check-integrity
+test update-fk-set-null-after-update-trigger-on-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(key INTEGER UNIQUE, x INTEGER);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       pkey INTEGER REFERENCES parent(key) ON UPDATE SET NULL);
+    INSERT INTO parent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    CREATE TRIGGER tr AFTER UPDATE ON child BEGIN
+      UPDATE parent SET x = x + 1 WHERE x > 0;
+    END;
+    UPDATE parent SET key = key + 10 WHERE x > 150;
+    SELECT key, x FROM parent ORDER BY rowid;
+}
+expect {
+    1|102
+    12|202
+    13|302
+}
+
+# Multi-column FK with cascade.
+@cross-check-integrity
+test update-fk-multicol-cascade {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(a INTEGER, b INTEGER, x INTEGER, UNIQUE(a, b));
+    CREATE TABLE child(id INTEGER PRIMARY KEY, ca INTEGER, cb INTEGER,
+                       FOREIGN KEY(ca, cb) REFERENCES parent(a, b) ON UPDATE CASCADE);
+    INSERT INTO parent VALUES (1,1,100),(2,2,200),(3,3,300);
+    INSERT INTO child  VALUES (10,1,1),(20,2,2),(30,3,3);
+    CREATE TRIGGER tr AFTER UPDATE ON child BEGIN
+      UPDATE parent SET x = 0 WHERE x > 0;
+    END;
+    UPDATE parent SET a = a + 10 WHERE x > 150;
+    SELECT a, b, x FROM parent ORDER BY rowid;
+    SELECT 'sep';
+    SELECT id, ca, cb FROM child ORDER BY id;
+}
+expect {
+    1|1|0
+    12|2|0
+    13|3|0
+    sep
+    10|1|1
+    20|12|2
+    30|13|3
+}
+
+# BEFORE UPDATE trigger on child mutates parent during cascade.
+@cross-check-integrity
+test update-fk-cascade-before-update-trigger-on-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(key INTEGER UNIQUE, x INTEGER);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       pkey INTEGER REFERENCES parent(key) ON UPDATE CASCADE);
+    INSERT INTO parent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    CREATE TRIGGER tr BEFORE UPDATE ON child BEGIN
+      UPDATE parent SET x = 0 WHERE rowid > 0;
+    END;
+    UPDATE parent SET key = key + 10 WHERE x > 150;
+    SELECT key, x FROM parent ORDER BY rowid;
+    SELECT 'sep';
+    SELECT id, pkey FROM child ORDER BY id;
+}
+expect {
+    1|0
+    12|0
+    13|0
+    sep
+    10|1
+    20|12
+    30|13
+}
+
+# FK references parent's INTEGER PRIMARY KEY (rowid alias). The existing
+# KeyMutation safety path also catches this, but it is good to exercise
+# the FkCascade path explicitly so future refactors don't regress.
+@cross-check-integrity
+test update-fk-cascade-rowid-alias-parent {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE TABLE child(cid INTEGER PRIMARY KEY,
+                       pid INTEGER REFERENCES parent(id) ON UPDATE CASCADE);
+    INSERT INTO parent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    CREATE TRIGGER tr AFTER UPDATE ON child BEGIN
+      UPDATE parent SET x = 0 WHERE id > 0;
+    END;
+    UPDATE parent SET id = id + 10 WHERE x > 150;
+    SELECT id, x FROM parent ORDER BY rowid;
+    SELECT 'sep';
+    SELECT cid, pid FROM child ORDER BY cid;
+}
+expect {
+    1|0
+    12|0
+    13|0
+    sep
+    10|1
+    20|12
+    30|13
+}
+
+# Sanity check: an UPDATE that does NOT touch a parent FK column should
+# behave as before — no cascade fires, scan does not need materialization.
+@cross-check-integrity
+test update-fk-no-cascade-when-key-untouched {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(key INTEGER UNIQUE, x INTEGER);
+    CREATE TABLE child(id INTEGER PRIMARY KEY,
+                       pkey INTEGER REFERENCES parent(key) ON UPDATE CASCADE);
+    INSERT INTO parent VALUES (1,100),(2,200),(3,300);
+    INSERT INTO child  VALUES (10,1),(20,2),(30,3);
+    UPDATE parent SET x = x + 1 WHERE x > 150;
+    SELECT key, x FROM parent ORDER BY rowid;
+    SELECT 'sep';
+    SELECT id, pkey FROM child ORDER BY id;
+}
+expect {
+    1|100
+    2|201
+    3|301
+    sep
+    10|1
+    20|2
+    30|3
+}


### PR DESCRIPTION
When an UPDATE on a parent table changes a column referenced by an FK with a cascading action (CASCADE / SET NULL / SET DEFAULT), the cascade fires writes on referencing tables. Triggers on those tables can write back to the parent, mutating rows the UPDATE scan is still iterating. The optimizer previously only forced write-set materialization for triggers declared directly on the target table, so cross-table cascade
+ trigger paths slipped through and caused later rows to be skipped or visited twice.

Detect this case in `update_write_set_reason` by walking FKs that reference the target and adding a new `DmlSafetyReason::FkCascade` when any FK has a non-NoAction/non-Restrict on_update action whose parent key may change due to this update. The plan then materializes target rowids before any writes, keeping the iteration set stable.

Closes #6460