### PR TITLE
simulator: add OverflowChainIntegrity + NestedSavepointConsistency properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * sql_generation: bucketed `gen_random_text` distribution (95% short / 4% medium / 1% overflow up to ~16 KiB) so simulator-driven workloads can exercise B-tree overflow page allocation.
+* simulator: add `OverflowChainIntegrity` DST property that drives the B-tree overflow page chain allocator with >8 KiB payloads across the in-page/overflow boundary. Enabled by default; gated by `--disable-overflow-chain-integrity`.
 
 ## 0.5.0 -- 2026-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+* sql_generation: bucketed `gen_random_text` distribution (95% short / 4% medium / 1% overflow up to ~16 KiB) so simulator-driven workloads can exercise B-tree overflow page allocation.
+
 ## 0.5.0 -- 2026-03-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 * sql_generation: bucketed `gen_random_text` distribution (95% short / 4% medium / 1% overflow up to ~16 KiB) so simulator-driven workloads can exercise B-tree overflow page allocation.
 * simulator: add `OverflowChainIntegrity` DST property that drives the B-tree overflow page chain allocator with >8 KiB payloads across the in-page/overflow boundary. Enabled by default; gated by `--disable-overflow-chain-integrity`.
+* simulator: add `NestedSavepointConsistency` DST property that drives 2–4 level nested `SAVEPOINT`s with random writes between levels and randomized `RELEASE`/`ROLLBACK TO` close patterns. Enabled by default; gated by `--disable-nested-savepoint-consistency`.
 
 ## 0.5.0 -- 2026-03-04
 

--- a/sql_generation/generation/mod.rs
+++ b/sql_generation/generation/mod.rs
@@ -168,11 +168,15 @@ pub fn pick_n_unique<R: Rng + ?Sized>(
 /// gen_random_text uses `anarchist_readable_name_generator_lib` to generate random
 /// readable names for tables, columns, text values etc.
 pub fn gen_random_text<R: Rng + ?Sized>(rng: &mut R) -> String {
-    let big_text = rng.random_ratio(1, 1000);
-    if big_text {
-        // let max_size: u64 = 2 * 1024 * 1024 * 1024;
-        let max_size: u64 = 2 * 1024;
-        let size = rng.random_range(1024..max_size);
+    // 95% short names, 4% medium text, 1% overflow text (>max_local ~3900B on 4KiB pages) to exercise overflow chains.
+    let size = if rng.random_ratio(95, 100) {
+        None
+    } else if rng.random_ratio(4, 5) {
+        Some(rng.random_range(100..1024))
+    } else {
+        Some(rng.random_range(4096..16384))
+    };
+    if let Some(size) = size {
         let mut name = String::with_capacity(size as usize);
         for i in 0..size {
             name.push(((i % 26) as u8 + b'A') as char);

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -73,6 +73,7 @@ simulator covers and tests.
 | SELECT ... JOIN USING     | No      |                                                                                   |
 | SELECT ... NATURAL JOIN   | No      |                                                                                   |
 | UPDATE                    | Partial |                                                                                   |
+| Overflow page chains      | Partial | Covered by OverflowChainIntegrity property (large payload insert/update/delete).  |
 | VACUUM                    | No      |                                                                                   |
 | WITH clause               | No      |                                                                                   |
 | WINDOW functions          | No      |                                                                                   |

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -59,6 +59,7 @@ simulator covers and tests.
 | ROLLBACK TRANSACTION      | Partial | TODO                                                                              |
 | ROLLBACK TO SAVEPOINT     | Partial | Covered by SavepointRollback property.                                            |
 | SAVEPOINT                 | Partial | Covered by SavepointRollback property.                                            |
+| Nested savepoints         | Partial | Covered by NestedSavepointConsistency property (2-4 levels, mixed close actions). |
 | SELECT                    | Partial | TODO                                                                              |
 | SELECT ... WHERE          | Partial | TODO                                                                              |
 | SELECT ... WHERE ... LIKE | No      |                                                                                   |

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -36,7 +36,7 @@ use crate::{
             Assertion, Interaction, InteractionBuilder, InteractionType, PropertyMetadata,
         },
         metrics::Remaining,
-        property::{InteractiveQueryInfo, Property, PropertyDiscriminants},
+        property::{CloseAction, InteractiveQueryInfo, Property, PropertyDiscriminants},
     },
     runner::env::SimulatorEnv,
 };
@@ -234,6 +234,16 @@ impl Property {
                         unreachable!()
                     };
                     random_main_table_write(rng, ctx, write_kinds)
+                }
+            }
+            Property::NestedSavepointConsistency { .. } => {
+                |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, _property: &Property| {
+                    const WRITE_KINDS: &[QueryDiscriminants] = &[
+                        QueryDiscriminants::Insert,
+                        QueryDiscriminants::Update,
+                        QueryDiscriminants::Delete,
+                    ];
+                    random_main_table_write(rng, ctx, WRITE_KINDS)
                 }
             }
             Property::OverflowChainIntegrity { .. } => {
@@ -1268,6 +1278,76 @@ impl Property {
                 interactions.push(assert_integrity_check(tables, connection_index));
                 interactions
             }
+            Property::NestedSavepointConsistency {
+                table,
+                savepoint_names,
+                queries,
+                level_sizes,
+                close_actions,
+            } => {
+                let depth = savepoint_names.len();
+                assert!((2..=4).contains(&depth));
+                assert_eq!(level_sizes.len(), depth);
+                assert_eq!(close_actions.len(), depth);
+                assert_eq!(level_sizes.iter().sum::<usize>(), queries.len());
+
+                let mut query_chunks = Vec::with_capacity(depth);
+                let mut offset = 0usize;
+                for size in level_sizes {
+                    let end = offset + *size;
+                    query_chunks.push(queries[offset..end].to_vec());
+                    offset = end;
+                }
+
+                let mut interactions = Vec::new();
+                for i in 0..depth {
+                    interactions.push(InteractionBuilder::with_interaction(
+                        InteractionType::Query(Query::Savepoint(Savepoint {
+                            name: savepoint_names[i].clone(),
+                        })),
+                    ));
+                    interactions.extend(query_chunks[i].iter().cloned().map(|query| {
+                        InteractionBuilder::with_interaction(InteractionType::Query(query))
+                    }));
+                }
+
+                for i in (0..depth).rev() {
+                    let savepoint_name = savepoint_names[i].clone();
+                    match close_actions[i] {
+                        CloseAction::Release => {
+                            interactions.push(InteractionBuilder::with_interaction(
+                                InteractionType::Query(Query::ReleaseSavepoint(ReleaseSavepoint {
+                                    name: savepoint_name,
+                                })),
+                            ));
+                        }
+                        CloseAction::RollbackTo | CloseAction::RollbackToThenRelease => {
+                            interactions.push(InteractionBuilder::with_interaction(
+                                InteractionType::Query(Query::RollbackToSavepoint(
+                                    RollbackToSavepoint {
+                                        name: savepoint_name.clone(),
+                                    },
+                                )),
+                            ));
+                            interactions.push(InteractionBuilder::with_interaction(
+                                InteractionType::Query(Query::ReleaseSavepoint(ReleaseSavepoint {
+                                    name: savepoint_name,
+                                })),
+                            ));
+                        }
+                    }
+                }
+
+                interactions.extend(assert_all_table_values(
+                    std::slice::from_ref(table),
+                    connection_index,
+                ));
+                interactions.push(assert_integrity_check(
+                    std::slice::from_ref(table),
+                    connection_index,
+                ));
+                interactions
+            }
             Property::OverflowChainIntegrity {
                 table,
                 column,
@@ -1830,6 +1910,53 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_nested_savepoint_consistency<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let candidates = ctx
+        .tables()
+        .iter()
+        .filter(|t| !t.name.contains('.'))
+        .collect::<Vec<_>>();
+    let Some(table) = (if candidates.is_empty() {
+        ctx.tables().first()
+    } else {
+        Some(*pick(&candidates, rng))
+    }) else {
+        return Property::Queries {
+            queries: Vec::new(),
+        };
+    };
+
+    let table = table.name.clone();
+    let depth = rng.random_range(2..=4);
+    let savepoint_names = (0..depth)
+        .map(|i| format!("sim_nested_{}_{}", rng.random::<u32>(), i))
+        .collect::<Vec<_>>();
+    let level_sizes = (0..depth)
+        .map(|_| rng.random_range(1..=3))
+        .collect::<Vec<_>>();
+    let queries = std::iter::repeat_n(Query::Placeholder, level_sizes.iter().sum()).collect();
+    let close_actions = (0..depth)
+        .map(|_| match rng.random_range(0..3) {
+            0 => CloseAction::Release,
+            1 => CloseAction::RollbackTo,
+            _ => CloseAction::RollbackToThenRelease,
+        })
+        .collect::<Vec<_>>();
+
+    Property::NestedSavepointConsistency {
+        table,
+        savepoint_names,
+        queries,
+        level_sizes,
+        close_actions,
+    }
+}
+
 fn overflow_large_value_a() -> String {
     format!("{}{}", "overflow_a_", "x".repeat(8192))
 }
@@ -2103,6 +2230,9 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
             PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
+            PropertyDiscriminants::NestedSavepointConsistency => {
+                property_nested_savepoint_consistency
+            }
             PropertyDiscriminants::OverflowChainIntegrity => property_overflow_chain_integrity,
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
@@ -2159,6 +2289,16 @@ impl PropertyDiscriminants {
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
                     remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::NestedSavepointConsistency => {
+                if !env.opts.disable_nested_savepoint_consistency
+                    && !env.profile.mvcc
+                    && ctx.tables().iter().any(|table| !table.name.contains('.'))
+                {
+                    u32::min(remaining.insert, remaining.update).max(1)
                 } else {
                     0
                 }
@@ -2271,6 +2411,9 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::NestedSavepointConsistency => QueryCapabilities::INSERT
+                .union(QueryCapabilities::UPDATE)
+                .union(QueryCapabilities::DELETE),
             PropertyDiscriminants::OverflowChainIntegrity => QueryCapabilities::INSERT
                 .union(QueryCapabilities::UPDATE)
                 .union(QueryCapabilities::DELETE)

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -236,6 +236,41 @@ impl Property {
                     random_main_table_write(rng, ctx, write_kinds)
                 }
             }
+            Property::OverflowChainIntegrity { .. } => {
+                |rng: &mut R, ctx: &G, query_distr: &QueryDistribution, property: &Property| {
+                    let Property::OverflowChainIntegrity { table, column, .. } = property else {
+                        unreachable!()
+                    };
+                    let query = Query::arbitrary_from(rng, ctx, query_distr);
+                    let tracked_row = vec![SimValue(types::Value::Text(
+                        overflow_large_value_a().into(),
+                    ))];
+                    let tracked_table = Table {
+                        name: table.clone(),
+                        columns: vec![sql_generation::model::table::Column {
+                            name: column.clone(),
+                            column_type: ColumnType::Text,
+                            constraints: Vec::new(),
+                        }],
+                        rows: vec![tracked_row],
+                        indexes: Vec::new(),
+                    };
+                    match &query {
+                        Query::Drop(Drop { table: t }) if *t == *table => None,
+                        Query::AlterTable(AlterTable { table_name: t, .. }) if *t == *table => None,
+                        Query::Delete(Delete {
+                            table: t,
+                            predicate,
+                        }) if *t == *table
+                            && predicate.test(&tracked_table.rows[0], &tracked_table) =>
+                        {
+                            None
+                        }
+                        Query::Update(Update { table: t, .. }) if *t == *table => None,
+                        _ => Some(query),
+                    }
+                }
+            }
             Property::Queries { .. } => {
                 unreachable!("No extensional querie generation for `Property::Queries`")
             }
@@ -1233,6 +1268,123 @@ impl Property {
                 interactions.push(assert_integrity_check(tables, connection_index));
                 interactions
             }
+            Property::OverflowChainIntegrity {
+                table,
+                column,
+                queries,
+            } => {
+                let mut interactions = Vec::with_capacity(queries.len() + 11);
+                if table.starts_with("__overflow_chain_integrity_") {
+                    interactions.push({
+                        let mut builder = InteractionBuilder::with_interaction(
+                            InteractionType::Query(Query::Create(Create {
+                                table: Table {
+                                    name: table.clone(),
+                                    columns: vec![sql_generation::model::table::Column {
+                                        name: column.clone(),
+                                        column_type: ColumnType::Blob,
+                                        constraints: Vec::new(),
+                                    }],
+                                    rows: Vec::new(),
+                                    indexes: Vec::new(),
+                                },
+                            })),
+                        );
+                        builder.ignore_error(true);
+                        builder
+                    });
+                }
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Insert(Insert::Values {
+                        table: table.clone(),
+                        values: vec![vec![SimValue(types::Value::Text(
+                            overflow_large_value_a().into(),
+                        ))]],
+                        on_conflict: None,
+                    })),
+                ));
+                for i in 0..4 {
+                    let alt_value = if i % 2 == 0 {
+                        overflow_large_value_b()
+                    } else {
+                        overflow_large_value_a()
+                    };
+                    interactions.push(InteractionBuilder::with_interaction(
+                        InteractionType::Query(Query::Insert(Insert::Values {
+                            table: table.clone(),
+                            values: vec![vec![SimValue(types::Value::Text(alt_value.into()))]],
+                            on_conflict: None,
+                        })),
+                    ));
+                }
+                interactions.extend(queries.clone().into_iter().map(|query| {
+                    let mut builder =
+                        InteractionBuilder::with_interaction(InteractionType::Query(query));
+                    builder.property_meta(PropertyMetadata::new(self, true));
+                    builder
+                }));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Update(Update {
+                        table: table.clone(),
+                        set_values: vec![(
+                            column.clone(),
+                            SetValue::Simple(SimValue(types::Value::Text(
+                                overflow_small_value().into(),
+                            ))),
+                        )],
+                        predicate: Predicate::eq(
+                            Predicate::column(column.clone()),
+                            Predicate::value(SimValue(types::Value::Text(
+                                overflow_large_value_a().into(),
+                            ))),
+                        ),
+                    })),
+                ));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Update(Update {
+                        table: table.clone(),
+                        set_values: vec![(
+                            column.clone(),
+                            SetValue::Simple(SimValue(types::Value::Text(
+                                overflow_large_value_b().into(),
+                            ))),
+                        )],
+                        predicate: Predicate::eq(
+                            Predicate::column(column.clone()),
+                            Predicate::value(SimValue(types::Value::Text(
+                                overflow_small_value().into(),
+                            ))),
+                        ),
+                    })),
+                ));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Delete(Delete {
+                        table: table.clone(),
+                        predicate: Predicate::eq(
+                            Predicate::column(column.clone()),
+                            Predicate::value(SimValue(types::Value::Text(
+                                overflow_large_value_b().into(),
+                            ))),
+                        ),
+                    })),
+                ));
+                interactions.extend(assert_all_table_values(
+                    std::slice::from_ref(table),
+                    connection_index,
+                ));
+                interactions.push(assert_integrity_check(
+                    std::slice::from_ref(table),
+                    connection_index,
+                ));
+                if table.starts_with("__overflow_chain_integrity_") {
+                    interactions.push(InteractionBuilder::with_interaction(
+                        InteractionType::Query(Query::Drop(Drop {
+                            table: table.clone(),
+                        })),
+                    ));
+                }
+                interactions
+            }
         };
 
         assert!(!interactions.is_empty());
@@ -1678,6 +1830,58 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     }
 }
 
+fn overflow_large_value_a() -> String {
+    format!("{}{}", "overflow_a_", "x".repeat(8192))
+}
+
+fn overflow_large_value_b() -> String {
+    format!("{}{}", "overflow_b_", "y".repeat(8192))
+}
+
+fn overflow_small_value() -> &'static str {
+    "small-overflow-marker"
+}
+
+fn property_overflow_chain_integrity<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let candidate_tables = ctx
+        .tables()
+        .iter()
+        .filter_map(|table| {
+            if table.columns.len() != 1 {
+                return None;
+            }
+            table.columns.first().and_then(|column| {
+                if matches!(column.column_type, ColumnType::Text | ColumnType::Blob) {
+                    Some((table.name.clone(), column.name.clone()))
+                } else {
+                    None
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let (table, column) = if candidate_tables.is_empty() {
+        (
+            format!("__overflow_chain_integrity_{}", rng.random::<u32>()),
+            "payload".to_string(),
+        )
+    } else {
+        pick(&candidate_tables, rng).clone()
+    };
+
+    let amount = rng.random_range(0..3);
+    Property::OverflowChainIntegrity {
+        table,
+        column,
+        queries: vec![Query::Placeholder; amount],
+    }
+}
+
 fn property_table_has_expected_content<R: rand::Rng + ?Sized>(
     rng: &mut R,
     _query_distr: &QueryDistribution,
@@ -1899,6 +2103,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
             PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
+            PropertyDiscriminants::OverflowChainIntegrity => property_overflow_chain_integrity,
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
@@ -1954,6 +2159,13 @@ impl PropertyDiscriminants {
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
                     remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::OverflowChainIntegrity => {
+                if !env.opts.disable_overflow_chain_integrity && !env.profile.mvcc {
+                    (u32::min(remaining.insert, remaining.update) / 2).max(1)
                 } else {
                     0
                 }
@@ -2059,6 +2271,10 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::OverflowChainIntegrity => QueryCapabilities::INSERT
+                .union(QueryCapabilities::UPDATE)
+                .union(QueryCapabilities::DELETE)
+                .union(QueryCapabilities::CREATE),
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -191,6 +191,18 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// OverflowChainIntegrity exercises the B-tree overflow page chain allocator.
+    /// It inserts a row with an \>8 KiB TEXT/BLOB payload (well above the 4 KiB
+    /// page max-local threshold), then mutates the payload across the
+    /// in-page <-> overflow boundary multiple times (shrink to <200 B, regrow to
+    /// \>8 KiB) before deleting it. Asserts shadow-model parity and PRAGMA
+    /// integrity_check on the target table. Catches overflow allocator /
+    /// deallocator and freelist-interaction bugs.
+    OverflowChainIntegrity {
+        table: String,
+        column: String,
+        queries: Vec<Query>,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -220,6 +232,7 @@ impl Property {
                 | Property::DeleteSelect { .. }
                 | Property::DropSelect { .. }
                 | Property::SavepointRollback { .. }
+                | Property::OverflowChainIntegrity { .. }
                 | Property::Queries { .. }
         )
     }
@@ -231,6 +244,7 @@ impl Property {
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
+            | Property::OverflowChainIntegrity { queries, .. }
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -3,6 +3,13 @@ use sql_generation::model::query::{Create, Insert, Select, predicate::Predicate,
 
 use crate::model::{Query, QueryDiscriminants};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CloseAction {
+    Release,
+    RollbackTo,
+    RollbackToThenRelease,
+}
+
 /// Properties are representations of executable specifications
 /// about the database behavior.
 #[derive(Debug, Clone, Serialize, Deserialize, strum::EnumDiscriminants, strum::IntoStaticStr)]
@@ -191,6 +198,20 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// NestedSavepointConsistency stress-tests the engine's nested savepoint
+    /// state-restoration logic. It opens 2-4 nested SAVEPOINTs with random writes
+    /// interleaved between levels, then closes them innermost-first with a
+    /// randomized mix of RELEASE / ROLLBACK TO actions. After the close sequence,
+    /// the property asserts shadow-model parity and PRAGMA integrity_check on the
+    /// target table. Targets bugs in subjournal coalescing, partial unwinding,
+    /// and page-cache restoration across nested levels.
+    NestedSavepointConsistency {
+        table: String,
+        savepoint_names: Vec<String>,
+        queries: Vec<Query>,
+        level_sizes: Vec<usize>,
+        close_actions: Vec<CloseAction>,
+    },
     /// OverflowChainIntegrity exercises the B-tree overflow page chain allocator.
     /// It inserts a row with an \>8 KiB TEXT/BLOB payload (well above the 4 KiB
     /// page max-local threshold), then mutates the payload across the
@@ -232,6 +253,7 @@ impl Property {
                 | Property::DeleteSelect { .. }
                 | Property::DropSelect { .. }
                 | Property::SavepointRollback { .. }
+                | Property::NestedSavepointConsistency { .. }
                 | Property::OverflowChainIntegrity { .. }
                 | Property::Queries { .. }
         )
@@ -244,6 +266,7 @@ impl Property {
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
+            | Property::NestedSavepointConsistency { queries, .. }
             | Property::OverflowChainIntegrity { queries, .. }
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -153,6 +153,12 @@ pub struct SimulatorCLI {
     pub disable_savepoint_rollback: bool,
     #[clap(
         long,
+        help = "disable Nested-Savepoint-Consistency Property",
+        default_value_t = false
+    )]
+    pub disable_nested_savepoint_consistency: bool,
+    #[clap(
+        long,
         help = "disable Overflow-Chain-Integrity Property",
         default_value_t = false
     )]

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -151,6 +151,12 @@ pub struct SimulatorCLI {
         default_value_t = false
     )]
     pub disable_savepoint_rollback: bool,
+    #[clap(
+        long,
+        help = "disable Overflow-Chain-Integrity Property",
+        default_value_t = false
+    )]
+    pub disable_overflow_chain_integrity: bool,
     #[clap(long, help = "disable FsyncNoWait Property", default_value_t = true)]
     pub disable_fsync_no_wait: bool,
     #[clap(long, help = "disable FaultyQuery Property")]

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1105,6 +1105,7 @@ impl SimulatorEnv {
             disable_union_all_preserves_cardinality: cli_opts
                 .disable_union_all_preserves_cardinality,
             disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
+            disable_nested_savepoint_consistency: cli_opts.disable_nested_savepoint_consistency,
             disable_overflow_chain_integrity: cli_opts.disable_overflow_chain_integrity,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
@@ -1444,6 +1445,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_where_true_false_null: bool,
     pub(crate) disable_union_all_preserves_cardinality: bool,
     pub(crate) disable_savepoint_rollback: bool,
+    pub(crate) disable_nested_savepoint_consistency: bool,
     pub(crate) disable_overflow_chain_integrity: bool,
     pub(crate) disable_fsync_no_wait: bool,
     pub(crate) disable_faulty_query: bool,

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1105,6 +1105,7 @@ impl SimulatorEnv {
             disable_union_all_preserves_cardinality: cli_opts
                 .disable_union_all_preserves_cardinality,
             disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
+            disable_overflow_chain_integrity: cli_opts.disable_overflow_chain_integrity,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
             page_size: 4096, // TODO: randomize this too
@@ -1443,6 +1444,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_where_true_false_null: bool,
     pub(crate) disable_union_all_preserves_cardinality: bool,
     pub(crate) disable_savepoint_rollback: bool,
+    pub(crate) disable_overflow_chain_integrity: bool,
     pub(crate) disable_fsync_no_wait: bool,
     pub(crate) disable_faulty_query: bool,
     pub(crate) disable_reopen_database: bool,


### PR DESCRIPTION
## Summary

Adds two new DST properties and the SQL-generation lift needed to drive them, both exercising B-tree code paths that the simulator could not previously reach.

- **`OverflowChainIntegrity`** — inserts an >8 KiB TEXT payload, mutates it across the in-page ↔ overflow boundary (shrink to <200 B, regrow to >8 KiB), then deletes. Asserts shadow-model parity + `PRAGMA integrity_check` on the target table. The end-of-run rusqlite integrity check validates structural overflow chains as the corruption oracle. Note that `core/storage/btree.rs:6056` has a long-standing `TODO` for "Overflow pages are correct" in turso's own integrity_check — this property closes that visibility gap from DST.

- **`NestedSavepointConsistency`** — generates 2–4 nested `SAVEPOINT`s with random writes between levels, then closes innermost-first with a randomized mix of `RELEASE` / `ROLLBACK TO` / `ROLLBACK TO`-then-`RELEASE`. Asserts shadow-model parity + integrity_check. Targets subjournal coalescing, partial unwinding, and page-cache restoration across nested levels.

- **Generator cap lift in `sql_generation/generation/mod.rs`** — `gen_random_text` now uses a 95/4/1 distribution (short / medium / overflow) producing up to ~16 KiB payloads occasionally. SQLite's `max_local` on a 4 KiB page is ~4061 bytes, so the overflow bucket starting at 4096 guarantees overflow allocation.

Both properties are enabled by default and have `--disable-overflow-chain-integrity` and `--disable-nested-savepoint-consistency` CLI flags. Both are weight-gated on "at least one main (non-attached) table exists" and skip themselves under MVCC.

## What this does *not* claim

Across ~400 distinct fuzz seeds spanning default / write_heavy_spill / write_stress / savepoint_stress profiles, no data corruption surfaced through these properties. This PR is a **coverage improvement**, not a corruption disclosure — opening it because the surfaces it exercises (overflow chains, nested savepoint state-restoration) are high-value blind spots, regardless of whether bugs live there today.

A follow-up issue will propose extending the simulator to drive explicit `PRAGMA wal_checkpoint(TRUNCATE)` between writes and re-enable sync-fault injection (currently neutered at `testing/simulator/runner/file.rs:194` per issue #2091). The WAL → main-DB checkpoint phase is the largest remaining unaudited surface for DST-detectable corruption.

## Test plan

- [x] \`cargo build -p limbo_sim\` clean
- [x] \`cargo clippy -p limbo_sim --all-features --all-targets -- --deny=warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test -p limbo_sim\` — 27/27 pass
- [x] 30-iteration fuzz on \`-n 300 -k 80 -t 30 --disable-heuristic-shrinking\` — all succeed
- [x] 5 manual seeds (42, 100, 999, 31337, 7777) — all reach \`simulation succeeded\`
- [x] Property invocation counts on seed 31337: OverflowChainIntegrity ×2, NestedSavepointConsistency ×10 (vs SavepointRollback ×22, InsertValuesSelect ×8) — healthy distribution