### PR TITLE
core/mvcc: fix MVCC insert preserving stale B-tree cursor residency

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1416,17 +1416,17 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
         // Check if the cursor is currently positioned at a B-tree row that matches
         // the row we're inserting. This indicates we're updating a B-tree-resident row
         // that doesn't yet have an MVCC version.
-        let (in_btree, was_btree_resident) = match &self.current_pos {
+        let was_btree_resident = match &self.current_pos {
             CursorPosition::Loaded {
                 row_id: current_row_id,
                 in_btree,
-            } => (*in_btree, *in_btree && *current_row_id == row.id),
-            _ => (false, false),
+            } => *in_btree && *current_row_id == row.id,
+            _ => false,
         };
 
         self.current_pos = CursorPosition::Loaded {
             row_id: row.id.clone(),
-            in_btree,
+            in_btree: was_btree_resident,
         };
         let maybe_index_id = match &self.mv_cursor_type {
             MvccCursorType::Index(_) => Some(self.table_id),
@@ -1467,6 +1467,13 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             CursorPosition::Loaded { row_id, in_btree } => (row_id, in_btree),
             _ => panic!("Cannot delete: no current row"),
         };
+        if in_btree {
+            turso_assert!(
+                self.is_btree_allocated(),
+                "MVCC cursor marked current row as B-tree resident without an allocated B-tree",
+                { "row_id": &rowid }
+            );
+        }
         let maybe_index_id = match &self.mv_cursor_type {
             MvccCursorType::Index(_) => Some(self.table_id),
             MvccCursorType::Table => None,
@@ -1487,6 +1494,12 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
         // in the btree but not the mv store. In this case, we create a tombstone for the row
         // based on the btree row.
         if !was_deleted {
+            // The cursor can also be positioned on a row that was rolled back
+            // after seek. That row does not exist in either MVCC or the B-tree.
+            if !in_btree {
+                self.invalidate_record();
+                return Ok(IOResult::Done(()));
+            }
             // The btree cursor must be correctly positioned and cannot cause IO to happen
             // because we pre-fetched the record above when `in_btree` was true.
             let IOResult::Done(Some(record)) = self.record()? else {


### PR DESCRIPTION
## Description

During an MVCC insert, the cursor may already be positioned on a B-tree row. We should preserve btree_resident = true only when that cursor position refers to the same row being updated. If the insert is for a different row, it is a new MVCC version and must be marked btree_resident = false.

I [tried](https://github.com/tursodatabase/turso/commit/c21ff9aeb0819f7f7c2e051dbdcecc80f2c52bfd) but I could not come up with a good regression test for this patch.

## Description of AI Usage

Took the help of clanker where it said that just invalidating the record is enough for non resident rows (see the diff)