### PR TITLE
core/translate: Fix RENAME COLUMN rewriting ORDER BY alias references in triggers

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -3039,14 +3039,9 @@ fn apply_select_for_column_rename(
     // an output column alias refers to that alias, not to a column in the
     // FROM clause. Such a reference must not be rewritten — its identity is
     // the alias label, which is independent of the renamed table column.
-    let order_by_aliases = crate::util::order_by_alias_targets(select);
-
+    let body = &select.body;
     for sorted_col in &mut select.order_by {
-        if crate::util::order_by_expr_matches_output_alias(
-            &sorted_col.expr,
-            old_col_norm,
-            &order_by_aliases,
-        ) {
+        if crate::util::is_order_by_alias_ref(body, &sorted_col.expr, old_col_norm) {
             continue;
         }
         apply_expr_for_column_rename(

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -3035,7 +3035,20 @@ fn apply_select_for_column_rename(
         _ => outer_target_qualifiers.to_vec(),
     };
 
+    // Per SQLite's ORDER BY resolution rules, a bare identifier that matches
+    // an output column alias refers to that alias, not to a column in the
+    // FROM clause. Such a reference must not be rewritten — its identity is
+    // the alias label, which is independent of the renamed table column.
+    let order_by_aliases = crate::util::order_by_alias_targets(select);
+
     for sorted_col in &mut select.order_by {
+        if crate::util::order_by_expr_matches_output_alias(
+            &sorted_col.expr,
+            old_col_norm,
+            &order_by_aliases,
+        ) {
+            continue;
+        }
         apply_expr_for_column_rename(
             mode,
             &mut sorted_col.expr,
@@ -5256,26 +5269,7 @@ fn collect_select_table_visible_columns_from_output(
 }
 
 fn collect_one_select_output_columns(one_select: &ast::OneSelect) -> Vec<String> {
-    match one_select {
-        ast::OneSelect::Select { columns, .. } => {
-            columns.iter().filter_map(result_column_name).collect()
-        }
-        ast::OneSelect::Values(_) => Vec::new(),
-    }
-}
-
-fn result_column_name(column: &ast::ResultColumn) -> Option<String> {
-    match column {
-        ast::ResultColumn::Expr(_, Some(alias)) => Some(normalize_ident(alias.name().as_str())),
-        ast::ResultColumn::Expr(expr, None) => match expr.as_ref() {
-            ast::Expr::Id(name) | ast::Expr::Name(name) => Some(normalize_ident(name.as_str())),
-            ast::Expr::Qualified(_, col) | ast::Expr::DoublyQualified(_, _, col) => {
-                Some(normalize_ident(col.as_str()))
-            }
-            _ => None,
-        },
-        _ => None,
-    }
+    crate::util::output_column_aliases(one_select)
 }
 
 /// Check a single expression node for invalid column references after a DROP COLUMN.

--- a/core/util.rs
+++ b/core/util.rs
@@ -3345,6 +3345,58 @@ pub fn rewrite_trigger_cmd_table_refs(cmd: &mut ast::TriggerCmd, old_tbl: &str, 
     }
 }
 
+/// Collect the names by which each result column of a single SELECT arm can be
+/// referenced from ORDER BY. Mirrors the set of identifiers SQLite would
+/// consider when resolving a bare ORDER BY identifier against that arm's
+/// output column list.
+pub(crate) fn output_column_aliases(one_select: &ast::OneSelect) -> Vec<String> {
+    let ast::OneSelect::Select { columns, .. } = one_select else {
+        return Vec::new();
+    };
+    columns
+        .iter()
+        .filter_map(|col| match col {
+            ast::ResultColumn::Expr(_, Some(alias)) => Some(normalize_ident(alias.name().as_str())),
+            ast::ResultColumn::Expr(expr, None) => match expr.as_ref() {
+                ast::Expr::Id(name) | ast::Expr::Name(name) => Some(normalize_ident(name.as_str())),
+                ast::Expr::Qualified(_, col) | ast::Expr::DoublyQualified(_, _, col) => {
+                    Some(normalize_ident(col.as_str()))
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+/// Collect ORDER BY alias-resolution targets across every arm of a SELECT,
+/// including each compound arm. SQLite resolves a compound SELECT's ORDER BY
+/// alias by searching the body and then each compound arm in order, so any of
+/// their output column aliases qualifies.
+pub(crate) fn order_by_alias_targets(select: &ast::Select) -> Vec<String> {
+    let mut aliases = output_column_aliases(&select.body.select);
+    for compound in &select.body.compounds {
+        aliases.extend(output_column_aliases(&compound.select));
+    }
+    aliases
+}
+
+/// Returns true when `expr` is a bare identifier that names the renamed column
+/// and also matches one of the SELECT's output column aliases — i.e., this is
+/// an ORDER BY alias reference, not a FROM-clause column reference.
+pub(crate) fn order_by_expr_matches_output_alias(
+    expr: &ast::Expr,
+    old_col_norm: &str,
+    aliases: &[String],
+) -> bool {
+    let name = match expr {
+        ast::Expr::Id(name) | ast::Expr::Name(name) => name.as_str(),
+        _ => return false,
+    };
+    let name_norm = normalize_ident(name);
+    name_norm == old_col_norm && aliases.iter().any(|alias| alias == &name_norm)
+}
+
 /// Scope-aware version of `rewrite_select_column_refs` that checks table qualifiers.
 fn rewrite_select_column_refs_scoped(
     select: &mut ast::Select,
@@ -3395,7 +3447,16 @@ fn rewrite_select_column_refs_scoped(
     };
     let rename_unqualified =
         !target_qualifiers.is_empty() || target_table.eq_ignore_ascii_case(trigger_table);
+    // Per SQLite's ORDER BY resolution rules, a bare identifier matching an
+    // output column alias is treated as that alias, not as a FROM-clause
+    // column reference. Such a reference must not be rewritten — the alias
+    // label is independent of the renamed table column.
+    let order_by_aliases = order_by_alias_targets(select);
+    let old_col_norm = normalize_ident(old_col);
     for col in &mut select.order_by {
+        if order_by_expr_matches_output_alias(&col.expr, &old_col_norm, &order_by_aliases) {
+            continue;
+        }
         rename_identifiers_scoped_inner(
             &mut col.expr,
             target_table,
@@ -4031,8 +4092,17 @@ fn select_still_references_renamed_column(
     let rename_unqualified =
         !target_qualifiers.is_empty() || target_table.eq_ignore_ascii_case(trigger_table);
 
+    // Bare identifiers in ORDER BY that match an output column alias are
+    // alias references, not FROM-clause column references, so they don't
+    // count as a stale reference to the renamed column.
+    let order_by_aliases = order_by_alias_targets(select);
+    let old_col_norm = normalize_ident(old_col);
+
     let mut found = false;
     for sorted_col in &select.order_by {
+        if order_by_expr_matches_output_alias(&sorted_col.expr, &old_col_norm, &order_by_aliases) {
+            continue;
+        }
         if expr_still_references_renamed_column(
             &sorted_col.expr,
             target_table,

--- a/core/util.rs
+++ b/core/util.rs
@@ -3369,32 +3369,48 @@ pub(crate) fn output_column_aliases(one_select: &ast::OneSelect) -> Vec<String> 
         .collect()
 }
 
-/// Collect ORDER BY alias-resolution targets across every arm of a SELECT,
-/// including each compound arm. SQLite resolves a compound SELECT's ORDER BY
-/// alias by searching the body and then each compound arm in order, so any of
-/// their output column aliases qualifies.
-pub(crate) fn order_by_alias_targets(select: &ast::Select) -> Vec<String> {
-    let mut aliases = output_column_aliases(&select.body.select);
-    for compound in &select.body.compounds {
-        aliases.extend(output_column_aliases(&compound.select));
-    }
-    aliases
-}
-
 /// Returns true when `expr` is a bare identifier that names the renamed column
-/// and also matches one of the SELECT's output column aliases — i.e., this is
-/// an ORDER BY alias reference, not a FROM-clause column reference.
-pub(crate) fn order_by_expr_matches_output_alias(
+/// and resolves to one of the SELECT's output column aliases (in the body or
+/// any compound arm). Per SQLite's ORDER BY resolution rules, such a reference
+/// is to the alias label, not to a FROM-clause column, so a column rename
+/// must leave it alone.
+///
+/// Cheap in the common case: short-circuits before scanning aliases when the
+/// expr is not a bare identifier or does not match `old_col`.
+pub(crate) fn is_order_by_alias_ref(
+    body: &ast::SelectBody,
     expr: &ast::Expr,
-    old_col_norm: &str,
-    aliases: &[String],
+    old_col: &str,
 ) -> bool {
     let name = match expr {
-        ast::Expr::Id(name) | ast::Expr::Name(name) => name.as_str(),
+        ast::Expr::Id(n) | ast::Expr::Name(n) => n.as_str(),
         _ => return false,
     };
-    let name_norm = normalize_ident(name);
-    name_norm == old_col_norm && aliases.iter().any(|alias| alias == &name_norm)
+    if !name.eq_ignore_ascii_case(old_col) {
+        return false;
+    }
+    one_select_has_explicit_alias(&body.select, name)
+        || body
+            .compounds
+            .iter()
+            .any(|c| one_select_has_explicit_alias(&c.select, name))
+}
+
+// Only user-provided aliases (`AS x` or elided form) block ORDER BY rewriting.
+// `As::ImplicitColumnName` is synthesized by the parser from the original
+// expression text to label unaliased columns and is decoupled from the
+// underlying expression — it must not be treated as an alias for rename
+// purposes, since SQLite rewrites such ORDER BY refs along with the column.
+fn one_select_has_explicit_alias(one_select: &ast::OneSelect, name: &str) -> bool {
+    let ast::OneSelect::Select { columns, .. } = one_select else {
+        return false;
+    };
+    columns.iter().any(|col| match col {
+        ast::ResultColumn::Expr(_, Some(alias)) if alias.is_explicit() => {
+            alias.name().as_str().eq_ignore_ascii_case(name)
+        }
+        _ => false,
+    })
 }
 
 /// Scope-aware version of `rewrite_select_column_refs` that checks table qualifiers.
@@ -3451,10 +3467,9 @@ fn rewrite_select_column_refs_scoped(
     // output column alias is treated as that alias, not as a FROM-clause
     // column reference. Such a reference must not be rewritten — the alias
     // label is independent of the renamed table column.
-    let order_by_aliases = order_by_alias_targets(select);
-    let old_col_norm = normalize_ident(old_col);
+    let body = &select.body;
     for col in &mut select.order_by {
-        if order_by_expr_matches_output_alias(&col.expr, &old_col_norm, &order_by_aliases) {
+        if is_order_by_alias_ref(body, &col.expr, old_col) {
             continue;
         }
         rename_identifiers_scoped_inner(
@@ -4095,12 +4110,11 @@ fn select_still_references_renamed_column(
     // Bare identifiers in ORDER BY that match an output column alias are
     // alias references, not FROM-clause column references, so they don't
     // count as a stale reference to the renamed column.
-    let order_by_aliases = order_by_alias_targets(select);
-    let old_col_norm = normalize_ident(old_col);
+    let body = &select.body;
 
     let mut found = false;
     for sorted_col in &select.order_by {
-        if order_by_expr_matches_output_alias(&sorted_col.expr, &old_col_norm, &order_by_aliases) {
+        if is_order_by_alias_ref(body, &sorted_col.expr, old_col) {
             continue;
         }
         if expr_still_references_renamed_column(

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -1687,6 +1687,69 @@ expect {
     2|1
 }
 
+# Bare-column result column (no explicit AS) carries an implicit column-name
+# alias in the AST. That implicit alias is NOT a user-provided alias — it
+# tracks the original expression text. SQLite rewrites both the result column
+# and the ORDER BY ref consistently in this case, and so must we. Only an
+# explicit `AS x` (or its elided form) blocks the ORDER BY rewrite.
+test alter-table-rename-column-trigger-order-by-implicit-alias {
+    DROP TABLE IF EXISTS src;
+    DROP TABLE IF EXISTS dst;
+    DROP TABLE IF EXISTS log;
+    CREATE TABLE src (a, b);
+    CREATE TABLE dst (x);
+    CREATE TABLE log (v);
+    INSERT INTO src VALUES (10, 1), (20, 2);
+    CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+        INSERT INTO log SELECT b FROM src ORDER BY b;
+    END;
+    ALTER TABLE src RENAME COLUMN b TO c;
+    INSERT INTO dst VALUES (1);
+    SELECT group_concat(v, '|') FROM log;
+}
+expect {
+    1|2
+}
+
+# Stored SQL form of the implicit-alias case: both the result column and the
+# ORDER BY identifier must be rewritten from `b` to `c`.
+test alter-table-rename-column-trigger-order-by-implicit-alias-stored-sql {
+    DROP TABLE IF EXISTS src;
+    DROP TABLE IF EXISTS dst;
+    DROP TABLE IF EXISTS log;
+    CREATE TABLE src (a, b);
+    CREATE TABLE dst (x);
+    CREATE TABLE log (v);
+    CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+        INSERT INTO log SELECT b FROM src ORDER BY b;
+    END;
+    ALTER TABLE src RENAME COLUMN b TO c;
+    SELECT sql FROM sqlite_schema WHERE name = 'trig';
+}
+expect pattern {
+    CREATE TRIGGER trig AFTER INSERT ON dst\s+BEGIN\s+INSERT INTO log SELECT c FROM src ORDER BY c;?\s+END
+}
+
+# Qualified result column whose column-half matches the renamed column. The
+# ORDER BY bare identifier does not refer to a user-provided alias and must
+# be rewritten alongside both the result column and the FROM-clause column.
+test alter-table-rename-column-trigger-order-by-qualified-result-col {
+    DROP TABLE IF EXISTS src;
+    DROP TABLE IF EXISTS dst;
+    DROP TABLE IF EXISTS log;
+    CREATE TABLE src (a, b);
+    CREATE TABLE dst (x);
+    CREATE TABLE log (v);
+    CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+        INSERT INTO log SELECT src.b FROM src ORDER BY b;
+    END;
+    ALTER TABLE src RENAME COLUMN b TO c;
+    SELECT sql FROM sqlite_schema WHERE name = 'trig';
+}
+expect pattern {
+    CREATE TRIGGER trig AFTER INSERT ON dst\s+BEGIN\s+INSERT INTO log SELECT src\.c FROM src ORDER BY c;?\s+END
+}
+
 # Round-trip rename: renaming away and back must restore the original column
 # name in the stored trigger SQL (issue #6625). Previously the in-memory
 # trigger.sql was not refreshed after a column rename, so the second rename

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -1600,6 +1600,93 @@ expect {
     500
 }
 
+# https://github.com/tursodatabase/turso/issues/6332
+# Per SQLite's ORDER BY resolution rules, a bare identifier that matches
+# an output column alias refers to that alias, not to a FROM column. So
+# renaming src.b -> src.c must leave the trigger's `ORDER BY b` alone,
+# keeping the result ordered by the alias for src.a.
+test alter-table-rename-column-trigger-order-by-alias {
+    DROP TABLE IF EXISTS src;
+    DROP TABLE IF EXISTS dst;
+    DROP TABLE IF EXISTS log;
+    CREATE TABLE src (a, b);
+    CREATE TABLE dst (x);
+    CREATE TABLE log (v);
+    INSERT INTO src VALUES (2, 100), (1, 200);
+    CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+        INSERT INTO log SELECT a AS b FROM src ORDER BY b;
+    END;
+    ALTER TABLE src RENAME COLUMN b TO c;
+    INSERT INTO dst VALUES (1);
+    SELECT group_concat(v, '|') FROM log;
+}
+expect {
+    1|2
+}
+
+# The stored trigger SQL must also preserve the alias name `b` in ORDER BY
+# (not rewrite it to `c`), since the alias-resolution rule means it never
+# referred to the renamed table column to begin with.
+test alter-table-rename-column-trigger-order-by-alias-stored-sql {
+    DROP TABLE IF EXISTS src;
+    DROP TABLE IF EXISTS dst;
+    DROP TABLE IF EXISTS log;
+    CREATE TABLE src (a, b);
+    CREATE TABLE dst (x);
+    CREATE TABLE log (v);
+    CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+        INSERT INTO log SELECT a AS b FROM src ORDER BY b;
+    END;
+    ALTER TABLE src RENAME COLUMN b TO c;
+    SELECT sql FROM sqlite_schema WHERE name = 'trig';
+}
+expect pattern {
+    CREATE TRIGGER trig AFTER INSERT ON dst\s+BEGIN\s+INSERT INTO log SELECT a AS b FROM src ORDER BY b;?\s+END
+}
+
+# Compound SELECT: SQLite resolves a compound's ORDER BY alias by searching
+# every arm in order, so `ORDER BY b` matches the alias introduced in the
+# second arm and must be preserved across a column rename — even though the
+# first arm has no `b` alias.
+test alter-table-rename-column-trigger-order-by-alias-compound {
+    DROP TABLE IF EXISTS src;
+    DROP TABLE IF EXISTS dst;
+    DROP TABLE IF EXISTS log;
+    CREATE TABLE src (a, b);
+    CREATE TABLE dst (x);
+    CREATE TABLE log (v);
+    CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+        INSERT INTO log SELECT a FROM src UNION ALL SELECT a AS b FROM src ORDER BY b;
+    END;
+    ALTER TABLE src RENAME COLUMN b TO c;
+    SELECT sql FROM sqlite_schema WHERE name = 'trig';
+}
+expect pattern {
+    CREATE TRIGGER trig AFTER INSERT ON dst\s+BEGIN\s+INSERT INTO log SELECT a FROM src UNION ALL SELECT a AS b FROM src ORDER BY b;?\s+END
+}
+
+# Counter-case: when the ORDER BY bare identifier does not match an output
+# column alias, it is a normal FROM-clause column reference and must be
+# rewritten consistently with the column rename.
+test alter-table-rename-column-trigger-order-by-not-alias {
+    DROP TABLE IF EXISTS src;
+    DROP TABLE IF EXISTS dst;
+    DROP TABLE IF EXISTS log;
+    CREATE TABLE src (a, b);
+    CREATE TABLE dst (x);
+    CREATE TABLE log (v);
+    INSERT INTO src VALUES (2, 100), (1, 200);
+    CREATE TRIGGER trig AFTER INSERT ON dst BEGIN
+        INSERT INTO log SELECT a FROM src ORDER BY b;
+    END;
+    ALTER TABLE src RENAME COLUMN b TO c;
+    INSERT INTO dst VALUES (1);
+    SELECT group_concat(v, '|') FROM log;
+}
+expect {
+    2|1
+}
+
 # Round-trip rename: renaming away and back must restore the original column
 # name in the stored trigger SQL (issue #6625). Previously the in-memory
 # trigger.sql was not refreshed after a column rename, so the second rename


### PR DESCRIPTION
ALTER TABLE RENAME COLUMN walked every reachable SELECT's ORDER BY and
rewrote any bare identifier matching the old column name. Per SQLite's
ORDER BY resolution rules, a bare identifier that matches an output
column alias refers to that alias, not to a FROM-clause column, so it
must not be rewritten when the underlying table column is renamed.

After `ALTER TABLE src RENAME COLUMN b TO c`, a trigger body like
`INSERT INTO log SELECT a AS b FROM src ORDER BY b` was being rewritten
to `ORDER BY c`, flipping the result ordering from the alias for `a`
to the renamed table column. Skip the rewrite when the ORDER BY
identifier matches an output column alias, in all three places that
walk ORDER BY during RENAME COLUMN: the rewrite pass, the scoped
identifier rewriter, and the stale-reference check.

Closes #6332.
