### PR TITLE
core/vdbe: don't realify integers in OP_Eq REAL-affinity coercion

### DIFF
--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -237,6 +237,37 @@ impl Affinity {
         }
     }
 
+    /// Like [`Self::convert`] but for the value-pre-conversion that comparison
+    /// opcodes apply via the affinity flag in `OP_Eq` and friends.
+    ///
+    /// Storage and default-value paths use [`Self::convert`], which forces
+    /// `Numeric::Integer` operands into `Numeric::Float` for `Affinity::Real`.
+    /// That's correct for *storing* into a REAL column, but would silently
+    /// lose precision when used to compare a REAL column against a 64-bit
+    /// integer literal: `i as f64` rounds the integer onto the nearest
+    /// representable double, which can collapse to the same double as the
+    /// column's value even when the underlying integer is distinct.
+    ///
+    /// SQLite avoids this by only applying numeric affinity to TEXT operands
+    /// in `OP_Eq` (see `applyNumericAffinity` in `vdbeaux.c`); int-vs-real
+    /// comparisons fall through to `sqlite3IntFloatCompare`, which keeps the
+    /// integer at full 64-bit precision.
+    pub fn convert_for_compare<'a>(
+        &self,
+        val: &'a impl AsValueRef,
+    ) -> Option<Either<ValueRef<'a>, Value>> {
+        let val_ref = val.as_value_ref();
+        let is_text = matches!(val_ref, ValueRef::Text(_));
+        match self {
+            Affinity::Numeric | Affinity::Integer | Affinity::Real => is_text
+                .then(|| apply_numeric_affinity(val_ref, false))
+                .flatten()
+                .map(Either::Left),
+            Affinity::Text => self.convert(val),
+            Affinity::Blob => None,
+        }
+    }
+
     /// Return TRUE if the given expression is a constant which would be
     /// unchanged by OP_Affinity with the affinity given in the second
     /// argument.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -973,7 +973,10 @@ pub fn op_comparison(
         }
     }
 
-    let (new_lhs, new_rhs) = (affinity.convert(lhs_value), affinity.convert(rhs_value));
+    let (new_lhs, new_rhs) = (
+        affinity.convert_for_compare(lhs_value),
+        affinity.convert_for_compare(rhs_value),
+    );
 
     let should_jump = op.compare(
         new_lhs

--- a/testing/sqltests/tests/compare.sqltest
+++ b/testing/sqltests/tests/compare.sqltest
@@ -709,3 +709,22 @@ test compare-int-float-lt-negative-zero {
 expect {
     -1
 }
+
+# Regression: comparing a REAL column with an integer literal whose i64-to-f64
+# conversion lands on the same double as the column's stored value must still
+# preserve the original integer's precision. We were applying REAL affinity to
+# the literal (Numeric::Integer -> f64) before comparing, which collapsed the
+# integer onto the column's float and lied about equality. SQLite only applies
+# numeric affinity to TEXT operands here, leaving the int/real comparison to
+# the precise sqlite3IntFloatCompare path.
+test compare-real-vs-int-literal-int-precision {
+    CREATE TABLE t (c REAL);
+    INSERT INTO t VALUES (1367756182.0 * -1367756182);
+    SELECT c, c = -1870756973399217200, c < -1870756973399217200, c > -1870756973399217200 FROM t;
+}
+expect {
+    -1.87075697339922e+18|0|0|1
+}
+expect @js {
+    -1870756973399217200|0|0|1
+}


### PR DESCRIPTION
## Description

`Eq`, `Ne`, `Lt`, ... were running both sides of every comparison through `Affinity::convert` before delegating to the comparison kernel. For `Affinity::Real` that path force-promotes any `Numeric::Integer` operand to `Numeric::Float` (`i as f64`), which silently rounds 64-bit integers onto the nearest representable double. When a `REAL` column value is mathematically distinct from an integer literal but the literal's `i64->f64` image collapses onto the column's stored double, the two operands become bit-equal floats and the comparison returns equal spuriously.

SQLite handles this by only applying numeric affinity to TEXT operands inside the comparison opcodes (see `applyNumericAffinity` in `vdbeaux.c`); int/real pairs fall through to `sqlite3IntFloatCompare`, which keeps the integer at full 64-bit precision. Mirror that here: introduce `Affinity::convert_for_compare`, used by op_comparison, that coerces TEXT to numeric for any of the numeric affinities but leaves existing Integer/Float values alone. The original `convert` is still used for storage and default-value paths, which legitimately want to realify integers landing in a REAL slot.

Caught while introducing virtual columns in the simulator.

## Description of AI Usage

Claude Code