### PR TITLE
core/translate: Ignore preserved-side LEFT JOIN ON terms when proving partial indexes

### DIFF
--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1199,9 +1199,16 @@ fn can_use_partial_index(
     let mut index_conjuncts: Vec<ast::Expr> = Vec::new();
     break_predicate_at_and_boundaries(&bound, &mut index_conjuncts);
     index_conjuncts.iter().all(|ic| {
-        query_where_clause
-            .iter()
-            .any(|t| exprs_are_equivalent(ic, &t.expr))
+        query_where_clause.iter().any(|t| {
+            // A LEFT JOIN ON term only filters the joined table; rows from the
+            // preserved table can still survive without matching that term.
+            if t.from_outer_join
+                .is_some_and(|outer_join_tbl| outer_join_tbl != table_reference.internal_id)
+            {
+                return false;
+            }
+            exprs_are_equivalent(ic, &t.expr)
+        })
     })
     // TODO: recognize implication beyond syntactic equivalence (e.g. `x = 5` implies
     // `x IS NOT NULL`, `x > 10` implies `x > 5`).

--- a/sql_generation/generation/query.rs
+++ b/sql_generation/generation/query.rs
@@ -625,6 +625,7 @@ impl Arbitrary for CreateIndex {
                 index_name,
                 table_name: table.name.clone(),
                 columns,
+                where_clause: None,
             },
         }
     }

--- a/sql_generation/model/query/create_index.rs
+++ b/sql_generation/model/query/create_index.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::table::Index;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateIndex {
     pub index: Index,
 }
@@ -50,6 +50,10 @@ impl std::fmt::Display for CreateIndex {
                 .map(|(name, order)| format!("{name} {order}"))
                 .collect::<Vec<String>>()
                 .join(", ")
-        )
+        )?;
+        if let Some(where_clause) = &self.index.where_clause {
+            write!(f, " WHERE {where_clause}")?;
+        }
+        Ok(())
     }
 }

--- a/sql_generation/model/query/predicate.rs
+++ b/sql_generation/model/query/predicate.rs
@@ -6,9 +6,9 @@ use turso_parser::ast::{
     fmt::{BlankContext, ToTokens},
 };
 
-use crate::model::table::{SimValue, Table, TableContext};
+use crate::model::table::{ContextColumn, SimValue, Table, TableContext};
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Predicate(pub ast::Expr);
 
 impl Predicate {
@@ -108,18 +108,33 @@ pub fn expr_to_value<T: TableContext>(
     table: &T,
 ) -> Option<SimValue> {
     match expr {
-        ast::Expr::DoublyQualified(_, _, col_name)
-        | ast::Expr::Qualified(_, col_name)
-        | ast::Expr::Id(col_name) => {
+        ast::Expr::DoublyQualified(db_name, table_name, col_name) => {
             let columns = table.columns().collect::<Vec<_>>();
-            let col_name = col_name.as_str();
             assert_eq!(row.len(), columns.len());
-            columns
-                .iter()
-                .zip(row.iter())
-                .find(|(column, _)| column.column.name == col_name)
-                .map(|(_, value)| value)
-                .cloned()
+            find_column_value(
+                row,
+                &columns,
+                ColumnQualifier::DbTable {
+                    db_name: db_name.as_str(),
+                    table_name: table_name.as_str(),
+                },
+                col_name.as_str(),
+            )
+        }
+        ast::Expr::Qualified(table_name, col_name) => {
+            let columns = table.columns().collect::<Vec<_>>();
+            assert_eq!(row.len(), columns.len());
+            find_column_value(
+                row,
+                &columns,
+                ColumnQualifier::Table(table_name.as_str()),
+                col_name.as_str(),
+            )
+        }
+        ast::Expr::Id(col_name) => {
+            let columns = table.columns().collect::<Vec<_>>();
+            assert_eq!(row.len(), columns.len());
+            find_column_value(row, &columns, ColumnQualifier::Any, col_name.as_str())
         }
         ast::Expr::Literal(literal) => Some(literal.into()),
         ast::Expr::Binary(lhs, op, rhs) => {
@@ -148,12 +163,126 @@ pub fn expr_to_value<T: TableContext>(
             assert_eq!(exprs.len(), 1);
             expr_to_value(&exprs[0], row, table)
         }
+        ast::Expr::InList { lhs, not, rhs } => {
+            let lhs = expr_to_value(lhs, row, table)?;
+            let mut found = false;
+            for expr in rhs {
+                let candidate = expr_to_value(expr, row, table)?;
+                if lhs == candidate {
+                    found = true;
+                    break;
+                }
+            }
+            Some(if *not { !found } else { found }.into())
+        }
         _ => unreachable!("{:?}", expr),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ColumnQualifier<'a> {
+    Any,
+    Table(&'a str),
+    DbTable {
+        db_name: &'a str,
+        table_name: &'a str,
+    },
+}
+
+fn find_column_value(
+    row: &[SimValue],
+    columns: &[ContextColumn<'_>],
+    qualifier: ColumnQualifier<'_>,
+    col_name: &str,
+) -> Option<SimValue> {
+    columns
+        .iter()
+        .zip(row.iter())
+        .find(|(column, _)| {
+            column.column.name == col_name && column_matches_qualifier(column.table_name, qualifier)
+        })
+        .map(|(_, value)| value)
+        .cloned()
+}
+
+fn column_matches_qualifier(column_table_name: &str, qualifier: ColumnQualifier<'_>) -> bool {
+    match qualifier {
+        ColumnQualifier::Any => true,
+        ColumnQualifier::Table(table_name) => column_table_name == table_name,
+        ColumnQualifier::DbTable {
+            db_name,
+            table_name,
+        } => column_table_name
+            .split_once('.')
+            .is_some_and(|(column_db, column_table)| {
+                column_db == db_name && column_table == table_name
+            }),
     }
 }
 
 impl Display for Predicate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.displayer(&BlankContext).fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use turso_core::types;
+    use turso_parser::ast;
+
+    use crate::model::table::{Column, ColumnType, JoinTable};
+
+    use super::*;
+
+    fn int_col(name: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            column_type: ColumnType::Integer,
+            constraints: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn qualified_columns_resolve_to_the_matching_table() {
+        let src = Table {
+            name: "src".to_string(),
+            columns: vec![int_col("x")],
+            rows: Vec::new(),
+            indexes: Vec::new(),
+        };
+        let rhs = Table {
+            name: "rhs".to_string(),
+            columns: vec![int_col("x")],
+            rows: Vec::new(),
+            indexes: Vec::new(),
+        };
+        let join_table = JoinTable {
+            tables: vec![src, rhs],
+            rows: vec![vec![
+                SimValue(types::Value::from_i64(10)),
+                SimValue(types::Value::from_i64(20)),
+            ]],
+        };
+        let row = &join_table.rows[0];
+
+        let src_x =
+            ast::Expr::Qualified(ast::Name::from_string("src"), ast::Name::from_string("x"));
+        let rhs_x =
+            ast::Expr::Qualified(ast::Name::from_string("rhs"), ast::Name::from_string("x"));
+        let bare_x = ast::Expr::Id(ast::Name::from_string("x"));
+
+        assert_eq!(
+            expr_to_value(&src_x, row, &join_table),
+            Some(SimValue(types::Value::from_i64(10)))
+        );
+        assert_eq!(
+            expr_to_value(&rhs_x, row, &join_table),
+            Some(SimValue(types::Value::from_i64(20)))
+        );
+        assert_eq!(
+            expr_to_value(&bare_x, row, &join_table),
+            Some(SimValue(types::Value::from_i64(10)))
+        );
     }
 }

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -141,11 +141,14 @@ impl Display for ColumnType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Index {
     pub table_name: String,
     pub index_name: String,
     pub columns: Vec<(String, SortOrder)>,
+    /// Optional `WHERE` predicate that turns this into a partial index.
+    #[serde(default)]
+    pub where_clause: Option<Predicate>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -1165,6 +1165,7 @@ pub fn create_initial_indexes(rng: &mut ChaCha8Rng, tables: &[Table]) -> Vec<Cre
                             index_name,
                             table_name: table.name.clone(),
                             columns: selected_columns,
+                            where_clause: None,
                         },
                     };
                     indexes.push(create_index);

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -69,7 +69,7 @@ simulator covers and tests.
 | SELECT ... JOIN           | Partial | TODO                                                                              |
 | SELECT ... CROSS JOIN     | No      | SQLite CROSS JOIN means "do not reorder joins". We don't support that yet anyway. |
 | SELECT ... INNER JOIN     | Partial | TODO                                                                              |
-| SELECT ... OUTER JOIN     | No      |                                                                                   |
+| SELECT ... OUTER JOIN     | Partial | Targeted LEFT JOIN / partial-index materialization property.                      |
 | SELECT ... JOIN USING     | No      |                                                                                   |
 | SELECT ... NATURAL JOIN   | No      |                                                                                   |
 | UPDATE                    | Partial |                                                                                   |

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -12,19 +12,22 @@ use sql_generation::{
     generation::{Arbitrary, ArbitraryFrom, GenerationContext, pick, pick_index},
     model::{
         query::{
-            Create, Delete, Drop, Insert, Select,
+            Create, CreateIndex, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
             predicate::Predicate,
-            select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
+            select::{
+                CompoundOperator, CompoundSelect, FromClause, ResultColumn, SelectBody,
+                SelectInner, SelectTable,
+            },
             transaction::{Begin, Commit, Rollback},
             update::{SetValue, Update},
         },
-        table::{ColumnType, SimValue, Table},
+        table::{Column, ColumnType, Index, JoinType, JoinedTable, SimValue, Table},
     },
 };
 use strum::IntoEnumIterator;
 use turso_core::{LimboError, Numeric, types};
-use turso_parser::ast::{self, Distinctness};
+use turso_parser::ast::{self, ColumnConstraint, Distinctness, SortOrder};
 
 use crate::{
     common::print_diff,
@@ -247,6 +250,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::LeftJoinPartialIndex { .. }
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => {
                 unreachable!("No extensional queries")
@@ -1206,6 +1210,12 @@ impl Property {
                 .into_iter()
                 .map(|query| InteractionBuilder::with_interaction(InteractionType::Query(query)))
                 .collect(),
+            Property::LeftJoinPartialIndex {
+                src_table,
+                rhs_table,
+                dst_table,
+                index_name,
+            } => left_join_partial_index_interactions(src_table, rhs_table, dst_table, index_name),
             Property::SavepointRollback {
                 queries, tables, ..
             } => {
@@ -1248,6 +1258,206 @@ impl Property {
             })
             .collect()
     }
+}
+
+fn left_join_partial_index_interactions(
+    src_table: &str,
+    rhs_table: &str,
+    dst_table: &str,
+    index_name: &str,
+) -> Vec<InteractionBuilder> {
+    fn int_col(name: &str, constraints: Vec<ColumnConstraint>) -> Column {
+        Column {
+            name: name.to_string(),
+            column_type: ColumnType::Integer,
+            constraints,
+        }
+    }
+    fn int_lit(value: i64) -> ast::Expr {
+        ast::Expr::Literal(ast::Literal::Numeric(value.to_string()))
+    }
+    fn qualified(table: &str, col: &str) -> ast::Expr {
+        ast::Expr::Qualified(ast::Name::from_string(table), ast::Name::from_string(col))
+    }
+
+    let pk_constraint = ColumnConstraint::PrimaryKey {
+        order: None,
+        conflict_clause: None,
+        auto_increment: false,
+    };
+    let create_src = Query::Create(Create {
+        table: Table {
+            name: src_table.to_string(),
+            columns: vec![
+                int_col("id", vec![pk_constraint]),
+                int_col("c", vec![]),
+                int_col("x", vec![]),
+            ],
+            rows: vec![],
+            indexes: vec![],
+        },
+    });
+    let create_rhs = Query::Create(Create {
+        table: Table {
+            name: rhs_table.to_string(),
+            columns: vec![int_col("x", vec![])],
+            rows: vec![],
+            indexes: vec![],
+        },
+    });
+    let create_dst = Query::Create(Create {
+        table: Table {
+            name: dst_table.to_string(),
+            columns: vec![
+                int_col("id", vec![]),
+                int_col("c", vec![]),
+                int_col("x", vec![]),
+                int_col("ux", vec![]),
+            ],
+            rows: vec![],
+            indexes: vec![],
+        },
+    });
+
+    let insert_src = Query::Insert(Insert::Values {
+        table: src_table.to_string(),
+        values: vec![vec![
+            SimValue(types::Value::from_i64(1)),
+            SimValue(types::Value::from_i64(0)),
+            SimValue(types::Value::from_i64(10)),
+        ]],
+        on_conflict: None,
+    });
+
+    let partial_index = Query::CreateIndex(CreateIndex {
+        index: Index {
+            index_name: index_name.to_string(),
+            table_name: src_table.to_string(),
+            columns: vec![("x".to_string(), SortOrder::Asc)],
+            where_clause: Some(Predicate(ast::Expr::Binary(
+                Box::new(ast::Expr::Id(ast::Name::exact("c".to_string()))),
+                ast::Operator::Equals,
+                Box::new(int_lit(1)),
+            ))),
+        },
+    });
+
+    let join_on = Predicate(ast::Expr::Binary(
+        Box::new(ast::Expr::Binary(
+            Box::new(qualified(src_table, "c")),
+            ast::Operator::Equals,
+            Box::new(int_lit(1)),
+        )),
+        ast::Operator::And,
+        Box::new(ast::Expr::Binary(
+            Box::new(qualified(rhs_table, "x")),
+            ast::Operator::Equals,
+            Box::new(qualified(src_table, "x")),
+        )),
+    ));
+    let where_clause = Predicate(ast::Expr::InList {
+        lhs: Box::new(qualified(src_table, "x")),
+        not: false,
+        rhs: vec![Box::new(int_lit(10))],
+    });
+    let join_select = Select {
+        body: SelectBody {
+            select: Box::new(SelectInner {
+                distinctness: Distinctness::All,
+                columns: vec![
+                    ResultColumn::Column(format!("{src_table}.id")),
+                    ResultColumn::Column(format!("{src_table}.c")),
+                    ResultColumn::Column(format!("{src_table}.x")),
+                    ResultColumn::Column(format!("{rhs_table}.x")),
+                ],
+                from: Some(FromClause {
+                    table: SelectTable::Table(src_table.to_string()),
+                    joins: vec![JoinedTable {
+                        table: rhs_table.to_string(),
+                        join_type: JoinType::Left,
+                        on: join_on,
+                    }],
+                }),
+                where_clause,
+                order_by: None,
+            }),
+            compounds: vec![],
+        },
+        limit: None,
+    };
+    let insert_dst = Query::Insert(Insert::Select {
+        table: dst_table.to_string(),
+        select: Box::new(join_select),
+    });
+
+    let check_predicate = Predicate(ast::Expr::Binary(
+        Box::new(ast::Expr::Binary(
+            Box::new(ast::Expr::Binary(
+                Box::new(ast::Expr::Binary(
+                    Box::new(ast::Expr::Id(ast::Name::exact("id".to_string()))),
+                    ast::Operator::Equals,
+                    Box::new(int_lit(1)),
+                )),
+                ast::Operator::And,
+                Box::new(ast::Expr::Binary(
+                    Box::new(ast::Expr::Id(ast::Name::exact("c".to_string()))),
+                    ast::Operator::Equals,
+                    Box::new(int_lit(0)),
+                )),
+            )),
+            ast::Operator::And,
+            Box::new(ast::Expr::Binary(
+                Box::new(ast::Expr::Id(ast::Name::exact("x".to_string()))),
+                ast::Operator::Equals,
+                Box::new(int_lit(10)),
+            )),
+        )),
+        ast::Operator::And,
+        Box::new(ast::Expr::Binary(
+            Box::new(ast::Expr::Id(ast::Name::exact("ux".to_string()))),
+            ast::Operator::Is,
+            Box::new(ast::Expr::Literal(ast::Literal::Null)),
+        )),
+    ));
+    let check_select = Query::Select(Select::simple(dst_table.to_string(), check_predicate));
+
+    let dst_for_error = dst_table.to_string();
+    let assertion = InteractionType::Assertion(Assertion::new(
+        format!("{dst_table} should contain the unmatched LEFT JOIN preserved row"),
+        move |stack: &Vec<ResultSet>, _| {
+            let Some(rows) = stack.last() else {
+                return Err(LimboError::InternalError(
+                    "LeftJoinPartialIndex: missing check query result".to_string(),
+                ));
+            };
+            let Ok(rows) = rows else {
+                return Ok(Err(format!("check query failed: {rows:?}")));
+            };
+            if rows.len() == 1 {
+                Ok(Ok(()))
+            } else {
+                Ok(Err(format!(
+                    "expected one unmatched left row in {dst_for_error}, got {}",
+                    rows.len()
+                )))
+            }
+        },
+        vec![dst_table.to_string()],
+    ));
+
+    [
+        InteractionType::Query(create_src),
+        InteractionType::Query(create_rhs),
+        InteractionType::Query(create_dst),
+        InteractionType::Query(insert_src),
+        InteractionType::Query(partial_index),
+        InteractionType::Query(insert_dst),
+        InteractionType::Query(check_select),
+        assertion,
+    ]
+    .into_iter()
+    .map(InteractionBuilder::with_interaction)
+    .collect()
 }
 
 fn random_main_table_write<R: rand::Rng + ?Sized>(
@@ -1703,6 +1913,21 @@ fn property_all_tables_have_expected_content<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_left_join_partial_index<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    _ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let suffix: u32 = rng.random();
+    Property::LeftJoinPartialIndex {
+        src_table: format!("sim_ljpidx_src_{suffix:x}"),
+        rhs_table: format!("sim_ljpidx_rhs_{suffix:x}"),
+        dst_table: format!("sim_ljpidx_dst_{suffix:x}"),
+        index_name: format!("sim_ljpidx_idx_{suffix:x}"),
+    }
+}
+
 fn property_select_limit<R: rand::Rng + ?Sized>(
     rng: &mut R,
     _query_distr: &QueryDistribution,
@@ -1903,6 +2128,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
             }
+            PropertyDiscriminants::LeftJoinPartialIndex => property_left_join_partial_index,
             PropertyDiscriminants::DoubleCreateFailure => property_double_create_failure,
             PropertyDiscriminants::SelectLimit => property_select_limit,
             PropertyDiscriminants::DeleteSelect => property_delete_select,
@@ -1954,6 +2180,13 @@ impl PropertyDiscriminants {
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
                     remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::LeftJoinPartialIndex => {
+                if !env.profile.mvcc && remaining.insert > 0 && remaining.create_index > 0 {
+                    remaining.create_index.max(1)
                 } else {
                     0
                 }
@@ -2059,6 +2292,9 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::LeftJoinPartialIndex => QueryCapabilities::CREATE
+                .union(QueryCapabilities::INSERT)
+                .union(QueryCapabilities::CREATE_INDEX),
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -911,6 +911,32 @@ impl Shadow for FromClause {
                     }
                     join_table.rows = new_rows;
                 }
+                JoinType::Left => {
+                    let prev_rows = std::mem::take(&mut join_table.rows);
+                    let null_rhs: Vec<SimValue> =
+                        vec![SimValue(Value::Null); joined_table.columns.len()];
+                    let mut new_rows = Vec::new();
+                    for row1 in prev_rows.into_iter() {
+                        let mut matched = false;
+                        for row2 in joined_table.rows.iter() {
+                            let combined_row =
+                                row1.iter().chain(row2.iter()).cloned().collect::<Vec<_>>();
+                            if join.on.test(&combined_row, &join_table) {
+                                new_rows.push(combined_row);
+                                matched = true;
+                            }
+                        }
+                        if !matched {
+                            new_rows.push(
+                                row1.iter()
+                                    .chain(null_rhs.iter())
+                                    .cloned()
+                                    .collect::<Vec<_>>(),
+                            );
+                        }
+                    }
+                    join_table.rows = new_rows;
+                }
                 _ => todo!(),
             }
         }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -191,6 +191,15 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// Ensures LEFT JOIN ON terms that reference the preserved table do not
+    /// imply a partial index on that preserved table. The unmatched left row
+    /// must still be materialized with NULL right-side columns.
+    LeftJoinPartialIndex {
+        src_table: String,
+        rhs_table: String,
+        dst_table: String,
+        index_name: String,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -238,6 +247,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::LeftJoinPartialIndex { .. }
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => None,
         }

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -89,7 +89,7 @@ pub enum TxOperation {
     },
     CreateIndex {
         table_name: String,
-        index: sql_generation::model::table::Index,
+        index: Box<sql_generation::model::table::Index>,
     },
     DropIndex {
         table_name: String,
@@ -237,7 +237,10 @@ impl TransactionTables {
     ) {
         self.expect_snapshot_mut()
             .operations
-            .push(TxOperation::CreateIndex { table_name, index });
+            .push(TxOperation::CreateIndex {
+                table_name,
+                index: Box::new(index),
+            });
     }
 
     pub fn record_drop_index(&mut self, table_name: String, index_name: String) {
@@ -639,7 +642,7 @@ where
                             .iter_mut()
                             .find(|t| &t.name == table_name)
                             .expect("Table should exist in committed tables");
-                        committed.indexes.push(index.clone());
+                        committed.indexes.push((**index).clone());
                     }
                     TxOperation::DropIndex {
                         table_name,

--- a/testing/sqltests/tests/partial_idx.sqltest
+++ b/testing/sqltests/tests/partial_idx.sqltest
@@ -1197,3 +1197,50 @@ test partial-index-full-scan-correctness {
 expect {
     2
 }
+
+@cross-check-integrity
+test partial-index-left-join-on-preserved-table-not-implied {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c INT, x INT);
+    CREATE TABLE u(x INT);
+    CREATE TABLE dst(id INT, c INT, x INT, ux INT);
+    INSERT INTO t VALUES (1, 0, 10);
+    CREATE INDEX idx_t_x_c1 ON t(x) WHERE c = 1;
+    INSERT INTO dst
+        SELECT t.id, t.c, t.x, u.x
+        FROM t LEFT JOIN u ON t.c = 1 AND u.x = t.x
+        WHERE t.x IN (10);
+    SELECT id, c, x, ux IS NULL FROM dst;
+}
+expect {
+    1|0|10|1
+}
+
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test plan-partial-index-left-join-preserved-where-term-still-implies-index {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, c INT, x INT);
+    CREATE TABLE u(x INT);
+    CREATE INDEX idx_t_x_c1 ON t(x) WHERE c = 1;
+    EXPLAIN QUERY PLAN
+        SELECT t.id, u.x
+        FROM t LEFT JOIN u ON u.x = t.x
+        WHERE t.c = 1 AND t.x = 10;
+}
+expect {
+    1|0|0|HASH JOIN u
+    2|0|0|SEARCH t USING INDEX idx_t_x_c1 (x=?)
+}
+
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test plan-partial-index-left-join-rhs-on-term-still-implies-rhs-index {
+    CREATE TABLE l(id INTEGER PRIMARY KEY, x INT);
+    CREATE TABLE r(x INT, c INT, payload TEXT);
+    CREATE INDEX idx_r_x_c1 ON r(x) WHERE c = 1;
+    EXPLAIN QUERY PLAN
+        SELECT l.id, r.payload
+        FROM l LEFT JOIN r ON r.c = 1 AND r.x = l.x
+        WHERE l.x IN (10);
+}
+expect {
+    1|0|0|SCAN l
+    2|0|0|SEARCH r USING INDEX idx_r_x_c1 (x=?) LEFT-JOIN
+}


### PR DESCRIPTION
## Description

Turso could incorrectly use a partial index on the preserved side of a `LEFT JOIN`
when the partial-index predicate only appeared in the join's `ON` clause.

For example, with an index:

```sql
CREATE INDEX t_x_c1 ON t(x) WHERE c = 1;
```

this query shape should still preserve rows from `t` where `c != 1`:

```sql
INSERT INTO dst
SELECT t.id, t.c, t.x, u.x
FROM t
LEFT JOIN u ON t.c = 1 AND u.x = t.x
WHERE t.x IN (10);
```

SQLite emits the unmatched left row with `NULL` right-side columns. Turso could
prove the partial index from `t.c = 1` in the `ON` clause, scan only `t_x_c1`,
and materialize no row into `dst`.

The fix changes partial-index implication so an outer-join term is ignored
unless it belongs to the same table reference whose partial index is being
considered. That keeps ordinary `WHERE` predicates and joined-table `ON`
constraints usable, while preventing preserved-side `ON` predicates from being
treated as global filters.

The patch also adds simulator coverage for this interaction. The new
`Property::LeftJoinPartialIndex` deterministically materializes the bug
shape (`CREATE INDEX ... WHERE c = 1`, then `INSERT ... SELECT ... LEFT
JOIN ... ON src.c = 1 ...`) and asserts the unmatched preserved row is
present in the destination table.

To express that shape through the existing typed `Query` model, the patch adds
the missing typed pieces instead of a raw-SQL simulator escape hatch:

- `sql_generation::Index` gains an optional `where_clause: Option<Predicate>`
  so partial-index syntax has a typed representation.
- The simulator shadow model learns `LEFT JOIN` and `InList` evaluation so an
  `Insert::Select` over a LEFT JOIN is verified end-to-end.
- Qualified column evaluation in the simulator shadow now respects the table
  qualifier in joined-table contexts, so duplicate column names like `src.x`
  and `rhs.x` do not collapse to the first matching column.

Three `partial_idx.sqltest` regressions are included: the preserved-side bug
case, an `EXPLAIN QUERY PLAN` pin that a preserved-side `WHERE t.c = 1` term
still uses the preserved-side partial index, and an `EXPLAIN QUERY PLAN` pin
that the right-side `LEFT JOIN ON r.c = 1` case still uses the right-side
partial index.

## Motivation and context

This is a SQLite compatibility and materialization correctness issue. A
preserved-side `LEFT JOIN ON` predicate is not equivalent to a global `WHERE`
predicate: unmatched rows from the preserved table still survive after `ON`
processing.

The new simulator property exposes the bug as a deterministic differential
failure on buggy code. With seed `2026051102`, the property materializes into a
destination table and the check query for the unmatched preserved row returns
the row on SQLite but no row on buggy Turso, so the differential runner flags a
divergence.

The recorded fail-before output in the local notes is:

```text
Differences (-turso|+rusqlite):
 [
     [
-        "0",
+        "1",
     ],
 ]
seed: 2026051102
```

After the optimizer fix, the same seed succeeds and `simulator-output/diff.sql`
contains `LeftJoinPartialIndex` blocks for the new property.

## Tests

Passed locally:

```text
cargo fmt --check
git diff --check upstream/main...HEAD
cargo test -p sql_generation qualified_columns_resolve_to_the_matching_table
make -C testing/sqltests run-one FILE=tests/partial_idx.sqltest
cargo run -p limbo_sim -- --maximum-tests 1 --seed 2026051102 --disable-bugbase --differential --io-backend memory --keep-files
cargo clippy --workspace --all-features --all-targets -- --deny=warnings
./testing/concurrent-simulator/bin/run
make test
```

`partial_idx.sqltest` reports 84 passed, including the new preserved-side bug
case and the two partial-index plan guards. The simulator seed `2026051102`
reports `simulation succeeded` on the fixed tree. The concurrent simulator fast
sanity run also passed.



## Description of AI Usage

Codex Security was used to scan candidate correctness findings and flagged
the LEFT JOIN / partial-index planner issue. I reduced that signal to a
minimal SQL shape and confirmed the SQLite/Turso divergence.

I used Codex and Claude Code to help write the optimizer fix, add the typed
simulator property and sqltest regression coverage, verify the failing and
fixed behavior, and review the final code changes. I reviewed the final diff
and test output locally before preparing this PR.