### PR TITLE
fix(vdbe): use round-half-away-from-zero in ROUND() to match SQLite

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -772,6 +772,7 @@ impl Value {
     }
 
     pub fn exec_round(&self, precision: Option<&Value>) -> Value {
+        // See `round_half_away_from_zero` below for the precision > 0 path.
         let Some(f) = Numeric::from_value(self).map(|v| v.to_f64()) else {
             return Value::Null;
         };
@@ -793,11 +794,7 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
-            .expect("formatted float should always parse successfully")
-            .into();
-
-        Value::from_f64(f)
+        Value::from_f64(round_half_away_from_zero(f, precision))
     }
 
     fn _exec_trim(&self, pattern: Option<&Value>, trim_type: TrimType) -> Value {
@@ -1354,6 +1351,86 @@ impl Value {
             .collect();
         Value::build_text(result)
     }
+}
+
+/// Round `f` to `precision` fractional digits using round-half-away-from-zero,
+/// matching SQLite's `printf("%.*f", ...)` behaviour.
+///
+/// Rust's `format!("{f:.precision$}")` uses banker's rounding (round-half-to-even),
+/// which makes `ROUND(2.25, 1)` return `2.2` instead of SQLite's `2.3`. Naively
+/// switching to a `(f * 10^precision).round() / 10^precision` rescale would also
+/// be wrong: `0.15 * 10` rounds up to *exactly* `1.5` in IEEE 754 (because the
+/// f64 for 0.15 is `0.149999…994`), so the rescaled approach incorrectly produces
+/// `0.2`, while SQLite's printf-on-the-decimal-expansion approach correctly
+/// produces `0.1`.
+///
+/// Instead, we work directly on the f64's decimal expansion: format with enough
+/// fractional digits to capture every meaningful bit (35 — well beyond f64's
+/// ~17 significant digits), then look at the digit at position `precision`. If
+/// it is `>= '5'` we increment the kept prefix in magnitude (with carry into the
+/// integer part); otherwise we truncate. Negative sign is reattached at the end.
+///
+/// Precondition: `1 <= precision <= 30` and `f` is finite within the i64-safe
+/// range (callers handle the precision-zero and out-of-range cases).
+fn round_half_away_from_zero(f: f64, precision: usize) -> f64 {
+    debug_assert!(precision > 0 && precision <= 30);
+    let sign_negative = f.is_sign_negative();
+    let abs_f = f.abs();
+
+    // 35 fractional digits exceeds f64's precision so the digit we look at to
+    // decide rounding is meaningful, not noise.
+    const EXTRA_DIGITS: usize = 35;
+    let formatted = format!("{abs_f:.EXTRA_DIGITS$}");
+    let dot = formatted
+        .find('.')
+        .expect("formatted f64 with precision contains a decimal point");
+    let int_part = &formatted[..dot];
+    let frac_part = &formatted[dot + 1..];
+    debug_assert_eq!(frac_part.len(), EXTRA_DIGITS);
+
+    let next_digit = frac_part.as_bytes()[precision];
+    let rounded = if next_digit >= b'5' {
+        increment_decimal_magnitude(int_part, &frac_part[..precision])
+    } else {
+        format!("{int_part}.{}", &frac_part[..precision])
+    };
+
+    let abs_result: f64 = rounded
+        .parse()
+        .expect("rounded decimal string should parse as f64");
+    if sign_negative {
+        -abs_result
+    } else {
+        abs_result
+    }
+}
+
+/// Add 1 to the magnitude of the decimal `int_str.frac_str`, propagating carry
+/// from the last fractional digit up through the integer part.
+fn increment_decimal_magnitude(int_str: &str, frac_str: &str) -> String {
+    let mut digits = Vec::with_capacity(int_str.len() + frac_str.len() + 1);
+    digits.extend_from_slice(int_str.as_bytes());
+    digits.extend_from_slice(frac_str.as_bytes());
+
+    let mut carry = 1u8;
+    for d in digits.iter_mut().rev() {
+        if carry == 0 {
+            break;
+        }
+        let v = *d - b'0' + carry;
+        *d = (v % 10) + b'0';
+        carry = v / 10;
+    }
+    if carry > 0 {
+        digits.insert(0, b'0' + carry);
+    }
+
+    let int_len = digits.len() - frac_str.len();
+    let mut s = String::from_utf8(digits).expect("ascii digits remain ascii");
+    if !frac_str.is_empty() {
+        s.insert(int_len, '.');
+    }
+    s
 }
 
 /// Parse exactly `n` hex digits into a u32. Mirrors SQLite's isNHex().
@@ -2719,6 +2796,52 @@ mod tests {
         let input_val = Value::from_f64(100.123);
         let expected_val = Value::Null;
         assert_eq!(input_val.exec_round(Some(&Value::Null)), expected_val);
+    }
+
+    /// https://github.com/tursodatabase/turso/issues/5748
+    ///
+    /// `ROUND(x, n)` must use round-half-away-from-zero (matching SQLite's
+    /// printf-style rounding), not Rust's default banker's rounding. Each row
+    /// here was cross-checked against the `sqlite3` CLI; a few are FP-artifact
+    /// cases where the f64 lies just below the decimal "halfway" and the
+    /// result rounds *toward* zero — they're included on purpose because a
+    /// naive `(f * 10^n).round() / 10^n` fix gets them wrong.
+    #[test]
+    fn test_exec_round_half_away_from_zero() {
+        let cases: &[(f64, i64, f64)] = &[
+            // Exactly halfway (2.25 is exact in binary): banker's would give
+            // 2.2, away-from-zero gives 2.3.
+            (2.25, 1, 2.3),
+            (-2.25, 1, -2.3),
+            // 2.35 stored as 2.350…009 — already above halfway, both methods
+            // agreed; kept as a regression check.
+            (2.35, 1, 2.4),
+            // 0.15 stored as 0.149…994 — below halfway, must truncate to 0.1.
+            // A `(f * 10).round()` rescale would incorrectly produce 0.2.
+            (0.15, 1, 0.1),
+            // 2.55 stored as 2.549…998 — same trap, must give 2.5.
+            (2.55, 1, 2.5),
+            // 0.05 stored as 0.050…028 — just above halfway, rounds up to 0.1.
+            (0.05, 1, 0.1),
+            (-0.05, 1, -0.1),
+            // Carry must propagate from fractional into integer part.
+            // 9.95 itself is *below* halfway in f64 (9.949…) so we use 9.96
+            // which is above (9.960…0085) and actually triggers the carry.
+            (9.96, 1, 10.0),
+            (99.999, 2, 100.0),
+            (0.9999, 2, 1.0),
+            // Multi-digit precision cases.
+            (0.125, 2, 0.13),
+            (0.375, 2, 0.38),
+        ];
+        for &(input, prec, expected) in cases {
+            let got = Value::from_f64(input).exec_round(Some(&Value::from_i64(prec)));
+            assert_eq!(
+                got,
+                Value::from_f64(expected),
+                "ROUND({input}, {prec}) expected {expected}, got {got:?}",
+            );
+        }
     }
 
     #[test]

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -855,6 +855,76 @@ test round-null-precision {
 expect {
 }
 
+# https://github.com/tursodatabase/turso/issues/5748
+# ROUND must use round-half-away-from-zero (matching SQLite's printf), not
+# banker's rounding. The cases below are the canonical halfway case (2.25),
+# the negative mirror, and FP-artifact cases that distinguish a correct
+# decimal-string-based rounding from a naive (f * 10^n).round() rescale.
+test round-half-away-from-zero-positive {
+    SELECT round(2.25, 1);
+}
+expect {
+    2.3
+}
+
+test round-half-away-from-zero-negative {
+    SELECT round(-2.25, 1);
+}
+expect {
+    -2.3
+}
+
+test round-fp-artifact-rounds-down-fifteen {
+    SELECT round(0.15, 1);
+}
+expect {
+    0.1
+}
+
+test round-fp-artifact-rounds-down-twofiftyfive {
+    SELECT round(2.55, 1);
+}
+expect {
+    2.5
+}
+
+test round-five-hundredths-rounds-up {
+    SELECT round(0.05, 1);
+}
+expect {
+    0.1
+}
+
+test round-carry-propagates-into-integer {
+    SELECT round(9.96, 1);
+}
+expect {
+    10.0
+}
+expect @js {
+    10
+}
+
+test round-carry-cascades-multi-digit {
+    SELECT round(99.999, 2);
+}
+expect {
+    100.0
+}
+expect @js {
+    100
+}
+
+test round-carry-fraction-to-integer {
+    SELECT round(0.9999, 2);
+}
+expect {
+    1.0
+}
+expect @js {
+    1
+}
+
 test length-text {
     SELECT length('limbo');
 }


### PR DESCRIPTION
## Description

`ROUND(x, n)` for `n > 0` was going through `format!("{f:.precision$}")`, which uses Rust's default banker's rounding (round-half-to-even). SQLite's `printf`-style rounding is round-half-away-from-zero, so `ROUND(2.25, 1)` returned `2.2` in turso instead of SQLite's `2.3`.

Replaces the `format!` call with a small `round_half_away_from_zero` helper that works on the f64's decimal expansion: format with 35 fractional digits (well past f64's ~17 significant figures), look at the digit at position `n`, then either truncate the kept prefix or increment it in magnitude with carry into the integer part. The precision-zero path is unchanged — it already used the correct `(f + 0.5).trunc()` cast.

Closes #5748.

## Motivation and context

The obvious-looking fix — switch `format!` for `(f * 10^n).round() / 10^n` — gets a different class of cases wrong. `0.15` in f64 is `0.149999…994`, but multiplying by `10` rounds *up* to exactly `1.5`, so the rescale produces `0.2`. SQLite's printf-on-the-decimal-expansion approach gives `0.1`, because the actual stored value is below the halfway point. Same shape with `2.55` → `2.5`, `9.95` → `9.9`, etc.

The decimal-string approach handles those cases by reading the digit that the f64 *actually has* at that position, not a re-scaled approximation.

Test matrix (each row cross-checked against the `sqlite3` CLI):

| input | precision | expected | why |
|---|---|---|---|
| `2.25` | 1 | `2.3` | exact halfway in binary, away-from-zero |
| `-2.25` | 1 | `-2.3` | negative mirror |
| `2.35` | 1 | `2.4` | f64 is `2.350…009`, just above halfway — regression check |
| `0.15` | 1 | `0.1` | f64 is `0.149…994`, below halfway |
| `2.55` | 1 | `2.5` | same trap |
| `0.05` | 1 | `0.1` | f64 is `0.050…028`, just above halfway |
| `9.96` | 1 | `10.0` | carry into integer (using `.96` rather than `.95` because `9.95` itself is below halfway) |
| `99.999` | 2 | `100.0` | carry cascades multiple digits |
| `0.9999` | 2 | `1.0` | carry from frac into int |
| `0.125`, `0.375` | 2 | `0.13`, `0.38` | multi-digit precision |

Both Rust unit tests (`test_exec_round_half_away_from_zero` in `core/vdbe/value.rs`) and SQL-level tests (`testing/sqltests/tests/scalar-functions.sqltest`) are added.

## Description of AI Usage

I traced the bug to `core/vdbe/value.rs::exec_round` from the issue's pointer and verified the divergence with `sqlite3`. The design choice — decimal-string rounding rather than a rescale-and-round — was mine, made after running the FP-artifact cases (`0.15`, `2.55`, `9.95`) against the sqlite3 CLI and seeing where the rescale would diverge from SQLite. I used Claude Code to help draft the carry-propagation helper and the test matrix, and to format the final commit message; every expected value in the tests was verified against `sqlite3` before committing.