### PR TITLE
core/storage: Fix savepoint rollback under cache pressure

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -204,12 +204,27 @@ impl PageCache {
 
     #[inline]
     pub fn insert(&mut self, key: PageCacheKey, value: PageRef) -> Result<(), CacheError> {
-        self._insert(key, value, false)
+        self._insert(key, value, false, false)
     }
 
     #[inline]
     pub fn upsert_page(&mut self, key: PageCacheKey, value: PageRef) -> Result<(), CacheError> {
-        self._insert(key, value, true)
+        self._insert(key, value, true, false)
+    }
+
+    /// Insert or replace a page without enforcing the cache capacity.
+    ///
+    /// Savepoint rollback uses this while restoring subjournaled before-images:
+    /// rollback must restore every page it journaled even when the cache is full
+    /// of dirty pages that cannot be evicted yet. Normal cache insertions still
+    /// enforce capacity and will drain the temporary excess as pages become
+    /// spillable or clean.
+    pub fn force_upsert_page(
+        &mut self,
+        key: PageCacheKey,
+        value: PageRef,
+    ) -> Result<(), CacheError> {
+        self._insert(key, value, true, true)
     }
 
     pub fn _insert(
@@ -217,6 +232,7 @@ impl PageCache {
         key: PageCacheKey,
         value: PageRef,
         update_in_place: bool,
+        bypass_capacity: bool,
     ) -> Result<(), CacheError> {
         trace!("insert(key={:?})", key);
 
@@ -252,7 +268,7 @@ impl PageCache {
         }
 
         // Key doesn't exist, proceed with new entry
-        self.make_room_for(1)?;
+        self.make_room_for(1, bypass_capacity)?;
 
         // Track evictable count for the new page
         let is_evictable = Self::counted_as_evictable(&value);
@@ -585,17 +601,16 @@ impl PageCache {
     /// their ref_bit and leaving them in place; only pages with ref_bit == 0 are evicted.
     ///
     /// Returns `CacheError::Full` if not enough pages can be evicted
-    pub fn make_room_for(&mut self, n: usize) -> Result<(), CacheError> {
+    pub fn make_room_for(&mut self, n: usize, bypass_capacity: bool) -> Result<(), CacheError> {
+        if bypass_capacity {
+            return Ok(());
+        }
         if n > self.capacity {
             return Err(CacheError::Full);
         }
-        let available = self.capacity - self.len();
-        if n <= available {
-            return Ok(());
-        }
 
-        let need = n - available;
-        for _ in 0..need {
+        let target_len = self.capacity - n;
+        while self.len() > target_len {
             self.evict_one()?;
         }
         Ok(())
@@ -1078,6 +1093,40 @@ mod tests {
 
         assert_eq!(result, Err(CacheError::Full));
         assert_eq!(cache.len(), 2);
+        cache.verify_cache_integrity();
+    }
+
+    #[test]
+    fn test_force_upsert_allows_temporary_over_capacity_cache() {
+        let mut cache = PageCache::new_with_spill(2, true);
+        let key2 = insert_page(&mut cache, 2);
+        let key3 = insert_page(&mut cache, 3);
+
+        for key in [key2, key3] {
+            cache.notify_page_dirty(key);
+            cache.peek(&key, false).unwrap().set_dirty();
+        }
+
+        let key4 = create_key(4);
+        let page4 = page_with_content(4);
+        page4.set_dirty();
+        cache.force_upsert_page(key4, page4).unwrap();
+
+        assert_eq!(cache.len(), 3);
+        assert!(cache.contains_key(&key4));
+        cache.verify_cache_integrity();
+
+        for key in [key2, key3] {
+            cache.notify_page_spilled(key);
+            cache.peek(&key, false).unwrap().set_spilled();
+        }
+
+        let key5 = create_key(5);
+        cache.insert(key5, page_with_content(5)).unwrap();
+
+        assert_eq!(cache.len(), 2);
+        assert!(cache.contains_key(&key4));
+        assert!(cache.contains_key(&key5));
         cache.verify_cache_integrity();
     }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2007,7 +2007,7 @@ impl Pager {
             // rolled-back savepoint/statement.
             page.set_dirty();
             dirty_pages.insert(page_id);
-            self.upsert_page_in_cache(page_id as usize, page, true)?;
+            self.force_upsert_page_in_cache(page_id as usize, page)?;
         }
 
         let truncate_completion = subjournal.truncate(journal_start_offset)?;
@@ -3592,7 +3592,7 @@ impl Pager {
                     if spilled {
                         // After spilling, try to evict clean pages to make room in the cache
                         let mut cache = self.page_cache.write();
-                        if let Err(e) = cache.make_room_for(1) {
+                        if let Err(e) = cache.make_room_for(1, false) {
                             // Cache is completely full with unevictable pages
                             tracing::error!(
                                 "ensure_cache_space: {e} cache full, could not make room"
@@ -5024,6 +5024,27 @@ impl Pager {
                 "Failed to insert loaded page {id} into cache: {e:?}"
             ))
         })?;
+        page.set_loaded();
+        page.clear_wal_tag();
+        Ok(())
+    }
+
+    fn force_upsert_page_in_cache(&self, id: usize, page: PageRef) -> Result<(), LimboError> {
+        let mut cache = self.page_cache.write();
+        let page_key = PageCacheKey::new(id);
+
+        turso_assert!(
+            page.is_dirty(),
+            "restored savepoint page must be dirty",
+            { "page_id": id }
+        );
+        cache
+            .force_upsert_page(page_key, page.clone())
+            .map_err(|e| {
+                LimboError::InternalError(format!(
+                    "Failed to restore savepoint page {id} into cache: {e:?}"
+                ))
+            })?;
         page.set_loaded();
         page.clear_wal_tag();
         Ok(())

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6,7 +6,8 @@ use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{
-    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME, SQLITE_SEQUENCE_TABLE_NAME,
+    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME,
+    SQLITE_SEQUENCE_TABLE_NAME,
 };
 use crate::state_machine::StateMachine;
 use crate::storage::btree::{
@@ -13021,11 +13022,13 @@ pub fn op_alter_column(
             let column_count = btree.columns().len();
             for i in 0..column_count {
                 let cols_view = btree.columns();
-                cols_view[i]
+                if let Some(new_sql) = cols_view[i]
                     .generated_expr()
                     .map(|expr| render_gencol_expr_sql_with_new_names(expr, cols_view))
                     .transpose()?
-                    .map(|new_sql| btree.columns_mut()[i].set_generated_original_sql(new_sql));
+                {
+                    btree.columns_mut()[i].set_generated_original_sql(new_sql)
+                }
             }
         } else {
             btree.columns_mut()[*column_index] = new_column.clone();

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -2565,7 +2565,10 @@ pub unsafe extern "C" fn sqlite3_complete(sql: *const ffi::c_char) -> ffi::c_int
         return 0;
     }
     let s = CStr::from_ptr(sql).to_bytes();
-    s.iter().rev().find(|&&b| !b.is_ascii_whitespace()).map_or(0, |&b| (b == b';') as ffi::c_int)
+    s.iter()
+        .rev()
+        .find(|&&b| !b.is_ascii_whitespace())
+        .map_or(0, |&b| (b == b';') as ffi::c_int)
 }
 
 #[no_mangle]

--- a/testing/sqltests/tests/savepoint.sqltest
+++ b/testing/sqltests/tests/savepoint.sqltest
@@ -452,3 +452,39 @@ expect {
     1|100000
     2|500000
 }
+
+# Regression test for #6351: ROLLBACK TO must restore every subjournaled
+# before-image even when the page cache is full of dirty pages.
+@cross-check-integrity
+test savepoint-rollback-cache-spill-issue-6351 {
+    PRAGMA page_size = 512;
+    PRAGMA cache_size = 2;
+    PRAGMA cache_spill = ON;
+
+    CREATE TABLE t6351(a INTEGER PRIMARY KEY, b INT, p BLOB);
+    INSERT INTO t6351
+        SELECT value, value % 43, randomblob(2550)
+        FROM generate_series(1, 135);
+
+    SAVEPOINT s1;
+    DELETE FROM t6351 WHERE a BETWEEN 27 AND 60;
+    INSERT INTO t6351
+        SELECT value + 2700, value % 43, randomblob(3062)
+        FROM generate_series(1, 27);
+    UPDATE t6351 SET p = randomblob(2806) WHERE a BETWEEN 67 AND 78;
+    ROLLBACK TO s1;
+    RELEASE s1;
+
+    SELECT COUNT(*) FROM t6351;
+    SELECT COUNT(*) FROM t6351 WHERE a BETWEEN 27 AND 60;
+    SELECT MIN(a), MAX(a) FROM t6351;
+    SELECT length(p) FROM t6351 WHERE a IN (1, 67, 135);
+}
+expect {
+    135
+    34
+    1|135
+    2550
+    2550
+    2550
+}


### PR DESCRIPTION
## Description
On a savepoint rollback, we need to be able to insert into the `PageCache` regardless of the capacity so that we avoid returning a `Full` error. SQLite does something similar with the `SPILLFLAG_ROLLBACK` in `pager.c`, that bypasses the cache size capacity check. It sets the `createflag == 2` for `pcache1FetchStage2` which will try to allocate a new page and fail only on OOM

Closes https://github.com/tursodatabase/turso/issues/6351

## Description of AI Usage
Codex did it after I asked to look in SQLite source code
