### PR TITLE
fix/optimizer: resolve indexes per table reference, not by table name (fixes attach)

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1,7 +1,6 @@
 use crate::sync::Arc;
 use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
-use std::collections::VecDeque;
 
 use turso_ext::{ConstraintInfo, ConstraintUsage, ResultCode};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
@@ -44,6 +43,7 @@ use super::{
         btree_access_order_consumed, subquery_intrinsic_order_consumed, ColumnTarget,
         EqualityPrefixScope, OrderTarget,
     },
+    AvailableIndexes,
 };
 use crate::translate::planner::TableMask;
 
@@ -204,7 +204,7 @@ pub(super) fn choose_best_btree_candidate(
     rhs_table_idx: usize,
     maybe_order_target: Option<&OrderTarget>,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     analyze_stats: &AnalyzeStats,
     input_cardinality: f64,
     base_row_count: RowCountEstimate,
@@ -659,7 +659,7 @@ pub fn find_best_access_method_for_join_order(
     join_order: &[JoinOrderMember],
     planning_context: JoinPlanningContext<'_>,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
@@ -713,7 +713,7 @@ fn find_best_access_method_for_btree(
     join_order: &[JoinOrderMember],
     maybe_order_target: Option<&OrderTarget>,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -12,12 +12,11 @@ use crate::{
     Result,
 };
 use crate::{turso_assert, turso_debug_assert};
-use rustc_hash::FxHashMap as HashMap;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintOp};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
-use super::cost_params::CostModelParams;
+use super::{cost_params::CostModelParams, AvailableIndexes};
 
 /// Represents a single condition derived from a `WHERE` clause term
 /// that constrains a specific column of a table.
@@ -249,8 +248,7 @@ fn estimate_selectivity(
     schema: &Schema,
     table_name: &str,
     column: Option<&Column>,
-    column_pos: Option<usize>,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    index: Option<&Index>,
     op: ConstraintOperator,
     params: &CostModelParams,
     is_rowid: bool,
@@ -273,40 +271,27 @@ fn estimate_selectivity(
 
             if is_pk_or_rowid_alias {
                 selectivity_when_unique
-            } else if let Some(col_pos) = column_pos {
-                // For non-unique columns, find an index containing this column and use its stats
-                if let Some(indexes) = available_indexes.get(table_name) {
-                    for index in indexes {
-                        // Check if this index has our column as its first column
-                        // (selectivity is most accurate when column is leftmost in index)
-                        if let Some(idx_col_pos) = index.column_table_pos_to_index_pos(col_pos) {
-                            // Only use stats if column is first in index (idx_col_pos == 0)
-                            // because that's when the distinct count is most useful
-                            if idx_col_pos == 0 {
-                                // Only use unique selectivity for single-column unique indexes.
-                                // For composite unique indexes like tpc-h (l_orderkey, l_linenumber),
-                                // the first column alone is NOT unique.
-                                if index.unique && index.columns.len() == 1 {
-                                    return selectivity_when_unique;
-                                }
-                                if let Some(stats) = table_stats {
-                                    if let Some(idx_stat) = stats.index_stats.get(&index.name) {
-                                        if let (Some(total), Some(&avg_rows)) = (
-                                            idx_stat.total_rows,
-                                            idx_stat.avg_rows_per_distinct_prefix.first(),
-                                        ) {
-                                            if total > 0 && avg_rows > 0 {
-                                                // selectivity = avg_rows_per_key / total_rows
-                                                return avg_rows as f64 / total as f64;
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    return params.sel_eq_indexed;
-                                }
+            } else if let Some(index) = index {
+                // Only use unique selectivity for single-column unique indexes.
+                // For composite unique indexes like tpc-h (l_orderkey, l_linenumber),
+                // the first column alone is NOT unique.
+                if index.unique && index.columns.len() == 1 {
+                    return selectivity_when_unique;
+                }
+                if let Some(stats) = table_stats {
+                    if let Some(idx_stat) = stats.index_stats.get(&index.name) {
+                        if let (Some(total), Some(&avg_rows)) = (
+                            idx_stat.total_rows,
+                            idx_stat.avg_rows_per_distinct_prefix.first(),
+                        ) {
+                            if total > 0 && avg_rows > 0 {
+                                // selectivity = avg_rows_per_key / total_rows
+                                return avg_rows as f64 / total as f64;
                             }
                         }
                     }
+                } else {
+                    return params.sel_eq_indexed;
                 }
                 // Fallback: use hardcoded selectivity for non-indexed columns
                 // Don't scale by row_count - keep it distinct from PK selectivity
@@ -337,9 +322,8 @@ fn estimate_constraint_selectivity(
     schema: &Schema,
     table_reference: &JoinedTable,
     column: Option<&Column>,
-    column_pos: Option<usize>,
     operator: ConstraintOperator,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    index: Option<&Index>,
     params: &CostModelParams,
     is_rowid: bool,
 ) -> f64 {
@@ -347,12 +331,44 @@ fn estimate_constraint_selectivity(
         schema,
         table_reference.table.get_name(),
         column,
-        column_pos,
-        available_indexes,
+        index,
         operator,
         params,
         is_rowid,
     )
+}
+
+fn selectivity_index_for_column<'a>(
+    schema: &Schema,
+    table_reference: &JoinedTable,
+    available_indexes: &'a AvailableIndexes,
+    column_pos: usize,
+) -> Option<&'a Index> {
+    let table_stats = schema
+        .analyze_stats
+        .table_stats(table_reference.table.get_name());
+    available_indexes
+        .btree_indexes_for_column(table_reference.internal_id, column_pos)
+        .find(|index| {
+            if index.unique && index.columns.len() == 1 {
+                return true;
+            }
+            let Some(table_stats) = table_stats else {
+                return true;
+            };
+            table_stats
+                .index_stats
+                .get(&index.name)
+                .is_some_and(|idx_stat| {
+                    matches!(
+                        (
+                            idx_stat.total_rows,
+                            idx_stat.avg_rows_per_distinct_prefix.first()
+                        ),
+                        (Some(total), Some(&avg_rows)) if total > 0 && avg_rows > 0
+                    )
+                })
+        })
 }
 
 fn expression_matches_table(
@@ -379,7 +395,7 @@ fn expression_matches_table(
 pub fn constraints_from_where_clause(
     where_clause: &[WhereTerm],
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -397,7 +413,7 @@ pub fn constraints_from_where_clause(
             table_id: table_reference.internal_id,
             constraints: Vec::new(),
             candidates: available_indexes
-                .get(table_reference.table.get_name())
+                .indexes_for_table(table_reference.internal_id)
                 .map_or(Vec::new(), |indexes| {
                     indexes
                         .iter()
@@ -416,6 +432,10 @@ pub fn constraints_from_where_clause(
             index: None,
             refs: Vec::new(),
         });
+
+        let index_for_column = |column_pos| {
+            selectivity_index_for_column(schema, table_reference, available_indexes, column_pos)
+        };
 
         for (i, term) in where_clause.iter().enumerate() {
             // Constraints originating from a LEFT JOIN must always be evaluated in that join's RHS table's loop,
@@ -444,9 +464,8 @@ pub fn constraints_from_where_clause(
                                     schema,
                                     table_reference,
                                     Some(table_column),
-                                    Some(*column),
                                     operator,
-                                    available_indexes,
+                                    index_for_column(*column),
                                     params,
                                     false,
                                 ),
@@ -473,9 +492,8 @@ pub fn constraints_from_where_clause(
                                     schema,
                                     table_reference,
                                     col,
-                                    col_pos,
                                     operator,
-                                    available_indexes,
+                                    None,
                                     params,
                                     true,
                                 ),
@@ -495,9 +513,8 @@ pub fn constraints_from_where_clause(
                             schema,
                             table_reference,
                             None,
-                            None,
                             operator,
-                            available_indexes,
+                            None,
                             params,
                             false,
                         );
@@ -538,9 +555,8 @@ pub fn constraints_from_where_clause(
                                     schema,
                                     table_reference,
                                     Some(table_column),
-                                    Some(*column),
                                     operator,
-                                    available_indexes,
+                                    index_for_column(*column),
                                     params,
                                     false,
                                 ),
@@ -567,9 +583,8 @@ pub fn constraints_from_where_clause(
                                     schema,
                                     table_reference,
                                     col,
-                                    col_pos,
                                     operator,
-                                    available_indexes,
+                                    None,
                                     params,
                                     true,
                                 ),
@@ -589,9 +604,8 @@ pub fn constraints_from_where_clause(
                             schema,
                             table_reference,
                             None,
-                            None,
                             operator,
-                            available_indexes,
+                            None,
                             params,
                             false,
                         );
@@ -803,9 +817,9 @@ pub fn constraints_from_where_clause(
                 });
             }
             for index in available_indexes
-                .get(table_reference.table.get_name())
-                .unwrap_or(&VecDeque::new())
-                .iter()
+                .indexes_for_table(table_reference.internal_id)
+                .into_iter()
+                .flat_map(|indexes| indexes.iter())
                 .filter(|idx| idx.index_method.is_none())
             {
                 if let Some(position_in_index) = match constraint.table_col_pos {
@@ -1261,7 +1275,7 @@ pub fn estimate_partial_index_where_selectivity(
     where_expr: &ast::Expr,
     table_reference: &JoinedTable,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     params: &CostModelParams,
 ) -> f64 {
     let mut bound = where_expr.clone();
@@ -1273,7 +1287,7 @@ fn estimate_bound_expr_selectivity(
     expr: &ast::Expr,
     table_reference: &JoinedTable,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     params: &CostModelParams,
 ) -> f64 {
     use ast::Expr;
@@ -1305,16 +1319,10 @@ fn estimate_bound_expr_selectivity(
     let leaf_selectivity = |lhs: &ast::Expr, rhs: &ast::Expr, op: ConstraintOperator| -> f64 {
         let resolved = resolve_side(lhs).or_else(|| resolve_side(rhs));
         let (col, col_pos, is_rowid) = resolved.unwrap_or((None, None, false));
-        estimate_constraint_selectivity(
-            schema,
-            table_reference,
-            col,
-            col_pos,
-            op,
-            available_indexes,
-            params,
-            is_rowid,
-        )
+        let index = col_pos.and_then(|pos| {
+            selectivity_index_for_column(schema, table_reference, available_indexes, pos)
+        });
+        estimate_constraint_selectivity(schema, table_reference, col, op, index, params, is_rowid)
     };
 
     match expr {
@@ -1375,16 +1383,18 @@ fn estimate_bound_expr_selectivity(
         Expr::InList { lhs, not, rhs } => {
             let resolved = resolve_side(lhs);
             let (col, col_pos, is_rowid) = resolved.unwrap_or((None, None, false));
+            let index = col_pos.and_then(|pos| {
+                selectivity_index_for_column(schema, table_reference, available_indexes, pos)
+            });
             estimate_constraint_selectivity(
                 schema,
                 table_reference,
                 col,
-                col_pos,
                 ConstraintOperator::In {
                     not: *not,
                     estimated_values: rhs.len() as f64,
                 },
-                available_indexes,
+                index,
                 params,
                 is_rowid,
             )
@@ -1627,7 +1637,6 @@ pub(crate) fn analyze_binary_term_for_index(
     table_reference: &JoinedTable,
     indexes: Option<&VecDeque<Arc<Index>>>,
     rowid_alias_column: Option<usize>,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
@@ -1662,9 +1671,8 @@ pub(crate) fn analyze_binary_term_for_index(
         schema,
         table_reference,
         table_column,
-        table_col_pos,
         operator,
-        available_indexes,
+        best_index.as_deref(),
         params,
         is_rowid,
     );

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1,6 +1,3 @@
-use std::collections::VecDeque;
-use std::sync::Arc;
-
 use crate::{turso_assert_eq, turso_assert_greater_than};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -13,10 +10,10 @@ use super::{
     constraints::TableConstraints,
     cost_params::CostModelParams,
     order::OrderTarget,
-    IndexMethodCandidate,
+    AvailableIndexes, IndexMethodCandidate,
 };
 use crate::{
-    schema::{Index, Schema},
+    schema::Schema,
     stats::AnalyzeStats,
     translate::{
         expr::{walk_expr, WalkControl},
@@ -164,7 +161,7 @@ pub fn join_lhs_and_rhs<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<JoinN>> {
@@ -892,7 +889,7 @@ pub fn compute_best_join_order<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
@@ -930,7 +927,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
@@ -1364,7 +1361,7 @@ pub fn compute_greedy_join_order<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
@@ -1624,7 +1621,7 @@ pub fn compute_naive_left_deep_plan<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<JoinN>> {
@@ -1831,7 +1828,7 @@ mod tests {
     /// Test that [compute_best_join_order] returns None when there are no table references.
     fn test_compute_best_join_order_empty() {
         let table_references = TableReferences::new(vec![], vec![]);
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let mut where_clause = vec![];
 
         let mut access_methods_arena = Vec::new();
@@ -1874,7 +1871,7 @@ mod tests {
         let mut table_id_counter = TableRefIdCounter::new();
         let joined_tables = vec![_create_table_reference(t1, None, table_id_counter.next())];
         let table_references = TableReferences::new(joined_tables, vec![]);
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let mut where_clause = vec![];
 
         let mut access_methods_arena = Vec::new();
@@ -1932,7 +1929,7 @@ mod tests {
 
         let table_references = TableReferences::new(joined_tables, vec![]);
         let mut access_methods_arena = Vec::new();
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let table_constraints = constraints_from_where_clause(
             &where_clause,
             &table_references,
@@ -1998,7 +1995,7 @@ mod tests {
 
         let table_references = TableReferences::new(joined_tables, vec![]);
         let mut access_methods_arena = Vec::new();
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         let index = Arc::new(Index {
             name: "sqlite_autoindex_test_table_1".to_string(),
             table_name: "test_table".to_string(),
@@ -2018,7 +2015,11 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("test_table".to_string(), VecDeque::from([index]));
+        available_indexes.insert_for_table_name(
+            table_references.joined_tables(),
+            "test_table",
+            VecDeque::from([index]),
+        );
 
         let table_constraints = constraints_from_where_clause(
             &where_clause,
@@ -2090,7 +2091,7 @@ mod tests {
         const TABLE1: usize = 0;
         const TABLE2: usize = 1;
 
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         // Index on the outer table (table1)
         let index1 = Arc::new(Index {
             name: "index1".to_string(),
@@ -2111,7 +2112,7 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("table1".to_string(), VecDeque::from([index1]));
+        available_indexes.insert_for_table_name(&joined_tables, "table1", VecDeque::from([index1]));
 
         // SELECT * FROM table1 JOIN table2 WHERE table1.id = table2.id
         // expecting table2 to be chosen first due to the index on table1.id
@@ -2228,7 +2229,7 @@ mod tests {
         const TABLE_NO_CUSTOMERS: usize = 1;
         const TABLE_NO_ORDER_ITEMS: usize = 2;
 
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         ["orders", "customers", "order_items"]
             .iter()
             .for_each(|table_name| {
@@ -2253,7 +2254,11 @@ mod tests {
                     index_method: None,
                     on_conflict: None,
                 });
-                available_indexes.insert(table_name.to_string(), VecDeque::from([index]));
+                available_indexes.insert_for_table_name(
+                    &joined_tables,
+                    table_name,
+                    VecDeque::from([index]),
+                );
             });
         let customer_id_idx = Arc::new(Index {
             name: "orders_customer_id_idx".to_string(),
@@ -2294,12 +2299,8 @@ mod tests {
             on_conflict: None,
         });
 
-        available_indexes
-            .entry("orders".to_string())
-            .and_modify(|v| v.push_front(customer_id_idx));
-        available_indexes
-            .entry("order_items".to_string())
-            .and_modify(|v| v.push_front(order_id_idx));
+        available_indexes.push_front_for_table_name(&joined_tables, "orders", customer_id_idx);
+        available_indexes.push_front_for_table_name(&joined_tables, "order_items", order_id_idx);
 
         // SELECT * FROM orders JOIN customers JOIN order_items
         // WHERE orders.customer_id = customers.id AND orders.id = order_items.order_id AND customers.id = 42
@@ -2456,7 +2457,7 @@ mod tests {
         ];
 
         let table_references = TableReferences::new(joined_tables, vec![]);
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let mut access_methods_arena = Vec::new();
         let table_constraints = constraints_from_where_clause(
             &where_clause,
@@ -2583,7 +2584,7 @@ mod tests {
 
         let table_references = TableReferences::new(joined_tables, vec![]);
         let mut access_methods_arena = Vec::new();
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let table_constraints = constraints_from_where_clause(
             &where_clause,
             &table_references,
@@ -2663,7 +2664,7 @@ mod tests {
             tables.push(_create_btree_table(&format!("t{}", i + 1), columns));
         }
 
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
 
         let mut table_id_counter = TableRefIdCounter::new();
         // Create table references
@@ -2798,8 +2799,7 @@ mod tests {
             on_conflict: None,
         });
 
-        let mut available_indexes = HashMap::default();
-        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
+        let mut available_indexes = AvailableIndexes::default();
 
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
@@ -2814,6 +2814,7 @@ mod tests {
             database_id: MAIN_DB_ID,
             indexed: None,
         });
+        available_indexes.insert_for_table_name(&joined_tables, "t1", VecDeque::from([index]));
 
         // Create where clause that only references second column
         let mut where_clause = vec![WhereTerm {
@@ -2876,7 +2877,7 @@ mod tests {
     fn test_index_skips_middle_column() {
         let mut table_id_counter = TableRefIdCounter::new();
         let mut joined_tables = Vec::new();
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
 
         let columns = _create_column_list(&["c1", "c2", "c3"], Type::Integer);
         let table = _create_btree_table("t1", columns);
@@ -2917,8 +2918,6 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
-
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
             op: Operation::default_scan_for(&table),
@@ -2932,6 +2931,7 @@ mod tests {
             database_id: MAIN_DB_ID,
             indexed: None,
         });
+        available_indexes.insert_for_table_name(&joined_tables, "t1", VecDeque::from([index]));
 
         // Create where clause that references first and third columns
         let mut where_clause = vec![
@@ -3015,7 +3015,7 @@ mod tests {
     fn test_index_stops_at_range_operator() {
         let mut table_id_counter = TableRefIdCounter::new();
         let mut joined_tables = Vec::new();
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
 
         let columns = _create_column_list(&["c1", "c2", "c3"], Type::Integer);
         let table = _create_btree_table("t1", columns);
@@ -3056,8 +3056,6 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
-
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
             op: Operation::default_scan_for(&table),
@@ -3071,6 +3069,7 @@ mod tests {
             database_id: MAIN_DB_ID,
             indexed: None,
         });
+        available_indexes.insert_for_table_name(&joined_tables, "t1", VecDeque::from([index]));
 
         // Create where clause: c1 = 5 AND c2 > 10 AND c3 = 7
         let mut where_clause = vec![
@@ -3314,7 +3313,7 @@ mod tests {
         const TABLE2: usize = 1;
 
         // Index on t2.a
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         let index_t2_a = Arc::new(Index {
             name: "idx_t2_a".to_string(),
             table_name: "t2".to_string(),
@@ -3334,7 +3333,7 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("t2".to_string(), VecDeque::from([index_t2_a]));
+        available_indexes.insert_for_table_name(&joined_tables, "t2", VecDeque::from([index_t2_a]));
 
         // WHERE t1.a = t2.a
         let mut where_clause = vec![_create_binary_expr(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -65,7 +65,7 @@ use rustc_hash::FxHashMap as HashMap;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintUsage};
 use turso_parser::ast::RefAct;
-use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TriggerEvent};
+use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TableInternalId, TriggerEvent};
 
 pub(crate) mod access_method;
 pub(crate) mod constraints;
@@ -76,6 +76,98 @@ pub(crate) mod lift_common_subexpressions;
 pub(crate) mod multi_index;
 pub(crate) mod order;
 pub(crate) mod unnest;
+
+#[derive(Debug, Default)]
+pub(crate) struct AvailableIndexes {
+    indexes_by_table_id: HashMap<TableInternalId, VecDeque<Arc<Index>>>,
+}
+
+impl AvailableIndexes {
+    fn for_table_references(resolver: &Resolver, table_references: &TableReferences) -> Self {
+        let mut available_indexes = Self::default();
+        for table_ref in table_references.joined_tables() {
+            if !matches!(table_ref.table, Table::BTree(_) | Table::Virtual(_)) {
+                continue;
+            }
+            let indexes = resolver.with_schema(table_ref.database_id, |schema| {
+                schema.indexes.get(table_ref.table.get_name()).cloned()
+            });
+            if let Some(indexes) = indexes {
+                available_indexes
+                    .indexes_by_table_id
+                    .insert(table_ref.internal_id, indexes);
+            }
+        }
+        available_indexes
+    }
+
+    pub(crate) fn indexes_for_table(
+        &self,
+        table_id: TableInternalId,
+    ) -> Option<&VecDeque<Arc<Index>>> {
+        self.indexes_by_table_id.get(&table_id)
+    }
+
+    pub(crate) fn btree_indexes_for_column(
+        &self,
+        table_id: TableInternalId,
+        column_pos: usize,
+    ) -> impl Iterator<Item = &Index> {
+        self.indexes_for_table(table_id)
+            .into_iter()
+            .flat_map(|indexes| indexes.iter())
+            .filter(move |index| {
+                index.index_method.is_none()
+                    && index.column_table_pos_to_index_pos(column_pos) == Some(0)
+            })
+            .map(Arc::as_ref)
+    }
+
+    fn btree_index_by_name(
+        &self,
+        table_id: TableInternalId,
+        index_name: &str,
+    ) -> Option<Arc<Index>> {
+        self.indexes_for_table(table_id)?
+            .iter()
+            .find(|index| {
+                index.name.eq_ignore_ascii_case(index_name) && index.index_method.is_none()
+            })
+            .cloned()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_for_table_name(
+        &mut self,
+        joined_tables: &[JoinedTable],
+        table_name: &str,
+        indexes: VecDeque<Arc<Index>>,
+    ) {
+        let table_ref = joined_tables
+            .iter()
+            .find(|table_ref| table_ref.table.get_name() == table_name)
+            .expect("test table should exist");
+        self.indexes_by_table_id
+            .insert(table_ref.internal_id, indexes);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn push_front_for_table_name(
+        &mut self,
+        joined_tables: &[JoinedTable],
+        table_name: &str,
+        index: Arc<Index>,
+    ) {
+        let table_ref = joined_tables
+            .iter()
+            .find(|table_ref| table_ref.table.get_name() == table_name)
+            .expect("test table should exist");
+        self.indexes_by_table_id
+            .entry(table_ref.internal_id)
+            .or_default()
+            .push_front(index);
+    }
+}
 
 /// A candidate index method that could be used for table access in a join query.
 /// This struct captures all information needed to construct an IndexMethodQuery
@@ -353,7 +445,7 @@ fn sorted_arguments_from_parameters(parameters: &HashMap<i32, ast::Expr>) -> Vec
 #[allow(clippy::too_many_arguments)]
 fn collect_index_method_candidates(
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     where_clause: &[WhereTerm],
     order_by: &[(
         Box<ast::Expr>,
@@ -375,7 +467,7 @@ fn collect_index_method_candidates(
 
     let tables = table_references.joined_tables();
     for (table_idx, table) in tables.iter().enumerate() {
-        let Some(indexes) = available_indexes.get(table.table.get_name()) else {
+        let Some(indexes) = available_indexes.indexes_for_table(table.internal_id) else {
             continue;
         };
 
@@ -447,17 +539,16 @@ pub fn optimize_plan(
     plan: &mut Plan,
     resolver: &Resolver,
 ) -> Result<()> {
-    let schema = resolver.schema();
     match plan {
-        Plan::Select(plan) => optimize_select_plan(plan, schema)?,
-        Plan::Delete(plan) => optimize_delete_plan(plan, schema)?,
+        Plan::Select(plan) => optimize_select_plan(plan, resolver)?,
+        Plan::Delete(plan) => optimize_delete_plan(plan, resolver)?,
         Plan::Update(plan) => optimize_update_plan(program, plan, resolver)?,
         Plan::CompoundSelect {
             left, right_most, ..
         } => {
-            optimize_select_plan(right_most, schema)?;
+            optimize_select_plan(right_most, resolver)?;
             for (plan, _) in left {
-                optimize_select_plan(plan, schema)?;
+                optimize_select_plan(plan, resolver)?;
             }
         }
     }
@@ -640,7 +731,8 @@ struct OptimizeTableAccessResult {
  * but having them separate makes them easier to understand
  */
 #[turso_macros::trace_stack]
-pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
+    let schema = resolver.schema();
     // Transform MATCH expressions to fts_match() for FTS optimizer recognition
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
     transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
@@ -665,7 +757,9 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
             }
         }
     }
-    optimize_subqueries(plan, schema)?;
+    optimize_subqueries(plan, resolver)?;
+    let available_indexes =
+        AvailableIndexes::for_table_references(resolver, &plan.table_references);
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
@@ -679,7 +773,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
         schema,
         &mut plan.result_columns,
         &mut plan.table_references,
-        &schema.indexes,
+        &available_indexes,
         &mut plan.where_clause,
         &mut plan.order_by,
         &mut plan.group_by,
@@ -730,12 +824,15 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
         plan.estimated_output_rows = Some(est);
     }
 
-    reoptimize_correlated_subqueries(plan, schema)?;
+    reoptimize_correlated_subqueries(plan, resolver)?;
 
     Ok(())
 }
 
-fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
+fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()> {
+    let schema = resolver.schema();
+    let available_indexes =
+        AvailableIndexes::for_table_references(resolver, &plan.table_references);
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
     transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
 
@@ -748,14 +845,14 @@ fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
     }
 
     if let Some(rowset_plan) = plan.rowset_plan.as_mut() {
-        optimize_select_plan(rowset_plan, schema)?;
+        optimize_select_plan(rowset_plan, resolver)?;
     }
 
     let _ = optimize_table_access(
         schema,
         &mut plan.result_columns,
         &mut plan.table_references,
-        &schema.indexes,
+        &available_indexes,
         &mut plan.where_clause,
         &mut plan.order_by,
         &mut None,
@@ -805,17 +902,18 @@ fn optimize_update_plan(
                 .as_mut()
                 .expect("UPDATE ... FROM must build its write-set SELECT before optimization")
                 .select,
-            schema,
+            resolver,
         )?;
         return Ok(());
     }
 
     let mut order_by = vec![];
+    let available_indexes = AvailableIndexes::for_table_references(resolver, &target_tables);
     let optimize_result = optimize_table_access(
         schema,
         &mut [],
         &mut target_tables,
-        &schema.indexes,
+        &available_indexes,
         &mut plan.where_clause,
         &mut order_by,
         &mut None,
@@ -1193,19 +1291,19 @@ fn update_from_set_result_columns(set_clauses: &[UpdateSetClause]) -> Vec<Result
         .collect()
 }
 
-fn optimize_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+fn optimize_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
     for table in plan.table_references.joined_tables_mut() {
         if let Table::FromClauseSubquery(from_clause_subquery) = &mut table.table {
             let from_clause_subquery = Arc::make_mut(from_clause_subquery);
             // Use match to handle both SelectPlan and CompoundSelect variants
             match from_clause_subquery.plan.as_mut() {
-                Plan::Select(select_plan) => optimize_select_plan(select_plan, schema)?,
+                Plan::Select(select_plan) => optimize_select_plan(select_plan, resolver)?,
                 Plan::CompoundSelect {
                     left, right_most, ..
                 } => {
-                    optimize_select_plan(right_most, schema)?;
+                    optimize_select_plan(right_most, resolver)?;
                     for (select_plan, _) in left {
-                        optimize_select_plan(select_plan, schema)?;
+                        optimize_select_plan(select_plan, resolver)?;
                     }
                 }
                 Plan::Delete(_) | Plan::Update(_) => {
@@ -1233,7 +1331,7 @@ fn optimize_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
 /// strictly larger. The recursive call therefore only propagates larger hints
 /// down the subquery tree; it does not oscillate based on newly estimated row
 /// counts.
-fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
     let Some(invocation_hint) = plan
         .input_cardinality_hint
         .or(plan.estimated_output_rows)
@@ -1267,7 +1365,7 @@ fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, schema: &Schema) -> R
         }
 
         inner_plan.input_cardinality_hint = Some(invocation_hint);
-        optimize_select_plan(inner_plan, schema)?;
+        optimize_select_plan(inner_plan, resolver)?;
     }
 
     Ok(())
@@ -1304,7 +1402,7 @@ fn select_plan_contains_cte_from_clause_subquery(plan: &SelectPlan) -> bool {
 fn optimize_table_access_with_custom_modules(
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     where_query: &mut [WhereTerm],
     order_by: &mut Vec<(
         Box<ast::Expr>,
@@ -1328,7 +1426,7 @@ fn optimize_table_access_with_custom_modules(
     // Only optimize the first table with custom index methods.
     // This allows FTS to be used as the driving table in joins.
     let table = &mut tables[0];
-    let Some(indexes) = available_indexes.get(table.table.get_name()) else {
+    let Some(indexes) = available_indexes.indexes_for_table(table.internal_id) else {
         return Ok(false);
     };
     for index in indexes {
@@ -1638,16 +1736,16 @@ fn expr_has_null_masking_for_table(expr: &ast::Expr, table_id: ast::TableInterna
 /// filtering constraint candidates accordingly.
 fn enforce_indexed_by_hints(
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     constraints_per_table: &mut [TableConstraints],
 ) -> Result<()> {
     for (i, table_ref) in table_references.joined_tables().iter().enumerate() {
         let Some(ref indexed) = table_ref.indexed else {
             continue;
         };
-        let Some(btree) = table_ref.btree() else {
+        if table_ref.btree().is_none() {
             continue;
-        };
+        }
         let Some(cs) = constraints_per_table.get_mut(i) else {
             continue;
         };
@@ -1655,11 +1753,8 @@ fn enforce_indexed_by_hints(
             ast::Indexed::IndexedBy(name) => {
                 let idx_name = name.as_str();
                 // Verify the index exists and belongs to this table.
-                let forced_index = available_indexes.get(&btree.name).and_then(|indexes| {
-                    indexes.iter().find(|idx| {
-                        idx.name.eq_ignore_ascii_case(idx_name) && idx.index_method.is_none()
-                    })
-                });
+                let forced_index =
+                    available_indexes.btree_index_by_name(table_ref.internal_id, idx_name);
                 let Some(forced_index) = forced_index else {
                     crate::bail_parse_error!("no such index: {}", idx_name);
                 };
@@ -1704,7 +1799,7 @@ fn optimize_table_access(
     schema: &Schema,
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     where_clause: &mut [WhereTerm],
     order_by: &mut Vec<(
         Box<ast::Expr>,
@@ -1736,8 +1831,8 @@ fn optimize_table_access(
     }
 
     let has_expression_index = table_references.joined_tables().iter().any(|t| {
-        matches!(&t.table, Table::BTree(btree) if available_indexes
-            .get(&btree.name)
+        matches!(&t.table, Table::BTree(_) if available_indexes
+            .indexes_for_table(t.internal_id)
             .is_some_and(|indexes| indexes.iter().any(|index| index.is_expression_index())))
     });
 

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -22,14 +22,14 @@ use crate::translate::optimizer::cost::{
     AnalyzeCtx, Cost, IndexInfo, RowCountEstimate,
 };
 use crate::translate::optimizer::cost_params::CostModelParams;
+use crate::translate::optimizer::AvailableIndexes;
 use crate::translate::plan::{
     BitSet, InSeekSource, JoinedTable, NonFromClauseSubquery, SetOperation, TableReferences,
     UnionBranchPrePostFilters, WhereTerm,
 };
 use crate::translate::planner::{table_mask_from_expr, TableMask};
-use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
-use std::{collections::VecDeque, sync::Arc};
+use std::sync::Arc;
 use turso_macros::turso_assert_eq;
 use turso_parser::ast::{self, TableInternalId};
 
@@ -147,7 +147,7 @@ fn get_table_local_constraints_for_branch(
     from_outer_join: Option<TableInternalId>,
     table_reference: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -330,7 +330,7 @@ fn choose_multi_index_branch_access(
     lhs_mask: &TableMask,
     rhs_idx: usize,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     base_row_count: RowCountEstimate,
     analyze_stats: &AnalyzeStats,
     params: &CostModelParams,
@@ -509,7 +509,7 @@ fn estimate_residual_expr_selectivity(
     expr: &ast::Expr,
     rhs_table: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -604,7 +604,7 @@ fn estimate_multi_or_residual_selectivity(
     residual_exprs: &[ast::Expr],
     rhs_table: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -635,7 +635,7 @@ fn evaluate_multi_index_branches(
     where_term_idx: usize,
     rhs_table: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     base_row_count: RowCountEstimate,
@@ -758,15 +758,14 @@ fn evaluate_multi_index_branches(
 fn analyze_and_terms_for_multi_index(
     table_reference: &JoinedTable,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
 ) -> Option<AndClauseDecomposition> {
     let table_id = table_reference.internal_id;
-    let table_name = table_reference.table.get_name();
-    let indexes = available_indexes.get(table_name);
+    let indexes = available_indexes.indexes_for_table(table_reference.internal_id);
     let rowid_alias_column = table_reference
         .columns()
         .iter()
@@ -871,7 +870,6 @@ fn analyze_and_terms_for_multi_index(
                 table_reference,
                 indexes,
                 rowid_alias_column,
-                available_indexes,
                 table_references,
                 subqueries,
                 schema,
@@ -905,7 +903,7 @@ fn analyze_and_terms_for_multi_index(
 pub fn consider_multi_index_union(
     rhs_table: &JoinedTable,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
@@ -1035,7 +1033,7 @@ pub fn consider_multi_index_union(
 pub fn consider_multi_index_intersection(
     rhs_table: &JoinedTable,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
@@ -1151,6 +1149,7 @@ mod tests {
                 access_method::AccessMethodParams,
                 cost::{Cost, RowCountEstimate},
                 cost_params::DEFAULT_PARAMS,
+                AvailableIndexes,
             },
             plan::{
                 ColumnUsedMask, JoinInfo, JoinType, JoinedTable, Operation, TableReferences,
@@ -1161,7 +1160,6 @@ mod tests {
         vdbe::builder::TableRefIdCounter,
         MAIN_DB_ID,
     };
-    use rustc_hash::FxHashMap as HashMap;
     use std::{collections::VecDeque, sync::Arc};
     use turso_parser::ast::{self, Expr, Operator, SortOrder, TableInternalId};
 
@@ -1311,9 +1309,10 @@ mod tests {
         const ITEM: usize = 1;
         const META: usize = 2;
 
-        let mut available_indexes = HashMap::default();
-        available_indexes.insert(
-            "item".to_string(),
+        let mut available_indexes = AvailableIndexes::default();
+        available_indexes.insert_for_table_name(
+            &joined_tables,
+            "item",
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_id".to_string(),
                 table_name: "item".to_string(),
@@ -1460,9 +1459,10 @@ mod tests {
         let joined_tables = vec![create_table_reference(item, None, table_id_counter.next())];
         let item_id = joined_tables[0].internal_id;
 
-        let mut available_indexes = HashMap::default();
-        available_indexes.insert(
-            "item".to_string(),
+        let mut available_indexes = AvailableIndexes::default();
+        available_indexes.insert_for_table_name(
+            &joined_tables,
+            "item",
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_a".to_string(),
                 table_name: "item".to_string(),
@@ -1573,9 +1573,10 @@ mod tests {
         const LINK: usize = 0;
         const ITEM: usize = 1;
 
-        let mut available_indexes = HashMap::default();
-        available_indexes.insert(
-            "item".to_string(),
+        let mut available_indexes = AvailableIndexes::default();
+        available_indexes.insert_for_table_name(
+            &joined_tables,
+            "item",
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_id_kind".to_string(),
                 table_name: "item".to_string(),
@@ -1769,9 +1770,10 @@ mod tests {
         let link_id = joined_tables[LINK].internal_id;
         let item_id = joined_tables[ITEM].internal_id;
 
-        let mut available_indexes = HashMap::default();
-        available_indexes.insert(
-            "item".to_string(),
+        let mut available_indexes = AvailableIndexes::default();
+        available_indexes.insert_for_table_name(
+            &joined_tables,
+            "item",
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_id".to_string(),
                 table_name: "item".to_string(),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -641,7 +641,7 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                optimize_select_plan(&mut plan, resolver.schema())?;
+                optimize_select_plan(&mut plan, resolver)?;
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
                 out_subqueries.push(NonFromClauseSubquery {
@@ -693,7 +693,7 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                optimize_select_plan(&mut plan, resolver.schema())?;
+                optimize_select_plan(&mut plan, resolver)?;
                 let reg_count = plan.result_columns.len();
                 let reg_start = program.alloc_registers(reg_count);
 
@@ -790,7 +790,7 @@ fn get_subquery_parser<'a>(
                 )?;
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
-                        optimize_select_plan(&mut select_plan, resolver.schema())?;
+                        optimize_select_plan(&mut select_plan, resolver)?;
                         Plan::Select(select_plan)
                     }
                     Plan::CompoundSelect {
@@ -800,9 +800,9 @@ fn get_subquery_parser<'a>(
                         offset,
                         order_by,
                     } => {
-                        optimize_select_plan(&mut right_most, resolver.schema())?;
+                        optimize_select_plan(&mut right_most, resolver)?;
                         for (select_plan, _) in left.iter_mut() {
-                            optimize_select_plan(select_plan, resolver.schema())?;
+                            optimize_select_plan(select_plan, resolver)?;
                         }
                         Plan::CompoundSelect {
                             left,

--- a/testing/sqltests/tests/indexed_by.sqltest
+++ b/testing/sqltests/tests/indexed_by.sqltest
@@ -150,3 +150,42 @@ expect {
     1|10
     1|20
 }
+
+test indexed-by-attached-qualified-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t15(a, b);
+    CREATE INDEX aux.i15 ON t15(a);
+    INSERT INTO aux.t15 VALUES(2, 'two');
+    INSERT INTO aux.t15 VALUES(1, 'one');
+    SELECT b FROM aux.t15 INDEXED BY i15 WHERE a >= 1 ORDER BY a;
+}
+expect {
+    one
+    two
+}
+
+test indexed-by-temp-qualified-table {
+    CREATE TEMP TABLE t16(a, b);
+    CREATE INDEX i16 ON t16(a);
+    INSERT INTO temp.t16 VALUES(2, 'two');
+    INSERT INTO temp.t16 VALUES(1, 'one');
+    SELECT b FROM temp.t16 INDEXED BY i16 WHERE a >= 1 ORDER BY a;
+}
+expect {
+    one
+    two
+}
+
+test indexed-by-attached-update-delete {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t17(a, b);
+    CREATE INDEX aux.i17 ON t17(a);
+    INSERT INTO aux.t17 VALUES(1, 'one');
+    INSERT INTO aux.t17 VALUES(2, 'two');
+    UPDATE aux.t17 INDEXED BY i17 SET b = 'updated' WHERE a = 1;
+    DELETE FROM aux.t17 INDEXED BY i17 WHERE a = 2;
+    SELECT a, b FROM aux.t17 ORDER BY a;
+}
+expect {
+    1|updated
+}

--- a/testing/sqltests/tests/snapshot_tests/indexes/indexes.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/indexes/indexes.sqltest
@@ -100,6 +100,30 @@ setup unordered_materialized_prices {
     INSERT INTO products VALUES (10), (25), (15), (125);
 }
 
+setup attached_schema_indexes {
+    CREATE TABLE same_name (
+        id INTEGER PRIMARY KEY,
+        a INTEGER NOT NULL,
+        b TEXT NOT NULL
+    );
+    CREATE INDEX idx_same_main_a ON same_name(a);
+
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.same_name (
+        id INTEGER PRIMARY KEY,
+        a INTEGER NOT NULL,
+        b TEXT NOT NULL
+    );
+    CREATE INDEX aux.idx_same_aux_a ON same_name(a);
+
+    CREATE TEMP TABLE same_name (
+        id INTEGER PRIMARY KEY,
+        a INTEGER NOT NULL,
+        b TEXT NOT NULL
+    );
+    CREATE INDEX idx_same_temp_a ON same_name(a);
+}
+
 # =============================================================================
 # 1. Simple Index Lookup - WHERE indexed_col = ?
 # =============================================================================
@@ -790,4 +814,25 @@ snapshot-eqp indexed-by-three-way-join {
     JOIN orders o INDEXED BY idx_orders_status_shipping ON p.id = o.customer_id
     JOIN events e ON o.id = e.severity
     WHERE p.category = 'electronics' AND o.status = 'shipped';
+}
+
+@setup attached_schema_indexes
+snapshot-eqp attached-qualified-index-lookup {
+    SELECT b FROM aux.same_name WHERE a = 7;
+}
+
+@setup attached_schema_indexes
+snapshot-eqp same-name-main-and-attached-index-lookup {
+    SELECT m.b, x.b
+    FROM main.same_name AS m
+    JOIN aux.same_name AS x ON x.a = m.a
+    WHERE m.a = 1 AND x.a = 2;
+}
+
+@setup attached_schema_indexes
+snapshot-eqp same-name-temp-and-main-index-lookup {
+    SELECT t.b, m.b
+    FROM temp.same_name AS t
+    JOIN main.same_name AS m ON m.a = t.a
+    WHERE t.a = 1 AND m.a = 2;
 }

--- a/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__attached-qualified-index-lookup.snap
+++ b/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__attached-qualified-index-lookup.snap
@@ -1,0 +1,13 @@
+---
+source: indexes.sqltest
+expression: SELECT b FROM aux.same_name WHERE a = 7;
+info:
+  statement_type: SELECT
+  tables:
+  - aux.same_name
+  setup_blocks:
+  - attached_schema_indexes
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH same_name USING INDEX idx_same_aux_a (a=?)

--- a/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__same-name-main-and-attached-index-lookup.snap
+++ b/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__same-name-main-and-attached-index-lookup.snap
@@ -1,0 +1,20 @@
+---
+source: indexes.sqltest
+expression: |-
+  SELECT m.b, x.b
+      FROM main.same_name AS m
+      JOIN aux.same_name AS x ON x.a = m.a
+      WHERE m.a = 1 AND x.a = 2;
+info:
+  statement_type: SELECT
+  tables:
+  - aux.same_name
+  - main.same_name
+  - x.a
+  setup_blocks:
+  - attached_schema_indexes
+  database: ':memory:'
+---
+QUERY PLAN
+|--SEARCH m USING INDEX idx_same_main_a (a=?)
+`--SEARCH x USING INDEX idx_same_aux_a (a=?)

--- a/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__same-name-temp-and-main-index-lookup.snap
+++ b/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__same-name-temp-and-main-index-lookup.snap
@@ -1,0 +1,20 @@
+---
+source: indexes.sqltest
+expression: |-
+  SELECT t.b, m.b
+      FROM temp.same_name AS t
+      JOIN main.same_name AS m ON m.a = t.a
+      WHERE t.a = 1 AND m.a = 2;
+info:
+  statement_type: SELECT
+  tables:
+  - m.a
+  - main.same_name
+  - temp.same_name
+  setup_blocks:
+  - attached_schema_indexes
+  database: ':memory:'
+---
+QUERY PLAN
+|--SEARCH t USING INDEX idx_same_temp_a (a=?)
+`--SEARCH m USING INDEX idx_same_main_a (a=?)


### PR DESCRIPTION
The optimizer previously carried available indexes in a map keyed only by table name. That works for simple main-schema queries, but attached and temp schemas can legally contain tables with the same name, so a qualified table reference could see the wrong schema's index list or miss the intended one entirely.

Build the available-index map from the resolved table references instead: each entry is keyed by the table reference internal id and populated from that reference's database id. Thread that typed map through btree access, join ordering, multi-index planning, and custom index-method planning so all consumers use the already-resolved table identity. Add INDEXED BY and EQP snapshot coverage for attached, main, and temp tables with colliding names.
