### PR TITLE
Fix attached-database index lookup

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1,7 +1,6 @@
 use crate::sync::Arc;
 use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
-use std::collections::VecDeque;
 
 use turso_ext::{ConstraintInfo, ConstraintUsage, ResultCode};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
@@ -44,6 +43,7 @@ use super::{
         btree_access_order_consumed, subquery_intrinsic_order_consumed, ColumnTarget,
         EqualityPrefixScope, OrderTarget,
     },
+    AvailableIndexes,
 };
 use crate::translate::planner::TableMask;
 
@@ -204,7 +204,7 @@ pub(super) fn choose_best_btree_candidate(
     rhs_table_idx: usize,
     maybe_order_target: Option<&OrderTarget>,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     analyze_stats: &AnalyzeStats,
     input_cardinality: f64,
     base_row_count: RowCountEstimate,
@@ -659,7 +659,7 @@ pub fn find_best_access_method_for_join_order(
     join_order: &[JoinOrderMember],
     planning_context: JoinPlanningContext<'_>,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
@@ -713,7 +713,7 @@ fn find_best_access_method_for_btree(
     join_order: &[JoinOrderMember],
     maybe_order_target: Option<&OrderTarget>,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -12,12 +12,11 @@ use crate::{
     Result,
 };
 use crate::{turso_assert, turso_debug_assert};
-use rustc_hash::FxHashMap as HashMap;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintOp};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
-use super::cost_params::CostModelParams;
+use super::{cost_params::CostModelParams, AvailableIndexes};
 
 /// Represents a single condition derived from a `WHERE` clause term
 /// that constrains a specific column of a table.
@@ -250,7 +249,7 @@ fn estimate_selectivity(
     table_name: &str,
     column: Option<&Column>,
     column_pos: Option<usize>,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: Option<&VecDeque<Arc<Index>>>,
     op: ConstraintOperator,
     params: &CostModelParams,
     is_rowid: bool,
@@ -275,7 +274,7 @@ fn estimate_selectivity(
                 selectivity_when_unique
             } else if let Some(col_pos) = column_pos {
                 // For non-unique columns, find an index containing this column and use its stats
-                if let Some(indexes) = available_indexes.get(table_name) {
+                if let Some(indexes) = available_indexes {
                     for index in indexes {
                         // Check if this index has our column as its first column
                         // (selectivity is most accurate when column is leftmost in index)
@@ -339,7 +338,7 @@ fn estimate_constraint_selectivity(
     column: Option<&Column>,
     column_pos: Option<usize>,
     operator: ConstraintOperator,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     params: &CostModelParams,
     is_rowid: bool,
 ) -> f64 {
@@ -348,7 +347,7 @@ fn estimate_constraint_selectivity(
         table_reference.table.get_name(),
         column,
         column_pos,
-        available_indexes,
+        available_indexes.get(table_reference),
         operator,
         params,
         is_rowid,
@@ -379,7 +378,7 @@ fn expression_matches_table(
 pub fn constraints_from_where_clause(
     where_clause: &[WhereTerm],
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -397,7 +396,7 @@ pub fn constraints_from_where_clause(
             table_id: table_reference.internal_id,
             constraints: Vec::new(),
             candidates: available_indexes
-                .get(table_reference.table.get_name())
+                .get(table_reference)
                 .map_or(Vec::new(), |indexes| {
                     indexes
                         .iter()
@@ -802,9 +801,11 @@ pub fn constraints_from_where_clause(
                     sort_order: SortOrder::Asc,
                 });
             }
-            for index in available_indexes
-                .get(table_reference.table.get_name())
-                .unwrap_or(&VecDeque::new())
+            let empty_indexes = VecDeque::new();
+            let table_indexes = available_indexes
+                .get(table_reference)
+                .unwrap_or(&empty_indexes);
+            for index in table_indexes
                 .iter()
                 .filter(|idx| idx.index_method.is_none())
             {
@@ -1261,7 +1262,7 @@ pub fn estimate_partial_index_where_selectivity(
     where_expr: &ast::Expr,
     table_reference: &JoinedTable,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     params: &CostModelParams,
 ) -> f64 {
     let mut bound = where_expr.clone();
@@ -1273,7 +1274,7 @@ fn estimate_bound_expr_selectivity(
     expr: &ast::Expr,
     table_reference: &JoinedTable,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     params: &CostModelParams,
 ) -> f64 {
     use ast::Expr;
@@ -1627,7 +1628,7 @@ pub(crate) fn analyze_binary_term_for_index(
     table_reference: &JoinedTable,
     indexes: Option<&VecDeque<Arc<Index>>>,
     rowid_alias_column: Option<usize>,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1,6 +1,3 @@
-use std::collections::VecDeque;
-use std::sync::Arc;
-
 use crate::{turso_assert_eq, turso_assert_greater_than};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -13,10 +10,10 @@ use super::{
     constraints::TableConstraints,
     cost_params::CostModelParams,
     order::OrderTarget,
-    IndexMethodCandidate,
+    AvailableIndexes, IndexMethodCandidate,
 };
 use crate::{
-    schema::{Index, Schema},
+    schema::Schema,
     stats::AnalyzeStats,
     translate::{
         expr::{walk_expr, WalkControl},
@@ -164,7 +161,7 @@ pub fn join_lhs_and_rhs<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<JoinN>> {
@@ -892,7 +889,7 @@ pub fn compute_best_join_order<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
@@ -930,7 +927,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
@@ -1364,7 +1361,7 @@ pub fn compute_greedy_join_order<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
@@ -1624,7 +1621,7 @@ pub fn compute_naive_left_deep_plan<'a>(
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
     analyze_stats: &AnalyzeStats,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<JoinN>> {
@@ -1831,7 +1828,7 @@ mod tests {
     /// Test that [compute_best_join_order] returns None when there are no table references.
     fn test_compute_best_join_order_empty() {
         let table_references = TableReferences::new(vec![], vec![]);
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let mut where_clause = vec![];
 
         let mut access_methods_arena = Vec::new();
@@ -1874,7 +1871,7 @@ mod tests {
         let mut table_id_counter = TableRefIdCounter::new();
         let joined_tables = vec![_create_table_reference(t1, None, table_id_counter.next())];
         let table_references = TableReferences::new(joined_tables, vec![]);
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let mut where_clause = vec![];
 
         let mut access_methods_arena = Vec::new();
@@ -1932,7 +1929,7 @@ mod tests {
 
         let table_references = TableReferences::new(joined_tables, vec![]);
         let mut access_methods_arena = Vec::new();
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let table_constraints = constraints_from_where_clause(
             &where_clause,
             &table_references,
@@ -1996,9 +1993,10 @@ mod tests {
             _create_numeric_literal("42"),
         )];
 
+        let table_id = joined_tables[0].internal_id;
         let table_references = TableReferences::new(joined_tables, vec![]);
         let mut access_methods_arena = Vec::new();
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         let index = Arc::new(Index {
             name: "sqlite_autoindex_test_table_1".to_string(),
             table_name: "test_table".to_string(),
@@ -2018,7 +2016,7 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("test_table".to_string(), VecDeque::from([index]));
+        available_indexes.insert(table_id, VecDeque::from([index]));
 
         let table_constraints = constraints_from_where_clause(
             &where_clause,
@@ -2090,7 +2088,7 @@ mod tests {
         const TABLE1: usize = 0;
         const TABLE2: usize = 1;
 
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         // Index on the outer table (table1)
         let index1 = Arc::new(Index {
             name: "index1".to_string(),
@@ -2111,7 +2109,7 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("table1".to_string(), VecDeque::from([index1]));
+        available_indexes.insert(joined_tables[TABLE1].internal_id, VecDeque::from([index1]));
 
         // SELECT * FROM table1 JOIN table2 WHERE table1.id = table2.id
         // expecting table2 to be chosen first due to the index on table1.id
@@ -2228,33 +2226,64 @@ mod tests {
         const TABLE_NO_CUSTOMERS: usize = 1;
         const TABLE_NO_ORDER_ITEMS: usize = 2;
 
-        let mut available_indexes = HashMap::default();
-        ["orders", "customers", "order_items"]
-            .iter()
-            .for_each(|table_name| {
-                // add primary key index called sqlite_autoindex_<tablename>_1
-                let index_name = format!("sqlite_autoindex_{table_name}_1");
-                let index = Arc::new(Index {
-                    name: index_name,
-                    where_clause: None,
-                    table_name: table_name.to_string(),
-                    columns: vec![IndexColumn {
-                        name: "id".to_string(),
-                        order: SortOrder::Asc,
-                        pos_in_table: 0,
-                        collation: None,
-                        default: None,
-                        expr: None,
-                    }],
-                    unique: true,
-                    ephemeral: false,
-                    root_page: 1,
-                    has_rowid: true,
-                    index_method: None,
-                    on_conflict: None,
-                });
-                available_indexes.insert(table_name.to_string(), VecDeque::from([index]));
-            });
+        let mut available_indexes = AvailableIndexes::default();
+        let orders_pk = Arc::new(Index {
+            name: "sqlite_autoindex_orders_1".to_string(),
+            where_clause: None,
+            table_name: "orders".to_string(),
+            columns: vec![IndexColumn {
+                name: "id".to_string(),
+                order: SortOrder::Asc,
+                pos_in_table: 0,
+                collation: None,
+                default: None,
+                expr: None,
+            }],
+            unique: true,
+            ephemeral: false,
+            root_page: 1,
+            has_rowid: true,
+            index_method: None,
+            on_conflict: None,
+        });
+        let customers_pk = Arc::new(Index {
+            name: "sqlite_autoindex_customers_1".to_string(),
+            where_clause: None,
+            table_name: "customers".to_string(),
+            columns: vec![IndexColumn {
+                name: "id".to_string(),
+                order: SortOrder::Asc,
+                pos_in_table: 0,
+                collation: None,
+                default: None,
+                expr: None,
+            }],
+            unique: true,
+            ephemeral: false,
+            root_page: 1,
+            has_rowid: true,
+            index_method: None,
+            on_conflict: None,
+        });
+        let order_items_pk = Arc::new(Index {
+            name: "sqlite_autoindex_order_items_1".to_string(),
+            where_clause: None,
+            table_name: "order_items".to_string(),
+            columns: vec![IndexColumn {
+                name: "id".to_string(),
+                order: SortOrder::Asc,
+                pos_in_table: 0,
+                collation: None,
+                default: None,
+                expr: None,
+            }],
+            unique: true,
+            ephemeral: false,
+            root_page: 1,
+            has_rowid: true,
+            index_method: None,
+            on_conflict: None,
+        });
         let customer_id_idx = Arc::new(Index {
             name: "orders_customer_id_idx".to_string(),
             table_name: "orders".to_string(),
@@ -2294,12 +2323,21 @@ mod tests {
             on_conflict: None,
         });
 
-        available_indexes
-            .entry("orders".to_string())
-            .and_modify(|v| v.push_front(customer_id_idx));
-        available_indexes
-            .entry("order_items".to_string())
-            .and_modify(|v| v.push_front(order_id_idx));
+        let mut orders_indexes = VecDeque::from([orders_pk]);
+        orders_indexes.push_front(customer_id_idx);
+        available_indexes.insert(joined_tables[TABLE_NO_ORDERS].internal_id, orders_indexes);
+
+        available_indexes.insert(
+            joined_tables[TABLE_NO_CUSTOMERS].internal_id,
+            VecDeque::from([customers_pk]),
+        );
+
+        let mut order_items_indexes = VecDeque::from([order_items_pk]);
+        order_items_indexes.push_front(order_id_idx);
+        available_indexes.insert(
+            joined_tables[TABLE_NO_ORDER_ITEMS].internal_id,
+            order_items_indexes,
+        );
 
         // SELECT * FROM orders JOIN customers JOIN order_items
         // WHERE orders.customer_id = customers.id AND orders.id = order_items.order_id AND customers.id = 42
@@ -2456,7 +2494,7 @@ mod tests {
         ];
 
         let table_references = TableReferences::new(joined_tables, vec![]);
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let mut access_methods_arena = Vec::new();
         let table_constraints = constraints_from_where_clause(
             &where_clause,
@@ -2583,7 +2621,7 @@ mod tests {
 
         let table_references = TableReferences::new(joined_tables, vec![]);
         let mut access_methods_arena = Vec::new();
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
         let table_constraints = constraints_from_where_clause(
             &where_clause,
             &table_references,
@@ -2663,7 +2701,7 @@ mod tests {
             tables.push(_create_btree_table(&format!("t{}", i + 1), columns));
         }
 
-        let available_indexes = HashMap::default();
+        let available_indexes = AvailableIndexes::default();
 
         let mut table_id_counter = TableRefIdCounter::new();
         // Create table references
@@ -2798,14 +2836,14 @@ mod tests {
             on_conflict: None,
         });
 
-        let mut available_indexes = HashMap::default();
-        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
+        let mut available_indexes = AvailableIndexes::default();
+        let table_id = table_id_counter.next();
 
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
             op: Operation::default_scan_for(&table),
             table,
-            internal_id: table_id_counter.next(),
+            internal_id: table_id,
             identifier: "t1".to_string(),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
@@ -2814,6 +2852,7 @@ mod tests {
             database_id: MAIN_DB_ID,
             indexed: None,
         });
+        available_indexes.insert(table_id, VecDeque::from([index]));
 
         // Create where clause that only references second column
         let mut where_clause = vec![WhereTerm {
@@ -2876,7 +2915,7 @@ mod tests {
     fn test_index_skips_middle_column() {
         let mut table_id_counter = TableRefIdCounter::new();
         let mut joined_tables = Vec::new();
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
 
         let columns = _create_column_list(&["c1", "c2", "c3"], Type::Integer);
         let table = _create_btree_table("t1", columns);
@@ -2917,13 +2956,13 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
+        let table_id = table_id_counter.next();
 
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
             op: Operation::default_scan_for(&table),
             table,
-            internal_id: table_id_counter.next(),
+            internal_id: table_id,
             identifier: "t1".to_string(),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
@@ -2932,6 +2971,7 @@ mod tests {
             database_id: MAIN_DB_ID,
             indexed: None,
         });
+        available_indexes.insert(table_id, VecDeque::from([index]));
 
         // Create where clause that references first and third columns
         let mut where_clause = vec![
@@ -3015,7 +3055,7 @@ mod tests {
     fn test_index_stops_at_range_operator() {
         let mut table_id_counter = TableRefIdCounter::new();
         let mut joined_tables = Vec::new();
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
 
         let columns = _create_column_list(&["c1", "c2", "c3"], Type::Integer);
         let table = _create_btree_table("t1", columns);
@@ -3056,13 +3096,13 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("t1".to_string(), VecDeque::from([index]));
+        let table_id = table_id_counter.next();
 
         let table = Table::BTree(table);
         joined_tables.push(JoinedTable {
             op: Operation::default_scan_for(&table),
             table,
-            internal_id: table_id_counter.next(),
+            internal_id: table_id,
             identifier: "t1".to_string(),
             join_info: None,
             col_used_mask: ColumnUsedMask::default(),
@@ -3071,6 +3111,7 @@ mod tests {
             database_id: MAIN_DB_ID,
             indexed: None,
         });
+        available_indexes.insert(table_id, VecDeque::from([index]));
 
         // Create where clause: c1 = 5 AND c2 > 10 AND c3 = 7
         let mut where_clause = vec![
@@ -3314,7 +3355,7 @@ mod tests {
         const TABLE2: usize = 1;
 
         // Index on t2.a
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         let index_t2_a = Arc::new(Index {
             name: "idx_t2_a".to_string(),
             table_name: "t2".to_string(),
@@ -3334,7 +3375,10 @@ mod tests {
             index_method: None,
             on_conflict: None,
         });
-        available_indexes.insert("t2".to_string(), VecDeque::from([index_t2_a]));
+        available_indexes.insert(
+            joined_tables[TABLE2].internal_id,
+            VecDeque::from([index_t2_a]),
+        );
 
         // WHERE t1.a = t2.a
         let mut where_clause = vec![_create_binary_expr(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -65,7 +65,7 @@ use rustc_hash::FxHashMap as HashMap;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintUsage};
 use turso_parser::ast::RefAct;
-use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TriggerEvent};
+use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TableInternalId, TriggerEvent};
 
 pub(crate) mod access_method;
 pub(crate) mod constraints;
@@ -108,6 +108,44 @@ impl IndexMethodCandidate {
             arguments: self.arguments.clone(),
             covered_columns: self.covered_columns.clone(),
         }
+    }
+}
+
+/// Indexes available to the optimizer for each resolved table reference.
+///
+/// Table names are not unique across attached databases, so production lookup is
+/// keyed by the table reference's internal id after name resolution has selected
+/// a concrete database.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct AvailableIndexes {
+    by_table_id: HashMap<TableInternalId, VecDeque<Arc<Index>>>,
+}
+
+impl AvailableIndexes {
+    fn from_table_references(table_references: &TableReferences, resolver: &Resolver) -> Self {
+        let mut indexes = Self::default();
+        for table in table_references.joined_tables() {
+            if table.btree().is_none() {
+                continue;
+            }
+            let table_indexes = resolver.with_schema(table.database_id, |schema| {
+                schema
+                    .get_indices(table.table.get_name())
+                    .cloned()
+                    .collect()
+            });
+            indexes.by_table_id.insert(table.internal_id, table_indexes);
+        }
+        indexes
+    }
+
+    pub(crate) fn get(&self, table: &JoinedTable) -> Option<&VecDeque<Arc<Index>>> {
+        self.by_table_id.get(&table.internal_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert(&mut self, table_id: TableInternalId, indexes: VecDeque<Arc<Index>>) {
+        self.by_table_id.insert(table_id, indexes);
     }
 }
 
@@ -353,7 +391,7 @@ fn sorted_arguments_from_parameters(parameters: &HashMap<i32, ast::Expr>) -> Vec
 #[allow(clippy::too_many_arguments)]
 fn collect_index_method_candidates(
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     where_clause: &[WhereTerm],
     order_by: &[(
         Box<ast::Expr>,
@@ -375,7 +413,7 @@ fn collect_index_method_candidates(
 
     let tables = table_references.joined_tables();
     for (table_idx, table) in tables.iter().enumerate() {
-        let Some(indexes) = available_indexes.get(table.table.get_name()) else {
+        let Some(indexes) = available_indexes.get(table) else {
             continue;
         };
 
@@ -447,17 +485,16 @@ pub fn optimize_plan(
     plan: &mut Plan,
     resolver: &Resolver,
 ) -> Result<()> {
-    let schema = resolver.schema();
     match plan {
-        Plan::Select(plan) => optimize_select_plan(plan, schema)?,
-        Plan::Delete(plan) => optimize_delete_plan(plan, schema)?,
+        Plan::Select(plan) => optimize_select_plan(plan, resolver)?,
+        Plan::Delete(plan) => optimize_delete_plan(plan, resolver)?,
         Plan::Update(plan) => optimize_update_plan(program, plan, resolver)?,
         Plan::CompoundSelect {
             left, right_most, ..
         } => {
-            optimize_select_plan(right_most, schema)?;
+            optimize_select_plan(right_most, resolver)?;
             for (plan, _) in left {
-                optimize_select_plan(plan, schema)?;
+                optimize_select_plan(plan, resolver)?;
             }
         }
     }
@@ -470,7 +507,7 @@ pub fn optimize_plan(
 /// Transform MATCH expressions to fts_match() function calls.
 fn transform_match_to_fts_match(
     where_clause: &mut [WhereTerm],
-    schema: &Schema,
+    resolver: &Resolver,
     table_references: &TableReferences,
 ) -> Result<()> {
     use super::ast::{FunctionTail, LikeOperator, Name, TableInternalId};
@@ -493,7 +530,10 @@ fn transform_match_to_fts_match(
             .find(|t| t.internal_id == table_id)
             .and_then(|t| {
                 if let Table::BTree(btree) = &t.table {
-                    Some(schema.has_fts_index(&btree.name))
+                    Some(
+                        resolver
+                            .with_schema(t.database_id, |schema| schema.has_fts_index(&btree.name)),
+                    )
                 } else {
                     None
                 }
@@ -640,10 +680,11 @@ struct OptimizeTableAccessResult {
  * but having them separate makes them easier to understand
  */
 #[turso_macros::trace_stack]
-pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
+    let schema = resolver.schema();
     // Transform MATCH expressions to fts_match() for FTS optimizer recognition
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &plan.table_references)?;
 
     unnest::unnest_exists_subqueries(plan)?;
     // EXISTS only needs 1 row. Add LIMIT 1 to surviving (non-unnested) EXISTS
@@ -665,7 +706,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
             }
         }
     }
-    optimize_subqueries(plan, schema)?;
+    optimize_subqueries(plan, resolver)?;
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
@@ -675,11 +716,13 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
     }
 
     plan.simple_aggregate = detect_simple_aggregate(plan);
+    let available_indexes =
+        AvailableIndexes::from_table_references(&plan.table_references, resolver);
     let best_join_order = optimize_table_access(
         schema,
         &mut plan.result_columns,
         &mut plan.table_references,
-        &schema.indexes,
+        &available_indexes,
         &mut plan.where_clause,
         &mut plan.order_by,
         &mut plan.group_by,
@@ -730,14 +773,15 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, schema: &Schema) -> Result<()
         plan.estimated_output_rows = Some(est);
     }
 
-    reoptimize_correlated_subqueries(plan, schema)?;
+    reoptimize_correlated_subqueries(plan, resolver)?;
 
     Ok(())
 }
 
-fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
+fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()> {
+    let schema = resolver.schema();
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &plan.table_references)?;
 
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
@@ -748,14 +792,16 @@ fn optimize_delete_plan(plan: &mut DeletePlan, schema: &Schema) -> Result<()> {
     }
 
     if let Some(rowset_plan) = plan.rowset_plan.as_mut() {
-        optimize_select_plan(rowset_plan, schema)?;
+        optimize_select_plan(rowset_plan, resolver)?;
     }
 
+    let available_indexes =
+        AvailableIndexes::from_table_references(&plan.table_references, resolver);
     let _ = optimize_table_access(
         schema,
         &mut plan.result_columns,
         &mut plan.table_references,
-        &schema.indexes,
+        &available_indexes,
         &mut plan.where_clause,
         &mut plan.order_by,
         &mut None,
@@ -784,7 +830,7 @@ fn optimize_update_plan(
         plan.from_tables.outer_query_refs().to_vec(),
     );
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &target_tables)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &target_tables)?;
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?
@@ -805,17 +851,18 @@ fn optimize_update_plan(
                 .as_mut()
                 .expect("UPDATE ... FROM must build its write-set SELECT before optimization")
                 .select,
-            schema,
+            resolver,
         )?;
         return Ok(());
     }
 
     let mut order_by = vec![];
+    let available_indexes = AvailableIndexes::from_table_references(&target_tables, resolver);
     let optimize_result = optimize_table_access(
         schema,
         &mut [],
         &mut target_tables,
-        &schema.indexes,
+        &available_indexes,
         &mut plan.where_clause,
         &mut order_by,
         &mut None,
@@ -1193,19 +1240,19 @@ fn update_from_set_result_columns(set_clauses: &[UpdateSetClause]) -> Vec<Result
         .collect()
 }
 
-fn optimize_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+fn optimize_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
     for table in plan.table_references.joined_tables_mut() {
         if let Table::FromClauseSubquery(from_clause_subquery) = &mut table.table {
             let from_clause_subquery = Arc::make_mut(from_clause_subquery);
             // Use match to handle both SelectPlan and CompoundSelect variants
             match from_clause_subquery.plan.as_mut() {
-                Plan::Select(select_plan) => optimize_select_plan(select_plan, schema)?,
+                Plan::Select(select_plan) => optimize_select_plan(select_plan, resolver)?,
                 Plan::CompoundSelect {
                     left, right_most, ..
                 } => {
-                    optimize_select_plan(right_most, schema)?;
+                    optimize_select_plan(right_most, resolver)?;
                     for (select_plan, _) in left {
-                        optimize_select_plan(select_plan, schema)?;
+                        optimize_select_plan(select_plan, resolver)?;
                     }
                 }
                 Plan::Delete(_) | Plan::Update(_) => {
@@ -1233,7 +1280,7 @@ fn optimize_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
 /// strictly larger. The recursive call therefore only propagates larger hints
 /// down the subquery tree; it does not oscillate based on newly estimated row
 /// counts.
-fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, schema: &Schema) -> Result<()> {
+fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
     let Some(invocation_hint) = plan
         .input_cardinality_hint
         .or(plan.estimated_output_rows)
@@ -1267,7 +1314,7 @@ fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, schema: &Schema) -> R
         }
 
         inner_plan.input_cardinality_hint = Some(invocation_hint);
-        optimize_select_plan(inner_plan, schema)?;
+        optimize_select_plan(inner_plan, resolver)?;
     }
 
     Ok(())
@@ -1304,7 +1351,7 @@ fn select_plan_contains_cte_from_clause_subquery(plan: &SelectPlan) -> bool {
 fn optimize_table_access_with_custom_modules(
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     where_query: &mut [WhereTerm],
     order_by: &mut Vec<(
         Box<ast::Expr>,
@@ -1328,7 +1375,7 @@ fn optimize_table_access_with_custom_modules(
     // Only optimize the first table with custom index methods.
     // This allows FTS to be used as the driving table in joins.
     let table = &mut tables[0];
-    let Some(indexes) = available_indexes.get(table.table.get_name()) else {
+    let Some(indexes) = available_indexes.get(table) else {
         return Ok(false);
     };
     for index in indexes {
@@ -1638,16 +1685,16 @@ fn expr_has_null_masking_for_table(expr: &ast::Expr, table_id: ast::TableInterna
 /// filtering constraint candidates accordingly.
 fn enforce_indexed_by_hints(
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     constraints_per_table: &mut [TableConstraints],
 ) -> Result<()> {
     for (i, table_ref) in table_references.joined_tables().iter().enumerate() {
         let Some(ref indexed) = table_ref.indexed else {
             continue;
         };
-        let Some(btree) = table_ref.btree() else {
+        if table_ref.btree().is_none() {
             continue;
-        };
+        }
         let Some(cs) = constraints_per_table.get_mut(i) else {
             continue;
         };
@@ -1655,7 +1702,7 @@ fn enforce_indexed_by_hints(
             ast::Indexed::IndexedBy(name) => {
                 let idx_name = name.as_str();
                 // Verify the index exists and belongs to this table.
-                let forced_index = available_indexes.get(&btree.name).and_then(|indexes| {
+                let forced_index = available_indexes.get(table_ref).and_then(|indexes| {
                     indexes.iter().find(|idx| {
                         idx.name.eq_ignore_ascii_case(idx_name) && idx.index_method.is_none()
                     })
@@ -1704,7 +1751,7 @@ fn optimize_table_access(
     schema: &Schema,
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     where_clause: &mut [WhereTerm],
     order_by: &mut Vec<(
         Box<ast::Expr>,
@@ -1736,8 +1783,8 @@ fn optimize_table_access(
     }
 
     let has_expression_index = table_references.joined_tables().iter().any(|t| {
-        matches!(&t.table, Table::BTree(btree) if available_indexes
-            .get(&btree.name)
+        matches!(&t.table, Table::BTree(_) if available_indexes
+            .get(t)
             .is_some_and(|indexes| indexes.iter().any(|index| index.is_expression_index())))
     });
 

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -27,11 +27,12 @@ use crate::translate::plan::{
     UnionBranchPrePostFilters, WhereTerm,
 };
 use crate::translate::planner::{table_mask_from_expr, TableMask};
-use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
-use std::{collections::VecDeque, sync::Arc};
+use std::sync::Arc;
 use turso_macros::turso_assert_eq;
 use turso_parser::ast::{self, TableInternalId};
+
+use super::AvailableIndexes;
 
 #[derive(Debug, Clone)]
 /// Parameters for a single branch of a multi-index scan.
@@ -147,7 +148,7 @@ fn get_table_local_constraints_for_branch(
     from_outer_join: Option<TableInternalId>,
     table_reference: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -330,7 +331,7 @@ fn choose_multi_index_branch_access(
     lhs_mask: &TableMask,
     rhs_idx: usize,
     schema: &Schema,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     base_row_count: RowCountEstimate,
     analyze_stats: &AnalyzeStats,
     params: &CostModelParams,
@@ -509,7 +510,7 @@ fn estimate_residual_expr_selectivity(
     expr: &ast::Expr,
     rhs_table: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -604,7 +605,7 @@ fn estimate_multi_or_residual_selectivity(
     residual_exprs: &[ast::Expr],
     rhs_table: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
@@ -635,7 +636,7 @@ fn evaluate_multi_index_branches(
     where_term_idx: usize,
     rhs_table: &JoinedTable,
     table_references: &TableReferences,
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     base_row_count: RowCountEstimate,
@@ -758,15 +759,14 @@ fn evaluate_multi_index_branches(
 fn analyze_and_terms_for_multi_index(
     table_reference: &JoinedTable,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
     params: &CostModelParams,
 ) -> Option<AndClauseDecomposition> {
     let table_id = table_reference.internal_id;
-    let table_name = table_reference.table.get_name();
-    let indexes = available_indexes.get(table_name);
+    let indexes = available_indexes.get(table_reference);
     let rowid_alias_column = table_reference
         .columns()
         .iter()
@@ -905,7 +905,7 @@ fn analyze_and_terms_for_multi_index(
 pub fn consider_multi_index_union(
     rhs_table: &JoinedTable,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
@@ -1035,7 +1035,7 @@ pub fn consider_multi_index_union(
 pub fn consider_multi_index_intersection(
     rhs_table: &JoinedTable,
     where_clause: &[WhereTerm],
-    available_indexes: &HashMap<String, VecDeque<Arc<Index>>>,
+    available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
     schema: &Schema,
@@ -1151,6 +1151,7 @@ mod tests {
                 access_method::AccessMethodParams,
                 cost::{Cost, RowCountEstimate},
                 cost_params::DEFAULT_PARAMS,
+                AvailableIndexes,
             },
             plan::{
                 ColumnUsedMask, JoinInfo, JoinType, JoinedTable, Operation, TableReferences,
@@ -1161,7 +1162,6 @@ mod tests {
         vdbe::builder::TableRefIdCounter,
         MAIN_DB_ID,
     };
-    use rustc_hash::FxHashMap as HashMap;
     use std::{collections::VecDeque, sync::Arc};
     use turso_parser::ast::{self, Expr, Operator, SortOrder, TableInternalId};
 
@@ -1311,9 +1311,9 @@ mod tests {
         const ITEM: usize = 1;
         const META: usize = 2;
 
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         available_indexes.insert(
-            "item".to_string(),
+            joined_tables[ITEM].internal_id,
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_id".to_string(),
                 table_name: "item".to_string(),
@@ -1460,9 +1460,9 @@ mod tests {
         let joined_tables = vec![create_table_reference(item, None, table_id_counter.next())];
         let item_id = joined_tables[0].internal_id;
 
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         available_indexes.insert(
-            "item".to_string(),
+            joined_tables[0].internal_id,
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_a".to_string(),
                 table_name: "item".to_string(),
@@ -1573,9 +1573,9 @@ mod tests {
         const LINK: usize = 0;
         const ITEM: usize = 1;
 
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         available_indexes.insert(
-            "item".to_string(),
+            joined_tables[ITEM].internal_id,
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_id_kind".to_string(),
                 table_name: "item".to_string(),
@@ -1769,9 +1769,9 @@ mod tests {
         let link_id = joined_tables[LINK].internal_id;
         let item_id = joined_tables[ITEM].internal_id;
 
-        let mut available_indexes = HashMap::default();
+        let mut available_indexes = AvailableIndexes::default();
         available_indexes.insert(
-            "item".to_string(),
+            joined_tables[ITEM].internal_id,
             VecDeque::from([Arc::new(Index {
                 name: "idx_item_id".to_string(),
                 table_name: "item".to_string(),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -641,7 +641,7 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                optimize_select_plan(&mut plan, resolver.schema())?;
+                optimize_select_plan(&mut plan, resolver)?;
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
                 out_subqueries.push(NonFromClauseSubquery {
@@ -693,7 +693,7 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                optimize_select_plan(&mut plan, resolver.schema())?;
+                optimize_select_plan(&mut plan, resolver)?;
                 let reg_count = plan.result_columns.len();
                 let reg_start = program.alloc_registers(reg_count);
 
@@ -790,7 +790,7 @@ fn get_subquery_parser<'a>(
                 )?;
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
-                        optimize_select_plan(&mut select_plan, resolver.schema())?;
+                        optimize_select_plan(&mut select_plan, resolver)?;
                         Plan::Select(select_plan)
                     }
                     Plan::CompoundSelect {
@@ -800,9 +800,9 @@ fn get_subquery_parser<'a>(
                         offset,
                         order_by,
                     } => {
-                        optimize_select_plan(&mut right_most, resolver.schema())?;
+                        optimize_select_plan(&mut right_most, resolver)?;
                         for (select_plan, _) in left.iter_mut() {
-                            optimize_select_plan(select_plan, resolver.schema())?;
+                            optimize_select_plan(select_plan, resolver)?;
                         }
                         Plan::CompoundSelect {
                             left,

--- a/testing/sqltests/tests/attached_db_index_planning.sqltest
+++ b/testing/sqltests/tests/attached_db_index_planning.sqltest
@@ -1,0 +1,42 @@
+@database :memory:
+@skip-file-if mvcc "attach is not supported for mvcc"
+
+# Attached database tables can have the same table names as main. Index lookup
+# must follow the resolved table reference's database, not the table name alone.
+
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test plan-attached-db-index-used {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t (a INTEGER, b TEXT);
+    CREATE INDEX aux.idx_aux_t_a ON t(a);
+    EXPLAIN QUERY PLAN SELECT b FROM aux.t WHERE a = 1;
+}
+expect {
+    1|0|0|SEARCH t USING INDEX idx_aux_t_a (a=?)
+}
+
+@cross-check-integrity
+test attached-db-does-not-borrow-main-index {
+    CREATE TABLE t (a INTEGER, b TEXT);
+    CREATE INDEX idx_main_t_a ON t(a);
+    INSERT INTO t VALUES (1, 'main-one');
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t (a INTEGER, b TEXT);
+    INSERT INTO aux.t VALUES (1, 'aux-one'), (2, 'aux-two');
+    SELECT b FROM aux.t WHERE a = 1;
+}
+expect {
+    aux-one
+}
+
+@cross-check-integrity
+test attached-db-indexed-by-finds-attached-index {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t (a INTEGER, b TEXT);
+    CREATE INDEX aux.idx_aux_t_a ON t(a);
+    INSERT INTO aux.t VALUES (1, 'one'), (2, 'two');
+    SELECT b FROM aux.t INDEXED BY idx_aux_t_a WHERE a = 2;
+}
+expect {
+    two
+}


### PR DESCRIPTION
Make optimizer index lookup follow resolved table references instead of table names so attached databases no longer borrow main-db indexes or miss their own indexes. Build available index sets per resolved table/database, thread that through join planning, constraints, multi-index paths, custom index methods, and subquery re-optimization, and use the same resolver-aware lookup for FTS MATCH rewriting and INDEXED BY validation.

Add a Turso sqltest regression covering attached-db EQP, correct INDEXED BY behavior, and a correctness case that previously tried to use a main-db index for an attached table.
