### PR TITLE
ci: add YAML linter for GitHub Actions workflows

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,23 @@
+name: YAML Lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  yaml-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install actionlint
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          sudo mv actionlint /usr/local/bin/
+      - name: Lint GitHub Actions workflows
+        run: actionlint -color


### PR DESCRIPTION
Add an actionlint CI workflow that runs whenever files in `.github/` are modified in a PR.

This prevents silent YAML syntax failures like the indentation issue in #6692 that caused the Rust workflow to stop running without any indication.

### Changes
- New workflow `.github/workflows/yaml-lint.yml` using [actionlint](https://github.com/rhysd/actionlint)
- Triggers on PRs that touch `.github/**` files
- Uses concurrency groups to cancel stale runs

Fixes #6702