### PR TITLE
testing/simulator: randomize page_size + run integrity_check under MVCCSimulator randomize page size

### DIFF
--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -37,6 +37,22 @@ pub struct Profile {
     pub query: QueryProfile,
     #[garde(range(min = 200, max = 2000))]
     pub cache_size_pages: Option<usize>,
+    /// DB page size in bytes. None = engine default (4096). Must be a power of 2
+    /// in [512, 65536]. The simulator's `--randomize-page-size` CLI flag overrides
+    /// this on a per-run basis.
+    #[garde(custom(validate_page_size))]
+    pub page_size: Option<u32>,
+}
+
+fn validate_page_size(value: &Option<u32>, _: &()) -> garde::Result {
+    if let Some(v) = value
+        && !matches!(*v, 512 | 1024 | 2048 | 4096 | 8192 | 16384 | 32768 | 65536)
+    {
+        return Err(garde::Error::new(format!(
+            "page_size must be a power of two in [512, 65536], got {v}"
+        )));
+    }
+    Ok(())
 }
 
 impl Default for Profile {
@@ -47,6 +63,7 @@ impl Default for Profile {
             io: Default::default(),
             query: Default::default(),
             cache_size_pages: Some(2000),
+            page_size: None,
         }
     }
 }
@@ -221,6 +238,7 @@ impl Profile {
             mvcc: true,
             max_connections: 2,
             cache_size_pages: Some(2000),
+            page_size: None,
         };
         profile.validate().unwrap();
         profile

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -167,6 +167,18 @@ pub struct SimulatorCLI {
     pub mvcc: Option<bool>,
     #[clap(
         long,
+        help = "Override DB page size in bytes (power of 2 in [512, 65536]). Conflicts with --randomize-page-size."
+    )]
+    pub page_size: Option<u32>,
+    #[clap(
+        long,
+        help = "Pick a random valid DB page size (512, 1024, 2048, 4096, 8192, 16384, 32768, 65536) per run, derived from seed.",
+        default_value_t = false,
+        conflicts_with = "page_size"
+    )]
+    pub randomize_page_size: bool,
+    #[clap(
+        long,
         help = "Keep all database and plan files",
         default_value_t = false
     )]
@@ -236,6 +248,13 @@ impl SimulatorCLI {
                 self.maximum_tests
             );
             self.minimum_tests = self.maximum_tests;
+        }
+        if let Some(ps) = self.page_size
+            && !matches!(ps, 512 | 1024 | 2048 | 4096 | 8192 | 16384 | 32768 | 65536)
+        {
+            anyhow::bail!(
+                "--page-size must be a power of two in [512, 65536], got {ps}"
+            );
         }
         Ok(())
     }

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -26,6 +26,30 @@ use crate::runner::memory::io::MemorySimIO;
 const DEFAULT_CACHE_SIZE: usize = 2000;
 use super::cli::SimulatorCLI;
 
+/// Valid SQLite DB page sizes in bytes (powers of two in [512, 65536]).
+const VALID_PAGE_SIZES: [u32; 8] = [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
+
+/// Resolve the page size to use for this simulation run.
+///
+/// Resolution order (first non-None wins):
+/// 1. Explicit `--page-size` CLI override.
+/// 2. `--randomize-page-size` CLI flag → seed-derived random pick from VALID_PAGE_SIZES.
+/// 3. `Profile::page_size` (set by the profile file).
+/// 4. Engine default `4096` for backwards-compatible behavior.
+fn resolve_page_size<R: Rng>(cli_opts: &SimulatorCLI, profile: &Profile, rng: &mut R) -> usize {
+    if let Some(ps) = cli_opts.page_size {
+        return ps as usize;
+    }
+    if cli_opts.randomize_page_size {
+        let idx = rng.random_range(0..VALID_PAGE_SIZES.len());
+        return VALID_PAGE_SIZES[idx] as usize;
+    }
+    if let Some(ps) = profile.page_size {
+        return ps as usize;
+    }
+    4096
+}
+
 /// Pre-create attached DB files with MVCC journal mode so that journal modes
 /// are compatible when ATTACH happens later during simulation.
 fn enable_mvcc_on_attached_dbs(io: &Arc<dyn SimIO>, aux_paths: impl Iterator<Item = PathBuf>) {
@@ -1107,7 +1131,7 @@ impl SimulatorEnv {
             disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
-            page_size: 4096, // TODO: randomize this too
+            page_size: resolve_page_size(cli_opts, profile, &mut rng),
             max_interactions: rng.random_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_time_simulation: cli_opts.maximum_time,
             disable_reopen_database: cli_opts.disable_reopen_database,
@@ -1213,6 +1237,19 @@ impl SimulatorEnv {
                 panic!("error opening simulator test file {db_path:?}: {e:?}");
             }
         };
+
+        // Apply PRAGMA page_size before any tables exist so the value lands in the
+        // database header. Skip the default 4096: emitting it would still be valid
+        // but adds a needless write on every legacy run.
+        if opts.page_size != 4096 {
+            let conn = db
+                .connect()
+                .expect("Failed to create connection for page_size setup");
+            conn.execute(format!("PRAGMA page_size = {}", opts.page_size))
+                .unwrap_or_else(|e| {
+                    panic!("Failed to set PRAGMA page_size = {}: {e:?}", opts.page_size)
+                });
+        }
 
         // Switch to MVCC mode if the profile says to use MVCC
         if profile.mvcc {

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -247,8 +247,11 @@ pub fn execute_interaction_turso(
             }
 
             stack.push(results);
-            // TODO: skip integrity check with mvcc
-            if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
+            // Previously this skipped integrity_check entirely under MVCC. We now run it
+            // both modes — under MVCC we throttle to 1/40 instead of 1/10 since the check
+            // is more expensive when snapshot state has to be reconciled.
+            let check_ratio = if env.profile.mvcc { 40 } else { 10 };
+            if env.rng.random_ratio(1, check_ratio) {
                 let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
                 else {
                     unreachable!()
@@ -309,8 +312,9 @@ pub fn execute_interaction_turso(
             stack.push(results);
             // Reset fault injection
             env.io.inject_fault(false);
-            // TODO: skip integrity check with mvcc
-            if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
+            // Same MVCC-aware throttling as the regular Query path above.
+            let check_ratio = if env.profile.mvcc { 40 } else { 10 };
+            if env.rng.random_ratio(1, check_ratio) {
                 limbo_integrity_check(&conn)?;
             }
         }


### PR DESCRIPTION
Two small simulator improvements that close out two explicit TODOs in `testing/simulator/`. Together they widen the test surface and (in my testing)
  immediately surfaced a real MVCC data-corruption bug — filed separately in #6820 .

  ## 1. Randomize `page_size` (closes the TODO at `runner/env.rs:1110`)

  - New `Profile::page_size: Option<u32>` lets a custom profile fix a page size, validated against the SQLite-valid set {512, 1024, 2048, 4096, 8192, 16384,
   32768, 65536}.
  - New `--page-size N` CLI flag overrides the profile for repros.
  - New `--randomize-page-size` CLI flag picks a fresh value from the valid set per run, derived from the seed so reproducibility is preserved.
  - When the resolved value isn't the engine default 4096, the simulator issues `PRAGMA page_size = N` on a setup connection right after the database is
  opened and before any tables exist, so it lands in the DB header.

  Existing behavior is preserved when none of the new knobs are set — the legacy 4096 path keeps running unchanged.

  ## 2. Run `integrity_check` under MVCC too (closes the TODO at `runner/execution.rs:250`)

  Previously the periodic `PRAGMA integrity_check` was gated on `!env.profile.mvcc`, so MVCC simulations had no periodic correctness oracle between operations. The final SQLite check still ran, but a failure could not be localized. Now the check runs in both modes, throttled to 1/40 under MVCC (vs. 1/10 otherwise) since reconciling snapshot state is more expensive.

  ## Why these two together

  Both touch the same area (per-run config of the simulator), both close existing TODOs the maintainers had already noted, and the combined diff is small.
  Happy to split into two PRs if preferred.

  ## Sanity

  - `cargo check -p limbo_sim`: clean (only pre-existing warnings unrelated to this change).
  - `cargo build --release -p limbo_sim`: clean.
  - 30 seeds × `--randomize-page-size` on default profile: 30/30 pass.
  - 15 seeds × `--randomize-page-size --differential` (vs SQLite): 15/15 pass.
  - Hitting `--profile simple_mvcc` immediately reproduces a pre-existing data-corruption bug on every seed (see #6820 ); this PR doesn't fix that
  bug, but it makes future MVCC-targeted runs strictly more informative.