### PR TITLE
test: add ANALYZE coverage to simulator

### DIFF
--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -10,7 +10,8 @@ use crate::model::query::select::{
 };
 use crate::model::query::update::{SetValue, Update};
 use crate::model::query::{
-    Create, CreateIndex, Delete, Drop, DropIndex, Insert, OnConflict, Select, UpdateSetItem,
+    Analyze, AnalyzeTarget, Create, CreateIndex, Delete, Drop, DropIndex, Insert, OnConflict,
+    Select, UpdateSetItem,
 };
 use crate::model::table::{
     Column, ColumnType, Index, JoinType, JoinedTable, Name, SimValue, Table, TableContext,
@@ -570,6 +571,61 @@ impl Arbitrary for Drop {
         Self {
             table: table.name.clone(),
         }
+    }
+}
+
+type AnalyzeChoice<'a, R> = (usize, Box<dyn Fn(&mut R) -> Option<Analyze> + 'a>);
+
+impl Arbitrary for Analyze {
+    fn arbitrary<R: Rng + ?Sized, C: GenerationContext>(rng: &mut R, env: &C) -> Self {
+        let has_tables = !env.tables().is_empty();
+        let has_indexes = env.tables().iter().any(|table| !table.indexes.is_empty());
+
+        let mut choices: Vec<AnalyzeChoice<'_, R>> = vec![(
+            4,
+            Box::new(|_| {
+                Some(Analyze {
+                    target: AnalyzeTarget::All,
+                })
+            }),
+        )];
+
+        if has_tables {
+            choices.push((
+                4,
+                Box::new(|rng| {
+                    let table = pick(env.tables(), rng);
+                    Some(Analyze {
+                        target: AnalyzeTarget::Table {
+                            table_name: table.name.clone(),
+                        },
+                    })
+                }),
+            ));
+        }
+
+        if has_indexes {
+            choices.push((
+                2,
+                Box::new(|rng| {
+                    let tables_with_indexes = env
+                        .tables()
+                        .iter()
+                        .filter(|table| !table.indexes.is_empty())
+                        .collect::<Vec<_>>();
+                    let table = pick(&tables_with_indexes, rng);
+                    let index = pick(&table.indexes, rng);
+                    Some(Analyze {
+                        target: AnalyzeTarget::Index {
+                            table_name: table.name.clone(),
+                            index_name: index.index_name.clone(),
+                        },
+                    })
+                }),
+            ));
+        }
+
+        backtrack(choices, rng).expect("analyze should always have at least the all-database form")
     }
 }
 

--- a/sql_generation/model/query/analyze.rs
+++ b/sql_generation/model/query/analyze.rs
@@ -1,0 +1,93 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Analyze {
+    pub target: AnalyzeTarget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum AnalyzeTarget {
+    All,
+    Table {
+        table_name: String,
+    },
+    Index {
+        table_name: String,
+        index_name: String,
+    },
+}
+
+impl std::fmt::Display for Analyze {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.target {
+            AnalyzeTarget::All => write!(f, "ANALYZE"),
+            AnalyzeTarget::Table { table_name } => write!(f, "ANALYZE {table_name}"),
+            AnalyzeTarget::Index {
+                table_name,
+                index_name,
+            } => {
+                // In SQLite, ANALYZE index syntax uses: ANALYZE [db.]index_name.
+                // The database prefix goes on the index name.
+                let db_prefix = table_name
+                    .split_once('.')
+                    .map(|(db, _)| format!("{db}."))
+                    .unwrap_or_default();
+                write!(f, "ANALYZE {db_prefix}{index_name}")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_supported_analyze_targets() {
+        assert_eq!(
+            Analyze {
+                target: AnalyzeTarget::All
+            }
+            .to_string(),
+            "ANALYZE"
+        );
+        assert_eq!(
+            Analyze {
+                target: AnalyzeTarget::Table {
+                    table_name: "t".to_string()
+                }
+            }
+            .to_string(),
+            "ANALYZE t"
+        );
+        assert_eq!(
+            Analyze {
+                target: AnalyzeTarget::Table {
+                    table_name: "aux.t".to_string()
+                }
+            }
+            .to_string(),
+            "ANALYZE aux.t"
+        );
+        assert_eq!(
+            Analyze {
+                target: AnalyzeTarget::Index {
+                    table_name: "t".to_string(),
+                    index_name: "idx_t".to_string()
+                }
+            }
+            .to_string(),
+            "ANALYZE idx_t"
+        );
+        assert_eq!(
+            Analyze {
+                target: AnalyzeTarget::Index {
+                    table_name: "aux.t".to_string(),
+                    index_name: "idx_t".to_string()
+                }
+            }
+            .to_string(),
+            "ANALYZE aux.idx_t"
+        );
+    }
+}

--- a/sql_generation/model/query/mod.rs
+++ b/sql_generation/model/query/mod.rs
@@ -1,3 +1,4 @@
+pub use analyze::{Analyze, AnalyzeTarget};
 pub use create::Create;
 pub use create_index::CreateIndex;
 pub use delete::Delete;
@@ -7,6 +8,7 @@ pub use insert::{Insert, OnConflict, UpdateSetItem};
 pub use select::Select;
 
 pub mod alter_table;
+pub mod analyze;
 pub mod create;
 pub mod create_index;
 pub mod delete;

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -31,7 +31,7 @@ simulator covers and tests.
 | Statement                 | Status  | Comment                                                                           |
 | ------------------------- | ------- | --------------------------------------------------------------------------------- |
 | ALTER TABLE               | Partial | TODO                                                                              |
-| ANALYZE                   | No      |                                                                                   |
+| ANALYZE                   | Partial | Generates `ANALYZE`, `ANALYZE <table>`, and `ANALYZE <index>`; `sqlite_stat1` is not shadow-modeled. |
 | ATTACH DATABASE           | No      |                                                                                   |
 | BEGIN TRANSACTION         | Partial | TODO                                                                              |
 | COMMIT TRANSACTION        | Partial | TODO                                                                              |

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -11,7 +11,7 @@ use sql_generation::{
     generation::{Arbitrary, ArbitraryFrom, GenerationContext, query::SelectFree},
     model::{
         query::{
-            Create, CreateIndex, Delete, DropIndex, Insert, Select,
+            Analyze, Create, CreateIndex, Delete, DropIndex, Insert, Select,
             alter_table::AlterTable,
             pragma::{Pragma, VacuumMode},
             update::Update,
@@ -59,6 +59,10 @@ fn random_update<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationC
 fn random_drop<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationContext) -> Query {
     assert!(!conn_ctx.tables().is_empty());
     Query::Drop(sql_generation::model::query::Drop::arbitrary(rng, conn_ctx))
+}
+
+fn random_analyze<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationContext) -> Query {
+    Query::Analyze(Analyze::arbitrary(rng, conn_ctx))
 }
 
 fn random_create_index<R: rand::Rng + ?Sized>(
@@ -150,6 +154,7 @@ impl QueryDiscriminants {
             QueryDiscriminants::CreateIndex => random_create_index,
             QueryDiscriminants::AlterTable => random_alter_table,
             QueryDiscriminants::DropIndex => random_drop_index,
+            QueryDiscriminants::Analyze => random_analyze,
             QueryDiscriminants::Begin
             | QueryDiscriminants::Commit
             | QueryDiscriminants::Rollback
@@ -178,6 +183,7 @@ impl QueryDiscriminants {
             QueryDiscriminants::CreateIndex => remaining.create_index,
             QueryDiscriminants::AlterTable => remaining.alter_table,
             QueryDiscriminants::DropIndex => remaining.drop_index,
+            QueryDiscriminants::Analyze => remaining.analyze,
             QueryDiscriminants::Begin
             | QueryDiscriminants::Commit
             | QueryDiscriminants::Rollback

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -21,6 +21,7 @@ pub struct Remaining {
     pub drop: u32,
     pub alter_table: u32,
     pub drop_index: u32,
+    pub analyze: u32,
     pub pragma_count: u32,
 }
 
@@ -43,6 +44,7 @@ impl Remaining {
         let total_drop = (max_interactions * opts.drop_table_weight) / total_weight;
         let total_alter_table = (max_interactions * opts.alter_table_weight) / total_weight;
         let total_drop_index = (max_interactions * opts.drop_index) / total_weight;
+        let total_analyze = (max_interactions * opts.analyze_weight) / total_weight;
         let total_pragma = (max_interactions * opts.pragma_weight) / total_weight;
 
         let remaining_select = total_select
@@ -73,7 +75,10 @@ impl Remaining {
             .unwrap_or_default();
 
         let mut remaining_drop_index = total_drop_index
-            .checked_sub(stats.alter_table_count)
+            .checked_sub(stats.drop_index_count)
+            .unwrap_or_default();
+        let remaining_analyze = total_analyze
+            .checked_sub(stats.analyze_count)
             .unwrap_or_default();
 
         if mvcc {
@@ -101,6 +106,7 @@ impl Remaining {
             update: remaining_update,
             alter_table: remaining_alter_table,
             drop_index: remaining_drop_index,
+            analyze: remaining_analyze,
             pragma_count: remaining_pragma,
         }
     }
@@ -120,6 +126,7 @@ pub(crate) struct InteractionStats {
     pub rollback_count: u32,
     pub alter_table_count: u32,
     pub drop_index_count: u32,
+    pub analyze_count: u32,
     pub pragma_count: u32,
 }
 
@@ -150,6 +157,7 @@ impl InteractionStats {
             Query::ReleaseSavepoint(_) => self.commit_count += 1,
             Query::AlterTable(_) => self.alter_table_count += 1,
             Query::DropIndex(_) => self.drop_index_count += 1,
+            Query::Analyze(_) => self.analyze_count += 1,
             Query::Placeholder => {}
             Query::Pragma(_) => self.pragma_count += 1,
         }
@@ -160,7 +168,7 @@ impl Display for InteractionStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Read: {}, Insert: {}, Delete: {}, Update: {}, Create: {}, CreateIndex: {}, Drop: {}, Begin: {}, Commit: {}, Rollback: {}, Alter Table: {}, Drop Index: {}",
+            "Read: {}, Insert: {}, Delete: {}, Update: {}, Create: {}, CreateIndex: {}, Drop: {}, Begin: {}, Commit: {}, Rollback: {}, Alter Table: {}, Drop Index: {}, Analyze: {}",
             self.select_count,
             self.insert_count,
             self.delete_count,
@@ -173,6 +181,114 @@ impl Display for InteractionStats {
             self.rollback_count,
             self.alter_table_count,
             self.drop_index_count,
+            self.analyze_count,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sql_generation::{
+        generation::{GenerationContext, Opts},
+        model::table::{Index, Table},
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestContext {
+        opts: Opts,
+        tables: Vec<Table>,
+    }
+
+    impl GenerationContext for TestContext {
+        fn tables(&self) -> &Vec<Table> {
+            &self.tables
+        }
+
+        fn opts(&self) -> &Opts {
+            &self.opts
+        }
+    }
+
+    #[test]
+    fn drop_index_remaining_uses_drop_index_weight_and_count() {
+        let profile = QueryProfile {
+            select_weight: 0,
+            create_table_weight: 0,
+            create_index_weight: 0,
+            insert_weight: 0,
+            update_weight: 0,
+            delete_weight: 0,
+            drop_table_weight: 0,
+            alter_table_weight: 0,
+            drop_index: 10,
+            analyze_weight: 0,
+            pragma_weight: 0,
+            ..Default::default()
+        };
+        assert_eq!(profile.total_weight(), profile.drop_index);
+
+        let context = TestContext {
+            tables: vec![Table {
+                name: "t".to_string(),
+                columns: vec![],
+                rows: vec![],
+                indexes: vec![Index {
+                    table_name: "t".to_string(),
+                    index_name: "idx_t".to_string(),
+                    columns: vec![],
+                }],
+            }],
+            ..Default::default()
+        };
+
+        let remaining = Remaining::new(
+            100,
+            &profile,
+            &InteractionStats {
+                drop_index_count: 2,
+                alter_table_count: 999,
+                ..Default::default()
+            },
+            false,
+            &context,
+        );
+
+        assert_eq!(remaining.drop_index, 98);
+    }
+
+    #[test]
+    fn analyze_remaining_uses_analyze_weight_and_count() {
+        let profile = QueryProfile {
+            select_weight: 0,
+            create_table_weight: 0,
+            create_index_weight: 0,
+            insert_weight: 0,
+            update_weight: 0,
+            delete_weight: 0,
+            drop_table_weight: 0,
+            alter_table_weight: 0,
+            drop_index: 0,
+            analyze_weight: 10,
+            pragma_weight: 0,
+            ..Default::default()
+        };
+        assert_eq!(profile.total_weight(), profile.analyze_weight);
+
+        let remaining = Remaining::new(
+            100,
+            &profile,
+            &InteractionStats {
+                analyze_count: 2,
+                alter_table_count: 999,
+                drop_index_count: 999,
+                ..Default::default()
+            },
+            false,
+            &TestContext::default(),
+        );
+
+        assert_eq!(remaining.analyze, 98);
     }
 }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sql_generation::model::query::select::SelectTable;
 use sql_generation::model::{
     query::{
-        Create, CreateIndex, Delete, Drop, DropIndex, Insert, Select,
+        Analyze, AnalyzeTarget, Create, CreateIndex, Delete, Drop, DropIndex, Insert, Select,
         alter_table::{AlterTable, AlterTableType},
         pragma::Pragma,
         select::{CompoundOperator, FromClause, ResultColumn, SelectInner},
@@ -286,6 +286,7 @@ pub enum Query {
     CreateIndex(CreateIndex),
     AlterTable(AlterTable),
     DropIndex(DropIndex),
+    Analyze(Analyze),
     Begin(Begin),
     Commit(Commit),
     Rollback(Rollback),
@@ -339,6 +340,13 @@ impl Query {
             })
             | Query::DropIndex(DropIndex {
                 table_name: table, ..
+            })
+            | Query::Analyze(Analyze {
+                target:
+                    AnalyzeTarget::Table { table_name: table }
+                    | AnalyzeTarget::Index {
+                        table_name: table, ..
+                    },
             }) => IndexSet::from_iter([table.clone()]),
             Query::Begin(_)
             | Query::Commit(_)
@@ -347,7 +355,10 @@ impl Query {
             | Query::RollbackToSavepoint(_)
             | Query::ReleaseSavepoint(_)
             | Query::Placeholder
-            | Query::Pragma(_) => IndexSet::new(),
+            | Query::Pragma(_)
+            | Query::Analyze(Analyze {
+                target: AnalyzeTarget::All,
+            }) => IndexSet::new(),
         }
     }
     pub fn uses(&self) -> Vec<String> {
@@ -369,6 +380,13 @@ impl Query {
             })
             | Query::DropIndex(DropIndex {
                 table_name: table, ..
+            })
+            | Query::Analyze(Analyze {
+                target:
+                    AnalyzeTarget::Table { table_name: table }
+                    | AnalyzeTarget::Index {
+                        table_name: table, ..
+                    },
             }) => vec![table.clone()],
             Query::Begin(..) | Query::Commit(..) | Query::Rollback(..) => vec![],
             Query::Savepoint(..) | Query::RollbackToSavepoint(..) | Query::ReleaseSavepoint(..) => {
@@ -376,6 +394,9 @@ impl Query {
             }
             Query::Placeholder => vec![],
             Query::Pragma(_) => vec![],
+            Query::Analyze(Analyze {
+                target: AnalyzeTarget::All,
+            }) => vec![],
         }
     }
 
@@ -401,6 +422,7 @@ impl Query {
                 | Self::Drop(..)
                 | Self::AlterTable(..)
                 | Self::DropIndex(..)
+                | Self::Analyze(..)
         )
     }
 
@@ -432,6 +454,7 @@ impl Display for Query {
             Self::CreateIndex(create_index) => write!(f, "{create_index}"),
             Self::AlterTable(alter_table) => write!(f, "{alter_table}"),
             Self::DropIndex(drop_index) => write!(f, "{drop_index}"),
+            Self::Analyze(analyze) => write!(f, "{analyze}"),
             Self::Begin(begin) => write!(f, "{begin}"),
             Self::Commit(commit) => write!(f, "{commit}"),
             Self::Rollback(rollback) => write!(f, "{rollback}"),
@@ -461,6 +484,7 @@ impl Shadow for Query {
             Query::CreateIndex(create_index) => Ok(create_index.shadow(env)),
             Query::AlterTable(alter_table) => alter_table.shadow(env),
             Query::DropIndex(drop_index) => drop_index.shadow(env),
+            Query::Analyze(_) => Ok(vec![]),
             Query::Begin(begin) => Ok(begin.shadow(env)),
             Query::Commit(commit) => Ok(commit.shadow(env)),
             Query::Rollback(rollback) => Ok(rollback.shadow(env)),
@@ -485,6 +509,7 @@ bitflags! {
         const CREATE_INDEX = 1 << 6;
         const ALTER_TABLE = 1 << 7;
         const DROP_INDEX = 1 << 8;
+        const ANALYZE = 1 << 9;
     }
 }
 
@@ -515,6 +540,7 @@ impl From<QueryDiscriminants> for QueryCapabilities {
             QueryDiscriminants::CreateIndex => Self::CREATE_INDEX,
             QueryDiscriminants::AlterTable => Self::ALTER_TABLE,
             QueryDiscriminants::DropIndex => Self::DROP_INDEX,
+            QueryDiscriminants::Analyze => Self::ANALYZE,
             QueryDiscriminants::Begin
             | QueryDiscriminants::Commit
             | QueryDiscriminants::Rollback
@@ -542,6 +568,7 @@ impl QueryDiscriminants {
         QueryDiscriminants::CreateIndex,
         QueryDiscriminants::AlterTable,
         QueryDiscriminants::DropIndex,
+        QueryDiscriminants::Analyze,
         QueryDiscriminants::Pragma,
     ];
 }

--- a/testing/simulator/profiles/query.rs
+++ b/testing/simulator/profiles/query.rs
@@ -30,6 +30,8 @@ pub struct QueryProfile {
     #[garde(skip)]
     pub drop_index: u32,
     #[garde(skip)]
+    pub analyze_weight: u32,
+    #[garde(skip)]
     pub pragma_weight: u32,
 }
 
@@ -47,6 +49,7 @@ impl Default for QueryProfile {
             drop_table_weight: 2,
             alter_table_weight: 2,
             drop_index: 2,
+            analyze_weight: 2,
             pragma_weight: 2,
         }
     }
@@ -63,6 +66,8 @@ impl QueryProfile {
             + self.delete_weight
             + self.drop_table_weight
             + self.alter_table_weight
+            + self.drop_index
+            + self.analyze_weight
             + self.pragma_weight
     }
 }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -109,6 +109,8 @@ pub struct SimulatorCLI {
     pub disable_create_index: bool,
     #[clap(long, help = "disable DROP Statement")]
     pub disable_drop: bool,
+    #[clap(long, help = "disable ANALYZE Statement")]
+    pub disable_analyze: bool,
     #[clap(
         long,
         help = "disable Insert-Values-Select Property",

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1163,6 +1163,9 @@ impl SimulatorEnv {
         if let Some(min_tick) = cli_opts.min_tick {
             profile.io.latency.min_tick = min_tick;
         }
+        if cli_opts.disable_analyze {
+            profile.query.analyze_weight = 0;
+        }
         if cli_opts.differential {
             // Disable faults when running against sqlite as we cannot control faults on it
             profile.io.enable = false;


### PR DESCRIPTION
## Summary

- Add simulator generation/model support for `ANALYZE`, `ANALYZE <table>`, and `ANALYZE <index>`.
- Wire `ANALYZE` through simulator query selection, capabilities, metrics, shadow execution, and `--disable-analyze`.
- Mark simulator `ANALYZE` coverage as partial because `sqlite_stat1` contents are intentionally not shadow-modeled.
- Fix a small simulator accounting issue where `drop_index` quota was not included in total query weight and remaining drop-index quota used the wrong counter.

## Scope notes

This PR deliberately does not add a `sqlite_stat1` oracle or assert exact ANALYZE statistics. The existing ANALYZE sqltest still exposes current stat-row correctness differences, so this simulator change focuses on statement coverage, transaction/write-path pressure, schema invalidation, and differential/runtime failures.

It also avoids nearby work areas such as `REINDEX`, `PRAGMA index_xinfo`, database-target `ANALYZE main`, and optimizer algorithm changes.

## Verification

- `cargo fmt --check`
- `cargo check -p sql_generation -p limbo_sim`
- `cargo test -p sql_generation -p limbo_sim`
- `cargo clippy -p sql_generation -p limbo_sim --all-targets -- --deny=warnings`
- `cargo run -p limbo_sim --bin limbo_sim -- --seed 4242 --minimum-tests 200 --maximum-tests 200 --disable-bugbase --disable-integrity-check --io-backend memory`
  - succeeded, stats included `Analyze: 2`
- `cargo run -p limbo_sim --bin limbo_sim -- --seed 4243 --minimum-tests 120 --maximum-tests 120 --disable-bugbase --disable-integrity-check --io-backend memory --differential`
  - succeeded, log included `ANALYZE` executed by both Turso and rusqlite
- `cargo run -p limbo_sim --bin limbo_sim -- --seed 4244 --minimum-tests 150 --maximum-tests 150 --disable-bugbase --io-backend memory`
  - succeeded with integrity check enabled, stats included `Analyze: 1`
- Custom high-ANALYZE simulator profile generated all three forms:
  - `ANALYZE`: 46
  - `ANALYZE <table>`: 43
  - `ANALYZE <index>`: 51

## Known existing behavior

- `cargo run --bin test-runner -- run testing/sqltests/turso-tests/analyze.sqltest --backend rust` currently builds and runs, but 9/12 cases fail due existing `sqlite_stat1` result differences. This is intentionally outside this simulator coverage PR.

## Description of AI Usage

I used ChatGPT GPT-5.5 Pro with GitHub access to review the issue/PR overlap and plan the narrow simulator-coverage scope, then used Codex for implementation and local verification. I also used GPT-5.5 Pro once after implementation for a focused review pass.
