### PR TITLE
core: invalidate deferred seek in op_seek_rowid

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4786,6 +4786,7 @@ pub fn op_seek_rowid(
     if !target_pc.is_offset() {
         crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
     }
+    invalidate_deferred_seeks_for_cursor(state, *cursor_id);
     let (pc, did_seek) = {
         let cursor = get_cursor!(state, *cursor_id);
 

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4956,3 +4956,24 @@ expect @js {
     -2929861166669336|-5586410532100113|X'0303'|-8516271698769449|11446132865438784
     ok
 }
+
+# UPDATE with an OR-decomposed WHERE that mixes a virtual gencol
+# predicate and a unique-column range predicate
+test update-or-virtual-deferred-seek-no-panic-implicit-index {
+    CREATE TABLE t (a TEXT UNIQUE, b INTEGER AS (395) VIRTUAL);
+    INSERT INTO t (a) VALUES ('u1'), ('u2');
+    UPDATE t SET a = 'q' WHERE (b = 395 AND a = 'u1') OR (a < 'z');
+}
+expect error {
+    UNIQUE constraint failed
+}
+
+test update-or-virtual-deferred-seek-no-panic-explicit-index {
+    CREATE TABLE t (a TEXT UNIQUE, b INTEGER AS (395) VIRTUAL);
+    CREATE INDEX t_idx ON t (a DESC, b DESC);
+    INSERT INTO t (a) VALUES ('u1'), ('u2');
+    UPDATE t SET a = 'q' WHERE (b = 395 AND a = 'u1') OR (a < 'z');
+}
+expect error {
+    UNIQUE constraint failed
+}


### PR DESCRIPTION
## Description

`OR` statements on constant-folded virtual column panicked with:

```
thread 'main' panicked at core/vdbe/execute.rs:4651:49:
index cursor should have a record
```

This is because we never cleared the `DeferredSeek` in `Seek`. Previously, this was mitigated by `Column` using the deferred seek, but when virtual columns are constant-folded, there is no `Column`. See an AI-generated explanation below.

## Why it only showed up with virtual gencols

Comparing bytecode for the same WHERE shape `((b=395 AND a='u1') OR (a<'z'))`:

Non-virtual b INTEGER (works, emits a clean UNIQUE error):

```
10  DeferredSeek 2 1
11  Column       1 1 6     <-- reads b from table cursor → MATERIALIZES the deferred seek here
12  Ne           r[6], r[7]
```

Virtual b AS (395) VIRTUAL (panics):

```
10  DeferredSeek 2 1
11  Affinity     6 1 D     <-- value is constant-folded; r[6] already holds 395
12  Ne           r[6], r[7] <-- never touches the table cursor
```

In the non-virtual case, op_column at line 11 takes the deferred seek and clears it (execute.rs:1705), so by the time the second sub-scan runs the index cursor to EOF, there's no stale deferred seek to honor. With a constant virtual gencol, there is no Column read in the residual at all — the predicate compares two registers — so the deferred seek emitted at line 10 stays armed, the second sub-scan exhausts the index cursor, and SeekRowid+RowId then dereferences the EOF index cursor.

Found while adding virtual columns to the simulator.

## Description of AI Usage

Claude Code, then I deleted some comments