### PR TITLE
mvcc: preserve rowid allocator bumps during initialization

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5268,7 +5268,10 @@ impl RowidAllocator {
     /// Initialize from btree max. Called once per table, under lock.
     pub fn initialize(&self, rowid: Option<i64>) {
         tracing::trace!("initialize({rowid:?})");
-        self.max_rowid.store(rowid.unwrap_or(0), Ordering::SeqCst);
+        // Explicit inserts can bump the allocator before the first automatic rowid
+        // initializes it. Preserve that higher observed value instead of replacing
+        // it with a lower visible btree max from another concurrent transaction.
+        self.insert_row_id_maybe_update(rowid.unwrap_or(0));
         self.initialized.store(true, Ordering::SeqCst);
     }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9922,3 +9922,34 @@ fn test_read_lock_leak_deferred_then_concurrent() {
     let rows = get_rows(&conn1, "SELECT * FROM t1");
     assert_eq!(rows.len(), 1);
 }
+
+#[test]
+fn test_mvcc_rowid_allocator_preserves_explicit_rowids_seen_before_first_auto_rowid() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn0 = db.connect();
+    let conn1 = db.connect();
+
+    conn0
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    conn0.execute("BEGIN CONCURRENT").unwrap();
+
+    conn1
+        .execute("INSERT INTO t VALUES (10, 'a'), (11, 'b')")
+        .unwrap();
+    conn0
+        .execute("INSERT INTO t VALUES (1, 'c'), (NULL, 'd')")
+        .unwrap();
+
+    let rows = get_rows(&conn0, "SELECT id FROM t WHERE val = 'd'");
+    assert_eq!(rows[0][0].to_string(), "12");
+
+    conn1
+        .execute("UPDATE t SET val = 'a2' WHERE id = 10")
+        .unwrap();
+    conn1.execute("INSERT INTO t VALUES (NULL, 'e')").unwrap();
+
+    let rows = get_rows(&conn1, "SELECT id FROM t WHERE val = 'e'");
+    assert_eq!(rows[0][0].to_string(), "13");
+}

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -881,6 +881,7 @@ fn reopen_database(env: &mut SimulatorEnv) {
             env.rollback_conn(conn_index);
         }
     }
+    env.mvcc_rowid_allocators.clear();
 
     env.connections.clear();
 

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -211,6 +211,7 @@ fn validate_integer_pk_row_non_null(
 }
 
 fn prepare_insert_rows(
+    tables: &mut ShadowTablesMut,
     table_name: &str,
     columns: &[Column],
     existing_rows: &[Vec<SimValue>],
@@ -219,11 +220,36 @@ fn prepare_insert_rows(
     let mut new_rows = input_rows.to_vec();
 
     if let Some(pk_idx) = integer_pk_index(columns) {
-        let mut alloc = RowidAllocator::new(existing_rows, pk_idx);
-        new_rows = new_rows
-            .iter()
-            .map(|r| normalize_integer_pk_row(table_name, columns, pk_idx, &mut alloc, r))
-            .collect::<anyhow::Result<Vec<_>>>()?;
+        if tables.uses_mvcc_rowid_allocator() {
+            new_rows = new_rows
+                .iter()
+                .map(|r| {
+                    ensure_row_width(table_name, columns, r)?;
+                    let mut out = r.clone();
+                    if out[pk_idx].0 == Value::Null {
+                        let new_id = tables
+                            .allocate_mvcc_rowid(table_name, existing_rows, pk_idx)
+                            .expect("MVCC rowid allocator should be available");
+                        out[pk_idx] = SimValue(Value::from_i64(new_id));
+                    } else if let Some(i) = out[pk_idx].0.as_int() {
+                        tables.observe_mvcc_rowid(table_name, i);
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "datatype mismatch: table '{}' INTEGER PRIMARY KEY column '{}' must be an integer",
+                            table_name,
+                            columns[pk_idx].name
+                        ));
+                    }
+                    Ok(out)
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+        } else {
+            let mut alloc = RowidAllocator::new(existing_rows, pk_idx);
+            new_rows = new_rows
+                .iter()
+                .map(|r| normalize_integer_pk_row(table_name, columns, pk_idx, &mut alloc, r))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+        }
     } else {
         for r in &new_rows {
             ensure_row_width(table_name, columns, r)?;
@@ -553,6 +579,7 @@ impl Shadow for Create {
         if !tables.iter().any(|t| t.name == self.table.name) {
             // Record the operation BEFORE applying it to current_tables
             tables.record_create_table(self.table.clone());
+            tables.reset_mvcc_rowid_allocator(&self.table.name);
             tables.push(self.table.clone());
             Ok(vec![])
         } else {
@@ -631,6 +658,7 @@ impl Shadow for Drop {
 
         // Record the drop for transaction tracking
         tables.record_drop_table(self.table.clone());
+        tables.remove_mvcc_rowid_allocator(&self.table);
 
         tables.retain(|t| t.name != self.table);
 
@@ -654,8 +682,9 @@ impl Shadow for Insert {
                     .ok_or_else(|| anyhow::anyhow!("Table {} does not exist", table_name))?;
 
                 let columns = tables[table_pos].columns.clone();
+                let existing_rows = tables[table_pos].rows.clone();
                 let rows =
-                    prepare_insert_rows(&table_name, &columns, &tables[table_pos].rows, &raw_rows)?;
+                    prepare_insert_rows(tables, &table_name, &columns, &existing_rows, &raw_rows)?;
 
                 for row in &rows {
                     tables.record_insert(table_name.clone(), row.clone());
@@ -676,13 +705,15 @@ impl Shadow for Insert {
                     .ok_or_else(|| anyhow::anyhow!("Table {} does not exist", table_name))?;
 
                 let columns = tables[table_pos].columns.clone();
+                let existing_rows = tables[table_pos].rows.clone();
 
                 match on_conflict {
                     None => {
                         let new_rows = prepare_insert_rows(
+                            tables,
                             &table_name,
                             &columns,
-                            &tables[table_pos].rows,
+                            &existing_rows,
                             values,
                         )?;
 
@@ -724,8 +755,11 @@ impl Shadow for Insert {
 
                         let pk_idx_opt = integer_pk_index(&columns);
                         let mut staged_rows = tables[table_pos].rows.clone();
-                        let mut alloc_opt =
-                            pk_idx_opt.map(|pk_idx| RowidAllocator::new(&staged_rows, pk_idx));
+                        let mut alloc_opt = if tables.uses_mvcc_rowid_allocator() {
+                            None
+                        } else {
+                            pk_idx_opt.map(|pk_idx| RowidAllocator::new(&staged_rows, pk_idx))
+                        };
 
                         enum StagedOp {
                             Insert(Vec<SimValue>),
@@ -739,16 +773,35 @@ impl Shadow for Insert {
                         for raw_row in values.iter() {
                             ensure_row_width(&table_name, &columns, raw_row)?;
 
-                            let excluded_row = if let (Some(pk_idx), Some(alloc)) =
-                                (pk_idx_opt, alloc_opt.as_mut())
-                            {
-                                normalize_integer_pk_row(
-                                    &table_name,
-                                    &columns,
-                                    pk_idx,
-                                    alloc,
-                                    raw_row,
-                                )?
+                            let excluded_row = if let Some(pk_idx) = pk_idx_opt {
+                                if tables.uses_mvcc_rowid_allocator() {
+                                    let mut out = raw_row.clone();
+                                    if out[pk_idx].0 == Value::Null {
+                                        let new_id = tables
+                                            .allocate_mvcc_rowid(&table_name, &staged_rows, pk_idx)
+                                            .expect("MVCC rowid allocator should be available");
+                                        out[pk_idx] = SimValue(Value::from_i64(new_id));
+                                    } else if let Some(i) = out[pk_idx].0.as_int() {
+                                        tables.observe_mvcc_rowid(&table_name, i);
+                                    } else {
+                                        return Err(anyhow::anyhow!(
+                                            "datatype mismatch: table '{}' INTEGER PRIMARY KEY column '{}' must be an integer",
+                                            table_name,
+                                            columns[pk_idx].name
+                                        ));
+                                    }
+                                    out
+                                } else if let Some(alloc) = alloc_opt.as_mut() {
+                                    normalize_integer_pk_row(
+                                        &table_name,
+                                        &columns,
+                                        pk_idx,
+                                        alloc,
+                                        raw_row,
+                                    )?
+                                } else {
+                                    raw_row.clone()
+                                }
                             } else {
                                 raw_row.clone()
                             };
@@ -810,9 +863,7 @@ impl Shadow for Insert {
                                         new_row[dst_idx] = excluded_row[src_idx].clone();
                                     }
 
-                                    if let (Some(pk_idx), Some(alloc)) =
-                                        (pk_idx_opt, alloc_opt.as_mut())
-                                    {
+                                    if let Some(pk_idx) = pk_idx_opt {
                                         validate_integer_pk_row_non_null(
                                             &table_name,
                                             &columns,
@@ -820,7 +871,11 @@ impl Shadow for Insert {
                                             &new_row,
                                         )?;
                                         if let Some(i) = new_row[pk_idx].0.as_int() {
-                                            alloc.observe(i);
+                                            if tables.uses_mvcc_rowid_allocator() {
+                                                tables.observe_mvcc_rowid(&table_name, i);
+                                            } else if let Some(alloc) = alloc_opt.as_mut() {
+                                                alloc.observe(i);
+                                            }
                                         }
                                     }
 
@@ -1134,6 +1189,9 @@ impl Shadow for Update {
         if let Some(pk_idx) = integer_pk_index(&columns) {
             for (_, _, new_row) in &updates {
                 validate_integer_pk_row_non_null(&self.table, &columns, pk_idx, new_row)?;
+                if let Some(rowid) = new_row[pk_idx].0.as_int() {
+                    tables.observe_mvcc_rowid(&self.table, rowid);
+                }
             }
         }
 
@@ -1212,7 +1270,8 @@ impl Shadow for AlterTable {
                     Some(prefix) => format!("{prefix}.{new_name}"),
                     None => new_name.clone(),
                 };
-                tables.record_rename_table(self.table_name.clone(), qualified_new);
+                tables.record_rename_table(self.table_name.clone(), qualified_new.clone());
+                tables.rename_mvcc_rowid_allocator(&self.table_name, &qualified_new);
             }
             AlterTableType::AddColumn { column } => {
                 tables.record_add_column(self.table_name.clone(), column.clone());

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -122,6 +122,34 @@ pub enum TxOperation {
     },
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct MvccRowidAllocator {
+    max_rowid: i64,
+    initialized: bool,
+}
+
+impl MvccRowidAllocator {
+    pub fn observe(&mut self, rowid: i64) {
+        if rowid > self.max_rowid {
+            self.max_rowid = rowid;
+        }
+    }
+
+    pub fn allocate(&mut self, existing_rows: &[Vec<SimValue>], pk_idx: usize) -> i64 {
+        if !self.initialized {
+            for row in existing_rows {
+                if let Some(rowid) = row.get(pk_idx).and_then(|value| value.0.as_int()) {
+                    self.observe(rowid);
+                }
+            }
+            self.initialized = true;
+        }
+
+        self.max_rowid = self.max_rowid.saturating_add(1);
+        self.max_rowid
+    }
+}
+
 /// Database snapshot
 #[derive(Debug, Clone)]
 pub struct Snapshot {
@@ -318,6 +346,7 @@ pub struct ShadowTables<'a> {
 pub struct ShadowTablesMut<'a> {
     commited_tables: &'a mut Vec<Table>,
     transaction_tables: &'a mut Option<TransactionTables>,
+    mvcc_rowid_allocators: Option<&'a mut HashMap<String, MvccRowidAllocator>>,
 }
 
 impl<'a> ShadowTables<'a> {
@@ -352,6 +381,53 @@ where
             .map_or(self.commited_tables, |v| {
                 &mut v.expect_snapshot_mut().current_tables
             })
+    }
+
+    pub fn uses_mvcc_rowid_allocator(&self) -> bool {
+        self.mvcc_rowid_allocators.is_some()
+    }
+
+    pub fn allocate_mvcc_rowid(
+        &mut self,
+        table_name: &str,
+        existing_rows: &[Vec<SimValue>],
+        pk_idx: usize,
+    ) -> Option<i64> {
+        self.mvcc_rowid_allocators.as_mut().map(|allocators| {
+            allocators
+                .entry(table_name.to_string())
+                .or_default()
+                .allocate(existing_rows, pk_idx)
+        })
+    }
+
+    pub fn observe_mvcc_rowid(&mut self, table_name: &str, rowid: i64) {
+        if let Some(allocators) = self.mvcc_rowid_allocators.as_mut() {
+            allocators
+                .entry(table_name.to_string())
+                .or_default()
+                .observe(rowid);
+        }
+    }
+
+    pub fn reset_mvcc_rowid_allocator(&mut self, table_name: &str) {
+        if let Some(allocators) = self.mvcc_rowid_allocators.as_mut() {
+            allocators.remove(table_name);
+        }
+    }
+
+    pub fn remove_mvcc_rowid_allocator(&mut self, table_name: &str) {
+        if let Some(allocators) = self.mvcc_rowid_allocators.as_mut() {
+            allocators.remove(table_name);
+        }
+    }
+
+    pub fn rename_mvcc_rowid_allocator(&mut self, old_name: &str, new_name: &str) {
+        if let Some(allocators) = self.mvcc_rowid_allocators.as_mut()
+            && let Some(allocator) = allocators.remove(old_name)
+        {
+            allocators.insert(new_name.to_string(), allocator);
+        }
     }
 
     /// Record that a row was inserted during the current transaction
@@ -815,6 +891,7 @@ mod tests {
         ShadowTablesMut {
             commited_tables,
             transaction_tables,
+            mvcc_rowid_allocators: None,
         }
     }
 
@@ -911,6 +988,7 @@ pub(crate) struct SimulatorEnv {
     connection_last_query: Bitmap<64>,
     // Table data that is committed into the database or wal
     pub committed_tables: Vec<Table>,
+    pub mvcc_rowid_allocators: HashMap<String, MvccRowidAllocator>,
     /// Names of attached databases (e.g. ["aux0", "aux1", "aux2"])
     pub(crate) attached_dbs: Vec<String>,
 }
@@ -937,6 +1015,7 @@ impl SimulatorEnv {
             connection_tables: self.connection_tables.clone(),
             connection_last_query: self.connection_last_query,
             committed_tables: self.committed_tables.clone(),
+            mvcc_rowid_allocators: self.mvcc_rowid_allocators.clone(),
             attached_dbs: self.attached_dbs.clone(),
         }
     }
@@ -1247,6 +1326,7 @@ impl SimulatorEnv {
             io_backend,
             profile: profile.clone(),
             committed_tables: Vec::new(),
+            mvcc_rowid_allocators: HashMap::new(),
             connection_tables: vec![None; profile.max_connections],
             connection_last_query: Bitmap::new(),
             attached_dbs,
@@ -1310,6 +1390,7 @@ impl SimulatorEnv {
         self.committed_tables.clear();
         self.connection_tables.iter_mut().for_each(|t| *t = None);
         self.connection_last_query = Bitmap::new();
+        self.mvcc_rowid_allocators.clear();
     }
 
     // TODO: does not yet create the appropriate context to avoid WriteWriteConflitcs
@@ -1377,9 +1458,11 @@ impl SimulatorEnv {
     }
 
     pub fn get_conn_tables_mut(&mut self, conn_index: usize) -> ShadowTablesMut<'_> {
+        let mvcc_rowid_allocators = self.profile.mvcc.then_some(&mut self.mvcc_rowid_allocators);
         ShadowTablesMut {
             transaction_tables: self.connection_tables.get_mut(conn_index).unwrap(),
             commited_tables: &mut self.committed_tables,
+            mvcc_rowid_allocators,
         }
     }
 }

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -221,6 +221,11 @@ pub fn execute_interaction_turso(
                 let continuation = match err {
                     err if is_recoverable_tx_error(err) => {
                         if error_causes_rollback(err) && env.conn_in_transaction(connection_index) {
+                            // A statement may have advanced MVCC's global rowid allocator
+                            // before hitting a write-write conflict. Apply the shadow query
+                            // first so allocator side effects survive the transaction rollback.
+                            let _ =
+                                interaction.shadow(&mut env.get_conn_tables_mut(connection_index));
                             env.rollback_conn(connection_index);
                         }
                         ExecutionContinuation::NextInteractionOutsideThisProperty


### PR DESCRIPTION
## Summary
- Preserve explicit rowid bumps that happen before the MVCC rowid allocator's first automatic-rowid initialization.
- Add a regression covering concurrent explicit inserts followed by automatic rowids.
- Update the simulator shadow model to use MVCC-style global rowid allocation, including write-conflict rollback and database reopen behavior.

## Why
The simulator found a `simple_mvcc` case where an automatic rowid could collide with an existing explicit rowid. The allocator could be bumped by explicit inserts, then later initialized from a lower visible btree max in another concurrent transaction, losing the higher observed value.

## Verification
- `RUSTUP_TOOLCHAIN=1.91.1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p turso_core test_mvcc_rowid_allocator_preserves_explicit_rowids_seen_before_first_auto_rowid -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.91.1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p limbo_sim -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.91.1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo run -q --bin limbo_sim -- --seed 34 --profile simple_mvcc --maximum-time 20 --minimum-tests 20 --maximum-tests 160 --io-backend memory --disable-bugbase --keep-files --disable-integrity-check`
- `simple_mvcc` seeds 1-80 with `--disable-integrity-check`
- `git diff --check`

Note: I used `--disable-integrity-check` for the simulator seed runs on this branch because the normal final integrity check currently hits the separate MVCC/rusqlite false positive addressed in draft PR #6727.
