### PR TITLE
github: Pin nyrkio/change-detection to commit SHA

### DIFF
--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Bench
         run: make bench-exclude-tpc-h  2>&1 | tee output.txt
       - name: Analyze benchmark result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: nightly/turso
           tool: criterion
@@ -79,7 +79,7 @@ jobs:
         run: make clickbench
 
       - name: Analyze TURSO result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: nightly/clickbench/turso
           tool: time
@@ -105,7 +105,7 @@ jobs:
           nyrkio-settings-threshold: 0%
 
       - name: Analyze SQLITE3 result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: nightly/clickbench/sqlite3
           tool: time
@@ -147,7 +147,7 @@ jobs:
       - name: Bench
         run: cargo bench --bench tpc_h_benchmark  2>&1 | tee output.txt
       - name: Analyze benchmark result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: nightly/tpc-h
           tool: criterion

--- a/.github/workflows/rust_perf.yml
+++ b/.github/workflows/rust_perf.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Merge outputs
         run: cat bench-output-*/output.txt > output.txt
       - name: Analyze benchmark result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: turso
           tool: criterion
@@ -116,7 +116,7 @@ jobs:
         run: make clickbench
 
       - name: Analyze TURSO result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: clickbench/turso
           tool: time
@@ -142,7 +142,7 @@ jobs:
           nyrkio-settings-threshold: 0%
 
       - name: Analyze SQLITE3 result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: clickbench/sqlite3
           tool: time
@@ -185,7 +185,7 @@ jobs:
       - name: Bench
         run: cargo bench --bench tpc_h_benchmark --locked  2>&1 | tee output.txt
       - name: Analyze benchmark result with Nyrkiö
-        uses: nyrkio/change-detection@HEAD
+        uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:
           name: tpc-h
           tool: criterion


### PR DESCRIPTION
@HEAD floats to whatever the action repo's default branch currently points at, so any push there propagates instantly into our perf workflows. perf_nightly.yml also runs with secrets, which would expose them to attacker-controlled code if the upstream were compromised.