### PR TITLE
feat(sim): Add ATTACH and DETACH support to simulator infrastructure

### DIFF
--- a/sql_generation/model/query/attach.rs
+++ b/sql_generation/model/query/attach.rs
@@ -1,0 +1,14 @@
+use std::fmt::Display;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Attach {
+    pub database_path: String,
+    pub alias: String,
+}
+
+impl Display for Attach {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ATTACH DATABASE '{}' AS {}", self.database_path, self.alias)
+    }
+}

--- a/sql_generation/model/query/detach.rs
+++ b/sql_generation/model/query/detach.rs
@@ -1,0 +1,13 @@
+use std::fmt::Display;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Detach {
+    pub alias: String,
+}
+
+impl Display for Detach {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DETACH DATABASE {}", self.alias)
+    }
+}

--- a/sql_generation/model/query/mod.rs
+++ b/sql_generation/model/query/mod.rs
@@ -5,6 +5,8 @@ pub use drop::Drop;
 pub use drop_index::DropIndex;
 pub use insert::{Insert, OnConflict, UpdateSetItem};
 pub use select::Select;
+pub use attach::Attach;
+pub use detach::Detach;
 
 pub mod alter_table;
 pub mod create;
@@ -18,3 +20,5 @@ pub mod predicate;
 pub mod select;
 pub mod transaction;
 pub mod update;
+pub mod attach;
+pub mod detach;

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -155,8 +155,10 @@ impl QueryDiscriminants {
             | QueryDiscriminants::Rollback
             | QueryDiscriminants::Savepoint
             | QueryDiscriminants::RollbackToSavepoint
-            | QueryDiscriminants::ReleaseSavepoint => {
-                unreachable!("transactional queries should not be generated")
+            | QueryDiscriminants::ReleaseSavepoint
+            | QueryDiscriminants::Attach
+            | QueryDiscriminants::Detach => {
+                unreachable!("transactional or explicit queries should not be generated")
             }
             QueryDiscriminants::Placeholder => {
                 unreachable!("Query Placeholders should not be generated")
@@ -183,8 +185,10 @@ impl QueryDiscriminants {
             | QueryDiscriminants::Rollback
             | QueryDiscriminants::Savepoint
             | QueryDiscriminants::RollbackToSavepoint
-            | QueryDiscriminants::ReleaseSavepoint => {
-                unreachable!("transactional queries should not be generated")
+            | QueryDiscriminants::ReleaseSavepoint
+            | QueryDiscriminants::Attach
+            | QueryDiscriminants::Detach => {
+                unreachable!("transactional or explicit queries should not be generated")
             }
             QueryDiscriminants::Placeholder => {
                 unreachable!("Query Placeholders should not be generated")

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -152,6 +152,7 @@ impl InteractionStats {
             Query::DropIndex(_) => self.drop_index_count += 1,
             Query::Placeholder => {}
             Query::Pragma(_) => self.pragma_count += 1,
+            Query::Attach(_) | Query::Detach(_) => {}
         }
     }
 }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -9,6 +9,8 @@ use sql_generation::model::{
     query::{
         Create, CreateIndex, Delete, Drop, DropIndex, Insert, Select,
         alter_table::{AlterTable, AlterTableType},
+        attach::Attach,
+        detach::Detach,
         pragma::Pragma,
         select::{CompoundOperator, FromClause, ResultColumn, SelectInner},
         transaction::{Begin, Commit, Rollback},
@@ -286,6 +288,8 @@ pub enum Query {
     CreateIndex(CreateIndex),
     AlterTable(AlterTable),
     DropIndex(DropIndex),
+    Attach(Attach),
+    Detach(Detach),
     Begin(Begin),
     Commit(Commit),
     Rollback(Rollback),
@@ -340,6 +344,7 @@ impl Query {
             | Query::DropIndex(DropIndex {
                 table_name: table, ..
             }) => IndexSet::from_iter([table.clone()]),
+            Query::Attach(_) | Query::Detach(_) => IndexSet::new(),
             Query::Begin(_)
             | Query::Commit(_)
             | Query::Rollback(_)
@@ -370,6 +375,7 @@ impl Query {
             | Query::DropIndex(DropIndex {
                 table_name: table, ..
             }) => vec![table.clone()],
+            Query::Attach(_) | Query::Detach(_) => vec![],
             Query::Begin(..) | Query::Commit(..) | Query::Rollback(..) => vec![],
             Query::Savepoint(..) | Query::RollbackToSavepoint(..) | Query::ReleaseSavepoint(..) => {
                 vec![]
@@ -401,6 +407,8 @@ impl Query {
                 | Self::Drop(..)
                 | Self::AlterTable(..)
                 | Self::DropIndex(..)
+                | Self::Attach(..)
+                | Self::Detach(..)
         )
     }
 
@@ -432,6 +440,8 @@ impl Display for Query {
             Self::CreateIndex(create_index) => write!(f, "{create_index}"),
             Self::AlterTable(alter_table) => write!(f, "{alter_table}"),
             Self::DropIndex(drop_index) => write!(f, "{drop_index}"),
+            Self::Attach(attach) => write!(f, "{attach}"),
+            Self::Detach(detach) => write!(f, "{detach}"),
             Self::Begin(begin) => write!(f, "{begin}"),
             Self::Commit(commit) => write!(f, "{commit}"),
             Self::Rollback(rollback) => write!(f, "{rollback}"),
@@ -461,6 +471,8 @@ impl Shadow for Query {
             Query::CreateIndex(create_index) => Ok(create_index.shadow(env)),
             Query::AlterTable(alter_table) => alter_table.shadow(env),
             Query::DropIndex(drop_index) => drop_index.shadow(env),
+            Query::Attach(attach) => attach.shadow(env),
+            Query::Detach(detach) => detach.shadow(env),
             Query::Begin(begin) => Ok(begin.shadow(env)),
             Query::Commit(commit) => Ok(commit.shadow(env)),
             Query::Rollback(rollback) => Ok(rollback.shadow(env)),
@@ -485,6 +497,8 @@ bitflags! {
         const CREATE_INDEX = 1 << 6;
         const ALTER_TABLE = 1 << 7;
         const DROP_INDEX = 1 << 8;
+        const ATTACH = 1 << 9;
+        const DETACH = 1 << 10;
     }
 }
 
@@ -515,6 +529,8 @@ impl From<QueryDiscriminants> for QueryCapabilities {
             QueryDiscriminants::CreateIndex => Self::CREATE_INDEX,
             QueryDiscriminants::AlterTable => Self::ALTER_TABLE,
             QueryDiscriminants::DropIndex => Self::DROP_INDEX,
+            QueryDiscriminants::Attach => Self::ATTACH,
+            QueryDiscriminants::Detach => Self::DETACH,
             QueryDiscriminants::Begin
             | QueryDiscriminants::Commit
             | QueryDiscriminants::Rollback
@@ -1313,6 +1329,22 @@ impl Shadow for DropIndex {
         table
             .indexes
             .retain(|index| index.index_name != self.index_name);
+        Ok(vec![])
+    }
+}
+
+impl Shadow for Attach {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+
+    fn shadow(&self, _tables: &mut ShadowTablesMut<'_>) -> Self::Result {
+        Ok(vec![])
+    }
+}
+
+impl Shadow for Detach {
+    type Result = anyhow::Result<Vec<Vec<SimValue>>>;
+
+    fn shadow(&self, _tables: &mut ShadowTablesMut<'_>) -> Self::Result {
         Ok(vec![])
     }
 }


### PR DESCRIPTION
This PR adds `ATTACH` and `DETACH` support to the simulator testing infrastructure. This implements the AST definitions and sets up empty Shadow trait implementations to prevent crashes when the fuzzer generates these statements. Fixes #2183.