### PR TITLE
Fixing text integer larger than i64 saturation

### DIFF
--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -79,10 +79,10 @@ impl Numeric {
                         match optional_integer {
                             None => Some(Self::Float(real)),
                             Some(val) => Some(if real == val as f64 {
-                                                Self::Integer(val)
-                                            } else {
-                                                Self::Float(real)
-                                            })
+                                Self::Integer(val)
+                            } else {
+                                Self::Float(real)
+                            }),
                         }
                     }
                 }
@@ -200,14 +200,16 @@ impl<T: AsRef<str>> From<T> for Numeric {
                 Self::Float(value)
             }
             Some(StrToF64::Decimal(real) | StrToF64::DecimalPrefix(real)) => {
-                let optional_integer = str_to_i64(s);
+                let optional_integer = str_to_i64(text);
                 match optional_integer {
                     None => Self::Float(real),
-                    Some(val) => if real == val as f64 {
-                                        Self::Integer(val)
-                                    } else {
-                                        Self::Float(real)
-                                    }
+                    Some(val) => {
+                        if real == val as f64 {
+                            Self::Integer(val)
+                        } else {
+                            Self::Float(real)
+                        }
+                    }
                 }
             }
         }

--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -75,13 +75,15 @@ impl Numeric {
                     | Some(StrToF64::DecimalPrefix(_)) => None,
                     Some(StrToF64::Fractional(value)) => Some(Self::Float(value)),
                     Some(StrToF64::Decimal(real)) => {
-                        let integer = str_to_i64(s).unwrap_or(0);
-
-                        Some(if real == integer as f64 {
-                            Self::Integer(integer)
-                        } else {
-                            Self::Float(real)
-                        })
+                        let optional_integer = str_to_i64(s);
+                        match optional_integer {
+                            None => Some(Self::Float(real)),
+                            Some(val) => Some(if real == val as f64 {
+                                                Self::Integer(val)
+                                            } else {
+                                                Self::Float(real)
+                                            })
+                        }
                     }
                 }
             }
@@ -198,12 +200,14 @@ impl<T: AsRef<str>> From<T> for Numeric {
                 Self::Float(value)
             }
             Some(StrToF64::Decimal(real) | StrToF64::DecimalPrefix(real)) => {
-                let integer = str_to_i64(text).unwrap_or(0);
-
-                if real == integer as f64 {
-                    Self::Integer(integer)
-                } else {
-                    Self::Float(real)
+                let optional_integer = str_to_i64(s);
+                match optional_integer {
+                    None => Self::Float(real),
+                    Some(val) => if real == val as f64 {
+                                        Self::Integer(val)
+                                    } else {
+                                        Self::Float(real)
+                                    }
                 }
             }
         }
@@ -542,15 +546,15 @@ pub fn str_to_i64(input: impl AsRef<str>) -> Option<i64> {
 
     iter.next_if(|(_, ch)| matches!(ch, '+' | '-'));
     let Some((end, _)) = iter.take_while(|(_, ch)| ch.is_ascii_digit()).last() else {
-        return Some(0);
+        return None;
     };
 
     input[0..=end].parse::<i64>().map_or_else(
         |err| match err.kind() {
-            std::num::IntErrorKind::PosOverflow => Some(i64::MAX),
-            std::num::IntErrorKind::NegOverflow => Some(i64::MIN),
+            std::num::IntErrorKind::PosOverflow => None,
+            std::num::IntErrorKind::NegOverflow => None,
             std::num::IntErrorKind::Empty => unreachable!(),
-            _ => Some(0),
+            _ => None,
         },
         Some,
     )

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -2503,7 +2503,7 @@ test add-zero-large-int-text {
     SELECT typeof('9223372036854775808'+0), quote('9223372036854775808'+0);
 }
 expect {
-    real|9.22337203685478e+18
+    real|9.22337203685477581e+18
 }
 
 test numeric-order-by-coercion {
@@ -2514,8 +2514,8 @@ test numeric-order-by-coercion {
     SELECT rowid, quote(a), typeof(a+0), quote(a+0) FROM t ORDER BY a+0;
 }
 expect {
-    2|9.22337203685478e+18|real|9.22337203685478e+18
-    1|9223372036854775807|integer|9223372036854775807
+    2|'9223372036854775807'|real|9223372036854775807
+    1|'9223372036854775808'|integer|9.22337203685477581e+18
 }
 
 

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -2498,3 +2498,24 @@ test func7-pg-411 {
 expect {
     0.5
 }
+
+test add-zero-large-int-text {
+    SELECT typeof('9223372036854775808'+0), quote('9223372036854775808'+0);
+}
+expect {
+    real|9.22337203685478e+18
+}
+
+test numeric-order-by-coercion {
+    CREATE TABLE t(a);
+    INSERT INTO t(rowid,a) VALUES(2,'9223372036854775807');
+    INSERT INTO t(rowid,a) VALUES(1,'9223372036854775808');
+
+    SELECT rowid, quote(a), typeof(a+0), quote(a+0) FROM t ORDER BY a+0;
+}
+expect {
+    2|9.22337203685478e+18|real|9.22337203685478e+18
+    1|9223372036854775807|integer|9223372036854775807
+}
+
+


### PR DESCRIPTION
## Description

`str_to_i64` method returns Some from all code branches inside it. This contradicts the use of return type `Option<i64>`. The intended use of the method is to parse integer part of any passed string. So for strings like
- ++ABC it used to return `Some(0)`. Actually it should return `None`, because this string value can't give us any valid integer
- For values which used to overflow`i64`, the method saturated to i64::MAX, but logically it should return `None` because the string can't be parsed into a valid `i64`.
- In general, this method logically should return `None` for any string value which can't be parsed into a valid `i64`

## Motivation and context

Fixes https://github.com/tursodatabase/turso/issues/6704. Follow the issue for more context.


## Description of AI Usage

Code is written by hand. But the fix and all the formatting standards were vetted by codex.
