### PR TITLE
core/mvcc: preserve rowid allocator watermark

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5299,7 +5299,25 @@ impl RowidAllocator {
     /// Initialize from btree max. Called once per table, under lock.
     pub fn initialize(&self, rowid: Option<i64>) {
         tracing::trace!("initialize({rowid:?})");
-        self.max_rowid.store(rowid.unwrap_or(0), Ordering::SeqCst);
+        if let Some(rowid) = rowid {
+            loop {
+                let cur = self.max_rowid.load(Ordering::SeqCst);
+                // Preserve an explicit-rowid watermark that may already have
+                // raised the allocator, while still allowing a negative btree
+                // max to initialize an otherwise untouched allocator.
+                let next = if cur == 0 || rowid > cur { rowid } else { cur };
+                if next == cur {
+                    break;
+                }
+                if self
+                    .max_rowid
+                    .compare_exchange(cur, next, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    break;
+                }
+            }
+        }
         self.initialized.store(true, Ordering::SeqCst);
     }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8138,6 +8138,56 @@ fn test_three_concurrent_autoincrement_inserts() {
     );
 }
 
+/// A concurrent explicit rowid insert must raise the allocator watermark before
+/// another transaction performs auto-rowid allocation. Otherwise later auto
+/// inserts can overwrite the explicit row and leave secondary indexes stale.
+#[test]
+fn test_concurrent_explicit_rowid_preserves_auto_rowid_watermark() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn1
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, k INTEGER)")
+        .unwrap();
+    conn1.execute("CREATE INDEX t_k ON t(k)").unwrap();
+
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    conn1
+        .execute("INSERT INTO t(id, v, k) VALUES (5, 'A', 999)")
+        .unwrap();
+
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+    conn2
+        .execute("INSERT INTO t(v, k) VALUES ('B', 100)")
+        .unwrap();
+    conn2.execute("COMMIT").unwrap();
+    conn1.execute("COMMIT").unwrap();
+
+    for (v, k) in [("p2", 200), ("p3", 300), ("p4", 400), ("p5", 500)] {
+        conn1
+            .execute(format!("INSERT INTO t(v, k) VALUES ('{v}', {k})"))
+            .unwrap();
+    }
+
+    let integrity = get_rows(&conn1, "PRAGMA integrity_check");
+    assert_eq!(integrity.len(), 1);
+    assert_eq!(
+        integrity[0][0].to_string(),
+        "ok",
+        "integrity_check should not report stale secondary index entries"
+    );
+
+    let indexed = get_rows(
+        &conn1,
+        "SELECT rowid, v, k FROM t INDEXED BY t_k WHERE k = 999",
+    );
+    assert_eq!(indexed.len(), 1);
+    assert_eq!(indexed[0][0].as_int().unwrap(), 5);
+    assert_eq!(indexed[0][1].to_string(), "A");
+    assert_eq!(indexed[0][2].as_int().unwrap(), 999);
+}
+
 /// Deterministic reproduction of the sqlite_sequence pollution bug.
 ///
 /// Two concurrent transactions insert into an AUTOINCREMENT table.

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -12,14 +12,14 @@ use sql_generation::{
     generation::{Arbitrary, ArbitraryFrom, GenerationContext, pick, pick_index},
     model::{
         query::{
-            Create, Delete, Drop, Insert, Select,
+            Create, CreateIndex, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
             predicate::Predicate,
             select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
             transaction::{Begin, Commit, Rollback},
             update::{SetValue, Update},
         },
-        table::{ColumnType, SimValue, Table},
+        table::{Column, ColumnType, Index, SimValue, Table},
     },
 };
 use strum::IntoEnumIterator;
@@ -247,6 +247,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::MvccExplicitRowidThenAutoRowid
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => {
                 unreachable!("No extensional queries")
@@ -1233,6 +1234,76 @@ impl Property {
                 interactions.push(assert_integrity_check(tables, connection_index));
                 interactions
             }
+            Property::MvccExplicitRowidThenAutoRowid => {
+                let table_name = format!("sim_mvcc_rowid_{}", id.get());
+                let index_name = format!("idx_{}_k", id.get());
+                let peer_connection_index = if connection_index == 0 { 1 } else { 0 };
+
+                let peer = |query| {
+                    let mut builder =
+                        InteractionBuilder::with_interaction(InteractionType::Query(query));
+                    builder.connection_index(peer_connection_index);
+                    builder
+                };
+
+                let create = Query::Create(Create {
+                    table: mvcc_rowid_table(table_name.clone()),
+                });
+                let create_index = Query::CreateIndex(CreateIndex {
+                    index: Index {
+                        table_name: table_name.clone(),
+                        index_name: index_name.clone(),
+                        columns: vec![("k".to_string(), ast::SortOrder::Asc)],
+                    },
+                });
+
+                let mut interactions = Vec::new();
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(create),
+                ));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(create_index),
+                ));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Begin(Begin::Concurrent)),
+                ));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Insert(Insert::Values {
+                        table: table_name.clone(),
+                        values: vec![vec![sim_int(5), sim_text("A"), sim_int(999)]],
+                        on_conflict: None,
+                    })),
+                ));
+                interactions.push(peer(Query::Begin(Begin::Concurrent)));
+                interactions.push(peer(Query::Insert(Insert::Values {
+                    table: table_name.clone(),
+                    values: vec![vec![SimValue::NULL, sim_text("B"), sim_int(100)]],
+                    on_conflict: None,
+                })));
+                interactions.push(peer(Query::Commit(Commit)));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Commit(Commit)),
+                ));
+
+                for (value, key) in [("p2", 200), ("p3", 300), ("p4", 400), ("p5", 500)] {
+                    interactions.push(InteractionBuilder::with_interaction(
+                        InteractionType::Query(Query::Insert(Insert::Values {
+                            table: table_name.clone(),
+                            values: vec![vec![SimValue::NULL, sim_text(value), sim_int(key)]],
+                            on_conflict: None,
+                        })),
+                    ));
+                }
+
+                interactions.push(assert_integrity_check(
+                    std::slice::from_ref(&table_name),
+                    connection_index,
+                ));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Drop(Drop { table: table_name })),
+                ));
+                interactions
+            }
         };
 
         assert!(!interactions.is_empty());
@@ -1243,10 +1314,47 @@ impl Property {
                 if !builder.has_property_meta() {
                     builder.property_meta(PropertyMetadata::new(self, false));
                 }
-                builder.connection_index(connection_index).id(id);
+                builder.connection_index_if_unset(connection_index).id(id);
                 builder.build().unwrap()
             })
             .collect()
+    }
+}
+
+fn sim_int(value: i64) -> SimValue {
+    SimValue(types::Value::from_i64(value))
+}
+
+fn sim_text(value: &str) -> SimValue {
+    SimValue(types::Value::Text(value.to_string().into()))
+}
+
+fn mvcc_rowid_table(name: String) -> Table {
+    Table {
+        name,
+        columns: vec![
+            Column {
+                name: "id".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![ast::ColumnConstraint::PrimaryKey {
+                    order: None,
+                    conflict_clause: None,
+                    auto_increment: false,
+                }],
+            },
+            Column {
+                name: "v".to_string(),
+                column_type: ColumnType::Text,
+                constraints: vec![],
+            },
+            Column {
+                name: "k".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            },
+        ],
+        rows: vec![],
+        indexes: vec![],
     }
 }
 
@@ -1417,7 +1525,7 @@ fn random_main_table_delete<R: rand::Rng + ?Sized>(rng: &mut R, table: &Table) -
 fn assert_integrity_check(tables: &[String], connection_index: usize) -> InteractionBuilder {
     let tables = tables.to_vec();
     InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
-        "PRAGMA integrity_check should be ok after savepoint rollback".to_string(),
+        "PRAGMA integrity_check should be ok".to_string(),
         move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
             let result = run_integrity_check(env, connection_index)?;
             if result == "ok" {
@@ -1887,6 +1995,15 @@ fn property_faulty_query<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_mvcc_explicit_rowid_then_auto_rowid<R: rand::Rng + ?Sized>(
+    _rng: &mut R,
+    _query_distr: &QueryDistribution,
+    _ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    Property::MvccExplicitRowidThenAutoRowid
+}
+
 type PropertyGenFunc<R, G> = fn(&mut R, &QueryDistribution, &G, bool) -> Property;
 
 impl PropertyDiscriminants {
@@ -1914,6 +2031,9 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
+            PropertyDiscriminants::MvccExplicitRowidThenAutoRowid => {
+                property_mvcc_explicit_rowid_then_auto_rowid
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
             }
@@ -2033,6 +2153,13 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::MvccExplicitRowidThenAutoRowid => {
+                if env.profile.mvcc && env.profile.max_connections >= 2 {
+                    25
+                } else {
+                    0
+                }
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -2074,6 +2201,10 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
+            PropertyDiscriminants::MvccExplicitRowidThenAutoRowid => QueryCapabilities::CREATE
+                .union(QueryCapabilities::CREATE_INDEX)
+                .union(QueryCapabilities::INSERT)
+                .union(QueryCapabilities::DROP),
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -494,6 +494,13 @@ impl InteractionBuilder {
         builder
     }
 
+    pub fn connection_index_if_unset(&mut self, connection_index: usize) -> &mut Self {
+        if self.connection_index.is_none() {
+            self.connection_index(connection_index);
+        }
+        self
+    }
+
     /// Checks to see if the property metadata was already set
     pub fn has_property_meta(&self) -> bool {
         self.property_meta.is_some()

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -191,6 +191,13 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// MVCC property for concurrent explicit-rowid and auto-rowid INSERTs.
+    ///
+    /// It verifies that an explicit rowid in one concurrent transaction bumps
+    /// the global rowid allocator before another transaction allocates an
+    /// automatic rowid, then checks integrity after additional auto-rowid
+    /// inserts stress the secondary index.
+    MvccExplicitRowidThenAutoRowid,
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -238,6 +245,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::MvccExplicitRowidThenAutoRowid
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => None,
         }


### PR DESCRIPTION
Fixes #6770.

This preserves the MVCC rowid allocator watermark when an explicit-rowid insert has already raised it before the allocator is initialized from the btree. Previously, initialization could overwrite that in-flight watermark with the btree max, allowing later auto-rowid inserts to reuse the explicit rowid and leave secondary indexes out of sync.

The patch also adds a deterministic regression test and a simulator property that drives the same two-connection explicit-rowid/auto-rowid interleaving, asserts `PRAGMA integrity_check`, and drops the generated fixture table afterward so later shadow-model checks are not polluted by the synthetic scenario.

Test plan:
- `CARGO_HOME=$PWD/.cargo-home RUSTUP_HOME=$PWD/.rustup-home RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `CARGO_HOME=$PWD/.cargo-home RUSTUP_HOME=$PWD/.rustup-home RUSTUP_TOOLCHAIN=stable cargo test -p turso_core test_concurrent_explicit_rowid_preserves_auto_rowid_watermark`
- `CARGO_HOME=$PWD/.cargo-home RUSTUP_HOME=$PWD/.rustup-home RUSTUP_TOOLCHAIN=stable cargo check -p limbo_sim`
- `CARGO_HOME=$PWD/.cargo-home RUSTUP_HOME=$PWD/.rustup-home RUSTUP_TOOLCHAIN=stable cargo run -p limbo_sim -- --seed 2394334951063522357 --profile simple_mvcc --maximum-tests 120 --minimum-tests 80 --maximum-time 30 --disable-integrity-check --disable-bugbase --disable-heuristic-shrinking`

Note: the seeded simulator run disables the outer final integrity check because `simple_mvcc` currently reports `file is not a database` there independently; the new property itself performs an in-run `PRAGMA integrity_check` assertion.