### PR TITLE
core: roll back DML runtime expression errors

### DIFF
--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -26,7 +26,7 @@ use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
 use crate::{sync::Arc, Connection, Result};
-use turso_parser::ast::{ResolveType, TriggerEvent};
+use turso_parser::ast::{Expr, ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.
 pub(crate) fn any_index_or_ipk_has_replace(
@@ -113,6 +113,111 @@ pub(crate) fn constraint_may_abort(
     // Default ABORT applies to NOT NULL and CHECK (they aren't per-index).
     let default_aborts = has_notnull || has_check;
     pk_aborts || idx_aborts || default_aborts
+}
+
+fn expr_may_abort_at_runtime(expr: &Expr) -> bool {
+    match expr {
+        Expr::FunctionCall { .. }
+        | Expr::FunctionCallStar { .. }
+        | Expr::Raise(_, _)
+        | Expr::Exists(_)
+        | Expr::Subquery(_)
+        | Expr::SubqueryResult { .. }
+        | Expr::InSelect { .. }
+        | Expr::InTable { .. } => true,
+        Expr::Like {
+            lhs, rhs, escape, ..
+        } => escape.is_some() || expr_may_abort_at_runtime(lhs) || expr_may_abort_at_runtime(rhs),
+        Expr::Between {
+            lhs, start, end, ..
+        } => {
+            expr_may_abort_at_runtime(lhs)
+                || expr_may_abort_at_runtime(start)
+                || expr_may_abort_at_runtime(end)
+        }
+        Expr::Binary(lhs, _, rhs) => {
+            expr_may_abort_at_runtime(lhs) || expr_may_abort_at_runtime(rhs)
+        }
+        Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            base.as_deref().is_some_and(expr_may_abort_at_runtime)
+                || when_then_pairs.iter().any(|(when_expr, then_expr)| {
+                    expr_may_abort_at_runtime(when_expr) || expr_may_abort_at_runtime(then_expr)
+                })
+                || else_expr.as_deref().is_some_and(expr_may_abort_at_runtime)
+        }
+        Expr::Cast { expr, .. }
+        | Expr::Collate(expr, _)
+        | Expr::IsNull(expr)
+        | Expr::NotNull(expr)
+        | Expr::Unary(_, expr)
+        | Expr::FieldAccess { base: expr, .. } => expr_may_abort_at_runtime(expr),
+        Expr::InList { lhs, rhs, .. } => {
+            expr_may_abort_at_runtime(lhs) || rhs.iter().any(|expr| expr_may_abort_at_runtime(expr))
+        }
+        Expr::Parenthesized(exprs) => exprs.iter().any(|expr| expr_may_abort_at_runtime(expr)),
+        Expr::Array { .. } | Expr::Subscript { .. } => true,
+        Expr::Id(_)
+        | Expr::Column { .. }
+        | Expr::RowId { .. }
+        | Expr::Literal(_)
+        | Expr::DoublyQualified(..)
+        | Expr::Name(_)
+        | Expr::Qualified(..)
+        | Expr::Variable(_)
+        | Expr::Register(_)
+        | Expr::Default => false,
+    }
+}
+
+fn update_expr_may_abort(plan: &UpdatePlan) -> bool {
+    plan.set_clauses
+        .iter()
+        .any(|set_clause| expr_may_abort_at_runtime(set_clause.emitted_expr()))
+        || plan
+            .where_clause
+            .iter()
+            .any(|term| expr_may_abort_at_runtime(&term.expr))
+        || plan.returning.as_ref().is_some_and(|columns| {
+            columns
+                .iter()
+                .any(|column| expr_may_abort_at_runtime(&column.expr))
+        })
+        || plan.indexes_to_update.iter().any(|index| {
+            index
+                .where_clause
+                .as_deref()
+                .is_some_and(expr_may_abort_at_runtime)
+                || index
+                    .columns
+                    .iter()
+                    .filter_map(|column| column.expr.as_deref())
+                    .any(expr_may_abort_at_runtime)
+        })
+}
+
+fn delete_expr_may_abort(plan: &DeletePlan) -> bool {
+    plan.where_clause
+        .iter()
+        .any(|term| expr_may_abort_at_runtime(&term.expr))
+        || plan
+            .result_columns
+            .iter()
+            .any(|column| expr_may_abort_at_runtime(&column.expr))
+        || plan.indexes.iter().any(|index| {
+            index
+                .where_clause
+                .as_deref()
+                .is_some_and(expr_may_abort_at_runtime)
+                || index
+                    .columns
+                    .iter()
+                    .filter_map(|column| column.expr.as_deref())
+                    .any(expr_may_abort_at_runtime)
+        })
 }
 
 /// Set multi_write / may_abort for INSERT statements.
@@ -233,6 +338,7 @@ pub(crate) fn set_update_stmt_journal_flags(
 
     let may_abort = has_triggers
         || has_fks
+        || update_expr_may_abort(plan)
         || constraint_may_abort(
             has_statement_conflict,
             or_conflict,
@@ -274,9 +380,8 @@ pub(crate) fn set_delete_stmt_journal_flags(
     }
 
     // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
-    // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
-        program.set_may_abort(false);
-    }
+    // Triggers, FKs, and row-dependent runtime expressions can still abort
+    // after earlier rows in the statement have been deleted.
+    program.set_may_abort(has_triggers || has_fks || delete_expr_may_abort(plan));
     Ok(())
 }

--- a/testing/simulator/runner/memory/mod.rs
+++ b/testing/simulator/runner/memory/mod.rs
@@ -5,3 +5,5 @@ pub mod io;
 mod mvcc_recovery;
 #[cfg(test)]
 mod statement_abandon;
+#[cfg(test)]
+mod statement_rollback;

--- a/testing/simulator/runner/memory/statement_rollback.rs
+++ b/testing/simulator/runner/memory/statement_rollback.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
+
+use crate::runner::memory::io::MemorySimIO;
+
+fn make_conn(seed: u64) -> Result<(Arc<Connection>, Arc<MemorySimIO>)> {
+    let io = Arc::new(MemorySimIO::new(
+        seed, 4096, 100, // Always schedule operations asynchronously.
+        1, 5,
+    ));
+    let db = Database::open_file_with_flags(
+        io.clone() as Arc<dyn IO>,
+        &format!("sim_stmt_rollback_{seed}.db"),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    Ok((db.connect()?, io))
+}
+
+fn query_rows(conn: &Arc<Connection>, io: &MemorySimIO, sql: &str) -> Result<Vec<Vec<i64>>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist");
+                rows.push(
+                    (0..row.get_values().count())
+                        .map(|idx| row.get(idx).unwrap())
+                        .collect(),
+                );
+            }
+            StepResult::Done => return Ok(rows),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn sim_update_runtime_expression_error_rolls_back_prior_rows() -> Result<()> {
+    let (conn, io) = make_conn(501)?;
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10),(2,20)")?;
+
+    conn.execute("BEGIN")?;
+    let update = conn.execute(
+        "UPDATE t SET x = CASE WHEN id=1 THEN 11 ELSE (char(120) LIKE char(120) ESCAPE (char(121)||char(121))) END",
+    );
+    assert!(update.is_err(), "UPDATE should fail on invalid ESCAPE");
+    assert_eq!(
+        query_rows(&conn, io.as_ref(), "SELECT id,x FROM t ORDER BY id")?,
+        vec![vec![1, 10], vec![2, 20]]
+    );
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
+#[test]
+fn sim_update_partial_index_expression_error_rolls_back_prior_rows() -> Result<()> {
+    let (conn, io) = make_conn(502)?;
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,1,1),(2,2,1),(3,3,1)")?;
+    conn.execute(
+        "CREATE INDEX idx ON t(a) WHERE CASE WHEN b=2 THEN 'x' LIKE 'x' ESCAPE 'yy' ELSE 1 END",
+    )?;
+
+    conn.execute("BEGIN")?;
+    let update = conn.execute("UPDATE t SET b=CASE WHEN id=2 THEN 2 ELSE b+10 END");
+    assert!(
+        update.is_err(),
+        "UPDATE should fail while maintaining the partial index"
+    );
+    assert_eq!(
+        query_rows(&conn, io.as_ref(), "SELECT id,a,b FROM t ORDER BY id")?,
+        vec![vec![1, 1, 1], vec![2, 2, 1], vec![3, 3, 1]]
+    );
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
+#[test]
+fn sim_delete_runtime_expression_error_rolls_back_prior_rows() -> Result<()> {
+    let (conn, io) = make_conn(503)?;
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10),(2,20)")?;
+
+    conn.execute("BEGIN")?;
+    let delete = conn.execute(
+        "DELETE FROM t WHERE CASE WHEN id=2 THEN (char(120) LIKE char(120) ESCAPE (char(121)||char(121))) ELSE 1 END",
+    );
+    assert!(delete.is_err(), "DELETE should fail on invalid ESCAPE");
+    assert_eq!(
+        query_rows(&conn, io.as_ref(), "SELECT id,x FROM t ORDER BY id")?,
+        vec![vec![1, 10], vec![2, 20]]
+    );
+    conn.execute("COMMIT")?;
+    Ok(())
+}

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -289,6 +289,76 @@ fn update_composite_unique_partial_cols(tmp_db: TempDatabase) -> anyhow::Result<
     Ok(())
 }
 
+#[turso_macros::test]
+fn update_runtime_expression_error_rolls_back_prior_rows(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10),(2,20)")?;
+
+    let update = "UPDATE t SET x = CASE WHEN id=1 THEN 11 ELSE (char(120) LIKE char(120) ESCAPE (char(121)||char(121))) END";
+    assert!(
+        needs_stmt_journal(&conn, update),
+        "row-dependent runtime expression failures need statement rollback"
+    );
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(update);
+    assert!(result.is_err(), "UPDATE should fail on invalid ESCAPE");
+
+    let rows = query_rows(&conn, "SELECT id,x FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|10", "2|20"],
+        "failed UPDATE must roll back rows written before the expression error"
+    );
+
+    conn.execute("COMMIT")?;
+    let rows = query_rows(&conn, "SELECT id,x FROM t ORDER BY id");
+    assert_eq!(rows, vec!["1|10", "2|20"]);
+    Ok(())
+}
+
+#[turso_macros::test]
+fn update_partial_index_expression_error_rolls_back_prior_rows(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,1,1),(2,2,1),(3,3,1)")?;
+    conn.execute(
+        "CREATE INDEX idx ON t(a) WHERE CASE WHEN b=2 THEN 'x' LIKE 'x' ESCAPE 'yy' ELSE 1 END",
+    )?;
+
+    let update = "UPDATE t SET b=CASE WHEN id=2 THEN 2 ELSE b+10 END";
+    assert!(
+        needs_stmt_journal(&conn, update),
+        "partial-index predicate errors need statement rollback"
+    );
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(update);
+    assert!(
+        result.is_err(),
+        "UPDATE should fail while maintaining the partial index"
+    );
+
+    let rows = query_rows(&conn, "SELECT id,a,b FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|1|1", "2|2|1", "3|3|1"],
+        "failed partial-index UPDATE must roll back earlier row writes"
+    );
+
+    let ic = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(ic, vec!["ok"], "integrity_check failed after UPDATE abort");
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 // ──────────────────────────────────────────────────────────
 // DELETE
 // ──────────────────────────────────────────────────────────
@@ -314,6 +384,36 @@ fn delete_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
 fn delete_by_unique_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
     assert!(!needs_stmt_journal(&conn, "DELETE FROM t WHERE b = 5"));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn delete_runtime_expression_error_rolls_back_prior_rows(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10),(2,20)")?;
+
+    let delete = "DELETE FROM t WHERE CASE WHEN id=2 THEN (char(120) LIKE char(120) ESCAPE (char(121)||char(121))) ELSE 1 END";
+    assert!(
+        needs_stmt_journal(&conn, delete),
+        "row-dependent runtime expression failures need statement rollback"
+    );
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(delete);
+    assert!(result.is_err(), "DELETE should fail on invalid ESCAPE");
+
+    let rows = query_rows(&conn, "SELECT id,x FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|10", "2|20"],
+        "failed DELETE must roll back rows deleted before the expression error"
+    );
+
+    conn.execute("COMMIT")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Description

Fixes #6879.

This updates statement-journal analysis so DML statements keep statement rollback protection when row-dependent runtime expressions can abort after earlier rows have already been modified.

Covered cases:

- `UPDATE` SET/WHERE/RETURNING expressions
- updated expression-index keys and partial-index predicates
- `DELETE` WHERE/RETURNING expressions
- deleted expression-index keys and partial-index predicates

I also added focused regression coverage in both the simulator memory tests and the statement-journal integration tests.

## Motivation and context

A runtime expression error, for example an invalid `LIKE ... ESCAPE`, can happen on a later row after an earlier row in the same statement was already updated or deleted. In an explicit transaction, that statement must roll back its own partial effects while leaving the transaction usable.

The new simulator-memory tests cover the issue-class against simulated async IO:

- `sim_update_runtime_expression_error_rolls_back_prior_rows`
- `sim_update_partial_index_expression_error_rolls_back_prior_rows`
- `sim_delete_runtime_expression_error_rolls_back_prior_rows`

## Description of AI Usage

This PR was implemented with OpenAI Codex assistance. Codex inspected the issue and relevant statement-journal code, implemented the patch, added regression tests, and ran the focused verification commands. I reviewed the resulting diff and test output.

Verification run locally:

```text
cargo fmt --check
cargo test -p limbo_sim statement_rollback -- --nocapture
cargo test -p core_tester --test integration_tests stmt_journal -- --nocapture
cargo clippy -p turso_core -p limbo_sim -p core_tester --tests -- -D warnings
```
