### PR TITLE
core/mvcc: exempt read-only transactions from schema-conflict check

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1759,12 +1759,18 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     }
                 }
 
-                if mvcc_store
-                    .last_committed_schema_change_ts
-                    .load(Ordering::Acquire)
-                    > tx.begin_ts
+                // Schema changes made after a writing transaction began invalidate
+                // its planned writes against a possibly-obsolete schema and force
+                // it to abort. A read-only transaction took a consistent pre-DDL
+                // snapshot and has nothing to invalidate, so it is exempt.
+                let has_writes =
+                    !tx.write_set.lock().is_empty() || tx.header_dirty.load(Ordering::Acquire);
+                if has_writes
+                    && mvcc_store
+                        .last_committed_schema_change_ts
+                        .load(Ordering::Acquire)
+                        > tx.begin_ts
                 {
-                    // Schema changes made after the transaction began always cause a [SchemaConflict] error and the tx must abort.
                     return Err(LimboError::SchemaConflict);
                 }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -11702,3 +11702,32 @@ fn abandoned_commit_in_committed_state_should_not_block_subsequent_checkpoint() 
 
     conn_b.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }
+
+/// A read-only `BEGIN CONCURRENT` must not be aborted at COMMIT by DDL that
+/// committed on another connection between its `BEGIN` and `COMMIT`. The
+/// reader saw a consistent pre-DDL snapshot and has no writes to invalidate,
+/// so there is nothing for the schema-conflict check to protect against.
+///
+/// Regression for `mvcc_findings/ACTION_PLAN.md` issue A1 (global schema
+/// cookie aborts unrelated transactions).
+#[test]
+fn read_only_bc_survives_unrelated_ddl() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+
+    let c1 = db.connect();
+    let c2 = db.connect();
+
+    c1.execute("CREATE TABLE t(x INT)").unwrap();
+    c1.execute("INSERT INTO t VALUES (1)").unwrap();
+
+    c2.execute("BEGIN CONCURRENT").unwrap();
+    let rows = get_rows(&c2, "SELECT * FROM t");
+    assert_eq!(rows.len(), 1);
+
+    // Unrelated DDL on a different table while c2 is mid-BC.
+    c1.execute("CREATE TABLE u(z INT)").unwrap();
+
+    // A read-only BC saw a consistent snapshot and has nothing to invalidate.
+    c2.execute("COMMIT")
+        .expect("read-only BEGIN CONCURRENT must not be aborted by unrelated DDL");
+}

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1653,14 +1653,19 @@ pub fn test_mvcc_stale_snapshot_after_schema_updated() {
         .build();
     let conn1 = tmp_db.connect_limbo();
     let conn2 = tmp_db.connect_limbo();
-    // Setup: create initial table
+    // Setup: create initial tables
     conn1
         .execute("CREATE TABLE t (key TEXT PRIMARY KEY, value TEXT)")
         .unwrap();
+    conn1
+        .execute("CREATE TABLE u (key TEXT PRIMARY KEY, value TEXT)")
+        .unwrap();
     // conn1: Start a CONCURRENT transaction
     conn1.execute("BEGIN CONCURRENT").unwrap();
-    // Do something to establish the MVCC snapshot
-    conn1.execute("SELECT * FROM t").unwrap();
+    // Perform a write to establish the MVCC snapshot + get marked as write transaction internally
+    conn1
+        .execute("INSERT INTO u VALUES ('test_key', 'test_value')")
+        .unwrap();
     // conn2: Modify schema while conn1's CONCURRENT transaction is active
     conn2.execute("CREATE TABLE t2 (x)").unwrap();
     // conn1: Try to COMMIT - should fail with SchemaConflict
@@ -1673,11 +1678,9 @@ pub fn test_mvcc_stale_snapshot_after_schema_updated() {
         .unwrap();
 
     // conn1: Start a new CONCURRENT transaction
-    // BUG: This should get a fresh MVCC snapshot, but it reuses the old one
     conn1.execute("BEGIN CONCURRENT").unwrap();
 
     // conn1: SELECT should see the row inserted by conn2
-    // BUG: Due to stale snapshot, this returns empty result
     let rows: Vec<(String, String)> = conn1.exec_rows("SELECT * FROM t WHERE key = 'test_key'");
 
     assert_eq!(


### PR DESCRIPTION
A `BEGIN CONCURRENT` that performs no writes saw a consistent pre-DDL snapshot and has nothing the schema-conflict check needs to protect. Previously, the check at the top of `CommitState::Initial` was unconditional, so a read-only BC aborted with `SchemaConflict` whenever any other connection committed DDL between its BEGIN and COMMIT, even on unrelated objects. Long-lived analytics readers were silently killed by routine schema housekeeping like `CREATE INDEX IF NOT EXISTS`.

Gate the check on `has_writes` (write_set non-empty or header dirty), the same readiness signal the existing read-only fast path uses a few lines below. Writing transactions still abort as before, preserving correctness against operations against a possibly-obsolete schema.

Adds regression test `read_only_bc_survives_unrelated_ddl`.