### PR TITLE
core/translate: fix AUTOINCREMENT sequence for INSERT OR FAIL

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -164,6 +164,8 @@ pub struct InsertEmitCtx<'a> {
     pub cdc_table: Option<(usize, Arc<BTreeTable>)>,
     /// Autoincrement sequence table info
     pub autoincrement_meta: Option<AutoincMeta>,
+    /// Max rowid inserted by INSERT OR FAIL into an AUTOINCREMENT table.
+    pub autoincrement_or_fail_max_reg: Option<usize>,
     /// The database index (0 = main, 1 = temp, 2+ = attached)
     pub database_id: usize,
     /// Ephemeral table for buffering RETURNING results.
@@ -221,6 +223,7 @@ impl<'a> InsertEmitCtx<'a> {
             cdc_table,
             num_values,
             autoincrement_meta: None,
+            autoincrement_or_fail_max_reg: None,
             database_id,
             returning_buffer: None,
         })
@@ -418,6 +421,15 @@ pub fn translate_insert(
     program
         .flags
         .set_has_statement_conflict(on_conflict.is_some());
+
+    if btree_table.has_autoincrement && matches!(ctx.on_conflict, ResolveType::Fail) {
+        let max_reg = program.alloc_register();
+        program.emit_insn(Insn::Integer {
+            dest: max_reg,
+            value: 0,
+        });
+        ctx.autoincrement_or_fail_max_reg = Some(max_reg);
+    }
 
     // Open an ephemeral table for buffering RETURNING results.
     // All DML completes before any RETURNING rows are yielded to the caller.
@@ -673,7 +685,7 @@ pub fn translate_insert(
     // For AUTOINCREMENT tables with an explicit rowid, update sqlite_sequence
     // before CHECK constraints. SQLite updates sqlite_sequence even when
     // INSERT OR IGNORE skips the row due to a CHECK failure.
-    if has_user_provided_rowid {
+    if has_user_provided_rowid && ctx.autoincrement_or_fail_max_reg.is_none() {
         if let Some(AutoincMeta {
             seq_cursor_id,
             r_seq,
@@ -1007,7 +1019,12 @@ pub fn translate_insert(
         )?;
     }
 
-    if let Some(AutoincMeta {
+    if let Some(max_reg) = ctx.autoincrement_or_fail_max_reg {
+        program.emit_insn(Insn::MemMax {
+            dest_reg: max_reg,
+            src_reg: insertion.key_register(),
+        });
+    } else if let Some(AutoincMeta {
         seq_cursor_id,
         r_seq,
         r_seq_rowid,
@@ -1243,6 +1260,7 @@ fn emit_epilogue(
         });
     }
     program.preassign_label_to_next_insn(ctx.loop_labels.stmt_epilogue);
+    emit_autoincrement_or_fail_epilogue(program, resolver, ctx)?;
     if let Some((cdc_cursor_id, _)) = &ctx.cdc_table {
         emit_cdc_autocommit_commit(program, resolver, *cdc_cursor_id)?;
     }
@@ -1255,6 +1273,58 @@ fn emit_epilogue(
         emit_returning_scan_back(program, buf);
     }
     program.preassign_label_to_next_insn(ctx.halt_label);
+    Ok(())
+}
+
+fn emit_autoincrement_or_fail_epilogue(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    ctx: &InsertEmitCtx,
+) -> Result<()> {
+    let Some(max_key_reg) = ctx.autoincrement_or_fail_max_reg else {
+        return Ok(());
+    };
+    let Some(AutoincMeta {
+        seq_cursor_id,
+        r_seq,
+        r_seq_rowid,
+        table_name_reg,
+    }) = ctx.autoincrement_meta
+    else {
+        return Ok(());
+    };
+
+    reload_autoincrement_state(
+        program,
+        AutoincMeta {
+            seq_cursor_id,
+            r_seq,
+            r_seq_rowid,
+            table_name_reg,
+        },
+    );
+
+    let done_label = program.allocate_label();
+    program.emit_insn(Insn::Le {
+        lhs: max_key_reg,
+        rhs: r_seq,
+        target_pc: done_label,
+        flags: Default::default(),
+        collation: None,
+    });
+    emit_update_sqlite_sequence(
+        program,
+        resolver,
+        ctx.database_id,
+        seq_cursor_id,
+        r_seq_rowid,
+        table_name_reg,
+        max_key_reg,
+    )?;
+    program.preassign_label_to_next_insn(done_label);
+    program.emit_insn(Insn::Close {
+        cursor_id: seq_cursor_id,
+    });
     Ok(())
 }
 
@@ -1496,15 +1566,17 @@ fn emit_rowid_generation(
             value: 1,
         });
 
-        emit_update_sqlite_sequence(
-            program,
-            resolver,
-            ctx.database_id,
-            seq_cursor_id,
-            r_seq_rowid,
-            table_name_reg,
-            insertion.key_register(),
-        )?;
+        if ctx.autoincrement_or_fail_max_reg.is_none() {
+            emit_update_sqlite_sequence(
+                program,
+                resolver,
+                ctx.database_id,
+                seq_cursor_id,
+                r_seq_rowid,
+                table_name_reg,
+                insertion.key_register(),
+            )?;
+        }
     } else {
         program.emit_insn(Insn::NewRowid {
             cursor: ctx.cursor_id,

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -4609,6 +4609,55 @@ fn test_autocommit_fail_update_check_constraint(tmp_db: TempDatabase) {
     assert_eq!(ic, "ok");
 }
 
+/// INSERT OR FAIL into an AUTOINCREMENT table preserves earlier rows, but
+/// sqlite_sequence is not advanced for the failed statement.
+#[turso_macros::test]
+fn test_insert_or_fail_autoincrement_sequence_rollback(tmp_db: TempDatabase) {
+    drop(tmp_db);
+    let limbo_db = TempDatabase::builder()
+        .with_db_name("insert_or_fail_autoincrement.db")
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+    for s in [
+        "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, x INT CHECK(x > 0))",
+        "INSERT INTO t(x) VALUES(1)",
+    ] {
+        sqlite_try_exec(&sqlite_conn, s).unwrap();
+        limbo_try_exec(&limbo_conn, s).unwrap();
+    }
+
+    let conflict_sql = "INSERT OR FAIL INTO t(x) VALUES(2),(-1),(3)";
+    assert!(sqlite_try_exec(&sqlite_conn, conflict_sql).is_err());
+    assert!(limbo_try_exec(&limbo_conn, conflict_sql).is_err());
+
+    let verify_sql = "SELECT 't', id, x FROM t \
+                      UNION ALL \
+                      SELECT 's', 0, seq FROM sqlite_sequence WHERE name = 't' \
+                      ORDER BY 1, 2";
+    let diff = compare_tables(
+        "INSERT OR FAIL AUTOINCREMENT sequence rollback",
+        &sqlite_conn,
+        &limbo_conn,
+        verify_sql,
+    );
+    assert!(diff.is_none(), "{diff:?}");
+
+    sqlite_try_exec(&sqlite_conn, "INSERT INTO t(x) VALUES(9)").unwrap();
+    limbo_try_exec(&limbo_conn, "INSERT INTO t(x) VALUES(9)").unwrap();
+    let diff = compare_tables(
+        "INSERT after failed AUTOINCREMENT OR FAIL",
+        &sqlite_conn,
+        &limbo_conn,
+        verify_sql,
+    );
+    assert!(diff.is_none(), "{diff:?}");
+
+    let ic = sqlite_integrity_check(&limbo_db.path);
+    assert_eq!(ic, "ok");
+}
+
 // ---------------------------------------------------------------------------
 // Deferred FK + REPLACE UPDATE regression
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes AUTOINCREMENT sequence handling for `INSERT OR FAIL` statements.

For AUTOINCREMENT inserts, Turso updated `sqlite_sequence` while each row was being processed. With `OR FAIL`, SQLite preserves rows inserted before the failing row, but does not advance `sqlite_sequence` for the failed statement. Before this change, Turso could leave `sqlite_sequence` ahead of SQLite and the next generated rowid could diverge.

This patch tracks the maximum rowid successfully inserted by an `INSERT OR FAIL` statement and writes `sqlite_sequence` only from the statement epilogue. If a later row fails, the epilogue is skipped and the sequence remains unchanged, matching SQLite.

## Motivation and context

Reproducer before this fix:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, x INT CHECK(x > 0));
INSERT INTO t(x) VALUES (1);
INSERT OR FAIL INTO t(x) VALUES (2), (-1), (3);
INSERT INTO t(x) VALUES (9);

SELECT 't', id, x FROM t
UNION ALL
SELECT 's', 0, seq FROM sqlite_sequence WHERE name = 't'
ORDER BY 1, 2;
```

SQLite returns:

```text
s|0|3
t|1|1
t|2|2
t|3|9
```

Turso previously returned:

```text
s|0|4
t|1|1
t|2|2
t|4|9
```

The new regression test compares both the immediate post-failure state and the next generated rowid against SQLite.

Tests run:

```text
cargo test -p core_tester --test integration_tests test_insert_or_fail_autoincrement_sequence_rollback -- --nocapture
```

I also ran a local SQLite/Turso differential constraint matrix covering ABORT/FAIL/IGNORE/REPLACE, triggers, savepoints, foreign keys, and AUTOINCREMENT edge cases.

## Description of AI Usage

Used AI assistance for codebase navigation, generating differential repro cases, and iterating on the fix. The final code and regression test were reviewed and verified locally.