### PR TITLE
 core/mvcc: publish schema roots after checkpoint pager commit

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1327,14 +1327,18 @@ impl Connection {
         if self.schema_reparse_in_progress() {
             return;
         }
-        let current_schema_version = self.schema.read().schema_version;
+        let current_schema = self.schema.read().clone();
         let schema = self.db.schema.lock();
         if matches!(self.get_tx_state(), TransactionState::None)
             && self.get_mv_tx().is_none()
             && self.next_attached_mv_tx().is_none()
-            && current_schema_version != schema.schema_version
+            // MVCC checkpoint can publish root-page and dropped-root updates
+            // without changing SQLite's user-visible schema cookie.
+            && (current_schema.schema_version != schema.schema_version
+                || (self.mvcc_enabled() && !Arc::ptr_eq(&current_schema, &schema)))
         {
             *self.schema.write() = schema.clone();
+            self.bump_prepare_context_generation();
         }
     }
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1332,8 +1332,10 @@ impl Connection {
         if matches!(self.get_tx_state(), TransactionState::None)
             && self.get_mv_tx().is_none()
             && self.next_attached_mv_tx().is_none()
-            // MVCC checkpoint can publish root-page and dropped-root updates
-            // without changing SQLite's user-visible schema cookie.
+            // In MVCC, checkpoint root publication can replace Database::schema
+            // without changing SQLite's schema cookie. If this connection
+            // still holds an older Schema snapshot, prepared statements must be
+            // invalidated and recompiled against the current roots.
             && (current_schema.schema_version != schema.schema_version
                 || (self.mvcc_enabled() && !Arc::ptr_eq(&current_schema, &schema)))
         {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -732,9 +732,31 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         }
     }
 
-    fn publish_checkpointed_schema_roots(&mut self) -> Result<()> {
+    fn has_unpublished_schema_changes(&self) -> bool {
+        let schema = self.connection.db.schema.lock();
+        !schema.dropped_root_pages.is_empty()
+            || schema
+                .tables
+                .values()
+                .any(|table| table.btree().is_some_and(|btree| btree.root_page < 0))
+            || schema
+                .indexes
+                .values()
+                .flatten()
+                .any(|index| index.root_page < 0)
+    }
+
+    fn has_pending_root_publication(&self) -> bool {
+        !self.created_btrees.is_empty() || self.has_unpublished_schema_changes()
+    }
+
+    fn publish_checkpointed_schema_roots(&mut self) {
+        if !self.has_pending_root_publication() {
+            return;
+        }
+
         // Patch sqlite_schema in MV Store to contain positive rootpages instead of negative ones
-        // for tables and indexes that were flushed to the physical database
+        // for tables and indexes that were flushed to the physical database.
         for (sqlite_schema_rowid, (_, row_version)) in self.created_btrees.drain() {
             let key = RowID {
                 table_id: SQLITE_SCHEMA_MVCC_TABLE_ID,
@@ -763,60 +785,58 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             }
         }
 
-        // Patch in-memory schema to do the same
-        self.connection.db.with_schema_mut(|schema| {
-            for table in schema.tables.values_mut() {
-                let table = Arc::get_mut(table).expect("this should be the only reference");
-                let Some(btree_table) = table.btree_mut() else {
-                    continue;
-                };
-                let btree_table = Arc::make_mut(btree_table);
-                if btree_table.root_page < 0 {
-                    let table_id = MVTableId::from(btree_table.root_page);
+        if !self.has_unpublished_schema_changes() {
+            return;
+        }
+
+        // Patch in-memory schema to do the same. This must happen as soon as the
+        // pager commit succeeds because the committed root pages are then visible
+        // through WAL even if the later WAL checkpoint/log truncation is busy.
+        let mut schema_ref = self.connection.db.schema.lock();
+        let schema = Arc::make_mut(&mut *schema_ref);
+        for table in schema.tables.values_mut() {
+            let table = Arc::get_mut(table).expect("this should be the only reference");
+            let Some(btree_table) = table.btree_mut() else {
+                continue;
+            };
+            let btree_table = Arc::make_mut(btree_table);
+            if btree_table.root_page < 0 {
+                let table_id = MVTableId::from(btree_table.root_page);
+                let entry = self
+                    .mvstore
+                    .table_id_to_rootpage
+                    .get(&table_id)
+                    .expect("we should have checkpointed table with table_id {table_id:?}");
+                let value = entry
+                    .value()
+                    .expect("table with id {table_id:?} should have a mapping");
+                btree_table.root_page = value as i64;
+            }
+        }
+        for table_index_list in schema.indexes.values_mut() {
+            for index in table_index_list.iter_mut() {
+                if index.root_page < 0 {
+                    let table_id = MVTableId::from(index.root_page);
                     let entry = self
                         .mvstore
                         .table_id_to_rootpage
                         .get(&table_id)
-                        .expect("we should have checkpointed table with table_id {table_id:?}");
+                        .expect("we should have checkpointed index with table_id {table_id:?}");
                     let value = entry
                         .value()
-                        .expect("table with id {table_id:?} should have a mapping");
-                    btree_table.root_page = value as i64;
+                        .expect("index with id {table_id:?} should have a mapping");
+                    let index = Arc::make_mut(index);
+                    index.root_page = value as i64;
                 }
             }
-            for table_index_list in schema.indexes.values_mut() {
-                for index in table_index_list.iter_mut() {
-                    if index.root_page < 0 {
-                        let table_id = MVTableId::from(index.root_page);
-                        let entry =
-                            self.mvstore.table_id_to_rootpage.get(&table_id).expect(
-                                "we should have checkpointed index with table_id {table_id:?}",
-                            );
-                        let value = entry
-                            .value()
-                            .expect("index with id {table_id:?} should have a mapping");
-                        let index = Arc::make_mut(index);
-                        index.root_page = value as i64;
-                    }
-                }
-            }
+        }
 
-            schema.schema_version += 1;
-            // Clear dropped root pages now that the checkpoint has completed.
-            // The btree pages for dropped tables have been freed, so integrity_check
-            // no longer needs to track them.
-            schema.dropped_root_pages.clear();
-            let _ = self.pager.io.block(|| {
-                self.pager.with_header_mut(|header| {
-                    header.schema_cookie = schema.schema_version.into();
-                    self.mvstore.global_header.write().replace(*header);
-                    IOResult::Done(())
-                })
-            })?;
-            Ok(())
-        })?;
-
-        Ok(())
+        // Clear dropped root pages now that the pager commit contains the btree frees.
+        // integrity_check should now follow the committed freelist state instead.
+        schema.dropped_root_pages.clear();
+        drop(schema_ref);
+        *self.connection.schema.write() = self.connection.db.clone_schema();
+        self.connection.bump_prepare_context_generation();
     }
 
     /// Garbage-collect row versions for rows that were just checkpointed.
@@ -1558,7 +1578,12 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             )
                         })?;
                         self.mvstore.global_header.write().replace(header);
+                        self.publish_checkpointed_schema_roots();
                         inject_transition_failure!(
+                            self,
+                            CheckpointYieldPoint::AfterDurableBoundaryAdvanced
+                        );
+                        inject_transition_yield!(
                             self,
                             CheckpointYieldPoint::AfterDurableBoundaryAdvanced
                         );
@@ -1668,7 +1693,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
             CheckpointState::Finalize => {
                 tracing::debug!("Releasing blocking checkpoint lock");
-                self.publish_checkpointed_schema_roots()?;
+                turso_assert!(
+                    !self.has_pending_root_publication(),
+                    "checkpoint finalized after pager writes without publishing schema changes"
+                );
 
                 self.mvstore
                     .durable_txid_max

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -732,6 +732,93 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         }
     }
 
+    fn publish_checkpointed_schema_roots(&mut self) -> Result<()> {
+        // Patch sqlite_schema in MV Store to contain positive rootpages instead of negative ones
+        // for tables and indexes that were flushed to the physical database
+        for (sqlite_schema_rowid, (_, row_version)) in self.created_btrees.drain() {
+            let key = RowID {
+                table_id: SQLITE_SCHEMA_MVCC_TABLE_ID,
+                row_id: RowKey::Int(sqlite_schema_rowid),
+            };
+            let sqlite_schema_row = self
+                .mvstore
+                .rows
+                .get(&key)
+                .expect("sqlite_schema row not found");
+            let mut row_versions = sqlite_schema_row.value().write();
+            // row_version is a clone of the original with only the root
+            // page column patched, so it shares the same version id. We
+            // must replace the original in-place rather than append,
+            // otherwise the version chain ends up with two entries that
+            // have identical (id, begin, end). A later DELETE only marks
+            // one of them as ended (it returns after the first match),
+            // leaving the other as a phantom current version that causes
+            // spurious write-write conflicts at commit time.
+            let vid = row_version.id;
+            if let Some(existing) = row_versions.iter_mut().find(|rv| rv.id == vid) {
+                *existing = row_version;
+            } else {
+                self.mvstore
+                    .insert_version_raw(&mut row_versions, row_version);
+            }
+        }
+
+        // Patch in-memory schema to do the same
+        self.connection.db.with_schema_mut(|schema| {
+            for table in schema.tables.values_mut() {
+                let table = Arc::get_mut(table).expect("this should be the only reference");
+                let Some(btree_table) = table.btree_mut() else {
+                    continue;
+                };
+                let btree_table = Arc::make_mut(btree_table);
+                if btree_table.root_page < 0 {
+                    let table_id = MVTableId::from(btree_table.root_page);
+                    let entry = self
+                        .mvstore
+                        .table_id_to_rootpage
+                        .get(&table_id)
+                        .expect("we should have checkpointed table with table_id {table_id:?}");
+                    let value = entry
+                        .value()
+                        .expect("table with id {table_id:?} should have a mapping");
+                    btree_table.root_page = value as i64;
+                }
+            }
+            for table_index_list in schema.indexes.values_mut() {
+                for index in table_index_list.iter_mut() {
+                    if index.root_page < 0 {
+                        let table_id = MVTableId::from(index.root_page);
+                        let entry =
+                            self.mvstore.table_id_to_rootpage.get(&table_id).expect(
+                                "we should have checkpointed index with table_id {table_id:?}",
+                            );
+                        let value = entry
+                            .value()
+                            .expect("index with id {table_id:?} should have a mapping");
+                        let index = Arc::make_mut(index);
+                        index.root_page = value as i64;
+                    }
+                }
+            }
+
+            schema.schema_version += 1;
+            // Clear dropped root pages now that the checkpoint has completed.
+            // The btree pages for dropped tables have been freed, so integrity_check
+            // no longer needs to track them.
+            schema.dropped_root_pages.clear();
+            let _ = self.pager.io.block(|| {
+                self.pager.with_header_mut(|header| {
+                    header.schema_cookie = schema.schema_version.into();
+                    self.mvstore.global_header.write().replace(*header);
+                    IOResult::Done(())
+                })
+            })?;
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
     /// Garbage-collect row versions for rows that were just checkpointed.
     /// Must be called AFTER durable_txid_max is updated and BEFORE the
     /// checkpoint lock is released (no concurrent writers under blocking lock).
@@ -1581,89 +1668,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
             CheckpointState::Finalize => {
                 tracing::debug!("Releasing blocking checkpoint lock");
-                // Patch sqlite_schema in MV Store to contain positive rootpages instead of negative ones
-                // for tables and indexes that were flushed to the physical database
-                for (sqlite_schema_rowid, (_, row_version)) in self.created_btrees.drain() {
-                    let key = RowID {
-                        table_id: SQLITE_SCHEMA_MVCC_TABLE_ID,
-                        row_id: RowKey::Int(sqlite_schema_rowid),
-                    };
-                    let sqlite_schema_row = self
-                        .mvstore
-                        .rows
-                        .get(&key)
-                        .expect("sqlite_schema row not found");
-                    let mut row_versions = sqlite_schema_row.value().write();
-                    // row_version is a clone of the original with only the root
-                    // page column patched, so it shares the same version id. We
-                    // must replace the original in-place rather than append,
-                    // otherwise the version chain ends up with two entries that
-                    // have identical (id, begin, end). A later DELETE only marks
-                    // one of them as ended (it returns after the first match),
-                    // leaving the other as a phantom current version that causes
-                    // spurious write-write conflicts at commit time.
-                    let vid = row_version.id;
-                    if let Some(existing) = row_versions.iter_mut().find(|rv| rv.id == vid) {
-                        *existing = row_version;
-                    } else {
-                        self.mvstore
-                            .insert_version_raw(&mut row_versions, row_version);
-                    }
-                }
-
-                // Patch in-memory schema to do the same
-                self.connection.db.with_schema_mut(|schema| {
-                    for table in schema.tables.values_mut() {
-                        let table = Arc::get_mut(table).expect("this should be the only reference");
-                        let Some(btree_table) = table.btree_mut() else {
-                            continue;
-                        };
-                        let btree_table = Arc::make_mut(btree_table);
-                        if btree_table.root_page < 0 {
-                            let table_id = MVTableId::from(btree_table.root_page);
-                            let entry = self.mvstore.table_id_to_rootpage.get(&table_id).expect(
-                                "we should have checkpointed table with table_id {table_id:?}",
-                            );
-                            let value = entry
-                                .value()
-                                .expect("table with id {table_id:?} should have a mapping");
-                            btree_table.root_page = value as i64;
-                        }
-                    }
-                    for table_index_list in schema.indexes.values_mut() {
-                        for index in table_index_list.iter_mut() {
-                            if index.root_page < 0 {
-                                let table_id = MVTableId::from(index.root_page);
-                                let entry = self
-                                    .mvstore
-                                    .table_id_to_rootpage
-                                    .get(&table_id)
-                                    .expect(
-                                    "we should have checkpointed index with table_id {table_id:?}",
-                                );
-                                let value = entry
-                                    .value()
-                                    .expect("index with id {table_id:?} should have a mapping");
-                                let index = Arc::make_mut(index);
-                                index.root_page = value as i64;
-                            }
-                        }
-                    }
-
-                    schema.schema_version += 1;
-                    // Clear dropped root pages now that the checkpoint has completed.
-                    // The btree pages for dropped tables have been freed, so integrity_check
-                    // no longer needs to track them.
-                    schema.dropped_root_pages.clear();
-                    let _ = self.pager.io.block(|| {
-                        self.pager.with_header_mut(|header| {
-                            header.schema_cookie = schema.schema_version.into();
-                            self.mvstore.global_header.write().replace(*header);
-                            IOResult::Done(())
-                        })
-                    })?;
-                    Ok(())
-                })?;
+                self.publish_checkpointed_schema_roots()?;
 
                 self.mvstore
                     .durable_txid_max

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -18,7 +18,9 @@ use crate::storage::sqlite3_ondisk::{
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sync::Mutex;
 use crate::sync::RwLock;
-use crate::{Buffer, Completion, DatabaseOpts, EncryptionKey, LimboError, OpenFlags};
+use crate::{
+    Buffer, Completion, DatabaseOpts, EncryptionKey, LimboError, OpenFlags, StatementStatusCounter,
+};
 use quickcheck::{Arbitrary, Gen};
 use quickcheck_macros::quickcheck;
 use rand::{Rng, SeedableRng};
@@ -52,6 +54,10 @@ impl FixedYieldInjector {
             remaining: Mutex::new(points.into_iter().collect()),
         })
     }
+
+    fn is_empty(&self) -> bool {
+        self.remaining.lock().is_empty()
+    }
 }
 
 impl YieldInjector for FixedYieldInjector {
@@ -70,6 +76,10 @@ impl FixedFailureInjector {
         Arc::new(Self {
             remaining: Mutex::new(points.into_iter().collect()),
         })
+    }
+
+    fn is_empty(&self) -> bool {
+        self.remaining.lock().is_empty()
     }
 }
 
@@ -2256,6 +2266,179 @@ fn test_meta_checkpoint_case_10_metadata_upsert_is_atomic_with_pager_commit() {
         meta[0][0].as_int().unwrap() >= 1,
         "expected metadata boundary to persist with pager commit"
     );
+}
+
+/// What this test checks: ordinary prepared reads recompile when checkpoint publishes a table root page.
+/// Why this matters: root publication invalidates compiled bytecode generally, not only PRAGMA integrity_check.
+#[test]
+fn test_prepared_select_reprepares_after_checkpoint_root_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    let mut stmt = conn.prepare("SELECT id, v FROM t ORDER BY id").unwrap();
+    assert_eq!(stmt.stmt_status(StatementStatusCounter::Reprepare), 0);
+
+    conn.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(&rows[0][1].to_string(), "a");
+    assert_eq!(stmt.stmt_status(StatementStatusCounter::Reprepare), 1);
+}
+
+/// What this test checks: data-only MVCC checkpoints do not invalidate already-prepared statements.
+/// Why this matters: only root/drop publication should force reprepare; ordinary row checkpointing should leave prepared bytecode reusable.
+#[test]
+fn test_prepared_select_does_not_reprepare_after_data_only_checkpoint() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut stmt = conn.prepare("SELECT id, v FROM t ORDER BY id").unwrap();
+    assert_eq!(stmt.stmt_status(StatementStatusCounter::Reprepare), 0);
+
+    conn.execute("INSERT INTO t VALUES (2, 'b')").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(&rows[0][1].to_string(), "a");
+    assert_eq!(rows[1][0].as_int().unwrap(), 2);
+    assert_eq!(&rows[1][1].to_string(), "b");
+    assert_eq!(stmt.stmt_status(StatementStatusCounter::Reprepare), 0);
+}
+
+/// What this test checks: prepared index lookups recompile when checkpoint publishes an index root page.
+/// Why this matters: table and index roots are published independently, and stale index bytecode must not survive checkpoint.
+#[test]
+fn test_prepared_index_lookup_reprepares_after_checkpoint_root_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, payload TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+
+    let mut stmt = conn
+        .prepare("SELECT id, payload FROM t INDEXED BY idx_t_v WHERE v = 'b'")
+        .unwrap();
+    assert_eq!(stmt.stmt_status(StatementStatusCounter::Reprepare), 0);
+
+    conn.execute("INSERT INTO t VALUES (1, 'a', 'one')")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (2, 'b', 'two')")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = stmt.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+    assert_eq!(&rows[0][1].to_string(), "two");
+    assert_eq!(stmt.stmt_status(StatementStatusCounter::Reprepare), 1);
+}
+
+/// What this test checks: the public statement API can yield in auto-checkpoint and then surface a post-durable-boundary checkpoint failure without losing committed root-page state.
+/// Why this matters: checkpoint roots are visible through WAL at this boundary, so error cleanup must keep integrity_check and reads coherent.
+#[test]
+fn test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses_user_apis() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+    let stale_schema_conn = db.connect();
+    let mut stale_integrity_check = stale_schema_conn.prepare("PRAGMA integrity_check").unwrap();
+    let schema_version = get_rows(&conn, "PRAGMA schema_version");
+    assert_eq!(schema_version.len(), 1);
+    let schema_version_before_checkpoint = schema_version[0][0].as_int().unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+
+    let injector = FixedYieldInjector::new([CheckpointYieldPoint::BeforeAcquireLock.point()]);
+    conn.set_yield_injector(Some(injector.clone()));
+    let failure_injector = FixedFailureInjector::new([(
+        CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+        LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
+    )]);
+    conn.set_failure_injector(Some(failure_injector.clone()));
+
+    let mut same_conn_stale_integrity_check = conn.prepare("PRAGMA integrity_check").unwrap();
+    let mut insert_stmt = conn.prepare("INSERT INTO t VALUES (1, 'a')").unwrap();
+    let mut yielded_before_checkpoint_lock = false;
+    for _ in 0..10_000 {
+        match insert_stmt.step().unwrap() {
+            crate::StepResult::IO if injector.is_empty() => {
+                yielded_before_checkpoint_lock = true;
+                break;
+            }
+            crate::StepResult::IO => {}
+            crate::StepResult::Done => {
+                panic!("INSERT completed before checkpoint acquire-lock yield fired")
+            }
+            other => panic!("unexpected INSERT step result before yield: {other:?}"),
+        }
+    }
+    assert!(
+        yielded_before_checkpoint_lock,
+        "expected INSERT auto-checkpoint to yield before acquiring the checkpoint lock"
+    );
+
+    let mut completed_after_durable_boundary_failure = false;
+    for _ in 0..10_000 {
+        match insert_stmt.step() {
+            Ok(crate::StepResult::Done) if failure_injector.is_empty() => {
+                completed_after_durable_boundary_failure = true;
+                break;
+            }
+            Ok(crate::StepResult::Done) => {
+                panic!("INSERT completed before checkpoint durable-boundary failure fired")
+            }
+            Err(err) => panic!("unexpected INSERT error after yield: {err:?}"),
+            Ok(crate::StepResult::IO) => {}
+            Ok(other) => panic!("unexpected INSERT step result after yield: {other:?}"),
+        }
+    }
+    assert!(
+        completed_after_durable_boundary_failure,
+        "expected INSERT auto-checkpoint to observe durable-boundary failure and finish"
+    );
+
+    conn.set_yield_injector(None);
+    conn.set_failure_injector(None);
+
+    let schema_version = get_rows(&conn, "PRAGMA schema_version");
+    assert_eq!(schema_version.len(), 1);
+    assert_eq!(
+        schema_version[0][0].as_int().unwrap(),
+        schema_version_before_checkpoint
+    );
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    let rows = same_conn_stale_integrity_check.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    let rows = stale_integrity_check.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    let rows = get_rows(&stale_schema_conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+
+    let rows = get_rows(&conn, "SELECT id, v FROM t");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(&rows[0][1].to_string(), "a");
 }
 
 /// What this test checks: Auto-checkpoint post-commit failure does not invalidate committed transaction visibility on restart.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2344,8 +2344,10 @@ fn test_prepared_index_lookup_reprepares_after_checkpoint_root_publish() {
     assert_eq!(stmt.stmt_status(StatementStatusCounter::Reprepare), 1);
 }
 
-/// What this test checks: the public statement API can yield in auto-checkpoint and then surface a post-durable-boundary checkpoint failure without losing committed root-page state.
-/// Why this matters: checkpoint roots are visible through WAL at this boundary, so error cleanup must keep integrity_check and reads coherent.
+/// Runs an auto-checkpoint, forces it to yield, then injects an error after the
+/// pager commit has made the new root pages visible. Even though later checkpoint
+/// cleanup fails, prepared integrity_check statements must use the committed root
+/// pages and report a clean database.
 #[test]
 fn test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses_user_apis() {
     let db = MvccTestDbNoConn::new_with_random_db();

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -290,15 +290,19 @@ impl Statement {
                 .fetch_add(1, Ordering::SeqCst);
             self.counted_as_active_root = true;
         }
-        if matches!(self.state.execution_state, ProgramExecutionState::Init)
-            && !self
+        if matches!(self.state.execution_state, ProgramExecutionState::Init) {
+            if self.program.connection.mvcc_enabled() {
+                self.program.connection.maybe_update_schema();
+            }
+            if !self
                 .program
                 .prepare_context
                 .matches_connection(&self.program.connection)
-        {
-            if let Err(err) = self.reprepare() {
-                self.release_active_root_if_counted();
-                return Err(err);
+            {
+                if let Err(err) = self.reprepare() {
+                    self.release_active_root_if_counted();
+                    return Err(err);
+                }
             }
         }
 

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -292,6 +292,8 @@ impl Statement {
         }
         if matches!(self.state.execution_state, ProgramExecutionState::Init) {
             if self.program.connection.mvcc_enabled() {
+                // MVCC checkpoints can publish internal schema roots without changing
+                // SQLite's schema cookie, so refresh before deciding whether to reprepare.
                 self.program.connection.maybe_update_schema();
             }
             if !self


### PR DESCRIPTION
## Description

Fix for the bug where integrity check was failing. It is not a corruption bug, rather incorrect reporting from integrity check.

## Motivation and context

In MVCC checkpoint, first we rewrite the db log changes to the SQLite, by writing to WAL. Once it is done, we checkpoint it. Once the log changes are written to WAL, we might need to refresh the schema even if the subsequent checkpoint or IO fail. The changes are persisted once pager commits them to WAL. However, we were updating the schema at the last, not right after the pager commit.

So, as a fix, we publish checkpointed MVCC schema roots immediately after pager commit, before later WAL checkpoint / log cleanup phases can fail or yield.

This bug was found by Antithesis:

```
Limbo Test | 2026-05-10
Conducted on 2026-05-10 01:02 UTC
Source: main
Turso - schedule on main (f3990897da902f31fabe2c27d9b6221b6aa04cae) by LeMikaelF (scheduled run)
```

So the DB was not corrupt. Just that integrity check was failing in that connection.

Thanks to codex, the regression test has the same shape as Antithesis:

```rust

cargo test -p turso_core test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses_user_apis -- --nocapture

thread 'mvcc::database::tests::test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses_user_apis' panicked at core/mvcc/database/tests.rs:2425:5:
assertion `left == right` failed
  left: "*** in database main ***\nPage 3: never used\nPage 4: never used"
 right: "ok"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test mvcc::database::tests::test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses_user_apis ... FAILED

failures:

failures:
    mvcc::database::tests::test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses_user_apis
```

## Description of AI Usage

Used Codex to debug the issue and also write the test so that it is similar to the report. I verified the regression test and the fix.