### PR TITLE
fix/attach&FTS: use attached database pager for FTS files

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2198,7 +2198,16 @@ impl Connection {
                     .map(|temp_db| temp_db.pager.clone())
                     .expect("temp database should be initialized after ensure_temp_database"))
             }
-            _ => Ok(self.attached_databases.read().get_pager_by_index(index)),
+            _ => {
+                let attached_databases = self.attached_databases.read();
+                let Some(pager) = attached_databases.get_pager_by_index(index) else {
+                    return Err(LimboError::InternalError(format!(
+                        "database {} is no longer attached",
+                        index
+                    )));
+                };
+                Ok(pager)
+            }
         }
     }
 

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1926,6 +1926,11 @@ impl FtsCursor {
         Err(LimboError::InternalError("no directory initialized".into()))
     }
 
+    fn pager_for_database(&self, conn: &Arc<Connection>) -> Result<Arc<Pager>> {
+        let database_id = self.database_id.unwrap_or(crate::MAIN_DB_ID);
+        conn.get_pager_from_database_index(&database_id)
+    }
+
     /// Internal helper to continue flush_writes state machine
     fn flush_writes_internal(&mut self) -> Result<IOResult<()>> {
         loop {
@@ -2443,8 +2448,6 @@ impl Drop for FtsCursor {
             }
         };
 
-        let pager = conn.pager.load().clone();
-
         // Check if we're already in a flushing state (from commit_and_flush)
         // This can happen when commit_and_flush started a flush but yielded for IO
         // and the cursor is being dropped before the flush completed
@@ -2462,6 +2465,14 @@ impl Drop for FtsCursor {
 
         if is_flushing {
             turso_assert!(conn.is_in_write_tx(), "FTS Drop: in-progress flush abandoned (transaction already committed). pre_commit should have completed the flush.");
+
+            let pager = match self.pager_for_database(&conn) {
+                Ok(pager) => pager,
+                Err(e) => {
+                    tracing::error!("FTS Drop: failed to get pager during flush: {}", e);
+                    return;
+                }
+            };
 
             tracing::debug!("FTS Drop: completing in-progress flush");
             loop {
@@ -2534,6 +2545,14 @@ impl Drop for FtsCursor {
             writes,
             write_idx: 0,
             chunk_idx: Some(0),
+        };
+
+        let pager = match self.pager_for_database(&conn) {
+            Ok(pager) => pager,
+            Err(e) => {
+                tracing::error!("FTS Drop: failed to get pager during pending flush: {}", e);
+                return;
+            }
         };
 
         // Run blocking flush
@@ -2711,7 +2730,7 @@ impl IndexMethodCursor for FtsCursor {
                         );
 
                         // Create HybridBTreeDirectory with catalog and pre-assembled hot files
-                        let pager = conn.pager.load().clone();
+                        let pager = conn.get_pager_from_database_index(&database_id)?;
                         let root_page = self.btree_root_page.ok_or_else(|| {
                             LimboError::InternalError("btree_root_page not set".into())
                         })?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2601,12 +2601,10 @@ impl DatabaseCatalog {
         }
     }
 
-    fn get_pager_by_index(&self, idx: &usize) -> Arc<Pager> {
-        let (_db, pager) = self
-            .index_to_data
+    fn get_pager_by_index(&self, idx: &usize) -> Option<Arc<Pager>> {
+        self.index_to_data
             .get(idx)
-            .expect("If we are looking up a database by index, it must exist.");
-        pager.clone()
+            .map(|(_db, pager)| pager.clone())
     }
 
     fn add(&mut self, s: &str) -> usize {


### PR DESCRIPTION
FTS indexes on attached databases loaded their file directory with the main database pager. After detach and reattach, lazy file reads could use an attached root page through the main pager and fail with a pinned page error.

Resolve the pager from the FTS cursor database id when loading the directory and when stepping drop-time flush IO.