### PR TITLE
core/schema: Preserve AUTOINCREMENT after DROP COLUMN

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2943,6 +2943,9 @@ impl BTreeTable {
             }
             if needs_pk_inline && column.primary_key() {
                 sql.push_str(" PRIMARY KEY");
+                if self.has_autoincrement && column.is_rowid_alias() {
+                    sql.push_str(" AUTOINCREMENT");
+                }
             }
 
             if let Some(default) = &column.default {
@@ -5837,6 +5840,20 @@ mod tests {
         assert_eq!(
             reconstructed_sql,
             "CREATE TABLE test_normal (id INTEGER, name TEXT)"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_autoincrement_preserved_in_to_sql() -> Result<()> {
+        let sql = r#"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, doomed INT, v TEXT)"#;
+        let table = BTreeTable::from_sql(sql, 0)?;
+
+        assert!(table.has_autoincrement);
+        assert_eq!(
+            table.to_sql(),
+            "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, doomed INT, v TEXT)"
         );
 
         Ok(())

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -328,3 +328,22 @@ test autoinc-expicit-negative-rowid-initializes-seq-table {
 } expect {
 	t|0
 }
+
+# Regression test for https://github.com/tursodatabase/turso/issues/6963
+@cross-check-integrity
+test autoinc-alter-drop-column-preserves-schema {
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        doomed INT,
+        v TEXT
+    );
+    INSERT INTO t(doomed, v) VALUES (9, 'a'), (8, 'b');
+    ALTER TABLE t DROP COLUMN doomed;
+    INSERT INTO t(v) VALUES ('c');
+    SELECT sql LIKE '%AUTOINCREMENT%' FROM sqlite_schema WHERE name='t';
+    SELECT name, seq FROM sqlite_sequence WHERE name='t';
+}
+expect {
+    1
+    t|3
+}

--- a/tests/integration/query_processing/test_alter_table_reopen.rs
+++ b/tests/integration/query_processing/test_alter_table_reopen.rs
@@ -1,13 +1,76 @@
-//! Reopen-DB tests for ALTER TABLE ADD COLUMN with table-level UNIQUE constraints.
+//! Reopen-DB tests for ALTER TABLE schema rewrites.
 //!
-//! BTreeTable::to_sql() must emit table-level UNIQUE (...) so that after ADD COLUMN
-//! the stored schema in sqlite_schema still matches the sqlite_autoindex_* entries.
+//! BTreeTable::to_sql() must preserve schema details so that after ALTER TABLE
+//! the stored schema in sqlite_schema still matches the table metadata.
+//!
+//! For table-level UNIQUE (...), sqlite_schema must still match the sqlite_autoindex_* entries.
 //! Otherwise reopen triggers populate_indices panic: "all automatic indexes parsed
 //! from sqlite_schema should have been consumed, but N remain".
 //! See https://github.com/tursodatabase/turso/issues/5616
 
 use crate::common::{ExecRows, TempDatabase};
 use tempfile::TempDir;
+
+/// After ALTER TABLE DROP COLUMN on an AUTOINCREMENT table, reopen must parse
+/// the persisted schema as AUTOINCREMENT and avoid reusing deleted rowids.
+#[test]
+fn test_alter_table_drop_column_preserves_autoincrement_reopen() {
+    let path = TempDir::new()
+        .unwrap()
+        .keep()
+        .join("alter_drop_col_autoincrement_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute(
+            "CREATE TABLE t(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                doomed INT,
+                v TEXT
+            )",
+        )
+        .unwrap();
+        conn.execute("INSERT INTO t(doomed, v) VALUES (9, 'a'), (8, 'b')")
+            .unwrap();
+        conn.execute("ALTER TABLE t DROP COLUMN doomed").unwrap();
+        conn.execute("INSERT INTO t(v) VALUES ('c')").unwrap();
+        conn.close().unwrap();
+    }
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+
+        let schema: Vec<(i64,)> =
+            conn.exec_rows("SELECT sql LIKE '%AUTOINCREMENT%' FROM sqlite_schema WHERE name = 't'");
+        assert_eq!(schema, vec![(1,)]);
+
+        let seq_before: Vec<(String, i64)> =
+            conn.exec_rows("SELECT name, seq FROM sqlite_sequence WHERE name = 't'");
+        assert_eq!(seq_before, vec![("t".into(), 3)]);
+
+        conn.execute("INSERT INTO t(v) VALUES ('d')").unwrap();
+        conn.execute("DELETE FROM t WHERE v = 'd'").unwrap();
+        conn.execute("INSERT INTO t(v) VALUES ('e')").unwrap();
+
+        let rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t ORDER BY id");
+        assert_eq!(
+            rows,
+            vec![
+                (1, "a".into()),
+                (2, "b".into()),
+                (3, "c".into()),
+                (5, "e".into()),
+            ]
+        );
+
+        let seq_after: Vec<(String, i64)> =
+            conn.exec_rows("SELECT name, seq FROM sqlite_sequence WHERE name = 't'");
+        assert_eq!(seq_after, vec![("t".into(), 5)]);
+        conn.close().unwrap();
+    }
+}
 
 /// After ALTER TABLE ADD COLUMN on a table with UNIQUE(stream_id, version), reopen
 /// must succeed (no orphan autoindex) and the unique constraint must still be enforced.


### PR DESCRIPTION
## Description

Preserve `AUTOINCREMENT` when `BTreeTable::to_sql()` reconstructs a single-column rowid alias primary key. This keeps `ALTER TABLE ... DROP COLUMN` from rewriting `sqlite_schema.sql` without the `AUTOINCREMENT` marker.

Fixes #6963

## Motivation and context

After `DROP COLUMN`, Turso rewrites the table definition through `to_sql()`. The table retained `has_autoincrement`, but the reconstructed SQL emitted only `INTEGER PRIMARY KEY`. Reopening the database then parses the table as non-autoincrement and can reuse rowids that should remain reserved.

## Description of AI Usage

Used Codex to inspect the issue, locate the schema rewrite path, implement the narrow serializer fix, add regression coverage, and run targeted verification. I reviewed the diff and test output before submitting.

## Verification

- `cargo test -p turso_core test_autoincrement_preserved_in_to_sql`
- `make -C testing/sqltests run-filter FILTER='autoinc-alter-drop-column-preserves-schema'`
- `cargo test -p core_tester --test integration_tests test_alter_table_drop_column_preserves_autoincrement_reopen`
- `cargo fmt --check`
- `git diff --check`
