### PR TITLE
core/storage: Fix savepoint rollback index btree seek

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2032,13 +2032,18 @@ impl Pager {
             turso_assert!(c.succeeded(), "memory IO should complete immediately");
             current_offset += page_size;
             rollback_bitset.insert(page_id);
-            // The restored image is the transaction-visible state at the
-            // savepoint, not necessarily durable state. Keep it dirty so cache
-            // eviction cannot drop uncommitted changes that predate the
-            // rolled-back savepoint/statement.
-            page.set_dirty();
-            dirty_pages.insert(page_id);
-            self.upsert_page_in_cache(page_id as usize, page, true)?;
+            let was_dirty_at_start = savepoint.dirty_pages_at_start.contains(page_id);
+            if was_dirty_at_start {
+                // The restored image is the transaction-visible state at the
+                // savepoint, not necessarily durable state. Keep pages that
+                // were already dirty at savepoint-open dirty so eviction
+                // cannot drop older uncommitted changes.
+                page.set_dirty();
+                dirty_pages.insert(page_id);
+            } else {
+                dirty_pages.remove(page_id);
+            }
+            self.upsert_page_in_cache(page_id as usize, page, was_dirty_at_start)?;
         }
 
         let truncate_completion = subjournal.truncate(journal_start_offset)?;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -371,19 +371,36 @@ impl PageInner {
         }
     }
 
+    /// Read a cell pointer entry with bounds checks so corrupt headers surface as
+    /// `LimboError::Corrupt` instead of panicking on raw slice indexing.
+    #[inline(always)]
+    fn read_cell_pointer(&self, idx: usize) -> crate::Result<usize> {
+        let buf = self.as_ptr();
+        let cell_count = self.cell_count();
+        crate::assert_or_bail_corrupt!(
+            idx < cell_count,
+            "cell index {} out of bounds for page {} with {} cells",
+            idx,
+            self.id,
+            cell_count
+        );
+        let cell_pointer_in_array = self.header_size() + (idx * CELL_PTR_SIZE_BYTES);
+        let absolute_offset = self.offset() + cell_pointer_in_array;
+        crate::assert_or_bail_corrupt!(
+            absolute_offset + CELL_PTR_SIZE_BYTES <= buf.len(),
+            "cell pointer array offset {} out of bounds for page {} with page size {}",
+            absolute_offset,
+            self.id,
+            buf.len()
+        );
+        Ok(u16::from_be_bytes([buf[absolute_offset], buf[absolute_offset + 1]]) as usize)
+    }
+
     #[inline]
     pub fn cell_get(&self, idx: usize, usable_size: usize) -> crate::Result<BTreeCell> {
         tracing::trace!("cell_get(idx={})", idx);
         let buf = self.as_ptr();
-
-        let ncells = self.cell_count();
-        turso_assert_less_than!(idx, ncells,
-            "cell_get: idx out of bounds",
-            {"idx": idx, "ncells": ncells}
-        );
-        let cell_pointer_array_start = self.header_size();
-        let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
-        let cell_pointer = self.read_u16(cell_pointer) as usize;
+        let cell_pointer = self.read_cell_pointer(idx)?;
 
         let static_buf: &'static [u8] = unsafe { std::mem::transmute::<&[u8], &'static [u8]>(buf) };
         read_btree_cell(static_buf, self, cell_pointer, usable_size)
@@ -393,9 +410,7 @@ impl PageInner {
     pub fn cell_table_interior_read_rowid(&self, idx: usize) -> crate::Result<i64> {
         turso_debug_assert!(matches!(self.page_type(), Ok(PageType::TableInterior)));
         let buf = self.as_ptr();
-        let cell_pointer_array_start = self.header_size();
-        let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
-        let cell_pointer = self.read_u16(cell_pointer) as usize;
+        let cell_pointer = self.read_cell_pointer(idx)?;
         const LEFT_CHILD_PAGE_SIZE_BYTES: usize = 4;
         let (rowid, _) = read_varint(crate::slice_in_bounds_or_corrupt!(
             buf,
@@ -411,9 +426,7 @@ impl PageInner {
             Ok(PageType::TableInterior) | Ok(PageType::IndexInterior)
         ));
         let buf = self.as_ptr();
-        let cell_pointer_array_start = self.header_size();
-        let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
-        let cell_pointer = self.read_u16(cell_pointer) as usize;
+        let cell_pointer = self.read_cell_pointer(idx)?;
         crate::assert_or_bail_corrupt!(
             cell_pointer + 4 <= buf.len(),
             "cell pointer {} out of bounds for page size {}",
@@ -432,9 +445,7 @@ impl PageInner {
     pub fn cell_table_leaf_read_rowid(&self, idx: usize) -> crate::Result<i64> {
         turso_debug_assert!(matches!(self.page_type(), Ok(PageType::TableLeaf)));
         let buf = self.as_ptr();
-        let cell_pointer_array_start = self.header_size();
-        let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
-        let cell_pointer = self.read_u16(cell_pointer) as usize;
+        let cell_pointer = self.read_cell_pointer(idx)?;
         let mut pos = cell_pointer;
         let (_, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(buf, pos..))?;
         pos += nr;
@@ -455,25 +466,7 @@ impl PageInner {
         usable_size: usize,
     ) -> crate::Result<(&'static [u8], u64, Option<u32>)> {
         let buf = self.as_ptr();
-        let cell_count = self.cell_count();
-        crate::assert_or_bail_corrupt!(
-            idx < cell_count,
-            "cell index {} out of bounds for index page {} with {} cells",
-            idx,
-            self.id,
-            cell_count
-        );
-        let cell_pointer_array_start = self.header_size();
-        let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
-        crate::assert_or_bail_corrupt!(
-            cell_pointer + CELL_PTR_SIZE_BYTES <= buf.len(),
-            "cell pointer offset {} out of bounds for index page {} with {} cells and page size {}",
-            cell_pointer,
-            self.id,
-            cell_count,
-            buf.len()
-        );
-        let cell_offset = self.read_u16(cell_pointer) as usize;
+        let cell_offset = self.read_cell_pointer(idx)?;
 
         let page_type = self.page_type()?;
         let (payload_size, varint_len, header_skip) = match page_type {
@@ -5479,9 +5472,13 @@ pub(crate) mod ptrmap {
 mod tests {
     use crate::sync::Arc;
 
+    use crate::error::LimboError;
+    use crate::io::Buffer;
     use crate::sync::RwLock;
 
+    use crate::storage::btree::offset::BTREE_CELL_COUNT;
     use crate::storage::page_cache::{PageCache, PageCacheKey};
+    use crate::storage::sqlite3_ondisk::PageType;
 
     use super::Page;
 
@@ -5506,6 +5503,54 @@ mod tests {
         let page_key = PageCacheKey::new(1);
         let page = cache.get(&page_key).unwrap();
         assert_eq!(page.unwrap().get().id, 1);
+    }
+
+    // Create a synthetic page with no cells and a valid header.
+    // Tests can optionally corrupt fields (like cell_count) to exercise error paths.
+    fn make_empty_page(page_type: PageType, page_size: usize) -> Arc<Page> {
+        let page = Arc::new(Page::new(2));
+        {
+            let inner = page.get();
+            inner.buffer = Some(Arc::new(Buffer::new_temporary(page_size)));
+        }
+        page.set_loaded();
+        let contents = page.get_contents();
+        contents.write_page_type(page_type as u8);
+        contents.write_first_freeblock(0);
+        contents.write_cell_count(0);
+        contents.write_cell_content_area(page_size);
+        contents.write_fragmented_bytes_count(0);
+        if matches!(page_type, PageType::TableInterior | PageType::IndexInterior) {
+            contents.write_rightmost_ptr(0);
+        }
+        page
+    }
+
+    // Exercises the `idx < cell_count` guard:
+    // page has 0 cells, asking for cell 0 should return Corrupt.
+    #[test]
+    fn cell_index_read_payload_ptr_rejects_index_past_cell_count() {
+        let index_leaf = make_empty_page(PageType::IndexLeaf, 512);
+        let contents = index_leaf.get_contents();
+
+        let err = contents.cell_index_read_payload_ptr(0, 504).unwrap_err();
+        assert!(matches!(err, LimboError::Corrupt(_)), "got {err:?}");
+    }
+
+    // Exercises the `absolute_offset + 2 <= page.len()` guard:
+    // corrupt cell_count passes the first check, but the pointer-array slot is past the page buffer.
+    #[test]
+    fn cell_index_read_payload_ptr_rejects_pointer_entry_past_page_end() {
+        let index_leaf = make_empty_page(PageType::IndexLeaf, 512);
+        index_leaf
+            .get_contents()
+            .write_u16(BTREE_CELL_COUNT, 19_500);
+        let contents = index_leaf.get_contents();
+
+        let err = contents
+            .cell_index_read_payload_ptr(19_485, 504)
+            .unwrap_err();
+        assert!(matches!(err, LimboError::Corrupt(_)), "got {err:?}");
     }
 }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -455,8 +455,24 @@ impl PageInner {
         usable_size: usize,
     ) -> crate::Result<(&'static [u8], u64, Option<u32>)> {
         let buf = self.as_ptr();
+        let cell_count = self.cell_count();
+        crate::assert_or_bail_corrupt!(
+            idx < cell_count,
+            "cell index {} out of bounds for index page {} with {} cells",
+            idx,
+            self.id,
+            cell_count
+        );
         let cell_pointer_array_start = self.header_size();
         let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
+        crate::assert_or_bail_corrupt!(
+            cell_pointer + CELL_PTR_SIZE_BYTES <= buf.len(),
+            "cell pointer offset {} out of bounds for index page {} with {} cells and page size {}",
+            cell_pointer,
+            self.id,
+            cell_count,
+            buf.len()
+        );
         let cell_offset = self.read_u16(cell_pointer) as usize;
 
         let page_type = self.page_type()?;
@@ -1224,7 +1240,9 @@ struct SavepointSnapshot {
     kind: SavepointKind,
     start_offset: u64,
     db_size: u32,
+    dirty_pages_at_start: RoaringBitmap,
     wal_max_frame: u64,
+    wal_checkpoint_seq: u32,
     wal_checksum: (u32, u32),
     deferred_fk_violations: isize,
 }
@@ -1241,9 +1259,13 @@ struct Savepoint {
     /// If the database grows during the savepoint and a rollback to the savepoint is performed,
     /// the pages exceeding the database size at the start of the savepoint will be ignored.
     db_size: AtomicU32,
+    /// Dirty pages that existed before this savepoint was opened.
+    dirty_pages_at_start: RoaringBitmap,
     /// We might want to rollback.
     /// WAL max frame at the start of the savepoint.
     wal_max_frame: AtomicU64,
+    /// WAL checkpoint sequence at the start of the savepoint.
+    wal_checkpoint_seq: AtomicU32,
     /// WAL checksum at the start of the savepoint.
     wal_checksum: RwLock<(u32, u32)>,
     /// Deferred FK counter value at the start of this savepoint.
@@ -1251,11 +1273,14 @@ struct Savepoint {
 }
 
 impl Savepoint {
+    #[expect(clippy::too_many_arguments)]
     fn new(
         kind: SavepointKind,
         subjournal_offset: u64,
         db_size: u32,
+        dirty_pages_at_start: RoaringBitmap,
         wal_max_frame: u64,
+        wal_checkpoint_seq: u32,
         wal_checksum: (u32, u32),
         deferred_fk_violations: isize,
     ) -> Self {
@@ -1265,7 +1290,9 @@ impl Savepoint {
             write_offset: AtomicU64::new(subjournal_offset),
             page_bitmap: RwLock::new(RoaringBitmap::new()),
             db_size: AtomicU32::new(db_size),
+            dirty_pages_at_start,
             wal_max_frame: AtomicU64::new(wal_max_frame),
+            wal_checkpoint_seq: AtomicU32::new(wal_checkpoint_seq),
             wal_checksum: RwLock::new(wal_checksum),
             deferred_fk_violations: AtomicIsize::new(deferred_fk_violations),
         }
@@ -1296,7 +1323,9 @@ impl Savepoint {
             kind: self.kind.clone(),
             start_offset: self.start_offset(),
             db_size: self.db_size.load(Ordering::Acquire),
+            dirty_pages_at_start: self.dirty_pages_at_start.clone(),
             wal_max_frame: self.wal_max_frame.load(Ordering::Acquire),
+            wal_checkpoint_seq: self.wal_checkpoint_seq.load(Ordering::Acquire),
             wal_checksum: *self.wal_checksum.read(),
             deferred_fk_violations: self.deferred_fk_violations.load(Ordering::Acquire),
         }
@@ -1309,7 +1338,9 @@ impl Savepoint {
             write_offset: AtomicU64::new(snapshot.start_offset),
             page_bitmap: RwLock::new(RoaringBitmap::new()),
             db_size: AtomicU32::new(snapshot.db_size),
+            dirty_pages_at_start: snapshot.dirty_pages_at_start,
             wal_max_frame: AtomicU64::new(snapshot.wal_max_frame),
+            wal_checkpoint_seq: AtomicU32::new(snapshot.wal_checkpoint_seq),
             wal_checksum: RwLock::new(snapshot.wal_checksum),
             deferred_fk_violations: AtomicIsize::new(snapshot.deferred_fk_violations),
         }
@@ -1933,22 +1964,29 @@ impl Pager {
         db_size: u32,
         deferred_fk_violations: isize,
     ) -> Result<()> {
+        let dirty_pages_at_start = self.dirty_pages.read().clone();
         let subjournal_offset = self
             .savepoints
             .read()
             .last()
             .map(|savepoint| savepoint.write_offset())
             .unwrap_or(0);
-        let (wal_max_frame, wal_checksum) = if let Some(wal) = &self.wal {
-            (wal.get_max_frame(), wal.get_last_checksum())
+        let (wal_max_frame, wal_checkpoint_seq, wal_checksum) = if let Some(wal) = &self.wal {
+            (
+                wal.get_max_frame(),
+                wal.get_checkpoint_seq(),
+                wal.get_last_checksum(),
+            )
         } else {
-            (0, (0, 0))
+            (0, 0, (0, 0))
         };
         let savepoint = Savepoint::new(
             kind,
             subjournal_offset,
             db_size,
+            dirty_pages_at_start,
             wal_max_frame,
+            wal_checkpoint_seq,
             wal_checksum,
             deferred_fk_violations,
         );
@@ -2016,15 +2054,37 @@ impl Pager {
             "memory IO should complete immediately"
         );
 
-        // Discard all dirty pages allocated after the savepoint. These pages
-        // are never subjournaled (see subjournal_page_if_required), so the loop
-        // above won't encounter them. We must clean them from dirty_pages before
-        // truncating the cache, or phantom dirty entries survive into commit.
         {
             let mut cache = self.page_cache.write();
+            // Restored pages must regain the dirty/spilled state they had when
+            // the savepoint was opened so cache bookkeeping matches the
+            // rolled-back page contents.
+            for page_id in rollback_bitset.iter() {
+                let key = PageCacheKey::new(page_id as usize);
+                let Some(page) = cache.peek(&key, false) else {
+                    continue;
+                };
+                if savepoint.dirty_pages_at_start.contains(page_id) {
+                    if !page.is_dirty() {
+                        cache.notify_page_dirty(key);
+                    }
+                    page.clear_spilled();
+                    page.set_dirty();
+                    dirty_pages.insert(page_id);
+                } else {
+                    page.clear_spilled();
+                    page.clear_dirty();
+                    dirty_pages.remove(page_id);
+                    page.try_unpin();
+                }
+            }
+            // Dirty pages allocated after the savepoint are never subjournaled
+            // (see subjournal_page_if_required), so remove them before
+            // truncating the cache to avoid phantom dirty entries at commit.
             for page_id in dirty_pages.iter().filter(|&id| id > db_size) {
                 if let Some(page) = cache.get(&PageCacheKey::new(page_id as usize))? {
                     page.clear_dirty();
+                    page.clear_spilled();
                     page.try_unpin();
                 }
             }
@@ -2033,8 +2093,15 @@ impl Pager {
         }
 
         if let Some(wal) = &self.wal {
+            let current_checkpoint_seq = wal.get_checkpoint_seq();
+            let current_max_frame = wal.get_max_frame();
+            let rollback_frame = if current_checkpoint_seq == savepoint.wal_checkpoint_seq {
+                savepoint.wal_max_frame.min(current_max_frame)
+            } else {
+                0
+            };
             wal.rollback(Some(RollbackTo {
-                frame: savepoint.wal_max_frame,
+                frame: rollback_frame,
                 checksum: savepoint.wal_checksum,
             }));
             self.page_cache

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3794,7 +3794,14 @@ impl Wal for WalFile {
             .unwrap_or(snapshot.max_frame);
         let last_checksum = rollback_to
             .as_ref()
-            .map(|r| r.checksum)
+            .map(|r| {
+                if r.frame == 0 {
+                    let hdr = self.coordination.wal_header();
+                    (hdr.checksum_1, hdr.checksum_2)
+                } else {
+                    r.checksum
+                }
+            })
             .unwrap_or(snapshot.last_checksum);
         self.coordination.rollback_cache(max_frame);
         *self.last_checksum.write() = last_checksum;

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2970,10 +2970,9 @@ pub fn translate_expr(
                 }
                 ResolveType::Replace => {
                     crate::bail_parse_error!("REPLACE is not valid for RAISE");
-                }
-                // If the custom type requires parameters but the CAST
-                // doesn't provide them (e.g. CAST(x AS NUMERIC) vs
-                // CAST(x AS numeric(10,2))), fall through to regular CAST.
+                } // If the custom type requires parameters but the CAST
+                  // doesn't provide them (e.g. CAST(x AS NUMERIC) vs
+                  // CAST(x AS numeric(10,2))), fall through to regular CAST.
             }
             Ok(target_register)
         }

--- a/testing/sqltests/tests/savepoint.sqltest
+++ b/testing/sqltests/tests/savepoint.sqltest
@@ -280,6 +280,43 @@ expect {
 }
 
 @cross-check-integrity
+test savepoint-rollback-restores-index-pages-for-indexed-seek {
+    PRAGMA page_size = 512;
+    PRAGMA cache_size = 2;
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT UNIQUE, c TEXT);
+    CREATE INDEX i_c_b ON t(c, b);
+    INSERT INTO t
+    SELECT
+        value,
+        printf('sv35_%05d_', value) || hex(randomblob(90)),
+        printf('sc35_%05d_', value) || hex(randomblob(180))
+    FROM generate_series(1, 495);
+    SAVEPOINT s;
+    DELETE FROM t WHERE a BETWEEN 105 AND 385;
+    INSERT INTO t
+    SELECT
+        value + 9000,
+        printf('sv35_new%05d_', value) || hex(randomblob(120)),
+        printf('sc35_new%05d_', value) || hex(randomblob(220))
+    FROM generate_series(1, 120);
+    ROLLBACK TO s;
+    RELEASE s;
+    SELECT count(*), min(a), max(a)
+    FROM (
+        SELECT a
+        FROM t INDEXED BY i_c_b
+        WHERE c >= 'sc35_'
+        ORDER BY c, b
+        LIMIT 240
+    );
+    PRAGMA integrity_check;
+}
+expect {
+    240|1|240
+    ok
+}
+
+@cross-check-integrity
 test savepoint-release-root-with-deferred-fk-fails {
     PRAGMA foreign_keys = ON;
     CREATE TABLE p(id INTEGER PRIMARY KEY);


### PR DESCRIPTION
## Description
Fix savepoint rollback after WAL generation changes so indexed reads do not observe stale page state after ROLLBACK TO SAVEPOINT.

This change:

- records WAL checkpoint generation in savepoint snapshots
- rolls WAL back safely across checkpoint/restart boundaries
- restores WAL checksum correctly when rolling back to frame 0
- adds a sqltest reproducer
- hardens cell-pointer reads to return Corrupt(...) instead of panicking


## Motivation and context
#6357


## Description of AI Usage
Used AI to:

- investigate and narrow the root cause
- propose and implement the pager/WAL fix
- add regression coverage and defensive hardening
- run targeted validation and refine the test shape

All code changes and conclusions were reviewed and validated locally.
