### PR TITLE
bindings/tcl: accumulate rows across statements in `db eval`

### DIFF
--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -93,6 +93,24 @@ set result [db eval {SELECT add2(3, 7);}]
 assert_eq "db func with two args" 10 $result
 
 # ---------------------------------------------------------------------------
+# Probe 4: multi-statement `db eval` accumulates rows from every statement.
+# Regression test for the select3-8.100 failure where the per-statement reset
+# of the result list dropped rows from earlier statements (e.g. a SELECT
+# followed by `PRAGMA integrity_check`). Upstream tclsqlite appends rows from
+# every statement in the script to a single result list.
+# ---------------------------------------------------------------------------
+
+db eval {DROP TABLE IF EXISTS tm;}
+set multi_sql {
+    CREATE TABLE tm(a, b);
+    INSERT INTO tm VALUES (1, 'one'), (2, 'two');
+    SELECT a, b FROM tm ORDER BY a;
+    SELECT count(*) FROM tm;
+}
+assert_eq "multi-statement db eval keeps rows from every statement" \
+    {1 one 2 two 2} [db eval $multi_sql]
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -333,12 +333,6 @@ static int exec_sql_collect(TursoDb *tdb,
         /* Bind TCL variables to any parameters */
         bind_tcl_variables(interp, stmt);
 
-        /* reset the list for each non-empty statement so the caller
-           sees the results of the final one (matches SQLite tclsqlite behaviour) */
-        Tcl_DecrRefCount(result_list);
-        result_list = Tcl_NewListObj(0, NULL);
-        Tcl_IncrRefCount(result_list);
-
         int ncols = sqlite3_column_count(stmt);
 
         while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {


### PR DESCRIPTION
The multi-statement path of `db eval` reset its result list on every
non-empty statement, so only rows from the final statement survived.
Upstream tclsqlite creates the result list once before the step loop
and appends rows from every statement in the script.

This caused `select3-8.100` (and the cascading 8.101…146 failures) in
`tclsh ./testing/conformance/sqlite3/select3.test` to drop the row from
the trailing `SELECT` when followed by `PRAGMA integrity_check`,
returning just `ok` instead of `{} 1.0 ok`.

Remove the per-statement reset and add a probe in `test_probes.tcl`
that exercises a multi-statement script and asserts rows from every
statement are preserved.
