### PR TITLE
Fix: index seek precision loss on negated integer literal against REAL column

### DIFF
--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -282,13 +282,23 @@ impl Affinity {
         if !self.has_affinity() {
             return true;
         }
-        // TODO: check for unary minus in the expr, as it may be an additional optimization.
-        // This involves mostly likely walking the expression
-        match expr {
+
+        // Unwrap unary +/-; track minus since `-'5'` / `-x'01'` aren't the bare literal.
+        let mut inner = expr;
+        let mut unary_minus = false;
+        while let Expr::Unary(op, sub) = inner {
+            match op {
+                turso_parser::ast::UnaryOperator::Negative => unary_minus = true,
+                turso_parser::ast::UnaryOperator::Positive => {}
+                _ => break,
+            }
+            inner = sub;
+        }
+        match inner {
             Expr::Literal(literal) => match literal {
                 Literal::Numeric(_) => self.is_numeric(),
-                Literal::String(_) => matches!(self, Affinity::Text),
-                Literal::Blob(_) => true,
+                Literal::String(_) => !unary_minus && matches!(self, Affinity::Text),
+                Literal::Blob(_) => !unary_minus,
                 _ => false,
             },
             Expr::Column {
@@ -697,6 +707,38 @@ mod tests {
             ValueRef::Numeric(Numeric::Float(f)) => assert!(f64::from(f).is_infinite()),
             other => panic!("expected Float, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_expr_needs_no_affinity_change_unary_signs() {
+        use turso_parser::ast::UnaryOperator;
+
+        let num = Expr::Literal(Literal::Numeric("5".into()));
+        let neg_num = Expr::Unary(UnaryOperator::Negative, Box::new(num.clone()));
+        let pos_num = Expr::Unary(UnaryOperator::Positive, Box::new(num.clone()));
+
+        assert!(Affinity::Real.expr_needs_no_affinity_change(&neg_num));
+        assert!(Affinity::Integer.expr_needs_no_affinity_change(&neg_num));
+        assert!(Affinity::Numeric.expr_needs_no_affinity_change(&neg_num));
+        assert!(Affinity::Real.expr_needs_no_affinity_change(&pos_num));
+
+        let s = Expr::Literal(Literal::String("'5'".into()));
+        let neg_s = Expr::Unary(UnaryOperator::Negative, Box::new(s.clone()));
+        let pos_s = Expr::Unary(UnaryOperator::Positive, Box::new(s.clone()));
+
+        assert!(Affinity::Text.expr_needs_no_affinity_change(&s));
+        assert!(Affinity::Text.expr_needs_no_affinity_change(&pos_s));
+        assert!(!Affinity::Text.expr_needs_no_affinity_change(&neg_s));
+        assert!(!Affinity::Real.expr_needs_no_affinity_change(&neg_s));
+
+        let blob = Expr::Literal(Literal::Blob("01".into()));
+        let neg_blob = Expr::Unary(UnaryOperator::Negative, Box::new(blob.clone()));
+        let pos_blob = Expr::Unary(UnaryOperator::Positive, Box::new(blob.clone()));
+
+        assert!(Affinity::Text.expr_needs_no_affinity_change(&blob));
+        assert!(Affinity::Text.expr_needs_no_affinity_change(&pos_blob));
+        assert!(!Affinity::Text.expr_needs_no_affinity_change(&neg_blob));
+        assert!(!Affinity::Real.expr_needs_no_affinity_change(&neg_blob));
     }
 
     #[test]

--- a/testing/sqltests/tests/index-seek-unary-signs.sqltest
+++ b/testing/sqltests/tests/index-seek-unary-signs.sqltest
@@ -1,0 +1,130 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t (f REAL);
+    CREATE INDEX t_f ON t(f);
+    INSERT INTO t VALUES (-2701729208700874036);
+}
+
+@setup schema
+test real-index-near-miss-low {
+    SELECT count(*) FROM t WHERE f = -2701729208700874000;
+}
+expect {
+    0
+}
+
+@setup schema
+test real-index-original-int {
+    SELECT count(*) FROM t WHERE f = -2701729208700874036;
+}
+expect {
+    0
+}
+
+@setup schema
+test real-index-roundtrip-int {
+    SELECT count(*) FROM t WHERE f = -2701729208700874240;
+}
+expect {
+    1
+}
+
+setup schema_unique {
+    CREATE TABLE q (f REAL UNIQUE);
+    INSERT INTO q VALUES (-2701729208700874036);
+}
+
+@setup schema_unique
+test real-unique-near-miss {
+    SELECT count(*) FROM q WHERE f = -2701729208700874000;
+}
+expect {
+    0
+}
+
+@setup schema_unique
+test real-unique-roundtrip {
+    SELECT count(*) FROM q WHERE f = -2701729208700874240;
+}
+expect {
+    1
+}
+
+setup schema_text {
+    CREATE TABLE st (s TEXT);
+    CREATE INDEX st_s ON st(s);
+    INSERT INTO st VALUES ('-5');
+    INSERT INTO st VALUES ('5');
+}
+
+@setup schema_text
+test text-index-plain {
+    SELECT count(*) FROM st WHERE s = '5';
+}
+expect {
+    1
+}
+
+@setup schema_text
+test text-index-unary-plus {
+    SELECT count(*) FROM st WHERE s = +'5';
+}
+expect {
+    1
+}
+
+@setup schema_text
+test text-index-unary-minus {
+    SELECT count(*) FROM st WHERE s = -'5';
+}
+expect {
+    1
+}
+
+@setup schema_text
+test text-index-unary-minus-row {
+    SELECT s FROM st WHERE s = -'5';
+}
+expect {
+    -5
+}
+
+setup schema_blob {
+    CREATE TABLE sb (data BLOB);
+    CREATE INDEX sb_data ON sb(data);
+    INSERT INTO sb VALUES (x'05');
+    INSERT INTO sb VALUES (x'00');
+}
+
+@setup schema_blob
+test blob-index-plain {
+    SELECT count(*) FROM sb WHERE data = x'05';
+}
+expect {
+    1
+}
+
+@setup schema_blob
+test blob-index-unary-plus {
+    SELECT count(*) FROM sb WHERE data = +x'05';
+}
+expect {
+    1
+}
+
+@setup schema_blob
+test blob-index-unary-minus {
+    SELECT count(*) FROM sb WHERE data = -x'05';
+}
+expect {
+    0
+}
+
+@setup schema_blob
+test blob-index-unary-minus-zero {
+    SELECT count(*) FROM sb WHERE data = -x'00';
+}
+expect {
+    0
+}


### PR DESCRIPTION


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
Unwrap unary `+/-` in `expr_needs_no_affinity_change` so a negated numeric literal stays a constant on `REAL` index seeks while `-'5' `/  ` -x'01'` still go through `OP_Affinity`. 

Closes #6715 

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
Used Claude to generate the code based on the SQLite reference implementation