### PR TITLE
simulator: drive wal_checkpoint in stress profile

### DIFF
--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    WalCheckpoint(CheckpointMode),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,6 +14,14 @@ pub enum VacuumMode {
     None,
     Incremental,
     Full,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CheckpointMode {
+    Passive,
+    Full,
+    Restart,
+    Truncate,
 }
 
 impl Display for Pragma {
@@ -31,6 +40,15 @@ impl Display for Pragma {
             Pragma::ForeignKeyList(table_name) => {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
+            }
+            Pragma::WalCheckpoint(mode) => {
+                let mode = match mode {
+                    CheckpointMode::Passive => "PASSIVE",
+                    CheckpointMode::Full => "FULL",
+                    CheckpointMode::Restart => "RESTART",
+                    CheckpointMode::Truncate => "TRUNCATE",
+                };
+                write!(f, "PRAGMA wal_checkpoint({mode})")
             }
         }
     }

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -154,7 +154,7 @@ simulator covers and tests.
 | PRAGMA vdbe_listing              | No         |                                                  |
 | PRAGMA vdbe_trace                | No         |                                                  |
 | PRAGMA wal_autocheckpoint        | No         |                                                  |
-| PRAGMA wal_checkpoint            | No         |                                                  |
+| PRAGMA wal_checkpoint            | Partial    | Explicit CheckpointStress property drives modes  |
 | PRAGMA writable_schema           | No         |                                                  |
 
 ### Expressions

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -14,6 +14,7 @@ use sql_generation::{
         query::{
             Create, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
+            pragma::{CheckpointMode, Pragma},
             predicate::Predicate,
             select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
             transaction::{Begin, Commit, Rollback},
@@ -231,6 +232,14 @@ impl Property {
             Property::SavepointRollback { .. } => {
                 |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
                     let Property::SavepointRollback { write_kinds, .. } = property else {
+                        unreachable!()
+                    };
+                    random_main_table_write(rng, ctx, write_kinds)
+                }
+            }
+            Property::CheckpointStress { .. } => {
+                |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
+                    let Property::CheckpointStress { write_kinds, .. } = property else {
                         unreachable!()
                     };
                     random_main_table_write(rng, ctx, write_kinds)
@@ -1233,6 +1242,33 @@ impl Property {
                 interactions.push(assert_integrity_check(tables, connection_index));
                 interactions
             }
+            Property::CheckpointStress {
+                queries,
+                tables,
+                checkpoint_mode,
+                commit_before_checkpoint,
+                ..
+            } => {
+                let mut interactions = Vec::with_capacity(
+                    queries.len() + usize::from(*commit_before_checkpoint) + 2 + tables.len() * 2,
+                );
+                interactions.extend(queries.clone().into_iter().map(|query| {
+                    InteractionBuilder::with_interaction(InteractionType::Query(query))
+                }));
+                if *commit_before_checkpoint {
+                    interactions.push(InteractionBuilder::with_interaction(
+                        InteractionType::Query(Query::Commit(Commit)),
+                    ));
+                }
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Pragma(Pragma::WalCheckpoint(
+                        checkpoint_mode.clone(),
+                    ))),
+                ));
+                interactions.extend(assert_all_table_values(tables, connection_index));
+                interactions.push(assert_integrity_check(tables, connection_index));
+                interactions
+            }
         };
 
         assert!(!interactions.is_empty());
@@ -1678,6 +1714,55 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_checkpoint_stress<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    mvcc: bool,
+) -> Property {
+    let tables = ctx
+        .tables()
+        .iter()
+        .filter(|table| !table.name.contains('.'))
+        .map(|table| table.name.clone())
+        .collect::<Vec<_>>();
+    assert!(!tables.is_empty());
+
+    let write_kinds = query_distr
+        .positive_items()
+        .filter(|query| {
+            matches!(
+                query,
+                QueryDiscriminants::Insert
+                    | QueryDiscriminants::Update
+                    | QueryDiscriminants::Delete
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(!write_kinds.is_empty());
+
+    let checkpoint_mode = if mvcc {
+        CheckpointMode::Truncate
+    } else {
+        let checkpoint_modes = [
+            CheckpointMode::Passive,
+            CheckpointMode::Full,
+            CheckpointMode::Restart,
+            CheckpointMode::Truncate,
+        ];
+        pick(&checkpoint_modes, rng).clone()
+    };
+    let amount = rng.random_range(1..=5);
+
+    Property::CheckpointStress {
+        queries: std::iter::repeat_n(Query::Placeholder, amount).collect(),
+        tables,
+        write_kinds,
+        checkpoint_mode,
+        commit_before_checkpoint: mvcc,
+    }
+}
+
 fn property_table_has_expected_content<R: rand::Rng + ?Sized>(
     rng: &mut R,
     _query_distr: &QueryDistribution,
@@ -1899,6 +1984,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
             PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
+            PropertyDiscriminants::CheckpointStress => property_checkpoint_stress,
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
@@ -1954,6 +2040,15 @@ impl PropertyDiscriminants {
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
                     remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::CheckpointStress => {
+                let has_main_table = ctx.tables().iter().any(|table| !table.name.contains('.'));
+                let write_weight = remaining.insert + remaining.update + remaining.delete;
+                if has_main_table && write_weight > 0 && remaining.pragma_count > 0 {
+                    write_weight.min(remaining.pragma_count).max(1)
                 } else {
                     0
                 }
@@ -2059,6 +2154,7 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::CheckpointStress => QueryCapabilities::INSERT,
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -468,7 +468,9 @@ impl Shadow for Query {
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
-            Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(
+                Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_) | Pragma::WalCheckpoint(_),
+            ) => Ok(vec![]),
         }
     }
 }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
-use sql_generation::model::query::{Create, Insert, Select, predicate::Predicate, update::Update};
+use sql_generation::model::query::{
+    Create, Insert, Select, pragma::CheckpointMode, predicate::Predicate, update::Update,
+};
 
 use crate::model::{Query, QueryDiscriminants};
 
@@ -191,6 +193,15 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// CheckpointStress drives write traffic, runs an explicit WAL checkpoint,
+    /// then verifies the shadow model and integrity_check.
+    CheckpointStress {
+        queries: Vec<Query>,
+        tables: Vec<String>,
+        write_kinds: Vec<QueryDiscriminants>,
+        checkpoint_mode: CheckpointMode,
+        commit_before_checkpoint: bool,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -220,6 +231,7 @@ impl Property {
                 | Property::DeleteSelect { .. }
                 | Property::DropSelect { .. }
                 | Property::SavepointRollback { .. }
+                | Property::CheckpointStress { .. }
                 | Property::Queries { .. }
         )
     }
@@ -231,6 +243,7 @@ impl Property {
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
+            | Property::CheckpointStress { queries, .. }
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }

--- a/testing/simulator/profiles/mod.rs
+++ b/testing/simulator/profiles/mod.rs
@@ -129,6 +129,23 @@ impl Profile {
         profile
     }
 
+    pub fn checkpoint_stress() -> Self {
+        let mut profile = Self::write_stress();
+        profile.io.fault.enable = false;
+        profile.max_connections = 1;
+        profile.query.select_weight = 10;
+        profile.query.insert_weight = 45;
+        profile.query.update_weight = 35;
+        profile.query.delete_weight = 10;
+        profile.query.create_index_weight = 0;
+        profile.query.drop_index = 0;
+        profile.query.drop_table_weight = 0;
+        profile.query.alter_table_weight = 0;
+        profile.query.pragma_weight = 40;
+        profile.validate().unwrap();
+        profile
+    }
+
     /// Profile that biases generation toward named savepoint rollback under
     /// cache pressure, where WAL spill and page restoration bugs tend to hide.
     pub fn savepoint_stress() -> Self {
@@ -234,6 +251,7 @@ impl Profile {
             ProfileType::Faultless => Self::faultless(),
             ProfileType::SimpleMvcc => Self::simple_mvcc(),
             ProfileType::WriteStress => Self::write_stress(),
+            ProfileType::CheckpointStress => Self::checkpoint_stress(),
             ProfileType::SavepointStress => Self::savepoint_stress(),
             ProfileType::Custom(path) => {
                 Self::parse(path).with_context(|| "failed to parse JSON profile")?
@@ -276,6 +294,7 @@ pub enum ProfileType {
     Faultless,
     SimpleMvcc,
     WriteStress,
+    CheckpointStress,
     SavepointStress,
     #[strum(disabled)]
     Custom(PathBuf),


### PR DESCRIPTION
## Summary
- add sql generation support for PRAGMA wal_checkpoint modes
- add a CheckpointStress simulator property that interleaves writes with explicit checkpoints and existing table/integrity assertions
- add a checkpoint_stress profile and mark wal_checkpoint coverage as partial

Refs #7045.

## Testing
- cargo fmt --all --check
- cargo check -p limbo_sim
- cargo build -p limbo_sim
- for seeds 1..20: limbo_sim --profile checkpoint_stress --seed <seed> -n 80 -k 40 -t 20 --disable-bugbase --disable-faulty-query --io-backend memory
- seed 21 keep-files run confirmed generated PRAGMA wal_checkpoint calls and sqlite3 pragma integrity_check returned ok