### PR TITLE
core: roll back rowid datatype mismatches

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -45,6 +45,8 @@ pub enum LimboError {
     InvalidFormatter(String),
     #[error("Runtime error: {0}")]
     Constraint(String),
+    #[error("Runtime error: datatype mismatch")]
+    DatatypeMismatch,
     #[error("Runtime error: {0}")]
     /// We need to specify for ROLLBACK|FAIL resolve types when to roll the tx back
     /// so instead of matching on the string, we introduce a specific ForeignKeyConstraint error

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10082,18 +10082,18 @@ pub fn op_must_be_int(
         Value::Numeric(Numeric::Integer(_)) => {}
         Value::Numeric(Numeric::Float(f)) => match cast_real_to_integer(f64::from(*f)) {
             Ok(i) => state.registers[*reg].set_int(i),
-            Err(_) => bail_constraint_error!("datatype mismatch"),
+            Err(_) => return Err(LimboError::DatatypeMismatch),
         },
         Value::Text(text) => match checked_cast_text_to_numeric(text.as_str(), true) {
             Ok(Value::Numeric(Numeric::Integer(i))) => state.registers[*reg].set_int(i),
             Ok(Value::Numeric(Numeric::Float(f))) => match cast_real_to_integer(f64::from(f)) {
                 Ok(i) => state.registers[*reg].set_int(i),
-                Err(_) => bail_constraint_error!("datatype mismatch"),
+                Err(_) => return Err(LimboError::DatatypeMismatch),
             },
-            _ => bail_constraint_error!("datatype mismatch"),
+            _ => return Err(LimboError::DatatypeMismatch),
         },
         _ => {
-            bail_constraint_error!("datatype mismatch");
+            return Err(LimboError::DatatypeMismatch);
         }
     };
     state.pc += 1;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2249,10 +2249,10 @@ impl Program {
                 // Schema updated errors do not cause a rollback; the statement will be reprepared and retried,
                 // and the caller is expected to handle transaction cleanup explicitly if needed.
                 Some(LimboError::SchemaUpdated) => {}
-                // Foreign key constraint errors: ON CONFLICT does NOT apply to FK violations.
-                // FK errors always behave like ABORT: rollback statement,
-                // rollback transaction in autocommit mode.
-                Some(LimboError::ForeignKeyConstraint(_)) => {
+                // Foreign key and rowid datatype mismatch errors are not governed
+                // by ON CONFLICT. They behave like ABORT: rollback the statement,
+                // and rollback the transaction in autocommit mode.
+                Some(LimboError::ForeignKeyConstraint(_)) | Some(LimboError::DatatypeMismatch) => {
                     if self.connection.get_auto_commit() {
                         self.rollback_current_txn(pager);
                     }

--- a/testing/simulator/runner/memory/mod.rs
+++ b/testing/simulator/runner/memory/mod.rs
@@ -4,4 +4,6 @@ pub mod io;
 #[cfg(test)]
 mod mvcc_recovery;
 #[cfg(test)]
+mod rowid_rollback;
+#[cfg(test)]
 mod statement_abandon;

--- a/testing/simulator/runner/memory/rowid_rollback.rs
+++ b/testing/simulator/runner/memory/rowid_rollback.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
+
+use crate::runner::memory::io::MemorySimIO;
+
+fn make_conn(seed: u64) -> Result<(Arc<Connection>, Arc<MemorySimIO>)> {
+    let io = Arc::new(MemorySimIO::new(seed, 4096, 100, 1, 5));
+    let db = Database::open_file_with_flags(
+        io.clone() as Arc<dyn IO>,
+        &format!("sim_rowid_rollback_{seed}.db"),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    let conn = db.connect()?;
+    Ok((conn, io))
+}
+
+fn query_rows(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<Vec<(i64, String)>> {
+    let mut stmt = conn.prepare("SELECT id, val FROM t ORDER BY id")?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist");
+                rows.push((
+                    row.get::<i64>(0).expect("id column should exist"),
+                    row.get::<String>(1).expect("val column should exist"),
+                ));
+            }
+            StepResult::Done => return Ok(rows),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn sim_insert_or_fail_rowid_mismatch_rolls_back_statement() -> Result<()> {
+    let (conn, io) = make_conn(21)?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")?;
+
+    let err = conn
+        .execute("INSERT OR FAIL INTO t VALUES (1, 'one'), ('bad', 'bad')")
+        .expect_err("rowid mismatch should fail");
+    assert_eq!(err.to_string(), "Runtime error: datatype mismatch");
+    assert_eq!(query_rows(&conn, io.as_ref())?, Vec::<(i64, String)>::new());
+    Ok(())
+}
+
+#[test]
+fn sim_update_or_fail_rowid_mismatch_rolls_back_statement() -> Result<()> {
+    let (conn, io) = make_conn(22)?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")?;
+    conn.execute("INSERT INTO t VALUES (1, 'one'), (2, 'two')")?;
+
+    let err = conn
+        .execute(
+            "UPDATE OR FAIL t \
+             SET val = 'changed', id = CASE WHEN id = 2 THEN 'bad' ELSE id END \
+             WHERE TRUE",
+        )
+        .expect_err("rowid mismatch should fail");
+    assert_eq!(err.to_string(), "Runtime error: datatype mismatch");
+    assert_eq!(
+        query_rows(&conn, io.as_ref())?,
+        vec![(1, "one".to_string()), (2, "two".to_string())]
+    );
+    Ok(())
+}

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -1775,6 +1775,27 @@ fn test_insert_or_fail_unique_constraint(tmp_db: TempDatabase) {
 }
 
 #[turso_macros::test]
+fn test_insert_or_fail_rowid_datatype_mismatch_rolls_back_statement(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+
+    let result = conn.execute("INSERT OR FAIL INTO t VALUES (1, 'one'), ('bad', 'bad')");
+    assert_eq!(
+        result.expect_err("rowid mismatch should fail").to_string(),
+        "Runtime error: datatype mismatch"
+    );
+
+    let stmt = conn
+        .query("SELECT id, val FROM t ORDER BY id")
+        .unwrap()
+        .unwrap();
+    let rows = helper_read_all_rows(stmt);
+    assert_eq!(rows, Vec::<Vec<Value>>::new());
+}
+
+#[turso_macros::test]
 /// UPDATE OR FAIL should keep changes made by the statement before the error.
 /// Unlike ABORT (the default), FAIL does not roll back successful updates within the same statement.
 fn test_update_or_fail_keeps_prior_changes(tmp_db: TempDatabase) {
@@ -1800,6 +1821,39 @@ fn test_update_or_fail_keeps_prior_changes(tmp_db: TempDatabase) {
         vec![
             vec![Value::from_i64(1), Value::from_i64(10)],
             vec![Value::from_i64(2), Value::from_i64(20)],
+        ]
+    );
+}
+
+#[turso_macros::test]
+fn test_update_or_fail_rowid_datatype_mismatch_rolls_back_statement(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'one'), (2, 'two')")
+        .unwrap();
+
+    let result = conn.execute(
+        "UPDATE OR FAIL t \
+         SET val = 'changed', id = CASE WHEN id = 2 THEN 'bad' ELSE id END \
+         WHERE TRUE",
+    );
+    assert_eq!(
+        result.expect_err("rowid mismatch should fail").to_string(),
+        "Runtime error: datatype mismatch"
+    );
+
+    let stmt = conn
+        .query("SELECT id, val FROM t ORDER BY id")
+        .unwrap()
+        .unwrap();
+    let rows = helper_read_all_rows(stmt);
+    assert_eq!(
+        rows,
+        vec![
+            vec![Value::from_i64(1), Value::Text("one".into())],
+            vec![Value::from_i64(2), Value::Text("two".into())],
         ]
     );
 }


### PR DESCRIPTION
## Summary

`MustBeInt` reported rowid conversion failures as `LimboError::Constraint`. In `INSERT OR FAIL` and `UPDATE OR FAIL`, that allowed Turso to treat `datatype mismatch` like an `ON CONFLICT FAIL` constraint error and preserve earlier writes from the same autocommit statement.

SQLite reports the same rowid conversion failure as a datatype mismatch outside `ON CONFLICT`, so the statement rolls back. This patch gives rowid datatype mismatch its own error variant, routes it through ABORT-style rollback, and adds simulator plus integration regressions for insert and update paths.

Related: #6850 describes the same root cause but was auto-closed by Fossier before maintainer review. This PR includes deterministic simulator coverage that fails before the fix and passes after it.

## Repro on latest release

Verified against released `v0.5.3` (`09c149a776b5140bfff3e3dee1dc786177d2615a`).

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT);
INSERT INTO t VALUES(1,'one'),(2,'two');
UPDATE OR FAIL t
  SET b='changed', id=CASE WHEN id=2 THEN 'bad' ELSE id END
  WHERE TRUE;
SELECT id, typeof(id), b FROM t ORDER BY id;
```

Turso `v0.5.3`:

```text
Error: Runtime error: datatype mismatch
1|integer|changed
2|integer|two
```

SQLite:

```text
Error: stepping, datatype mismatch (20)
1|integer|one
2|integer|two
```

The same mismatch exists for multi-row insert:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT);
INSERT OR FAIL INTO t(id,b) VALUES(1,'one'),('bad','bad');
SELECT id, typeof(id), b FROM t ORDER BY id;
```

Turso `v0.5.3` leaves `1|integer|one`; SQLite leaves the table empty.

## Validation

Fail-before evidence:

- `cargo test -p limbo_sim rowid_mismatch -- --nocapture` failed both new simulator tests before the fix.
- `cargo test -p core_tester --test integration_tests rowid_datatype_mismatch -- --nocapture` failed both new integration tests before the fix.

Pass-after evidence:

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p turso_core`
- `cargo test -p limbo_sim rowid_mismatch -- --nocapture`
- `cargo test -p core_tester --test integration_tests rowid_datatype_mismatch -- --nocapture`
- `cargo test -p core_tester --test integration_tests or_fail -- --nocapture`
- Manual repros against patched `target/debug/tursodb`, released `v0.5.3` `tursodb`, and system SQLite.

The wider `or_fail` regression sweep confirms normal `OR FAIL` partial-success behavior is preserved for ordinary constraints while rowid datatype mismatch now rolls back like SQLite.