### PR TITLE
bindings/javascript: Make Database.prepare() return a promise

### DIFF
--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -96,7 +96,7 @@ class Database {
    *
    * @param {string} sql - The SQL statement string to prepare.
    */
-  prepare(sql) {
+  prepare(sql: string): Promise<Statement> {
     // Only throw if we connected before but now the database is closed
     // Allow implicit connection if not connected yet
     if (this.connected && !this.open) {
@@ -108,9 +108,9 @@ class Database {
 
     try {
       if (this.connected) {
-        return new Statement(maybeValue(this.db.prepare(sql)), this.db, this.execLock, this.ioStep);
+        return new Statement(maybeValue(this.db.prepare(sql)), this.db, this.execLock, this.ioStep) as unknown as Promise<Statement>;
       } else {
-        return new Statement(maybePromise(() => this.connect().then(() => this.db.prepare(sql))), this.db, this.execLock, this.ioStep)
+        return new Statement(maybePromise(() => this.connect().then(() => this.db.prepare(sql))), this.db, this.execLock, this.ioStep) as unknown as Promise<Statement>;
       }
     } catch (err) {
       throw convertError(err);
@@ -164,7 +164,7 @@ class Database {
    * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
    */
   async run(sql, ...bindParameters) {
-    const stmt = this.prepare(sql);
+    const stmt = await this.prepare(sql);
     try {
       return await stmt.run(...bindParameters);
     } finally {
@@ -179,7 +179,7 @@ class Database {
    * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
    */
   async get(sql, ...bindParameters) {
-    const stmt = this.prepare(sql);
+    const stmt = await this.prepare(sql);
     try {
       return await stmt.get(...bindParameters);
     } finally {
@@ -194,7 +194,7 @@ class Database {
    * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
    */
   async all(sql, ...bindParameters) {
-    const stmt = this.prepare(sql);
+    const stmt = await this.prepare(sql);
     try {
       return await stmt.all(...bindParameters);
     } finally {
@@ -209,7 +209,7 @@ class Database {
    * @param {...any} bindParameters - Bind parameters, optionally followed by a query options object.
    */
   async *iterate(sql, ...bindParameters) {
-    const stmt = this.prepare(sql);
+    const stmt = await this.prepare(sql);
     try {
       yield* stmt.iterate(...bindParameters);
     } finally {
@@ -228,7 +228,7 @@ class Database {
 
     const pragma = `PRAGMA ${source}`;
 
-    const stmt = this.prepare(pragma);
+    const stmt = await this.prepare(pragma);
     try {
       const results = await stmt.all();
       return results;

--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -26,7 +26,7 @@ test('in-memory-db-async', async () => {
     const db = await connect(":memory:");
     await db.exec("CREATE TABLE t(x)");
     await db.exec("INSERT INTO t VALUES (1), (2), (3)");
-    const stmt = db.prepare("SELECT * FROM t WHERE x % 2 = ?");
+    const stmt = await db.prepare("SELECT * FROM t WHERE x % 2 = ?");
     const rows = await stmt.all([1]);
     expect(rows).toEqual([{ x: 1 }, { x: 3 }]);
 })
@@ -34,7 +34,7 @@ test('in-memory-db-async', async () => {
 test('exec multiple statements', async () => {
     const db = await connect(":memory:");
     await db.exec("CREATE TABLE t(x); INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)");
-    const stmt = db.prepare("SELECT * FROM t");
+    const stmt = await db.prepare("SELECT * FROM t");
     const rows = await stmt.all();
     expect(rows).toEqual([{ x: 1 }, { x: 2 }]);
 })
@@ -51,7 +51,7 @@ test('readonly-db', async () => {
         {
             const ro = await connect(path, { readonly: true });
             await expect(async () => await ro.exec("INSERT INTO t VALUES (2)")).rejects.toThrowError(/Resource is read-only/g);
-            expect(await ro.prepare("SELECT * FROM t").all()).toEqual([{ x: 1 }])
+            expect(await (await ro.prepare("SELECT * FROM t")).all()).toEqual([{ x: 1 }])
             ro.close();
         }
     } finally {
@@ -67,34 +67,34 @@ test('file-must-exist', async () => {
 
 test('implicit connect', async () => {
     const db = new Database(':memory:');
-    const defer = db.prepare("SELECT * FROM t");
+    const defer = await db.prepare("SELECT * FROM t");
     await expect(async () => await defer.all()).rejects.toThrowError(/no such table: t/);
-    expect(() => db.prepare("SELECT * FROM t")).toThrowError(/no such table: t/);
-    expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }]);
+    await expect(async () => await db.prepare("SELECT * FROM t")).rejects.toThrowError(/no such table: t/);
+    expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }]);
 })
 
 test('zero-limit-bug', async () => {
     const db = await connect(':memory:');
-    const create = db.prepare(`CREATE TABLE users (name TEXT NOT NULL);`);
+    const create = await db.prepare(`CREATE TABLE users (name TEXT NOT NULL);`);
     await create.run();
 
-    const insert = db.prepare(
+    const insert = await db.prepare(
         `insert into "users" values (?), (?), (?);`,
     );
     await insert.run('John', 'Jane', 'Jack');
 
-    const stmt1 = db.prepare(`select * from "users" limit ?;`);
+    const stmt1 = await db.prepare(`select * from "users" limit ?;`);
     expect(await stmt1.all(0)).toEqual([]);
     let rows = [{ name: 'John' }, { name: 'Jane' }, { name: 'Jack' }, { name: 'John' }, { name: 'Jane' }, { name: 'Jack' }];
     for (const limit of [0, 1, 2, 3, 4, 5, 6, 7]) {
-        const stmt2 = db.prepare(`select * from "users" union all select * from "users" limit ?;`);
+        const stmt2 = await db.prepare(`select * from "users" union all select * from "users" limit ?;`);
         expect(await stmt2.all(limit)).toEqual(rows.slice(0, Math.min(limit, 6)));
     }
 })
 
 test('avg-bug', async () => {
     const db = await connect(':memory:');
-    const create = db.prepare(`create table "aggregate_table" (
+    const create = await db.prepare(`create table "aggregate_table" (
         "id" integer primary key autoincrement not null,
         "name" text not null,
         "a" integer,
@@ -104,7 +104,7 @@ test('avg-bug', async () => {
     );`);
 
     await create.run();
-    const insert = db.prepare(
+    const insert = await db.prepare(
         `insert into "aggregate_table" ("id", "name", "a", "b", "c", "null_only") values (null, ?, ?, ?, ?, null), (null, ?, ?, ?, ?, null), (null, ?, ?, ?, ?, null), (null, ?, ?, ?, ?, null), (null, ?, ?, ?, ?, null), (null, ?, ?, ?, ?, null), (null, ?, ?, ?, ?, null);`,
     );
 
@@ -118,19 +118,19 @@ test('avg-bug', async () => {
         'value 6', null, null, 150,
     );
 
-    expect(await db.prepare(`select avg("a") from "aggregate_table";`).get()).toEqual({ 'avg("a")': 24 });
-    expect(await db.prepare(`select avg("null_only") from "aggregate_table";`).get()).toEqual({ 'avg("null_only")': null });
-    expect(await db.prepare(`select avg(distinct "b") from "aggregate_table";`).get()).toEqual({ 'avg(distinct "b")': 42.5 });
+    expect(await (await db.prepare(`select avg("a") from "aggregate_table";`)).get()).toEqual({ 'avg("a")': 24 });
+    expect(await (await db.prepare(`select avg("null_only") from "aggregate_table";`)).get()).toEqual({ 'avg("null_only")': null });
+    expect(await (await db.prepare(`select avg(distinct "b") from "aggregate_table";`)).get()).toEqual({ 'avg(distinct "b")': 42.5 });
 })
 
 test('insert returning test', async () => {
     const db = await connect(':memory:');
-    await db.prepare(`create table t (x);`).run();
-    const x1 = await db.prepare(`insert into t values (1), (2) returning x`).get();
-    const x2 = await db.prepare(`insert into t values (3), (4) returning x`).get();
+    await (await db.prepare(`create table t (x);`)).run();
+    const x1 = await (await db.prepare(`insert into t values (1), (2) returning x`)).get();
+    const x2 = await (await db.prepare(`insert into t values (3), (4) returning x`)).get();
     expect(x1).toEqual({ x: 1 });
     expect(x2).toEqual({ x: 3 });
-    const all = await db.prepare(`select * from t`).all();
+    const all = await (await db.prepare(`select * from t`)).all();
     expect(all).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }])
 })
 
@@ -141,17 +141,17 @@ test('offset-bug', async () => {
         name TEXT NOT NULL,
         verified integer not null default 0
     );`);
-    const insert = db.prepare(`INSERT INTO users (name) VALUES (?),(?);`);
+    const insert = await db.prepare(`INSERT INTO users (name) VALUES (?),(?);`);
     await insert.run('John', 'John1');
 
-    const stmt = db.prepare(`SELECT * FROM users LIMIT ? OFFSET ?;`);
+    const stmt = await db.prepare(`SELECT * FROM users LIMIT ? OFFSET ?;`);
     expect(await stmt.all(1, 1)).toEqual([{ id: 2, name: 'John1', verified: 0 }])
 })
 
 test('conflict-bug', async () => {
     const db = await connect(':memory:');
 
-    const create = db.prepare(`create table "conflict_chain_example" (
+    const create = await db.prepare(`create table "conflict_chain_example" (
         id integer not null unique,
         name text not null,
         email text not null,
@@ -159,7 +159,7 @@ test('conflict-bug', async () => {
     )`);
     await create.run();
 
-    await db.prepare(`insert into "conflict_chain_example" ("id", "name", "email") values (?, ?, ?), (?, ?, ?)`).run(
+    await (await db.prepare(`insert into "conflict_chain_example" ("id", "name", "email") values (?, ?, ?), (?, ?, ?)`)).run(
         1,
         'John',
         'john@example.com',
@@ -168,12 +168,12 @@ test('conflict-bug', async () => {
         '2john@example.com',
     );
 
-    const insert = db.prepare(
+    const insert = await db.prepare(
         `insert into "conflict_chain_example" ("id", "name", "email") values (?, ?, ?), (?, ?, ?) on conflict ("conflict_chain_example"."id", "conflict_chain_example"."name") do update set "email" = ? on conflict ("conflict_chain_example"."id") do nothing`,
     );
     await insert.run(1, 'John', 'john@example.com', 2, 'Anthony', 'idthief@example.com', 'john1@example.com');
 
-    expect(await db.prepare("SELECT * FROM conflict_chain_example").all()).toEqual([
+    expect(await (await db.prepare("SELECT * FROM conflict_chain_example")).all()).toEqual([
         { id: 1, name: 'John', email: 'john1@example.com' },
         { id: 2, name: 'John Second', email: '2john@example.com' }
     ]);
@@ -185,14 +185,14 @@ test('on-disk db', async () => {
         const db1 = await connect(path);
         await db1.exec("CREATE TABLE t(x)");
         await db1.exec("INSERT INTO t VALUES (1), (2), (3)");
-        const stmt1 = db1.prepare("SELECT * FROM t WHERE x % 2 = ?");
+        const stmt1 = await db1.prepare("SELECT * FROM t WHERE x % 2 = ?");
         expect(stmt1.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
         const rows1 = await stmt1.all([1]);
         expect(rows1).toEqual([{ x: 1 }, { x: 3 }]);
         db1.close();
 
         const db2 = await connect(path);
-        const stmt2 = db2.prepare("SELECT * FROM t WHERE x % 2 = ?");
+        const stmt2 = await db2.prepare("SELECT * FROM t WHERE x % 2 = ?");
         expect(stmt2.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
         const rows2 = await stmt2.all([1]);
         expect(rows2).toEqual([{ x: 1 }, { x: 3 }]);
@@ -216,7 +216,7 @@ test('attach', async () => {
 
         await db1.exec(`ATTACH '${path2}' as secondary`);
 
-        const stmt = db1.prepare("SELECT * FROM t UNION ALL SELECT * FROM secondary.q");
+        const stmt = await db1.prepare("SELECT * FROM t UNION ALL SELECT * FROM secondary.q");
         expect(stmt.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
         const rows = await stmt.all([1]);
         expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }, { x: 5 }, { x: 6 }]);
@@ -239,9 +239,9 @@ test('fts', async () => {
     `);
 
     // fts_match search
-    const matchResults = await db.prepare(
+    const matchResults = await (await db.prepare(
         "SELECT id, title, fts_score(title, body, 'programming language') as score FROM documents WHERE fts_match(title, body, 'programming language')"
-    ).all();
+    )).all();
     expect(matchResults.length).toBe(2);
     expect(matchResults.map(r => r.id).sort()).toEqual([1, 2]);
     for (const row of matchResults) {
@@ -249,24 +249,24 @@ test('fts', async () => {
     }
 
     // fts_highlight
-    const highlightResults = await db.prepare(
+    const highlightResults = await (await db.prepare(
         "SELECT id, fts_highlight(title, '<b>', '</b>', 'Rust') as highlighted FROM documents WHERE fts_match(title, body, 'Rust')"
-    ).all();
+    )).all();
     expect(highlightResults.length).toBe(1);
     expect(highlightResults[0].id).toBe(1);
     expect(highlightResults[0].highlighted).toContain('<b>');
     expect(highlightResults[0].highlighted).toContain('Rust');
 
     // no match
-    const noResults = await db.prepare(
+    const noResults = await (await db.prepare(
         "SELECT * FROM documents WHERE fts_match(title, body, 'nonexistentterm')"
-    ).all();
+    )).all();
     expect(noResults.length).toBe(0);
 })
 
 test('blobs', async () => {
     const db = await connect(":memory:");
-    const rows = await db.prepare("SELECT x'1020' as x").all();
+    const rows = await (await db.prepare("SELECT x'1020' as x")).all();
     expect(rows).toEqual([{ x: Buffer.from([16, 32]) }])
 })
 
@@ -287,7 +287,7 @@ test('encryption', async () => {
         const db2 = await connect(path, {
             encryption: { cipher: 'aegis256', hexkey }
         });
-        const rows = await db2.prepare("SELECT COUNT(*) as cnt FROM t").all();
+        const rows = await (await db2.prepare("SELECT COUNT(*) as cnt FROM t")).all();
         expect(rows).toEqual([{ cnt: 1024 }]);
         db2.close();
 
@@ -296,13 +296,13 @@ test('encryption', async () => {
             const db3 = await connect(path, {
                 encryption: { cipher: 'aegis256', hexkey: wrongKey }
             });
-            await db3.prepare("SELECT * FROM t").all();
+            await (await db3.prepare("SELECT * FROM t")).all();
         }).rejects.toThrow();
 
         // Opening without encryption MUST fail
         await expect(async () => {
             const db4 = await connect(path);
-            await db4.prepare("SELECT * FROM t").all();
+            await (await db4.prepare("SELECT * FROM t")).all();
         }).rejects.toThrow();
     } finally {
         unlinkSync(path);
@@ -314,11 +314,11 @@ test('example-1', async () => {
     const db = await connect(':memory:');
     await db.exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
 
-    const insert = db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
+    const insert = await db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
     await insert.run('Alice', 'alice@example.com');
     await insert.run('Bob', 'bob@example.com');
 
-    const users = await db.prepare('SELECT * FROM users').all();
+    const users = await (await db.prepare('SELECT * FROM users')).all();
     expect(users).toEqual([
         { id: 1, name: 'Alice', email: 'alice@example.com' },
         { id: 2, name: 'Bob', email: 'bob@example.com' }
@@ -330,7 +330,7 @@ test('example-2', async () => {
     await db.exec('CREATE TABLE users (name, email)');
     // Using transactions for atomic operations
     const transaction = db.transaction(async (users) => {
-        const insert = db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
+        const insert = await db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
         for (const user of users) {
             await insert.run(user.name, user.email);
         }
@@ -342,7 +342,7 @@ test('example-2', async () => {
         { name: 'Bob', email: 'bob@example.com' }
     ]);
 
-    const rows = await db.prepare('SELECT * FROM users').all();
+    const rows = await (await db.prepare('SELECT * FROM users')).all();
     expect(rows).toEqual([
         { name: 'Alice', email: 'alice@example.com' },
         { name: 'Bob', email: 'bob@example.com' }

--- a/bindings/javascript/packages/wasm/promise.test.ts
+++ b/bindings/javascript/packages/wasm/promise.test.ts
@@ -22,7 +22,7 @@ test('big schema test', async () => {
         const db = await connect("local.db");
         for (let i = 0; i < N; i++) {
             console.info(`i = ${i}`);
-            const stmt = db.prepare(`CREATE TABLE t_${i} (x)`)
+            const stmt = await db.prepare(`CREATE TABLE t_${i} (x)`)
             await stmt.all();
             await stmt.close();
         }
@@ -31,7 +31,7 @@ test('big schema test', async () => {
     {
         console.info('open db again');
         const db = await connect("local.db");
-        const rows = await db.prepare("SELECT * FROM sqlite_master").all();
+        const rows = await (await db.prepare("SELECT * FROM sqlite_master")).all();
         expect(rows).toHaveLength(N);
     }
 })
@@ -40,19 +40,19 @@ test('vector-test', async () => {
     const db = await connect(":memory:");
     const v1 = new Array(1024).fill(0).map((_, i) => i);
     const v2 = new Array(1024).fill(0).map((_, i) => 1024 - i);
-    const result = await db.prepare(`SELECT
+    const result = await (await db.prepare(`SELECT
         vector_distance_cos(vector32('${JSON.stringify(v1)}'), vector32('${JSON.stringify(v2)}')) as cosf32,
         vector_distance_cos(vector64('${JSON.stringify(v1)}'), vector64('${JSON.stringify(v2)}')) as cosf64,
         vector_distance_l2(vector32('${JSON.stringify(v1)}'), vector32('${JSON.stringify(v2)}')) as l2f32,
         vector_distance_l2(vector64('${JSON.stringify(v1)}'), vector64('${JSON.stringify(v2)}')) as l2f64
-    `).all();
+    `)).all();
     console.info(result);
     await db.close();
 })
 
 test('explain', async () => {
     const db = await connect(":memory:");
-    const stmt = db.prepare("EXPLAIN SELECT 1");
+    const stmt = await db.prepare("EXPLAIN SELECT 1");
     expect(stmt.columns()).toEqual([
         {
             "name": "addr",
@@ -146,7 +146,7 @@ test('in-memory db', async () => {
     const db = await connect(":memory:");
     await db.exec("CREATE TABLE t(x)");
     await db.exec("INSERT INTO t VALUES (1), (2), (3)");
-    const stmt = db.prepare("SELECT * FROM t WHERE x % 2 = ?");
+    const stmt = await db.prepare("SELECT * FROM t WHERE x % 2 = ?");
     const rows = await stmt.all([1]);
     expect(rows).toEqual([{ x: 1 }, { x: 3 }]);
     await db.close();
@@ -155,21 +155,21 @@ test('in-memory db', async () => {
 
 test('implicit connect', async () => {
     const db = new Database(':memory:');
-    const defer = db.prepare("SELECT * FROM t");
+    const defer = await db.prepare("SELECT * FROM t");
     await expect(async () => await defer.all()).rejects.toThrowError(/no such table: t/);
-    expect(() => db.prepare("SELECT * FROM t")).toThrowError(/no such table: t/);
-    expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }]);
+    await expect(async () => await db.prepare("SELECT * FROM t")).rejects.toThrowError(/no such table: t/);
+    expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }]);
     await db.close();
 })
 
 test('on-disk db large inserts', async () => {
     const path = `test-${(Math.random() * 10000) | 0}.db`;
     const db1 = await connect(path);
-    await db1.prepare("CREATE TABLE t(x)").run();
-    await db1.prepare("INSERT INTO t VALUES (randomblob(10 * 4096 + 0))").run();
-    await db1.prepare("INSERT INTO t VALUES (randomblob(10 * 4096 + 1))").run();
-    await db1.prepare("INSERT INTO t VALUES (randomblob(10 * 4096 + 2))").run();
-    const stmt1 = db1.prepare("SELECT length(x) as l FROM t");
+    await (await db1.prepare("CREATE TABLE t(x)")).run();
+    await (await db1.prepare("INSERT INTO t VALUES (randomblob(10 * 4096 + 0))")).run();
+    await (await db1.prepare("INSERT INTO t VALUES (randomblob(10 * 4096 + 1))")).run();
+    await (await db1.prepare("INSERT INTO t VALUES (randomblob(10 * 4096 + 2))")).run();
+    const stmt1 = await db1.prepare("SELECT length(x) as l FROM t");
     expect(stmt1.columns()).toEqual([{ name: "l", column: null, database: null, table: null, type: null }]);
     const rows1 = await stmt1.all();
     expect(rows1).toEqual([{ l: 10 * 4096 }, { l: 10 * 4096 + 1 }, { l: 10 * 4096 + 2 }]);
@@ -178,10 +178,10 @@ test('on-disk db large inserts', async () => {
     await db1.exec("INSERT INTO t VALUES (1)");
     await db1.exec("ROLLBACK");
 
-    const rows2 = await db1.prepare("SELECT length(x) as l FROM t").all();
+    const rows2 = await (await db1.prepare("SELECT length(x) as l FROM t")).all();
     expect(rows2).toEqual([{ l: 10 * 4096 }, { l: 10 * 4096 + 1 }, { l: 10 * 4096 + 2 }]);
 
-    await db1.prepare("PRAGMA wal_checkpoint(TRUNCATE)").run();
+    await (await db1.prepare("PRAGMA wal_checkpoint(TRUNCATE)")).run();
     await db1.close();
 })
 
@@ -190,7 +190,7 @@ test('on-disk db', async () => {
     const db1 = await connect(path);
     await db1.exec("CREATE TABLE t(x)");
     await db1.exec("INSERT INTO t VALUES (1), (2), (3)");
-    const stmt1 = db1.prepare("SELECT * FROM t WHERE x % 2 = ?");
+    const stmt1 = await db1.prepare("SELECT * FROM t WHERE x % 2 = ?");
     expect(stmt1.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
     const rows1 = await stmt1.all([1]);
     expect(rows1).toEqual([{ x: 1 }, { x: 3 }]);
@@ -198,7 +198,7 @@ test('on-disk db', async () => {
     await db1.close();
 
     const db2 = await connect(path);
-    const stmt2 = db2.prepare("SELECT * FROM t WHERE x % 2 = ?");
+    const stmt2 = await db2.prepare("SELECT * FROM t WHERE x % 2 = ?");
     expect(stmt2.columns()).toEqual([{ name: "x", column: null, database: null, table: null, type: null }]);
     const rows2 = await stmt2.all([1]);
     expect(rows2).toEqual([{ x: 1 }, { x: 3 }]);
@@ -226,14 +226,14 @@ test('on-disk db', async () => {
 
 test('blobs', async () => {
     const db = await connect(":memory:");
-    const rows = await db.prepare("SELECT x'1020' as x").all();
+    const rows = await (await db.prepare("SELECT x'1020' as x")).all();
     expect(rows).toEqual([{ x: new Uint8Array([16, 32]) }])
     await db.close();
 })
 
 test("datetime('now')", async () => {
     const db = await connect(":memory:");
-    const rows = await db.prepare("SELECT datetime('now') as now").all();
+    const rows = await (await db.prepare("SELECT datetime('now') as now")).all();
     expect(rows).toHaveLength(1);
     expect(rows[0].now).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
     await db.close();
@@ -243,11 +243,11 @@ test('example-1', async () => {
     const db = await connect(':memory:');
     await db.exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)');
 
-    const insert = db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
+    const insert = await db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
     await insert.run('Alice', 'alice@example.com');
     await insert.run('Bob', 'bob@example.com');
 
-    const users = await db.prepare('SELECT * FROM users').all();
+    const users = await (await db.prepare('SELECT * FROM users')).all();
     expect(users).toEqual([
         { id: 1, name: 'Alice', email: 'alice@example.com' },
         { id: 2, name: 'Bob', email: 'bob@example.com' }
@@ -260,7 +260,7 @@ test('example-2', async () => {
     await db.exec('CREATE TABLE users (name, email)');
     // Using transactions for atomic operations
     const transaction = db.transaction(async (users) => {
-        const insert = db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
+        const insert = await db.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
         for (const user of users) {
             await insert.run(user.name, user.email);
         }
@@ -272,7 +272,7 @@ test('example-2', async () => {
         { name: 'Bob', email: 'bob@example.com' }
     ]);
 
-    const rows = await db.prepare('SELECT * FROM users').all();
+    const rows = await (await db.prepare('SELECT * FROM users')).all();
     expect(rows).toEqual([
         { name: 'Alice', email: 'alice@example.com' },
         { name: 'Bob', email: 'bob@example.com' }
@@ -287,7 +287,7 @@ test('sorter-wasm', async () => {
         await db.exec(`INSERT INTO t VALUES (${i}, randomblob(10 * 1024))`);
     }
 
-    expect(await db.prepare("SELECT length(v) as l FROM (SELECT v FROM t ORDER BY k)").all()).toEqual(new Array(1024).fill({ l: 10 * 1024 }));
+    expect(await (await db.prepare("SELECT length(v) as l FROM (SELECT v FROM t ORDER BY k)")).all()).toEqual(new Array(1024).fill({ l: 10 * 1024 }));
     await db.close();
 })
 
@@ -302,6 +302,6 @@ test('hash-join-wasm', { timeout: 60_000 }, async () => {
         await db.exec(`INSERT INTO b VALUES (${i}, randomblob(100 * 1024))`);
     }
 
-    expect(await db.prepare("SELECT length(a) as a, length(b) as b FROM (SELECT a.v as a, b.v as b FROM a INNER JOIN b ON a.k = b.k)").all()).toEqual(new Array(1024).fill({ a: 100 * 1024, b: 100 * 1024 }));
+    expect(await (await db.prepare("SELECT length(a) as a, length(b) as b FROM (SELECT a.v as a, b.v as b FROM a INNER JOIN b ON a.k = b.k)")).all()).toEqual(new Array(1024).fill({ a: 100 * 1024, b: 100 * 1024 }));
     await db.close();
 })

--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -49,7 +49,7 @@ test.skipIf(process.env.LOCAL_SYNC_SERVER)('partial sync concurrency', async ({ 
     }
     const qs = [];
     for (const db of dbs) {
-        qs.push(db.prepare("SELECT COUNT(*) as cnt FROM partial").all());
+        qs.push((await db.prepare("SELECT COUNT(*) as cnt FROM partial")).all());
     }
     const values = await Promise.all(qs);
     expect(values).toEqual(new Array(16).fill([{ cnt: 2000 }]))
@@ -86,12 +86,12 @@ test.skipIf(process.env.LOCAL_SYNC_SERVER)('partial sync (prefix bootstrap strat
     expect((await db.stats()).networkReceivedBytes).toBeLessThanOrEqual(128 * (1024 + 128));
 
     // select of one record shouldn't increase amount of received data
-    expect(await db.prepare("SELECT length(value) as length FROM partial LIMIT 1").all()).toEqual([{ length: 1024 }]);
+    expect(await (await db.prepare("SELECT length(value) as length FROM partial LIMIT 1")).all()).toEqual([{ length: 1024 }]);
     expect((await db.stats()).networkReceivedBytes).toBeLessThanOrEqual(128 * (1024 + 128));
 
-    await db.prepare("INSERT INTO partial VALUES (-1)").run();
+    await (await db.prepare("INSERT INTO partial VALUES (-1)")).run();
 
-    expect(await db.prepare("SELECT COUNT(*) as cnt FROM partial").all()).toEqual([{ cnt: 2001 }]);
+    expect(await (await db.prepare("SELECT COUNT(*) as cnt FROM partial")).all()).toEqual([{ cnt: 2001 }]);
     expect((await db.stats()).networkReceivedBytes).toBeGreaterThanOrEqual(2000 * 1024);
 }, { timeout: 300_000 })
 
@@ -124,15 +124,15 @@ test.skipIf(process.env.LOCAL_SYNC_SERVER)('partial sync (prefix bootstrap strat
 
     const startLast = performance.now();
     // select of one record shouldn't increase amount of received data
-    expect(await db.prepare("SELECT length(value) as length FROM partial LIMIT 1").all()).toEqual([{ length: 1024 }]);
+    expect(await (await db.prepare("SELECT length(value) as length FROM partial LIMIT 1")).all()).toEqual([{ length: 1024 }]);
     console.info('select last', 'elapsed', performance.now() - startLast);
 
     expect((await db.stats()).networkReceivedBytes).toBeLessThanOrEqual(2 * 128 * (1024 + 128));
 
-    await db.prepare("INSERT INTO partial VALUES (-1)").run();
+    await (await db.prepare("INSERT INTO partial VALUES (-1)")).run();
 
     const startAll = performance.now();
-    expect(await db.prepare("SELECT COUNT(*) as cnt FROM partial").all()).toEqual([{ cnt: 2001 }]);
+    expect(await (await db.prepare("SELECT COUNT(*) as cnt FROM partial")).all()).toEqual([{ cnt: 2001 }]);
     console.info('select all', 'elapsed', performance.now() - startAll);
 
     expect((await db.stats()).networkReceivedBytes).toBeGreaterThanOrEqual(2000 * 1024);
@@ -168,15 +168,15 @@ test.skipIf(process.env.LOCAL_SYNC_SERVER)('partial sync (prefix bootstrap strat
 
     const startLast = performance.now();
     // select of one record shouldn't increase amount of received data
-    expect(await db.prepare("SELECT length(value) as length FROM partial LIMIT 1").all()).toEqual([{ length: 1024 }]);
+    expect(await (await db.prepare("SELECT length(value) as length FROM partial LIMIT 1")).all()).toEqual([{ length: 1024 }]);
     console.info('select last', 'elapsed', performance.now() - startLast);
 
     expect((await db.stats()).networkReceivedBytes).toBeLessThanOrEqual(10 * 128 * (1024 + 128));
 
-    await db.prepare("INSERT INTO partial VALUES (-1)").run();
+    await (await db.prepare("INSERT INTO partial VALUES (-1)")).run();
 
     const startAll = performance.now();
-    expect(await db.prepare("SELECT COUNT(*) as cnt FROM partial").all()).toEqual([{ cnt: 2001 }]);
+    expect(await (await db.prepare("SELECT COUNT(*) as cnt FROM partial")).all()).toEqual([{ cnt: 2001 }]);
     console.info('select all', 'elapsed', performance.now() - startAll);
 
     expect((await db.stats()).networkReceivedBytes).toBeGreaterThanOrEqual(2000 * 1024);
@@ -210,14 +210,14 @@ test.skipIf(process.env.LOCAL_SYNC_SERVER)('partial sync (query bootstrap strate
     expect((await db.stats()).networkReceivedBytes).toBeLessThanOrEqual(10 * (4096 + 128));
 
     // select of one record shouldn't increase amount of received data by a lot
-    expect(await db.prepare("SELECT length(value) as length FROM partial_keyed LIMIT 1").all()).toEqual([{ length: 1024 }]);
+    expect(await (await db.prepare("SELECT length(value) as length FROM partial_keyed LIMIT 1")).all()).toEqual([{ length: 1024 }]);
     expect((await db.stats()).networkReceivedBytes).toBeLessThanOrEqual(10 * (4096 + 128));
 
-    await db.prepare("INSERT INTO partial_keyed VALUES (-1, -1)").run();
+    await (await db.prepare("INSERT INTO partial_keyed VALUES (-1, -1)")).run();
     const n1 = await db.stats();
 
     // same as bootstrap query - we shouldn't bring any more pages
-    expect(await db.prepare("SELECT length(value) as length FROM partial_keyed WHERE key = 1000").all()).toEqual([{ length: 1024 }]);
+    expect(await (await db.prepare("SELECT length(value) as length FROM partial_keyed WHERE key = 1000")).all()).toEqual([{ length: 1024 }]);
     const n2 = await db.stats();
     expect(n1.networkReceivedBytes).toEqual(n2.networkReceivedBytes);
 })
@@ -236,7 +236,7 @@ test('concurrent-actions-consistency', async ({ server }) => {
         await db.close();
     }
     const db1 = await connect({ path: ':memory:', url: server.dbUrl() });
-    console.info('run_info', await db1.prepare("SELECT * FROM sqlite_master").all());
+    console.info('run_info', await (await db1.prepare("SELECT * FROM sqlite_master")).all());
     await db1.exec("PRAGMA busy_timeout=100");
     const pull = async function (iterations: number) {
         for (let i = 0; i < iterations; i++) {
@@ -263,9 +263,9 @@ test('concurrent-actions-consistency', async ({ server }) => {
     const run = async function (iterations: number) {
         let rows = 0;
         for (let i = 0; i < iterations; i++) {
-            await db1.prepare("UPDATE rows SET value = value + 1 WHERE key = ?").run('key');
+            await (await db1.prepare("UPDATE rows SET value = value + 1 WHERE key = ?")).run('key');
             rows += 1;
-            const { cnt } = await db1.prepare("SELECT value as cnt FROM rows WHERE key = ?").get(['key']);
+            const { cnt } = await (await db1.prepare("SELECT value as cnt FROM rows WHERE key = ?")).get(['key']);
             expect(cnt).toBe(rows);
             await new Promise(resolve => setTimeout(resolve, 10 * (Math.random() + 1)));
         }
@@ -275,19 +275,19 @@ test('concurrent-actions-consistency', async ({ server }) => {
 
 test('simple-db', async () => {
     const db = new Database({ path: ':memory:' });
-    expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }])
+    expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }])
     await db.exec("CREATE TABLE t(x)");
     await db.exec("INSERT INTO t VALUES (1), (2), (3)");
-    expect(await db.prepare("SELECT * FROM t").all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
+    expect(await (await db.prepare("SELECT * FROM t")).all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
     await expect(async () => await db.pull()).rejects.toThrowError(/sync is disabled as database was opened without sync support/);
 })
 
 test('implicit connect', async ({ server }) => {
     const db = new Database({ path: ':memory:', url: server.dbUrl() });
-    const defer = db.prepare("SELECT * FROM not_found");
+    const defer = await db.prepare("SELECT * FROM not_found");
     await expect(async () => await defer.all()).rejects.toThrowError(/no such table: not_found/);
-    expect(() => db.prepare("SELECT * FROM not_found")).toThrowError(/no such table: not_found/);
-    expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }]);
+    await expect(async () => await db.prepare("SELECT * FROM not_found")).rejects.toThrowError(/no such table: not_found/);
+    expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }]);
 })
 
 test('defered sync', async ({ server }) => {
@@ -302,13 +302,13 @@ test('defered sync', async ({ server }) => {
 
     let url: string | null = null;
     const db = new Database({ path: ':memory:', url: () => url });
-    await db.prepare("CREATE TABLE t(x)").run();
-    await db.prepare("INSERT INTO t VALUES (1), (2), (3), (42)").run();
-    expect(await db.prepare("SELECT * FROM t").all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
+    await (await db.prepare("CREATE TABLE t(x)")).run();
+    await (await db.prepare("INSERT INTO t VALUES (1), (2), (3), (42)")).run();
+    expect(await (await db.prepare("SELECT * FROM t")).all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
     await expect(async () => await db.pull()).rejects.toThrow(/url is empty - sync is paused/);
     url = server.dbUrl();
     await db.pull();
-    expect(await db.prepare("SELECT * FROM t").all()).toEqual([{ x: 100 }, { x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
+    expect(await (await db.prepare("SELECT * FROM t")).all()).toEqual([{ x: 100 }, { x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
 })
 
 // TODO: re-enable encryption tests once local sync server supports the encrypted-tenant URL pattern.
@@ -374,7 +374,7 @@ test('select-after-push', async ({ server }) => {
     }
     {
         const db = await connect({ path: ':memory:', url: server.dbUrl() });
-        const rows = await db.prepare('SELECT * FROM t').all();
+        const rows = await (await db.prepare('SELECT * FROM t')).all();
         expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
     }
 })
@@ -393,7 +393,7 @@ test('select-without-push', async ({ server }) => {
     }
     {
         const db = await connect({ path: ':memory:', url: server.dbUrl() });
-        const rows = await db.prepare('SELECT * FROM t').all();
+        const rows = await (await db.prepare('SELECT * FROM t')).all();
         expect(rows).toEqual([])
     }
 })
@@ -415,8 +415,8 @@ test('merge-non-overlapping-keys', async ({ server }) => {
     await Promise.all([db1.push(), db2.push()]);
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM q').all();
-    const rows2 = await db1.prepare('SELECT * FROM q').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+    const rows2 = await (await db1.prepare('SELECT * FROM q')).all();
     const expected = [{ x: 'k1', y: 'value1' }, { x: 'k2', y: 'value2' }, { x: 'k3', y: 'value3' }, { x: 'k4', y: 'value4' }, { x: 'k5', y: 'value5' }];
     expect(rows1.sort(localeCompare)).toEqual(expected.sort(localeCompare))
     expect(rows2.sort(localeCompare)).toEqual(expected.sort(localeCompare))
@@ -440,8 +440,8 @@ test('last-push-wins', async ({ server }) => {
     await db1.push();
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM q').all();
-    const rows2 = await db1.prepare('SELECT * FROM q').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+    const rows2 = await (await db1.prepare('SELECT * FROM q')).all();
     const expected = [{ x: 'k1', y: 'value1' }, { x: 'k2', y: 'value2' }, { x: 'k3', y: 'value5' }, { x: 'k4', y: 'value4' }];
     expect(rows1.sort(localeCompare)).toEqual(expected.sort(localeCompare))
     expect(rows2.sort(localeCompare)).toEqual(expected.sort(localeCompare))
@@ -466,8 +466,8 @@ test('last-push-wins-with-delete', async ({ server }) => {
     await db1.push();
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM q').all();
-    const rows2 = await db1.prepare('SELECT * FROM q').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+    const rows2 = await (await db1.prepare('SELECT * FROM q')).all();
     const expected = [{ x: 'k3', y: 'value5' }];
     expect(rows1).toEqual(expected)
     expect(rows2).toEqual(expected)
@@ -538,7 +538,7 @@ test('persistence-push', async ({ server }) => {
             const db2 = await connect({ path: path, url: server.dbUrl() });
             await db2.exec(`INSERT INTO q VALUES ('k3', 'v3')`);
             await db2.exec(`INSERT INTO q VALUES ('k4', 'v4')`);
-            const stmt = db2.prepare('SELECT * FROM q');
+            const stmt = await db2.prepare('SELECT * FROM q');
             const rows = await stmt.all();
             const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }, { x: 'k3', y: 'v3' }, { x: 'k4', y: 'v4' }];
             expect(rows).toEqual(expected)
@@ -554,7 +554,7 @@ test('persistence-push', async ({ server }) => {
 
         {
             const db4 = await connect({ path: path, url: server.dbUrl() });
-            const rows = await db4.prepare('SELECT * FROM q').all();
+            const rows = await (await db4.prepare('SELECT * FROM q')).all();
             const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }, { x: 'k3', y: 'v3' }, { x: 'k4', y: 'v4' }];
             expect(rows).toEqual(expected)
             await db4.close();
@@ -584,7 +584,7 @@ test('persistence-offline', async ({ server }) => {
         }
         {
             const db = await connect({ path: path, url: "https://not-valid-url.localhost" });
-            const rows = await db.prepare("SELECT * FROM q").all();
+            const rows = await (await db.prepare("SELECT * FROM q")).all();
             const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }];
             expect(rows.sort(localeCompare)).toEqual(expected.sort(localeCompare))
             await db.close();
@@ -620,8 +620,8 @@ test('persistence-pull-push', async ({ server }) => {
         console.info(stats1, stats2);
         expect(stats1.revision).not.toBe(stats2.revision);
 
-        const rows1 = await db1.prepare('SELECT * FROM q').all();
-        const rows2 = await db2.prepare('SELECT * FROM q').all();
+        const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+        const rows2 = await (await db2.prepare('SELECT * FROM q')).all();
         const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }, { x: 'k3', y: 'v3' }, { x: 'k4', y: 'v4' }];
         expect(rows1.sort(localeCompare)).toEqual(expected.sort(localeCompare))
         expect(rows2.sort(localeCompare)).toEqual(expected.sort(localeCompare))
@@ -816,9 +816,9 @@ test('checkpoint-and-actions', async ({ server }) => {
     let rows = 0;
     const run = async function (iterations: number) {
         for (let i = 0; i < iterations; i++) {
-            await db1.prepare("UPDATE rows SET value = value + 1 WHERE key = ?").run('key');
+            await (await db1.prepare("UPDATE rows SET value = value + 1 WHERE key = ?")).run('key');
             rows += 1;
-            const { cnt } = await db1.prepare("SELECT value as cnt FROM rows WHERE key = ?").get(['key']);
+            const { cnt } = await (await db1.prepare("SELECT value as cnt FROM rows WHERE key = ?")).get(['key']);
             console.info('CHECK', cnt, rows);
             expect(cnt).toBe(rows);
             await new Promise(resolve => setTimeout(resolve, 10 * (1 + Math.random())));
@@ -855,8 +855,8 @@ test('transform', async ({ server }) => {
     await Promise.all([db1.push(), db2.push()]);
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM counter').all();
-    const rows2 = await db2.prepare('SELECT * FROM counter').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM counter')).all();
+    const rows2 = await (await db2.prepare('SELECT * FROM counter')).all();
     expect(rows1).toEqual([{ key: '1', value: 2 }]);
     expect(rows2).toEqual([{ key: '1', value: 2 }]);
 })
@@ -898,8 +898,8 @@ test('transform-many', async ({ server }) => {
     await Promise.all([db1.pull(), db2.pull()]);
     console.info('pull', performance.now() - start);
 
-    const rows1 = await db1.prepare('SELECT * FROM counter').all();
-    const rows2 = await db2.prepare('SELECT * FROM counter').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM counter')).all();
+    const rows2 = await (await db2.prepare('SELECT * FROM counter')).all();
     expect(rows1).toEqual([{ key: '1', value: 1001 + 1002 }]);
     expect(rows2).toEqual([{ key: '1', value: 1001 + 1002 }]);
 })
@@ -942,9 +942,9 @@ test('push operations threshold splits batches', async ({ server }) => {
     // Fresh client bootstraps from the remote — every row pushed in batches
     // must be visible.
     const db2 = await connect({ path: ':memory:', url: server.dbUrl() });
-    const cnt = await db2.prepare('SELECT COUNT(*) as c FROM q').all();
+    const cnt = await (await db2.prepare('SELECT COUNT(*) as c FROM q')).all();
     expect(cnt).toEqual([{ c: expectedTotal }]);
-    const last = await db2.prepare('SELECT MAX(x) as m FROM q').all();
+    const last = await (await db2.prepare('SELECT MAX(x) as m FROM q')).all();
     expect(last).toEqual([{ m: expectedTotal - 1 }]);
 })
 
@@ -959,7 +959,7 @@ test('custom fetch override is invoked', async ({ server }) => {
     await db.exec("INSERT INTO t VALUES (1), (2), (3)");
     await db.push();
     expect(calls).toBeGreaterThan(0);
-    const rows = await db.prepare('SELECT x FROM t ORDER BY x').all();
+    const rows = await (await db.prepare('SELECT x FROM t ORDER BY x')).all();
     expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }]);
 })
 
@@ -986,7 +986,7 @@ test('retryFetch retries transient network failures', async ({ server }) => {
     expect(attemptsObserved).toBeGreaterThanOrEqual(2);
     expect(dropsRemaining).toBe(0);
     const db2 = await connect({ path: ':memory:', url: server.dbUrl() });
-    const rows = await db2.prepare('SELECT x FROM t ORDER BY x').all();
+    const rows = await (await db2.prepare('SELECT x FROM t ORDER BY x')).all();
     expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }]);
 })
 
@@ -1041,9 +1041,9 @@ test('pullBytesThreshold splits bootstrap into multiple chunks', async ({ server
     expect(pullUpdatesCalls).toBe(expectedChunks);
 
     // Bootstrapped data must be intact regardless of the chunked fetch.
-    const cnt = await db.prepare("SELECT COUNT(*) as c FROM big").all();
+    const cnt = await (await db.prepare("SELECT COUNT(*) as c FROM big")).all();
     expect(cnt).toEqual([{ c: 50 }]);
-    const sizes = await db.prepare("SELECT length(y) as len FROM big LIMIT 1").all();
+    const sizes = await (await db.prepare("SELECT length(y) as len FROM big LIMIT 1")).all();
     expect(sizes).toEqual([{ len: 1024 }]);
 })
 
@@ -1120,7 +1120,7 @@ test('unreliable fetch eventually drains all push batches', async ({ server }) =
     // fresh client, in the exact order they were inserted (no gaps, no
     // duplicates, no reordering across batch boundaries).
     const db2 = await connect({ path: ':memory:', url: server.dbUrl() });
-    const rows = await db2.prepare('SELECT x FROM q ORDER BY x').all();
+    const rows = await (await db2.prepare('SELECT x FROM q ORDER BY x')).all();
     const expected = Array.from({ length: TOTAL_ROWS }, (_, i) => ({ x: i }));
     expect(rows).toEqual(expected);
 })
@@ -1172,6 +1172,6 @@ test('push failure leaves server state on transaction boundary', async ({ server
     // present (rows 0..4); the second must not have leaked any rows
     // (transaction-boundary respected, not split mid-flight).
     const db2 = await connect({ path: ':memory:', url: server.dbUrl() });
-    const rows = await db2.prepare('SELECT x FROM q ORDER BY x').all();
+    const rows = await (await db2.prepare('SELECT x FROM q ORDER BY x')).all();
     expect(rows).toEqual([{ x: 0 }, { x: 1 }, { x: 2 }, { x: 3 }, { x: 4 }]);
 })

--- a/bindings/javascript/sync/packages/native/promise.ts
+++ b/bindings/javascript/sync/packages/native/promise.ts
@@ -232,8 +232,8 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
-        const localStmt = super.prepare(sql);
+    override async prepare(sql: string) {
+        const localStmt = await super.prepare(sql);
 
         if (!this.#remoteWriter) {
             return localStmt;

--- a/bindings/javascript/sync/packages/native/remote-write.test.ts
+++ b/bindings/javascript/sync/packages/native/remote-write.test.ts
@@ -30,7 +30,7 @@ test('remote write: exec insert and read back', async () => {
     const db = await connect(remoteWriteOpts());
     await db.exec("INSERT INTO rw_exec VALUES (1, 'hello')");
 
-    const rows = await db.prepare("SELECT * FROM rw_exec").all();
+    const rows = await (await db.prepare("SELECT * FROM rw_exec")).all();
     expect(rows).toEqual([{ id: 1, value: 'hello' }]);
     await db.close();
 })
@@ -44,10 +44,10 @@ test('remote write: prepared statement write', async () => {
 
     const db = await connect(remoteWriteOpts());
     for (let i = 1; i <= 5; i++) {
-        await db.prepare("INSERT INTO rw_prepared(x) VALUES (?)").run([i * 10]);
+        await (await db.prepare("INSERT INTO rw_prepared(x) VALUES (?)")).run([i * 10]);
     }
 
-    const rows = await db.prepare("SELECT x FROM rw_prepared ORDER BY x").all();
+    const rows = await (await db.prepare("SELECT x FROM rw_prepared ORDER BY x")).all();
     expect(rows).toEqual([{ x: 10 }, { x: 20 }, { x: 30 }, { x: 40 }, { x: 50 }]);
     await db.close();
 })
@@ -61,7 +61,7 @@ test('remote write: reads stay local', async () => {
     await seed.close();
 
     const db = await connect(remoteWriteOpts());
-    const rows = await db.prepare("SELECT * FROM rw_read").all();
+    const rows = await (await db.prepare("SELECT * FROM rw_read")).all();
     expect(rows).toEqual([{ id: 1, value: 'local' }]);
     await db.close();
 })
@@ -75,13 +75,13 @@ test('remote write: transaction commit', async () => {
 
     const db = await connect(remoteWriteOpts());
     const txn = db.transaction(async () => {
-        await db.prepare("INSERT INTO rw_txn(value) VALUES (?)").run([1]);
-        await db.prepare("INSERT INTO rw_txn(value) VALUES (?)").run([2]);
-        await db.prepare("INSERT INTO rw_txn(value) VALUES (?)").run([3]);
+        await (await db.prepare("INSERT INTO rw_txn(value) VALUES (?)")).run([1]);
+        await (await db.prepare("INSERT INTO rw_txn(value) VALUES (?)")).run([2]);
+        await (await db.prepare("INSERT INTO rw_txn(value) VALUES (?)")).run([3]);
     });
     await txn();
 
-    const rows = await db.prepare("SELECT value FROM rw_txn ORDER BY value").all();
+    const rows = await (await db.prepare("SELECT value FROM rw_txn ORDER BY value")).all();
     expect(rows).toEqual([{ value: 1 }, { value: 2 }, { value: 3 }]);
     await db.close();
 })
@@ -96,12 +96,12 @@ test('remote write: transaction rollback on error', async () => {
 
     const db = await connect(remoteWriteOpts());
     const txn = db.transaction(async () => {
-        await db.prepare("INSERT INTO rw_rollback(value) VALUES (?)").run([200]);
+        await (await db.prepare("INSERT INTO rw_rollback(value) VALUES (?)")).run([200]);
         throw new Error("deliberate rollback");
     });
     await expect(txn()).rejects.toThrow("deliberate rollback");
 
-    const rows = await db.prepare("SELECT value FROM rw_rollback ORDER BY value").all();
+    const rows = await (await db.prepare("SELECT value FROM rw_rollback ORDER BY value")).all();
     expect(rows).toEqual([{ value: 100 }]);
     await db.close();
 })
@@ -119,7 +119,7 @@ test('remote write: exec with BEGIN/COMMIT', async () => {
     await db.exec("INSERT INTO rw_exec_txn VALUES (2, 'b')");
     await db.exec("COMMIT");
 
-    const rows = await db.prepare("SELECT value FROM rw_exec_txn ORDER BY id").all();
+    const rows = await (await db.prepare("SELECT value FROM rw_exec_txn ORDER BY id")).all();
     expect(rows).toEqual([{ value: 'a' }, { value: 'b' }]);
     await db.close();
 })
@@ -137,7 +137,7 @@ test('remote write: second client sees writes after pull', async () => {
     // second client pulls and should see the remote write
     const db2 = await connect(localSyncedDbOpts());
 
-    const rows = await db2.prepare("SELECT * FROM rw_visible").all();
+    const rows = await (await db2.prepare("SELECT * FROM rw_visible")).all();
     expect(rows).toEqual([{ id: 1, value: 'from-remote-write' }]);
 
     await db1.close();
@@ -155,11 +155,11 @@ test('remote write: update and delete', async () => {
     const db = await connect(remoteWriteOpts());
     await db.exec("UPDATE rw_update SET value = 'updated' WHERE id = 1");
 
-    let rows = await db.prepare("SELECT value FROM rw_update WHERE id = 1").all();
+    let rows = await (await db.prepare("SELECT value FROM rw_update WHERE id = 1")).all();
     expect(rows).toEqual([{ value: 'updated' }]);
 
     await db.exec("DELETE FROM rw_update WHERE id = 1");
-    rows = await db.prepare("SELECT COUNT(*) as cnt FROM rw_update").all();
+    rows = await (await db.prepare("SELECT COUNT(*) as cnt FROM rw_update")).all();
     expect(rows).toEqual([{ cnt: 0 }]);
     await db.close();
 })
@@ -183,12 +183,12 @@ test('remote write: unique conflict rejected at write time', async () => {
     ).rejects.toThrow(/UNIQUE constraint failed/);
 
     // both clients see exactly the same single row
-    const rows1 = await db1.prepare("SELECT key, value FROM rw_conflict").all();
-    const rows2 = await db2.prepare("SELECT key, value FROM rw_conflict").all();
+    const rows1 = await (await db1.prepare("SELECT key, value FROM rw_conflict")).all();
+    const rows2 = await (await db2.prepare("SELECT key, value FROM rw_conflict")).all();
     expect(rows1).toEqual([{ key: 'a', value: 'taken' }]);
     expect(rows2).toEqual([]);
     await db2.pull();
-    const rows3 = await db2.prepare("SELECT key, value FROM rw_conflict").all();
+    const rows3 = await (await db2.prepare("SELECT key, value FROM rw_conflict")).all();
     expect(rows3).toEqual([{ key: 'a', value: 'taken' }]);
 
     await db1.close();
@@ -205,12 +205,12 @@ test('remote write: DDL create table and use it', async () => {
     await db.exec("CREATE TABLE rw_ddl(id INTEGER PRIMARY KEY, name TEXT)");
     await db.exec("INSERT INTO rw_ddl(name) VALUES ('after-create')");
 
-    const rows = await db.prepare("SELECT name FROM rw_ddl").all();
+    const rows = await (await db.prepare("SELECT name FROM rw_ddl")).all();
     expect(rows).toEqual([{ name: 'after-create' }]);
 
     // second client should see the new table
     const db2 = await connect(localSyncedDbOpts());
-    const rows2 = await db2.prepare("SELECT name FROM rw_ddl").all();
+    const rows2 = await (await db2.prepare("SELECT name FROM rw_ddl")).all();
     expect(rows2).toEqual([{ name: 'after-create' }]);
 
     await db.close();
@@ -229,7 +229,7 @@ test('remote write: DDL alter table adds column', async () => {
     await db.exec("ALTER TABLE rw_alter ADD COLUMN b TEXT DEFAULT 'default_b'");
     await db.exec("INSERT INTO rw_alter(a, b) VALUES ('after', 'new_b')");
 
-    const rows = await db.prepare("SELECT a, b FROM rw_alter ORDER BY a").all();
+    const rows = await (await db.prepare("SELECT a, b FROM rw_alter ORDER BY a")).all();
     expect(rows).toEqual([
         { a: 'after', b: 'new_b' },
         { a: 'before', b: 'default_b' },
@@ -246,7 +246,7 @@ test('remote write: DDL drop table', async () => {
     const db = await connect(remoteWriteOpts());
     await db.exec("DROP TABLE rw_drop");
 
-    await expect(() => db.prepare("SELECT * FROM rw_drop")).toThrow(/no such table/);
+    await expect(async () => await db.prepare("SELECT * FROM rw_drop")).rejects.toThrow(/no such table/);
     await db.close();
 })
 
@@ -261,7 +261,7 @@ test('remote write: DDL create index', async () => {
     await db.exec("CREATE INDEX IF NOT EXISTS idx_rw_value ON rw_idx(value)");
     await db.exec("INSERT INTO rw_idx(value) VALUES ('indexed')");
 
-    const rows = await db.prepare("SELECT value FROM rw_idx").all();
+    const rows = await (await db.prepare("SELECT value FROM rw_idx")).all();
     expect(rows).toEqual([{ value: 'indexed' }]);
     await db.close();
 })
@@ -276,7 +276,7 @@ test('remote write: read-only transaction goes remote, not local', async () => {
 
     // db1 connects with remote writes — local replica has 'original'
     const db1 = await connect(remoteWriteOpts());
-    const localRows = await db1.prepare("SELECT value FROM rw_read_txn").all();
+    const localRows = await (await db1.prepare("SELECT value FROM rw_read_txn")).all();
     expect(localRows).toEqual([{ value: 'original' }]);
 
     // another client updates the remote behind db1's back
@@ -286,12 +286,12 @@ test('remote write: read-only transaction goes remote, not local', async () => {
     await db2.close();
 
     // db1's local replica is stale — outside a txn, reads are local
-    const staleRows = await db1.prepare("SELECT value FROM rw_read_txn").all();
+    const staleRows = await (await db1.prepare("SELECT value FROM rw_read_txn")).all();
     expect(staleRows).toEqual([{ value: 'original' }]);
 
     // inside a transaction, reads should go remote and see 'updated'
     await db1.exec("BEGIN");
-    const txnRows = await db1.prepare("SELECT value FROM rw_read_txn").all();
+    const txnRows = await (await db1.prepare("SELECT value FROM rw_read_txn")).all();
     expect(txnRows[0]).toMatchObject({ value: 'updated' });
     await db1.exec("COMMIT");
 
@@ -306,15 +306,15 @@ test('remote write: insert returning', async () => {
     await seed.close();
 
     const db = await connect(remoteWriteOpts());
-    const rows = await db.prepare("INSERT INTO rw_returning(value) VALUES (?) RETURNING id, value").all(['hello']);
+    const rows = await (await db.prepare("INSERT INTO rw_returning(value) VALUES (?) RETURNING id, value")).all(['hello']);
     expect(rows).toMatchObject([{ id: 1, value: 'hello' }]);
 
-    expect(await db.prepare("SELECT * FROM rw_returning").all()).toMatchObject([{ id: 1, value: 'hello' }]);
+    expect(await (await db.prepare("SELECT * FROM rw_returning")).all()).toMatchObject([{ id: 1, value: 'hello' }]);
 
-    const rows2 = await db.prepare("INSERT INTO rw_returning(value) VALUES (?) RETURNING id, value").all(['world']);
+    const rows2 = await (await db.prepare("INSERT INTO rw_returning(value) VALUES (?) RETURNING id, value")).all(['world']);
     expect(rows2).toMatchObject([{ id: 2, value: 'world' }]);
 
-    expect(await db.prepare("SELECT * FROM rw_returning").all()).toMatchObject([
+    expect(await (await db.prepare("SELECT * FROM rw_returning")).all()).toMatchObject([
         { id: 1, value: 'hello' },
         { id: 2, value: 'world' },
     ]);
@@ -331,9 +331,9 @@ test('remote write: blob round-trip', async () => {
 
     const db = await connect(remoteWriteOpts());
     const blob = Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd]);
-    await db.prepare("INSERT INTO rw_blob(data) VALUES (?)").run([blob]);
+    await (await db.prepare("INSERT INTO rw_blob(data) VALUES (?)")).run([blob]);
 
-    const rows = await db.prepare("SELECT data FROM rw_blob").all();
+    const rows = await (await db.prepare("SELECT data FROM rw_blob")).all();
     expect(Buffer.from(rows[0].data)).toEqual(blob);
     await db.close();
 })

--- a/bindings/javascript/sync/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-bundle.ts
@@ -251,8 +251,8 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
-        const localStmt = super.prepare(sql);
+    override async prepare(sql: string) {
+        const localStmt = await super.prepare(sql);
 
         if (!this.#remoteWriter) {
             return localStmt;

--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -251,8 +251,8 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
-        const localStmt = super.prepare(sql);
+    override async prepare(sql: string) {
+        const localStmt = await super.prepare(sql);
 
         if (!this.#remoteWriter) {
             return localStmt;

--- a/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
@@ -251,8 +251,8 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
-        const localStmt = super.prepare(sql);
+    override async prepare(sql: string) {
+        const localStmt = await super.prepare(sql);
 
         if (!this.#remoteWriter) {
             return localStmt;

--- a/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
@@ -251,8 +251,8 @@ class Database extends DatabasePromise {
      * Prepares a SQL statement for execution.
      * When remoteWrites is enabled, returns a wrapper that routes writes to remote.
      */
-    override prepare(sql: string) {
-        const localStmt = super.prepare(sql);
+    override async prepare(sql: string) {
+        const localStmt = await super.prepare(sql);
 
         if (!this.#remoteWriter) {
             return localStmt;

--- a/bindings/javascript/sync/packages/wasm/promise.test.ts
+++ b/bindings/javascript/sync/packages/wasm/promise.test.ts
@@ -13,7 +13,7 @@ test('open non-sync db', async () => {
     const db = await connect({ path: 'local.db' });
     await db.exec("CREATE TABLE t(x)");
     await db.exec("INSERT INTO t VALUES (1), (2), (3)");
-    expect(await (await db.prepare("SELECT * FROM t").all())).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
+    expect(await (await db.prepare("SELECT * FROM t")).all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
 })
 
 test('checkpoint-and-actions', async () => {
@@ -31,7 +31,7 @@ test('checkpoint-and-actions', async () => {
     }
     const db1 = await connect({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL });
     await db1.exec("PRAGMA busy_timeout=100");
-    console.info('run_info', await db1.prepare("SELECT * FROM sqlite_master").all());
+    console.info('run_info', await (await db1.prepare("SELECT * FROM sqlite_master")).all());
     const pull = async function (iterations: number) {
         for (let i = 0; i < iterations; i++) {
             console.info('pull', i);
@@ -60,9 +60,9 @@ test('checkpoint-and-actions', async () => {
         let rows = 0;
         for (let i = 0; i < iterations; i++) {
             console.info('run', i, rows);
-            await db1.prepare("UPDATE rows SET value = value + 1 WHERE key = ?").run('key');
+            await (await db1.prepare("UPDATE rows SET value = value + 1 WHERE key = ?")).run('key');
             rows += 1;
-            const { cnt } = await db1.prepare("SELECT value as cnt FROM rows WHERE key = ?").get(['key']);
+            const { cnt } = await (await db1.prepare("SELECT value as cnt FROM rows WHERE key = ?")).get(['key']);
             expect(cnt).toBe(rows);
             await new Promise(resolve => setTimeout(resolve, 1));
         }
@@ -72,31 +72,31 @@ test('checkpoint-and-actions', async () => {
 
 test('implicit connect', async () => {
     const db = new Database({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL });
-    const defer = db.prepare("SELECT * FROM not_found");
+    const defer = await db.prepare("SELECT * FROM not_found");
     await expect(async () => await defer.all()).rejects.toThrowError(/no such table: not_found/);
-    expect(() => db.prepare("SELECT * FROM not_found")).toThrowError(/no such table: not_found/);
-    expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }]);
+    await expect(async () => await db.prepare("SELECT * FROM not_found")).rejects.toThrowError(/no such table: not_found/);
+    expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }]);
 })
 
 test('simple-db', async () => {
     const db = new Database({ path: ':memory:' });
-    expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }])
+    expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }])
     await db.exec("CREATE TABLE t(x)");
     await db.exec("INSERT INTO t VALUES (1), (2), (3)");
-    expect(await db.prepare("SELECT * FROM t").all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
+    expect(await (await db.prepare("SELECT * FROM t")).all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
     await expect(async () => await db.pull()).rejects.toThrowError(/sync is disabled as database was opened without sync support/);
 })
 
 test('reconnect-db', async () => {
     {
         const db = await connect({ path: 'local.db', url: process.env.VITE_TURSO_DB_URL });
-        const stmt = db.prepare("SELECT * FROM turso_cdc");
+        const stmt = await db.prepare("SELECT * FROM turso_cdc");
         expect(await stmt.all()).toEqual([])
         stmt.close();
     }
     {
         const db = await connect({ path: 'local.db', url: process.env.VITE_TURSO_DB_URL });
-        const stmt = db.prepare("SELECT * FROM turso_cdc");
+        const stmt = await db.prepare("SELECT * FROM turso_cdc");
         expect(await stmt.all()).toEqual([])
         stmt.close();
     }
@@ -104,10 +104,10 @@ test('reconnect-db', async () => {
 
 test('implicit connect', async () => {
     const db = new Database({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL });
-    const defer = db.prepare("SELECT * FROM not_found");
+    const defer = await db.prepare("SELECT * FROM not_found");
     await expect(async () => await defer.all()).rejects.toThrowError(/no such table: not_found/);
-    expect(() => db.prepare("SELECT * FROM not_found")).toThrowError(/no such table: not_found/);
-    expect(await db.prepare("SELECT 1 as x").all()).toEqual([{ x: 1 }]);
+    await expect(async () => await db.prepare("SELECT * FROM not_found")).rejects.toThrowError(/no such table: not_found/);
+    expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }]);
 })
 
 test('defered sync', async () => {
@@ -122,13 +122,13 @@ test('defered sync', async () => {
 
     let url: string | null = null;
     const db = new Database({ path: ':memory:', url: () => url });
-    await db.prepare("CREATE TABLE t(x)").run();
-    await db.prepare("INSERT INTO t VALUES (1), (2), (3), (42)").run();
-    expect(await db.prepare("SELECT * FROM t").all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
+    await (await db.prepare("CREATE TABLE t(x)")).run();
+    await (await db.prepare("INSERT INTO t VALUES (1), (2), (3), (42)")).run();
+    expect(await (await db.prepare("SELECT * FROM t")).all()).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
     await expect(async () => await db.pull()).rejects.toThrow(/url is empty - sync is paused/);
     url = process.env.VITE_TURSO_DB_URL ?? null;
     await db.pull();
-    expect(await db.prepare("SELECT * FROM t").all()).toEqual([{ x: 100 }, { x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
+    expect(await (await db.prepare("SELECT * FROM t")).all()).toEqual([{ x: 100 }, { x: 1 }, { x: 2 }, { x: 3 }, { x: 42 }]);
 })
 
 // TODO: re-enable encryption tests once local sync server supports the encrypted-tenant URL pattern.
@@ -194,7 +194,7 @@ test('select-after-push', async () => {
     }
     {
         const db = await connect({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL });
-        const rows = await db.prepare('SELECT * FROM t').all();
+        const rows = await (await db.prepare('SELECT * FROM t')).all();
         expect(rows).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }])
     }
 })
@@ -213,7 +213,7 @@ test('select-without-push', async () => {
     }
     {
         const db = await connect({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL });
-        const rows = await db.prepare('SELECT * FROM t').all();
+        const rows = await (await db.prepare('SELECT * FROM t')).all();
         expect(rows).toEqual([])
     }
 })
@@ -235,8 +235,8 @@ test('merge-non-overlapping-keys', async () => {
     await Promise.all([db1.push(), db2.push()]);
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM q').all();
-    const rows2 = await db1.prepare('SELECT * FROM q').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+    const rows2 = await (await db1.prepare('SELECT * FROM q')).all();
     const expected = [{ x: 'k1', y: 'value1' }, { x: 'k2', y: 'value2' }, { x: 'k3', y: 'value3' }, { x: 'k4', y: 'value4' }, { x: 'k5', y: 'value5' }];
     expect(rows1.sort(localeCompare)).toEqual(expected.sort(localeCompare))
     expect(rows2.sort(localeCompare)).toEqual(expected.sort(localeCompare))
@@ -260,8 +260,8 @@ test('last-push-wins', async () => {
     await db1.push();
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM q').all();
-    const rows2 = await db1.prepare('SELECT * FROM q').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+    const rows2 = await (await db1.prepare('SELECT * FROM q')).all();
     const expected = [{ x: 'k1', y: 'value1' }, { x: 'k2', y: 'value2' }, { x: 'k3', y: 'value5' }, { x: 'k4', y: 'value4' }];
     expect(rows1.sort(localeCompare)).toEqual(expected.sort(localeCompare))
     expect(rows2.sort(localeCompare)).toEqual(expected.sort(localeCompare))
@@ -286,8 +286,8 @@ test('last-push-wins-with-delete', async () => {
     await db1.push();
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM q').all();
-    const rows2 = await db1.prepare('SELECT * FROM q').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+    const rows2 = await (await db1.prepare('SELECT * FROM q')).all();
     const expected = [{ x: 'k3', y: 'value5' }];
     expect(rows1).toEqual(expected)
     expect(rows2).toEqual(expected)
@@ -356,7 +356,7 @@ test('persistence-push', async () => {
         const db2 = await connect({ path: path, url: process.env.VITE_TURSO_DB_URL });
         await db2.exec(`INSERT INTO q VALUES ('k3', 'v3')`);
         await db2.exec(`INSERT INTO q VALUES ('k4', 'v4')`);
-        const stmt = db2.prepare('SELECT * FROM q');
+        const stmt = await db2.prepare('SELECT * FROM q');
         const rows = await stmt.all();
         const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }, { x: 'k3', y: 'v3' }, { x: 'k4', y: 'v4' }];
         expect(rows).toEqual(expected)
@@ -372,7 +372,7 @@ test('persistence-push', async () => {
 
     {
         const db4 = await connect({ path: path, url: process.env.VITE_TURSO_DB_URL });
-        const rows = await db4.prepare('SELECT * FROM q').all();
+        const rows = await (await db4.prepare('SELECT * FROM q')).all();
         const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }, { x: 'k3', y: 'v3' }, { x: 'k4', y: 'v4' }];
         expect(rows).toEqual(expected)
         await db4.close();
@@ -397,7 +397,7 @@ test('persistence-offline', async () => {
     }
     {
         const db = await connect({ path: path, url: "https://not-valid-url.localhost" });
-        const rows = await db.prepare("SELECT * FROM q").all();
+        const rows = await (await db.prepare("SELECT * FROM q")).all();
         const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }];
         expect(rows.sort(localeCompare)).toEqual(expected.sort(localeCompare))
         await db.close();
@@ -429,8 +429,8 @@ test('persistence-pull-push', async () => {
     console.info(stats1, stats2);
     expect(stats1.revision).not.toBe(stats2.revision);
 
-    const rows1 = await db1.prepare('SELECT * FROM q').all();
-    const rows2 = await db2.prepare('SELECT * FROM q').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM q')).all();
+    const rows2 = await (await db2.prepare('SELECT * FROM q')).all();
     const expected = [{ x: 'k1', y: 'v1' }, { x: 'k2', y: 'v2' }, { x: 'k3', y: 'v3' }, { x: 'k4', y: 'v4' }];
     expect(rows1.sort(localeCompare)).toEqual(expected.sort(localeCompare))
     expect(rows2.sort(localeCompare)).toEqual(expected.sort(localeCompare))
@@ -548,7 +548,7 @@ test('concurrent-updates', { timeout: 60000 }, async () => {
     await Promise.all(dbs.map(db => db.pull()));
     let results = [];
     for (let i = 0; i < dbs.length; i++) {
-        results.push((await dbs[i].prepare('SELECT x, y FROM three').all()).sort(localeCompare));
+        results.push((await (await dbs[i].prepare('SELECT x, y FROM three')).all()).sort(localeCompare));
     }
     for (let i = 0; i < dbs.length; i++) {
         expect(results[i]).toEqual(results[0]);
@@ -586,8 +586,8 @@ test('transform', async () => {
     await Promise.all([db1.push(), db2.push()]);
     await Promise.all([db1.pull(), db2.pull()]);
 
-    const rows1 = await db1.prepare('SELECT * FROM counter').all();
-    const rows2 = await db2.prepare('SELECT * FROM counter').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM counter')).all();
+    const rows2 = await (await db2.prepare('SELECT * FROM counter')).all();
     expect(rows1).toEqual([{ key: '1', value: 2 }]);
     expect(rows2).toEqual([{ key: '1', value: 2 }]);
 })
@@ -629,8 +629,8 @@ test('transform-many', async () => {
     await Promise.all([db1.pull(), db2.pull()]);
     console.info('pull', performance.now() - start);
 
-    const rows1 = await db1.prepare('SELECT * FROM counter').all();
-    const rows2 = await db2.prepare('SELECT * FROM counter').all();
+    const rows1 = await (await db1.prepare('SELECT * FROM counter')).all();
+    const rows2 = await (await db2.prepare('SELECT * FROM counter')).all();
     expect(rows1).toEqual([{ key: '1', value: 1001 + 1002 }]);
     expect(rows2).toEqual([{ key: '1', value: 1001 + 1002 }]);
 })


### PR DESCRIPTION
The prepare() method needs to be async for most of the JavaScript SDKs,
for example, the serverless one, because preparation requires I/O. This
commit unifies all the SDKs to have the same interface, except for the
better-sqlite3 compatibility APIs that are sync.

Note that the `@tursodatabase/database` package `Database.prepare()` is
still implemented synchronously internally. That's a future improvement
we should look into.
