### PR TITLE
core/fts: always load pager from db index

### DIFF
--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -2711,7 +2711,7 @@ impl IndexMethodCursor for FtsCursor {
                         );
 
                         // Create HybridBTreeDirectory with catalog and pre-assembled hot files
-                        let pager = conn.pager.load().clone();
+                        let pager = conn.get_pager_from_database_index(&database_id)?;
                         let root_page = self.btree_root_page.ok_or_else(|| {
                             LimboError::InternalError("btree_root_page not set".into())
                         })?;


### PR DESCRIPTION
## Description

Whenever we are loading a pager, we should always load using database index instead of `conn.pager` because if the db is attached one, then main pager will get assigned to the attached db.

Fix fixes the CI as well, currently the failing test: `test_attach_inherits_index_method_flag_on_reattach`
