### PR TITLE
github: Pin PThorpe92/fossier to commit SHA

### DIFF
--- a/.github/workflows/fossier.yml
+++ b/.github/workflows/fossier.yml
@@ -26,7 +26,7 @@ jobs:
             echo "has_command=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: PThorpe92/fossier@main
+      - uses: PThorpe92/fossier@f4abfcf3ffb60b6d59337126d092ffbb41405685
         if: github.event_name != 'issue_comment' || steps.check-cmd.outputs.has_command == 'true'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The fossier action ran under pull_request_target with contents: write and FOSSIER_REGISTRY_API_KEY exposed, pinned only to @main. A rewrite of that branch (or a maintainer account compromise) would have run attacker-controlled code in a trusted context.