### PR TITLE
github: Pin cargo-bins/cargo-binstall to commit SHA

### DIFF
--- a/.github/workflows/stack-sizes.yml
+++ b/.github/workflows/stack-sizes.yml
@@ -53,7 +53,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@bbd0a7de0e936c8c626fa0e93584169d58ff1307
 
       - name: Install report dependencies
         shell: bash


### PR DESCRIPTION
@main floats with whatever cargo-binstall's default branch points at, so any push there gets executed in this workflow on the next run.