### PR TITLE
fix: skip uncheckpointed rootpage-zero schema deletes

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -467,11 +467,16 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 });
             // - It is a delete, AND some version of the row exists in the database file.
             let is_delete_and_exists_in_db_file = end_ts.is_some() && exists_in_db_file;
-            // - It is a delete of a sqlite_schema row that hasn't been checkpointed yet. We need to
-            //   return these even if they don't exist in the DB file so we can track destroyed
-            //   tables/indexes and skip their data rows.
+            // - It is a delete of a b-tree-backed sqlite_schema row that hasn't been checkpointed
+            //   yet. We need to return these even if they don't exist in the DB file so we can track
+            //   destroyed tables/indexes and skip their data/index rows.
+            //
+            //   Rootpage-0 schema objects (views/triggers) do not own a b-tree. If they were created
+            //   and dropped before any checkpoint, there is no physical sqlite_schema row to delete;
+            //   checkpointing them would try to delete a never-written row from the pager b-tree.
             let is_schema_delete = table_id == SQLITE_SCHEMA_MVCC_TABLE_ID
                 && !exists_in_db_file
+                && sqlite_schema_btree_identity(version).is_some()
                 && self
                     .durable_txid_max_old
                     .is_none_or(|txid_max_old| end_ts.is_some_and(|e| e > u64::from(txid_max_old)));
@@ -1905,6 +1910,47 @@ mod tests {
 
         assert_eq!(sqlite_schema_btree_identity(&tombstone), None);
         assert!(!is_schema_metadata_only_rewrite(&tombstone, None));
+    }
+
+    #[test]
+    fn checkpoint_skips_never_checkpointed_rootpage_zero_schema_delete() {
+        let db = MvccTestDbNoConn::new();
+        let conn = db.connect();
+        let checkpoint = CheckpointStateMachine::new(
+            conn.pager.load().clone(),
+            db.get_mvcc_store(),
+            conn.clone(),
+            true,
+            conn.get_sync_mode(),
+        );
+        let trigger = sqlite_schema_row_version(9, "trigger", "trg_t", "t", 0, Some(1), Some(2));
+
+        let versions =
+            checkpoint.maybe_get_checkpointable_versions(&[trigger], SQLITE_SCHEMA_MVCC_TABLE_ID);
+
+        assert!(
+            versions.is_empty(),
+            "a rootpage-0 trigger/view created and dropped before checkpoint has no physical sqlite_schema row to delete"
+        );
+    }
+
+    #[test]
+    fn checkpoint_tracks_never_checkpointed_btree_schema_delete() {
+        let db = MvccTestDbNoConn::new();
+        let conn = db.connect();
+        let checkpoint = CheckpointStateMachine::new(
+            conn.pager.load().clone(),
+            db.get_mvcc_store(),
+            conn.clone(),
+            true,
+            conn.get_sync_mode(),
+        );
+        let table = sqlite_schema_row_version(2, "table", "t", "t", -2, Some(1), Some(2));
+
+        let versions = checkpoint
+            .maybe_get_checkpointable_versions(&[table.clone()], SQLITE_SCHEMA_MVCC_TABLE_ID);
+
+        assert_eq!(versions.as_slice(), &[table]);
     }
 
     fn index_row_version(

--- a/testing/sqltests/tests/mvcc-schema-rootpage-zero-checkpoint.sqltest
+++ b/testing/sqltests/tests/mvcc-schema-rootpage-zero-checkpoint.sqltest
@@ -1,0 +1,52 @@
+@database :temp:
+@skip-file-if sqlite "MVCC is not supported in SQLite"
+@backend cli
+
+# Regression for https://github.com/tursodatabase/turso/issues/6938:
+# rootpage-0 sqlite_schema rows (views/triggers) that are created and dropped
+# before the first MVCC checkpoint never exist in the physical sqlite_schema
+# b-tree, so checkpoint must not try to delete them from pager storage.
+
+@requires trigger "requires trigger support"
+test mvcc-drop-uncheckpointed-trigger-then-checkpoint {
+    PRAGMA journal_mode='MVCC';
+    CREATE TABLE t(id INTEGER PRIMARY KEY, u TEXT UNIQUE, v TEXT);
+    CREATE TRIGGER tr_ai AFTER INSERT ON t BEGIN SELECT RAISE(ABORT,'boom'); END;
+    DROP TRIGGER tr_ai;
+    PRAGMA wal_checkpoint(TRUNCATE);
+    PRAGMA integrity_check;
+}
+expect {
+    mvcc
+    0|0|0
+    ok
+}
+
+test mvcc-drop-uncheckpointed-view-then-checkpoint {
+    PRAGMA journal_mode='MVCC';
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE VIEW v_t AS SELECT v FROM t;
+    DROP VIEW v_t;
+    PRAGMA wal_checkpoint(TRUNCATE);
+    PRAGMA integrity_check;
+}
+expect {
+    mvcc
+    0|0|0
+    ok
+}
+
+@requires trigger "requires trigger support"
+test mvcc-drop-uncheckpointed-table-with-trigger-then-checkpoint {
+    PRAGMA journal_mode='MVCC';
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+    CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+    DROP TABLE t;
+    PRAGMA wal_checkpoint(TRUNCATE);
+    PRAGMA integrity_check;
+}
+expect {
+    mvcc
+    0|0|0
+    ok
+}


### PR DESCRIPTION
## Summary
- Skip never-checkpointed rootpage-0 `sqlite_schema` deletes during MVCC checkpoint collection.
- Keep the existing special handling for never-checkpointed table/index schema deletes so dropped b-trees still mark their table/index rows as destroyed.
- Add regression sqltests for dropping an uncheckpointed trigger, view, and table-with-trigger before `PRAGMA wal_checkpoint(TRUNCATE)`.

## Root cause
MVCC checkpoint collection returned every uncheckpointed `sqlite_schema` delete, even when the schema row described a rootpage-0 object like a view or trigger. Those objects do not own a physical b-tree. If they are created and dropped before the first checkpoint, their schema rows only live in the MVCC store and never exist in pager-backed `sqlite_schema`, so checkpoint later tried to physically delete a row that had never been written and failed with `MVCC delete: rowid ... not found`.

The fix only uses the "schema delete even when not in the DB file" path for b-tree-backed schema rows. Rootpage-0 deletes are still checkpointed normally if they already exist in the DB file via the existing `is_delete_and_exists_in_db_file` path.

Fixes #6938

## Test Plan
- Red/green verified: the new sqltest failed before the fix with `MVCC delete: rowid ... not found`, and passes after the fix.
- `/home/merlin/work/turso/target/debug/test-runner check testing/sqltests/tests/mvcc-schema-rootpage-zero-checkpoint.sqltest`
- `/home/merlin/work/turso/target/debug/test-runner run --backend cli --binary /home/merlin/work/turso-target/debug/tursodb --jobs 1 --timeout 120 testing/sqltests/tests/mvcc-schema-rootpage-zero-checkpoint.sqltest`
- `CARGO_TARGET_DIR=/home/merlin/work/turso-target cargo test -p turso_core checkpoint_state_machine --lib`
- `CARGO_TARGET_DIR=/home/merlin/work/turso-target cargo fmt --check`
- `CARGO_TARGET_DIR=/home/merlin/work/turso-target cargo clippy -p turso_core --all-targets -- --deny=warnings`
