### PR TITLE
add a test for xfer optimization bug in sqlite

### DIFF
--- a/testing/sqltests/tests/check_constraint.sqltest
+++ b/testing/sqltests/tests/check_constraint.sqltest
@@ -1848,6 +1848,23 @@ expect {
     CHECK constraint failed in t
 }
 
+# Regression for SQLite xfer optimization bypassing CHECK(rowid=...)
+# validation during INSERT INTO ... SELECT.
+# https://sqlite.org/forum/forumpost/6dcc95e3ca750dbc
+@skip-if sqlite "SQLite xfer optimization bug; fixed on trunk for 3.54, not in released 3.53"
+test check_constraint_insert_select_validates_destination_rowid {
+    CREATE TABLE s(a CHECK(rowid=1));
+    CREATE TABLE d(a CHECK(rowid=1));
+
+    INSERT INTO s(rowid,a) VALUES(1,'src-ok');
+    INSERT INTO d(rowid,a) VALUES(1,'dst-ok');
+
+    PRAGMA integrity_check;
+    INSERT INTO d SELECT * FROM s;
+}
+expect error {
+    CHECK constraint failed.*rowid
+}
 
 @cross-check-integrity
 test check_constraint_text_affinity_coercion_pass {


### PR DESCRIPTION
https://sqlite.org/forum/forumpost/6dcc95e3ca750dbc

thsi is similar to previous xfer bug where xfer (insert .. select) optimization bypasses check constraints , we probably won't get this fix in any new minor release.

> drh says This bug goes back to before version 3.5.1 (2007-10-04). I have checked in a fix for at [2026-05-11T16:58:05.251Z](https://sqlite.org/src/info/2026-05-11T16:58:05.251Z), which will appear in the 3.54 release. Because this bug has been in the code for 20 years and nobody has noticed and because it is not a vulnerability, I won't both cherrypicking the fix onto branch-3.53.