### PR TITLE
core: evaluate aggregate filter subqueries before aggregation

### DIFF
--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -14,7 +14,8 @@ use crate::{
             emit_program_for_select_with_resolver, emit_query,
         },
         expr::{
-            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr_mut, WalkControl,
+            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr, walk_expr_mut,
+            WalkControl,
         },
         optimizer::optimize_select_plan,
         plan::{
@@ -345,7 +346,7 @@ pub fn plan_subqueries_from_select_plan(
         recollect_aggregates(plan, resolver)?;
     }
 
-    assign_select_subquery_eval_phases(plan);
+    assign_select_subquery_eval_phases(plan)?;
     mark_shared_cte_materialization_requirements(
         &mut plan.table_references,
         &mut plan.non_from_clause_subqueries,
@@ -1969,18 +1970,44 @@ pub fn emit_non_from_clause_subqueries_for_eval_at(
     )
 }
 
-fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) {
+fn collect_subquery_result_ids(
+    expr: &ast::Expr,
+    ids: &mut Vec<ast::TableInternalId>,
+) -> Result<()> {
+    walk_expr(expr, &mut |expr| {
+        if let ast::Expr::SubqueryResult { subquery_id, .. } = expr {
+            ids.push(*subquery_id);
+        }
+        Ok(WalkControl::Continue)
+    })?;
+    Ok(())
+}
+
+fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) -> Result<()> {
     let has_grouped_output = plan
         .group_by
         .as_ref()
         .is_some_and(|group_by| !group_by.exprs.is_empty());
 
+    let mut aggregate_input_subqueries = Vec::new();
+    for aggregate in &plan.aggregates {
+        for arg in &aggregate.args {
+            collect_subquery_result_ids(arg, &mut aggregate_input_subqueries)?;
+        }
+        if let Some(filter_expr) = &aggregate.filter_expr {
+            collect_subquery_result_ids(filter_expr, &mut aggregate_input_subqueries)?;
+        }
+    }
+
     for subquery in plan.non_from_clause_subqueries.iter_mut() {
-        subquery.eval_phase = match subquery.origin {
-            SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy if has_grouped_output => {
+        let is_aggregate_input = aggregate_input_subqueries.contains(&subquery.internal_id);
+        subquery.eval_phase = match (subquery.origin, has_grouped_output, is_aggregate_input) {
+            (SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy, true, false) => {
                 SubqueryEvalPhase::GroupedOutput
             }
             _ => subquery.origin.phase_floor(),
         };
     }
+
+    Ok(())
 }

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -46,6 +46,26 @@ fn checkpoint_attached_database(
 }
 
 #[turso_macros::test]
+fn test_in_subquery_inside_aggregate_filter_is_ready_before_aggregate_step(
+    _tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new());
+    let conn = db.connect_limbo();
+    let aux_path = db.path.with_extension("attach_aggregate_filter.db");
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY)")?;
+    conn.execute("INSERT INTO t VALUES (1)")?;
+    conn.execute("CREATE TABLE aux.u(x INTEGER PRIMARY KEY)")?;
+    conn.execute("INSERT INTO aux.u VALUES (1)")?;
+
+    let rows = limbo_exec_rows(&conn, "SELECT * FROM aux.u WHERE EXISTS (SELECT 1 FROM aux.u GROUP BY x HAVING count(x) FILTER (WHERE 1 IN (SELECT a FROM t LIMIT 1)) <= 1)");
+    assert_eq!(rows.len(), 1);
+
+    Ok(())
+}
+
+#[turso_macros::test]
 fn test_attached_schema_refreshes_after_other_connection_create(
     tmp_db: TempDatabase,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- keep subqueries used by aggregate args/filter expressions on the pre-aggregation evaluation path
- add a regression test for an aggregate FILTER expression that contains an IN subquery over an attached database

## Root cause
Grouped HAVING/ORDER BY subqueries were moved to grouped-output evaluation even when the subquery belonged to an aggregate input. Aggregate FILTER expressions run while stepping rows, so the generated bytecode could probe the IN-subquery ephemeral cursor before it was opened.

## Tests
- cargo test -p core_tester test_in_subquery_inside_aggregate_filter_is_ready_before_aggregate_step -- --nocapture
- cargo test -p core_tester --test integration_tests attach:: -- --nocapture
- differential_fuzzer -s 12960939164282862537 -t 2 -c 5 -n 100 -g sql-gen -k