### PR TITLE
core/translate: Fix ordinal ORDER BY and GROUP BY with COLLATE

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1076,6 +1076,20 @@ fn replace_column_number_with_copy_of_column_expr(
     columns: &[ResultSetColumn],
     clause_name: &str,
 ) -> Result<()> {
+    match order_by_or_group_by_expr {
+        ast::Expr::Collate(inner, _) => {
+            return replace_column_number_with_copy_of_column_expr(inner, columns, clause_name);
+        }
+        ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+            return replace_column_number_with_copy_of_column_expr(
+                exprs[0].as_mut(),
+                columns,
+                clause_name,
+            );
+        }
+        _ => {}
+    }
+
     // Extract the numeric literal string, handling both bare integers (e.g. `2`)
     // and unary-plus integers (e.g. `+2`). In SQLite, `ORDER BY +2` strips the
     // unary plus and still resolves `2` as a column index reference.

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -1277,6 +1277,56 @@ expect {
     a|b|c|Z
 }
 
+@cross-check-integrity
+test collate_orderby_nested_parens_ordinal_with_explicit_collate {
+    CREATE TABLE t_orderby_nested_parens (x TEXT);
+    INSERT INTO t_orderby_nested_parens VALUES ('b'), ('Z'), ('c'), ('a');
+    SELECT group_concat(x, '|') FROM (
+        SELECT x FROM t_orderby_nested_parens ORDER BY ((1)) COLLATE NOCASE
+    );
+}
+expect {
+    a|b|c|Z
+}
+
+@cross-check-integrity
+test collate_orderby_ordinal_with_collate_inside_parens {
+    CREATE TABLE t_orderby_collate_in_parens (x TEXT);
+    INSERT INTO t_orderby_collate_in_parens VALUES ('b'), ('Z'), ('c'), ('a');
+    SELECT group_concat(x, '|') FROM (
+        SELECT x FROM t_orderby_collate_in_parens ORDER BY (1 COLLATE NOCASE)
+    );
+}
+expect {
+    a|b|c|Z
+}
+
+@cross-check-integrity
+test collate_orderby_ordinal_overrides_column_collate {
+    CREATE TABLE t_orderby_override (x TEXT);
+    INSERT INTO t_orderby_override VALUES ('b'), ('Z'), ('c'), ('a');
+    -- ORDER BY's explicit COLLATE NOCASE overrides the column-level COLLATE BINARY.
+    SELECT group_concat(y, '|') FROM (
+        SELECT x COLLATE BINARY AS y FROM t_orderby_override ORDER BY 1 COLLATE NOCASE
+    );
+}
+expect {
+    a|b|c|Z
+}
+
+@cross-check-integrity
+test collate_orderby_ordinal_inherits_column_collate {
+    CREATE TABLE t_orderby_inherit (x TEXT);
+    INSERT INTO t_orderby_inherit VALUES ('b'), ('Z'), ('c'), ('a');
+    -- No explicit COLLATE on ORDER BY: the column's COLLATE NOCASE applies.
+    SELECT group_concat(y, '|') FROM (
+        SELECT x COLLATE NOCASE AS y FROM t_orderby_inherit ORDER BY 1
+    );
+}
+expect {
+    a|b|c|Z
+}
+
 # =============================================================================
 # COLLATION PROPAGATION THROUGH CONCAT (||)
 # =============================================================================

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -1241,6 +1241,42 @@ expect {
     CHERRY
 }
 
+@cross-check-integrity
+test collate_orderby_ordinal_with_explicit_collate {
+    CREATE TABLE t_orderby_ordinal (x TEXT);
+    INSERT INTO t_orderby_ordinal VALUES ('b'), ('Z'), ('c'), ('a');
+    SELECT group_concat(x, '|') FROM (
+        SELECT x FROM t_orderby_ordinal ORDER BY 1 COLLATE NOCASE
+    );
+}
+expect {
+    a|b|c|Z
+}
+
+@cross-check-integrity
+test collate_groupby_ordinal_with_explicit_collate {
+    CREATE TABLE t_groupby_ordinal (x TEXT, v INTEGER);
+    INSERT INTO t_groupby_ordinal VALUES ('b', 2), ('A', 1), ('c', 3), ('a', 4);
+    SELECT count(*) FROM (
+        SELECT x FROM t_groupby_ordinal GROUP BY 1 COLLATE NOCASE
+    );
+}
+expect {
+    3
+}
+
+@cross-check-integrity
+test collate_orderby_parenthesized_ordinal_with_explicit_collate {
+    CREATE TABLE t_orderby_parenthesized_ordinal (x TEXT);
+    INSERT INTO t_orderby_parenthesized_ordinal VALUES ('b'), ('Z'), ('c'), ('a');
+    SELECT group_concat(x, '|') FROM (
+        SELECT x FROM t_orderby_parenthesized_ordinal ORDER BY (1) COLLATE NOCASE
+    );
+}
+expect {
+    a|b|c|Z
+}
+
 # =============================================================================
 # COLLATION PROPAGATION THROUGH CONCAT (||)
 # =============================================================================


### PR DESCRIPTION
## Summary
- resolve ordinal ORDER BY/GROUP BY terms through COLLATE and single parentheses before binding
- add regressions for ORDER BY 1 COLLATE NOCASE, GROUP BY 1 COLLATE NOCASE, and ORDER BY (1) COLLATE NOCASE

## Why
SQLite treats integer ORDER BY/GROUP BY terms as result-column references even when they are wrapped by COLLATE or parentheses. Turso left those forms as literal constants, so ORDER BY could keep insertion order and GROUP BY could collapse everything into one group.

Fixes #6410.

## Tests
- cargo fmt --check
- cargo run --bin test-runner -- run tests --backend rust --filter collate_*ordinal* --snapshot-filter __never__
- cargo build --package turso_cli
- cargo run --bin test-runner -- run tests --backend cli --binary ..\..\target\debug\tursodb.exe --filter collate_*ordinal* --snapshot-filter __never__