### PR TITLE
Fix RETURNING DML rollback analysis

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1166,6 +1166,7 @@ pub fn translate_insert(
             btree_table.has_autoincrement,
             notnull_col_exists,
             has_unique,
+            !result_columns.is_empty(),
         );
     }
 

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -11,8 +11,10 @@
 //! unnecessary. The condition is: `usesStmtJournal = isMultiWrite && mayAbort`.
 //!
 //! - **isMultiWrite**: the statement may modify more than one row (or more than
-//!   one table, e.g. FK counter + data table). A single-row write is atomic —
-//!   either all writes happen or none do — so no partial state to roll back.
+//!   one table, e.g. FK counter + data table). A single-row write is normally
+//!   atomic — either all writes happen or none do — so no partial state to roll
+//!   back. Post-write RETURNING evaluation is the exception: it can abort after
+//!   the row write has already happened.
 //!
 //! - **mayAbort**: the statement may fail mid-execution with an ABORT (e.g.
 //!   constraint violation, FK violation, RAISE(ABORT) in a trigger). If a
@@ -135,6 +137,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     has_autoincrement: bool,
     notnull_col_exists: bool,
     has_unique: bool,
+    has_returning: bool,
 ) {
     let index_modes: Vec<(Option<ResolveType>, bool)> = resolver.with_schema(database_id, |s| {
         s.get_indices(&table.name)
@@ -150,6 +153,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     let has_check = !table.check_constraints.is_empty();
     let may_abort = has_triggers
         || has_fks
+        || has_returning
         || constraint_may_abort(
             has_statement_conflict,
             statement_conflict,
@@ -162,11 +166,13 @@ pub(crate) fn set_insert_stmt_journal_flags(
 
     // UPSERT is multi-write because DO UPDATE modifies an existing row.
     // AUTOINCREMENT is multi-write because sqlite_sequence is updated before constraint checks.
+    // RETURNING can abort after the physical row write, even for a single-row INSERT.
     if !inserting_multiple_rows
         && !has_triggers
         && !any_replace
         && !has_upsert
         && !has_autoincrement
+        && !has_returning
     {
         program.set_multi_write(false);
     }
@@ -199,6 +205,7 @@ pub(crate) fn set_update_stmt_journal_flags(
         &btree_table,
     );
     let has_fks = table_has_fks(connection, resolver, database_id, btree_table.name.as_str());
+    let has_returning = plan.returning.as_ref().is_some_and(|r| !r.is_empty());
 
     let or_conflict = plan.or_conflict.unwrap_or(ResolveType::Abort);
     let has_statement_conflict = plan.or_conflict.is_some();
@@ -212,9 +219,10 @@ pub(crate) fn set_update_stmt_journal_flags(
 
     // Ephemeral tables (used for key mutation / Halloween protection) always scan all
     // collected rows, so affects_max_1_row() returns false — multi_write stays true.
+    // RETURNING can abort after the physical row write, even for a single-row UPDATE.
     let is_single_row =
         plan.limit.is_none() && plan.offset.is_none() && target_table.op.affects_max_1_row();
-    if is_single_row && !has_triggers && !any_replace && !has_fks {
+    if is_single_row && !has_triggers && !any_replace && !has_fks && !has_returning {
         program.set_multi_write(false);
     }
 
@@ -233,6 +241,7 @@ pub(crate) fn set_update_stmt_journal_flags(
 
     let may_abort = has_triggers
         || has_fks
+        || has_returning
         || constraint_may_abort(
             has_statement_conflict,
             or_conflict,
@@ -264,18 +273,20 @@ pub(crate) fn set_delete_stmt_journal_flags(
     };
     let has_triggers = plan.safety.reasons.contains(&DmlSafetyReason::Trigger);
     let has_fks = table_has_fks(connection, resolver, database_id, btree_table.name.as_str());
+    let has_returning = !plan.result_columns.is_empty();
 
     // After rowset rewriting (for triggers/safety), the target table op is reset to a
     // Scan, so affects_max_1_row correctly returns false — no false optimization.
+    // RETURNING can abort after the physical row write, even for a single-row DELETE.
     let is_single_row =
         plan.limit.is_none() && plan.offset.is_none() && target_table.op.affects_max_1_row();
-    if is_single_row && !has_triggers && !has_fks {
+    if is_single_row && !has_triggers && !has_fks && !has_returning {
         program.set_multi_write(false);
     }
 
-    // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
-    // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
+    // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply.
+    // RETURNING runs after each physical write and can still abort the statement.
+    if !has_triggers && !has_fks && !has_returning {
         program.set_may_abort(false);
     }
     Ok(())

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -110,6 +110,53 @@ fn insert_or_replace_single_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// RETURNING expressions are evaluated after the physical INSERT. If a RETURNING
+/// expression fails inside an explicit transaction, the statement journal must
+/// restore any row or index writes that already happened.
+#[turso_macros::test(init_sql = "CREATE TABLE t (a UNIQUE, b);")]
+fn insert_returning_expression_error_needs_stmt_journal(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "INSERT INTO t VALUES (1, 2) RETURNING 'x' LIKE 'x' ESCAPE 'yy'"
+    ));
+    assert!(needs_stmt_journal(
+        &conn,
+        "INSERT OR REPLACE INTO t VALUES (1, 2) RETURNING 'x' LIKE 'x' ESCAPE 'yy'"
+    ));
+    Ok(())
+}
+
+/// Regression: INSERT OR REPLACE deletes the conflicting row before evaluating
+/// RETURNING. A RETURNING error must roll back the replacement.
+#[turso_macros::test]
+fn insert_replace_returning_error_preserves_conflicting_row(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a INT UNIQUE, b INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10)")?;
+
+    conn.execute("BEGIN")?;
+    let result =
+        conn.execute("INSERT OR REPLACE INTO t VALUES(1,20) RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "INSERT should fail in RETURNING");
+
+    let rows = query_rows(&conn, "SELECT rowid, a, b FROM t");
+    assert_eq!(rows, vec!["1|1|10"], "original row should be preserved");
+
+    let ic = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(
+        ic,
+        vec!["ok"],
+        "integrity_check failed after RETURNING error"
+    );
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 /// AUTOINCREMENT is multi-write (writes to sqlite_sequence).
 /// No constraints → may_abort=false. needs_stmt = true && false = false.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, v);")]
@@ -289,6 +336,45 @@ fn update_composite_unique_partial_cols(tmp_db: TempDatabase) -> anyhow::Result<
     Ok(())
 }
 
+/// RETURNING expressions are evaluated after the physical UPDATE, so even a
+/// single-row UPDATE needs statement rollback protection when RETURNING fails.
+#[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a);")]
+fn update_returning_expression_error_needs_stmt_journal(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "UPDATE t SET a = 1 WHERE id = 5 RETURNING 'x' LIKE 'x' ESCAPE 'yy'"
+    ));
+    Ok(())
+}
+
+/// Regression: an UPDATE with a failing RETURNING expression must roll back the
+/// rows it already modified inside the surrounding transaction.
+#[turso_macros::test]
+fn update_returning_error_rolls_back_updated_rows(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a INT)")?;
+    conn.execute("INSERT INTO t VALUES(1),(2)")?;
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute("UPDATE t SET a = a + 10 RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "UPDATE should fail in RETURNING");
+
+    let rows = query_rows(&conn, "SELECT a FROM t ORDER BY a");
+    assert_eq!(rows, vec!["1", "2"], "rows should remain unchanged");
+
+    let ic = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(
+        ic,
+        vec!["ok"],
+        "integrity_check failed after RETURNING error"
+    );
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 // ──────────────────────────────────────────────────────────
 // DELETE
 // ──────────────────────────────────────────────────────────
@@ -339,6 +425,45 @@ fn delete_by_rowid_with_fk(tmp_db: TempDatabase) -> anyhow::Result<()> {
     // FK constraint checks modify deferred violation counter before the statement can abort,
     // so multi_write stays true. needs_stmt = true && true = true.
     assert!(needs_stmt_journal(&conn, "DELETE FROM parent WHERE id = 5"));
+    Ok(())
+}
+
+/// RETURNING expressions are evaluated after the physical DELETE, so even a
+/// single-row DELETE needs statement rollback protection when RETURNING fails.
+#[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a);")]
+fn delete_returning_expression_error_needs_stmt_journal(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "DELETE FROM t WHERE id = 5 RETURNING 'x' LIKE 'x' ESCAPE 'yy'"
+    ));
+    Ok(())
+}
+
+/// Regression: a DELETE with a failing RETURNING expression must roll back the
+/// rows it already removed inside the surrounding transaction.
+#[turso_macros::test]
+fn delete_returning_error_rolls_back_deleted_rows(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a INT)")?;
+    conn.execute("INSERT INTO t VALUES(1),(2)")?;
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute("DELETE FROM t WHERE a=1 RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "DELETE should fail in RETURNING");
+
+    let rows = query_rows(&conn, "SELECT a FROM t ORDER BY a");
+    assert_eq!(rows, vec!["1", "2"], "rows should remain unchanged");
+
+    let ic = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(
+        ic,
+        vec!["ok"],
+        "integrity_check failed after RETURNING error"
+    );
+    conn.execute("COMMIT")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Description

This updates statement-journal analysis for INSERT, UPDATE, and DELETE statements with RETURNING clauses. RETURNING expressions are evaluated after the physical row write, so a RETURNING error can otherwise leave statement-local writes behind inside an explicit transaction.

The change keeps the statement journal enabled for DML with RETURNING by treating RETURNING as both a possible abort source and a reason not to apply the single-row multi-write optimization.

## Motivation and context

Fixes #6878.

Without a statement subtransaction, a failing RETURNING expression can commit partial DML effects, including DELETE row removal and INSERT OR REPLACE conflict-row replacement.

## Description of AI Usage

This PR was prepared with OpenAI Codex assistance for code search, implementation, and local verification. The final diff and test results were inspected before submission.

## Test Plan

- `cargo fmt --check`
- `cargo test -p core_tester --test integration_tests stmt_journal -- --nocapture`
- `cargo test -p core_tester --test integration_tests returning -- --nocapture`
- `cargo test -p turso_core --lib`
- `cargo check -p turso_core`
- `cargo clippy -p turso_core --all-targets -- --deny=warnings`