### PR TITLE
sim: add Fault::DiskFull for ENOSPC injection

### DIFF
--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -340,11 +340,21 @@ fn random_fault<R: rand::Rng + ?Sized>(
     env: &SimulatorEnv,
     conn_index: usize,
 ) -> Interactions {
-    let faults = if env.opts.disable_reopen_database {
+    // DiskFull / DiskFreed are paired: if the disk is already full, we
+    // generate the "freed" recovery fault, otherwise we can either trigger a
+    // disconnect, reopen, or fill the disk. This keeps the simulator from
+    // entering an unrecoverable state where every write would fail forever.
+    let disk_already_full = env.io.is_disk_full();
+    let mut faults = if env.opts.disable_reopen_database {
         vec![Fault::Disconnect]
     } else {
         vec![Fault::Disconnect, Fault::ReopenDatabase]
     };
+    if disk_already_full {
+        faults.push(Fault::DiskFreed);
+    } else {
+        faults.push(Fault::DiskFull);
+    }
     let fault = faults[rng.random_range(0..faults.len())];
     Interactions::new(conn_index, InteractionsType::Fault(fault))
 }

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -435,6 +435,11 @@ impl Assertion {
 pub enum Fault {
     Disconnect,
     ReopenDatabase,
+    /// Simulate the host running out of disk space: subsequent `pwrite` and
+    /// `sync` calls fail with an ENOSPC-like error until the disk is "freed".
+    DiskFull,
+    /// Clear the disk-full state set by an earlier `DiskFull` fault.
+    DiskFreed,
 }
 
 impl Display for Fault {
@@ -442,6 +447,8 @@ impl Display for Fault {
         match self {
             Fault::Disconnect => write!(f, "DISCONNECT"),
             Fault::ReopenDatabase => write!(f, "REOPEN_DATABASE"),
+            Fault::DiskFull => write!(f, "DISK_FULL"),
+            Fault::DiskFreed => write!(f, "DISK_FREED"),
         }
     }
 }
@@ -704,6 +711,12 @@ impl InteractionType {
                     }
                     Fault::ReopenDatabase => {
                         reopen_database(env);
+                    }
+                    Fault::DiskFull => {
+                        env.io.inject_disk_full(true);
+                    }
+                    Fault::DiskFreed => {
+                        env.io.inject_disk_full(false);
                     }
                 }
                 Ok(())

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -19,6 +19,13 @@ fn error_causes_rollback(err: &LimboError) -> bool {
     matches!(err, LimboError::WriteWriteConflict)
 }
 
+/// Returns true if the error was produced by an injected `Fault::DiskFull`.
+/// These are expected: a pwrite failed because we asked it to. Subsequent
+/// interactions should continue against the same database state.
+fn is_injected_disk_full_error(err: &LimboError) -> bool {
+    matches!(err, LimboError::InternalError(msg) if msg == crate::runner::DISK_FULL_ERROR_MSG)
+}
+
 use crate::{
     generation::Shadow as _,
     model::{
@@ -221,6 +228,17 @@ pub fn execute_interaction_turso(
                 let continuation = match err {
                     err if is_recoverable_tx_error(err) => {
                         if error_causes_rollback(err) && env.conn_in_transaction(connection_index) {
+                            env.rollback_conn(connection_index);
+                        }
+                        ExecutionContinuation::NextInteractionOutsideThisProperty
+                    }
+                    err if is_injected_disk_full_error(err) => {
+                        // A pwrite failed because we injected ENOSPC. Treat
+                        // the transaction as aborted (Turso cannot durably
+                        // land the write) and continue with the next
+                        // interaction. The fault remains active until a
+                        // `Fault::DiskFreed` interaction clears it.
+                        if env.conn_in_transaction(connection_index) {
                             env.rollback_conn(connection_index);
                         }
                         ExecutionContinuation::NextInteractionOutsideThisProperty

--- a/testing/simulator/runner/file.rs
+++ b/testing/simulator/runner/file.rs
@@ -9,11 +9,16 @@ use rand_chacha::ChaCha8Rng;
 use tracing::{Level, instrument};
 use turso_core::{File, Result};
 
-use crate::runner::{FAULT_ERROR_MSG, clock::SimulatorClock};
+use crate::runner::{DISK_FULL_ERROR_MSG, FAULT_ERROR_MSG, clock::SimulatorClock};
 pub(crate) struct SimulatorFile {
     pub path: String,
     pub(crate) inner: Arc<dyn File>,
     pub(crate) fault: Cell<bool>,
+    /// When set, `pwrite` and `sync` fail as if the filesystem ran out of
+    /// space. Reads continue to succeed because the data they need is already
+    /// allocated. Cleared by a subsequent `inject_disk_full(false)`.
+    pub(crate) disk_full: Cell<bool>,
+    pub(crate) nr_disk_full_faults: Cell<usize>,
 
     /// Number of `pread` function calls (both success and failures).
     pub(crate) nr_pread_calls: Cell<usize>,
@@ -65,6 +70,10 @@ unsafe impl Sync for SimulatorFile {}
 impl SimulatorFile {
     pub(crate) fn inject_fault(&self, fault: bool) {
         self.fault.replace(fault);
+    }
+
+    pub(crate) fn inject_disk_full(&self, full: bool) {
+        self.disk_full.replace(full);
     }
 
     pub(crate) fn stats_table(&self) -> String {
@@ -172,6 +181,14 @@ impl File for SimulatorFile {
                 FAULT_ERROR_MSG.into(),
             ));
         }
+        if self.disk_full.get() {
+            tracing::debug!("pwrite disk-full fault");
+            self.nr_disk_full_faults
+                .set(self.nr_disk_full_faults.get() + 1);
+            return Err(turso_core::LimboError::InternalError(
+                DISK_FULL_ERROR_MSG.into(),
+            ));
+        }
         if let Some(latency) = self.generate_latency_duration() {
             let cloned_c = c.clone();
             let op = Box::new(move |file: &SimulatorFile| file.inner.pwrite(pos, buffer, cloned_c));
@@ -228,6 +245,14 @@ impl File for SimulatorFile {
             self.nr_pwrite_faults.set(self.nr_pwrite_faults.get() + 1);
             return Err(turso_core::LimboError::InternalError(
                 FAULT_ERROR_MSG.into(),
+            ));
+        }
+        if self.disk_full.get() {
+            tracing::debug!("pwritev disk-full fault");
+            self.nr_disk_full_faults
+                .set(self.nr_disk_full_faults.get() + 1);
+            return Err(turso_core::LimboError::InternalError(
+                DISK_FULL_ERROR_MSG.into(),
             ));
         }
         if let Some(latency) = self.generate_latency_duration() {

--- a/testing/simulator/runner/io.rs
+++ b/testing/simulator/runner/io.rs
@@ -68,6 +68,16 @@ impl SimIO for SimulatorIO {
         }
     }
 
+    fn inject_disk_full(&self, full: bool) {
+        for file in self.files.borrow().iter() {
+            file.inject_disk_full(full);
+        }
+    }
+
+    fn is_disk_full(&self) -> bool {
+        self.files.borrow().iter().any(|file| file.disk_full.get())
+    }
+
     fn inject_fault_selective(&self, faults: &[(&str, bool)]) {
         for file in self.files.borrow().iter() {
             for (stem, fault) in faults {
@@ -133,9 +143,11 @@ impl IO for SimulatorIO {
             path: path.to_string(),
             inner,
             fault: Cell::new(false),
+            disk_full: Cell::new(false),
             nr_pread_faults: Cell::new(0),
             nr_pwrite_faults: Cell::new(0),
             nr_sync_faults: Cell::new(0),
+            nr_disk_full_faults: Cell::new(0),
             nr_pread_calls: Cell::new(0),
             nr_pwrite_calls: Cell::new(0),
             nr_sync_calls: Cell::new(0),

--- a/testing/simulator/runner/memory/file.rs
+++ b/testing/simulator/runner/memory/file.rs
@@ -55,6 +55,10 @@ pub struct MemorySimFile {
     pub latency_probability: u8,
     clock: Arc<SimulatorClock>,
     fault: Cell<bool>,
+    /// Mimics filesystem ENOSPC: while set, queued writes complete in
+    /// aborted form so the simulator exercises write-failure recovery paths
+    /// without affecting reads.
+    disk_full: Cell<bool>,
 }
 
 unsafe impl Send for MemorySimFile {}
@@ -78,11 +82,20 @@ impl MemorySimFile {
             latency_probability,
             clock,
             fault: Cell::new(false),
+            disk_full: Cell::new(false),
         }
     }
 
     pub fn inject_fault(&self, fault: bool) {
         self.fault.set(fault);
+    }
+
+    pub fn inject_disk_full(&self, full: bool) {
+        self.disk_full.set(full);
+    }
+
+    pub fn is_disk_full(&self) -> bool {
+        self.disk_full.get()
     }
 
     pub fn stats_table(&self) -> String {
@@ -132,7 +145,13 @@ impl MemorySimFile {
 
     fn insert_op(&self, op: OperationType) {
         // FIXME: currently avoid any fsync faults until we correctly define the expected behaviour in the simulator
-        let fault = self.fault.get() && !matches!(op, OperationType::Sync { .. });
+        let is_write = matches!(
+            op,
+            OperationType::Write { .. } | OperationType::WriteV { .. }
+        );
+        let disk_full_fault = self.disk_full.get() && is_write;
+        let fault =
+            (self.fault.get() && !matches!(op, OperationType::Sync { .. })) || disk_full_fault;
         if fault {
             let mut io_tracker = self.io_tracker.borrow_mut();
             match &op {

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -178,6 +178,19 @@ impl SimIO for MemorySimIO {
         }
     }
 
+    fn inject_disk_full(&self, full: bool) {
+        for file in self.files.borrow().values() {
+            file.inject_disk_full(full);
+        }
+        if full {
+            tracing::debug!("disk-full fault injected");
+        }
+    }
+
+    fn is_disk_full(&self) -> bool {
+        self.files.borrow().values().any(|file| file.is_disk_full())
+    }
+
     fn inject_fault_selective(&self, faults: &[(&str, bool)]) {
         for (path, file) in self.files.borrow().iter() {
             for (stem, fault) in faults {

--- a/testing/simulator/runner/mod.rs
+++ b/testing/simulator/runner/mod.rs
@@ -11,6 +11,7 @@ pub mod io;
 pub mod memory;
 
 pub const FAULT_ERROR_MSG: &str = "Injected Fault";
+pub const DISK_FULL_ERROR_MSG: &str = "Injected Fault: disk full (ENOSPC)";
 
 pub trait SimIO: turso_core::IO {
     fn inject_fault(&self, fault: bool);
@@ -19,6 +20,17 @@ pub trait SimIO: turso_core::IO {
     /// Each entry in `faults` is `(path_stem, should_fault)`.
     /// Files whose path contains a given stem get that fault setting.
     fn inject_fault_selective(&self, faults: &[(&str, bool)]);
+
+    /// Toggle the "disk full" state for all files managed by this IO.
+    /// While true, `pwrite`/`sync` return an ENOSPC-like error so the
+    /// simulator can exercise error paths that real hosts hit when the
+    /// underlying filesystem fills up. Reads continue to succeed.
+    fn inject_disk_full(&self, full: bool);
+
+    /// Whether the disk is currently in the "full" state.
+    /// Used by the fault generator to decide whether to free the disk
+    /// instead of filling it again.
+    fn is_disk_full(&self) -> bool;
 
     fn print_stats(&self);
 


### PR DESCRIPTION
Adds `Fault::DiskFull` / `Fault::DiskFreed` to the simulator so the engine's write-failure path gets exercised when the host filesystem runs out of space. Closes #2662.

When `DiskFull` is active, pwrite/pwritev return an ENOSPC-style `InternalError`. Reads, locks, and sync are intentionally left alone -- reads of already-allocated data don't fail with ENOSPC, and sync-fault semantics are still gated by #2091.

The generator inspects `is_disk_full()` before each fault choice, so it picks `DiskFreed` while full and `DiskFull` while clean. That keeps the simulator from getting stuck in a permanently-failing state.

`execute_interaction` recognises the injected error as recoverable: rolls back any in-flight transaction and moves to the next interaction outside the current property, the same way `WriteWriteConflict` is handled today.

Plumbing landed for both backends (`runner/file.rs`/`io.rs` and `runner/memory/*`).

### Test plan

- [x] `cargo build --bin limbo_sim`
- [x] `cargo fmt -p limbo_sim`
- [x] `cargo clippy --bin limbo_sim --all-features --all-targets -- --deny=warnings`
- [x] `cargo run --bin limbo_sim` on seeds 1, 2, 7, 13, 42, 100 -- all complete and the post-sim integrity check passes; seed 13 cycles fill→free→fill→free

Replay support in `plan_to_test.rs` and per-file selective disk-full are left as follow-ups; the existing "unknown fault, skip" branch handles the new variants safely on the parser side.

/claim #2662
