### PR TITLE
Fix UPSERT target register comparison metadata

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -150,6 +150,9 @@ pub struct Resolver<'a> {
     /// mechanism, but operates as a side-channel since limbo rewrites the AST rather
     /// than redirecting column reads at codegen time.
     pub register_affinities: HashMap<usize, Affinity>,
+    /// Maps register indices to column collations for expression evaluation after
+    /// column references have been rewritten to Expr::Register.
+    pub register_collations: HashMap<usize, CollationSeq>,
     /// Affinity metadata for planned scalar subqueries keyed by their internal ID.
     /// This lets comparison affinity follow SQLite rules for expressions like
     /// `(SELECT text_col FROM ...) > some_numeric_expr`.
@@ -278,6 +281,7 @@ impl<'a> Resolver<'a> {
             expr_to_reg_cache_enabled: false,
             expr_to_reg_cache: Vec::new(),
             register_affinities: HashMap::default(),
+            register_collations: HashMap::default(),
             subquery_affinities: RefCell::new(HashMap::default()),
             self_table_scope: RefCell::new(None),
             enable_custom_types,
@@ -306,6 +310,7 @@ impl<'a> Resolver<'a> {
             expr_to_reg_cache_enabled: false,
             expr_to_reg_cache: Vec::new(),
             register_affinities: HashMap::default(),
+            register_collations: HashMap::default(),
             subquery_affinities: RefCell::new(self.subquery_affinities.borrow().clone()),
             self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
             enable_custom_types: self.enable_custom_types,
@@ -326,6 +331,7 @@ impl<'a> Resolver<'a> {
             expr_to_reg_cache_enabled: self.expr_to_reg_cache_enabled,
             expr_to_reg_cache: self.expr_to_reg_cache.clone(),
             register_affinities: self.register_affinities.clone(),
+            register_collations: self.register_collations.clone(),
             subquery_affinities: RefCell::new(self.subquery_affinities.borrow().clone()),
             self_table_scope: RefCell::new(self.self_table_scope.borrow().clone()),
             enable_custom_types: self.enable_custom_types,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1543,6 +1543,10 @@ fn emit_update_insns<'a>(
                 .resolver
                 .register_affinities
                 .insert(layout.to_register(start, idx), col.affinity());
+            t_ctx
+                .resolver
+                .register_collations
+                .insert(layout.to_register(start, idx), col.collation());
         }
         t_ctx
             .resolver
@@ -2568,5 +2572,6 @@ fn emit_update_insns<'a>(
     program.preassign_label_to_next_insn(trigger_ignore_jump_label);
 
     t_ctx.resolver.register_affinities.clear();
+    t_ctx.resolver.register_collations.clear();
     Ok(())
 }

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -3063,6 +3063,9 @@ pub fn translate_expr(
         }
         ast::Expr::Register(src_reg) => {
             // For DBSP expression compilation: copy from source register to target
+            if let Some(collation) = resolver.register_collations.get(src_reg) {
+                program.set_collation(Some((*collation, false)));
+            }
             program.emit_insn(Insn::Copy {
                 src_reg: *src_reg,
                 dst_reg: target_register,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -906,6 +906,7 @@ pub fn translate_insert(
     }
 
     resolver.register_affinities.clear();
+    resolver.register_collations.clear();
 
     let mut insert_flags = InsertFlags::new();
 
@@ -2356,6 +2357,10 @@ impl<'a> Insertion<'a> {
     /// Return the register that contains the record built using the MakeRecord instruction.
     pub fn record_register(&self) -> usize {
         self.record_reg
+    }
+
+    pub fn col_mappings(&self) -> &[ColMapping<'a>] {
+        &self.col_mappings
     }
 
     fn has_virtual_columns(&self) -> bool {

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -879,6 +879,7 @@ pub fn fire_trigger(
     let ctx = &decode_trigger_registers(program, resolver, ctx)?;
 
     let saved_register_affinities = std::mem::take(&mut resolver.register_affinities);
+    let saved_register_collations = std::mem::take(&mut resolver.register_collations);
     populate_trigger_register_affinities(resolver, ctx);
     let result = (|| -> Result<()> {
         // Evaluate WHEN clause if present
@@ -950,6 +951,7 @@ pub fn fire_trigger(
         Ok(())
     })();
     resolver.register_affinities = saved_register_affinities;
+    resolver.register_collations = saved_register_collations;
     result
 }
 

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -180,6 +180,47 @@ fn collect_changed_cols(
     (cols_changed, rowid_changed)
 }
 
+fn populate_row_register_metadata(
+    resolver: &mut Resolver,
+    table: &Table,
+    row_start: usize,
+    rowid_reg: usize,
+    layout: &ColumnLayout,
+) {
+    let is_strict = table.btree().is_some_and(|bt| bt.is_strict);
+    for (idx, col) in table.columns().iter().enumerate() {
+        let reg = if col.is_rowid_alias() {
+            rowid_reg
+        } else {
+            layout.to_register(row_start, idx)
+        };
+        let affinity = if col.is_rowid_alias() {
+            Affinity::Integer
+        } else {
+            col.affinity_with_strict(is_strict)
+        };
+        resolver.register_affinities.insert(reg, affinity);
+        resolver.register_collations.insert(reg, col.collation());
+    }
+    resolver
+        .register_affinities
+        .insert(rowid_reg, Affinity::Integer);
+}
+
+fn populate_insertion_register_metadata(resolver: &mut Resolver, insertion: &Insertion) {
+    for cm in insertion.col_mappings() {
+        resolver
+            .register_affinities
+            .insert(cm.register, cm.column.affinity());
+        resolver
+            .register_collations
+            .insert(cm.register, cm.column.collation());
+    }
+    resolver
+        .register_affinities
+        .insert(insertion.key_register(), Affinity::Integer);
+}
+
 #[inline]
 fn upsert_index_is_affected(
     table: &Table,
@@ -515,6 +556,14 @@ pub fn emit_upsert(
     // For WHERE and SET, use decoded_current_start if available (STRICT with custom types),
     // otherwise fall back to current_start (already decoded or non-custom-type).
     let expr_current_start = decoded_current_start.unwrap_or(current_start);
+    populate_row_register_metadata(
+        resolver,
+        table,
+        expr_current_start,
+        ctx.conflict_rowid_reg,
+        &layout,
+    );
+    populate_insertion_register_metadata(resolver, insertion);
 
     // WHERE on target row
     if let Some(pred) = where_clause.as_mut() {
@@ -682,6 +731,13 @@ pub fn emit_upsert(
     }
 
     let (directly_changed_cols, rowid_changed) = collect_changed_cols(table, set_pairs);
+    populate_row_register_metadata(
+        resolver,
+        table,
+        new_start,
+        new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg),
+        &layout,
+    );
 
     // Fire BEFORE UPDATE triggers
     let upsert_database_id = ctx.database_id;

--- a/testing/simulator/runner/memory/mod.rs
+++ b/testing/simulator/runner/memory/mod.rs
@@ -5,3 +5,5 @@ pub mod io;
 mod mvcc_recovery;
 #[cfg(test)]
 mod statement_abandon;
+#[cfg(test)]
+mod upsert_register_metadata;

--- a/testing/simulator/runner/memory/upsert_register_metadata.rs
+++ b/testing/simulator/runner/memory/upsert_register_metadata.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
+
+use crate::runner::memory::io::MemorySimIO;
+
+fn make_conn(seed: u64) -> Result<(Arc<Connection>, Arc<MemorySimIO>)> {
+    let io = Arc::new(MemorySimIO::new(seed, 4096, 100, 1, 5));
+    let path = format!("sim_upsert_register_metadata_{seed}.db");
+    let db = Database::open_file_with_flags(
+        io.clone() as Arc<dyn IO>,
+        &path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    Ok((db.connect()?, io))
+}
+
+fn query_rows(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<Vec<(i64, String, i64)>> {
+    let mut stmt = conn.prepare("SELECT id, CAST(a AS TEXT), x FROM t ORDER BY id")?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist");
+                rows.push((
+                    row.get::<i64>(0).expect("id column should exist"),
+                    row.get::<String>(1).expect("a column should exist"),
+                    row.get::<i64>(2).expect("x column should exist"),
+                ));
+            }
+            StepResult::Done => return Ok(rows),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+fn query_integrity(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<String> {
+    let mut stmt = conn.prepare("PRAGMA integrity_check")?;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist");
+                return Ok(row.get::<String>(0).expect("integrity row should exist"));
+            }
+            StepResult::Done => panic!("integrity_check ended without a row"),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn sim_upsert_where_respects_rewritten_target_column_affinity() -> Result<()> {
+    let (conn, io) = make_conn(6866)?;
+    conn.execute("PRAGMA journal_mode=WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, x INT)")?;
+    conn.execute("CREATE INDEX idx_x ON t(x)")?;
+    conn.execute("INSERT INTO t VALUES(1,10,100)")?;
+    conn.execute("INSERT INTO t VALUES(2,20,200)")?;
+
+    conn.execute("BEGIN")?;
+    conn.execute(
+        "INSERT OR FAIL INTO t(id,a,x) VALUES(1,99,999) \
+         ON CONFLICT(id) DO UPDATE SET id=2 WHERE a < '2'",
+    )?;
+    conn.execute("COMMIT")?;
+
+    assert_eq!(
+        query_rows(&conn, io.as_ref())?,
+        vec![(1, "10".to_string(), 100), (2, "20".to_string(), 200)]
+    );
+    assert_eq!(query_integrity(&conn, io.as_ref())?, "ok");
+    Ok(())
+}
+
+#[test]
+fn sim_upsert_where_respects_rewritten_target_column_collation() -> Result<()> {
+    let (conn, io) = make_conn(6867)?;
+    conn.execute("PRAGMA journal_mode=WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT COLLATE NOCASE, x INT)")?;
+    conn.execute("CREATE INDEX idx_x ON t(x)")?;
+    conn.execute("INSERT INTO t VALUES(1,'A',100)")?;
+    conn.execute("INSERT INTO t VALUES(2,'B',200)")?;
+
+    conn.execute("BEGIN")?;
+    conn.execute(
+        "INSERT OR FAIL INTO t(id,a,x) VALUES(1,'Z',999) \
+         ON CONFLICT(id) DO UPDATE SET id=2 WHERE a != 'a'",
+    )?;
+    conn.execute("COMMIT")?;
+
+    assert_eq!(
+        query_rows(&conn, io.as_ref())?,
+        vec![(1, "A".to_string(), 100), (2, "B".to_string(), 200)]
+    );
+    assert_eq!(query_integrity(&conn, io.as_ref())?, "ok");
+    Ok(())
+}

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -4702,3 +4702,85 @@ fn test_update_replace_deferred_fk_multiple_children(tmp_db: TempDatabase) {
         "SELECT * FROM parent ORDER BY id",
     );
 }
+
+#[turso_macros::test]
+fn test_upsert_do_update_where_uses_target_column_affinity(tmp_db: TempDatabase) {
+    drop(tmp_db);
+    let limbo_db = TempDatabase::builder()
+        .with_db_name("upsert_where_affinity.db")
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+    for sql in [
+        "PRAGMA journal_mode=WAL",
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, x INT)",
+        "CREATE INDEX idx_x ON t(x)",
+        "INSERT INTO t VALUES(1,10,100)",
+        "INSERT INTO t VALUES(2,20,200)",
+        "BEGIN",
+    ] {
+        sqlite_try_exec(&sqlite_conn, sql).unwrap();
+        limbo_try_exec(&limbo_conn, sql).unwrap();
+    }
+
+    let upsert = "INSERT OR FAIL INTO t(id,a,x) VALUES(1,99,999) \
+                  ON CONFLICT(id) DO UPDATE SET id=2 WHERE a < '2'";
+    sqlite_try_exec(&sqlite_conn, upsert).unwrap();
+    limbo_try_exec(&limbo_conn, upsert).unwrap();
+
+    for sql in ["COMMIT", "PRAGMA integrity_check"] {
+        sqlite_try_exec(&sqlite_conn, sql).unwrap();
+        limbo_try_exec(&limbo_conn, sql).unwrap();
+    }
+
+    let diff = compare_tables(
+        "upsert where target column affinity",
+        &sqlite_conn,
+        &limbo_conn,
+        "SELECT id,a,x FROM t ORDER BY id",
+    );
+    assert!(diff.is_none(), "{diff:?}");
+    assert_eq!(sqlite_integrity_check(&limbo_db.path), "ok");
+}
+
+#[turso_macros::test]
+fn test_upsert_do_update_where_uses_target_column_collation(tmp_db: TempDatabase) {
+    drop(tmp_db);
+    let limbo_db = TempDatabase::builder()
+        .with_db_name("upsert_where_collation.db")
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+    for sql in [
+        "PRAGMA journal_mode=WAL",
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT COLLATE NOCASE, x INT)",
+        "CREATE INDEX idx_x ON t(x)",
+        "INSERT INTO t VALUES(1,'A',100)",
+        "INSERT INTO t VALUES(2,'B',200)",
+        "BEGIN",
+    ] {
+        sqlite_try_exec(&sqlite_conn, sql).unwrap();
+        limbo_try_exec(&limbo_conn, sql).unwrap();
+    }
+
+    let upsert = "INSERT OR FAIL INTO t(id,a,x) VALUES(1,'Z',999) \
+                  ON CONFLICT(id) DO UPDATE SET id=2 WHERE a != 'a'";
+    sqlite_try_exec(&sqlite_conn, upsert).unwrap();
+    limbo_try_exec(&limbo_conn, upsert).unwrap();
+
+    for sql in ["COMMIT", "PRAGMA integrity_check"] {
+        sqlite_try_exec(&sqlite_conn, sql).unwrap();
+        limbo_try_exec(&limbo_conn, sql).unwrap();
+    }
+
+    let diff = compare_tables(
+        "upsert where target column collation",
+        &sqlite_conn,
+        &limbo_conn,
+        "SELECT id,a,x FROM t ORDER BY id",
+    );
+    assert!(diff.is_none(), "{diff:?}");
+    assert_eq!(sqlite_integrity_check(&limbo_db.path), "ok");
+}


### PR DESCRIPTION
## Description

Fixes #6866.
Fixes #6867.

UPSERT DO UPDATE rewrites target-table column references in WHERE/SET expressions to `Expr::Register` so those expressions read from the saved target-row image. The rewrite dropped the original column comparison metadata: affinity and collation. That made predicates such as `a < '2'` on an INTEGER column and `a != 'a'` on a `TEXT COLLATE NOCASE` column evaluate with raw register semantics instead of SQLite's column semantics.

When those predicates incorrectly evaluated true, a rowid-changing DO UPDATE arm could run, hit a later conflict, and leave secondary index state inconsistent. This PR keeps register-to-column metadata alongside the existing register affinity side channel, and populates it for UPSERT target-row and excluded-row registers before translated predicates run.

This complements the open ordering hardening in #6923: that PR mitigates one corruption consequence by delaying index deletion, while this fixes the predicate semantics that incorrectly enter the DO UPDATE arm in the first place.

## Simulator coverage

Added deterministic memory-simulator regressions for both repro classes:

- `sim_upsert_where_respects_rewritten_target_column_affinity`
- `sim_upsert_where_respects_rewritten_target_column_collation`

Both use simulated async memory I/O, WAL mode, the repro UPSERT shape, and `PRAGMA integrity_check`.

## Test plan

- `cargo test -p core_tester test_upsert_do_update_where_uses_target_column_affinity --test integration_tests -- --nocapture`
- `cargo test -p core_tester test_upsert_do_update_where_uses_target_column_collation --test integration_tests -- --nocapture`
- `cargo test -p core_tester test_upsert_do_update_where_uses_target_column --test integration_tests -- --nocapture`
- `cargo test -p limbo_sim upsert_register_metadata -- --nocapture`
- `cargo test -p core_tester conflict_resolution:: --test integration_tests -- --nocapture`
- `cargo fmt --check -p turso_core`
- `cargo fmt --check -p core_tester`
- `cargo fmt --check -p limbo_sim`
- `git diff --check`

## Description of AI Usage

Prepared with OpenAI Codex assistance for code search, implementation, and local verification. I inspected the final diff and ran the validation above before submitting.
