### PR TITLE
fix: roll back DML returning expression errors

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1,36 +1,36 @@
-#[cfg(all(feature = "fs", feature = "conn_raw_api"))]
-use crate::Page;
 use crate::error::io_error;
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_points::{FailureInjector, YieldInjector};
 use crate::statement::StatementOrigin;
 use crate::storage::{journal_mode, pager::SavepointResult};
 use crate::sync::{
-    Arc, RwLock,
     atomic::{
-        AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU8, AtomicU16, AtomicU64, Ordering,
+        AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicU8, Ordering,
     },
+    Arc, RwLock,
 };
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
 use crate::util::{OpenMode, OpenOptions};
+#[cfg(all(feature = "fs", feature = "conn_raw_api"))]
+use crate::Page;
 use crate::{
-    AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
-    BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
-    Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
-    EncryptionKey, EncryptionOpts, IndexMethod, LimboError, MvStore, OpenFlags, PageSize, Pager,
-    Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
-    Trigger, Value, VirtualTable, WalAutoActions, ast, function,
-    io::{IO, MemoryIO},
+    ast, function,
+    io::{MemoryIO, IO},
     parse_schema_rows,
     progress::{ProgressHandler, ProgressHandlerCallback},
     refresh_analyze_stats, translate,
     util::IOExt,
-    vdbe,
+    vdbe, AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
+    BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
+    Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
+    EncryptionKey, EncryptionOpts, IndexMethod, LimboError, MvStore, OpenFlags, PageSize, Pager,
+    Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
+    Trigger, Value, VirtualTable, WalAutoActions,
 };
-use crate::{MAIN_DB_ID, TEMP_DB_ID};
 use crate::{is_memory_like, turso_assert};
+use crate::{MAIN_DB_ID, TEMP_DB_ID};
 use arc_swap::ArcSwap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
@@ -40,8 +40,8 @@ use std::ops::Deref;
 use std::path::Path;
 #[cfg(not(target_family = "wasm"))]
 use tempfile::TempDir;
-use tracing::{Level, instrument};
-use turso_macros::{AtomicEnum, turso_assert_ne};
+use tracing::{instrument, Level};
+use turso_macros::{turso_assert_ne, AtomicEnum};
 
 #[cfg(feature = "simulator")]
 fn db_identity_for_testing(db_path: &Path) -> Result<(u32, u32)> {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1,36 +1,36 @@
+#[cfg(all(feature = "fs", feature = "conn_raw_api"))]
+use crate::Page;
 use crate::error::io_error;
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_points::{FailureInjector, YieldInjector};
 use crate::statement::StatementOrigin;
 use crate::storage::{journal_mode, pager::SavepointResult};
 use crate::sync::{
-    atomic::{
-        AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicU8, Ordering,
-    },
     Arc, RwLock,
+    atomic::{
+        AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU8, AtomicU16, AtomicU64, Ordering,
+    },
 };
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
 use crate::util::{OpenMode, OpenOptions};
-#[cfg(all(feature = "fs", feature = "conn_raw_api"))]
-use crate::Page;
 use crate::{
-    ast, function,
-    io::{MemoryIO, IO},
-    parse_schema_rows,
-    progress::{ProgressHandler, ProgressHandlerCallback},
-    refresh_analyze_stats, translate,
-    util::IOExt,
-    vdbe, AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
+    AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
     Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
     EncryptionKey, EncryptionOpts, IndexMethod, LimboError, MvStore, OpenFlags, PageSize, Pager,
     Parser, Program, QueryMode, QueryRunner, Result, Schema, Statement, SyncMode, TransactionMode,
-    Trigger, Value, VirtualTable, WalAutoActions,
+    Trigger, Value, VirtualTable, WalAutoActions, ast, function,
+    io::{IO, MemoryIO},
+    parse_schema_rows,
+    progress::{ProgressHandler, ProgressHandlerCallback},
+    refresh_analyze_stats, translate,
+    util::IOExt,
+    vdbe,
 };
-use crate::{is_memory_like, turso_assert};
 use crate::{MAIN_DB_ID, TEMP_DB_ID};
+use crate::{is_memory_like, turso_assert};
 use arc_swap::ArcSwap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
@@ -40,8 +40,8 @@ use std::ops::Deref;
 use std::path::Path;
 #[cfg(not(target_family = "wasm"))]
 use tempfile::TempDir;
-use tracing::{instrument, Level};
-use turso_macros::{turso_assert_ne, AtomicEnum};
+use tracing::{Level, instrument};
+use turso_macros::{AtomicEnum, turso_assert_ne};
 
 #[cfg(feature = "simulator")]
 fn db_identity_for_testing(db_path: &Path) -> Result<(u32, u32)> {
@@ -3441,6 +3441,82 @@ mod tests {
             Value::Text(text) => text.as_str(),
             other => panic!("expected text value, got {other:?}"),
         }
+    }
+
+    fn query_i64_rows(conn: &Arc<Connection>, sql: &str) -> Vec<Vec<i64>> {
+        let mut stmt = conn.prepare(sql).unwrap();
+        let mut rows = Vec::new();
+        stmt.run_with_row_callback(|row| {
+            rows.push((0..row.len()).map(|i| row.get::<i64>(i).unwrap()).collect());
+            Ok(())
+        })
+        .unwrap();
+        rows
+    }
+
+    #[test]
+    fn test_delete_returning_error_rolls_back_statement_writes() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("delete-returning-rollback.db");
+        let conn = open_connection(&db_path);
+
+        conn.execute(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE t(a INT);
+             INSERT INTO t VALUES(1),(2);
+             BEGIN;",
+        )
+        .unwrap();
+        let err = conn
+            .execute(
+                "DELETE FROM t
+                 WHERE a=1
+                 RETURNING 'x' LIKE 'x' ESCAPE 'yy';",
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("ESCAPE expression must be a single character"),
+            "unexpected error: {err}"
+        );
+
+        assert_eq!(
+            query_i64_rows(&conn, "SELECT a FROM t ORDER BY a"),
+            vec![vec![1], vec![2]]
+        );
+        conn.execute("COMMIT").unwrap();
+    }
+
+    #[test]
+    fn test_insert_or_replace_returning_error_preserves_conflicting_row() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("replace-returning-rollback.db");
+        let conn = open_connection(&db_path);
+
+        conn.execute(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE r(a INT UNIQUE, b INT);
+             INSERT INTO r VALUES(1,10);
+             BEGIN;",
+        )
+        .unwrap();
+        let err = conn
+            .execute(
+                "INSERT OR REPLACE INTO r VALUES(1,20)
+                 RETURNING 'x' LIKE 'x' ESCAPE 'yy';",
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("ESCAPE expression must be a single character"),
+            "unexpected error: {err}"
+        );
+
+        assert_eq!(
+            query_i64_rows(&conn, "SELECT rowid,a,b FROM r"),
+            vec![vec![1, 1, 10]]
+        );
+        conn.execute("COMMIT").unwrap();
     }
 
     // given a attached 'alias', return the Database and Pager for that attached database

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -2,34 +2,37 @@ use crate::schema::ColumnLayout;
 use crate::translate::emitter::{emit_index_column_value_old_image, gencol};
 use crate::turso_debug_assert;
 use crate::{
+    CaptureDataChangesExt, Connection, LimboError, Result, VirtualTable,
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
     schema::{
-        self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef, Table,
-        SQLITE_SEQUENCE_TABLE_NAME,
+        self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef,
+        SQLITE_SEQUENCE_TABLE_NAME, Table,
     },
     sync::Arc,
     translate::{
         emitter::{
-            delete::emit_fk_child_decrement_on_delete, emit_cdc_autocommit_commit,
-            emit_cdc_full_record, emit_cdc_insns, emit_cdc_patch_record, emit_check_constraints,
-            emit_make_record, prepare_cdc_if_necessary, OperationMode, Resolver,
+            OperationMode, Resolver, delete::emit_fk_child_decrement_on_delete,
+            emit_cdc_autocommit_commit, emit_cdc_full_record, emit_cdc_insns,
+            emit_cdc_patch_record, emit_check_constraints, emit_make_record,
+            prepare_cdc_if_necessary,
         },
         expr::{
+            BindingBehavior, NoConstantOptReason, ReturningBufferCtx, WalkControl,
             bind_and_rewrite_expr, emit_returning_results, emit_returning_scan_back,
             process_returning_clause, restore_returning_row_image_in_cache,
             seed_returning_row_image_in_cache, translate_expr, translate_expr_no_constant_opt,
-            walk_expr, BindingBehavior, NoConstantOptReason, ReturningBufferCtx, WalkControl,
+            walk_expr,
         },
         fkeys::{
-            build_index_affinity_string, emit_fk_restrict_halt, emit_fk_violation,
-            emit_guarded_fk_decrement, index_probe, open_read_index, open_read_table,
-            ForeignKeyActions,
+            ForeignKeyActions, build_index_affinity_string, emit_fk_restrict_halt,
+            emit_fk_violation, emit_guarded_fk_decrement, index_probe, open_read_index,
+            open_read_table,
         },
         plan::{
             ColumnUsedMask, EvalAt, JoinedTable, Operation, QueryDestination, ResultSetColumn,
             TableReferences,
         },
-        planner::{plan_ctes_as_outer_refs, ROWID_STRS},
+        planner::{ROWID_STRS, plan_ctes_as_outer_refs},
         select::translate_select,
         stmt_journal::{any_index_or_ipk_has_replace, set_insert_stmt_journal_flags},
         subquery::{
@@ -37,21 +40,20 @@ use crate::{
             plan_subqueries_from_returning,
         },
         trigger_exec::{
-            fire_trigger, get_triggers_including_temp, has_triggers_including_temp, TriggerContext,
+            TriggerContext, fire_trigger, get_triggers_including_temp, has_triggers_including_temp,
         },
         upsert::{
-            collect_set_clauses_for_upsert, emit_upsert, resolve_upsert_target,
-            ResolvedUpsertTarget,
+            ResolvedUpsertTarget, collect_set_clauses_for_upsert, emit_upsert,
+            resolve_upsert_target,
         },
     },
     util::normalize_ident,
     vdbe::{
+        BranchOffset,
         affinity::Affinity,
         builder::{CursorKey, CursorType, DmlColumnContext, ProgramBuilder, ProgramBuilderOpts},
-        insn::{to_u16, CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral},
-        BranchOffset,
+        insn::{CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral, to_u16},
     },
-    CaptureDataChangesExt, Connection, LimboError, Result, VirtualTable,
 };
 use gencol::compute_virtual_columns;
 use std::num::NonZeroUsize;
@@ -1166,6 +1168,7 @@ pub fn translate_insert(
             btree_table.has_autoincrement,
             notnull_col_exists,
             has_unique,
+            !result_columns.is_empty(),
         );
     }
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -2,37 +2,34 @@ use crate::schema::ColumnLayout;
 use crate::translate::emitter::{emit_index_column_value_old_image, gencol};
 use crate::turso_debug_assert;
 use crate::{
-    CaptureDataChangesExt, Connection, LimboError, Result, VirtualTable,
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
     schema::{
-        self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef,
-        SQLITE_SEQUENCE_TABLE_NAME, Table,
+        self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef, Table,
+        SQLITE_SEQUENCE_TABLE_NAME,
     },
     sync::Arc,
     translate::{
         emitter::{
-            OperationMode, Resolver, delete::emit_fk_child_decrement_on_delete,
-            emit_cdc_autocommit_commit, emit_cdc_full_record, emit_cdc_insns,
-            emit_cdc_patch_record, emit_check_constraints, emit_make_record,
-            prepare_cdc_if_necessary,
+            delete::emit_fk_child_decrement_on_delete, emit_cdc_autocommit_commit,
+            emit_cdc_full_record, emit_cdc_insns, emit_cdc_patch_record, emit_check_constraints,
+            emit_make_record, prepare_cdc_if_necessary, OperationMode, Resolver,
         },
         expr::{
-            BindingBehavior, NoConstantOptReason, ReturningBufferCtx, WalkControl,
             bind_and_rewrite_expr, emit_returning_results, emit_returning_scan_back,
             process_returning_clause, restore_returning_row_image_in_cache,
             seed_returning_row_image_in_cache, translate_expr, translate_expr_no_constant_opt,
-            walk_expr,
+            walk_expr, BindingBehavior, NoConstantOptReason, ReturningBufferCtx, WalkControl,
         },
         fkeys::{
-            ForeignKeyActions, build_index_affinity_string, emit_fk_restrict_halt,
-            emit_fk_violation, emit_guarded_fk_decrement, index_probe, open_read_index,
-            open_read_table,
+            build_index_affinity_string, emit_fk_restrict_halt, emit_fk_violation,
+            emit_guarded_fk_decrement, index_probe, open_read_index, open_read_table,
+            ForeignKeyActions,
         },
         plan::{
             ColumnUsedMask, EvalAt, JoinedTable, Operation, QueryDestination, ResultSetColumn,
             TableReferences,
         },
-        planner::{ROWID_STRS, plan_ctes_as_outer_refs},
+        planner::{plan_ctes_as_outer_refs, ROWID_STRS},
         select::translate_select,
         stmt_journal::{any_index_or_ipk_has_replace, set_insert_stmt_journal_flags},
         subquery::{
@@ -40,20 +37,21 @@ use crate::{
             plan_subqueries_from_returning,
         },
         trigger_exec::{
-            TriggerContext, fire_trigger, get_triggers_including_temp, has_triggers_including_temp,
+            fire_trigger, get_triggers_including_temp, has_triggers_including_temp, TriggerContext,
         },
         upsert::{
-            ResolvedUpsertTarget, collect_set_clauses_for_upsert, emit_upsert,
-            resolve_upsert_target,
+            collect_set_clauses_for_upsert, emit_upsert, resolve_upsert_target,
+            ResolvedUpsertTarget,
         },
     },
     util::normalize_ident,
     vdbe::{
-        BranchOffset,
         affinity::Affinity,
         builder::{CursorKey, CursorType, DmlColumnContext, ProgramBuilder, ProgramBuilderOpts},
-        insn::{CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral, to_u16},
+        insn::{to_u16, CmpInsFlags, IdxInsertFlags, InsertFlags, Insn, RegisterOrLiteral},
+        BranchOffset,
     },
+    CaptureDataChangesExt, Connection, LimboError, Result, VirtualTable,
 };
 use gencol::compute_virtual_columns;
 use std::num::NonZeroUsize;

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -25,7 +25,7 @@ use crate::translate::emitter::Resolver;
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
-use crate::{Connection, Result, sync::Arc};
+use crate::{sync::Arc, Connection, Result};
 use turso_parser::ast::{ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -25,7 +25,7 @@ use crate::translate::emitter::Resolver;
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
-use crate::{sync::Arc, Connection, Result};
+use crate::{Connection, Result, sync::Arc};
 use turso_parser::ast::{ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.
@@ -135,6 +135,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     has_autoincrement: bool,
     notnull_col_exists: bool,
     has_unique: bool,
+    has_returning: bool,
 ) {
     let index_modes: Vec<(Option<ResolveType>, bool)> = resolver.with_schema(database_id, |s| {
         s.get_indices(&table.name)
@@ -148,7 +149,8 @@ pub(crate) fn set_insert_stmt_journal_flags(
         index_modes.iter().map(|(oc, _)| *oc),
     );
     let has_check = !table.check_constraints.is_empty();
-    let may_abort = has_triggers
+    let may_abort = has_returning
+        || has_triggers
         || has_fks
         || constraint_may_abort(
             has_statement_conflict,
@@ -231,7 +233,8 @@ pub(crate) fn set_update_stmt_journal_flags(
     let has_unique =
         !btree_table.unique_sets.is_empty() || plan.indexes_to_update.iter().any(|idx| idx.unique);
 
-    let may_abort = has_triggers
+    let may_abort = plan.returning.is_some()
+        || has_triggers
         || has_fks
         || constraint_may_abort(
             has_statement_conflict,
@@ -275,7 +278,7 @@ pub(crate) fn set_delete_stmt_journal_flags(
 
     // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
     // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
+    if !has_triggers && !has_fks && plan.result_columns.is_empty() {
         program.set_may_abort(false);
     }
     Ok(())


### PR DESCRIPTION
## Summary
- add statement-journal coverage for DML statements with `RETURNING` expressions that can abort after rows were physically written
- preserve rows on `DELETE ... RETURNING` expression errors inside explicit transactions
- preserve conflicting rows on `INSERT OR REPLACE ... RETURNING` expression errors
- formatted with `cargo fmt --all`

Fixes #6878

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p turso_core returning_error --features fs -- --nocapture`
- `cargo check -p turso_core`

Supersedes #6892, which was closed because GitHub did not synchronize the fork branch after the formatting follow-up commit.
