### PR TITLE
core/vdbe: preserve expression index sentinel after DROP COLUMN

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6,7 +6,7 @@ use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{
-    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME,
+    render_gencol_expr_sql_with_new_names, Schema, Table, EXPR_INDEX_SENTINEL, SCHEMA_TABLE_NAME,
     SQLITE_SEQUENCE_TABLE_NAME,
 };
 use crate::state_machine::StateMachine;
@@ -12820,7 +12820,9 @@ pub fn op_drop_column(
             for index in indexes {
                 let index = Arc::get_mut(index).expect("this should be the only strong reference");
                 for index_column in index.columns.iter_mut() {
-                    if index_column.pos_in_table > *column_index {
+                    if index_column.pos_in_table != EXPR_INDEX_SENTINEL
+                        && index_column.pos_in_table > *column_index
+                    {
                         index_column.pos_in_table -= 1;
                     }
                     if let Some(ref mut expr) = index_column.expr {

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -922,6 +922,20 @@ expect {
 }
 
 @cross-check-integrity
+test alter-table-drop-column-expression-index-update-after-unreferenced-drop {
+    CREATE TABLE t(h TEXT PRIMARY KEY, r TEXT, g INTEGER NOT NULL) STRICT;
+    CREATE INDEX idx_t_expr ON t((h));
+    CREATE INDEX idx_t_combo ON t(h DESC, (h IS NOT NULL), g);
+    ALTER TABLE t DROP COLUMN r;
+    INSERT INTO t(h,g) VALUES('a',1);
+    UPDATE t SET g=2 WHERE h IN (SELECT h FROM t WHERE g <= LENGTH('x'));
+    SELECT h,g FROM t;
+}
+expect {
+    a|2
+}
+
+@cross-check-integrity
 test alter-table-rename-column-updates-unique-sets {
     CREATE TABLE t(a INTEGER, b TEXT, UNIQUE(b));
     INSERT INTO t VALUES (1, 'hello');


### PR DESCRIPTION
## Description

`ALTER TABLE ... DROP COLUMN` remaps cached index column positions after removing a table column. Expression index entries use `EXPR_INDEX_SENTINEL` in `IndexColumn::pos_in_table`, but that remap decremented every position greater than the dropped column, so an expression-index sentinel became `usize::MAX - 1`.

A later `UPDATE` that touched an index containing both normal columns and expression columns could then treat the corrupted sentinel as a real table column and panic while checking generated-column dependencies.

This patch leaves expression-index sentinel values untouched while still shifting real table-column positions and expression AST self-table references.

## Motivation and context

Reduced from differential-fuzzer seed `6715847242732049136`.

SQLite returns:

```text
a|2
```

Before this change, Turso panicked:

```text
index out of bounds: the len is 2 but the index is 18446744073709551614
```

This is related to #5769's observation that expression-index metadata changes after an unrelated `DROP COLUMN`, but it does not attempt to change Turso's existing `PRAGMA index_xinfo` expression display behavior.

## Description of AI Usage

AI-assisted with Codex for running the fuzzer workflow, reducing the repro, and drafting the patch. I reviewed the root cause and verified the final change locally.

## Testing

- `cargo fmt --check`
- `cargo check -p turso_core`
- `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`
- `cargo run -q --bin test-runner check tests/alter_table.sqltest`
- `cargo run -q --bin test-runner run tests/alter_table.sqltest --backend rust --snapshot-mode no`
- `scripts/diff.sh "CREATE TABLE t(h TEXT PRIMARY KEY, r TEXT, g INTEGER NOT NULL) STRICT; CREATE INDEX idx_t_expr ON t((h)); CREATE INDEX idx_t_combo ON t(h DESC, (h IS NOT NULL), g); ALTER TABLE t DROP COLUMN r; INSERT INTO t(h,g) VALUES('a',1); UPDATE t SET g=2 WHERE h IN (SELECT h FROM t WHERE g <= LENGTH('x')); SELECT h,g FROM t;" "drop-column expression-index update panic minimal main"`
- `cargo run -q -p differential-fuzzer --bin differential_fuzzer -- -g sql-gen-prop -s 6715847242732049136 -n 120 -k`
