### PR TITLE
fix: stop function calls inheriting argument collation

### DIFF
--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -114,39 +114,9 @@ pub fn get_expr_collation_ctx(
     top_expr: &Expr,
     referenced_tables: &TableReferences,
 ) -> Result<Option<(CollationSeq, bool)>> {
-    let mut maybe_column_collseq = None;
-    let mut maybe_explicit_collseq = None;
-
-    walk_expr(top_expr, &mut |expr: &Expr| -> Result<WalkControl> {
-        match expr {
-            Expr::Collate(_, seq) => {
-                if maybe_explicit_collseq.is_none() {
-                    maybe_explicit_collseq =
-                        Some(CollationSeq::new(seq.as_str()).unwrap_or_default());
-                }
-                return Ok(WalkControl::SkipChildren);
-            }
-            Expr::Column { table, column, .. } => {
-                // generated columns (the SELF_TABLE placeholder) don't inherit an implicit
-                // collation from their expression, so we skip them
-                if !table.is_self_table() {
-                    let (_, table_ref) = referenced_tables
-                        .find_table_by_internal_id(*table)
-                        .ok_or_else(|| {
-                            crate::LimboError::ParseError("table not found".to_string())
-                        })?;
-                    let column = table_ref.get_column_at(*column).ok_or_else(|| {
-                        crate::LimboError::ParseError("column not found".to_string())
-                    })?;
-                    if maybe_column_collseq.is_none() {
-                        maybe_column_collseq = Some(column.collation());
-                    }
-                }
-            }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    })?;
+    let maybe_explicit_collseq = get_explicit_collseq_from_expr(top_expr)?;
+    let maybe_column_collseq =
+        get_implicit_column_collseq_from_expr(top_expr, referenced_tables, true, true)?;
 
     Ok(maybe_explicit_collseq
         .map(|collation| (collation, true))
@@ -179,21 +149,49 @@ fn get_collseq_parts_from_expr(
     top_expr: &Expr,
     referenced_tables: &TableReferences,
 ) -> Result<(Option<CollationSeq>, Option<CollationSeq>)> {
-    let mut maybe_column_collseq = None;
+    let maybe_explicit_collseq = get_explicit_collseq_from_expr(top_expr)?;
+    let maybe_column_collseq =
+        get_implicit_column_collseq_from_expr(top_expr, referenced_tables, false, false)?;
+
+    Ok((maybe_explicit_collseq, maybe_column_collseq))
+}
+
+fn get_explicit_collseq_from_expr(top_expr: &Expr) -> Result<Option<CollationSeq>> {
     let mut maybe_explicit_collseq = None;
 
     walk_expr(top_expr, &mut |expr: &Expr| -> Result<WalkControl> {
+        if let Expr::Collate(_, seq) = expr {
+            if maybe_explicit_collseq.is_none() {
+                maybe_explicit_collseq = Some(CollationSeq::new(seq.as_str()).unwrap_or_default());
+            }
+            return Ok(WalkControl::SkipChildren);
+        }
+        Ok(WalkControl::Continue)
+    })?;
+
+    Ok(maybe_explicit_collseq)
+}
+
+fn get_implicit_column_collseq_from_expr(
+    top_expr: &Expr,
+    referenced_tables: &TableReferences,
+    include_default_binary: bool,
+    skip_self_table: bool,
+) -> Result<Option<CollationSeq>> {
+    let mut maybe_column_collseq = None;
+
+    walk_expr(top_expr, &mut |expr: &Expr| -> Result<WalkControl> {
         match expr {
-            Expr::Collate(_, seq) => {
-                // Only store the first (leftmost) COLLATE operator we find
-                if maybe_explicit_collseq.is_none() {
-                    maybe_explicit_collseq =
-                        Some(CollationSeq::new(seq.as_str()).unwrap_or_default());
-                }
-                // Skip children since we've found a COLLATE operator
+            Expr::Collate(_, _) => {
+                return Ok(WalkControl::SkipChildren);
+            }
+            Expr::FunctionCall { .. } | Expr::FunctionCallStar { .. } => {
                 return Ok(WalkControl::SkipChildren);
             }
             Expr::Column { table, column, .. } => {
+                if skip_self_table && table.is_self_table() {
+                    return Ok(WalkControl::Continue);
+                }
                 let (_, table_ref) = referenced_tables
                     .find_table_by_internal_id(*table)
                     .ok_or_else(|| crate::LimboError::ParseError("table not found".to_string()))?;
@@ -201,7 +199,11 @@ fn get_collseq_parts_from_expr(
                     .get_column_at(*column)
                     .ok_or_else(|| crate::LimboError::ParseError("column not found".to_string()))?;
                 if maybe_column_collseq.is_none() {
-                    maybe_column_collseq = column.collation_opt();
+                    maybe_column_collseq = if include_default_binary {
+                        Some(column.collation())
+                    } else {
+                        column.collation_opt()
+                    };
                 }
                 return Ok(WalkControl::Continue);
             }
@@ -212,7 +214,11 @@ fn get_collseq_parts_from_expr(
                 if let Some(btree) = table_ref.btree() {
                     if let Some((_, rowid_alias_col)) = btree.get_rowid_alias_column() {
                         if maybe_column_collseq.is_none() {
-                            maybe_column_collseq = rowid_alias_col.collation_opt();
+                            maybe_column_collseq = if include_default_binary {
+                                Some(rowid_alias_col.collation())
+                            } else {
+                                rowid_alias_col.collation_opt()
+                            };
                         }
                     }
                 }
@@ -223,14 +229,16 @@ fn get_collseq_parts_from_expr(
         Ok(WalkControl::Continue)
     })?;
 
-    Ok((maybe_explicit_collseq, maybe_column_collseq))
+    Ok(maybe_column_collseq)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{sync::Arc, MAIN_DB_ID};
 
-    use turso_parser::ast::{Literal, Name, Operator, TableInternalId, UnaryOperator};
+    use turso_parser::ast::{
+        FunctionTail, Literal, Name, Operator, TableInternalId, UnaryOperator,
+    };
 
     use crate::{
         schema::{BTreeCharacteristics, BTreeTable, ColDef, Column, Table, Type},
@@ -387,6 +395,71 @@ mod tests {
         let expr = Expr::binary(lhs, Operator::Add, rhs);
         let collseq = get_collseq_from_expr(&expr, &table_references).unwrap();
         assert_eq!(collseq, Some(CollationSeq::NoCase));
+    }
+
+    #[test]
+    fn test_function_call_does_not_inherit_argument_column_collation() {
+        let table_references = get_table_references_single_table_single_column_with_collation(
+            Some(CollationSeq::Rtrim),
+        );
+        let expr = Expr::FunctionCall {
+            name: Name::exact("lower".to_string()),
+            distinctness: None,
+            args: vec![Box::new(Expr::Column {
+                database: None,
+                table: TableInternalId::from(1),
+                column: 0,
+                is_rowid_alias: false,
+            })],
+            order_by: vec![],
+            filter_over: FunctionTail {
+                filter_clause: None,
+                over_clause: None,
+            },
+        };
+
+        assert_eq!(
+            get_collseq_from_expr(&expr, &table_references).unwrap(),
+            None
+        );
+        assert_eq!(
+            get_expr_collation_ctx(&expr, &table_references).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_function_call_preserves_explicit_argument_collation() {
+        let table_references = get_table_references_single_table_single_column_with_collation(
+            Some(CollationSeq::Rtrim),
+        );
+        let expr = Expr::FunctionCall {
+            name: Name::exact("lower".to_string()),
+            distinctness: None,
+            args: vec![Box::new(Expr::Collate(
+                Box::new(Expr::Column {
+                    database: None,
+                    table: TableInternalId::from(1),
+                    column: 0,
+                    is_rowid_alias: false,
+                }),
+                Name::exact("NOCASE".to_string()),
+            ))],
+            order_by: vec![],
+            filter_over: FunctionTail {
+                filter_clause: None,
+                over_clause: None,
+            },
+        };
+
+        assert_eq!(
+            get_collseq_from_expr(&expr, &table_references).unwrap(),
+            Some(CollationSeq::NoCase)
+        );
+        assert_eq!(
+            get_expr_collation_ctx(&expr, &table_references).unwrap(),
+            Some((CollationSeq::NoCase, true))
+        );
     }
 
     #[test]

--- a/core/translate/main_loop/init.rs
+++ b/core/translate/main_loop/init.rs
@@ -66,8 +66,7 @@ impl InitLoop {
                 "DISTINCT aggregate functions must have exactly one argument"
             );
             let collations =
-                vec![get_collseq_from_expr(&agg.original_expr, tables)?
-                    .unwrap_or(CollationSeq::Binary)];
+                vec![get_collseq_from_expr(&agg.args[0], tables)?.unwrap_or(CollationSeq::Binary)];
             let hash_table_id = program.alloc_hash_table_id();
             agg.distinctness = Distinctness::Distinct {
                 ctx: Some(DistinctCtx {

--- a/testing/sqltests/tests/expression-index-collation.sqltest
+++ b/testing/sqltests/tests/expression-index-collation.sqltest
@@ -1,0 +1,30 @@
+@database :memory:
+
+test expression-index-function-order-uses-binary-collation {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c TEXT COLLATE RTRIM);
+    CREATE INDEX idx_expr ON t(lower(c), id DESC);
+    INSERT INTO t VALUES (1, ''), (2, ' '), (3, '  '), (4, '');
+    SELECT id, quote(c) FROM t INDEXED BY idx_expr
+        WHERE lower(c) IS NOT NULL
+        ORDER BY lower(c), id DESC;
+}
+expect {
+    4|''
+    1|''
+    2|' '
+    3|'  '
+}
+
+test expression-index-substr-order-uses-binary-collation {
+    CREATE TABLE u(id INTEGER PRIMARY KEY, d TEXT COLLATE NOCASE);
+    CREATE INDEX idx_substr ON u(substr(d, 1, 1), id);
+    INSERT INTO u VALUES (1, 'a'), (2, 'A'), (3, 'b');
+    SELECT id, d FROM u INDEXED BY idx_substr
+        WHERE substr(d, 1, 1) IS NOT NULL
+        ORDER BY substr(d, 1, 1), id;
+}
+expect {
+    2|A
+    1|a
+    3|b
+}

--- a/tests/fuzz/orderby_collation.rs
+++ b/tests/fuzz/orderby_collation.rs
@@ -25,6 +25,30 @@ mod tests {
         "b ", "B ", "a  ", "A  ", " a", " A", "abc", "ABC",
     ];
 
+    struct FunctionExprCase {
+        table_collation: &'static str,
+        expression: &'static str,
+        values: &'static [&'static str],
+    }
+
+    const FUNCTION_EXPR_CASES: [FunctionExprCase; 3] = [
+        FunctionExprCase {
+            table_collation: "RTRIM",
+            expression: "lower(c1)",
+            values: &["", " ", "  ", "", "x", "x "],
+        },
+        FunctionExprCase {
+            table_collation: "NOCASE",
+            expression: "substr(c1, 1, 1)",
+            values: &["A", "a", "B", "b", "C", "c"],
+        },
+        FunctionExprCase {
+            table_collation: "RTRIM",
+            expression: "substr(c1 COLLATE NOCASE, 1, 1)",
+            values: &["A", "a", "B", "b", "C", "c"],
+        },
+    ];
+
     /// Compare two strings using the specified collation.
     /// Returns Ordering::Equal if they are equal under the collation.
     fn compare_with_collation(a: &str, b: &str, collation: &str) -> std::cmp::Ordering {
@@ -105,6 +129,54 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    /// Function expressions should not inherit implicit collation from their
+    /// arguments, but explicit COLLATE operators inside the expression still apply.
+    #[turso_macros::test(mvcc)]
+    pub fn orderby_function_expression_index_collation_regression(db: TempDatabase) {
+        let builder = helpers::builder_from_db(&db);
+
+        for case in FUNCTION_EXPR_CASES.iter() {
+            let table_ddl = format!(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, c1 TEXT COLLATE {})",
+                case.table_collation
+            );
+            let index_ddl = format!("CREATE INDEX idx ON t ({}, id DESC)", case.expression);
+
+            let limbo_db = builder.clone().with_init_sql(&table_ddl).build();
+            let limbo_conn = limbo_db.connect_limbo();
+            limbo_conn.execute(&index_ddl).unwrap();
+
+            let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+            sqlite_conn.execute(&table_ddl, ()).unwrap();
+            sqlite_conn.execute(&index_ddl, ()).unwrap();
+
+            for (idx, value) in case.values.iter().enumerate() {
+                let insert = format!(
+                    "INSERT INTO t VALUES ({}, '{}')",
+                    idx + 1,
+                    value.replace("'", "''")
+                );
+                sqlite_conn.execute(&insert, ()).unwrap();
+                limbo_conn.execute(&insert).unwrap();
+            }
+
+            let query = format!(
+                "SELECT id, quote(c1) FROM t INDEXED BY idx WHERE {} IS NOT NULL ORDER BY {}, id DESC",
+                case.expression, case.expression
+            );
+            let sqlite_rows = sqlite_exec_rows(&sqlite_conn, &query);
+            let limbo_rows = limbo_exec_rows(&limbo_conn, &query);
+
+            similar_asserts::assert_eq!(
+                Turso: limbo_rows,
+                Sqlite: sqlite_rows,
+                "MISMATCH!\nQuery: {query}\nTable: {table_ddl}\nIndex: {index_ddl}\nTurso ({} rows)\nSQLite ({} rows)",
+                limbo_rows.len(),
+                sqlite_rows.len(),
+            );
+        }
     }
 
     /// Test ORDER BY with explicit COLLATE that differs from index collation.


### PR DESCRIPTION
## Description

Closes #6706.

Function expressions were inheriting the collation of column arguments when deriving expression collation. That made ORDER BY lower(c) use c's declared COLLATE RTRIM or COLLATE NOCASE, even though the function result should use BINARY unless the expression has an explicit COLLATE.

This splits explicit COLLATE discovery from implicit column-collation discovery, and stops implicit column collation at function-call boundaries. Explicit COLLATE inside the expression is still detected.

Added sqltests and a differential fuzz regression for expression indexes on function expressions with non-BINARY base column collations.

## Testing

- cargo test -q -p turso_core --features pure-rust-crypto collate -- --nocapture
- cargo check -q -p turso_core --features pure-rust-crypto
- cargo run -q --bin test-runner -- run tests/expression-index-collation.sqltest --backend cli --binary C:\tmp\turso-target-6706-small\debug\tursodb.exe
- cargo run -q --bin test-runner -- run tests/expression-index-collation.sqltest --backend rust
- cargo test -p core_tester --test fuzz_tests --no-default-features --features test_helper,pure-rust-crypto orderby_function_expression_index_collation_regression -- --nocapture