### PR TITLE
simulator: Fix drop index count accounting

### DIFF
--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -73,7 +73,7 @@ impl Remaining {
             .unwrap_or_default();
 
         let mut remaining_drop_index = total_drop_index
-            .checked_sub(stats.alter_table_count)
+            .checked_sub(stats.drop_index_count)
             .unwrap_or_default();
 
         if mvcc {
@@ -174,5 +174,93 @@ impl Display for InteractionStats {
             self.alter_table_count,
             self.drop_index_count,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sql_generation::{
+        generation::{GenerationContext, Opts},
+        model::table::{Index, Table},
+    };
+    use turso_parser::ast::SortOrder;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestContext {
+        opts: Opts,
+        tables: Vec<Table>,
+    }
+
+    impl GenerationContext for TestContext {
+        fn tables(&self) -> &Vec<Table> {
+            &self.tables
+        }
+
+        fn opts(&self) -> &Opts {
+            &self.opts
+        }
+    }
+
+    fn table_with_index() -> Table {
+        Table {
+            name: "t".to_string(),
+            columns: vec![],
+            rows: vec![],
+            indexes: vec![Index {
+                table_name: "t".to_string(),
+                index_name: "idx_t".to_string(),
+                columns: vec![("a".to_string(), SortOrder::Asc)],
+            }],
+        }
+    }
+
+    #[test]
+    fn total_weight_includes_drop_index_weight() {
+        let profile = QueryProfile::default();
+
+        let expected = profile.select_weight
+            + profile.create_table_weight
+            + profile.create_index_weight
+            + profile.insert_weight
+            + profile.update_weight
+            + profile.delete_weight
+            + profile.drop_table_weight
+            + profile.alter_table_weight
+            + profile.drop_index
+            + profile.pragma_weight;
+
+        assert_eq!(profile.total_weight(), expected);
+    }
+
+    #[test]
+    fn remaining_drop_index_uses_drop_index_stats() {
+        let profile = QueryProfile {
+            select_weight: 90,
+            create_table_weight: 0,
+            create_index_weight: 0,
+            insert_weight: 0,
+            update_weight: 0,
+            delete_weight: 0,
+            drop_table_weight: 0,
+            alter_table_weight: 0,
+            drop_index: 10,
+            pragma_weight: 0,
+            ..Default::default()
+        };
+        let stats = InteractionStats {
+            drop_index_count: 4,
+            alter_table_count: 0,
+            ..Default::default()
+        };
+        let ctx = TestContext {
+            tables: vec![table_with_index()],
+            ..Default::default()
+        };
+
+        let remaining = Remaining::new(100, &profile, &stats, false, &ctx);
+
+        assert_eq!(remaining.drop_index, 6);
     }
 }

--- a/testing/simulator/profiles/query.rs
+++ b/testing/simulator/profiles/query.rs
@@ -63,6 +63,7 @@ impl QueryProfile {
             + self.delete_weight
             + self.drop_table_weight
             + self.alter_table_weight
+            + self.drop_index
             + self.pragma_weight
     }
 }


### PR DESCRIPTION
## Summary
- Include `drop_index` in simulator query-profile total weight calculations.
- Decrement remaining drop-index budget using `drop_index_count` instead of `alter_table_count`.
- Add focused regression tests for both accounting paths.

## Why
While working through the Turso simulator challenge path, I noticed `DROP INDEX` generation accounting was undercounted in two places:

1. `QueryProfile::total_weight()` omitted `drop_index`, so the configured drop-index weight did not contribute to the denominator used for per-operation budgets.
2. `Remaining::new()` subtracted `alter_table_count` from the remaining drop-index quota instead of `drop_index_count`.

This makes the simulator's generated operation mix diverge from the configured profile and can starve or overrun `DROP INDEX` coverage depending on the surrounding profile.

## Test plan
- `cargo test -p limbo_sim model::metrics::tests -- --nocapture`
- `cargo test -p limbo_sim --bins`
- `cargo check -p limbo_sim --bins`
- `cargo clippy -p limbo_sim --bins --tests -- -D warnings`
