### PR TITLE
Sync engine update pull time

### DIFF
--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -290,6 +290,30 @@ test('implicit connect', async ({ server }) => {
     expect(await (await db.prepare("SELECT 1 as x")).all()).toEqual([{ x: 1 }]);
 })
 
+test('pull with no remote changes updates lastPullUnixTime', async ({ server }) => {
+    {
+        const db = await connect({ path: ':memory:', url: server.dbUrl() });
+        await db.exec("CREATE TABLE IF NOT EXISTS t(x)");
+        await db.exec("DELETE FROM t");
+        await db.exec("INSERT INTO t VALUES (1)");
+        await db.push();
+        await db.close();
+    }
+
+    // fresh client bootstraps from the remote - nothing new to pull afterwards
+    const db = await connect({ path: ':memory:', url: server.dbUrl() });
+    const before = (await db.stats()).lastPullUnixTime;
+
+    // unix time has 1s resolution - wait long enough for the timestamp to advance
+    await new Promise(resolve => setTimeout(resolve, 1500));
+
+    // remote has no new changes - pull returns false but must still bump lastPullUnixTime
+    expect(await db.pull()).toBe(false);
+
+    const after = (await db.stats()).lastPullUnixTime;
+    expect(after).toBeGreaterThan(before);
+})
+
 test('defered sync', async ({ server }) => {
     {
         const db = await connect({ path: ':memory:', url: server.dbUrl() });

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1137,6 +1137,34 @@ mod tests {
     }
 
     #[tokio::test]
+    pub async fn test_sync_pull_no_changes_updates_last_pull_unix_time() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let server = TursoServer::new().await.unwrap();
+        server.db_sql("CREATE TABLE t(x)").await.unwrap();
+        server.db_sql("INSERT INTO t VALUES (1)").await.unwrap();
+
+        let db = crate::sync::Builder::new_remote(":memory:")
+            .with_remote_url(server.db_url())
+            .build()
+            .await
+            .unwrap();
+
+        let before = db.stats().await.unwrap().last_pull_unix_time.unwrap();
+
+        // unix time has 1s resolution - wait long enough for the timestamp to advance
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        // remote has no new changes since bootstrap - pull is a no-op
+        assert!(!db.pull().await.unwrap());
+
+        let after = db.stats().await.unwrap().last_pull_unix_time.unwrap();
+        assert!(
+            after > before,
+            "last_pull_unix_time must advance after a no-op pull: before={before}, after={after}"
+        );
+    }
+
+    #[tokio::test]
     pub async fn test_sync_push() {
         let _ = tracing_subscriber::fmt::try_init();
         let server = TursoServer::new().await.unwrap();

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -807,6 +807,10 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 "wait_changes(path={}): no changes detected",
                 self.main_db_path
             );
+            self.update_meta(coro, |m| {
+                m.last_pull_unix_time = Some(now.secs);
+            })
+            .await?;
             return Ok(DbChangesStatus {
                 time: now,
                 revision: next_revision,


### PR DESCRIPTION
properly update last pull time in sync engine stats even if remote has no changes