### PR TITLE
fix: align AUTOINCREMENT seq coercion with SQLite

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -720,7 +720,15 @@ pub fn translate_insert(
             program.emit_insn(Insn::Goto {
                 target_pc: explicit_done_label,
             });
+
+            // Existing row + key <= seq: leave sqlite_sequence untouched (matches
+            // SQLite, which only rewrites the row when the key advances seq —
+            // important for non-numeric seq values like text 'abc' so the
+            // original storage class is preserved).
             program.preassign_label_to_next_insn(skip_seq_update_label);
+            program.emit_insn(Insn::Goto {
+                target_pc: explicit_done_label,
+            });
 
             // Missing sqlite_sequence row: materialize it once with max(existing_seq, explicit_key).
             // For first explicit negative insert this yields seq=0, matching SQLite.
@@ -1679,6 +1687,14 @@ fn reload_autoincrement_state(program: &mut ProgramBuilder, meta: AutoincMeta) {
     });
 
     program.emit_column_or_rowid(seq_cursor_id, 1, r_seq);
+    // Force r_seq to integer storage class — SQLite emits AddImm r[seq], 0 here
+    // for AUTOINCREMENT; without it a non-numeric sqlite_sequence.seq (e.g.
+    // UPDATE sqlite_sequence SET seq='5abc') flows through MemMax and the
+    // i64::MAX overflow guard as Text and bypasses both.
+    program.emit_insn(Insn::AddImm {
+        register: r_seq,
+        value: 0,
+    });
     program.emit_insn(Insn::RowId {
         cursor_id: seq_cursor_id,
         dest: r_seq_rowid,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -721,17 +721,14 @@ pub fn translate_insert(
                 target_pc: explicit_done_label,
             });
 
-            // Existing row + key <= seq: leave sqlite_sequence untouched (matches
-            // SQLite, which only rewrites the row when the key advances seq —
-            // important for non-numeric seq values like text 'abc' so the
-            // original storage class is preserved).
+            // SQLite leaves sqlite_sequence unchanged when the explicit key
+            // does not advance seq.
             program.preassign_label_to_next_insn(skip_seq_update_label);
             program.emit_insn(Insn::Goto {
                 target_pc: explicit_done_label,
             });
 
-            // Missing sqlite_sequence row: materialize it once with max(existing_seq, explicit_key).
-            // For first explicit negative insert this yields seq=0, matching SQLite.
+            // If sqlite_sequence has no row yet, write max(0, explicit_key).
             program.preassign_label_to_next_insn(missing_row_label);
             let seq_to_write_reg = program.alloc_register();
             program.emit_insn(Insn::Copy {
@@ -1687,10 +1684,7 @@ fn reload_autoincrement_state(program: &mut ProgramBuilder, meta: AutoincMeta) {
     });
 
     program.emit_column_or_rowid(seq_cursor_id, 1, r_seq);
-    // Force r_seq to integer storage class — SQLite emits AddImm r[seq], 0 here
-    // for AUTOINCREMENT; without it a non-numeric sqlite_sequence.seq (e.g.
-    // UPDATE sqlite_sequence SET seq='5abc') flows through MemMax and the
-    // i64::MAX overflow guard as Text and bypasses both.
+    // SQLite emits AddImm r[seq], 0 here. OP_AddImm always leaves an integer.
     program.emit_insn(Insn::AddImm {
         register: r_seq,
         value: 0,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11676,14 +11676,7 @@ pub fn op_add_imm(
         Register::Record(_) => &Value::Null,
     };
 
-    // Match SQLite's OP_AddImm semantics: coerce operand to integer
-    // (sqlite3VdbeIntValue), then add. Text/Blob use integer-prefix parsing
-    // — sign + digits, stops at first non-digit, no exponent or decimal
-    // handling (CAST AS INTEGER takes the same path; see vdbe/value.rs).
-    // Float saturates via sqlite3RealToI64. Final add uses wrapping_add to
-    // mirror SQLite's silent VDBE-layer overflow; the AUTOINCREMENT path's
-    // Ne r_key, i64::MAX → SQLITE_FULL guard (translate/insert.rs) catches
-    // the overflow case before AddImm runs.
+    // SQLite coerces the register to an integer before adding.
     let lhs = match current_value {
         Value::Numeric(Numeric::Integer(i)) => *i,
         Value::Numeric(Numeric::Float(f)) => real_to_i64(f64::from(*f)),
@@ -14300,12 +14293,8 @@ fn execute_turso_version(version_integer: i64) -> String {
     format!("{major}.{minor}.{release}")
 }
 
-/// Coerce a value to i64 using SQLite's `sqlite3VdbeIntValue` rules: integer
-/// prefix parse for Text/Blob (sign + digits, stops at first non-digit, no
-/// exponent/decimal), saturating cast for Float, 0 for Null. Result matches
-/// what `OP_AddImm reg, 0` produces, so callers can rely on the two ops
-/// agreeing on text→int coercion (e.g. AUTOINCREMENT's MemMax-after-AddImm-0
-/// sequence in translate/insert.rs).
+/// Coerce a value to i64 using the same non-NULL conversion rules as
+/// SQLite's OP_AddImm.
 pub fn extract_int_value<V: AsValueRef>(value: V) -> i64 {
     let value = value.as_value_ref();
     match value {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -34,7 +34,7 @@ use crate::util::{
     trigger_still_references_renamed_column, trim_ascii_whitespace, RewrittenView,
 };
 use crate::vdbe::affinity::{
-    apply_numeric_affinity, try_for_float, Affinity, NumericParseResult, ParsedNumber,
+    apply_numeric_affinity, real_to_i64, try_for_float, Affinity, NumericParseResult, ParsedNumber,
 };
 use crate::vdbe::hash_table::{
     HashEntry, HashInsertResult, HashTable, HashTableConfig, PendingHashInsert, DEFAULT_MEM_BUDGET,
@@ -11676,13 +11676,24 @@ pub fn op_add_imm(
         Register::Record(_) => &Value::Null,
     };
 
-    let int_val = match current_value {
-        Value::Numeric(Numeric::Integer(i)) => i + value,
-        Value::Numeric(Numeric::Float(f)) => (f64::from(*f) as i64) + value,
-        Value::Text(s) => s.as_str().parse::<i64>().unwrap_or(0) + value,
-        Value::Blob(_) => *value, // BLOB becomes the added value
-        Value::Null => *value,    // NULL becomes the added value
+    // Match SQLite's OP_AddImm semantics: coerce operand to integer
+    // (sqlite3VdbeIntValue), then add. Text/Blob use integer-prefix parsing
+    // — sign + digits, stops at first non-digit, no exponent or decimal
+    // handling (CAST AS INTEGER takes the same path; see vdbe/value.rs).
+    // Float saturates via sqlite3RealToI64. Final add uses wrapping_add to
+    // mirror SQLite's silent VDBE-layer overflow; the AUTOINCREMENT path's
+    // Ne r_key, i64::MAX → SQLITE_FULL guard (translate/insert.rs) catches
+    // the overflow case before AddImm runs.
+    let lhs = match current_value {
+        Value::Numeric(Numeric::Integer(i)) => *i,
+        Value::Numeric(Numeric::Float(f)) => real_to_i64(f64::from(*f)),
+        Value::Text(s) => crate::numeric::str_to_i64(s.as_str()).unwrap_or(0),
+        Value::Blob(b) => {
+            crate::numeric::str_to_i64(String::from_utf8_lossy(b).as_ref()).unwrap_or(0)
+        }
+        Value::Null => 0,
     };
+    let int_val = lhs.wrapping_add(*value);
 
     state.registers[*register].set_int(int_val);
     state.pc += 1;
@@ -14289,32 +14300,20 @@ fn execute_turso_version(version_integer: i64) -> String {
     format!("{major}.{minor}.{release}")
 }
 
+/// Coerce a value to i64 using SQLite's `sqlite3VdbeIntValue` rules: integer
+/// prefix parse for Text/Blob (sign + digits, stops at first non-digit, no
+/// exponent/decimal), saturating cast for Float, 0 for Null. Result matches
+/// what `OP_AddImm reg, 0` produces, so callers can rely on the two ops
+/// agreeing on text→int coercion (e.g. AUTOINCREMENT's MemMax-after-AddImm-0
+/// sequence in translate/insert.rs).
 pub fn extract_int_value<V: AsValueRef>(value: V) -> i64 {
     let value = value.as_value_ref();
     match value {
         ValueRef::Numeric(Numeric::Integer(i)) => i,
-        ValueRef::Numeric(Numeric::Float(f)) => {
-            let f = f64::from(f);
-            // Use sqlite3RealToI64 equivalent
-            if f < -9223372036854774784.0 {
-                i64::MIN
-            } else if f > 9223372036854774784.0 {
-                i64::MAX
-            } else {
-                f as i64
-            }
-        }
-        ValueRef::Text(t) => {
-            // Try to parse as integer, return 0 if failed
-            t.as_str().parse::<i64>().unwrap_or(0)
-        }
+        ValueRef::Numeric(Numeric::Float(f)) => real_to_i64(f64::from(f)),
+        ValueRef::Text(t) => crate::numeric::str_to_i64(t.as_str()).unwrap_or(0),
         ValueRef::Blob(b) => {
-            // Try to parse blob as string then as integer
-            if let Ok(s) = std::str::from_utf8(b) {
-                s.parse::<i64>().unwrap_or(0)
-            } else {
-                0
-            }
+            crate::numeric::str_to_i64(String::from_utf8_lossy(b).as_ref()).unwrap_or(0)
         }
         ValueRef::Null => 0,
     }

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -347,3 +347,137 @@ expect {
     1
     t|3
 }
+
+# regression tests for https://github.com/tursodatabase/turso/issues/6969
+
+# Partial-numeric text.
+@cross-check-integrity
+test autoinc-seq-text-prefix-coercion {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT);
+	INSERT INTO t DEFAULT VALUES;
+	UPDATE sqlite_sequence SET seq='5abc' WHERE name='t';
+	INSERT INTO t DEFAULT VALUES;
+	SELECT a FROM t ORDER BY a;
+	SELECT typeof(seq), seq FROM sqlite_sequence WHERE name='t';
+}
+expect {
+	1
+	6
+	integer|6
+}
+
+# Exponent-bearing text.
+@cross-check-integrity
+test autoinc-seq-text-with-exponent-stops-at-e {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT);
+	INSERT INTO t DEFAULT VALUES;
+	UPDATE sqlite_sequence SET seq='1e10' WHERE name='t';
+	INSERT INTO t DEFAULT VALUES;
+	SELECT a FROM t ORDER BY a;
+	SELECT typeof(seq), seq FROM sqlite_sequence WHERE name='t';
+}
+expect {
+	1
+	2
+	integer|2
+}
+
+# Negative-exponent text.
+@cross-check-integrity
+test autoinc-seq-text-with-negative-exponent {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT);
+	INSERT INTO t DEFAULT VALUES;
+	UPDATE sqlite_sequence SET seq='5e-1' WHERE name='t';
+	INSERT INTO t DEFAULT VALUES;
+	SELECT a FROM t ORDER BY a;
+}
+expect {
+	1
+	6
+}
+
+# Blob input.
+@cross-check-integrity
+test autoinc-seq-blob-prefix-coercion {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT);
+	INSERT INTO t DEFAULT VALUES;
+	UPDATE sqlite_sequence SET seq=x'31653130' WHERE name='t';
+	INSERT INTO t DEFAULT VALUES;
+	SELECT a FROM t ORDER BY a;
+}
+expect {
+	1
+	2
+}
+
+# Blob input with leading vertical-tab whitespace.
+@cross-check-integrity
+test autoinc-seq-blob-leading-vtab-whitespace {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT);
+	INSERT INTO t DEFAULT VALUES;
+	UPDATE sqlite_sequence SET seq=x'0b35616263' WHERE name='t';
+	INSERT INTO t DEFAULT VALUES;
+	SELECT a FROM t ORDER BY a;
+}
+expect {
+	1
+	6
+}
+
+# sqlite_sequence.seq at i64::MAX.
+test autoinc-seq-text-at-i64-max-returns-full {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT);
+	INSERT INTO t DEFAULT VALUES;
+	UPDATE sqlite_sequence SET seq='9223372036854775807' WHERE name='t';
+	INSERT INTO t DEFAULT VALUES;
+}
+expect error {
+}
+
+# Explicit rowid below seq leaves sqlite_sequence unchanged.
+@cross-check-integrity
+test autoinc-explicit-rowid-below-text-prefix-preserves-row {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, v);
+	INSERT INTO t VALUES(1, 'first');
+	UPDATE sqlite_sequence SET seq='5abc' WHERE name='t';
+	INSERT INTO t VALUES(3, 'explicit');
+	SELECT a FROM t ORDER BY a;
+	SELECT typeof(seq), seq FROM sqlite_sequence WHERE name='t';
+}
+expect {
+	1
+	3
+	text|5abc
+}
+
+# Explicit rowid above seq updates sqlite_sequence.
+@cross-check-integrity
+test autoinc-explicit-rowid-above-text-prefix-advances {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, v);
+	INSERT INTO t VALUES(1, 'first');
+	UPDATE sqlite_sequence SET seq='5abc' WHERE name='t';
+	INSERT INTO t VALUES(10, 'explicit');
+	SELECT a FROM t ORDER BY a;
+	SELECT typeof(seq), seq FROM sqlite_sequence WHERE name='t';
+}
+expect {
+	1
+	10
+	integer|10
+}
+
+# Explicit rowid below blob seq leaves sqlite_sequence unchanged.
+@cross-check-integrity
+test autoinc-explicit-rowid-below-blob-prefix-preserves-row {
+	CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, v);
+	INSERT INTO t VALUES(1, 'first');
+	UPDATE sqlite_sequence SET seq=x'3561' WHERE name='t';
+	INSERT INTO t VALUES(3, 'explicit');
+	SELECT a FROM t ORDER BY a;
+	SELECT typeof(seq), seq FROM sqlite_sequence WHERE name='t';
+}
+expect {
+	1
+	3
+	blob|5a
+}

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -349,7 +349,6 @@ expect {
 }
 
 # regression tests for https://github.com/tursodatabase/turso/issues/6969
-
 # Partial-numeric text.
 @cross-check-integrity
 test autoinc-seq-text-prefix-coercion {


### PR DESCRIPTION
## Description

Fix AUTOINCREMENT handling when `sqlite_sequence.seq` is stored as text or blob.

  This change makes Turso follow SQLite's integer coercion rules when reading
  `sqlite_sequence.seq`:
  - reload AUTOINCREMENT state with `AddImm 0` so `seq` is coerced before
    `MemMax` and overflow checks
  - make `OP_AddImm` use SQLite-style integer coercion for text, blob, float,
    and null values
  - unify `extract_int_value()` with the same coercion rules used by
    `OP_AddImm` and `CAST AS INTEGER`
  - fix the explicit-rowid AUTOINCREMENT path so `key <= seq` really skips the
    `sqlite_sequence` update and preserves the original storage class

The PR also adds regressions for text/blob prefix parsing, exponent-like inputs, vertical-tab blob whitespace, `i64::MAX` overflow, and explicit-rowid preserve/advance behavior.


<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

This fixes AUTOINCREMENT divergence from SQLite around manual updates to
  `sqlite_sequence.seq`.

  Before this change:
  - partial numeric text like `'5abc'` could be treated as `0`
  - text `i64::MAX` could bypass the overflow guard and panic in debug builds
  - explicit-rowid inserts could rewrite `sqlite_sequence` when they should
    leave it untouched
  - integer coercion rules were inconsistent across `OP_AddImm`,
    `extract_int_value()`, and `CAST AS INTEGER`

After this change, those paths use the same SQLite-compatible coercion rules and the AUTOINCREMENT behavior matches SQLite for the covered cases.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Closes #6969

## Description of AI Usage

- Agents were used to identify the mismatch between strict integer parsing and SQLite's integer-prefix coercion
- Everything is reviwed
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
