### PR TITLE
core: rebuild ALTER COLUMN indexes

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -2295,6 +2295,7 @@ mod tests {
                     None,
                     ColDef {
                         primary_key: true,
+                        primary_key_is_inline: true,
                         rowid_alias: true,
                         notnull: true,
                         ..Default::default()
@@ -2333,6 +2334,7 @@ mod tests {
                     None,
                     ColDef {
                         primary_key: true,
+                        primary_key_is_inline: true,
                         rowid_alias: true,
                         notnull: true,
                         ..Default::default()
@@ -2375,6 +2377,7 @@ mod tests {
                     None,
                     ColDef {
                         primary_key: true,
+                        primary_key_is_inline: true,
                         rowid_alias: true,
                         notnull: true,
                         ..Default::default()
@@ -2422,6 +2425,7 @@ mod tests {
                     None,
                     ColDef {
                         primary_key: true,
+                        primary_key_is_inline: true,
                         rowid_alias: true,
                         notnull: true,
                         ..Default::default()
@@ -2455,6 +2459,7 @@ mod tests {
                     None,
                     ColDef {
                         primary_key: true,
+                        primary_key_is_inline: true,
                         rowid_alias: true,
                         notnull: true,
                         ..Default::default()
@@ -2502,6 +2507,7 @@ mod tests {
                     None,
                     ColDef {
                         primary_key: true,
+                        primary_key_is_inline: true,
                         rowid_alias: true,
                         notnull: true,
                         ..Default::default()

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -1445,6 +1445,7 @@ mod tests {
                 None,
                 ColDef {
                     primary_key: true,
+                    primary_key_is_inline: true,
                     rowid_alias: true,
                     notnull: true,
                     explicit_notnull: false,
@@ -1478,6 +1479,7 @@ mod tests {
                 None,
                 ColDef {
                     primary_key: true,
+                    primary_key_is_inline: true,
                     rowid_alias: true,
                     notnull: true,
                     explicit_notnull: false,
@@ -1524,6 +1526,7 @@ mod tests {
                 None,
                 ColDef {
                     primary_key: true,
+                    primary_key_is_inline: true,
                     rowid_alias: true,
                     notnull: true,
                     explicit_notnull: false,

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -102,6 +102,14 @@ enum CountState {
     NextBtree { count: usize },
     CheckBtreeKey { count: usize },
 }
+
+#[derive(Debug, Clone, Copy)]
+enum ClearBtreeState {
+    Rewind,
+    DeleteCurrent { deleted: usize },
+    Next { deleted: usize },
+}
+
 #[derive(Debug, Clone)]
 enum MvccLazyCursorState {
     Next(NextState),
@@ -122,6 +130,7 @@ pub(crate) enum CursorYieldPoint {
     SeekBtreeProgress,
     ExistsBtreeFallback,
     CountProgress,
+    ClearBtreeProgress,
     AdvanceBtreeForwardProgress,
     AdvanceBtreeBackwardProgress,
 }
@@ -360,6 +369,8 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     state: Option<MvccLazyCursorState>,
     // we keep count_state separate to be able to call other public functions like rewind and next
     count_state: Option<CountState>,
+    // clear_btree is allowed to call other cursor methods, so its progress is tracked separately
+    clear_state: Option<ClearBtreeState>,
     btree_advance_state: Option<AdvanceBtreeState>,
     /// Dual-cursor peek state for proper iteration
     dual_peek: DualCursorPeek,
@@ -411,6 +422,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             creating_new_rowid: false,
             state: None,
             count_state: None,
+            clear_state: None,
             btree_advance_state: None,
             dual_peek: DualCursorPeek::default(),
         })
@@ -1730,11 +1742,46 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
     }
 
     fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>> {
-        todo!()
+        self.set_null_flag(false);
+        loop {
+            match self.clear_state {
+                None => {
+                    self.clear_state = Some(ClearBtreeState::Rewind);
+                    inject_io_yield!(self, CursorYieldPoint::ClearBtreeProgress);
+                }
+                Some(ClearBtreeState::Rewind) => {
+                    return_if_io!(self.rewind());
+                    self.clear_state = Some(ClearBtreeState::DeleteCurrent { deleted: 0 });
+                    inject_io_yield!(self, CursorYieldPoint::ClearBtreeProgress);
+                }
+                Some(ClearBtreeState::DeleteCurrent { deleted }) => {
+                    if !self.has_record() {
+                        self.clear_state = None;
+                        self.table_iterator = None;
+                        self.index_iterator = None;
+                        self.btree_advance_state = None;
+                        self.reset_dual_peek();
+                        self.current_pos = CursorPosition::BeforeFirst;
+                        self.invalidate_record();
+                        return Ok(IOResult::Done(Some(deleted)));
+                    }
+                    return_if_io!(self.delete());
+                    self.clear_state = Some(ClearBtreeState::Next {
+                        deleted: deleted + 1,
+                    });
+                    inject_io_yield!(self, CursorYieldPoint::ClearBtreeProgress);
+                }
+                Some(ClearBtreeState::Next { deleted }) => {
+                    return_if_io!(self.next());
+                    self.clear_state = Some(ClearBtreeState::DeleteCurrent { deleted });
+                    inject_io_yield!(self, CursorYieldPoint::ClearBtreeProgress);
+                }
+            }
+        }
     }
 
     fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>> {
-        todo!()
+        self.clear_btree()
     }
 
     fn count(&mut self) -> Result<IOResult<usize>> {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4260,6 +4260,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 let mut order = SortOrder::Asc;
                 let mut unique = false;
                 let mut collation = None;
+                let mut primary_key_is_inline = false;
                 for c_def in constraints {
                     match &c_def.constraint {
                         ast::ColumnConstraint::Check(expr) => {
@@ -4292,6 +4293,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                                 );
                             }
                             primary_key = true;
+                            primary_key_is_inline = true;
                             if *auto_increment {
                                 has_autoincrement = true;
                             }
@@ -4444,6 +4446,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     collation,
                     ColDef {
                         primary_key,
+                        primary_key_is_inline,
                         rowid_alias: typename_exactly_integer
                             && primary_key
                             && !primary_key_desc_columns_constraint,
@@ -4759,6 +4762,7 @@ pub struct Column {
     pub default: Option<Box<Expr>>,
     generated_type: GeneratedType,
     raw: u32,
+    primary_key_is_inline: bool,
     explicit_notnull: bool,
     /// ON CONFLICT clause for NOT NULL constraint on this column.
     pub notnull_conflict_clause: Option<ResolveType>,
@@ -4767,6 +4771,7 @@ pub struct Column {
 #[derive(Default)]
 pub struct ColDef {
     pub primary_key: bool,
+    pub primary_key_is_inline: bool,
     pub rowid_alias: bool,
     pub notnull: bool,
     pub explicit_notnull: bool,
@@ -4921,6 +4926,7 @@ impl Column {
             default,
             generated_type,
             raw,
+            primary_key_is_inline: coldef.primary_key_is_inline,
             explicit_notnull: coldef.explicit_notnull,
             notnull_conflict_clause: coldef.notnull_conflict_clause,
         }
@@ -4971,6 +4977,10 @@ impl Column {
     #[inline]
     pub fn primary_key(&self) -> bool {
         self.raw & F_PRIMARY_KEY != 0
+    }
+    #[inline]
+    pub const fn primary_key_is_inline(&self) -> bool {
+        self.primary_key_is_inline
     }
     #[inline]
     pub const fn is_rowid_alias(&self) -> bool {
@@ -5047,6 +5057,10 @@ impl Column {
     #[inline]
     pub const fn set_primary_key(&mut self, v: bool) {
         self.set_flag(F_PRIMARY_KEY, v);
+    }
+    #[inline]
+    pub const fn set_primary_key_is_inline(&mut self, v: bool) {
+        self.primary_key_is_inline = v;
     }
     #[inline]
     pub const fn set_rowid_alias(&mut self, v: bool) {
@@ -5172,6 +5186,7 @@ impl TryFrom<&ColumnDefinition> for Column {
             collation,
             ColDef {
                 primary_key,
+                primary_key_is_inline: primary_key,
                 rowid_alias: primary_key && matches!(ty, Type::Integer),
                 notnull,
                 explicit_notnull: notnull,

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -6,28 +6,40 @@ use turso_parser::{
 };
 
 use super::{
+    insert::format_unique_violation_desc,
     schema::{validate_check_expr, SQLITE_TABLEID},
     update::translate_update_for_schema_change,
 };
 use crate::{
-    error::SQLITE_CONSTRAINT_CHECK,
+    error::{SQLITE_CONSTRAINT_CHECK, SQLITE_CONSTRAINT_UNIQUE},
     function::{AlterTableFunc, Func},
-    schema::{CheckConstraint, Column, ForeignKey, Table, RESERVED_TABLE_PREFIXES},
+    schema::{
+        CheckConstraint, Column, ForeignKey, Index, PseudoCursorType, Table,
+        RESERVED_TABLE_PREFIXES,
+    },
     translate::{
         emitter::{emit_check_constraints, gencol::compute_virtual_columns, Resolver},
-        expr::{translate_expr, walk_expr, walk_expr_mut, WalkControl},
-        plan::{ColumnMask, ColumnUsedMask, OuterQueryReference, TableReferences},
+        expr::{
+            translate_condition_expr, translate_expr, walk_expr, walk_expr_mut, ConditionMetadata,
+            WalkControl,
+        },
+        index::emit_index_column_value_from_cursor,
+        plan::{
+            ColumnMask, ColumnUsedMask, IterationDirection, JoinedTable, Operation,
+            OuterQueryReference, Scan, TableReferences,
+        },
         trigger::create_trigger_to_sql,
     },
     util::{
         check_expr_references_column, escape_sql_string_literal, normalize_ident,
-        parse_numeric_literal, rewrite_check_expr_table_refs, rewrite_trigger_cmd_table_refs,
-        rewrite_view_sql_for_column_rename,
+        parse_numeric_literal, rename_identifiers, rewrite_check_expr_table_refs,
+        rewrite_trigger_cmd_table_refs, rewrite_view_sql_for_column_rename,
+        PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX,
     },
     vdbe::{
         affinity::Affinity,
-        builder::{CursorType, DmlColumnContext, ProgramBuilder},
-        insn::{to_u16, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
+        builder::{CursorKey, CursorType, DmlColumnContext, ProgramBuilder},
+        insn::{to_u16, CmpInsFlags, Cookie, IdxInsertFlags, Insn, RegisterOrLiteral},
     },
     vtab::VirtualTable,
     LimboError, Numeric, Result, Value,
@@ -1812,6 +1824,12 @@ pub fn translate_alter_table(
                 ));
             }
 
+            let autoindexes_to_drop = if rename {
+                Vec::new()
+            } else {
+                autoindexes_dropped_by_alter_column(&btree, column_index, resolver, database_id)
+            };
+
             let (rewrites_physical_layout, replacement_column) = match rename {
                 true => (false, None),
                 false => {
@@ -1896,6 +1914,22 @@ pub fn translate_alter_table(
                 Some(table)
             } else {
                 None
+            };
+            let indexes_to_rebuild = if let Some(rewritten_table) = rewritten_table.as_ref() {
+                indexes_rebuilt_by_alter_column(
+                    AlterColumnIndexRebuild {
+                        original_table: &btree,
+                        rewritten_table,
+                        column_index,
+                        old_column_name: from,
+                        new_column_name: definition.col_name.as_str(),
+                        dropped_indexes: &autoindexes_to_drop,
+                    },
+                    resolver,
+                    database_id,
+                )?
+            } else {
+                Vec::new()
             };
 
             // If renaming, rewrite trigger SQL for all triggers that reference this column
@@ -2107,6 +2141,8 @@ pub fn translate_alter_table(
                 });
             });
 
+            emit_drop_autoindexes(program, cursor_id, database_id, &autoindexes_to_drop);
+
             // Update trigger SQL for renamed columns
             for (trigger_database_id, trigger_name, new_sql) in triggers_to_rewrite {
                 let escaped_sql = escape_sql_string_literal(&new_sql);
@@ -2187,6 +2223,7 @@ pub fn translate_alter_table(
             }
 
             if let Some(rewritten_table) = rewritten_table {
+                let rewritten_table = Arc::new(rewritten_table);
                 emit_add_virtual_column_validation(
                     program,
                     &rewritten_table,
@@ -2232,6 +2269,13 @@ pub fn translate_alter_table(
                     connection,
                     database_id,
                 );
+                emit_rebuild_indexes(
+                    program,
+                    rewritten_table,
+                    &indexes_to_rebuild,
+                    resolver,
+                    database_id,
+                )?;
             }
 
             if clears_autoincrement_sequence {
@@ -2340,6 +2384,557 @@ fn non_virtual_affinity_str(table: &BTreeTable) -> String {
         .filter(|col| !col.is_virtual_generated())
         .map(|col| col.affinity_with_strict(table.is_strict).aff_mask())
         .collect()
+}
+
+struct AlterColumnIndexRebuild<'a> {
+    original_table: &'a BTreeTable,
+    rewritten_table: &'a BTreeTable,
+    column_index: usize,
+    old_column_name: &'a str,
+    new_column_name: &'a str,
+    dropped_indexes: &'a [Arc<Index>],
+}
+
+fn indexes_rebuilt_by_alter_column(
+    ctx: AlterColumnIndexRebuild<'_>,
+    resolver: &Resolver,
+    database_id: usize,
+) -> Result<Vec<Arc<Index>>> {
+    let AlterColumnIndexRebuild {
+        original_table,
+        rewritten_table,
+        column_index,
+        old_column_name,
+        new_column_name,
+        dropped_indexes,
+    } = ctx;
+
+    let old_column_name = normalize_ident(old_column_name);
+    let dropped_index_names = dropped_indexes
+        .iter()
+        .map(|index| index.name.clone())
+        .collect::<HashSet<_>>();
+    let indexes = resolver.with_schema(database_id, |schema| {
+        schema
+            .get_indices(&original_table.name)
+            .filter(|index| !dropped_index_names.contains(&index.name))
+            .filter(|index| index_references_altered_column(index, column_index, &old_column_name))
+            .cloned()
+            .collect::<Vec<_>>()
+    });
+
+    let mut rewritten_indexes = Vec::with_capacity(indexes.len());
+    for index in indexes {
+        if index.index_method.is_some() && !index.is_backing_btree_index() {
+            return Err(LimboError::ParseError(format!(
+                "cannot alter column referenced by custom index {}",
+                index.name
+            )));
+        }
+
+        let mut rewritten_index = index.as_ref().clone();
+        rewrite_index_column_references(
+            &mut rewritten_index,
+            rewritten_table,
+            column_index,
+            &old_column_name,
+            new_column_name,
+        );
+        rewritten_indexes.push(Arc::new(rewritten_index));
+    }
+
+    Ok(rewritten_indexes)
+}
+
+fn index_references_altered_column(
+    index: &Index,
+    column_index: usize,
+    old_column_name: &str,
+) -> bool {
+    index.columns.iter().any(|column| {
+        column.pos_in_table == column_index
+            || column
+                .expr
+                .as_ref()
+                .is_some_and(|expr| check_expr_references_column(expr, old_column_name))
+    }) || index
+        .where_clause
+        .as_ref()
+        .is_some_and(|expr| check_expr_references_column(expr, old_column_name))
+}
+
+fn rewrite_index_column_references(
+    index: &mut Index,
+    rewritten_table: &BTreeTable,
+    column_index: usize,
+    old_column_name: &str,
+    new_column_name: &str,
+) {
+    let Some(new_column) = rewritten_table.columns().get(column_index) else {
+        return;
+    };
+    let Some(normalized_new_column_name) = new_column.name.as_deref().map(normalize_ident) else {
+        return;
+    };
+
+    for index_column in &mut index.columns {
+        if index_column.pos_in_table == column_index && index_column.expr.is_none() {
+            index_column.name.clone_from(&normalized_new_column_name);
+            index_column.collation = new_column.collation_opt();
+            index_column.default.clone_from(&new_column.default);
+        }
+
+        if let Some(expr) = index_column.expr.as_mut() {
+            rename_identifiers(expr, old_column_name, new_column_name);
+        }
+    }
+
+    if let Some(where_clause) = index.where_clause.as_mut() {
+        rename_identifiers(where_clause, old_column_name, new_column_name);
+    }
+}
+
+fn emit_rebuild_indexes(
+    program: &mut ProgramBuilder,
+    table: Arc<BTreeTable>,
+    indexes: &[Arc<Index>],
+    resolver: &Resolver,
+    database_id: usize,
+) -> Result<()> {
+    for index in indexes {
+        emit_rebuild_index(program, table.clone(), index.clone(), resolver, database_id)?;
+    }
+    Ok(())
+}
+
+fn emit_rebuild_index(
+    program: &mut ProgramBuilder,
+    table: Arc<BTreeTable>,
+    index: Arc<Index>,
+    resolver: &Resolver,
+    database_id: usize,
+) -> Result<()> {
+    if index.unique {
+        return emit_rebuild_unique_index(program, table, index, resolver, database_id);
+    }
+
+    let table_ref = program.table_reference_counter.next();
+    let index_cursor_id = program.alloc_cursor_index(None, &index)?;
+    let table_cursor_id = program.alloc_cursor_id_keyed(
+        CursorKey::table(table_ref),
+        CursorType::BTreeTable(table.clone()),
+    );
+    let mut table_references = TableReferences::new(
+        vec![JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            table: Table::BTree(table.clone()),
+            identifier: table.name.clone(),
+            internal_id: table_ref,
+            join_info: None,
+            col_used_mask: ColumnUsedMask::default(),
+            column_use_counts: Vec::new(),
+            expression_index_usages: Vec::new(),
+            database_id,
+            indexed: None,
+        }],
+        vec![],
+    );
+    let where_clause = index.bind_where_expr(Some(&mut table_references), resolver);
+
+    program.emit_insn(Insn::OpenWrite {
+        cursor_id: index_cursor_id,
+        root_page: RegisterOrLiteral::Literal(index.root_page),
+        db: database_id,
+    });
+    program.emit_insn(Insn::ResetSorter {
+        cursor_id: index_cursor_id,
+    });
+    program.emit_insn(Insn::OpenRead {
+        cursor_id: table_cursor_id,
+        root_page: table.root_page,
+        db: database_id,
+    });
+
+    let loop_start_label = program.allocate_label();
+    let loop_end_label = program.allocate_label();
+    program.emit_insn(Insn::Rewind {
+        cursor_id: table_cursor_id,
+        pc_if_empty: loop_end_label,
+    });
+    program.preassign_label_to_next_insn(loop_start_label);
+
+    let mut skip_row_label = None;
+    if let Some(where_clause) = where_clause {
+        let label = program.allocate_label();
+        let condition_true_label = program.allocate_label();
+        translate_condition_expr(
+            program,
+            &table_references,
+            &where_clause,
+            ConditionMetadata {
+                jump_if_condition_is_true: false,
+                jump_target_when_false: label,
+                jump_target_when_true: condition_true_label,
+                jump_target_when_null: label,
+            },
+            resolver,
+        )?;
+        program.preassign_label_to_next_insn(condition_true_label);
+        skip_row_label = Some(label);
+    }
+
+    let start_reg = program.alloc_registers(index.columns.len() + 1);
+    for (i, column) in index.columns.iter().enumerate() {
+        emit_index_column_value_from_cursor(
+            program,
+            resolver,
+            &mut table_references,
+            table_cursor_id,
+            table.as_ref(),
+            column,
+            start_reg + i,
+        )?;
+    }
+    let rowid_reg = start_reg + index.columns.len();
+    program.emit_insn(Insn::RowId {
+        cursor_id: table_cursor_id,
+        dest: rowid_reg,
+    });
+    let record_reg = program.alloc_register();
+    program.emit_insn(Insn::MakeRecord {
+        start_reg: to_u16(start_reg),
+        count: to_u16(index.columns.len() + 1),
+        dest_reg: to_u16(record_reg),
+        index_name: Some(index.name.clone()),
+        affinity_str: None,
+    });
+    program.emit_insn(Insn::IdxInsert {
+        cursor_id: index_cursor_id,
+        record_reg,
+        unpacked_start: Some(start_reg),
+        unpacked_count: Some((index.columns.len() + 1) as u16),
+        flags: IdxInsertFlags::new(),
+    });
+
+    if let Some(skip_row_label) = skip_row_label {
+        program.preassign_label_to_next_insn(skip_row_label);
+    }
+    program.emit_insn(Insn::Next {
+        cursor_id: table_cursor_id,
+        pc_if_next: loop_start_label,
+    });
+    program.preassign_label_to_next_insn(loop_end_label);
+    program.close_cursors(&[table_cursor_id, index_cursor_id]);
+
+    Ok(())
+}
+
+fn emit_rebuild_unique_index(
+    program: &mut ProgramBuilder,
+    table: Arc<BTreeTable>,
+    index: Arc<Index>,
+    resolver: &Resolver,
+    database_id: usize,
+) -> Result<()> {
+    let table_ref = program.table_reference_counter.next();
+    let index_cursor_id = program.alloc_cursor_index(None, &index)?;
+    let table_cursor_id = program.alloc_cursor_id_keyed(
+        CursorKey::table(table_ref),
+        CursorType::BTreeTable(table.clone()),
+    );
+    let sorter_cursor_id = program.alloc_cursor_id(CursorType::Sorter);
+    let pseudo_cursor_id = program.alloc_cursor_id(CursorType::Pseudo(PseudoCursorType {
+        column_count: table.columns().len(),
+    }));
+    let mut table_references = TableReferences::new(
+        vec![JoinedTable {
+            op: Operation::Scan(Scan::BTreeTable {
+                iter_dir: IterationDirection::Forwards,
+                index: None,
+            }),
+            table: Table::BTree(table.clone()),
+            identifier: table.name.clone(),
+            internal_id: table_ref,
+            join_info: None,
+            col_used_mask: ColumnUsedMask::default(),
+            column_use_counts: Vec::new(),
+            expression_index_usages: Vec::new(),
+            database_id,
+            indexed: None,
+        }],
+        vec![],
+    );
+    let where_clause = index.bind_where_expr(Some(&mut table_references), resolver);
+
+    let order_collations_nulls = index
+        .columns
+        .iter()
+        .map(|column| (column.order, column.collation, None))
+        .collect();
+    program.emit_insn(Insn::SorterOpen {
+        cursor_id: sorter_cursor_id,
+        columns: index.columns.len(),
+        order_collations_nulls,
+        comparators: vec![],
+    });
+    let content_reg = program.alloc_register();
+    program.emit_insn(Insn::OpenPseudo {
+        cursor_id: pseudo_cursor_id,
+        content_reg,
+        num_fields: index.columns.len() + 1,
+    });
+    program.emit_insn(Insn::OpenRead {
+        cursor_id: table_cursor_id,
+        root_page: table.root_page,
+        db: database_id,
+    });
+
+    let loop_start_label = program.allocate_label();
+    let loop_end_label = program.allocate_label();
+    program.emit_insn(Insn::Rewind {
+        cursor_id: table_cursor_id,
+        pc_if_empty: loop_end_label,
+    });
+    program.preassign_label_to_next_insn(loop_start_label);
+
+    let mut skip_row_label = None;
+    if let Some(where_clause) = where_clause {
+        let label = program.allocate_label();
+        let condition_true_label = program.allocate_label();
+        translate_condition_expr(
+            program,
+            &table_references,
+            &where_clause,
+            ConditionMetadata {
+                jump_if_condition_is_true: false,
+                jump_target_when_false: label,
+                jump_target_when_true: condition_true_label,
+                jump_target_when_null: label,
+            },
+            resolver,
+        )?;
+        program.preassign_label_to_next_insn(condition_true_label);
+        skip_row_label = Some(label);
+    }
+
+    let start_reg = program.alloc_registers(index.columns.len() + 1);
+    for (i, column) in index.columns.iter().enumerate() {
+        emit_index_column_value_from_cursor(
+            program,
+            resolver,
+            &mut table_references,
+            table_cursor_id,
+            table.as_ref(),
+            column,
+            start_reg + i,
+        )?;
+    }
+    let rowid_reg = start_reg + index.columns.len();
+    program.emit_insn(Insn::RowId {
+        cursor_id: table_cursor_id,
+        dest: rowid_reg,
+    });
+    let record_reg = program.alloc_register();
+    program.emit_insn(Insn::MakeRecord {
+        start_reg: to_u16(start_reg),
+        count: to_u16(index.columns.len() + 1),
+        dest_reg: to_u16(record_reg),
+        index_name: Some(index.name.clone()),
+        affinity_str: None,
+    });
+    program.emit_insn(Insn::SorterInsert {
+        cursor_id: sorter_cursor_id,
+        record_reg,
+    });
+
+    if let Some(skip_row_label) = skip_row_label {
+        program.preassign_label_to_next_insn(skip_row_label);
+    }
+    program.emit_insn(Insn::Next {
+        cursor_id: table_cursor_id,
+        pc_if_next: loop_start_label,
+    });
+    program.preassign_label_to_next_insn(loop_end_label);
+
+    program.emit_insn(Insn::OpenWrite {
+        cursor_id: index_cursor_id,
+        root_page: RegisterOrLiteral::Literal(index.root_page),
+        db: database_id,
+    });
+    program.emit_insn(Insn::ResetSorter {
+        cursor_id: index_cursor_id,
+    });
+
+    let sorted_loop_start = program.allocate_label();
+    let sorted_loop_end = program.allocate_label();
+    program.emit_insn(Insn::SorterSort {
+        cursor_id: sorter_cursor_id,
+        pc_if_empty: sorted_loop_end,
+    });
+
+    let sorted_record_reg = program.alloc_register();
+    let goto_label = program.allocate_label();
+    let label_after_sorter_compare = program.allocate_label();
+    program.preassign_label_to_next_insn(goto_label);
+    program.emit_insn(Insn::Goto {
+        target_pc: label_after_sorter_compare,
+    });
+    program.preassign_label_to_next_insn(sorted_loop_start);
+    program.emit_insn(Insn::SorterCompare {
+        cursor_id: sorter_cursor_id,
+        sorted_record_reg,
+        num_regs: index.columns.len(),
+        pc_when_nonequal: goto_label,
+    });
+    program.emit_insn(Insn::Halt {
+        err_code: SQLITE_CONSTRAINT_UNIQUE,
+        description: format_unique_violation_desc(table.name.as_str(), &index),
+        on_error: None,
+        description_reg: None,
+    });
+    program.preassign_label_to_next_insn(label_after_sorter_compare);
+
+    program.emit_insn(Insn::SorterData {
+        pseudo_cursor: pseudo_cursor_id,
+        cursor_id: sorter_cursor_id,
+        dest_reg: sorted_record_reg,
+    });
+    program.emit_insn(Insn::SeekEnd {
+        cursor_id: index_cursor_id,
+    });
+    program.emit_insn(Insn::IdxInsert {
+        cursor_id: index_cursor_id,
+        record_reg: sorted_record_reg,
+        unpacked_start: None,
+        unpacked_count: None,
+        flags: IdxInsertFlags::new().use_seek(false),
+    });
+    program.emit_insn(Insn::SorterNext {
+        cursor_id: sorter_cursor_id,
+        pc_if_next: sorted_loop_start,
+    });
+    program.preassign_label_to_next_insn(sorted_loop_end);
+    program.close_cursors(&[sorter_cursor_id, table_cursor_id, index_cursor_id]);
+
+    Ok(())
+}
+
+fn autoindexes_dropped_by_alter_column(
+    table: &BTreeTable,
+    column_index: usize,
+    resolver: &Resolver,
+    database_id: usize,
+) -> Vec<Arc<Index>> {
+    let Some(column) = table.columns().get(column_index) else {
+        return Vec::new();
+    };
+    let Some(column_name) = column.name.as_deref() else {
+        return Vec::new();
+    };
+
+    let drops_inline_constraint =
+        column.unique() || (column.primary_key_is_inline() && !column.is_rowid_alias());
+    if !drops_inline_constraint {
+        return Vec::new();
+    }
+
+    let normalized_column_name = normalize_ident(column_name);
+    let mut seen = HashSet::default();
+    resolver.with_schema(database_id, |schema| {
+        schema
+            .get_indices(&table.name)
+            .filter(|index| {
+                index
+                    .name
+                    .starts_with(PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX)
+                    && index.columns.len() == 1
+                    && index.columns[0]
+                        .name
+                        .eq_ignore_ascii_case(&normalized_column_name)
+            })
+            .filter(|index| seen.insert(index.name.clone()))
+            .cloned()
+            .collect()
+    })
+}
+
+fn emit_drop_autoindexes(
+    program: &mut ProgramBuilder,
+    schema_cursor_id: usize,
+    database_id: usize,
+    indexes: &[Arc<Index>],
+) {
+    if indexes.is_empty() {
+        return;
+    }
+
+    let index_type_reg = program.emit_string8_new_reg("index".to_string());
+    program.mark_last_insn_constant();
+    let row_id_reg = program.alloc_register();
+    let value_reg = program.alloc_register();
+
+    for index in indexes {
+        let index_name_reg = program.emit_string8_new_reg(index.name.clone());
+        program.mark_last_insn_constant();
+        let loop_start_label = program.allocate_label();
+        let loop_end_label = program.allocate_label();
+
+        program.emit_insn(Insn::Rewind {
+            cursor_id: schema_cursor_id,
+            pc_if_empty: loop_end_label,
+        });
+        program.preassign_label_to_next_insn(loop_start_label);
+
+        let next_label = program.allocate_label();
+        program.emit_column_or_rowid(schema_cursor_id, 1, value_reg);
+        program.emit_insn(Insn::Ne {
+            lhs: index_name_reg,
+            rhs: value_reg,
+            target_pc: next_label,
+            flags: CmpInsFlags::default(),
+            collation: program.curr_collation(),
+        });
+
+        program.emit_column_or_rowid(schema_cursor_id, 0, value_reg);
+        program.emit_insn(Insn::Ne {
+            lhs: index_type_reg,
+            rhs: value_reg,
+            target_pc: next_label,
+            flags: CmpInsFlags::default(),
+            collation: program.curr_collation(),
+        });
+
+        program.emit_insn(Insn::RowId {
+            cursor_id: schema_cursor_id,
+            dest: row_id_reg,
+        });
+        program.emit_insn(Insn::Delete {
+            cursor_id: schema_cursor_id,
+            table_name: SQLITE_TABLEID.to_string(),
+            is_part_of_update: false,
+        });
+
+        program.preassign_label_to_next_insn(next_label);
+        program.emit_insn(Insn::Next {
+            cursor_id: schema_cursor_id,
+            pc_if_next: loop_start_label,
+        });
+        program.preassign_label_to_next_insn(loop_end_label);
+
+        program.emit_insn(Insn::Destroy {
+            db: database_id,
+            root: index.root_page,
+            former_root_reg: 0,
+            is_temp: 0,
+        });
+        program.emit_insn(Insn::DropIndex {
+            index: index.clone(),
+            db: database_id,
+        });
+    }
 }
 
 fn translate_rename_virtual_table(

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -970,6 +970,7 @@ mod tests {
             collation,
             ColDef {
                 primary_key: true,
+                primary_key_is_inline: true,
                 rowid_alias: true,
                 notnull: false,
                 explicit_notnull: false,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1151,7 +1151,7 @@ fn string_literal_eq(value: &str, expected: &str) -> bool {
     value.trim_matches('\'').eq_ignore_ascii_case(expected)
 }
 
-fn emit_index_column_value_from_cursor(
+pub(crate) fn emit_index_column_value_from_cursor(
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     table_references: &mut TableReferences,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -2365,6 +2365,7 @@ pub static ROWID_COLUMN: std::sync::LazyLock<Column> = std::sync::LazyLock::new(
         None,
         ColDef {
             primary_key: true,
+            primary_key_is_inline: true,
             rowid_alias: true,
             notnull: true,
             explicit_notnull: false,

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -2423,6 +2423,7 @@ mod tests {
                 None,
                 ColDef {
                     primary_key: true,
+                    primary_key_is_inline: true,
                     rowid_alias: true,
                     notnull: true,
                     ..Default::default()
@@ -2458,6 +2459,7 @@ mod tests {
                 None,
                 ColDef {
                     primary_key: true,
+                    primary_key_is_inline: true,
                     rowid_alias: true,
                     notnull: true,
                     ..Default::default()
@@ -2505,6 +2507,7 @@ mod tests {
                 None,
                 ColDef {
                     primary_key: true,
+                    primary_key_is_inline: true,
                     rowid_alias: true,
                     notnull: true,
                     ..Default::default()

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11368,7 +11368,7 @@ pub fn op_reset_sorter(
     let cursor = state.get_cursor(*cursor_id);
 
     match cursor_type {
-        CursorType::BTreeTable(_) => {
+        CursorType::BTreeTable(_) | CursorType::BTreeIndex(_) => {
             let cursor = cursor.as_btree_mut();
             return_if_io!(cursor.clear_btree());
         }
@@ -14238,6 +14238,9 @@ pub fn op_alter_column(
                     } else if ic.name.eq_ignore_ascii_case(&existing_column_name) {
                         ic.name.clone_from(&new_name);
                     }
+                    if let Some(expr) = ic.expr.as_mut() {
+                        rename_identifiers(expr, &old_column_name, &new_name);
+                    }
                 }
                 // Update partial index WHERE clause column references
                 if let Some(ref mut wc) = idx.where_clause {
@@ -14269,6 +14272,35 @@ pub fn op_alter_column(
                 }
             }
         } else {
+            let old_col_normalized = normalize_ident(&old_column_name);
+            let drops_inline_primary_key = btree.columns()[*column_index].primary_key_is_inline();
+            let drops_inline_unique = btree.columns()[*column_index].unique();
+
+            if drops_inline_primary_key {
+                btree
+                    .primary_key_columns
+                    .retain(|(name, _)| !name.eq_ignore_ascii_case(&old_col_normalized));
+                btree.unique_sets.retain(|unique_set| {
+                    !(unique_set.is_primary_key
+                        && unique_set.columns.len() == 1
+                        && unique_set.columns[0]
+                            .0
+                            .eq_ignore_ascii_case(&old_col_normalized))
+                });
+                btree.has_autoincrement = false;
+                btree.rowid_alias_conflict_clause = None;
+            }
+
+            if drops_inline_unique {
+                btree.unique_sets.retain(|unique_set| {
+                    !(!unique_set.is_primary_key
+                        && unique_set.columns.len() == 1
+                        && unique_set.columns[0]
+                            .0
+                            .eq_ignore_ascii_case(&old_col_normalized))
+                });
+            }
+
             btree.columns_mut()[*column_index] = new_column.clone();
         }
 

--- a/testing/sqltests/tests/alter_rename_column_partial_idx.sqltest
+++ b/testing/sqltests/tests/alter_rename_column_partial_idx.sqltest
@@ -97,6 +97,19 @@ expect pattern {
 }
 
 @cross-check-integrity
+test rename-column-expression-index-insert-after-is-not-null {
+    CREATE TABLE t (a TEXT);
+    CREATE INDEX idx ON t ((a IS NOT NULL));
+    ALTER TABLE t RENAME COLUMN a TO b;
+    INSERT INTO t(b) VALUES (NULL), ('x');
+    SELECT b IS NOT NULL FROM t ORDER BY rowid;
+}
+expect {
+    0
+    1
+}
+
+@cross-check-integrity
 test rename-column-updates-expression-index-multi-column {
     CREATE TABLE t (a, b, c);
     CREATE INDEX idx ON t (a + b * 2);

--- a/testing/sqltests/turso-tests/alter_column.sqltest
+++ b/testing/sqltests/turso-tests/alter_column.sqltest
@@ -5,10 +5,12 @@ test alter-column-rename-and-type {
     CREATE INDEX i ON t (a);
     ALTER TABLE t ALTER COLUMN a TO b BLOB;
     SELECT sql FROM sqlite_schema;
+    PRAGMA integrity_check;
 }
 expect {
     CREATE TABLE t (b BLOB)
     CREATE INDEX i ON t (b)
+    ok
 }
 
 test fail-alter-column-primary-key {
@@ -23,6 +25,88 @@ test fail-alter-column-unique {
     ALTER TABLE t ALTER COLUMN a TO a UNIQUE;
 }
 expect error {
+}
+
+test alter-column-inline-primary-key-drops-autoindex {
+    CREATE TABLE t (a TEXT PRIMARY KEY, b TEXT);
+    INSERT INTO t VALUES ('1', 'one');
+    ALTER TABLE t ALTER COLUMN a TO a2 INTEGER;
+    SELECT count(*) FROM sqlite_schema WHERE type = 'index' AND tbl_name = 't';
+    PRAGMA integrity_check;
+    SELECT a2, b FROM t;
+}
+expect {
+    0
+    ok
+    1|one
+}
+
+test alter-column-inline-unique-drops-autoindex {
+    CREATE TABLE t (a TEXT UNIQUE, b TEXT);
+    INSERT INTO t VALUES ('1', 'one');
+    ALTER TABLE t ALTER COLUMN a TO a2 INTEGER;
+    SELECT count(*) FROM sqlite_schema WHERE type = 'index' AND tbl_name = 't';
+    PRAGMA integrity_check;
+    SELECT a2, b FROM t;
+}
+expect {
+    0
+    ok
+    1|one
+}
+
+test alter-column-table-unique-rebuilds-autoindex {
+    CREATE TABLE t (a TEXT, b TEXT, UNIQUE(a));
+    INSERT INTO t VALUES ('1', 'one');
+    ALTER TABLE t ALTER COLUMN a TO a2 INTEGER;
+    SELECT count(*) FROM sqlite_schema WHERE type = 'index' AND tbl_name = 't';
+    PRAGMA integrity_check;
+    SELECT a2, b FROM t;
+}
+expect {
+    1
+    ok
+    1|one
+}
+
+test fail-alter-column-table-unique-duplicate-after-affinity {
+    CREATE TABLE t (a TEXT, b TEXT, UNIQUE(a));
+    INSERT INTO t VALUES ('1', 'one'), ('01', 'zero-one');
+    ALTER TABLE t ALTER COLUMN a TO a2 INTEGER;
+}
+expect error {
+    UNIQUE constraint failed
+}
+
+test alter-column-expression-index-rebuilds {
+    CREATE TABLE t (a TEXT, b TEXT);
+    CREATE INDEX i ON t(a || b);
+    INSERT INTO t VALUES ('1', 'x');
+    ALTER TABLE t ALTER COLUMN a TO a2 INTEGER;
+    SELECT sql FROM sqlite_schema WHERE name = 'i';
+    PRAGMA integrity_check;
+    SELECT a2, b FROM t;
+}
+expect {
+    CREATE INDEX i ON t (a2 || b)
+    ok
+    1|x
+}
+
+test alter-column-partial-index-rebuilds {
+    CREATE TABLE t (a TEXT, b TEXT);
+    CREATE INDEX i ON t(a) WHERE b = 'x';
+    INSERT INTO t VALUES ('1', 'x'), ('2', 'y');
+    ALTER TABLE t ALTER COLUMN a TO a2 INTEGER;
+    SELECT sql FROM sqlite_schema WHERE name = 'i';
+    PRAGMA integrity_check;
+    SELECT a2, b FROM t ORDER BY b;
+}
+expect {
+    CREATE INDEX i ON t (a2) WHERE b = 'x'
+    ok
+    1|x
+    2|y
 }
 
 test alter-table-rename-pk-column {


### PR DESCRIPTION
This fixes ALTER COLUMN when the changed column is referenced by indexes or inline constraints.

Before this, ALTER COLUMN could rewrite the table data but leave index btrees and sqlite_schema index entries representing the old definition. That affected inline UNIQUE/PRIMARY KEY autoindexes as well as regular indexes, partial indexes, expression indexes, and table-level UNIQUE/PRIMARY KEY indexes.

The change:
- tracks whether a PRIMARY KEY constraint came from the column definition or from table-level schema
- drops inline UNIQUE/PRIMARY KEY autoindexes when ALTER COLUMN removes that inline constraint
- rebuilds affected indexes after the table rewrite
- keeps UNIQUE checks on the rebuild path so duplicate keys after the new affinity fail instead of leaving stale indexes

Validation:
- cargo check -p turso_core
- cargo run -p test-runner -- run testing/sqltests/turso-tests/alter_column.sqltest --backend rust --mvcc --snapshot-mode no
- cargo run -p test-runner -- run testing/sqltests/turso-tests/alter_column.sqltest --backend cli --mvcc --snapshot-mode no