### PR TITLE
Fix simulator panic on Windows when dropping unlocked files

### DIFF
--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -395,6 +395,14 @@ impl File for WindowsFile {
 
         if result == FALSE {
             let err = std::io::Error::last_os_error();
+            // ERROR_NOT_LOCKED (158): the byte-range is already unlocked.
+            // POSIX `flock`/`fcntl` treat releasing an unlocked region as a
+            // no-op; match that here so callers (notably the simulator's
+            // `Drop for SimulatorFile`) don't see a spurious error when a
+            // file is dropped without ever being locked.
+            if err.raw_os_error() == Some(158) {
+                return Ok(());
+            }
             return Err(LimboError::LockingError(format!(
                 "Failed to release file lock: {err}"
             )));

--- a/testing/simulator/runner/file.rs
+++ b/testing/simulator/runner/file.rs
@@ -270,7 +270,12 @@ impl File for SimulatorFile {
 
 impl Drop for SimulatorFile {
     fn drop(&mut self) {
-        self.inner.unlock_file().expect("Failed to unlock file");
+        // Drop must never panic. Log unlock failures instead of `.expect`;
+        // the underlying lock will be released by the OS when the handle
+        // closes regardless.
+        if let Err(e) = self.inner.unlock_file() {
+            tracing::warn!("SimulatorFile drop: unlock_file failed: {e:?}");
+        }
     }
 }
 


### PR DESCRIPTION
Hi! Coming from the [Turso Challenge](https://algora.io/challenges/turso). While trying to find a corruption bug with the DST simulator from a Windows box I found the simulator panics on every run during plan-generation cleanup, which prevented any seeding/exploration. This PR is the fix.

## Root cause

Two layers stack into the panic:

1. `WindowsFile::unlock_file` in `core/io/windows.rs` calls `UnlockFileEx` and treats every non-zero error as a failure. On Windows that includes [`ERROR_NOT_LOCKED` (158)](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-) — released a byte-range that was never locked — which POSIX `flock`/`fcntl` silently accept. POSIX-only contributors and CI never see this path.
2. `Drop for SimulatorFile` in `testing/simulator/runner/file.rs` calls `self.inner.unlock_file().expect("Failed to unlock file")`. Because drop must never panic, the Windows-only error bubbles up through the simulator's panic hook (`ERROR limbo_sim: 171: Failed to unlock file: LockingError("Failed to release file lock: The segment is already unlocked. (os error 158)")`), which aborts every run.

## Fix

- `core/io/windows.rs`: treat `ERROR_NOT_LOCKED` (158) as success in `WindowsFile::unlock_file`. This matches POSIX semantics and is the same convention the rest of `turso_core` already assumes for already-released locks.
- `testing/simulator/runner/file.rs`: replace `.expect` in the `SimulatorFile` drop with a `tracing::warn!` log. Drop should never panic regardless of what the underlying file reports — the OS releases the lock when the handle is closed anyway.

## Validation

Local box: Windows 11, `rustc 1.88.0-x86_64-pc-windows-gnu` (the toolchain the repo's `rust-toolchain.toml` pins) with MinGW-w64 GCC 16.1 from scoop.

| | before | after |
|---|---|---|
| `./target/release/limbo_sim.exe -s 1 -n 100 -k 30 -t 15` | panic in `Drop for SimulatorFile` at plan-generation cleanup | `simulation succeeded` |
| `./target/release/limbo_sim.exe -s 17 -n 100 -k 30 -t 15` | same panic | `simulation succeeded` |
| Sweep seeds 1..30 with `-n 200 -k 50 -t 20` | 0 succeeded | 30/30 `simulation succeeded` |

Tested both with and without the fault profile enabled; no regression on the existing 15 properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)