### PR TITLE
superseded by #6856

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -686,7 +686,9 @@ fn update_pragma(
         }
         PragmaName::ForeignKeys => {
             let enabled = parse_pragma_enabled(&value);
-            connection.set_foreign_keys_enabled(enabled);
+            if connection.get_auto_commit() {
+                connection.set_foreign_keys_enabled(enabled);
+            }
             Ok(TransactionMode::None)
         }
         PragmaName::IAmADummy | PragmaName::RequireWhere => {

--- a/testing/simulator/runner/memory/foreign_keys.rs
+++ b/testing/simulator/runner/memory/foreign_keys.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
+
+use crate::runner::memory::io::MemorySimIO;
+
+fn make_conn(seed: u64) -> Result<(Arc<Connection>, Arc<MemorySimIO>)> {
+    let io = Arc::new(MemorySimIO::new(seed, 4096, 100, 1, 5));
+    let db = Database::open_file_with_flags(
+        io.clone() as Arc<dyn IO>,
+        &format!("sim_fk_pragma_{seed}.db"),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    Ok((db.connect()?, io))
+}
+
+fn query_count(conn: &Arc<Connection>, io: &MemorySimIO, table: &str) -> Result<i64> {
+    let mut stmt = conn.prepare(format!("SELECT COUNT(*) FROM {table}"))?;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist for count query");
+                return Ok(row.get::<i64>(0).expect("count column should exist"));
+            }
+            StepResult::Done => panic!("count query ended without a row"),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn sim_foreign_keys_pragma_ignored_inside_transaction() -> Result<()> {
+    let (conn, io) = make_conn(214)?;
+
+    conn.execute("PRAGMA foreign_keys=OFF")?;
+    conn.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")?;
+    conn.execute(
+        "CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON DELETE CASCADE)",
+    )?;
+    conn.execute("INSERT INTO p VALUES(1)")?;
+    conn.execute("INSERT INTO c VALUES(10,1)")?;
+
+    conn.execute("BEGIN")?;
+    conn.execute("PRAGMA foreign_keys=ON")?;
+    conn.execute("DELETE FROM p WHERE id=1")?;
+    conn.execute("COMMIT")?;
+
+    assert_eq!(query_count(&conn, io.as_ref(), "p")?, 0);
+    assert_eq!(query_count(&conn, io.as_ref(), "c")?, 1);
+    Ok(())
+}

--- a/testing/simulator/runner/memory/mod.rs
+++ b/testing/simulator/runner/memory/mod.rs
@@ -2,6 +2,8 @@ pub mod file;
 pub mod io;
 
 #[cfg(test)]
+mod foreign_keys;
+#[cfg(test)]
 mod mvcc_recovery;
 #[cfg(test)]
 mod statement_abandon;

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -2375,6 +2375,25 @@ expect {
     10|999
 }
 
+@cross-check-integrity
+test fk-pragma-change-inside-transaction-is-noop {
+    PRAGMA foreign_keys=OFF;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON DELETE CASCADE);
+    INSERT INTO p VALUES(1);
+    INSERT INTO c VALUES(10,1);
+    BEGIN;
+    PRAGMA foreign_keys=ON;
+    DELETE FROM p WHERE id=1;
+    COMMIT;
+    SELECT 'p', count(*) FROM p;
+    SELECT 'c', count(*) FROM c;
+}
+expect {
+    p|0
+    c|1
+}
+
 # DROP parent should succeed with multiple orphaned FK values
 @cross-check-integrity
 test fk-drop-parent-ok-with-multiple-orphaned-fks {


### PR DESCRIPTION
Superseded by clean replacement PR #6856. Please review #6856 instead.

Disclosure: this PR body edit was drafted with AI assistance.