### PR TITLE
Fix autovacuum ptrmap freelist reuse

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -11,6 +11,8 @@ use super::{
         write_varint_to_vec, IndexInteriorCell, IndexLeafCell, OverflowCell, MINIMUM_CELL_SIZE,
     },
 };
+#[cfg(not(feature = "omit_autovacuum"))]
+use crate::storage::pager::ptrmap::PtrmapType;
 use crate::{
     io::CompletionGroup,
     io_yield_one,
@@ -2672,6 +2674,24 @@ impl BTreeCursor {
             usable_space,
         )?;
         parent_contents.write_rightmost_ptr(new_rightmost_leaf.get().id as u32);
+        #[cfg(not(feature = "omit_autovacuum"))]
+        if self.pager.get_auto_vacuum_mode() == crate::storage::pager::AutoVacuumMode::Full {
+            let parent_id = parent.get().id as u32;
+            self.pager.io.block(|| {
+                self.pager.ptrmap_put(
+                    old_rightmost_leaf.get().id as u32,
+                    PtrmapType::BTreeNode,
+                    parent_id,
+                )
+            })?;
+            self.pager.io.block(|| {
+                self.pager.ptrmap_put(
+                    new_rightmost_leaf.get().id as u32,
+                    PtrmapType::BTreeNode,
+                    parent_id,
+                )
+            })?;
+        }
         // Continue balance from the parent page (inserting the new divider cell may have overflowed the parent)
         self.stack.pop();
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1397,12 +1397,14 @@ enum AllocatePageState {
     ///   and set the next trunk page as the database's "first freelist trunk page".
     SearchAvailableFreeListLeaf {
         trunk_page: PageRef,
+        current_db_size: u32,
     },
     /// If a freelist leaf is found, reuse it for the page allocation and remove it from the trunk page.
     ReuseFreelistLeaf {
         trunk_page: PageRef,
         leaf_page: PageRef,
         number_of_freelist_leaves: u32,
+        current_db_size: u32,
     },
     /// If a suitable freelist leaf is not found, allocate an entirely new page.
     AllocateNewPage {
@@ -4826,12 +4828,18 @@ impl Pager {
                     let (trunk_page, c) = self.read_page(first_freelist_trunk_page_id as i64)?;
                     // Pin trunk_page to prevent eviction while stored in state machine
                     trunk_page.pin();
-                    *state = AllocatePageState::SearchAvailableFreeListLeaf { trunk_page };
+                    *state = AllocatePageState::SearchAvailableFreeListLeaf {
+                        trunk_page,
+                        current_db_size: new_db_size,
+                    };
                     if let Some(c) = c {
                         io_yield_one!(c);
                     }
                 }
-                AllocatePageState::SearchAvailableFreeListLeaf { trunk_page } => {
+                AllocatePageState::SearchAvailableFreeListLeaf {
+                    trunk_page,
+                    current_db_size,
+                } => {
                     turso_assert!(
                         trunk_page.is_loaded(),
                         "Freelist trunk page is not loaded",
@@ -4865,6 +4873,7 @@ impl Pager {
                             trunk_page: trunk_page.clone(),
                             leaf_page,
                             number_of_freelist_leaves,
+                            current_db_size: *current_db_size,
                         };
                         if let Some(c) = c {
                             io_yield_one!(c);
@@ -4877,6 +4886,7 @@ impl Pager {
                     // Update the database's first freelist trunk page to the next trunk page (may be 0 if there are no more trunk pages).
                     header.freelist_trunk_page = next_trunk_page_id.into();
                     header.freelist_pages = (header.freelist_pages.get() - 1).into();
+                    header.database_size = (*current_db_size).into();
                     self.add_dirty(trunk_page)?;
                     // zero out the page
                     turso_assert!(
@@ -4904,6 +4914,7 @@ impl Pager {
                     trunk_page,
                     leaf_page,
                     number_of_freelist_leaves,
+                    current_db_size,
                 } => {
                     turso_assert!(
                         leaf_page.is_loaded(),
@@ -4953,6 +4964,7 @@ impl Pager {
                     );
 
                     header.freelist_pages = (header.freelist_pages.get() - 1).into();
+                    header.database_size = (*current_db_size).into();
                     // Unpin both pages before returning - caller takes ownership of leaf_page
                     trunk_page.unpin();
                     leaf_page.unpin();

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -1,6 +1,7 @@
 use crate::common::{
     compute_dbhash, compute_dbhash_with_database_opts, compute_dbhash_with_options,
-    compute_dbhash_with_options_and_database_opts, do_flush, ExecRows, TempDatabase,
+    compute_dbhash_with_options_and_database_opts, do_flush, sqlite_exec_rows, ExecRows,
+    TempDatabase,
 };
 use crate::queued_io::{QueuedIo, QueuedIoOpKind};
 use rusqlite::Connection as SqliteConnection;
@@ -5544,6 +5545,54 @@ fn test_mvcc_plain_vacuum_preserves_full_autovacuum_after_reopen() -> anyhow::Re
     assert_eq!(scalar_i64(&reopened_conn, "PRAGMA auto_vacuum"), 1);
     assert_eq!(run_integrity_check(&reopened_conn), "ok");
     assert_eq!(scalar_i64(&reopened_conn, "SELECT COUNT(*) FROM t"), 120);
+
+    Ok(())
+}
+
+#[test]
+fn test_full_autovacuum_freelist_reuse_updates_header_at_ptrmap_boundary() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let db_path = temp_dir.path().join("ptrmap-boundary-freelist.db");
+    {
+        let sqlite_conn = SqliteConnection::open(&db_path)?;
+        sqlite_conn.execute_batch(
+            "PRAGMA page_size=512; \
+             PRAGMA auto_vacuum=full; \
+             CREATE TABLE seed(x);",
+        )?;
+    }
+
+    let opts = DatabaseOpts::new().with_autovacuum(true);
+    let tmp_db = TempDatabase::new_with_existent_with_opts(&db_path, opts);
+    {
+        let conn = tmp_db.connect_limbo();
+        conn.execute(
+            "CREATE TABLE t(x);
+             BEGIN;
+             INSERT INTO t VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+             INSERT INTO t VALUES (11),(12),(13),(14),(15),(16),(17),(18),(19),(20);
+             INSERT INTO t VALUES (21),(22),(23),(24),(25),(26),(27),(28),(29),(30);
+             INSERT INTO t VALUES (31),(32),(33),(34),(35),(36),(37),(38),(39),(40);
+             INSERT INTO t VALUES (41),(42),(43),(44),(45),(46),(47),(48),(49),(50);
+             INSERT INTO t VALUES (51),(52),(53),(54),(55),(56),(57),(58),(59),(60);
+             INSERT INTO t VALUES (61),(62),(63),(64),(65),(66),(67),(68),(69),(70);
+             INSERT INTO t VALUES (71),(72),(73),(74),(75),(76),(77),(78),(79),(80);
+             INSERT INTO t VALUES (81),(82),(83),(84),(85),(86),(87),(88),(89),(90);
+             INSERT INTO t VALUES (91),(92),(93),(94),(95),(96),(97),(98),(99),(100);
+             DELETE FROM t WHERE x IN (1,2,3);
+             INSERT INTO t VALUES (101),(102),(103),(104),(105);
+             COMMIT;",
+        )?;
+        assert_eq!(run_integrity_check(&conn), "ok");
+        do_flush(&conn, &tmp_db)?;
+    }
+
+    let sqlite_conn = SqliteConnection::open(&db_path)?;
+    assert_eq!(sqlite_scalar_i64(&sqlite_conn, "PRAGMA page_size"), 512);
+    assert_eq!(
+        sqlite_exec_rows(&sqlite_conn, "PRAGMA integrity_check"),
+        vec![vec![rusqlite::types::Value::Text("ok".to_string())]]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #6774.

This fixes the full-autovacuum corruption path where `Pager::allocate_page()` can allocate a pointer-map page at a database-size boundary, then return a reused freelist page without carrying the bumped database size into the header. The PR also updates the table-leaf `balance_quick` split path to write pointer-map entries for the old and new child pages under the parent. Without that, the issue reproducer still leaves SQLite unable to read ptrmap entries for the split children.

## Reproduction

Before the fix, the issue reproducer produced:

```text
Turso PRAGMA integrity_check: ok
SQLite PRAGMA integrity_check:
*** in database main ***
Tree 4 page 4 right child: Failed to read ptrmap key=6
Tree 4 page 4 right child: Failed to read ptrmap key=5
```

After the fix, the same script produces:

```text
Turso PRAGMA integrity_check: ok
SQLite PRAGMA integrity_check: ok
```

## Tests

```text
PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check
PATH="$HOME/.cargo/bin:$PATH" cargo test -p turso_core storage::pager::ptrmap_tests::test_ptrmap_page_allocation
PATH="$HOME/.cargo/bin:$PATH" cargo test -p core_tester --test integration_tests test_full_autovacuum_freelist_reuse_updates_header_at_ptrmap_boundary
PATH="$HOME/.cargo/bin:$PATH" cargo build -p turso_cli --bin tursodb
```

I also reran the original shell reproducer from #6774 against `target/debug/tursodb --experimental-autovacuum` and verified SQLite reports `ok` afterward.
