### PR TITLE
simulator: catch FK OR FAIL rollback mismatch

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2945,7 +2945,10 @@ pub fn halt(
         // For FAIL mode with autocommit, commit partial changes before returning error.
         // This matches SQLite behavior where FAIL keeps changes made before the error.
         // Note: ON CONFLICT FAIL does NOT apply to FK violations, so we check for those first.
-        if program.resolve_type == ResolveType::Fail && auto_commit {
+        if program.resolve_type == ResolveType::Fail
+            && auto_commit
+            && !matches!(error, LimboError::ForeignKeyConstraint(_))
+        {
             // Check for immediate FK violations - FK errors don't respect ON CONFLICT
             if program.connection.foreign_keys_enabled()
                 && state.get_fk_immediate_violations_during_stmt() > 0

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -243,6 +243,7 @@ impl Property {
                 unreachable!("No extensional queries")
             }
             Property::SelectLimit { .. }
+            | Property::ForeignKeyConflictRollback { .. }
             | Property::SelectSelectOptimizer { .. }
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
@@ -989,6 +990,67 @@ impl Property {
                 .into_iter()
                 .map(InteractionBuilder::with_interaction)
                 .collect()
+            }
+            Property::ForeignKeyConflictRollback {
+                parent_table,
+                child_table,
+            } => {
+                let select_children = InteractionType::Query(Query::RawSql(format!(
+                    "SELECT id, pid, val FROM {child_table} ORDER BY id"
+                )));
+                let assertion = InteractionType::Assertion(Assertion::new(
+                    format!(
+                        "INSERT OR FAIL foreign-key violation should roll back all rows in {child_table}"
+                    ),
+                    move |stack: &Vec<ResultSet>, _| {
+                        let rows = stack.last().unwrap();
+                        match rows {
+                            Ok(rows) if rows.is_empty() => Ok(Ok(())),
+                            Ok(rows) => Ok(Err(format!(
+                                "expected no child rows after FK violation, got {} rows: {}",
+                                rows.len(),
+                                rows.iter()
+                                    .map(|r| print_row(r))
+                                    .collect::<Vec<String>>()
+                                    .join(", ")
+                            ))),
+                            Err(err) => Err(LimboError::InternalError(format!(
+                                "failed to read child table after FK violation: {err}"
+                            ))),
+                        }
+                    },
+                    vec![],
+                ));
+
+                let mut failing_insert = InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::RawSql(format!(
+                        "INSERT OR FAIL INTO {child_table} VALUES (1, 1, 'ok'), (2, 99, 'bad')"
+                    ))),
+                );
+                failing_insert.ignore_error(true);
+
+                vec![
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::RawSql(
+                        "PRAGMA foreign_keys=ON".to_string(),
+                    ))),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::RawSql(
+                        format!("CREATE TABLE {parent_table}(id INTEGER PRIMARY KEY)"),
+                    ))),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::RawSql(
+                        format!(
+                            "CREATE TABLE {child_table}(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES {parent_table}(id), val TEXT)"
+                        ),
+                    ))),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::RawSql(
+                        format!("CREATE INDEX {child_table}_val_idx ON {child_table}(val)"),
+                    ))),
+                    InteractionBuilder::with_interaction(InteractionType::Query(Query::RawSql(
+                        format!("INSERT INTO {parent_table} VALUES(1)"),
+                    ))),
+                    failing_insert,
+                    InteractionBuilder::with_interaction(select_children),
+                    InteractionBuilder::with_interaction(assertion),
+                ]
             }
             Property::WhereTrueFalseNull { select, predicate } => {
                 let tables_dependencies = select.dependencies().into_iter().collect::<Vec<_>>();
@@ -1887,6 +1949,19 @@ fn property_faulty_query<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_foreign_key_conflict_rollback<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    _ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let suffix = rng.random_range(1_000_000u32..=9_999_999u32);
+    Property::ForeignKeyConflictRollback {
+        parent_table: format!("fk_parent_{suffix}"),
+        child_table: format!("fk_child_{suffix}"),
+    }
+}
+
 type PropertyGenFunc<R, G> = fn(&mut R, &QueryDistribution, &G, bool) -> Property;
 
 impl PropertyDiscriminants {
@@ -1914,6 +1989,9 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
+            PropertyDiscriminants::ForeignKeyConflictRollback => {
+                property_foreign_key_conflict_rollback
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
             }
@@ -2033,6 +2111,13 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::ForeignKeyConflictRollback => {
+                if !env.profile.mvcc {
+                    1
+                } else {
+                    0
+                }
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -2074,6 +2159,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
+            PropertyDiscriminants::ForeignKeyConflictRollback => QueryCapabilities::NONE,
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -155,7 +155,8 @@ impl QueryDiscriminants {
             | QueryDiscriminants::Rollback
             | QueryDiscriminants::Savepoint
             | QueryDiscriminants::RollbackToSavepoint
-            | QueryDiscriminants::ReleaseSavepoint => {
+            | QueryDiscriminants::ReleaseSavepoint
+            | QueryDiscriminants::RawSql => {
                 unreachable!("transactional queries should not be generated")
             }
             QueryDiscriminants::Placeholder => {
@@ -183,7 +184,8 @@ impl QueryDiscriminants {
             | QueryDiscriminants::Rollback
             | QueryDiscriminants::Savepoint
             | QueryDiscriminants::RollbackToSavepoint
-            | QueryDiscriminants::ReleaseSavepoint => {
+            | QueryDiscriminants::ReleaseSavepoint
+            | QueryDiscriminants::RawSql => {
                 unreachable!("transactional queries should not be generated")
             }
             QueryDiscriminants::Placeholder => {

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -150,6 +150,7 @@ impl InteractionStats {
             Query::ReleaseSavepoint(_) => self.commit_count += 1,
             Query::AlterTable(_) => self.alter_table_count += 1,
             Query::DropIndex(_) => self.drop_index_count += 1,
+            Query::RawSql(_) => {}
             Query::Placeholder => {}
             Query::Pragma(_) => self.pragma_count += 1,
         }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -293,6 +293,7 @@ pub enum Query {
     RollbackToSavepoint(RollbackToSavepoint),
     ReleaseSavepoint(ReleaseSavepoint),
     Pragma(Pragma),
+    RawSql(String),
     /// Placeholder query that still needs to be generated
     Placeholder,
 }
@@ -346,6 +347,7 @@ impl Query {
             | Query::Savepoint(_)
             | Query::RollbackToSavepoint(_)
             | Query::ReleaseSavepoint(_)
+            | Query::RawSql(_)
             | Query::Placeholder
             | Query::Pragma(_) => IndexSet::new(),
         }
@@ -374,6 +376,7 @@ impl Query {
             Query::Savepoint(..) | Query::RollbackToSavepoint(..) | Query::ReleaseSavepoint(..) => {
                 vec![]
             }
+            Query::RawSql(_) => vec![],
             Query::Placeholder => vec![],
             Query::Pragma(_) => vec![],
         }
@@ -438,6 +441,7 @@ impl Display for Query {
             Self::Savepoint(savepoint) => write!(f, "{savepoint}"),
             Self::RollbackToSavepoint(rollback_to) => write!(f, "{rollback_to}"),
             Self::ReleaseSavepoint(release) => write!(f, "{release}"),
+            Self::RawSql(sql) => write!(f, "{sql}"),
             Self::Placeholder => Ok(()),
             Query::Pragma(pragma) => write!(f, "{pragma}"),
         }
@@ -467,6 +471,7 @@ impl Shadow for Query {
             Query::Savepoint(savepoint) => Ok(savepoint.shadow(env)),
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
+            Query::RawSql(_) => Ok(vec![]),
             Query::Placeholder => Ok(vec![]),
             Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
         }
@@ -523,6 +528,7 @@ impl From<QueryDiscriminants> for QueryCapabilities {
             | QueryDiscriminants::ReleaseSavepoint => {
                 unreachable!("QueryCapabilities do not apply to transaction queries")
             }
+            QueryDiscriminants::RawSql => Self::NONE,
             QueryDiscriminants::Placeholder => {
                 unreachable!("QueryCapabilities do not apply to query Placeholder")
             }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -191,6 +191,12 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// ForeignKeyConflictRollback verifies that ON CONFLICT FAIL does not
+    /// preserve earlier rows when the error is a foreign-key violation.
+    ForeignKeyConflictRollback {
+        parent_table: String,
+        child_table: String,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -234,6 +240,7 @@ impl Property {
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }
+            | Property::ForeignKeyConflictRollback { .. }
             | Property::SelectSelectOptimizer { .. }
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -459,6 +459,7 @@ fn execute_query_rusqlite(
         );
     }
     match query {
+        Query::RawSql(sql) => execute_raw_sql_rusqlite(connection, sql),
         Query::Select(select) => {
             let mut stmt = connection.prepare(select.to_string().as_str())?;
             let rows = stmt.query_map([], |row| {
@@ -499,4 +500,47 @@ fn execute_query_rusqlite(
             Ok(vec![])
         }
     }
+}
+
+fn execute_raw_sql_rusqlite(
+    connection: &rusqlite::Connection,
+    sql: &str,
+) -> rusqlite::Result<Vec<Vec<SimValue>>> {
+    let mut stmt = connection.prepare(sql)?;
+    if stmt.column_count() == 0 {
+        drop(stmt);
+        connection.execute(sql, ())?;
+        return Ok(vec![]);
+    }
+
+    let rows = stmt.query_map([], |row| {
+        let mut values = vec![];
+        for i in 0.. {
+            let value = match row.get(i) {
+                Ok(value) => value,
+                Err(err) => match err {
+                    rusqlite::Error::InvalidColumnIndex(_) => break,
+                    _ => {
+                        tracing::error!(?err);
+                        panic!("{err}")
+                    }
+                },
+            };
+            let value = match value {
+                rusqlite::types::Value::Null => Value::Null,
+                rusqlite::types::Value::Integer(i) => Value::from_i64(i),
+                rusqlite::types::Value::Real(f) => Value::from_f64(f),
+                rusqlite::types::Value::Text(s) => Value::build_text(s),
+                rusqlite::types::Value::Blob(b) => Value::Blob(b),
+            };
+            values.push(SimValue(value));
+        }
+        Ok(values)
+    })?;
+
+    let mut result = vec![];
+    for row in rows {
+        result.push(row?);
+    }
+    Ok(result)
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -69,10 +69,7 @@ impl IO for TestIo {
     fn cancel(&self, c: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.cancel(c)
     }
-    fn drain_completions(
-        &self,
-        completions: &[turso_core::Completion],
-    ) -> turso_core::Result<()> {
+    fn drain_completions(&self, completions: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.drain_completions(completions)
     }
     fn fill_bytes(&self, dest: &mut [u8]) {

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -2503,6 +2503,27 @@ fn test_update_or_ignore_fk_not_suppressed(tmp_db: TempDatabase) -> anyhow::Resu
     Ok(())
 }
 
+/// INSERT OR FAIL does NOT preserve earlier rows when the failure is a FK violation.
+/// ON CONFLICT algorithms do not apply to foreign keys, so this behaves like ABORT.
+#[turso_macros::test]
+fn test_insert_or_fail_fk_violation_rolls_back_statement(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    drop(tmp_db);
+    run_fk_constraint_case(
+        "insert_or_fail_fk_violation_rollback",
+        &[
+            "CREATE TABLE parent(id INTEGER PRIMARY KEY)",
+            "CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id), val TEXT)",
+            "CREATE INDEX child_val_idx ON child(val)",
+        ],
+        &["INSERT INTO parent VALUES(1)"],
+        "INSERT OR FAIL INTO child VALUES(1, 1, 'ok'), (2, 99, 'bad')",
+        "SELECT * FROM child ORDER BY id",
+    );
+    Ok(())
+}
+
 /// UPDATE OR REPLACE does NOT suppress FK violations.
 #[turso_macros::test]
 fn test_update_or_replace_fk_not_suppressed(tmp_db: TempDatabase) -> anyhow::Result<()> {


### PR DESCRIPTION
## Description

This fixes an `INSERT OR FAIL` foreign-key statement rollback mismatch and adds simulator coverage for it.

`ON CONFLICT FAIL` keeps prior row changes for uniqueness/check/not-null conflicts, but SQLite does not apply conflict algorithms to foreign-key violations. A multi-row `INSERT OR FAIL` that hits a FK violation must roll back the whole statement.

Before this patch, Turso committed earlier rows in autocommit mode before returning the FK error:

```sql
PRAGMA foreign_keys=ON;
CREATE TABLE parent(id INTEGER PRIMARY KEY);
CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id), val TEXT);
CREATE INDEX child_val_idx ON child(val);
INSERT INTO parent VALUES(1);
INSERT OR FAIL INTO child VALUES(1,1,'ok'),(2,99,'bad');
SELECT * FROM child ORDER BY id;
```

On `v0.6.0-pre.30`, Turso returns the FK error but leaves `1|1|ok` in `child`; SQLite returns the FK error and leaves `child` empty.

The fix skips the autocommit `FAIL` partial-commit path when the error is a foreign-key constraint failure. The added integration test verifies the SQLite-compatible empty result.

The simulator coverage adds a raw-SQL property for this FK rollback case. Applying only the simulator changes to `v0.6.0-pre.30` and running seed `202605120101` fails with Turso returning the surviving child row while rusqlite returns no rows. The same seed passes with this fix.

## Motivation and context

This targets the Algora Turso challenge: a default-enabled, latest-release data consistency bug that survived deterministic simulation. A failed FK statement could durably leave rows that SQLite rolls back and that the application should be able to assume were not inserted.

Validation run locally:

```text
cargo build --bin tursodb
cargo build --bin limbo_sim
cargo test --test integration_tests test_insert_or_fail_fk_violation_rolls_back_statement
cargo test --test integration_tests test_autocommit_fail_insert_partial_committed
cargo test --test integration_tests test_update_or_ignore_fk_not_suppressed
./target/debug/limbo_sim --seed 202605120101 --minimum-tests 20 --maximum-tests 80 --maximum-time 20 --profile faultless --differential --disable-bugbase --disable-heuristic-shrinking --keep-files
cargo fmt --all --check
git diff --check
```

## Description of AI Usage

AI assistance was used to explore the FK conflict-resolution path, build the release reproducer, draft the simulator coverage, and run local validation. I reviewed the patch, reproduction, and test output before submitting.
