### PR TITLE
concurrent-simulator: give reopen drain its own budget

### DIFF
--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -240,6 +240,14 @@ pub struct WhopperOpts {
     pub max_connections: usize,
     /// Maximum number of simulation steps to run.
     pub max_steps: usize,
+    /// Maximum iterations the reopen drain loop runs before declaring an
+    /// engine-level infinite loop. Drain iterations do not count against
+    /// `max_steps`: legitimate IO-heavy operations (e.g.
+    /// `PRAGMA integrity_check`) can use thousands of yields per page and
+    /// would routinely exhaust the main budget during a reopen near the end
+    /// of a run. Exceeding `max_drain_steps` within a single reopen surfaces
+    /// as an error.
+    pub max_drain_steps: usize,
     /// Probability of cosmic ray bit flip on each step (0.0-1.0).
     pub cosmic_ray_probability: f64,
     /// Keep mmap I/O files on disk after run.
@@ -266,6 +274,7 @@ impl Default for WhopperOpts {
             seed: None,
             max_connections: 4,
             max_steps: 100_000,
+            max_drain_steps: 1_000_000,
             cosmic_ray_probability: 0.0,
             keep_files: false,
             enable_mvcc: false,
@@ -316,6 +325,11 @@ impl WhopperOpts {
 
     pub fn with_max_steps(mut self, max_steps: usize) -> Self {
         self.max_steps = max_steps;
+        self
+    }
+
+    pub fn with_max_drain_steps(mut self, max_drain_steps: usize) -> Self {
+        self.max_drain_steps = max_drain_steps;
         self
     }
 
@@ -480,6 +494,7 @@ pub struct Whopper {
     pub rng: ChaCha8Rng,
     pub current_step: usize,
     pub max_steps: usize,
+    pub max_drain_steps: usize,
     pub seed: u64,
     pub stats: Stats,
     /// Chaotic workload profiles: (probability, name, profile).
@@ -606,6 +621,7 @@ impl Whopper {
             opts: Opts::default(),
             current_step: 0,
             max_steps: opts.max_steps,
+            max_drain_steps: opts.max_drain_steps,
             seed,
             stats: Stats::default(),
             chaotic_profiles: opts.chaotic_profiles,
@@ -1001,24 +1017,27 @@ impl Whopper {
         );
 
         let fibers = &mut self.context.fibers;
-        // Drain active statements, counting each iteration against the
-        // simulator's step budget. Without this, a leaked lock (e.g. a sibling
-        // fiber holding pager_commit_lock with no statement left for us to
-        // step) keeps the loop spinning past max_steps. If we exhaust the
-        // budget while statements are still live, fail loudly: silent
-        // fall-through would let the outer `run` loop exit with status 0 and
-        // mask a hang as a passing CI run.
+        // Drain active statements with a per-reopen budget independent of
+        // `max_steps`. The main loop's step budget governs how long the
+        // simulator runs overall; drain is a finalization phase that runs
+        // until either every fiber's in-flight statement has terminated
+        // (Done/Busy/Err) or `max_drain_steps` iterations elapse. The latter
+        // catches genuine engine-side infinite loops (leaked lock,
+        // unresolvable IO yield). Legitimate IO-heavy operations like
+        // `PRAGMA integrity_check` can run for thousands of yields per page,
+        // so the cap needs to comfortably exceed that.
+        let mut drain_iterations = 0usize;
         while fibers.iter().any(|f| f.statement.borrow().is_some()) {
-            if self.current_step >= self.max_steps {
+            if drain_iterations >= self.max_drain_steps {
                 let stuck: Vec<usize> = fibers
                     .iter()
                     .enumerate()
                     .filter_map(|(i, f)| f.statement.borrow().is_some().then_some(i))
                     .collect();
                 anyhow::bail!(
-                    "reopen drain exhausted max_steps ({}) with statements still live on fibers {:?}; \
-                     likely a leaked lock or other deadlock in the engine",
-                    self.max_steps,
+                    "reopen drain exceeded max_drain_steps ({}) with statements still live on \
+                     fibers {:?}; likely a leaked lock or other infinite loop in the engine",
+                    self.max_drain_steps,
                     stuck,
                 );
             }
@@ -1075,7 +1094,7 @@ impl Whopper {
                 }
             }
             self.io.step().unwrap();
-            self.current_step += 1;
+            drain_iterations += 1;
         }
 
         // Close and drop all fiber connections to release database Arc references

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -47,6 +47,12 @@ struct Args {
     /// Max steps
     #[arg(long)]
     max_steps: Option<usize>,
+    /// Max iterations the reopen drain loop runs before declaring an
+    /// engine-side infinite loop. Drain iterations do not count against
+    /// `--max-steps` — legitimate IO-heavy operations like
+    /// `PRAGMA integrity_check` can use thousands of yields per page.
+    #[arg(long)]
+    max_drain_steps: Option<usize>,
     /// Keep files on disk after run
     #[arg(long)]
     keep: bool,
@@ -380,6 +386,9 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
 
     if let Some(max_steps) = args.max_steps {
         base_opts = base_opts.with_max_steps(max_steps);
+    }
+    if let Some(max_drain_steps) = args.max_drain_steps {
+        base_opts = base_opts.with_max_drain_steps(max_drain_steps);
     }
 
     let (workloads, properties, elle_tables, chaotic_profiles) =


### PR DESCRIPTION
7580dbdc9 ("concurrent-simulator: bound reopen drain loop with max_steps")
bounded reopen drain by the shared `max_steps` budget. That's overly
strict for legitimate IO-heavy statements: `PRAGMA integrity_check`
yields once per page read (cache-cold in MVCC mode after any commit
advances WAL state, since `mvcc_refresh_if_db_changed` nukes the cache
on every snapshot diff). A reopen that triggers late in a run has only
a few hundred main-loop steps left, far short of the ~3000 yields the
checker needs, and bails with a misleading "leaked lock" message.

Split the budget. Drain iterations no longer count against `max_steps`;
they have a dedicated `max_drain_steps` cap (default 1_000_000, exposed
as `--max-drain-steps`) that's large enough to absorb legitimate
IO-heavy finalization but still catches real engine-side infinite loops
(unresolvable IO yield, leaked lock with no other fiber able to make
progress).

Hitting `max_steps` during drain is no longer a panic — it just exits
the drain and falls through to the existing connection-close path,
which rolls back any in-flight transactions through `rollback_tx`.
