### PR TITLE
Fix DML expression abort statement journals

### DIFF
--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -25,7 +25,7 @@ use crate::translate::emitter::Resolver;
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
-use crate::{sync::Arc, Connection, Result};
+use crate::{Connection, Result, sync::Arc};
 use turso_parser::ast::{ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.
@@ -148,7 +148,12 @@ pub(crate) fn set_insert_stmt_journal_flags(
         index_modes.iter().map(|(oc, _)| *oc),
     );
     let has_check = !table.check_constraints.is_empty();
-    let may_abort = has_triggers
+    // Multi-row INSERT can evaluate row-dependent SELECT/VALUES expressions
+    // while writes are already in progress. Those expressions are not captured
+    // by constraint analysis, so keep the statement savepoint unless the insert
+    // is proven single-row.
+    let may_abort = inserting_multiple_rows
+        || has_triggers
         || has_fks
         || constraint_may_abort(
             has_statement_conflict,
@@ -231,7 +236,12 @@ pub(crate) fn set_update_stmt_journal_flags(
     let has_unique =
         !btree_table.unique_sets.is_empty() || plan.indexes_to_update.iter().any(|idx| idx.unique);
 
-    let may_abort = has_triggers
+    // Row-dependent expressions in SET, WHERE, or index maintenance can fail
+    // after earlier rows have already been written. Unless this UPDATE is
+    // proven single-row, keep the statement savepoint available even when the
+    // schema has no aborting constraints.
+    let may_abort = !is_single_row
+        || has_triggers
         || has_fks
         || constraint_may_abort(
             has_statement_conflict,
@@ -273,9 +283,11 @@ pub(crate) fn set_delete_stmt_journal_flags(
         program.set_multi_write(false);
     }
 
-    // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
-    // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
+    // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply.
+    // Multi-row DELETE still evaluates row-dependent WHERE/RETURNING
+    // expressions while writes are in progress, so only a proven single-row
+    // delete can disable the statement savepoint here.
+    if is_single_row && !has_triggers && !has_fks {
         program.set_may_abort(false);
     }
     Ok(())

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1,7 +1,7 @@
 use crate::common::{
-    self, compute_dbhash, limbo_exec_rows, maybe_setup_tracing, rusqlite_integrity_check, ExecRows,
+    self, ExecRows, compute_dbhash, limbo_exec_rows, maybe_setup_tracing, rusqlite_integrity_check,
 };
-use crate::common::{compare_string, do_flush, TempDatabase};
+use crate::common::{TempDatabase, compare_string, do_flush};
 use log::debug;
 use rusqlite::types::Value as RValue;
 use std::io::{Read, Seek, Write};
@@ -196,7 +196,7 @@ fn test_regression_multi_row_insert(tmp_db: TempDatabase) -> anyhow::Result<()> 
     })?;
 
     assert_eq!(current_read_index, 4); // Verify we read all rows
-                                       // sort ids
+    // sort ids
     actual_ids.sort();
     assert_eq!(actual_ids, expected_ids);
     Ok(())
@@ -1324,6 +1324,112 @@ pub fn test_conflict_inside_txn(limbo: TempDatabase) {
             ]
         ],
         limbo_exec_rows(&conn2, "SELECT * FROM t")
+    );
+}
+
+#[turso_macros::test]
+pub fn test_update_expression_error_rolls_back_statement_inside_txn(limbo: TempDatabase) {
+    let conn = limbo.db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = WAL").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES(1, 10), (2, 20)")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert!(
+        conn.execute(
+            "UPDATE t
+                SET x = CASE
+                    WHEN id = 1 THEN 11
+                    ELSE (char(120) LIKE char(120) ESCAPE (char(121) || char(121)))
+                END"
+        )
+        .is_err()
+    );
+
+    assert_eq!(
+        vec![
+            vec![RValue::Integer(1), RValue::Integer(10)],
+            vec![RValue::Integer(2), RValue::Integer(20)],
+        ],
+        limbo_exec_rows(&conn, "SELECT id, x FROM t ORDER BY id")
+    );
+
+    conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        vec![
+            vec![RValue::Integer(1), RValue::Integer(10)],
+            vec![RValue::Integer(2), RValue::Integer(20)],
+        ],
+        limbo_exec_rows(&conn, "SELECT id, x FROM t ORDER BY id")
+    );
+}
+
+#[turso_macros::test]
+pub fn test_delete_expression_error_rolls_back_statement_inside_txn(limbo: TempDatabase) {
+    let conn = limbo.db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = WAL").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES(1), (2)").unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert!(
+        conn.execute(
+            "DELETE FROM t
+              WHERE CASE
+                    WHEN id = 1 THEN 1
+                    ELSE (char(120) LIKE char(120) ESCAPE (char(121) || char(121)))
+                END"
+        )
+        .is_err()
+    );
+
+    assert_eq!(
+        vec![vec![RValue::Integer(1)], vec![RValue::Integer(2)]],
+        limbo_exec_rows(&conn, "SELECT id FROM t ORDER BY id")
+    );
+
+    conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        vec![vec![RValue::Integer(1)], vec![RValue::Integer(2)]],
+        limbo_exec_rows(&conn, "SELECT id FROM t ORDER BY id")
+    );
+}
+
+#[turso_macros::test]
+pub fn test_insert_expression_error_rolls_back_statement_inside_txn(limbo: TempDatabase) {
+    let conn = limbo.db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = WAL").unwrap();
+    conn.execute("CREATE TABLE t(x INT)").unwrap();
+    conn.execute("CREATE TABLE src(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("INSERT INTO src VALUES(1), (2)").unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert!(
+        conn.execute(
+            "INSERT INTO t
+                SELECT CASE
+                    WHEN id = 1 THEN 10
+                    ELSE (char(120) LIKE char(120) ESCAPE (char(121) || char(121)))
+                END
+                FROM src
+                ORDER BY id"
+        )
+        .is_err()
+    );
+
+    assert_eq!(
+        Vec::<Vec<RValue>>::new(),
+        limbo_exec_rows(&conn, "SELECT x FROM t ORDER BY x")
+    );
+
+    conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        Vec::<Vec<RValue>>::new(),
+        limbo_exec_rows(&conn, "SELECT x FROM t ORDER BY x")
     );
 }
 


### PR DESCRIPTION
## Summary

Fix statement-journal analysis for DML statements whose row-dependent expression/index work can abort after earlier writes have already happened.

This branch currently covers two public data-corruption repros:

- Fixes #6879: multi-row INSERT, UPDATE, and DELETE statements can leak partial effects inside an explicit transaction when a later row-dependent expression aborts.
- Fixes #6877: single-row INSERT OR REPLACE can delete the conflicting row before a later replacement-row expression-index evaluation aborts.

The root cause was that `may_abort` only considered schema constraints, triggers, and foreign keys. Row-dependent SELECT/VALUES, SET, WHERE, index-maintenance expressions, and REPLACE delete-before-insert paths can also fail after writes, so those paths need a statement savepoint unless the statement is proven safe.

## Simulator coverage

The fork branch now includes deterministic simulator regressions in `testing/simulator/runner/memory/statement_journal.rs` for both corruption paths:

- failed row-dependent UPDATE expression evaluation must roll back earlier row writes in the same statement
- failed INSERT OR REPLACE expression-index maintenance must restore the conflicting row deleted by REPLACE preflight

## Validation

- `cargo test -p limbo_sim statement_journal -- --nocapture`
- `cargo test -p core_tester expression_error_rolls_back_statement_inside_txn --test integration_tests -- --nocapture`
- `cargo test -p core_tester expression_index_abort_preserves_row --test integration_tests -- --nocapture`
- `cargo test -p core_tester stmt_journal --test integration_tests -- --nocapture`
- `cargo test -p core_tester test_conflict --test integration_tests -- --nocapture`
- `cargo test -p core_tester test_savepoint_rollback_uses_current_wal_snapshot --test integration_tests -- --nocapture`
- `cargo fmt --check`
- `(cd fuzz && cargo fmt --check)`
- `git diff --check -- core/translate/stmt_journal.rs tests/integration/stmt_journal.rs tests/integration/query_processing/test_write_path.rs`

Note: this PR was auto-closed by Fossier before maintainer review. I opened manual-review request #6962 per the bot instructions. The fork branch is updated to commit `eef2b2f56`.
