### PR TITLE
Preserve dirty WAL pages during savepoint rollback

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3430,6 +3430,16 @@ mod tests {
         }
     }
 
+    fn query_single_text(conn: &Arc<Connection>, sql: &str) -> String {
+        let mut stmt = conn.prepare(sql).unwrap();
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                text_value(stmt.row().unwrap().get::<&Value>(0).unwrap()).to_string()
+            }
+            other => panic!("expected a row, got {other:?}"),
+        }
+    }
+
     fn text_value(value: &Value) -> &str {
         match value {
             Value::Text(text) => text.as_str(),
@@ -3486,6 +3496,47 @@ mod tests {
         let second_db = Database::open_file(io, ":memory:reopen").unwrap();
         let second = second_db.connect().unwrap();
         assert_eq!(query_single_i64(&second, "SELECT x FROM t"), 99);
+    }
+
+    #[test]
+    fn test_statement_rollback_under_cache_pressure_spills_restored_pages() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("statement_rollback_spill.db");
+        let conn = open_connection(&db_path);
+
+        conn.execute("PRAGMA cache_size=20").unwrap();
+        conn.execute("PRAGMA journal_mode=WAL").unwrap();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, u TEXT UNIQUE, pad TEXT)")
+            .unwrap();
+
+        let pad = "x".repeat(3000);
+        for i in 1..=220 {
+            conn.execute(format!("INSERT INTO t(u, pad) VALUES('u{i}', '{pad}')"))
+                .unwrap();
+        }
+
+        conn.execute("SAVEPOINT s").unwrap();
+        let updated_pad = "y".repeat(3000);
+        let err = conn
+            .execute(format!(
+                "UPDATE t
+                 SET pad = '{updated_pad}',
+                     u = CASE WHEN id = 220 THEN 'u1' ELSE u END"
+            ))
+            .expect_err("update should fail on the unique index");
+        assert!(
+            err.to_string().contains("UNIQUE constraint failed"),
+            "unexpected error: {err}"
+        );
+
+        assert_eq!(query_single_text(&conn, "PRAGMA integrity_check"), "ok");
+        assert_eq!(query_single_i64(&conn, "SELECT count(*) FROM t"), 220);
+
+        conn.execute("ROLLBACK TO s").unwrap();
+        conn.execute("RELEASE s").unwrap();
+        conn.execute("COMMIT").unwrap();
+        assert_eq!(query_single_text(&conn, "PRAGMA integrity_check"), "ok");
     }
 
     #[test]

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -1,5 +1,6 @@
 use crate::sync::{atomic::Ordering, Arc};
 use intrusive_collections::{intrusive_adapter, LinkedList, LinkedListLink};
+use roaring::RoaringBitmap;
 use rustc_hash::FxHashMap as HashMap;
 use tracing::trace;
 
@@ -718,29 +719,58 @@ impl PageCache {
         Ok(())
     }
 
-    /// Removes clean cached pages that were read from WAL frames newer than a
-    /// rollback target. Dirty pages are preserved because they may contain
-    /// restored transaction-local state that still needs to be committed or
-    /// rolled back by an outer savepoint.
-    pub fn delete_clean_pages_after_wal_frame(&mut self, max_frame: u64) -> Result<(), CacheError> {
-        for key in self
-            .map
-            .iter()
-            .filter_map(|(key, &entry_ptr)| {
-                let entry = unsafe { &*entry_ptr };
-                let page = &entry.page;
-                if !page.is_dirty() && page.has_wal_tag() {
-                    let (frame, _) = page.wal_tag_pair();
-                    if frame > max_frame {
-                        return Some(*key);
+    /// Invalidates cached pages that reference WAL frames newer than a rollback target.
+    ///
+    /// Clean pages can be dropped and re-read from the rollback target. Dirty pages
+    /// must stay in cache, but if they were spilled to a frame that has just been
+    /// rolled back they are no longer safe to evict.
+    pub fn invalidate_pages_after_wal_frame(
+        &mut self,
+        max_frame: u64,
+        dirty_pages: &RoaringBitmap,
+    ) -> Result<(), CacheError> {
+        let mut clean_keys = Vec::new();
+        let mut dirty_keys = Vec::new();
+
+        for (key, &entry_ptr) in self.map.iter() {
+            let entry = unsafe { &*entry_ptr };
+            let page = &entry.page;
+            if page.has_wal_tag() {
+                let (frame, _) = page.wal_tag_pair();
+                if frame > max_frame {
+                    if dirty_pages.contains(key.0 as u32) {
+                        dirty_keys.push(*key);
+                    } else {
+                        clean_keys.push(*key);
                     }
                 }
-                None
-            })
-            .collect::<Vec<_>>()
-        {
+            }
+        }
+
+        for key in dirty_keys {
+            if let Some(&entry_ptr) = self.map.get(&key) {
+                let entry = unsafe { &*entry_ptr };
+                let page = &entry.page;
+                if page.has_wal_tag() {
+                    let (frame, _) = page.wal_tag_pair();
+                    if frame > max_frame {
+                        let was_evictable = Self::counted_as_evictable(page);
+                        page.set_dirty();
+                        let is_evictable = Self::counted_as_evictable(page);
+                        if was_evictable && !is_evictable {
+                            self.evictable_count = self.evictable_count.saturating_sub(1);
+                        } else if !was_evictable && is_evictable {
+                            self.evictable_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        for key in clean_keys {
             self.delete(key)?;
         }
+
         Ok(())
     }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1866,19 +1866,21 @@ impl Pager {
     /// Rollback to the newest savepoint. This basically just means reading the subjournal from the start offset
     /// of the savepoint to the end of the subjournal and restoring the page images to the page cache.
     pub fn rollback_to_newest_savepoint(&self) -> Result<bool> {
-        let mut savepoints = self.savepoints.write();
-        if !matches!(
-            savepoints.last().map(|savepoint| &savepoint.kind),
-            Some(SavepointKind::Statement)
-        ) {
-            return Ok(false);
-        }
-        let savepoint = savepoints.pop().expect("savepoint must exist");
-        let journal_end_offset = savepoint.write_offset();
-        let savepoint = savepoint.snapshot();
+        let (savepoint, journal_end_offset) = {
+            let mut savepoints = self.savepoints.write();
+            if !matches!(
+                savepoints.last().map(|savepoint| &savepoint.kind),
+                Some(SavepointKind::Statement)
+            ) {
+                return Ok(false);
+            }
+            let savepoint = savepoints.pop().expect("savepoint must exist");
+            (savepoint.snapshot(), savepoint.write_offset())
+        };
 
         self.rollback_to_snapshot(&savepoint, journal_end_offset)?;
 
+        let savepoints = self.savepoints.write();
         if let Some(parent) = savepoints.last() {
             parent.set_write_offset(savepoint.start_offset);
         }
@@ -1961,19 +1963,21 @@ impl Pager {
         savepoint: &SavepointSnapshot,
         journal_end_offset: u64,
     ) -> Result<()> {
-        let subjournal = self.subjournal.read();
-        let Some(subjournal) = subjournal.as_ref() else {
-            return Ok(());
+        let subjournal = {
+            let subjournal = self.subjournal.read();
+            let Some(subjournal) = subjournal.as_ref() else {
+                return Ok(());
+            };
+            subjournal.clone()
         };
 
         let journal_start_offset = savepoint.start_offset;
         let db_size = savepoint.db_size;
 
         let mut rollback_bitset = RoaringBitmap::new();
+        let mut rollback_pages = Vec::new();
         let mut current_offset = journal_start_offset;
         let page_size = self.page_size.load(Ordering::SeqCst) as u64;
-        let mut dirty_pages = self.dirty_pages.write();
-
         while current_offset < journal_end_offset {
             let page_id_buffer = Arc::new(self.buffer_pool.allocate(4));
             let c = subjournal.read_page_number(current_offset, page_id_buffer.clone())?;
@@ -2001,13 +2005,64 @@ impl Pager {
             turso_assert!(c.succeeded(), "memory IO should complete immediately");
             current_offset += page_size;
             rollback_bitset.insert(page_id);
+            rollback_pages.push((page_id, page));
+        }
+
+        let preserved_dirty_pages = if self.wal.is_some() {
+            let dirty_pages_to_preserve = {
+                let dirty_pages = self.dirty_pages.read();
+                let mut cache = self.page_cache.write();
+                dirty_pages
+                    .iter()
+                    .filter(|&page_id| page_id <= db_size && !rollback_bitset.contains(page_id))
+                    .filter(|&page_id| {
+                        cache
+                            .peek(&PageCacheKey::new(page_id as usize), false)
+                            .is_none()
+                    })
+                    .collect::<Vec<_>>()
+            };
+
+            let mut preserved_pages = Vec::with_capacity(dirty_pages_to_preserve.len());
+            for page_id in dirty_pages_to_preserve {
+                let (page, completion) = self.read_page_no_cache(page_id as i64, None, false)?;
+                self.io.wait_for_completion(completion)?;
+                page.set_dirty();
+                preserved_pages.push((page_id, page));
+            }
+            preserved_pages
+        } else {
+            Vec::new()
+        };
+
+        if let Some(wal) = &self.wal {
+            wal.rollback(Some(RollbackTo {
+                frame: savepoint.wal_max_frame,
+                checksum: savepoint.wal_checksum,
+            }));
+            let dirty_pages = self.dirty_pages.read();
+            self.page_cache
+                .write()
+                .invalidate_pages_after_wal_frame(savepoint.wal_max_frame, &dirty_pages)
+                .map_err(|e| {
+                    LimboError::InternalError(format!(
+                        "failed to invalidate rolled-back WAL pages: {e:?}"
+                    ))
+                })?;
+        }
+
+        for (page_id, page) in preserved_dirty_pages {
+            self.upsert_page_in_cache_spilling(page_id as usize, page, true)?;
+        }
+
+        for (page_id, page) in rollback_pages {
             // The restored image is the transaction-visible state at the
             // savepoint, not necessarily durable state. Keep it dirty so cache
             // eviction cannot drop uncommitted changes that predate the
             // rolled-back savepoint/statement.
             page.set_dirty();
-            dirty_pages.insert(page_id);
-            self.upsert_page_in_cache(page_id as usize, page, true)?;
+            self.dirty_pages.write().insert(page_id);
+            self.upsert_page_in_cache_spilling(page_id as usize, page, true)?;
         }
 
         let truncate_completion = subjournal.truncate(journal_start_offset)?;
@@ -2021,6 +2076,7 @@ impl Pager {
         // above won't encounter them. We must clean them from dirty_pages before
         // truncating the cache, or phantom dirty entries survive into commit.
         {
+            let mut dirty_pages = self.dirty_pages.write();
             let mut cache = self.page_cache.write();
             for page_id in dirty_pages.iter().filter(|&id| id > db_size) {
                 if let Some(page) = cache.get(&PageCacheKey::new(page_id as usize))? {
@@ -2030,21 +2086,6 @@ impl Pager {
             }
             dirty_pages.remove_range((db_size + 1)..);
             cache.truncate(db_size as usize)?;
-        }
-
-        if let Some(wal) = &self.wal {
-            wal.rollback(Some(RollbackTo {
-                frame: savepoint.wal_max_frame,
-                checksum: savepoint.wal_checksum,
-            }));
-            self.page_cache
-                .write()
-                .delete_clean_pages_after_wal_frame(savepoint.wal_max_frame)
-                .map_err(|e| {
-                    LimboError::InternalError(format!(
-                        "failed to invalidate rolled-back WAL pages: {e:?}"
-                    ))
-                })?;
         }
 
         Ok(())
@@ -5012,6 +5053,57 @@ impl Pager {
         page: PageRef,
         dirty_page_must_exist: bool,
     ) -> Result<(), LimboError> {
+        self.try_upsert_page_in_cache(id, page.clone(), dirty_page_must_exist)
+            .map_err(|e| {
+                LimboError::InternalError(format!(
+                    "Failed to insert loaded page {id} into cache: {e:?}"
+                ))
+            })?;
+        page.set_loaded();
+        page.clear_wal_tag();
+        Ok(())
+    }
+
+    fn upsert_page_in_cache_spilling(
+        &self,
+        id: usize,
+        page: PageRef,
+        dirty_page_must_exist: bool,
+    ) -> Result<(), LimboError> {
+        loop {
+            match self.try_upsert_page_in_cache(id, page.clone(), dirty_page_must_exist) {
+                Ok(()) => {
+                    page.set_loaded();
+                    page.clear_wal_tag();
+                    return Ok(());
+                }
+                Err(CacheError::Full) => match self.try_spill_dirty_pages()? {
+                    IOResult::Done(true) => continue,
+                    IOResult::Done(false) => {
+                        return Err(LimboError::InternalError(format!(
+                            "Failed to insert loaded page {id} into cache: {:?}",
+                            CacheError::Full
+                        )));
+                    }
+                    IOResult::IO(io) => {
+                        io.wait(self.io.as_ref())?;
+                    }
+                },
+                Err(e) => {
+                    return Err(LimboError::InternalError(format!(
+                        "Failed to insert loaded page {id} into cache: {e:?}"
+                    )));
+                }
+            }
+        }
+    }
+
+    fn try_upsert_page_in_cache(
+        &self,
+        id: usize,
+        page: PageRef,
+        dirty_page_must_exist: bool,
+    ) -> Result<(), CacheError> {
         let mut cache = self.page_cache.write();
         let page_key = PageCacheKey::new(id);
 
@@ -5019,14 +5111,7 @@ impl Pager {
         if dirty_page_must_exist {
             turso_assert!(page.is_dirty(), "page must be dirty for upsert", { "page_id": id });
         }
-        cache.upsert_page(page_key, page.clone()).map_err(|e| {
-            LimboError::InternalError(format!(
-                "Failed to insert loaded page {id} into cache: {e:?}"
-            ))
-        })?;
-        page.set_loaded();
-        page.clear_wal_tag();
-        Ok(())
+        cache.upsert_page(page_key, page)
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]


### PR DESCRIPTION
## Summary

Fix savepoint rollback when the page cache is under pressure and dirty pages have been spilled to WAL.

The rollback path now:

- releases the statement savepoint lock before restoring pages, so rollback cleanup can spill/read without deadlocking on savepoint state
- scans the subjournal first, then preserves evicted dirty pages before rolling WAL back to the savepoint frame
- invalidates WAL-backed cache entries with awareness of `dirty_pages`, so logically dirty pages are kept dirty in memory instead of being dropped as clean pages after their backing WAL frames are truncated
- uses a spill-aware cache upsert while restoring rollback pages

This prevents a failed statement rollback from losing dirty transaction-local pages and later surfacing as `CacheFull`, short reads, or integrity failures.

Related: #6713 reported/fixed the same general failure mode but was auto-closed by the trust bot before review. This PR is a separate narrower implementation; credit to @explorrrr for the prior report/patch context.

## Repro covered

The regression test creates a WAL transaction with a small cache, inserts large rows, opens a savepoint, then runs a multi-row `UPDATE` that aborts on a UNIQUE violation. Before the fix, rollback could fail or leave the connection unable to read/commit because restored dirty pages depended on WAL frames that were later rolled back. The test verifies:

- the failed `UPDATE` returns the expected UNIQUE constraint error
- `PRAGMA integrity_check` remains `ok` immediately after statement rollback
- the named savepoint can be rolled back/released
- `COMMIT` succeeds and final `PRAGMA integrity_check` is `ok`

## Validation

- `rustfmt --edition 2021 --check core/connection.rs core/storage/page_cache.rs core/storage/pager.rs`
- `git diff --check`
- `cargo test -p turso_core connection::tests::test_statement_rollback_under_cache_pressure_spills_restored_pages --features "fs pure-rust-crypto" -- --exact --nocapture`
- `cargo test -p turso_core storage::page_cache --features "fs pure-rust-crypto" -- --nocapture`
- `cargo test -p core_tester --test integration_tests query_processing::test_write_path::test_savepoint_rollback_uses_current_wal_snapshot --features "pure-rust-crypto" -- --exact --nocapture`
- `cargo test -p core_tester --test integration_tests query_processing::test_transactions::test_wal_savepoint_rollback_on_constraint_violation --features "pure-rust-crypto" -- --exact --ignored --nocapture`
- `cargo test -p core_tester --test integration_tests wal::test_wal::test_savepoint_rollback_after_cache_spill_preserves_wal_pages --features "pure-rust-crypto" -- --exact --ignored --nocapture`
- `cargo build -p limbo_sim --features turso_core/pure-rust-crypto`
