### PR TITLE
fix: avoid CDC overwriting last insert rowid

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1320,7 +1320,7 @@ fn emit_cdc_insns_v1(
         cursor: cdc_cursor_id,
         key_reg: rowid_reg,
         record_reg,
-        flag: InsertFlags::new(),
+        flag: InsertFlags::new().skip_last_rowid(),
         table_name: "".to_string(),
     });
     Ok(())
@@ -1459,7 +1459,7 @@ fn emit_cdc_insns_v2(
         cursor: cdc_cursor_id,
         key_reg: rowid_reg,
         record_reg,
-        flag: InsertFlags::new(),
+        flag: InsertFlags::new().skip_last_rowid(),
         table_name: "".to_string(),
     });
     Ok(())
@@ -1545,7 +1545,7 @@ pub fn emit_cdc_commit_insns(
         cursor: cdc_cursor_id,
         key_reg: rowid_reg,
         record_reg,
-        flag: InsertFlags::new(),
+        flag: InsertFlags::new().skip_last_rowid(),
         table_name: "".to_string(),
     });
     Ok(())

--- a/testing/sqltests/tests/last_insert_rowid.sqltest
+++ b/testing/sqltests/tests/last_insert_rowid.sqltest
@@ -54,3 +54,14 @@ expect {
     50|c
     50
 }
+
+@skip-if mvcc "CDC not supported in MVCC mode"
+test last-insert-rowid-unchanged-by-cdc-internal-inserts {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT);
+    PRAGMA capture_data_changes_conn = 'full';
+    INSERT INTO t1 VALUES (42, 'hello');
+    SELECT last_insert_rowid();
+}
+expect {
+    42
+}


### PR DESCRIPTION
## Description
Preserve the user's `last_insert_rowid()` value when CDC is enabled.

CDC writes internal rows into the `turso_cdc` table for data changes and v2 commit records. Those internal inserts should not update the connection-level last inserted rowid, so this changes the CDC insert bytecode to use `SKIP_LAST_ROWID`.

## Motivation and context
With CDC enabled, a user insert could set `last_insert_rowid()` correctly and then have it overwritten by CDC's internal insert into `turso_cdc`. For example, inserting rowid `42` could return `2`, the rowid of the CDC commit record, instead of `42`.

This adds a sqltest regression covering CDC-enabled inserts and keeps the internal CDC bookkeeping rows from changing `last_insert_rowid()`.


## Testing
Before the fix, the new regression test failed as expected:

```text
[FAIL] last-insert-rowid-unchanged-by-cdc-internal-inserts
--- expected
+++ actual
-42
+2
```

After the fix:

```text
cargo run -p test-runner -- run testing/sqltests/tests/last_insert_rowid.sqltest

4 passed
All tests passed!
```

## Description of AI Usage

AI was used in a supporting role.


closes #6611