### PR TITLE
Keep temp trigger body DML unqualified

### DIFF
--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -560,7 +560,10 @@ fn execute_trigger_commands(
     // Ordinary non-main triggers need unqualified DML targets rewritten into the
     // trigger's schema. Temp-backed triggers intentionally keep unqualified names
     // unresolved so they can follow SQLite's normal temp/main lookup rules.
-    let db_name = if database_id == crate::MAIN_DB_ID || database_id == crate::TEMP_DB_ID {
+    let db_name = if trigger.temporary
+        || database_id == crate::MAIN_DB_ID
+        || database_id == crate::TEMP_DB_ID
+    {
         None
     } else {
         resolver

--- a/testing/sqltests/tests/trigger_attach_regression.sqltest
+++ b/testing/sqltests/tests/trigger_attach_regression.sqltest
@@ -605,6 +605,25 @@ expect {
     1|gone
 }
 
+test temp-trigger-on-attached-table-body-resolves-main {
+    ATTACH ':memory:' AS aux;
+    CREATE TABLE main_log (id INTEGER);
+    INSERT INTO main_log VALUES (1);
+    CREATE TABLE aux.attached_src (id INTEGER);
+    INSERT INTO aux.attached_src VALUES (10);
+    CREATE TEMP TRIGGER trg_temp_aux BEFORE DELETE ON attached_src
+    BEGIN
+        DELETE FROM main_log WHERE id = 1;
+    END;
+    DELETE FROM aux.attached_src;
+    SELECT COUNT(*) FROM main_log;
+    SELECT COUNT(*) FROM aux.attached_src;
+}
+expect {
+    0
+    0
+}
+
 # Multiple trigger commands all referencing same attached db should work
 test trigger-attached-db-multi-cmd-same-db {
     ATTACH ':memory:' AS aux;


### PR DESCRIPTION
Fixes #6852.

A TEMP TRIGGER can fire on a table in an attached database while unqualified body DML should still resolve through SQLite normal temp/main/attached lookup order. This avoids retargeting those body statements to the fired table attached schema while preserving same-database qualification for ordinary triggers.

Verification:
- `make -C testing/sqltests run-rust ARGS='--filter temp-trigger-on-attached-table-body-resolves-main --snapshot-filter __never__'`
