### PR TITLE
[codex] fix drop column expression index sentinel

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12820,7 +12820,9 @@ pub fn op_drop_column(
             for index in indexes {
                 let index = Arc::get_mut(index).expect("this should be the only strong reference");
                 for index_column in index.columns.iter_mut() {
-                    if index_column.pos_in_table > *column_index {
+                    if index_column.pos_in_table != crate::schema::EXPR_INDEX_SENTINEL
+                        && index_column.pos_in_table > *column_index
+                    {
                         index_column.pos_in_table -= 1;
                     }
                     if let Some(ref mut expr) = index_column.expr {

--- a/testing/sqltests/tests/alter_table.sqltest
+++ b/testing/sqltests/tests/alter_table.sqltest
@@ -922,6 +922,19 @@ expect {
 }
 
 @cross-check-integrity
+test alter-table-drop-column-keeps-expr-index-sentinel {
+    CREATE TABLE t(a TEXT PRIMARY KEY, b INTEGER, c INTEGER);
+    CREATE INDEX i_expr ON t(a, (b IS NOT NULL));
+    INSERT INTO t VALUES('x', 1, 2);
+    ALTER TABLE t DROP COLUMN c;
+    UPDATE t SET b = b;
+    SELECT a, b FROM t;
+}
+expect {
+    x|1
+}
+
+@cross-check-integrity
 test alter-table-rename-column-updates-unique-sets {
     CREATE TABLE t(a INTEGER, b TEXT, UNIQUE(b));
     INSERT INTO t VALUES (1, 'hello');


### PR DESCRIPTION
## summary

- Preserve the expression-index sentinel when `ALTER TABLE DROP COLUMN` shifts index column positions.
- Add a regression for dropping an unrelated column while an expression index survives.

## root cause

Expression indexes use `EXPR_INDEX_SENTINEL` for expression columns. The drop-column rewrite decremented every index column position greater than the dropped column index. That also changed the sentinel from `usize::MAX` to `usize::MAX - 1`, so a later `UPDATE` treated it as a real table column index and panicked.

Fuzzer seed that exposed this: `10161735584407258411`.

## validation

- `make -C testing/sqltests run-one FILE=tests/alter_table.sqltest`
- `cargo check -p turso_core`
- `cargo fmt --check`
- `git diff --check`
- `./target/debug/differential_fuzzer -s 10161735584407258411 -g sql-gen-prop -t 3 -c 5 -n 220`
