### PR TITLE
core/vacuum: reenable disabled vacuum tests

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2502,6 +2502,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             self.finalized_tx_states.is_empty(),
             "MVCC VACUUM reset requires finalized transaction cache to be cleared"
         );
+        // Drop empty buckets left by checkpoint GC: their table_ids reference
+        // pre-VACUUM root pages and can alias new objects after root-page
+        // reuse, corrupting `index_rows` lookups and SkipMap ordering.
+        self.rows.clear();
+        self.index_rows.clear();
         let root_pages = schema
             .tables
             .values()
@@ -2523,14 +2528,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 "post-VACUUM B-tree root page must be positive"
             );
         }
-        let keys = self
-            .table_id_to_rootpage
-            .iter()
-            .map(|entry| *entry.key())
-            .collect::<Vec<_>>();
-        for key in keys {
-            self.table_id_to_rootpage.remove(&key);
-        }
+        self.table_id_to_rootpage.clear();
         self.table_id_to_last_rowid.write().clear();
         self.insert_table_id_to_rootpage(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1));
         for root_page in root_pages {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -263,7 +263,6 @@ fn mvcc_reset_after_vacuum_installs_header_and_rootpages() {
 }
 
 #[test]
-#[ignore]
 fn mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets() {
     let db = MvccTestDb::new();
     db.conn

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2716,7 +2716,6 @@ mod tests {
 
     #[cfg(not(target_family = "wasm"))]
     #[test]
-    #[ignore]
     fn capture_target_metadata_uses_final_header_cookie_and_preserves_tvfs() -> Result<()> {
         let io: Arc<dyn crate::IO> = Arc::new(crate::io::PlatformIO::new()?);
         let source_dir = tempfile::tempdir().unwrap();
@@ -2730,7 +2729,15 @@ mod tests {
             None,
         )?;
         let source_conn = source_db.connect()?;
-        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, 0)?;
+        // Source is uninitialized so its header reserved_space isn't usable.
+        // Derive from the IOContext to keep reserved_space and the auto-
+        // installed checksum context consistent under `feature = "checksum"`.
+        let reserved_space = source_conn
+            .get_pager()
+            .io_ctx
+            .read()
+            .get_reserved_space_bytes();
+        let temp = open_vacuum_temp_db(&source_conn, &source_db, 4096, reserved_space)?;
 
         temp.conn.execute("BEGIN IMMEDIATE")?;
         temp.conn

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -5110,7 +5110,6 @@ fn test_plain_vacuum_copy_batch_page_count_boundaries() -> anyhow::Result<()> {
 /// may be no user schema pages to copy, but VACUUM still must leave the file
 /// usable and folded.
 #[test]
-#[ignore]
 fn test_plain_vacuum_empty_schema_physical_contract() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_empty();
     let conn = tmp_db.connect_limbo();
@@ -5122,7 +5121,7 @@ fn test_plain_vacuum_empty_schema_physical_contract() -> anyhow::Result<()> {
         .expect_err("VACUUM on an uninitialized database should return an error");
     assert_eq!(
         err.to_string(),
-        "Internal error: begin_blocking_tx can be done on an initialized database (page 1 must already be allocated)",
+        "Internal error: begin_vacuum_blocking_tx can be done on an initialized database (page 1 must already be allocated)",
         "expected initialization error, got: {err}"
     );
     Ok(())
@@ -5131,13 +5130,6 @@ fn test_plain_vacuum_empty_schema_physical_contract() -> anyhow::Result<()> {
 /// Initialized DB whose user schema has been fully torn down — page 1 exists,
 /// but there are no user tables or indexes. VACUUM must succeed and leave the
 /// DB queryable at the minimum page count.
-///
-/// FIXME: currently ignored because Turso's VACUUM does not reclaim the root
-/// page of the dropped table. SQLite produces page_count=1 for the same
-/// sequence; Turso produces page_count > 1. The integrity_check passes, so
-/// this is a compaction/correctness gap in the target-pager rebuild rather
-/// than a data-loss bug.
-#[ignore = "VACUUM does not reclaim dropped-table root pages (diverges from SQLite)"]
 #[test]
 fn test_plain_vacuum_initialized_but_empty_schema() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_empty();
@@ -5841,7 +5833,6 @@ fn assert_mvcc_multi_object_vacuum_workload(conn: &Arc<Connection>) -> anyhow::R
 }
 
 #[test]
-#[ignore]
 fn test_mvcc_plain_vacuum_multi_object_rootpage_reset() -> anyhow::Result<()> {
     let tmp_db =
         TempDatabase::new_with_mvcc("test_mvcc_plain_vacuum_multi_object_rootpage_reset.db");
@@ -5897,7 +5888,6 @@ fn test_mvcc_plain_vacuum_multi_object_rootpage_reset() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_mvcc_plain_vacuum_discards_reused_index_rootpage_state() -> anyhow::Result<()> {
     let tmp_db = TempDatabase::new_with_mvcc(
         "test_mvcc_plain_vacuum_discards_reused_index_rootpage_state.db",


### PR DESCRIPTION
## Description

This PR reenables vacuum tests which were disabled earlier. These were failing:

1. in MVCC mode, we weren't cleaning up properly post vacuum. 
2. in one of the test, the checksum bit wasn't set correctly 

With these changes in, the tests now pass.


