### PR TITLE
docs: fix javascript documentation reference

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -466,7 +466,7 @@ turso> SELECT * FROM t;
 
 Turso supports a JavaScript API, both with native and WebAssembly package options.
 
-Please read the [JavaScript API reference](docs/javascript-api-reference.md) for more information.
+Please read the [JavaScript API reference](javascript-api-reference.md) for more information.
 
 ### Installation
 


### PR DESCRIPTION


<!-- 
# NOTICE:
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description
Fix the link to the `javascript-api-reference.md` document from within the `#javascript-api` section of `manual.md`

It still had the `docs/` prefix, but the `manual.md` and `javascript-api-reference.md` are in the same directory (siblings), so that prefix was unnecessary and thus pointing to a file that didn't exit. 
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context
Fix the Javascript API documentation link so it points to the correct file. 
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage
None. Simple manual documentation fix. 
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
