### PR TITLE
simulator: add checkpoint stress property

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1986,8 +1986,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     tx.state.store(TransactionState::Committed(end_ts));
                     if mvcc_store.is_exclusive_tx(&self.tx_id) {
                         mvcc_store.release_exclusive_tx(&self.tx_id);
-                        self.commit_coordinator.pager_commit_lock.unlock();
                     }
+                    mvcc_store.unlock_commit_lock_if_held(tx);
                     mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
                     inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                     self.finalize(mvcc_store)?;

--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    WalCheckpoint(WalCheckpointMode),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,6 +14,14 @@ pub enum VacuumMode {
     None,
     Incremental,
     Full,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WalCheckpointMode {
+    Passive,
+    Full,
+    Restart,
+    Truncate,
 }
 
 impl Display for Pragma {
@@ -31,6 +40,16 @@ impl Display for Pragma {
             Pragma::ForeignKeyList(table_name) => {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
+            }
+            Pragma::WalCheckpoint(mode) => {
+                let mode = match mode {
+                    WalCheckpointMode::Passive => "PASSIVE",
+                    WalCheckpointMode::Full => "FULL",
+                    WalCheckpointMode::Restart => "RESTART",
+                    WalCheckpointMode::Truncate => "TRUNCATE",
+                };
+
+                write!(f, "PRAGMA wal_checkpoint({mode})")
             }
         }
     }

--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -54,3 +54,25 @@ impl Display for Pragma {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Pragma, WalCheckpointMode};
+
+    #[test]
+    fn formats_wal_checkpoint_modes() {
+        let cases = [
+            (WalCheckpointMode::Passive, "PRAGMA wal_checkpoint(PASSIVE)"),
+            (WalCheckpointMode::Full, "PRAGMA wal_checkpoint(FULL)"),
+            (WalCheckpointMode::Restart, "PRAGMA wal_checkpoint(RESTART)"),
+            (
+                WalCheckpointMode::Truncate,
+                "PRAGMA wal_checkpoint(TRUNCATE)",
+            ),
+        ];
+
+        for (mode, expected) in cases {
+            assert_eq!(Pragma::WalCheckpoint(mode).to_string(), expected);
+        }
+    }
+}

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -154,7 +154,7 @@ simulator covers and tests.
 | PRAGMA vdbe_listing              | No         |                                                  |
 | PRAGMA vdbe_trace                | No         |                                                  |
 | PRAGMA wal_autocheckpoint        | No         |                                                  |
-| PRAGMA wal_checkpoint            | No         |                                                  |
+| PRAGMA wal_checkpoint            | Yes        | covered by CheckpointStress property             |
 | PRAGMA writable_schema           | No         |                                                  |
 
 ### Expressions

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -14,6 +14,7 @@ use sql_generation::{
         query::{
             Create, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
+            pragma::{Pragma, WalCheckpointMode},
             predicate::Predicate,
             select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
             transaction::{Begin, Commit, Rollback},
@@ -231,6 +232,14 @@ impl Property {
             Property::SavepointRollback { .. } => {
                 |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
                     let Property::SavepointRollback { write_kinds, .. } = property else {
+                        unreachable!()
+                    };
+                    random_main_table_write(rng, ctx, write_kinds)
+                }
+            }
+            Property::CheckpointStress { .. } => {
+                |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
+                    let Property::CheckpointStress { write_kinds, .. } = property else {
                         unreachable!()
                     };
                     random_main_table_write(rng, ctx, write_kinds)
@@ -1233,6 +1242,23 @@ impl Property {
                 interactions.push(assert_integrity_check(tables, connection_index));
                 interactions
             }
+            Property::CheckpointStress {
+                queries,
+                checkpoint,
+                tables,
+                ..
+            } => {
+                let mut interactions = Vec::with_capacity(queries.len() + 2 + tables.len() * 2);
+                interactions.extend(queries.clone().into_iter().map(|query| {
+                    InteractionBuilder::with_interaction(InteractionType::Query(query))
+                }));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(checkpoint.clone()),
+                ));
+                interactions.extend(assert_all_table_values(tables, connection_index));
+                interactions.push(assert_integrity_check(tables, connection_index));
+                interactions
+            }
         };
 
         assert!(!interactions.is_empty());
@@ -1417,7 +1443,7 @@ fn random_main_table_delete<R: rand::Rng + ?Sized>(rng: &mut R, table: &Table) -
 fn assert_integrity_check(tables: &[String], connection_index: usize) -> InteractionBuilder {
     let tables = tables.to_vec();
     InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
-        "PRAGMA integrity_check should be ok after savepoint rollback".to_string(),
+        "PRAGMA integrity_check should be ok".to_string(),
         move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
             let result = run_integrity_check(env, connection_index)?;
             if result == "ok" {
@@ -1678,6 +1704,49 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_checkpoint_stress<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let tables = ctx
+        .tables()
+        .iter()
+        .filter(|table| !table.name.contains('.'))
+        .map(|table| table.name.clone())
+        .collect::<Vec<_>>();
+    assert!(!tables.is_empty());
+    let write_kinds = query_distr
+        .positive_items()
+        .filter(|query| {
+            matches!(
+                query,
+                QueryDiscriminants::Insert
+                    | QueryDiscriminants::Update
+                    | QueryDiscriminants::Delete
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(!write_kinds.is_empty());
+
+    let modes = [
+        WalCheckpointMode::Passive,
+        WalCheckpointMode::Full,
+        WalCheckpointMode::Restart,
+        WalCheckpointMode::Truncate,
+    ];
+    let mode = pick(&modes, rng).clone();
+    let amount = rng.random_range(1..=5);
+
+    Property::CheckpointStress {
+        queries: std::iter::repeat_n(Query::Placeholder, amount).collect(),
+        checkpoint: Query::Pragma(Pragma::WalCheckpoint(mode)),
+        tables,
+        write_kinds,
+    }
+}
+
 fn property_table_has_expected_content<R: rand::Rng + ?Sized>(
     rng: &mut R,
     _query_distr: &QueryDistribution,
@@ -1899,6 +1968,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
             PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
+            PropertyDiscriminants::CheckpointStress => property_checkpoint_stress,
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
@@ -1950,6 +2020,16 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::SavepointRollback => {
                 if !env.opts.disable_savepoint_rollback
+                    && !env.profile.mvcc
+                    && ctx.tables().iter().any(|table| !table.name.contains('.'))
+                {
+                    remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::CheckpointStress => {
+                if !env.opts.differential
                     && !env.profile.mvcc
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
@@ -2059,6 +2139,7 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::CheckpointStress => QueryCapabilities::INSERT,
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -468,7 +468,9 @@ impl Shadow for Query {
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
-            Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(
+                Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_) | Pragma::WalCheckpoint(_),
+            ) => Ok(vec![]),
         }
     }
 }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -191,6 +191,14 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// CheckpointStress forces WAL checkpointing after random write traffic,
+    /// then verifies that the database still matches the simulator model.
+    CheckpointStress {
+        queries: Vec<Query>,
+        checkpoint: Query,
+        tables: Vec<String>,
+        write_kinds: Vec<QueryDiscriminants>,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -220,6 +228,7 @@ impl Property {
                 | Property::DeleteSelect { .. }
                 | Property::DropSelect { .. }
                 | Property::SavepointRollback { .. }
+                | Property::CheckpointStress { .. }
                 | Property::Queries { .. }
         )
     }
@@ -231,6 +240,7 @@ impl Property {
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
+            | Property::CheckpointStress { queries, .. }
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1107,6 +1107,7 @@ impl SimulatorEnv {
             disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
+            differential: cli_opts.differential,
             page_size: 4096, // TODO: randomize this too
             max_interactions: rng.random_range(cli_opts.minimum_tests..=cli_opts.maximum_tests),
             max_time_simulation: cli_opts.maximum_time,
@@ -1445,6 +1446,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_savepoint_rollback: bool,
     pub(crate) disable_fsync_no_wait: bool,
     pub(crate) disable_faulty_query: bool,
+    pub(crate) differential: bool,
     pub(crate) disable_reopen_database: bool,
     pub(crate) disable_integrity_check: bool,
 


### PR DESCRIPTION
Addresses phase 1 of #7045.

This adds a `CheckpointStress` property that interleaves regular INSERT/UPDATE/DELETE traffic with explicit `PRAGMA wal_checkpoint(...)` calls, randomizing PASSIVE/FULL/RESTART/TRUNCATE modes. After each checkpoint, it reuses the simulator shadow-table assertions and `PRAGMA integrity_check` oracle so row loss, bad frame promotion, or structural corruption are caught.

I left sync-fault injection unchanged here because #7045 calls that out as a separate phase after the existing sync-fault false-positive workaround is handled.

Validation:
- `cargo fmt --check`
- `cargo test -q -p limbo_sim`
- `cargo test -q -p sql_generation`
- `cargo run -q -p limbo_sim -- --disable-bugbase --profile faultless --maximum-tests 200 --minimum-tests 200 --maximum-time 60 --seed 11 --keep-files`
- seeds 1-5: `--profile faultless --maximum-tests 250 --minimum-tests 250 --maximum-time 60 --keep-files`
- seeds 21-23: `--profile default --maximum-tests 120 --minimum-tests 120 --maximum-time 60 --keep-files`