### PR TITLE
core: enforce checks added by ALTER COLUMN

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1693,9 +1693,35 @@ pub fn translate_alter_table(
 
             let rewritten_table = if rewrites_physical_layout {
                 let mut table = btree.clone();
-                table.columns_mut()[column_index] =
-                    replacement_column.expect("replacement_column must exist for ALTER COLUMN");
+                table.columns_mut()[column_index] = replacement_column
+                    .as_ref()
+                    .expect("replacement_column must exist for ALTER COLUMN")
+                    .clone();
                 table.prepare_generated_columns()?;
+                Some(table)
+            } else {
+                None
+            };
+
+            let constraint_validation_table = if !rename {
+                let mut table = btree.clone();
+                table.columns_mut()[column_index] = replacement_column
+                    .as_ref()
+                    .expect("replacement_column must exist for ALTER COLUMN")
+                    .clone();
+                table.prepare_generated_columns()?;
+
+                let column_names: Vec<&str> = table
+                    .columns()
+                    .iter()
+                    .filter_map(|c| c.name.as_deref())
+                    .collect();
+                for constraint in &definition.constraints {
+                    if let ast::ColumnConstraint::Check(expr) = &constraint.constraint {
+                        validate_check_expr(expr, &table.name, &column_names, resolver)?;
+                    }
+                }
+
                 Some(table)
             } else {
                 None
@@ -1989,17 +2015,19 @@ pub fn translate_alter_table(
                 });
             }
 
-            if let Some(rewritten_table) = rewritten_table {
+            if let Some(validation_table) = &constraint_validation_table {
                 emit_add_virtual_column_validation(
                     program,
-                    &rewritten_table,
-                    &rewritten_table.columns()[column_index],
+                    validation_table,
+                    &validation_table.columns()[column_index],
                     &definition.constraints,
                     resolver,
                     connection,
                     database_id,
                 )?;
+            }
 
+            if let Some(rewritten_table) = rewritten_table {
                 let original_columns = original_btree.columns();
                 let source_column_by_schema_idx = rewritten_table
                     .columns()

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6,7 +6,7 @@ use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{
-    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME,
+    render_gencol_expr_sql_with_new_names, CheckConstraint, Schema, Table, SCHEMA_TABLE_NAME,
     SQLITE_SEQUENCE_TABLE_NAME,
 };
 use crate::state_machine::StateMachine;
@@ -13067,13 +13067,36 @@ pub fn op_alter_column(
             }
         }
 
-        // Update CHECK constraint expressions to reference the new column name
+        if !*rename {
+            btree.check_constraints.retain(|c| {
+                c.column
+                    .as_ref()
+                    .is_none_or(|col| !col.eq_ignore_ascii_case(&old_column_name))
+            });
+        }
+
+        // Update CHECK constraint expressions to reference the new column name.
+        // For ALTER COLUMN, this keeps table-level checks and checks attached to
+        // other columns aligned after the column rename while the replaced
+        // column-level checks are rebuilt from the new definition below.
         let old_col_normalized = normalize_ident(&old_column_name);
         for check in &mut btree.check_constraints {
             rename_identifiers(&mut check.expr, &old_col_normalized, &new_name);
             if let Some(ref mut col) = check.column {
                 if col.eq_ignore_ascii_case(&old_column_name) {
                     col.clone_from(&new_name);
+                }
+            }
+        }
+
+        if !*rename {
+            for constraint in &definition.constraints {
+                if let ast::ColumnConstraint::Check(expr) = &constraint.constraint {
+                    btree.check_constraints.push(CheckConstraint::new(
+                        constraint.name.as_ref(),
+                        expr,
+                        Some(&new_name),
+                    ));
                 }
             }
         }

--- a/testing/sqltests/turso-tests/alter_column.sqltest
+++ b/testing/sqltests/turso-tests/alter_column.sqltest
@@ -455,6 +455,36 @@ expect error {
     CHECK constraint failed
 }
 
+test alter-column-check-validates-existing-rows {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES(-1);
+    ALTER TABLE t ALTER COLUMN a TO b INTEGER CHECK(b > 0);
+}
+expect error {
+    CHECK constraint failed
+}
+
+test alter-column-check-enforced-current-connection {
+    CREATE TABLE t(a INTEGER);
+    ALTER TABLE t ALTER COLUMN a TO b INTEGER CHECK(b > 0);
+    INSERT INTO t VALUES(-1);
+}
+expect error {
+    CHECK constraint failed
+}
+
+test alter-column-check-allows-valid-row {
+    CREATE TABLE t(a INTEGER);
+    ALTER TABLE t ALTER COLUMN a TO b INTEGER CHECK(b > 0);
+    INSERT INTO t VALUES(1);
+    SELECT b FROM t;
+    PRAGMA integrity_check;
+}
+expect {
+    1
+    ok
+}
+
 # Add column with a foreign key reference and verify schema SQL
 test alter-table-add-column-with-fk-updates-schema {
     CREATE TABLE t(a);


### PR DESCRIPTION
Replaces #6832, which was auto-closed by Fossier before the branch was updated. Manual review request: #6833.

Fixes #6773.

## Summary
- validate CHECK constraints added by `ALTER TABLE ... ALTER COLUMN` against existing rows before accepting the schema change
- refresh the current connection's in-memory `check_constraints` for non-rename ALTER COLUMN operations
- replace old column-level CHECK constraints for the altered column with the new column definition's CHECK constraints
- add regression coverage for invalid existing rows, current-connection enforcement, and a valid insert after ALTER COLUMN

## Reproduction on base main
Against `a9418e183`, the two failing repro tests both fail with `expected error but query succeeded`:
- existing invalid row accepted by `ALTER COLUMN ... CHECK(b > 0)`
- invalid insert accepted in the same connection after adding the CHECK via ALTER COLUMN

## Testing
- `cargo fmt --check`
- `cargo check -p test-runner`
- `cargo run -p test-runner --bin test-runner -- run turso-tests\alter_column.sqltest --backend rust --filter '*alter-column-check*' --snapshot-mode no -j 1`

Commit author/committer uses the GitHub noreply address for `danieljimol`.