### PR TITLE
sqlite3: add missing symbols required to link with sqlx-sqlite

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -711,6 +711,51 @@ impl Statement {
         }
     }
 
+    pub fn get_column_database_name(&self, idx: usize) -> Option<String> {
+        if self.query_mode == QueryMode::Explain || self.query_mode == QueryMode::ExplainQueryPlan {
+            return None;
+        }
+        let column = &self.program.result_columns.get(idx).expect("No column");
+        match &column.expr {
+            turso_parser::ast::Expr::Column { table, .. } => {
+                let joined = self
+                    .program
+                    .table_references
+                    .find_joined_table_by_internal_id(*table)?;
+                self.program
+                    .connection
+                    .get_database_name_by_index(joined.database_id)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn get_column_origin_name(&self, idx: usize) -> Option<Cow<'_, str>> {
+        if self.query_mode == QueryMode::Explain || self.query_mode == QueryMode::ExplainQueryPlan {
+            return None;
+        }
+        let column = &self.program.result_columns.get(idx).expect("No column");
+        match &column.expr {
+            turso_parser::ast::Expr::Column {
+                table,
+                column: col_idx,
+                ..
+            } => {
+                let joined = self
+                    .program
+                    .table_references
+                    .find_joined_table_by_internal_id(*table)?;
+                joined
+                    .table
+                    .get_column_at(*col_idx)?
+                    .name
+                    .as_deref()
+                    .map(Cow::Borrowed)
+            }
+            _ => None,
+        }
+    }
+
     /// Returns the declared type of a result column.
     ///
     /// This behaves similarly to SQLite's `sqlite3_column_decltype()`:

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -164,6 +164,7 @@ pub struct sqlite3_stmt {
     /// High-water mark of `search_count` already published to the global
     /// counter, so each step contributes only the delta.
     pub(crate) prev_search_count: i64,
+    pub(crate) sql: Option<CString>,
 }
 
 impl sqlite3_stmt {
@@ -177,6 +178,7 @@ impl sqlite3_stmt {
             text_cache: vec![vec![]; n_cols],
             value_cache: (0..n_cols).map(|_| None).collect(),
             prev_search_count: 0,
+            sql: None,
         }
     }
     #[inline]
@@ -829,6 +831,7 @@ pub unsafe extern "C" fn sqlite3_prepare_v2(
         *tail = sql.add(stmt.tail_offset());
     }
     let new_stmt = Box::leak(Box::new(sqlite3_stmt::new(raw_db, stmt)));
+    new_stmt.sql = CString::new(sql_str).ok();
 
     new_stmt.next = db.stmt_list;
     db.stmt_list = new_stmt;
@@ -3024,19 +3027,23 @@ unsafe fn set_db_err(db: &mut sqlite3Inner, err: LimboError) -> i32 {
     code
 }
 
-// Symbols required by libsqlite3-sys / sqlx-sqlite that are not yet
-// implemented in Turso.  They are declared here so the dynamic library links
-// successfully; each returns a safe no-op value.
+// Symbols required by libsqlite3-sys / sqlx-sqlite.
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_update_hook(
     _db: *mut sqlite3,
     _callback: Option<
-        unsafe extern "C" fn(*mut ffi::c_void, ffi::c_int, *const ffi::c_char, *const ffi::c_char, i64),
+        unsafe extern "C" fn(
+            *mut ffi::c_void,
+            ffi::c_int,
+            *const ffi::c_char,
+            *const ffi::c_char,
+            i64,
+        ),
     >,
     _context: *mut ffi::c_void,
 ) -> *mut ffi::c_void {
-    std::ptr::null_mut()
+    stub!();
 }
 
 #[no_mangle]
@@ -3045,7 +3052,7 @@ pub unsafe extern "C" fn sqlite3_commit_hook(
     _callback: Option<unsafe extern "C" fn(*mut ffi::c_void) -> ffi::c_int>,
     _context: *mut ffi::c_void,
 ) -> *mut ffi::c_void {
-    std::ptr::null_mut()
+    stub!();
 }
 
 #[no_mangle]
@@ -3054,13 +3061,24 @@ pub unsafe extern "C" fn sqlite3_rollback_hook(
     _callback: Option<unsafe extern "C" fn(*mut ffi::c_void)>,
     _context: *mut ffi::c_void,
 ) {
+    stub!();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_extended_result_codes(
-    _db: *mut sqlite3,
-    _onoff: ffi::c_int,
+    raw_db: *mut sqlite3,
+    onoff: ffi::c_int,
 ) -> ffi::c_int {
+    if raw_db.is_null() {
+        return SQLITE_MISUSE;
+    }
+    let db = &mut *raw_db;
+    let mut db = db.inner.lock().unwrap();
+    db.err_mask = if onoff != 0 {
+        0xFFFFFFFFu32 as i32
+    } else {
+        0xFF
+    };
     SQLITE_OK
 }
 
@@ -3080,28 +3098,67 @@ pub unsafe extern "C" fn sqlite3_unlock_notify(
     _callback: Option<unsafe extern "C" fn(*mut *mut ffi::c_void, ffi::c_int)>,
     _context: *mut ffi::c_void,
 ) -> ffi::c_int {
-    SQLITE_OK
+    stub!();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_sql(_stmt: *mut sqlite3_stmt) -> *const ffi::c_char {
-    std::ptr::null()
+pub unsafe extern "C" fn sqlite3_sql(stmt: *mut sqlite3_stmt) -> *const ffi::c_char {
+    if stmt.is_null() {
+        return std::ptr::null();
+    }
+    let stmt = &*stmt;
+    stmt.sql
+        .as_ref()
+        .map(|s| s.as_ptr())
+        .unwrap_or(std::ptr::null())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_column_database_name(
-    _stmt: *mut sqlite3_stmt,
-    _idx: ffi::c_int,
+    stmt: *mut sqlite3_stmt,
+    idx: ffi::c_int,
 ) -> *const ffi::c_char {
-    std::ptr::null()
+    if stmt.is_null() {
+        return std::ptr::null();
+    }
+    let stmt = &mut *stmt;
+    let idx = match usize::try_from(idx) {
+        Ok(i) => i,
+        Err(_) => return std::ptr::null(),
+    };
+    let name = match stmt.stmt.get_column_database_name(idx) {
+        Some(n) => n,
+        None => return std::ptr::null(),
+    };
+    let c_string = match CString::new(name) {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null(),
+    };
+    c_string.into_raw()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_column_origin_name(
-    _stmt: *mut sqlite3_stmt,
-    _idx: ffi::c_int,
+    stmt: *mut sqlite3_stmt,
+    idx: ffi::c_int,
 ) -> *const ffi::c_char {
-    std::ptr::null()
+    if stmt.is_null() {
+        return std::ptr::null();
+    }
+    let stmt = &mut *stmt;
+    let idx = match usize::try_from(idx) {
+        Ok(i) => i,
+        Err(_) => return std::ptr::null(),
+    };
+    let binding = match stmt.stmt.get_column_origin_name(idx) {
+        Some(n) => n.into_owned(),
+        None => return std::ptr::null(),
+    };
+    let c_string = match CString::new(binding) {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null(),
+    };
+    c_string.into_raw()
 }
 
 #[no_mangle]

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -3024,6 +3024,115 @@ unsafe fn set_db_err(db: &mut sqlite3Inner, err: LimboError) -> i32 {
     code
 }
 
+// Symbols required by libsqlite3-sys / sqlx-sqlite that are not yet
+// implemented in Turso.  They are declared here so the dynamic library links
+// successfully; each returns a safe no-op value.
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_update_hook(
+    _db: *mut sqlite3,
+    _callback: Option<
+        unsafe extern "C" fn(*mut ffi::c_void, ffi::c_int, *const ffi::c_char, *const ffi::c_char, i64),
+    >,
+    _context: *mut ffi::c_void,
+) -> *mut ffi::c_void {
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_commit_hook(
+    _db: *mut sqlite3,
+    _callback: Option<unsafe extern "C" fn(*mut ffi::c_void) -> ffi::c_int>,
+    _context: *mut ffi::c_void,
+) -> *mut ffi::c_void {
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_rollback_hook(
+    _db: *mut sqlite3,
+    _callback: Option<unsafe extern "C" fn(*mut ffi::c_void)>,
+    _context: *mut ffi::c_void,
+) {
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_extended_result_codes(
+    _db: *mut sqlite3,
+    _onoff: ffi::c_int,
+) -> ffi::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_load_extension(
+    _db: *mut sqlite3,
+    _z_file: *const ffi::c_char,
+    _z_proc: *const ffi::c_char,
+    _pz_err_msg: *mut *mut ffi::c_char,
+) -> ffi::c_int {
+    SQLITE_ERROR
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_unlock_notify(
+    _db: *mut sqlite3,
+    _callback: Option<unsafe extern "C" fn(*mut *mut ffi::c_void, ffi::c_int)>,
+    _context: *mut ffi::c_void,
+) -> ffi::c_int {
+    SQLITE_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_sql(_stmt: *mut sqlite3_stmt) -> *const ffi::c_char {
+    std::ptr::null()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_column_database_name(
+    _stmt: *mut sqlite3_stmt,
+    _idx: ffi::c_int,
+) -> *const ffi::c_char {
+    std::ptr::null()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_column_origin_name(
+    _stmt: *mut sqlite3_stmt,
+    _idx: ffi::c_int,
+) -> *const ffi::c_char {
+    std::ptr::null()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_bind_blob64(
+    stmt: *mut sqlite3_stmt,
+    idx: ffi::c_int,
+    blob: *const ffi::c_void,
+    len: u64,
+    destructor: Option<unsafe extern "C" fn(*mut ffi::c_void)>,
+) -> ffi::c_int {
+    if len > ffi::c_int::MAX as u64 {
+        return SQLITE_TOOBIG;
+    }
+    sqlite3_bind_blob(stmt, idx, blob, len as ffi::c_int, destructor)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_bind_text64(
+    stmt: *mut sqlite3_stmt,
+    idx: ffi::c_int,
+    text: *const ffi::c_char,
+    len: u64,
+    destructor: Option<unsafe extern "C" fn(*mut ffi::c_void)>,
+    _encoding: ffi::c_uchar,
+) -> ffi::c_int {
+    if len > ffi::c_int::MAX as u64 {
+        return SQLITE_TOOBIG;
+    }
+    sqlite3_bind_text(stmt, idx, text, len as ffi::c_int, destructor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -176,6 +176,25 @@ extern "C" {
     fn sqlite3_value_dup(value: *mut libc::c_void) -> *mut libc::c_void;
     fn sqlite3_value_free(value: *mut libc::c_void);
     fn sqlite3_context_db_handle(context: *mut libc::c_void) -> *mut libc::c_void;
+    fn sqlite3_bind_blob64(
+        stmt: *mut sqlite3_stmt,
+        idx: i32,
+        blob: *const libc::c_void,
+        len: u64,
+        destructor: Option<unsafe extern "C" fn(*mut libc::c_void)>,
+    ) -> i32;
+    fn sqlite3_bind_text64(
+        stmt: *mut sqlite3_stmt,
+        idx: i32,
+        text: *const libc::c_char,
+        len: u64,
+        destructor: Option<unsafe extern "C" fn(*mut libc::c_void)>,
+        encoding: libc::c_uchar,
+    ) -> i32;
+    fn sqlite3_sql(stmt: *mut sqlite3_stmt) -> *const libc::c_char;
+    fn sqlite3_column_database_name(stmt: *mut sqlite3_stmt, idx: i32) -> *const libc::c_char;
+    fn sqlite3_column_origin_name(stmt: *mut sqlite3_stmt, idx: i32) -> *const libc::c_char;
+    fn sqlite3_extended_result_codes(db: *mut sqlite3, onoff: i32) -> i32;
 }
 
 const SQLITE_OK: i32 = 0;
@@ -3633,6 +3652,217 @@ mod tests {
             let null_handle = sqlite3_context_db_handle(ptr::null_mut());
             assert!(null_handle.is_null());
 
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_bind_blob64() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"CREATE TABLE t (data BLOB)".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_DONE);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            let blob: &[u8] = &[0xCA, 0xFE, 0xBA, 0xBE];
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"INSERT INTO t VALUES (?)".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(
+                sqlite3_bind_blob64(stmt, 1, blob.as_ptr() as *const _, blob.len() as u64, None),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_DONE);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT data FROM t".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut()
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            let ptr = sqlite3_column_blob(stmt, 0);
+            let len = sqlite3_column_bytes(stmt, 0);
+            assert_eq!(len, 4);
+            let got = std::slice::from_raw_parts(ptr as *const u8, len as usize);
+            assert_eq!(got, blob);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_bind_text64() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"CREATE TABLE t (val TEXT)".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_DONE);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            let text = b"hello\0";
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"INSERT INTO t VALUES (?)".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            // SQLITE_UTF8 = 1
+            assert_eq!(
+                sqlite3_bind_text64(
+                    stmt,
+                    1,
+                    text.as_ptr() as *const libc::c_char,
+                    5, // length without null terminator
+                    None,
+                    1,
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_DONE);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT val FROM t".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut()
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            let result = sqlite3_column_text(stmt, 0);
+            assert!(!result.is_null());
+            let got = std::ffi::CStr::from_ptr(result).to_str().unwrap();
+            assert_eq!(got, "hello");
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_sql() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(db, c"SELECT 42".as_ptr(), -1, &mut stmt, ptr::null_mut()),
+                SQLITE_OK
+            );
+            let sql_ptr = sqlite3_sql(stmt);
+            assert!(!sql_ptr.is_null());
+            let sql = std::ffi::CStr::from_ptr(sql_ptr).to_str().unwrap();
+            assert_eq!(sql, "SELECT 42");
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_column_database_and_origin_name() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            assert_eq!(
+                sqlite3_exec(
+                    db,
+                    c"CREATE TABLE users (id INTEGER, name TEXT)".as_ptr(),
+                    None,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+
+            let mut stmt: *mut sqlite3_stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT id AS user_id, name FROM users".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+
+            // database name is always "main" for local tables
+            let db_name_ptr = sqlite3_column_database_name(stmt, 0);
+            assert!(!db_name_ptr.is_null());
+            let db_name = std::ffi::CStr::from_ptr(db_name_ptr).to_str().unwrap();
+            assert_eq!(db_name, "main");
+
+            // origin name is the real column name, not the alias
+            let origin_ptr = sqlite3_column_origin_name(stmt, 0);
+            assert!(!origin_ptr.is_null());
+            let origin = std::ffi::CStr::from_ptr(origin_ptr).to_str().unwrap();
+            assert_eq!(origin, "id");
+
+            let origin2_ptr = sqlite3_column_origin_name(stmt, 1);
+            assert!(!origin2_ptr.is_null());
+            let origin2 = std::ffi::CStr::from_ptr(origin2_ptr).to_str().unwrap();
+            assert_eq!(origin2, "name");
+
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_extended_result_codes() {
+        unsafe {
+            let mut db: *mut sqlite3 = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+            assert_eq!(sqlite3_extended_result_codes(db, 1), SQLITE_OK);
+            assert_eq!(sqlite3_extended_result_codes(db, 0), SQLITE_OK);
             assert_eq!(sqlite3_close(db), SQLITE_OK);
         }
     }


### PR DESCRIPTION
## Description


libsqlite3-sys and sqlx-sqlite reference several sqlite3_* symbols that Turso does not yet export. Add no-op declarations so the dynamic library links without undefined-symbol errors:

  update_hook, commit_hook, rollback_hook  — return NULL (no previous hook)
  extended_result_codes                    — SQLITE_OK (already default)
  load_extension                           — SQLITE_ERROR (not supported)
  unlock_notify                            — SQLITE_OK (no WAL lock needed)
  sqlite3_sql                              — NULL (not tracked yet)
  column_database_name / column_origin_name — NULL
  bind_blob64 / bind_text64               — delegate to bind_blob/bind_text

## Motivation and context

sqlx can directly use the Turso's C API as sqlite-unbundled with this patch + the others discussed in the main issue (see first comment).


## Description of AI Usage

I used AI for the writing of the patch itself and the code; last time I forgot a git patch when pushing a repo so a bunch of slop I was testing also got to the branch, sorry =(.

Also, I don't throughly understand sqlite's C API, so most of the research for the PR were also from AI explaining these symbols for me.