### PR TITLE
github: Fix broken Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -373,9 +373,10 @@ jobs:
       - name: Run Windows CLI multiprocess VFS regression
         run: cargo test -q -p turso_cli input::tests::experimental_win_iocp_backend_is_available_for_path_databases -- --exact
       - name: Run Windows core multiprocess regressions
-        run: cargo test -q -p turso_core --features "fs experimental_win_iocp" multiprocess_tests:: -- --nocapture
+        run: |
+          cargo test -q -p turso_core --features "fs experimental_win_iocp" multiprocess_tests:: -- --nocapture
       - name: Run Windows multiprocess startup smoke
-          run: cargo run -q -p turso_whopper -- --mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01
+        run: cargo run -q -p turso_whopper -- --mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01
 
   test-sqlite:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
## Description

The Github action file is broken which is making it to not run any tests. Before:

```
$ ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust.yml"); puts "yaml ok"'

/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/psych.rb:456:in `parse': (.github/workflows/rust.yml): mapping values are not allowed in this context at line 379 column 14 (Psych::SyntaxError)
```

after:

```
$ ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust.yml"); puts "yaml ok"'

yaml ok
```