### PR TITLE
core: fix UPSERT DO UPDATE index rollback

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -441,6 +441,9 @@ pub fn translate_insert(
         database_id,
     )?;
     let has_upsert = !upsert_actions.is_empty();
+    let has_upsert_do_update = upsert_actions
+        .iter()
+        .any(|(_, _, upsert)| matches!(&upsert.do_clause, UpsertDo::Set { .. }));
 
     // Set up the program to return result columns if RETURNING is specified
     if !result_columns.is_empty() {
@@ -1186,7 +1189,7 @@ pub fn translate_insert(
             inserting_multiple_rows,
             has_triggers,
             has_fks,
-            has_upsert,
+            has_upsert_do_update,
             btree_table.has_autoincrement,
             notnull_col_exists,
             has_unique,

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -131,7 +131,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     inserting_multiple_rows: bool,
     has_triggers: bool,
     has_fks: bool,
-    has_upsert: bool,
+    has_upsert_do_update: bool,
     has_autoincrement: bool,
     notnull_col_exists: bool,
     has_unique: bool,
@@ -157,7 +157,8 @@ pub(crate) fn set_insert_stmt_journal_flags(
     // inserts do not need this because there is no prior row in the
     // outer-tx write_set to roll back.
     let autoinc_may_abort_multi_row = has_autoincrement && inserting_multiple_rows;
-    let may_abort = has_triggers
+    let may_abort = has_upsert_do_update
+        || has_triggers
         || has_fks
         || autoinc_may_abort_multi_row
         || constraint_may_abort(
@@ -175,7 +176,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     if !inserting_multiple_rows
         && !has_triggers
         && !any_replace
-        && !has_upsert
+        && !has_upsert_do_update
         && !has_autoincrement
     {
         program.set_multi_write(false);

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -934,8 +934,27 @@ pub fn emit_upsert(
         }
     }
 
-    // Index rebuild (DELETE old, INSERT new), honoring partial-index WHEREs
+    // Index rebuild, honoring partial-index WHEREs.
+    //
+    // Evaluate predicates, build NEW keys, and check uniqueness before mutating
+    // any index. The DO UPDATE arm always uses ABORT semantics, but statement
+    // OR FAIL still sets the top-level program resolve type. Keeping all
+    // fallible expression evaluation ahead of IdxDelete prevents an expression
+    // error from preserving partial index maintenance as FAIL.
     if let Some(before) = before_start {
+        struct UpsertIndexUpdateCtx {
+            idx_meta: Arc<Index>,
+            idx_cursor_id: usize,
+            record_reg: usize,
+            idx_start_reg: usize,
+            num_cols: usize,
+            old_satisfies_where: Option<usize>,
+            new_satisfies_where: Option<usize>,
+        }
+
+        let mut idx_phase_ctxs = Vec::new();
+
+        // Phase 1: evaluate predicates, build NEW keys, and check unique constraints.
         for (idx_name, _root, idx_cid) in &ctx.idx_cursors {
             let idx_meta = resolver
                 .with_schema(ctx.database_id, |s| {
@@ -962,67 +981,6 @@ pub fn emit_upsert(
                 program, table, &idx_meta, new_start, new_rowid, resolver, &layout,
             );
 
-            // Skip delete if BEFORE predicate false/NULL
-            let maybe_skip_del = before_pred_reg.map(|r| {
-                let lbl = program.allocate_label();
-                program.emit_insn(Insn::IfNot {
-                    reg: r,
-                    target_pc: lbl,
-                    jump_if_null: true,
-                });
-                lbl
-            });
-
-            // DELETE old key
-            let del = program.alloc_registers(k + 1);
-            for (i, ic) in idx_meta.columns.iter().enumerate() {
-                if ic.expr.is_some() {
-                    emit_upsert_expr_index_value(
-                        program,
-                        resolver,
-                        table,
-                        ic,
-                        before,
-                        ctx.conflict_rowid_reg,
-                        del + i,
-                        &layout,
-                    )?;
-                } else {
-                    let (ci, _) = table.get_column_by_name(&ic.name).unwrap();
-                    program.emit_insn(Insn::Copy {
-                        src_reg: layout.to_register(before, ci),
-                        dst_reg: del + i,
-                        extra_amount: 0,
-                    });
-                }
-            }
-            program.emit_insn(Insn::Copy {
-                src_reg: ctx.conflict_rowid_reg,
-                dst_reg: del + k,
-                extra_amount: 0,
-            });
-            program.emit_insn(Insn::IdxDelete {
-                start_reg: del,
-                num_regs: k + 1,
-                cursor_id: *idx_cid,
-                raise_error_if_no_matching_entry: false,
-            });
-            if let Some(label) = maybe_skip_del {
-                program.preassign_label_to_next_insn(label);
-            }
-
-            // Skip insert if NEW predicate false/NULL
-            let maybe_skip_ins = new_pred_reg.map(|r| {
-                let lbl = program.allocate_label();
-                program.emit_insn(Insn::IfNot {
-                    reg: r,
-                    target_pc: lbl,
-                    jump_if_null: true,
-                });
-                lbl
-            });
-
-            // INSERT new key (use NEW rowid if present)
             let ins = program.alloc_registers(k + 1);
             for (i, ic) in idx_meta.columns.iter().enumerate() {
                 if ic.expr.is_some() {
@@ -1063,6 +1021,13 @@ pub fn emit_upsert(
             if idx_meta.unique {
                 // Affinity on the key columns for the NoConflict probe
                 let ok = program.allocate_label();
+                if let Some(new_pred_reg) = new_pred_reg {
+                    program.emit_insn(Insn::IfNot {
+                        reg: new_pred_reg,
+                        target_pc: ok,
+                        jump_if_null: true,
+                    });
+                }
                 let aff: String = idx_meta
                     .columns
                     .iter()
@@ -1100,32 +1065,109 @@ pub fn emit_upsert(
                     dest: hit,
                 });
                 program.emit_insn(Insn::Eq {
-                    lhs: new_rowid,
+                    lhs: ctx.conflict_rowid_reg,
                     rhs: hit,
                     target_pc: ok,
                     flags: CmpInsFlags::default(),
                     collation: program.curr_collation(),
                 });
-                let description = format_unique_violation_desc(table.get_name(), &idx_meta);
+                let description = format!(
+                    "UNIQUE constraint failed: {} (19)",
+                    format_unique_violation_desc(table.get_name(), &idx_meta)
+                );
                 program.emit_insn(Insn::Halt {
                     err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
                     description,
-                    on_error: None,
+                    on_error: Some(ast::ResolveType::Abort),
                     description_reg: None,
                 });
                 program.preassign_label_to_next_insn(ok);
             }
 
-            program.emit_insn(Insn::IdxInsert {
-                cursor_id: *idx_cid,
+            idx_phase_ctxs.push(UpsertIndexUpdateCtx {
+                idx_meta,
+                idx_cursor_id: *idx_cid,
                 record_reg: rec,
-                unpacked_start: Some(ins),
-                unpacked_count: Some((k + 1) as u16),
+                idx_start_reg: ins,
+                num_cols: k,
+                old_satisfies_where: before_pred_reg,
+                new_satisfies_where: new_pred_reg,
+            });
+        }
+
+        // Phase 2: delete OLD keys after every fallible NEW-key build/check passed.
+        for idx_ctx in &idx_phase_ctxs {
+            let maybe_skip_del = idx_ctx.old_satisfies_where.map(|r| {
+                let lbl = program.allocate_label();
+                program.emit_insn(Insn::IfNot {
+                    reg: r,
+                    target_pc: lbl,
+                    jump_if_null: true,
+                });
+                lbl
+            });
+
+            let del = program.alloc_registers(idx_ctx.num_cols + 1);
+            for (i, ic) in idx_ctx.idx_meta.columns.iter().enumerate() {
+                if ic.expr.is_some() {
+                    emit_upsert_expr_index_value(
+                        program,
+                        resolver,
+                        table,
+                        ic,
+                        before,
+                        ctx.conflict_rowid_reg,
+                        del + i,
+                        &layout,
+                    )?;
+                } else {
+                    let (ci, _) = table.get_column_by_name(&ic.name).unwrap();
+                    program.emit_insn(Insn::Copy {
+                        src_reg: layout.to_register(before, ci),
+                        dst_reg: del + i,
+                        extra_amount: 0,
+                    });
+                }
+            }
+            program.emit_insn(Insn::Copy {
+                src_reg: ctx.conflict_rowid_reg,
+                dst_reg: del + idx_ctx.num_cols,
+                extra_amount: 0,
+            });
+            program.emit_insn(Insn::IdxDelete {
+                start_reg: del,
+                num_regs: idx_ctx.num_cols + 1,
+                cursor_id: idx_ctx.idx_cursor_id,
+                raise_error_if_no_matching_entry: false,
+            });
+
+            if let Some(label) = maybe_skip_del {
+                program.preassign_label_to_next_insn(label);
+            }
+        }
+
+        // Phase 3: insert NEW keys.
+        for idx_ctx in &idx_phase_ctxs {
+            let maybe_skip_ins = idx_ctx.new_satisfies_where.map(|r| {
+                let lbl = program.allocate_label();
+                program.emit_insn(Insn::IfNot {
+                    reg: r,
+                    target_pc: lbl,
+                    jump_if_null: true,
+                });
+                lbl
+            });
+
+            program.emit_insn(Insn::IdxInsert {
+                cursor_id: idx_ctx.idx_cursor_id,
+                record_reg: idx_ctx.record_reg,
+                unpacked_start: Some(idx_ctx.idx_start_reg),
+                unpacked_count: Some((idx_ctx.num_cols + 1) as u16),
                 flags: IdxInsertFlags::new().nchange(true),
             });
 
-            if let Some(lbl) = maybe_skip_ins {
-                program.preassign_label_to_next_insn(lbl);
+            if let Some(label) = maybe_skip_ins {
+                program.preassign_label_to_next_insn(label);
             }
         }
     }
@@ -1162,7 +1204,7 @@ pub fn emit_upsert(
         program.emit_insn(Insn::Halt {
             err_code: SQLITE_CONSTRAINT_PRIMARYKEY,
             description: format!(
-                "{}.{}",
+                "UNIQUE constraint failed: {}.{} (19)",
                 table.get_name(),
                 table
                     .columns()
@@ -1171,7 +1213,7 @@ pub fn emit_upsert(
                     .and_then(|c| c.name.as_deref())
                     .unwrap_or("rowid")
             ),
-            on_error: None,
+            on_error: Some(ast::ResolveType::Abort),
             description_reg: None,
         });
         program.preassign_label_to_next_insn(ok);

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -1883,6 +1883,190 @@ fn test_commit_phase_non_replace_index_integrity(tmp_db: TempDatabase) -> anyhow
     Ok(())
 }
 
+/// UPSERT DO UPDATE always uses ABORT semantics for errors raised by the
+/// update arm. A statement-level OR FAIL must not preserve partial index
+/// maintenance from the failed DO UPDATE.
+#[turso_macros::test]
+fn test_upsert_do_update_failure_rolls_back_index_maintenance(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    let label = "upsert_do_update_failure_rolls_back_index_maintenance";
+    let limbo_db = TempDatabase::builder()
+        .with_db_name(format!("{label}.db"))
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    let setup = "\
+        CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, b INT, c INT UNIQUE);\
+        CREATE INDEX idx_b ON t(b);\
+        INSERT INTO t VALUES(1,1,10,10);\
+        INSERT INTO t VALUES(2,2,20,20);\
+        BEGIN;\
+    ";
+    limbo_conn.execute(setup).unwrap();
+    sqlite_conn.execute_batch(setup).unwrap();
+
+    let failing_upsert = "\
+        INSERT OR FAIL INTO t VALUES(3,1,30,30)\
+        ON CONFLICT(u) DO UPDATE SET b=99,c=20;\
+    ";
+    assert!(limbo_try_exec(&limbo_conn, failing_upsert).is_err());
+    assert!(sqlite_try_exec(&sqlite_conn, failing_upsert).is_err());
+
+    if let Some(e) = compare_tables(
+        label,
+        &sqlite_conn,
+        &limbo_conn,
+        "SELECT id,u,b,c FROM t ORDER BY id",
+    ) {
+        panic!("{e}");
+    }
+
+    let limbo_idx_rows = limbo_exec_rows(
+        &limbo_conn,
+        "SELECT id,u,b,c FROM t INDEXED BY idx_b ORDER BY b",
+    );
+    let sqlite_idx_rows = sqlite_exec_rows(
+        &sqlite_conn,
+        "SELECT id,u,b,c FROM t INDEXED BY idx_b ORDER BY b",
+    );
+    assert_eq!(
+        limbo_idx_rows, sqlite_idx_rows,
+        "[{label}] idx_b scan diverged after failed UPSERT DO UPDATE"
+    );
+
+    limbo_conn.execute("COMMIT").unwrap();
+    sqlite_conn.execute_batch("COMMIT").unwrap();
+
+    let db_path = limbo_db.path.clone();
+    drop(limbo_conn);
+    drop(limbo_db);
+    let ic = sqlite_integrity_check(&db_path);
+    assert_eq!(ic, "ok", "[{label}] integrity_check: {ic}");
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_upsert_do_update_expression_index_error_keeps_indexes_intact(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    let label = "upsert_do_update_expression_index_error_keeps_indexes_intact";
+    let limbo_db = TempDatabase::builder()
+        .with_db_name(format!("{label}.db"))
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    let setup = "\
+        CREATE TABLE t(id INTEGER PRIMARY KEY, b INT);\
+        CREATE INDEX idx ON t(\
+            CASE \
+                WHEN b=2 THEN 'x' LIKE 'x' ESCAPE 'yy' \
+                ELSE b \
+            END\
+        );\
+        INSERT INTO t VALUES(1,1);\
+        BEGIN;\
+    ";
+    limbo_conn.execute(setup).unwrap();
+    sqlite_conn.execute_batch(setup).unwrap();
+
+    let failing_upsert = "\
+        INSERT OR FAIL INTO t(id,b) VALUES(1,2)\
+        ON CONFLICT(id) DO UPDATE SET b=excluded.b;\
+    ";
+    assert!(limbo_try_exec(&limbo_conn, failing_upsert).is_err());
+    assert!(sqlite_try_exec(&sqlite_conn, failing_upsert).is_err());
+
+    if let Some(e) = compare_tables(label, &sqlite_conn, &limbo_conn, "SELECT id,b FROM t") {
+        panic!("{e}");
+    }
+
+    let limbo_idx_rows = limbo_exec_rows(&limbo_conn, "SELECT id,b FROM t INDEXED BY idx");
+    let sqlite_idx_rows = sqlite_exec_rows(&sqlite_conn, "SELECT id,b FROM t INDEXED BY idx");
+    assert_eq!(
+        limbo_idx_rows, sqlite_idx_rows,
+        "[{label}] expression index scan diverged after failed UPSERT DO UPDATE"
+    );
+
+    limbo_conn.execute("COMMIT").unwrap();
+    sqlite_conn.execute_batch("COMMIT").unwrap();
+
+    let db_path = limbo_db.path.clone();
+    drop(limbo_conn);
+    drop(limbo_db);
+    let ic = sqlite_integrity_check(&db_path);
+    assert_eq!(ic, "ok", "[{label}] integrity_check: {ic}");
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_upsert_do_update_skips_unique_check_when_new_partial_predicate_false(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    let label = "upsert_do_update_skips_unique_check_when_new_partial_predicate_false";
+    let limbo_db = TempDatabase::builder()
+        .with_db_name(format!("{label}.db"))
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+    let setup = "\
+        CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, k TEXT, c0 INT, c1 INT);\
+        CREATE UNIQUE INDEX idx_k_active ON t(k) WHERE c0 <= 11;\
+        INSERT INTO t(id,k,c0,c1) VALUES(1,'kk',4,0);\
+        INSERT INTO t(id,k,c0,c1) VALUES(2,'dd',4,0);\
+    ";
+    limbo_conn.execute(setup).unwrap();
+    sqlite_conn.execute_batch(setup).unwrap();
+
+    let upsert = "\
+        INSERT INTO t(k,c0,c1) VALUES('kk',4,0)\
+        ON CONFLICT DO UPDATE SET c0 = 14, k = 'dd', c1 = 6;\
+    ";
+    limbo_conn.execute(upsert).unwrap();
+    sqlite_conn.execute_batch(upsert).unwrap();
+
+    if let Some(e) = compare_tables(
+        label,
+        &sqlite_conn,
+        &limbo_conn,
+        "SELECT id,k,c0,c1 FROM t ORDER BY id",
+    ) {
+        panic!("{e}");
+    }
+
+    let limbo_idx_rows = limbo_exec_rows(
+        &limbo_conn,
+        "SELECT id,k,c0,c1 FROM t INDEXED BY idx_k_active WHERE c0 <= 11 ORDER BY id",
+    );
+    let sqlite_idx_rows = sqlite_exec_rows(
+        &sqlite_conn,
+        "SELECT id,k,c0,c1 FROM t INDEXED BY idx_k_active WHERE c0 <= 11 ORDER BY id",
+    );
+    assert_eq!(
+        limbo_idx_rows, sqlite_idx_rows,
+        "[{label}] partial index scan diverged after UPSERT DO UPDATE"
+    );
+
+    let db_path = limbo_db.path.clone();
+    drop(limbo_conn);
+    drop(limbo_db);
+    let ic = sqlite_integrity_check(&db_path);
+    assert_eq!(ic, "ok", "[{label}] integrity_check: {ic}");
+
+    Ok(())
+}
+
 /// Test that partial indexes with REPLACE don't corrupt when another index has ABORT.
 /// This specifically tests the three-phase separation: Phase 1 checks the partial index
 /// constraint BEFORE Phase 2/3 mutate any index entries.

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -97,6 +97,18 @@ fn insert_or_ignore_multi_row_unique(tmp_db: TempDatabase) -> anyhow::Result<()>
     Ok(())
 }
 
+/// UPSERT DO UPDATE can run an UPDATE arm after the INSERT conflict and then
+/// fail, so it keeps statement rollback enabled.
+#[turso_macros::test(init_sql = "CREATE TABLE t (a UNIQUE, b);")]
+fn insert_upsert_do_update_needs_stmt_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "INSERT INTO t VALUES (1, 2) ON CONFLICT(a) DO UPDATE SET b = excluded.b"
+    ));
+    Ok(())
+}
+
 /// INSERT OR REPLACE is multi-write (REPLACE may delete conflicting rows).
 /// But may_abort=false (conflict resolution is not OE_Abort).
 /// needs_stmt = true && false = false.


### PR DESCRIPTION
Fixes #6858.

This fixes the UPSERT DO UPDATE path when the update arm fails after index maintenance has started.

The old code could delete the old secondary index entry before all new index values and uniqueness checks had been proven safe. With `INSERT OR FAIL ... ON CONFLICT DO UPDATE`, a later DO UPDATE error could leave the row data unchanged but the index missing the row.

This changes the UPSERT DO UPDATE index rebuild to:

1. evaluate partial-index predicates, build new index keys, and run unique checks first
2. delete old index entries only after those fallible checks pass
3. insert the new index entries after that

It also treats UPSERT as a statement-abort risk for statement journal analysis, because the DO UPDATE arm can fail even when the top-level INSERT uses a different conflict mode.

Tests added for both repro shapes from the issue:

- secondary unique conflict after an index entry was removed
- expression-index error while building the replacement key

Validation:

- `cargo fmt --check`
- `cargo test -p core_tester --test integration_tests test_upsert_do_update -- --nocapture`
- `cargo test -p core_tester --test integration_tests conflict_resolution:: -- --nocapture`