### PR TITLE
Refresh cached sql when renaming columns

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3461,6 +3461,28 @@ pub fn resolve_gencol_expr_columns(gencol_expr: &mut Expr, columns: &[Column]) -
     Ok(())
 }
 
+/// Re-render the SQL text of a generated-column expression using current column names. The input
+/// AST may have been previously resolved into `Expr::Column { table: SELF_TABLE, column: idx, .. }`
+/// nodes; we replace each such self-table reference with a fresh `Expr::Id(<col-name>)` before
+/// stringifying so the result round-trips through the parser, even if a referenced column was
+/// renamed since the original `original_sql` was captured.
+pub fn render_gencol_expr_sql_with_new_names(expr: &Expr, columns: &[Column]) -> Result<String> {
+    let mut clone = expr.clone();
+    walk_expr_mut(&mut clone, &mut |e| -> Result<WalkControl> {
+        if let Expr::Column { table, column, .. } = e {
+            if table.is_self_table() {
+                if let Some(col) = columns.get(*column) {
+                    if let Some(name) = col.name.as_ref() {
+                        *e = Expr::Id(Name::exact(name.clone()));
+                    }
+                }
+            }
+        }
+        Ok(WalkControl::Continue)
+    })?;
+    Ok(clone.to_string())
+}
+
 pub(crate) fn validate_generated_expr(expr: &Expr) -> Result<()> {
     use ast::Expr;
     match expr {
@@ -4581,6 +4603,17 @@ impl Column {
         match &mut self.generated_type {
             GeneratedType::Virtual { expr, .. } => Some(expr.as_mut()),
             GeneratedType::NotGenerated => None,
+        }
+    }
+
+    #[inline]
+    pub fn set_generated_original_sql(&mut self, new_sql: String) {
+        if let GeneratedType::Virtual {
+            ref mut original_sql,
+            ..
+        } = self.generated_type
+        {
+            *original_sql = new_sql;
         }
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5,7 +5,9 @@ use crate::mvcc::cursor::{MvccCursorType, NextRowidResult};
 use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
-use crate::schema::{Schema, Table, SCHEMA_TABLE_NAME, SQLITE_SEQUENCE_TABLE_NAME};
+use crate::schema::{
+    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME, SQLITE_SEQUENCE_TABLE_NAME,
+};
 use crate::state_machine::StateMachine;
 use crate::storage::btree::{
     integrity_check, CursorTrait, IntegrityCheckError, IntegrityCheckState, PageCategory,
@@ -13016,6 +13018,17 @@ pub fn op_alter_column(
         }
         if *rename {
             btree.columns_mut()[*column_index].name = Some(new_name.clone());
+
+            // Refresh the cached sql in generated columns
+            let column_count = btree.columns().len();
+            for i in 0..column_count {
+                let cols_view = btree.columns();
+                cols_view[i]
+                    .generated_expr()
+                    .map(|expr| render_gencol_expr_sql_with_new_names(expr, cols_view))
+                    .transpose()?
+                    .map(|new_sql| btree.columns_mut()[i].set_generated_original_sql(new_sql));
+            }
         } else {
             btree.columns_mut()[*column_index] = new_column.clone();
         }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3416,6 +3416,16 @@ expect pattern {
     ^CREATE TABLE t2 ?\(a, z AS \(a \+ 1\)\)$
 }
 
+test rename_then_drop_keeps_renamed_column {
+    CREATE TABLE t (a REAL AS (e), c INTEGER, d BLOB, f INTEGER AS (c * e), e REAL);
+    ALTER TABLE t RENAME COLUMN e TO ee;
+    ALTER TABLE t DROP COLUMN d;
+    SELECT sql FROM sqlite_master WHERE name = 't';
+}
+expect {
+    CREATE TABLE t (a REAL AS (ee), c INTEGER, f INTEGER AS (c * ee), ee REAL)
+}
+
 # =============================================================================
 # 15. INTEGER PRIMARY KEY Reference in Generated Columns
 # =============================================================================


### PR DESCRIPTION
## Description

Old column names in generated column expressions could sometimes be revived after a `RENAME COLUMN` if the cached sql was used, for example of there was a `RENAME COLUMN` followed by a `DROP COLUMN`.

## Description of AI Usage

Claude Code and manual polishing