### PR TITLE
core/mvcc: fix stale MVCC checkpoint bounds

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -4,6 +4,9 @@ use crate::mvcc::database::{
     WriteRowStateMachine, MVCC_META_KEY_PERSISTENT_TX_TS_MAX, MVCC_META_TABLE_NAME,
     SQLITE_SCHEMA_MVCC_TABLE_ID,
 };
+#[cfg(any(test, injected_yields))]
+use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
+use crate::mvcc::yield_points::{inject_transition_failure, inject_transition_yield};
 use crate::schema::Index;
 use crate::state_machine::{StateMachine, StateTransition, TransitionResult};
 use crate::storage::btree::{BTreeCursor, CursorTrait};
@@ -21,6 +24,8 @@ use crate::{
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::num::NonZeroU64;
+#[cfg(any(test, injected_yields))]
+use strum::EnumCount;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CheckpointState {
@@ -59,6 +64,29 @@ pub enum CheckpointState {
     Finalize,
 }
 
+#[cfg(any(test, injected_yields))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumCount)]
+#[repr(u8)]
+pub(crate) enum CheckpointYieldPoint {
+    BeforeAcquireLock,
+    AfterDurableBoundaryAdvanced,
+}
+
+#[cfg(any(test, injected_yields))]
+impl YieldPointMarker for CheckpointYieldPoint {
+    const POINT_COUNT: u8 = Self::COUNT as u8;
+
+    fn ordinal(self) -> u8 {
+        self as u8
+    }
+}
+
+#[cfg(any(test, injected_yields))]
+fn checkpoint_yield_key() -> u64 {
+    const CHECKPOINT_SELECTION_TAG: u64 = 0xC4EC_9011_C4EC_9011;
+    CHECKPOINT_SELECTION_TAG
+}
+
 /// The states of the locks held by the state machine - these are tracked for error handling so that they are
 /// released if the state machine fails.
 pub struct LockStates {
@@ -95,6 +123,8 @@ pub struct CheckpointStateMachine<Clock: LogicalClock> {
     mvstore: Arc<MvStore<Clock>>,
     /// Connection to the database
     connection: Arc<Connection>,
+    #[cfg(any(test, injected_yields))]
+    yield_instance_id: u64,
     /// Lock used to block other transactions from running during the checkpoint
     checkpoint_lock: Arc<TursoRwLock>,
     /// All committed versions to write to the B-tree.
@@ -134,6 +164,18 @@ pub struct CheckpointStateMachine<Clock: LogicalClock> {
     staged_checkpoint_header: Option<DatabaseHeader>,
     /// Guard to avoid restaging page 1 across CommitPagerTxn async retries.
     header_staged_for_commit: bool,
+}
+
+#[cfg(any(test, injected_yields))]
+impl<Clock: LogicalClock> ProvidesYieldContext for CheckpointStateMachine<Clock> {
+    fn yield_context(&self) -> YieldContext {
+        YieldContext::new(
+            self.connection.yield_injector(),
+            self.connection.failure_injector(),
+            self.yield_instance_id,
+            checkpoint_yield_key(),
+        )
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -279,6 +321,8 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         let durable_mvcc_metadata = !connection.db.is_in_memory_db() && mvcc_meta_table.is_some();
         let durable_tx_max = mvstore.durable_txid_max.load(Ordering::SeqCst);
         let durable_txid_max_old = NonZeroU64::new(durable_tx_max);
+        #[cfg(any(test, injected_yields))]
+        let yield_instance_id = connection.next_yield_instance_id();
         Self {
             state: CheckpointState::AcquireLock,
             lock_states: LockStates {
@@ -291,6 +335,8 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             durable_txid_max_new: mvstore.durable_txid_max.load(Ordering::SeqCst),
             mvstore,
             connection,
+            #[cfg(any(test, injected_yields))]
+            yield_instance_id,
             checkpoint_lock,
             write_set: Vec::new(),
             write_row_state_machine: None,
@@ -810,6 +856,8 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
     fn step_inner(&mut self, _context: &()) -> Result<TransitionResult<CheckpointResult>> {
         match &self.state {
             CheckpointState::AcquireLock => {
+                inject_transition_yield!(self, CheckpointYieldPoint::BeforeAcquireLock);
+
                 tracing::info!("Acquiring blocking checkpoint lock");
                 let locked = self.checkpoint_lock.write();
                 if !locked {
@@ -1412,6 +1460,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             )
                         })?;
                         self.mvstore.global_header.write().replace(header);
+                        inject_transition_failure!(
+                            self,
+                            CheckpointYieldPoint::AfterDurableBoundaryAdvanced
+                        );
                         Ok(TransitionResult::Continue)
                     }
                     IOResult::IO(io) => Ok(TransitionResult::Io(io)),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -284,6 +284,12 @@ fn is_schema_metadata_only_rewrite(current: &RowVersion, next: Option<&RowVersio
 }
 
 impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
+    fn refresh_checkpoint_bounds(&mut self) {
+        let durable_tx_max = self.mvstore.durable_txid_max.load(Ordering::SeqCst);
+        self.durable_txid_max_old = NonZeroU64::new(durable_tx_max);
+        self.durable_txid_max_new = durable_tx_max;
+    }
+
     pub fn new(
         pager: Arc<Pager>,
         mvstore: Arc<MvStore<Clock>>,
@@ -332,7 +338,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             },
             pager,
             durable_txid_max_old,
-            durable_txid_max_new: mvstore.durable_txid_max.load(Ordering::SeqCst),
+            durable_txid_max_new: durable_tx_max,
             mvstore,
             connection,
             #[cfg(any(test, injected_yields))]
@@ -864,6 +870,11 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     return Err(crate::LimboError::Busy);
                 }
                 self.lock_states.blocking_checkpoint_lock_held = true;
+
+                // Checkpoint state machines can be created before they are run.
+                // Resample after serializing with other checkpoints so already-durable
+                // index deletes are not replayed.
+                self.refresh_checkpoint_bounds();
 
                 self.collect_committed_table_row_versions();
                 tracing::info!("Collected {} committed versions", self.write_set.len());

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -52,6 +52,8 @@ use tracing::instrument;
 use tracing::Level;
 
 pub mod checkpoint_state_machine;
+#[cfg(any(test, injected_yields))]
+pub(crate) use checkpoint_state_machine::CheckpointYieldPoint;
 pub use checkpoint_state_machine::{CheckpointState, CheckpointStateMachine};
 
 use super::persistent_storage::logical_log::{

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -52,8 +52,6 @@ use tracing::instrument;
 use tracing::Level;
 
 pub mod checkpoint_state_machine;
-#[cfg(any(test, injected_yields))]
-pub(crate) use checkpoint_state_machine::CheckpointYieldPoint;
 pub use checkpoint_state_machine::{CheckpointState, CheckpointStateMachine};
 
 use super::persistent_storage::logical_log::{

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2316,6 +2316,132 @@ fn test_meta_checkpoint_case_11_auto_checkpoint_failure_after_commit_remains_rec
     );
 }
 
+/// What this test checks: a checkpoint state machine created before another checkpoint
+/// advances the durable boundary must resample that boundary after taking the checkpoint lock.
+/// Why this matters: otherwise a delayed checkpoint can replay an already-durable unique-index
+/// delete and fail. This test uses raw APIs, check test_checkpoint_resamples_boundary_before_starting_with_yield_injection
+/// which uses only user facing APIs to simulate the same error.
+#[test]
+fn test_checkpoint_resamples_boundary_before_starting() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE dry_floor_846 (
+            sour_sand_972 BLOB UNIQUE,
+            sour_river_140 REAL,
+            sweet_wall_518 BLOB,
+            fast_grass_379 TEXT,
+            dark_wave_139 REAL UNIQUE,
+            sad_wind_216 INTEGER UNIQUE PRIMARY KEY
+        )",
+    )
+    .unwrap();
+
+    conn.execute(
+        "INSERT INTO dry_floor_846 (
+            sour_sand_972, sour_river_140, sweet_wall_518,
+            fast_grass_379, dark_wave_139, sad_wind_216
+        ) VALUES (
+            zeroblob(16), 6.85, x'736d6172745f6c6561665f353637',
+            'wild_hill_714', 8.43, 788
+        )",
+    )
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mvcc_store = db.get_mvcc_store();
+    let first_boundary = mvcc_store.durable_txid_max.load(Ordering::SeqCst);
+    assert!(first_boundary > 0);
+
+    conn.execute(
+        "UPDATE dry_floor_846
+            SET sour_sand_972 = x'66756c6c5f737461725f333732',
+                sour_river_140 = 5.75,
+                sweet_wall_518 = zeroblob(32),
+                fast_grass_379 = 'old_moon_16',
+                dark_wave_139 = 2.90
+          WHERE sad_wind_216 = 788",
+    )
+    .unwrap();
+    let update_ts = mvcc_store.last_committed_tx_ts.load(Ordering::SeqCst);
+    assert!(update_ts > first_boundary);
+
+    let delayed_conn = db.connect();
+    let delayed_pager = delayed_conn.pager.load().clone();
+    let mut delayed_checkpoint = CheckpointStateMachine::new(
+        delayed_pager.clone(),
+        mvcc_store.clone(),
+        delayed_conn.clone(),
+        true,
+        delayed_conn.get_sync_mode(),
+    );
+    let (old_boundary, _) = delayed_checkpoint.checkpoint_bounds_for_test();
+    assert_eq!(old_boundary, Some(first_boundary));
+
+    let interrupted_conn = db.connect();
+    let interrupted_pager = interrupted_conn.pager.load().clone();
+    let mut interrupted_checkpoint = CheckpointStateMachine::new(
+        interrupted_pager.clone(),
+        mvcc_store.clone(),
+        interrupted_conn.clone(),
+        true,
+        interrupted_conn.get_sync_mode(),
+    );
+    let mut reached_wal_checkpoint = false;
+    for _ in 0..50_000 {
+        if interrupted_checkpoint.state_for_test() == CheckpointState::CheckpointWal {
+            reached_wal_checkpoint = true;
+            break;
+        }
+        match interrupted_checkpoint.step(&()).unwrap() {
+            TransitionResult::Io(io) => io.wait(interrupted_pager.io.as_ref()).unwrap(),
+            TransitionResult::Continue => {}
+            TransitionResult::Done(_) => {
+                panic!("checkpoint finished before reaching WAL checkpoint")
+            }
+        }
+    }
+    assert!(
+        reached_wal_checkpoint,
+        "expected checkpoint to reach WAL checkpoint"
+    );
+    assert_eq!(
+        mvcc_store.durable_txid_max.load(Ordering::SeqCst),
+        update_ts
+    );
+    interrupted_checkpoint.cleanup_after_external_io_error();
+
+    let mut finished = false;
+    for _ in 0..50_000 {
+        match delayed_checkpoint.step(&()).unwrap() {
+            TransitionResult::Io(io) => io.wait(delayed_pager.io.as_ref()).unwrap(),
+            TransitionResult::Continue => {}
+            TransitionResult::Done(_) => {
+                finished = true;
+                break;
+            }
+        }
+    }
+    assert!(finished, "delayed checkpoint did not finish");
+
+    let rows = get_rows(
+        &conn,
+        "SELECT sad_wind_216, dark_wave_139, hex(sour_sand_972)
+           FROM dry_floor_846
+          WHERE sad_wind_216 = 788",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 788);
+    assert_eq!(rows[0][1].to_string(), "2.9");
+    assert_eq!(&rows[0][2].to_string(), "66756C6C5F737461725F333732");
+
+    let integrity = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(integrity.len(), 1);
+    assert_eq!(&integrity[0][0].to_string(), "ok");
+}
+
 /// What this test checks: Replay gate uses metadata boundary and never applies frames at or below it.
 /// Why this matters: This enforces exactly-once effects at the DB-file apply boundary.
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2442,6 +2442,101 @@ fn test_checkpoint_resamples_boundary_before_starting() {
     assert_eq!(&integrity[0][0].to_string(), "ok");
 }
 
+/// What this test checks: a checkpoint state machine created before another checkpoint
+/// advances the durable boundary must resample that boundary after taking the checkpoint lock.
+/// Why this matters: otherwise a delayed checkpoint can replay an already-durable unique-index
+/// delete and fail.
+#[test]
+fn test_checkpoint_resamples_boundary_before_starting_with_yield_injection() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE dry_floor_846 (
+            sour_sand_972 BLOB UNIQUE,
+            sour_river_140 REAL,
+            sweet_wall_518 BLOB,
+            fast_grass_379 TEXT,
+            dark_wave_139 REAL UNIQUE,
+            sad_wind_216 INTEGER UNIQUE PRIMARY KEY
+        )",
+    )
+    .unwrap();
+
+    conn.execute(
+        "INSERT INTO dry_floor_846 (
+            sour_sand_972, sour_river_140, sweet_wall_518,
+            fast_grass_379, dark_wave_139, sad_wind_216
+        ) VALUES (
+            zeroblob(16), 6.85, x'736d6172745f6c6561665f353637',
+            'wild_hill_714', 8.43, 788
+        )",
+    )
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mvcc_store = db.get_mvcc_store();
+    let first_boundary = mvcc_store.durable_txid_max.load(Ordering::SeqCst);
+    assert!(first_boundary > 0);
+
+    conn.execute(
+        "UPDATE dry_floor_846
+            SET sour_sand_972 = x'66756c6c5f737461725f333732',
+                sour_river_140 = 5.75,
+                sweet_wall_518 = zeroblob(32),
+                fast_grass_379 = 'old_moon_16',
+                dark_wave_139 = 2.90
+          WHERE sad_wind_216 = 788",
+    )
+    .unwrap();
+    let update_ts = mvcc_store.last_committed_tx_ts.load(Ordering::SeqCst);
+    assert!(update_ts > first_boundary);
+
+    let delayed_conn = db.connect();
+    delayed_conn.set_yield_injector(Some(FixedYieldInjector::new([
+        CheckpointYieldPoint::BeforeAcquireLock.point(),
+    ])));
+    let mut delayed_checkpoint = delayed_conn.prepare("PRAGMA journal_mode = 'wal'").unwrap();
+    assert!(
+        matches!(delayed_checkpoint.step().unwrap(), StepResult::IO),
+        "first checkpoint should yield before acquiring the checkpoint lock"
+    );
+
+    let interleaving_conn = db.connect();
+    interleaving_conn.set_failure_injector(Some(FixedFailureInjector::new([(
+        CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+        LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
+    )])));
+    interleaving_conn
+        .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        .expect_err("interleaving checkpoint should fail after advancing durable boundary");
+    interleaving_conn.set_failure_injector(None);
+    assert_eq!(
+        mvcc_store.durable_txid_max.load(Ordering::SeqCst),
+        update_ts
+    );
+
+    let journal_mode_rows = delayed_checkpoint.run_collect_rows().unwrap();
+    assert_eq!(journal_mode_rows.len(), 1);
+    assert_eq!(&journal_mode_rows[0][0].to_string(), "wal");
+
+    let rows = get_rows(
+        &conn,
+        "SELECT sad_wind_216, dark_wave_139, hex(sour_sand_972)
+           FROM dry_floor_846
+          WHERE sad_wind_216 = 788",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 788);
+    assert_eq!(rows[0][1].to_string(), "2.9");
+    assert_eq!(&rows[0][2].to_string(), "66756C6C5F737461725F333732");
+
+    let integrity = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(integrity.len(), 1);
+    assert_eq!(&integrity[0][0].to_string(), "ok");
+}
+
 /// What this test checks: Replay gate uses metadata boundary and never applies frames at or below it.
 /// Why this matters: This enforces exactly-once effects at the DB-file apply boundary.
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::io::PlatformIO;
 use crate::mvcc::clock::MvccClock;
 use crate::mvcc::cursor::{CursorYieldPoint, MvccCursorType};
+use crate::mvcc::database::checkpoint_state_machine::CheckpointYieldPoint;
 use crate::mvcc::persistent_storage::logical_log::{
     ENCRYPTED_PAYLOAD_CHUNK_SIZE, FRAME_MAGIC, LOG_HDR_SIZE,
 };


### PR DESCRIPTION
## Description

Refresh MVCC checkpoint bounds after acquiring the checkpoint lock, before doing any real work (especially before collecting row/index versions). This prevents a delayed checkpoint state machine from replaying already-durable changes after another checkpoint which has advanced the durable boundary.

Think of following sequence:

1. conn0: starts checkpoint, and is paused. At this point it has noted the checkpoint bounds
2. conn1: starts checkpoint, finishes and advances the durable boundary
3. conn0: resumes, acquires checkpoint lock and proceeds checkpointing based on the stale info

This bug was found in Antithesis. The run details are as follows:

```
Limbo Test | 2026-05-08
Conducted on 2026-05-08 00:59 UTC
Source: main
Turso - schedule on main (7bc892446f591e7b3967e74b52b29bca35a585cf) by LeMikaelF (scheduled run)
```

It comes with two regression tests, one uses raw APIs and another with user facing APIs with yield injectors. Thanks to codex, the regression tests have exact same shape as Antithesis failures:

```shell
$ cargo test -p turso_core mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting -- --exact

failures:

---- mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting stdout ----
path: /var/folders/4j/jw2gb7b969b8pr24v1jqbdxw0000gn/T/.tmptVBwqA/test_18035616234565617925

thread 'mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting' panicked at core/mvcc/database/tests.rs:2417:44:
called `Result::unwrap()` on an `Err` value: Corrupt("MVCC delete: rowid SortableIndexKey { key: ImmutableRecord { payload: [3, 7, 2, 64, 32, 220, 40, 245, 194, 143, 92, 3, 20] }, metadata: IndexInfo { key_info: [KeyInfo { sort_order: Asc, collation: Binary, nulls_order: None }, KeyInfo { sort_order: Asc, collation: Binary, nulls_order: None }], has_rowid: true, num_cols: 2, is_unique: true } } not found")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1746 filtered out; finished in 0.02s

error: test failed, to rerun pass `-p turso_core --lib`


$ cargo test -p turso_core mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting_with_yield_injection -- --exact

failures:

---- mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting_with_yield_injection stdout ----
path: /var/folders/4j/jw2gb7b969b8pr24v1jqbdxw0000gn/T/.tmp6b1EoB/test_18346938514175919045

thread 'mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting_with_yield_injection' panicked at core/mvcc/database/tests.rs:2519:67:
called `Result::unwrap()` on an `Err` value: Corrupt("MVCC delete: rowid SortableIndexKey { key: ImmutableRecord { payload: [3, 7, 2, 64, 32, 220, 40, 245, 194, 143, 92, 3, 20] }, metadata: IndexInfo { key_info: [KeyInfo { sort_order: Asc, collation: Binary, nulls_order: None }, KeyInfo { sort_order: Asc, collation: Binary, nulls_order: None }], has_rowid: true, num_cols: 2, is_unique: true } } not found")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    mvcc::database::tests::test_checkpoint_resamples_boundary_before_starting_with_yield_injection
```

I also added new yield injector points, to detect checkpoint state machine transitions 

 ## Description of AI Usage

Took aid of LLM for 