### PR TITLE
Fix DROP COLUMN expression index metadata

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6,7 +6,7 @@ use crate::mvcc::database::CheckpointStateMachine;
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{
-    render_gencol_expr_sql_with_new_names, Schema, Table, SCHEMA_TABLE_NAME,
+    render_gencol_expr_sql_with_new_names, Schema, Table, EXPR_INDEX_SENTINEL, SCHEMA_TABLE_NAME,
     SQLITE_SEQUENCE_TABLE_NAME,
 };
 use crate::state_machine::StateMachine;
@@ -12820,7 +12820,9 @@ pub fn op_drop_column(
             for index in indexes {
                 let index = Arc::get_mut(index).expect("this should be the only strong reference");
                 for index_column in index.columns.iter_mut() {
-                    if index_column.pos_in_table > *column_index {
+                    if index_column.pos_in_table != EXPR_INDEX_SENTINEL
+                        && index_column.pos_in_table > *column_index
+                    {
                         index_column.pos_in_table -= 1;
                     }
                     if let Some(ref mut expr) = index_column.expr {

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -922,6 +922,19 @@ expect {
 }
 
 @cross-check-integrity
+test alter-table-drop-column-preserves-expression-index-sentinel {
+    CREATE TABLE t(a INTEGER, b INTEGER, c TEXT, d INTEGER);
+    CREATE INDEX i_expr ON t(a, date(c), c);
+    INSERT INTO t VALUES(1, 2, '2026-01-01', 3);
+    ALTER TABLE t DROP COLUMN b;
+    UPDATE t SET a = 5 WHERE c = '2026-01-01';
+    SELECT a, c, d FROM t;
+}
+expect {
+    5|2026-01-01|3
+}
+
+@cross-check-integrity
 test alter-table-rename-column-updates-unique-sets {
     CREATE TABLE t(a INTEGER, b TEXT, UNIQUE(b));
     INSERT INTO t VALUES (1, 'hello');


### PR DESCRIPTION
## Summary
- Preserve expression-index sentinel positions when `ALTER TABLE ... DROP COLUMN` shifts cached index metadata.
- Keep real indexed columns after the dropped column shifting left as before.
- Add a regression covering an expression index that survives a dropped unrelated column and is maintained by a later `UPDATE`.

## Root cause
`op_drop_column` shifted every index column position greater than the dropped column index. Expression index columns use `EXPR_INDEX_SENTINEL` (`usize::MAX`), so the shift changed the sentinel into `usize::MAX - 1`. A later `UPDATE` then treated that value as a real table column position while collecting index dependencies and panicked.

## Validation
- `cargo run --target x86_64-pc-windows-gnu --bin test-runner -- run tests --backend rust --filter alter-table-drop-column-preserves-expression-index-sentinel`
- `cargo run --target x86_64-pc-windows-gnu --bin test-runner -- run tests --backend rust --filter '*drop-column-expr-index*'`
- `cargo run -q --target x86_64-pc-windows-gnu -p differential-fuzzer --bin differential_fuzzer -- -g sql-gen-prop -s 1612963277229922712 -n 90`
- `cargo fmt --check`
- `cargo check --target x86_64-pc-windows-gnu -p turso_core`