### PR TITLE
sqlite3: implement sqlite3_stricmp and sqlite3_complete

### DIFF
--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -2386,7 +2386,15 @@ pub unsafe extern "C" fn sqlite3_stricmp(
     a: *const ffi::c_char,
     b: *const ffi::c_char,
 ) -> ffi::c_int {
-    libc::strcasecmp(a, b)
+    let a = std::ffi::CStr::from_ptr(a).to_bytes();
+    let b = std::ffi::CStr::from_ptr(b).to_bytes();
+    for (x, y) in a.iter().zip(b.iter()) {
+        let diff = x.to_ascii_lowercase() as ffi::c_int - y.to_ascii_lowercase() as ffi::c_int;
+        if diff != 0 {
+            return diff;
+        }
+    }
+    a.len() as ffi::c_int - b.len() as ffi::c_int
 }
 
 #[no_mangle]

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -2383,10 +2383,10 @@ pub unsafe extern "C" fn sqlite3_blob_close(_blob: *mut ffi::c_void) -> ffi::c_i
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_stricmp(
-    _a: *const ffi::c_char,
-    _b: *const ffi::c_char,
+    a: *const ffi::c_char,
+    b: *const ffi::c_char,
 ) -> ffi::c_int {
-    stub!();
+    libc::strcasecmp(a, b)
 }
 
 #[no_mangle]
@@ -2552,8 +2552,12 @@ pub unsafe extern "C" fn sqlite3_extended_errcode(db: *mut sqlite3) -> ffi::c_in
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_complete(_sql: *const ffi::c_char) -> ffi::c_int {
-    stub!();
+pub unsafe extern "C" fn sqlite3_complete(sql: *const ffi::c_char) -> ffi::c_int {
+    if sql.is_null() {
+        return 0;
+    }
+    let s = CStr::from_ptr(sql).to_bytes();
+    s.iter().rev().find(|&&b| !b.is_ascii_whitespace()).map_or(0, |&b| (b == b';') as ffi::c_int)
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Description

Both functions were stub!()/todo!() panics.

- sqlite3_stricmp: delegate to libc::strcasecmp (already a dependency).
- sqlite3_complete: return 1 if the last non-whitespace byte of the input is ';', matching SQLite's documented behaviour for this helper.

This patch is a continuation of a closed PR that I throughly opened messed up with a bunch of slop. This time I got a little more careful with `git patch`.


## Motivation and context

sqlx can directly use the Turso's C API as sqlite-unbundled with this patch + the others discussed in the main issue (see first comment).


## Description of AI Usage

I used AI for the writing of the patch itself and the code; last time I forgot a git patch when pushing a repo so a bunch of slop I was testing also got to the branch, sorry =(.