### PR TITLE
simulator: generate explicit integrity checks

### DIFF
--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    IntegrityCheck,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,6 +33,7 @@ impl Display for Pragma {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
             }
+            Pragma::IntegrityCheck => write!(f, "PRAGMA integrity_check"),
         }
     }
 }

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -84,6 +84,10 @@ fn random_create_index<R: rand::Rng + ?Sized>(
 }
 
 fn random_pragma<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationContext) -> Query {
+    if rng.random_bool(0.25) {
+        return Query::Pragma(Pragma::IntegrityCheck);
+    }
+
     if !conn_ctx.tables().is_empty() && rng.random_bool(0.5) {
         let table = conn_ctx.tables().choose(rng).unwrap();
         return Query::Pragma(Pragma::ForeignKeyList(table.name.clone()));

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -468,7 +468,9 @@ impl Shadow for Query {
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
-            Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(
+                Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_) | Pragma::IntegrityCheck,
+            ) => Ok(vec![]),
         }
     }
 }

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -177,7 +177,7 @@ impl Profile {
                 drop_table_weight: 0,
                 alter_table_weight: 0,
                 drop_index: 0,
-                pragma_weight: 0,
+                pragma_weight: 10,
                 ..Default::default()
             },
             ..Default::default()

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -246,6 +246,12 @@ pub fn execute_interaction_turso(
                 return Ok(ExecutionContinuation::NextInteraction);
             }
 
+            if let Query::Pragma(sql_generation::model::query::pragma::Pragma::IntegrityCheck) =
+                query
+            {
+                assert_integrity_check_result(results.as_ref().expect("checked above"))?;
+            }
+
             stack.push(results);
             // TODO: skip integrity check with mvcc
             if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
@@ -321,6 +327,38 @@ pub fn execute_interaction_turso(
         )));
     }
     Ok(ExecutionContinuation::NextInteraction)
+}
+
+fn assert_integrity_check_result(rows: &[Vec<SimValue>]) -> Result<()> {
+    if rows.is_empty() {
+        return Err(LimboError::InternalError(
+            "PRAGMA integrity_check did not return a value".to_string(),
+        ));
+    }
+
+    let mut messages = Vec::new();
+    for row in rows {
+        let Some(value) = row.first() else {
+            return Err(LimboError::InternalError(
+                "PRAGMA integrity_check returned an empty row".to_string(),
+            ));
+        };
+        let Some(text) = value.0.to_text() else {
+            return Err(LimboError::InternalError(
+                "PRAGMA integrity_check returned a non-text value".to_string(),
+            ));
+        };
+        messages.push(text.to_string());
+    }
+
+    let message = messages.join("\n");
+    if message.eq_ignore_ascii_case("ok") {
+        Ok(())
+    } else {
+        Err(LimboError::InternalError(format!(
+            "Integrity Check Failed: {message}"
+        )))
+    }
 }
 
 fn limbo_integrity_check(conn: &Arc<Connection>) -> Result<()> {
@@ -459,37 +497,9 @@ fn execute_query_rusqlite(
         );
     }
     match query {
-        Query::Select(select) => {
-            let mut stmt = connection.prepare(select.to_string().as_str())?;
-            let rows = stmt.query_map([], |row| {
-                let mut values = vec![];
-                for i in 0.. {
-                    let value = match row.get(i) {
-                        Ok(value) => value,
-                        Err(err) => match err {
-                            rusqlite::Error::InvalidColumnIndex(_) => break,
-                            _ => {
-                                tracing::error!(?err);
-                                panic!("{err}")
-                            }
-                        },
-                    };
-                    let value = match value {
-                        rusqlite::types::Value::Null => Value::Null,
-                        rusqlite::types::Value::Integer(i) => Value::from_i64(i),
-                        rusqlite::types::Value::Real(f) => Value::from_f64(f),
-                        rusqlite::types::Value::Text(s) => Value::build_text(s),
-                        rusqlite::types::Value::Blob(b) => Value::Blob(b),
-                    };
-                    values.push(SimValue(value));
-                }
-                Ok(values)
-            })?;
-            let mut result = vec![];
-            for row in rows {
-                result.push(row?);
-            }
-            Ok(result)
+        Query::Select(select) => query_rusqlite_rows(connection, &select.to_string()),
+        Query::Pragma(sql_generation::model::query::pragma::Pragma::IntegrityCheck) => {
+            query_rusqlite_rows(connection, &query.to_string())
         }
         Query::Placeholder => {
             unreachable!("simulation cannot have a placeholder Query for execution")
@@ -499,4 +509,40 @@ fn execute_query_rusqlite(
             Ok(vec![])
         }
     }
+}
+
+fn query_rusqlite_rows(
+    connection: &rusqlite::Connection,
+    query: &str,
+) -> rusqlite::Result<Vec<Vec<SimValue>>> {
+    let mut stmt = connection.prepare(query)?;
+    let rows = stmt.query_map([], |row| {
+        let mut values = vec![];
+        for i in 0.. {
+            let value = match row.get(i) {
+                Ok(value) => value,
+                Err(err) => match err {
+                    rusqlite::Error::InvalidColumnIndex(_) => break,
+                    _ => {
+                        tracing::error!(?err);
+                        panic!("{err}")
+                    }
+                },
+            };
+            let value = match value {
+                rusqlite::types::Value::Null => Value::Null,
+                rusqlite::types::Value::Integer(i) => Value::from_i64(i),
+                rusqlite::types::Value::Real(f) => Value::from_f64(f),
+                rusqlite::types::Value::Text(s) => Value::build_text(s),
+                rusqlite::types::Value::Blob(b) => Value::Blob(b),
+            };
+            values.push(SimValue(value));
+        }
+        Ok(values)
+    })?;
+    let mut result = vec![];
+    for row in rows {
+        result.push(row?);
+    }
+    Ok(result)
 }


### PR DESCRIPTION
## Summary
- add `PRAGMA integrity_check` to the generated pragma model
- enable pragma generation in the `savepoint_stress` simulator profile so integrity checks can interleave with savepoint/cache-pressure workloads
- treat explicit integrity-check result rows as assertions in the simulator runner, failing if the result is not `ok`
- allow the rusqlite differential path to execute and normalize the same integrity-check rows

This is intended as a Turso challenge simulator-hardening contribution: it makes the simulator check for corruption closer to the operation that caused it, instead of relying only on end-of-run checks.

Challenge context: https://algora.io/challenges/turso

## Validation
- `/Users/punkyrest/.cargo/bin/cargo fmt --check`
- `/Users/punkyrest/.cargo/bin/cargo test -p limbo_sim` -> 27 passed
- `target/debug/limbo_sim --profile savepoint_stress --maximum-tests 50 --minimum-tests 20 --maximum-time 5 --disable-bugbase --disable-update --disable-delete` -> simulation succeeded, seed `14660474688651373517`
