### PR TITLE
core/mvcc: clean up faulted auto-checkpoints

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1029,6 +1029,15 @@ pub struct DeleteRowStateMachine {
 }
 
 impl<Clock: LogicalClock> CommitStateMachine<Clock> {
+    pub(crate) fn cleanup_mvcc_checkpoint_state(&mut self) {
+        if let CommitState::Checkpoint { state_machine } = &mut self.state {
+            state_machine
+                .lock()
+                .inner_mut()
+                .cleanup_after_external_io_error();
+        }
+    }
+
     fn new(
         state: CommitState<Clock>,
         tx_id: TxID,
@@ -5112,11 +5121,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
                         panic!("Index writes must be to a record");
                     };
-                    self.insert_index_version(
-                        rowid.table_id,
-                        Arc::new(sortable_key),
-                        row_version,
-                    );
+                    self.insert_index_version(rowid.table_id, Arc::new(sortable_key), row_version);
                 }
                 StreamingResult::DeleteIndexRow {
                     row,

--- a/core/state_machine.rs
+++ b/core/state_machine.rs
@@ -89,6 +89,10 @@ impl<State: StateTransition> StateMachine<State> {
         Ok(())
     }
 
+    pub(crate) fn inner_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+
     pub fn is_finalized(&self) -> bool {
         self.is_finalized
     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -192,6 +192,20 @@ enum CommitState {
     },
 }
 
+impl CommitState {
+    fn cleanup_mvcc_checkpoint_state(&mut self) {
+        match self {
+            CommitState::CommittingMvcc { state_machine } => {
+                state_machine.inner_mut().cleanup_mvcc_checkpoint_state()
+            }
+            CommitState::CommittingAttachedMvcc { state_machine, .. } => {
+                state_machine.inner_mut().cleanup_mvcc_checkpoint_state()
+            }
+            CommitState::Ready | CommitState::Committing | CommitState::CommittingAttached => {}
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Register {
     Value(Value),
@@ -810,7 +824,11 @@ impl ProgramState {
         #[cfg(feature = "json")]
         self.json_cache.clear();
 
-        // Reset state machines
+        // A caller can reset or drop a statement after an MVCC auto-checkpoint
+        // has yielded I/O. Waiting for that I/O does not step the nested
+        // CheckpointStateMachine again, so release its checkpoint lock before
+        // replacing commit_state with Ready.
+        self.commit_state.cleanup_mvcc_checkpoint_state();
         self.active_op_state.clear();
         self.seek_state = OpSeekState::Start;
         self.current_collation = None;
@@ -2168,6 +2186,12 @@ impl Program {
         }
 
         let mut abort_error: Option<LimboError> = None;
+        // MVCC auto-checkpoint is owned by commit_state, not by normal_step().
+        // If its yielded I/O fails, normal_step sees the error before
+        // CommitStateMachine::Checkpoint gets another step, so the checkpoint
+        // state machine cannot run its own error cleanup. abort() is the first
+        // statement cleanup path that still owns that commit_state.
+        state.commit_state.cleanup_mvcc_checkpoint_state();
 
         // VACUUM (and VACUUM INTO) state can own internal helper statements whose drop path
         // releases nested guards. Clean it before checking whether this program

--- a/testing/simulator/runner/memory/mvcc_recovery.rs
+++ b/testing/simulator/runner/memory/mvcc_recovery.rs
@@ -440,6 +440,53 @@ fn sim_mvcc_faulted_checkpoint_does_not_block_other_connection() -> Result<()> {
     Ok(())
 }
 
+/// Regression protected:
+///
+/// `DELETE FROM t WHERE id = 1` commits its MVCC transaction and then starts an
+/// auto-checkpoint because `mvcc_checkpoint_threshold` is 0. If that checkpoint
+/// yields for WAL I/O and the I/O fails, `Program::normal_step` sees the error
+/// before `CommitStateMachine::Checkpoint` gets another step. Without explicit
+/// cleanup from `Program::abort()` or `ProgramState::reset()`, the checkpoint
+/// write lock stays held and a second connection can get `Database is busy` when
+/// it tries to insert row 2.
+#[test]
+fn sim_mvcc_faulted_auto_checkpoint_does_not_block_other_connection() -> Result<()> {
+    let seed = 211;
+    let io = make_io(seed, 100);
+    let temp_dir = tempfile::TempDir::new()?;
+    let path = temp_dir
+        .path()
+        .join(format!("sim_mvcc_auto_checkpoint_lock_cleanup_{seed}.db"));
+    let path = path.to_str().expect("temp dir path should be valid UTF-8");
+
+    let (conn1, conn2) = open_two_conns(io.clone(), path)?;
+    enable_mvcc(&conn1)?;
+    conn1.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn1.execute("INSERT INTO t VALUES (1, 'a')")?;
+    conn1.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    // Force the DELETE commit to enter CommitStateMachine::Checkpoint.
+    conn1.execute("PRAGMA mvcc_checkpoint_threshold = 0")?;
+
+    // The DELETE commits the MVCC transaction before the auto-checkpoint reports
+    // this WAL fault through ProgramState::io_completions.
+    set_fault(io.as_ref(), true, false);
+    let delete = conn1.execute("DELETE FROM t WHERE id = 1");
+    clear_faults(io.as_ref());
+    assert!(
+        delete.is_err(),
+        "auto-checkpoint should fail while WAL faults are injected"
+    );
+
+    // This insert takes the checkpoint read lock before starting its MVCC
+    // transaction. A leaked checkpoint write lock makes it return Busy.
+    conn2.execute("INSERT INTO t VALUES (2, 'from_conn2')")?;
+    assert_eq!(
+        query_rows(&conn2, io.as_ref())?,
+        vec![(2, "from_conn2".to_string())]
+    );
+    Ok(())
+}
+
 /// What this test checks: A faulted `ALTER TABLE ... RENAME` behaves atomically across restart.
 /// Why this matters: Schema changes should look all-or-nothing to users; half-renamed tables are corruption by another name.
 #[test]


### PR DESCRIPTION
An MVCC auto-checkpoint runs inside statement commit.

If that checkpoint yields I/O and the I/O fails, the VDBE sees the error before it re-enters the nested checkpoint state machine. The old path returned CheckpointFailed, but it did not ask the checkpoint to clear pager/WAL checkpoint state or unlock the checkpoint lock.

The row change was already committed, but another connection could then hit "Database is busy" because it was still stuck behind the failed checkpoint.

Let the VDBE reach into the commit state and clean up any nested checkpoint on I/O error, abort, and reset. The simulator test injects a WAL fault during an auto-checkpoint and then verifies that a second connection can write.