### PR TITLE
fix: accept uuid blobs in strict uuid columns

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -669,7 +669,7 @@ fn bootstrap_builtin_types(registry: &mut HashMap<String, Arc<TypeDef>>) -> crat
 
     let type_sqls: &[&str] = &[
         #[cfg(feature = "uuid")]
-        "CREATE TYPE uuid(value text) BASE blob ENCODE uuid_blob(value) DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
+        "CREATE TYPE uuid(value any) BASE blob ENCODE uuid_blob(value) DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
         "CREATE TYPE boolean(value any) BASE integer ENCODE boolean_to_int(value) DECODE CASE WHEN value THEN 1 ELSE 0 END OPERATOR '<'",
         #[cfg(feature = "json")]
         "CREATE TYPE json(value text) BASE text ENCODE json(value) DECODE value",

--- a/core/uuid.rs
+++ b/core/uuid.rs
@@ -133,14 +133,31 @@ fn uuid_str(args: &[Value]) -> Value {
 
 #[scalar(name = "uuid_blob")]
 fn uuid_blob(&self, args: &[Value]) -> Value {
-    let Some(text) = args.first().and_then(|a| a.to_text()) else {
+    let Some(value) = args.first() else {
         return Value::error_with_message(
             "wrong number of arguments to function uuid_blob()".into(),
         );
     };
-    match uuid::Uuid::parse_str(text) {
-        Ok(uuid) => Value::from_blob(uuid.as_bytes().to_vec()),
-        Err(_) => Value::null(),
+    match value.value_type() {
+        ValueType::Blob => {
+            let Some(blob) = value.to_blob() else {
+                return Value::null();
+            };
+            match uuid::Uuid::from_slice(blob.as_slice()) {
+                Ok(uuid) => Value::from_blob(uuid.as_bytes().to_vec()),
+                Err(_) => Value::null(),
+            }
+        }
+        ValueType::Text => {
+            let Some(text) = value.to_text() else {
+                return Value::null();
+            };
+            match uuid::Uuid::parse_str(text) {
+                Ok(uuid) => Value::from_blob(uuid.as_bytes().to_vec()),
+                Err(_) => Value::null(),
+            }
+        }
+        _ => Value::null(),
     }
 }
 

--- a/tests/integration/functions/test_uuid.rs
+++ b/tests/integration/functions/test_uuid.rs
@@ -47,3 +47,41 @@ fn uuid7_timestamp_ms_valid_string(tmp_db: TempDatabase) {
     );
     assert_eq!(result, vec![vec![RusqliteValue::Integer(1736720789)]]);
 }
+
+/// The built-in `uuid` type stores UUIDs as blobs, so it must accept the
+/// blob-producing UUID helpers directly in STRICT tables.
+#[test]
+fn uuid_type_accepts_blob_helpers_in_strict_table() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_custom_types(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE events (id uuid PRIMARY KEY, name TEXT) STRICT")
+        .unwrap();
+    conn.execute("INSERT INTO events VALUES (uuid4(), 'launch')")
+        .unwrap();
+    conn.execute("INSERT INTO events VALUES ('01945ca0-3189-76c0-9a8f-caf310fc8b8e', 'known')")
+        .unwrap();
+
+    let result = limbo_exec_rows(
+        &conn,
+        "SELECT typeof(id), length(id), id, name FROM events ORDER BY name",
+    );
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0][0], RusqliteValue::Text("text".to_string()));
+    assert_eq!(result[0][1], RusqliteValue::Integer(36));
+    assert_eq!(
+        result[0][2],
+        RusqliteValue::Text("01945ca0-3189-76c0-9a8f-caf310fc8b8e".to_string())
+    );
+    assert_eq!(result[0][3], RusqliteValue::Text("known".to_string()));
+    assert_eq!(result[1][0], RusqliteValue::Text("text".to_string()));
+    assert_eq!(result[1][1], RusqliteValue::Integer(36));
+    assert_eq!(result[1][3], RusqliteValue::Text("launch".to_string()));
+    let uuid = match &result[1][2] {
+        RusqliteValue::Text(uuid) => uuid,
+        other => panic!("expected uuid text, got {other:?}"),
+    };
+    assert_eq!(uuid.len(), 36);
+}


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Allows the built-in `uuid` custom type to accept both text UUIDs and blob UUIDs in STRICT tables. `uuid_blob()` now passes through valid 16-byte UUID blobs, and the built-in `uuid` type declares `value any` so blob-producing helpers like `uuid4()` and `uuid7()` can reach the encoder.

Fixes #6221.

## Motivation and context

The documented STRICT-table example fails today when inserting `uuid4()` into a `uuid` column because pre-encode TypeCheck sees a BLOB value against the custom type's declared TEXT input and aborts with:

`cannot store BLOB value in TEXT column events.id (19)`

This keeps existing text UUID input working while also accepting the blob helper output that the UUID extension already exposes.

## Tests

```bash
docker run --rm -e PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin -v turso-cargo:/usr/local/cargo -v turso-rustup:/usr/local/rustup -v /home/tq/repos/turso:/app -w /app rust:1.91 bash -c 'cargo fmt --check'

docker run --rm -e PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin -v turso-cargo:/usr/local/cargo -v turso-rustup:/usr/local/rustup -v /home/tq/repos/turso:/app -w /app rust:1.91 bash -c 'cargo test -p core_tester --test integration_tests functions::test_uuid -- --nocapture'

docker run --rm -e PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin -v turso-cargo:/usr/local/cargo -v turso-rustup:/usr/local/rustup -v /home/tq/repos/turso:/app -w /app rust:1.91 bash -c 'cargo test -p core_tester --test integration_tests custom_types -- --nocapture'
```

## Description of AI Usage

Implemented with AI assistance under direct human review. I used the agent to triage the issue, inspect the custom-type and UUID paths, add a failing regression test, make the minimal code change, and run the targeted Docker-based verification above. I reviewed the resulting diff and test output before submitting.