### PR TITLE
Fix breaking test with a diff yield point

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -991,6 +991,7 @@ pub(crate) enum CommitYieldPoint {
     CommitValidation,
     WaitForDependencies,
     LogRecordPrepared,
+    BeforeCommittedTimestampWatermarkUpdate,
     /// Boundary right after `remove_tx` runs but before the connection cache
     /// is cleared by the caller at vdbe/mod.rs. Used for failure injection
     /// to reproduce divergence between `mv_store.txs` and `connection.mv_tx_id`.
@@ -2002,6 +2003,11 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     .global_header
                     .write()
                     .replace(*tx_unlocked.header.read());
+
+                inject_transition_yield!(
+                    self,
+                    CommitYieldPoint::BeforeCommittedTimestampWatermarkUpdate
+                );
 
                 // Since we assign a commit timestamp and then we drive the commit to completion,
                 // it is totally possible for so an older transaction can finish after a newer one.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2884,7 +2884,8 @@ fn test_checkpoint_stale_unique_index_delete_with_out_of_order_commit_yield() {
 /// Steps:
 /// 1. Disable automatic checkpoints and create a baseline table.
 /// 2. Checkpoint the baseline state so the durable boundary is non-zero.
-/// 3. Start an older concurrent transaction and yield it after it takes a commit timestamp.
+/// 3. Start an older concurrent transaction and yield it after it commits, releases the
+///    commit lock, and is just about to update the committed timestamp watermark.
 /// 4. Commit a newer `CREATE TABLE` plus row insert through ordinary SQL.
 /// 5. Resume the older transaction; without a monotonic committed watermark this regresses
 ///    the checkpoint boundary source.
@@ -2910,12 +2911,12 @@ fn test_checkpoint_stale_boundary_does_not_replay_checkpointed_create_table_afte
             .execute("UPDATE s SET v = 'older_commit' WHERE id = 1")
             .unwrap();
         older.set_yield_injector(Some(FixedYieldInjector::new([
-            CommitYieldPoint::LogRecordPrepared.point(),
+            CommitYieldPoint::BeforeCommittedTimestampWatermarkUpdate.point(),
         ])));
         let mut older_commit = older.prepare("COMMIT").unwrap();
         assert!(
             matches!(older_commit.step().unwrap(), StepResult::IO),
-            "older commit should yield after taking its commit timestamp"
+            "older commit should yield before updating the committed timestamp watermark"
         );
 
         let creator = db.connect();


### PR DESCRIPTION
## Description

The test landed earlier before we fixed MVCC locks. Basically, if one connection is in `Preparing` and another tries to run DDL statements, it gets busy now. It wasn't the case earlier. 

So I adjusted the test to use a different yield point. The test is still a regression test, fails without the patch introduced in https://github.com/tursodatabase/turso/pull/7029 