### PR TITLE
core: guard deep expression translation

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,7 +65,7 @@ bytes = "1.11.1"
 itertools.workspace = true
 
 [features]
-default = ["io_uring", "mimalloc", "experimental_win_iocp"]
+default = ["io_uring", "mimalloc", "experimental_win_iocp", "stacker"]
 io_uring = ["turso_core/io_uring"]
 experimental_win_iocp = ["turso_core/experimental_win_iocp"]
 tracing_release = ["turso_core/tracing_release"]

--- a/cli/tests/non_interactive_exit_code.rs
+++ b/cli/tests/non_interactive_exit_code.rs
@@ -84,6 +84,69 @@ fn sql_argument_runtime_error_stops_execution() {
     assert_eq!(output.status.code(), Some(1));
 }
 
+#[test]
+fn sql_argument_deep_expression_returns_error_instead_of_aborting() {
+    let sql = format!("select {};", vec!["1"; 1502].join("+"));
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg(sql)
+        .output()
+        .expect("failed to run tursodb");
+
+    let output_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.status.code(), Some(1), "output: {output_text}");
+    assert!(
+        output_text.contains("Expression tree is too large (maximum depth 1000)"),
+        "expected expression-depth error, got: {output_text}"
+    );
+}
+
+#[test]
+fn sql_argument_deep_schema_expression_returns_error_instead_of_aborting() {
+    let sql = format!("create table t(x check({}));", vec!["1"; 1502].join("+"));
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg(sql)
+        .output()
+        .expect("failed to run tursodb");
+
+    let output_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.status.code(), Some(1), "output: {output_text}");
+    assert!(
+        output_text.contains("Expression tree is too large (maximum depth 1000)"),
+        "expected expression-depth error, got: {output_text}"
+    );
+}
+
+#[test]
+fn sql_argument_deep_valid_expression_executes() {
+    let sql = format!("select {};", vec!["1"; 1000].join("+"));
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg(sql)
+        .output()
+        .expect("failed to run tursodb");
+
+    let output_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.status.code(), Some(0), "output: {output_text}");
+    assert!(
+        output_text.contains("1000"),
+        "expected expression result, got: {output_text}"
+    );
+}
+
 /// A6: Syntax error returns non-zero
 #[test]
 fn sql_argument_syntax_error_returns_nonzero() {

--- a/core/stack.rs
+++ b/core/stack.rs
@@ -12,6 +12,21 @@ macro_rules! trace_stack {
 pub(crate) use trace_stack;
 
 #[cfg(feature = "stacker")]
+#[inline]
+pub(crate) fn maybe_grow<R>(f: impl FnOnce() -> R) -> R {
+    const RED_ZONE: usize = 8 * 1024 * 1024;
+    const STACK_SIZE: usize = 64 * 1024 * 1024;
+
+    stacker::maybe_grow(RED_ZONE, STACK_SIZE, f)
+}
+
+#[cfg(not(feature = "stacker"))]
+#[inline]
+pub(crate) fn maybe_grow<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}
+
+#[cfg(feature = "stacker")]
 pub(crate) struct TraceGuard {
     label: &'static str,
     detail: Option<&'static str>,

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -111,3 +111,8 @@ pub use walk::{
     expr_references_any_subquery, expr_references_subquery_id, walk_expr, walk_expr_mut,
     WalkControl,
 };
+pub(crate) use walk::{
+    validate_expr_depth, validate_from_clause_expr_depth, validate_limit_expr_depth,
+    validate_result_columns_expr_depth, validate_select_expr_depth,
+    validate_sorted_columns_expr_depth,
+};

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -1,4 +1,32 @@
 use super::*;
+use std::cell::Cell;
+
+thread_local! {
+    static TRANSLATE_EXPR_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+struct TranslateExprDepthGuard;
+
+impl Drop for TranslateExprDepthGuard {
+    fn drop(&mut self) {
+        TRANSLATE_EXPR_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+        });
+    }
+}
+
+fn enter_translate_expr(expr: &ast::Expr) -> Result<TranslateExprDepthGuard> {
+    let needs_validation = TRANSLATE_EXPR_DEPTH.with(|depth| depth.get() == 0);
+    if needs_validation {
+        validate_expr_depth(expr)?;
+    }
+
+    TRANSLATE_EXPR_DEPTH.with(|depth| {
+        depth.set(depth.get() + 1);
+    });
+
+    Ok(TranslateExprDepthGuard)
+}
 
 /// Reason why [translate_expr_no_constant_opt()] was called.
 #[derive(Debug)]
@@ -98,6 +126,21 @@ pub fn translate_expr(
     target_register: usize,
     resolver: &Resolver,
 ) -> Result<usize> {
+    crate::stack::maybe_grow(|| {
+        translate_expr_impl(program, referenced_tables, expr, target_register, resolver)
+    })
+}
+
+#[inline(never)]
+fn translate_expr_impl(
+    program: &mut ProgramBuilder,
+    referenced_tables: Option<&TableReferences>,
+    expr: &ast::Expr,
+    target_register: usize,
+    resolver: &Resolver,
+) -> Result<usize> {
+    let _expr_depth_guard = enter_translate_expr(expr)?;
+
     let constant_span = if expr.is_constant(resolver) {
         if !program.constant_span_is_open() {
             Some(program.constant_span_start())

--- a/core/translate/expr/walk.rs
+++ b/core/translate/expr/walk.rs
@@ -1,8 +1,332 @@
 use super::*;
 
+const MAX_EXPR_DEPTH: usize = 1000;
+
 pub enum WalkControl {
     Continue,     // Visit children
     SkipChildren, // Skip children but continue walking siblings
+}
+
+pub(crate) fn validate_expr_depth(expr: &ast::Expr) -> Result<()> {
+    let mut stack = vec![(expr, 1usize)];
+
+    while let Some((expr, depth)) = stack.pop() {
+        if depth > MAX_EXPR_DEPTH {
+            crate::bail_parse_error!(
+                "Expression tree is too large (maximum depth {MAX_EXPR_DEPTH})"
+            );
+        }
+
+        let child_depth = depth + 1;
+        match expr {
+            ast::Expr::SubqueryResult { lhs, .. } => {
+                if let Some(lhs) = lhs.as_deref() {
+                    stack.push((lhs, child_depth));
+                }
+            }
+            ast::Expr::Between {
+                lhs, start, end, ..
+            } => {
+                stack.push((end, child_depth));
+                stack.push((start, child_depth));
+                stack.push((lhs, child_depth));
+            }
+            ast::Expr::Binary(lhs, _, rhs) => {
+                stack.push((rhs, child_depth));
+                stack.push((lhs, child_depth));
+            }
+            ast::Expr::Case {
+                base,
+                when_then_pairs,
+                else_expr,
+            } => {
+                if let Some(else_expr) = else_expr.as_deref() {
+                    stack.push((else_expr, child_depth));
+                }
+                for (when_expr, then_expr) in when_then_pairs.iter().rev() {
+                    stack.push((then_expr, child_depth));
+                    stack.push((when_expr, child_depth));
+                }
+                if let Some(base) = base.as_deref() {
+                    stack.push((base, child_depth));
+                }
+            }
+            ast::Expr::Cast { expr, .. }
+            | ast::Expr::Collate(expr, _)
+            | ast::Expr::IsNull(expr)
+            | ast::Expr::NotNull(expr)
+            | ast::Expr::Unary(_, expr) => {
+                stack.push((expr, child_depth));
+            }
+            ast::Expr::Exists(select) | ast::Expr::Subquery(select) => {
+                validate_select_expr_depth(select)?;
+            }
+            ast::Expr::FunctionCall {
+                args,
+                order_by,
+                filter_over,
+                ..
+            } => {
+                push_function_tail_exprs_with_depth(&mut stack, filter_over, child_depth);
+                for sort_col in order_by.iter().rev() {
+                    stack.push((&sort_col.expr, child_depth));
+                }
+                for arg in args.iter().rev() {
+                    stack.push((arg, child_depth));
+                }
+            }
+            ast::Expr::FunctionCallStar { filter_over, .. } => {
+                push_function_tail_exprs_with_depth(&mut stack, filter_over, child_depth);
+            }
+            ast::Expr::InList { lhs, rhs, .. } => {
+                for expr in rhs.iter().rev() {
+                    stack.push((expr, child_depth));
+                }
+                stack.push((lhs, child_depth));
+            }
+            ast::Expr::InSelect { lhs, rhs, .. } => {
+                validate_select_expr_depth(rhs)?;
+                stack.push((lhs, child_depth));
+            }
+            ast::Expr::InTable { lhs, args, .. } => {
+                for expr in args.iter().rev() {
+                    stack.push((expr, child_depth));
+                }
+                stack.push((lhs, child_depth));
+            }
+            ast::Expr::Like {
+                lhs, rhs, escape, ..
+            } => {
+                if let Some(escape) = escape.as_deref() {
+                    stack.push((escape, child_depth));
+                }
+                stack.push((rhs, child_depth));
+                stack.push((lhs, child_depth));
+            }
+            ast::Expr::Parenthesized(exprs) => {
+                for expr in exprs.iter().rev() {
+                    stack.push((expr, child_depth));
+                }
+            }
+            ast::Expr::Raise(_, expr) => {
+                if let Some(expr) = expr.as_deref() {
+                    stack.push((expr, child_depth));
+                }
+            }
+            ast::Expr::Array { elements } => {
+                for expr in elements.iter().rev() {
+                    stack.push((expr, child_depth));
+                }
+            }
+            ast::Expr::Subscript { base, index } => {
+                stack.push((index, child_depth));
+                stack.push((base, child_depth));
+            }
+            ast::Expr::FieldAccess { base, .. } => {
+                stack.push((base, child_depth));
+            }
+            ast::Expr::Id(_)
+            | ast::Expr::Column { .. }
+            | ast::Expr::RowId { .. }
+            | ast::Expr::Literal(_)
+            | ast::Expr::DoublyQualified(..)
+            | ast::Expr::Name(_)
+            | ast::Expr::Qualified(..)
+            | ast::Expr::Variable(_)
+            | ast::Expr::Register(_)
+            | ast::Expr::Default => {}
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_select_expr_depth(select: &ast::Select) -> Result<()> {
+    let mut selects = vec![select];
+
+    while let Some(select) = selects.pop() {
+        if let Some(with) = &select.with {
+            for cte in with.ctes.iter().rev() {
+                selects.push(&cte.select);
+            }
+        }
+
+        validate_one_select_expr_depth(&select.body.select, &mut selects)?;
+        for compound in &select.body.compounds {
+            validate_one_select_expr_depth(&compound.select, &mut selects)?;
+        }
+        validate_sorted_columns_expr_depth(&select.order_by)?;
+        if let Some(limit) = &select.limit {
+            validate_limit_expr_depth(limit)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_one_select_expr_depth<'a>(
+    select: &'a ast::OneSelect,
+    selects: &mut Vec<&'a ast::Select>,
+) -> Result<()> {
+    match select {
+        ast::OneSelect::Select {
+            columns,
+            from,
+            where_clause,
+            group_by,
+            window_clause,
+            ..
+        } => {
+            validate_result_columns_expr_depth(columns)?;
+            if let Some(from) = from {
+                validate_from_clause_expr_depth(from, selects)?;
+            }
+            if let Some(where_clause) = where_clause {
+                validate_expr_depth(where_clause)?;
+            }
+            if let Some(group_by) = group_by {
+                for expr in &group_by.exprs {
+                    validate_expr_depth(expr)?;
+                }
+                if let Some(having) = &group_by.having {
+                    validate_expr_depth(having)?;
+                }
+            }
+            for window in window_clause {
+                for expr in &window.window.partition_by {
+                    validate_expr_depth(expr)?;
+                }
+                validate_sorted_columns_expr_depth(&window.window.order_by)?;
+                if let Some(frame_clause) = &window.window.frame_clause {
+                    validate_frame_bound_expr_depth(&frame_clause.start)?;
+                    if let Some(end) = &frame_clause.end {
+                        validate_frame_bound_expr_depth(end)?;
+                    }
+                }
+            }
+        }
+        ast::OneSelect::Values(rows) => {
+            for row in rows {
+                for expr in row {
+                    validate_expr_depth(expr)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_from_clause_expr_depth<'a>(
+    from: &'a ast::FromClause,
+    selects: &mut Vec<&'a ast::Select>,
+) -> Result<()> {
+    validate_select_table_expr_depth(&from.select, selects)?;
+    for join in &from.joins {
+        validate_select_table_expr_depth(&join.table, selects)?;
+        if let Some(ast::JoinConstraint::On(expr)) = &join.constraint {
+            validate_expr_depth(expr)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_select_table_expr_depth<'a>(
+    table: &'a ast::SelectTable,
+    selects: &mut Vec<&'a ast::Select>,
+) -> Result<()> {
+    match table {
+        ast::SelectTable::Table(_, _, _) => {}
+        ast::SelectTable::TableCall(_, args, _) => {
+            for arg in args {
+                validate_expr_depth(arg)?;
+            }
+        }
+        ast::SelectTable::Select(select, _) => selects.push(select),
+        ast::SelectTable::Sub(from, _) => validate_from_clause_expr_depth(from, selects)?,
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_result_columns_expr_depth(columns: &[ast::ResultColumn]) -> Result<()> {
+    for column in columns {
+        if let ast::ResultColumn::Expr(expr, _) = column {
+            validate_expr_depth(expr)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_sorted_columns_expr_depth(columns: &[ast::SortedColumn]) -> Result<()> {
+    for column in columns {
+        validate_expr_depth(&column.expr)?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_limit_expr_depth(limit: &ast::Limit) -> Result<()> {
+    validate_expr_depth(&limit.expr)?;
+    if let Some(offset) = &limit.offset {
+        validate_expr_depth(offset)?;
+    }
+
+    Ok(())
+}
+
+fn validate_frame_bound_expr_depth(bound: &ast::FrameBound) -> Result<()> {
+    match bound {
+        ast::FrameBound::Following(expr) | ast::FrameBound::Preceding(expr) => {
+            validate_expr_depth(expr)?;
+        }
+        ast::FrameBound::CurrentRow
+        | ast::FrameBound::UnboundedFollowing
+        | ast::FrameBound::UnboundedPreceding => {}
+    }
+
+    Ok(())
+}
+
+fn push_function_tail_exprs_with_depth<'a>(
+    stack: &mut Vec<(&'a ast::Expr, usize)>,
+    tail: &'a ast::FunctionTail,
+    depth: usize,
+) {
+    if let Some(filter_clause) = tail.filter_clause.as_deref() {
+        stack.push((filter_clause, depth));
+    }
+    if let Some(ast::Over::Window(window)) = &tail.over_clause {
+        if let Some(frame_clause) = &window.frame_clause {
+            push_frame_bound_expr_with_depth(stack, &frame_clause.start, depth);
+            if let Some(end_bound) = &frame_clause.end {
+                push_frame_bound_expr_with_depth(stack, end_bound, depth);
+            }
+        }
+        for sort_col in window.order_by.iter().rev() {
+            stack.push((&sort_col.expr, depth));
+        }
+        for part_expr in window.partition_by.iter().rev() {
+            stack.push((part_expr, depth));
+        }
+    }
+}
+
+fn push_frame_bound_expr_with_depth<'a>(
+    stack: &mut Vec<(&'a ast::Expr, usize)>,
+    bound: &'a ast::FrameBound,
+    depth: usize,
+) {
+    match bound {
+        ast::FrameBound::Following(expr) | ast::FrameBound::Preceding(expr) => {
+            stack.push((expr, depth));
+        }
+        ast::FrameBound::CurrentRow
+        | ast::FrameBound::UnboundedFollowing
+        | ast::FrameBound::UnboundedPreceding => {}
+    }
 }
 
 /// Recursively walks an immutable expression, applying a function to each sub-expression.

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -79,6 +79,8 @@ pub fn translate(
     input: &str,
 ) -> Result<Program> {
     tracing::trace!("querying {}", input);
+    validate_stmt_expr_depth(&stmt)?;
+
     let change_cnt_on = matches!(
         stmt,
         ast::Stmt::CreateIndex { .. }
@@ -124,6 +126,326 @@ pub fn translate(
     program.epilogue(schema);
 
     program.build(connection, change_cnt_on, input)
+}
+
+fn validate_stmt_expr_depth(stmt: &ast::Stmt) -> Result<()> {
+    match stmt {
+        ast::Stmt::AlterTable(alter) => validate_alter_table_expr_depth(alter),
+        ast::Stmt::Attach { expr, db_name, key } => {
+            expr::validate_expr_depth(expr)?;
+            expr::validate_expr_depth(db_name)?;
+            if let Some(key) = key.as_deref() {
+                expr::validate_expr_depth(key)?;
+            }
+            Ok(())
+        }
+        ast::Stmt::CreateIndex {
+            columns,
+            with_clause,
+            where_clause,
+            ..
+        } => {
+            expr::validate_sorted_columns_expr_depth(columns)?;
+            for (_, expr) in with_clause {
+                expr::validate_expr_depth(expr)?;
+            }
+            if let Some(where_clause) = where_clause.as_deref() {
+                expr::validate_expr_depth(where_clause)?;
+            }
+            Ok(())
+        }
+        ast::Stmt::CreateTable { body, .. } => validate_create_table_body_expr_depth(body),
+        ast::Stmt::CreateTrigger {
+            when_clause,
+            commands,
+            ..
+        } => {
+            if let Some(when_clause) = when_clause.as_deref() {
+                expr::validate_expr_depth(when_clause)?;
+            }
+            for command in commands {
+                validate_trigger_command_expr_depth(command)?;
+            }
+            Ok(())
+        }
+        ast::Stmt::CreateView { select, .. }
+        | ast::Stmt::CreateMaterializedView { select, .. }
+        | ast::Stmt::Select(select) => expr::validate_select_expr_depth(select),
+        ast::Stmt::CreateType { body, .. } => validate_create_type_body_expr_depth(body),
+        ast::Stmt::CreateDomain {
+            default,
+            constraints,
+            ..
+        } => {
+            if let Some(default) = default.as_deref() {
+                expr::validate_expr_depth(default)?;
+            }
+            for constraint in constraints {
+                expr::validate_expr_depth(&constraint.check)?;
+            }
+            Ok(())
+        }
+        ast::Stmt::Delete {
+            with,
+            where_clause,
+            returning,
+            order_by,
+            limit,
+            ..
+        } => {
+            validate_with_expr_depth(with.as_ref())?;
+            if let Some(where_clause) = where_clause.as_deref() {
+                expr::validate_expr_depth(where_clause)?;
+            }
+            expr::validate_result_columns_expr_depth(returning)?;
+            expr::validate_sorted_columns_expr_depth(order_by)?;
+            if let Some(limit) = limit {
+                expr::validate_limit_expr_depth(limit)?;
+            }
+            Ok(())
+        }
+        ast::Stmt::Detach { name } => expr::validate_expr_depth(name),
+        ast::Stmt::Insert {
+            with,
+            body,
+            returning,
+            ..
+        } => {
+            validate_with_expr_depth(with.as_ref())?;
+            validate_insert_body_expr_depth(body)?;
+            expr::validate_result_columns_expr_depth(returning)
+        }
+        ast::Stmt::Pragma { body, .. } => {
+            if let Some(body) = body {
+                validate_pragma_body_expr_depth(body)?;
+            }
+            Ok(())
+        }
+        ast::Stmt::Update(update) => validate_update_expr_depth(update),
+        ast::Stmt::Vacuum { into, .. } => {
+            if let Some(into) = into.as_deref() {
+                expr::validate_expr_depth(into)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn validate_alter_table_expr_depth(alter: &ast::AlterTable) -> Result<()> {
+    match &alter.body {
+        ast::AlterTableBody::AddColumn(column)
+        | ast::AlterTableBody::AlterColumn { new: column, .. } => {
+            validate_column_definition_expr_depth(column)
+        }
+        ast::AlterTableBody::RenameTo(_)
+        | ast::AlterTableBody::RenameColumn { .. }
+        | ast::AlterTableBody::DropColumn(_) => Ok(()),
+    }
+}
+
+fn validate_create_table_body_expr_depth(body: &ast::CreateTableBody) -> Result<()> {
+    match body {
+        ast::CreateTableBody::ColumnsAndConstraints {
+            columns,
+            constraints,
+            ..
+        } => {
+            for column in columns {
+                validate_column_definition_expr_depth(column)?;
+            }
+            for constraint in constraints {
+                validate_table_constraint_expr_depth(&constraint.constraint)?;
+            }
+            Ok(())
+        }
+        ast::CreateTableBody::AsSelect(select) => expr::validate_select_expr_depth(select),
+    }
+}
+
+fn validate_column_definition_expr_depth(column: &ast::ColumnDefinition) -> Result<()> {
+    if let Some(ty) = &column.col_type {
+        validate_type_expr_depth(ty)?;
+    }
+    for constraint in &column.constraints {
+        validate_column_constraint_expr_depth(&constraint.constraint)?;
+    }
+    Ok(())
+}
+
+fn validate_column_constraint_expr_depth(constraint: &ast::ColumnConstraint) -> Result<()> {
+    match constraint {
+        ast::ColumnConstraint::Check(expr)
+        | ast::ColumnConstraint::Default(expr)
+        | ast::ColumnConstraint::Generated { expr, .. } => expr::validate_expr_depth(expr),
+        ast::ColumnConstraint::PrimaryKey { .. }
+        | ast::ColumnConstraint::NotNull { .. }
+        | ast::ColumnConstraint::Unique(_)
+        | ast::ColumnConstraint::Collate { .. }
+        | ast::ColumnConstraint::ForeignKey { .. } => Ok(()),
+    }
+}
+
+fn validate_table_constraint_expr_depth(constraint: &ast::TableConstraint) -> Result<()> {
+    match constraint {
+        ast::TableConstraint::PrimaryKey { columns, .. }
+        | ast::TableConstraint::Unique { columns, .. } => {
+            expr::validate_sorted_columns_expr_depth(columns)
+        }
+        ast::TableConstraint::Check(expr) => expr::validate_expr_depth(expr),
+        ast::TableConstraint::ForeignKey { .. } => Ok(()),
+    }
+}
+
+fn validate_create_type_body_expr_depth(body: &ast::CreateTypeBody) -> Result<()> {
+    match body {
+        ast::CreateTypeBody::CustomType {
+            encode,
+            decode,
+            default,
+            ..
+        } => {
+            for custom_expr in [encode.as_deref(), decode.as_deref(), default.as_deref()]
+                .into_iter()
+                .flatten()
+            {
+                expr::validate_expr_depth(custom_expr)?;
+            }
+            Ok(())
+        }
+        ast::CreateTypeBody::Struct(fields) | ast::CreateTypeBody::Union(fields) => {
+            for field in fields {
+                validate_type_expr_depth(&field.field_type)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn validate_type_expr_depth(ty: &ast::Type) -> Result<()> {
+    match &ty.size {
+        Some(ast::TypeSize::MaxSize(expr)) => expr::validate_expr_depth(expr),
+        Some(ast::TypeSize::TypeSize(lhs, rhs)) => {
+            expr::validate_expr_depth(lhs)?;
+            expr::validate_expr_depth(rhs)
+        }
+        None => Ok(()),
+    }
+}
+
+fn validate_insert_body_expr_depth(body: &ast::InsertBody) -> Result<()> {
+    match body {
+        ast::InsertBody::Select(select, upsert) => {
+            expr::validate_select_expr_depth(select)?;
+            if let Some(upsert) = upsert.as_deref() {
+                validate_upsert_expr_depth(upsert)?;
+            }
+            Ok(())
+        }
+        ast::InsertBody::DefaultValues => Ok(()),
+    }
+}
+
+fn validate_update_expr_depth(update: &ast::Update) -> Result<()> {
+    validate_with_expr_depth(update.with.as_ref())?;
+    for set in &update.sets {
+        expr::validate_expr_depth(&set.expr)?;
+    }
+    if let Some(from) = &update.from {
+        expr::validate_from_clause_expr_depth(from, &mut Vec::new())?;
+    }
+    if let Some(where_clause) = update.where_clause.as_deref() {
+        expr::validate_expr_depth(where_clause)?;
+    }
+    expr::validate_result_columns_expr_depth(&update.returning)?;
+    expr::validate_sorted_columns_expr_depth(&update.order_by)?;
+    if let Some(limit) = &update.limit {
+        expr::validate_limit_expr_depth(limit)?;
+    }
+    Ok(())
+}
+
+fn validate_with_expr_depth(with: Option<&ast::With>) -> Result<()> {
+    if let Some(with) = with {
+        for cte in &with.ctes {
+            expr::validate_select_expr_depth(&cte.select)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_upsert_expr_depth(upsert: &ast::Upsert) -> Result<()> {
+    let mut upsert = Some(upsert);
+    while let Some(current) = upsert {
+        if let Some(index) = &current.index {
+            expr::validate_sorted_columns_expr_depth(&index.targets)?;
+            if let Some(where_clause) = index.where_clause.as_deref() {
+                expr::validate_expr_depth(where_clause)?;
+            }
+        }
+        match &current.do_clause {
+            ast::UpsertDo::Set { sets, where_clause } => {
+                for set in sets {
+                    expr::validate_expr_depth(&set.expr)?;
+                }
+                if let Some(where_clause) = where_clause.as_deref() {
+                    expr::validate_expr_depth(where_clause)?;
+                }
+            }
+            ast::UpsertDo::Nothing => {}
+        }
+        upsert = current.next.as_deref();
+    }
+    Ok(())
+}
+
+fn validate_pragma_body_expr_depth(body: &ast::PragmaBody) -> Result<()> {
+    match body {
+        ast::PragmaBody::Equals(expr) | ast::PragmaBody::Call(expr) => {
+            expr::validate_expr_depth(expr)
+        }
+    }
+}
+
+fn validate_trigger_command_expr_depth(command: &ast::TriggerCmd) -> Result<()> {
+    match command {
+        ast::TriggerCmd::Update {
+            sets,
+            from,
+            where_clause,
+            ..
+        } => {
+            for set in sets {
+                expr::validate_expr_depth(&set.expr)?;
+            }
+            if let Some(from) = from {
+                expr::validate_from_clause_expr_depth(from, &mut Vec::new())?;
+            }
+            if let Some(where_clause) = where_clause.as_deref() {
+                expr::validate_expr_depth(where_clause)?;
+            }
+            Ok(())
+        }
+        ast::TriggerCmd::Insert {
+            select,
+            upsert,
+            returning,
+            ..
+        } => {
+            expr::validate_select_expr_depth(select)?;
+            if let Some(upsert) = upsert.as_deref() {
+                validate_upsert_expr_depth(upsert)?;
+            }
+            expr::validate_result_columns_expr_depth(returning)
+        }
+        ast::TriggerCmd::Delete { where_clause, .. } => {
+            if let Some(where_clause) = where_clause.as_deref() {
+                expr::validate_expr_depth(where_clause)?;
+            }
+            Ok(())
+        }
+        ast::TriggerCmd::Select(select) => expr::validate_select_expr_depth(select),
+    }
 }
 
 // TODO: for now leaving the return value as a Program. But ideally to support nested parsing of arbitraty

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2944,96 +2944,113 @@ impl Optimizable for ast::Expr {
     }
     /// Returns true if the expression is a constant i.e. does not depend on columns and can be evaluated only once during the execution
     fn is_constant(&self, resolver: &Resolver<'_>) -> bool {
-        match self {
-            Expr::SubqueryResult { .. } => false,
-            Expr::Between {
-                lhs, start, end, ..
-            } => {
-                lhs.is_constant(resolver)
-                    && start.is_constant(resolver)
-                    && end.is_constant(resolver)
-            }
-            Expr::Binary(expr, _, expr1) => {
-                expr.is_constant(resolver) && expr1.is_constant(resolver)
-            }
-            Expr::Case {
-                base,
-                when_then_pairs,
-                else_expr,
-            } => {
-                base.as_ref().is_none_or(|base| base.is_constant(resolver))
-                    && when_then_pairs.iter().all(|(when, then)| {
-                        when.is_constant(resolver) && then.is_constant(resolver)
-                    })
-                    && else_expr
-                        .as_ref()
-                        .is_none_or(|else_expr| else_expr.is_constant(resolver))
-            }
-            Expr::Cast { expr, .. } => expr.is_constant(resolver),
-            Expr::Collate(expr, _) => expr.is_constant(resolver),
-            // Not constant. Normally rewritten to Expr::Column by the optimizer,
-            // but CHECK constraints bypass the rewrite pass and legitimately
-            // contain DoublyQualified nodes.
-            Expr::DoublyQualified(_, _, _) => false,
-            Expr::Exists(_) => false,
-            Expr::FunctionCall {
-                args,
-                name,
-                filter_over,
-                ..
-            } => {
-                if filter_over.over_clause.is_some() {
-                    return false;
+        let mut stack = vec![self];
+
+        while let Some(expr) = stack.pop() {
+            match expr {
+                Expr::SubqueryResult { .. }
+                | Expr::Column { .. }
+                | Expr::RowId { .. }
+                | Expr::InSelect { .. }
+                | Expr::InTable { .. }
+                | Expr::Name(_)
+                | Expr::Qualified(_, _)
+                | Expr::FieldAccess { .. }
+                | Expr::Subquery(_)
+                | Expr::Register(_) => return false,
+                Expr::Between {
+                    lhs, start, end, ..
+                } => {
+                    stack.push(end);
+                    stack.push(start);
+                    stack.push(lhs);
                 }
-                let Some(func) = resolver
-                    .resolve_function(name.as_str(), args.len())
-                    .ok()
-                    .flatten()
-                else {
-                    return false;
-                };
-                func.is_deterministic() && args.iter().all(|arg| arg.is_constant(resolver))
-            }
-            Expr::FunctionCallStar { .. } => false,
-            Expr::Id(_) => true,
-            Expr::Column { .. } => false,
-            Expr::RowId { .. } => false,
-            Expr::InList { lhs, rhs, .. } => {
-                lhs.is_constant(resolver)
-                    && (rhs.is_empty() || rhs.iter().all(|v| v.is_constant(resolver)))
-            }
-            Expr::InSelect { .. } => {
-                false // might be constant, too annoying to check subqueries etc. implement later
-            }
-            Expr::InTable { .. } => false,
-            Expr::IsNull(expr) => expr.is_constant(resolver),
-            Expr::Like {
-                lhs, rhs, escape, ..
-            } => {
-                lhs.is_constant(resolver)
-                    && rhs.is_constant(resolver)
-                    && escape
-                        .as_ref()
-                        .is_none_or(|escape| escape.is_constant(resolver))
-            }
-            Expr::Literal(_) => true,
-            Expr::Name(_) => false,
-            Expr::NotNull(expr) => expr.is_constant(resolver),
-            Expr::Parenthesized(exprs) => exprs.iter().all(|expr| expr.is_constant(resolver)),
-            // Not constant. Normally rewritten to Expr::Column by the optimizer,
-            // but CHECK constraints bypass the rewrite pass and legitimately
-            // contain Qualified nodes.
-            Expr::Qualified(_, _) | Expr::FieldAccess { .. } => false,
-            Expr::Raise(_, expr) => expr.as_ref().is_none_or(|expr| expr.is_constant(resolver)),
-            Expr::Subquery(_) => false,
-            Expr::Unary(_, expr) => expr.is_constant(resolver),
-            Expr::Variable(_) => true,
-            Expr::Register(_) => false,
-            Expr::Default => true,
-            Expr::Array { .. } | Expr::Subscript { .. } => {
-                unreachable!("Array and Subscript are desugared into function calls by the parser")
+                Expr::Binary(expr, _, expr1) => {
+                    stack.push(expr1);
+                    stack.push(expr);
+                }
+                Expr::Case {
+                    base,
+                    when_then_pairs,
+                    else_expr,
+                } => {
+                    if let Some(else_expr) = else_expr.as_ref() {
+                        stack.push(else_expr);
+                    }
+                    for (when, then) in when_then_pairs.iter().rev() {
+                        stack.push(then);
+                        stack.push(when);
+                    }
+                    if let Some(base) = base.as_ref() {
+                        stack.push(base);
+                    }
+                }
+                Expr::Cast { expr, .. }
+                | Expr::Collate(expr, _)
+                | Expr::IsNull(expr)
+                | Expr::NotNull(expr)
+                | Expr::Unary(_, expr) => stack.push(expr),
+                Expr::DoublyQualified(_, _, _) => return false,
+                Expr::Exists(_) => return false,
+                Expr::FunctionCall {
+                    args,
+                    name,
+                    filter_over,
+                    ..
+                } => {
+                    if filter_over.over_clause.is_some() {
+                        return false;
+                    }
+                    let Some(func) = resolver
+                        .resolve_function(name.as_str(), args.len())
+                        .ok()
+                        .flatten()
+                    else {
+                        return false;
+                    };
+                    if !func.is_deterministic() {
+                        return false;
+                    }
+                    for arg in args.iter().rev() {
+                        stack.push(arg);
+                    }
+                }
+                Expr::FunctionCallStar { .. } => return false,
+                Expr::InList { lhs, rhs, .. } => {
+                    for expr in rhs.iter().rev() {
+                        stack.push(expr);
+                    }
+                    stack.push(lhs);
+                }
+                Expr::Like {
+                    lhs, rhs, escape, ..
+                } => {
+                    if let Some(escape) = escape.as_ref() {
+                        stack.push(escape);
+                    }
+                    stack.push(rhs);
+                    stack.push(lhs);
+                }
+                Expr::Parenthesized(exprs) => {
+                    for expr in exprs.iter().rev() {
+                        stack.push(expr);
+                    }
+                }
+                Expr::Raise(_, expr) => {
+                    if let Some(expr) = expr.as_ref() {
+                        stack.push(expr);
+                    }
+                }
+                Expr::Id(_) | Expr::Literal(_) | Expr::Variable(_) | Expr::Default => {}
+                Expr::Array { .. } | Expr::Subscript { .. } => {
+                    unreachable!(
+                        "Array and Subscript are desugared into function calls by the parser"
+                    )
+                }
             }
         }
+
+        true
     }
     /// Returns true if the expression is a constant expression that, when evaluated as a condition, is always true or false
     fn check_always_true_or_false(&self) -> Result<Option<AlwaysTrueOrFalse>> {

--- a/macros/src/trace_stack.rs
+++ b/macros/src/trace_stack.rs
@@ -68,8 +68,10 @@ pub(crate) fn trace_stack_attribute(attr: TokenStream, input: TokenStream) -> To
         let guard = trace_guard(&args, &function.sig.ident);
         let body = &function.block;
         function.block = syn::parse_quote!({
-            #guard
-            #body
+            crate::stack::maybe_grow(|| {
+                #guard
+                #body
+            })
         });
         return quote!(#function).into();
     }
@@ -78,8 +80,10 @@ pub(crate) fn trace_stack_attribute(attr: TokenStream, input: TokenStream) -> To
         let guard = trace_guard(&args, &function.sig.ident);
         let body = &function.block;
         function.block = syn::parse_quote!({
-            #guard
-            #body
+            crate::stack::maybe_grow(|| {
+                #guard
+                #body
+            })
         });
         return quote!(#function).into();
     }

--- a/testing/differential-oracle/fuzzer/Cargo.toml
+++ b/testing/differential-oracle/fuzzer/Cargo.toml
@@ -22,7 +22,7 @@ path = "custom_types_fuzzer.rs"
 path = "lib.rs"
 
 [dependencies]
-turso_core = { workspace = true, features = ["simulator"] }
+turso_core = { workspace = true, features = ["simulator", "stacker"] }
 sql_gen_prop = { path = "../sql_gen_prop" }
 sql_gen = { path = "../sql_gen", features = ["serde"] }
 rusqlite.workspace = true


### PR DESCRIPTION
# NOTICE:

## Description

This adds a depth guard for SQL expression translation so extremely deep expression trees return a clean parse error instead of overflowing the process stack.

The change also moves the constant-expression check to an iterative walk and routes traced stack-heavy translation through `stacker` when enabled.

## Motivation and context

I reproduced a stack overflow from the differential fuzzer with:

```sh
target/debug/differential_fuzzer -s 4553014462801496916 -t 2 -c 5 -n 120 -g sql-gen -k
```

A hand-built deeply nested `select 1 + 1 + ...` also aborted the CLI before returning an error. With this change, over-deep expressions fail with:

```text
Expression tree is too large (maximum depth 1000)
```

Valid expressions up to the configured limit still execute.

## Verification

```sh
git diff --check origin/main..HEAD
cargo test -p turso_cli --test non_interactive_exit_code -- --nocapture
cargo test -p turso_core expr --lib -- --nocapture
cargo build -p differential-fuzzer --bin differential_fuzzer
./target/debug/differential_fuzzer -s 4553014462801496916 -t 2 -c 5 -n 120 -g sql-gen -k
cargo build -p turso_cli --release
```

I also checked release CLI behavior for 1000, 1001, and 3000-term expressions: 1000 terms succeeds; deeper expressions return the new parse error instead of aborting.

## Description of AI Usage

AI-assisted with OpenAI Codex. Codex helped trace the fuzzer crash, implement the guarded expression walk, add regression tests, and run the validation commands. I reviewed the diff and verification output before submitting.
