### PR TITLE
fix(translate): scope index lookup in DROP TABLE to target database

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -5,8 +5,8 @@ use crate::ext::VTabImpl;
 use crate::function::{Deterministic, Func, MathFunc, ScalarFunc};
 use crate::schema::{
     create_table, translate_ident_to_string_literal, BTreeCharacteristics, BTreeTable, ColDef,
-    Column, SchemaObjectType, Table, Type, RESERVED_TABLE_PREFIXES, SQLITE_SEQUENCE_TABLE_NAME,
-    TURSO_TYPES_TABLE_NAME,
+    Column, Index, SchemaObjectType, Table, Type, RESERVED_TABLE_PREFIXES,
+    SQLITE_SEQUENCE_TABLE_NAME, TURSO_TYPES_TABLE_NAME,
 };
 use crate::stats::STATS_TABLE;
 use crate::storage::pager::CreateBTreeFlags;
@@ -2021,8 +2021,9 @@ pub fn translate_drop_table(
     }
 
     //  2. Destroy the indices within a loop
-    let indices = resolver.schema().get_indices(tbl_name.name.as_str());
-    for index in indices {
+    let indices: Vec<Arc<Index>> = resolver
+        .with_schema(database_id, |s| s.get_indices(name).cloned().collect());
+    for index in &indices {
         if index.index_method.is_some() && !index.is_backing_btree_index() {
             // Index methods without backing btree need special destroy handling
             let cursor_id = program.alloc_cursor_index(None, index)?;

--- a/testing/sqltests/turso-tests/attach/writes.sqltest
+++ b/testing/sqltests/turso-tests/attach/writes.sqltest
@@ -35,6 +35,28 @@ expect {
     0
 }
 
+# Regression test for #6772: DROP TABLE on attached DB must destroy
+# the attached DB's index pages, not the main DB's.  Before the fix,
+# resolver.schema().get_indices() always read from main, so dropping
+# an attached table with an index would either leak pages or try to
+# destroy a wrong root page (ShortRead / corruption).
+test attach-write-drop-table-with-index-no-leak {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE INDEX aux.idx_t1_x ON t1(x);
+    INSERT INTO aux.t1 VALUES(1, 10);
+    DROP TABLE aux.t1;
+    SELECT count(*) FROM aux.sqlite_schema WHERE name='t1' OR name='idx_t1_x';
+    CREATE TABLE aux.t1(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE INDEX aux.idx_t1_x ON t1(x);
+    INSERT INTO aux.t1 VALUES(1, 10);
+    SELECT * FROM aux.t1;
+}
+expect {
+    0
+    1|10
+}
+
 test attach-write-drop-table-if-exists {
     ATTACH ':memory:' AS aux;
     DROP TABLE IF EXISTS aux.t1;


### PR DESCRIPTION
## Summary

Fixes #6772 — DROP TABLE on attached database destroys wrong index pages

### Root Cause

In `translate_drop_table`, the index destruction loop uses `resolver.schema().get_indices()` which unconditionally reads from the **main** database schema. When dropping a table on an attached database, this returns main's index root pages instead of the attached DB's, causing:

- **Silent page leaks** — auxiliary DB `page_count` grows monotonically
- **ShortRead / IO errors** — when main has fewer pages than auxiliary

### Fix

Replace the unscoped lookup with `resolver.with_schema(database_id, ...)`, consistent with every other schema lookup in this function.

```diff
-    let indices = resolver.schema().get_indices(tbl_name.name.as_str());
-    for index in indices {
+    let indices: Vec<Arc<Index>> = resolver
+        .with_schema(database_id, |s| s.get_indices(name).cloned().collect());
+    for index in &indices {
```

### Testing

- Added regression test `attach-write-drop-table-with-index-no-leak`
- All 229 SQL tests pass
- Both reproducers from the issue verified manually