### PR TITLE
Fix statement rollback for DML RETURNING errors

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1166,6 +1166,7 @@ pub fn translate_insert(
             btree_table.has_autoincrement,
             notnull_col_exists,
             has_unique,
+            !result_columns.is_empty(),
         );
     }
 

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -11,8 +11,9 @@
 //! unnecessary. The condition is: `usesStmtJournal = isMultiWrite && mayAbort`.
 //!
 //! - **isMultiWrite**: the statement may modify more than one row (or more than
-//!   one table, e.g. FK counter + data table). A single-row write is atomic —
-//!   either all writes happen or none do — so no partial state to roll back.
+//!   one table, e.g. FK counter + data table). A single-row write is normally
+//!   atomic, but DML RETURNING is evaluated after the physical write and can
+//!   still abort; keep statement-journal protection for that path.
 //!
 //! - **mayAbort**: the statement may fail mid-execution with an ABORT (e.g.
 //!   constraint violation, FK violation, RAISE(ABORT) in a trigger). If a
@@ -135,6 +136,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     has_autoincrement: bool,
     notnull_col_exists: bool,
     has_unique: bool,
+    has_returning: bool,
 ) {
     let index_modes: Vec<(Option<ResolveType>, bool)> = resolver.with_schema(database_id, |s| {
         s.get_indices(&table.name)
@@ -150,6 +152,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
     let has_check = !table.check_constraints.is_empty();
     let may_abort = has_triggers
         || has_fks
+        || has_returning
         || constraint_may_abort(
             has_statement_conflict,
             statement_conflict,
@@ -167,6 +170,7 @@ pub(crate) fn set_insert_stmt_journal_flags(
         && !any_replace
         && !has_upsert
         && !has_autoincrement
+        && !has_returning
     {
         program.set_multi_write(false);
     }
@@ -215,7 +219,9 @@ pub(crate) fn set_update_stmt_journal_flags(
     let is_single_row =
         plan.limit.is_none() && plan.offset.is_none() && target_table.op.affects_max_1_row();
     if is_single_row && !has_triggers && !any_replace && !has_fks {
-        program.set_multi_write(false);
+        if !plan.returning.as_ref().is_some_and(|r| !r.is_empty()) {
+            program.set_multi_write(false);
+        }
     }
 
     let has_notnull_cols = plan.set_clauses.iter().any(|set_clause| {
@@ -233,6 +239,7 @@ pub(crate) fn set_update_stmt_journal_flags(
 
     let may_abort = has_triggers
         || has_fks
+        || plan.returning.as_ref().is_some_and(|r| !r.is_empty())
         || constraint_may_abort(
             has_statement_conflict,
             or_conflict,
@@ -269,13 +276,14 @@ pub(crate) fn set_delete_stmt_journal_flags(
     // Scan, so affects_max_1_row correctly returns false — no false optimization.
     let is_single_row =
         plan.limit.is_none() && plan.offset.is_none() && target_table.op.affects_max_1_row();
-    if is_single_row && !has_triggers && !has_fks {
+    let has_returning = !plan.result_columns.is_empty();
+    if is_single_row && !has_triggers && !has_fks && !has_returning {
         program.set_multi_write(false);
     }
 
     // DELETE has no ON CONFLICT clause, so NOT NULL/CHECK/UNIQUE don't apply —
     // only triggers (RAISE(ABORT)) or FK violations can abort.
-    if !has_triggers && !has_fks {
+    if !has_triggers && !has_fks && !has_returning {
         program.set_may_abort(false);
     }
     Ok(())

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -129,6 +129,56 @@ fn insert_autoincrement_notnull(tmp_db: TempDatabase) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// RETURNING expressions run after the physical insert and can abort at runtime,
+/// so even single-row INSERT needs statement-journal protection.
+#[turso_macros::test(init_sql = "CREATE TABLE t (a);")]
+fn insert_returning_needs_stmt_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "INSERT INTO t VALUES (1) RETURNING a"
+    ));
+    Ok(())
+}
+
+/// Regression: a RETURNING runtime error after a single-row INSERT must roll
+/// back the inserted row inside an explicit transaction.
+#[turso_macros::test]
+fn insert_returning_error_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a)")?;
+    conn.execute("BEGIN")?;
+
+    let result = conn.execute("INSERT INTO t VALUES(1) RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "INSERT RETURNING should fail");
+
+    let rows = query_rows(&conn, "SELECT * FROM t");
+    assert!(rows.is_empty(), "failed INSERT must not leave a row");
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
+/// Regression: INSERT OR REPLACE deletes the conflicting row before RETURNING.
+/// If RETURNING aborts, the replacement must be undone and the old row restored.
+#[turso_macros::test]
+fn insert_or_replace_returning_error_in_tx_rolls_back_replace(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a INT UNIQUE, b INT)")?;
+    conn.execute("INSERT INTO t VALUES(1,10)")?;
+    conn.execute("BEGIN")?;
+
+    let result =
+        conn.execute("INSERT OR REPLACE INTO t VALUES(1,20) RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "INSERT OR REPLACE RETURNING should fail");
+
+    let rows = query_rows(&conn, "SELECT rowid, a, b FROM t");
+    assert_eq!(rows, vec!["1|1|10"]);
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 /// INSERT with SELECT as source is multi-row.
 #[turso_macros::test(init_sql = "CREATE TABLE t (a NOT NULL);")]
 fn insert_select_source(tmp_db: TempDatabase) -> anyhow::Result<()> {
@@ -289,6 +339,37 @@ fn update_composite_unique_partial_cols(tmp_db: TempDatabase) -> anyhow::Result<
     Ok(())
 }
 
+/// RETURNING expressions run after the physical update and can abort at runtime,
+/// so even a rowid-targeted UPDATE needs statement-journal protection.
+#[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a);")]
+fn update_returning_needs_stmt_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "UPDATE t SET a = 1 WHERE id = 5 RETURNING a"
+    ));
+    Ok(())
+}
+
+/// Regression: a RETURNING runtime error after a single-row UPDATE must roll
+/// back the updated row inside an explicit transaction.
+#[turso_macros::test]
+fn update_returning_error_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT)")?;
+    conn.execute("INSERT INTO t VALUES(1, 'old')")?;
+    conn.execute("BEGIN")?;
+
+    let result =
+        conn.execute("UPDATE t SET a = 'new' WHERE id = 1 RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "UPDATE RETURNING should fail");
+
+    let rows = query_rows(&conn, "SELECT id, a FROM t");
+    assert_eq!(rows, vec!["1|old"]);
+    conn.execute("COMMIT")?;
+    Ok(())
+}
+
 // ──────────────────────────────────────────────────────────
 // DELETE
 // ──────────────────────────────────────────────────────────
@@ -339,6 +420,36 @@ fn delete_by_rowid_with_fk(tmp_db: TempDatabase) -> anyhow::Result<()> {
     // FK constraint checks modify deferred violation counter before the statement can abort,
     // so multi_write stays true. needs_stmt = true && true = true.
     assert!(needs_stmt_journal(&conn, "DELETE FROM parent WHERE id = 5"));
+    Ok(())
+}
+
+/// RETURNING expressions run after the physical delete and can abort at runtime,
+/// so even a rowid-targeted DELETE needs statement-journal protection.
+#[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, a);")]
+fn delete_returning_needs_stmt_journal(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    assert!(needs_stmt_journal(
+        &conn,
+        "DELETE FROM t WHERE id = 5 RETURNING a"
+    ));
+    Ok(())
+}
+
+/// Regression: a RETURNING runtime error after DELETE must roll back already
+/// deleted rows inside an explicit transaction.
+#[turso_macros::test]
+fn delete_returning_error_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a INT)")?;
+    conn.execute("INSERT INTO t VALUES(1),(2)")?;
+    conn.execute("BEGIN")?;
+
+    let result = conn.execute("DELETE FROM t WHERE a = 1 RETURNING 'x' LIKE 'x' ESCAPE 'yy'");
+    assert!(result.is_err(), "DELETE RETURNING should fail");
+
+    let rows = query_rows(&conn, "SELECT * FROM t ORDER BY a");
+    assert_eq!(rows, vec!["1", "2"]);
+    conn.execute("COMMIT")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- include DML RETURNING runtime failures in statement-journal analysis
- keep statement-journal protection for single-row INSERT/UPDATE/DELETE with RETURNING because RETURNING is evaluated after the physical write
- add regression coverage for INSERT, INSERT OR REPLACE, UPDATE, and DELETE RETURNING aborts inside explicit transactions

## Root cause
DML emitters can perform the physical row write before evaluating RETURNING expressions. If a RETURNING expression fails at runtime and the statement journal was optimized away, the write can remain visible inside the surrounding transaction.

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p core_tester --test integration_tests stmt_journal -- --nocapture
- cargo build -p turso_cli --bin tursodb
- manual CLI repros for DELETE and UPDATE RETURNING rollback

Fixes #6878