### PR TITLE
core/mvcc: Deduplicate row versions by arc pointer and leave write set in transaction

### DIFF
--- a/core/benches/create_index_benchmark.rs
+++ b/core/benches/create_index_benchmark.rs
@@ -59,25 +59,25 @@ fn run_to_completion(
     Ok(())
 }
 
-fn exec_limbo(conn: &Arc<turso_core::Connection>, db: &Arc<Database>, sql: &str) {
+fn exec_turso(conn: &Arc<turso_core::Connection>, db: &Arc<Database>, sql: &str) {
     let mut stmt = conn.query(sql).unwrap().unwrap();
     run_to_completion(&mut stmt, db).unwrap();
 }
 
-/// Open a fresh limbo db in MVCC mode (the production deployment target).
+/// Open a fresh turso db in MVCC mode (the production deployment target).
 /// `PRAGMA journal_mode = 'mvcc'` must be set before any other DML.
 /// Auto-checkpoint is disabled (`mvcc_checkpoint_threshold = -1`) so the
 /// timed CREATE INDEX work doesn't get interleaved with checkpoint flushes;
 /// this isolates the index-build cost from the checkpoint cost.
-fn open_limbo(temp_dir: &TempDir) -> (Arc<Database>, Arc<turso_core::Connection>) {
+fn open_turso(temp_dir: &TempDir) -> (Arc<Database>, Arc<turso_core::Connection>) {
     let db_path = temp_dir.path().join("create_index_bench.db");
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
     let conn = db.connect().unwrap();
-    exec_limbo(&conn, &db, "PRAGMA journal_mode = 'mvcc'");
-    exec_limbo(&conn, &db, "PRAGMA mvcc_checkpoint_threshold = -1");
-    exec_limbo(&conn, &db, "PRAGMA synchronous = FULL");
+    exec_turso(&conn, &db, "PRAGMA journal_mode = 'mvcc'");
+    exec_turso(&conn, &db, "PRAGMA mvcc_checkpoint_threshold = -1");
+    exec_turso(&conn, &db, "PRAGMA synchronous = FULL");
     assert!(
         db.get_mv_store().is_some(),
         "MVCC store should be initialized after PRAGMA journal_mode = 'mvcc'"
@@ -85,7 +85,7 @@ fn open_limbo(temp_dir: &TempDir) -> (Arc<Database>, Arc<turso_core::Connection>
     (db, conn)
 }
 
-/// Open a fresh rusqlite db matching the limbo configuration.
+/// Open a fresh rusqlite db matching the turso configuration.
 fn open_rusqlite(temp_dir: &TempDir) -> rusqlite::Connection {
     let db_path = temp_dir.path().join("create_index_bench.db");
     let conn = rusqlite::Connection::open(db_path).unwrap();
@@ -98,8 +98,8 @@ fn open_rusqlite(temp_dir: &TempDir) -> rusqlite::Connection {
 
 /// Build a table with `row_count` rows of `(id INTEGER PK, val INTEGER, payload TEXT)`.
 /// `val` is non-monotonic so that index sort + B-tree fill is not trivial.
-fn populate_limbo(db: &Arc<Database>, conn: &Arc<turso_core::Connection>, row_count: usize) {
-    exec_limbo(
+fn populate_turso(db: &Arc<Database>, conn: &Arc<turso_core::Connection>, row_count: usize) {
+    exec_turso(
         conn,
         db,
         "CREATE TABLE t (id INTEGER PRIMARY KEY, val INTEGER, payload TEXT)",
@@ -108,7 +108,7 @@ fn populate_limbo(db: &Arc<Database>, conn: &Arc<turso_core::Connection>, row_co
     // Bulk insert in batches inside a single transaction. Smaller batches
     // keep the parser/VDBE work bounded; the surrounding txn amortizes commit.
     let batch_size: usize = 1000;
-    exec_limbo(conn, db, "BEGIN");
+    exec_turso(conn, db, "BEGIN");
     let mut i = 0usize;
     while i < row_count {
         let end = (i + batch_size).min(row_count);
@@ -122,10 +122,10 @@ fn populate_limbo(db: &Arc<Database>, conn: &Arc<turso_core::Connection>, row_co
             let val = (j as i64).wrapping_mul(2654435761) & 0x7fff_ffff;
             sql.push_str(&format!("({j}, {val}, 'payload_{j}')"));
         }
-        exec_limbo(conn, db, &sql);
+        exec_turso(conn, db, &sql);
         i = end;
     }
-    exec_limbo(conn, db, "COMMIT");
+    exec_turso(conn, db, "COMMIT");
 }
 
 fn populate_rusqlite(conn: &rusqlite::Connection, row_count: usize) {
@@ -206,29 +206,49 @@ fn bench_create_index(criterion: &mut Criterion) {
         group.warm_up_time(warm_up);
         group.measurement_time(measurement);
 
-        // ---- limbo ----
+        // ---- Turso total latency ----
         {
             let temp_dir = tempfile::tempdir().unwrap();
-            let (db, conn) = open_limbo(&temp_dir);
-            populate_limbo(&db, &conn, row_count);
+            let (db, conn) = open_turso(&temp_dir);
+            populate_turso(&db, &conn, row_count);
 
-            group.bench_function(BenchmarkId::new("limbo_create_index", row_count), |b| {
+            group.bench_function(BenchmarkId::new("turso_total", row_count), |b| {
                 b.iter_custom(|iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
-                        exec_limbo(&conn, &db, "CREATE INDEX idx_val ON t(val)");
+                        exec_turso(&conn, &db, "BEGIN");
+                        exec_turso(&conn, &db, "CREATE INDEX idx_val ON t(val)");
+                        exec_turso(&conn, &db, "COMMIT");
                         total += start.elapsed();
                         // Restore the un-indexed state for the next sample.
-                        exec_limbo(&conn, &db, "DROP INDEX idx_val");
+                        exec_turso(&conn, &db, "DROP INDEX idx_val");
                     }
                     total
                 });
             });
-            // Keep temp_dir alive until after the bench runs.
-            drop(conn);
-            drop(db);
-            drop(temp_dir);
+        }
+
+        // ---- Turso commit latency ----
+        {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let (db, conn) = open_turso(&temp_dir);
+            populate_turso(&db, &conn, row_count);
+
+            group.bench_function(BenchmarkId::new("turso_commit_only", row_count), |b| {
+                b.iter_custom(|iters| {
+                    let mut total = std::time::Duration::ZERO;
+                    for _ in 0..iters {
+                        exec_turso(&conn, &db, "BEGIN");
+                        exec_turso(&conn, &db, "CREATE INDEX idx_val ON t(val)");
+                        let start = std::time::Instant::now();
+                        exec_turso(&conn, &db, "COMMIT");
+                        total += start.elapsed();
+                        exec_turso(&conn, &db, "DROP INDEX idx_val");
+                    }
+                    total
+                });
+            });
         }
 
         // ---- sqlite ----
@@ -294,21 +314,21 @@ fn bench_create_index_commit(criterion: &mut Criterion) {
 
         {
             let temp_dir = tempfile::tempdir().unwrap();
-            let (db, conn) = open_limbo(&temp_dir);
-            populate_limbo(&db, &conn, row_count);
+            let (db, conn) = open_turso(&temp_dir);
+            populate_turso(&db, &conn, row_count);
 
             group.bench_function(
-                BenchmarkId::new("limbo_create_index_commit", row_count),
+                BenchmarkId::new("turso_create_index_commit", row_count),
                 |b| {
                     b.iter_custom(|iters| {
                         let mut total = std::time::Duration::ZERO;
                         for _ in 0..iters {
                             let start = std::time::Instant::now();
-                            exec_limbo(&conn, &db, "BEGIN");
-                            exec_limbo(&conn, &db, "CREATE INDEX idx_val ON t(val)");
-                            exec_limbo(&conn, &db, "COMMIT");
+                            exec_turso(&conn, &db, "BEGIN");
+                            exec_turso(&conn, &db, "CREATE INDEX idx_val ON t(val)");
+                            exec_turso(&conn, &db, "COMMIT");
                             total += start.elapsed();
-                            exec_limbo(&conn, &db, "DROP INDEX idx_val");
+                            exec_turso(&conn, &db, "DROP INDEX idx_val");
                         }
                         total
                     });
@@ -338,8 +358,6 @@ fn bench_create_index_commit(criterion: &mut Criterion) {
                     total
                 });
             });
-            drop(conn);
-            drop(temp_dir);
         }
     }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -986,9 +986,6 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     /// Threaded through so that `finish_committed_tx` can clear the matching
     /// connection-level mv_tx slot atomically with `remove_tx`.
     db_id: usize,
-    /// Write set (rowids) sorted by table id and row id, along with a reference to the
-    /// corresponding versions.
-    write_set: Vec<(RowID, RowVersions)>,
     commit_coordinator: Arc<CommitCoordinator>,
     header: Arc<RwLock<Option<DatabaseHeader>>>,
     pager: Arc<Pager>,
@@ -1065,7 +1062,6 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             tx_id,
             connection,
             db_id,
-            write_set: Vec::new(),
             commit_coordinator,
             pager,
             header,
@@ -1339,7 +1335,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
 
         // Process schema rows (sqlite_schema) before data rows so that during log
         // replay the table_id_to_rootpage map is populated before data row inserts
-        // reference it. `self.write_set` is sorted by table_id descending (most
+        // reference it. `tx.write_set` is sorted by table_id descending (most
         // negative first), which would otherwise place data table rows
         // (e.g. table_id=-3) before schema rows (table_id=-1).
 
@@ -1415,19 +1411,21 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
         };
 
-        // First pass: schema rows only (ordering matters for recovery)
-        for (id, row_versions) in &self.write_set {
-            if id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(row_versions, &mut log_record);
+        {
+            let ws = tx.write_set.lock();
+            // First pass: schema rows only (ordering matters for recovery)
+            for (id, row_versions) in ws.iter() {
+                if id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    collect_versions(row_versions, &mut log_record);
+                }
+            }
+            // Second pass: all non-schema rows
+            for (id, row_versions) in ws.iter() {
+                if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    collect_versions(row_versions, &mut log_record);
+                }
             }
         }
-        // Second pass: all non-schema rows
-        for (id, row_versions) in &self.write_set {
-            if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
-                collect_versions(row_versions, &mut log_record);
-            }
-        }
-
         log_record
     }
 
@@ -1435,16 +1433,16 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     /// transaction has been finalized as Committed(end_ts).
     /// This must run as postprocessing step i.e. the txn is written to log and is durable
     fn rewrite_live_versions_to_timestamps(&self, mvcc_store: &Arc<MvStore<Clock>>, end_ts: u64) {
-        let tx_state = mvcc_store
-            .txs
-            .get(&self.tx_id)
-            .map(|entry| entry.value().state.load());
+        let tx_entry = mvcc_store.txs.get(&self.tx_id);
+        let tx = tx_entry.as_ref().map(|entry| entry.value());
         turso_assert!(
-            matches!(tx_state, Some(TransactionState::Committed(ts)) if ts == end_ts),
+            matches!(tx.map(|t| t.state.load()), Some(TransactionState::Committed(ts)) if ts == end_ts),
             "rewrite_live_versions_to_timestamps requires a committed transaction state"
         );
+        let Some(tx) = tx else { return };
 
-        for (_id, row_versions) in &self.write_set {
+        let ws = tx.write_set.lock();
+        for (_id, row_versions) in ws.iter() {
             let mut row_versions = row_versions.write();
             for row_version in row_versions.iter_mut() {
                 if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
@@ -1618,20 +1616,19 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                  ** 2. Validate if there are no phantoms by walking the scans from scan_set
                  */
                 tracing::trace!("commit_tx(tx_id={})", self.tx_id);
-                self.write_set
-                    .extend_from_slice(tx.write_set.lock().as_slice());
-                self.write_set.sort_by(|(a, _), (b, _)| {
-                    // table ids are negative, and sqlite_schema has id -1 so we want to sort in descending order of table id
-                    b.table_id.cmp(&a.table_id).then(a.row_id.cmp(&b.row_id))
-                });
-                // The transaction's write_set may now contain duplicates
-                // (e.g. INSERT then UPDATE on the same row), since
-                // `insert_to_write_set` no longer pays for a `contains`
-                // check. After the sort, equal RowIDs are adjacent, so
-                // `dedup_by_key` collapses them in linear time.
-                self.write_set.dedup_by(|a, b| a.0 == b.0);
+                // The transaction's write_set may contain duplicates (e.g. INSERT then UPDATE on
+                // the same row) since `insert_to_write_set` skips a `contains` check; sort makes
+                // equal RowIDs adjacent so `dedup_by` collapses them in linear time.
+                let write_set_is_empty = {
+                    let mut write_set = tx.write_set.lock();
+                    write_set.sort_by(|(a, _), (b, _)| {
+                        b.table_id.cmp(&a.table_id).then(a.row_id.cmp(&b.row_id))
+                    });
+                    write_set.dedup_by(|a, b| a.0 == b.0);
+                    write_set.is_empty()
+                };
                 // Header-only writes must not take this fast path; they need durable log records.
-                if self.write_set.is_empty() && !tx.header_dirty.load(Ordering::Acquire) {
+                if write_set_is_empty && !tx.header_dirty.load(Ordering::Acquire) {
                     turso_assert!(
                         tx.commit_dep_set.lock().is_empty(),
                         "MVCC read only transaction should not have commit dependencies on other txns"
@@ -1684,7 +1681,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     .ok_or(LimboError::TxTerminated)?;
                 let tx = tx.value();
 
-                for (id, _chain) in &self.write_set {
+                for (id, _chain) in tx.write_set.lock().iter() {
                     if id.row_id.is_int_key() {
                         self.check_rowid_for_conflicts(id, *end_ts, tx, mvcc_store)?;
                     } else {
@@ -1736,7 +1733,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // going through CommitEnd. CommitEnd updates last_committed_tx_ts
                 // which would make a read-only transaction look like a write,
                 // causing spurious Busy errors from acquire_exclusive_tx.
-                if self.write_set.is_empty() && !tx.header_dirty.load(Ordering::Acquire) {
+                if tx.write_set.lock().is_empty() && !tx.header_dirty.load(Ordering::Acquire) {
                     turso_assert!(
                         tx.commit_dep_set.lock().is_empty(),
                         "MVCC read-only transaction should not have other transactions depending on it"

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -456,6 +456,60 @@ struct SavepointRollbackResult {
     deferred_fk_violations: isize,
 }
 
+#[derive(Debug, Default)]
+struct WriteSet {
+    entries: Vec<(RowID, RowVersions)>,
+    /// A set of the pointer addresses of the `RowVersions`. Used to deduplicate entries.
+    ///
+    /// This is correct because instances of [RowVersions] are created once per [RowID] and then
+    /// reused by cloning the [Arc]. It would be nice to encode this in the type system, but I'm
+    /// not sure how.
+    seen: HashSet<usize>,
+}
+
+impl WriteSet {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` if this `RowVersions` was not already contained in the write set.
+    fn insert(&mut self, id: RowID, row_versions: RowVersions) -> bool {
+        let ptr = Arc::as_ptr(&row_versions) as usize;
+        if self.seen.insert(ptr) {
+            self.entries.push((id, row_versions));
+            true
+        } else {
+            false
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn iter(&self) -> std::slice::Iter<'_, (RowID, RowVersions)> {
+        self.entries.iter()
+    }
+
+    /// Retain entries where `keep(rowid, row_versions)` returns true.
+    fn retain<F: FnMut(&RowID, &RowVersions) -> bool>(&mut self, mut keep: F) {
+        let seen = &mut self.seen;
+        self.entries.retain(|(rowid, rv)| {
+            if keep(rowid, rv) {
+                true
+            } else {
+                seen.remove(&(Arc::as_ptr(rv) as usize));
+                false
+            }
+        });
+    }
+
+    /// Clones the write set into a [Vec].
+    fn to_vec(&self) -> Vec<(RowID, RowVersions)> {
+        self.entries.clone()
+    }
+}
+
 /// Transaction
 #[derive(Debug)]
 pub struct Transaction {
@@ -465,11 +519,8 @@ pub struct Transaction {
     tx_id: u64,
     /// The transaction begin timestamp.
     begin_ts: u64,
-    /// The transaction write set. Single-writer (the txn's own connection),
-    /// so plain `Mutex<Vec<_>>` is enough; the previous `SkipSet` was paying
-    /// for unused concurrent-insert semantics. Duplicates are allowed —
-    /// consumers (commit, rollback) dedup as needed.
-    write_set: Mutex<Vec<(RowID, RowVersions)>>,
+    /// The transaction write set. Only writer is the [Transaction]'s own connection.
+    write_set: Mutex<WriteSet>,
     /// The transaction read set.
     read_set: SkipSet<RowID>,
     /// The transaction header.
@@ -501,7 +552,7 @@ impl Transaction {
             state: TransactionState::Active.into(),
             tx_id,
             begin_ts,
-            write_set: Mutex::new(Vec::new()),
+            write_set: Mutex::new(WriteSet::new()),
             read_set: SkipSet::new(),
             header: RwLock::new(header),
             header_dirty: AtomicBool::new(false),
@@ -529,7 +580,7 @@ impl Transaction {
                 .newly_added_to_write_set
                 .push((id.clone(), row_versions.clone()));
         }
-        self.write_set.lock().push((id, row_versions));
+        self.write_set.lock().insert(id, row_versions);
     }
 
     /// Begin a new savepoint for statement-level tracking.
@@ -1616,17 +1667,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                  ** 2. Validate if there are no phantoms by walking the scans from scan_set
                  */
                 tracing::trace!("commit_tx(tx_id={})", self.tx_id);
-                // The transaction's write_set may contain duplicates (e.g. INSERT then UPDATE on
-                // the same row) since `insert_to_write_set` skips a `contains` check; sort makes
-                // equal RowIDs adjacent so `dedup_by` collapses them in linear time.
-                let write_set_is_empty = {
-                    let mut write_set = tx.write_set.lock();
-                    write_set.sort_by(|(a, _), (b, _)| {
-                        b.table_id.cmp(&a.table_id).then(a.row_id.cmp(&b.row_id))
-                    });
-                    write_set.dedup_by(|a, b| a.0 == b.0);
-                    write_set.is_empty()
-                };
+                let write_set_is_empty = tx.write_set.lock().is_empty();
                 // Header-only writes must not take this fast path; they need durable log records.
                 if write_set_is_empty && !tx.header_dirty.load(Ordering::Acquire) {
                     turso_assert!(
@@ -3710,7 +3751,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
         // Snapshot under the lock so we can drop it before recursing into
         // `rollback_rowid` (which may take other locks).
-        let write_set_snapshot: Vec<(RowID, RowVersions)> = tx.write_set.lock().clone();
+        let write_set_snapshot: Vec<(RowID, RowVersions)> = tx.write_set.lock().to_vec();
         for (_rowid, row_versions) in &write_set_snapshot {
             for rv in row_versions.write().iter_mut() {
                 rollback_row_version(tx_id, rv);
@@ -3974,11 +4015,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let tx = tx.value();
         // Single pass: drop entries that appear in `rowids` AND have no
         // surviving uncommitted version (parent savepoints may still pin
-        // them). Since `write_set` is now a Vec that tolerates duplicates,
-        // every matching occurrence is dropped together — equivalent to
-        // calling `remove` once per rowid against the old SkipSet.
+        // them).
         let mut write_set = tx.write_set.lock();
-        write_set.retain(|(rowid, _chain)| {
+        write_set.retain(|rowid, _rv| {
             if !rowids.contains(rowid) {
                 return true;
             }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -3486,7 +3486,7 @@ fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Transaction {
         state,
         tx_id,
         begin_ts,
-        write_set: Mutex::new(Vec::new()),
+        write_set: Mutex::new(WriteSet::new()),
         read_set: SkipSet::new(),
         header: RwLock::new(DatabaseHeader::default()),
         header_dirty: AtomicBool::new(false),
@@ -4843,10 +4843,12 @@ fn transaction_display() {
     let begin_ts = 20250914;
 
     let empty_versions = || Arc::new(RwLock::new(Vec::new()));
-    let write_set = Mutex::new(vec![
-        (RowID::new((-2).into(), RowKey::Int(11)), empty_versions()),
-        (RowID::new((-2).into(), RowKey::Int(13)), empty_versions()),
-    ]);
+    let write_set = Mutex::new({
+        let mut write_set = WriteSet::new();
+        write_set.insert(RowID::new((-2).into(), RowKey::Int(11)), empty_versions());
+        write_set.insert(RowID::new((-2).into(), RowKey::Int(13)), empty_versions());
+        write_set
+    });
 
     let read_set = SkipSet::new();
     read_set.insert(RowID::new((-2).into(), RowKey::Int(17)));


### PR DESCRIPTION
## Description

This PR contains 2 optimizations.

### 1. `Transaction` now owns the write set

Previously, we cloned `Transaction::write_set` into `CommitStateMachine::write_set`. This wasn't necessary.

### 2. Deduplicate row versions by `Arc` pointer addresses

We carry the write set in a `Vec<RowID, RowVersions>`, where `RowVersions` is a type alias for an `Arc` wrapping a version chain (not a real chain, I know, more like a sequence).

Before committing, we need to deduplicate the row versions, keeping only one of each. It doesn't matter which one we keep, since the values are `Arc`s anyways, so duplicates will always have Arcs referring to the same version chain.

Previously, we did this by sorting the `Vec` and then calling `Vec::dedup` on it. We can avoid this if instead, we keep the write set in a set-like structure, where values are deduplicated by their `Arc` pointer. This is what the `WriteSet` type does. I tried using a `HashMap<usize, (RowID, RowVersions)>`, but the commit-time iteration was too slow. I could have used an `IndexMap<usize, RowID, RowVersions>`, but I preferred having a domain type.

One thing isn't so comfortable with this solution: nothing encodes the critical invariant that there exists at most one `*RowVersions` per `RowID`.

### Benchmark

I separated `create_index_benchmark.rs` to measure (1) commit-only latency and (2) full-tx latency.

## Performance improvement

  | Metric                 | cache-row-versions | WriteSet | cache→WriteSet |
|------------------------|--------------------|----------|----------------|
| turso_total 100K       | 197 ms             | 188 ms   | -5%            |
| turso_commit_only 100K | 26.7 ms            | 22.2 ms  | -17%           |
| turso_total 500K       | 1113 ms            | 1146 ms  | +3%    |
| turso_commit_only 500K | 141 ms             | 101 ms   | -28%           |
| Max RSS                | 9909 MB            | 10000 MB | ~0%            |


## Description of AI Usage

Claude Code spent many hours benchmarking various data structures against the baseline, and figured out the arc-deduplication solution (long story short).