### PR TITLE
pager: expand cache when full during statement savepoint rollback

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5019,11 +5019,18 @@ impl Pager {
         if dirty_page_must_exist {
             turso_assert!(page.is_dirty(), "page must be dirty for upsert", { "page_id": id });
         }
-        cache.upsert_page(page_key, page.clone()).map_err(|e| {
-            LimboError::InternalError(format!(
-                "Failed to insert loaded page {id} into cache: {e:?}"
-            ))
-        })?;
+        // During rollback we must not fail -- if the cache is full (e.g. all
+        // pages are dirty and cannot be evicted), temporarily expand capacity
+        // by 1 so the restored page can always be inserted.
+        if cache.upsert_page(page_key.clone(), page.clone()).is_err() {
+            let old_cap = cache.capacity();
+            let _ = cache.resize(old_cap + 1);
+            cache.upsert_page(page_key, page.clone()).map_err(|e| {
+                LimboError::InternalError(format!(
+                    "Failed to insert loaded page {id} into cache: {e:?}"
+                ))
+            })?;
+        }
         page.set_loaded();
         page.clear_wal_tag();
         Ok(())


### PR DESCRIPTION
Fixes #6679

## Root Cause

When a statement savepoint rollback is triggered (e.g. UNIQUE or CHECK constraint violation), `upsert_page_in_cache` fails with `Failed to insert loaded page into cache: Full` if all cached pages are dirty and cannot be evicted. This leaves the rollback incomplete causing database corruption visible via `PRAGMA integrity_check`.

## Fix

If `upsert_page` fails because the cache is full, temporarily resize the cache capacity by 1 to guarantee the restored page can always be inserted. Rollback must never fail.

## Validation

Before fix: rollback errors + `integrity_check` reports corruption  
After fix: constraint error raised correctly, `integrity_check: ok`

Simulator seed confirmed:
```
cargo run -p limbo_sim -- --differential --io-backend memory --profile savepoint_stress --seed 13824768406187730451 -n 500 -k 100 -t 60 --disable-bugbase
```