### PR TITLE
core/mvcc: ensure we cannot deadlock on Preparing concurrent

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3487,12 +3487,22 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // Check if any CONCURRENT writer is in Preparing state. If there is one,
         // we must wait for it to complete before proceeding. Otherwise, we can
         // have concurrent txn deadlock trying to acquire pager_commit_lock.
-        let any_concurrent_in_preparing = self.txs.iter().any(|entry| {
-            let other_tx_id = *entry.key();
-            if other_tx_id == tx_id {
-                return false;
-            }
-            matches!(entry.value().state.load(), TransactionState::Preparing(_))
+        //
+        // The scan runs under the clock mutex (via `get_commit_timestamp`)
+        // so it serializes with `prepare_tx`'s `Preparing(end_ts)` publish,
+        // which already takes the same mutex. This closes the TOCTOU
+        // window where another transaction stores `Preparing` between
+        // our scan and the lock acquisition below. The timestamp is
+        // discarded; only the lock acquisition matters.
+        let mut any_concurrent_in_preparing = false;
+        self.clock.get_timestamp(|_ts| {
+            any_concurrent_in_preparing = self.txs.iter().any(|entry| {
+                let other_tx_id = *entry.key();
+                if other_tx_id == tx_id {
+                    return false;
+                }
+                matches!(entry.value().state.load(), TransactionState::Preparing(_))
+            });
         });
         if any_concurrent_in_preparing {
             tracing::debug!(

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1584,7 +1584,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // and we proceed without losing any of the writer's work.
                 if !mvcc_store.is_exclusive_tx(&self.tx_id)
                     && mvcc_store.has_exclusive_tx()
-                    && !tx.write_set.is_empty()
+                    && !tx.write_set.lock().is_empty()
                 {
                     return Ok(TransitionResult::Io(IOCompletions::Single(
                         Completion::new_yield(),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1570,6 +1570,27 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     return Err(LimboError::SchemaConflict);
                 }
 
+                // A CONCURRENT writer must not transition to Preparing while
+                // an exclusive tx is active. Otherwise the exclusive tx could
+                // speculatively read a Preparing row from this writer and
+                // form a wait-for cycle: writer waits for pager_commit_lock
+                // (held by the exclusive tx), exclusive tx waits in
+                // WaitForDependencies for this writer to commit.
+                //
+                // Yield IO and re-check on the next step. We have not drawn
+                // an end_ts and have not mutated any row versions, so
+                // waiting here costs nothing the exclusive tx needs. Once
+                // the exclusive tx finishes, has_exclusive_tx returns false
+                // and we proceed without losing any of the writer's work.
+                if !mvcc_store.is_exclusive_tx(&self.tx_id)
+                    && mvcc_store.has_exclusive_tx()
+                    && !tx.write_set.is_empty()
+                {
+                    return Ok(TransitionResult::Io(IOCompletions::Single(
+                        Completion::new_yield(),
+                    )));
+                }
+
                 // Atomically generate end_ts and publish Preparing(end_ts) while the
                 // clock lock is held. This closes the TOCTOU window
                 // Consider the example:
@@ -3461,6 +3482,29 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         if !already_exclusive {
             self.acquire_exclusive_tx(&tx_id)
                 .inspect_err(|_| unlock_checkpoint_guard())?;
+        }
+
+        // Check if any CONCURRENT writer is in Preparing state. If there is one,
+        // we must wait for it to complete before proceeding. Otherwise, we can
+        // have concurrent txn deadlock trying to acquire pager_commit_lock.
+        let any_concurrent_in_preparing = self.txs.iter().any(|entry| {
+            let other_tx_id = *entry.key();
+            if other_tx_id == tx_id {
+                return false;
+            }
+            matches!(entry.value().state.load(), TransactionState::Preparing(_))
+        });
+        if any_concurrent_in_preparing {
+            tracing::debug!(
+                "begin_exclusive_tx: tx_id={} returned Busy because a \
+                 CONCURRENT writer is in Preparing",
+                tx_id
+            );
+            if !already_exclusive {
+                self.release_exclusive_tx(&tx_id);
+            }
+            unlock_checkpoint_guard();
+            return Err(LimboError::Busy);
         }
 
         let already_holds_commit_lock = maybe_existing_tx_id

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -10174,6 +10174,70 @@ fn test_snapshot_stability_full() {
 }
 
 #[test]
+fn test_concurrent_and_exclusive_deadlock_reproducer() {
+    let db = MvccTestDbNoConn::new();
+    let conn_a = db.connect();
+    let conn_b = db.connect();
+
+    conn_a
+        .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    // Pause conn_a at the boundary right after Preparing(end_ts) is
+    // published, before BeginCommitLogicalLog acquires the lock.
+    conn_a.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::LogRecordPrepared.point(),
+    ])));
+    conn_a.execute("BEGIN CONCURRENT").unwrap();
+    conn_a
+        .execute("INSERT INTO t VALUES (3, 'concurrent')")
+        .unwrap();
+    let mut stmt_a = conn_a.prepare("COMMIT").unwrap();
+    loop {
+        if matches!(stmt_a.step().unwrap(), crate::StepResult::IO) {
+            break;
+        }
+    }
+
+    // Drive both transactions to completion.
+    let mut conn_b_done = false;
+    let mut conn_a_done = false;
+    loop {
+        if !conn_b_done {
+            match conn_b.execute("BEGIN IMMEDIATE") {
+                Ok(_) => {
+                    conn_b
+                        .execute("INSERT INTO t VALUES (2, 'exclusive')")
+                        .unwrap();
+                    // SELECT triggers spec-read of conn_a's Preparing row →
+                    // pre-fix this registers the commit dep that closes the cycle.
+                    conn_b.execute("SELECT v FROM t WHERE id = 3").unwrap();
+                    conn_b.execute("COMMIT").unwrap();
+                    conn_b_done = true;
+                }
+                Err(LimboError::Busy) => {}
+                Err(e) => panic!("unexpected error from BEGIN IMMEDIATE: {e:?}"),
+            }
+        }
+        if !conn_a_done {
+            match stmt_a.step().unwrap() {
+                crate::StepResult::Done => conn_a_done = true,
+                crate::StepResult::IO => {}
+                other => panic!("unexpected step result: {other:?}"),
+            }
+        }
+        if conn_a_done && conn_b_done {
+            break;
+        }
+    }
+    drop(stmt_a);
+    assert!(conn_a_done && conn_b_done);
+
+    let rows = get_rows(&conn_a, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 2, "both rows must be visible; got {rows:?}");
+}
+
+#[test]
 fn test_read_lock_leak_deferred_then_concurrent() {
     let db = MvccTestDbNoConn::new_with_random_db();
     let conn0 = db.connect();

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -418,9 +418,7 @@ impl TursoRwLock {
         (self.0.load(Ordering::Acquire) >> Self::VALUE_SHIFT) as u32
     }
 
-    /// Non-mutating check for whether the writer bit is currently set.
-    /// Intended for diagnostics and tests that want to assert lock state
-    /// without acquiring (which would itself perturb the state).
+    /// Returns whether the writer bit is currently set, without acquiring.
     #[inline]
     pub fn is_writer_held(&self) -> bool {
         Self::has_writer(self.0.load(Ordering::Acquire))

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -418,6 +418,14 @@ impl TursoRwLock {
         (self.0.load(Ordering::Acquire) >> Self::VALUE_SHIFT) as u32
     }
 
+    /// Non-mutating check for whether the writer bit is currently set.
+    /// Intended for diagnostics and tests that want to assert lock state
+    /// without acquiring (which would itself perturb the state).
+    #[inline]
+    pub fn is_writer_held(&self) -> bool {
+        Self::has_writer(self.0.load(Ordering::Acquire))
+    }
+
     #[inline]
     /// Set the embedded value while holding the write lock.
     pub fn set_value_exclusive(&self, v: u32) {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -69,10 +69,7 @@ impl IO for TestIo {
     fn cancel(&self, c: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.cancel(c)
     }
-    fn drain_completions(
-        &self,
-        completions: &[turso_core::Completion],
-    ) -> turso_core::Result<()> {
+    fn drain_completions(&self, completions: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.drain_completions(completions)
     }
     fn fill_bytes(&self, dest: &mut [u8]) {


### PR DESCRIPTION
## Description

Sequence that produces the cycle:

1. tx_A (BEGIN CONCURRENT + writes) reaches CommitState::Initial, calls prepare_tx which publishes Preparing(end_ts_A). Continues through Commit → WaitForDependencies (no deps) → state machine sits at BeginCommitLogicalLog (lock not yet acquired).
2. tx_B (BEGIN IMMEDIATE or auto-commit write) calls begin_exclusive_tx (mod.rs:3441-3463) which acquires pager_commit_lock writer-bit and sets is_exclusive_tx.
3. tx_B's SELECT/read traverses a row version with begin = TxID(tx_A) whose state is Preparing(end_ts_A). Hekaton §2.7 speculative-read fires at mod.rs:5547: tx_B.begin_ts > tx_A.end_ts, so register_commit_dependency(tx_B → tx_A) increments tx_B.commit_dep_counter and adds tx_B to tx_A's commit_dep_set.
4. tx_B's COMMIT enters WaitForDependencies (mod.rs:1739), sees commit_dep_counter > 0, yields IO. Lock still held.
5. tx_A resumes its commit pipeline → BeginCommitLogicalLog body (mod.rs:1813) → lock.write() returns false (held by tx_B) → yields IO. Repeats forever.

**fix**
(1) Initial-state gate — closes the brief window between tx.state.store(Preparing(ts)) and the existing exclusivity check at line 1710. Added in CommitState::Initial, before prepare_tx:
(2) begin_exclusive_tx scan — after the exclusive_tx CAS but before the lock acquire, refuse to start as exclusive while any tx is already in Preparing:

## Description of AI Usage
Worked with claude to find an debug this issue. After reproducing it I laid out different ideas of fixes and tasked claude to implement this one. I reviewed it and fixed the comments.
