### PR TITLE
Fix savepoint rollback under cache pressure

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1866,19 +1866,21 @@ impl Pager {
     /// Rollback to the newest savepoint. This basically just means reading the subjournal from the start offset
     /// of the savepoint to the end of the subjournal and restoring the page images to the page cache.
     pub fn rollback_to_newest_savepoint(&self) -> Result<bool> {
-        let mut savepoints = self.savepoints.write();
-        if !matches!(
-            savepoints.last().map(|savepoint| &savepoint.kind),
-            Some(SavepointKind::Statement)
-        ) {
-            return Ok(false);
-        }
-        let savepoint = savepoints.pop().expect("savepoint must exist");
-        let journal_end_offset = savepoint.write_offset();
-        let savepoint = savepoint.snapshot();
+        let (savepoint, journal_end_offset) = {
+            let mut savepoints = self.savepoints.write();
+            if !matches!(
+                savepoints.last().map(|savepoint| &savepoint.kind),
+                Some(SavepointKind::Statement)
+            ) {
+                return Ok(false);
+            }
+            let savepoint = savepoints.pop().expect("savepoint must exist");
+            (savepoint.snapshot(), savepoint.write_offset())
+        };
 
         self.rollback_to_snapshot(&savepoint, journal_end_offset)?;
 
+        let savepoints = self.savepoints.write();
         if let Some(parent) = savepoints.last() {
             parent.set_write_offset(savepoint.start_offset);
         }
@@ -1961,18 +1963,22 @@ impl Pager {
         savepoint: &SavepointSnapshot,
         journal_end_offset: u64,
     ) -> Result<()> {
-        let subjournal = self.subjournal.read();
-        let Some(subjournal) = subjournal.as_ref() else {
-            return Ok(());
+        let subjournal = {
+            let subjournal = self.subjournal.read();
+            let Some(subjournal) = subjournal.as_ref() else {
+                return Ok(());
+            };
+            subjournal.clone()
         };
 
         let journal_start_offset = savepoint.start_offset;
         let db_size = savepoint.db_size;
+        let original_cache_capacity = self.page_cache.read().capacity();
+        let mut cache_capacity_was_expanded = false;
 
         let mut rollback_bitset = RoaringBitmap::new();
         let mut current_offset = journal_start_offset;
         let page_size = self.page_size.load(Ordering::SeqCst) as u64;
-        let mut dirty_pages = self.dirty_pages.write();
 
         while current_offset < journal_end_offset {
             let page_id_buffer = Arc::new(self.buffer_pool.allocate(4));
@@ -2006,8 +2012,13 @@ impl Pager {
             // eviction cannot drop uncommitted changes that predate the
             // rolled-back savepoint/statement.
             page.set_dirty();
-            dirty_pages.insert(page_id);
-            self.upsert_page_in_cache(page_id as usize, page, true)?;
+            self.dirty_pages.write().insert(page_id);
+            self.upsert_page_in_cache_allow_overflow(
+                page_id as usize,
+                page,
+                true,
+                &mut cache_capacity_was_expanded,
+            )?;
         }
 
         let truncate_completion = subjournal.truncate(journal_start_offset)?;
@@ -2021,6 +2032,7 @@ impl Pager {
         // above won't encounter them. We must clean them from dirty_pages before
         // truncating the cache, or phantom dirty entries survive into commit.
         {
+            let mut dirty_pages = self.dirty_pages.write();
             let mut cache = self.page_cache.write();
             for page_id in dirty_pages.iter().filter(|&id| id > db_size) {
                 if let Some(page) = cache.get(&PageCacheKey::new(page_id as usize))? {
@@ -2045,6 +2057,10 @@ impl Pager {
                         "failed to invalidate rolled-back WAL pages: {e:?}"
                     ))
                 })?;
+        }
+
+        if cache_capacity_was_expanded {
+            self.restore_page_cache_capacity(original_cache_capacity)?;
         }
 
         Ok(())
@@ -5012,6 +5028,71 @@ impl Pager {
         page: PageRef,
         dirty_page_must_exist: bool,
     ) -> Result<(), LimboError> {
+        self.try_upsert_page_in_cache(id, page, dirty_page_must_exist)
+            .map_err(|e| {
+                LimboError::InternalError(format!(
+                    "Failed to insert loaded page {id} into cache: {e:?}"
+                ))
+            })
+    }
+
+    fn upsert_page_in_cache_allow_overflow(
+        &self,
+        id: usize,
+        page: PageRef,
+        dirty_page_must_exist: bool,
+        cache_capacity_was_expanded: &mut bool,
+    ) -> Result<(), LimboError> {
+        match self.try_upsert_page_in_cache(id, page.clone(), dirty_page_must_exist) {
+            Ok(()) => return Ok(()),
+            Err(CacheError::Full) => {
+                let mut cache = self.page_cache.write();
+                let expanded_capacity = cache.len() + 1;
+                cache.resize(expanded_capacity);
+                *cache_capacity_was_expanded = true;
+            }
+            Err(e) => {
+                return Err(LimboError::InternalError(format!(
+                    "Failed to insert loaded page {id} into cache: {e:?}"
+                )));
+            }
+        }
+
+        self.try_upsert_page_in_cache(id, page, dirty_page_must_exist)
+            .map_err(|e| {
+                LimboError::InternalError(format!(
+                    "Failed to insert loaded page {id} into cache: {e:?}"
+                ))
+            })
+    }
+
+    fn restore_page_cache_capacity(&self, capacity: usize) -> Result<()> {
+        loop {
+            {
+                let mut cache = self.page_cache.write();
+                if cache.capacity() <= capacity {
+                    return Ok(());
+                }
+                if matches!(cache.resize(capacity), CacheResizeResult::Done) {
+                    return Ok(());
+                }
+                cache.set_spill_threshold(capacity.max(1));
+            }
+
+            match self.try_spill_dirty_pages()? {
+                IOResult::Done(true) => {}
+                IOResult::Done(false) => return Ok(()),
+                IOResult::IO(completions) => completions.wait(self.io.as_ref())?,
+            }
+        }
+    }
+
+    fn try_upsert_page_in_cache(
+        &self,
+        id: usize,
+        page: PageRef,
+        dirty_page_must_exist: bool,
+    ) -> Result<(), CacheError> {
         let mut cache = self.page_cache.write();
         let page_key = PageCacheKey::new(id);
 
@@ -5019,11 +5100,7 @@ impl Pager {
         if dirty_page_must_exist {
             turso_assert!(page.is_dirty(), "page must be dirty for upsert", { "page_id": id });
         }
-        cache.upsert_page(page_key, page.clone()).map_err(|e| {
-            LimboError::InternalError(format!(
-                "Failed to insert loaded page {id} into cache: {e:?}"
-            ))
-        })?;
+        cache.upsert_page(page_key, page.clone())?;
         page.set_loaded();
         page.clear_wal_tag();
         Ok(())

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6,7 +6,8 @@ use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{
-    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME, SQLITE_SEQUENCE_TABLE_NAME,
+    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME,
+    SQLITE_SEQUENCE_TABLE_NAME,
 };
 use crate::state_machine::StateMachine;
 use crate::storage::btree::{

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -53,12 +53,12 @@ simulator covers and tests.
 | INSERT                    | Partial | TODO                                                                              |
 | ON CONFLICT clause        | No      |                                                                                   |
 | REINDEX                   | No      |                                                                                   |
-| RELEASE SAVEPOINT         | Partial | Covered by SavepointRollback property.                                            |
+| RELEASE SAVEPOINT         | Partial | Covered by SavepointRollback and SavepointRollbackReopen properties.              |
 | REPLACE                   | No      |                                                                                   |
 | RETURNING clause          | No      | TODO                                                                              |
 | ROLLBACK TRANSACTION      | Partial | TODO                                                                              |
-| ROLLBACK TO SAVEPOINT     | Partial | Covered by SavepointRollback property.                                            |
-| SAVEPOINT                 | Partial | Covered by SavepointRollback property.                                            |
+| ROLLBACK TO SAVEPOINT     | Partial | Covered by SavepointRollback and SavepointRollbackReopen properties.              |
+| SAVEPOINT                 | Partial | Covered by SavepointRollback and SavepointRollbackReopen properties.              |
 | SELECT                    | Partial | TODO                                                                              |
 | SELECT ... WHERE          | Partial | TODO                                                                              |
 | SELECT ... WHERE ... LIKE | No      |                                                                                   |
@@ -115,7 +115,7 @@ simulator covers and tests.
 | PRAGMA index_info                | No         |                                                  |
 | PRAGMA index_list                | No         |                                                  |
 | PRAGMA index_xinfo               | No         |                                                  |
-| PRAGMA integrity_check           | No         |                                                  |
+| PRAGMA integrity_check           | Partial    | Checked after savepoint rollback properties.      |
 | PRAGMA journal_mode              | No         |                                                  |
 | PRAGMA journal_size_limit        | No         |                                                  |
 | PRAGMA legacy_alter_table        | No         |                                                  |

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -33,7 +33,7 @@ use crate::{
         Query, QueryCapabilities, QueryDiscriminants, ReleaseSavepoint, ResultSet,
         RollbackToSavepoint, Savepoint,
         interactions::{
-            Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
+            Assertion, Fault, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
         },
         metrics::Remaining,
         property::{InteractiveQueryInfo, Property, PropertyDiscriminants},
@@ -231,6 +231,14 @@ impl Property {
             Property::SavepointRollback { .. } => {
                 |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
                     let Property::SavepointRollback { write_kinds, .. } = property else {
+                        unreachable!()
+                    };
+                    random_main_table_write(rng, ctx, write_kinds)
+                }
+            }
+            Property::SavepointRollbackReopen { .. } => {
+                |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
+                    let Property::SavepointRollbackReopen { write_kinds, .. } = property else {
                         unreachable!()
                     };
                     random_main_table_write(rng, ctx, write_kinds)
@@ -1208,31 +1216,10 @@ impl Property {
                 .collect(),
             Property::SavepointRollback {
                 queries, tables, ..
-            } => {
-                let savepoint_name = format!("sim_sp_{}", id.get());
-                let mut interactions = Vec::with_capacity(queries.len() + 4 + tables.len() * 2);
-                interactions.push(InteractionBuilder::with_interaction(
-                    InteractionType::Query(Query::Savepoint(Savepoint {
-                        name: savepoint_name.clone(),
-                    })),
-                ));
-                interactions.extend(queries.clone().into_iter().map(|query| {
-                    InteractionBuilder::with_interaction(InteractionType::Query(query))
-                }));
-                interactions.push(InteractionBuilder::with_interaction(
-                    InteractionType::Query(Query::RollbackToSavepoint(RollbackToSavepoint {
-                        name: savepoint_name.clone(),
-                    })),
-                ));
-                interactions.push(InteractionBuilder::with_interaction(
-                    InteractionType::Query(Query::ReleaseSavepoint(ReleaseSavepoint {
-                        name: savepoint_name,
-                    })),
-                ));
-                interactions.extend(assert_all_table_values(tables, connection_index));
-                interactions.push(assert_integrity_check(tables, connection_index));
-                interactions
-            }
+            } => savepoint_rollback_interactions(queries, tables, connection_index, id, false),
+            Property::SavepointRollbackReopen {
+                queries, tables, ..
+            } => savepoint_rollback_interactions(queries, tables, connection_index, id, true),
         };
 
         assert!(!interactions.is_empty());
@@ -1248,6 +1235,46 @@ impl Property {
             })
             .collect()
     }
+}
+
+fn savepoint_rollback_interactions(
+    queries: &[Query],
+    tables: &[String],
+    connection_index: usize,
+    id: NonZeroUsize,
+    reopen: bool,
+) -> Vec<InteractionBuilder> {
+    let savepoint_name = format!("sim_sp_{}", id.get());
+    let mut interactions = Vec::with_capacity(queries.len() + 5 + tables.len() * 2);
+    interactions.push(InteractionBuilder::with_interaction(
+        InteractionType::Query(Query::Savepoint(Savepoint {
+            name: savepoint_name.clone(),
+        })),
+    ));
+    interactions.extend(
+        queries
+            .iter()
+            .cloned()
+            .map(|query| InteractionBuilder::with_interaction(InteractionType::Query(query))),
+    );
+    interactions.push(InteractionBuilder::with_interaction(
+        InteractionType::Query(Query::RollbackToSavepoint(RollbackToSavepoint {
+            name: savepoint_name.clone(),
+        })),
+    ));
+    interactions.push(InteractionBuilder::with_interaction(
+        InteractionType::Query(Query::ReleaseSavepoint(ReleaseSavepoint {
+            name: savepoint_name,
+        })),
+    ));
+    if reopen {
+        interactions.push(InteractionBuilder::with_interaction(
+            InteractionType::Fault(Fault::ReopenDatabase),
+        ));
+    }
+    interactions.extend(assert_all_table_values(tables, connection_index));
+    interactions.push(assert_integrity_check(tables, connection_index));
+    interactions
 }
 
 fn random_main_table_write<R: rand::Rng + ?Sized>(
@@ -1651,6 +1678,24 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     ctx: &impl GenerationContext,
     _mvcc: bool,
 ) -> Property {
+    property_savepoint_rollback_impl(rng, query_distr, ctx, false)
+}
+
+fn property_savepoint_rollback_reopen<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    property_savepoint_rollback_impl(rng, query_distr, ctx, true)
+}
+
+fn property_savepoint_rollback_impl<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    reopen: bool,
+) -> Property {
     let tables = ctx
         .tables()
         .iter()
@@ -1671,10 +1716,19 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
         .collect::<Vec<_>>();
     assert!(!write_kinds.is_empty());
     let amount = rng.random_range(1..=5);
-    Property::SavepointRollback {
-        queries: std::iter::repeat_n(Query::Placeholder, amount).collect(),
-        tables,
-        write_kinds,
+    let queries = std::iter::repeat_n(Query::Placeholder, amount).collect();
+    if reopen {
+        Property::SavepointRollbackReopen {
+            queries,
+            tables,
+            write_kinds,
+        }
+    } else {
+        Property::SavepointRollback {
+            queries,
+            tables,
+            write_kinds,
+        }
     }
 }
 
@@ -1899,6 +1953,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
             PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
+            PropertyDiscriminants::SavepointRollbackReopen => property_savepoint_rollback_reopen,
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
@@ -1950,6 +2005,17 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::SavepointRollback => {
                 if !env.opts.disable_savepoint_rollback
+                    && !env.profile.mvcc
+                    && ctx.tables().iter().any(|table| !table.name.contains('.'))
+                {
+                    remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::SavepointRollbackReopen => {
+                if !env.opts.disable_savepoint_rollback
+                    && !env.opts.disable_reopen_database
                     && !env.profile.mvcc
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
@@ -2059,6 +2125,7 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::SavepointRollbackReopen => QueryCapabilities::INSERT,
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,
@@ -2159,4 +2226,55 @@ fn print_row(row: &[SimValue]) -> String {
         })
         .collect::<Vec<String>>()
         .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn savepoint_rollback_reopen_reopens_before_assertions() {
+        let property = Property::SavepointRollbackReopen {
+            queries: vec![Query::Placeholder],
+            tables: vec!["t".to_string()],
+            write_kinds: vec![QueryDiscriminants::Insert],
+        };
+
+        let id = NonZeroUsize::new(7).unwrap();
+        let interactions = property.interactions(2, id);
+
+        assert!(
+            interactions
+                .iter()
+                .all(|interaction| interaction.connection_index == 2 && interaction.id() == id)
+        );
+
+        let release_idx = interactions
+            .iter()
+            .position(|interaction| {
+                matches!(
+                    &interaction.interaction,
+                    InteractionType::Query(Query::ReleaseSavepoint(_))
+                )
+            })
+            .expect("property should release the savepoint");
+        let reopen_idx = interactions
+            .iter()
+            .position(|interaction| {
+                matches!(
+                    &interaction.interaction,
+                    InteractionType::Fault(Fault::ReopenDatabase)
+                )
+            })
+            .expect("property should reopen the database");
+        let assertion_idx = interactions
+            .iter()
+            .position(|interaction| {
+                matches!(&interaction.interaction, InteractionType::Assertion(_))
+            })
+            .expect("property should assert table contents after rollback");
+
+        assert!(release_idx < reopen_idx);
+        assert!(reopen_idx < assertion_idx);
+    }
 }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -191,6 +191,14 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// SavepointRollbackReopen is the same rollback invariant, but forces a
+    /// database reopen before checking the contents. This exercises persisted
+    /// WAL state and page cache recovery after rolled-back writes.
+    SavepointRollbackReopen {
+        queries: Vec<Query>,
+        tables: Vec<String>,
+        write_kinds: Vec<QueryDiscriminants>,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -220,6 +228,7 @@ impl Property {
                 | Property::DeleteSelect { .. }
                 | Property::DropSelect { .. }
                 | Property::SavepointRollback { .. }
+                | Property::SavepointRollbackReopen { .. }
                 | Property::Queries { .. }
         )
     }
@@ -231,6 +240,7 @@ impl Property {
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
+            | Property::SavepointRollbackReopen { queries, .. }
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }

--- a/testing/simulator/runner/memory/statement_abandon.rs
+++ b/testing/simulator/runner/memory/statement_abandon.rs
@@ -88,6 +88,23 @@ fn query_rows(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<Vec<(i64, Stri
     }
 }
 
+fn query_integrity_check(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<String> {
+    let mut stmt = conn.prepare("PRAGMA integrity_check")?;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("integrity_check should return a row");
+                return Ok(row
+                    .get::<String>(0)
+                    .expect("integrity_check column should exist"));
+            }
+            StepResult::Done => panic!("integrity_check ended without a row"),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
 #[test]
 fn sim_abandon_during_dml_rolls_back() -> Result<()> {
     let (conn, io) = make_conn(1)?;
@@ -279,6 +296,42 @@ fn sim_reset_releases_subjournal_when_abort_called_without_error() -> Result<()>
         query_rows(&conn, io.as_ref())?,
         vec![(99, "ok".to_string())]
     );
+    Ok(())
+}
+
+#[test]
+fn sim_statement_rollback_under_cache_pressure_does_not_corrupt_db() -> Result<()> {
+    let (conn, io) = make_conn(8)?;
+    conn.execute("PRAGMA cache_size=10")?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, u INTEGER UNIQUE, v TEXT)")?;
+
+    conn.execute("BEGIN")?;
+    let payload = "a".repeat(2048);
+    for id in 1..=700 {
+        conn.execute(format!("INSERT INTO t VALUES ({id}, {id}, '{payload}')"))?;
+    }
+    conn.execute("COMMIT")?;
+
+    let update_payload = "x".repeat(3072);
+    let mut stmt = conn.prepare(format!(
+        "UPDATE t SET v = '{update_payload}', u = CASE WHEN id = 350 THEN 1 ELSE u END WHERE id <= 700"
+    ))?;
+    let err = loop {
+        match stmt.step() {
+            Ok(StepResult::IO) => io.step()?,
+            Ok(StepResult::Done) => panic!("update should fail with a UNIQUE constraint"),
+            Ok(other) => panic!("unexpected step result: {other:?}"),
+            Err(err) => break err,
+        }
+    };
+    assert!(
+        err.to_string().contains("UNIQUE constraint failed"),
+        "expected UNIQUE constraint, got {err}"
+    );
+    drop(stmt);
+
+    assert_eq!(query_count(&conn, io.as_ref())?, 700);
+    assert_eq!(query_integrity_check(&conn, io.as_ref())?, "ok");
     Ok(())
 }
 


### PR DESCRIPTION
## Description

Fix a statement savepoint rollback failure under page cache pressure.

The pager can now restore subjournal pages during statement rollback without spilling partially rolled-back state to WAL. The simulator also covers savepoint rollback followed by database reopen, and a focused regression test covers UNIQUE-abort rollback under a small page cache.

Validation run:

- `cargo fmt --check`
- `cargo test -q -p limbo_sim`
- `cargo test -q -p turso_core storage::pager`
- `./scripts/run-sim --seed 7151061446128656584 --maximum-tests 500 --min-tick 10 --max-tick 50 --profile savepoint_stress --disable-reopen-database --disable-bugbase --keep-files`
- `./scripts/run-sim --maximum-tests 1000 --min-tick 10 --max-tick 50 --profile savepoint_stress --disable-bugbase --keep-files`
- `PATH="/opt/homebrew/opt/sqlite/bin:/opt/homebrew/opt/tcl-tk/bin:$PATH" make test`

`cargo clippy --workspace --all-features --all-targets -- --deny=warnings` was also run. It failed on existing workspace warnings outside this PR's logic, including `core/io/unix.rs`, `core/vdbe/vacuum.rs`, `core/translate/...`, and an existing `core/vdbe/execute.rs:13025` warning. This PR only formats an import in `core/vdbe/execute.rs`.

## Motivation and context

A simulator seed reproduced a corruption path where a multi-row statement hit a UNIQUE constraint, abort tried to roll back the statement savepoint, and restoring subjournal pages failed because the page cache was full of dirty pages. That left abort cleanup incomplete and a later read could fail with a short read.

The fix keeps rollback state in memory by temporarily allowing the page cache to grow, then restores the configured capacity after rollback. It also shortens savepoint, subjournal, and dirty-page lock lifetimes so rollback cleanup can restore pages and recover WAL state safely.

## Description of AI Usage

Codex was used to investigate the simulator failure, inspect pager/subjournal rollback behavior, implement the fix and simulator coverage, run validation commands, and draft this PR description. The committer remains responsible for reviewing and validating the changes.
