### PR TITLE
Feature/6444 pragma vdbe trace

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -207,7 +207,7 @@ ongoing work to pass the full SQLite TCL test suite.
 | PRAGMA vdbe_addoptrace           | ❌ No         |                                              |
 | PRAGMA vdbe_debug                | ❌ No         |                                              |
 | PRAGMA vdbe_listing              | ❌ No         |                                              |
-| PRAGMA vdbe_trace                | ❌ No         |                                              |
+| PRAGMA vdbe_trace                | ✅ Yes        |                                              |
 | PRAGMA wal_autocheckpoint        | ❌ No         |                                              |
 | PRAGMA wal_checkpoint            | 🚧 Partial    | Not Needed calling with param (pragma-value) |
 | PRAGMA writable_schema           | ❌ No         |                                              |

--- a/cli/tests/vdbe_trace.rs
+++ b/cli/tests/vdbe_trace.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-fn assert_trace(sql: &str, expected: &str) {
+fn assert_trace(sql: &str, expected_stdout: &str, expected_stderr: &str) {
     let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
         .args(["-m", "list", ":memory:", sql])
         .output()
@@ -12,15 +12,20 @@ fn assert_trace(sql: &str, expected: &str) {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let got: Vec<&str> = stdout.lines().map(str::trim_end).collect();
-    let want: Vec<&str> = expected.lines().map(str::trim_end).collect();
-    assert_eq!(got, want, "\n--- full stdout ---\n{stdout}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let got_out: Vec<&str> = stdout.lines().map(str::trim_end).collect();
+    let want_out: Vec<&str> = expected_stdout.lines().map(str::trim_end).collect();
+    assert_eq!(got_out, want_out, "\n--- full stdout ---\n{stdout}");
+    let got_err: Vec<&str> = stderr.lines().map(str::trim_end).collect();
+    let want_err: Vec<&str> = expected_stderr.lines().map(str::trim_end).collect();
+    assert_eq!(got_err, want_err, "\n--- full stderr ---\n{stderr}");
 }
 
 #[test]
 fn vdbe_trace_on_traces_literal_select() {
     assert_trace(
         "PRAGMA vdbe_trace = ON; SELECT 7;",
+        "7",
         "\
 VDBE Trace:
 0     Init               0     2     0                    0   Start at 2
@@ -32,7 +37,6 @@ VDBE Trace:
 R[1] = 7
 4     Goto               0     1     0                    0
 1     ResultRow          1     1     0                    0   output=r[1]
-7
 2     Halt               0     0     0                    0",
     );
 }
@@ -41,6 +45,7 @@ R[1] = 7
 fn vdbe_trace_on_traces_computed_expression() {
     assert_trace(
         "PRAGMA vdbe_trace = ON; SELECT 3 + 4;",
+        "7",
         "\
 VDBE Trace:
 0     Init               0     2     0                    0   Start at 2
@@ -56,12 +61,11 @@ R[3] = 4
 R[1] = 7
 6     Goto               0     1     0                    0
 1     ResultRow          1     1     0                    0   output=r[1]
-7
 2     Halt               0     0     0                    0",
     );
 }
 
 #[test]
 fn vdbe_trace_off_by_default_emits_only_result() {
-    assert_trace("SELECT 7;", "7");
+    assert_trace("SELECT 7;", "7", "");
 }

--- a/cli/tests/vdbe_trace.rs
+++ b/cli/tests/vdbe_trace.rs
@@ -1,0 +1,67 @@
+use std::process::Command;
+
+fn assert_trace(sql: &str, expected: &str) {
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .args(["-m", "list", ":memory:", sql])
+        .output()
+        .expect("failed to run tursodb");
+    assert!(
+        output.status.success(),
+        "tursodb exited with {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let got: Vec<&str> = stdout.lines().map(str::trim_end).collect();
+    let want: Vec<&str> = expected.lines().map(str::trim_end).collect();
+    assert_eq!(got, want, "\n--- full stdout ---\n{stdout}");
+}
+
+#[test]
+fn vdbe_trace_on_traces_literal_select() {
+    assert_trace(
+        "PRAGMA vdbe_trace = ON; SELECT 7;",
+        "\
+VDBE Trace:
+0     Init               0     2     0                    0   Start at 2
+2     Goto               0     1     0                    0
+1     Halt               0     0     0                    0
+VDBE Trace:
+0     Init               0     3     0                    0   Start at 3
+3     Integer            7     1     0                    0   r[1]=7
+R[1] = 7
+4     Goto               0     1     0                    0
+1     ResultRow          1     1     0                    0   output=r[1]
+7
+2     Halt               0     0     0                    0",
+    );
+}
+
+#[test]
+fn vdbe_trace_on_traces_computed_expression() {
+    assert_trace(
+        "PRAGMA vdbe_trace = ON; SELECT 3 + 4;",
+        "\
+VDBE Trace:
+0     Init               0     2     0                    0   Start at 2
+2     Goto               0     1     0                    0
+1     Halt               0     0     0                    0
+VDBE Trace:
+0     Init               0     3     0                    0   Start at 3
+3     Integer            3     2     0                    0   r[2]=3
+R[2] = 3
+4     Integer            4     3     0                    0   r[3]=4
+R[3] = 4
+5     Add                2     3     1                    0   r[1]=r[2]+r[3]
+R[1] = 7
+6     Goto               0     1     0                    0
+1     ResultRow          1     1     0                    0   output=r[1]
+7
+2     Halt               0     0     0                    0",
+    );
+}
+
+#[test]
+fn vdbe_trace_off_by_default_emits_only_result() {
+    assert_trace("SELECT 7;", "7");
+}

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -196,6 +196,7 @@ pub struct Connection {
     /// Attached databases
     pub(super) attached_databases: RwLock<DatabaseCatalog>,
     pub(super) query_only: AtomicBool,
+    pub(super) vdbe_trace: AtomicBool,
     /// If enabled, the UPDATE/DELETE statements must have a WHERE clause
     pub(super) dml_require_where: AtomicBool,
     /// SQLite DQS misfeature: when ON (default), unresolved double-quoted identifiers
@@ -2761,6 +2762,14 @@ impl Connection {
     pub fn set_query_only(&self, value: bool) {
         self.query_only.store(value, Ordering::SeqCst);
         self.bump_prepare_context_generation();
+    }
+
+    pub fn set_vdbe_trace(&self, value: bool) {
+        self.vdbe_trace.store(value, Ordering::SeqCst);
+    }
+
+    pub fn get_vdbe_trace(&self) -> bool {
+        self.vdbe_trace.load(Ordering::SeqCst)
     }
 
     pub fn get_dml_require_where(&self) -> bool {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1691,6 +1691,7 @@ impl Database {
             temp: crate::connection::TempDbContext::new(),
             attached_databases: RwLock::new(DatabaseCatalog::new()),
             query_only: AtomicBool::new(false),
+            vdbe_trace: AtomicBool::new(false),
             dml_require_where: AtomicBool::new(false),
             dqs_dml: AtomicBool::new(true),
             mv_tx: RwLock::new(None),

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -218,7 +218,7 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
         ),
         VdbeTrace => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
-            &["vbde_trace"],
+            &["vdbe_trace"],
         ),
     }
 }

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -216,6 +216,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::Result0,
             &["type", "parent", "encode", "decode", "default", "operators"],
         ),
+        VdbeTrace => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["vbde_trace"],
+        ),
     }
 }
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -752,6 +752,12 @@ fn update_pragma(
             connection.set_temp_store(temp_store);
             Ok(TransactionMode::None)
         }
+        PragmaName::VdbeTrace => {
+            let enabled = parse_pragma_enabled(&value);
+            connection.set_vdbe_trace(enabled);
+            Ok(TransactionMode::None)
+        }
+
         PragmaName::FunctionList => query_pragma(
             PragmaName::FunctionList,
             resolver,
@@ -1450,6 +1456,14 @@ fn query_pragma(
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
 
+            Ok(TransactionMode::None)
+        }
+        PragmaName::VdbeTrace => {
+            let register = program.alloc_register();
+            let is_enabled = connection.get_vdbe_trace();
+            program.emit_int(is_enabled as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)
         }
         PragmaName::FreelistCount => {

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1458,14 +1458,7 @@ fn query_pragma(
 
             Ok(TransactionMode::None)
         }
-        PragmaName::VdbeTrace => {
-            let register = program.alloc_register();
-            let is_enabled = connection.get_vdbe_trace();
-            program.emit_int(is_enabled as i64, register);
-            program.emit_result_row(register, 1);
-            program.add_pragma_result_column(pragma.to_string());
-            Ok(TransactionMode::None)
-        }
+        PragmaName::VdbeTrace => Ok(TransactionMode::None),
         PragmaName::FreelistCount => {
             let value = pager.freepage_list();
             let register = program.alloc_register();

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1534,7 +1534,8 @@ impl Program {
         pager: &Arc<Pager>,
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
-        let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
+        let enable_tracing =
+            tracing::enabled!(tracing::Level::TRACE) || self.connection.get_vdbe_trace();
         loop {
             if self.connection.is_closed() {
                 // Connection is closed for whatever reason, rollback the transaction.
@@ -1583,7 +1584,28 @@ impl Program {
             let (insn, _) = &self.insns[state.pc as usize];
             let insn_function = insn.to_function();
             if enable_tracing {
-                trace_insn(self, state.pc as InsnReference, insn);
+                if self.connection.get_vdbe_trace() {
+                    if matches!(insn, Insn::Init { .. }) {
+                        println!("VDBE Trace:");
+                    }
+
+                    println!(
+                        "{}",
+                        explain::insn_to_str(
+                            self,
+                            state.pc as InsnReference,
+                            insn,
+                            String::new(),
+                            self.comments
+                                .iter()
+                                .find(|(offset, _)| *offset == state.pc as InsnReference)
+                                .map(|(_, comment)| comment)
+                                .copied()
+                        )
+                    );
+                } else {
+                    trace_insn(self, state.pc as InsnReference, insn);
+                }
                 crate::stack::trace_remaining("program_step:opcode");
             }
             // Always increment VM steps for every loop iteration

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1599,9 +1599,9 @@ impl Program {
                     {
                         if old_reg != new_reg {
                             match new_reg {
-                                Register::Value(v) => println!("R[{i}] = {v}"),
-                                Register::Aggregate(_) => println!("R[{i}] = <aggregate>"),
-                                Register::Record(_) => println!("R[{i}] = <record>"),
+                                Register::Value(v) => eprintln!("R[{i}] = {v}"),
+                                Register::Aggregate(_) => eprintln!("R[{i}] = <aggregate>"),
+                                Register::Record(_) => eprintln!("R[{i}] = <record>"),
                             }
                         }
                     }
@@ -1610,9 +1610,9 @@ impl Program {
 
                 // Print CURRENT opcode
                 if matches!(insn, Insn::Init { .. }) {
-                    println!("VDBE Trace:");
+                    eprintln!("VDBE Trace:");
                 }
-                println!(
+                eprintln!(
                     "{}",
                     explain::insn_to_str(
                         self,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -230,7 +230,7 @@ impl CommitState {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Register {
     Value(Value),
     Aggregate(AggContext),
@@ -624,6 +624,8 @@ pub struct ProgramState {
     pub(crate) cursors: Vec<Option<Cursor>>,
     cursor_seqs: Vec<i64>,
     registers: Box<[Register]>,
+    /// Trace state: last pc we printed a line for, and a register snapshot for diffing.
+    pre_op_registers: Option<Box<[Register]>>,
     pub(crate) result_row: Option<Row>,
     last_compare: Option<std::cmp::Ordering>,
     deferred_seeks: Vec<Option<DeferredSeekState>>,
@@ -721,6 +723,7 @@ impl ProgramState {
             cursors,
             cursor_seqs,
             registers,
+            pre_op_registers: None,
             result_row: None,
             last_compare: None,
             deferred_seeks: vec![None; max_cursors],
@@ -1585,10 +1588,28 @@ impl Program {
             let insn_function = insn.to_function();
             if enable_tracing {
                 if self.connection.get_vdbe_trace() {
+                    // Diff registers from PREVIOUS opcode
+                    // The last opcode (Halt) won't have its diff printed, but Halt
+                    // doesn't write to any registers
+                    if let Some(ref old) = state.pre_op_registers {
+                        for (i, (old_reg, new_reg)) in
+                            old.iter().zip(state.registers.iter()).enumerate()
+                        {
+                            if old_reg != new_reg {
+                                match new_reg {
+                                    Register::Value(v) => println!("R[{i}] = {v}"),
+                                    Register::Aggregate(_) => println!("R[{i}] = <aggregate>"),
+                                    Register::Record(_) => println!("R[{i}] = <record>"),
+                                }
+                            }
+                        }
+                        state.pre_op_registers = None;
+                    }
+
+                    // Print CURRENT opcode
                     if matches!(insn, Insn::Init { .. }) {
                         println!("VDBE Trace:");
                     }
-
                     println!(
                         "{}",
                         explain::insn_to_str(
@@ -1603,6 +1624,8 @@ impl Program {
                                 .copied()
                         )
                     );
+                    // Snapshot for next iteration
+                    state.pre_op_registers = Some(state.registers.clone());
                 } else {
                     trace_insn(self, state.pc as InsnReference, insn);
                 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -624,7 +624,7 @@ pub struct ProgramState {
     pub(crate) cursors: Vec<Option<Cursor>>,
     cursor_seqs: Vec<i64>,
     registers: Box<[Register]>,
-    /// Trace state: last pc we printed a line for, and a register snapshot for diffing.
+    /// Trace state: register snapshot for diffing.
     pre_op_registers: Option<Box<[Register]>>,
     pub(crate) result_row: Option<Row>,
     last_compare: Option<std::cmp::Ordering>,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1537,8 +1537,7 @@ impl Program {
         pager: &Arc<Pager>,
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
-        let enable_tracing =
-            tracing::enabled!(tracing::Level::TRACE) || self.connection.get_vdbe_trace();
+        let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
         loop {
             if self.connection.is_closed() {
                 // Connection is closed for whatever reason, rollback the transaction.
@@ -1587,49 +1586,48 @@ impl Program {
             let (insn, _) = &self.insns[state.pc as usize];
             let insn_function = insn.to_function();
             if enable_tracing {
-                if self.connection.get_vdbe_trace() {
-                    // Diff registers from PREVIOUS opcode
-                    // The last opcode (Halt) won't have its diff printed, but Halt
-                    // doesn't write to any registers
-                    if let Some(ref old) = state.pre_op_registers {
-                        for (i, (old_reg, new_reg)) in
-                            old.iter().zip(state.registers.iter()).enumerate()
-                        {
-                            if old_reg != new_reg {
-                                match new_reg {
-                                    Register::Value(v) => println!("R[{i}] = {v}"),
-                                    Register::Aggregate(_) => println!("R[{i}] = <aggregate>"),
-                                    Register::Record(_) => println!("R[{i}] = <record>"),
-                                }
+                trace_insn(self, state.pc as InsnReference, insn);
+                crate::stack::trace_remaining("program_step:opcode");
+            }
+            if self.connection.get_vdbe_trace() {
+                // Diff registers from PREVIOUS opcode
+                // The last opcode (Halt) won't have its diff printed, but Halt
+                // doesn't write to any registers
+                if let Some(ref old) = state.pre_op_registers {
+                    for (i, (old_reg, new_reg)) in
+                        old.iter().zip(state.registers.iter()).enumerate()
+                    {
+                        if old_reg != new_reg {
+                            match new_reg {
+                                Register::Value(v) => println!("R[{i}] = {v}"),
+                                Register::Aggregate(_) => println!("R[{i}] = <aggregate>"),
+                                Register::Record(_) => println!("R[{i}] = <record>"),
                             }
                         }
-                        state.pre_op_registers = None;
                     }
-
-                    // Print CURRENT opcode
-                    if matches!(insn, Insn::Init { .. }) {
-                        println!("VDBE Trace:");
-                    }
-                    println!(
-                        "{}",
-                        explain::insn_to_str(
-                            self,
-                            state.pc as InsnReference,
-                            insn,
-                            String::new(),
-                            self.comments
-                                .iter()
-                                .find(|(offset, _)| *offset == state.pc as InsnReference)
-                                .map(|(_, comment)| comment)
-                                .copied()
-                        )
-                    );
-                    // Snapshot for next iteration
-                    state.pre_op_registers = Some(state.registers.clone());
-                } else {
-                    trace_insn(self, state.pc as InsnReference, insn);
+                    state.pre_op_registers = None;
                 }
-                crate::stack::trace_remaining("program_step:opcode");
+
+                // Print CURRENT opcode
+                if matches!(insn, Insn::Init { .. }) {
+                    println!("VDBE Trace:");
+                }
+                println!(
+                    "{}",
+                    explain::insn_to_str(
+                        self,
+                        state.pc as InsnReference,
+                        insn,
+                        String::new(),
+                        self.comments
+                            .iter()
+                            .find(|(offset, _)| *offset == state.pc as InsnReference)
+                            .map(|(_, comment)| comment)
+                            .copied()
+                    )
+                );
+                // Snapshot for next iteration
+                state.pre_op_registers = Some(state.registers.clone());
             }
             // Always increment VM steps for every loop iteration
             state.metrics.vm_steps = state.metrics.vm_steps.saturating_add(1);

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1845,6 +1845,8 @@ pub enum PragmaName {
     ListTypes,
     /// Deprecated no-op: control whether callback is invoked for empty result sets
     EmptyResultCallbacks,
+    /// VDBE opcode trace output
+    VdbeTrace,
 }
 
 /// `CREATE TRIGGER` time

--- a/testing/sqltests/tests/pragma_vdbe_trace.sqltest
+++ b/testing/sqltests/tests/pragma_vdbe_trace.sqltest
@@ -1,0 +1,73 @@
+@database :memory:
+
+# PRAGMA vdbe_trace get/set round-trip. The query form returns the
+# connection's current trace flag as 1 (enabled) or 0 (disabled).
+
+test pragma-vdbe-trace-default-off {
+    PRAGMA vdbe_trace;
+}
+expect {
+    0
+}
+
+test pragma-vdbe-trace-on {
+    PRAGMA vdbe_trace = ON;
+    PRAGMA vdbe_trace;
+}
+expect {
+    1
+}
+
+test pragma-vdbe-trace-off {
+    PRAGMA vdbe_trace = ON;
+    PRAGMA vdbe_trace = OFF;
+    PRAGMA vdbe_trace;
+}
+expect {
+    0
+}
+
+test pragma-vdbe-trace-true {
+    PRAGMA vdbe_trace = OFF;
+    PRAGMA vdbe_trace = TRUE;
+    PRAGMA vdbe_trace;
+}
+expect {
+    1
+}
+
+test pragma-vdbe-trace-false {
+    PRAGMA vdbe_trace = ON;
+    PRAGMA vdbe_trace = FALSE;
+    PRAGMA vdbe_trace;
+}
+expect {
+    0
+}
+
+test pragma-vdbe-trace-numeric-one {
+    PRAGMA vdbe_trace = 0;
+    PRAGMA vdbe_trace = 1;
+    PRAGMA vdbe_trace;
+}
+expect {
+    1
+}
+
+test pragma-vdbe-trace-numeric-zero {
+    PRAGMA vdbe_trace = 1;
+    PRAGMA vdbe_trace = 0;
+    PRAGMA vdbe_trace;
+}
+expect {
+    0
+}
+
+test pragma-vdbe-trace-numeric-nonzero-true {
+    PRAGMA vdbe_trace = 0;
+    PRAGMA vdbe_trace = 2;
+    PRAGMA vdbe_trace;
+}
+expect {
+    1
+}

--- a/testing/sqltests/tests/pragma_vdbe_trace.sqltest
+++ b/testing/sqltests/tests/pragma_vdbe_trace.sqltest
@@ -1,73 +1,14 @@
 @database :memory:
 
-# PRAGMA vdbe_trace get/set round-trip. The query form returns the
-# connection's current trace flag as 1 (enabled) or 0 (disabled).
-
-test pragma-vdbe-trace-default-off {
-    PRAGMA vdbe_trace;
-}
-expect {
-    0
-}
-
-test pragma-vdbe-trace-on {
+test pragma-vdbe-trace {
     PRAGMA vdbe_trace = ON;
-    PRAGMA vdbe_trace;
-}
-expect {
-    1
-}
-
-test pragma-vdbe-trace-off {
-    PRAGMA vdbe_trace = ON;
-    PRAGMA vdbe_trace = OFF;
-    PRAGMA vdbe_trace;
-}
-expect {
-    0
-}
-
-test pragma-vdbe-trace-true {
     PRAGMA vdbe_trace = OFF;
     PRAGMA vdbe_trace = TRUE;
-    PRAGMA vdbe_trace;
-}
-expect {
-    1
-}
-
-test pragma-vdbe-trace-false {
-    PRAGMA vdbe_trace = ON;
     PRAGMA vdbe_trace = FALSE;
-    PRAGMA vdbe_trace;
-}
-expect {
-    0
-}
-
-test pragma-vdbe-trace-numeric-one {
     PRAGMA vdbe_trace = 0;
     PRAGMA vdbe_trace = 1;
-    PRAGMA vdbe_trace;
-}
-expect {
-    1
-}
-
-test pragma-vdbe-trace-numeric-zero {
-    PRAGMA vdbe_trace = 1;
-    PRAGMA vdbe_trace = 0;
-    PRAGMA vdbe_trace;
-}
-expect {
-    0
-}
-
-test pragma-vdbe-trace-numeric-nonzero-true {
-    PRAGMA vdbe_trace = 0;
     PRAGMA vdbe_trace = 2;
     PRAGMA vdbe_trace;
 }
 expect {
-    1
 }


### PR DESCRIPTION
## Description

Adds `PRAGMA vdbe_trace=ON/OFF` for runtime VDBE opcode tracing. When enabled, each executed opcode is printed to stdout followed by any register values that changed.

```
VDBE Trace:
0     Init               0     3     0                    0   Start at 3
3     Integer            1     2     0                    0   r[2]=1
R[2] = 1
4     Add                2     2     1                    0   r[1]=r[2]+r[2]
R[1] = 2
```

Register diffs use snapshot-and-compare.

## Motivation and context

Closes #6444

## Description of AI Usage

Claude Code was used for code base exploration