### PR TITLE
Protect DML rollback for row-dependent expression errors

### DIFF
--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -22,6 +22,7 @@
 //! into this module to set them to `false` when safe.
 
 use crate::translate::emitter::Resolver;
+use crate::translate::expr::{walk_expr, WalkControl};
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
@@ -67,154 +68,80 @@ fn table_has_fks(
 }
 
 fn expr_depends_on_row(expr: &Expr) -> bool {
-    match expr {
-        // Planned DML expressions are usually bound to Column/RowId. Schema-stored
-        // index expressions still contain identifiers, and here they only appear
-        // after the index was selected for maintenance.
-        Expr::Column { .. }
-        | Expr::DoublyQualified(_, _, _)
-        | Expr::Id(_)
-        | Expr::Name(_)
-        | Expr::Qualified(_, _)
-        | Expr::RowId { .. }
-        | Expr::Register(_)
-        | Expr::SubqueryResult { .. } => true,
-        Expr::Exists(_) | Expr::Subquery(_) | Expr::InSelect { .. } => true,
-        Expr::Between {
-            lhs, start, end, ..
-        } => expr_depends_on_row(lhs) || expr_depends_on_row(start) || expr_depends_on_row(end),
-        Expr::Binary(lhs, _, rhs) => expr_depends_on_row(lhs) || expr_depends_on_row(rhs),
-        Expr::Case {
-            base,
-            when_then_pairs,
-            else_expr,
-        } => {
-            base.as_ref().is_some_and(|expr| expr_depends_on_row(expr))
-                || when_then_pairs
-                    .iter()
-                    .any(|(when, then)| expr_depends_on_row(when) || expr_depends_on_row(then))
-                || else_expr
-                    .as_ref()
-                    .is_some_and(|expr| expr_depends_on_row(expr))
+    let mut depends_on_row = false;
+    // Planned DML expressions are usually bound to Column/RowId. Schema-stored
+    // index expressions still contain identifiers, and here they only appear
+    // after the index was selected for maintenance.
+    let _ = walk_expr(expr, &mut |expr| -> Result<WalkControl> {
+        match expr {
+            Expr::Column { .. }
+            | Expr::DoublyQualified(_, _, _)
+            | Expr::Id(_)
+            | Expr::Name(_)
+            | Expr::Qualified(_, _)
+            | Expr::RowId { .. }
+            | Expr::Register(_)
+            | Expr::SubqueryResult { .. }
+            | Expr::Exists(_)
+            | Expr::Subquery(_)
+            | Expr::InSelect { .. } => {
+                depends_on_row = true;
+                Ok(WalkControl::SkipChildren)
+            }
+            Expr::Array { elements } => {
+                if elements.iter().any(|expr| expr_depends_on_row(expr)) {
+                    depends_on_row = true;
+                }
+                Ok(WalkControl::SkipChildren)
+            }
+            Expr::Subscript { base, index } => {
+                if expr_depends_on_row(base) || expr_depends_on_row(index) {
+                    depends_on_row = true;
+                }
+                Ok(WalkControl::SkipChildren)
+            }
+            _ => Ok(WalkControl::Continue),
         }
-        Expr::Cast { expr, .. }
-        | Expr::Collate(expr, _)
-        | Expr::IsNull(expr)
-        | Expr::NotNull(expr)
-        | Expr::Unary(_, expr)
-        | Expr::FieldAccess { base: expr, .. } => expr_depends_on_row(expr),
-        Expr::FunctionCall {
-            args,
-            order_by,
-            filter_over,
-            ..
-        } => {
-            args.iter().any(|expr| expr_depends_on_row(expr))
-                || order_by.iter().any(|col| expr_depends_on_row(&col.expr))
-                || filter_over
-                    .filter_clause
-                    .as_ref()
-                    .is_some_and(|expr| expr_depends_on_row(expr))
-        }
-        Expr::FunctionCallStar { filter_over, .. } => filter_over
-            .filter_clause
-            .as_ref()
-            .is_some_and(|expr| expr_depends_on_row(expr)),
-        Expr::InList { lhs, rhs, .. } => {
-            expr_depends_on_row(lhs) || rhs.iter().any(|expr| expr_depends_on_row(expr))
-        }
-        Expr::InTable { lhs, args, .. } => {
-            expr_depends_on_row(lhs) || args.iter().any(|expr| expr_depends_on_row(expr))
-        }
-        Expr::Like {
-            lhs, rhs, escape, ..
-        } => {
-            expr_depends_on_row(lhs)
-                || expr_depends_on_row(rhs)
-                || escape
-                    .as_ref()
-                    .is_some_and(|expr| expr_depends_on_row(expr))
-        }
-        Expr::Parenthesized(exprs) => exprs.iter().any(|expr| expr_depends_on_row(expr)),
-        Expr::Raise(_, expr) => expr.as_ref().is_some_and(|expr| expr_depends_on_row(expr)),
-        Expr::Array { elements } => elements.iter().any(|expr| expr_depends_on_row(expr)),
-        Expr::Subscript { base, index } => expr_depends_on_row(base) || expr_depends_on_row(index),
-        Expr::Literal(_) | Expr::Variable(_) | Expr::Default => false,
-    }
+    });
+    depends_on_row
 }
 
 fn expr_has_runtime_abort_source(expr: &Expr) -> bool {
-    match expr {
-        Expr::FunctionCall { .. }
-        | Expr::FunctionCallStar { .. }
-        | Expr::Raise(_, _)
-        | Expr::Exists(_)
-        | Expr::Subquery(_)
-        | Expr::SubqueryResult { .. }
-        | Expr::InSelect { .. }
-        | Expr::InTable { .. }
-        | Expr::FieldAccess { .. }
-        | Expr::Subscript { .. } => true,
-        Expr::Like {
-            lhs,
-            op,
-            rhs,
-            escape,
-            ..
-        } => {
-            escape.is_some()
-                || matches!(op, LikeOperator::Match | LikeOperator::Regexp)
-                || expr_has_runtime_abort_source(lhs)
-                || expr_has_runtime_abort_source(rhs)
+    let mut has_runtime_abort_source = false;
+    let _ = walk_expr(expr, &mut |expr| -> Result<WalkControl> {
+        match expr {
+            Expr::FunctionCall { .. }
+            | Expr::FunctionCallStar { .. }
+            | Expr::Raise(_, _)
+            | Expr::Exists(_)
+            | Expr::Subquery(_)
+            | Expr::SubqueryResult { .. }
+            | Expr::InSelect { .. }
+            | Expr::InTable { .. }
+            | Expr::FieldAccess { .. }
+            | Expr::Subscript { .. } => {
+                has_runtime_abort_source = true;
+                Ok(WalkControl::SkipChildren)
+            }
+            Expr::Like { op, escape, .. }
+                if escape.is_some() || matches!(op, LikeOperator::Match | LikeOperator::Regexp) =>
+            {
+                has_runtime_abort_source = true;
+                Ok(WalkControl::SkipChildren)
+            }
+            Expr::Array { elements } => {
+                if elements
+                    .iter()
+                    .any(|expr| expr_has_runtime_abort_source(expr))
+                {
+                    has_runtime_abort_source = true;
+                }
+                Ok(WalkControl::SkipChildren)
+            }
+            _ => Ok(WalkControl::Continue),
         }
-        Expr::Between {
-            lhs, start, end, ..
-        } => {
-            expr_has_runtime_abort_source(lhs)
-                || expr_has_runtime_abort_source(start)
-                || expr_has_runtime_abort_source(end)
-        }
-        Expr::Binary(lhs, _, rhs) => {
-            expr_has_runtime_abort_source(lhs) || expr_has_runtime_abort_source(rhs)
-        }
-        Expr::Case {
-            base,
-            when_then_pairs,
-            else_expr,
-        } => {
-            base.as_ref()
-                .is_some_and(|expr| expr_has_runtime_abort_source(expr))
-                || when_then_pairs.iter().any(|(when, then)| {
-                    expr_has_runtime_abort_source(when) || expr_has_runtime_abort_source(then)
-                })
-                || else_expr
-                    .as_ref()
-                    .is_some_and(|expr| expr_has_runtime_abort_source(expr))
-        }
-        Expr::Cast { expr, .. }
-        | Expr::Collate(expr, _)
-        | Expr::IsNull(expr)
-        | Expr::NotNull(expr)
-        | Expr::Unary(_, expr) => expr_has_runtime_abort_source(expr),
-        Expr::InList { lhs, rhs, .. } => {
-            expr_has_runtime_abort_source(lhs)
-                || rhs.iter().any(|expr| expr_has_runtime_abort_source(expr))
-        }
-        Expr::Parenthesized(exprs) => exprs.iter().any(|expr| expr_has_runtime_abort_source(expr)),
-        Expr::Array { elements } => elements
-            .iter()
-            .any(|expr| expr_has_runtime_abort_source(expr)),
-        Expr::Column { .. }
-        | Expr::Register(_)
-        | Expr::DoublyQualified(_, _, _)
-        | Expr::Id(_)
-        | Expr::Literal(_)
-        | Expr::Name(_)
-        | Expr::Qualified(_, _)
-        | Expr::RowId { .. }
-        | Expr::Variable(_)
-        | Expr::Default => false,
-    }
+    });
+    has_runtime_abort_source
 }
 
 fn expr_may_abort_after_write(expr: &Expr) -> bool {

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -22,12 +22,13 @@
 //! into this module to set them to `false` when safe.
 
 use crate::translate::emitter::Resolver;
-use crate::translate::expr::{walk_expr, WalkControl};
+use crate::translate::expr::WalkControl;
 use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
+use crate::util::walk_expr_with_subqueries;
 use crate::vdbe::builder::ProgramBuilder;
 use crate::{sync::Arc, Connection, Result};
-use turso_parser::ast::{Expr, LikeOperator, ResolveType, TriggerEvent};
+use turso_parser::ast::{Expr, ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.
 pub(crate) fn any_index_or_ipk_has_replace(
@@ -67,97 +68,46 @@ fn table_has_fks(
             || resolver.with_schema(database_id, |s| s.any_resolved_fks_referencing(table_name)))
 }
 
-fn expr_depends_on_row(expr: &Expr) -> bool {
-    let mut depends_on_row = false;
-    // Planned DML expressions are usually bound to Column/RowId. Schema-stored
-    // index expressions still contain identifiers, and here they only appear
-    // after the index was selected for maintenance.
-    let _ = walk_expr(expr, &mut |expr| -> Result<WalkControl> {
-        match expr {
+/// Conservative test for "this expression's value can change row-to-row".
+///
+/// Per-row expression evaluation can fail mid-loop (bad LIKE ESCAPE, malformed
+/// datetime, type cast overflow, etc.), and a multi-row DML that has already
+/// written earlier rows then needs a statement journal to roll those writes back.
+///
+/// DML expressions reach us bound (`Id`/`Qualified` rewritten to `Column`), but
+/// schema-stored index `expr`/`where_clause` are unbound — we match both forms.
+fn expr_is_row_dependent(expr: &Expr) -> bool {
+    let mut found = false;
+    let _ = walk_expr_with_subqueries(expr, &mut |e| -> Result<WalkControl> {
+        if matches!(
+            e,
             Expr::Column { .. }
-            | Expr::DoublyQualified(_, _, _)
-            | Expr::Id(_)
-            | Expr::Name(_)
-            | Expr::Qualified(_, _)
-            | Expr::RowId { .. }
-            | Expr::Register(_)
-            | Expr::SubqueryResult { .. }
-            | Expr::Exists(_)
-            | Expr::Subquery(_)
-            | Expr::InSelect { .. } => {
-                depends_on_row = true;
-                Ok(WalkControl::SkipChildren)
-            }
-            Expr::Array { elements } => {
-                if elements.iter().any(|expr| expr_depends_on_row(expr)) {
-                    depends_on_row = true;
-                }
-                Ok(WalkControl::SkipChildren)
-            }
-            Expr::Subscript { base, index } => {
-                if expr_depends_on_row(base) || expr_depends_on_row(index) {
-                    depends_on_row = true;
-                }
-                Ok(WalkControl::SkipChildren)
-            }
-            _ => Ok(WalkControl::Continue),
+                | Expr::RowId { .. }
+                | Expr::Register(_)
+                | Expr::SubqueryResult { .. }
+                | Expr::Id(_)
+                | Expr::Name(_)
+                | Expr::Qualified(..)
+                | Expr::DoublyQualified(..)
+        ) {
+            found = true;
+            return Ok(WalkControl::SkipChildren);
         }
+        Ok(WalkControl::Continue)
     });
-    depends_on_row
+    found
 }
 
-fn expr_has_runtime_abort_source(expr: &Expr) -> bool {
-    let mut has_runtime_abort_source = false;
-    let _ = walk_expr(expr, &mut |expr| -> Result<WalkControl> {
-        match expr {
-            Expr::FunctionCall { .. }
-            | Expr::FunctionCallStar { .. }
-            | Expr::Raise(_, _)
-            | Expr::Exists(_)
-            | Expr::Subquery(_)
-            | Expr::SubqueryResult { .. }
-            | Expr::InSelect { .. }
-            | Expr::InTable { .. }
-            | Expr::FieldAccess { .. }
-            | Expr::Subscript { .. } => {
-                has_runtime_abort_source = true;
-                Ok(WalkControl::SkipChildren)
-            }
-            Expr::Like { op, escape, .. }
-                if escape.is_some() || matches!(op, LikeOperator::Match | LikeOperator::Regexp) =>
-            {
-                has_runtime_abort_source = true;
-                Ok(WalkControl::SkipChildren)
-            }
-            Expr::Array { elements } => {
-                if elements
-                    .iter()
-                    .any(|expr| expr_has_runtime_abort_source(expr))
-                {
-                    has_runtime_abort_source = true;
-                }
-                Ok(WalkControl::SkipChildren)
-            }
-            _ => Ok(WalkControl::Continue),
-        }
-    });
-    has_runtime_abort_source
-}
-
-fn expr_may_abort_after_write(expr: &Expr) -> bool {
-    expr_depends_on_row(expr) && expr_has_runtime_abort_source(expr)
-}
-
-fn index_expr_may_abort_after_write(index: &crate::schema::Index) -> bool {
+fn index_has_row_dependent_expr(index: &Arc<crate::schema::Index>) -> bool {
     index
         .columns
         .iter()
         .filter_map(|column| column.expr.as_deref())
-        .any(expr_may_abort_after_write)
+        .any(expr_is_row_dependent)
         || index
             .where_clause
             .as_deref()
-            .is_some_and(expr_may_abort_after_write)
+            .is_some_and(expr_is_row_dependent)
 }
 
 /// Determine whether any constraint's effective resolution can trigger an
@@ -327,15 +277,15 @@ pub(crate) fn set_update_stmt_journal_flags(
     let row_expr_may_abort = plan
         .where_clause
         .iter()
-        .any(|term| expr_may_abort_after_write(&term.expr))
+        .any(|term| expr_is_row_dependent(&term.expr))
         || plan
             .set_clauses
             .iter()
-            .any(|set_clause| expr_may_abort_after_write(&set_clause.expr))
+            .any(|set_clause| expr_is_row_dependent(&set_clause.expr))
         || plan
             .indexes_to_update
             .iter()
-            .any(|index| index_expr_may_abort_after_write(index));
+            .any(index_has_row_dependent_expr);
 
     let may_abort = has_triggers
         || has_fks
@@ -385,11 +335,8 @@ pub(crate) fn set_delete_stmt_journal_flags(
     let row_expr_may_abort = plan
         .where_clause
         .iter()
-        .any(|term| expr_may_abort_after_write(&term.expr))
-        || plan
-            .indexes
-            .iter()
-            .any(|index| index_expr_may_abort_after_write(index));
+        .any(|term| expr_is_row_dependent(&term.expr))
+        || plan.indexes.iter().any(index_has_row_dependent_expr);
     if !has_triggers && !has_fks && !row_expr_may_abort {
         program.set_may_abort(false);
     }

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -26,7 +26,7 @@ use crate::translate::plan::{DeletePlan, DmlSafetyReason, UpdatePlan};
 use crate::translate::trigger_exec::has_triggers_including_temp;
 use crate::vdbe::builder::ProgramBuilder;
 use crate::{sync::Arc, Connection, Result};
-use turso_parser::ast::{ResolveType, TriggerEvent};
+use turso_parser::ast::{Expr, LikeOperator, ResolveType, TriggerEvent};
 
 /// Check whether any DDL-level constraint (IPK or index) uses REPLACE.
 pub(crate) fn any_index_or_ipk_has_replace(
@@ -64,6 +64,173 @@ fn table_has_fks(
     connection.foreign_keys_enabled()
         && (resolver.with_schema(database_id, |s| s.has_child_fks(table_name))
             || resolver.with_schema(database_id, |s| s.any_resolved_fks_referencing(table_name)))
+}
+
+fn expr_depends_on_row(expr: &Expr) -> bool {
+    match expr {
+        // Planned DML expressions are usually bound to Column/RowId. Schema-stored
+        // index expressions still contain identifiers, and here they only appear
+        // after the index was selected for maintenance.
+        Expr::Column { .. }
+        | Expr::DoublyQualified(_, _, _)
+        | Expr::Id(_)
+        | Expr::Name(_)
+        | Expr::Qualified(_, _)
+        | Expr::RowId { .. }
+        | Expr::Register(_)
+        | Expr::SubqueryResult { .. } => true,
+        Expr::Exists(_) | Expr::Subquery(_) | Expr::InSelect { .. } => true,
+        Expr::Between {
+            lhs, start, end, ..
+        } => expr_depends_on_row(lhs) || expr_depends_on_row(start) || expr_depends_on_row(end),
+        Expr::Binary(lhs, _, rhs) => expr_depends_on_row(lhs) || expr_depends_on_row(rhs),
+        Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            base.as_ref().is_some_and(|expr| expr_depends_on_row(expr))
+                || when_then_pairs
+                    .iter()
+                    .any(|(when, then)| expr_depends_on_row(when) || expr_depends_on_row(then))
+                || else_expr
+                    .as_ref()
+                    .is_some_and(|expr| expr_depends_on_row(expr))
+        }
+        Expr::Cast { expr, .. }
+        | Expr::Collate(expr, _)
+        | Expr::IsNull(expr)
+        | Expr::NotNull(expr)
+        | Expr::Unary(_, expr)
+        | Expr::FieldAccess { base: expr, .. } => expr_depends_on_row(expr),
+        Expr::FunctionCall {
+            args,
+            order_by,
+            filter_over,
+            ..
+        } => {
+            args.iter().any(|expr| expr_depends_on_row(expr))
+                || order_by.iter().any(|col| expr_depends_on_row(&col.expr))
+                || filter_over
+                    .filter_clause
+                    .as_ref()
+                    .is_some_and(|expr| expr_depends_on_row(expr))
+        }
+        Expr::FunctionCallStar { filter_over, .. } => filter_over
+            .filter_clause
+            .as_ref()
+            .is_some_and(|expr| expr_depends_on_row(expr)),
+        Expr::InList { lhs, rhs, .. } => {
+            expr_depends_on_row(lhs) || rhs.iter().any(|expr| expr_depends_on_row(expr))
+        }
+        Expr::InTable { lhs, args, .. } => {
+            expr_depends_on_row(lhs) || args.iter().any(|expr| expr_depends_on_row(expr))
+        }
+        Expr::Like {
+            lhs, rhs, escape, ..
+        } => {
+            expr_depends_on_row(lhs)
+                || expr_depends_on_row(rhs)
+                || escape
+                    .as_ref()
+                    .is_some_and(|expr| expr_depends_on_row(expr))
+        }
+        Expr::Parenthesized(exprs) => exprs.iter().any(|expr| expr_depends_on_row(expr)),
+        Expr::Raise(_, expr) => expr.as_ref().is_some_and(|expr| expr_depends_on_row(expr)),
+        Expr::Array { elements } => elements.iter().any(|expr| expr_depends_on_row(expr)),
+        Expr::Subscript { base, index } => expr_depends_on_row(base) || expr_depends_on_row(index),
+        Expr::Literal(_) | Expr::Variable(_) | Expr::Default => false,
+    }
+}
+
+fn expr_has_runtime_abort_source(expr: &Expr) -> bool {
+    match expr {
+        Expr::FunctionCall { .. }
+        | Expr::FunctionCallStar { .. }
+        | Expr::Raise(_, _)
+        | Expr::Exists(_)
+        | Expr::Subquery(_)
+        | Expr::SubqueryResult { .. }
+        | Expr::InSelect { .. }
+        | Expr::InTable { .. }
+        | Expr::FieldAccess { .. }
+        | Expr::Subscript { .. } => true,
+        Expr::Like {
+            lhs,
+            op,
+            rhs,
+            escape,
+            ..
+        } => {
+            escape.is_some()
+                || matches!(op, LikeOperator::Match | LikeOperator::Regexp)
+                || expr_has_runtime_abort_source(lhs)
+                || expr_has_runtime_abort_source(rhs)
+        }
+        Expr::Between {
+            lhs, start, end, ..
+        } => {
+            expr_has_runtime_abort_source(lhs)
+                || expr_has_runtime_abort_source(start)
+                || expr_has_runtime_abort_source(end)
+        }
+        Expr::Binary(lhs, _, rhs) => {
+            expr_has_runtime_abort_source(lhs) || expr_has_runtime_abort_source(rhs)
+        }
+        Expr::Case {
+            base,
+            when_then_pairs,
+            else_expr,
+        } => {
+            base.as_ref()
+                .is_some_and(|expr| expr_has_runtime_abort_source(expr))
+                || when_then_pairs.iter().any(|(when, then)| {
+                    expr_has_runtime_abort_source(when) || expr_has_runtime_abort_source(then)
+                })
+                || else_expr
+                    .as_ref()
+                    .is_some_and(|expr| expr_has_runtime_abort_source(expr))
+        }
+        Expr::Cast { expr, .. }
+        | Expr::Collate(expr, _)
+        | Expr::IsNull(expr)
+        | Expr::NotNull(expr)
+        | Expr::Unary(_, expr) => expr_has_runtime_abort_source(expr),
+        Expr::InList { lhs, rhs, .. } => {
+            expr_has_runtime_abort_source(lhs)
+                || rhs.iter().any(|expr| expr_has_runtime_abort_source(expr))
+        }
+        Expr::Parenthesized(exprs) => exprs.iter().any(|expr| expr_has_runtime_abort_source(expr)),
+        Expr::Array { elements } => elements
+            .iter()
+            .any(|expr| expr_has_runtime_abort_source(expr)),
+        Expr::Column { .. }
+        | Expr::Register(_)
+        | Expr::DoublyQualified(_, _, _)
+        | Expr::Id(_)
+        | Expr::Literal(_)
+        | Expr::Name(_)
+        | Expr::Qualified(_, _)
+        | Expr::RowId { .. }
+        | Expr::Variable(_)
+        | Expr::Default => false,
+    }
+}
+
+fn expr_may_abort_after_write(expr: &Expr) -> bool {
+    expr_depends_on_row(expr) && expr_has_runtime_abort_source(expr)
+}
+
+fn index_expr_may_abort_after_write(index: &crate::schema::Index) -> bool {
+    index
+        .columns
+        .iter()
+        .filter_map(|column| column.expr.as_deref())
+        .any(expr_may_abort_after_write)
+        || index
+            .where_clause
+            .as_deref()
+            .is_some_and(expr_may_abort_after_write)
 }
 
 /// Determine whether any constraint's effective resolution can trigger an
@@ -230,9 +397,22 @@ pub(crate) fn set_update_stmt_journal_flags(
     let has_check = !btree_table.check_constraints.is_empty();
     let has_unique =
         !btree_table.unique_sets.is_empty() || plan.indexes_to_update.iter().any(|idx| idx.unique);
+    let row_expr_may_abort = plan
+        .where_clause
+        .iter()
+        .any(|term| expr_may_abort_after_write(&term.expr))
+        || plan
+            .set_clauses
+            .iter()
+            .any(|set_clause| expr_may_abort_after_write(&set_clause.expr))
+        || plan
+            .indexes_to_update
+            .iter()
+            .any(|index| index_expr_may_abort_after_write(index));
 
     let may_abort = has_triggers
         || has_fks
+        || row_expr_may_abort
         || constraint_may_abort(
             has_statement_conflict,
             or_conflict,
@@ -275,7 +455,15 @@ pub(crate) fn set_delete_stmt_journal_flags(
 
     // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
     // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
+    let row_expr_may_abort = plan
+        .where_clause
+        .iter()
+        .any(|term| expr_may_abort_after_write(&term.expr))
+        || plan
+            .indexes
+            .iter()
+            .any(|index| index_expr_may_abort_after_write(index));
+    if !has_triggers && !has_fks && !row_expr_may_abort {
         program.set_may_abort(false);
     }
     Ok(())

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -289,6 +289,88 @@ fn update_composite_unique_partial_cols(tmp_db: TempDatabase) -> anyhow::Result<
     Ok(())
 }
 
+/// A row-dependent runtime expression error can happen after earlier rows were
+/// already updated, so multi-row UPDATE needs a statement journal even without
+/// schema constraints.
+#[turso_macros::test]
+fn update_runtime_expr_error_rolls_back_statement(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10),(2,20)")?;
+
+    assert!(needs_stmt_journal(
+        &conn,
+        "UPDATE t SET x = CASE
+            WHEN id=1 THEN 11
+            ELSE (char(120) LIKE char(120) ESCAPE (char(121)||char(121)))
+        END"
+    ));
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(
+        "UPDATE t SET x = CASE
+            WHEN id=1 THEN 11
+            ELSE (char(120) LIKE char(120) ESCAPE (char(121)||char(121)))
+        END",
+    );
+    assert!(result.is_err(), "UPDATE should fail on invalid ESCAPE");
+
+    let rows = query_rows(&conn, "SELECT id,x FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|10", "2|20"],
+        "failed UPDATE should roll back all row changes"
+    );
+
+    conn.execute("COMMIT")?;
+    let rows = query_rows(&conn, "SELECT id,x FROM t ORDER BY id");
+    assert_eq!(rows, vec!["1|10", "2|20"]);
+    Ok(())
+}
+
+/// Partial-index predicates are evaluated while maintaining indexes for each
+/// updated row. If one aborts, previous row updates must be undone.
+#[turso_macros::test]
+fn update_partial_index_expr_error_rolls_back_statement(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,1,1),(2,2,1),(3,3,1)")?;
+    conn.execute(
+        "CREATE INDEX idx ON t(a)
+         WHERE CASE
+           WHEN b=2 THEN 'x' LIKE 'x' ESCAPE 'yy'
+           ELSE 1
+         END",
+    )?;
+
+    assert!(needs_stmt_journal(
+        &conn,
+        "UPDATE t SET a=a, b=CASE WHEN id=2 THEN 2 ELSE b+10 END"
+    ));
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute("UPDATE t SET a=a, b=CASE WHEN id=2 THEN 2 ELSE b+10 END");
+    assert!(
+        result.is_err(),
+        "UPDATE should fail while evaluating partial index predicate"
+    );
+
+    let rows = query_rows(&conn, "SELECT id,a,b FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|1|1", "2|2|1", "3|3|1"],
+        "failed UPDATE should roll back all row changes"
+    );
+    let ic = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(ic, vec!["ok"]);
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 // ──────────────────────────────────────────────────────────
 // DELETE
 // ──────────────────────────────────────────────────────────
@@ -339,6 +421,43 @@ fn delete_by_rowid_with_fk(tmp_db: TempDatabase) -> anyhow::Result<()> {
     // FK constraint checks modify deferred violation counter before the statement can abort,
     // so multi_write stays true. needs_stmt = true && true = true.
     assert!(needs_stmt_journal(&conn, "DELETE FROM parent WHERE id = 5"));
+    Ok(())
+}
+
+/// DELETE predicates can also abort after earlier rows were removed.
+#[turso_macros::test]
+fn delete_runtime_expr_error_rolls_back_statement(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10),(2,20)")?;
+
+    assert!(needs_stmt_journal(
+        &conn,
+        "DELETE FROM t
+         WHERE CASE
+           WHEN id=1 THEN 1
+           ELSE 'x' LIKE 'x' ESCAPE 'yy'
+         END"
+    ));
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(
+        "DELETE FROM t
+         WHERE CASE
+           WHEN id=1 THEN 1
+           ELSE 'x' LIKE 'x' ESCAPE 'yy'
+         END",
+    );
+    assert!(result.is_err(), "DELETE should fail on invalid ESCAPE");
+
+    let rows = query_rows(&conn, "SELECT id,x FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|10", "2|20"],
+        "failed DELETE should roll back all row changes"
+    );
+    conn.execute("COMMIT")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Fixes #6879 by making statement-journal `may_abort` analysis account for row-dependent expression evaluation in UPDATE and DELETE, not only schema constraints, triggers, and FKs.

## Root Cause
Statement journals are enabled with `usesStmtJournal = isMultiWrite && mayAbort`. For multi-row UPDATE/DELETE statements, `stmt_journal.rs` could set `mayAbort=false` when the schema had no aborting constraints. Runtime expression evaluation can still fail after earlier rows have already been written, for example an invalid `LIKE ... ESCAPE` expression on a later row or a maintained partial-index predicate.

## Fix
- Detect row-dependent runtime expression abort sources in UPDATE SET/WHERE expressions and DELETE WHERE expressions.
- Include maintained expression-index keys and partial-index predicates in the same analysis.
- Keep the existing fast path for simple DML with no row-dependent abort source.
- Use the existing expression walker for the analysis to keep the new logic aligned with other translation code.

## Tests
- UPDATE SET expression failure rolls back prior row writes.
- UPDATE partial-index predicate failure rolls back prior row writes and preserves integrity.
- DELETE predicate failure rolls back prior deleted rows.

Local verification:
- `cargo test -p core_tester --test integration_tests stmt_journal -- --nocapture`
- `cargo test -p core_tester --test fuzz_tests subjournal -- --nocapture`

## CI Note
The earlier Rust workflow failure was in `sync::tests::test_sync_parallel_writes_with_sync_ops` with `Busy("database is locked")` during a concurrent sync/write test. This PR only changes UPDATE/DELETE statement-journal flag analysis; the follow-up push reruns CI on the latest commit.