### PR TITLE
core/mvcc: remove clone of write_buf in logical log

### DIFF
--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -556,8 +556,7 @@ impl LogicalLog {
     }
 
     /// Serializes a transaction into `write_buf`, optionally calls
-    /// `on_serialization_complete` with a zero-copy reference to the frame bytes,
-    /// then writes to disk. `write_buf` retains its allocation across calls.
+    /// `on_serialization_complete` with a zero-copy reference to the frame bytes.
     ///
     /// `advance_offset_immediately`: when true, the writer offset advances right
     /// after the pwrite (checkpoint path). When false, the offset stays behind

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -623,8 +623,11 @@ impl LogicalLog {
             cb(&self.write_buf, crc)?;
         }
 
-        // 7. Copy write_buf into an I/O buffer and pwrite. write_buf keeps its allocation.
-        let buffer = Arc::new(Buffer::new(self.write_buf.to_vec()));
+        // 7. Hand off the populated buffer to the I/O layer without copying.
+        // `to_vec()` would allocate a second N-byte buffer and memcpy, briefly
+        // holding two full copies in memory — fatal for million-row commits.
+        // `take` swaps in a fresh empty Vec; the next call grows from zero.
+        let buffer = Arc::new(Buffer::new(std::mem::take(&mut self.write_buf)));
         let c = Completion::new_write({
             let buffer_len = buffer.len();
             move |res: Result<i32, CompletionError>| {


### PR DESCRIPTION

## Description

`write_buf` can get quite big, we use this buffer only to schedule I/O with it so no need to clone it, we can simply swap buffers.

