### PR TITLE
Allow DELETE from sqlite_sequence rows

### DIFF
--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -31,7 +31,7 @@ fn validate_delete(
     // Check if this is a system table that should be protected from direct writes
     if !connection.is_nested_stmt()
         && !connection.is_mvcc_bootstrap_connection()
-        && crate::schema::is_system_table(tbl_name)
+        && !crate::schema::allow_user_dml(tbl_name)
     {
         crate::bail_parse_error!("table {tbl_name} may not be modified");
     }

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -126,6 +126,17 @@ expect {
     1235|2
 }
 
+# SQLite allows direct DELETE from sqlite_sequence rows.
+@cross-check-integrity
+test autoinc-manual-delete-from-sequence-table {
+    CREATE TABLE t1(x INTEGER PRIMARY KEY AUTOINCREMENT, y);
+    INSERT INTO t1 VALUES(NULL, 1);
+    DELETE FROM sqlite_sequence WHERE name='t1';
+    SELECT * FROM sqlite_sequence;
+}
+expect {
+}
+
 # Test: AUTOINCREMENT works for multiple tables independently.
 @cross-check-integrity
 test autoinc-multiple-tables {


### PR DESCRIPTION
Fixes #6967
/claim #6967

## Summary
- allow user DELETE statements against `sqlite_sequence`, matching the existing UPDATE behavior and SQLite compatibility
- keep direct writes blocked for `sqlite_schema` and `__turso_internal_*` tables by reusing the same DML guard as UPDATE
- add an AUTOINCREMENT sqltest covering manual deletion from `sqlite_sequence`

## Verification
- `cargo fmt --check`
- `cd testing/sqltests && cargo run --bin test-runner -- run tests/autoincr.sqltest --backend cli --binary ../../target/debug/tursodb`

## Notes
The released `Turso 0.5.3` binary reproduces the bug with `Parse error: table sqlite_sequence may not be modified`; the same regression case passes against this branch.