### PR TITLE
batch row_versions in mvcc commit

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3329,6 +3329,24 @@ impl Connection {
             None => Err(LimboError::InternalError("MVCC not enabled".into())),
         }
     }
+
+    pub(crate) fn set_mvcc_commit_log_batch_size(&self, batch_size: u64) -> Result<()> {
+        match self.db.get_mv_store().as_ref() {
+            Some(mv_store) => {
+                mv_store.set_commit_log_batch_size(batch_size)?;
+                self.bump_prepare_context_generation();
+                Ok(())
+            }
+            None => Err(LimboError::InternalError("MVCC not enabled".into())),
+        }
+    }
+
+    pub(crate) fn mvcc_commit_log_batch_size(&self) -> Result<u64> {
+        match self.db.get_mv_store().as_ref() {
+            Some(mv_store) => Ok(mv_store.commit_log_batch_size()),
+            None => Err(LimboError::InternalError("MVCC not enabled".into())),
+        }
+    }
 }
 
 pub type Row = vdbe::Row;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -886,6 +886,11 @@ pub enum CommitState<Clock: LogicalClock> {
     WaitForDependencies {
         end_ts: u64,
     },
+    /// Build the committed log record incrementally, yielding every
+    /// `MVCC_COMMIT_BATCH_SIZE` rowids so that very large write sets
+    /// (e.g. CREATE INDEX on a multi-million row table) don't monopolize
+    /// the executor.
+    BuildLogRecord(BuildLogRecordCtx),
     BeginCommitLogicalLog {
         end_ts: u64,
         log_record: LogRecord,
@@ -904,7 +909,45 @@ pub enum CommitState<Clock: LogicalClock> {
     CommitEnd {
         end_ts: u64,
     },
+    /// Publish committed timestamps into the live MVCC chains in chunks
+    /// of `MVCC_COMMIT_BATCH_SIZE` rowids, yielding between chunks. The
+    /// transaction is already in the Committed state at this point, so
+    /// readers consult `txs[tx_id]` to resolve any TxID references that
+    /// haven't been rewritten yet.
+    RewriteLiveVersions(RewriteLiveVersionsCtx),
+    /// Final post-rewrite cleanup: drain commit dependents, release the
+    /// commit lock, update the global header, finish the tx, and start
+    /// auto-checkpoint if needed.
+    FinalizeCommit {
+        end_ts: u64,
+    },
 }
+
+/// Iteration state for the chunked `BuildLogRecord` step.
+#[derive(Debug)]
+pub struct BuildLogRecordCtx {
+    pub end_ts: u64,
+    pub log_record: LogRecord,
+    /// Index into `CommitStateMachine::write_set` for the current pass.
+    pub cursor: usize,
+    /// True while emitting schema rows (sqlite_schema), false during the
+    /// data-row pass. Schema rows are emitted first so log replay sees
+    /// CREATE TABLE before related INSERTs.
+    pub schema_process: bool,
+}
+
+/// Iteration state for the chunked `RewriteLiveVersions` step.
+#[derive(Debug)]
+pub struct RewriteLiveVersionsCtx {
+    pub end_ts: u64,
+    /// Index into `CommitStateMachine::write_set`.
+    pub cursor: usize,
+}
+
+/// How many rowids `BuildLogRecord` / `RewriteLiveVersions` process before
+/// yielding to the executor. Picked to amortize state-machine overhead
+/// while keeping a CREATE INDEX on a 2M-row table responsive.
+const MVCC_COMMIT_BATCH_SIZE: usize = 1024;
 
 #[derive(Debug)]
 pub enum WriteRowState {
@@ -934,6 +977,10 @@ impl CommitCoordinator {
 pub(crate) enum CommitYieldPoint {
     CommitValidation,
     WaitForDependencies,
+    /// Fires once on the first entry into `step_build_log_record` (cursor=0,
+    /// schema_process=true), before any chunk processing. Pairs with
+    /// `LogRecordPrepared` to bracket the BuildLogRecord chunked yields.
+    BuildLogRecordStart,
     LogRecordPrepared,
     /// Boundary right after `remove_tx` runs but before the connection cache
     /// is cleared by the caller at vdbe/mod.rs. Used for failure injection
@@ -1326,25 +1373,36 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         Ok(())
     }
 
-    /// Build the committed image for the logical log without mutating the
-    /// live MVCC version chains, which must stay TxID-backed until CommitEnd.
-    fn build_committed_log_record(
+    /// Run one chunked step of `BuildLogRecord`. Processes up to
+    /// `MVCC_COMMIT_BATCH_SIZE` rowids per call, then yields. Schema rows
+    /// (table_id == SQLITE_SCHEMA_MVCC_TABLE_ID) are emitted before data rows
+    /// in two passes so that log replay sees CREATE TABLE before INSERTs.
+    fn step_build_log_record(
         &mut self,
         mvcc_store: &Arc<MvStore<Clock>>,
-        tx: &Transaction,
-        end_ts: u64,
-    ) -> LogRecord {
-        let mut log_record = LogRecord::new(end_ts);
-        if tx.header_dirty.load(Ordering::Acquire) {
-            // Persist the transaction-local header snapshot in the same logical-log frame.
-            log_record.header = Some(*tx.header.read());
+    ) -> Result<TransitionResult<()>> {
+        // First entry into BuildLogRecord (no chunk processed yet): a yield-
+        // point to bracket the chunked yields so tests can count them exactly.
+        // Must run before the `&mut self.state` re-bind below — the macro
+        // calls `self.yield_context()` which needs `&self`.
+        let is_first_entry = matches!(
+            self.state,
+            CommitState::BuildLogRecord(BuildLogRecordCtx {
+                cursor: 0,
+                schema_process: true,
+                ..
+            })
+        );
+        if is_first_entry {
+            inject_transition_yield!(self, CommitYieldPoint::BuildLogRecordStart);
         }
 
-        // Process schema rows (sqlite_schema) before data rows so that during log
-        // replay the table_id_to_rootpage map is populated before data row inserts
-        // reference it. `self.write_set` is sorted by table_id descending (most
-        // negative first), which would otherwise place data table rows
-        // (e.g. table_id=-3) before schema rows (table_id=-1).
+        let tx_id = self.tx_id;
+        let write_set_len = self.write_set.len();
+        let CommitState::BuildLogRecord(ctx) = &mut self.state else {
+            unreachable!("step_build_log_record requires BuildLogRecord state")
+        };
+        let end_ts = ctx.end_ts;
 
         // Remap a table_id to its canonical form for the log. After checkpoint,
         // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
@@ -1369,11 +1427,11 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         let our_committed_image = |row_version: &RowVersion| -> Option<RowVersion> {
             let our_begin = matches!(
                 row_version.begin,
-                Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
             );
             let our_end = matches!(
                 row_version.end,
-                Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
             );
             if !our_begin && !our_end {
                 // row_version belongs to another tx
@@ -1440,58 +1498,104 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
         };
 
-        // First pass: schema rows only (ordering matters for recovery)
-        for id in &self.write_set {
-            if id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(id, &mut log_record);
+        let mut iterations = 0;
+        while ctx.cursor < write_set_len && iterations < MVCC_COMMIT_BATCH_SIZE {
+            let id = &self.write_set[ctx.cursor];
+            let is_schema = id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID;
+            // schema_process=true: schema rows only, false: data rows only.
+            let process = if ctx.schema_process {
+                is_schema
+            } else {
+                !is_schema
+            };
+            if process {
+                collect_versions(id, &mut ctx.log_record);
             }
-        }
-        // Second pass: all non-schema rows
-        for id in &self.write_set {
-            if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(id, &mut log_record);
-            }
+            ctx.cursor += 1;
+            iterations += 1;
         }
 
-        log_record
+        if ctx.cursor < write_set_len {
+            // More work remains in the current pass: yield and resume.
+            return Ok(TransitionResult::Io(IOCompletions::Single(
+                Completion::new_yield(),
+            )));
+        }
+
+        if ctx.schema_process {
+            // Schema pass done; start the data pass from the top.
+            ctx.schema_process = false;
+            ctx.cursor = 0;
+            return Ok(TransitionResult::Continue);
+        }
+
+        // Both passes complete. Move the assembled log record out and
+        // transition to BeginCommitLogicalLog (or directly to CommitEnd
+        // if there is nothing to log).
+        let log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
+        tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
+
+        if log_record.row_versions.is_empty() && log_record.header.is_none() {
+            // Nothing to log. We still need to release the commit lock here
+            // if this is an exclusive tx, mirroring the pre-chunk path
+            // through WaitForDependencies.
+            if mvcc_store.is_exclusive_tx(&self.tx_id) {
+                if let Some(tx_entry) = mvcc_store.txs.get(&self.tx_id) {
+                    mvcc_store.unlock_commit_lock_if_held(tx_entry.value());
+                }
+            }
+            self.state = CommitState::CommitEnd { end_ts };
+        } else {
+            self.state = CommitState::BeginCommitLogicalLog { end_ts, log_record };
+        }
+        inject_transition_yield!(self, CommitYieldPoint::LogRecordPrepared);
+        Ok(TransitionResult::Continue)
     }
 
-    /// Publish committed timestamps into the live MVCC chains after the
-    /// transaction has been finalized as Committed(end_ts).
-    /// This must run as postprocessing step i.e. the txn is written to log and is durable
-    fn rewrite_live_versions_to_timestamps(&self, mvcc_store: &Arc<MvStore<Clock>>, end_ts: u64) {
-        let tx_state = mvcc_store
-            .txs
-            .get(&self.tx_id)
-            .map(|entry| entry.value().state.load());
-        turso_assert!(
-            matches!(tx_state, Some(TransactionState::Committed(ts)) if ts == end_ts),
-            "rewrite_live_versions_to_timestamps requires a committed transaction state"
-        );
-
-        for id in &self.write_set {
+    /// Run one chunked step of `RewriteLiveVersions`. Processes up to
+    /// `MVCC_COMMIT_BATCH_SIZE` rowids per call, then yields. The transaction
+    /// is already in the Committed state at this point; un-rewritten TxID
+    /// references resolve via `txs[tx_id]` for visibility/conflict checks.
+    fn step_rewrite_live_versions(
+        &mut self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+    ) -> Result<TransitionResult<()>> {
+        let tx_id = self.tx_id;
+        let write_set_len = self.write_set.len();
+        let CommitState::RewriteLiveVersions(ctx) = &mut self.state else {
+            unreachable!("step_rewrite_live_versions requires RewriteLiveVersions state")
+        };
+        let end_ts = ctx.end_ts;
+        if ctx.cursor == 0 {
+            let tx_state = mvcc_store
+                .txs
+                .get(&tx_id)
+                .map(|entry| entry.value().state.load());
+            turso_assert!(
+                matches!(tx_state, Some(TransactionState::Committed(ts)) if ts == end_ts),
+                "RewriteLiveVersions requires a committed transaction state"
+            );
+        }
+        let mut iterations = 0;
+        while ctx.cursor < write_set_len && iterations < MVCC_COMMIT_BATCH_SIZE {
+            let id = &self.write_set[ctx.cursor];
+            // Inline rewrite: replace any TxID(tx_id) refs in the table-row
+            // chain and the index-row chain with Timestamp(end_ts).
             if let Some(row_versions) = mvcc_store.rows.get(id) {
                 let mut row_versions = row_versions.value().write();
                 for row_version in row_versions.iter_mut() {
-                    if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
-                        if id == self.tx_id {
-                            // Publish the committed begin timestamp into the live
-                            // version chain only after CommitEnd has decided the
-                            // transaction's fate.
+                    if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin {
+                        if rv_id == tx_id {
                             row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                         }
                     }
-                    if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
-                        if id == self.tx_id {
-                            // Publish the committed end timestamp into the live
-                            // version chain only after CommitEnd has decided the
-                            // transaction's fate.
+                    if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end {
+                        if rv_id == tx_id {
                             row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                         }
                     }
                 }
             }
-
             if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
                 let index = index.value();
                 let RowKey::Record(ref index_key) = id.row_id else {
@@ -1500,26 +1604,29 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 if let Some(row_versions) = index.get(index_key) {
                     let mut row_versions = row_versions.value().write();
                     for row_version in row_versions.iter_mut() {
-                        if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
-                            if id == self.tx_id {
-                                // Publish the committed begin timestamp into the live
-                                // version chain only after CommitEnd has decided the
-                                // transaction's fate.
+                        if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin {
+                            if rv_id == tx_id {
                                 row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                             }
                         }
-                        if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
-                            if id == self.tx_id {
-                                // Publish the committed end timestamp into the live
-                                // version chain only after CommitEnd has decided the
-                                // transaction's fate.
+                        if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end {
+                            if rv_id == tx_id {
                                 row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                             }
                         }
                     }
                 }
             }
+            ctx.cursor += 1;
+            iterations += 1;
         }
+        if ctx.cursor < write_set_len {
+            return Ok(TransitionResult::Io(IOCompletions::Single(
+                Completion::new_yield(),
+            )));
+        }
+        self.state = CommitState::FinalizeCommit { end_ts };
+        Ok(TransitionResult::Continue)
     }
 }
 
@@ -1807,25 +1914,29 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     return Ok(TransitionResult::Done(()));
                 }
 
-                // All dependencies resolved. Build the committed image for the
-                // logical log, but keep live row versions on TxID references
-                // until CommitEnd so rollback of an abandoned commit can still
-                // match them.
-                let log_record = self.build_committed_log_record(mvcc_store, tx, end_ts);
-                tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
-
-                if log_record.row_versions.is_empty() && log_record.header.is_none() {
-                    // Nothing to do, just end commit.
-                    if mvcc_store.is_exclusive_tx(&self.tx_id) {
-                        mvcc_store.unlock_commit_lock_if_held(tx);
-                    }
-                    self.state = CommitState::CommitEnd { end_ts };
-                } else {
-                    self.state = CommitState::BeginCommitLogicalLog { end_ts, log_record };
+                // All dependencies resolved. Initialize the log record (just
+                // the header snapshot, if any) and hand off to BuildLogRecord
+                // which fills in row_versions in `MVCC_COMMIT_BATCH_SIZE`-sized
+                // chunks, yielding between chunks. Live row versions stay on
+                // TxID references until CommitEnd so rollback of an abandoned
+                // commit can still match them.
+                let mut log_record = LogRecord::new(end_ts);
+                if tx.header_dirty.load(Ordering::Acquire) {
+                    log_record.header = Some(*tx.header.read());
                 }
-                inject_transition_yield!(self, CommitYieldPoint::LogRecordPrepared);
+                self.state = CommitState::BuildLogRecord(BuildLogRecordCtx {
+                    end_ts,
+                    log_record,
+                    cursor: 0,
+                    schema_process: true,
+                });
                 return Ok(TransitionResult::Continue);
             }
+            // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Pulled out
+            // to a helper because the arm body needs `&mut self` to mutate
+            // the cursor / pass / log_record inside the variant, which
+            // conflicts with the outer `&self.state` match borrow.
+            CommitState::BuildLogRecord(_) => self.step_build_log_record(mvcc_store),
             CommitState::BeginCommitLogicalLog { end_ts, log_record } => {
                 if !mvcc_store.is_exclusive_tx(&self.tx_id) {
                     // logical log needs to be serialized
@@ -1899,7 +2010,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // Order of operations matters here:
                 // 1. Advance logical log writer offset (makes the written bytes "owned")
                 // 2. Mark transaction Committed
-                // 3. Rewrite live row versions from TxID to Timestamp
+                // 3. Rewrite live row versions from TxID to Timestamp (chunked
+                //    in `RewriteLiveVersions` so 2M-row write sets don't stall)
                 // 4. Notify dependents
                 // 5. Release commit lock (allows next committer)
                 // 6. Update cached global header
@@ -1935,7 +2047,24 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     .state
                     .store(TransactionState::Committed(*end_ts));
 
-                self.rewrite_live_versions_to_timestamps(mvcc_store, *end_ts);
+                // Hand off to the chunked rewriter. Between chunks readers
+                // resolve any unwritten TxID refs via `txs[tx_id]` which now
+                // reports Committed(end_ts).
+                self.state = CommitState::RewriteLiveVersions(RewriteLiveVersionsCtx {
+                    end_ts: *end_ts,
+                    cursor: 0,
+                });
+                Ok(TransitionResult::Continue)
+            }
+            // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Same
+            // helper-dispatch reason as BuildLogRecord above.
+            CommitState::RewriteLiveVersions(_) => self.step_rewrite_live_versions(mvcc_store),
+            CommitState::FinalizeCommit { end_ts } => {
+                let tx = mvcc_store
+                    .txs
+                    .get(&self.tx_id)
+                    .ok_or_else(|| LimboError::NoSuchTransactionID(self.tx_id.to_string()))?;
+                let tx_unlocked = tx.value();
 
                 // Hekaton Section 3.3: "The transaction then processes all outgoing
                 // commit dependencies listed in its CommitDepSet. If it committed, it
@@ -5719,6 +5848,7 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
                 .debug_struct("WaitForDependencies")
                 .field("end_ts", end_ts)
                 .finish(),
+            Self::BuildLogRecord(ctx) => f.debug_tuple("BuildLogRecord").field(ctx).finish(),
             Self::BeginCommitLogicalLog { end_ts, log_record } => f
                 .debug_struct("BeginCommitLogicalLog")
                 .field("end_ts", end_ts)
@@ -5736,6 +5866,13 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
             Self::CommitEnd { end_ts } => {
                 f.debug_struct("CommitEnd").field("end_ts", end_ts).finish()
             }
+            Self::RewriteLiveVersions(ctx) => {
+                f.debug_tuple("RewriteLiveVersions").field(ctx).finish()
+            }
+            Self::FinalizeCommit { end_ts } => f
+                .debug_struct("FinalizeCommit")
+                .field("end_ts", end_ts)
+                .finish(),
         }
     }
 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -64,6 +64,9 @@ pub mod hermitage_tests;
 #[cfg(test)]
 pub mod tests;
 
+pub const DEFAULT_MVCC_COMMIT_LOG_BATCH_SIZE: u64 = 1024;
+pub const MAX_MVCC_COMMIT_LOG_BATCH_SIZE: u64 = 65_536;
+
 /// Sentinel value for `MvStore::exclusive_tx` indicating no exclusive transaction is active.
 const NO_EXCLUSIVE_TX: u64 = 0;
 
@@ -877,10 +880,9 @@ pub enum CommitState<Clock: LogicalClock> {
     WaitForDependencies {
         end_ts: u64,
     },
-    /// Count the committed logical-log frame incrementally, yielding every
-    /// `MVCC_COMMIT_BATCH_SIZE` rowids so that very large write sets
-    /// (e.g. CREATE INDEX on a multi-million row table) don't monopolize
-    /// the executor.
+    /// Count the committed logical-log frame incrementally, yielding after the
+    /// configured commit-log rowid budget so that very large write sets (e.g.
+    /// CREATE INDEX on a multi-million row table) don't monopolize the executor.
     CountCommitLog {
         end_ts: u64,
         header: Option<DatabaseHeader>,
@@ -978,10 +980,10 @@ pub struct RewriteLiveVersionsCtx {
     pub cursor: usize,
 }
 
-/// How many rowids the commit-log scans and live-version rewrite process before
-/// yielding to the executor. Picked to amortize state-machine overhead
-/// while keeping a CREATE INDEX on a 2M-row table responsive.
-const MVCC_COMMIT_BATCH_SIZE: usize = 1024;
+/// How many rowids the live-version rewrite processes before yielding to the
+/// executor. Commit-log scans use the configurable
+/// `mvcc_commit_log_batch_size` budget, whose default matches this value.
+const MVCC_COMMIT_BATCH_SIZE: usize = DEFAULT_MVCC_COMMIT_LOG_BATCH_SIZE as usize;
 
 #[derive(Debug)]
 pub enum WriteRowState {
@@ -1554,6 +1556,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         mut emit: impl FnMut(LogOpRef<'_>) -> Result<()>,
     ) -> Result<CommitLogScanOutcome> {
         let write_set_len = self.write_set.len();
+        let batch_size = mvcc_store.commit_log_batch_size() as usize;
         let mut iterations = 0usize;
 
         loop {
@@ -1605,9 +1608,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                     let Some(row_versions) = index.get(index_key) else {
                         scan.write_set_index += 1;
                         iterations += 1;
-                        if iterations >= MVCC_COMMIT_BATCH_SIZE
-                            && scan.write_set_index < write_set_len
-                        {
+                        if iterations >= batch_size && scan.write_set_index < write_set_len {
                             return Ok(CommitLogScanOutcome::Yield);
                         }
                         continue;
@@ -1625,7 +1626,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             scan.write_set_index += 1;
             scan.accumulator = CommitLogChainAccumulator::default();
             iterations += 1;
-            if iterations >= MVCC_COMMIT_BATCH_SIZE && scan.write_set_index < write_set_len {
+            if iterations >= batch_size && scan.write_set_index < write_set_len {
                 // More work remains in the current pass: yield and resume.
                 return Ok(CommitLogScanOutcome::Yield);
             }
@@ -2649,6 +2650,7 @@ pub struct MvStore<Clock: LogicalClock> {
     /// If there are two concurrent BEGIN (non-CONCURRENT) transactions, and one tries to promote
     /// to exclusive, it will abort if another transaction committed after its begin timestamp.
     last_committed_tx_ts: AtomicU64,
+    commit_log_batch_size: AtomicU64,
     table_id_to_last_rowid: RwLock<HashMap<MVTableId, Arc<RowidAllocator>>>,
 }
 
@@ -2723,6 +2725,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             durable_txid_max: AtomicU64::new(0),
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
+            commit_log_batch_size: AtomicU64::new(DEFAULT_MVCC_COMMIT_LOG_BATCH_SIZE),
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
         }
     }
@@ -5541,6 +5544,21 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
     pub fn checkpoint_threshold(&self) -> i64 {
         self.storage.checkpoint_threshold()
+    }
+
+    pub fn set_commit_log_batch_size(&self, batch_size: u64) -> Result<()> {
+        if !(1..=MAX_MVCC_COMMIT_LOG_BATCH_SIZE).contains(&batch_size) {
+            return Err(LimboError::InternalError(format!(
+                "mvcc_commit_log_batch_size must be between 1 and {MAX_MVCC_COMMIT_LOG_BATCH_SIZE}"
+            )));
+        }
+        self.commit_log_batch_size
+            .store(batch_size, Ordering::Relaxed);
+        Ok(())
+    }
+
+    pub fn commit_log_batch_size(&self) -> u64 {
+        self.commit_log_batch_size.load(Ordering::Relaxed)
     }
 
     pub fn get_real_table_id(&self, table_id: i64) -> i64 {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2138,6 +2138,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 let outcome =
                     self.write_commit_log_batch(mvcc_store, &mut scan, &mut frame_builder)?;
                 if matches!(outcome, CommitLogScanOutcome::Yield) {
+                    let completion = mvcc_store.storage.flush_log_tx_frame(&mut frame_builder)?;
                     self.pending_log_frame_builder = Some(frame_builder);
                     self.state = CommitState::BeginCommitLogicalLog {
                         end_ts: *end_ts,
@@ -2145,9 +2146,17 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         scan,
                         stats: *stats,
                     };
-                    return Ok(TransitionResult::Io(IOCompletions::Single(
-                        Completion::new_yield(),
-                    )));
+                    return if let Some(completion) = completion {
+                        if completion.succeeded() {
+                            Ok(TransitionResult::Continue)
+                        } else {
+                            Ok(TransitionResult::Io(IOCompletions::Single(completion)))
+                        }
+                    } else {
+                        Ok(TransitionResult::Io(IOCompletions::Single(
+                            Completion::new_yield(),
+                        )))
+                    };
                 }
                 if let Some(header) = header {
                     frame_builder.append_header(header)?;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1579,18 +1579,22 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         let mut iterations = 0;
         while ctx.cursor < write_set_len && iterations < MVCC_COMMIT_BATCH_SIZE {
             let id = &self.write_set[ctx.cursor];
-            // Inline rewrite: replace any TxID(tx_id) refs in the table-row
-            // chain and the index-row chain with Timestamp(end_ts).
             if let Some(row_versions) = mvcc_store.rows.get(id) {
                 let mut row_versions = row_versions.value().write();
                 for row_version in row_versions.iter_mut() {
-                    if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin {
-                        if rv_id == tx_id {
+                    if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
+                        if id == tx_id {
+                            // Publish the committed begin timestamp into the live
+                            // version chain only after CommitEnd has decided the
+                            // transaction's fate.
                             row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                         }
                     }
-                    if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end {
-                        if rv_id == tx_id {
+                    if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
+                        if id == tx_id {
+                            // Publish the committed end timestamp into the live
+                            // version chain only after CommitEnd has decided the
+                            // transaction's fate.
                             row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                         }
                     }
@@ -1604,13 +1608,19 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 if let Some(row_versions) = index.get(index_key) {
                     let mut row_versions = row_versions.value().write();
                     for row_version in row_versions.iter_mut() {
-                        if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin {
-                            if rv_id == tx_id {
+                        if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
+                            if id == tx_id {
+                                // Publish the committed begin timestamp into the live
+                                // version chain only after CommitEnd has decided the
+                                // transaction's fate.
                                 row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                             }
                         }
-                        if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end {
-                            if rv_id == tx_id {
+                        if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
+                            if id == tx_id {
+                                // Publish the committed end timestamp into the live
+                                // version chain only after CommitEnd has decided the
+                                // transaction's fate.
                                 row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                             }
                         }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2138,7 +2138,9 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 let outcome =
                     self.write_commit_log_batch(mvcc_store, &mut scan, &mut frame_builder)?;
                 if matches!(outcome, CommitLogScanOutcome::Yield) {
-                    let completion = mvcc_store.storage.flush_log_tx_frame(&mut frame_builder)?;
+                    let completion = mvcc_store
+                        .storage
+                        .flush_log_tx_frame(&mut frame_builder, None)?;
                     self.pending_log_frame_builder = Some(frame_builder);
                     self.state = CommitState::BeginCommitLogicalLog {
                         end_ts: *end_ts,
@@ -2161,9 +2163,10 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 if let Some(header) = header {
                     frame_builder.append_header(header)?;
                 }
-                let (c, append_bytes) = mvcc_store
-                    .storage
-                    .finish_log_tx_frame(frame_builder, None)?;
+                let (c, append_bytes) =
+                    mvcc_store
+                        .storage
+                        .finish_log_tx_frame(frame_builder, None, None)?;
                 self.pending_log_append_bytes = Some(append_bytes);
                 self.state = CommitState::SyncLogicalLog { end_ts: *end_ts };
                 // if Completion Completed without errors we can continue

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -55,7 +55,8 @@ pub mod checkpoint_state_machine;
 pub use checkpoint_state_machine::{CheckpointState, CheckpointStateMachine};
 
 use super::persistent_storage::logical_log::{
-    HeaderReadResult, StreamingLogicalLogReader, StreamingResult, LOG_HDR_SIZE,
+    serialized_header_entry_size, serialized_log_op_entry_size, HeaderReadResult, LogFrameBuilder,
+    LogOpRef, StreamingLogicalLogReader, StreamingResult, LOG_HDR_SIZE,
 };
 
 #[cfg(test)]
@@ -339,16 +340,6 @@ pub struct LogRecord {
     pub(crate) tx_timestamp: TxID,
     pub row_versions: Vec<RowVersion>,
     pub header: Option<DatabaseHeader>,
-}
-
-impl LogRecord {
-    fn new(tx_timestamp: TxID) -> Self {
-        Self {
-            tx_timestamp,
-            row_versions: Vec::new(),
-            header: None,
-        }
-    }
 }
 
 /// A transaction timestamp or ID.
@@ -886,14 +877,21 @@ pub enum CommitState<Clock: LogicalClock> {
     WaitForDependencies {
         end_ts: u64,
     },
-    /// Build the committed log record incrementally, yielding every
+    /// Count the committed logical-log frame incrementally, yielding every
     /// `MVCC_COMMIT_BATCH_SIZE` rowids so that very large write sets
     /// (e.g. CREATE INDEX on a multi-million row table) don't monopolize
     /// the executor.
-    BuildLogRecord(BuildLogRecordCtx),
+    CountCommitLog {
+        end_ts: u64,
+        header: Option<DatabaseHeader>,
+        scan: CommitLogScanState,
+        stats: CommitLogStats,
+    },
     BeginCommitLogicalLog {
         end_ts: u64,
-        log_record: LogRecord,
+        header: Option<DatabaseHeader>,
+        scan: CommitLogScanState,
+        stats: CommitLogStats,
     },
     EndCommitLogicalLog {
         end_ts: u64,
@@ -923,17 +921,53 @@ pub enum CommitState<Clock: LogicalClock> {
     },
 }
 
-/// Iteration state for the chunked `BuildLogRecord` step.
-#[derive(Debug)]
-pub struct BuildLogRecordCtx {
-    pub end_ts: u64,
-    pub log_record: LogRecord,
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CommitLogStats {
+    op_count: u32,
+    payload_size: u64,
+}
+
+/// Iteration state for chunked commit-log counting/writing.
+#[derive(Clone, Debug)]
+pub struct CommitLogScanState {
+    pass: CommitLogWriteSetPass,
     /// Index into `CommitStateMachine::write_set` for the current pass.
-    pub cursor: usize,
-    /// True while emitting schema rows (sqlite_schema), false during the
-    /// data-row pass. Schema rows are emitted first so log replay sees
-    /// CREATE TABLE before related INSERTs.
-    pub schema_process: bool,
+    write_set_index: usize,
+    accumulator: CommitLogChainAccumulator,
+}
+
+impl Default for CommitLogScanState {
+    fn default() -> Self {
+        Self {
+            pass: CommitLogWriteSetPass::Schema,
+            write_set_index: 0,
+            accumulator: CommitLogChainAccumulator::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CommitLogWriteSetPass {
+    Schema,
+    NonSchema,
+    Done,
+}
+
+#[derive(Clone, Debug, Default)]
+struct CommitLogChainAccumulator {
+    own_version: Option<CommitLogProjection>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CommitLogProjection {
+    version_id: u64,
+    table_id: MVTableId,
+    is_delete: bool,
+}
+
+enum CommitLogScanOutcome {
+    Yield,
+    Done,
 }
 
 /// Iteration state for the chunked `RewriteLiveVersions` step.
@@ -944,7 +978,7 @@ pub struct RewriteLiveVersionsCtx {
     pub cursor: usize,
 }
 
-/// How many rowids `BuildLogRecord` / `RewriteLiveVersions` process before
+/// How many rowids the commit-log scans and live-version rewrite process before
 /// yielding to the executor. Picked to amortize state-machine overhead
 /// while keeping a CREATE INDEX on a 2M-row table responsive.
 const MVCC_COMMIT_BATCH_SIZE: usize = 1024;
@@ -977,9 +1011,9 @@ impl CommitCoordinator {
 pub(crate) enum CommitYieldPoint {
     CommitValidation,
     WaitForDependencies,
-    /// Fires once on the first entry into `step_build_log_record` (cursor=0,
-    /// schema_process=true), before any chunk processing. Pairs with
-    /// `LogRecordPrepared` to bracket the BuildLogRecord chunked yields.
+    /// Fires once on the first entry into commit-log counting, before any chunk
+    /// processing. Pairs with `LogRecordPrepared` to bracket chunked commit-log
+    /// scan yields.
     BuildLogRecordStart,
     LogRecordPrepared,
     /// Boundary right after `remove_tx` runs but before the connection cache
@@ -1035,6 +1069,7 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     pager: Arc<Pager>,
     /// Bytes appended to the logical log for this commit; applied to writer offset only after durability and before lock release.
     pending_log_append_bytes: Option<u64>,
+    pending_log_frame_builder: Option<LogFrameBuilder>,
     /// The synchronous mode for fsync operations. When set to Off, fsync is skipped.
     sync_mode: SyncMode,
     _phantom: PhantomData<Clock>,
@@ -1120,6 +1155,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             pager,
             header,
             pending_log_append_bytes: None,
+            pending_log_frame_builder: None,
             sync_mode,
             _phantom: PhantomData,
         }
@@ -1373,183 +1409,260 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         Ok(())
     }
 
-    /// Run one chunked step of `BuildLogRecord`. Processes up to
-    /// `MVCC_COMMIT_BATCH_SIZE` rowids per call, then yields. Schema rows
-    /// (table_id == SQLITE_SCHEMA_MVCC_TABLE_ID) are emitted before data rows
-    /// in two passes so that log replay sees CREATE TABLE before INSERTs.
-    fn step_build_log_record(
-        &mut self,
+    fn acquire_commit_log_lock(
+        &self,
         mvcc_store: &Arc<MvStore<Clock>>,
-    ) -> Result<TransitionResult<()>> {
-        // First entry into BuildLogRecord (no chunk processed yet): a yield-
-        // point to bracket the chunked yields so tests can count them exactly.
-        // Must run before the `&mut self.state` re-bind below — the macro
-        // calls `self.yield_context()` which needs `&self`.
-        let is_first_entry = matches!(
-            self.state,
-            CommitState::BuildLogRecord(BuildLogRecordCtx {
-                cursor: 0,
-                schema_process: true,
-                ..
-            })
-        );
-        if is_first_entry {
-            inject_transition_yield!(self, CommitYieldPoint::BuildLogRecordStart);
+    ) -> Result<Option<IOCompletions>> {
+        if mvcc_store.is_exclusive_tx(&self.tx_id) {
+            return Ok(None);
         }
 
-        let tx_id = self.tx_id;
-        let write_set_len = self.write_set.len();
-        let CommitState::BuildLogRecord(ctx) = &mut self.state else {
-            unreachable!("step_build_log_record requires BuildLogRecord state")
-        };
-        let end_ts = ctx.end_ts;
+        let tx = mvcc_store
+            .txs
+            .get(&self.tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(self.tx_id.to_string()))?;
+        let tx = tx.value();
+        if tx.pager_commit_lock_held.load(Ordering::Acquire) {
+            return Ok(None);
+        }
 
-        // Remap a table_id to its canonical form for the log. After checkpoint,
-        // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
-        // (e.g. -58). On recovery, bootstrap reconstructs the map using
-        // -(root_page), so log records must use that canonical form to be found.
-        let canonicalize_table_id = |version: &mut RowVersion| {
-            let table_id = version.row.id.table_id;
-            if table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                return;
-            }
+        let locked = self.commit_coordinator.pager_commit_lock.write();
+        if !locked {
+            return Ok(Some(IOCompletions::Single(Completion::new_yield())));
+        }
+        tx.pager_commit_lock_held.store(true, Ordering::Release);
+        Ok(None)
+    }
+
+    fn projected_log_action(
+        &self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+        row_version: &RowVersion,
+    ) -> Option<CommitLogProjection> {
+        // Return a projection only if our tx contributed to this version and
+        // must therefore log it.
+        let our_begin = matches!(
+            row_version.begin,
+            Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+        );
+        let our_end = matches!(
+            row_version.end,
+            Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+        );
+        if !our_begin && !our_end {
+            // row_version belongs to another tx.
+            return None;
+        }
+
+        let mut table_id = row_version.row.id.table_id;
+        if table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+            // Remap a table_id to its canonical form for the log. After checkpoint,
+            // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
+            // (e.g. -58). On recovery, bootstrap reconstructs the map using
+            // -(root_page), so log records must use that canonical form to be found.
             if let Some(entry) = mvcc_store.table_id_to_rootpage.get(&table_id) {
                 if let Some(root_page) = *entry.value() {
-                    let canonical = MVTableId::from(-(root_page as i64));
-                    if canonical != table_id {
-                        version.row.id.table_id = canonical;
-                    }
+                    table_id = MVTableId::from(-(root_page as i64));
                 }
             }
-        };
+        }
 
-        // Returns Some(row_version) if our tx contributed to it and if we must therefore log it.
-        let our_committed_image = |row_version: &RowVersion| -> Option<RowVersion> {
-            let our_begin = matches!(
-                row_version.begin,
-                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
-            );
-            let our_end = matches!(
-                row_version.end,
-                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
-            );
-            if !our_begin && !our_end {
-                // row_version belongs to another tx
-                return None;
-            }
-            let mut committed = row_version.clone();
-            if our_begin {
-                // New version is valid STARTING FROM the committing
-                // transaction's end timestamp. See Hekaton page 299.
-                committed.begin = Some(TxTimestampOrID::Timestamp(end_ts));
+        Some(CommitLogProjection {
+            version_id: row_version.id,
+            table_id,
+            is_delete: our_end,
+        })
+    }
 
-                if !our_end {
-                    // A version row_version we inserted may have row_version.end == tx_b.tx_id,
-                    // where tx_b is a concurrent tx. This is because when a tx transitions to
-                    // Preparing, its row_version becomes *speculatively updatable*, and a tx tx_b
-                    // is allowed to change row_version.end from None to tx_b.tx_id to delete it
+    fn emit_commit_log_accumulator(
+        versions: &[RowVersion],
+        accumulator: &CommitLogChainAccumulator,
+        mut emit: impl FnMut(LogOpRef<'_>) -> Result<()>,
+    ) -> Result<()> {
+        if let Some(projection) = accumulator.own_version {
+            let Some(row_version) = versions.iter().find(|rv| rv.id == projection.version_id)
+            else {
+                return Err(LimboError::InternalError(format!(
+                    "committed log version id {} disappeared before serialization",
+                    projection.version_id
+                )));
+            };
+            let op = LogOpRef {
+                table_id: projection.table_id,
+                row_key: &row_version.row.id.row_id,
+                payload: row_version.row.payload(),
+                is_delete: projection.is_delete,
+                btree_resident: row_version.btree_resident,
+            };
+            emit(op)?;
+        }
+        Ok(())
+    }
+
+    fn process_commit_log_versions(
+        &self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+        versions: &[RowVersion],
+        accumulator: &mut CommitLogChainAccumulator,
+        mut emit: impl FnMut(LogOpRef<'_>) -> Result<()>,
+    ) -> Result<()> {
+        for row_version in versions.iter() {
+            if let Some(projection) = self.projected_log_action(mvcc_store, row_version) {
+                if projection.is_delete
+                    && !matches!(
+                        row_version.begin,
+                        Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+                    )
+                {
+                    // Old version is valid UNTIL the committing transaction's
+                    // end timestamp. See Hekaton page 299. The frame commit_ts
+                    // supplies that end timestamp during replay.
+                    let op = LogOpRef {
+                        table_id: projection.table_id,
+                        row_key: &row_version.row.id.row_id,
+                        payload: row_version.row.payload(),
+                        is_delete: true,
+                        btree_resident: row_version.btree_resident,
+                    };
+                    emit(op)?;
+                } else {
+                    // New version is valid STARTING FROM the committing
+                    // transaction's end timestamp. See Hekaton page 299.
+                    //
+                    // A version we inserted may have row_version.end == tx_b.tx_id,
+                    // where tx_b is a concurrent tx. This is because when a tx
+                    // transitions to Preparing, its row_version becomes
+                    // *speculatively updatable*, and tx_b is allowed to change
+                    // row_version.end from None to tx_b.tx_id to delete it
                     // (see the Hekaton paper, §3.1, heading "check updatability").
                     //
-                    // That deletion is tx_b's contribution, and tx_b will log it on its own commit.
-                    // Our log record must capture our own contribution, but if the `end` field is
-                    // set, it will be serialized as a OP_DELETE_* in the logical log, so we unset
-                    // it so that it will be serialized as an OP_UPSERT_*. tx_b will take care of
-                    // logging the deletion.
-                    committed.end = None;
+                    // That deletion is tx_b's contribution, and tx_b will log it
+                    // on its own commit. Because `projection.is_delete` only tracks
+                    // our own end marker, a speculative end by tx_b leaves this as
+                    // our upsert; an end by this tx keeps the final projected delete.
+                    accumulator.own_version = Some(projection);
                 }
             }
-            if our_end {
-                // Old version is valid UNTIL the committing
-                // transaction's end timestamp. See Hekaton page 299.
-                committed.end = Some(TxTimestampOrID::Timestamp(end_ts));
-            }
-            Some(committed)
-        };
+        }
+        Self::emit_commit_log_accumulator(versions, accumulator, emit)
+    }
 
-        let collect_versions = |id: &RowID, log_record: &mut LogRecord| {
-            if let Some(row_versions) = mvcc_store.rows.get(id) {
-                let row_versions = row_versions.value().read();
-                for row_version in row_versions.iter() {
-                    if let Some(mut committed_version) = our_committed_image(row_version) {
-                        canonicalize_table_id(&mut committed_version);
-                        mvcc_store
-                            .insert_version_raw(&mut log_record.row_versions, committed_version);
-                    }
-                }
+    fn process_commit_log_scan(
+        &self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+        scan: &mut CommitLogScanState,
+        mut emit: impl FnMut(LogOpRef<'_>) -> Result<()>,
+    ) -> Result<CommitLogScanOutcome> {
+        let write_set_len = self.write_set.len();
+        let mut iterations = 0usize;
+
+        loop {
+            match scan.pass {
+                CommitLogWriteSetPass::Done => return Ok(CommitLogScanOutcome::Done),
+                CommitLogWriteSetPass::Schema | CommitLogWriteSetPass::NonSchema => {}
             }
 
-            if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
-                let index = index.value();
-                let RowKey::Record(ref index_key) = id.row_id else {
-                    panic!("Index writes must have a record key");
+            if scan.write_set_index >= write_set_len {
+                scan.pass = match scan.pass {
+                    // Schema pass done; start the data pass from the top.
+                    CommitLogWriteSetPass::Schema => CommitLogWriteSetPass::NonSchema,
+                    CommitLogWriteSetPass::NonSchema => CommitLogWriteSetPass::Done,
+                    CommitLogWriteSetPass::Done => CommitLogWriteSetPass::Done,
                 };
-                if let Some(row_versions) = index.get(index_key) {
-                    let row_versions = row_versions.value().read();
-                    for row_version in row_versions.iter() {
-                        if let Some(mut committed_version) = our_committed_image(row_version) {
-                            canonicalize_table_id(&mut committed_version);
-                            mvcc_store.insert_version_raw(
-                                &mut log_record.row_versions,
-                                committed_version,
-                            );
-                        }
-                    }
-                }
+                scan.write_set_index = 0;
+                scan.accumulator = CommitLogChainAccumulator::default();
+                iterations = 0;
+                continue;
             }
-        };
 
-        let mut iterations = 0;
-        while ctx.cursor < write_set_len && iterations < MVCC_COMMIT_BATCH_SIZE {
-            let id = &self.write_set[ctx.cursor];
+            let id = &self.write_set[scan.write_set_index];
             let is_schema = id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID;
-            // schema_process=true: schema rows only, false: data rows only.
-            let process = if ctx.schema_process {
-                is_schema
-            } else {
-                !is_schema
+            // Schema pass emits schema rows only; data pass emits non-schema rows.
+            // Keeping schema rows first ensures log replay sees CREATE TABLE before
+            // related INSERTs.
+            let should_process = match scan.pass {
+                CommitLogWriteSetPass::Schema => is_schema,
+                CommitLogWriteSetPass::NonSchema => !is_schema,
+                CommitLogWriteSetPass::Done => false,
             };
-            if process {
-                collect_versions(id, &mut ctx.log_record);
-            }
-            ctx.cursor += 1;
-            iterations += 1;
-        }
 
-        if ctx.cursor < write_set_len {
-            // More work remains in the current pass: yield and resume.
-            return Ok(TransitionResult::Io(IOCompletions::Single(
-                Completion::new_yield(),
-            )));
-        }
-
-        if ctx.schema_process {
-            // Schema pass done; start the data pass from the top.
-            ctx.schema_process = false;
-            ctx.cursor = 0;
-            return Ok(TransitionResult::Continue);
-        }
-
-        // Both passes complete. Move the assembled log record out and
-        // transition to BeginCommitLogicalLog (or directly to CommitEnd
-        // if there is nothing to log).
-        let log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
-        tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
-
-        if log_record.row_versions.is_empty() && log_record.header.is_none() {
-            // Nothing to log. We still need to release the commit lock here
-            // if this is an exclusive tx, mirroring the pre-chunk path
-            // through WaitForDependencies.
-            if mvcc_store.is_exclusive_tx(&self.tx_id) {
-                if let Some(tx_entry) = mvcc_store.txs.get(&self.tx_id) {
-                    mvcc_store.unlock_commit_lock_if_held(tx_entry.value());
+            if should_process {
+                if id.row_id.is_int_key() {
+                    if let Some(row_versions) = mvcc_store.rows.get(id) {
+                        let row_versions = row_versions.value().read();
+                        self.process_commit_log_versions(
+                            mvcc_store,
+                            &row_versions,
+                            &mut scan.accumulator,
+                            &mut emit,
+                        )?;
+                    }
+                } else if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
+                    let index = index.value();
+                    let RowKey::Record(ref index_key) = id.row_id else {
+                        panic!("Index writes must have a record key");
+                    };
+                    let Some(row_versions) = index.get(index_key) else {
+                        scan.write_set_index += 1;
+                        iterations += 1;
+                        if iterations >= MVCC_COMMIT_BATCH_SIZE
+                            && scan.write_set_index < write_set_len
+                        {
+                            return Ok(CommitLogScanOutcome::Yield);
+                        }
+                        continue;
+                    };
+                    let row_versions = row_versions.value().read();
+                    self.process_commit_log_versions(
+                        mvcc_store,
+                        &row_versions,
+                        &mut scan.accumulator,
+                        &mut emit,
+                    )?;
                 }
             }
-            self.state = CommitState::CommitEnd { end_ts };
-        } else {
-            self.state = CommitState::BeginCommitLogicalLog { end_ts, log_record };
+
+            scan.write_set_index += 1;
+            scan.accumulator = CommitLogChainAccumulator::default();
+            iterations += 1;
+            if iterations >= MVCC_COMMIT_BATCH_SIZE && scan.write_set_index < write_set_len {
+                // More work remains in the current pass: yield and resume.
+                return Ok(CommitLogScanOutcome::Yield);
+            }
         }
-        inject_transition_yield!(self, CommitYieldPoint::LogRecordPrepared);
-        Ok(TransitionResult::Continue)
+    }
+
+    fn count_commit_log_batch(
+        &self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+        scan: &mut CommitLogScanState,
+        stats: &mut CommitLogStats,
+    ) -> Result<CommitLogScanOutcome> {
+        self.process_commit_log_scan(mvcc_store, scan, |op| {
+            stats.op_count = stats
+                .op_count
+                .checked_add(1)
+                .ok_or_else(|| LimboError::InternalError("logical log op_count overflow".into()))?;
+            stats.payload_size =
+                stats
+                    .payload_size
+                    .checked_add(u64::try_from(serialized_log_op_entry_size(&op)).map_err(
+                        |_| LimboError::InternalError("logical log op size exceeds u64".into()),
+                    )?)
+                    .ok_or_else(|| {
+                        LimboError::InternalError("logical log payload size overflow".into())
+                    })?;
+            Ok(())
+        })
+    }
+
+    fn write_commit_log_batch(
+        &self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+        scan: &mut CommitLogScanState,
+        builder: &mut LogFrameBuilder,
+    ) -> Result<CommitLogScanOutcome> {
+        self.process_commit_log_scan(mvcc_store, scan, |op| builder.append_op(&op))
     }
 
     /// Run one chunked step of `RewriteLiveVersions`. Processes up to
@@ -1924,47 +2037,123 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     return Ok(TransitionResult::Done(()));
                 }
 
-                // All dependencies resolved. Initialize the log record (just
-                // the header snapshot, if any) and hand off to BuildLogRecord
-                // which fills in row_versions in `MVCC_COMMIT_BATCH_SIZE`-sized
-                // chunks, yielding between chunks. Live row versions stay on
-                // TxID references until CommitEnd so rollback of an abandoned
-                // commit can still match them.
-                let mut log_record = LogRecord::new(end_ts);
-                if tx.header_dirty.load(Ordering::Acquire) {
-                    log_record.header = Some(*tx.header.read());
+                // All dependencies resolved. Count and write the committed
+                // logical-log projection in bounded scans. Live row versions
+                // stay on TxID references until CommitEnd so rollback of an
+                // abandoned commit can still match them.
+                let header = tx
+                    .header_dirty
+                    .load(Ordering::Acquire)
+                    .then(|| *tx.header.read());
+                let mut stats = CommitLogStats::default();
+                if header.is_some() {
+                    stats.op_count = 1;
+                    stats.payload_size = serialized_header_entry_size() as u64;
                 }
-                self.state = CommitState::BuildLogRecord(BuildLogRecordCtx {
+                self.state = CommitState::CountCommitLog {
                     end_ts,
-                    log_record,
-                    cursor: 0,
-                    schema_process: true,
-                });
+                    header,
+                    scan: CommitLogScanState::default(),
+                    stats,
+                };
                 return Ok(TransitionResult::Continue);
             }
-            // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Pulled out
-            // to a helper because the arm body needs `&mut self` to mutate
-            // the cursor / pass / log_record inside the variant, which
-            // conflicts with the outer `&self.state` match borrow.
-            CommitState::BuildLogRecord(_) => self.step_build_log_record(mvcc_store),
-            CommitState::BeginCommitLogicalLog { end_ts, log_record } => {
-                if !mvcc_store.is_exclusive_tx(&self.tx_id) {
-                    // logical log needs to be serialized
-                    let locked = self.commit_coordinator.pager_commit_lock.write();
-                    if !locked {
-                        return Ok(TransitionResult::Io(IOCompletions::Single(
-                            Completion::new_yield(),
-                        )));
+            CommitState::CountCommitLog {
+                end_ts,
+                header,
+                scan,
+                stats,
+            } => {
+                // First entry into commit-log counting (no chunk processed yet):
+                // a yield point to bracket the chunked yields so tests can count
+                // them exactly. Must run before the state is replaced below
+                // because the macro calls `self.yield_context()` which needs
+                // `&self`.
+                let is_first_entry = matches!(
+                    scan,
+                    CommitLogScanState {
+                        pass: CommitLogWriteSetPass::Schema,
+                        write_set_index: 0,
+                        ..
                     }
-                    let tx = mvcc_store
-                        .txs
-                        .get(&self.tx_id)
-                        .ok_or_else(|| LimboError::NoSuchTransactionID(self.tx_id.to_string()))?;
-                    tx.value()
-                        .pager_commit_lock_held
-                        .store(true, Ordering::Release);
+                ) && stats.op_count == u32::from(header.is_some());
+                if is_first_entry {
+                    inject_transition_yield!(self, CommitYieldPoint::BuildLogRecordStart);
                 }
-                let (c, append_bytes) = mvcc_store.storage.log_tx(log_record, None)?;
+                if let Some(io) = self.acquire_commit_log_lock(mvcc_store)? {
+                    return Ok(TransitionResult::Io(io));
+                }
+
+                let mut scan = scan.clone();
+                let mut stats = *stats;
+                let outcome = self.count_commit_log_batch(mvcc_store, &mut scan, &mut stats)?;
+                if matches!(outcome, CommitLogScanOutcome::Yield) {
+                    self.state = CommitState::CountCommitLog {
+                        end_ts: *end_ts,
+                        header: *header,
+                        scan,
+                        stats,
+                    };
+                    return Ok(TransitionResult::Io(IOCompletions::Single(
+                        Completion::new_yield(),
+                    )));
+                }
+
+                tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
+                // Both counting passes complete. Move to writing the bounded
+                // frame (or directly to CommitEnd if there is nothing to log).
+                if stats.op_count == 0 {
+                    self.state = CommitState::CommitEnd { end_ts: *end_ts };
+                } else {
+                    self.state = CommitState::BeginCommitLogicalLog {
+                        end_ts: *end_ts,
+                        header: *header,
+                        scan: CommitLogScanState::default(),
+                        stats,
+                    };
+                }
+                inject_transition_yield!(self, CommitYieldPoint::LogRecordPrepared);
+                return Ok(TransitionResult::Continue);
+            }
+            CommitState::BeginCommitLogicalLog {
+                end_ts,
+                header,
+                scan,
+                stats,
+            } => {
+                if let Some(io) = self.acquire_commit_log_lock(mvcc_store)? {
+                    return Ok(TransitionResult::Io(io));
+                }
+
+                let mut scan = scan.clone();
+                let mut frame_builder = match self.pending_log_frame_builder.take() {
+                    Some(builder) => builder,
+                    None => mvcc_store.storage.begin_log_tx_frame(
+                        *end_ts,
+                        stats.op_count,
+                        stats.payload_size,
+                    )?,
+                };
+                let outcome =
+                    self.write_commit_log_batch(mvcc_store, &mut scan, &mut frame_builder)?;
+                if matches!(outcome, CommitLogScanOutcome::Yield) {
+                    self.pending_log_frame_builder = Some(frame_builder);
+                    self.state = CommitState::BeginCommitLogicalLog {
+                        end_ts: *end_ts,
+                        header: *header,
+                        scan,
+                        stats: *stats,
+                    };
+                    return Ok(TransitionResult::Io(IOCompletions::Single(
+                        Completion::new_yield(),
+                    )));
+                }
+                if let Some(header) = header {
+                    frame_builder.append_header(header)?;
+                }
+                let (c, append_bytes) = mvcc_store
+                    .storage
+                    .finish_log_tx_frame(frame_builder, None)?;
                 self.pending_log_append_bytes = Some(append_bytes);
                 self.state = CommitState::SyncLogicalLog { end_ts: *end_ts };
                 // if Completion Completed without errors we can continue
@@ -2066,8 +2255,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 });
                 Ok(TransitionResult::Continue)
             }
-            // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Same
-            // helper-dispatch reason as BuildLogRecord above.
+            // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Keep this
+            // helper-dispatched like the commit-log scan states above.
             CommitState::RewriteLiveVersions(_) => self.step_rewrite_live_versions(mvcc_store),
             CommitState::FinalizeCommit { end_ts } => {
                 let tx = mvcc_store
@@ -5858,11 +6047,29 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
                 .debug_struct("WaitForDependencies")
                 .field("end_ts", end_ts)
                 .finish(),
-            Self::BuildLogRecord(ctx) => f.debug_tuple("BuildLogRecord").field(ctx).finish(),
-            Self::BeginCommitLogicalLog { end_ts, log_record } => f
+            Self::CountCommitLog {
+                end_ts,
+                header,
+                scan,
+                stats,
+            } => f
+                .debug_struct("CountCommitLog")
+                .field("end_ts", end_ts)
+                .field("header", header)
+                .field("scan", scan)
+                .field("stats", stats)
+                .finish(),
+            Self::BeginCommitLogicalLog {
+                end_ts,
+                header,
+                scan,
+                stats,
+            } => f
                 .debug_struct("BeginCommitLogicalLog")
                 .field("end_ts", end_ts)
-                .field("log_record", log_record)
+                .field("header", header)
+                .field("scan", scan)
+                .field("stats", stats)
                 .finish(),
             Self::EndCommitLogicalLog { end_ts } => f
                 .debug_struct("EndCommitLogicalLog")

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7610,6 +7610,65 @@ fn test_concurrent_commit_yield_spin() {
     assert_eq!(rows[0][0].as_int().unwrap(), 1);
 }
 
+#[test]
+fn test_mvcc_commit_log_batch_size_pragma() {
+    let db = MvccTestDbNoConn::new();
+    let conn = db.connect();
+
+    let rows = get_rows(&conn, "PRAGMA mvcc_commit_log_batch_size");
+    assert_eq!(
+        rows[0][0].as_int().unwrap(),
+        DEFAULT_MVCC_COMMIT_LOG_BATCH_SIZE as i64
+    );
+
+    conn.execute("PRAGMA mvcc_commit_log_batch_size = 1")
+        .unwrap();
+    let rows = get_rows(&conn, "PRAGMA mvcc_commit_log_batch_size");
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+
+    assert!(conn
+        .execute("PRAGMA mvcc_commit_log_batch_size = 0")
+        .is_err());
+    assert!(conn
+        .execute(format!(
+            "PRAGMA mvcc_commit_log_batch_size = {}",
+            MAX_MVCC_COMMIT_LOG_BATCH_SIZE + 1
+        ))
+        .is_err());
+}
+
+#[test]
+fn test_commit_log_batch_size_yields_and_commits() {
+    let db = MvccTestDbNoConn::new();
+    let conn = db.connect();
+
+    conn.execute("PRAGMA mvcc_commit_log_batch_size = 1")
+        .unwrap();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    for id in 1..=4 {
+        conn.execute(format!("INSERT INTO t VALUES ({id}, 'v{id}')"))
+            .unwrap();
+    }
+
+    let mut stmt = conn.prepare("COMMIT").unwrap();
+    let mut yielded = false;
+    loop {
+        match stmt.step().unwrap() {
+            crate::StepResult::IO => yielded = true,
+            crate::StepResult::Done => break,
+            other => panic!("unexpected COMMIT step result: {other:?}"),
+        }
+    }
+    drop(stmt);
+    assert!(yielded, "tiny commit log batch size should force IO yields");
+
+    let rows = get_rows(&conn, "SELECT COUNT(*) FROM t");
+    assert_eq!(rows[0][0].as_int().unwrap(), 4);
+    conn.close().unwrap();
+}
+
 fn abandon_commit_after_first_io(conn: &Arc<Connection>, mv_store: &Arc<MvStore<MvccClock>>) {
     let lock = &mv_store.commit_coordinator.pager_commit_lock;
     assert!(lock.write(), "should acquire commit lock");

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7669,6 +7669,32 @@ fn test_commit_log_batch_size_yields_and_commits() {
     conn.close().unwrap();
 }
 
+#[test]
+fn test_commit_log_tiny_batch_multi_write_frame_recovers() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_commit_log_batch_size = 1")
+            .unwrap();
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("BEGIN CONCURRENT").unwrap();
+        for id in 1..=8 {
+            conn.execute(format!("INSERT INTO t VALUES ({id}, 'v{id}')"))
+                .unwrap();
+        }
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT COUNT(*), SUM(id) FROM t");
+    assert_eq!(rows[0][0].as_int().unwrap(), 8);
+    assert_eq!(rows[0][1].as_int().unwrap(), 36);
+    conn.close().unwrap();
+}
+
 fn abandon_commit_after_first_io(conn: &Arc<Connection>, mv_store: &Arc<MvStore<MvccClock>>) {
     let lock = &mv_store.commit_coordinator.pager_commit_lock;
     assert!(lock.write(), "should acquire commit lock");

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7656,6 +7656,117 @@ fn test_abandoned_commit_rolls_back_insert_with_injected_yield() {
     observer.close().unwrap();
 }
 
+/// `step_build_log_record` chunks the commit's write_set into batches of
+/// `MVCC_COMMIT_BATCH_SIZE` rowids and yields between batches so that a
+/// large commit (e.g. CREATE INDEX over millions of rows) can't monopolize
+/// the executor.
+///
+/// We bracket the chunked yields with two injected yield points:
+/// `BuildLogRecordStart` (fires once on first entry into BuildLogRecord) and
+/// `LogRecordPrepared` (fires once after both passes complete). The IOs
+/// observed strictly between these two are the chunked yields, so the count
+/// is exact.
+///
+/// With `n_rows = 3 * BATCH_SIZE`, both passes (schema-row + data-row) walk
+/// the full write_set, each yielding twice and then transitioning without a
+/// final yield. Expected: 4 chunked yields between Start and Prepared.
+#[test]
+fn test_build_log_record_yields_for_large_write_set() {
+    use super::MVCC_COMMIT_BATCH_SIZE;
+
+    /// Yields once at each of the bracketing points and toggles the
+    /// corresponding flag so the test can detect when the bracket opens
+    /// and closes.
+    #[derive(Debug)]
+    struct BracketingYieldInjector {
+        start: YieldPoint,
+        end: YieldPoint,
+        started: Arc<AtomicBool>,
+        finished: Arc<AtomicBool>,
+    }
+    impl YieldInjector for BracketingYieldInjector {
+        fn should_yield(&self, _instance_id: u64, _selection_key: u64, point: YieldPoint) -> bool {
+            if point == self.start && !self.started.load(Ordering::SeqCst) {
+                self.started.store(true, Ordering::SeqCst);
+                return true;
+            }
+            if point == self.end && !self.finished.load(Ordering::SeqCst) {
+                self.finished.store(true, Ordering::SeqCst);
+                return true;
+            }
+            false
+        }
+    }
+
+    let db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    let n_rows = 3 * MVCC_COMMIT_BATCH_SIZE;
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    for i in 1..=n_rows {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, 'val')"))
+            .unwrap();
+    }
+
+    let started = Arc::new(AtomicBool::new(false));
+    let finished = Arc::new(AtomicBool::new(false));
+    conn.set_yield_injector(Some(Arc::new(BracketingYieldInjector {
+        start: CommitYieldPoint::BuildLogRecordStart.point(),
+        end: CommitYieldPoint::LogRecordPrepared.point(),
+        started: started.clone(),
+        finished: finished.clone(),
+    })));
+
+    let mut stmt = conn.prepare("COMMIT").unwrap();
+    let mut chunked_io_yields = 0;
+    let mut saw_start = false;
+    loop {
+        match stmt.step().unwrap() {
+            crate::StepResult::IO => {
+                if !saw_start {
+                    // Wait for the BuildLogRecordStart yield to open the bracket.
+                    // IOs before this came from earlier states (Initial → Commit
+                    // → WaitForDependencies); they don't count.
+                    if started.load(Ordering::SeqCst) {
+                        saw_start = true;
+                    }
+                    continue;
+                }
+                if finished.load(Ordering::SeqCst) {
+                    // The IO we just popped is the LogRecordPrepared injection
+                    // closing the bracket. Don't count it.
+                    break;
+                }
+                // Strictly between Start and Prepared: a chunked yield from
+                // `Completion::new_yield()` in step_build_log_record's loop.
+                chunked_io_yields += 1;
+            }
+            crate::StepResult::Done => break,
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+
+    assert!(
+        saw_start,
+        "BuildLogRecordStart yield never fired — BuildLogRecord state never reached"
+    );
+    assert!(
+        finished.load(Ordering::SeqCst),
+        "LogRecordPrepared yield never fired — BuildLogRecord did not complete"
+    );
+    // n_rows = 3 * BATCH_SIZE → 2 yields per pass × 2 passes = 4 chunked yields.
+    assert_eq!(
+        chunked_io_yields, 4,
+        "with {n_rows} rows, expected exactly 4 chunked IO yields between \
+         BuildLogRecordStart and LogRecordPrepared, got {chunked_io_yields}"
+    );
+
+    drop(stmt);
+    conn.close().unwrap();
+}
+
 /// Regression guard for the `mv_store.txs` ↔ `connection.mv_tx_id` divergence
 /// originally observed in production as `Transaction <id> not found while
 /// releasing savepoint` (panic) and `NoSuchTransactionID(<id>)` (read-path

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7656,14 +7656,15 @@ fn test_abandoned_commit_rolls_back_insert_with_injected_yield() {
     observer.close().unwrap();
 }
 
-/// `step_build_log_record` chunks the commit's write_set into batches of
+/// Commit-log counting/writing chunks the commit's write_set into batches of
 /// `MVCC_COMMIT_BATCH_SIZE` rowids and yields between batches so that a
 /// large commit (e.g. CREATE INDEX over millions of rows) can't monopolize
 /// the executor.
 ///
 /// We bracket the chunked yields with two injected yield points:
-/// `BuildLogRecordStart` (fires once on first entry into BuildLogRecord) and
-/// `LogRecordPrepared` (fires once after both passes complete). The IOs
+/// `BuildLogRecordStart` (kept as the stable test-facing name, now fired on
+/// first entry into commit-log counting) and `LogRecordPrepared` (fires once
+/// after both counting passes complete). The IOs
 /// observed strictly between these two are the chunked yields, so the count
 /// is exact.
 ///
@@ -7740,7 +7741,7 @@ fn test_build_log_record_yields_for_large_write_set() {
                     break;
                 }
                 // Strictly between Start and Prepared: a chunked yield from
-                // `Completion::new_yield()` in step_build_log_record's loop.
+                // `Completion::new_yield()` in the commit-log scan loop.
                 chunked_io_yields += 1;
             }
             crate::StepResult::Done => break,
@@ -7750,11 +7751,11 @@ fn test_build_log_record_yields_for_large_write_set() {
 
     assert!(
         saw_start,
-        "BuildLogRecordStart yield never fired — BuildLogRecord state never reached"
+        "BuildLogRecordStart yield never fired - commit-log counting was not reached"
     );
     assert!(
         finished.load(Ordering::SeqCst),
-        "LogRecordPrepared yield never fired — BuildLogRecord did not complete"
+        "LogRecordPrepared yield never fired - commit-log counting did not complete"
     );
     // n_rows = 3 * BATCH_SIZE → 2 yields per pass × 2 passes = 4 chunked yields.
     assert_eq!(
@@ -7764,6 +7765,110 @@ fn test_build_log_record_yields_for_large_write_set() {
     );
 
     drop(stmt);
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_large_commit_log_scan_yields_and_commits() {
+    use super::MVCC_COMMIT_BATCH_SIZE;
+
+    let db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    let n_rows = MVCC_COMMIT_BATCH_SIZE + 1;
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    for i in 1..=n_rows {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, 'v{i}')"))
+            .unwrap();
+    }
+
+    let mut stmt = conn.prepare("COMMIT").unwrap();
+    let mut yielded = false;
+    loop {
+        match stmt.step().unwrap() {
+            crate::StepResult::IO => yielded = true,
+            crate::StepResult::Done => break,
+            other => panic!("unexpected COMMIT step result: {other:?}"),
+        }
+    }
+    drop(stmt);
+    assert!(yielded, "large commit-log scan should yield");
+
+    let rows = get_rows(&conn, "SELECT COUNT(*) FROM t");
+    assert_eq!(rows[0][0].as_int().unwrap(), n_rows as i64);
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_commit_log_large_single_chain_final_image_recovers() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'seed')").unwrap();
+        conn.execute("BEGIN CONCURRENT").unwrap();
+        for i in 1..=150 {
+            conn.execute(format!("UPDATE t SET v = 'v{i}' WHERE id = 1"))
+                .unwrap();
+        }
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT COUNT(*) FROM t WHERE id = 1 AND v = 'v150'");
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_commit_log_schema_before_data_replays_after_restart() {
+    let mut db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+    {
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("CREATE TABLE replayed (id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO replayed VALUES (1, 'ok')")
+            .unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT COUNT(*) FROM replayed WHERE v = 'ok'");
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    conn.close().unwrap();
+}
+
+#[test]
+fn test_encrypted_large_commit_log_batches_recover() {
+    const KEY128: &str = "b1bbfda4f589dc9daaf004fe21111e00";
+    let mut db = MvccTestDbNoConn::new_encrypted_with_cipher(KEY128, "aes128gcm");
+    let payload = "x".repeat(2048);
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("BEGIN CONCURRENT").unwrap();
+        for id in 1..=48 {
+            conn.execute(format!("INSERT INTO t VALUES ({id}, '{payload}')"))
+                .unwrap();
+        }
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT COUNT(*), SUM(length(v)) FROM t");
+    assert_eq!(rows[0][0].as_int().unwrap(), 48);
+    assert_eq!(rows[0][1].as_int().unwrap(), 48 * 2048);
     conn.close().unwrap();
 }
 

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -239,6 +239,10 @@ pub const DEFAULT_LOG_CHECKPOINT_THRESHOLD: i64 = 4120 * 1000;
 /// the serialized frame bytes and the running CRC, before the disk write.
 pub type OnSerializationComplete<'a> = Option<&'a dyn Fn(&[u8], u32) -> crate::Result<()>>;
 
+/// Optional callback invoked with each serialized logical-log frame chunk before
+/// that chunk is moved into the pending write buffer.
+pub type OnLogFrameChunk<'a> = Option<&'a dyn Fn(&[u8]) -> crate::Result<()>>;
+
 /// Borrowed logical-log operation used by MVCC commit serialization.
 ///
 /// This projects a live row version after applying the committing
@@ -611,6 +615,7 @@ impl LogicalLog {
     pub(crate) fn pwrite_deferred_frame_chunk(
         &mut self,
         builder: &mut LogFrameBuilder,
+        on_chunk: OnLogFrameChunk<'_>,
     ) -> Result<Option<Completion>> {
         turso_assert!(
             self.offset == builder.base_offset,
@@ -620,12 +625,13 @@ impl LogicalLog {
             self.running_crc == builder.base_running_crc,
             "logical log running CRC changed while building deferred frame"
         );
-        builder.pwrite_current_chunk(&self.file)
+        builder.pwrite_current_chunk(&self.file, on_chunk)
     }
 
     pub(crate) fn pwrite_deferred_frame(
         &mut self,
         mut builder: LogFrameBuilder,
+        on_chunk: OnLogFrameChunk<'_>,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
         turso_assert!(
@@ -650,7 +656,7 @@ impl LogicalLog {
         }
 
         let c = builder
-            .pwrite_current_chunk(&self.file)?
+            .pwrite_current_chunk(&self.file, on_chunk)?
             .ok_or_else(|| LimboError::InternalError("empty logical log frame".into()))?;
         self.pending_running_crc = Some(crc);
         Ok((c, builder.bytes_scheduled))
@@ -1036,13 +1042,22 @@ impl LogFrameBuilder {
         Ok(())
     }
 
-    fn pwrite_current_chunk(&mut self, file: &Arc<dyn File>) -> Result<Option<Completion>> {
+    fn pwrite_current_chunk(
+        &mut self,
+        file: &Arc<dyn File>,
+        on_chunk: OnLogFrameChunk<'_>,
+    ) -> Result<Option<Completion>> {
         if self.write_buf.is_empty() {
             return Ok(None);
         }
-        if let Some(crc_start) = self.crc_start {
-            self.frame_running_crc =
-                crc32c::crc32c_append(self.frame_running_crc, &self.write_buf[crc_start..]);
+        let next_crc = self.crc_start.map(|crc_start| {
+            crc32c::crc32c_append(self.frame_running_crc, &self.write_buf[crc_start..])
+        });
+        if let Some(cb) = on_chunk {
+            cb(&self.write_buf)?;
+        }
+        if let Some(next_crc) = next_crc {
+            self.frame_running_crc = next_crc;
         }
 
         let write_offset = self.next_write_offset;
@@ -2713,6 +2728,7 @@ enum ParsedOp {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
     use std::collections::BTreeSet;
     use std::sync::Once;
 
@@ -2741,10 +2757,11 @@ mod tests {
     use super::{
         build_encrypted_chunk_aad, encrypted_chunk_blob_size, encrypted_chunk_plaintext_len,
         encrypted_payload_blob_size, encrypted_payload_chunk_count, serialize_header_entry,
-        serialize_op_entry, HeaderReadResult, LogHeader, LogicalLog, ParseResult, ParsedOp,
-        StreamingLogicalLogReader, StreamingResult, ENCRYPTED_CHUNK_AAD_SIZE,
-        ENCRYPTED_PAYLOAD_CHUNK_SIZE, END_MAGIC, FRAME_MAGIC, LOG_HDR_CRC_START,
-        LOG_HDR_RESERVED_START, LOG_HDR_SIZE, LOG_VERSION, TX_HEADER_SIZE, TX_TRAILER_SIZE,
+        serialize_op_entry, serialized_log_op_entry_size, HeaderReadResult, LogHeader, LogOpRef,
+        LogicalLog, ParseResult, ParsedOp, StreamingLogicalLogReader, StreamingResult,
+        ENCRYPTED_CHUNK_AAD_SIZE, ENCRYPTED_PAYLOAD_CHUNK_SIZE, END_MAGIC, FRAME_MAGIC,
+        LOG_HDR_CRC_START, LOG_HDR_RESERVED_START, LOG_HDR_SIZE, LOG_VERSION, TX_HEADER_SIZE,
+        TX_TRAILER_SIZE,
     };
     use crate::OpenFlags;
     use crate::{turso_assert, turso_assert_less_than};
@@ -2846,6 +2863,89 @@ mod tests {
             }
         }
         ops
+    }
+
+    #[test]
+    fn test_deferred_frame_chunk_callback_observes_flushed_bytes() {
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file("test.db-log", OpenFlags::Create, false)
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+
+        let row1 = generate_simple_string_row((-2).into(), 1, "one");
+        let row2 = generate_simple_string_row((-2).into(), 2, "two");
+        let op1 = LogOpRef {
+            table_id: row1.id.table_id,
+            row_key: &row1.id.row_id,
+            payload: row1.payload(),
+            is_delete: false,
+            btree_resident: false,
+        };
+        let op2 = LogOpRef {
+            table_id: row2.id.table_id,
+            row_key: &row2.id.row_id,
+            payload: row2.payload(),
+            is_delete: false,
+            btree_resident: false,
+        };
+        let payload_size =
+            (serialized_log_op_entry_size(&op1) + serialized_log_op_entry_size(&op2)) as u64;
+
+        let mut builder = log
+            .begin_deferred_frame_builder(10, 2, payload_size)
+            .unwrap();
+        let captured_chunks = RefCell::new(Vec::<Vec<u8>>::new());
+        let capture_chunk = |bytes: &[u8]| {
+            captured_chunks.borrow_mut().push(bytes.to_vec());
+            Ok(())
+        };
+
+        builder.append_op(&op1).unwrap();
+        let c = log
+            .pwrite_deferred_frame_chunk(&mut builder, Some(&capture_chunk))
+            .unwrap()
+            .expect("partial flush should write the current frame chunk");
+        io.wait_for_completion(c).unwrap();
+
+        builder.append_op(&op2).unwrap();
+        let (c, append_bytes) = log
+            .pwrite_deferred_frame(builder, Some(&capture_chunk), None)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        let captured_chunks = captured_chunks.borrow();
+        assert_eq!(captured_chunks.len(), 2);
+        assert_eq!(
+            append_bytes as usize,
+            captured_chunks
+                .iter()
+                .map(|chunk| chunk.len())
+                .sum::<usize>()
+        );
+        assert!(
+            captured_chunks[0].len() > TX_HEADER_SIZE,
+            "partial callback should observe the tx header plus first op"
+        );
+
+        let read_back = read_table_ops(file, &io);
+        assert_eq!(
+            read_back,
+            vec![
+                ExpectedTableOp::Upsert {
+                    rowid: 1,
+                    payload: row1.payload().to_vec(),
+                    commit_ts: 10,
+                    btree_resident: false,
+                },
+                ExpectedTableOp::Upsert {
+                    rowid: 2,
+                    payload: row2.payload().to_vec(),
+                    commit_ts: 10,
+                    btree_resident: false,
+                },
+            ]
+        );
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -222,7 +222,7 @@ use crate::{
     io::ReadComplete,
     mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},
     storage::sqlite3_ondisk::{
-        read_varint, read_varint_partial, varint_len, write_varint_to_vec, DatabaseHeader,
+        read_varint, read_varint_partial, varint_len, write_varint, DatabaseHeader,
     },
     types::IndexInfo,
     Buffer, Completion, CompletionError, LimboError, Result,
@@ -238,6 +238,18 @@ pub const DEFAULT_LOG_CHECKPOINT_THRESHOLD: i64 = 4120 * 1000;
 /// Optional callback invoked after serialization with a zero-copy reference to
 /// the serialized frame bytes and the running CRC, before the disk write.
 pub type OnSerializationComplete<'a> = Option<&'a dyn Fn(&[u8], u32) -> crate::Result<()>>;
+
+/// Borrowed logical-log operation used by MVCC commit serialization.
+///
+/// This projects a live row version after applying the committing
+/// transaction's timestamp rules without cloning the row payload.
+pub(crate) struct LogOpRef<'a> {
+    pub table_id: MVTableId,
+    pub row_key: &'a RowKey,
+    pub payload: &'a [u8],
+    pub is_delete: bool,
+    pub btree_resident: bool,
+}
 
 const LOG_MAGIC: u32 = 0x4C4D4C32; // "LML2" in LE
 const LOG_VERSION: u8 = 2;
@@ -555,6 +567,87 @@ impl LogicalLog {
         self.encryption_ctx.as_ref()
     }
 
+    pub(crate) fn begin_deferred_frame_builder(
+        &mut self,
+        commit_ts: u64,
+        op_count: u32,
+        payload_size: u64,
+    ) -> Result<LogFrameBuilder> {
+        let is_first_write = self.offset == 0;
+        if is_first_write && self.header.is_none() {
+            let header = LogHeader::new(&self.io);
+            self.running_crc = derive_initial_crc(header.salt);
+            self.header = Some(header);
+        }
+
+        let mut write_buf = Vec::new();
+        if is_first_write {
+            let header_bytes = self.header.as_ref().unwrap().encode();
+            write_buf.extend_from_slice(&header_bytes);
+        }
+
+        let tx_header_start = write_buf.len();
+        write_buf.resize(tx_header_start + TX_HEADER_SIZE, 0);
+
+        let salt = self
+            .header
+            .as_ref()
+            .expect("log header must be set before writing")
+            .salt;
+        LogFrameBuilder::new(
+            write_buf,
+            tx_header_start,
+            self.offset,
+            self.running_crc,
+            self.encryption_ctx.clone(),
+            salt,
+            self.encrypted_payload_chunk_size,
+            commit_ts,
+            op_count,
+            payload_size,
+        )
+    }
+
+    pub(crate) fn pwrite_deferred_frame(
+        &mut self,
+        mut builder: LogFrameBuilder,
+        on_serialization_complete: OnSerializationComplete<'_>,
+    ) -> Result<(Completion, u64)> {
+        turso_assert!(
+            self.offset == builder.base_offset,
+            "logical log offset changed while building deferred frame"
+        );
+        turso_assert!(
+            self.running_crc == builder.base_running_crc,
+            "logical log running CRC changed while building deferred frame"
+        );
+
+        let crc = builder.finish()?;
+
+        if let Some(cb) = on_serialization_complete {
+            cb(&builder.write_buf, crc)?;
+        }
+
+        let buffer = Arc::new(Buffer::new(builder.write_buf));
+        let c = Completion::new_write({
+            let buffer_len = buffer.len();
+            move |res: Result<i32, CompletionError>| {
+                let Ok(bytes_written) = res else {
+                    return;
+                };
+                turso_assert!(
+                    bytes_written == buffer_len as i32,
+                    "wrote({bytes_written}) != expected({buffer_len})"
+                );
+            }
+        });
+
+        let buffer_len = buffer.len();
+        let c = self.file.pwrite(self.offset, buffer, c)?;
+        self.pending_running_crc = Some(crc);
+        Ok((c, buffer_len as u64))
+    }
+
     /// Serializes a transaction into `write_buf`, optionally calls
     /// `on_serialization_complete` with a zero-copy reference to the frame bytes,
     /// then writes to disk. `write_buf` retains its allocation across calls.
@@ -842,23 +935,275 @@ impl LogicalLog {
     }
 }
 
+pub struct LogFrameBuilder {
+    write_buf: Vec<u8>,
+    tx_header_start: usize,
+    base_offset: u64,
+    base_running_crc: u32,
+    encryption_ctx: Option<EncryptionContext>,
+    salt: u64,
+    encrypted_payload_chunk_size: usize,
+    encrypted_plaintext_chunk: Vec<u8>,
+    encrypted_chunk_index: u32,
+    encrypted_chunk_count: usize,
+    commit_ts: u64,
+    op_count: u32,
+    payload_size: u64,
+    emitted_ops: u32,
+    emitted_payload_size: u64,
+    payload_finished: bool,
+}
+
+impl LogFrameBuilder {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        mut write_buf: Vec<u8>,
+        tx_header_start: usize,
+        base_offset: u64,
+        base_running_crc: u32,
+        encryption_ctx: Option<EncryptionContext>,
+        salt: u64,
+        encrypted_payload_chunk_size: usize,
+        commit_ts: u64,
+        op_count: u32,
+        payload_size: u64,
+    ) -> Result<Self> {
+        let payload_size_usize = usize::try_from(payload_size).map_err(|_| {
+            LimboError::InternalError("logical log payload exceeds usize".to_string())
+        })?;
+        let encrypted_chunk_count =
+            encrypted_payload_chunk_count(payload_size_usize, encrypted_payload_chunk_size);
+        if let Some(enc_ctx) = &encryption_ctx {
+            let total_on_disk_size = encrypted_payload_blob_size(
+                payload_size_usize,
+                encrypted_payload_chunk_size,
+                enc_ctx.tag_size(),
+                enc_ctx.nonce_size(),
+            )?;
+            write_buf.reserve(total_on_disk_size);
+        } else {
+            write_buf.reserve(payload_size_usize);
+        }
+
+        Ok(Self {
+            write_buf,
+            tx_header_start,
+            base_offset,
+            base_running_crc,
+            encryption_ctx,
+            salt,
+            encrypted_payload_chunk_size,
+            encrypted_plaintext_chunk: Vec::with_capacity(encrypted_payload_chunk_size),
+            encrypted_chunk_index: 0,
+            encrypted_chunk_count,
+            commit_ts,
+            op_count,
+            payload_size,
+            emitted_ops: 0,
+            emitted_payload_size: 0,
+            payload_finished: false,
+        })
+    }
+
+    pub(crate) fn append_op(&mut self, op: &LogOpRef<'_>) -> Result<()> {
+        serialize_log_op_entry_to_sink(op, &mut |bytes| self.append_payload_bytes(bytes))?;
+        self.emitted_ops = self
+            .emitted_ops
+            .checked_add(1)
+            .expect("logical log emitted op count overflow");
+        Ok(())
+    }
+
+    pub(crate) fn append_header(&mut self, header: &DatabaseHeader) -> Result<()> {
+        serialize_header_entry_to_sink(header, &mut |bytes| self.append_payload_bytes(bytes))?;
+        self.emitted_ops = self
+            .emitted_ops
+            .checked_add(1)
+            .expect("logical log emitted op count overflow");
+        Ok(())
+    }
+
+    fn append_payload_bytes(&mut self, mut bytes: &[u8]) -> Result<()> {
+        self.emitted_payload_size = self
+            .emitted_payload_size
+            .checked_add(u64::try_from(bytes.len()).map_err(|_| {
+                LimboError::InternalError("logical log payload chunk exceeds u64".to_string())
+            })?)
+            .ok_or_else(|| {
+                LimboError::InternalError("logical log payload size overflow".to_string())
+            })?;
+
+        if self.encryption_ctx.is_none() {
+            self.write_buf.extend_from_slice(bytes);
+            return Ok(());
+        }
+
+        while !bytes.is_empty() {
+            let remaining = self
+                .encrypted_payload_chunk_size
+                .checked_sub(self.encrypted_plaintext_chunk.len())
+                .expect("encrypted plaintext chunk cannot exceed configured chunk size");
+            let take = remaining.min(bytes.len());
+            self.encrypted_plaintext_chunk
+                .extend_from_slice(&bytes[..take]);
+            bytes = &bytes[take..];
+            if self.encrypted_plaintext_chunk.len() == self.encrypted_payload_chunk_size {
+                self.flush_encrypted_chunk(false)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn flush_encrypted_chunk(&mut self, is_last_chunk: bool) -> Result<()> {
+        let Some(enc_ctx) = &self.encryption_ctx else {
+            return Ok(());
+        };
+        if self.encrypted_plaintext_chunk.is_empty() && !is_last_chunk {
+            return Ok(());
+        }
+        let aad = build_encrypted_chunk_aad(
+            self.salt,
+            is_last_chunk.then_some(self.payload_size),
+            self.op_count,
+            self.commit_ts,
+            self.encrypted_chunk_index,
+        );
+        let (ciphertext, nonce) = enc_ctx.encrypt_chunk(&self.encrypted_plaintext_chunk, &aad)?;
+        debug_assert_eq!(
+            ciphertext.len(),
+            self.encrypted_plaintext_chunk.len() + enc_ctx.tag_size(),
+            "encrypt_chunk output size mismatch: expected plaintext({}) + tag({}), got {}",
+            self.encrypted_plaintext_chunk.len(),
+            enc_ctx.tag_size(),
+            ciphertext.len(),
+        );
+        self.write_buf.extend_from_slice(&ciphertext);
+        self.write_buf.extend_from_slice(&nonce);
+        self.encrypted_plaintext_chunk.clear();
+        self.encrypted_chunk_index = self
+            .encrypted_chunk_index
+            .checked_add(1)
+            .ok_or_else(|| LimboError::InternalError("encrypted chunk index overflow".into()))?;
+        Ok(())
+    }
+
+    fn finish_payload(&mut self) -> Result<()> {
+        if self.payload_finished {
+            return Ok(());
+        }
+        turso_assert!(
+            self.emitted_ops == self.op_count,
+            "logical log emitted op count mismatch"
+        );
+        turso_assert!(
+            self.emitted_payload_size == self.payload_size,
+            "logical log emitted payload size mismatch"
+        );
+        if self.encryption_ctx.is_some() {
+            self.flush_encrypted_chunk(true)?;
+            turso_assert!(
+                self.encrypted_chunk_index as usize == self.encrypted_chunk_count,
+                "logical log encrypted chunk count mismatch"
+            );
+        }
+        self.payload_finished = true;
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<u32> {
+        self.finish_payload()?;
+        let payload_end = self.write_buf.len();
+
+        self.write_buf[self.tx_header_start..self.tx_header_start + 4]
+            .copy_from_slice(&FRAME_MAGIC.to_le_bytes());
+        self.write_buf[self.tx_header_start + 4..self.tx_header_start + 12]
+            .copy_from_slice(&self.payload_size.to_le_bytes());
+        self.write_buf[self.tx_header_start + 12..self.tx_header_start + 16]
+            .copy_from_slice(&self.op_count.to_le_bytes());
+        self.write_buf[self.tx_header_start + 16..self.tx_header_start + 24]
+            .copy_from_slice(&self.commit_ts.to_le_bytes());
+
+        let crc = crc32c::crc32c_append(
+            self.base_running_crc,
+            &self.write_buf[self.tx_header_start..payload_end],
+        );
+        self.write_buf.extend_from_slice(&crc.to_le_bytes());
+        self.write_buf.extend_from_slice(&END_MAGIC.to_le_bytes());
+        Ok(crc)
+    }
+}
+
 /// Serialize one op into `buffer`.
 /// Op layout: tag(1) | flags(1) | table_id(4, le i32) | payload_len(varint) | payload(variable)
 fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion) -> Result<()> {
-    let is_delete = row_version.end.is_some();
-    let tag = match (&row_version.row.id.row_id, is_delete) {
+    let op = LogOpRef {
+        table_id: row_version.row.id.table_id,
+        row_key: &row_version.row.id.row_id,
+        payload: row_version.row.payload(),
+        is_delete: row_version.end.is_some(),
+        btree_resident: row_version.btree_resident,
+    };
+    serialize_log_op_entry_to_sink(&op, &mut |bytes| {
+        buffer.extend_from_slice(bytes);
+        Ok(())
+    })
+}
+
+pub(crate) fn serialized_log_op_entry_size(op: &LogOpRef<'_>) -> usize {
+    let tag = log_op_tag(op);
+    let body_len = match tag {
+        OP_UPSERT_TABLE => {
+            let RowKey::Int(rowid) = op.row_key else {
+                unreachable!("table ops must have RowKey::Int")
+            };
+            let rowid_len = varint_len(*rowid as u64);
+            let payload_len = rowid_len + op.payload.len();
+            varint_len(payload_len as u64) + rowid_len + op.payload.len()
+        }
+        OP_DELETE_TABLE => {
+            let RowKey::Int(rowid) = op.row_key else {
+                unreachable!("table ops must have RowKey::Int")
+            };
+            let rowid_len = varint_len(*rowid as u64);
+            varint_len(rowid_len as u64) + rowid_len
+        }
+        OP_UPSERT_INDEX | OP_DELETE_INDEX => varint_len(op.payload.len() as u64) + op.payload.len(),
+        _ => unreachable!("invalid logical log op tag"),
+    };
+    1 + 1 + 4 + body_len
+}
+
+pub(crate) fn serialized_header_entry_size() -> usize {
+    1 + 1 + 4 + varint_len(DatabaseHeader::SIZE as u64) + DatabaseHeader::SIZE
+}
+
+fn log_op_tag(op: &LogOpRef<'_>) -> u8 {
+    match (op.row_key, op.is_delete) {
         (RowKey::Int(_), false) => OP_UPSERT_TABLE,
         (RowKey::Int(_), true) => OP_DELETE_TABLE,
         (RowKey::Record(_), false) => OP_UPSERT_INDEX,
         (RowKey::Record(_), true) => OP_DELETE_INDEX,
-    };
+    }
+}
+
+fn write_varint_to_sink(value: u64, sink: &mut impl FnMut(&[u8]) -> Result<()>) -> Result<()> {
+    let mut varint = [0; 9];
+    let n = write_varint(&mut varint, value);
+    sink(&varint[..n])
+}
+
+fn serialize_log_op_entry_to_sink(
+    op: &LogOpRef<'_>,
+    sink: &mut impl FnMut(&[u8]) -> Result<()>,
+) -> Result<()> {
+    let tag = log_op_tag(op);
 
     let mut flags = 0u8;
-    if row_version.btree_resident {
+    if op.btree_resident {
         flags |= OP_FLAG_BTREE_RESIDENT;
     }
 
-    let table_id_i64: i64 = row_version.row.id.table_id.into();
+    let table_id_i64: i64 = op.table_id.into();
     turso_assert!(
         table_id_i64 < 0,
         "table_id_i64 should be negative, but got {table_id_i64}"
@@ -869,36 +1214,34 @@ fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion) -> Result<
     );
     let table_id_i32 = table_id_i64 as i32;
 
-    buffer.push(tag);
-    buffer.push(flags);
-    buffer.extend_from_slice(&table_id_i32.to_le_bytes());
+    sink(&[tag])?;
+    sink(&[flags])?;
+    sink(&table_id_i32.to_le_bytes())?;
 
     match tag {
         OP_UPSERT_TABLE => {
-            let RowKey::Int(rowid) = row_version.row.id.row_id else {
+            let RowKey::Int(rowid) = op.row_key else {
                 unreachable!("table ops must have RowKey::Int")
             };
-            let record_bytes = row_version.row.payload();
-            let rowid_u64 = rowid as u64;
+            let rowid_u64 = *rowid as u64;
             let rowid_len = varint_len(rowid_u64);
-            let payload_len = rowid_len + record_bytes.len();
-            write_varint_to_vec(payload_len as u64, buffer);
-            write_varint_to_vec(rowid_u64, buffer);
-            buffer.extend_from_slice(record_bytes);
+            let payload_len = rowid_len + op.payload.len();
+            write_varint_to_sink(payload_len as u64, sink)?;
+            write_varint_to_sink(rowid_u64, sink)?;
+            sink(op.payload)?;
         }
         OP_DELETE_TABLE => {
-            let RowKey::Int(rowid) = row_version.row.id.row_id else {
+            let RowKey::Int(rowid) = op.row_key else {
                 unreachable!("table ops must have RowKey::Int")
             };
-            let rowid_u64 = rowid as u64;
+            let rowid_u64 = *rowid as u64;
             let rowid_len = varint_len(rowid_u64);
-            write_varint_to_vec(rowid_len as u64, buffer);
-            write_varint_to_vec(rowid_u64, buffer);
+            write_varint_to_sink(rowid_len as u64, sink)?;
+            write_varint_to_sink(rowid_u64, sink)?;
         }
         OP_UPSERT_INDEX | OP_DELETE_INDEX => {
-            let key_bytes = row_version.row.payload();
-            write_varint_to_vec(key_bytes.len() as u64, buffer);
-            buffer.extend_from_slice(key_bytes);
+            write_varint_to_sink(op.payload.len() as u64, sink)?;
+            sink(op.payload)?;
         }
         _ => {
             return Err(LimboError::InternalError(format!(
@@ -911,12 +1254,24 @@ fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion) -> Result<
 }
 
 fn serialize_header_entry(buffer: &mut Vec<u8>, header: &DatabaseHeader) {
+    serialize_header_entry_to_sink(header, &mut |bytes| {
+        buffer.extend_from_slice(bytes);
+        Ok(())
+    })
+    .expect("serializing header entry into Vec cannot fail");
+}
+
+fn serialize_header_entry_to_sink(
+    header: &DatabaseHeader,
+    sink: &mut impl FnMut(&[u8]) -> Result<()>,
+) -> Result<()> {
     // Header op uses tag-only addressing (table_id=0, flags=0) and fixed payload length.
-    buffer.push(OP_UPDATE_HEADER);
-    buffer.push(0);
-    buffer.extend_from_slice(&0i32.to_le_bytes());
-    write_varint_to_vec(DatabaseHeader::SIZE as u64, buffer);
-    buffer.extend_from_slice(bytemuck::bytes_of(header));
+    sink(&[OP_UPDATE_HEADER])?;
+    sink(&[0])?;
+    sink(&0i32.to_le_bytes())?;
+    write_varint_to_sink(DatabaseHeader::SIZE as u64, sink)?;
+    sink(bytemuck::bytes_of(header))?;
+    Ok(())
 }
 
 /// Parse all ops from a decrypted plaintext buffer.

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -608,6 +608,21 @@ impl LogicalLog {
         )
     }
 
+    pub(crate) fn pwrite_deferred_frame_chunk(
+        &mut self,
+        builder: &mut LogFrameBuilder,
+    ) -> Result<Option<Completion>> {
+        turso_assert!(
+            self.offset == builder.base_offset,
+            "logical log offset changed while building deferred frame"
+        );
+        turso_assert!(
+            self.running_crc == builder.base_running_crc,
+            "logical log running CRC changed while building deferred frame"
+        );
+        builder.pwrite_current_chunk(&self.file)
+    }
+
     pub(crate) fn pwrite_deferred_frame(
         &mut self,
         mut builder: LogFrameBuilder,
@@ -623,29 +638,22 @@ impl LogicalLog {
         );
 
         let crc = builder.finish()?;
+        if builder.flushed_chunks > 0 && on_serialization_complete.is_some() {
+            return Err(LimboError::InternalError(
+                "serialization callback is not supported after partial logical-log frame writes"
+                    .into(),
+            ));
+        }
 
         if let Some(cb) = on_serialization_complete {
             cb(&builder.write_buf, crc)?;
         }
 
-        let buffer = Arc::new(Buffer::new(builder.write_buf));
-        let c = Completion::new_write({
-            let buffer_len = buffer.len();
-            move |res: Result<i32, CompletionError>| {
-                let Ok(bytes_written) = res else {
-                    return;
-                };
-                turso_assert!(
-                    bytes_written == buffer_len as i32,
-                    "wrote({bytes_written}) != expected({buffer_len})"
-                );
-            }
-        });
-
-        let buffer_len = buffer.len();
-        let c = self.file.pwrite(self.offset, buffer, c)?;
+        let c = builder
+            .pwrite_current_chunk(&self.file)?
+            .ok_or_else(|| LimboError::InternalError("empty logical log frame".into()))?;
         self.pending_running_crc = Some(crc);
-        Ok((c, buffer_len as u64))
+        Ok((c, builder.bytes_scheduled))
     }
 
     /// Serializes a transaction into `write_buf`, optionally calls
@@ -937,9 +945,13 @@ impl LogicalLog {
 
 pub struct LogFrameBuilder {
     write_buf: Vec<u8>,
-    tx_header_start: usize,
+    crc_start: Option<usize>,
     base_offset: u64,
     base_running_crc: u32,
+    frame_running_crc: u32,
+    next_write_offset: u64,
+    bytes_scheduled: u64,
+    flushed_chunks: u64,
     encryption_ctx: Option<EncryptionContext>,
     salt: u64,
     encrypted_payload_chunk_size: usize,
@@ -973,23 +985,24 @@ impl LogFrameBuilder {
         })?;
         let encrypted_chunk_count =
             encrypted_payload_chunk_count(payload_size_usize, encrypted_payload_chunk_size);
-        if let Some(enc_ctx) = &encryption_ctx {
-            let total_on_disk_size = encrypted_payload_blob_size(
-                payload_size_usize,
-                encrypted_payload_chunk_size,
-                enc_ctx.tag_size(),
-                enc_ctx.nonce_size(),
-            )?;
-            write_buf.reserve(total_on_disk_size);
-        } else {
-            write_buf.reserve(payload_size_usize);
-        }
+        write_buf.reserve(TX_HEADER_SIZE);
+        write_buf[tx_header_start..tx_header_start + 4].copy_from_slice(&FRAME_MAGIC.to_le_bytes());
+        write_buf[tx_header_start + 4..tx_header_start + 12]
+            .copy_from_slice(&payload_size.to_le_bytes());
+        write_buf[tx_header_start + 12..tx_header_start + 16]
+            .copy_from_slice(&op_count.to_le_bytes());
+        write_buf[tx_header_start + 16..tx_header_start + 24]
+            .copy_from_slice(&commit_ts.to_le_bytes());
 
         Ok(Self {
             write_buf,
-            tx_header_start,
+            crc_start: Some(tx_header_start),
             base_offset,
             base_running_crc,
+            frame_running_crc: base_running_crc,
+            next_write_offset: base_offset,
+            bytes_scheduled: 0,
+            flushed_chunks: 0,
             encryption_ctx,
             salt,
             encrypted_payload_chunk_size,
@@ -1021,6 +1034,51 @@ impl LogFrameBuilder {
             .checked_add(1)
             .expect("logical log emitted op count overflow");
         Ok(())
+    }
+
+    fn pwrite_current_chunk(&mut self, file: &Arc<dyn File>) -> Result<Option<Completion>> {
+        if self.write_buf.is_empty() {
+            return Ok(None);
+        }
+        if let Some(crc_start) = self.crc_start {
+            self.frame_running_crc =
+                crc32c::crc32c_append(self.frame_running_crc, &self.write_buf[crc_start..]);
+        }
+
+        let write_offset = self.next_write_offset;
+        let write_buf = std::mem::take(&mut self.write_buf);
+        let buffer = Arc::new(Buffer::new(write_buf));
+        let c = Completion::new_write({
+            let buffer_len = buffer.len();
+            move |res: Result<i32, CompletionError>| {
+                let Ok(bytes_written) = res else {
+                    return;
+                };
+                turso_assert!(
+                    bytes_written == buffer_len as i32,
+                    "wrote({bytes_written}) != expected({buffer_len})"
+                );
+            }
+        });
+
+        let buffer_len = buffer.len();
+        let c = file.pwrite(write_offset, buffer, c)?;
+        let buffer_len = u64::try_from(buffer_len)
+            .map_err(|_| LimboError::InternalError("logical log chunk exceeds u64".into()))?;
+        self.next_write_offset = self
+            .next_write_offset
+            .checked_add(buffer_len)
+            .ok_or_else(|| LimboError::InternalError("logical log write offset overflow".into()))?;
+        self.bytes_scheduled = self
+            .bytes_scheduled
+            .checked_add(buffer_len)
+            .ok_or_else(|| LimboError::InternalError("logical log write size overflow".into()))?;
+        self.flushed_chunks = self
+            .flushed_chunks
+            .checked_add(1)
+            .ok_or_else(|| LimboError::InternalError("logical log chunk count overflow".into()))?;
+        self.crc_start = Some(0);
+        Ok(Some(c))
     }
 
     fn append_payload_bytes(&mut self, mut bytes: &[u8]) -> Result<()> {
@@ -1112,21 +1170,12 @@ impl LogFrameBuilder {
 
     fn finish(&mut self) -> Result<u32> {
         self.finish_payload()?;
-        let payload_end = self.write_buf.len();
-
-        self.write_buf[self.tx_header_start..self.tx_header_start + 4]
-            .copy_from_slice(&FRAME_MAGIC.to_le_bytes());
-        self.write_buf[self.tx_header_start + 4..self.tx_header_start + 12]
-            .copy_from_slice(&self.payload_size.to_le_bytes());
-        self.write_buf[self.tx_header_start + 12..self.tx_header_start + 16]
-            .copy_from_slice(&self.op_count.to_le_bytes());
-        self.write_buf[self.tx_header_start + 16..self.tx_header_start + 24]
-            .copy_from_slice(&self.commit_ts.to_le_bytes());
-
-        let crc = crc32c::crc32c_append(
-            self.base_running_crc,
-            &self.write_buf[self.tx_header_start..payload_end],
-        );
+        let crc = if let Some(crc_start) = self.crc_start.take() {
+            crc32c::crc32c_append(self.frame_running_crc, &self.write_buf[crc_start..])
+        } else {
+            self.frame_running_crc
+        };
+        self.frame_running_crc = crc;
         self.write_buf.extend_from_slice(&crc.to_le_bytes());
         self.write_buf.extend_from_slice(&END_MAGIC.to_le_bytes());
         Ok(crc)

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 pub mod logical_log;
 use crate::mvcc::database::LogRecord;
 use crate::mvcc::persistent_storage::logical_log::{
-    LogicalLog, OnSerializationComplete, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
+    LogFrameBuilder, LogicalLog, OnSerializationComplete, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
 };
 use crate::{CheckpointResult, Completion, File, Result};
 
@@ -23,6 +23,23 @@ pub trait DurableStorage: Send + Sync + Debug {
     fn log_tx(
         &self,
         m: &LogRecord,
+        on_serialization_complete: OnSerializationComplete<'_>,
+    ) -> Result<(Completion, u64)>;
+
+    /// Start a bounded logical-log frame whose payload will be appended in
+    /// commit-log scan chunks.
+    fn begin_log_tx_frame(
+        &self,
+        commit_ts: u64,
+        op_count: u32,
+        payload_size: u64,
+    ) -> Result<LogFrameBuilder>;
+
+    /// Finish and write a previously-started frame without advancing the writer
+    /// offset. The offset is advanced only after commit durability succeeds.
+    fn finish_log_tx_frame(
+        &self,
+        builder: LogFrameBuilder,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)>;
 
@@ -113,6 +130,27 @@ impl DurableStorage for Storage {
         self.logical_log
             .write()
             .log_tx_deferred_offset(m, on_serialization_complete)
+    }
+
+    fn begin_log_tx_frame(
+        &self,
+        commit_ts: u64,
+        op_count: u32,
+        payload_size: u64,
+    ) -> Result<LogFrameBuilder> {
+        self.logical_log
+            .write()
+            .begin_deferred_frame_builder(commit_ts, op_count, payload_size)
+    }
+
+    fn finish_log_tx_frame(
+        &self,
+        builder: LogFrameBuilder,
+        on_serialization_complete: OnSerializationComplete<'_>,
+    ) -> Result<(Completion, u64)> {
+        self.logical_log
+            .write()
+            .pwrite_deferred_frame(builder, on_serialization_complete)
     }
 
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion> {

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -8,7 +8,8 @@ use std::fmt::Debug;
 pub mod logical_log;
 use crate::mvcc::database::LogRecord;
 use crate::mvcc::persistent_storage::logical_log::{
-    LogFrameBuilder, LogicalLog, OnSerializationComplete, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
+    LogFrameBuilder, LogicalLog, OnLogFrameChunk, OnSerializationComplete,
+    DEFAULT_LOG_CHECKPOINT_THRESHOLD,
 };
 use crate::{CheckpointResult, Completion, File, Result};
 
@@ -37,13 +38,18 @@ pub trait DurableStorage: Send + Sync + Debug {
 
     /// Write the currently buffered frame bytes and clear the builder's buffer.
     /// The writer offset is still advanced only after commit durability succeeds.
-    fn flush_log_tx_frame(&self, builder: &mut LogFrameBuilder) -> Result<Option<Completion>>;
+    fn flush_log_tx_frame(
+        &self,
+        builder: &mut LogFrameBuilder,
+        on_chunk: OnLogFrameChunk<'_>,
+    ) -> Result<Option<Completion>>;
 
     /// Finish and write a previously-started frame without advancing the writer
     /// offset. The offset is advanced only after commit durability succeeds.
     fn finish_log_tx_frame(
         &self,
         builder: LogFrameBuilder,
+        on_chunk: OnLogFrameChunk<'_>,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)>;
 
@@ -147,20 +153,25 @@ impl DurableStorage for Storage {
             .begin_deferred_frame_builder(commit_ts, op_count, payload_size)
     }
 
-    fn flush_log_tx_frame(&self, builder: &mut LogFrameBuilder) -> Result<Option<Completion>> {
+    fn flush_log_tx_frame(
+        &self,
+        builder: &mut LogFrameBuilder,
+        on_chunk: OnLogFrameChunk<'_>,
+    ) -> Result<Option<Completion>> {
         self.logical_log
             .write()
-            .pwrite_deferred_frame_chunk(builder)
+            .pwrite_deferred_frame_chunk(builder, on_chunk)
     }
 
     fn finish_log_tx_frame(
         &self,
         builder: LogFrameBuilder,
+        on_chunk: OnLogFrameChunk<'_>,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
         self.logical_log
             .write()
-            .pwrite_deferred_frame(builder, on_serialization_complete)
+            .pwrite_deferred_frame(builder, on_chunk, on_serialization_complete)
     }
 
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion> {

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -35,6 +35,10 @@ pub trait DurableStorage: Send + Sync + Debug {
         payload_size: u64,
     ) -> Result<LogFrameBuilder>;
 
+    /// Write the currently buffered frame bytes and clear the builder's buffer.
+    /// The writer offset is still advanced only after commit durability succeeds.
+    fn flush_log_tx_frame(&self, builder: &mut LogFrameBuilder) -> Result<Option<Completion>>;
+
     /// Finish and write a previously-started frame without advancing the writer
     /// offset. The offset is advanced only after commit durability succeeds.
     fn finish_log_tx_frame(
@@ -141,6 +145,12 @@ impl DurableStorage for Storage {
         self.logical_log
             .write()
             .begin_deferred_frame_builder(commit_ts, op_count, payload_size)
+    }
+
+    fn flush_log_tx_frame(&self, builder: &mut LogFrameBuilder) -> Result<Option<Completion>> {
+        self.logical_log
+            .write()
+            .pwrite_deferred_frame_chunk(builder)
     }
 
     fn finish_log_tx_frame(

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -178,6 +178,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["mvcc_checkpoint_threshold"],
         ),
+        PragmaName::MvccCommitLogBatchSize => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["mvcc_commit_log_batch_size"],
+        ),
         ForeignKeys => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["foreign_keys"],

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -684,6 +684,18 @@ fn update_pragma(
             connection.set_mvcc_checkpoint_threshold(threshold)?;
             Ok(TransactionMode::None)
         }
+        PragmaName::MvccCommitLogBatchSize => {
+            let max = crate::mvcc::database::MAX_MVCC_COMMIT_LOG_BATCH_SIZE as i64;
+            let batch_size = match parse_signed_number(&value)? {
+                Value::Numeric(Numeric::Integer(size)) if (1..=max).contains(&size) => size as u64,
+                _ => bail_parse_error!(
+                    "mvcc_commit_log_batch_size must be an integer between 1 and {max}"
+                ),
+            };
+
+            connection.set_mvcc_commit_log_batch_size(batch_size)?;
+            Ok(TransactionMode::None)
+        }
         PragmaName::ForeignKeys => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_foreign_keys_enabled(enabled);
@@ -1503,6 +1515,14 @@ fn query_pragma(
             let threshold = connection.mvcc_checkpoint_threshold()?;
             let register = program.alloc_register();
             program.emit_int(threshold, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::MvccCommitLogBatchSize => {
+            let batch_size = connection.mvcc_commit_log_batch_size()?;
+            let register = program.alloc_register();
+            program.emit_int(batch_size as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1841,6 +1841,8 @@ pub enum PragmaName {
     WalCheckpoint,
     /// Sets or queries the threshold (in bytes) at which MVCC triggers an automatic checkpoint.
     MvccCheckpointThreshold,
+    /// Sets or queries how many write-set rowids MVCC commit-log preparation processes before yielding.
+    MvccCommitLogBatchSize,
     /// List all available types (built-in and custom)
     ListTypes,
     /// Deprecated no-op: control whether callback is invoked for empty result sets

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -68,6 +68,13 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
             .begin_log_tx_frame(commit_ts, op_count, payload_size)
     }
 
+    fn flush_log_tx_frame(
+        &self,
+        builder: &mut turso_core::mvcc::persistent_storage::logical_log::LogFrameBuilder,
+    ) -> turso_core::Result<Option<turso_core::Completion>> {
+        self.inner.flush_log_tx_frame(builder)
+    }
+
     fn finish_log_tx_frame(
         &self,
         builder: turso_core::mvcc::persistent_storage::logical_log::LogFrameBuilder,

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -71,17 +71,19 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
     fn flush_log_tx_frame(
         &self,
         builder: &mut turso_core::mvcc::persistent_storage::logical_log::LogFrameBuilder,
+        on_chunk: Option<&dyn Fn(&[u8]) -> turso_core::Result<()>>,
     ) -> turso_core::Result<Option<turso_core::Completion>> {
-        self.inner.flush_log_tx_frame(builder)
+        self.inner.flush_log_tx_frame(builder, on_chunk)
     }
 
     fn finish_log_tx_frame(
         &self,
         builder: turso_core::mvcc::persistent_storage::logical_log::LogFrameBuilder,
+        on_chunk: Option<&dyn Fn(&[u8]) -> turso_core::Result<()>>,
         on_serialization_complete: Option<&dyn Fn(&[u8], u32) -> turso_core::Result<()>>,
     ) -> turso_core::Result<(turso_core::Completion, u64)> {
         self.inner
-            .finish_log_tx_frame(builder, on_serialization_complete)
+            .finish_log_tx_frame(builder, on_chunk, on_serialization_complete)
     }
 
     fn sync(

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -55,6 +55,28 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
         self.inner.log_tx(m, on_serialization_complete)
     }
 
+    fn begin_log_tx_frame(
+        &self,
+        commit_ts: u64,
+        op_count: u32,
+        payload_size: u64,
+    ) -> turso_core::Result<turso_core::mvcc::persistent_storage::logical_log::LogFrameBuilder>
+    {
+        self.used_log_tx
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.inner
+            .begin_log_tx_frame(commit_ts, op_count, payload_size)
+    }
+
+    fn finish_log_tx_frame(
+        &self,
+        builder: turso_core::mvcc::persistent_storage::logical_log::LogFrameBuilder,
+        on_serialization_complete: Option<&dyn Fn(&[u8], u32) -> turso_core::Result<()>>,
+    ) -> turso_core::Result<(turso_core::Completion, u64)> {
+        self.inner
+            .finish_log_tx_frame(builder, on_serialization_complete)
+    }
+
     fn sync(
         &self,
         sync_type: turso_core::io::FileSyncType,


### PR DESCRIPTION
## Description
Currently rebased on top of https://github.com/tursodatabase/turso/pull/6766. 
- Does some modifications to avoid cloning `RowVersions`.
- Adds a pragma as well to adjust the batch size for mvcc commit
- instead of appending to a write buffer and then emitting a single big write, we break up into smaller writes to disk and clear the buffer afterwards. This just bounds memory in terms of the batch size, not in terms of bytes (which is an interesting future step after we have some implementation of `allocator_api`)

## Motivation and context
Be memory bounded in logical log commit path

## Description of AI Usage
AI did it with my wants
