### PR TITLE
Fix UPDATE statement journal for fallible expressions

### DIFF
--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -26,7 +26,7 @@ use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
 use crate::{sync::Arc, Connection, Result};
-use turso_parser::ast::{ResolveType, TriggerEvent};
+use turso_parser::ast::{Expr, ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.
 pub(crate) fn any_index_or_ipk_has_replace(
@@ -173,6 +173,81 @@ pub(crate) fn set_insert_stmt_journal_flags(
     program.set_may_abort(may_abort);
 }
 
+/// Return true when an expression may throw while an UPDATE is already in its
+/// row-write loop. Multi-row UPDATE statements need statement rollback when one
+/// of these expressions can abort after earlier rows were written.
+fn expr_may_abort_during_update(expr: &Expr) -> bool {
+    match expr {
+        Expr::FunctionCall { .. }
+        | Expr::FunctionCallStar { .. }
+        | Expr::InSelect { .. }
+        | Expr::InTable { .. }
+        | Expr::Like { .. }
+        | Expr::Raise(..)
+        | Expr::Subquery(..)
+        | Expr::Exists(..)
+        | Expr::SubqueryResult { .. } => true,
+        Expr::Between {
+            lhs, start, end, ..
+        } => {
+            expr_may_abort_during_update(lhs)
+                || expr_may_abort_during_update(start)
+                || expr_may_abort_during_update(end)
+        }
+        Expr::Binary(lhs, _, rhs) => {
+            expr_may_abort_during_update(lhs) || expr_may_abort_during_update(rhs)
+        }
+        Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            base.as_deref().is_some_and(expr_may_abort_during_update)
+                || when_then_pairs.iter().any(|(when_expr, then_expr)| {
+                    expr_may_abort_during_update(when_expr)
+                        || expr_may_abort_during_update(then_expr)
+                })
+                || else_expr
+                    .as_deref()
+                    .is_some_and(expr_may_abort_during_update)
+        }
+        Expr::Cast { expr, .. }
+        | Expr::Collate(expr, _)
+        | Expr::FieldAccess { base: expr, .. }
+        | Expr::IsNull(expr)
+        | Expr::NotNull(expr)
+        | Expr::Unary(_, expr) => expr_may_abort_during_update(expr),
+        Expr::InList { lhs, rhs, .. } => {
+            expr_may_abort_during_update(lhs)
+                || rhs.iter().any(|expr| expr_may_abort_during_update(expr))
+        }
+        Expr::Parenthesized(exprs) => exprs.iter().any(|expr| expr_may_abort_during_update(expr)),
+        Expr::Array { .. } | Expr::Subscript { .. } => true,
+        Expr::Id(_)
+        | Expr::Column { .. }
+        | Expr::RowId { .. }
+        | Expr::Literal(_)
+        | Expr::DoublyQualified(..)
+        | Expr::Name(_)
+        | Expr::Qualified(..)
+        | Expr::Variable(_)
+        | Expr::Register(_)
+        | Expr::Default => false,
+    }
+}
+
+fn index_expr_may_abort_during_update(index: &crate::schema::Index) -> bool {
+    index
+        .where_clause
+        .as_deref()
+        .is_some_and(expr_may_abort_during_update)
+        || index.columns.iter().any(|col| {
+            col.expr
+                .as_deref()
+                .is_some_and(expr_may_abort_during_update)
+        })
+}
+
 /// Set multi_write / may_abort for UPDATE statements.
 pub(crate) fn set_update_stmt_journal_flags(
     program: &mut ProgramBuilder,
@@ -230,9 +305,19 @@ pub(crate) fn set_update_stmt_journal_flags(
     let has_check = !btree_table.check_constraints.is_empty();
     let has_unique =
         !btree_table.unique_sets.is_empty() || plan.indexes_to_update.iter().any(|idx| idx.unique);
+    let update_expr_may_abort = plan
+        .set_clauses
+        .iter()
+        .any(|set_clause| expr_may_abort_during_update(set_clause.emitted_expr()));
+    let index_expr_may_abort = plan
+        .indexes_to_update
+        .iter()
+        .any(|idx| index_expr_may_abort_during_update(idx));
 
     let may_abort = has_triggers
         || has_fks
+        || update_expr_may_abort
+        || index_expr_may_abort
         || constraint_may_abort(
             has_statement_conflict,
             or_conflict,

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -289,6 +289,86 @@ fn update_composite_unique_partial_cols(tmp_db: TempDatabase) -> anyhow::Result<
     Ok(())
 }
 
+#[turso_macros::test]
+fn update_fallible_set_expr_rolls_back_prior_rows(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode=WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")?;
+    conn.execute("INSERT INTO t VALUES(1, 10), (2, 20)")?;
+
+    let update_sql = "
+        UPDATE t
+        SET x = CASE
+            WHEN id=1 THEN 11
+            ELSE ('x' LIKE 'x' ESCAPE 'yy')
+        END
+    ";
+    assert!(
+        needs_stmt_journal(&conn, update_sql),
+        "fallible row-dependent SET expressions need statement rollback"
+    );
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(update_sql);
+    assert!(result.is_err(), "UPDATE should fail on invalid ESCAPE");
+
+    let rows = query_rows(&conn, "SELECT id, x FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|10", "2|20"],
+        "failed UPDATE must roll back rows written before the expression error"
+    );
+    conn.execute("COMMIT")?;
+
+    let rows = query_rows(&conn, "SELECT id, x FROM t ORDER BY id");
+    assert_eq!(rows, vec!["1|10", "2|20"]);
+    Ok(())
+}
+
+#[turso_macros::test]
+fn update_fallible_partial_index_expr_rolls_back_prior_rows(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode=WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT)")?;
+    conn.execute("INSERT INTO t VALUES(1, 1, 1), (2, 2, 1), (3, 3, 1)")?;
+    conn.execute(
+        "
+        CREATE INDEX idx ON t(a)
+        WHERE CASE
+            WHEN b=2 THEN 'x' LIKE 'x' ESCAPE 'yy'
+            ELSE 1
+        END
+        ",
+    )?;
+
+    let update_sql = "UPDATE t SET b=CASE WHEN id=2 THEN 2 ELSE b+10 END";
+    assert!(
+        needs_stmt_journal(&conn, update_sql),
+        "fallible partial index predicates need statement rollback"
+    );
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(update_sql);
+    assert!(
+        result.is_err(),
+        "UPDATE should fail when the new partial-index predicate errors"
+    );
+
+    let rows = query_rows(&conn, "SELECT id, a, b FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|1|1", "2|2|1", "3|3|1"],
+        "failed UPDATE must roll back rows written before the partial-index error"
+    );
+
+    let ic = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(ic, vec!["ok"]);
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 // ──────────────────────────────────────────────────────────
 // DELETE
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #6879.

This updates the UPDATE statement-journal analysis to treat fallible row-dependent work as `may_abort`, including:

- SET expressions that can throw during the UPDATE row loop
- expression index values
- partial index predicates evaluated against the new row image

It also adds regression coverage for two failure modes where a multi-row UPDATE errored after an earlier row had already been written.

## Root cause

`set_update_stmt_journal_flags` only considered triggers, foreign keys, and schema constraints when deciding `may_abort`. That let multi-row UPDATE statements skip statement rollback even when per-row expression evaluation could abort after prior rows had already been modified.

For example, an invalid `LIKE ... ESCAPE` expression can be row-dependent: row 1 updates successfully, row 2 throws, and without a statement journal the earlier write can survive the failed statement inside an explicit transaction.

## Validation

- `rustfmt --edition 2021 --check core/translate/stmt_journal.rs tests/integration/stmt_journal.rs`
- `cargo test -p core_tester --test integration_tests update_fallible -- --nocapture`
- `./target/debug/deps/integration_tests-2df5008017bb8710 stmt_journal --nocapture`

AI-assisted with Codex; I reviewed the change and ran the checks locally.
