### PR TITLE
core/mvcc: serialize buffer directly, avoid 2x buffer heap size

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -521,6 +521,13 @@ pub type BufferData = Pin<Box<[u8]>>;
 
 pub enum Buffer {
     Heap(BufferData),
+    /// A heap buffer with a logical start offset: only `data[start..]` is
+    /// exposed via [`Buffer::as_slice`] / [`Buffer::len`]. Used to skip a
+    /// pre-allocated prefix without shifting bytes in memory before I/O.
+    HeapView {
+        data: BufferData,
+        start: usize,
+    },
     Pooled(ArenaBuffer),
 }
 
@@ -529,20 +536,39 @@ impl Debug for Buffer {
         match self {
             Self::Pooled(p) => write!(f, "Pooled(len={})", p.logical_len()),
             Self::Heap(buf) => write!(f, "{buf:?}: {}", buf.len()),
+            Self::HeapView { data, start } => {
+                write!(
+                    f,
+                    "HeapView({start}..{}, view_len={})",
+                    data.len(),
+                    data.len() - start
+                )
+            }
         }
     }
 }
 
 impl Drop for Buffer {
     fn drop(&mut self) {
-        let len = self.len();
-        if let Self::Heap(buf) = self {
-            TEMP_BUFFER_CACHE.with(|cache| {
-                let mut cache = cache.borrow_mut();
-                // take ownership of the buffer by swapping it with a dummy
-                let buffer = std::mem::replace(buf, Pin::new(vec![].into_boxed_slice()));
-                cache.return_buffer(buffer, len);
-            });
+        match self {
+            Self::Heap(buf) => {
+                let underlying_len = buf.len();
+                TEMP_BUFFER_CACHE.with(|cache| {
+                    let mut cache = cache.borrow_mut();
+                    // take ownership of the buffer by swapping it with a dummy
+                    let buffer = std::mem::replace(buf, Pin::new(vec![].into_boxed_slice()));
+                    cache.return_buffer(buffer, underlying_len);
+                });
+            }
+            Self::HeapView { data, .. } => {
+                let underlying_len = data.len();
+                TEMP_BUFFER_CACHE.with(|cache| {
+                    let mut cache = cache.borrow_mut();
+                    let buffer = std::mem::replace(data, Pin::new(vec![].into_boxed_slice()));
+                    cache.return_buffer(buffer, underlying_len);
+                });
+            }
+            Self::Pooled(_) => {}
         }
     }
 }
@@ -553,11 +579,28 @@ impl Buffer {
         Self::Heap(Pin::new(data.into_boxed_slice()))
     }
 
+    /// Wraps `data` so that only bytes `[start..]` are visible via
+    /// [`Buffer::as_slice`] / [`Buffer::len`]. The skipped prefix lives in
+    /// memory but is never read by the I/O layer — useful when a caller
+    /// has pre-allocated optional framing room at the front of a buffer
+    /// and wants to elide it on a particular write without a memmove.
+    pub fn new_with_start(data: Vec<u8>, start: usize) -> Self {
+        assert!(
+            start <= data.len(),
+            "Buffer::new_with_start: start ({start}) > data.len() ({})",
+            data.len()
+        );
+        Self::HeapView {
+            data: Pin::new(data.into_boxed_slice()),
+            start,
+        }
+    }
+
     /// Returns the index of the underlying `Arena` if it was registered with
     /// io_uring. Only for use with `UringIO` backend.
     pub fn fixed_id(&self) -> Option<u32> {
         match self {
-            Self::Heap { .. } => None,
+            Self::Heap(..) | Self::HeapView { .. } => None,
             Self::Pooled(buf) => buf.fixed_id(),
         }
     }
@@ -579,6 +622,7 @@ impl Buffer {
     pub fn len(&self) -> usize {
         match self {
             Self::Heap(buf) => buf.len(),
+            Self::HeapView { data, start } => data.len() - *start,
             Self::Pooled(buf) => buf.logical_len(),
         }
     }
@@ -593,6 +637,13 @@ impl Buffer {
                 // SAFETY: The buffer is guaranteed to be valid for the lifetime of the slice
                 unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) }
             }
+            Self::HeapView { data, start } => {
+                // SAFETY: `start` was bounds-checked at construction; the buffer
+                // is valid for the lifetime of the returned slice.
+                unsafe {
+                    std::slice::from_raw_parts(data.as_ptr().add(*start), data.len() - *start)
+                }
+            }
             Self::Pooled(buf) => buf,
         }
     }
@@ -605,6 +656,7 @@ impl Buffer {
     pub fn as_ptr(&self) -> *const u8 {
         match self {
             Self::Heap(buf) => buf.as_ptr(),
+            Self::HeapView { data, start } => unsafe { data.as_ptr().add(*start) },
             Self::Pooled(buf) => buf.as_ptr(),
         }
     }
@@ -612,6 +664,7 @@ impl Buffer {
     pub fn as_mut_ptr(&self) -> *mut u8 {
         match self {
             Self::Heap(buf) => buf.as_ptr() as *mut u8,
+            Self::HeapView { data, start } => unsafe { (data.as_ptr() as *mut u8).add(*start) },
             Self::Pooled(buf) => buf.as_ptr() as *mut u8,
         }
     }
@@ -623,7 +676,7 @@ impl Buffer {
 
     #[inline]
     pub fn is_heap(&self) -> bool {
-        matches!(self, Self::Heap(..))
+        matches!(self, Self::Heap(..) | Self::HeapView { .. })
     }
 }
 

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -551,20 +551,12 @@ impl Debug for Buffer {
 impl Drop for Buffer {
     fn drop(&mut self) {
         match self {
-            Self::Heap(buf) => {
+            Self::Heap(buf) | Self::HeapView { data: buf, .. } => {
                 let underlying_len = buf.len();
                 TEMP_BUFFER_CACHE.with(|cache| {
                     let mut cache = cache.borrow_mut();
                     // take ownership of the buffer by swapping it with a dummy
                     let buffer = std::mem::replace(buf, Pin::new(vec![].into_boxed_slice()));
-                    cache.return_buffer(buffer, underlying_len);
-                });
-            }
-            Self::HeapView { data, .. } => {
-                let underlying_len = data.len();
-                TEMP_BUFFER_CACHE.with(|cache| {
-                    let mut cache = cache.borrow_mut();
-                    let buffer = std::mem::replace(data, Pin::new(vec![].into_boxed_slice()));
                     cache.return_buffer(buffer, underlying_len);
                 });
             }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -342,19 +342,6 @@ pub type TxID = u64;
 /// pre-serialized into a frame buffer that the logical-log flush path
 /// finalizes (backfills the TX header, appends the CRC trailer, optionally
 /// chunk-encrypts the payload) and writes to disk.
-///
-/// `buf` is laid out from construction with a `LOG_HDR_SIZE + TX_HEADER_SIZE`
-/// zero prefix so ops can be appended directly at the right offset. The
-/// flush path backfills the prefix in place and never shifts the payload:
-/// - First-write commits fill the log header slot and write the whole buffer.
-/// - Non-first-write commits leave the log header slot as zeros and wrap the
-///   buffer with `Buffer::new_with_start(..., LOG_HDR_SIZE)`, so the I/O
-///   layer simply skips the 56 unused bytes without a memmove.
-///
-/// The buffer is populated incrementally during commit via
-/// [`DurableStorage::serialize_row_version`] and
-/// [`DurableStorage::serialize_database_header`], so the committing
-/// transaction never materializes a `Vec<RowVersion>`-sized intermediate.
 #[derive(Clone, Debug)]
 pub struct LogRecord {
     pub(crate) tx_timestamp: TxID,
@@ -1947,11 +1934,6 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             return Ok(TransitionResult::Continue);
         }
 
-        // Both row-version passes complete. Append the captured DatabaseHeader
-        // op (if any) at the tail of the payload — this preserves the on-disk
-        // order: row-version ops first, header op last. (Order matches the
-        // previous implementation where `serialize_ops_into_write_buf` walked
-        // `row_versions` then optionally serialized `header`.)
         if let Some(header) = ctx.pending_header.take() {
             mvcc_store
                 .storage
@@ -2413,15 +2395,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .store(true, Ordering::Release);
                 }
                 let end_ts = *end_ts;
-                // The pattern binding `end_ts: &u64` is no longer used after
-                // the copy above, so NLL drops the shared borrow on
-                // `self.state` and lets us swap it mutably here. We swap
-                // ahead of `log_tx` because `log_tx` consumes the LogRecord's
-                // buffer in place (it becomes the on-disk frame buffer
-                // handed to pwrite); on error the LogRecord is partially
-                // framed and not usable for retry — which matches the
-                // pre-existing semantics where a log_tx failure aborts the
-                // commit.
                 let mut log_record = match std::mem::replace(
                     &mut self.state,
                     CommitState::SyncLogicalLog { end_ts },

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -338,22 +338,106 @@ pub enum RowVersionState {
 }
 pub type TxID = u64;
 
-/// A log record contains all durable effects of a committed transaction.
-/// Besides row/index version deltas, this can include a header-only mutation.
+/// A log record contains all durable effects of a committed transaction,
+/// pre-serialized into a frame buffer that the logical-log flush path
+/// finalizes (backfills the TX header, appends the CRC trailer, optionally
+/// chunk-encrypts the payload) and writes to disk.
+///
+/// `buf` is laid out from construction with a `LOG_HDR_SIZE + TX_HEADER_SIZE`
+/// zero prefix so ops can be appended directly at the right offset. The
+/// flush path backfills the prefix in place and never shifts the payload:
+/// - First-write commits fill the log header slot and write the whole buffer.
+/// - Non-first-write commits leave the log header slot as zeros and wrap the
+///   buffer with `Buffer::new_with_start(..., LOG_HDR_SIZE)`, so the I/O
+///   layer simply skips the 56 unused bytes without a memmove.
+///
+/// The buffer is populated incrementally during commit via
+/// [`DurableStorage::serialize_row_version`] and
+/// [`DurableStorage::serialize_database_header`], so the committing
+/// transaction never materializes a `Vec<RowVersion>`-sized intermediate.
 #[derive(Clone, Debug)]
 pub struct LogRecord {
     pub(crate) tx_timestamp: TxID,
-    pub row_versions: Vec<RowVersion>,
-    pub header: Option<DatabaseHeader>,
+    /// Frame buffer that grows in place into the on-disk representation.
+    /// The first `LOG_HDR_SIZE + TX_HEADER_SIZE` bytes are pre-reserved
+    /// (zeros) so that op-entry appends land at the correct on-disk
+    /// offset; the flush path backfills the framing prefix and appends
+    /// the trailer.
+    pub buf: Vec<u8>,
+    /// Number of op entries appended to `buf`. Includes any header op.
+    pub op_count: u32,
+    /// True once a `DatabaseHeader` op has been appended. At most one
+    /// header op is allowed per transaction.
+    pub has_header: bool,
 }
 
 impl LogRecord {
-    fn new(tx_timestamp: TxID) -> Self {
+    pub(crate) fn new(tx_timestamp: TxID) -> Self {
         Self {
             tx_timestamp,
-            row_versions: Vec::new(),
-            header: None,
+            // Pre-reserve the framing prefix at the front of buf:
+            //   [LOG_HDR slot (56B) | TX_HEADER slot (24B) | <ops here>]
+            // The log-header slot is only filled on the very first write to
+            // a log file; otherwise it stays zero and the flush path wraps
+            // the buf with `Buffer::new_with_start(..., LOG_HDR_SIZE)` so
+            // those 56 bytes never reach disk.
+            buf: vec![0u8; crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE],
+            op_count: 0,
+            has_header: false,
         }
+    }
+
+    /// Plaintext payload size: bytes contributed by serialized ops, excluding
+    /// the pre-reserved framing prefix at the front of `buf`.
+    pub(crate) fn payload_size(&self) -> usize {
+        self.buf.len() - crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE
+    }
+
+    /// True iff no ops (row versions or header) have been appended.
+    pub fn is_empty(&self) -> bool {
+        self.op_count == 0
+    }
+
+    /// Test-only constructor that eagerly serializes a list of row versions
+    /// and an optional `DatabaseHeader` into the payload buffer using the
+    /// production wire format. Production code uses
+    /// [`DurableStorage::serialize_row_version`] and
+    /// [`DurableStorage::serialize_database_header`] instead so the bytes are
+    /// appended one op at a time.
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        tx_timestamp: TxID,
+        row_versions: &[RowVersion],
+        header: Option<DatabaseHeader>,
+    ) -> Self {
+        let mut record = Self::new(tx_timestamp);
+        for rv in row_versions {
+            record.push_row_version_for_test(rv);
+        }
+        if let Some(hdr) = header {
+            record.set_header_for_test(&hdr);
+        }
+        record
+    }
+
+    /// Test-only: append one row-version op to the payload buffer.
+    #[cfg(test)]
+    pub(crate) fn push_row_version_for_test(&mut self, row_version: &RowVersion) {
+        crate::mvcc::persistent_storage::logical_log::serialize_op_entry(
+            &mut self.buf,
+            row_version,
+        )
+        .expect("failed to serialize row version in test");
+        self.op_count += 1;
+    }
+
+    /// Test-only: append a `DatabaseHeader` op to the payload buffer.
+    #[cfg(test)]
+    pub(crate) fn set_header_for_test(&mut self, header: &DatabaseHeader) {
+        assert!(!self.has_header, "header op appended twice in test");
+        crate::mvcc::persistent_storage::logical_log::serialize_header_entry(&mut self.buf, header);
+        self.has_header = true;
+        self.op_count += 1;
     }
 }
 
@@ -993,6 +1077,11 @@ pub struct BuildLogRecordCtx {
     /// data-row pass. Schema rows are emitted first so log replay sees
     /// CREATE TABLE before related INSERTs.
     pub schema_process: bool,
+    /// Snapshot of `tx.header` taken when `header_dirty` was observed
+    /// at the start of BuildLogRecord. Appended as an `OP_UPDATE_HEADER`
+    /// op after both row-version passes complete (preserves on-disk
+    /// order: ops first, header last).
+    pub pending_header: Option<DatabaseHeader>,
 }
 
 /// Iteration state for the chunked `RewriteLiveVersions` step.
@@ -1637,7 +1726,8 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         };
 
         let collect_versions = |row_versions: &Arc<RwLock<Vec<RowVersion>>>,
-                                log_record: &mut LogRecord| {
+                                log_record: &mut LogRecord|
+         -> Result<()> {
             // `log_record.row_versions` is the logical transaction log. Recovery
             // replays it in this order. `insert_version_raw` is for the versions
             // of one MVCC entry: one table row, one sqlite_schema row, or one
@@ -1697,7 +1787,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             // - append those versions to `log_record.row_versions` without sorting
             //   them against versions from other write-set entries.
 
-            let entry_start = log_record.row_versions.len();
+            let mut entry_versions: Vec<RowVersion> = Vec::new();
             let row_versions = row_versions.read();
 
             // A tombstone over a row that was already in the B-tree before this
@@ -1783,8 +1873,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                     continue;
                 };
                 canonicalize_table_id(&mut committed_version);
-                let entry_slice = &log_record.row_versions[entry_start..];
-                let replaces_last = entry_slice.last().is_some_and(|last| {
+                let replaces_last = entry_versions.last().is_some_and(|last| {
                     last.row.id == committed_version.row.id
                         && matches!(
                             (&last.begin, &committed_version.begin),
@@ -1795,8 +1884,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         )
                 });
                 if replaces_last {
-                    *log_record
-                        .row_versions
+                    *entry_versions
                         .last_mut()
                         .expect("last version checked above") = committed_version;
                     continue;
@@ -1814,14 +1902,18 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                             )
                     };
                     turso_assert!(
-                        !log_record.row_versions[entry_start..]
-                            .iter()
-                            .any(same_row_and_begin),
+                        !entry_versions.iter().any(same_row_and_begin),
                         "one write-set entry produced non-adjacent log versions with the same row id and commit timestamp"
                     );
                 }
-                log_record.row_versions.push(committed_version);
+                entry_versions.push(committed_version);
             }
+            for committed_version in &entry_versions {
+                mvcc_store
+                    .storage
+                    .serialize_row_version(log_record, committed_version)?;
+            }
+            Ok(())
         };
 
         // Process schema rows (sqlite_schema) before data/index rows so that
@@ -1841,7 +1933,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 !is_schema
             };
             if process {
-                collect_versions(row_versions, &mut ctx.log_record);
+                collect_versions(row_versions, &mut ctx.log_record)?;
             }
             ctx.cursor += 1;
             iterations += 1;
@@ -1861,13 +1953,24 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             return Ok(TransitionResult::Continue);
         }
 
-        // Both passes complete. Move the assembled log record out and
-        // transition to BeginCommitLogicalLog (or directly to CommitEnd
-        // if there is nothing to log).
+        // Both row-version passes complete. Append the captured DatabaseHeader
+        // op (if any) at the tail of the payload — this preserves the on-disk
+        // order: row-version ops first, header op last. (Order matches the
+        // previous implementation where `serialize_ops_into_write_buf` walked
+        // `row_versions` then optionally serialized `header`.)
+        if let Some(header) = ctx.pending_header.take() {
+            mvcc_store
+                .storage
+                .serialize_database_header(&mut ctx.log_record, &header)?;
+        }
+
+        // Move the assembled log record out and transition to
+        // BeginCommitLogicalLog (or directly to CommitEnd if there is nothing
+        // to log).
         let log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
         tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
 
-        if log_record.row_versions.is_empty() && log_record.header.is_none() {
+        if log_record.is_empty() {
             // Nothing to log. We still need to release the commit lock here
             // if this is an exclusive tx, mirroring the pre-chunk path
             // through WaitForDependencies.
@@ -2274,21 +2377,22 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     return Ok(TransitionResult::Done(()));
                 }
 
-                // All dependencies resolved. Initialize the log record (just
-                // the header snapshot, if any) and hand off to BuildLogRecord
-                // which fills in row_versions in `MVCC_COMMIT_BATCH_SIZE`-sized
-                // chunks, yielding between chunks. Live row versions stay on
-                // TxID references until CommitEnd so rollback of an abandoned
-                // commit can still match them.
-                let mut log_record = LogRecord::new(end_ts);
-                if tx.header_dirty.load(Ordering::Acquire) {
-                    log_record.header = Some(*tx.header.read());
-                }
+                // All dependencies resolved. Initialize an empty log record
+                // (`buf` is grown incrementally during BuildLogRecord) and
+                // snapshot the dirty header for the tail of the payload.
+                // Live row versions stay on TxID references until CommitEnd
+                // so rollback of an abandoned commit can still match them.
+                let pending_header = if tx.header_dirty.load(Ordering::Acquire) {
+                    Some(*tx.header.read())
+                } else {
+                    None
+                };
                 self.state = CommitState::BuildLogRecord(BuildLogRecordCtx {
                     end_ts,
-                    log_record,
+                    log_record: LogRecord::new(end_ts),
                     cursor: 0,
                     schema_process: true,
+                    pending_header,
                 });
                 return Ok(TransitionResult::Continue);
             }
@@ -2297,7 +2401,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
             // the cursor / pass / log_record inside the variant, which
             // conflicts with the outer `&self.state` match borrow.
             CommitState::BuildLogRecord(_) => self.step_build_log_record(mvcc_store),
-            CommitState::BeginCommitLogicalLog { end_ts, log_record } => {
+            CommitState::BeginCommitLogicalLog { end_ts, .. } => {
                 if !mvcc_store.is_exclusive_tx(&self.tx_id) {
                     // logical log needs to be serialized.
                     let tx = mvcc_store
@@ -2314,9 +2418,25 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .pager_commit_lock_held
                         .store(true, Ordering::Release);
                 }
-                let (c, append_bytes) = mvcc_store.storage.log_tx(log_record, None)?;
+                let end_ts = *end_ts;
+                // The pattern binding `end_ts: &u64` is no longer used after
+                // the copy above, so NLL drops the shared borrow on
+                // `self.state` and lets us swap it mutably here. We swap
+                // ahead of `log_tx` because `log_tx` consumes the LogRecord's
+                // buffer in place (it becomes the on-disk frame buffer
+                // handed to pwrite); on error the LogRecord is partially
+                // framed and not usable for retry — which matches the
+                // pre-existing semantics where a log_tx failure aborts the
+                // commit.
+                let mut log_record = match std::mem::replace(
+                    &mut self.state,
+                    CommitState::SyncLogicalLog { end_ts },
+                ) {
+                    CommitState::BeginCommitLogicalLog { log_record, .. } => log_record,
+                    _ => unreachable!(),
+                };
+                let (c, append_bytes) = mvcc_store.storage.log_tx(&mut log_record, None)?;
                 self.pending_log_append_bytes = Some(append_bytes);
-                self.state = CommitState::SyncLogicalLog { end_ts: *end_ts };
                 // if Completion Completed without errors we can continue
                 if c.succeeded() {
                     Ok(TransitionResult::Continue)

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -376,7 +376,12 @@ impl LogRecord {
 
     /// True iff no ops (row versions or header) have been appended.
     pub fn is_empty(&self) -> bool {
-        self.op_count == 0
+        let empty = self.op_count == 0;
+        turso_assert!(
+            !empty || !self.has_header,
+            "header shouldn't have been written"
+        );
+        empty
     }
 
     /// Test-only constructor that eagerly serializes a list of row versions

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2395,14 +2395,14 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .store(true, Ordering::Release);
                 }
                 let end_ts = *end_ts;
-                let mut log_record = match std::mem::replace(
+                let log_record = match std::mem::replace(
                     &mut self.state,
                     CommitState::SyncLogicalLog { end_ts },
                 ) {
                     CommitState::BeginCommitLogicalLog { log_record, .. } => log_record,
                     _ => unreachable!(),
                 };
-                let (c, append_bytes) = mvcc_store.storage.log_tx(&mut log_record, None)?;
+                let (c, append_bytes) = mvcc_store.storage.log_tx(log_record, None)?;
                 self.pending_log_append_bytes = Some(append_bytes);
                 // if Completion Completed without errors we can continue
                 if c.succeeded() {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -387,12 +387,6 @@ impl LogRecord {
         }
     }
 
-    /// Plaintext payload size: bytes contributed by serialized ops, excluding
-    /// the pre-reserved framing prefix at the front of `buf`.
-    pub(crate) fn payload_size(&self) -> usize {
-        self.buf.len() - crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE
-    }
-
     /// True iff no ops (row versions or header) have been appended.
     pub fn is_empty(&self) -> bool {
         self.op_count == 0

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -12692,7 +12692,7 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         }
         fn log_tx(
             &self,
-            m: &mut LogRecord,
+            m: LogRecord,
             c: OnSerializationComplete<'_>,
         ) -> Result<(Completion, u64)> {
             if self.arm_log_tx_busy.swap(false, Ordering::AcqRel) {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -12650,10 +12650,11 @@ fn dropped_attached_commit_rolls_back_remaining_attached_mvcc_txs() {
 fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
     use crate::io::FileSyncType;
     use crate::mvcc;
-    use crate::mvcc::database::LogRecord;
+    use crate::mvcc::database::{LogRecord, RowVersion};
     use crate::mvcc::persistent_storage::logical_log::{LogHeader, OnSerializationComplete};
     use crate::mvcc::persistent_storage::DurableStorage;
     use crate::storage::encryption::EncryptionContext;
+    use crate::storage::sqlite3_ondisk::DatabaseHeader;
     use crate::{CheckpointResult, File, Result, IO};
     use std::time::Duration;
 
@@ -12675,9 +12676,23 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         }
     }
     impl DurableStorage for BusyOnLogTxStorage {
+        fn serialize_row_version(
+            &self,
+            log_record: &mut LogRecord,
+            row_version: &RowVersion,
+        ) -> Result<()> {
+            self.inner.serialize_row_version(log_record, row_version)
+        }
+        fn serialize_database_header(
+            &self,
+            log_record: &mut LogRecord,
+            header: &DatabaseHeader,
+        ) -> Result<()> {
+            self.inner.serialize_database_header(log_record, header)
+        }
         fn log_tx(
             &self,
-            m: &LogRecord,
+            m: &mut LogRecord,
             c: OnSerializationComplete<'_>,
         ) -> Result<(Completion, u64)> {
             if self.arm_log_tx_busy.swap(false, Ordering::AcqRel) {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3571,8 +3571,7 @@ mod tests {
         // the reader's magic validation check.
         let commit_ts = 201u64;
         let db_header = DatabaseHeader::default();
-        let header_tx =
-            crate::mvcc::database::LogRecord::for_test(commit_ts, &[], Some(db_header));
+        let header_tx = crate::mvcc::database::LogRecord::for_test(commit_ts, &[], Some(db_header));
         let c = log.log_tx(header_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -3811,8 +3810,7 @@ mod tests {
                     btree_resident,
                 }
             });
-            let tx =
-                crate::mvcc::database::LogRecord::for_test(commit_ts, &[row_version], None);
+            let tx = crate::mvcc::database::LogRecord::for_test(commit_ts, &[row_version], None);
             let Ok(c) = log.log_tx(tx) else {
                 return false;
             };
@@ -5660,8 +5658,7 @@ mod tests {
 
         // Write 2 frames.
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-        let first_tx =
-            crate::mvcc::database::LogRecord::for_test(100, &[first_row_version], None);
+        let first_tx = crate::mvcc::database::LogRecord::for_test(100, &[first_row_version], None);
         append_encrypted_tx(&mut log, &io, first_tx);
         let second_tx = crate::mvcc::database::LogRecord::for_test(
             101,
@@ -5838,8 +5835,7 @@ mod tests {
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
         let first_row_version = make_test_row_version(table_id, 1, "prefix", 500);
         let expected_prefix_record_bytes = first_row_version.row.payload().to_vec();
-        let first_tx =
-            crate::mvcc::database::LogRecord::for_test(500, &[first_row_version], None);
+        let first_tx = crate::mvcc::database::LogRecord::for_test(500, &[first_row_version], None);
         let c = log.log_tx(first_tx).unwrap();
         io.wait_for_completion(c).unwrap();
         let second_frame_start = log.offset as usize;

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -269,10 +269,7 @@ pub(crate) const TX_HEADER_SIZE: usize = 24; // FRAME_MAGIC(4) + payload_size(8)
 const TX_TRAILER_SIZE: usize = 8; // crc32c(4) + END_MAGIC(4)
 const TX_MIN_FRAME_SIZE: usize = TX_HEADER_SIZE + TX_TRAILER_SIZE; // 32
 
-/// Total bytes pre-reserved at the front of a `LogRecord::buf` so the flush
-/// path never has to shift the payload. The log-header slot is included for
-/// first-write commits; non-first-write commits leave it as zeros in memory
-/// and skip it at I/O time via `Buffer::new_with_start(..., LOG_HDR_SIZE)`.
+/// Total bytes pre-reserved at the front of a `LogRecord::buf`.
 pub(crate) const LOG_RECORD_PREFIX_SIZE: usize = LOG_HDR_SIZE + TX_HEADER_SIZE;
 
 fn encrypted_payload_chunk_count(payload_size: usize, chunk_size: usize) -> usize {
@@ -560,14 +557,6 @@ impl LogicalLog {
     /// — optional log header, TX header, optional chunked encryption, CRC
     /// trailer — and pwrites the resulting frame to disk.
     ///
-    /// Ops are serialized into `tx.buf` during commit
-    /// (see [`DurableStorage::serialize_row_version`] /
-    /// [`DurableStorage::serialize_database_header`]); this function adds the
-    /// framing in place so the same allocation that held the plaintext payload
-    /// becomes the on-disk frame buffer handed to the I/O layer. There is no
-    /// separate `write_buf` held by `LogicalLog` — once we hand the buffer to
-    /// pwrite, `tx.buf` is left empty.
-    ///
     /// `advance_offset_immediately`: when true, the writer offset advances right
     /// after the pwrite (checkpoint path). When false, the offset stays behind
     /// until `advance_offset_after_success` is called (MVCC commit path).
@@ -581,10 +570,6 @@ impl LogicalLog {
         let commit_ts = tx.tx_timestamp;
         // `tx.buf` is laid out as:
         //   [LOG_HDR slot (56B, zeros)] [TX_HEADER slot (24B, zeros)] [payload]
-        // Both prefix slots were pre-reserved by `LogRecord::new`. The flush
-        // path either fills the LOG_HDR slot (first-write, single pwrite of
-        // the whole buf) or skips it via `Buffer::new_with_start` (every
-        // other commit) — never shifting the payload in memory.
         debug_assert!(
             tx.buf.len() >= LOG_RECORD_PREFIX_SIZE,
             "LogRecord buf missing pre-reserved framing prefix"
@@ -734,8 +719,6 @@ impl LogicalLog {
 
     /// Writes a transaction to the log and immediately advances the writer offset.
     /// Used for checkpoint-initiated writes where no two-phase commit is needed.
-    /// On return, `tx.buf` is empty: its allocation has been moved into the
-    /// pwrite buffer.
     pub fn log_tx(&mut self, tx: &mut LogRecord) -> Result<Completion> {
         let (c, _) = self.frame_and_pwrite_tx(tx, true, None)?;
         Ok(c)
@@ -744,9 +727,6 @@ impl LogicalLog {
     /// Writes a transaction to the log but does NOT advance the writer offset.
     /// Returns `(completion, bytes_written)`. The caller must call
     /// `advance_offset_after_success(bytes)` after confirming the commit succeeded.
-    ///
-    /// On return, `tx.buf` is empty: its allocation has been moved into the
-    /// pwrite buffer.
     ///
     /// If `on_serialization_complete` is provided, it is called with a zero-copy
     /// reference to the framed bytes and the running CRC after framing but

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -265,9 +265,15 @@ const OP_UPDATE_HEADER: u8 = 4;
 
 const OP_FLAG_BTREE_RESIDENT: u8 = 1 << 0;
 
-const TX_HEADER_SIZE: usize = 24; // FRAME_MAGIC(4) + payload_size(8) + op_count(4) + commit_ts(8)
+pub(crate) const TX_HEADER_SIZE: usize = 24; // FRAME_MAGIC(4) + payload_size(8) + op_count(4) + commit_ts(8)
 const TX_TRAILER_SIZE: usize = 8; // crc32c(4) + END_MAGIC(4)
 const TX_MIN_FRAME_SIZE: usize = TX_HEADER_SIZE + TX_TRAILER_SIZE; // 32
+
+/// Total bytes pre-reserved at the front of a `LogRecord::buf` so the flush
+/// path never has to shift the payload. The log-header slot is included for
+/// first-write commits; non-first-write commits leave it as zeros in memory
+/// and skip it at I/O time via `Buffer::new_with_start(..., LOG_HDR_SIZE)`.
+pub(crate) const LOG_RECORD_PREFIX_SIZE: usize = LOG_HDR_SIZE + TX_HEADER_SIZE;
 
 fn encrypted_payload_chunk_count(payload_size: usize, chunk_size: usize) -> usize {
     if payload_size == 0 {
@@ -485,7 +491,6 @@ pub struct LogicalLog {
     pub file: Arc<dyn File>,
     io: Arc<dyn crate::IO>,
     pub offset: u64,
-    write_buf: Vec<u8>,
     header: Option<LogHeader>,
     /// Running CRC state for chained checksums. Seeded from the header salt;
     /// updated after each committed frame. The next frame's CRC is computed as
@@ -499,8 +504,6 @@ pub struct LogicalLog {
     /// Plaintext bytes per encrypted payload chunk. Production uses the fixed format constant;
     /// tests may override via `new_with_encrypted_payload_chunk_size_for_test`.
     encrypted_payload_chunk_size: usize,
-    /// Reusable scratch buffer for ops serialization on the encrypted write path.
-    encryption_scratch_buffer: Vec<u8>,
 }
 
 impl LogicalLog {
@@ -514,13 +517,11 @@ impl LogicalLog {
             file,
             io,
             offset: 0,
-            write_buf: Vec::new(),
             header: None,
             running_crc: 0,
             pending_running_crc: None,
             encryption_ctx,
             encrypted_payload_chunk_size,
-            encryption_scratch_buffer: Vec::new(),
         }
     }
 
@@ -555,149 +556,85 @@ impl LogicalLog {
         self.encryption_ctx.as_ref()
     }
 
-    /// Serializes a transaction into `write_buf`, optionally calls
-    /// `on_serialization_complete` with a zero-copy reference to the frame bytes.
+    /// Wraps the pre-serialized payload (`tx.buf`) with the log/TX framing
+    /// — optional log header, TX header, optional chunked encryption, CRC
+    /// trailer — and pwrites the resulting frame to disk.
+    ///
+    /// Ops are serialized into `tx.buf` during commit
+    /// (see [`DurableStorage::serialize_row_version`] /
+    /// [`DurableStorage::serialize_database_header`]); this function adds the
+    /// framing in place so the same allocation that held the plaintext payload
+    /// becomes the on-disk frame buffer handed to the I/O layer. There is no
+    /// separate `write_buf` held by `LogicalLog` — once we hand the buffer to
+    /// pwrite, `tx.buf` is left empty.
     ///
     /// `advance_offset_immediately`: when true, the writer offset advances right
     /// after the pwrite (checkpoint path). When false, the offset stays behind
     /// until `advance_offset_after_success` is called (MVCC commit path).
-    fn serialize_and_pwrite_tx(
+    fn frame_and_pwrite_tx(
         &mut self,
-        tx: &LogRecord,
+        tx: &mut LogRecord,
         advance_offset_immediately: bool,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
-        self.write_buf.clear();
-
-        // 1. Serialize log header if it's first write
-        let is_first_write = self.offset == 0;
-        if is_first_write {
-            if self.header.is_none() {
-                let header = LogHeader::new(&self.io);
-                self.running_crc = derive_initial_crc(header.salt);
-                self.header = Some(header);
-            }
-            let header_bytes = self.header.as_ref().unwrap().encode();
-            self.write_buf.extend_from_slice(&header_bytes);
-        }
-
-        // 2. Serialize Transaction header.
-        // A header-only transaction is encoded as a single OP_UPDATE_HEADER op.
-        // payload_size is only known after serializing all ops. We reserve TX_HEADER_SIZE bytes
-        // as a placeholder and backfill all header fields in step 4.
-        let op_count = u32::try_from(tx.row_versions.len() + usize::from(tx.header.is_some()))
-            .map_err(|_| {
-                LimboError::InternalError("Logical log op_count exceeds u32".to_string())
-            })?;
+        let op_count = tx.op_count;
         let commit_ts = tx.tx_timestamp;
-        let tx_header_start = self.write_buf.len();
-        self.write_buf.resize(tx_header_start + TX_HEADER_SIZE, 0);
-
-        // 3. Serialize ops into write_buf (encrypted or plaintext).
-        let payload_size = self.serialize_ops_into_write_buf(tx, op_count, commit_ts)?;
-        let payload_end = self.write_buf.len();
-
-        // 4. Backfill TX HEADER: FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
-        self.write_buf[tx_header_start..tx_header_start + 4]
-            .copy_from_slice(&FRAME_MAGIC.to_le_bytes());
-        self.write_buf[tx_header_start + 4..tx_header_start + 12]
-            .copy_from_slice(&payload_size.to_le_bytes());
-        self.write_buf[tx_header_start + 12..tx_header_start + 16]
-            .copy_from_slice(&op_count.to_le_bytes());
-        self.write_buf[tx_header_start + 16..tx_header_start + 24]
-            .copy_from_slice(&commit_ts.to_le_bytes());
-
-        // 5. TX TRAILER layout (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
-        // CRC is chained: seeded from running_crc (salt-derived, or previous frame's CRC),
-        // covers TX_HEADER (24 B) + payload (encrypted or plaintext).
-        let crc = crc32c::crc32c_append(
-            self.running_crc,
-            &self.write_buf[tx_header_start..payload_end],
+        // `tx.buf` is laid out as:
+        //   [LOG_HDR slot (56B, zeros)] [TX_HEADER slot (24B, zeros)] [payload]
+        // Both prefix slots were pre-reserved by `LogRecord::new`. The flush
+        // path either fills the LOG_HDR slot (first-write, single pwrite of
+        // the whole buf) or skips it via `Buffer::new_with_start` (every
+        // other commit) — never shifting the payload in memory.
+        debug_assert!(
+            tx.buf.len() >= LOG_RECORD_PREFIX_SIZE,
+            "LogRecord buf missing pre-reserved framing prefix"
         );
-        self.write_buf.extend_from_slice(&crc.to_le_bytes());
-        self.write_buf.extend_from_slice(&END_MAGIC.to_le_bytes());
+        let payload_size = tx.buf.len() - LOG_RECORD_PREFIX_SIZE;
+        let payload_size_u64 = payload_size as u64;
 
-        // 6. Call observer before writing — zero-copy reference into write_buf.
-        if let Some(cb) = on_serialization_complete {
-            cb(&self.write_buf, crc)?;
+        // 1. Ensure we have a log header object (created lazily on first write).
+        let is_first_write = self.offset == 0;
+        if is_first_write && self.header.is_none() {
+            let header = LogHeader::new(&self.io);
+            self.running_crc = derive_initial_crc(header.salt);
+            self.header = Some(header);
         }
 
-        // 7. Hand off the populated buffer to the I/O layer without copying.
-        // `to_vec()` would allocate a second N-byte buffer and memcpy, briefly
-        // holding two full copies in memory — fatal for million-row commits.
-        // `take` swaps in a fresh empty Vec; the next call grows from zero.
-        let buffer = Arc::new(Buffer::new(std::mem::take(&mut self.write_buf)));
-        let c = Completion::new_write({
-            let buffer_len = buffer.len();
-            move |res: Result<i32, CompletionError>| {
-                let Ok(bytes_written) = res else {
-                    return;
-                };
-                turso_assert!(
-                    bytes_written == buffer_len as i32,
-                    "wrote({bytes_written}) != expected({buffer_len})"
-                );
-            }
-        });
-
-        let buffer_len = buffer.len();
-        let c = self.file.pwrite(self.offset, buffer, c)?;
-        if advance_offset_immediately {
-            self.offset += buffer_len as u64;
-            self.running_crc = crc;
-        } else {
-            self.pending_running_crc = Some(crc);
-        }
-        Ok((c, buffer_len as u64))
-    }
-
-    /// Serializes ops into `write_buf`, encrypting if an encryption context is set.
-    /// Returns the plaintext payload size (used in the TX header's `payload_size` field).
-    ///
-    /// Encrypted on-disk payload layout: repeated
-    /// `ciphertext(chunk_plain_len + tag_size) | nonce(nonce_size)` chunks.
-    fn serialize_ops_into_write_buf(
-        &mut self,
-        tx: &LogRecord,
-        op_count: u32,
-        commit_ts: u64,
-    ) -> Result<u64> {
+        // 2. Build the on-disk payload. Unencrypted is the zero-shift fast
+        // path: the plaintext is already at LOG_RECORD_PREFIX_SIZE. Encrypted
+        // has to re-emit the payload because its on-disk size differs from
+        // the plaintext size after chunked encryption.
         if let Some(enc_ctx) = &self.encryption_ctx {
-            self.encryption_scratch_buffer.clear();
-            for row_version in &tx.row_versions {
-                serialize_op_entry(&mut self.encryption_scratch_buffer, row_version)?;
-            }
-            if let Some(hdr) = tx.header {
-                serialize_header_entry(&mut self.encryption_scratch_buffer, &hdr);
-            }
-            let payload_size = self.encryption_scratch_buffer.len();
-
             let salt = self
                 .header
                 .as_ref()
                 .expect("log header must be set before writing")
                 .salt;
-            let total_on_disk_size = encrypted_payload_blob_size(
+            let on_disk_payload_size = encrypted_payload_blob_size(
                 payload_size,
                 self.encrypted_payload_chunk_size,
                 enc_ctx.tag_size(),
                 enc_ctx.nonce_size(),
             )?;
-            let write_buf_start = self.write_buf.len();
-            self.write_buf.reserve(total_on_disk_size);
+            let total = LOG_RECORD_PREFIX_SIZE + on_disk_payload_size + TX_TRAILER_SIZE;
+            // Move the plaintext out (`split_off` returns the tail past the
+            // framing prefix; `tx.buf` is left with just the 80-byte prefix
+            // to grow back into with encrypted chunks).
+            let plaintext = tx.buf.split_off(LOG_RECORD_PREFIX_SIZE);
+            debug_assert_eq!(plaintext.len(), payload_size);
+            tx.buf.reserve(total - tx.buf.len());
+
             let chunk_count =
                 encrypted_payload_chunk_count(payload_size, self.encrypted_payload_chunk_size);
-
-            let payload_size = payload_size as u64;
-            for (chunk_index, plaintext_chunk) in self
-                .encryption_scratch_buffer
+            let payload_start = tx.buf.len();
+            for (chunk_index, plaintext_chunk) in plaintext
                 .chunks(self.encrypted_payload_chunk_size)
                 .enumerate()
             {
                 let is_last_chunk = chunk_index + 1 == chunk_count;
                 let aad = build_encrypted_chunk_aad(
                     salt,
-                    is_last_chunk.then_some(payload_size),
+                    is_last_chunk.then_some(payload_size_u64),
                     op_count,
                     commit_ts,
                     u32::try_from(chunk_index).map_err(|_| {
@@ -706,7 +643,6 @@ impl LogicalLog {
                         )
                     })?,
                 );
-
                 let (ciphertext, nonce) = enc_ctx.encrypt_chunk(plaintext_chunk, &aad)?;
                 // encrypt_chunk returns ciphertext with the auth tag appended, so its
                 // length must be exactly plaintext_len + tag_size. The read path relies
@@ -719,30 +655,89 @@ impl LogicalLog {
                     enc_ctx.tag_size(),
                     ciphertext.len(),
                 );
-                self.write_buf.extend_from_slice(&ciphertext);
-                self.write_buf.extend_from_slice(&nonce);
+                tx.buf.extend_from_slice(&ciphertext);
+                tx.buf.extend_from_slice(&nonce);
             }
             turso_assert!(
-                self.write_buf.len() - write_buf_start == total_on_disk_size,
-                "encrypted write_buf size mismatch"
+                tx.buf.len() - payload_start == on_disk_payload_size,
+                "encrypted on-disk payload size mismatch"
             );
-            Ok(payload_size)
-        } else {
-            let payload_start = self.write_buf.len();
-            for row_version in &tx.row_versions {
-                serialize_op_entry(&mut self.write_buf, row_version)?;
-            }
-            if let Some(header) = tx.header {
-                serialize_header_entry(&mut self.write_buf, &header);
-            }
-            Ok((self.write_buf.len() - payload_start) as u64)
+            // `plaintext` is dropped here, freeing its allocation before pwrite.
         }
+        // Unencrypted: payload bytes are already in place at
+        // [LOG_RECORD_PREFIX_SIZE ..].
+
+        // 3. Backfill TX HEADER at offset LOG_HDR_SIZE:
+        //    FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
+        let tx_header_start = LOG_HDR_SIZE;
+        tx.buf[tx_header_start..tx_header_start + 4].copy_from_slice(&FRAME_MAGIC.to_le_bytes());
+        tx.buf[tx_header_start + 4..tx_header_start + 12]
+            .copy_from_slice(&payload_size_u64.to_le_bytes());
+        tx.buf[tx_header_start + 12..tx_header_start + 16].copy_from_slice(&op_count.to_le_bytes());
+        tx.buf[tx_header_start + 16..tx_header_start + 24]
+            .copy_from_slice(&commit_ts.to_le_bytes());
+
+        // 4. TX TRAILER (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
+        // CRC is chained: seeded from running_crc (salt-derived, or previous
+        // frame's CRC), covers TX_HEADER (24 B) + payload (encrypted or plain).
+        // The log header is NOT part of the CRC chain — it has its own header
+        // CRC stored within its 56 bytes.
+        let payload_end = tx.buf.len();
+        let crc = crc32c::crc32c_append(self.running_crc, &tx.buf[tx_header_start..payload_end]);
+        tx.buf.extend_from_slice(&crc.to_le_bytes());
+        tx.buf.extend_from_slice(&END_MAGIC.to_le_bytes());
+
+        // 5. Fill the LOG_HDR slot (first-write only). Non-first-write
+        // commits leave it as zeros; those bytes never reach disk because
+        // we wrap the buffer with `new_with_start(..., LOG_HDR_SIZE)` below.
+        if is_first_write {
+            let header_bytes = self.header.as_ref().unwrap().encode();
+            tx.buf[..LOG_HDR_SIZE].copy_from_slice(&header_bytes);
+        }
+
+        // 6. Observer hook: gets a zero-copy reference into the on-disk bytes.
+        let on_disk_start = if is_first_write { 0 } else { LOG_HDR_SIZE };
+        if let Some(cb) = on_serialization_complete {
+            cb(&tx.buf[on_disk_start..], crc)?;
+        }
+
+        // 7. Hand off `tx.buf` to the I/O layer without copying. `mem::take`
+        // leaves `tx.buf` as an empty Vec. For non-first-write commits, the
+        // Buffer wrapper exposes only `data[LOG_HDR_SIZE..]` so the unused
+        // 56-byte prefix never reaches disk — a single pwrite, no shift.
+        let raw = std::mem::take(&mut tx.buf);
+        let buffer = if is_first_write {
+            Arc::new(Buffer::new(raw))
+        } else {
+            Arc::new(Buffer::new_with_start(raw, LOG_HDR_SIZE))
+        };
+        let buffer_len = buffer.len();
+        let c = Completion::new_write(move |res: Result<i32, CompletionError>| {
+            let Ok(bytes_written) = res else {
+                return;
+            };
+            turso_assert!(
+                bytes_written == buffer_len as i32,
+                "wrote({bytes_written}) != expected({buffer_len})"
+            );
+        });
+
+        let c = self.file.pwrite(self.offset, buffer, c)?;
+        if advance_offset_immediately {
+            self.offset += buffer_len as u64;
+            self.running_crc = crc;
+        } else {
+            self.pending_running_crc = Some(crc);
+        }
+        Ok((c, buffer_len as u64))
     }
 
     /// Writes a transaction to the log and immediately advances the writer offset.
     /// Used for checkpoint-initiated writes where no two-phase commit is needed.
-    pub fn log_tx(&mut self, tx: &LogRecord) -> Result<Completion> {
-        let (c, _) = self.serialize_and_pwrite_tx(tx, true, None)?;
+    /// On return, `tx.buf` is empty: its allocation has been moved into the
+    /// pwrite buffer.
+    pub fn log_tx(&mut self, tx: &mut LogRecord) -> Result<Completion> {
+        let (c, _) = self.frame_and_pwrite_tx(tx, true, None)?;
         Ok(c)
     }
 
@@ -750,15 +745,18 @@ impl LogicalLog {
     /// Returns `(completion, bytes_written)`. The caller must call
     /// `advance_offset_after_success(bytes)` after confirming the commit succeeded.
     ///
+    /// On return, `tx.buf` is empty: its allocation has been moved into the
+    /// pwrite buffer.
+    ///
     /// If `on_serialization_complete` is provided, it is called with a zero-copy
-    /// reference to the serialized frame bytes and the running CRC after
-    /// serialization but before the disk write.
+    /// reference to the framed bytes and the running CRC after framing but
+    /// before the disk write.
     pub fn log_tx_deferred_offset(
         &mut self,
-        tx: &LogRecord,
+        tx: &mut LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
-        self.serialize_and_pwrite_tx(tx, false, on_serialization_complete)
+        self.frame_and_pwrite_tx(tx, false, on_serialization_complete)
     }
 
     pub fn advance_offset_after_success(&mut self, bytes: u64) {
@@ -846,7 +844,7 @@ impl LogicalLog {
 
 /// Serialize one op into `buffer`.
 /// Op layout: tag(1) | flags(1) | table_id(4, le i32) | payload_len(varint) | payload(variable)
-fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion) -> Result<()> {
+pub(crate) fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion) -> Result<()> {
     let is_delete = row_version.end.is_some();
     let tag = match (&row_version.row.id.row_id, is_delete) {
         (RowKey::Int(_), false) => OP_UPSERT_TABLE,
@@ -912,7 +910,7 @@ fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion) -> Result<
     Ok(())
 }
 
-fn serialize_header_entry(buffer: &mut Vec<u8>, header: &DatabaseHeader) {
+pub(crate) fn serialize_header_entry(buffer: &mut Vec<u8>, header: &DatabaseHeader) {
     // Header op uses tag-only addressing (table_id=0, flags=0) and fixed payload length.
     buffer.push(OP_UPDATE_HEADER);
     buffer.push(0);
@@ -2408,11 +2406,7 @@ mod tests {
         let file = io.open_file(file_name, OpenFlags::Create, false).unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: commit_ts,
-            row_versions: Vec::new(),
-            header: None,
-        };
+        let mut tx = crate::mvcc::database::LogRecord::new(commit_ts);
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
@@ -2421,8 +2415,8 @@ mod tests {
             row: row.clone(),
             btree_resident: false,
         };
-        tx.row_versions.push(version);
-        let c = log.log_tx(&tx).unwrap();
+        tx.push_row_version_for_test(&version);
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let rowid_len = varint_len(1);
@@ -2512,12 +2506,8 @@ mod tests {
             row,
             btree_resident,
         };
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: commit_ts,
-            row_versions: vec![row_version],
-            header: None,
-        };
-        let c = log.log_tx(&tx).unwrap();
+        let mut tx = crate::mvcc::database::LogRecord::for_test(commit_ts, &[row_version], None);
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
     }
 
@@ -2941,34 +2931,26 @@ mod tests {
         let op_size = 6 + payload_len_len + payload_len;
         let frame_size = TX_HEADER_SIZE + op_size + TX_TRAILER_SIZE;
 
-        let mut tx1 = crate::mvcc::database::LogRecord {
-            tx_timestamp: 10,
-            row_versions: Vec::new(),
-            header: None,
-        };
-        tx1.row_versions.push(crate::mvcc::database::RowVersion {
+        let mut tx1 = crate::mvcc::database::LogRecord::new(10);
+        tx1.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
             begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10)),
             end: None,
             row: row.clone(),
             btree_resident: false,
         });
-        let c = log.log_tx(&tx1).unwrap();
+        let c = log.log_tx(&mut tx1).unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut tx2 = crate::mvcc::database::LogRecord {
-            tx_timestamp: 20,
-            row_versions: Vec::new(),
-            header: None,
-        };
-        tx2.row_versions.push(crate::mvcc::database::RowVersion {
+        let mut tx2 = crate::mvcc::database::LogRecord::new(20);
+        tx2.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 2,
             begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(20)),
             end: None,
             row,
             btree_resident: false,
         });
-        let c = log.log_tx(&tx2).unwrap();
+        let c = log.log_tx(&mut tx2).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let file_size = file.size().unwrap() as usize;
@@ -3108,18 +3090,18 @@ mod tests {
 
         // Frame 3: deferred path — offset must not advance until confirmed.
         let row3 = generate_simple_string_row((-2).into(), 3, "deferred");
-        let tx3 = crate::mvcc::database::LogRecord {
-            tx_timestamp: 3,
-            row_versions: vec![crate::mvcc::database::RowVersion {
+        let mut tx3 = crate::mvcc::database::LogRecord::for_test(
+            3,
+            &[crate::mvcc::database::RowVersion {
                 id: 3,
                 begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(3)),
                 end: None,
                 row: row3,
                 btree_resident: false,
             }],
-            header: None,
-        };
-        let (c, bytes_written) = log.log_tx_deferred_offset(&tx3, None).unwrap();
+            None,
+        );
+        let (c, bytes_written) = log.log_tx_deferred_offset(&mut tx3, None).unwrap();
         io.wait_for_completion(c).unwrap();
 
         assert_eq!(
@@ -3160,11 +3142,7 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 123,
-            row_versions: Vec::new(),
-            header: None,
-        };
+        let mut tx = crate::mvcc::database::LogRecord::new(123);
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
@@ -3173,8 +3151,8 @@ mod tests {
             row,
             btree_resident: false,
         };
-        tx.row_versions.push(version);
-        let c = log.log_tx(&tx).unwrap();
+        tx.push_row_version_for_test(&version);
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Flip one byte in the op data (varint payload_len).
@@ -3402,12 +3380,8 @@ mod tests {
             .open_file("header-corrupt.db-log", crate::OpenFlags::Create, false)
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 77,
-            row_versions: vec![],
-            header: None,
-        };
-        let c = log.log_tx(&tx).unwrap();
+        let mut tx = crate::mvcc::database::LogRecord::for_test(77, &[], None);
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Corrupt magic bytes in the file header.
@@ -3609,24 +3583,17 @@ mod tests {
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
         // Frame 1: empty tx (no ops). The reader must skip it silently (ops.is_empty() → continue).
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 200,
-            row_versions: vec![],
-            header: None,
-        };
-        let c = log.log_tx(&tx).unwrap();
+        let mut tx = crate::mvcc::database::LogRecord::for_test(200, &[], None);
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Frame 2: header-only tx. DatabaseHeader::default() has the SQLite magic that passes
         // the reader's magic validation check.
         let commit_ts = 201u64;
         let db_header = DatabaseHeader::default();
-        let header_tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: commit_ts,
-            row_versions: vec![],
-            header: Some(db_header),
-        };
-        let c = log.log_tx(&header_tx).unwrap();
+        let mut header_tx =
+            crate::mvcc::database::LogRecord::for_test(commit_ts, &[], Some(db_header));
+        let c = log.log_tx(&mut header_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
@@ -3668,19 +3635,15 @@ mod tests {
             .open_file("bitflip.db-log", crate::OpenFlags::Create, false)
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
-        let mut tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 300,
-            row_versions: Vec::new(),
-            header: None,
-        };
-        tx.row_versions.push(crate::mvcc::database::RowVersion {
+        let mut tx = crate::mvcc::database::LogRecord::new(300);
+        tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
             begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(300)),
             end: None,
             row: generate_simple_string_row((-2).into(), 42, "flip"),
             btree_resident: false,
         });
-        let c = log.log_tx(&tx).unwrap();
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let size = file.size().unwrap() as usize;
@@ -3743,18 +3706,14 @@ mod tests {
 
         let mut expected = Vec::new();
         for tx_i in 0..128u64 {
-            let mut tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: 1_000 + tx_i,
-                row_versions: Vec::new(),
-                header: None,
-            };
+            let mut tx = crate::mvcc::database::LogRecord::new(1_000 + tx_i);
             let op_count = (rng.next_u64() % 4) as usize;
             for _ in 0..op_count {
                 let rowid = (rng.next_u64() % 64) as i64 + 1;
                 let btree_resident = (rng.next_u32() & 1) == 1;
                 let is_delete = (rng.next_u32() & 1) == 1;
                 if is_delete {
-                    tx.row_versions.push(crate::mvcc::database::RowVersion {
+                    tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                         id: 0,
                         begin: None,
                         end: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
@@ -3775,7 +3734,7 @@ mod tests {
                 } else {
                     let payload = format!("r-{tx_i}-{rowid}");
                     let row = generate_simple_string_row((-2).into(), rowid, &payload);
-                    tx.row_versions.push(crate::mvcc::database::RowVersion {
+                    tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
                         id: 0,
                         begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
                             tx.tx_timestamp,
@@ -3792,7 +3751,7 @@ mod tests {
                     });
                 }
             }
-            let c = log.log_tx(&tx).unwrap();
+            let c = log.log_tx(&mut tx).unwrap();
             io.wait_for_completion(c).unwrap();
         }
 
@@ -3801,11 +3760,7 @@ mod tests {
         // correctly when a single frame spans chunk boundaries.
         let large_commit_ts = 1_000 + 128u64;
         let large_text: String = "x".repeat(200);
-        let mut large_tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: large_commit_ts,
-            row_versions: Vec::new(),
-            header: None,
-        };
+        let mut large_tx = crate::mvcc::database::LogRecord::new(large_commit_ts);
         for rowid in 1..=30i64 {
             let row = generate_simple_string_row((-3).into(), rowid, &large_text);
             expected.push(ExpectedTableOp::Upsert {
@@ -3814,19 +3769,17 @@ mod tests {
                 commit_ts: large_commit_ts,
                 btree_resident: false,
             });
-            large_tx
-                .row_versions
-                .push(crate::mvcc::database::RowVersion {
-                    id: rowid as u64,
-                    begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
-                        large_commit_ts,
-                    )),
-                    end: None,
-                    row,
-                    btree_resident: false,
-                });
+            large_tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
+                id: rowid as u64,
+                begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(
+                    large_commit_ts,
+                )),
+                end: None,
+                row,
+                btree_resident: false,
+            });
         }
-        let c = log.log_tx(&large_tx).unwrap();
+        let c = log.log_tx(&mut large_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let got = read_table_ops(file.clone(), &io);
@@ -3878,12 +3831,9 @@ mod tests {
                     btree_resident,
                 }
             });
-            let tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: commit_ts,
-                row_versions: vec![row_version],
-                header: None,
-            };
-            let Ok(c) = log.log_tx(&tx) else {
+            let mut tx =
+                crate::mvcc::database::LogRecord::for_test(commit_ts, &[row_version], None);
+            let Ok(c) = log.log_tx(&mut tx) else {
                 return false;
             };
             if io.wait_for_completion(c).is_err() {
@@ -3961,11 +3911,7 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 55,
-            row_versions: Vec::new(),
-            header: None,
-        };
+        let mut tx = crate::mvcc::database::LogRecord::new(55);
         let mut row = generate_simple_string_row((-2).into(), 1, "foo");
         row.id.table_id = (-2).into();
         let version = crate::mvcc::database::RowVersion {
@@ -3975,8 +3921,8 @@ mod tests {
             row,
             btree_resident: true,
         };
-        tx.row_versions.push(version);
-        let c = log.log_tx(&tx).unwrap();
+        tx.push_row_version_for_test(&version);
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Verify the on-disk frame header binary layout.
@@ -4025,11 +3971,7 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 10,
-            row_versions: Vec::new(),
-            header: None,
-        };
+        let mut tx = crate::mvcc::database::LogRecord::new(10);
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
@@ -4038,8 +3980,8 @@ mod tests {
             row,
             btree_resident: false,
         };
-        tx.row_versions.push(version);
-        let c = log.log_tx(&tx).unwrap();
+        tx.push_row_version_for_test(&version);
+        let c = log.log_tx(&mut tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let c = file
@@ -4495,7 +4437,7 @@ mod tests {
     fn append_encrypted_tx(
         log: &mut LogicalLog,
         io: &Arc<dyn crate::IO>,
-        tx: &crate::mvcc::database::LogRecord,
+        tx: &mut crate::mvcc::database::LogRecord,
     ) {
         let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
@@ -4505,7 +4447,7 @@ mod tests {
         file: Arc<dyn crate::File>,
         io: &Arc<dyn crate::IO>,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
-        tx: &crate::mvcc::database::LogRecord,
+        tx: &mut crate::mvcc::database::LogRecord,
     ) {
         assert_eq!(
             file.size().unwrap(),
@@ -4521,7 +4463,7 @@ mod tests {
         io: &Arc<dyn crate::IO>,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
         encrypted_payload_chunk_size: usize,
-        tx: &crate::mvcc::database::LogRecord,
+        tx: &mut crate::mvcc::database::LogRecord,
     ) {
         assert_eq!(
             file.size().unwrap(),
@@ -4541,7 +4483,7 @@ mod tests {
         io: &Arc<dyn crate::IO>,
         file_name: &str,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
-        tx: &crate::mvcc::database::LogRecord,
+        tx: &mut crate::mvcc::database::LogRecord,
     ) -> Arc<dyn crate::File> {
         let file = open_test_file(io, file_name);
         write_first_encrypted_tx(file.clone(), io, enc_ctx, tx);
@@ -4553,7 +4495,7 @@ mod tests {
         file_name: &str,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
         encrypted_payload_chunk_size: usize,
-        tx: &crate::mvcc::database::LogRecord,
+        tx: &mut crate::mvcc::database::LogRecord,
     ) -> Arc<dyn crate::File> {
         let file = open_test_file(io, file_name);
         write_first_encrypted_tx_with_chunk_size_for_test(
@@ -4571,7 +4513,7 @@ mod tests {
         file_name: &str,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
         encrypted_payload_chunk_size: usize,
-        txs: &[crate::mvcc::database::LogRecord],
+        txs: &mut [crate::mvcc::database::LogRecord],
     ) -> Arc<dyn crate::File> {
         let file = open_test_file(io, file_name);
         let mut log = LogicalLog::new_with_payload_chunk_size(
@@ -4942,11 +4884,11 @@ mod tests {
                 expected_ops.push(expected_op);
             }
 
-            txs.push(crate::mvcc::database::LogRecord {
-                tx_timestamp: commit_ts,
-                row_versions,
-                header: None,
-            });
+            txs.push(crate::mvcc::database::LogRecord::for_test(
+                commit_ts,
+                &row_versions,
+                None,
+            ));
             expected_frames.push(expected_ops);
         }
 
@@ -5011,15 +4953,15 @@ mod tests {
             .to_vec();
 
         // Write one encrypted frame with 2 ops.
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 100,
-            row_versions: vec![
+        let mut tx = crate::mvcc::database::LogRecord::for_test(
+            100,
+            &[
                 make_test_row_version(table_id, 1, "hello", 100),
                 make_test_row_version(table_id, 2, "world", 100),
             ],
-            header: None,
-        };
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &tx);
+            None,
+        );
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
 
         // ── Layout invariant check ──
         // Read the raw TX header to extract payload_size.
@@ -5091,18 +5033,14 @@ mod tests {
         let value = "t".repeat(text_len);
         let row_version = make_test_row_version((-2).into(), 1, &value, 100);
         let expected_record_bytes = row_version.row.payload().to_vec();
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 100,
-            row_versions: vec![row_version],
-            header: None,
-        };
+        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
 
         let file = write_single_encrypted_tx_with_chunk_size_for_test(
             &io,
             "enc-roundtrip-test-chunk-size.db-log",
             &enc_ctx,
             TEST_CHUNK_SIZE,
-            &tx,
+            &mut tx,
         );
 
         assert_eq!(
@@ -5155,7 +5093,7 @@ mod tests {
         for case_index in 0..case_count {
             let case_seed = rng.next_u64();
             let include_forced_prefix = case_index == forced_case_index;
-            let (txs, expected_frames) = generate_encrypted_carry_fuzz_case(
+            let (mut txs, expected_frames) = generate_encrypted_carry_fuzz_case(
                 case_seed,
                 TEST_CHUNK_SIZE,
                 include_forced_prefix,
@@ -5166,7 +5104,7 @@ mod tests {
                 &format!("enc-carry-fuzz-{seed}-{case_index}.db-log"),
                 &enc_ctx,
                 TEST_CHUNK_SIZE,
-                &txs,
+                &mut txs,
             );
             let actual_frames = parse_all_encrypted_tx_ops_with_chunk_size_for_test(
                 file,
@@ -5276,16 +5214,16 @@ mod tests {
         ] {
             let text_len = text_len_for_single_upsert_table_op_size(payload_size);
             let value = "p".repeat(text_len);
-            let tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: 100,
-                row_versions: vec![make_test_row_version((-2).into(), 1, &value, 100)],
-                header: None,
-            };
+            let mut tx = crate::mvcc::database::LogRecord::for_test(
+                100,
+                &[make_test_row_version((-2).into(), 1, &value, 100)],
+                None,
+            );
             let file = write_single_encrypted_tx(
                 &io,
                 &format!("enc-layout-pinned-{payload_size}.db-log"),
                 &enc_ctx,
-                &tx,
+                &mut tx,
             );
 
             let frame_bytes = read_file_bytes(file.clone(), &io);
@@ -5319,12 +5257,12 @@ mod tests {
         let value = "s".repeat(text_len);
 
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 444,
-            row_versions: vec![make_test_row_version(table_id, 1, &value, 444)],
-            header: None,
-        };
-        append_encrypted_tx(&mut log, &io, &tx);
+        let mut tx = crate::mvcc::database::LogRecord::for_test(
+            444,
+            &[make_test_row_version(table_id, 1, &value, 444)],
+            None,
+        );
+        append_encrypted_tx(&mut log, &io, &mut tx);
 
         let frame_bytes = read_file_bytes(file.clone(), &io);
         let payload_size = u64::from_le_bytes(
@@ -5367,16 +5305,12 @@ mod tests {
             let value = "x".repeat(text_len);
             let row_version = make_test_row_version((-2).into(), 1, &value, 100);
             let expected_record_bytes = row_version.row.payload().to_vec();
-            let tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: 100,
-                row_versions: vec![row_version],
-                header: None,
-            };
+            let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
             let file = write_single_encrypted_tx(
                 &io,
                 &format!("enc-layout-{target_op_size}.db-log"),
                 &enc_ctx,
-                &tx,
+                &mut tx,
             );
 
             let frame_hdr = read_file_bytes(file.clone(), &io);
@@ -5415,12 +5349,8 @@ mod tests {
         let row_version = make_test_row_version((-2).into(), 1, &value, 100);
         let expected_record_bytes = row_version.row.payload().to_vec();
 
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 100,
-            row_versions: vec![row_version],
-            header: None,
-        };
-        let file = write_single_encrypted_tx(&io, "enc-cross-boundary.db-log", &enc_ctx, &tx);
+        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
+        let file = write_single_encrypted_tx(&io, "enc-cross-boundary.db-log", &enc_ctx, &mut tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 1);
         assert_upsert_table_op(&ops[0], (-2).into(), 1, &expected_record_bytes, 100);
@@ -5470,12 +5400,8 @@ mod tests {
             "chunk boundary should fall after the first payload_len varint byte"
         );
 
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 100,
-            row_versions: vec![filler, second],
-            header: None,
-        };
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &tx);
+        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[filler, second], None);
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 2);
         assert_upsert_table_op(&ops[0], (-2).into(), 1, &expected_filler_record_bytes, 100);
@@ -5513,12 +5439,8 @@ mod tests {
             "chunk boundary should split the header op after its first byte"
         );
 
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 100,
-            row_versions: vec![filler],
-            header: Some(header),
-        };
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &tx);
+        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[filler], Some(header));
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 2);
         assert_upsert_table_op(&ops[0], (-2).into(), 1, &expected_filler_record_bytes, 100);
@@ -5547,12 +5469,8 @@ mod tests {
             .iter()
             .map(|row_version| row_version.row.payload().to_vec())
             .collect::<Vec<_>>();
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 200,
-            row_versions,
-            header: None,
-        };
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &tx);
+        let mut tx = crate::mvcc::database::LogRecord::for_test(200, &row_versions, None);
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 96);
         for (idx, op) in ops.iter().enumerate() {
@@ -5578,12 +5496,8 @@ mod tests {
         let row_version = make_test_index_row_version(index_id, 42, &value, 250);
         let expected_payload = row_version.row.payload().to_vec();
 
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 250,
-            row_versions: vec![row_version],
-            header: None,
-        };
-        let file = write_single_encrypted_tx(&io, "enc-index-boundary.db-log", &enc_ctx, &tx);
+        let mut tx = crate::mvcc::database::LogRecord::for_test(250, &[row_version], None);
+        let file = write_single_encrypted_tx(&io, "enc-index-boundary.db-log", &enc_ctx, &mut tx);
 
         let frame_bytes = read_file_bytes(file.clone(), &io);
         let payload_size = u64::from_le_bytes(
@@ -5619,17 +5533,17 @@ mod tests {
 
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
         for i in 0..5u64 {
-            let tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: 100 + i,
-                row_versions: vec![make_test_row_version(
+            let mut tx = crate::mvcc::database::LogRecord::for_test(
+                100 + i,
+                &[make_test_row_version(
                     table_id,
                     i as i64,
                     &format!("val_{i}"),
                     100 + i,
                 )],
-                header: None,
-            };
-            append_encrypted_tx(&mut log, &io, &tx);
+                None,
+            );
+            append_encrypted_tx(&mut log, &io, &mut tx);
         }
 
         let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
@@ -5671,12 +5585,12 @@ mod tests {
                 .unwrap();
 
             let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-            let tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: 100,
-                row_versions: vec![make_test_row_version(table_id, 1, "secret", 100)],
-                header: None,
-            };
-            append_encrypted_tx(&mut log, &io, &tx);
+            let mut tx = crate::mvcc::database::LogRecord::for_test(
+                100,
+                &[make_test_row_version(table_id, 1, "secret", 100)],
+                None,
+            );
+            append_encrypted_tx(&mut log, &io, &mut tx);
 
             let mut reader = StreamingLogicalLogReader::new(file, Some(wrong_key_enc_ctx()));
             reader.read_header(&io).unwrap();
@@ -5697,12 +5611,12 @@ mod tests {
                 .unwrap();
 
             let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-            let tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: 100,
-                row_versions: vec![make_test_row_version(table_id, 1, "hdr_tamper", 100)],
-                header: None,
-            };
-            append_encrypted_tx(&mut log, &io, &tx);
+            let mut tx = crate::mvcc::database::LogRecord::for_test(
+                100,
+                &[make_test_row_version(table_id, 1, "hdr_tamper", 100)],
+                None,
+            );
+            append_encrypted_tx(&mut log, &io, &mut tx);
 
             // Flip a byte in the commit_ts field (TX header offset 16..24, file offset = LOG_HDR + 16).
             let corrupt_offset = (LOG_HDR_SIZE + 16) as u64;
@@ -5728,12 +5642,12 @@ mod tests {
                 .unwrap();
 
             let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-            let tx = crate::mvcc::database::LogRecord {
-                tx_timestamp: 100,
-                row_versions: vec![make_test_row_version(table_id, 1, "tamper_me", 100)],
-                header: None,
-            };
-            append_encrypted_tx(&mut log, &io, &tx);
+            let mut tx = crate::mvcc::database::LogRecord::for_test(
+                100,
+                &[make_test_row_version(table_id, 1, "tamper_me", 100)],
+                None,
+            );
+            append_encrypted_tx(&mut log, &io, &mut tx);
 
             // Flip a byte in the ciphertext (after log header + TX header).
             let corrupt_offset = (LOG_HDR_SIZE + TX_HEADER_SIZE + 1) as u64;
@@ -5766,18 +5680,15 @@ mod tests {
 
         // Write 2 frames.
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-        let first_tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 100,
-            row_versions: vec![first_row_version],
-            header: None,
-        };
-        append_encrypted_tx(&mut log, &io, &first_tx);
-        let second_tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 101,
-            row_versions: vec![make_test_row_version(table_id, 1, "data", 101)],
-            header: None,
-        };
-        append_encrypted_tx(&mut log, &io, &second_tx);
+        let mut first_tx =
+            crate::mvcc::database::LogRecord::for_test(100, &[first_row_version], None);
+        append_encrypted_tx(&mut log, &io, &mut first_tx);
+        let mut second_tx = crate::mvcc::database::LogRecord::for_test(
+            101,
+            &[make_test_row_version(table_id, 1, "data", 101)],
+            None,
+        );
+        append_encrypted_tx(&mut log, &io, &mut second_tx);
 
         // Truncate mid-way through the second frame.
         let file_size = file.size().unwrap();
@@ -5819,12 +5730,8 @@ mod tests {
         let base_file = open_test_file(&io, "enc-chunk-integrity-base.db-log");
         let row_version = make_test_row_version((-2).into(), 1, &value, 333);
         let expected_record_bytes = row_version.row.payload().to_vec();
-        let tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 333,
-            row_versions: vec![row_version],
-            header: None,
-        };
-        write_first_encrypted_tx(base_file.clone(), &io, &enc_ctx, &tx);
+        let mut tx = crate::mvcc::database::LogRecord::for_test(333, &[row_version], None);
+        write_first_encrypted_tx(base_file.clone(), &io, &enc_ctx, &mut tx);
         let base_ops = parse_only_encrypted_tx_ops(base_file.clone(), &io, &enc_ctx);
         assert_eq!(base_ops.len(), 1);
         assert_upsert_table_op(&base_ops[0], (-2).into(), 1, &expected_record_bytes, 333);
@@ -5951,21 +5858,18 @@ mod tests {
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
         let first_row_version = make_test_row_version(table_id, 1, "prefix", 500);
         let expected_prefix_record_bytes = first_row_version.row.payload().to_vec();
-        let first_tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 500,
-            row_versions: vec![first_row_version],
-            header: None,
-        };
-        let c = log.log_tx(&first_tx).unwrap();
+        let mut first_tx =
+            crate::mvcc::database::LogRecord::for_test(500, &[first_row_version], None);
+        let c = log.log_tx(&mut first_tx).unwrap();
         io.wait_for_completion(c).unwrap();
         let second_frame_start = log.offset as usize;
 
-        let second_tx = crate::mvcc::database::LogRecord {
-            tx_timestamp: 600,
-            row_versions: vec![make_test_row_version(table_id, 2, &value, 600)],
-            header: None,
-        };
-        let c = log.log_tx(&second_tx).unwrap();
+        let mut second_tx = crate::mvcc::database::LogRecord::for_test(
+            600,
+            &[make_test_row_version(table_id, 2, &value, 600)],
+            None,
+        );
+        let c = log.log_tx(&mut second_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let base_bytes = read_file_bytes(file.clone(), &io);

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -562,7 +562,7 @@ impl LogicalLog {
     /// until `advance_offset_after_success` is called (MVCC commit path).
     fn frame_and_pwrite_tx(
         &mut self,
-        tx: &mut LogRecord,
+        mut tx: LogRecord,
         advance_offset_immediately: bool,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
@@ -686,11 +686,11 @@ impl LogicalLog {
             cb(&tx.buf[on_disk_start..], crc)?;
         }
 
-        // 7. Hand off `tx.buf` to the I/O layer without copying. `mem::take`
-        // leaves `tx.buf` as an empty Vec. For non-first-write commits, the
-        // Buffer wrapper exposes only `data[LOG_HDR_SIZE..]` so the unused
-        // 56-byte prefix never reaches disk — a single pwrite, no shift.
-        let raw = std::mem::take(&mut tx.buf);
+        // 7. Hand off `tx.buf` to the I/O layer without copying. For
+        // non-first-write commits, the Buffer wrapper exposes only
+        // `data[LOG_HDR_SIZE..]` so the unused 56-byte prefix never reaches
+        // disk — a single pwrite, no shift.
+        let raw = tx.buf;
         let buffer = if is_first_write {
             Arc::new(Buffer::new(raw))
         } else {
@@ -719,7 +719,7 @@ impl LogicalLog {
 
     /// Writes a transaction to the log and immediately advances the writer offset.
     /// Used for checkpoint-initiated writes where no two-phase commit is needed.
-    pub fn log_tx(&mut self, tx: &mut LogRecord) -> Result<Completion> {
+    pub fn log_tx(&mut self, tx: LogRecord) -> Result<Completion> {
         let (c, _) = self.frame_and_pwrite_tx(tx, true, None)?;
         Ok(c)
     }
@@ -733,7 +733,7 @@ impl LogicalLog {
     /// before the disk write.
     pub fn log_tx_deferred_offset(
         &mut self,
-        tx: &mut LogRecord,
+        tx: LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
         self.frame_and_pwrite_tx(tx, false, on_serialization_complete)
@@ -2396,7 +2396,7 @@ mod tests {
             btree_resident: false,
         };
         tx.push_row_version_for_test(&version);
-        let c = log.log_tx(&mut tx).unwrap();
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let rowid_len = varint_len(1);
@@ -2486,8 +2486,8 @@ mod tests {
             row,
             btree_resident,
         };
-        let mut tx = crate::mvcc::database::LogRecord::for_test(commit_ts, &[row_version], None);
-        let c = log.log_tx(&mut tx).unwrap();
+        let tx = crate::mvcc::database::LogRecord::for_test(commit_ts, &[row_version], None);
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
     }
 
@@ -2919,7 +2919,7 @@ mod tests {
             row: row.clone(),
             btree_resident: false,
         });
-        let c = log.log_tx(&mut tx1).unwrap();
+        let c = log.log_tx(tx1).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let mut tx2 = crate::mvcc::database::LogRecord::new(20);
@@ -2930,7 +2930,7 @@ mod tests {
             row,
             btree_resident: false,
         });
-        let c = log.log_tx(&mut tx2).unwrap();
+        let c = log.log_tx(tx2).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let file_size = file.size().unwrap() as usize;
@@ -3070,7 +3070,7 @@ mod tests {
 
         // Frame 3: deferred path — offset must not advance until confirmed.
         let row3 = generate_simple_string_row((-2).into(), 3, "deferred");
-        let mut tx3 = crate::mvcc::database::LogRecord::for_test(
+        let tx3 = crate::mvcc::database::LogRecord::for_test(
             3,
             &[crate::mvcc::database::RowVersion {
                 id: 3,
@@ -3081,7 +3081,7 @@ mod tests {
             }],
             None,
         );
-        let (c, bytes_written) = log.log_tx_deferred_offset(&mut tx3, None).unwrap();
+        let (c, bytes_written) = log.log_tx_deferred_offset(tx3, None).unwrap();
         io.wait_for_completion(c).unwrap();
 
         assert_eq!(
@@ -3132,7 +3132,7 @@ mod tests {
             btree_resident: false,
         };
         tx.push_row_version_for_test(&version);
-        let c = log.log_tx(&mut tx).unwrap();
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Flip one byte in the op data (varint payload_len).
@@ -3360,8 +3360,8 @@ mod tests {
             .open_file("header-corrupt.db-log", crate::OpenFlags::Create, false)
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
-        let mut tx = crate::mvcc::database::LogRecord::for_test(77, &[], None);
-        let c = log.log_tx(&mut tx).unwrap();
+        let tx = crate::mvcc::database::LogRecord::for_test(77, &[], None);
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Corrupt magic bytes in the file header.
@@ -3563,17 +3563,17 @@ mod tests {
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
         // Frame 1: empty tx (no ops). The reader must skip it silently (ops.is_empty() → continue).
-        let mut tx = crate::mvcc::database::LogRecord::for_test(200, &[], None);
-        let c = log.log_tx(&mut tx).unwrap();
+        let tx = crate::mvcc::database::LogRecord::for_test(200, &[], None);
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Frame 2: header-only tx. DatabaseHeader::default() has the SQLite magic that passes
         // the reader's magic validation check.
         let commit_ts = 201u64;
         let db_header = DatabaseHeader::default();
-        let mut header_tx =
+        let header_tx =
             crate::mvcc::database::LogRecord::for_test(commit_ts, &[], Some(db_header));
-        let c = log.log_tx(&mut header_tx).unwrap();
+        let c = log.log_tx(header_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
@@ -3623,7 +3623,7 @@ mod tests {
             row: generate_simple_string_row((-2).into(), 42, "flip"),
             btree_resident: false,
         });
-        let c = log.log_tx(&mut tx).unwrap();
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let size = file.size().unwrap() as usize;
@@ -3731,7 +3731,7 @@ mod tests {
                     });
                 }
             }
-            let c = log.log_tx(&mut tx).unwrap();
+            let c = log.log_tx(tx).unwrap();
             io.wait_for_completion(c).unwrap();
         }
 
@@ -3759,7 +3759,7 @@ mod tests {
                 btree_resident: false,
             });
         }
-        let c = log.log_tx(&mut large_tx).unwrap();
+        let c = log.log_tx(large_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let got = read_table_ops(file.clone(), &io);
@@ -3811,9 +3811,9 @@ mod tests {
                     btree_resident,
                 }
             });
-            let mut tx =
+            let tx =
                 crate::mvcc::database::LogRecord::for_test(commit_ts, &[row_version], None);
-            let Ok(c) = log.log_tx(&mut tx) else {
+            let Ok(c) = log.log_tx(tx) else {
                 return false;
             };
             if io.wait_for_completion(c).is_err() {
@@ -3902,7 +3902,7 @@ mod tests {
             btree_resident: true,
         };
         tx.push_row_version_for_test(&version);
-        let c = log.log_tx(&mut tx).unwrap();
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         // Verify the on-disk frame header binary layout.
@@ -3961,7 +3961,7 @@ mod tests {
             btree_resident: false,
         };
         tx.push_row_version_for_test(&version);
-        let c = log.log_tx(&mut tx).unwrap();
+        let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let c = file
@@ -4417,7 +4417,7 @@ mod tests {
     fn append_encrypted_tx(
         log: &mut LogicalLog,
         io: &Arc<dyn crate::IO>,
-        tx: &mut crate::mvcc::database::LogRecord,
+        tx: crate::mvcc::database::LogRecord,
     ) {
         let c = log.log_tx(tx).unwrap();
         io.wait_for_completion(c).unwrap();
@@ -4427,7 +4427,7 @@ mod tests {
         file: Arc<dyn crate::File>,
         io: &Arc<dyn crate::IO>,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
-        tx: &mut crate::mvcc::database::LogRecord,
+        tx: crate::mvcc::database::LogRecord,
     ) {
         assert_eq!(
             file.size().unwrap(),
@@ -4443,7 +4443,7 @@ mod tests {
         io: &Arc<dyn crate::IO>,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
         encrypted_payload_chunk_size: usize,
-        tx: &mut crate::mvcc::database::LogRecord,
+        tx: crate::mvcc::database::LogRecord,
     ) {
         assert_eq!(
             file.size().unwrap(),
@@ -4463,7 +4463,7 @@ mod tests {
         io: &Arc<dyn crate::IO>,
         file_name: &str,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
-        tx: &mut crate::mvcc::database::LogRecord,
+        tx: crate::mvcc::database::LogRecord,
     ) -> Arc<dyn crate::File> {
         let file = open_test_file(io, file_name);
         write_first_encrypted_tx(file.clone(), io, enc_ctx, tx);
@@ -4475,7 +4475,7 @@ mod tests {
         file_name: &str,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
         encrypted_payload_chunk_size: usize,
-        tx: &mut crate::mvcc::database::LogRecord,
+        tx: crate::mvcc::database::LogRecord,
     ) -> Arc<dyn crate::File> {
         let file = open_test_file(io, file_name);
         write_first_encrypted_tx_with_chunk_size_for_test(
@@ -4493,7 +4493,7 @@ mod tests {
         file_name: &str,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
         encrypted_payload_chunk_size: usize,
-        txs: &mut [crate::mvcc::database::LogRecord],
+        txs: Vec<crate::mvcc::database::LogRecord>,
     ) -> Arc<dyn crate::File> {
         let file = open_test_file(io, file_name);
         let mut log = LogicalLog::new_with_payload_chunk_size(
@@ -4933,7 +4933,7 @@ mod tests {
             .to_vec();
 
         // Write one encrypted frame with 2 ops.
-        let mut tx = crate::mvcc::database::LogRecord::for_test(
+        let tx = crate::mvcc::database::LogRecord::for_test(
             100,
             &[
                 make_test_row_version(table_id, 1, "hello", 100),
@@ -4941,7 +4941,7 @@ mod tests {
             ],
             None,
         );
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, tx);
 
         // ── Layout invariant check ──
         // Read the raw TX header to extract payload_size.
@@ -5013,14 +5013,14 @@ mod tests {
         let value = "t".repeat(text_len);
         let row_version = make_test_row_version((-2).into(), 1, &value, 100);
         let expected_record_bytes = row_version.row.payload().to_vec();
-        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
+        let tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
 
         let file = write_single_encrypted_tx_with_chunk_size_for_test(
             &io,
             "enc-roundtrip-test-chunk-size.db-log",
             &enc_ctx,
             TEST_CHUNK_SIZE,
-            &mut tx,
+            tx,
         );
 
         assert_eq!(
@@ -5073,7 +5073,7 @@ mod tests {
         for case_index in 0..case_count {
             let case_seed = rng.next_u64();
             let include_forced_prefix = case_index == forced_case_index;
-            let (mut txs, expected_frames) = generate_encrypted_carry_fuzz_case(
+            let (txs, expected_frames) = generate_encrypted_carry_fuzz_case(
                 case_seed,
                 TEST_CHUNK_SIZE,
                 include_forced_prefix,
@@ -5084,7 +5084,7 @@ mod tests {
                 &format!("enc-carry-fuzz-{seed}-{case_index}.db-log"),
                 &enc_ctx,
                 TEST_CHUNK_SIZE,
-                &mut txs,
+                txs,
             );
             let actual_frames = parse_all_encrypted_tx_ops_with_chunk_size_for_test(
                 file,
@@ -5194,7 +5194,7 @@ mod tests {
         ] {
             let text_len = text_len_for_single_upsert_table_op_size(payload_size);
             let value = "p".repeat(text_len);
-            let mut tx = crate::mvcc::database::LogRecord::for_test(
+            let tx = crate::mvcc::database::LogRecord::for_test(
                 100,
                 &[make_test_row_version((-2).into(), 1, &value, 100)],
                 None,
@@ -5203,7 +5203,7 @@ mod tests {
                 &io,
                 &format!("enc-layout-pinned-{payload_size}.db-log"),
                 &enc_ctx,
-                &mut tx,
+                tx,
             );
 
             let frame_bytes = read_file_bytes(file.clone(), &io);
@@ -5237,12 +5237,12 @@ mod tests {
         let value = "s".repeat(text_len);
 
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-        let mut tx = crate::mvcc::database::LogRecord::for_test(
+        let tx = crate::mvcc::database::LogRecord::for_test(
             444,
             &[make_test_row_version(table_id, 1, &value, 444)],
             None,
         );
-        append_encrypted_tx(&mut log, &io, &mut tx);
+        append_encrypted_tx(&mut log, &io, tx);
 
         let frame_bytes = read_file_bytes(file.clone(), &io);
         let payload_size = u64::from_le_bytes(
@@ -5285,12 +5285,12 @@ mod tests {
             let value = "x".repeat(text_len);
             let row_version = make_test_row_version((-2).into(), 1, &value, 100);
             let expected_record_bytes = row_version.row.payload().to_vec();
-            let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
+            let tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
             let file = write_single_encrypted_tx(
                 &io,
                 &format!("enc-layout-{target_op_size}.db-log"),
                 &enc_ctx,
-                &mut tx,
+                tx,
             );
 
             let frame_hdr = read_file_bytes(file.clone(), &io);
@@ -5329,8 +5329,8 @@ mod tests {
         let row_version = make_test_row_version((-2).into(), 1, &value, 100);
         let expected_record_bytes = row_version.row.payload().to_vec();
 
-        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
-        let file = write_single_encrypted_tx(&io, "enc-cross-boundary.db-log", &enc_ctx, &mut tx);
+        let tx = crate::mvcc::database::LogRecord::for_test(100, &[row_version], None);
+        let file = write_single_encrypted_tx(&io, "enc-cross-boundary.db-log", &enc_ctx, tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 1);
         assert_upsert_table_op(&ops[0], (-2).into(), 1, &expected_record_bytes, 100);
@@ -5380,8 +5380,8 @@ mod tests {
             "chunk boundary should fall after the first payload_len varint byte"
         );
 
-        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[filler, second], None);
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
+        let tx = crate::mvcc::database::LogRecord::for_test(100, &[filler, second], None);
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 2);
         assert_upsert_table_op(&ops[0], (-2).into(), 1, &expected_filler_record_bytes, 100);
@@ -5419,8 +5419,8 @@ mod tests {
             "chunk boundary should split the header op after its first byte"
         );
 
-        let mut tx = crate::mvcc::database::LogRecord::for_test(100, &[filler], Some(header));
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
+        let tx = crate::mvcc::database::LogRecord::for_test(100, &[filler], Some(header));
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 2);
         assert_upsert_table_op(&ops[0], (-2).into(), 1, &expected_filler_record_bytes, 100);
@@ -5449,8 +5449,8 @@ mod tests {
             .iter()
             .map(|row_version| row_version.row.payload().to_vec())
             .collect::<Vec<_>>();
-        let mut tx = crate::mvcc::database::LogRecord::for_test(200, &row_versions, None);
-        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, &mut tx);
+        let tx = crate::mvcc::database::LogRecord::for_test(200, &row_versions, None);
+        write_first_encrypted_tx(file.clone(), &io, &enc_ctx, tx);
         let ops = parse_only_encrypted_tx_ops(file, &io, &enc_ctx);
         assert_eq!(ops.len(), 96);
         for (idx, op) in ops.iter().enumerate() {
@@ -5476,8 +5476,8 @@ mod tests {
         let row_version = make_test_index_row_version(index_id, 42, &value, 250);
         let expected_payload = row_version.row.payload().to_vec();
 
-        let mut tx = crate::mvcc::database::LogRecord::for_test(250, &[row_version], None);
-        let file = write_single_encrypted_tx(&io, "enc-index-boundary.db-log", &enc_ctx, &mut tx);
+        let tx = crate::mvcc::database::LogRecord::for_test(250, &[row_version], None);
+        let file = write_single_encrypted_tx(&io, "enc-index-boundary.db-log", &enc_ctx, tx);
 
         let frame_bytes = read_file_bytes(file.clone(), &io);
         let payload_size = u64::from_le_bytes(
@@ -5513,7 +5513,7 @@ mod tests {
 
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
         for i in 0..5u64 {
-            let mut tx = crate::mvcc::database::LogRecord::for_test(
+            let tx = crate::mvcc::database::LogRecord::for_test(
                 100 + i,
                 &[make_test_row_version(
                     table_id,
@@ -5523,7 +5523,7 @@ mod tests {
                 )],
                 None,
             );
-            append_encrypted_tx(&mut log, &io, &mut tx);
+            append_encrypted_tx(&mut log, &io, tx);
         }
 
         let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
@@ -5565,12 +5565,12 @@ mod tests {
                 .unwrap();
 
             let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-            let mut tx = crate::mvcc::database::LogRecord::for_test(
+            let tx = crate::mvcc::database::LogRecord::for_test(
                 100,
                 &[make_test_row_version(table_id, 1, "secret", 100)],
                 None,
             );
-            append_encrypted_tx(&mut log, &io, &mut tx);
+            append_encrypted_tx(&mut log, &io, tx);
 
             let mut reader = StreamingLogicalLogReader::new(file, Some(wrong_key_enc_ctx()));
             reader.read_header(&io).unwrap();
@@ -5591,12 +5591,12 @@ mod tests {
                 .unwrap();
 
             let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-            let mut tx = crate::mvcc::database::LogRecord::for_test(
+            let tx = crate::mvcc::database::LogRecord::for_test(
                 100,
                 &[make_test_row_version(table_id, 1, "hdr_tamper", 100)],
                 None,
             );
-            append_encrypted_tx(&mut log, &io, &mut tx);
+            append_encrypted_tx(&mut log, &io, tx);
 
             // Flip a byte in the commit_ts field (TX header offset 16..24, file offset = LOG_HDR + 16).
             let corrupt_offset = (LOG_HDR_SIZE + 16) as u64;
@@ -5622,12 +5622,12 @@ mod tests {
                 .unwrap();
 
             let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-            let mut tx = crate::mvcc::database::LogRecord::for_test(
+            let tx = crate::mvcc::database::LogRecord::for_test(
                 100,
                 &[make_test_row_version(table_id, 1, "tamper_me", 100)],
                 None,
             );
-            append_encrypted_tx(&mut log, &io, &mut tx);
+            append_encrypted_tx(&mut log, &io, tx);
 
             // Flip a byte in the ciphertext (after log header + TX header).
             let corrupt_offset = (LOG_HDR_SIZE + TX_HEADER_SIZE + 1) as u64;
@@ -5660,15 +5660,15 @@ mod tests {
 
         // Write 2 frames.
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
-        let mut first_tx =
+        let first_tx =
             crate::mvcc::database::LogRecord::for_test(100, &[first_row_version], None);
-        append_encrypted_tx(&mut log, &io, &mut first_tx);
-        let mut second_tx = crate::mvcc::database::LogRecord::for_test(
+        append_encrypted_tx(&mut log, &io, first_tx);
+        let second_tx = crate::mvcc::database::LogRecord::for_test(
             101,
             &[make_test_row_version(table_id, 1, "data", 101)],
             None,
         );
-        append_encrypted_tx(&mut log, &io, &mut second_tx);
+        append_encrypted_tx(&mut log, &io, second_tx);
 
         // Truncate mid-way through the second frame.
         let file_size = file.size().unwrap();
@@ -5710,8 +5710,8 @@ mod tests {
         let base_file = open_test_file(&io, "enc-chunk-integrity-base.db-log");
         let row_version = make_test_row_version((-2).into(), 1, &value, 333);
         let expected_record_bytes = row_version.row.payload().to_vec();
-        let mut tx = crate::mvcc::database::LogRecord::for_test(333, &[row_version], None);
-        write_first_encrypted_tx(base_file.clone(), &io, &enc_ctx, &mut tx);
+        let tx = crate::mvcc::database::LogRecord::for_test(333, &[row_version], None);
+        write_first_encrypted_tx(base_file.clone(), &io, &enc_ctx, tx);
         let base_ops = parse_only_encrypted_tx_ops(base_file.clone(), &io, &enc_ctx);
         assert_eq!(base_ops.len(), 1);
         assert_upsert_table_op(&base_ops[0], (-2).into(), 1, &expected_record_bytes, 333);
@@ -5838,18 +5838,18 @@ mod tests {
         let mut log = LogicalLog::new(file.clone(), io.clone(), Some(enc_ctx.clone()));
         let first_row_version = make_test_row_version(table_id, 1, "prefix", 500);
         let expected_prefix_record_bytes = first_row_version.row.payload().to_vec();
-        let mut first_tx =
+        let first_tx =
             crate::mvcc::database::LogRecord::for_test(500, &[first_row_version], None);
-        let c = log.log_tx(&mut first_tx).unwrap();
+        let c = log.log_tx(first_tx).unwrap();
         io.wait_for_completion(c).unwrap();
         let second_frame_start = log.offset as usize;
 
-        let mut second_tx = crate::mvcc::database::LogRecord::for_test(
+        let second_tx = crate::mvcc::database::LogRecord::for_test(
             600,
             &[make_test_row_version(table_id, 2, &value, 600)],
             None,
         );
-        let c = log.log_tx(&mut second_tx).unwrap();
+        let c = log.log_tx(second_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
         let base_bytes = read_file_bytes(file.clone(), &io);

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -1,28 +1,58 @@
 use crate::io::FileSyncType;
 use crate::storage::encryption::EncryptionContext;
+use crate::storage::sqlite3_ondisk::DatabaseHeader;
 use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use crate::sync::Arc;
 use crate::sync::RwLock;
+use crate::turso_assert;
 use std::fmt::Debug;
 
 pub mod logical_log;
-use crate::mvcc::database::LogRecord;
+use crate::mvcc::database::{LogRecord, RowVersion};
 use crate::mvcc::persistent_storage::logical_log::{
-    LogicalLog, OnSerializationComplete, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
+    serialize_header_entry, serialize_op_entry, LogicalLog, OnSerializationComplete,
+    DEFAULT_LOG_CHECKPOINT_THRESHOLD,
 };
-use crate::{CheckpointResult, Completion, File, Result};
+use crate::{CheckpointResult, Completion, File, LimboError, Result};
 
 pub trait DurableStorage: Send + Sync + Debug {
+    /// Append one row-version op to `log_record`'s payload buffer, in the
+    /// on-disk wire format used by the logical log. Updates `op_count`.
+    ///
+    /// Called incrementally during `BuildLogRecord` so the committing
+    /// transaction can stream bytes into the log record without first
+    /// collecting a `Vec<RowVersion>` intermediate.
+    fn serialize_row_version(
+        &self,
+        log_record: &mut LogRecord,
+        row_version: &RowVersion,
+    ) -> Result<()>;
+
+    /// Append a `DatabaseHeader` op to `log_record`'s payload buffer.
+    /// Asserts that no header op has already been appended. Updates
+    /// `op_count` and sets `has_header`.
+    fn serialize_database_header(
+        &self,
+        log_record: &mut LogRecord,
+        header: &DatabaseHeader,
+    ) -> Result<()>;
+
     /// Write a transaction to the logical log without advancing the writer offset.
     ///
+    /// `m.buf` is the plaintext payload built incrementally via
+    /// [`serialize_row_version`] and [`serialize_database_header`]. The
+    /// implementation reuses `m.buf` as the on-disk frame buffer (wrapping it
+    /// with the TX header, optional chunked encryption, and the trailer), then
+    /// hands the same allocation to the I/O layer — no separate framing buffer
+    /// is kept alive across calls. On return, `m.buf` is emptied.
+    ///
     /// If `on_serialization_complete` is provided, it is called with a zero-copy
-    /// reference to the serialized frame bytes and the running CRC after
-    /// serialization but before the disk write. The callback runs while the
-    /// internal write lock is held, so it should be fast (e.g. memcpy to a side
-    /// buffer).
+    /// reference to the framed bytes and the running CRC after framing but
+    /// before the disk write. The callback runs while the internal write lock
+    /// is held, so it should be fast (e.g. memcpy to a side buffer).
     fn log_tx(
         &self,
-        m: &LogRecord,
+        m: &mut LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)>;
 
@@ -105,9 +135,38 @@ impl Storage {
 }
 
 impl DurableStorage for Storage {
+    fn serialize_row_version(
+        &self,
+        log_record: &mut LogRecord,
+        row_version: &RowVersion,
+    ) -> Result<()> {
+        serialize_op_entry(&mut log_record.buf, row_version)?;
+        log_record.op_count = log_record.op_count.checked_add(1).ok_or_else(|| {
+            LimboError::InternalError("logical log op_count exceeds u32".to_string())
+        })?;
+        Ok(())
+    }
+
+    fn serialize_database_header(
+        &self,
+        log_record: &mut LogRecord,
+        header: &DatabaseHeader,
+    ) -> Result<()> {
+        turso_assert!(
+            !log_record.has_header,
+            "DatabaseHeader op appended more than once to a single LogRecord"
+        );
+        serialize_header_entry(&mut log_record.buf, header);
+        log_record.has_header = true;
+        log_record.op_count = log_record.op_count.checked_add(1).ok_or_else(|| {
+            LimboError::InternalError("logical log op_count exceeds u32".to_string())
+        })?;
+        Ok(())
+    }
+
     fn log_tx(
         &self,
-        m: &LogRecord,
+        m: &mut LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
         self.logical_log

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -39,7 +39,7 @@ pub trait DurableStorage: Send + Sync + Debug {
     /// is held, so it should be fast (e.g. memcpy to a side buffer).
     fn log_tx(
         &self,
-        m: &mut LogRecord,
+        m: LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)>;
 
@@ -153,7 +153,7 @@ impl DurableStorage for Storage {
 
     fn log_tx(
         &self,
-        m: &mut LogRecord,
+        m: LogRecord,
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)> {
         self.logical_log

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -18,10 +18,6 @@ use crate::{CheckpointResult, Completion, File, LimboError, Result};
 pub trait DurableStorage: Send + Sync + Debug {
     /// Append one row-version op to `log_record`'s payload buffer, in the
     /// on-disk wire format used by the logical log. Updates `op_count`.
-    ///
-    /// Called incrementally during `BuildLogRecord` so the committing
-    /// transaction can stream bytes into the log record without first
-    /// collecting a `Vec<RowVersion>` intermediate.
     fn serialize_row_version(
         &self,
         log_record: &mut LogRecord,
@@ -29,8 +25,6 @@ pub trait DurableStorage: Send + Sync + Debug {
     ) -> Result<()>;
 
     /// Append a `DatabaseHeader` op to `log_record`'s payload buffer.
-    /// Asserts that no header op has already been appended. Updates
-    /// `op_count` and sets `has_header`.
     fn serialize_database_header(
         &self,
         log_record: &mut LogRecord,
@@ -38,13 +32,6 @@ pub trait DurableStorage: Send + Sync + Debug {
     ) -> Result<()>;
 
     /// Write a transaction to the logical log without advancing the writer offset.
-    ///
-    /// `m.buf` is the plaintext payload built incrementally via
-    /// [`serialize_row_version`] and [`serialize_database_header`]. The
-    /// implementation reuses `m.buf` as the on-disk frame buffer (wrapping it
-    /// with the TX header, optional chunked encryption, and the trailer), then
-    /// hands the same allocation to the I/O layer — no separate framing buffer
-    /// is kept alive across calls. On return, `m.buf` is emptied.
     ///
     /// If `on_serialization_complete` is provided, it is called with a zero-copy
     /// reference to the framed bytes and the running CRC after framing but

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -63,7 +63,7 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
 
     fn log_tx(
         &self,
-        m: &mut turso_core::mvcc::database::LogRecord,
+        m: turso_core::mvcc::database::LogRecord,
         on_serialization_complete: Option<&dyn Fn(&[u8], u32) -> turso_core::Result<()>>,
     ) -> turso_core::Result<(turso_core::Completion, u64)> {
         self.used_log_tx

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -45,9 +45,25 @@ impl RecordingDurableStorage {
 }
 
 impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableStorage {
+    fn serialize_row_version(
+        &self,
+        log_record: &mut turso_core::mvcc::database::LogRecord,
+        row_version: &turso_core::mvcc::database::RowVersion,
+    ) -> turso_core::Result<()> {
+        self.inner.serialize_row_version(log_record, row_version)
+    }
+
+    fn serialize_database_header(
+        &self,
+        log_record: &mut turso_core::mvcc::database::LogRecord,
+        header: &turso_core::storage::sqlite3_ondisk::DatabaseHeader,
+    ) -> turso_core::Result<()> {
+        self.inner.serialize_database_header(log_record, header)
+    }
+
     fn log_tx(
         &self,
-        m: &turso_core::mvcc::database::LogRecord,
+        m: &mut turso_core::mvcc::database::LogRecord,
         on_serialization_complete: Option<&dyn Fn(&[u8], u32) -> turso_core::Result<()>>,
     ) -> turso_core::Result<(turso_core::Completion, u64)> {
         self.used_log_tx


### PR DESCRIPTION
Fixes: https://github.com/tursodatabase/turso/issues/6764

## Description

As we all know, cloning is the root of all evils (uncle iroh). We've been building a `LogRecord` which has a `Vec<RowVersion>` which we then serialize into a `Vec<u8>`. This is obviously bad for performance because we could instead serialize directly instead of serializing a cloned list of rows. This is also bad for heap usage because we basically allocated twice the amount of buffers.

In this PR we solve this by serializing directly in CommitStateMachine and then on `log_tx` we simply finalize the format.

TODO: 
- [x] run a memory benchmark on create index
- [x] run performance benchmark with create index
- [x] do a last review of the ai generated code. I've iterate through it and it looks okay but I want to make sure we don't do something stupid  

**disclaimer** this PR is based of the branch in https://github.com/tursodatabase/turso/pull/7033

## Results

### Commit only benchmark (500K rows)
```
CREATE INDEX on populated table/turso_commit_only/500000
                        time:   [58.764 ms 74.007 ms 90.640 ms]
                        thrpt:  [5.5163 Melem/s 6.7561 Melem/s 8.5087 Melem/s]
                 change:
                        time:   [-56.717% -43.530% -27.793%] (p = 0.00 < 0.05)
                        thrpt:  [+38.490% +77.085% +131.04%]
                        Performance has improved.
```

### BEGIN + CREATE INDEX + COMMIT (500k rows)
**Not significant**
```
CREATE INDEX on populated table/turso_total/500000
                        time:   [1.3931 s 1.4936 s 1.6220 s]
                        thrpt:  [308.27 Kelem/s 334.75 Kelem/s 358.90 Kelem/s]
                 change:
                        time:   [-10.834% -1.2017% +10.229%] (p = 0.84 > 0.05)
                        thrpt:  [-9.2794% +1.2163% +12.151%]
```
### Peak memory usage
`~480 MB (−2.6%) usage`


## Description of AI Usage

Clanker galore. I basically knew what needed to be done. Like having new functions in `DurableStorage` which would abstract serialization implementation from the `CommitStateMachine`, preallocate LogHeader buffer bytes before appending ops... One cute optimization that clanker did is implementing `Buffer::HeapView` which allows us to have a the buffer with some prefix we may or not want to be flushed to disk.