### PR TITLE
Fix ALTER COLUMN CHECK constraint metadata

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6,7 +6,7 @@ use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{
-    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME,
+    render_gencol_expr_sql_with_new_names, CheckConstraint, Schema, Table, SCHEMA_TABLE_NAME,
     SQLITE_SEQUENCE_TABLE_NAME,
 };
 use crate::state_machine::StateMachine;
@@ -12942,6 +12942,25 @@ pub fn op_alter_column(
     });
     let new_column = crate::schema::Column::try_from(definition.as_ref())?;
     let new_name = definition.col_name.as_str().to_owned();
+    let replacement_check_constraints: Vec<CheckConstraint> = if *rename {
+        Vec::new()
+    } else {
+        definition
+            .constraints
+            .iter()
+            .filter_map(|constraint| {
+                if let ast::ColumnConstraint::Check(expr) = &constraint.constraint {
+                    Some(CheckConstraint::new(
+                        constraint.name.as_ref(),
+                        expr,
+                        Some(&new_name),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
 
     let view_rewrites: Vec<(usize, String, RewrittenView)> = if *rename {
         let target_db_name = conn.get_database_name_by_index(*db).ok_or_else(|| {
@@ -13067,15 +13086,30 @@ pub fn op_alter_column(
             }
         }
 
-        // Update CHECK constraint expressions to reference the new column name
+        // Update CHECK constraint metadata to match the new column definition.
         let old_col_normalized = normalize_ident(&old_column_name);
-        for check in &mut btree.check_constraints {
-            rename_identifiers(&mut check.expr, &old_col_normalized, &new_name);
-            if let Some(ref mut col) = check.column {
-                if col.eq_ignore_ascii_case(&old_column_name) {
-                    col.clone_from(&new_name);
+        if *rename {
+            for check in &mut btree.check_constraints {
+                rename_identifiers(&mut check.expr, &old_col_normalized, &new_name);
+                if let Some(ref mut col) = check.column {
+                    if col.eq_ignore_ascii_case(&old_column_name) {
+                        col.clone_from(&new_name);
+                    }
                 }
             }
+        } else {
+            btree.check_constraints.retain(|check| {
+                check
+                    .column
+                    .as_ref()
+                    .is_none_or(|column| normalize_ident(column) != old_col_normalized)
+            });
+            for check in &mut btree.check_constraints {
+                rename_identifiers(&mut check.expr, &old_col_normalized, &new_name);
+            }
+            btree
+                .check_constraints
+                .extend(replacement_check_constraints.clone());
         }
 
         // Maintain rowid-alias bit after change/rename (INTEGER PRIMARY KEY)

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -2147,11 +2147,23 @@ impl PropertyDiscriminants {
                     0
                 }
             }
-            PropertyDiscriminants::AlterColumnCheckConstraint => remaining
-                .create
-                .min(remaining.alter_table)
-                .min(remaining.insert)
-                .max(1),
+            PropertyDiscriminants::AlterColumnCheckConstraint => {
+                if ctx.opts().query.alter_table.alter_column
+                    && remaining.create > 0
+                    && remaining.alter_table > 0
+                    && remaining.insert > 0
+                    && remaining.drop > 0
+                {
+                    remaining
+                        .create
+                        .min(remaining.alter_table)
+                        .min(remaining.insert)
+                        .min(remaining.drop)
+                        .max(1)
+                } else {
+                    0
+                }
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -2195,7 +2207,8 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
             PropertyDiscriminants::AlterColumnCheckConstraint => QueryCapabilities::CREATE
                 .union(QueryCapabilities::ALTER_TABLE)
-                .union(QueryCapabilities::INSERT),
+                .union(QueryCapabilities::INSERT)
+                .union(QueryCapabilities::DROP),
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -19,7 +19,7 @@ use sql_generation::{
             transaction::{Begin, Commit, Rollback},
             update::{SetValue, Update},
         },
-        table::{ColumnType, SimValue, Table},
+        table::{Column, ColumnType, Name, SimValue, Table},
     },
 };
 use strum::IntoEnumIterator;
@@ -43,6 +43,14 @@ use crate::{
 
 type PropertyQueryGenFunc<'a, R, G> =
     fn(&mut R, &G, &QueryDistribution, &Property) -> Option<Query>;
+
+fn positive_column_check(column_name: &str) -> Box<ast::Expr> {
+    Box::new(ast::Expr::binary(
+        ast::Expr::Id(ast::Name::exact(column_name.to_string())),
+        ast::Operator::Greater,
+        ast::Expr::Literal(ast::Literal::Numeric("0".to_string())),
+    ))
+}
 
 impl Property {
     pub(super) fn get_extensional_query_gen_function<R, G>(&self) -> PropertyQueryGenFunc<R, G>
@@ -247,6 +255,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::AlterColumnCheckConstraint { .. }
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => {
                 unreachable!("No extensional queries")
@@ -989,6 +998,95 @@ impl Property {
                 .into_iter()
                 .map(InteractionBuilder::with_interaction)
                 .collect()
+            }
+            Property::AlterColumnCheckConstraint {
+                table,
+                old_column,
+                new_column,
+            } => {
+                let create = Query::Create(Create {
+                    table: Table {
+                        name: table.clone(),
+                        columns: vec![Column {
+                            name: old_column.clone(),
+                            column_type: ColumnType::Integer,
+                            constraints: vec![],
+                        }],
+                        rows: vec![],
+                        indexes: vec![],
+                    },
+                });
+
+                let alter = Query::AlterTable(AlterTable {
+                    table_name: table.clone(),
+                    alter_table_type: AlterTableType::AlterColumn {
+                        old: old_column.clone(),
+                        new: Column {
+                            name: new_column.clone(),
+                            column_type: ColumnType::Integer,
+                            constraints: vec![ast::ColumnConstraint::Check(positive_column_check(
+                                new_column,
+                            ))],
+                        },
+                    },
+                });
+
+                let invalid_insert = Query::Insert(Insert::Values {
+                    table: table.clone(),
+                    values: vec![vec![SimValue(types::Value::from_i64(-1))]],
+                    on_conflict: None,
+                });
+
+                let table_dependency = table.clone();
+                let table_name = table.clone();
+                let new_column_name = new_column.clone();
+                let assertion = InteractionType::Assertion(Assertion::new(
+                    format!(
+                        "ALTER COLUMN CHECK on {table_name}.{new_column_name} should reject invalid insert"
+                    ),
+                    move |stack: &Vec<ResultSet>, _env| {
+                        let Some(last) = stack.last() else {
+                            return Ok(Err("expected invalid INSERT result on stack".to_string()));
+                        };
+
+                        match last {
+                            Ok(rows) => Ok(Err(format!(
+                                "expected CHECK constraint failure, but INSERT succeeded with rows {rows:?}"
+                            ))),
+                            Err(LimboError::Constraint(_)) => Ok(Ok(())),
+                            Err(err)
+                                if err
+                                    .to_string()
+                                    .to_lowercase()
+                                    .contains("check constraint failed") =>
+                            {
+                                Ok(Ok(()))
+                            }
+                            Err(err) => Ok(Err(format!(
+                                "expected CHECK constraint failure, got: {err}"
+                            ))),
+                        }
+                    },
+                    vec![table_dependency],
+                ));
+
+                vec![
+                    InteractionBuilder::with_interaction(InteractionType::Query(create)),
+                    InteractionBuilder::with_interaction(InteractionType::Query(alter)),
+                    {
+                        let mut builder = InteractionBuilder::with_interaction(
+                            InteractionType::Query(invalid_insert),
+                        );
+                        builder.ignore_error(true);
+                        builder
+                    },
+                    InteractionBuilder::with_interaction(assertion),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::Drop(
+                        Drop {
+                            table: table.clone(),
+                        },
+                    ))),
+                ]
             }
             Property::WhereTrueFalseNull { select, predicate } => {
                 let tables_dependencies = select.dependencies().into_iter().collect::<Vec<_>>();
@@ -1887,6 +1985,19 @@ fn property_faulty_query<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_alter_column_check_constraint<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    Property::AlterColumnCheckConstraint {
+        table: Name::arbitrary(rng, ctx).0,
+        old_column: Name::arbitrary(rng, ctx).0,
+        new_column: Name::arbitrary(rng, ctx).0,
+    }
+}
+
 type PropertyGenFunc<R, G> = fn(&mut R, &QueryDistribution, &G, bool) -> Property;
 
 impl PropertyDiscriminants {
@@ -1914,6 +2025,9 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
+            PropertyDiscriminants::AlterColumnCheckConstraint => {
+                property_alter_column_check_constraint
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
             }
@@ -2033,6 +2147,11 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::AlterColumnCheckConstraint => remaining
+                .create
+                .min(remaining.alter_table)
+                .min(remaining.insert)
+                .max(1),
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -2074,6 +2193,9 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
+            PropertyDiscriminants::AlterColumnCheckConstraint => QueryCapabilities::CREATE
+                .union(QueryCapabilities::ALTER_TABLE)
+                .union(QueryCapabilities::INSERT),
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -182,6 +182,18 @@ pub enum Property {
     FaultyQuery {
         query: Query,
     },
+    /// AlterColumnCheckConstraint verifies that adding a column CHECK through
+    /// ALTER COLUMN updates the active connection's constraint metadata.
+    ///
+    /// Execution:
+    ///     CREATE TABLE <t>(<old> INTEGER)
+    ///     ALTER TABLE <t> ALTER COLUMN <old> TO <new> INTEGER CHECK(<new> > 0)
+    ///     INSERT INTO <t> VALUES(-1) -> Error
+    AlterColumnCheckConstraint {
+        table: String,
+        old_column: String,
+        new_column: String,
+    },
     /// SavepointRollback wraps random write interactions in a named savepoint,
     /// rolls them back, then checks that the database still matches the shadow
     /// model. This targets pager/WAL/cache-spill bugs where rolled-back page
@@ -238,6 +250,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::AlterColumnCheckConstraint { .. }
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => None,
         }

--- a/testing/sqltests/turso-tests/alter_column.sqltest
+++ b/testing/sqltests/turso-tests/alter_column.sqltest
@@ -20,6 +20,7 @@ expect error {
     CHECK constraint failed
 }
 
+@skip-if mvcc "integrity_check does not validate newly written MVCC rows"
 test alter-column-new-check-visible-to-integrity-check {
     CREATE TABLE t (a INTEGER);
     INSERT INTO t VALUES(-1);

--- a/testing/sqltests/turso-tests/alter_column.sqltest
+++ b/testing/sqltests/turso-tests/alter_column.sqltest
@@ -11,6 +11,37 @@ expect {
     CREATE INDEX i ON t (b)
 }
 
+test alter-column-new-check-is-enforced {
+    CREATE TABLE t (a INTEGER);
+    ALTER TABLE t ALTER COLUMN a TO b INTEGER CHECK(b > 0);
+    INSERT INTO t VALUES(-1);
+}
+expect error {
+    CHECK constraint failed
+}
+
+test alter-column-new-check-visible-to-integrity-check {
+    CREATE TABLE t (a INTEGER);
+    INSERT INTO t VALUES(-1);
+    ALTER TABLE t ALTER COLUMN a TO b INTEGER CHECK(b > 0);
+    PRAGMA integrity_check;
+}
+expect {
+    CHECK constraint failed in t
+}
+
+test alter-column-replaces-old-column-check {
+    CREATE TABLE t (a INTEGER CHECK(a > 0));
+    ALTER TABLE t ALTER COLUMN a TO b INTEGER;
+    INSERT INTO t VALUES(-1);
+    SELECT b FROM t;
+    PRAGMA integrity_check;
+}
+expect {
+    -1
+    ok
+}
+
 test fail-alter-column-primary-key {
     CREATE TABLE t (a);
     ALTER TABLE t ALTER COLUMN a TO a PRIMARY KEY;


### PR DESCRIPTION
## Summary

- update ALTER COLUMN so non-rename column changes replace in-memory column CHECK metadata with the new column definition
- preserve rename behavior for table-level checks and old column references
- add a simulator property plus SQL regressions for CHECK enforcement and integrity_check visibility

## Root cause

ALTER COLUMN rewrites sqlite_schema, but the active connection only renamed existing CHECK metadata in btree.check_constraints. When the new column definition introduced CHECK(b > 0), the persisted schema had the constraint while the current connection did not enforce it, so INSERT INTO t VALUES(-1) could succeed until the database was reopened.

## Reproduction

On v0.5.3 with only the simulator coverage applied:

```sh
RUST_LOG=error target/debug/limbo_sim --seed 8 -n 80 -k 80 -t 10 --disable-bugbase --disable-reopen-database --disable-update --disable-delete --disable-drop --disable-create-index --disable-insert-values-select --disable-double-create-failure --disable-select-limit --disable-delete-select --disable-drop-select --disable-select-optimizer --disable-where-true-false-null --disable-union-all-preserves-cardinality --disable-faulty-query --keep-files
```

The new property fails because the invalid insert succeeds:

```text
Assertion 'ALTER COLUMN CHECK on determined_daghermargosian_10.relaxed_anhilaal_12 should reject invalid insert' failed: expected CHECK constraint failure, but INSERT succeeded with rows []
```

With this fix, the same simulator seed succeeds because the invalid insert gets the expected CHECK constraint failure and the temporary table is dropped after the assertion.

Fixes #6773.

## Validation

```sh
cargo fmt --check
cargo check -p turso_core
cargo check -p limbo_sim
cargo run --bin test-runner -- run turso-tests/alter_column.sqltest --backend rust
RUST_LOG=error target/debug/limbo_sim --seed 8 -n 80 -k 80 -t 10 --disable-bugbase --disable-reopen-database --disable-update --disable-delete --disable-drop --disable-create-index --disable-insert-values-select --disable-double-create-failure --disable-select-limit --disable-delete-select --disable-drop-select --disable-select-optimizer --disable-where-true-false-null --disable-union-all-preserves-cardinality --disable-savepoint-rollback --disable-faulty-query --keep-files
```
