### PR TITLE
[codex] Fix UPSERT before-trigger index corruption

### DIFF
--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -7,7 +7,9 @@ use turso_parser::ast::{self, TriggerEvent, TriggerTime, Upsert};
 use super::emitter::gencol::compute_virtual_columns;
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
 use crate::schema::{BTreeTable, ColumnLayout, IndexColumn, ROWID_SENTINEL};
-use crate::translate::emitter::{emit_check_constraints, emit_make_record, UpdateRowSource};
+use crate::translate::emitter::{
+    emit_check_constraints, emit_index_column_value_old_image, emit_make_record, UpdateRowSource,
+};
 use crate::translate::expr::{walk_expr, WalkControl};
 use crate::translate::fkeys::{
     emit_fk_child_update_counters, emit_fk_update_parent_actions, fire_fk_update_actions,
@@ -685,6 +687,7 @@ pub fn emit_upsert(
 
     // Fire BEFORE UPDATE triggers
     let upsert_database_id = ctx.database_id;
+    let mut has_before_update_triggers = false;
     let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) = table.btree() {
         let updated_column_indices: ColumnMask =
             set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
@@ -702,6 +705,7 @@ pub fn emit_upsert(
             .chain(std::iter::once(ctx.conflict_rowid_reg))
             .collect();
         if !relevant_before_update_triggers.is_empty() {
+            has_before_update_triggers = true;
             // NEW row values are in new_start registers. At this point they are
             // encoded (post-encode for STRICT custom types). Mark new_encoded=true
             // so fire_trigger's decode_trigger_registers will decode them.
@@ -783,6 +787,70 @@ pub fn emit_upsert(
     } else {
         None
     };
+
+    if has_before_update_triggers {
+        let updated_column_indices: ColumnMask =
+            set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
+        for (idx, col) in table.columns().iter().enumerate() {
+            if updated_column_indices.get(idx) || col.is_virtual_generated() {
+                continue;
+            }
+            let target_reg = layout.to_register(new_start, idx);
+            emit_table_column(
+                program,
+                ctx.cursor_id,
+                table_ref_id,
+                table_references,
+                col,
+                idx,
+                target_reg,
+                resolver,
+            )?;
+            if col.notnull() && !col.is_rowid_alias() {
+                program.emit_insn(Insn::HaltIfNull {
+                    target_reg,
+                    err_code: SQLITE_CONSTRAINT_NOTNULL,
+                    description: String::from(table.get_name())
+                        + "."
+                        + col.name.as_ref().map_or("", |name| name),
+                });
+            }
+        }
+
+        if ctx.table.has_virtual_columns() {
+            let rowid_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
+            let dml_ctx =
+                DmlColumnContext::layout(ctx.table.columns(), new_start, rowid_reg, layout.clone());
+            compute_virtual_columns(
+                program,
+                &ctx.table.columns_topo_sort()?,
+                &dml_ctx,
+                resolver,
+                ctx.table,
+            )?;
+        }
+
+        if let Some(bt) = table.btree() {
+            if !bt.check_constraints.is_empty() {
+                emit_check_constraints(
+                    program,
+                    &bt.check_constraints,
+                    resolver,
+                    &bt.name,
+                    new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg),
+                    bt.columns().iter().enumerate().filter_map(|(idx, col)| {
+                        col.name
+                            .as_deref()
+                            .map(|n| (n, layout.to_register(new_start, idx)))
+                    }),
+                    connection,
+                    ast::ResolveType::Abort,
+                    ctx.loop_labels.row_done,
+                    Some(table_references),
+                )?;
+            }
+        }
+    }
     let rowid_alias_idx = table.columns().iter().position(|c| c.is_rowid_alias());
     let has_direct_rowid_update = set_pairs
         .iter()
@@ -860,15 +928,19 @@ pub fn emit_upsert(
             }
             let k = idx_meta.columns.len();
 
-            let before_pred_reg = eval_partial_pred_for_row_image(
-                program,
-                table,
-                &idx_meta,
-                before,
-                ctx.conflict_rowid_reg,
-                resolver,
-                &layout,
-            );
+            let before_pred_reg = if has_before_update_triggers {
+                None
+            } else {
+                eval_partial_pred_for_row_image(
+                    program,
+                    table,
+                    &idx_meta,
+                    before,
+                    ctx.conflict_rowid_reg,
+                    resolver,
+                    &layout,
+                )
+            };
             let new_rowid = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
             let new_pred_reg = eval_partial_pred_for_row_image(
                 program, table, &idx_meta, new_start, new_rowid, resolver, &layout,
@@ -888,7 +960,17 @@ pub fn emit_upsert(
             // DELETE old key
             let del = program.alloc_registers(k + 1);
             for (i, ic) in idx_meta.columns.iter().enumerate() {
-                if ic.expr.is_some() {
+                if has_before_update_triggers {
+                    emit_index_column_value_old_image(
+                        program,
+                        resolver,
+                        table_references,
+                        ctx.cursor_id,
+                        table_ref_id,
+                        ic,
+                        del + i,
+                    )?;
+                } else if ic.expr.is_some() {
                     emit_upsert_expr_index_value(
                         program,
                         resolver,
@@ -908,11 +990,18 @@ pub fn emit_upsert(
                     });
                 }
             }
-            program.emit_insn(Insn::Copy {
-                src_reg: ctx.conflict_rowid_reg,
-                dst_reg: del + k,
-                extra_amount: 0,
-            });
+            if has_before_update_triggers {
+                program.emit_insn(Insn::RowId {
+                    cursor_id: ctx.cursor_id,
+                    dest: del + k,
+                });
+            } else {
+                program.emit_insn(Insn::Copy {
+                    src_reg: ctx.conflict_rowid_reg,
+                    dst_reg: del + k,
+                    extra_amount: 0,
+                });
+            }
             program.emit_insn(Insn::IdxDelete {
                 start_reg: del,
                 num_regs: k + 1,

--- a/testing/simulator/runner/memory/mod.rs
+++ b/testing/simulator/runner/memory/mod.rs
@@ -5,3 +5,5 @@ pub mod io;
 mod mvcc_recovery;
 #[cfg(test)]
 mod statement_abandon;
+#[cfg(test)]
+mod upsert_trigger;

--- a/testing/simulator/runner/memory/upsert_trigger.rs
+++ b/testing/simulator/runner/memory/upsert_trigger.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
+
+use crate::runner::memory::io::MemorySimIO;
+
+fn make_conn(seed: u64) -> Result<(Arc<Connection>, Arc<MemorySimIO>)> {
+    let io = Arc::new(MemorySimIO::new(
+        seed, 4096, 100, // Always schedule operations asynchronously.
+        1, 5,
+    ));
+    let db = Database::open_file_with_flags(
+        io.clone() as Arc<dyn IO>,
+        &format!("sim_upsert_trigger_{seed}.db"),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    Ok((db.connect()?, io))
+}
+
+fn query_rows(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<Vec<(i64, String, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, k, v FROM t INDEXED BY sqlite_autoindex_t_1 WHERE k = 'mid' AND v = 'new'",
+    )?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist");
+                rows.push((
+                    row.get::<i64>(0).expect("id column should exist"),
+                    row.get::<String>(1).expect("k column should exist"),
+                    row.get::<String>(2).expect("v column should exist"),
+                ));
+            }
+            StepResult::Done => return Ok(rows),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+fn integrity_check(conn: &Arc<Connection>, io: &MemorySimIO) -> Result<String> {
+    let mut stmt = conn.prepare("PRAGMA integrity_check")?;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("integrity_check row should exist");
+                return Ok(row
+                    .get::<String>(0)
+                    .expect("integrity_check should return text"));
+            }
+            StepResult::Done => panic!("integrity_check ended without a row"),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn sim_upsert_before_update_trigger_keeps_index_integrity() -> Result<()> {
+    let (conn, io) = make_conn(1)?;
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT, v TEXT, UNIQUE(k, v))")?;
+    conn.execute("INSERT INTO t VALUES(1, 'a', 'old')")?;
+    conn.execute(
+        "CREATE TRIGGER bu BEFORE UPDATE ON t BEGIN UPDATE t SET k = 'mid' WHERE id = OLD.id; END",
+    )?;
+    conn.execute(
+        "INSERT INTO t VALUES(1, 'ignored', 'ignored') \
+         ON CONFLICT(id) DO UPDATE SET v = 'new'",
+    )?;
+
+    assert_eq!(
+        query_rows(&conn, io.as_ref())?,
+        vec![(1, "mid".into(), "new".into())]
+    );
+    assert_eq!(integrity_check(&conn, io.as_ref())?, "ok");
+    Ok(())
+}

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -4327,6 +4327,110 @@ fn test_trigger_before_update_changes_value_unique_conflict(tmp_db: TempDatabase
     assert_eq!(ic, "ok");
 }
 
+/// UPSERT DO UPDATE must refresh non-SET columns after BEFORE UPDATE triggers.
+///
+/// SQLite keeps changes made by the BEFORE trigger for columns that the outer
+/// UPDATE did not set. If UPSERT writes the stale pre-trigger image instead,
+/// the table payload and unique index diverge.
+#[turso_macros::test]
+fn test_upsert_before_update_trigger_refreshes_non_set_indexed_columns(tmp_db: TempDatabase) {
+    drop(tmp_db);
+    let limbo_db = TempDatabase::builder()
+        .with_db_name("upsert_before_trigger_refresh.db")
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+    for sql in [
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT UNIQUE, v TEXT)",
+        "INSERT INTO t VALUES(1, 'a', 'old')",
+        "CREATE TRIGGER bu BEFORE UPDATE ON t BEGIN UPDATE t SET k = 'mid' WHERE id = OLD.id; END",
+    ] {
+        sqlite_try_exec(&sqlite_conn, sql).unwrap();
+        limbo_try_exec(&limbo_conn, sql).unwrap();
+    }
+
+    let upsert = "INSERT INTO t VALUES(1, 'ignored', 'new') \
+                  ON CONFLICT(id) DO UPDATE SET v = excluded.v";
+    sqlite_try_exec(&sqlite_conn, upsert).unwrap();
+    limbo_try_exec(&limbo_conn, upsert).unwrap();
+
+    let diff = compare_tables(
+        "upsert before trigger refresh",
+        &sqlite_conn,
+        &limbo_conn,
+        "SELECT id, k, v FROM t ORDER BY id",
+    );
+    assert!(diff.is_none(), "{diff:?}");
+
+    let sqlite_index_rows = sqlite_exec_rows(
+        &sqlite_conn,
+        "SELECT id, k, v FROM t INDEXED BY sqlite_autoindex_t_1 WHERE k = 'mid'",
+    );
+    let limbo_index_rows = limbo_exec_rows(
+        &limbo_conn,
+        "SELECT id, k, v FROM t INDEXED BY sqlite_autoindex_t_1 WHERE k = 'mid'",
+    );
+    assert_eq!(limbo_index_rows, sqlite_index_rows);
+
+    let db_path = limbo_db.path.clone();
+    drop(limbo_conn);
+    drop(limbo_db);
+    let ic = sqlite_integrity_check(&db_path);
+    assert_eq!(ic, "ok");
+}
+
+/// If a BEFORE UPDATE trigger changes one indexed column and UPSERT changes
+/// another column in the same index, the old index key to delete is the
+/// post-trigger key currently in the table, not the pre-trigger snapshot.
+#[turso_macros::test]
+fn test_upsert_before_update_trigger_deletes_post_trigger_index_key(tmp_db: TempDatabase) {
+    drop(tmp_db);
+    let limbo_db = TempDatabase::builder()
+        .with_db_name("upsert_before_trigger_composite_index.db")
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+    for sql in [
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT, v TEXT, UNIQUE(k, v))",
+        "INSERT INTO t VALUES(1, 'a', 'old')",
+        "CREATE TRIGGER bu BEFORE UPDATE ON t BEGIN UPDATE t SET k = 'mid' WHERE id = OLD.id; END",
+    ] {
+        sqlite_try_exec(&sqlite_conn, sql).unwrap();
+        limbo_try_exec(&limbo_conn, sql).unwrap();
+    }
+
+    let upsert = "INSERT INTO t VALUES(1, 'ignored', 'ignored') \
+                  ON CONFLICT(id) DO UPDATE SET v = 'new'";
+    sqlite_try_exec(&sqlite_conn, upsert).unwrap();
+    limbo_try_exec(&limbo_conn, upsert).unwrap();
+
+    let diff = compare_tables(
+        "upsert before trigger composite index",
+        &sqlite_conn,
+        &limbo_conn,
+        "SELECT id, k, v FROM t ORDER BY id",
+    );
+    assert!(diff.is_none(), "{diff:?}");
+
+    let sqlite_index_rows = sqlite_exec_rows(
+        &sqlite_conn,
+        "SELECT id, k, v FROM t INDEXED BY sqlite_autoindex_t_1 WHERE k = 'mid' AND v = 'new'",
+    );
+    let limbo_index_rows = limbo_exec_rows(
+        &limbo_conn,
+        "SELECT id, k, v FROM t INDEXED BY sqlite_autoindex_t_1 WHERE k = 'mid' AND v = 'new'",
+    );
+    assert_eq!(limbo_index_rows, sqlite_index_rows);
+
+    let db_path = limbo_db.path.clone();
+    drop(limbo_conn);
+    drop(limbo_db);
+    let ic = sqlite_integrity_check(&db_path);
+    assert_eq!(ic, "ok");
+}
+
 // ---------------------------------------------------------------------------
 // Gap 5: Autocommit FAIL semantics with partial row changes
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes a persisted index/table divergence in `INSERT ... ON CONFLICT DO UPDATE` when a `BEFORE UPDATE` trigger mutates the row being updated.

The bug is reproducible on current `main` with default features:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT, v TEXT, UNIQUE(k, v));
INSERT INTO t VALUES (1, 'a', 'old');
CREATE TRIGGER bu BEFORE UPDATE ON t BEGIN
  UPDATE t SET k = 'mid' WHERE id = OLD.id;
END;
INSERT INTO t VALUES (1, 'ignored', 'ignored')
  ON CONFLICT(id) DO UPDATE SET v = 'new';
SELECT id, k, v FROM t ORDER BY id;
PRAGMA integrity_check;
```

Before this patch, Turso writes the table row as `1|a|new` while the unique index still contains the trigger-written key. SQLite reports `wrong # of entries in index sqlite_autoindex_t_1` for the composite-index case, and the simpler single-column case reports `row 1 missing from index sqlite_autoindex_t_1`.

## Root cause

The normal `UPDATE` path already re-seeks and re-reads non-SET columns after `BEFORE UPDATE` triggers because those triggers may have changed the current row. The UPSERT `DO UPDATE` path re-seeked the row, but still kept using the pre-trigger row snapshot for non-SET columns and for old index-key deletion.

That means UPSERT could:

- overwrite trigger changes in the table payload for columns not mentioned in the outer `SET`, and
- delete the wrong old index key when a trigger changed one indexed column while the outer UPSERT changed another indexed column.

## Fix

After UPSERT `BEFORE UPDATE` triggers fire, this patch:

- refreshes non-SET base columns from the current table cursor into the UPSERT NEW image,
- recomputes virtual columns and CHECK constraints from the refreshed image, and
- deletes old index entries using the post-trigger old image from the table cursor, matching the regular UPDATE path.

## Tests

- Added two integration regressions comparing Turso against SQLite and checking the persisted database with SQLite `PRAGMA integrity_check`.
- Added a deterministic simulator regression under `MemorySimIO` for the composite-index corruption case.

Validation run locally on Windows:

```text
cargo fmt --check
cargo test -p core_tester --test integration_tests test_upsert_before_update_trigger_ -- --nocapture
cargo test -p core_tester --test integration_tests upsert -- --nocapture
cargo test -p core_tester --test integration_tests test_trigger_before_update_changes_value_unique_conflict -- --nocapture
cargo test -p limbo_sim sim_upsert_before_update_trigger_keeps_index_integrity -- --nocapture
cargo test -p limbo_sim -- --nocapture
```

I also rebuilt `tursodb` and verified the direct repro now returns `1|mid|new`, `PRAGMA integrity_check` returns `ok`, and the composite unique index lookup returns the same row.