### PR TITLE
Make `WITHOUT ROWID` support experimental

### DIFF
--- a/bindings/javascript/packages/common/types.ts
+++ b/bindings/javascript/packages/common/types.ts
@@ -1,4 +1,4 @@
-export type ExperimentalFeature = 'views' | 'strict' | 'encryption' | 'index_method' | 'autovacuum' | 'vacuum' | 'triggers' | 'attach' | 'multiprocess_wal';
+export type ExperimentalFeature = 'views' | 'strict' | 'encryption' | 'index_method' | 'autovacuum' | 'vacuum' | 'triggers' | 'attach' | 'multiprocess_wal' | 'without_rowid';
 
 /** Supported encryption ciphers for local database encryption. */
 export type EncryptionCipher = 'aes128gcm' | 'aes256gcm' | 'aegis256' | 'aegis256x2' | 'aegis128l' | 'aegis128x2' | 'aegis128x4'

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -283,6 +283,7 @@ fn connect_sync(db: &DatabaseInner) -> napi::Result<()> {
                     "attach" => core_opts.with_attach(true),
                     "generated_columns" => core_opts.with_generated_columns(true),
                     "multiprocess_wal" => core_opts.with_multiprocess_wal(true),
+                    "without_rowid" => core_opts.with_without_rowid(true),
                     _ => core_opts,
                 };
             }

--- a/bindings/javascript/turso-sql-runner.mjs
+++ b/bindings/javascript/turso-sql-runner.mjs
@@ -83,7 +83,7 @@ async function main() {
     let db;
     try {
         const { connect } = await import('@tursodatabase/database');
-        db = await connect(dbPath, { readonly, experimental: ['triggers', 'attach', 'generated_columns'] });
+        db = await connect(dbPath, { readonly, experimental: ['triggers', 'attach', 'generated_columns', 'without_rowid'] });
         // Enable safe integers to preserve precision for large integers
         db.defaultSafeIntegers(true);
     } catch (err) {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -147,6 +147,7 @@ pub struct Builder {
     enable_vacuum: bool,
     enable_generated_columns: bool,
     enable_multiprocess_wal: bool,
+    enable_without_rowid: bool,
     vfs: Option<String>,
     encryption_opts: Option<turso_sdk_kit::rsapi::EncryptionOpts>,
     io: Option<Arc<dyn turso_core::IO>>,
@@ -165,6 +166,7 @@ impl Builder {
             enable_vacuum: false,
             enable_generated_columns: false,
             enable_multiprocess_wal: false,
+            enable_without_rowid: false,
             vfs: None,
             encryption_opts: None,
             io: None,
@@ -226,6 +228,11 @@ impl Builder {
         self
     }
 
+    pub fn experimental_without_rowid(mut self, enabled: bool) -> Self {
+        self.enable_without_rowid = enabled;
+        self
+    }
+
     pub fn with_io(mut self, vfs: String) -> Self {
         self.vfs = Some(vfs);
         self
@@ -262,6 +269,9 @@ impl Builder {
         }
         if self.enable_multiprocess_wal {
             features.push("multiprocess_wal");
+        }
+        if self.enable_without_rowid {
+            features.push("without_rowid");
         }
         if features.is_empty() {
             return None;

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -95,6 +95,8 @@ pub struct Opts {
     pub experimental_attach: bool,
     #[clap(long, help = "Enable experimental generated columns feature")]
     pub experimental_generated_columns: bool,
+    #[clap(long, help = "Enable experimental WITHOUT ROWID tables feature")]
+    pub experimental_without_rowid: bool,
     #[clap(
         long,
         help = "Enable experimental multiprocess WAL coordination (on Windows, use --vfs experimental_win_iocp)"
@@ -241,6 +243,7 @@ impl Limbo {
             .with_vacuum(opts.experimental_vacuum)
             .with_attach(opts.experimental_attach)
             .with_generated_columns(opts.experimental_generated_columns)
+            .with_without_rowid(opts.experimental_without_rowid)
             .with_multiprocess_wal(opts.experimental_multiprocess_wal)
             .with_unsafe_testing(opts.unsafe_testing);
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -371,6 +371,7 @@ impl Connection {
             .with_index_method(self.db.experimental_index_method_enabled())
             .with_vacuum(self.db.experimental_vacuum_enabled())
             .with_generated_columns(self.db.experimental_generated_columns_enabled())
+            .with_without_rowid(self.db.experimental_without_rowid_enabled())
     }
 
     fn effective_temp_store(&self) -> crate::TempStore {
@@ -2006,6 +2007,10 @@ impl Connection {
         self.db.experimental_generated_columns_enabled()
     }
 
+    pub fn experimental_without_rowid_enabled(&self) -> bool {
+        self.db.experimental_without_rowid_enabled()
+    }
+
     pub fn mvcc_enabled(&self) -> bool {
         self.db.mvcc_enabled()
     }
@@ -2458,7 +2463,8 @@ impl Connection {
             .with_custom_types(self.db.experimental_custom_types_enabled())
             .with_index_method(self.db.experimental_index_method_enabled())
             .with_vacuum(self.db.experimental_vacuum_enabled())
-            .with_generated_columns(self.db.experimental_generated_columns_enabled());
+            .with_generated_columns(self.db.experimental_generated_columns_enabled())
+            .with_without_rowid(self.db.experimental_without_rowid_enabled());
         // Select the IO layer for the attached database:
         // - :memory: databases always get a fresh MemoryIO
         // - File-based databases reuse the parent's IO when the parent is also

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -397,6 +397,7 @@ mod tests {
                 enable_attach: false,
                 enable_generated_columns: false,
                 enable_multiprocess_wal: false,
+                enable_without_rowid: false,
                 unsafe_testing: false,
             },
             None,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -206,6 +206,7 @@ pub struct DatabaseOpts {
     pub enable_attach: bool,
     pub enable_generated_columns: bool,
     pub enable_multiprocess_wal: bool,
+    pub enable_without_rowid: bool,
     pub unsafe_testing: bool,
     enable_load_extension: bool,
 }
@@ -263,6 +264,11 @@ impl DatabaseOpts {
 
     pub fn with_multiprocess_wal(mut self, enable: bool) -> Self {
         self.enable_multiprocess_wal = enable;
+        self
+    }
+
+    pub fn with_without_rowid(mut self, enable: bool) -> Self {
+        self.enable_without_rowid = enable;
         self
     }
 
@@ -2406,6 +2412,10 @@ impl Database {
 
     pub fn experimental_multiprocess_wal_enabled(&self) -> bool {
         self.opts.enable_multiprocess_wal
+    }
+
+    pub fn experimental_without_rowid_enabled(&self) -> bool {
+        self.opts.enable_without_rowid
     }
 
     /// check if database is currently in MVCC mode

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1138,6 +1138,16 @@ pub fn translate_create_table(
         }
     }
 
+    if !connection.experimental_without_rowid_enabled() {
+        if let ast::CreateTableBody::ColumnsAndConstraints { options, .. } = &body {
+            if options.contains_without_rowid() {
+                bail_parse_error!(
+                    "WITHOUT ROWID tables are an experimental feature. Enable with --experimental-without-rowid flag"
+                );
+            }
+        }
+    }
+
     let opts = ProgramBuilderOpts::new(1, 30, 1);
     program.extend(&opts);
 

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -160,6 +160,7 @@ pub(crate) fn vacuum_target_opts_from_source(source_db: &Database) -> DatabaseOp
         .with_autovacuum(source_db.experimental_autovacuum_enabled())
         .with_attach(source_db.experimental_attach_enabled())
         .with_generated_columns(source_db.experimental_generated_columns_enabled())
+        .with_without_rowid(source_db.experimental_without_rowid_enabled())
 }
 
 pub(crate) fn reject_unsupported_vacuum_auto_vacuum_mode(mode: AutoVacuumMode) -> Result<()> {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -659,6 +659,7 @@ impl TursoDatabase {
                                 "attach" => opts.with_attach(true),
                                 "generated_columns" => opts.with_generated_columns(true),
                                 "multiprocess_wal" => opts.with_multiprocess_wal(true),
+                                "without_rowid" => opts.with_without_rowid(true),
                                 _ => opts,
                             };
                         }

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -29,7 +29,10 @@ pub extern "C" fn turso_enable_experimental() {
 fn default_db_opts() -> DatabaseOpts {
     let mut opts = DatabaseOpts::new();
     if EXPERIMENTAL_ENABLED.load(Ordering::Acquire) {
-        opts = opts.with_generated_columns(true).with_vacuum(true);
+        opts = opts
+            .with_generated_columns(true)
+            .with_vacuum(true)
+            .with_without_rowid(true);
     }
     opts
 }

--- a/testing/sqltests/src/backends/cli.rs
+++ b/testing/sqltests/src/backends/cli.rs
@@ -21,6 +21,7 @@ const TURSO_CLI_EXPERIMENTAL_FLAGS: &[&str] = &[
     "--experimental-index-method",
     "--experimental-generated-columns",
     "--experimental-vacuum",
+    "--experimental-without-rowid",
 ];
 
 /// CLI backend that executes SQL via the tursodb CLI tool

--- a/testing/sqltests/src/backends/rust.rs
+++ b/testing/sqltests/src/backends/rust.rs
@@ -16,6 +16,7 @@ const TURSO_RUST_EXPERIMENTAL_FEATURES: &[&str] = &[
     "custom_types",
     "generated_columns",
     "vacuum",
+    "without_rowid",
 ];
 
 fn apply_turso_experimental_features(mut builder: Builder) -> Builder {
@@ -27,6 +28,7 @@ fn apply_turso_experimental_features(mut builder: Builder) -> Builder {
             "custom_types" => builder.experimental_custom_types(true),
             "generated_columns" => builder.experimental_generated_columns(true),
             "vacuum" => builder.experimental_vacuum(true),
+            "without_rowid" => builder.experimental_without_rowid(true),
             _ => unreachable!("unexpected sqltests Rust backend experimental feature"),
         };
     }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -170,7 +170,7 @@ impl TempDatabaseBuilder {
         let mut opts = self
             .opts
             .unwrap_or_else(|| turso_core::DatabaseOpts::new().with_encryption(true));
-        opts = opts.with_vacuum(true);
+        opts = opts.with_vacuum(true).with_without_rowid(true);
 
         if self.enable_views {
             opts = opts.with_views(true);


### PR DESCRIPTION
Make the `WITHOUT ROWID` tables opt-in with an experimental CLI or SDK flags.

Fixes #6714
