### PR TITLE
Fix multi-row VALUES inserts into virtual tables

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3223,7 +3223,7 @@ fn translate_virtual_table_insert(
     program: &mut ProgramBuilder,
     virtual_table: Arc<VirtualTable>,
     columns: Vec<ast::Name>,
-    mut body: InsertBody,
+    body: InsertBody,
     on_conflict: Option<ResolveType>,
     resolver: &Resolver,
     connection: &Arc<crate::Connection>,
@@ -3244,14 +3244,27 @@ fn translate_virtual_table_insert(
     if virtual_table.readonly() && !allow_dbpage_write {
         crate::bail_constraint_error!("Table is read-only: {}", virtual_table.name);
     }
-    let (num_values, value) = match &mut body {
-        InsertBody::Select(select, None) => match &mut select.body.select {
-            OneSelect::Values(values) => (values[0].len(), values.pop().unwrap()),
-            _ => crate::bail_parse_error!("Virtual tables only support VALUES clause in INSERT"),
-        },
-        InsertBody::DefaultValues => (0, vec![]),
+    let rows = match body {
+        InsertBody::Select(select, None) => {
+            if !select.body.compounds.is_empty() {
+                crate::bail_parse_error!("Virtual tables only support VALUES clause in INSERT");
+            }
+            match select.body.select {
+                OneSelect::Values(values) => {
+                    if values.is_empty() {
+                        crate::bail_parse_error!("no values to insert");
+                    }
+                    values
+                }
+                _ => {
+                    crate::bail_parse_error!("Virtual tables only support VALUES clause in INSERT")
+                }
+            }
+        }
+        InsertBody::DefaultValues => vec![vec![]],
         _ => crate::bail_parse_error!("Unsupported INSERT body for virtual tables"),
     };
+    let num_values = rows[0].len();
     let table = Table::Virtual(virtual_table.clone());
     let cursor_id = program.alloc_cursor_id(CursorType::VirtualTable(virtual_table));
     program.emit_insn(Insn::VOpen { cursor_id });
@@ -3273,15 +3286,17 @@ fn translate_virtual_table_insert(
      * */
     let insertion = build_insertion(program, &table, &columns, num_values)?;
 
-    translate_rows_single(program, &value, &insertion, resolver, false)?;
     let conflict_action = on_conflict.as_ref().map(|c| c.bit_value()).unwrap_or(0) as u16;
 
-    program.emit_insn(Insn::VUpdate {
-        cursor_id,
-        arg_count: insertion.col_mappings.len() + 2, // +1 for NULL, +1 for rowid
-        start_reg: registers_start,
-        conflict_action,
-    });
+    for value in &rows {
+        translate_rows_single(program, value, &insertion, resolver, false)?;
+        program.emit_insn(Insn::VUpdate {
+            cursor_id,
+            arg_count: insertion.col_mappings.len() + 2, // +1 for NULL, +1 for rowid
+            start_reg: registers_start,
+            conflict_action,
+        });
+    }
 
     program.emit_insn(Insn::Close { cursor_id });
 

--- a/testing/system/vtab.test
+++ b/testing/system/vtab.test
@@ -109,6 +109,14 @@ do_execsql_test_on_specific_db {:memory:} insert-hidden-column {
     select comment from t where key = 'hidden';
 } {"my comment"}
 
+do_execsql_test_on_specific_db {:memory:} insert-multi-row-values {
+    create virtual table t using kv_store;
+    insert into t(key, value) values ('k1', 'v1'), ('k2', 'v2'), ('k3', 'v3');
+    select key, value from t order by key;
+} {k1|v1
+k2|v2
+k3|v3}
+
 # hidden columns should be excluded from * expansion
 do_execsql_test_on_specific_db {:memory:} select-star-hidden-column {
     create virtual table t using kv_store;


### PR DESCRIPTION
Fixes #6775.

Multi-row VALUES inserts into writable virtual tables were only emitting one VUpdate, because the translator popped the last row and discarded the rest.

This keeps the VALUES rows intact and emits one VUpdate per row. It also rejects compound SELECT bodies on the virtual-table insert path instead of ignoring them.

Checks:
- cargo fmt --check
- cargo build -p turso_cli -p turso_ext_tests
- cargo check -p turso_core
- SQLITE_EXEC=scripts/limbo-sqlite3 tclsh testing/system/vtab.test
