### PR TITLE
Fix #6772: scope index lookup in DROP TABLE to the correct database

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -5,8 +5,8 @@ use crate::ext::VTabImpl;
 use crate::function::{Deterministic, Func, MathFunc, ScalarFunc};
 use crate::schema::{
     create_table, translate_ident_to_string_literal, BTreeCharacteristics, BTreeTable, ColDef,
-    Column, SchemaObjectType, Table, Type, RESERVED_TABLE_PREFIXES, SQLITE_SEQUENCE_TABLE_NAME,
-    TURSO_TYPES_TABLE_NAME,
+    Column, Index, SchemaObjectType, Table, Type, RESERVED_TABLE_PREFIXES,
+    SQLITE_SEQUENCE_TABLE_NAME, TURSO_TYPES_TABLE_NAME,
 };
 use crate::stats::STATS_TABLE;
 use crate::storage::pager::CreateBTreeFlags;
@@ -2021,8 +2021,9 @@ pub fn translate_drop_table(
     }
 
     //  2. Destroy the indices within a loop
-    let indices = resolver.schema().get_indices(tbl_name.name.as_str());
-    for index in indices {
+    let indices: Vec<Arc<Index>> = resolver
+        .with_schema(database_id, |s| s.get_indices(tbl_name.name.as_str()).cloned().collect());
+    for index in &indices {
         if index.index_method.is_some() && !index.is_backing_btree_index() {
             // Index methods without backing btree need special destroy handling
             let cursor_id = program.alloc_cursor_index(None, index)?;

--- a/testing/sqltests/turso-tests/attach/writes.sqltest
+++ b/testing/sqltests/turso-tests/attach/writes.sqltest
@@ -1551,3 +1551,52 @@ test attach-temp-trigger-attached-target-not-confused-with-main {
 expect {
     0
 }
+# =============================================================================
+# Regression test for #6772
+# DROP TABLE on attached DB must destroy the attached DB's index pages,
+# not main's. Before the fix, resolver.schema().get_indices() always
+# read from main, so dropping an attached table with an index would
+# either leak pages or try to destroy a wrong root page (ShortRead).
+# =============================================================================
+
+# Reproducer 1: page leak
+# The dropped index's root page must be freed. After drop+recreate+reinsert,
+# page_count must stay at 3, not grow to 4.
+@skip-if mvcc "page_count not implemented for mvcc"
+test attach-write-drop-table-with-index-no-page-leak {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE INDEX aux.idx_t_x ON t(x);
+    INSERT INTO aux.t VALUES (1, 1);
+    PRAGMA aux.page_count;
+    DROP TABLE aux.t;
+    CREATE TABLE aux.t(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE INDEX aux.idx_t_x ON t(x);
+    INSERT INTO aux.t VALUES (1, 1);
+    PRAGMA aux.page_count;
+}
+expect {
+    3
+    3
+}
+
+# Reproducer 2: ShortRead / cross-DB corruption
+# When main also has a table 't' with an index, DROP TABLE aux.t must not
+# try to destroy main's index root page on aux's pager.
+test attach-write-drop-table-with-index-no-shortread {
+    CREATE TABLE pad0(q INT);
+    CREATE TABLE pad1(q INT);
+    CREATE TABLE pad2(q INT);
+    CREATE TABLE pad3(q INT);
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER);
+    CREATE INDEX idx_main_t_a ON t(a);
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE aux.t(id INTEGER PRIMARY KEY, x INTEGER);
+    CREATE INDEX aux.idx_t_x ON t(x);
+    INSERT INTO aux.t VALUES (1, 1);
+    DROP TABLE aux.t;
+    SELECT 'ok';
+}
+expect {
+    ok
+}


### PR DESCRIPTION
This PR fixes #6772 where dropping a table on an attached database corrupts indices in `main` or leaks pages.

**Root Cause:**
In `translate_drop_table()`, the index destruction logic was using `resolver.schema().get_indices()`, which unconditionally read from the `main` schema. Because of this, dropping an attached table either skipped index destruction (leaking pages in the attached DB) or erroneously tried to destroy a wrong root page if a table with the same name existed in `main` (causing a `ShortRead` / cross-DB corruption).

**Fix:**
Scope the index lookup to the correct database using `resolver.with_schema(...)`. 

**Testing:**
Added two regression tests in `testing/sqltests/turso-tests/attach/writes.sqltest` that explicitly reproduce both failure modes. I have verified that these tests **fail** on the base commit (one catches the page leak, the other triggers the `short read` error) and **pass** on this branch.

cc: @pavan-nambi @LeMikaelF - This PR includes rigorous tests that explicitly fail on the current main branch and pass after the fix. Please take a look and consider reopening/merging.
