### PR TITLE
testing/simulator: fix custom profiles and drop-index accounting

### DIFF
--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -73,7 +73,7 @@ impl Remaining {
             .unwrap_or_default();
 
         let mut remaining_drop_index = total_drop_index
-            .checked_sub(stats.alter_table_count)
+            .checked_sub(stats.drop_index_count)
             .unwrap_or_default();
 
         if mvcc {
@@ -174,5 +174,71 @@ impl Display for InteractionStats {
             self.alter_table_count,
             self.drop_index_count,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sql_generation::{
+        generation::{GenerationContext, Opts},
+        model::table::{Index, Table},
+    };
+
+    use super::{InteractionStats, Remaining};
+    use crate::profiles::query::QueryProfile;
+
+    #[derive(Default)]
+    struct TestContext {
+        opts: Opts,
+        tables: Vec<Table>,
+    }
+
+    impl GenerationContext for TestContext {
+        fn tables(&self) -> &Vec<Table> {
+            &self.tables
+        }
+
+        fn opts(&self) -> &Opts {
+            &self.opts
+        }
+    }
+
+    #[test]
+    fn drop_index_remaining_uses_drop_index_count() {
+        let query_profile = QueryProfile {
+            select_weight: 0,
+            create_table_weight: 0,
+            create_index_weight: 0,
+            insert_weight: 0,
+            update_weight: 0,
+            delete_weight: 0,
+            drop_table_weight: 0,
+            alter_table_weight: 0,
+            drop_index: 10,
+            pragma_weight: 0,
+            ..Default::default()
+        };
+        let stats = InteractionStats {
+            alter_table_count: 7,
+            drop_index_count: 4,
+            ..Default::default()
+        };
+        let context = TestContext {
+            tables: vec![Table {
+                name: "t".to_string(),
+                columns: vec![],
+                rows: vec![],
+                indexes: vec![Index {
+                    table_name: "t".to_string(),
+                    index_name: "idx_t".to_string(),
+                    columns: vec![],
+                }],
+            }],
+            ..Default::default()
+        };
+
+        let remaining = Remaining::new(10, &query_profile, &stats, false, &context);
+
+        assert_eq!(remaining.drop_index, 6);
     }
 }

--- a/testing/simulator/profiles/query.rs
+++ b/testing/simulator/profiles/query.rs
@@ -63,6 +63,7 @@ impl QueryProfile {
             + self.delete_weight
             + self.drop_table_weight
             + self.alter_table_weight
+            + self.drop_index
             + self.pragma_weight
     }
 }
@@ -75,4 +76,28 @@ pub enum QueryTypes {
     Update,
     Delete,
     DropTable,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueryProfile;
+
+    #[test]
+    fn total_weight_includes_drop_index() {
+        let profile = QueryProfile::default();
+
+        assert_eq!(
+            profile.total_weight(),
+            profile.select_weight
+                + profile.create_table_weight
+                + profile.create_index_weight
+                + profile.insert_weight
+                + profile.update_weight
+                + profile.delete_weight
+                + profile.drop_table_weight
+                + profile.alter_table_weight
+                + profile.drop_index
+                + profile.pragma_weight
+        );
+    }
 }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -1,6 +1,6 @@
 use clap::{
     Arg, Command, Error, Parser, ValueEnum,
-    builder::{PossibleValue, TypedValueParser, ValueParserFactory},
+    builder::{TypedValueParser, ValueParserFactory},
     command,
     error::{ContextKind, ContextValue, ErrorKind},
 };
@@ -282,22 +282,6 @@ impl TypedValueParser for ProfileTypeParser {
         })
     }
 
-    fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
-        use strum::VariantNames;
-        Some(Box::new(
-            Self::Value::VARIANTS
-                .iter()
-                .map(|variant| {
-                    // Custom variant should be listed as a Custom path
-                    if variant.eq_ignore_ascii_case("custom") {
-                        "CUSTOM_PATH"
-                    } else {
-                        variant
-                    }
-                })
-                .map(PossibleValue::new),
-        ))
-    }
 }
 
 impl ValueParserFactory for ProfileType {


### PR DESCRIPTION
## Summary

This fixes two simulator coverage/accounting issues:

- allow `--profile` to accept an existing custom profile path instead of rejecting every non-enum value during clap possible-value validation
- include `drop_index` in `QueryProfile::total_weight()` and subtract `drop_index_count` when computing remaining drop-index budget

The drop-index fixes keep schema churn profiles from under/incorrectly accounting `DROP INDEX` generation. I also added focused regression coverage for both accounting paths.

## Validation

```sh
cargo test -p limbo_sim drop_index
cargo check -p limbo_sim
```

I also used a local custom JSON5 schema-churn profile to confirm custom profile paths now parse and the simulator can run with the patched accounting:

```sh
cargo run -p limbo_sim -- --maximum-tests 180 --minimum-tests 60 --maximum-time 240 --profile /Users/user/project/4dollor/turso-profiles/schema_churn.json5 --differential --io-backend=default loop -n 5 --short-circuit
```

That smoke run completed successfully.

This PR was AI-assisted and manually reviewed/tested.