### PR TITLE
simulator: expose foreign_keys transaction data loss; fix pragma update

### DIFF
--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -686,7 +686,9 @@ fn update_pragma(
         }
         PragmaName::ForeignKeys => {
             let enabled = parse_pragma_enabled(&value);
-            connection.set_foreign_keys_enabled(enabled);
+            if connection.get_auto_commit() {
+                connection.set_foreign_keys_enabled(enabled);
+            }
             Ok(TransactionMode::None)
         }
         PragmaName::IAmADummy | PragmaName::RequireWhere => {

--- a/testing/simulator/runner/memory/foreign_keys.rs
+++ b/testing/simulator/runner/memory/foreign_keys.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
+
+use crate::runner::memory::io::MemorySimIO;
+
+fn make_conn(seed: u64) -> Result<(Arc<Connection>, Arc<MemorySimIO>)> {
+    let io = Arc::new(MemorySimIO::new(seed, 4096, 100, 1, 5));
+    let db = Database::open_file_with_flags(
+        io.clone() as Arc<dyn IO>,
+        &format!("sim_fk_pragma_{seed}.db"),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    Ok((db.connect()?, io))
+}
+
+fn query_count(conn: &Arc<Connection>, io: &MemorySimIO, table: &str) -> Result<i64> {
+    let mut stmt = conn.prepare(format!("SELECT COUNT(*) FROM {table}"))?;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist for count query");
+                return Ok(row.get::<i64>(0).expect("count column should exist"));
+            }
+            StepResult::Done => panic!("count query ended without a row"),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn sim_foreign_keys_pragma_ignored_inside_transaction() -> Result<()> {
+    let (conn, io) = make_conn(214)?;
+
+    conn.execute("PRAGMA foreign_keys=OFF")?;
+    conn.execute("CREATE TABLE p(id INTEGER PRIMARY KEY)")?;
+    conn.execute(
+        "CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON DELETE CASCADE)",
+    )?;
+    conn.execute("INSERT INTO p VALUES(1)")?;
+    conn.execute("INSERT INTO c VALUES(10,1)")?;
+
+    conn.execute("BEGIN")?;
+    conn.execute("PRAGMA foreign_keys=ON")?;
+    conn.execute("DELETE FROM p WHERE id=1")?;
+    conn.execute("COMMIT")?;
+
+    assert_eq!(query_count(&conn, io.as_ref(), "p")?, 0);
+    assert_eq!(query_count(&conn, io.as_ref(), "c")?, 1);
+    Ok(())
+}

--- a/testing/simulator/runner/memory/mod.rs
+++ b/testing/simulator/runner/memory/mod.rs
@@ -2,6 +2,8 @@ pub mod file;
 pub mod io;
 
 #[cfg(test)]
+mod foreign_keys;
+#[cfg(test)]
 mod mvcc_recovery;
 #[cfg(test)]
 mod statement_abandon;

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -2375,6 +2375,25 @@ expect {
     10|999
 }
 
+@cross-check-integrity
+test fk-pragma-change-inside-transaction-is-noop {
+    PRAGMA foreign_keys=OFF;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON DELETE CASCADE);
+    INSERT INTO p VALUES(1);
+    INSERT INTO c VALUES(10,1);
+    BEGIN;
+    PRAGMA foreign_keys=ON;
+    DELETE FROM p WHERE id=1;
+    COMMIT;
+    SELECT 'p', count(*) FROM p;
+    SELECT 'c', count(*) FROM c;
+}
+expect {
+    p|0
+    c|1
+}
+
 # DROP parent should succeed with multiple orphaned FK values
 @cross-check-integrity
 test fk-drop-parent-ok-with-multiple-orphaned-fks {


### PR DESCRIPTION
## Summary

Clean replacement for auto-closed PR #6854. `PRAGMA foreign_keys` was taking effect inside an active transaction. SQLite documents this as a no-op while a transaction or savepoint is active. When a transaction began with foreign keys disabled, then enabled them before deleting a parent row, Turso applied `ON DELETE CASCADE` and deleted child rows that SQLite preserves. This PR adds deterministic simulator coverage for that data-loss case and makes the pragma update no-op while `auto_commit` is false.

## Impact

Applications that toggle `PRAGMA foreign_keys` inside a transaction could get different behavior from SQLite. In the reproduced case, child rows are deleted by an unexpected `ON DELETE CASCADE` after `PRAGMA foreign_keys=ON` is issued inside the transaction. That data is gone after commit unless the application has its own backup or compensating state.

## Root cause

`core/translate/pragma.rs` unconditionally called `connection.set_foreign_keys_enabled(enabled)` for `PRAGMA foreign_keys`. That changed the connection FK flag even when the connection was already inside a transaction. Subsequent DML in the same transaction then ran with the new FK mode and triggered cascade behavior that should not have been active.

## Reproduction

Pre-fix commit:

```bash
git checkout cbeaabf26e751c1bbc156aded4ffafcb4f47203b
cargo build --package turso_cli
rm -f /tmp/turso-fk-pragma.db /tmp/turso-fk-pragma.db-wal /tmp/turso-fk-pragma.db-shm
printf "PRAGMA foreign_keys=OFF;\nCREATE TABLE p(id INTEGER PRIMARY KEY);\nCREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON DELETE CASCADE);\nINSERT INTO p VALUES(1);\nINSERT INTO c VALUES(10,1);\nBEGIN;\nPRAGMA foreign_keys=ON;\nDELETE FROM p WHERE id=1;\nCOMMIT;\nSELECT 'p', count(*) FROM p;\nSELECT 'c', count(*) FROM c;\n.exit\n" | ./target/debug/tursodb /tmp/turso-fk-pragma.db
```

Observed before the fix:

```text
p|0
c|0
```

SQLite reference behavior:

```text
p|0
c|1
```

The deterministic simulator coverage uses seed `214` in `testing/simulator/runner/memory/foreign_keys.rs`. Applying only the new simulator test on `cbeaabf26e751c1bbc156aded4ffafcb4f47203b` fails:

```bash
cargo test -p limbo_sim sim_foreign_keys_pragma_ignored_inside_transaction -- --nocapture
```

Failure before the fix:

```text
assertion `left == right` failed
  left: 0
 right: 1
```

## Fix

Only apply `PRAGMA foreign_keys` changes when the connection is in autocommit mode. If `auto_commit` is false, the statement succeeds but leaves the existing FK mode unchanged.

## Validation

Passed after the fix:

```bash
cargo fmt --check
git diff --check
cargo test -p limbo_sim sim_foreign_keys_pragma_ignored_inside_transaction -- --nocapture
make -C testing/sqltests run-one FILE=tests/foreign_keys.sqltest
cargo run --bin test-runner -- run tests/foreign_keys.sqltest --binary /usr/bin/sqlite3 --filter fk-pragma-change-inside-transaction-is-noop
```

Manual post-fix reproduction:

```text
p|0
c|1
```

Also attempted:

```bash
cargo clippy --workspace --all-features --all-targets -- --deny=warnings
```

This fails before reaching this change because existing `turso_parser` warnings in `parser/src/error.rs` are promoted by `--deny=warnings`.

Not run: full `cargo test` and `make test`.

## Bounty note

This appears to target the Turso Algora challenge because it adds deterministic simulator coverage for a new data-corruption/data-loss case in default-enabled functionality and includes the corresponding fix. Please confirm whether it qualifies.

Disclosure: this PR body was drafted with AI assistance.
