### PR TITLE
Validate skipped ORDER BY subqueries

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -20,7 +20,7 @@ use crate::translate::planner::{
 use crate::translate::result_row::emit_select_result;
 use crate::translate::subquery::{
     plan_subqueries_from_select_plan, plan_subqueries_from_values,
-    validate_subqueries_in_skipped_order_by,
+    validate_subqueries_in_skipped_order_by, validate_subqueries_in_truncated_order_by,
 };
 use crate::translate::window::plan_windows;
 use crate::util::{exprs_are_equivalent, normalize_ident};
@@ -712,6 +712,13 @@ fn prepare_one_select_plan(
                     _ => false,
                 };
                 if first_is_rowid {
+                    validate_subqueries_in_truncated_order_by(
+                        program,
+                        &plan.table_references,
+                        resolver,
+                        &plan.order_by[1..],
+                        connection,
+                    )?;
                     plan.order_by.truncate(1);
                 }
             }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -18,7 +18,10 @@ use crate::translate::planner::{
     parse_limit, parse_where, plan_ctes_as_outer_refs, resolve_window_and_aggregate_functions,
 };
 use crate::translate::result_row::emit_select_result;
-use crate::translate::subquery::{plan_subqueries_from_select_plan, plan_subqueries_from_values};
+use crate::translate::subquery::{
+    plan_subqueries_from_select_plan, plan_subqueries_from_values,
+    validate_subqueries_in_skipped_order_by,
+};
 use crate::translate::window::plan_windows;
 use crate::util::{exprs_are_equivalent, normalize_ident};
 use crate::vdbe::builder::ProgramBuilderOpts;
@@ -671,13 +674,21 @@ fn prepare_one_select_plan(
             plan.order_by = key;
 
             // Single-row aggregate queries (aggregates without GROUP BY and without window functions)
-            // produce exactly one row, so ORDER BY is meaningless. Clearing it here also avoids
-            // eagerly validating subqueries in ORDER BY that SQLite would skip due to optimization.
+            // produce exactly one row, so ORDER BY is meaningless. SQLite still binds subqueries
+            // inside the skipped ORDER BY for missing tables/columns, but skips arity checks that
+            // would only matter while evaluating the ORDER BY expression.
             // Note: HAVING without GROUP BY sets group_by to Some with empty exprs, still single-row.
             let is_single_row_aggregate = !plan.aggregates.is_empty()
                 && plan.group_by.as_ref().is_none_or(|gb| gb.exprs.is_empty())
                 && windows.is_empty();
             if is_single_row_aggregate {
+                validate_subqueries_in_skipped_order_by(
+                    program,
+                    &plan.table_references,
+                    resolver,
+                    &plan.order_by,
+                    connection,
+                )?;
                 plan.order_by.clear();
             }
 

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -212,6 +212,95 @@ pub(crate) fn mark_shared_cte_materialization_requirements(
     }
 }
 
+fn outer_query_refs_for(referenced_tables: &TableReferences) -> Vec<OuterQueryReference> {
+    referenced_tables
+        .joined_tables()
+        .iter()
+        .map(|t| {
+            // Extract cte_id from FromClauseSubquery if this is a CTE reference
+            let cte_id = match &t.table {
+                Table::FromClauseSubquery(subq) => subq.cte_id(),
+                _ => None,
+            };
+            OuterQueryReference {
+                table: t.table.clone(),
+                identifier: t.identifier.clone(),
+                internal_id: t.internal_id,
+                using_dedup_hidden_cols: t.using_dedup_hidden_cols(),
+                col_used_mask: ColumnUsedMask::default(),
+                cte_select: None,
+                cte_explicit_columns: vec![],
+                cte_id,
+                cte_definition_only: false,
+                rowid_referenced: false,
+                scope_depth: 0,
+            }
+        })
+        .chain(referenced_tables.outer_query_refs().iter().map(|t| {
+            OuterQueryReference {
+                table: t.table.clone(),
+                identifier: t.identifier.clone(),
+                internal_id: t.internal_id,
+                using_dedup_hidden_cols: t.using_dedup_hidden_cols.clone(),
+                col_used_mask: ColumnUsedMask::default(),
+                cte_select: t.cte_select.clone(),
+                cte_explicit_columns: t.cte_explicit_columns.clone(),
+                cte_id: t.cte_id, // Preserve CTE ID from outer query refs
+                cte_definition_only: t.cte_definition_only,
+                rowid_referenced: false,
+                scope_depth: t.scope_depth + 1,
+            }
+        }))
+        .collect::<Vec<_>>()
+}
+
+pub fn validate_subqueries_in_skipped_order_by(
+    program: &mut ProgramBuilder,
+    referenced_tables: &TableReferences,
+    resolver: &Resolver,
+    order_by: &[(Box<ast::Expr>, SortOrder, Option<ast::NullsOrder>)],
+    connection: &Arc<Connection>,
+) -> Result<()> {
+    let outer_query_refs = outer_query_refs_for(referenced_tables);
+
+    for (expr, _, _) in order_by {
+        walk_expr(expr, &mut |expr| {
+            let subselect = match expr {
+                ast::Expr::Exists(select) | ast::Expr::Subquery(select) => select,
+                ast::Expr::InSelect { rhs, .. } => rhs,
+                _ => return Ok(WalkControl::Continue),
+            };
+
+            if let Err(error) = prepare_select_plan(
+                subselect.clone(),
+                resolver,
+                program,
+                &outer_query_refs,
+                QueryDestination::Unset,
+                connection,
+            ) {
+                if !is_skipped_order_by_arity_error(&error) {
+                    return Err(error);
+                }
+            }
+            Ok(WalkControl::Continue)
+        })?;
+    }
+
+    Ok(())
+}
+
+fn is_skipped_order_by_arity_error(error: &crate::LimboError) -> bool {
+    let crate::LimboError::ParseError(message) = error else {
+        return false;
+    };
+
+    message.starts_with("sub-select returns ")
+        || message.contains(" must return 1 value")
+        || message.contains(" must return the same number of values")
+        || message == "row value misused"
+}
+
 // Compute query plans for subqueries occurring in any position other than the FROM clause.
 // This includes the WHERE clause, HAVING clause, GROUP BY clause, ORDER BY clause, LIMIT clause, and OFFSET clause.
 /// The AST expression containing the subquery ([ast::Expr::Exists], [ast::Expr::Subquery], [ast::Expr::InSelect]) is replaced with a [ast::Expr::SubqueryResult] expression.
@@ -518,50 +607,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
     // Most subqueries can reference columns from the outer query,
     // including nested cases where a subquery inside a subquery references columns from its parent's parent
     // and so on.
-    let get_outer_query_refs = |referenced_tables: &TableReferences| {
-        referenced_tables
-            .joined_tables()
-            .iter()
-            .map(|t| {
-                // Extract cte_id from FromClauseSubquery if this is a CTE reference
-                let cte_id = match &t.table {
-                    Table::FromClauseSubquery(subq) => subq.cte_id(),
-                    _ => None,
-                };
-                OuterQueryReference {
-                    table: t.table.clone(),
-                    identifier: t.identifier.clone(),
-                    internal_id: t.internal_id,
-                    using_dedup_hidden_cols: t.using_dedup_hidden_cols(),
-                    col_used_mask: ColumnUsedMask::default(),
-                    cte_select: None,
-                    cte_explicit_columns: vec![],
-                    cte_id,
-                    cte_definition_only: false,
-                    rowid_referenced: false,
-                    scope_depth: 0,
-                }
-            })
-            .chain(
-                referenced_tables
-                    .outer_query_refs()
-                    .iter()
-                    .map(|t| OuterQueryReference {
-                        table: t.table.clone(),
-                        identifier: t.identifier.clone(),
-                        internal_id: t.internal_id,
-                        using_dedup_hidden_cols: t.using_dedup_hidden_cols.clone(),
-                        col_used_mask: ColumnUsedMask::default(),
-                        cte_select: t.cte_select.clone(),
-                        cte_explicit_columns: t.cte_explicit_columns.clone(),
-                        cte_id: t.cte_id, // Preserve CTE ID from outer query refs
-                        cte_definition_only: t.cte_definition_only,
-                        rowid_referenced: false,
-                        scope_depth: t.scope_depth + 1,
-                    }),
-            )
-            .collect::<Vec<_>>()
-    };
+    let get_outer_query_refs = outer_query_refs_for;
 
     let mut subquery_parser = get_subquery_parser(
         program,

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -14,7 +14,8 @@ use crate::{
             emit_program_for_select_with_resolver, emit_query,
         },
         expr::{
-            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr_mut, WalkControl,
+            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr, walk_expr_mut,
+            WalkControl,
         },
         optimizer::optimize_select_plan,
         plan::{
@@ -280,6 +281,42 @@ pub fn validate_subqueries_in_skipped_order_by(
                 connection,
             ) {
                 if !is_skipped_order_by_arity_error(&error) {
+                    return Err(error);
+                }
+            }
+            Ok(WalkControl::Continue)
+        })?;
+    }
+
+    Ok(())
+}
+
+pub fn validate_subqueries_in_truncated_order_by(
+    program: &mut ProgramBuilder,
+    referenced_tables: &TableReferences,
+    resolver: &Resolver,
+    order_by: &[(Box<ast::Expr>, SortOrder, Option<ast::NullsOrder>)],
+    connection: &Arc<Connection>,
+) -> Result<()> {
+    let outer_query_refs = outer_query_refs_for(referenced_tables);
+
+    for (expr, _, _) in order_by {
+        walk_expr(expr, &mut |expr| {
+            let (subselect, suppress_direct_in_arity) = match expr {
+                ast::Expr::Exists(select) | ast::Expr::Subquery(select) => (select, false),
+                ast::Expr::InSelect { rhs, .. } => (rhs, true),
+                _ => return Ok(WalkControl::Continue),
+            };
+
+            if let Err(error) = prepare_select_plan(
+                subselect.clone(),
+                resolver,
+                program,
+                &outer_query_refs,
+                QueryDestination::Unset,
+                connection,
+            ) {
+                if !(suppress_direct_in_arity && is_skipped_order_by_arity_error(&error)) {
                     return Err(error);
                 }
             }

--- a/testing/sqltests/tests/orderby/memory.sqltest
+++ b/testing/sqltests/tests/orderby/memory.sqltest
@@ -164,6 +164,37 @@ expect {
     1
 }
 
+test orderby_rowid_truncation_validates_subquery_table {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+    SELECT a FROM t ORDER BY a, EXISTS(SELECT * FROM missing);
+}
+expect error {
+    no such table: missing
+}
+
+test orderby_rowid_truncation_validates_nested_subquery_arity {
+    CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT);
+    SELECT a FROM t ORDER BY a, EXISTS(SELECT * FROM t WHERE b IN (SELECT a, b FROM t));
+}
+expect error {
+    sub-select returns 2 columns - expected 1
+}
+
+test orderby_rowid_truncation_validates_shadowed_cte_arity {
+    CREATE TABLE t(a INTEGER PRIMARY KEY);
+    CREATE TEMPORARY TABLE u(c0, c1, c2, c3, c4, c5);
+    WITH cte_0 AS (SELECT a FROM t)
+    SELECT a
+    FROM cte_0
+    ORDER BY a, EXISTS(
+        WITH cte_0(c0) AS MATERIALIZED (SELECT * FROM temp.u)
+        SELECT c0 FROM cte_0
+    );
+}
+expect error {
+    table cte_0 has
+}
+
 # Unary-plus on integer literals should still resolve as column index
 # references, matching SQLite behavior.
 # Fixes select1-4.9.2 in testing/conformance/sqlite3/all.test.
@@ -253,4 +284,3 @@ test order-by-zero {
 expect error {
     1st ORDER BY term out of range - should be between 1 and 2
 }
-

--- a/testing/sqltests/tests/orderby/memory.sqltest
+++ b/testing/sqltests/tests/orderby/memory.sqltest
@@ -115,6 +115,30 @@ expect {
     2
 }
 
+test orderby_single_row_aggregate_validates_skipped_subquery_table {
+    CREATE TABLE t(a, b);
+    SELECT COUNT(a) FROM t ORDER BY EXISTS(SELECT * FROM missing);
+}
+expect error {
+    no such table: missing
+}
+
+test orderby_single_row_aggregate_validates_skipped_subquery_column {
+    CREATE TABLE t(a, b);
+    SELECT COUNT(a) FROM t ORDER BY EXISTS(SELECT missing_col FROM t);
+}
+expect error {
+    no such column: missing_col
+}
+
+test orderby_single_row_aggregate_skips_nested_subquery_arity {
+    CREATE TABLE t(a, b);
+    SELECT COUNT(a) FROM t ORDER BY EXISTS(SELECT * FROM t WHERE a IN (SELECT a, b FROM t));
+}
+expect {
+    0
+}
+
 # SQLite truncates ORDER BY after a rowid/INTEGER PRIMARY KEY column since the table is
 # stored in rowid order and a unique column means no ties. This skips validation of
 # subsequent clauses, so even invalid constructs like multi-column IN subqueries pass.

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -69,10 +69,7 @@ impl IO for TestIo {
     fn cancel(&self, c: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.cancel(c)
     }
-    fn drain_completions(
-        &self,
-        completions: &[turso_core::Completion],
-    ) -> turso_core::Result<()> {
+    fn drain_completions(&self, completions: &[turso_core::Completion]) -> turso_core::Result<()> {
         self.io.drain_completions(completions)
     }
     fn fill_bytes(&self, dest: &mut [u8]) {


### PR DESCRIPTION
Fixes #6851.

This keeps SQLite-compatible validation for subqueries inside `ORDER BY` terms even when those terms are skipped by rowid truncation or single-row aggregate planning. Direct expression arity checks that SQLite skips remain skipped, but nested subqueries are still prepared so missing tables, missing columns, and nested arity errors are reported.

Verification:
- `make -C testing/sqltests run-rust ARGS='--filter orderby_rowid_truncation_validates_subquery_table --snapshot-filter __never__'`
- `make -C testing/sqltests run-rust ARGS='--filter orderby_rowid_truncation_validates_nested_subquery_arity --snapshot-filter __never__'`
- `make -C testing/sqltests run-rust ARGS='--filter orderby_rowid_truncation_validates_shadowed_cte_arity --snapshot-filter __never__'`
- `cargo run --bin test-runner run testing/sqltests/tests/orderby/memory.sqltest --backend cli --binary /Users/openclaw/Documents/Codex/turso/.sqlite3/sqlite3 --filter orderby_rowid_truncation_validates_shadowed_cte_arity --snapshot-filter __never__`
- `cargo fmt --check`
