### PR TITLE
Match SQLite ASCII-only identifier folding

### DIFF
--- a/cli/commands/import.rs
+++ b/cli/commands/import.rs
@@ -273,5 +273,7 @@ pub fn normalize_ident(identifier: &str) -> String {
     } else {
         identifier
     }
-    .to_lowercase()
+    // SQLite's default case-insensitive identifier matching folds ASCII only.
+    // See https://sqlite.org/faq.html#q18.
+    .to_ascii_lowercase()
 }

--- a/core/util.rs
+++ b/core/util.rs
@@ -120,8 +120,9 @@ const QUOTE_PAIRS: &[(char, char)] = &[
 
 pub fn normalize_ident(identifier: &str) -> String {
     // quotes normalization already happened in the parser layer (see Name ast node implementation)
-    // so, we only need to convert identifier string to lowercase
-    identifier.to_lowercase()
+    // SQLite's default case-insensitive identifier matching folds ASCII only.
+    // See https://sqlite.org/faq.html#q18.
+    identifier.to_ascii_lowercase()
 }
 
 /// Escape a SQL string literal payload for safe interpolation inside single quotes.
@@ -4763,7 +4764,7 @@ pub mod tests {
     fn test_normalize_ident() {
         assert_eq!(normalize_ident("foo"), "foo");
         assert_eq!(normalize_ident("FOO"), "foo");
-        assert_eq!(normalize_ident("ὈΔΥΣΣΕΎΣ"), "ὀδυσσεύς");
+        assert_eq!(normalize_ident("ὈΔΥΣΣΕΎΣ"), "ὈΔΥΣΣΕΎΣ");
     }
 
     fn schema_with_tables(create_table_sqls: &[&str]) -> Schema {

--- a/testing/sqltests/tests/create_table.sqltest
+++ b/testing/sqltests/tests/create_table.sqltest
@@ -116,6 +116,34 @@ test create_table_duplicate_column_names_quoted {
 expect error {
 }
 
+# https://github.com/tursodatabase/turso/issues/5730
+@cross-check-integrity
+test create_table_non_ascii_case_distinct {
+    CREATE TABLE é(a);
+    CREATE TABLE É(a);
+    INSERT INTO é VALUES (1);
+    INSERT INTO É VALUES (2);
+    SELECT * FROM é;
+    SELECT * FROM É;
+}
+expect {
+    1
+    2
+}
+
+# https://github.com/tursodatabase/turso/issues/5730
+@cross-check-integrity
+test create_view_non_ascii_case_distinct {
+    CREATE VIEW é AS SELECT 1;
+    CREATE VIEW É AS SELECT 2;
+    SELECT * FROM é;
+    SELECT * FROM É;
+}
+expect {
+    1
+    2
+}
+
 @cross-check-integrity
 test create_table_view_collision-1 {
     CREATE VIEW v_same AS SELECT 1;


### PR DESCRIPTION
# NOTICE:

## Description

Switch identifier normalization from Unicode lowercasing to ASCII-only lowercasing so Turso matches SQLite default identifier case matching. This lets non-ASCII names that differ only by Unicode case coexist while preserving ASCII case-insensitive lookups.

Fixes #5730.

## Motivation and context

SQLite folds identifier case for ASCII characters only. Turso was using Rust Unicode lowercasing in core schema lookups and the import helper, so names like `é` and `É` collided even though SQLite accepts them as distinct table/view names.

## Tests

- `make -C testing/sqltests run-one FILE=tests/create_table.sqltest`
- `cargo test -p turso_core test_normalize_ident`
- `cargo test -p turso_cli normalize_ident`
- `make -C testing/sqltests check`
- `cargo fmt --check`
- verified the table/view repro SQL against system `sqlite3`

## Description of AI Usage

I used Codex to help locate the affected identifier-normalization paths, prepare the regression tests, and run the verification commands. I reviewed the final diff and test results before opening the PR.