### PR TITLE
ci: add actionlint workflow to lint GitHub Actions yamls

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - blacksmith
+    - blacksmith-2vcpu-ubuntu-2404-arm
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-6vcpu-macos-latest
+    - nyrkio_perf_server_4cpu_ubuntu2404

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,41 @@
+name: Actionlint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+        shell: bash
+
+      # Pre-existing baseline issues are temporarily ignored so this linter can
+      # be introduced without bundling unrelated action-version bumps. Remove
+      # these `-ignore` patterns in follow-up PRs once the baseline is clean.
+      - name: Run actionlint
+        run: |
+          ${{ steps.get_actionlint.outputs.executable }} \
+            -color \
+            -ignore 'the runner of "actions/(checkout|setup-python|stale)@v[0-9]+" action is too old to run on GitHub Actions\. update the action.s version to fix this issue' \
+            -ignore 'property "update_dep" is not defined in object type'
+        shell: bash


### PR DESCRIPTION
## 概要

\`.github/workflows\` 配下の YAML を **actionlint v1.7.7** で検証する CI を追加し、#6692 のような silent failure(ステップの \`run:\` のインデント崩れで workflow が黙って実行されない等)を PR 段階で落とせるようにします。

- \`.github/workflows/actionlint.yml\` …
  - トリガ: \`push: main\` と \`pull_request\`、いずれも \`paths:\` で \`.github/workflows/**\` または \`.github/actionlint.{yaml,yml}\` 変更時のみ起動
  - 公式の \`download-actionlint.bash\` で v1.7.7 を取得して実行
  - \`permissions: contents: read\`、\`timeout-minutes: 5\`、\`runs-on: ubuntu-latest\`
- \`.github/actionlint.yaml\` …
  - Turso が使う self-hosted runner ラベル (\`blacksmith\`, \`blacksmith-2vcpu-ubuntu-2404-arm\`, \`blacksmith-4vcpu-ubuntu-2404\`, \`blacksmith-6vcpu-macos-latest\`, \`nyrkio_perf_server_4cpu_ubuntu2404\`) を \`self-hosted-runner.labels\` に登録し、unknown label 警告を抑制

#### Baseline 既存問題の扱い

クリーン baseline を作ろうとすると無関係な action バージョン bump を多数巻き込むため、本 PR では actionlint の \`-ignore\` で 2 パターンだけ一時退避しています(別 PR で潰す前提):

1. \`actions/{checkout,setup-python,stale}@v[0-9]+\` の outdated-action 警告(14 件)
2. \`go.yml\` 内の \`steps.update_dep\` 未定義参照(1 件) ※ 既存 workflow にもともと残っていた expression エラー

新規に追加された invalid なシンタックス/labels/action 参照は引き続き fail します。

## 動作確認

ローカル(actionlint v1.7.7 / windows-amd64)で:

\`\`\`bash
actionlint -no-color -oneline \
  -ignore '...checkout|setup-python|stale...' \
  -ignore 'property "update_dep" is not defined in object type'
# → 出力なし / exit 0
\`\`\`

#6692 と同じ「\`run:\` の indent ズレ」を意図的に再現すると actionlint が落とすことも確認済み:

\`\`\`text
test-broken.yml:10:0: could not parse as YAML: yaml: line 10: mapping values are not allowed in this context [syntax-check]
\`\`\`

新規 workflow 自体も actionlint で検証して clean です。

Closes #6702

/claim #6702