### PR TITLE
core/mvcc: cache row versions to avoid second lookup

### DIFF
--- a/core/benches/create_index_benchmark.rs
+++ b/core/benches/create_index_benchmark.rs
@@ -187,6 +187,24 @@ fn bench_create_index(criterion: &mut Criterion) {
             _ => 10,
         };
         group.sample_size(samples);
+        // Per-iteration cost grows roughly linearly with row_count, so the
+        // default 5s measurement budget is too small for the larger sizes.
+        let (warm_up, measurement) = match row_count {
+            n if n <= 100_000 => (
+                std::time::Duration::from_secs(3),
+                std::time::Duration::from_secs(10),
+            ),
+            n if n <= 500_000 => (
+                std::time::Duration::from_secs(5),
+                std::time::Duration::from_secs(20),
+            ),
+            _ => (
+                std::time::Duration::from_secs(10),
+                std::time::Duration::from_secs(60),
+            ),
+        };
+        group.warm_up_time(warm_up);
+        group.measurement_time(measurement);
 
         // ---- limbo ----
         {
@@ -257,6 +275,22 @@ fn bench_create_index_commit(criterion: &mut Criterion) {
             _ => 10,
         };
         group.sample_size(samples);
+        let (warm_up, measurement) = match row_count {
+            n if n <= 100_000 => (
+                std::time::Duration::from_secs(3),
+                std::time::Duration::from_secs(10),
+            ),
+            n if n <= 500_000 => (
+                std::time::Duration::from_secs(5),
+                std::time::Duration::from_secs(20),
+            ),
+            _ => (
+                std::time::Duration::from_secs(10),
+                std::time::Duration::from_secs(60),
+            ),
+        };
+        group.warm_up_time(warm_up);
+        group.measurement_time(measurement);
 
         {
             let temp_dir = tempfile::tempdir().unwrap();

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,11 +1,10 @@
-use crate::sync::RwLock;
 use crate::turso_assert;
 use crossbeam_skiplist::map::Entry;
 use crossbeam_skiplist::SkipMap;
 
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
-    create_seek_range, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
+    create_seek_range, MVTableId, MvStore, Row, RowID, RowKey, RowVersions, SortableIndexKey,
 };
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
@@ -282,7 +281,7 @@ pub enum MvccCursorType {
 }
 
 pub(crate) type MvccIterator<'l, T> =
-    Box<dyn Iterator<Item = Entry<'l, T, RwLock<Vec<RowVersion>>>> + Send + Sync>;
+    Box<dyn Iterator<Item = Entry<'l, T, RowVersions>> + Send + Sync>;
 
 /// Extends the lifetime of a SkipMap iterator to `'static`.
 ///
@@ -309,16 +308,8 @@ macro_rules! static_iterator_hack {
         // SAFETY: See macro documentation above.
         unsafe {
             std::mem::transmute::<
-                Box<
-                    dyn Iterator<Item = Entry<'_, $key_type, RwLock<Vec<RowVersion>>>>
-                        + Send
-                        + Sync,
-                >,
-                Box<
-                    dyn Iterator<Item = Entry<'static, $key_type, RwLock<Vec<RowVersion>>>>
-                        + Send
-                        + Sync,
-                >,
+                Box<dyn Iterator<Item = Entry<'_, $key_type, RowVersions>> + Send + Sync>,
+                Box<dyn Iterator<Item = Entry<'static, $key_type, RowVersions>> + Send + Sync>,
             >($iter)
         }
     };

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -74,6 +74,9 @@ const NO_EXCLUSIVE_TX: u64 = 0;
 #[repr(transparent)]
 pub struct MVTableId(i64);
 
+/// The versions of a single row
+pub type RowVersions = Arc<RwLock<Vec<RowVersion>>>;
+
 impl MVTableId {
     pub fn new(value: i64) -> Self {
         turso_assert_less_than!(value, 0, "MVCC table IDs are always negative");
@@ -396,7 +399,7 @@ pub struct Savepoint {
     deleted_index_versions: Vec<((MVTableId, Arc<SortableIndexKey>), u64)>,
     /// RowIDs that were NEWLY added to write_set by this savepoint.
     /// On rollback: only these should be removed from write_set.
-    newly_added_to_write_set: Vec<RowID>,
+    newly_added_to_write_set: Vec<(RowID, RowVersions)>,
 }
 
 impl Savepoint {
@@ -466,7 +469,7 @@ pub struct Transaction {
     /// so plain `Mutex<Vec<_>>` is enough; the previous `SkipSet` was paying
     /// for unused concurrent-insert semantics. Duplicates are allowed —
     /// consumers (commit, rollback) dedup as needed.
-    write_set: Mutex<Vec<RowID>>,
+    write_set: Mutex<Vec<(RowID, RowVersions)>>,
     /// The transaction read set.
     read_set: SkipSet<RowID>,
     /// The transaction header.
@@ -514,7 +517,7 @@ impl Transaction {
         self.read_set.insert(id);
     }
 
-    fn insert_to_write_set(&self, id: RowID) {
+    fn insert_to_write_set(&self, id: RowID, row_versions: RowVersions) {
         // Always record in the current savepoint's `newly_added_to_write_set`.
         // Duplicates here are harmless: `rollback_savepoint_changes` collects
         // touched rowids into a BTreeSet (dedup), and the actual write_set
@@ -522,9 +525,11 @@ impl Transaction {
         // already pinned by a parent savepoint won't be evicted on inner
         // rollback.
         if let Some(savepoint) = self.savepoint_stack.write().last_mut() {
-            savepoint.newly_added_to_write_set.push(id.clone());
+            savepoint
+                .newly_added_to_write_set
+                .push((id.clone(), row_versions.clone()));
         }
-        self.write_set.lock().push(id);
+        self.write_set.lock().push((id, row_versions));
     }
 
     /// Begin a new savepoint for statement-level tracking.
@@ -753,11 +758,11 @@ impl std::fmt::Display for Transaction {
             self.begin_ts,
         )?;
 
-        for (i, v) in self.write_set.lock().iter().enumerate() {
+        for (i, (id, _chain)) in self.write_set.lock().iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?
             }
-            write!(f, "{v:?}")?;
+            write!(f, "{id:?}")?;
         }
 
         write!(f, "], read_set: [")?;
@@ -981,8 +986,9 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     /// Threaded through so that `finish_committed_tx` can clear the matching
     /// connection-level mv_tx slot atomically with `remove_tx`.
     db_id: usize,
-    /// Write set sorted by table id and row id
-    write_set: Vec<RowID>,
+    /// Write set (rowids) sorted by table id and row id, along with a reference to the
+    /// corresponding versions.
+    write_set: Vec<(RowID, RowVersions)>,
     commit_coordinator: Arc<CommitCoordinator>,
     header: Arc<RwLock<Option<DatabaseHeader>>>,
     pager: Arc<Pager>,
@@ -1399,48 +1405,26 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             Some(committed)
         };
 
-        let collect_versions = |id: &RowID, log_record: &mut LogRecord| {
-            if let Some(row_versions) = mvcc_store.rows.get(id) {
-                let row_versions = row_versions.value().read();
-                for row_version in row_versions.iter() {
-                    if let Some(mut committed_version) = our_committed_image(row_version) {
-                        canonicalize_table_id(&mut committed_version);
-                        mvcc_store
-                            .insert_version_raw(&mut log_record.row_versions, committed_version);
-                    }
-                }
-            }
-
-            if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
-                let index = index.value();
-                let RowKey::Record(ref index_key) = id.row_id else {
-                    panic!("Index writes must have a record key");
-                };
-                if let Some(row_versions) = index.get(index_key) {
-                    let row_versions = row_versions.value().read();
-                    for row_version in row_versions.iter() {
-                        if let Some(mut committed_version) = our_committed_image(row_version) {
-                            canonicalize_table_id(&mut committed_version);
-                            mvcc_store.insert_version_raw(
-                                &mut log_record.row_versions,
-                                committed_version,
-                            );
-                        }
-                    }
+        let collect_versions = |row_versions: &Arc<RwLock<Vec<RowVersion>>>,
+                                log_record: &mut LogRecord| {
+            for row_version in row_versions.read().iter() {
+                if let Some(mut committed_version) = our_committed_image(row_version) {
+                    canonicalize_table_id(&mut committed_version);
+                    mvcc_store.insert_version_raw(&mut log_record.row_versions, committed_version);
                 }
             }
         };
 
         // First pass: schema rows only (ordering matters for recovery)
-        for id in &self.write_set {
+        for (id, row_versions) in &self.write_set {
             if id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(id, &mut log_record);
+                collect_versions(row_versions, &mut log_record);
             }
         }
         // Second pass: all non-schema rows
-        for id in &self.write_set {
+        for (id, row_versions) in &self.write_set {
             if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(id, &mut log_record);
+                collect_versions(row_versions, &mut log_record);
             }
         }
 
@@ -1460,53 +1444,23 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             "rewrite_live_versions_to_timestamps requires a committed transaction state"
         );
 
-        for id in &self.write_set {
-            if let Some(row_versions) = mvcc_store.rows.get(id) {
-                let mut row_versions = row_versions.value().write();
-                for row_version in row_versions.iter_mut() {
-                    if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
-                        if id == self.tx_id {
-                            // Publish the committed begin timestamp into the live
-                            // version chain only after CommitEnd has decided the
-                            // transaction's fate.
-                            row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
-                        }
-                    }
-                    if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
-                        if id == self.tx_id {
-                            // Publish the committed end timestamp into the live
-                            // version chain only after CommitEnd has decided the
-                            // transaction's fate.
-                            row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
-                        }
+        for (_id, row_versions) in &self.write_set {
+            let mut row_versions = row_versions.write();
+            for row_version in row_versions.iter_mut() {
+                if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
+                    if id == self.tx_id {
+                        // Publish the committed begin timestamp into the live
+                        // version chain only after CommitEnd has decided the
+                        // transaction's fate.
+                        row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                     }
                 }
-            }
-
-            if let Some(index) = mvcc_store.index_rows.get(&id.table_id) {
-                let index = index.value();
-                let RowKey::Record(ref index_key) = id.row_id else {
-                    panic!("Index writes must have a record key");
-                };
-                if let Some(row_versions) = index.get(index_key) {
-                    let mut row_versions = row_versions.value().write();
-                    for row_version in row_versions.iter_mut() {
-                        if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
-                            if id == self.tx_id {
-                                // Publish the committed begin timestamp into the live
-                                // version chain only after CommitEnd has decided the
-                                // transaction's fate.
-                                row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
-                            }
-                        }
-                        if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
-                            if id == self.tx_id {
-                                // Publish the committed end timestamp into the live
-                                // version chain only after CommitEnd has decided the
-                                // transaction's fate.
-                                row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
-                            }
-                        }
+                if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
+                    if id == self.tx_id {
+                        // Publish the committed end timestamp into the live
+                        // version chain only after CommitEnd has decided the
+                        // transaction's fate.
+                        row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                     }
                 }
             }
@@ -1666,7 +1620,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 tracing::trace!("commit_tx(tx_id={})", self.tx_id);
                 self.write_set
                     .extend_from_slice(tx.write_set.lock().as_slice());
-                self.write_set.sort_by(|a, b| {
+                self.write_set.sort_by(|(a, _), (b, _)| {
                     // table ids are negative, and sqlite_schema has id -1 so we want to sort in descending order of table id
                     b.table_id.cmp(&a.table_id).then(a.row_id.cmp(&b.row_id))
                 });
@@ -1674,8 +1628,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // (e.g. INSERT then UPDATE on the same row), since
                 // `insert_to_write_set` no longer pays for a `contains`
                 // check. After the sort, equal RowIDs are adjacent, so
-                // `dedup` collapses them in linear time.
-                self.write_set.dedup();
+                // `dedup_by_key` collapses them in linear time.
+                self.write_set.dedup_by(|a, b| a.0 == b.0);
                 // Header-only writes must not take this fast path; they need durable log records.
                 if self.write_set.is_empty() && !tx.header_dirty.load(Ordering::Acquire) {
                     turso_assert!(
@@ -1730,7 +1684,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     .ok_or(LimboError::TxTerminated)?;
                 let tx = tx.value();
 
-                for id in &self.write_set {
+                for (id, _chain) in &self.write_set {
                     if id.row_id.is_int_key() {
                         self.check_rowid_for_conflicts(id, *end_ts, tx, mvcc_store)?;
                     } else {
@@ -1806,10 +1760,10 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
 
                 if log_record.row_versions.is_empty() && log_record.header.is_none() {
-                    // Nothing to do, just end commit.
                     if mvcc_store.is_exclusive_tx(&self.tx_id) {
                         mvcc_store.unlock_commit_lock_if_held(tx);
                     }
+                    // Nothing to do, just end commit.
                     self.state = CommitState::CommitEnd { end_ts };
                 } else {
                     self.state = CommitState::BeginCommitLogicalLog { end_ts, log_record };
@@ -2251,7 +2205,7 @@ pub struct RowidAllocator {
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock> {
-    pub rows: SkipMap<RowID, RwLock<Vec<RowVersion>>>,
+    pub rows: SkipMap<RowID, Arc<RwLock<Vec<RowVersion>>>>,
     /// Table ID is an opaque identifier that is only meaningful to the MV store.
     /// Each checkpointed MVCC table corresponds to a single B-tree on the pager,
     /// which naturally has a root page.
@@ -2267,7 +2221,7 @@ pub struct MvStore<Clock: LogicalClock> {
     /// Unlike table rows which are stored in a single map, we have a separate map for every index
     /// because operations like last() on an index are much easier when we don't have to take the
     /// table identifier into account.
-    pub index_rows: SkipMap<MVTableId, SkipMap<Arc<SortableIndexKey>, RwLock<Vec<RowVersion>>>>,
+    pub index_rows: SkipMap<MVTableId, SkipMap<Arc<SortableIndexKey>, RowVersions>>,
     txs: SkipMap<TxID, Transaction>,
     /// Final state for removed transactions. Readers may still race with stale TxID
     /// references in row versions after a transaction is removed from `txs`.
@@ -2746,12 +2700,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let RowKey::Record(sortable_key) = row.id.row_id else {
                     panic!("Index writes must be to a record");
                 };
-                tx.insert_to_write_set(id);
                 // Single SkipMap traversal: pass in a fresh Arc; the SkipMap
                 // returns the canonical Arc (ours on miss, an existing one
                 // on hit), which we hand to savepoint tracking.
-                let canonical_key =
+                let (canonical_key, row_versions) =
                     self.insert_index_version(index_id, Arc::new(sortable_key), row_version);
+                tx.insert_to_write_set(id, row_versions);
                 tx.record_created_index_version((index_id, canonical_key), version_id);
             }
             None => {
@@ -2768,11 +2722,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     row,
                     btree_resident: false,
                 };
-                tx.insert_to_write_set(id.clone());
                 tx.record_created_table_version(id.clone(), version_id);
                 let allocator = self.get_rowid_allocator(&id.table_id);
                 allocator.insert_row_id_maybe_update(id.row_id.to_int_or_panic());
-                self.insert_version(id, row_version);
+                let row_versions = self.insert_version(id.clone(), row_version);
+                tx.insert_to_write_set(id, row_versions);
             }
         }
         Ok(())
@@ -2802,19 +2756,20 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             .get(&tx_id)
             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
         let tx = tx.value();
-        tx.insert_to_write_set(id.clone());
         match maybe_index_id {
             Some(index_id) => {
                 let RowKey::Record(sortable_key) = row.id.row_id else {
                     panic!("Index writes must be to a record");
                 };
-                let canonical_key =
+                let (canonical_key, row_versions) =
                     self.insert_index_version(index_id, Arc::new(sortable_key), row_version);
+                tx.insert_to_write_set(id, row_versions);
                 tx.record_created_index_version((index_id, canonical_key), version_id);
             }
             None => {
                 tx.record_created_table_version(id.clone(), version_id);
-                self.insert_version(id, row_version);
+                let row_versions = self.insert_version(id.clone(), row_version);
+                tx.insert_to_write_set(id, row_versions);
             }
         }
         Ok(())
@@ -2855,9 +2810,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let RowKey::Record(sortable_key) = row.id.row_id else {
                     panic!("Index writes must be to a record");
                 };
-                tx.insert_to_write_set(id);
-                let canonical_key =
+                let (canonical_key, row_versions) =
                     self.insert_index_version(index_id, Arc::new(sortable_key), row_version);
+                tx.insert_to_write_set(id, row_versions);
                 tx.record_created_index_version((index_id, canonical_key), version_id);
             }
             None => {
@@ -2869,9 +2824,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     row,
                     btree_resident: true,
                 };
-                tx.insert_to_write_set(id.clone());
                 tx.record_created_table_version(id.clone(), version_id);
-                self.insert_version(id, row_version);
+                let row_versions = self.insert_version(id.clone(), row_version);
+                tx.insert_to_write_set(id, row_versions);
             }
         }
         Ok(())
@@ -2966,12 +2921,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let RowKey::Record(sortable_key) = id.row_id.clone() else {
                     panic!("Index deletes must have a record row_id");
                 };
-                let row_versions_opt = rows.get(&sortable_key);
-                if let Some(ref row_versions_entry) = row_versions_opt {
+                if let Some(ref row_versions_entry) = rows.get(&sortable_key) {
                     // Get the Arc key from the map entry for savepoint tracking
                     let arc_key = row_versions_entry.key().clone();
-                    let mut row_versions = row_versions_entry.value().write();
-                    for rv in row_versions.iter_mut().rev() {
+                    let row_versions = row_versions_entry.value().clone();
+                    for rv in row_versions.write().iter_mut().rev() {
                         let tx = self
                             .txs
                             .get(&tx_id)
@@ -2985,8 +2939,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
                         if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv) {
                             turso_assert_reachable!("write-write conflict on delete");
-                            drop(row_versions);
-                            drop(row_versions_opt);
                             return Err(LimboError::WriteWriteConflict);
                         }
 
@@ -2997,7 +2949,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             .get(&tx_id)
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
-                        tx.insert_to_write_set(id);
+                        tx.insert_to_write_set(id, row_versions.clone());
                         tx.record_deleted_index_version((index_id, arc_key), version_id);
                         return Ok(true);
                     }
@@ -3006,9 +2958,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             }
             None => {
                 let row_versions_opt = self.rows.get(&id);
-                if let Some(ref row_versions) = row_versions_opt {
-                    let mut row_versions = row_versions.value().write();
-                    for rv in row_versions.iter_mut().rev() {
+                if let Some(ref row_versions_entry) = row_versions_opt {
+                    let row_versions = row_versions_entry.value().clone();
+                    let mut locked_row_versions = row_versions.write();
+                    for rv in locked_row_versions.iter_mut().rev() {
                         let tx = self
                             .txs
                             .get(&tx_id)
@@ -3022,21 +2975,19 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
                         if is_write_write_conflict(&self.txs, &self.finalized_tx_states, tx, rv) {
                             turso_assert_reachable!("write-write conflict on delete");
-                            drop(row_versions);
-                            drop(row_versions_opt);
                             return Err(LimboError::WriteWriteConflict);
                         }
 
                         let version_id = rv.id;
                         rv.end = Some(TxTimestampOrID::TxID(tx.tx_id));
-                        drop(row_versions);
+                        drop(locked_row_versions);
                         drop(row_versions_opt);
                         let tx = self
                             .txs
                             .get(&tx_id)
                             .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
                         let tx = tx.value();
-                        tx.insert_to_write_set(id.clone());
+                        tx.insert_to_write_set(id.clone(), row_versions.clone());
                         tx.record_deleted_table_version(id.clone(), version_id);
                         return Ok(true);
                     }
@@ -3264,7 +3215,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn find_last_visible_version(
         &self,
         tx: &Transaction,
-        row: &crossbeam_skiplist::map::Entry<'_, RowID, RwLock<Vec<RowVersion>>>,
+        row: &Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>>,
     ) -> Option<RowID> {
         row.value()
             .read()
@@ -3277,7 +3228,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn find_last_visible_index_version(
         &self,
         tx: &Transaction,
-        row: crossbeam_skiplist::map::Entry<'_, Arc<SortableIndexKey>, RwLock<Vec<RowVersion>>>,
+        row: Entry<'_, Arc<SortableIndexKey>, Arc<RwLock<Vec<RowVersion>>>>,
     ) -> Option<RowID> {
         row.value()
             .read()
@@ -3293,7 +3244,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             Item = crossbeam_skiplist::map::Entry<
                 'a,
                 Arc<SortableIndexKey>,
-                RwLock<Vec<RowVersion>>,
+                Arc<RwLock<Vec<RowVersion>>>,
             >,
         >,
     {
@@ -3312,7 +3263,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         table_id: MVTableId,
     ) -> Option<RowID>
     where
-        I: Iterator<Item = crossbeam_skiplist::map::Entry<'a, RowID, RwLock<Vec<RowVersion>>>>,
+        I: Iterator<Item = Entry<'a, RowID, Arc<RwLock<Vec<RowVersion>>>>>,
     {
         loop {
             let row = rows.next()?;
@@ -3344,13 +3295,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             match direction {
                 IterationDirection::Forwards => Box::new(self.rows.range(range))
                     as Box<
-                        dyn Iterator<Item = Entry<'_, RowID, RwLock<Vec<RowVersion>>>>
+                        dyn Iterator<Item = Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>>>
                             + Send
                             + Sync,
                     >,
                 IterationDirection::Backwards => Box::new(self.rows.range(range).rev())
                     as Box<
-                        dyn Iterator<Item = Entry<'_, RowID, RwLock<Vec<RowVersion>>>>
+                        dyn Iterator<Item = Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>>>
                             + Send
                             + Sync,
                     >,
@@ -3391,14 +3342,16 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let iter_box = match direction {
             IterationDirection::Forwards => Box::new(index_rows.range(range))
                 as Box<
-                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RwLock<Vec<RowVersion>>>>
-                        + Send
+                    dyn Iterator<
+                            Item = Entry<'_, Arc<SortableIndexKey>, Arc<RwLock<Vec<RowVersion>>>>,
+                        > + Send
                         + Sync,
                 >,
             IterationDirection::Backwards => Box::new(index_rows.range(range).rev())
                 as Box<
-                    dyn Iterator<Item = Entry<'_, Arc<SortableIndexKey>, RwLock<Vec<RowVersion>>>>
-                        + Send
+                    dyn Iterator<
+                            Item = Entry<'_, Arc<SortableIndexKey>, Arc<RwLock<Vec<RowVersion>>>>,
+                        > + Send
                         + Sync,
                 >,
         };
@@ -3760,9 +3713,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
         // Snapshot under the lock so we can drop it before recursing into
         // `rollback_rowid` (which may take other locks).
-        let write_set_snapshot: Vec<RowID> = tx.write_set.lock().clone();
-        for rowid in &write_set_snapshot {
-            self.rollback_rowid(tx_id, rowid);
+        let write_set_snapshot: Vec<(RowID, RowVersions)> = tx.write_set.lock().clone();
+        for (_rowid, row_versions) in &write_set_snapshot {
+            for rv in row_versions.write().iter_mut() {
+                rollback_row_version(tx_id, rv);
+            }
         }
 
         if connection.schema.read().schema_version > connection.db.schema.lock().schema_version {
@@ -3773,7 +3728,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let tx = tx_unlocked.value();
         tx.state.store(TransactionState::Terminated);
         tracing::trace!("terminate(tx_id={})", tx_id);
-        // Safe to remove here: rollback_rowid (above) acquired the write lock on
+        // Safe to remove here: the rollback loop above acquired the write lock on
         // every row version chain in the write set, clearing all TxID references.
         // Any concurrent reader that held a read lock on one of those chains has
         // already completed its register_commit_dependency call (it runs under the
@@ -3782,41 +3737,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         self.remove_tx(tx_id);
     }
 
-    fn rollback_rowid(&self, tx_id: u64, rowid: &RowID) {
-        if rowid.row_id.is_int_key() {
-            self.rollback_table_rowid(tx_id, rowid);
-        } else {
-            self.rollback_index_rowid(tx_id, rowid);
-        }
-    }
-
     fn unlock_commit_lock_if_held(&self, tx: &Transaction) {
         if tx.pager_commit_lock_held.swap(false, Ordering::AcqRel) {
             self.commit_coordinator.pager_commit_lock.unlock();
-        }
-    }
-
-    fn rollback_index_rowid(&self, tx_id: u64, rowid: &RowID) {
-        if let Some(index) = self.index_rows.get(&rowid.table_id) {
-            let index = index.value();
-            let RowKey::Record(ref index_key) = rowid.row_id else {
-                panic!("Index writes must have a record key");
-            };
-            if let Some(row_versions) = index.get(index_key) {
-                let mut row_versions = row_versions.value().write();
-                for rv in row_versions.iter_mut() {
-                    rollback_row_version(tx_id, rv);
-                }
-            }
-        }
-    }
-
-    fn rollback_table_rowid(&self, tx_id: u64, rowid: &RowID) {
-        if let Some(row_versions) = self.rows.get(rowid) {
-            let mut row_versions = row_versions.value().write();
-            for rv in row_versions.iter_mut() {
-                rollback_row_version(tx_id, rv);
-            }
         }
     }
 
@@ -4004,7 +3927,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             }
         }
 
-        touched_rowids.extend(newly_added_to_write_set);
+        touched_rowids.extend(newly_added_to_write_set.into_iter().map(|(id, _)| id));
         self.remove_rolled_back_rows_from_write_set(tx_id, touched_rowids.clone());
 
         let tx = self
@@ -4058,7 +3981,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // every matching occurrence is dropped together — equivalent to
         // calling `remove` once per rowid against the old SkipSet.
         let mut write_set = tx.write_set.lock();
-        write_set.retain(|rowid| {
+        write_set.retain(|(rowid, _chain)| {
             if !rowids.contains(rowid) {
                 return true;
             }
@@ -4326,12 +4249,15 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
-    /// Inserts a new row version into the database, while making sure that
-    /// the row version is inserted in the correct order.
-    fn insert_version(&self, id: RowID, row_version: RowVersion) {
-        let versions = self.rows.get_or_insert_with(id, || RwLock::new(Vec::new()));
-        let mut versions = versions.value().write();
-        self.insert_version_raw(&mut versions, row_version)
+    /// Inserts a new row version into the database, while making sure that the row version
+    /// is inserted in the correct order. Returns a reference to the modified version chain.
+    fn insert_version(&self, id: RowID, row_version: RowVersion) -> Arc<RwLock<Vec<RowVersion>>> {
+        let versions = self
+            .rows
+            .get_or_insert_with(id, || Arc::new(RwLock::new(Vec::new())));
+        let row_versions = versions.value().clone();
+        self.insert_version_raw(&mut row_versions.write(), row_version);
+        row_versions
     }
 
     /// Gets an existing Arc<SortableIndexKey> from the index if the key exists,
@@ -4349,28 +4275,23 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     }
 
     /// Inserts (or appends to) the version chain for an index entry and returns
-    /// the canonical `Arc<SortableIndexKey>` that ended up in the SkipMap.
-    ///
-    /// Callers that previously did `get_or_create_index_key_arc` followed by
-    /// `insert_index_version` were paying for two SkipMap traversals; the
-    /// canonical Arc is now produced as a side effect of the single
-    /// `get_or_insert_with` traversal here, so they can drop the prelude.
+    /// the id and versions of the modified row.
     pub fn insert_index_version(
         &self,
         index_id: MVTableId,
         key: Arc<SortableIndexKey>,
         row_version: RowVersion,
-    ) -> Arc<SortableIndexKey> {
+    ) -> (Arc<SortableIndexKey>, RowVersions) {
         let index = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
         let index = index.value();
-        let entry = index.get_or_insert_with(key, || RwLock::new(Vec::new()));
+        let entry = index.get_or_insert_with(key, || Arc::new(RwLock::new(Vec::new())));
         // The Arc that's actually stored in the SkipMap may be the one we
         // passed in (on miss) or a pre-existing one (on hit). Return that
         // canonical Arc so savepoint tracking and the SkipMap stay in sync.
         let canonical_key = entry.key().clone();
-        let mut versions = entry.value().write();
-        self.insert_version_raw(&mut versions, row_version);
-        canonical_key
+        let row_versions = entry.value().clone();
+        self.insert_version_raw(&mut row_versions.write(), row_version);
+        (canonical_key, row_versions)
     }
 
     /// Inserts a new row version into the internal data structure for versions,
@@ -4982,9 +4903,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         btree_resident,
                     };
                     {
-                        let versions = self
-                            .rows
-                            .get_or_insert_with(rowid.clone(), || RwLock::new(Vec::new()));
+                        let versions = self.rows.get_or_insert_with(rowid.clone(), || {
+                            Arc::new(RwLock::new(Vec::new()))
+                        });
                         let mut versions = versions.value().write();
                         self.insert_version_raw(&mut versions, row_version);
                     }
@@ -5052,9 +4973,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             row: tombstone_row,
                             btree_resident,
                         };
-                        let versions = self
-                            .rows
-                            .get_or_insert_with(rowid.clone(), || RwLock::new(Vec::new()));
+                        let versions = self.rows.get_or_insert_with(rowid.clone(), || {
+                            Arc::new(RwLock::new(Vec::new()))
+                        });
                         let mut versions = versions.value().write();
                         self.insert_version_raw(&mut versions, row_version);
                     }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4842,9 +4842,10 @@ fn transaction_display() {
     let tx_id = 42;
     let begin_ts = 20250914;
 
+    let empty_versions = || Arc::new(RwLock::new(Vec::new()));
     let write_set = Mutex::new(vec![
-        RowID::new((-2).into(), RowKey::Int(11)),
-        RowID::new((-2).into(), RowKey::Int(13)),
+        (RowID::new((-2).into(), RowKey::Int(11)), empty_versions()),
+        (RowID::new((-2).into(), RowKey::Int(13)), empty_versions()),
     ]);
 
     let read_set = SkipSet::new();


### PR DESCRIPTION
## Description

We were spending a lot of time (19% of commit latency) looking up row versions in `SkipMap` just to set the tx's timestamps on them. To avoid this, I added an `Arc` around the `Vec<RowVersion>` so that we can cache them and avoid a second lookup.

We can't legally store the crossbeam `Entry<'_, K, V>` containing the version chains (not really chains, I know), because they belong to `MvStore`, and it's passed as a parameter to `CommitStateMachine::step`, and we have to hold on to the references across yields, which means storing them in a field in `CommitStateMachine`.

Locally this is yielding the expected performance improvement. This branch shaves 27% off the commit latency of a `CREATE INDEX` on a table with 2M rows and a 15-character index value.

Before:

<img width="1966" height="357" alt="image" src="https://github.com/user-attachments/assets/b1c6143c-1988-4b5b-89f0-6f599b0a2500" />

After:

<img width="1333" height="501" alt="image" src="https://github.com/user-attachments/assets/b278d2c1-15e3-410f-8415-82cf0ed3685d" />

<img width="1029" height="1125" alt="image" src="https://github.com/user-attachments/assets/a724427a-70e4-4127-8671-e109f926c593" />

## Description of AI Usage

Implemented by Claude Code and then cleaned up a little (mostly renaming things)