### PR TITLE
docs: mention array types in data-types and CREATE TYPE pages

### DIFF
--- a/docs/sql-reference/data-types.mdx
+++ b/docs/sql-reference/data-types.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Data Types
 
 # Data Types
 
-Turso uses the same dynamic type system as SQLite, where values have types but columns do not enforce a single type (unless using STRICT tables). Every value stored in Turso belongs to one of five storage classes.
+Turso uses the same dynamic type system as SQLite, where values have types but columns do not enforce a single type (unless using STRICT tables). Every value stored in Turso belongs to one of five storage classes. Turso extends this system with [custom types](#custom-types), [composite types](#composite-types-struct-and-union), and [native array types](#array-types) for STRICT tables.
 
 ## Storage Classes
 
@@ -99,7 +99,7 @@ STRICT tables only allow these base type names:
 | ANY | Any storage class (disables type checking for this column) |
 
 <Info>
-**Turso Extension**: STRICT tables also accept [custom type](/docs/sql-reference/statements/create-type) names. Custom types extend the type system with user-defined encoding, decoding, validation, and operator overloading.
+**Turso Extension**: STRICT tables also accept [custom type](/docs/sql-reference/statements/create-type) names, [composite types](#composite-types-struct-and-union) (STRUCT and UNION), and [array types](#array-types). Any base type can be turned into an array column by appending `[]` to the type name (e.g., `INTEGER[]`, `TEXT[]`). Arrays, custom types, and composite types are Turso-specific features.
 </Info>
 
 ## Custom Types

--- a/docs/sql-reference/statements/create-type.mdx
+++ b/docs/sql-reference/statements/create-type.mdx
@@ -467,6 +467,41 @@ CREATE TYPE point AS STRUCT(x INT, y INT);
 CREATE TABLE t(data point) STRICT;
 ```
 
+## Array Types
+
+Array columns store ordered collections of values. Unlike STRUCT and UNION, arrays don't require an explicit CREATE TYPE — declare them by appending `[]` to any base type name in a STRICT table column definition:
+
+```sql
+CREATE TABLE sensors (
+    id INTEGER PRIMARY KEY,
+    readings REAL[],
+    labels TEXT[],
+    flags INTEGER[]
+) STRICT;
+
+INSERT INTO sensors VALUES (1, ARRAY[1.5, 2.5, 3.5], ARRAY['temp','humidity'], '[0, 1, 1]');
+
+SELECT readings[0], labels[1], array_length(flags) FROM sensors;
+-- 1.5|humidity|3
+```
+
+Multi-dimensional arrays use multiple bracket pairs:
+
+```sql
+CREATE TABLE matrices (
+    id INTEGER PRIMARY KEY,
+    data INTEGER[][]
+) STRICT;
+
+INSERT INTO matrices VALUES (1, ARRAY[ARRAY[1,2], ARRAY[3,4]]);
+SELECT data[1][0] FROM matrices;
+-- 3
+```
+
+Element types are validated on insert — an `INTEGER[]` column rejects values that cannot be stored as integers. Arrays are stored internally as compact record-format BLOBs and displayed as JSON arrays on output.
+
+For the full set of array functions (`array_agg`, `array_append`, `array_contains`, `array_slice`, etc.), operators (`@>`, `&&`, `||`), and subscript syntax, see [Array Functions](/docs/sql-reference/functions/array).
+
 ## Restrictions
 
 - **STRICT tables only**: Custom type names are ignored in non-STRICT tables. The column uses standard type affinity rules instead.
@@ -580,4 +615,6 @@ SELECT amount + tax FROM transactions;
 - [DROP TYPE](/docs/sql-reference/statements/drop-type) for removing custom types
 - [CREATE DOMAIN](/docs/sql-reference/statements/create-domain) for defining constrained type aliases without ENCODE/DECODE logic
 - [Data Types](/docs/sql-reference/data-types) for an overview of the type system and type affinity
+- [Array Types](/docs/sql-reference/data-types#array-types) for native array columns (`INTEGER[]`, `TEXT[]`, etc.)
+- [Array Functions](/docs/sql-reference/functions/array) for array construction, manipulation, and operators
 - [CREATE TABLE](/docs/sql-reference/statements/create-table) for STRICT table definitions


### PR DESCRIPTION
## Summary
- **data-types.mdx**: Opening paragraph now introduces Turso type extensions (custom types, composite types, arrays). The "Allowed Types in STRICT Tables" callout now mentions arrays and the `[]` syntax alongside custom types and composites.
- **create-type.mdx**: New "Array Types" section with 1D and multi-dimensional examples, parallel to the existing STRUCT and UNION sections. Added array cross-references to See Also.

## Test plan
- [ ] Docs render correctly (mdx syntax, anchor links, cross-references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)