### PR TITLE
core/translate: don't rewrite b-tree when modifying a virtual column

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -995,29 +995,31 @@ pub fn translate_alter_table(
                 connection,
                 input,
                 |program| {
-                    let table_name = btree.name.clone();
-                    let source_column_by_schema_idx = btree
-                        .columns()
-                        .iter()
-                        .enumerate()
-                        .map(|(new_idx, column)| {
-                            if column.is_virtual_generated() {
-                                None
-                            } else if new_idx < dropped_index {
-                                Some(new_idx)
-                            } else {
-                                Some(new_idx + 1)
-                            }
-                        })
-                        .collect();
-                    emit_rewrite_table_rows(
-                        program,
-                        original_btree.clone(),
-                        &btree,
-                        source_column_by_schema_idx,
-                        connection,
-                        database_id,
-                    );
+                    if !original_btree.columns()[dropped_index].is_virtual_generated() {
+                        let source_column_by_schema_idx = btree
+                            .columns()
+                            .iter()
+                            .enumerate()
+                            .map(|(new_idx, column)| {
+                                if column.is_virtual_generated() {
+                                    None
+                                } else if new_idx < dropped_index {
+                                    Some(new_idx)
+                                } else {
+                                    Some(new_idx + 1)
+                                }
+                            })
+                            .collect();
+
+                        emit_rewrite_table_rows(
+                            program,
+                            original_btree.clone(),
+                            &btree,
+                            source_column_by_schema_idx,
+                            connection,
+                            database_id,
+                        );
+                    }
 
                     program.emit_insn(Insn::SetCookie {
                         db: database_id,
@@ -1028,7 +1030,7 @@ pub fn translate_alter_table(
 
                     program.emit_insn(Insn::DropColumn {
                         db: database_id,
-                        table: table_name,
+                        table: btree.name.clone(),
                         column_index: dropped_index,
                     })
                 },

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -3126,6 +3126,18 @@ expect {
     5|100
 }
 
+setup gencol_drop_virtual_setup {
+    CREATE TABLE t (a);
+    ALTER TABLE t ADD COLUMN b AS (a);
+    INSERT INTO t (a) VALUES (1), (2), (3);
+}
+
+@setup gencol_drop_virtual_setup
+@skip-if mvcc "MVCC updates sqlite_schema using Delete then Insert, so the snapshot is slightly different"
+snapshot gencol_drop_virtual_column_no_row_rewrite {
+    ALTER TABLE t DROP COLUMN b;
+}
+
 # Only non-generated column — rejected before dependency check
 test gencol_drop_only_regular_column_error {
     CREATE TABLE t1(a INT, b AS (a * 2));

--- a/testing/sqltests/tests/snapshots/gencol__gencol_drop_virtual_column_no_row_rewrite.snap
+++ b/testing/sqltests/tests/snapshots/gencol__gencol_drop_virtual_column_no_row_rewrite.snap
@@ -1,0 +1,41 @@
+---
+source: gencol.sqltest
+expression: ALTER TABLE t DROP COLUMN b;
+info:
+  statement_type: ALTER
+  tables:
+  - t
+  setup_blocks:
+  - gencol_drop_virtual_setup
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN sqlite_schema
+
+BYTECODE
+addr  opcode        p1  p2  p3  p4                  p5  comment
+   0  Init           0  20   0                       0  Start at 20
+   1  OpenWrite      0   1   0                       0  root=1; iDb=0
+   2  Rewind         0  17   0                       0  Rewind table sqlite_schema
+   3    Column       0   1   2                       0  r[2]=sqlite_schema.name
+   4    Ne           2   3  16  NoCase               0  if r[2]!=r[3] goto 16
+   5    Column       0   0   5                       0  r[5]=sqlite_schema.type
+   6    Ne           5   6  16  Binary               0  if r[5]!=r[6] goto 16
+   7    RowId        0   7   0                       0  r[7]=sqlite_schema.rowid
+   8    IsNull       7  17   0                       0  if (r[7]==NULL) goto 17
+   9    Column       0   0   8                       0  r[8]=sqlite_schema.type
+  10    Column       0   1   9                       0  r[9]=sqlite_schema.name
+  11    Column       0   2  10                       0  r[10]=sqlite_schema.tbl_name
+  12    Column       0   3  11                       0  r[11]=sqlite_schema.rootpage
+  13    Affinity     8   5   0                       0  r[8..13] = B, B, B, D, B
+  14    MakeRecord   8   5  13                       0  r[13]=mkrec(r[8..12])
+  15    Insert       0  13   7  sqlite_schema        8  intkey=r[7] data=r[13]
+  16  Next           0   3   0                       0
+  17  SetCookie      0   1   3                       0
+  18  DropColumn     0   0   0                       0  drop_column(t, 1)
+  19  Halt           0   0   0                       0
+  20  Transaction    0   2   2                       0  iDb=0 tx_mode=Write
+  21  String8        0   3   0  t                    0  r[3]='t'
+  22  String8        0   6   0  table                0  r[6]='table'
+  23  String8        0  12   0  CREATE TABLE t (a)   0  r[12]='CREATE TABLE t (a)'
+  24  Goto           0   1   0                       0


### PR DESCRIPTION
## Motivation and context

Easy optimization that I missed when implementing virtual columns.

I'm going to keep this PR open (not merging) until 0.6, and push to `mvcc-next` once it's reviewed.

## Description of AI Usage

Claude Code
