### PR TITLE
Fix OR FAIL rowid datatype mismatch rollback

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10078,22 +10078,26 @@ pub fn op_must_be_int(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(MustBeInt { reg }, insn);
+    // MustBeInt raises SQLITE_MISMATCH, not a conflict-policy constraint.
+    // Force ABORT semantics so UPDATE/INSERT OR FAIL cannot keep partial row writes.
+    let datatype_mismatch =
+        || LimboError::Raise(ResolveType::Abort, "datatype mismatch".to_string());
     match &state.registers[*reg].get_value() {
         Value::Numeric(Numeric::Integer(_)) => {}
         Value::Numeric(Numeric::Float(f)) => match cast_real_to_integer(f64::from(*f)) {
             Ok(i) => state.registers[*reg].set_int(i),
-            Err(_) => bail_constraint_error!("datatype mismatch"),
+            Err(_) => return Err(datatype_mismatch()),
         },
         Value::Text(text) => match checked_cast_text_to_numeric(text.as_str(), true) {
             Ok(Value::Numeric(Numeric::Integer(i))) => state.registers[*reg].set_int(i),
             Ok(Value::Numeric(Numeric::Float(f))) => match cast_real_to_integer(f64::from(f)) {
                 Ok(i) => state.registers[*reg].set_int(i),
-                Err(_) => bail_constraint_error!("datatype mismatch"),
+                Err(_) => return Err(datatype_mismatch()),
             },
-            _ => bail_constraint_error!("datatype mismatch"),
+            _ => return Err(datatype_mismatch()),
         },
         _ => {
-            bail_constraint_error!("datatype mismatch");
+            return Err(datatype_mismatch());
         }
     };
     state.pc += 1;
@@ -15529,6 +15533,75 @@ mod tests {
         };
         assert!(matches!(err, LimboError::Constraint(message) if message == "datatype mismatch"));
         assert_eq!(state.pc, 0);
+    }
+
+    fn open_memory_connection() -> Arc<Connection> {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            ":memory:",
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+        )
+        .unwrap();
+        db.connect().unwrap()
+    }
+
+    fn collect_ipk_rows(conn: &Arc<Connection>) -> Vec<(i64, String)> {
+        let mut rows = Vec::new();
+        let mut stmt = conn.prepare("SELECT id, b FROM t ORDER BY id").unwrap();
+        stmt.run_with_row_callback(|row| {
+            rows.push((row.get(0)?, row.get(1)?));
+            Ok(())
+        })
+        .unwrap();
+        rows
+    }
+
+    #[test]
+    fn test_update_or_fail_rowid_datatype_mismatch_rolls_back_statement() {
+        let conn = open_memory_connection();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'one'), (2, 'two')")
+            .unwrap();
+
+        let err = conn
+            .execute(
+                "UPDATE OR FAIL t \
+                 SET b = 'changed', id = CASE WHEN id = 2 THEN 'bad' ELSE id END \
+                 WHERE TRUE",
+            )
+            .expect_err("non-integer rowid assignment must fail");
+
+        assert!(
+            err.to_string().contains("datatype mismatch"),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(
+            collect_ipk_rows(&conn),
+            vec![(1, "one".to_string()), (2, "two".to_string())]
+        );
+        assert!(conn.get_auto_commit());
+    }
+
+    #[test]
+    fn test_insert_or_fail_rowid_datatype_mismatch_rolls_back_statement() {
+        let conn = open_memory_connection();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT)")
+            .unwrap();
+
+        let err = conn
+            .execute("INSERT OR FAIL INTO t(id, b) VALUES (1, 'one'), ('bad', 'bad')")
+            .expect_err("non-integer rowid assignment must fail");
+
+        assert!(
+            err.to_string().contains("datatype mismatch"),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(collect_ipk_rows(&conn), Vec::<(i64, String)>::new());
+        assert!(conn.get_auto_commit());
     }
 
     #[test]

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -69,10 +69,7 @@ impl IO for TestIo {
     fn cancel(&self, c: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.cancel(c)
     }
-    fn drain_completions(
-        &self,
-        completions: &[turso_core::Completion],
-    ) -> turso_core::Result<()> {
+    fn drain_completions(&self, completions: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.drain_completions(completions)
     }
     fn fill_bytes(&self, dest: &mut [u8]) {


### PR DESCRIPTION
## Summary

`MustBeInt` currently reports rowid conversion failures as `LimboError::Constraint`. In an `INSERT OR FAIL` or `UPDATE OR FAIL`, that makes Turso treat `datatype mismatch` like a conflict-policy failure and keep partial row writes that happened earlier in the same autocommit statement.

SQLite treats this opcode failure as `SQLITE_MISMATCH`, not an ON CONFLICT constraint failure, so the statement is rolled back.

This PR makes `MustBeInt` force ABORT semantics while preserving the user-facing `Runtime error: datatype mismatch` message, and adds regressions for both `UPDATE OR FAIL` and `INSERT OR FAIL` against `INTEGER PRIMARY KEY` rowid conversion failures.

## Repro

`v0.5.3` / current Turso before this patch partially commits the first row update:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT);
INSERT INTO t VALUES(1,'one'),(2,'two');
UPDATE OR FAIL t
  SET b='changed', id=CASE WHEN id=2 THEN 'bad' ELSE id END
  WHERE TRUE;
SELECT id, typeof(id), b FROM t ORDER BY id;
```

Turso `v0.5.3` result:

```text
Error: Runtime error: datatype mismatch
1|integer|changed
2|integer|two
```

SQLite result:

```text
Error: stepping, datatype mismatch (20)
1|integer|one
2|integer|two
```

The same issue exists for multi-row insert:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT);
INSERT OR FAIL INTO t(id,b) VALUES(1,'one'),('bad','bad');
SELECT id, typeof(id), b FROM t ORDER BY id;
```

Turso `v0.5.3` leaves row `1|integer|one`; SQLite leaves the table empty.

## Tests

- `cargo test -p turso_core rowid_datatype_mismatch --lib`
- `cargo build -p turso_cli --bin tursodb`
- Manual repros against patched `target/debug/tursodb`, `v0.5.3` `tursodb`, and system SQLite `3.43.2`
