### PR TITLE
[codex] fix aggregate filter subquery phase

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3442,6 +3442,38 @@ mod tests {
         }
     }
 
+    #[test]
+    fn aggregate_filter_subquery_in_having_does_not_panic() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("aggregate-filter-having.db");
+        let conn = open_connection(&db_path);
+
+        conn.execute("CREATE TABLE t(b INTEGER)").unwrap();
+        conn.execute("INSERT INTO t VALUES(1)").unwrap();
+
+        let row = query_single_i64(
+            &conn,
+            "SELECT b FROM t GROUP BY b HAVING COUNT(b) FILTER (WHERE 1 IN (SELECT b FROM t))",
+        );
+        assert_eq!(row, 1);
+    }
+
+    #[test]
+    fn aggregate_filter_subquery_in_order_by_does_not_panic() {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("aggregate-filter-order-by.db");
+        let conn = open_connection(&db_path);
+
+        conn.execute("CREATE TABLE t(b INTEGER)").unwrap();
+        conn.execute("INSERT INTO t VALUES(1)").unwrap();
+
+        let row = query_single_i64(
+            &conn,
+            "SELECT b FROM t GROUP BY b ORDER BY COUNT(b) FILTER (WHERE 1 IN (SELECT b FROM t))",
+        );
+        assert_eq!(row, 1);
+    }
+
     fn text_value(value: &Value) -> &str {
         match value {
             Value::Text(text) => text.as_str(),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -14,7 +14,8 @@ use crate::{
             emit_program_for_select_with_resolver, emit_query,
         },
         expr::{
-            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr_mut, WalkControl,
+            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr, walk_expr_mut,
+            WalkControl,
         },
         optimizer::optimize_select_plan,
         plan::{
@@ -1969,15 +1970,39 @@ pub fn emit_non_from_clause_subqueries_for_eval_at(
     )
 }
 
+fn aggregate_filter_subquery_ids(plan: &SelectPlan) -> Vec<ast::TableInternalId> {
+    let mut ids = Vec::new();
+    for aggregate in &plan.aggregates {
+        let Some(filter_expr) = &aggregate.filter_expr else {
+            continue;
+        };
+        let _ = walk_expr(
+            filter_expr,
+            &mut |expr: &ast::Expr| -> Result<WalkControl> {
+                if let ast::Expr::SubqueryResult { subquery_id, .. } = expr {
+                    ids.push(*subquery_id);
+                    return Ok(WalkControl::SkipChildren);
+                }
+                Ok(WalkControl::Continue)
+            },
+        );
+    }
+    ids
+}
+
 fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) {
     let has_grouped_output = plan
         .group_by
         .as_ref()
         .is_some_and(|group_by| !group_by.exprs.is_empty());
+    let filter_subquery_ids = aggregate_filter_subquery_ids(plan);
 
     for subquery in plan.non_from_clause_subqueries.iter_mut() {
+        let is_aggregate_filter_subquery = filter_subquery_ids.contains(&subquery.internal_id);
         subquery.eval_phase = match subquery.origin {
-            SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy if has_grouped_output => {
+            SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy
+                if has_grouped_output && !is_aggregate_filter_subquery =>
+            {
                 SubqueryEvalPhase::GroupedOutput
             }
             _ => subquery.origin.phase_floor(),


### PR DESCRIPTION
## Summary
- keep subqueries referenced by aggregate `FILTER` expressions out of the grouped-output-only phase
- add regressions for aggregate `FILTER` subqueries in grouped `HAVING` and `ORDER BY`

## Root cause
Grouped `HAVING` / `ORDER BY` subqueries are normally delayed until grouped output. When the subquery is inside an aggregate `FILTER`, that is too late: the filter predicate runs before `AggStep`, so `IN (SELECT ...)` could probe its ephemeral cursor before `OpenEphemeral` ran, panicking with `cursor id 0 is None`.

## Validation
- `cargo test -p turso_core aggregate_filter_subquery_in_`
- `cargo test -p turso_core --lib`
- `cargo run -p differential-fuzzer --bin differential_fuzzer -- --seed 1 --num-tables 2 --columns-per-table 4 --num-statements 24`
- `cargo build -p differential-fuzzer --release`
- `./target/release/differential_fuzzer --seed 1 --num-tables 2 --columns-per-table 4 --num-statements 24`
- `git diff --check`
