### PR TITLE
Fix materialized view deltas on statement rollback

### DIFF
--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -138,6 +138,8 @@ pub struct AllViewsTxState {
     states: Rc<RefCell<HashMap<String, Arc<ViewTransactionState>>>>,
 }
 
+pub(crate) type AllViewsTxStateSnapshot = Vec<(String, ViewTransactionState)>;
+
 // SAFETY: This needs to be audited for thread safety.
 // See: https://github.com/tursodatabase/turso/issues/1552
 unsafe impl Send for AllViewsTxState {}
@@ -173,6 +175,27 @@ impl AllViewsTxState {
     /// Clear all transaction states
     pub fn clear(&self) {
         self.states.borrow_mut().clear();
+    }
+
+    /// Capture the current transaction deltas so statement rollback can discard
+    /// only the deltas produced by the failed statement.
+    pub(crate) fn snapshot(&self) -> AllViewsTxStateSnapshot {
+        self.states
+            .borrow()
+            .iter()
+            .map(|(view_name, tx_state)| (view_name.clone(), tx_state.as_ref().clone()))
+            .collect()
+    }
+
+    /// Restore a previously captured transaction-delta snapshot.
+    pub(crate) fn restore(&self, snapshot: AllViewsTxStateSnapshot) {
+        let mut states = self.states.borrow_mut();
+        states.clear();
+        states.extend(
+            snapshot
+                .into_iter()
+                .map(|(view_name, tx_state)| (view_name, Arc::new(tx_state))),
+        );
     }
 
     /// Check if there are no transaction states

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -39,6 +39,7 @@ pub use crate::translate::collate::CollationSeq;
 use crate::{
     error::LimboError,
     function::{AggFunc, FuncCtx},
+    incremental::view::AllViewsTxStateSnapshot,
     mvcc::{database::CommitStateMachine, MvccClock},
     numeric::Numeric,
     return_if_io,
@@ -668,6 +669,7 @@ pub struct ProgramState {
     pub(crate) is_active_write: bool,
     /// Whether begin_statement was called (savepoint + FK bookkeeping active).
     has_stmt_transaction: bool,
+    view_transaction_states_when_stmt_started: Option<AllViewsTxStateSnapshot>,
     pub n_change: AtomicI64,
 }
 
@@ -725,6 +727,7 @@ impl ProgramState {
             uses_subjournal: false,
             is_active_write: false,
             has_stmt_transaction: false,
+            view_transaction_states_when_stmt_started: None,
             attached_savepoint_pagers: Vec::new(),
             n_change: AtomicI64::new(0),
             explain_state: RwLock::new(ExplainState::default()),
@@ -952,6 +955,8 @@ impl ProgramState {
         }
 
         self.has_stmt_transaction = true;
+        self.view_transaction_states_when_stmt_started =
+            Some(connection.view_transaction_states.snapshot());
 
         // Store the deferred foreign key violations counter at the start of the statement.
         // This is used to ensure that if an interactive transaction had deferred FK violations and a statement subtransaction rolls back,
@@ -987,6 +992,8 @@ impl ProgramState {
             return Ok(());
         }
         self.has_stmt_transaction = false;
+        let view_transaction_states_when_stmt_started =
+            self.view_transaction_states_when_stmt_started.take();
 
         // Drain attached pagers upfront so we can clean them up regardless of path.
         let attached_pagers: Vec<Arc<Pager>> = self.attached_savepoint_pagers.drain(..).collect();
@@ -1062,6 +1069,10 @@ impl ProgramState {
                 // Always restore FK violation counters on statement rollback,
                 // regardless of whether a pager savepoint was opened.
                 // Mirrors SQLite's vdbeCloseStatement (vdbeaux.c:3243-3246).
+                if let Some(snapshot) = view_transaction_states_when_stmt_started {
+                    connection.view_transaction_states.restore(snapshot);
+                }
+
                 connection.fk_deferred_violations.store(
                     self.fk_deferred_violations_when_stmt_started
                         .load(Ordering::Acquire),

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1768,6 +1768,73 @@ fn test_matview_row_loss_during_btree_split(tmp_db: TempDatabase) -> anyhow::Res
     Ok(())
 }
 
+#[turso_macros::test(views)]
+fn test_aborted_insert_does_not_leave_stale_materialized_view_delta(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER NOT NULL)")?;
+    conn.execute("CREATE MATERIALIZED VIEW mv AS SELECT v, COUNT(*) AS cnt FROM t GROUP BY v")?;
+    conn.execute("INSERT INTO t VALUES (1, 10)")?;
+    conn.execute("INSERT INTO t VALUES (2, 20)")?;
+
+    let err = conn
+        .execute("INSERT INTO t SELECT 3 AS id, 30 AS v UNION ALL SELECT 1, 99")
+        .unwrap_err();
+    assert!(matches!(err, LimboError::Constraint(_)));
+
+    conn.execute("INSERT INTO t VALUES (4, 40)")?;
+
+    let mv_rows = limbo_exec_rows(&conn, "SELECT v, cnt FROM mv ORDER BY v");
+    assert_eq!(
+        mv_rows,
+        vec![
+            vec![RValue::Integer(10), RValue::Integer(1)],
+            vec![RValue::Integer(20), RValue::Integer(1)],
+            vec![RValue::Integer(40), RValue::Integer(1)],
+        ]
+    );
+
+    let table_rows = limbo_exec_rows(&conn, "SELECT v, COUNT(*) FROM t GROUP BY v ORDER BY v");
+    assert_eq!(mv_rows, table_rows);
+
+    Ok(())
+}
+
+#[turso_macros::test(views)]
+fn test_statement_rollback_preserves_prior_materialized_view_deltas(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER NOT NULL)")?;
+    conn.execute("CREATE MATERIALIZED VIEW mv AS SELECT v, COUNT(*) AS cnt FROM t GROUP BY v")?;
+
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (1, 10)")?;
+    let err = conn
+        .execute("INSERT INTO t SELECT 2 AS id, 20 AS v UNION ALL SELECT 1, 99")
+        .unwrap_err();
+    assert!(matches!(err, LimboError::Constraint(_)));
+    conn.execute("INSERT INTO t VALUES (3, 30)")?;
+    conn.execute("COMMIT")?;
+
+    let mv_rows = limbo_exec_rows(&conn, "SELECT v, cnt FROM mv ORDER BY v");
+    assert_eq!(
+        mv_rows,
+        vec![
+            vec![RValue::Integer(10), RValue::Integer(1)],
+            vec![RValue::Integer(30), RValue::Integer(1)],
+        ]
+    );
+
+    let table_rows = limbo_exec_rows(&conn, "SELECT v, COUNT(*) FROM t GROUP BY v ORDER BY v");
+    assert_eq!(mv_rows, table_rows);
+
+    Ok(())
+}
+
 /// Regression test for simulator seed 867: UPDATE on an attached database table
 /// that changes the primary key (rowid) while a UNIQUE index exists would use
 /// the wrong database_id (0 instead of the attached db) for OpenWrite cursors,


### PR DESCRIPTION
## Summary
- Snapshot materialized-view transaction deltas when a statement savepoint starts.
- Restore that snapshot when the statement rolls back, so deltas produced by an aborted statement cannot leak into the next commit.
- Add regressions for #6771 covering both autocommit aborts and explicit transactions with prior successful statement deltas.

Fixes #6771.

## Reproduction fixed
Before this patch, the #6771 reproducer leaves a stale `(30, 1)` row in the materialized view after the `INSERT ... SELECT` aborts on a primary-key conflict. The base table does not contain that row, so the materialized view diverges from the source table.

After this patch, the materialized view and source table both return only `(10, 1)`, `(20, 1)`, and `(40, 1)` for the autocommit reproducer.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p core_tester --test integration_tests test_aborted_insert_does_not_leave_stale_materialized_view_delta -- --nocapture`
- `cargo test -p core_tester --test integration_tests test_statement_rollback_preserves_prior_materialized_view_deltas -- --nocapture`
- Manual CLI reproduction with `cargo run -q --bin tursodb -- --experimental-views -q -m list :memory:`

## Transparency
This PR was AI-assisted and manually reviewed before submission. The fix and tests were validated locally with the commands above.
