### PR TITLE
pager: allow cache growth when cache_spill is off

### DIFF
--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -611,7 +611,11 @@ impl PageCache {
 
         let target_len = self.capacity - n;
         while self.len() > target_len {
-            self.evict_one()?;
+            match self.evict_one() {
+                Ok(()) => {}
+                Err(CacheError::Full) if !self.spill_enabled => return Ok(()),
+                Err(e) => return Err(e),
+            }
         }
         Ok(())
     }
@@ -1093,6 +1097,27 @@ mod tests {
 
         assert_eq!(result, Err(CacheError::Full));
         assert_eq!(cache.len(), 2);
+        cache.verify_cache_integrity();
+    }
+
+    #[test]
+    fn test_insert_can_exceed_capacity_when_spilling_is_disabled() {
+        let mut cache = PageCache::new_with_spill(2, false);
+        let key2 = insert_page(&mut cache, 2);
+        let key3 = insert_page(&mut cache, 3);
+
+        for key in [key2, key3] {
+            cache.notify_page_dirty(key);
+            cache.peek(&key, false).unwrap().set_dirty();
+        }
+
+        let key4 = create_key(4);
+        cache.insert(key4, page_with_content(4)).unwrap();
+
+        assert_eq!(cache.len(), 3);
+        assert!(cache.contains_key(&key2));
+        assert!(cache.contains_key(&key3));
+        assert!(cache.contains_key(&key4));
         cache.verify_cache_integrity();
     }
 

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -110,6 +110,68 @@ fn test_savepoint_rollback_after_cache_spill_preserves_wal_pages(
     Ok(())
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
+#[turso_macros::test]
+fn test_cache_spill_off_large_update_does_not_partially_commit(tmp_db: TempDatabase) -> Result<()> {
+    maybe_setup_tracing();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size=512;")?;
+    conn.execute("PRAGMA journal_mode=WAL;")?;
+    conn.execute("PRAGMA temp_store=MEMORY;")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT NOT NULL, pad BLOB NOT NULL);")?;
+    conn.execute("CREATE INDEX idx_k ON t(k);")?;
+    conn.execute(
+        "WITH d(x) AS (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)),
+         nums(i) AS (
+             SELECT a.x + 10*b.x + 100*c.x + 1
+             FROM d a, d b, d c
+             WHERE (a.x + 10*b.x + 100*c.x) < 800
+         )
+         INSERT INTO t(id,k,pad)
+         SELECT i, 'k'||i, zeroblob(380) FROM nums ORDER BY i;",
+    )?;
+
+    conn.execute("PRAGMA cache_size=200;")?;
+    conn.execute("PRAGMA cache_spill=OFF;")?;
+
+    conn.execute("BEGIN;")?;
+    conn.execute("INSERT INTO t(id,k,pad) VALUES(1001,'k1001',zeroblob(380));")?;
+    conn.execute("INSERT INTO t(id,k,pad) VALUES(1002,'k1002',zeroblob(380));")?;
+    conn.execute(
+        "UPDATE t
+         SET k='u'||k, pad=zeroblob(381)
+         WHERE id BETWEEN 1 AND 800;",
+    )?;
+    conn.execute("COMMIT;")?;
+
+    assert_eq!(
+        execute_and_get_ints(&conn, "SELECT count(*), sum(length(pad)), sum(id) FROM t;",)?,
+        vec![802, 305560, 322403]
+    );
+    assert_eq!(
+        execute_and_get_ints(&conn, "SELECT count(*) FROM t WHERE id IN (1001,1002);")?,
+        vec![2]
+    );
+    assert_eq!(
+        execute_and_get_ints(&conn, "SELECT count(*) FROM t WHERE length(pad)=381;")?,
+        vec![800]
+    );
+    assert_eq!(
+        execute_and_get_ints(
+            &conn,
+            "SELECT count(*) FROM t WHERE k >= 'uk' AND k < 'ul';"
+        )?,
+        vec![800]
+    );
+    assert_eq!(
+        execute_and_get_strings(&conn, "PRAGMA integrity_check;")?,
+        vec!["ok"]
+    );
+
+    Ok(())
+}
+
 #[test]
 #[ignore = "ignored for now because it's flaky"]
 fn test_wal_1_writer_1_reader() -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #6947.
Also fixes #6951.

When `PRAGMA cache_spill=OFF` is set, the page cache should not force dirty pages to spill mid-transaction. The configured cache size is a spill/eviction target, not a hard correctness limit. Turso currently treats it as a hard limit: once the cache is full of dirty pages, the next cache insert returns `Full`, which is surfaced as `database is busy`. In the large WAL UPDATE repro from #6947 this leaves only part of the statement applied after `COMMIT`.

This change keeps the normal behavior for `cache_spill=ON`, but when spilling is disabled it evicts any clean/spilled pages it can and then allows the cache to grow temporarily if the remaining pages are unevictable. That lets the statement complete instead of failing midway with partial effects.

## Tests

- `cargo test -p turso_core test_insert_can_exceed_capacity_when_spilling_is_disabled -- --nocapture`
- `cargo test -p turso_core test_make_room_for_with_dirty_pages -- --nocapture`
- `cargo test -p core_tester --test integration_tests test_cache_spill_off_large_update_does_not_partially_commit -- --nocapture`
- Manual CLI repro for #6947: before this patch `database is busy` left 169/800 rows updated; after this patch all 800 rows update and `PRAGMA integrity_check` returns `ok`.
- Manual CLI repro for #6951: after this patch all 1600 rows are visible before and after commit and `PRAGMA integrity_check` returns `ok`.

## Disclosure

I used AI assistance to investigate the repro, make this patch, and run validation. I reviewed the final diff and test output before submitting.
