### PR TITLE
simulator: widen overflow-page coverage

### DIFF
--- a/sql_generation/generation/opts.rs
+++ b/sql_generation/generation/opts.rs
@@ -191,6 +191,10 @@ pub struct InsertOpts {
     pub max_rows: NonZeroU32,
     #[garde(range(min = 0.0, max = 1.0))]
     pub upsert_prob: f64,
+    /// If set, replaces one non-PK BLOB/TEXT value per row with `"X".repeat(size)`.
+    /// INSERT analog of `UpdateOpts.padding_size`.
+    #[garde(skip)]
+    pub padding_size: Option<usize>,
 }
 
 impl Default for InsertOpts {
@@ -199,6 +203,7 @@ impl Default for InsertOpts {
             min_rows: NonZero::new(1).unwrap(),
             max_rows: NonZero::new(10).unwrap(),
             upsert_prob: 0.15,
+            padding_size: None,
         }
     }
 }

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -354,6 +354,20 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
     let num_rows = rng.random_range(insert_opts.min_rows.get()..insert_opts.max_rows.get());
     let base_offset: i64 = rng.random_range(UNIQUE_BASE_OFFSET_RANGE);
 
+    let padding_target_idx: Option<usize> = insert_opts.padding_size.and_then(|_| {
+        let eligible: Vec<usize> = table
+            .columns
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, c)| {
+                (matches!(c.column_type, ColumnType::Blob | ColumnType::Text)
+                    && !c.has_unique_or_pk())
+                .then_some(idx)
+            })
+            .collect();
+        (!eligible.is_empty()).then(|| *pick(&eligible, rng))
+    });
+
     let values: Vec<Vec<SimValue>> = (0..num_rows)
         .map(|row_idx| {
             table
@@ -367,10 +381,18 @@ fn gen_insert_values<R: Rng + ?Sized, C: GenerationContext>(
                     if c.has_unique_or_pk() {
                         let offset =
                             base_offset + (col_idx as i64 * UNIQUE_COL_STRIDE) + row_idx as i64;
-                        SimValue::unique_for_type(&c.column_type, offset)
-                    } else {
-                        SimValue::arbitrary_from(rng, env, &c.column_type)
+                        return SimValue::unique_for_type(&c.column_type, offset);
                     }
+                    if Some(col_idx) == padding_target_idx {
+                        let size = insert_opts.padding_size.unwrap();
+                        let p = "X".repeat(size);
+                        return if matches!(c.column_type, ColumnType::Blob) {
+                            SimValue(turso_core::Value::Blob(p.into_bytes()))
+                        } else {
+                            SimValue(turso_core::Value::Text(p.into()))
+                        };
+                    }
+                    SimValue::arbitrary_from(rng, env, &c.column_type)
                 })
                 .collect()
         })

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -944,6 +944,7 @@ impl Property {
             }
             Property::FaultyQuery { query } => {
                 let query_clone = query.clone();
+                let deps: Vec<String> = query.dependencies().into_iter().collect();
                 // A fault may not occur as we first signal we want a fault injected,
                 // then when IO is called the fault triggers. It may happen that a fault is injected
                 // but no IO happens right after it
@@ -980,15 +981,15 @@ impl Property {
                             }
                         }
                     },
-                    query.dependencies().into_iter().collect(),
+                    deps.clone(),
                 );
-                [
-                    InteractionType::FaultyQuery(query.clone()),
-                    InteractionType::Assertion(assert),
+                vec![
+                    InteractionBuilder::with_interaction(InteractionType::FaultyQuery(
+                        query.clone(),
+                    )),
+                    InteractionBuilder::with_interaction(InteractionType::Assertion(assert)),
+                    assert_integrity_check("faulty query", &deps, connection_index),
                 ]
-                .into_iter()
-                .map(InteractionBuilder::with_interaction)
-                .collect()
             }
             Property::WhereTrueFalseNull { select, predicate } => {
                 let tables_dependencies = select.dependencies().into_iter().collect::<Vec<_>>();
@@ -1230,7 +1231,11 @@ impl Property {
                     })),
                 ));
                 interactions.extend(assert_all_table_values(tables, connection_index));
-                interactions.push(assert_integrity_check(tables, connection_index));
+                interactions.push(assert_integrity_check(
+                    "savepoint rollback",
+                    tables,
+                    connection_index,
+                ));
                 interactions
             }
         };
@@ -1414,10 +1419,14 @@ fn random_main_table_delete<R: rand::Rng + ?Sized>(rng: &mut R, table: &Table) -
     })
 }
 
-fn assert_integrity_check(tables: &[String], connection_index: usize) -> InteractionBuilder {
+fn assert_integrity_check(
+    label: &str,
+    tables: &[String],
+    connection_index: usize,
+) -> InteractionBuilder {
     let tables = tables.to_vec();
     InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
-        "PRAGMA integrity_check should be ok after savepoint rollback".to_string(),
+        format!("PRAGMA integrity_check should be ok after {label}"),
         move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
             let result = run_integrity_check(env, connection_index)?;
             if result == "ok" {

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -186,6 +186,48 @@ impl Profile {
         profile
     }
 
+    /// Forces overflow-page allocation on every INSERT and UPDATE
+    /// (`padding_size = 8K`, well past the ~1004B inline threshold).
+    /// Cache held at maximum so cache-pressure bugs do not dominate the
+    /// failure population.
+    pub fn overflow_stress() -> Self {
+        let profile = Profile {
+            cache_size_pages: Some(2000),
+            query: QueryProfile {
+                gen_opts: Opts {
+                    query: QueryOpts {
+                        insert: InsertOpts {
+                            min_rows: NonZeroU32::new(3).unwrap(),
+                            max_rows: NonZeroU32::new(15).unwrap(),
+                            padding_size: Some(8_000),
+                            ..Default::default()
+                        },
+                        update: UpdateOpts {
+                            padding_size: Some(8_000),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                insert_weight: 50,
+                update_weight: 20,
+                delete_weight: 15,
+                select_weight: 10,
+                create_index_weight: 5,
+                create_table_weight: 3,
+                drop_table_weight: 0,
+                alter_table_weight: 0,
+                drop_index: 0,
+                pragma_weight: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        profile.validate().unwrap();
+        profile
+    }
+
     pub fn faultless() -> Self {
         let profile = Profile {
             io: IOProfile {
@@ -235,6 +277,7 @@ impl Profile {
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
             ProfileType::SavepointStress => Self::savepoint_stress(),
+            ProfileType::OverflowStress => Self::overflow_stress(),
             ProfileType::Custom(path) => {
                 Self::parse(path).with_context(|| "failed to parse JSON profile")?
             }
@@ -277,6 +320,7 @@ pub enum ProfileType {
     SimpleMvcc,
     WriteStress,
     SavepointStress,
+    OverflowStress,
     #[strum(disabled)]
     Custom(PathBuf),
 }


### PR DESCRIPTION
Three extensions widening DST coverage of the overflow-page paths in `core/storage/btree.rs`:

1. **`InsertOpts.padding_size`**: INSERT analog of `UpdateOpts.padding_size`. When set, replaces one non-PK BLOB/TEXT column per row with `"X".repeat(size)`. Default `None`, so existing profiles are unchanged.

2. **`assert_integrity_check` after `FaultyQuery`**: previously only ran after `SavepointRollback`. Helper now takes a label so other properties can adopt it.

3. **New `overflow_stress` profile**: 8K INSERT and UPDATE padding at max cache, so every row spawns an overflow chain. With `cache_size_pages` lowered to 200, this profile reproduces #6679 from the INSERT path (a third route to the same bug, alongside `write_stress` and `savepoint_stress`).

I ran ~150 iterations across `overflow_stress`, an upsert-heavy variant, and an index-heavy variant. No new corruption surfaced; these patches do not catch a previously-unknown bug. Close it if you've got similar work going.

---

_PR drafted with assistance from Claude Opus 4.7._
