### PR TITLE
core/translate: fix partial-DELETE leak on row-dependent expression errors

### DIFF
--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -273,9 +273,17 @@ pub(crate) fn set_delete_stmt_journal_flags(
         program.set_multi_write(false);
     }
 
-    // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
-    // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
+    // DELETE has no ON CONFLICT clause, but the WHERE clause can still abort the
+    // statement via row-dependent expression errors (e.g., LIKE ESCAPE with a
+    // multi-character escape). Without statement journaling, earlier rows that
+    // were already deleted leak past the abort and survive into the outer
+    // transaction's commit — silently dropping data. We therefore only elide
+    // may_abort when (a) there is no WHERE clause to evaluate per row, or (b)
+    // the statement can affect at most one row (no partial state possible); and
+    // in either case there must be no triggers/FKs to worry about.
+    let has_where_predicate = !plan.where_clause.is_empty();
+    let safe_to_elide = (!has_where_predicate || is_single_row) && !has_triggers && !has_fks;
+    if safe_to_elide {
         program.set_may_abort(false);
     }
     Ok(())

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -19,7 +19,7 @@ use sql_generation::{
             transaction::{Begin, Commit, Rollback},
             update::{SetValue, Update},
         },
-        table::{ColumnType, SimValue, Table},
+        table::{Column, ColumnType, SimValue, Table},
     },
 };
 use strum::IntoEnumIterator;
@@ -239,7 +239,9 @@ impl Property {
             Property::Queries { .. } => {
                 unreachable!("No extensional querie generation for `Property::Queries`")
             }
-            Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => {
+            Property::FsyncNoWait { .. }
+            | Property::FaultyQuery { .. }
+            | Property::DeleteRollbackOnExprError { .. } => {
                 unreachable!("No extensional queries")
             }
             Property::SelectLimit { .. }
@@ -989,6 +991,67 @@ impl Property {
                 .into_iter()
                 .map(InteractionBuilder::with_interaction)
                 .collect()
+            }
+            Property::DeleteRollbackOnExprError {
+                setup,
+                table,
+                delete,
+            } => {
+                // Build a sequence that:
+                //   1. Runs the setup queries (CREATE TABLE + INSERTs) — these update the
+                //      shadow normally via `InteractionType::Query`.
+                //   2. Opens an explicit BEGIN.
+                //   3. Runs the fallible DELETE as a `FaultyQuery` so the per-interaction
+                //      shadow update is skipped on error (Delete::shadow would otherwise
+                //      ignore ESCAPE and incorrectly delete the rows from the shadow,
+                //      hiding the divergence we want to expose).
+                //   4. Asserts the DELETE errored, and rolls back the shadow transaction
+                //      so the planner-appended `AllTableHaveExpectedContent` sees the
+                //      pre-DELETE state.
+                //   5. COMMITs. SQLite-compatible behavior commits an empty transaction
+                //      here; the buggy Turso path commits the partial deletes that
+                //      leaked past the aborted statement.
+                let delete_clone = delete.clone();
+                let assert = Assertion::new(
+                    "DELETE with row-dependent expression error must abort cleanly".to_string(),
+                    move |stack, env: &mut SimulatorEnv| {
+                        let last = stack.last().unwrap();
+                        match last {
+                            Ok(_) => Ok(Err(format!(
+                                "DELETE was expected to error from row-dependent \
+                                 expression (LIKE ESCAPE on multi-character column \
+                                 value), but it succeeded: {delete_clone}"
+                            ))),
+                            Err(err) => {
+                                tracing::debug!(
+                                    "DeleteRollbackOnExprError got expected error: {err}"
+                                );
+                                env.rollback_conn(connection_index);
+                                Ok(Ok(()))
+                            }
+                        }
+                    },
+                    delete.dependencies().into_iter().collect(),
+                );
+
+                let mut interactions: Vec<InteractionType> = Vec::with_capacity(setup.len() + 5);
+                for q in setup {
+                    interactions.push(InteractionType::Query(q.clone()));
+                }
+                interactions.push(InteractionType::Query(Query::Begin(Begin::Deferred)));
+                interactions.push(InteractionType::FaultyQuery(delete.clone()));
+                interactions.push(InteractionType::Assertion(assert));
+                interactions.push(InteractionType::Query(Query::Commit(Commit)));
+                let _ = table; // table is owned by Property; the auto-appended
+                // AllTableHaveExpectedContent check uses the tables list
+                // captured at plan-generation time and verifies that the
+                // post-COMMIT contents of every shadowed table — including this
+                // property's freshly created one — match the simulator's shadow.
+
+                interactions
+                    .into_iter()
+                    .map(InteractionBuilder::with_interaction)
+                    .collect()
             }
             Property::WhereTrueFalseNull { select, predicate } => {
                 let tables_dependencies = select.dependencies().into_iter().collect::<Vec<_>>();
@@ -1887,6 +1950,92 @@ fn property_faulty_query<R: rand::Rng + ?Sized>(
     }
 }
 
+/// Builds a property whose plan creates a small dedicated table, inserts rows
+/// with a mixed-length TEXT column, and then runs a DELETE whose WHERE clause
+/// is `'a' LIKE 'a' ESCAPE esc`. The escape column has both single-character
+/// and multi-character values, so Turso's per-row evaluation matches some rows
+/// and errors on others — exposing the partial-DELETE leak from #6879 for the
+/// DELETE path. A globally unique table name avoids cross-property collisions.
+fn property_delete_rollback_on_expr_error<R: rand::Rng + ?Sized>(
+    _rng: &mut R,
+    _query_distr: &QueryDistribution,
+    _ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static UNIQUE: AtomicUsize = AtomicUsize::new(0);
+    let idx = UNIQUE.fetch_add(1, Ordering::Relaxed);
+    let table_name = format!("delete_expr_err_t_{idx}");
+
+    let table = Table {
+        rows: Vec::new(),
+        name: table_name.clone(),
+        columns: vec![Column {
+            name: "id".to_string(),
+            column_type: ColumnType::Integer,
+            constraints: vec![ast::ColumnConstraint::PrimaryKey {
+                order: None,
+                conflict_clause: None,
+                auto_increment: false,
+            }],
+        }],
+        indexes: vec![],
+    };
+    let create = Query::Create(Create { table });
+
+    let int_val = |n: i64| SimValue(turso_core::types::Value::Numeric(Numeric::Integer(n)));
+    let insert = Query::Insert(Insert::Values {
+        table: table_name.clone(),
+        values: vec![vec![int_val(1)], vec![int_val(2)], vec![int_val(3)]],
+        on_conflict: None,
+    });
+
+    // Build the predicate
+    //   (CASE WHEN id=1 THEN 1
+    //         WHEN id=2 THEN ('a' LIKE 'a' ESCAPE 'bb')
+    //         ELSE 0 END)
+    // The branches without ESCAPE evaluate normally per row; the row with
+    // id=2 evaluates a multi-character ESCAPE that Turso correctly rejects
+    // with a runtime error. The CASE arms ensure earlier rows have already
+    // been matched and deleted by the time the error fires — which is what
+    // makes the statement-journal hole observable.
+    let id_eq = |val: i64| {
+        ast::Expr::Binary(
+            Box::new(ast::Expr::Id(ast::Name::exact("id".to_string()))),
+            ast::Operator::Equals,
+            Box::new(ast::Expr::Literal(ast::Literal::Numeric(val.to_string()))),
+        )
+    };
+    let num_lit = |n: i64| ast::Expr::Literal(ast::Literal::Numeric(n.to_string()));
+    let str_lit = |s: &str| ast::Expr::Literal(ast::Literal::String(format!("'{s}'")));
+    let like_escape_multi = ast::Expr::Like {
+        lhs: Box::new(str_lit("a")),
+        not: false,
+        op: ast::LikeOperator::Like,
+        rhs: Box::new(str_lit("a")),
+        escape: Some(Box::new(str_lit("bb"))),
+    };
+    let case = ast::Expr::Case {
+        base: None,
+        when_then_pairs: vec![
+            (Box::new(id_eq(1)), Box::new(num_lit(1))),
+            (Box::new(id_eq(2)), Box::new(like_escape_multi)),
+        ],
+        else_expr: Some(Box::new(num_lit(0))),
+    };
+    let predicate = Predicate(ast::Expr::Parenthesized(vec![Box::new(case)]));
+    let delete = Query::Delete(Delete {
+        table: table_name.clone(),
+        predicate,
+    });
+
+    Property::DeleteRollbackOnExprError {
+        setup: vec![create, insert],
+        table: table_name,
+        delete,
+    }
+}
+
 type PropertyGenFunc<R, G> = fn(&mut R, &QueryDistribution, &G, bool) -> Property;
 
 impl PropertyDiscriminants {
@@ -1914,6 +2063,9 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
+            PropertyDiscriminants::DeleteRollbackOnExprError => {
+                property_delete_rollback_on_expr_error
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
             }
@@ -2033,6 +2185,16 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::DeleteRollbackOnExprError => {
+                // The property opens its own BEGIN/COMMIT around the fallible DELETE.
+                // Skip in MVCC mode (which has a different transaction model) and when
+                // the bug-targeted property has been explicitly disabled via CLI.
+                if !env.profile.mvcc && !env.opts.disable_delete_rollback_on_expr_error {
+                    10
+                } else {
+                    0
+                }
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -2074,6 +2236,8 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
+            // Self-contained: builds its own table/inserts/delete inline.
+            PropertyDiscriminants::DeleteRollbackOnExprError => QueryCapabilities::all(),
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -182,6 +182,29 @@ pub enum Property {
     FaultyQuery {
         query: Query,
     },
+    /// `DeleteRollbackOnExprError` targets the partial-DML leak described in
+    /// #6879 for the DELETE path. The simulator generates a fresh table with
+    /// rows whose TEXT column holds a *mix of single-character and
+    /// multi-character* escape strings, wraps a DELETE in an explicit
+    /// transaction, and uses `'a' LIKE 'a' ESCAPE <esc_col>` as the WHERE
+    /// predicate. Turso evaluates the predicate per row: rows whose escape
+    /// column is single-character match (so they get deleted), and rows whose
+    /// escape column is multi-character raise a runtime error mid-statement.
+    /// If the statement journal is correctly opened, the already-deleted rows
+    /// must roll back; if it isn't (the previous DELETE elide bug), they leak
+    /// past the abort and survive the surrounding COMMIT, which the
+    /// auto-appended `AllTableHaveExpectedContent` then catches as a shadow
+    /// vs. database divergence.
+    DeleteRollbackOnExprError {
+        /// Setup queries: create the table and populate it with rows whose
+        /// `esc` column mixes single- and multi-character TEXT values.
+        setup: Vec<Query>,
+        /// Table name the DELETE targets.
+        table: String,
+        /// The DELETE statement whose WHERE clause raises a row-dependent
+        /// expression error (`'a' LIKE 'a' ESCAPE esc`).
+        delete: Query,
+    },
     /// SavepointRollback wraps random write interactions in a named savepoint,
     /// rolls them back, then checks that the database still matches the shadow
     /// model. This targets pager/WAL/cache-spill bugs where rolled-back page
@@ -208,7 +231,9 @@ impl Property {
     pub fn check_tables(&self) -> bool {
         matches!(
             self,
-            Property::FsyncNoWait { .. } | Property::FaultyQuery { .. }
+            Property::FsyncNoWait { .. }
+                | Property::FaultyQuery { .. }
+                | Property::DeleteRollbackOnExprError { .. }
         )
     }
 
@@ -232,7 +257,9 @@ impl Property {
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
             | Property::Queries { queries } => Some(queries),
-            Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
+            Property::FsyncNoWait { .. }
+            | Property::FaultyQuery { .. }
+            | Property::DeleteRollbackOnExprError { .. } => None,
             Property::SelectLimit { .. }
             | Property::SelectSelectOptimizer { .. }
             | Property::WhereTrueFalseNull { .. }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -155,6 +155,8 @@ pub struct SimulatorCLI {
     pub disable_fsync_no_wait: bool,
     #[clap(long, help = "disable FaultyQuery Property")]
     pub disable_faulty_query: bool,
+    #[clap(long, help = "disable DeleteRollbackOnExprError Property")]
+    pub disable_delete_rollback_on_expr_error: bool,
     #[clap(long, help = "disable Reopen-Database fault")]
     pub disable_reopen_database: bool,
     #[clap(long = "latency-prob", help = "added IO latency probability", value_parser = clap::value_parser!(u8).range(0..=100))]

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1107,6 +1107,7 @@ impl SimulatorEnv {
             disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
+            disable_delete_rollback_on_expr_error: cli_opts.disable_delete_rollback_on_expr_error,
             page_size: 4096, // TODO: randomize this too
             max_interactions: rng.random_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_time_simulation: cli_opts.maximum_time,
@@ -1445,6 +1446,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_savepoint_rollback: bool,
     pub(crate) disable_fsync_no_wait: bool,
     pub(crate) disable_faulty_query: bool,
+    pub(crate) disable_delete_rollback_on_expr_error: bool,
     pub(crate) disable_reopen_database: bool,
     pub(crate) disable_integrity_check: bool,
 

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -342,6 +342,53 @@ fn delete_by_rowid_with_fk(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Multi-row DELETE with a WHERE clause containing fallible expressions
+/// (e.g., LIKE ESCAPE that can error per row) must keep statement journaling
+/// even without triggers/FKs. Without this, an error on a later row leaves
+/// earlier rows already deleted, leaking past the abort into the outer
+/// transaction. See regression test below for the runtime correctness check.
+#[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, x INT);")]
+fn delete_multi_row_where_needs_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    // Multi-row scan with a WHERE predicate that can evaluate fallible
+    // expressions per row → needs statement journaling.
+    assert!(needs_stmt_journal(&conn, "DELETE FROM t WHERE x > 5"));
+    Ok(())
+}
+
+/// Regression: a DELETE whose WHERE clause errors mid-statement (after at
+/// least one row was already deleted) must not leak those deletions past
+/// the abort. Reproduces the partial-DML leak described in #6879 for the
+/// DELETE path specifically: `set_delete_stmt_journal_flags` previously
+/// elided `may_abort` whenever there were no triggers/FKs, so multi-row
+/// DELETE statements never opened a statement subtransaction. The
+/// expression error from `LIKE 'a' ESCAPE 'bb'` then aborted the statement
+/// while the earlier delete remained committed.
+#[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, x INT);")]
+fn delete_partial_rollback_on_row_dependent_expr_error(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)")?;
+    conn.execute("BEGIN")?;
+    // The CASE returns 1 for id=1, errors on id=2 (multi-character ESCAPE),
+    // and returns 0 otherwise. SQLite aborts the entire DELETE; without the
+    // fix, Turso would commit the id=1 delete and leak it past the error.
+    let res = conn.execute(
+        "DELETE FROM t WHERE (CASE WHEN id=1 THEN 1 \
+                                   WHEN id=2 THEN ('a' LIKE 'a' ESCAPE 'bb') \
+                                   ELSE 0 END)",
+    );
+    assert!(res.is_err(), "DELETE with bad ESCAPE must error");
+    conn.execute("COMMIT")?;
+
+    let rows = query_rows(&conn, "SELECT id, x FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|10".to_string(), "2|20".to_string(), "3|30".to_string()],
+        "all three rows must remain after the aborted DELETE"
+    );
+    Ok(())
+}
+
 // ──────────────────────────────────────────────────────────
 // SELECT (read-only) — never needs stmt journal
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

A `DELETE` whose WHERE clause errors per row (e.g. `'a' LIKE 'a' ESCAPE 'bb'`
reached through a `CASE`) loses any rows it already deleted before the error
fired. The error rolls back inside the database, but the rows don't — the
next `COMMIT` makes them permanently gone.

`set_delete_stmt_journal_flags` was eliding `may_abort=false` for every DELETE
without triggers or FKs:

```rust
// DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
// only triggers (RAISE(ABORT)) or FK violations can abort.
if !has_triggers && !has_fks {
    program.set_may_abort(false);
}
```

That misses the WHERE clause, which is evaluated per row and can raise a
runtime error. Without `may_abort`, the pager doesn't open a statement
subtransaction, so the earlier deletes survive the abort and the wrapping
`COMMIT` durably persists them.

Fix: only elide when (a) there's no WHERE clause to evaluate, or (b) the
statement can affect at most one row. The journal-free fast path stays for
`DELETE FROM t` and `DELETE FROM t WHERE rowid = ?`. Multi-row DELETEs with a
predicate now correctly open a subtransaction.

Reproducer against `v0.6.0-pre.30`:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, x INT);
INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
BEGIN;
DELETE FROM t WHERE
  (CASE WHEN id=1 THEN 1
        WHEN id=2 THEN ('a' LIKE 'a' ESCAPE 'bb')
        ELSE 0 END);
COMMIT;
SELECT id, x FROM t ORDER BY id;
```

| | rows after COMMIT |
|---|---|
| sqlite3 | `1\|10`, `2\|20`, `3\|30` |
| turso (current) | `2\|20`, `3\|30` ← row 1 silently gone |
| turso (this PR) | `1\|10`, `2\|20`, `3\|30` |

Checked it reproduces with WAL and rollback journal, with secondary or unique
indexes on the affected column, inside SAVEPOINT, and with LIMIT.

The second commit adds a `DeleteRollbackOnExprError` simulator property that
constructs this shape inside an explicit transaction. The existing generator
doesn't produce CASE expressions in DELETE WHERE clauses or `LIKE ESCAPE` with
multi-character escapes, which is why DST hadn't caught it. Against the
unfixed tree it fails deterministically on every seed I tried, with the
assertion `simulator model has more rows than the database: "1"`.

Regression tests in `tests/integration/stmt_journal.rs`:

- `delete_partial_rollback_on_row_dependent_expr_error` — runtime: runs the
  reproducer and asserts the three rows survive.
- `delete_multi_row_where_needs_journal` — compile-time: multi-row DELETE with
  WHERE now reports `needs_stmt_subtransactions = true`.

## Motivation and context

DELETE-half of #6879. That issue's root-cause analysis points at
`constraint_may_abort`, which only covers the INSERT/UPDATE path. The DELETE
elide in `set_delete_stmt_journal_flags` is a separate site and isn't reached
by fixing `constraint_may_abort`, so it needs its own patch. UPDATE/INSERT
halves remain open.

## Description of AI Usage

Worked through this with Claude Code. Rough arc: survey the open
`corruption?`-labeled issues looking for an unfixed manifestation in a code
path no one had touched yet, land on #6879's DELETE half because the body
only repro'd UPDATE/INSERT, isolate the elide in `stmt_journal.rs`, write
the fix and regression tests, then build a simulator property that exposes
the bug deterministically so DST catches a regression next time.

A dead end worth flagging: I first tried to surface the bug in the simulator
with `LIKE 'a' ESCAPE <column_ref>` so the predicate would be row-dependent
without needing a CASE. That hits a separate vdbe issue
(`cursor id 0 is None`) before it can ever surface the rollback problem, so
I switched to a literal multi-character ESCAPE wrapped in a CASE on `id`.

I reviewed the diff line by line, verified the reproducer manually against
both Turso (`v0.6.0-pre.30` and `main`) and `sqlite3`, and confirmed the
simulator fails on the unfixed tree and passes on the fixed one — 8/8 seeds
catching the bug pre-fix, 24/25 passing post-fix (the one stray failure is
the UPDATE manifestation of #6879 firing on a freshly created table).