### PR TITLE
Fix exception swallowing and `SyntaxWarning` in Python 3.14.

### DIFF
--- a/bindings/python/turso/lib.py
+++ b/bindings/python/turso/lib.py
@@ -468,14 +468,22 @@ class Connection:
         traceback: TracebackType | None,
     ) -> bool:
         # sqlite3 behavior: In context manager, if no exception -> commit, else rollback (legacy and PEP 249 modes)
-        try:
-            if type is None:
+        if type is None:
+            try:
                 self.commit()
-            else:
-                self.rollback()
-        finally:
-            # Always propagate exceptions (returning False)
-            return False
+            except BaseException as commit_exc:
+                # sqlite3 behavior: if commit fails, try to rollback to unlock the database, then re-raise the commit exception
+                try:
+                    self.rollback()
+                except BaseException as rollback_exc:
+                    # If rollback also fails, chain the exceptions
+                    raise rollback_exc from commit_exc
+                raise
+        else:
+            self.rollback()
+
+        # Always propagate exceptions (returning False)
+        return False
 
 
 # Cursor goes SECOND


### PR DESCRIPTION
Currently, `pyturso` swallows exceptions raised by `self.commit()` and `self.rollback()` in `Connection.__exit__`, which breaks compatibility with Python’s `sqlite3` behavior:
https://github.com/python/cpython/blob/1e21cf6fee3830012e458c0fe5dbc6fcd45ace92/Modules/_sqlite/connection.c#L2365-L2400

This PR fixes that by ensuring exceptions are properly propagated and aligned with Python `sqlite3`.

It also removes a `return` from a `finally` block, which triggers a `SyntaxWarning` in Python 3.14 (PEP [765](https://peps.python.org/pep-0765/)).