### PR TITLE
Add regression test case for SQLite xfer optimization bug

### DIFF
--- a/testing/sqltests/tests/strict.sqltest
+++ b/testing/sqltests/tests/strict.sqltest
@@ -40,6 +40,21 @@ expect {
     1|CAFE|
 }
 
+# SQLite 3.53 can wrongly use the INSERT xfer optimization here, bypassing
+# STRICT type checks and leaving an integer stored in d.a.
+@skip-if sqlite "SQLite 3.53 xfer optimization bug for INSERT ... SELECT into incompatible STRICT tables; reported at https://sqlite.org/forum/forumpost/401abee549, fixed by SQLite check-in f8ca671997bf7bab18f282a2d5de9be0c03364bd for 3.54"
+@cross-check-integrity
+test strict-insert-select-any-to-blob-rejects-xfer {
+    CREATE TABLE s(a ANY) STRICT;
+    CREATE TABLE d(a BLOB) STRICT;
+    INSERT INTO s VALUES(1);
+    INSERT INTO d SELECT * FROM s;
+    SELECT typeof(a), quote(a) FROM d;
+    PRAGMA integrity_check;
+}
+expect error {
+}
+
 @cross-check-integrity
 test strict-explicit-null-insert {
     CREATE TABLE t5 (id INTEGER PRIMARY KEY, a INTEGER, b TEXT) STRICT;


### PR DESCRIPTION
we  currently dont do xfer optimization , this is a bug in sqlite which is fixed now

lets add this test case so we dont accidentally introduce this bug when we do optimization.