### PR TITLE
core/printf: return NULL for empty format

### DIFF
--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -1274,35 +1274,40 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     let mut result = String::new();
     let mut args_index = 1;
     let mut chars = format_str.chars().peekable();
-    // SQLite returns NULL if printf never allocates its accumulator. Most
-    // specifiers allocate only when they append bytes; %c can allocate a
-    // zero-length text result for NUL input.
-    let mut allocated = false;
+    if format_str.is_empty() {
+        return Ok(Value::Null);
+    }
+
+    // Track whether any output or specifier processing happened. SQLite's
+    // internal StrAccum buffer stays NULL until something triggers allocation
+    // (any literal text, %%, trailing %, or any specifier including %n).
+    // When an unknown specifier triggers early return before any allocation,
+    // the result is NULL. Otherwise it's the accumulated text (possibly "").
+    let mut touched = false;
+
     while let Some(c) = chars.next() {
         if c != '%' {
+            touched = true;
             result.push(c);
-            allocated = true;
             continue;
         }
 
         // Check for %%
         if chars.peek() == Some(&'%') {
+            touched = true;
             chars.next();
             result.push('%');
-            allocated = true;
             continue;
         }
 
         // Trailing '%' at end of format string is preserved
         if chars.peek().is_none() {
             result.push('%');
-            allocated = true;
             break;
         }
 
         // Parse the full format specifier
         let spec = parse_format_spec(&mut chars, values, &mut args_index);
-        let result_len_before = result.len();
 
         // Get the argument value (or use NULL if missing)
         let needs_arg = !matches!(spec.spec_type, 'n' | '\0');
@@ -1339,25 +1344,20 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
             'r' => format_ordinal(&mut result, arg, &spec),
             'n' => { /* silently ignored, no arg consumed */ }
             _ => {
-                // Unknown specifier: return NULL if SQLite's accumulator has
-                // not been allocated yet; otherwise return accumulated text.
-                if !allocated {
+                // Unknown specifier: return NULL if nothing was processed
+                // before this point, otherwise return accumulated text.
+                // This matches SQLite where the internal buffer (zText) stays
+                // NULL until any append is attempted.
+                if !touched {
                     return Ok(Value::Null);
                 }
                 break;
             }
         }
-
-        if result.len() > result_len_before || spec.spec_type == 'c' {
-            allocated = true;
-        }
+        touched = true;
     }
 
-    if !allocated {
-        Ok(Value::Null)
-    } else {
-        Ok(Value::build_text(result))
-    }
+    Ok(Value::build_text(result))
 }
 
 #[cfg(test)]
@@ -1631,12 +1631,10 @@ mod tests {
             assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
         }
         assert_eq!(exec_printf(&[text("")]).unwrap(), Value::Null);
-        assert_eq!(exec_printf(&[text("%s"), text("")]).unwrap(), Value::Null);
         assert_eq!(
-            exec_printf(&[text("%c"), text("")]).unwrap(),
+            exec_printf(&[text("%s"), text("")]).unwrap(),
             *text("").get_value()
         );
-        assert_eq!(exec_printf(&[text("%n%j")]).unwrap(), Value::Null);
     }
 
     #[test]
@@ -1994,7 +1992,7 @@ mod tests {
         // Precision truncates the NULL literal representation
         assert_eq!(
             exec_printf(&[text("%.0q"), Register::Value(Value::Null)]).unwrap(),
-            Value::Null
+            *text("").get_value()
         );
         assert_eq!(
             exec_printf(&[text("%.3q"), Register::Value(Value::Null)]).unwrap(),
@@ -2002,7 +2000,7 @@ mod tests {
         );
         assert_eq!(
             exec_printf(&[text("%.0Q"), Register::Value(Value::Null)]).unwrap(),
-            Value::Null
+            *text("").get_value()
         );
     }
 
@@ -2027,10 +2025,10 @@ mod tests {
             exec_printf(&[text("hello%b"), integer(42)]).unwrap(),
             *text("hello").get_value()
         );
-        // Unknown specifier after %n still returns NULL because %n emits no bytes.
+        // Unknown specifier after %n → "" (StrAccum was allocated by %n processing)
         assert_eq!(
             exec_printf(&[text("%n%b"), integer(42)]).unwrap(),
-            Value::Null,
+            *text("").get_value(),
         );
     }
 

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -1274,36 +1274,35 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     let mut result = String::new();
     let mut args_index = 1;
     let mut chars = format_str.chars().peekable();
-    // Track whether any output or specifier processing happened. SQLite's
-    // internal StrAccum buffer stays NULL until something triggers allocation
-    // (any literal text, %%, trailing %, or any specifier including %n).
-    // When an unknown specifier triggers early return before any allocation,
-    // the result is NULL. Otherwise it's the accumulated text (possibly "").
-    let mut touched = false;
-
+    // SQLite returns NULL if printf never allocates its accumulator. Most
+    // specifiers allocate only when they append bytes; %c can allocate a
+    // zero-length text result for NUL input.
+    let mut allocated = false;
     while let Some(c) = chars.next() {
         if c != '%' {
-            touched = true;
             result.push(c);
+            allocated = true;
             continue;
         }
 
         // Check for %%
         if chars.peek() == Some(&'%') {
-            touched = true;
             chars.next();
             result.push('%');
+            allocated = true;
             continue;
         }
 
         // Trailing '%' at end of format string is preserved
         if chars.peek().is_none() {
             result.push('%');
+            allocated = true;
             break;
         }
 
         // Parse the full format specifier
         let spec = parse_format_spec(&mut chars, values, &mut args_index);
+        let result_len_before = result.len();
 
         // Get the argument value (or use NULL if missing)
         let needs_arg = !matches!(spec.spec_type, 'n' | '\0');
@@ -1340,20 +1339,25 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
             'r' => format_ordinal(&mut result, arg, &spec),
             'n' => { /* silently ignored, no arg consumed */ }
             _ => {
-                // Unknown specifier: return NULL if nothing was processed
-                // before this point, otherwise return accumulated text.
-                // This matches SQLite where the internal buffer (zText) stays
-                // NULL until any append is attempted.
-                if !touched {
+                // Unknown specifier: return NULL if SQLite's accumulator has
+                // not been allocated yet; otherwise return accumulated text.
+                if !allocated {
                     return Ok(Value::Null);
                 }
                 break;
             }
         }
-        touched = true;
+
+        if result.len() > result_len_before || spec.spec_type == 'c' {
+            allocated = true;
+        }
     }
 
-    Ok(Value::build_text(result))
+    if !allocated {
+        Ok(Value::Null)
+    } else {
+        Ok(Value::build_text(result))
+    }
 }
 
 #[cfg(test)]
@@ -1609,7 +1613,6 @@ mod tests {
     #[test]
     fn test_printf_edge_cases() {
         let test_cases = vec![
-            (vec![text("")], text("")),
             (vec![text("%%%%")], text("%%")),
             (vec![text("No substitutions")], text("No substitutions")),
             (
@@ -1621,13 +1624,19 @@ mod tests {
             // Unknown specifier: NULL if nothing processed before, else accumulated text
             (vec![text("%d%j"), integer(42)], text("42")),
             (vec![text("hello%j")], text("hello")),
-            (vec![text("%n%j")], text("")),
             // Negative zero should not show minus sign
             (vec![text("%f"), float(-0.0)], text("0.000000")),
         ];
         for (input, expected) in test_cases {
             assert_eq!(exec_printf(&input).unwrap(), *expected.get_value());
         }
+        assert_eq!(exec_printf(&[text("")]).unwrap(), Value::Null);
+        assert_eq!(exec_printf(&[text("%s"), text("")]).unwrap(), Value::Null);
+        assert_eq!(
+            exec_printf(&[text("%c"), text("")]).unwrap(),
+            *text("").get_value()
+        );
+        assert_eq!(exec_printf(&[text("%n%j")]).unwrap(), Value::Null);
     }
 
     #[test]
@@ -1985,7 +1994,7 @@ mod tests {
         // Precision truncates the NULL literal representation
         assert_eq!(
             exec_printf(&[text("%.0q"), Register::Value(Value::Null)]).unwrap(),
-            *text("").get_value()
+            Value::Null
         );
         assert_eq!(
             exec_printf(&[text("%.3q"), Register::Value(Value::Null)]).unwrap(),
@@ -1993,7 +2002,7 @@ mod tests {
         );
         assert_eq!(
             exec_printf(&[text("%.0Q"), Register::Value(Value::Null)]).unwrap(),
-            *text("").get_value()
+            Value::Null
         );
     }
 
@@ -2018,10 +2027,10 @@ mod tests {
             exec_printf(&[text("hello%b"), integer(42)]).unwrap(),
             *text("hello").get_value()
         );
-        // Unknown specifier after %n → "" (StrAccum was allocated by %n processing)
+        // Unknown specifier after %n still returns NULL because %n emits no bytes.
         assert_eq!(
             exec_printf(&[text("%n%b"), integer(42)]).unwrap(),
-            *text("").get_value(),
+            Value::Null,
         );
     }
 

--- a/testing/sqltests/tests/scalar-functions-printf.sqltest
+++ b/testing/sqltests/tests/scalar-functions-printf.sqltest
@@ -770,13 +770,6 @@ expect {
     1
 }
 
-test printf-empty-string-result-null {
-    SELECT printf('%s', '') IS NULL, printf('%.0s', 'abc') IS NULL, printf('%n', 1) IS NULL;
-}
-expect {
-    1|1|1
-}
-
 test printf-empty-result-not-null-constraint {
     CREATE TABLE printf_empty_not_null(x TEXT NOT NULL);
     INSERT INTO printf_empty_not_null VALUES (printf('', NULL));

--- a/testing/sqltests/tests/scalar-functions-printf.sqltest
+++ b/testing/sqltests/tests/scalar-functions-printf.sqltest
@@ -763,6 +763,28 @@ expect {
     1
 }
 
+test printf-empty-format-null {
+    SELECT printf('') IS NULL;
+}
+expect {
+    1
+}
+
+test printf-empty-string-result-null {
+    SELECT printf('%s', '') IS NULL, printf('%.0s', 'abc') IS NULL, printf('%n', 1) IS NULL;
+}
+expect {
+    1|1|1
+}
+
+test printf-empty-result-not-null-constraint {
+    CREATE TABLE printf_empty_not_null(x TEXT NOT NULL);
+    INSERT INTO printf_empty_not_null VALUES (printf('', NULL));
+}
+expect error {
+    NOT NULL constraint failed: printf_empty_not_null.x
+}
+
 test printf-format-blob {
     SELECT printf(X'414243');
 }


### PR DESCRIPTION
## Summary

SQLite 3.49.1, the version used by the repo's SQL-test CI, returns `NULL` for an empty printf format string, including when extra arguments are ignored: `printf('')` and `printf('', NULL)`.

Turso returned empty text for that empty-format path because `exec_printf` always built a text value after the format loop. That can bypass constraints that SQLite rejects, for example:

```sql
INSERT INTO t(x TEXT NOT NULL) VALUES (printf('', NULL));
```

This patch returns `NULL` for the empty-format case while preserving existing specifier behavior for zero-length formatted output such as `%s`, `%.0s`, and `%n`. Those cases differ across SQLite versions and are intentionally left out of this scoped fix.

## Tests

- `.sqlite3/sqlite3 :memory: "SELECT printf('') IS NULL, printf('', NULL) IS NULL, printf('%s','') IS NULL, printf('%.0s','abc') IS NULL, printf('%n', 1) IS NULL;"`
- `cargo fmt --check`
- `cargo test -p turso_core printf`
- `cargo run -q --bin test-runner check testing/sqltests/tests/scalar-functions-printf.sqltest`
- `cargo run -q --bin test-runner run testing/sqltests/tests/scalar-functions-printf.sqltest --backend rust --snapshot-mode no`
- `cargo run -q -p differential-fuzzer --bin differential_fuzzer -- -g sql-gen-prop -s 7049436113739260507 -n 220 -k`
- `make -C testing/sqltests test-sqlite`
- `cargo check -p turso_core`
- `cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings`
