### PR TITLE
core/mvcc: don't let stale values affect the row versions during checkpoint

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1719,6 +1719,11 @@ impl<Clock: LogicalClock> StateTransition for CheckpointStateMachine<Clock> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mvcc::database::tests::MvccTestDbNoConn;
+    use crate::mvcc::database::SortableIndexKey;
+    use crate::translate::collate::CollationSeq;
+    use crate::types::{IndexInfo, KeyInfo};
+    use turso_parser::ast::SortOrder;
 
     fn sqlite_schema_row_version(
         rowid: i64,
@@ -1826,5 +1831,94 @@ mod tests {
 
         assert_eq!(sqlite_schema_btree_identity(&tombstone), None);
         assert!(!is_schema_metadata_only_rewrite(&tombstone, None));
+    }
+
+    fn index_row_version(
+        index_id: MVTableId,
+        key_text: &str,
+        rowid: i64,
+        version_id: u64,
+        begin: Option<u64>,
+        end: Option<u64>,
+        btree_resident: bool,
+    ) -> (Arc<SortableIndexKey>, RowVersion) {
+        let index_info = Arc::new(IndexInfo {
+            key_info: vec![
+                KeyInfo {
+                    sort_order: SortOrder::Asc,
+                    collation: CollationSeq::Binary,
+                    nulls_order: None,
+                },
+                KeyInfo {
+                    sort_order: SortOrder::Asc,
+                    collation: CollationSeq::Binary,
+                    nulls_order: None,
+                },
+            ],
+            has_rowid: true,
+            num_cols: 2,
+            is_unique: true,
+        });
+        let key_record = ImmutableRecord::from_values(
+            &[
+                Value::Text(crate::types::Text::new(key_text.to_string())),
+                Value::from_i64(rowid),
+            ],
+            2,
+        );
+        let sortable_key = SortableIndexKey::new_from_record(key_record, index_info);
+        let key_arc = Arc::new(sortable_key.clone());
+        let row = Row::new_index_row(RowID::new(index_id, RowKey::Record(sortable_key)), 2);
+        let row_version = RowVersion {
+            id: version_id,
+            begin: begin.map(TxTimestampOrID::Timestamp),
+            end: end.map(TxTimestampOrID::Timestamp),
+            row,
+            btree_resident,
+        };
+        (key_arc, row_version)
+    }
+
+    #[test]
+    fn checkpoint_retry_does_not_replay_checkpointed_btree_resident_delete() {
+        let db = MvccTestDbNoConn::new();
+        let conn = db.connect();
+        let mvstore = db.get_mvcc_store();
+        let pager = conn.pager.load().clone();
+        let mut checkpoint = CheckpointStateMachine::new(
+            pager,
+            mvstore.clone(),
+            conn.clone(),
+            true,
+            conn.get_sync_mode(),
+        );
+        checkpoint.durable_txid_max_old = std::num::NonZeroU64::new(10);
+        checkpoint.durable_txid_max_new = 10;
+
+        let index_id = MVTableId::from(-42);
+        let (garbage_key, garbage_version) =
+            index_row_version(index_id, "blue_river_906", 75, 1, None, None, true);
+        let (_, tombstone_version) =
+            index_row_version(index_id, "blue_river_906", 75, 2, None, Some(10), true);
+
+        mvstore.insert_index_version(index_id, garbage_key, garbage_version);
+        let entry = mvstore
+            .index_rows
+            .get(&index_id)
+            .expect("index entry should exist after first insert");
+        let tombstone_key = entry
+            .value()
+            .front()
+            .expect("key bucket should exist after first insert")
+            .key()
+            .clone();
+        mvstore.insert_index_version(index_id, tombstone_key, tombstone_version);
+
+        checkpoint.collect_committed_index_row_versions();
+
+        assert!(
+            checkpoint.index_write_set.is_empty(),
+            "a retry checkpoint must not replay a delete whose btree_resident tombstone was already made durable"
+        );
     }
 }

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -420,38 +420,42 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         let mut exists_in_db_file = false;
         // Iterate versions from oldest-to-newest to determine if the row exists in the database file and whether the newest version should be checkpointed.
         for version in versions.iter() {
-            // Rows marked btree_resident existed in the DB file before MVCC tracked them.
-            // This also applies to synthetic tombstones that use begin=None.
-            if version.btree_resident {
-                exists_in_db_file = true;
-            }
             // A row is in the database file if:
             // There is a version whose begin timestamp is <= than the last checkpoint timestamp, AND
             // There is NO version whose END timestamp is <= than the last checkpoint timestamp.
             let mut begin_ts = None;
             if let Some(TxTimestampOrID::Timestamp(b)) = version.begin {
                 begin_ts = Some(b);
-                // A row exists in the DB file if it was checkpointed in a previous checkpoint.
-                // For btree_resident rows we set exists_in_db_file above, regardless of begin encoding.
-                if self
-                    .durable_txid_max_old
-                    .is_some_and(|txid_max_old| b <= u64::from(txid_max_old))
-                {
-                    exists_in_db_file = true;
-                }
             }
             let mut end_ts = None;
             if let Some(TxTimestampOrID::Timestamp(e)) = version.end {
                 end_ts = Some(e);
-                if self
-                    .durable_txid_max_old
-                    .is_some_and(|txid_max_old| e <= u64::from(txid_max_old))
-                {
-                    exists_in_db_file = false;
-                }
             }
             if begin_ts.is_none() && end_ts.is_none() {
+                // Rolled-back garbage and active TxID-only placeholders are not part of
+                // the durable row history, so they must not influence DB-file existence.
                 continue;
+            }
+            // Rows marked btree_resident existed in the DB file before MVCC tracked them.
+            // This also applies to synthetic tombstones that use begin=None.
+            if version.btree_resident {
+                exists_in_db_file = true;
+            }
+            // A row exists in the DB file if it was checkpointed in a previous checkpoint.
+            // For btree_resident rows we seed exists_in_db_file above, regardless of begin encoding.
+            // These timestamp-derived transitions must run after the btree_resident seed so a
+            // checkpointed tombstone can clear DB-file existence on a retry checkpoint.
+            if self
+                .durable_txid_max_old
+                .is_some_and(|txid_max_old| begin_ts.is_some_and(|b| b <= u64::from(txid_max_old)))
+            {
+                exists_in_db_file = true;
+            }
+            if self
+                .durable_txid_max_old
+                .is_some_and(|txid_max_old| end_ts.is_some_and(|e| e <= u64::from(txid_max_old)))
+            {
+                exists_in_db_file = false;
             }
             // Should checkpoint the newest version if:
             // - It is not a delete and it hasn't been checkpointed yet OR (begin_ts > max_old)

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2538,6 +2538,111 @@ fn test_checkpoint_resamples_boundary_before_starting_with_yield_injection() {
     assert_eq!(&integrity[0][0].to_string(), "ok");
 }
 
+/// What this test checks: if one checkpoint makes a unique-index delete durable in the B-tree
+/// but fails before MVCC cleanup finishes, a later checkpoint retry must not try to delete that
+/// same unique key again.
+///
+/// Steps:
+/// 1. Disable automatic checkpoints.
+/// 2. Insert `(75, 'blue_river_906')`.
+/// 3. Checkpoint it so the blue key is durable in the B-tree.
+/// 4. Start and roll back a concurrent delete to leave stale MVCC state behind.
+/// 5. Update row `75` to `old_path_352`.
+/// 6. Run a checkpoint that commits pager changes and then fails after advancing the durable boundary.
+/// 7. Update row `75` again to `empty_path_27`, then to `shy_cloud_434`.
+/// 8. Retry checkpoint. Before the fix, this retried the old blue-key delete and hit
+///    `Corrupt("MVCC delete ... not found")`.
+#[test]
+fn test_checkpoint_retry_does_not_replay_checkpointed_btree_resident_unique_delete() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("CREATE UNIQUE INDEX idx_t_v ON t(v)").unwrap();
+    conn.execute("INSERT INTO t VALUES (75, 'blue_river_906')")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    conn.execute("DELETE FROM t WHERE id = 75").unwrap();
+    conn.execute("ROLLBACK").unwrap();
+    conn.execute("UPDATE t SET v = 'old_path_352' WHERE id = 75")
+        .unwrap();
+
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'blue_river_906'");
+    assert!(
+        rows.is_empty(),
+        "old unique key should no longer be visible"
+    );
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'old_path_352'");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 75);
+
+    let ckpt = db.connect();
+    ckpt.set_failure_injector(Some(FixedFailureInjector::new([(
+        CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+        LimboError::TxError("synthetic checkpoint failure after pager commit".to_string()),
+    )])));
+    let err = ckpt
+        .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        .expect_err("checkpoint should fail");
+    assert!(
+        matches!(err, LimboError::TxError(_)),
+        "expected injected checkpoint failure, got: {err:?}"
+    );
+
+    conn.execute("UPDATE t SET v = 'empty_path_27' WHERE id = 75")
+        .unwrap();
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    conn.execute("UPDATE t SET v = 'shy_cloud_434' WHERE id = 75")
+        .unwrap();
+    conn.execute("COMMIT").unwrap();
+
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'empty_path_27'");
+    assert!(
+        rows.is_empty(),
+        "intermediate unique key should not remain visible"
+    );
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'shy_cloud_434'");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 75);
+
+    let retry_conn = db.connect();
+    retry_conn
+        .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        .expect("retry checkpoint should not replay the already-durable blue delete");
+
+    let rows = get_rows(&conn, "SELECT id, v FROM t WHERE id = 75");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 75);
+    assert_eq!(rows[0][1].cast_text().unwrap(), "shy_cloud_434");
+
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'blue_river_906'");
+    assert!(
+        rows.is_empty(),
+        "blue key should stay absent after checkpoint retry"
+    );
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'old_path_352'");
+    assert!(
+        rows.is_empty(),
+        "old_path key should stay absent after checkpoint retry"
+    );
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'empty_path_27'");
+    assert!(
+        rows.is_empty(),
+        "empty_path key should stay absent after checkpoint retry"
+    );
+    let rows = get_rows(&conn, "SELECT id FROM t WHERE v = 'shy_cloud_434'");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 75);
+
+    let integrity = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(integrity.len(), 1);
+    assert_eq!(&integrity[0][0].to_string(), "ok");
+}
+
 /// What this test checks: Replay gate uses metadata boundary and never applies frames at or below it.
 /// Why this matters: This enforces exactly-once effects at the DB-file apply boundary.
 #[test]


### PR DESCRIPTION
## Description

Fix a bug where a checkpoint try to delete something that is already gone from the B-tree.

## Motivation and context

The bug is:

  - first checkpoint applies a delete to the real DB file
  - then checkpoint fails before it cleans up its MVCC bookkeeping, after deleting the row from physical file
  - later, a retry checkpoint looks at the stale bookkeeping and decides to delete key
  - but the key was already deleted from the real DB file
  - so the retry does a second delete and gets not found


The bug happens in `maybe_get_checkpointable_versions`. Given a version chain,  `maybe_get_checkpointable_versions` walks one version chain from oldest to newest and decides which committed version, if any, checkpoint still needs to apply to the disk.

While doing that, it maintains `exists_in_db_file` flag, to figure out does this key exist in the B-tree at the current durable checkpoint boundary.

It must ignore:

1. those already written (via previous checkpoint)
2. garbage versions (txs rolledback)
3. in flight

The bug was in how `exists_in_db_file` flag was updated.

A committed tombstone with end_ts <= durable_old means the delete is already durable, so the final answer must be exists_in_db_file = false. If btree_resident makes it true, checkpoint misclassifies the key as still present and replays a delete for a key that is already gone.


The fix is rather simple, don't touch `exists_in_db_file` for stale values. The diff is just:

```rust
for version in versions.iter() {
      let mut begin_ts = None;
      if let Some(TxTimestampOrID::Timestamp(b)) = version.begin { begin_ts = Some(b); }
      let mut end_ts = None;
      if let Some(TxTimestampOrID::Timestamp(e)) = version.end   { end_ts   = Some(e); }

      if begin_ts.is_none() && end_ts.is_none() {
          continue;                              // skip BEFORE touching the flag!
      }

      if version.btree_resident { exists_in_db_file = true; }
      if begin_ts.is_some_and(|b| b <= durable_old) { exists_in_db_file = true;  }
      if end_ts  .is_some_and(|e| e <= durable_old) { exists_in_db_file = false; }
      ...
  }
```

Comes with a regression test:

```
cargo test --package turso_core test_checkpoint_retry_does_not_replay_checkpointed_btree_resident_unique_delete -- --nocapture

thread 'mvcc::database::tests::test_checkpoint_retry_does_not_replay_checkpointed_btree_resident_unique_delete' panicked at core/mvcc/database/tests.rs:2605:10:
retry checkpoint should not replay the already-durable blue delete: Corrupt("MVCC delete: rowid SortableIndexKey { key: ImmutableRecord { payload: [3, 41, 1, 98, 108, 117, 101, 95, 114, 105, 118, 101, 114, 95, 57, 48, 54, 75] }, metadata: IndexInfo { key_info: [KeyInfo { sort_order: Asc, collation: Binary, nulls_order: None }, KeyInfo { sort_order: Asc, collation: Binary, nulls_order: None }], has_rowid: true, num_cols: 2, is_unique: true } } not found")

```

This bug was found by Antithesis:

```
Limbo Test | 2026-05-13
Conducted on 2026-05-13 01:02 UTC
Source: main
Turso - schedule on main (727a3f716d901b0ec2714e31ace87e812a464f36) by LeMikaelF (scheduled run)
```

# Description of AI Usage

For tests, and debugging. AI is really nice to get the exact same erorr as antithesis logs show.