### PR TITLE
fix: store WAL version byte in header for MVCC databases

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1526,8 +1526,9 @@ impl Database {
         }
 
         // Determine if we should open in MVCC mode based on the database header version
-        // MVCC is controlled only by the database header (set via PRAGMA journal_mode)
-        let open_mv_store = matches!(read_version, Version::Mvcc);
+        // or the presence of a logical log file (MVCC databases store WAL version in header
+        // for SQLite compatibility, so we also check for the log file).
+        let open_mv_store = matches!(read_version, Version::Mvcc) || log_exists;
 
         // Now check the Header Version to see which mode the DB file really is on
         // Track if header was modified so we can write it to disk
@@ -1547,7 +1548,18 @@ impl Database {
                 }
             }
             Version::Wal => false,
-            Version::Mvcc => false,
+            // MVCC version byte (0xFF) is written to header when PRAGMA journal_mode=mvcc is set.
+            // Rewrite to WAL (0x02) for SQLite on-disk format compatibility — MVCC mode is
+            // detected via the logical log file presence, not the header byte.
+            Version::Mvcc => {
+                if is_readonly {
+                    false
+                } else {
+                    header_mut.read_version = RawVersion::from(Version::Wal);
+                    header_mut.write_version = RawVersion::from(Version::Wal);
+                    true
+                }
+            }
         };
 
         // In WAL mode, a logical log is always unexpected.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2547,7 +2547,14 @@ impl Pager {
     /// Set the initial journal version in page 1 before the database is initialized.
     pub fn set_initial_journal_version(&self, version: sqlite3_ondisk::Version) -> Result<()> {
         turso_assert!(!self.db_initialized());
-        let raw_version = sqlite3_ondisk::RawVersion::from(version);
+        // MVCC mode uses 0xFF internally, but writing 0xFF to the on-disk SQLite header makes
+        // the file unreadable by standard SQLite ("file is not a database"). Store WAL (0x02)
+        // instead — MVCC mode is identified at open time via the logical log file presence.
+        let on_disk_version = match version {
+            sqlite3_ondisk::Version::Mvcc => sqlite3_ondisk::Version::Wal,
+            other => other,
+        };
+        let raw_version = sqlite3_ondisk::RawVersion::from(on_disk_version);
         let IOResult::Done(_) = self.with_header_mut(|header| {
             header.read_version = raw_version;
             header.write_version = raw_version;


### PR DESCRIPTION
## Problem

When opening a database in MVCC mode, `set_initial_journal_version` writes `Version::Mvcc (0xFF / 255)` to the SQLite header bytes at offsets 18-19. This is not a valid SQLite format version, causing the database file to be unreadable by standard SQLite tools and rusqlite (including the simulator integrity checker).

Fixes #6820

## Root Cause

`Version::Mvcc = 255` was written directly to the on-disk SQLite header. Standard SQLite only recognises version bytes 1 (legacy) and 2 (WAL). Anything else corrupts the file header.

## Fix

1. `pager.rs` - `set_initial_journal_version`: when version is `Version::Mvcc`, write `Version::Wal (2)` to disk instead. MVCC mode is identified by the logical log file presence, not the header byte.

2. `lib.rs` - `open`: detect MVCC via `log_exists` in addition to `Version::Mvcc` header check, so existing MVCC databases still open correctly.

## Testing

- `cargo test -p turso_core` - 1727 passed, 0 failed
- `cargo clippy --workspace --all-features` - clean
- Simulator `simple_mvcc` profile seeds 1, 2, 42 - integrity check passed on all

Closes #6820
/bounty algora