### PR TITLE
core: preserve UPDATE OR FAIL scan order

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -65,7 +65,9 @@ use rustc_hash::FxHashMap as HashMap;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintUsage};
 use turso_parser::ast::RefAct;
-use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TableInternalId, TriggerEvent};
+use turso_parser::ast::{
+    self, Expr, ResolveType, SortOrder, SubqueryType, TableInternalId, TriggerEvent,
+};
 
 pub(crate) mod access_method;
 pub(crate) mod constraints;
@@ -929,6 +931,33 @@ fn optimize_update_plan(
         .expect("UPDATE must optimize exactly one target table")
         .clone();
 
+    if matches!(
+        plan.or_conflict,
+        Some(ResolveType::Fail | ResolveType::Ignore)
+    ) {
+        // FAIL/IGNORE can expose row visitation order through partial writes.
+        // Avoid a secondary index chosen only as a covering full scan; keep
+        // NOT NULL index scans, which SQLite also routes through that index.
+        if let Operation::Scan(Scan::BTreeTable {
+            index: Some(index), ..
+        }) = &plan.target_table.op
+        {
+            let keep_index_scan = plan.where_clause.iter().any(|term| {
+                is_not_null_check_on_index(
+                    &term.expr,
+                    plan.target_table.internal_id,
+                    index.as_ref(),
+                )
+            });
+            if !keep_index_scan {
+                plan.target_table.op = Operation::Scan(Scan::BTreeTable {
+                    iter_dir: IterationDirection::Forwards,
+                    index: None,
+                });
+            }
+        }
+    }
+
     if let Some(reason) = update_write_set_reason(plan, resolver)? {
         plan.safety.require(reason);
     }
@@ -948,6 +977,31 @@ fn optimize_update_plan(
         .select
         .join_order = join_order;
     Ok(())
+}
+
+fn is_not_null_check_on_index(expr: &ast::Expr, table_id: TableInternalId, index: &Index) -> bool {
+    let expr_is_index_column = |expr: &ast::Expr| {
+        matches!(
+            expr,
+            ast::Expr::Column { table, column, .. }
+                if *table == table_id && index.column_table_pos_to_index_pos(*column).is_some()
+        )
+    };
+
+    match expr {
+        ast::Expr::NotNull(inner) => expr_is_index_column(inner),
+        ast::Expr::Binary(lhs, ast::Operator::IsNot, rhs)
+            if matches!(rhs.as_ref(), ast::Expr::Literal(ast::Literal::Null)) =>
+        {
+            expr_is_index_column(lhs)
+        }
+        ast::Expr::Binary(lhs, ast::Operator::IsNot, rhs)
+            if matches!(lhs.as_ref(), ast::Expr::Literal(ast::Literal::Null)) =>
+        {
+            expr_is_index_column(rhs)
+        }
+        _ => false,
+    }
 }
 
 fn update_write_set_reason(

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -4443,6 +4443,39 @@ fn test_autocommit_fail_update_partial_committed(tmp_db: TempDatabase) {
     assert_eq!(ic, "ok");
 }
 
+/// UPDATE OR FAIL partial effects must follow the same scan order as SQLite when
+/// a later row hits a UNIQUE conflict.
+#[turso_macros::test]
+fn test_autocommit_fail_update_partial_secondary_index_order(tmp_db: TempDatabase) {
+    drop(tmp_db);
+    let limbo_db = TempDatabase::builder()
+        .with_db_name("autocommit_fail_update_index_order.db")
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    for s in [
+        "CREATE TABLE t(a INTEGER PRIMARY KEY, b BLOB UNIQUE, c TEXT UNIQUE) STRICT",
+        "INSERT INTO t VALUES(-1, X'7A', 'p')",
+        "INSERT INTO t VALUES(2, X'64', '4')",
+    ] {
+        sqlite_try_exec(&sqlite_conn, s).unwrap();
+        limbo_try_exec(&limbo_conn, s).unwrap();
+    }
+
+    let conflict_sql = "UPDATE OR FAIL t SET b = X'2B' WHERE c OR a";
+    assert!(sqlite_try_exec(&sqlite_conn, conflict_sql).is_err());
+    assert!(limbo_try_exec(&limbo_conn, conflict_sql).is_err());
+    let diff = compare_tables(
+        "autocommit FAIL UPDATE secondary index order",
+        &sqlite_conn,
+        &limbo_conn,
+        "SELECT a, hex(b), c FROM t ORDER BY a",
+    );
+    assert!(diff.is_none(), "{diff:?}");
+    let ic = sqlite_integrity_check(&limbo_db.path);
+    assert_eq!(ic, "ok");
+}
+
 /// UPDATE OR FAIL in explicit transaction: partial updates survive, transaction can commit.
 #[turso_macros::test]
 fn test_explicit_txn_fail_update_partial_in_txn(tmp_db: TempDatabase) {


### PR DESCRIPTION
## Summary

- preserve SQLite-compatible row visitation order for `UPDATE OR FAIL` / `UPDATE OR IGNORE` when a covering secondary-index scan would otherwise change partial-write effects
- keep NOT NULL index scans intact where SQLite also uses the index
- add a regression test comparing Turso and SQLite for the secondary-index scan-order case

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p core_tester --test integration_tests fail_update -- --nocapture`
