### PR TITLE
fix: duplicated "the" in turso JS and Rust binding doc-comments

### DIFF
--- a/bindings/javascript/src/browser.rs
+++ b/bindings/javascript/src/browser.rs
@@ -18,7 +18,7 @@ impl Task for NoopTask {
 }
 
 #[napi]
-/// turso-db in the the browser requires explicit thread pool initialization
+/// turso-db in the browser requires explicit thread pool initialization
 /// so, we just put no-op task on the thread pool and force emnapi to allocate web worker
 pub fn init_thread_pool() -> napi::Result<AsyncTask<NoopTask>> {
     Ok(AsyncTask::new(NoopTask))

--- a/bindings/rust/src/connection.rs
+++ b/bindings/rust/src/connection.rs
@@ -228,7 +228,7 @@ impl Connection {
     /// This api defers slighty from: https://www.sqlite.org/c3ref/busy_timeout.html
     ///
     /// Instead of sleeping for linear amount of time specified by the user,
-    /// we will sleep in phases, until the the total amount of time is reached.
+    /// we will sleep in phases, until the total amount of time is reached.
     /// This means we first sleep of 1ms, then if we still return busy, we sleep for 2 ms, and repeat until a maximum of 100 ms per phase.
     ///
     /// Example:


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in doc-comments:
- `bindings/javascript/src/browser.rs` — "turso-db in the the browser requires" → "turso-db in the browser requires"
- `bindings/rust/src/connection.rs` — "until the the total amount of time" → "until the total amount of time"

No code/behavior change.