### PR TITLE
core/vdbe: add vdbe_yield_interval

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -247,6 +247,10 @@ pub struct Connection {
     /// Maximum execution time for a single statement on this connection.
     /// `Duration::ZERO` means disabled.
     pub(super) query_timeout_ms: AtomicU64,
+    /// Maximum number of VDBE step-loop iterations within a single `step()` call
+    /// before the program preemptively yields back to the cooperative scheduler.
+    /// `0` disables preemptive yielding (default).
+    pub(super) vdbe_yield_interval: AtomicU64,
     /// True when sqlite3_interrupt()-style cancellation is pending for active root statements.
     pub(super) interrupt_requested: AtomicBool,
     /// Whether this is an internal connection used for MVCC bootstrap
@@ -2983,6 +2987,18 @@ impl Connection {
     /// Get the query timeout duration.
     pub fn get_query_timeout(&self) -> Duration {
         Duration::from_millis(self.query_timeout_ms.load(Ordering::SeqCst))
+    }
+
+    /// Sets the maximum number of VDBE step-loop iterations within a single
+    /// `step()` call before the program preemptively yields back to the
+    /// cooperative scheduler. `0` disables preemptive yielding.
+    pub fn set_vdbe_yield_interval(&self, interval: u64) {
+        self.vdbe_yield_interval.store(interval, Ordering::Relaxed);
+    }
+
+    /// Get the VDBE preemptive yield interval. `0` means disabled.
+    pub fn get_vdbe_yield_interval(&self) -> u64 {
+        self.vdbe_yield_interval.load(Ordering::Relaxed)
     }
 
     /// Get a reference to the busy handler.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1714,6 +1714,7 @@ impl Database {
             busy_handler: RwLock::new(BusyHandler::None),
             progress_handler: ProgressHandler::new(),
             query_timeout_ms: AtomicU64::new(0),
+            vdbe_yield_interval: AtomicU64::new(0),
             interrupt_requested: AtomicBool::new(false),
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
             full_column_names: AtomicBool::new(false),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5112,11 +5112,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
                         panic!("Index writes must be to a record");
                     };
-                    self.insert_index_version(
-                        rowid.table_id,
-                        Arc::new(sortable_key),
-                        row_version,
-                    );
+                    self.insert_index_version(rowid.table_id, Arc::new(sortable_key), row_version);
                 }
                 StreamingResult::DeleteIndexRow {
                     row,

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -178,6 +178,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["mvcc_checkpoint_threshold"],
         ),
+        VdbeYieldInterval => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["vdbe_yield_interval"],
+        ),
         ForeignKeys => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["foreign_keys"],

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -1092,4 +1092,84 @@ mod tests {
             "cumulative metrics should include root and trigger writes"
         );
     }
+
+    #[test]
+    fn test_vdbe_yield_interval_default_is_zero() {
+        let conn = open_test_connection().unwrap();
+        assert_eq!(conn.get_vdbe_yield_interval(), 0);
+        let rows = count_pragma_int(&conn, "PRAGMA vdbe_yield_interval");
+        assert_eq!(rows, 0);
+    }
+
+    fn count_pragma_int(conn: &Arc<crate::Connection>, sql: &str) -> i64 {
+        let mut stmt = conn.prepare(sql).unwrap();
+        loop {
+            match stmt.step().unwrap() {
+                vdbe::StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    let value = row.get_values().next().unwrap().to_owned();
+                    match value {
+                        crate::Value::Numeric(crate::numeric::Numeric::Integer(i)) => return i,
+                        other => panic!("expected integer, got {other:?}"),
+                    }
+                }
+                vdbe::StepResult::IO => conn.get_pager().io.step().unwrap(),
+                vdbe::StepResult::Done => panic!("no row produced"),
+                _ => panic!("unexpected step result"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_vdbe_yield_interval_set_via_pragma() {
+        let conn = open_test_connection().unwrap();
+        conn.execute("PRAGMA vdbe_yield_interval=128").unwrap();
+        assert_eq!(conn.get_vdbe_yield_interval(), 128);
+        conn.execute("PRAGMA vdbe_yield_interval=0").unwrap();
+        assert_eq!(conn.get_vdbe_yield_interval(), 0);
+    }
+
+    fn run_counting_io(conn: &Arc<crate::Connection>, sql: &str) -> (u64, u64) {
+        let mut stmt = conn.prepare(sql).unwrap();
+        let mut io_returns: u64 = 0;
+        loop {
+            match stmt.step().unwrap() {
+                vdbe::StepResult::Done => break,
+                vdbe::StepResult::IO => {
+                    io_returns += 1;
+                    conn.get_pager().io.step().unwrap();
+                }
+                vdbe::StepResult::Row => {}
+                _ => panic!("unexpected step result"),
+            }
+        }
+        (io_returns, stmt.metrics().vm_steps)
+    }
+
+    #[test]
+    fn test_vdbe_yield_interval_yields_periodically() {
+        let conn = open_test_connection().unwrap();
+        conn.execute("CREATE TABLE t(x)").unwrap();
+        for i in 0..500 {
+            conn.execute(format!("INSERT INTO t VALUES ({i})"))
+                .unwrap();
+        }
+        // sum(x) iterates one VDBE step per row, unlike count(*) which has a
+        // fast path.
+        let sql = "SELECT sum(x) FROM t";
+
+        conn.set_vdbe_yield_interval(0);
+        let (baseline_io, baseline_vm_steps) = run_counting_io(&conn, sql);
+
+        conn.set_vdbe_yield_interval(8);
+        let (io_with_yield, yield_vm_steps) = run_counting_io(&conn, sql);
+
+        // We expect roughly vm_steps / interval preemptive yields. Allow a wide
+        // band to absorb prologue/epilogue iterations and any natural IO.
+        let expected_min_yields = yield_vm_steps / 16;
+        assert!(
+            io_with_yield > baseline_io + expected_min_yields,
+            "expected at least {expected_min_yields} extra yields, got {io_with_yield} (baseline {baseline_io}, vm_steps {yield_vm_steps} vs baseline {baseline_vm_steps})"
+        );
+    }
 }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -684,6 +684,15 @@ fn update_pragma(
             connection.set_mvcc_checkpoint_threshold(threshold)?;
             Ok(TransactionMode::None)
         }
+        PragmaName::VdbeYieldInterval => {
+            let interval = match parse_signed_number(&value)? {
+                Value::Numeric(Numeric::Integer(i)) if i >= 0 => i as u64,
+                Value::Numeric(Numeric::Float(f)) if f64::from(f) >= 0.0 => f64::from(f) as u64,
+                _ => bail_parse_error!("vdbe_yield_interval must be a non-negative integer"),
+            };
+            connection.set_vdbe_yield_interval(interval);
+            Ok(TransactionMode::None)
+        }
         PragmaName::ForeignKeys => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_foreign_keys_enabled(enabled);
@@ -1503,6 +1512,12 @@ fn query_pragma(
             let threshold = connection.mvcc_checkpoint_threshold()?;
             let register = program.alloc_register();
             program.emit_int(threshold, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::VdbeYieldInterval => {
+            program.emit_int(connection.get_vdbe_yield_interval() as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1493,6 +1493,8 @@ impl Program {
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
         let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
+        let yield_interval = self.connection.get_vdbe_yield_interval();
+        let mut iters_since_yield: u64 = 0;
         loop {
             if self.connection.is_closed() {
                 // Connection is closed for whatever reason, rollback the transaction.
@@ -1505,6 +1507,17 @@ impl Program {
             if self.maybe_request_interrupt(state, pager.io.as_ref()) {
                 self.abort(pager, None, state)?;
                 return Ok(StepResult::Interrupt);
+            }
+
+            // Preemptive yield: if we've iterated for too long without any
+            // natural I/O wait, return control to the cooperative scheduler so
+            // other connections can make progress. The next `step()` call will
+            // resume at the same `state.pc`.
+            if yield_interval > 0 && iters_since_yield >= yield_interval {
+                let yield_completion =
+                    crate::types::IOCompletions::Single(crate::io::Completion::new_yield());
+                yield_completion.set_waker(waker);
+                return Ok(StepResult::IO);
             }
 
             if let Some(io) = &state.io_completions {
@@ -1546,6 +1559,7 @@ impl Program {
             }
             // Always increment VM steps for every loop iteration
             state.metrics.vm_steps = state.metrics.vm_steps.saturating_add(1);
+            iters_since_yield = iters_since_yield.saturating_add(1);
 
             match insn_function(self, state, insn, pager) {
                 Ok(InsnFunctionStepResult::Step) => {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1841,6 +1841,10 @@ pub enum PragmaName {
     WalCheckpoint,
     /// Sets or queries the threshold (in bytes) at which MVCC triggers an automatic checkpoint.
     MvccCheckpointThreshold,
+    /// Sets or queries the maximum number of VDBE step-loop iterations within a
+    /// single `step()` call before the program preemptively yields back to the
+    /// cooperative scheduler. `0` disables preemptive yielding.
+    VdbeYieldInterval,
     /// List all available types (built-in and custom)
     ListTypes,
     /// Deprecated no-op: control whether callback is invoked for empty result sets


### PR DESCRIPTION
## Description

Added `PRAGMA vdbe_yield_interval = ...` to enable/disable yield on loop for VDBE.
`vdbe_yield_interval = 0` -> disable
`vdbe_yield_interval > 0` -> number of iterations to run step before yielding control



## Description of AI Usage

Tasked claude to write the code and iterated through it
