### PR TITLE
bindings/js: Fix last insert rowid bigint or number

### DIFF
--- a/bindings/javascript/packages/common/types.ts
+++ b/bindings/javascript/packages/common/types.ts
@@ -47,7 +47,7 @@ export interface NativeDatabase {
     defaultSafeIntegers(toggle: boolean);
     totalChanges(): number;
     changes(): number;
-    lastInsertRowid(): number;
+    lastInsertRowid(): number | bigint;
     close();
 }
 

--- a/bindings/javascript/packages/native/index.d.ts
+++ b/bindings/javascript/packages/native/index.d.ts
@@ -52,7 +52,7 @@ export declare class Database {
    *
    * The rowid of the last row inserted.
    */
-  lastInsertRowid(): number
+  lastInsertRowid(): number | bigint
   /**
    * Returns the number of changes made by the last statement.
    *

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -507,8 +507,13 @@ impl Database {
     ///
     /// The rowid of the last row inserted.
     #[napi]
-    pub fn last_insert_rowid(&self) -> napi::Result<i64> {
-        Ok(self.conn()?.last_insert_rowid())
+    pub fn last_insert_rowid(&self) -> napi::Result<Either<i64, BigInt>> {
+        let rowid = self.conn()?.last_insert_rowid();
+        if *self.inner()?.default_safe_integers.lock().unwrap() {
+            Ok(Either::B(BigInt::from(rowid)))
+        } else {
+            Ok(Either::A(rowid))
+        }
     }
 
     /// Returns the number of changes made by the last statement.

--- a/bindings/javascript/sync/packages/common/remote-writer.ts
+++ b/bindings/javascript/sync/packages/common/remote-writer.ts
@@ -44,7 +44,7 @@ export class RemoteWriter {
         columns: string[];
         rows: any[];
         rowsAffected: number;
-        lastInsertRowid: number | undefined;
+        lastInsertRowid: number | bigint | undefined;
     }> {
         if (this._inRemoteTxn) {
             return await this.session!.execute(sql, args);

--- a/bindings/javascript/sync/packages/native/index.d.ts
+++ b/bindings/javascript/sync/packages/native/index.d.ts
@@ -52,7 +52,7 @@ export declare class Database {
    *
    * The rowid of the last row inserted.
    */
-  lastInsertRowid(): number
+  lastInsertRowid(): number | bigint
   /**
    * Returns the number of changes made by the last statement.
    *

--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -282,6 +282,21 @@ test('simple-db', async () => {
     await expect(async () => await db.pull()).rejects.toThrowError(/sync is disabled as database was opened without sync support/);
 })
 
+test('Statement.run() preserves rowids above Number.MAX_SAFE_INTEGER', async () => {
+    const db = await connect({ path: ':memory:' });
+    try {
+        db.defaultSafeIntegers(true);
+        await db.exec("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)");
+
+        const info = await db.prepare("INSERT INTO t(id, value) VALUES (9007199254740993, 'x')").run();
+
+        expect(info.changes).toBe(1);
+        expect(info.lastInsertRowid).toBe(9007199254740993n);
+    } finally {
+        await db.close();
+    }
+})
+
 test('implicit connect', async ({ server }) => {
     const db = new Database({ path: ':memory:', url: server.dbUrl() });
     const defer = db.prepare("SELECT * FROM not_found");


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
`lastInsertRowid` now returns a `BigInt` when `defaultSafeIntegers(true)` is enabled, otherwise a `Number` (default behavior). Matches better-sqlite3's semantics https://github.com/WiseLibs/better-sqlite3/blob/master/src/objects/statement.cpp#L156-L158

## Description of AI Usage

I used Claude Code to implement the fix and add the appropriate tests.
