### PR TITLE
testing/sqltests: Add regression test for self-referential trigger after ALTER TABLE RENAME

### DIFF
--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -1289,6 +1289,72 @@ expect {
     t2
 }
 
+# https://github.com/tursodatabase/turso/issues/5838
+# Self-referential AFTER INSERT trigger that INSERTs back into its own table
+# must have its body rewritten on ALTER TABLE RENAME, otherwise the trigger
+# fires against the old name and BLOB/TEXT values land in the wrong columns.
+@cross-check-integrity
+test alter-table-rename-trigger-self-insert-sql-rewritten {
+    CREATE TABLE t1 (a TEXT, b BLOB, c INTEGER);
+    CREATE TRIGGER tr AFTER INSERT ON t1 FOR EACH ROW WHEN NEW.c < 2 BEGIN
+        INSERT INTO t1 (a, b, c) VALUES (NEW.a, NEW.b, NEW.c + 1);
+    END;
+    ALTER TABLE t1 RENAME TO t2;
+    SELECT sql FROM sqlite_schema WHERE type = 'trigger';
+}
+expect pattern {
+    CREATE TRIGGER tr AFTER INSERT ON "?t2"? FOR EACH ROW WHEN NEW\.c < 2 BEGIN\s+INSERT INTO "?t2"? \(a, b, c\) VALUES \(NEW\.a, NEW\.b, NEW\.c \+ 1\);?\s+END
+}
+
+# https://github.com/tursodatabase/turso/issues/5838
+# Same as above but checks runtime behavior: BLOB/TEXT values forwarded by
+# the trigger via NEW.* must land in the correct columns of the renamed table.
+@cross-check-integrity
+test alter-table-rename-trigger-self-insert-blob-text-binding {
+    CREATE TABLE t1 (a TEXT, b BLOB, c INTEGER);
+    CREATE TRIGGER tr AFTER INSERT ON t1 FOR EACH ROW WHEN NEW.c < 2 BEGIN
+        INSERT INTO t1 (a, b, c) VALUES (NEW.a, NEW.b, NEW.c + 1);
+    END;
+    ALTER TABLE t1 RENAME TO t2;
+    INSERT INTO t2 VALUES ('hello', X'DEADBEEF', 1);
+    SELECT rowid, quote(a), quote(b), quote(c) FROM t2 ORDER BY rowid;
+}
+expect {
+    1|'hello'|X'DEADBEEF'|1
+    2|'hello'|X'DEADBEEF'|2
+}
+
+# https://github.com/tursodatabase/turso/issues/5838
+# Wide-row variant of the regression: when the trigger body mixes NEW.col
+# references with literal BLOB/TEXT/INT values across many columns, every
+# value must land in its declared column after the table rename. This is
+# the exact misbinding pattern the differential fuzzer reduced to issue 5838.
+@cross-check-integrity
+test alter-table-rename-trigger-self-insert-wide-row {
+    CREATE TABLE wide (
+        c1 TEXT, c2 BLOB, c3 INTEGER, c4 REAL, c5 BLOB,
+        c6 TEXT, c7 INTEGER, c8 BLOB, c9 TEXT, c10 INTEGER
+    );
+    CREATE TRIGGER tr AFTER INSERT ON wide FOR EACH ROW WHEN NEW.c10 = 0 BEGIN
+        INSERT INTO wide (c1, c2, c3, c4, c5, c6, c7, c8, c9, c10) VALUES
+            (NEW.c1, NEW.c2, NEW.c3, NEW.c4, NEW.c5,
+             NEW.c6, NEW.c7, NEW.c8, NEW.c9, NEW.c10 + 1);
+    END;
+    ALTER TABLE wide RENAME TO wide2;
+    INSERT INTO wide2 VALUES (
+        'tx1', X'AA', 100, 1.5, X'BB',
+        'tx2', 200, X'CC', 'tx3', 0
+    );
+    SELECT rowid,
+           quote(c1), quote(c2), quote(c3), quote(c4), quote(c5),
+           quote(c6), quote(c7), quote(c8), quote(c9), quote(c10)
+    FROM wide2 ORDER BY rowid;
+}
+expect {
+    1|'tx1'|X'AA'|100|1.5|X'BB'|'tx2'|200|X'CC'|'tx3'|0
+    2|'tx1'|X'AA'|100|1.5|X'BB'|'tx2'|200|X'CC'|'tx3'|1
+}
+
 # --- Trigger rewriting for ALTER TABLE RENAME COLUMN ---
 
 # Verify trigger fires after column rename (NEW refs updated)


### PR DESCRIPTION
Issue #5838 reported that an AFTER INSERT trigger which writes back into
its own table started producing wrong rows once the table was renamed via
ALTER TABLE ... RENAME TO. The original reproducer was a 100+-column
generated workload from the differential fuzzer in which BLOB/TEXT values
written by the trigger no longer lined up with the corresponding columns
of the renamed table: the stored trigger body still referenced the old
table name, so on the next INSERT the trigger either silently failed to
fire (its target was now a non-existent symbol) or fired against the
wrong schema, leaving values bound to columns of a different type.

The bug was fixed by db2033d18 ("core/translate: Rewrite trigger bodies
on ALTER TABLE ddl stmts"), which rewrites stored trigger SQL on
ALTER TABLE so that table-name references in the body are updated
alongside the trigger's tbl_name. Existing trigger-rename tests in
alter_table.sqltest covered triggers that wrote into *other* renamed
tables, but not the self-INSERT case from #5838, which is the one that
exposes the column-misbinding symptom.

Three new tests are added to testing/sqltests/tests/alter_table.sqltest:

  - alter-table-rename-trigger-self-insert-sql-rewritten asserts that
    the stored trigger SQL has both the ON-clause and the body's
    INSERT INTO retargeted to the new table name.
  - alter-table-rename-trigger-self-insert-blob-text-binding inserts
    a row whose values include a TEXT and a BLOB and verifies, via
    quote(), that the trigger-inserted row lands with each value in
    its declared column.
  - alter-table-rename-trigger-self-insert-wide-row exercises a
    10-column scrambled-type variant matching the differential-fuzzer
    pattern from the issue, which is the shape that originally
    surfaced the misbinding.

All three tests fail on b739896f6 ("Merge 'fix: BEFORE INSERT trigger
sees raw values without column type affinity' from Preston Thorpe")
(the merge parent immediately preceding the fix) and pass on the current
tree, with @cross-check-integrity confirming agreement with sqlite3.

Fixes #5838
