### PR TITLE
[codex] Fix RETURNING DML statement rollback

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1164,6 +1164,7 @@ pub fn translate_insert(
             has_fks,
             has_upsert,
             btree_table.has_autoincrement,
+            !result_columns.is_empty(),
             notnull_col_exists,
             has_unique,
         );

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -133,6 +133,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     has_fks: bool,
     has_upsert: bool,
     has_autoincrement: bool,
+    has_returning: bool,
     notnull_col_exists: bool,
     has_unique: bool,
 ) {
@@ -150,6 +151,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     let has_check = !table.check_constraints.is_empty();
     let may_abort = has_triggers
         || has_fks
+        || has_returning
         || constraint_may_abort(
             has_statement_conflict,
             statement_conflict,
@@ -167,6 +169,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
         && !any_replace
         && !has_upsert
         && !has_autoincrement
+        && !has_returning
     {
         program.set_multi_write(false);
     }
@@ -209,12 +212,13 @@ pub(crate) fn set_update_stmt_journal_flags(
         btree_table.rowid_alias_conflict_clause,
         plan.indexes_to_update.iter().map(|idx| idx.on_conflict),
     );
+    let has_returning = plan.returning.as_ref().is_some_and(|r| !r.is_empty());
 
     // Ephemeral tables (used for key mutation / Halloween protection) always scan all
     // collected rows, so affects_max_1_row() returns false — multi_write stays true.
     let is_single_row =
         plan.limit.is_none() && plan.offset.is_none() && target_table.op.affects_max_1_row();
-    if is_single_row && !has_triggers && !any_replace && !has_fks {
+    if is_single_row && !has_triggers && !any_replace && !has_fks && !has_returning {
         program.set_multi_write(false);
     }
 
@@ -233,6 +237,7 @@ pub(crate) fn set_update_stmt_journal_flags(
 
     let may_abort = has_triggers
         || has_fks
+        || has_returning
         || constraint_may_abort(
             has_statement_conflict,
             or_conflict,
@@ -264,18 +269,19 @@ pub(crate) fn set_delete_stmt_journal_flags(
     };
     let has_triggers = plan.safety.reasons.contains(&DmlSafetyReason::Trigger);
     let has_fks = table_has_fks(connection, resolver, database_id, btree_table.name.as_str());
+    let has_returning = !plan.result_columns.is_empty();
 
     // After rowset rewriting (for triggers/safety), the target table op is reset to a
     // Scan, so affects_max_1_row correctly returns false — no false optimization.
     let is_single_row =
         plan.limit.is_none() && plan.offset.is_none() && target_table.op.affects_max_1_row();
-    if is_single_row && !has_triggers && !has_fks {
+    if is_single_row && !has_triggers && !has_fks && !has_returning {
         program.set_multi_write(false);
     }
 
     // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
     // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
+    if !has_triggers && !has_fks && !has_returning {
         program.set_may_abort(false);
     }
     Ok(())

--- a/testing/simulator/runner/memory/statement_abandon.rs
+++ b/testing/simulator/runner/memory/statement_abandon.rs
@@ -140,6 +140,25 @@ fn sim_abandon_after_first_returning_row_commits() -> Result<()> {
 }
 
 #[test]
+fn sim_returning_error_rolls_back_single_row_dml() -> Result<()> {
+    let (conn, io) = make_conn(9)?;
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("INSERT INTO t VALUES (1, 'old'), (2, 'keep')")?;
+
+    conn.execute("BEGIN")?;
+    let result =
+        conn.execute("UPDATE t SET v = 'new' WHERE id = 1 RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "UPDATE RETURNING should fail");
+    conn.execute("COMMIT")?;
+
+    assert_eq!(
+        query_rows(&conn, io.as_ref())?,
+        vec![(1, "old".to_string()), (2, "keep".to_string())]
+    );
+    Ok(())
+}
+
+#[test]
 fn sim_reset_error_does_not_hold_locks() -> Result<()> {
     let (conn, io) = make_conn(3)?;
     conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")?;

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -138,6 +138,58 @@ fn insert_select_source(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// RETURNING expressions are evaluated after the write. Even a single-row
+/// INSERT must keep a statement journal if a RETURNING expression can abort.
+#[turso_macros::test(init_sql = "CREATE TABLE t (a INTEGER PRIMARY KEY, b);")]
+fn insert_single_row_returning_needs_stmt_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "INSERT INTO t VALUES (1, 10) RETURNING 'x' LIKE 'x' ESCAPE 'yy'"
+    ));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn insert_returning_error_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER PRIMARY KEY, b)")?;
+    conn.execute("BEGIN")?;
+
+    let result = conn.execute("INSERT INTO t VALUES (1, 10) RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "INSERT RETURNING should fail");
+    conn.execute("COMMIT")?;
+
+    let rows = query_rows(&conn, "SELECT a, b FROM t ORDER BY a");
+    assert!(rows.is_empty(), "failed INSERT RETURNING must not persist");
+    assert_eq!(query_rows(&conn, "PRAGMA integrity_check"), vec!["ok"]);
+    Ok(())
+}
+
+#[turso_macros::test]
+fn insert_replace_returning_error_preserves_replaced_row(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER PRIMARY KEY, b TEXT)")?;
+    conn.execute("INSERT INTO t VALUES (1, 'old')")?;
+    conn.execute("BEGIN")?;
+
+    let result = conn
+        .execute("INSERT OR REPLACE INTO t VALUES (1, 'new') RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "INSERT OR REPLACE RETURNING should fail");
+    conn.execute("COMMIT")?;
+
+    let rows = query_rows(&conn, "SELECT a, b FROM t ORDER BY a");
+    assert_eq!(
+        rows,
+        vec!["1|old"],
+        "failed REPLACE RETURNING must preserve the original row"
+    );
+    assert_eq!(query_rows(&conn, "PRAGMA integrity_check"), vec!["ok"]);
+    Ok(())
+}
+
 /// Single-row INSERT with immediate FK constraints does NOT need a statement journal.
 /// Immediate FK violations emit a direct Halt before any writes (matching SQLite's
 /// usesStmtJournal=0 for this case), so there's nothing to roll back.
@@ -230,6 +282,40 @@ fn update_by_rowid_alias(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Single-row UPDATE normally skips the statement journal, but RETURNING can
+/// abort after the row has been rewritten.
+#[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a);")]
+fn update_by_rowid_returning_needs_stmt_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "UPDATE t SET a = 1 WHERE id = 5 RETURNING 'x' LIKE 'x' ESCAPE 'yy'"
+    ));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn update_returning_error_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a)")?;
+    conn.execute("INSERT INTO t VALUES (1, 10), (2, 20)")?;
+    conn.execute("BEGIN")?;
+
+    let result =
+        conn.execute("UPDATE t SET a = 11 WHERE id = 1 RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "UPDATE RETURNING should fail");
+    conn.execute("COMMIT")?;
+
+    let rows = query_rows(&conn, "SELECT id, a FROM t ORDER BY id");
+    assert_eq!(
+        rows,
+        vec!["1|10", "2|20"],
+        "failed UPDATE RETURNING must not persist"
+    );
+    assert_eq!(query_rows(&conn, "PRAGMA integrity_check"), vec!["ok"]);
+    Ok(())
+}
+
 /// UPDATE WHERE unique_col = ? → single-row (unique index equality seek).
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL, b UNIQUE);")]
 fn update_by_unique_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
@@ -314,6 +400,39 @@ fn delete_by_rowid(tmp_db: TempDatabase) -> anyhow::Result<()> {
 fn delete_by_unique_index(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let conn = tmp_db.connect_limbo();
     assert!(!needs_stmt_journal(&conn, "DELETE FROM t WHERE b = 5"));
+    Ok(())
+}
+
+/// Single-row DELETE normally skips the statement journal, but RETURNING can
+/// abort after the row has already been deleted.
+#[turso_macros::test(init_sql = "CREATE TABLE t (a INTEGER PRIMARY KEY, b);")]
+fn delete_by_rowid_returning_needs_stmt_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "DELETE FROM t WHERE a = 1 RETURNING 'x' LIKE 'x' ESCAPE 'yy'"
+    ));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn delete_returning_error_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER PRIMARY KEY, b)")?;
+    conn.execute("INSERT INTO t VALUES (1, 10), (2, 20)")?;
+    conn.execute("BEGIN")?;
+
+    let result = conn.execute("DELETE FROM t WHERE a = 1 RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "DELETE RETURNING should fail");
+    conn.execute("COMMIT")?;
+
+    let rows = query_rows(&conn, "SELECT a, b FROM t ORDER BY a");
+    assert_eq!(
+        rows,
+        vec!["1|10", "2|20"],
+        "failed DELETE RETURNING must not persist"
+    );
+    assert_eq!(query_rows(&conn, "PRAGMA integrity_check"), vec!["ok"]);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #6878 by keeping statement rollback enabled for DML statements with RETURNING clauses.

RETURNING expressions are evaluated after the persistent write path has already inserted, updated, deleted, or replaced the row. Before this patch, single-row DML could clear `is_multi_write`, and DELETE without triggers/FKs could also clear `may_abort`, so a RETURNING-time error inside an explicit transaction left already-written rows behind.

This patch treats RETURNING as a post-write abort source for INSERT, UPDATE, and DELETE statement-journal analysis. That preserves the existing buffered RETURNING behavior while ensuring failed RETURNING expressions roll back the DML statement.

The simulator side now also has a generated `ReturningErrorRollback` property. It emits a real transactional plan of the form: select snapshot, `BEGIN IMMEDIATE`, `UPDATE ... RETURNING <erroring expression>`, `COMMIT`, select snapshot, then asserts that the UPDATE errored and rows are unchanged. The bad RETURNING SQL is only produced by that property, so normal random DML/shadow behavior stays unchanged.

## Repro

Before the fix, Turso reported the RETURNING error but still persisted the DELETE:

```sql
PRAGMA journal_mode=WAL;
CREATE TABLE t(a INT);
INSERT INTO t VALUES(1),(2);
BEGIN;
DELETE FROM t WHERE a=1 RETURNING 'x' LIKE 'x' ESCAPE 'yy';
PRAGMA integrity_check;
SELECT * FROM t ORDER BY a;
COMMIT;
```

After the fix, Turso matches SQLite: the error is reported, `integrity_check` is `ok`, and both rows remain.

## Tests

- `cargo fmt --check`
- `cargo check -p limbo_sim`
- `cargo test -p core_tester --test integration_tests returning -- --nocapture`
- `cargo test -p core_tester --test integration_tests stmt_journal -- --nocapture`
- `cargo test -p limbo_sim sim_returning_error_rolls_back_single_row_dml -- --nocapture`
- `cargo test -p limbo_sim -- --nocapture`
- `cargo build -q -p turso_cli`
- Direct persisted-file CLI checks against SQLite/Turso for DELETE RETURNING, UPDATE RETURNING, and INSERT OR REPLACE RETURNING rollback