### PR TITLE
core/vdbe: Shift IndexColumn.expr column refs after DROP COLUMN

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12811,9 +12811,10 @@ pub fn op_drop_column(
         Ok(())
     })?;
 
-    // Update index.pos_in_table for all indexes.
-    // For example, if the dropped column had index 2, then anything that was indexed on column 3 or higher should be decremented by 1.
-    conn.with_database_schema_mut(*db, |schema| {
+    // Shift left pos_in_table in all indexes, and self-table placeholders in generated column
+    // expressions, to account for the dropped column. For example, if the dropped column had index
+    // 2, then anything that was indexed on column 3 or higher should be decremented by 1.
+    conn.with_database_schema_mut(*db, |schema| -> Result<()> {
         if let Some(indexes) = schema.indexes.get_mut(&normalized_table_name) {
             for index in indexes {
                 let index = Arc::get_mut(index).expect("this should be the only strong reference");
@@ -12821,10 +12822,24 @@ pub fn op_drop_column(
                     if index_column.pos_in_table > *column_index {
                         index_column.pos_in_table -= 1;
                     }
+                    if let Some(ref mut expr) = index_column.expr {
+                        crate::translate::expr::walk_expr_mut(expr, &mut |e| {
+                            if let ast::Expr::Column {
+                                table, column: c, ..
+                            } = e
+                            {
+                                if table.is_self_table() && *c > *column_index {
+                                    *c -= 1;
+                                }
+                            }
+                            Ok(crate::translate::expr::WalkControl::Continue)
+                        })?;
+                    }
                 }
             }
         }
-    });
+        Ok(())
+    })?;
 
     conn.with_schema(*db, |schema| -> crate::Result<()> {
         for (view_name, view) in schema.views.iter() {

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3426,6 +3426,21 @@ expect {
     CREATE TABLE t (a REAL AS (ee), c INTEGER, f INTEGER AS (c * ee), ee REAL)
 }
 
+test gencol_drop_column_shifts_index_expr {
+    CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER, d INTEGER AS (b + c));
+    INSERT INTO t (a, b, c) VALUES (1, 10, 20);
+    CREATE INDEX idx ON t (d);
+    ALTER TABLE t DROP COLUMN a;
+    INSERT INTO t (b, c) VALUES (100, 200);
+    SELECT * FROM t ORDER BY rowid;
+    PRAGMA integrity_check;
+}
+expect {
+    10|20|30
+    100|200|300
+    ok
+}
+
 # =============================================================================
 # 15. INTEGER PRIMARY KEY Reference in Generated Columns
 # =============================================================================


### PR DESCRIPTION
## Description

`ALTER TABLE DROP COLUMN` was decrementing column indices in two places — `BTreeTable::columns` (via `columns_mut().remove(...)`) and the `pos_in_table` field on every `IndexColumn` — but not the resolved `Expr::Column { column, .. }` nodes inside the `IndexColumn::expr` cache. That cache is a clone of either a generated column's resolved AS-expression or an expression-index expression, populated when the index was created.

When an index covered a generated column whose dependencies shifted, the next `INSERT` computed the index key from the stale indices: either landing on the wrong column slot (so the row's actual stored value was missing from the index, surfacing as `row N missing from index` in `PRAGMA integrity_check`), or, if the stale index now fell past the shrunk schema, raising `ParseError("column index out of bounds")` during a later compile.

Walk every `IndexColumn::expr` in the affected table's indexes the same way `shift_generated_column_indices_after_drop` already walks generated-column expressions, decrementing self-table column references greater than the dropped index.

## Description of AI Usage

Claude Code