### PR TITLE
core/translate: dispatch matview DML guard on target database (fixes #6273)

### DIFF
--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -46,23 +46,28 @@ fn validate_delete(
         crate::bail_parse_error!("DELETE from WITHOUT ROWID tables is not supported");
     }
 
-    // Check if this is a materialized view
-    if resolver.schema().is_materialized_view(tbl_name) {
+    // Check if this is a materialized view in the *target* database. Materialized views
+    // live in their owning schema only, so we must dispatch on `database_id` here:
+    // a materialized view named `mv` in `main` must not block DML on a regular table
+    // also named `mv` in an attached database (#6273).
+    if resolver.with_schema(database_id, |s| s.is_materialized_view(tbl_name)) {
         crate::bail_parse_error!("cannot modify materialized view {}", tbl_name);
     }
 
-    // Check if this table has any incompatible dependent views
-    resolver.schema().with_incompatible_dependent_views(tbl_name, |views| {
-    if !views.is_empty() {
-        use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
-        crate::bail_parse_error!(
-            "Cannot DELETE from table '{tbl_name}' because it has incompatible dependent materialized view(s): {}. \n\
-             These views were created with a different DBSP version than the current version ({DBSP_CIRCUIT_VERSION}). \n\
-             Please DROP and recreate the view(s) before modifying this table.",
-            views.iter().fold(String::new(), |_, s| s.to_string() + ", "),
-        );
-    }
-    Ok(())
+    // Check if this table has any incompatible dependent views in the *target* database.
+    resolver.with_schema(database_id, |s| {
+        s.with_incompatible_dependent_views(tbl_name, |views| {
+            if !views.is_empty() {
+                use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
+                crate::bail_parse_error!(
+                    "Cannot DELETE from table '{tbl_name}' because it has incompatible dependent materialized view(s): {}. \n\
+                     These views were created with a different DBSP version than the current version ({DBSP_CIRCUIT_VERSION}). \n\
+                     Please DROP and recreate the view(s) before modifying this table.",
+                    views.iter().fold(String::new(), |_, s| s.to_string() + ", "),
+                );
+            }
+            Ok(())
+        })
     })?;
     Ok(table)
 }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -76,9 +76,11 @@ fn validate(
     {
         crate::bail_parse_error!("table {} may not be modified", table_name);
     }
-    // Check if this table has any incompatible dependent views
-    // Check if this is a materialized view
-    if resolver.schema().is_materialized_view(table_name) {
+    // Check if this is a materialized view in the *target* database. Materialized views
+    // live in their owning schema only, so we must dispatch on `database_id` here:
+    // a materialized view named `mv` in `main` must not block DML on a regular table
+    // also named `mv` in an attached database (#6273).
+    if resolver.with_schema(database_id, |s| s.is_materialized_view(table_name)) {
         crate::bail_parse_error!("cannot modify materialized view {}", table_name);
     }
     if table.btree().is_some_and(|t| t.has_autoincrement)
@@ -88,17 +90,19 @@ fn validate(
             "AUTOINCREMENT is not supported in MVCC mode (journal_mode=experimental_mvcc)"
         );
     }
-    resolver.schema().with_incompatible_dependent_views(table_name, |views| {
-    if !views.is_empty() {
-        use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
-        crate::bail_parse_error!(
-            "Cannot DELETE from table '{table_name}' because it has incompatible dependent materialized view(s): {}. \n\
-             These views were created with a different DBSP version than the current version ({DBSP_CIRCUIT_VERSION}). \n\
-             Please DROP and recreate the view(s) before modifying this table.",
-            views.iter().fold(String::new(), |_, s| s.to_string() + ", "),
-        );
-    }
-    Ok(())
+    resolver.with_schema(database_id, |s| {
+        s.with_incompatible_dependent_views(table_name, |views| {
+            if !views.is_empty() {
+                use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
+                crate::bail_parse_error!(
+                    "Cannot DELETE from table '{table_name}' because it has incompatible dependent materialized view(s): {}. \n\
+                     These views were created with a different DBSP version than the current version ({DBSP_CIRCUIT_VERSION}). \n\
+                     Please DROP and recreate the view(s) before modifying this table.",
+                    views.iter().fold(String::new(), |_, s| s.to_string() + ", "),
+                );
+            }
+            Ok(())
+        })
     })
 }
 

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -9,7 +9,7 @@ use crate::translate::plan::{ColumnMask, Operation};
 use crate::translate::planner::{parse_limit, ROWID_STRS};
 use crate::{
     bail_parse_error,
-    schema::{Schema, Table},
+    schema::Table,
     util::normalize_ident,
     vdbe::builder::{ProgramBuilder, ProgramBuilderOpts},
     CaptureDataChangesExt, Connection,
@@ -201,7 +201,8 @@ fn prepare_and_optimize_update_plan(
 }
 
 fn validate_update(
-    schema: &Schema,
+    resolver: &Resolver,
+    database_id: usize,
     body: &ast::Update,
     table_name: &str,
     is_internal_schema_change: bool,
@@ -218,23 +219,28 @@ fn validate_update(
     if !body.order_by.is_empty() {
         bail_parse_error!("ORDER BY is not supported in UPDATE");
     }
-    // Check if this is a materialized view
-    if schema.is_materialized_view(table_name) {
+    // Check if this is a materialized view in the *target* database. Materialized views
+    // live in their owning schema only, so we must dispatch on `database_id` here:
+    // a materialized view named `mv` in `main` must not block DML on a regular table
+    // also named `mv` in an attached database (#6273).
+    if resolver.with_schema(database_id, |s| s.is_materialized_view(table_name)) {
         bail_parse_error!("cannot modify materialized view {}", table_name);
     }
 
-    // Check if this table has any incompatible dependent views
-    schema.with_incompatible_dependent_views(table_name, |views| {
-    if !views.is_empty() {
-        use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
-        crate::bail_parse_error!(
-            "Cannot UPDATE table '{table_name}' because it has incompatible dependent materialized view(s): {}. \n\
-             These views were created with a different DBSP version than the current version ({DBSP_CIRCUIT_VERSION}). \n\
-             Please DROP and recreate the view(s) before modifying this table.",
-            views.iter().map(|view| view.as_str()).collect::<Vec<_>>().join(", "),
-        );
-    }
-    Ok(())
+    // Check if this table has any incompatible dependent views in the *target* database.
+    resolver.with_schema(database_id, |s| {
+        s.with_incompatible_dependent_views(table_name, |views| {
+            if !views.is_empty() {
+                use crate::incremental::compiler::DBSP_CIRCUIT_VERSION;
+                crate::bail_parse_error!(
+                    "Cannot UPDATE table '{table_name}' because it has incompatible dependent materialized view(s): {}. \n\
+                     These views were created with a different DBSP version than the current version ({DBSP_CIRCUIT_VERSION}). \n\
+                     Please DROP and recreate the view(s) before modifying this table.",
+                    views.iter().map(|view| view.as_str()).collect::<Vec<_>>().join(", "),
+                );
+            }
+            Ok(())
+        })
     })
 }
 
@@ -246,7 +252,6 @@ fn prepare_update_plan(
     is_internal_schema_change: bool,
 ) -> crate::Result<UpdatePlan> {
     let database_id = resolver.resolve_existing_table_database_id_qualified(&body.tbl_name)?;
-    let schema = resolver.schema();
     let target_name = &body.tbl_name.name;
     let table = match resolver.with_schema(database_id, |s| s.get_table(target_name.as_str())) {
         Some(table) => table,
@@ -264,7 +269,8 @@ fn prepare_update_plan(
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
     program.begin_write_on_database(database_id, schema_cookie);
     validate_update(
-        schema,
+        resolver,
+        database_id,
         &body,
         target_name.as_str(),
         is_internal_schema_change,

--- a/testing/sqltests/turso-tests/attach/matview_collisions.sqltest
+++ b/testing/sqltests/turso-tests/attach/matview_collisions.sqltest
@@ -1,0 +1,87 @@
+@database :memory:
+@requires-file materialized_views ""
+@skip-file-if mvcc "materialized_views not supported with mvcc"
+
+# Regression tests for #6273: a materialized view in the *main* database must not
+# block INSERT / UPDATE / DELETE on a regular, same-named table that lives in an
+# attached database (and vice versa). Materialized views live in their owning
+# schema only, so the matview check needs to dispatch on the resolved
+# `database_id` of the target table rather than always reading from the main
+# database's schema.
+
+# DELETE on aux.mv1 must succeed even though main has a materialized view with
+# the same name targeting an unrelated source table.
+test attach-matview-collision-delete-aux-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.mv1 (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.mv1 VALUES (1, 'hello'), (2, 'world');
+    CREATE TABLE main.t1 (id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO main.t1 VALUES (1, 10);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM main.t1;
+    DELETE FROM aux.mv1 WHERE id = 1;
+    SELECT id, val FROM aux.mv1 ORDER BY id;
+}
+expect {
+    2|world
+}
+
+# UPDATE on aux.mv1 must succeed under the same shadowing.
+test attach-matview-collision-update-aux-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.mv1 (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.mv1 VALUES (1, 'hello');
+    CREATE TABLE main.t1 (id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO main.t1 VALUES (1, 10);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM main.t1;
+    UPDATE aux.mv1 SET val = 'updated' WHERE id = 1;
+    SELECT id, val FROM aux.mv1 ORDER BY id;
+}
+expect {
+    1|updated
+}
+
+# INSERT on aux.mv1 must succeed under the same shadowing.
+test attach-matview-collision-insert-aux-table {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.mv1 (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO aux.mv1 VALUES (1, 'hello');
+    CREATE TABLE main.t1 (id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO main.t1 VALUES (1, 10);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM main.t1;
+    INSERT INTO aux.mv1 VALUES (2, 'world');
+    SELECT id, val FROM aux.mv1 ORDER BY id;
+}
+expect {
+    1|hello
+    2|world
+}
+
+# Symmetric case: a materialized view in `aux` must not block DML against a
+# same-named regular table in `main`.
+test attach-matview-collision-write-main-table-aux-mv-shadow {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main.mv2 (id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO main.mv2 VALUES (1, 'orig');
+    CREATE TABLE aux.src (id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO aux.src VALUES (1, 99);
+    CREATE MATERIALIZED VIEW aux.mv2 AS SELECT * FROM aux.src;
+    INSERT INTO main.mv2 VALUES (2, 'second');
+    UPDATE main.mv2 SET val = 'patched' WHERE id = 1;
+    DELETE FROM main.mv2 WHERE id = 2;
+    SELECT id, val FROM main.mv2 ORDER BY id;
+}
+expect {
+    1|patched
+}
+
+# Sanity: when the target *is* a materialized view, the DML guard must still
+# fire. We only relax the check across schema boundaries.
+test attach-matview-collision-still-blocks-real-mv-target {
+    CREATE TABLE main.t1 (id INTEGER PRIMARY KEY, val INTEGER);
+    INSERT INTO main.t1 VALUES (1, 10);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM main.t1;
+    DELETE FROM main.mv1 WHERE id = 1;
+}
+expect error {
+    cannot modify materialized view mv1
+}


### PR DESCRIPTION
## Summary

Fixes #6273. The materialized-view DML guard (and its sibling
`incompatible dependent views` check) lived in three call sites and
each one read from `resolver.schema()` - i.e. the **main** database's
schema - so a materialized view named `mv` in `main` would
silently block `INSERT` / `UPDATE` / `DELETE` on a regular,
same-named table that lived in an attached database.

Reproducer (verbatim from the issue):

```sql
ATTACH '' AS aux;
CREATE TABLE aux.mv1 (id INTEGER PRIMARY KEY, val TEXT);
INSERT INTO aux.mv1 VALUES (1, 'hello');
CREATE TABLE main.t1 (id INTEGER PRIMARY KEY, val INTEGER);
INSERT INTO main.t1 VALUES (1, 10);
CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM main.t1;

DELETE FROM aux.mv1 WHERE id = 1;
-- before: `Parse error: cannot modify materialized view mv1`
-- after:  succeeds; `aux.mv1` is a regular table, unrelated to `main.mv1`
```

## What changed

Three call sites switched from `resolver.schema()` to
`resolver.with_schema(database_id, |s| s.is_materialized_view(name))` (and the
parallel `with_incompatible_dependent_views` lookup):

| File | Function | Before | After |
|------|----------|--------|-------|
| `core/translate/delete.rs` | `validate_delete` | `resolver.schema().is_materialized_view(...)` | `resolver.with_schema(database_id, ...)` |
| `core/translate/insert.rs` | `validate` | `resolver.schema().is_materialized_view(...)` | `resolver.with_schema(database_id, ...)` |
| `core/translate/update.rs` | `validate_update` | took `schema: &Schema` | now takes `(resolver, database_id)` |

`database_id` was already in scope at every call site - it's the resolved
id of the table being mutated, computed once at the top of
`translate_delete` / `translate_insert` / `translate_update`. The
DROP-TABLE handler in `schema.rs` already used the per-database lookup,
so this commit makes the four DML/DDL guards consistent.

This is a sibling fix to #6541 / commit `76f2a1c1`
(`optimizer: resolve indexes per table reference`) - same
`resolver.schema()` vs `resolver.with_schema(database_id, .)`
pattern, different consumer.

## Test plan

New file `testing/sqltests/turso-tests/attach/matview_collisions.sqltest`
with five tests:

- `attach-matview-collision-delete-aux-table` - `DELETE` on the
  shadowed table in `aux` succeeds.
- `attach-matview-collision-update-aux-table` - `UPDATE` on the
  shadowed table in `aux` succeeds.
- `attach-matview-collision-insert-aux-table` - `INSERT` on the
  shadowed table in `aux` succeeds.
- `attach-matview-collision-write-main-table-aux-mv-shadow` -
  symmetric direction (matview in `aux`, regular table in `main`).
- `attach-matview-collision-still-blocks-real-mv-target` - sanity
  check: the guard *does* still fire when the target itself is a
  materialized view.

The Rust sqltest backend already enables `experimental_attach` and
`experimental_materialized_views`, so the new file runs without
additional configuration.

/claim #6273