### PR TITLE
apply virtual gen-col affinity in OLD probe and NEW key

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -25,6 +25,7 @@ use super::{
 use crate::instrument;
 use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
+    EXPR_INDEX_SENTINEL,
 };
 use crate::translate::plan::ColumnMask;
 use crate::vdbe::{
@@ -1803,6 +1804,16 @@ pub(crate) fn emit_index_column_value_old_image(
             )?;
             Ok(())
         })?;
+        // For virtual generated column references, apply the column's 
+        // declared affinity to the computed expression result.
+        if idx_col.pos_in_table != EXPR_INDEX_SENTINEL {
+            if let Some(table) = program.btree_table_from_cursor(table_cursor_id) {
+                let column = &table.columns()[idx_col.pos_in_table];
+                if column.is_virtual_generated() {
+                    program.emit_column_affinity(dest_reg, column.affinity());
+                }
+            }
+        }
     } else if let Some(generated_column) = generated_column(program, table_cursor_id, idx_col) {
         emit_table_column(
             program,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1927,7 +1927,7 @@ fn emit_update_insns<'a>(
             .columns
             .iter()
             .map(|ic| {
-                if ic.expr.is_some() {
+                if ic.pos_in_table == EXPR_INDEX_SENTINEL {
                     Affinity::Blob.aff_mask()
                 } else {
                     target_table.table.columns()[ic.pos_in_table]

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -361,6 +361,7 @@ pub fn translate_create_index(
                 resolver,
                 &mut table_references,
                 table_cursor_id,
+                &tbl,
                 col,
                 start_reg + i,
             )?;
@@ -464,6 +465,7 @@ pub fn translate_create_index(
                 resolver,
                 &mut table_references,
                 table_cursor_id,
+                &tbl,
                 col,
                 start_reg + i,
             )?;
@@ -853,6 +855,7 @@ fn emit_index_column_value_from_cursor(
     resolver: &Resolver,
     table_references: &mut TableReferences,
     table_cursor_id: usize,
+    table: &BTreeTable,
     idx_col: &IndexColumn,
     dest_reg: usize,
 ) -> crate::Result<()> {
@@ -877,6 +880,14 @@ fn emit_index_column_value_from_cursor(
             translate_expr(program, Some(table_references), &expr, dest_reg, resolver)?;
             Ok(())
         })?;
+        // For virtual generated column references, apply the column's 
+        // declared affinity to the computed expression result.
+        if idx_col.pos_in_table != EXPR_INDEX_SENTINEL {
+            let column = &table.columns()[idx_col.pos_in_table];
+            if column.is_virtual_generated() {
+                program.emit_column_affinity(dest_reg, column.affinity());
+            }
+        }
     } else {
         program.emit_column_or_rowid(table_cursor_id, idx_col.pos_in_table, dest_reg);
     }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -5,7 +5,7 @@ use crate::{
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
     schema::{
         self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef, Table,
-        SQLITE_SEQUENCE_TABLE_NAME,
+        EXPR_INDEX_SENTINEL, SQLITE_SEQUENCE_TABLE_NAME,
     },
     sync::Arc,
     translate::{
@@ -3480,6 +3480,14 @@ fn emit_index_column_value_for_insert(
             table,
             dest_reg,
         )?;
+        // For virtual generated column references, apply the column's 
+        // declared affinity to the computed expression result.
+        if idx_col.pos_in_table != EXPR_INDEX_SENTINEL {
+            let column = &table.columns()[idx_col.pos_in_table];
+            if column.is_virtual_generated() {
+                program.emit_column_affinity(dest_reg, column.affinity());
+            }
+        }
     } else {
         let Some(cm) = insertion.get_col_mapping_by_name(&idx_col.name) else {
             return Err(LimboError::PlanningError(

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -1,7 +1,8 @@
 use crate::translate::expr::emit_table_column;
+use crate::vdbe::affinity::Affinity;
 use crate::vdbe::builder::SelfTableContext;
 use crate::{
-    schema::{GeneratedType, Index, Schema, Table},
+    schema::{GeneratedType, Index, Schema, Table, EXPR_INDEX_SENTINEL},
     translate::{
         emitter::Resolver,
         expr::{
@@ -24,7 +25,9 @@ pub const MAX_INTEGRITY_CHECK_ERRORS: usize = 100;
 
 enum BoundIndexColumn {
     Column(usize),
-    Expr(Box<ast::Expr>),
+    /// The affiniy is `Some` when the index column refers to a virtual generated column
+    /// (the affinity is the column's declared type).
+    Expr(Box<ast::Expr>, Option<Affinity>),
 }
 
 struct BoundIntegrityIndex {
@@ -267,11 +270,16 @@ fn translate_integrity_check_impl(
                 let mut unique_nullable = Vec::with_capacity(index.columns.len());
                 for col in &index.columns {
                     if let Some(expr) = col.expr.as_deref() {
-                        columns.push(BoundIndexColumn::Expr(Box::new(bind_expr_for_table(
-                            expr,
-                            &mut table_references,
-                            resolver,
-                        )?)));
+                        let affinity = if col.pos_in_table != EXPR_INDEX_SENTINEL {
+                            Some(btree_table.columns()[col.pos_in_table].affinity())
+                        } else {
+                            // expression indexes don't apply affinity from the basae table
+                            None
+                        };
+                        columns.push(BoundIndexColumn::Expr(
+                            Box::new(bind_expr_for_table(expr, &mut table_references, resolver)?),
+                            affinity,
+                        ));
                         unique_nullable.push(true);
                     } else {
                         columns.push(BoundIndexColumn::Column(col.pos_in_table));
@@ -310,7 +318,10 @@ fn translate_integrity_check_impl(
                     GeneratedType::Virtual { expr, .. } => {
                         let bound =
                             bind_expr_for_table(expr, &mut table_references, resolver).ok()?;
-                        Some((BoundIndexColumn::Expr(Box::new(bound)), name))
+                        Some((
+                            BoundIndexColumn::Expr(Box::new(bound), Some(col.affinity())),
+                            name,
+                        ))
                     }
                     GeneratedType::NotGenerated => Some((BoundIndexColumn::Column(idx), name)),
                 }
@@ -340,7 +351,7 @@ fn translate_integrity_check_impl(
                 BoundIndexColumn::Column(idx) => {
                     program.emit_column_or_rowid(table_cursor_id, *idx, col_value_reg);
                 }
-                BoundIndexColumn::Expr(expr) => {
+                BoundIndexColumn::Expr(expr, _affinity) => {
                     let self_table_context = table_references.joined_tables().first().map(|jt| {
                         SelfTableContext::ForSelect {
                             table_ref_id: jt.internal_id,
@@ -452,7 +463,7 @@ fn translate_integrity_check_impl(
                             resolver,
                         )?;
                     }
-                    BoundIndexColumn::Expr(expr) => {
+                    BoundIndexColumn::Expr(expr, affinity) => {
                         let self_table_context =
                             table_references.joined_tables().first().map(|jt| {
                                 SelfTableContext::ForSelect {
@@ -475,7 +486,10 @@ fn translate_integrity_check_impl(
                                 )?;
                                 Ok(())
                             },
-                        )?
+                        )?;
+                        if let Some(aff) = affinity {
+                            program.emit_column_affinity(target, *aff);
+                        }
                     }
                 }
             }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12811,9 +12811,10 @@ pub fn op_drop_column(
         Ok(())
     })?;
 
-    // Update index.pos_in_table for all indexes.
-    // For example, if the dropped column had index 2, then anything that was indexed on column 3 or higher should be decremented by 1.
-    conn.with_database_schema_mut(*db, |schema| {
+    // Shift left pos_in_table in all indexes, and self-table placeholders in generated column
+    // expressions, to account for the dropped column. For example, if the dropped column had index
+    // 2, then anything that was indexed on column 3 or higher should be decremented by 1.
+    conn.with_database_schema_mut(*db, |schema| -> Result<()> {
         if let Some(indexes) = schema.indexes.get_mut(&normalized_table_name) {
             for index in indexes {
                 let index = Arc::get_mut(index).expect("this should be the only strong reference");
@@ -12821,10 +12822,24 @@ pub fn op_drop_column(
                     if index_column.pos_in_table > *column_index {
                         index_column.pos_in_table -= 1;
                     }
+                    if let Some(ref mut expr) = index_column.expr {
+                        crate::translate::expr::walk_expr_mut(expr, &mut |e| {
+                            if let ast::Expr::Column {
+                                table, column: c, ..
+                            } = e
+                            {
+                                if table.is_self_table() && *c > *column_index {
+                                    *c -= 1;
+                                }
+                            }
+                            Ok(crate::translate::expr::WalkControl::Continue)
+                        })?;
+                    }
                 }
             }
         }
-    });
+        Ok(())
+    })?;
 
     conn.with_schema(*db, |schema| -> crate::Result<()> {
         for (view_name, view) in schema.views.iter() {

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3426,6 +3426,21 @@ expect {
     CREATE TABLE t (a REAL AS (ee), c INTEGER, f INTEGER AS (c * ee), ee REAL)
 }
 
+test gencol_drop_column_shifts_index_expr {
+    CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER, d INTEGER AS (b + c));
+    INSERT INTO t (a, b, c) VALUES (1, 10, 20);
+    CREATE INDEX idx ON t (d);
+    ALTER TABLE t DROP COLUMN a;
+    INSERT INTO t (b, c) VALUES (100, 200);
+    SELECT * FROM t ORDER BY rowid;
+    PRAGMA integrity_check;
+}
+expect {
+    10|20|30
+    100|200|300
+    ok
+}
+
 # =============================================================================
 # 15. INTEGER PRIMARY KEY Reference in Generated Columns
 # =============================================================================

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4908,3 +4908,39 @@ test gencol-virtual-affinity-applied-to-index {
 expect {
     ok
 }
+
+@cross-check-integrity
+test gencol-virtual-real-affinity-applied-to-index {
+    CREATE TABLE t (a INTEGER, b INTEGER, v REAL AS (a + b));
+    INSERT INTO t (a, b) VALUES (5000000000000001, 5000000000000002);
+    INSERT INTO t (a, b) VALUES (1, 2);
+    CREATE INDEX idx_v ON t (v);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+@cross-check-integrity
+test gencol-update-old-image-real-affinity-applied-to-index {
+    CREATE TABLE t (
+        a INTEGER,
+        b INTEGER,
+        c BLOB,
+        v1 INTEGER AS (a + b),
+        v2 REAL AS (-a - v1)
+    );
+    CREATE INDEX i ON t (c, v1, v2);
+    INSERT INTO t (a, b, c) VALUES (-2929861166669336, -5586410532100113, X'0102');
+    UPDATE t SET c = X'0303';
+    SELECT a, b, quote(c), v1, v2 FROM t INDEXED BY i;
+    PRAGMA integrity_check;
+}
+expect {
+    -2929861166669336|-5586410532100113|X'0303'|-8516271698769449|1.14461328654388e+16
+    ok
+}
+expect @js {
+    -2929861166669336|-5586410532100113|X'0303'|-8516271698769449|11446132865438784
+    ok
+}

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4896,3 +4896,15 @@ test update-expression-index-references-virtual-gencol {
     1|aaaaaa
     ok
 }
+
+@cross-check-integrity
+test gencol-virtual-affinity-applied-to-index {
+    CREATE TABLE t (a INTEGER, b INTEGER, v REAL AS (a + b));
+    INSERT INTO t (a, b) VALUES (5000000000000001, 5000000000000002);
+    INSERT INTO t (a, b) VALUES (1, 2);
+    CREATE INDEX idx_v ON t (v);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}


### PR DESCRIPTION
## Description

The previous fix for virtual generated columns in index records (https://github.com/tursodatabase/turso/pull/6707) covered
INSERT, CREATE INDEX, and integrity_check, but UPDATE has two more keys
that must be coerced to the column's declared affinity:

  - Phase 2 OLD-image probe for IdxDelete: when an IndexColumn references
    a virtual gen-col, resolve_sorted_columns inlines its expression into
    IndexColumn.expr, so emit_index_column_value_old_image takes the
    `idx_col.expr.is_some()` branch and never reaches the
    generated_column() path that applies affinity. Apply the column's
    affinity after the expression is translated, mirroring the fix in
    emit_index_column_value_from_cursor.

  - Phase 1 NEW-image bulk Insn::Affinity before MakeRecord: the mapping
    from IndexColumn -> affinity char keyed off `expr.is_some()`, which
    is true for both pure expression indices AND virtual gen-col index
    entries (because of the same resolve_sorted_columns inlining). The
    branch must instead key off pos_in_table == EXPR_INDEX_SENTINEL so
    only true expression indices stay Blob; virtual gen-col entries pick
    up the column's declared affinity.

Without these, an UPDATE that doesn't touch the virtual gen-col's source
columns but does touch some other index column rebuilt the OLD probe
key as INTEGER while the index entry was REAL — IdxDelete failed with
"no matching index entry" once a value exceeded 2^53. Once Phase 2 was
fixed in isolation, Phase 1 then wrote the NEW key with INTEGER serial
type, leaving integrity_check reporting the row as missing from the
index on the next probe.

Caught while working on adding virtual columns to the simulator.

## How to review this PR

There's 3 commits on this PR, but 2 belong to https://github.com/tursodatabase/turso/pull/6707 and https://github.com/tursodatabase/turso/pull/6694. So you can review just cff26aad750b3f043fb91343ca1c234eb3c8be6a, and I won't merge this until the other 2 are merged.

## Description of AI Usage

Claude Code