### PR TITLE
Improve whopper coverage for DROP TABLE

### DIFF
--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -77,6 +77,27 @@ fn step_stmt_with_injected_yield(
     stmt.step()
 }
 
+fn is_recoverable_operation_error(error: &turso_core::LimboError) -> bool {
+    match error {
+        turso_core::LimboError::SchemaUpdated
+        | turso_core::LimboError::SchemaConflict
+        | turso_core::LimboError::TableLocked
+        | turso_core::LimboError::Busy
+        | turso_core::LimboError::BusySnapshot
+        | turso_core::LimboError::WriteWriteConflict
+        | turso_core::LimboError::CommitDependencyAborted
+        | turso_core::LimboError::InvalidArgument(..) => true,
+        turso_core::LimboError::ParseError(message) => {
+            let message = message.to_ascii_lowercase();
+            message.contains("no such table")
+                || message.contains("no such index")
+                || (message.contains("does not exist")
+                    && (message.contains("table") || message.contains("index")))
+        }
+        _ => false,
+    }
+}
+
 /// A bounded container for sampling values with reservoir sampling.
 #[derive(Debug, Clone)]
 pub struct SamplesContainer<T> {
@@ -229,6 +250,23 @@ impl<K: Ord + Clone, V: Clone> MergableMap<K, V> {
     /// Compact the map by removing tombstones.
     pub fn compact(&mut self) {
         self.data.retain(|_, v| v.is_some());
+    }
+
+    /// Remove all live entries matching a predicate.
+    pub fn remove_where(&mut self, mut predicate: impl FnMut(&K, &V) -> bool) {
+        let keys_to_remove = self
+            .data
+            .iter()
+            .filter_map(|(key, value)| {
+                value
+                    .as_ref()
+                    .filter(|live_value| predicate(key, live_value))
+                    .map(|_| key.clone())
+            })
+            .collect::<Vec<_>>();
+        for key in keys_to_remove {
+            self.remove(&key);
+        }
     }
 }
 
@@ -798,23 +836,15 @@ impl Whopper {
             }
 
             if let Err(error) = op_result {
-                match error {
+                if is_recoverable_operation_error(&error) {
                     // initiate rollback in case of some errors for fiber within transaction
-                    turso_core::LimboError::SchemaUpdated
-                    | turso_core::LimboError::SchemaConflict
-                    | turso_core::LimboError::TableLocked
-                    | turso_core::LimboError::Busy
-                    | turso_core::LimboError::BusySnapshot
-                    | turso_core::LimboError::WriteWriteConflict
-                    | turso_core::LimboError::CommitDependencyAborted
-                    | turso_core::LimboError::InvalidArgument(..) => {
-                        if ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit() {
-                            ctx.fiber.current_op = Some(Operation::Rollback);
-                        } else {
-                            ctx.fiber.txn_id = None;
-                        }
+                    if ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit() {
+                        ctx.fiber.current_op = Some(Operation::Rollback);
+                    } else {
+                        ctx.fiber.txn_id = None;
                     }
-                    _ => return Err(error.into()),
+                } else {
+                    return Err(error.into());
                 }
             }
         }

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -356,6 +356,7 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
             (15, Box::new(DeleteWorkload)),
             (2, Box::new(CreateIndexWorkload)),
             (2, Box::new(DropIndexWorkload)),
+            (1, Box::new(DropTableWorkload)),
             (30, Box::new(BeginWorkload)),
             (10, Box::new(CommitWorkload)),
             (10, Box::new(RollbackWorkload)),

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -86,6 +86,8 @@ pub enum Operation {
     },
     /// Drop an index
     DropIndex { sql: String, index_name: String },
+    /// Drop a table
+    DropTable { sql: String, table_name: String },
     /// Create Elle list table for consistency checking
     CreateElleTable { table_name: String },
     /// Append value to an Elle list key
@@ -146,6 +148,7 @@ impl Operation {
             Operation::Delete { sql } => sql.clone(),
             Operation::CreateIndex { sql, .. } => sql.clone(),
             Operation::DropIndex { sql, .. } => sql.clone(),
+            Operation::DropTable { sql, .. } => sql.clone(),
             Operation::CreateElleTable { table_name } => {
                 // Store values as comma-separated integers (e.g., "1,2,3")
                 // This avoids JSON function complexity while still being parseable
@@ -254,6 +257,12 @@ impl Operation {
             Operation::DropIndex { index_name, .. } => {
                 sim_state.indexes.remove(index_name);
             }
+            Operation::DropTable { table_name, .. } => {
+                sim_state.tables.remove(table_name);
+                sim_state
+                    .indexes
+                    .remove_where(|_, indexed_table| indexed_table == table_name);
+            }
             Operation::CreateElleTable { table_name } => {
                 sim_state.elle_tables.insert(table_name.clone(), ());
             }
@@ -265,5 +274,56 @@ impl Operation {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+    use sql_generation::model::table::{Column, ColumnType, Table};
+    use turso_parser::ast::ColumnConstraint;
+
+    use super::*;
+
+    fn table(name: &str) -> Table {
+        Table {
+            name: name.to_string(),
+            columns: vec![Column {
+                name: "id".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![ColumnConstraint::PrimaryKey {
+                    order: None,
+                    conflict_clause: None,
+                    auto_increment: false,
+                }],
+            }],
+            rows: vec![],
+            indexes: vec![],
+        }
+    }
+
+    #[test]
+    fn drop_table_state_removes_table_and_indexes_for_that_table() {
+        let mut state = SimulatorState::new(
+            vec![table("dropped"), table("kept")],
+            vec![
+                ("dropped".to_string(), "idx_dropped".to_string()),
+                ("kept".to_string(), "idx_kept".to_string()),
+            ],
+        );
+        let mut stats = Stats::default();
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+
+        Operation::DropTable {
+            sql: "DROP TABLE dropped".to_string(),
+            table_name: "dropped".to_string(),
+        }
+        .apply_state_changes(&mut state, &mut stats, &mut rng, &Ok(vec![]));
+
+        assert!(!state.tables.contains_key(&"dropped".to_string()));
+        assert!(!state.indexes.contains_key(&"idx_dropped".to_string()));
+        assert!(state.tables.contains_key(&"kept".to_string()));
+        assert!(state.indexes.contains_key(&"idx_kept".to_string()));
     }
 }

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -1,15 +1,18 @@
 #![cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
 
+use rand::Rng;
 use std::path::Path;
 use std::sync::Arc;
 use turso_core::{Connection, Database, DatabaseOpts, IO, LimboError, OpenFlags};
 use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
 use turso_whopper::{
-    multiprocess_platform_io,
+    Whopper, WhopperOpts, multiprocess_platform_io,
+    properties::{IntegrityCheckProperty, SimpleKeysDoNotDisappear},
     workloads::{
         BeginWorkload, CommitWorkload, CreateIndexWorkload, CreateSimpleTableWorkload,
-        DeleteWorkload, DropIndexWorkload, IntegrityCheckWorkload, RollbackWorkload,
-        SimpleInsertWorkload, SimpleSelectWorkload, UpdateWorkload, WalCheckpointWorkload,
+        DeleteWorkload, DropIndexWorkload, DropTableWorkload, IntegrityCheckWorkload,
+        RollbackWorkload, SimpleInsertWorkload, SimpleSelectWorkload, UpdateWorkload,
+        WalCheckpointWorkload, Workload,
     },
 };
 
@@ -128,6 +131,60 @@ fn create_multiprocess_whopper_with_shape_and_keep(
         keep_files,
     })
     .expect("create multiprocess whopper")
+}
+
+fn run_drop_table_simulation(seed: u64, max_steps: usize) {
+    let mut whopper = Whopper::new(
+        WhopperOpts::fast()
+            .with_seed(seed)
+            .with_max_steps(max_steps)
+            .with_max_connections(4)
+            .with_workloads(drop_table_workloads())
+            .with_properties(vec![
+                Box::new(IntegrityCheckProperty),
+                Box::new(SimpleKeysDoNotDisappear::new()),
+            ]),
+    )
+    .expect("create whopper");
+
+    while !whopper.is_done() {
+        if whopper.rng.random_bool(0.03) {
+            whopper.reopen().expect("reopen database");
+        }
+        whopper.step().expect("step whopper");
+    }
+
+    whopper
+        .finalize_properties()
+        .expect("finalize simulator properties");
+}
+
+fn drop_table_workloads() -> Vec<(u32, Box<dyn Workload>)> {
+    vec![
+        (10, Box::new(IntegrityCheckWorkload)),
+        (5, Box::new(WalCheckpointWorkload)),
+        (10, Box::new(CreateSimpleTableWorkload)),
+        (20, Box::new(SimpleSelectWorkload)),
+        (20, Box::new(SimpleInsertWorkload)),
+        (15, Box::new(UpdateWorkload)),
+        (15, Box::new(DeleteWorkload)),
+        (2, Box::new(CreateIndexWorkload)),
+        (2, Box::new(DropIndexWorkload)),
+        (1, Box::new(DropTableWorkload)),
+        (30, Box::new(BeginWorkload)),
+        (10, Box::new(CommitWorkload)),
+        (10, Box::new(RollbackWorkload)),
+    ]
+}
+
+#[test]
+fn drop_table_invalidates_overlapping_prepared_statement_without_aborting_simulation() {
+    run_drop_table_simulation(1396198911938941063, 3200);
+}
+
+#[test]
+fn drop_table_missing_table_parse_error_does_not_abort_simulation() {
+    run_drop_table_simulation(13310883444243772729, 20000);
 }
 
 #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -6,7 +6,7 @@ use sql_generation::{
     generation::{Arbitrary, GenerationContext, Opts},
     model::{
         query::{
-            create_index::CreateIndex, delete::Delete, drop_index::DropIndex, insert::Insert,
+            Drop, create_index::CreateIndex, delete::Delete, drop_index::DropIndex, insert::Insert,
             select::Select, update::Update,
         },
         table::Table,
@@ -231,6 +231,24 @@ impl Workload for DropIndexWorkload {
         };
         let sql = drop_index.to_string();
         Some(Operation::DropIndex { sql, index_name })
+    }
+}
+
+/// Drop an existing generated table outside transactions.
+pub struct DropTableWorkload;
+
+impl Workload for DropTableWorkload {
+    fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        if *ctx.fiber_state != FiberState::Idle || ctx.tables_vec.len() <= 1 {
+            return None;
+        }
+
+        let drop_table = Drop::arbitrary(rng, ctx);
+        let table_name = drop_table.table.clone();
+        Some(Operation::DropTable {
+            sql: drop_table.to_string(),
+            table_name,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

- Add a DROP TABLE operation and workload to whopper so the default non-MVCC simulator can exercise table removal.
- Keep simulator table/index state in sync after a table is dropped.
- Treat overlapping DROP TABLE/DROP INDEX schema invalidation parse errors as recoverable simulator outcomes.
- Keep DROP TABLE generation out of `--enable-mvcc` runs for now, because MVCC DDL scheduling exposes a separate reopen-drain hang that should be handled independently.
- Add regression seeds for prepared statements invalidated by DROP TABLE.

## Validation

- cargo fmt --check
- cargo test -p turso_whopper
- cargo build -p turso_whopper --release
- exact failed CI seed after MVCC guard: `SEED=14701830900422398493 ./target/release/turso_whopper --mode fast --reopen-probability 0.01 --enable-mvcc`
- 50 release whopper runs with DROP TABLE enabled: `--mode fast --max-steps 20000 --max-connections 4 --reopen-probability 0.03`
