### PR TITLE
Avoid recursive scalar parenthesized expressions

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3430,6 +3430,16 @@ mod tests {
         }
     }
 
+    fn query_single_text(conn: &Arc<Connection>, sql: &str) -> String {
+        let mut stmt = conn.prepare(sql).unwrap();
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                text_value(stmt.row().unwrap().get::<&Value>(0).unwrap()).to_string()
+            }
+            other => panic!("expected a row, got {other:?}"),
+        }
+    }
+
     fn text_value(value: &Value) -> &str {
         match value {
             Value::Text(text) => text.as_str(),
@@ -3486,6 +3496,34 @@ mod tests {
         let second_db = Database::open_file(io, ":memory:reopen").unwrap();
         let second = second_db.connect().unwrap();
         assert_eq!(query_single_i64(&second, "SELECT x FROM t"), 99);
+    }
+
+    #[test]
+    fn test_generated_column_with_nested_parentheses_and_coalesce() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("generated_parenthesized.db");
+        let conn =
+            open_connection_with_opts(&db_path, DatabaseOpts::new().with_generated_columns(true));
+
+        conn.execute(
+            "CREATE TABLE t(
+                id INTEGER PRIMARY KEY,
+                a INTEGER,
+                b INTEGER,
+                c TEXT,
+                w TEXT GENERATED ALWAYS AS (c || ((a + coalesce(b, 0)) % 5)) VIRTUAL
+            )",
+        )
+        .unwrap();
+        conn.execute("INSERT INTO t(a, b, c) VALUES (1, 2, 'x')")
+            .unwrap();
+
+        assert_eq!(query_single_text(&conn, "SELECT w FROM t"), "x3");
+
+        conn.execute("CREATE INDEX idx_w ON t(w)").unwrap();
+        conn.execute("UPDATE t SET a = -36, b = 11 WHERE b IS NULL")
+            .unwrap();
+        assert_eq!(query_single_text(&conn, "PRAGMA integrity_check"), "ok");
     }
 
     #[test]

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -98,6 +98,14 @@ pub fn translate_expr(
     target_register: usize,
     resolver: &Resolver,
 ) -> Result<usize> {
+    let mut expr = expr;
+    while let ast::Expr::Parenthesized(exprs) = expr {
+        if exprs.len() != 1 {
+            break;
+        }
+        expr = exprs[0].as_ref();
+    }
+
     let constant_span = if expr.is_constant(resolver) {
         if !program.constant_span_is_open() {
             Some(program.constant_span_start())


### PR DESCRIPTION
## Summary
- unwrap scalar `Parenthesized` expressions once at the start of expression translation
- keep row-value parentheses on the existing multi-expression path
- add a regression test for a generated virtual column using nested parentheses and `coalesce`

## Why
A shallow generated-column expression like:

```sql
w TEXT GENERATED ALWAYS AS (c || ((a + coalesce(b, 0)) % 5)) VIRTUAL
```

could overflow the stack during translation when selecting the generated column. Scalar parentheses are semantically transparent, so normalizing them before constant/cached-expression handling avoids recursive translation without changing row-value behavior.

This is related to the broader stack-overflow class tracked in #5071, but it is a narrow fix for scalar parenthesized expressions rather than a full expression-depth limiter.

## Test plan
- `cargo test -p turso_core connection::tests::test_generated_column_with_nested_parentheses_and_coalesce --features "fs pure-rust-crypto" -- --exact --nocapture`
- `rustfmt --check core\connection.rs core\translate\expr\translator.rs`
- `git diff --check`
- CLI repro with `--experimental-generated-columns` returns `x3` and `ok`