### PR TITLE
simulator: stress checkpoints under sync faults

### DIFF
--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    WalCheckpoint(CheckpointMode),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,6 +14,14 @@ pub enum VacuumMode {
     None,
     Incremental,
     Full,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CheckpointMode {
+    Passive,
+    Full,
+    Restart,
+    Truncate,
 }
 
 impl Display for Pragma {
@@ -31,6 +40,15 @@ impl Display for Pragma {
             Pragma::ForeignKeyList(table_name) => {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
+            }
+            Pragma::WalCheckpoint(checkpoint_mode) => {
+                let mode = match checkpoint_mode {
+                    CheckpointMode::Passive => "PASSIVE",
+                    CheckpointMode::Full => "FULL",
+                    CheckpointMode::Restart => "RESTART",
+                    CheckpointMode::Truncate => "TRUNCATE",
+                };
+                write!(f, "PRAGMA wal_checkpoint({mode})")
             }
         }
     }

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -14,6 +14,7 @@ use sql_generation::{
         query::{
             Create, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
+            pragma::{CheckpointMode, Pragma},
             predicate::Predicate,
             select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
             transaction::{Begin, Commit, Rollback},
@@ -239,7 +240,9 @@ impl Property {
             Property::Queries { .. } => {
                 unreachable!("No extensional querie generation for `Property::Queries`")
             }
-            Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => {
+            Property::FsyncNoWait { .. }
+            | Property::FaultyQuery { .. }
+            | Property::CheckpointStress { .. } => {
                 unreachable!("No extensional queries")
             }
             Property::SelectLimit { .. }
@@ -990,6 +993,21 @@ impl Property {
                 .map(InteractionBuilder::with_interaction)
                 .collect()
             }
+            Property::CheckpointStress { mode, tables } => {
+                let mut interactions = Vec::with_capacity(tables.len() * 2 + 2);
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::FaultyQuery(Query::Pragma(Pragma::WalCheckpoint(
+                        mode.clone(),
+                    ))),
+                ));
+                interactions.extend(assert_all_table_values(tables, connection_index));
+                interactions.push(assert_integrity_check(
+                    "PRAGMA integrity_check should be ok after checkpoint",
+                    tables,
+                    connection_index,
+                ));
+                interactions
+            }
             Property::WhereTrueFalseNull { select, predicate } => {
                 let tables_dependencies = select.dependencies().into_iter().collect::<Vec<_>>();
                 let assumption = InteractionType::Assumption(Assertion::new(
@@ -1230,7 +1248,11 @@ impl Property {
                     })),
                 ));
                 interactions.extend(assert_all_table_values(tables, connection_index));
-                interactions.push(assert_integrity_check(tables, connection_index));
+                interactions.push(assert_integrity_check(
+                    "PRAGMA integrity_check should be ok after savepoint rollback",
+                    tables,
+                    connection_index,
+                ));
                 interactions
             }
         };
@@ -1414,10 +1436,14 @@ fn random_main_table_delete<R: rand::Rng + ?Sized>(rng: &mut R, table: &Table) -
     })
 }
 
-fn assert_integrity_check(tables: &[String], connection_index: usize) -> InteractionBuilder {
+fn assert_integrity_check(
+    message: &'static str,
+    tables: &[String],
+    connection_index: usize,
+) -> InteractionBuilder {
     let tables = tables.to_vec();
     InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
-        "PRAGMA integrity_check should be ok after savepoint rollback".to_string(),
+        message.to_string(),
         move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
             let result = run_integrity_check(env, connection_index)?;
             if result == "ok" {
@@ -1678,6 +1704,29 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_checkpoint_stress<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    _query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    const MODES: [CheckpointMode; 4] = [
+        CheckpointMode::Passive,
+        CheckpointMode::Full,
+        CheckpointMode::Restart,
+        CheckpointMode::Truncate,
+    ];
+
+    Property::CheckpointStress {
+        mode: pick(&MODES, rng).clone(),
+        tables: ctx
+            .tables()
+            .iter()
+            .map(|table| table.name.clone())
+            .collect(),
+    }
+}
+
 fn property_table_has_expected_content<R: rand::Rng + ?Sized>(
     rng: &mut R,
     _query_distr: &QueryDistribution,
@@ -1914,6 +1963,7 @@ impl PropertyDiscriminants {
             }
             PropertyDiscriminants::FsyncNoWait => property_fsync_no_wait,
             PropertyDiscriminants::FaultyQuery => property_faulty_query,
+            PropertyDiscriminants::CheckpointStress => property_checkpoint_stress,
             PropertyDiscriminants::Queries => {
                 unreachable!("should not try to generate queries property")
             }
@@ -2033,6 +2083,13 @@ impl PropertyDiscriminants {
                     0
                 }
             }
+            PropertyDiscriminants::CheckpointStress => {
+                if env.profile.io.enable && !ctx.tables().is_empty() {
+                    remaining.insert + remaining.update + remaining.delete + remaining.select.max(1)
+                } else {
+                    0
+                }
+            }
             PropertyDiscriminants::Queries => {
                 unreachable!("queries property should not be generated")
             }
@@ -2074,6 +2131,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::UnionAllPreservesCardinality => QueryCapabilities::SELECT,
             PropertyDiscriminants::FsyncNoWait => QueryCapabilities::all(),
             PropertyDiscriminants::FaultyQuery => QueryCapabilities::all(),
+            PropertyDiscriminants::CheckpointStress => QueryCapabilities::SELECT,
             PropertyDiscriminants::Queries => panic!("queries property should not be generated"),
         }
     }

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -792,7 +792,15 @@ impl InteractionType {
             }
             let mut rows = rows.unwrap().unwrap();
             let mut out = Vec::new();
-            let mut current_prob = 0.05;
+            let sync_only_checkpoint = matches!(
+                query,
+                Query::Pragma(sql_generation::model::query::pragma::Pragma::WalCheckpoint(
+                    _
+                ))
+            ) && env.profile.io.fault.sync
+                && !env.profile.io.fault.read
+                && !env.profile.io.fault.write;
+            let mut current_prob = if sync_only_checkpoint { 1.0 } else { 0.05 };
             let mut incr = 0.001;
 
             // Pre-compute path stems for selective fault injection
@@ -819,8 +827,6 @@ impl InteractionType {
                 .collect();
 
             loop {
-                let syncing = env.io.syncing();
-
                 // Decide faults independently per database
                 let main_fault = env.rng.random_bool(current_prob);
                 let aux_prob = (current_prob * 0.5).min(1.0);
@@ -831,8 +837,7 @@ impl InteractionType {
                 }
                 let any_fault = fault_pairs.iter().any(|(_, f)| *f);
 
-                // TODO: avoid for now injecting faults when syncing
-                if any_fault && !syncing {
+                if any_fault {
                     env.io.inject_fault_selective(&fault_pairs);
                 }
 

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -468,7 +468,9 @@ impl Shadow for Query {
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
-            Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(
+                Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_) | Pragma::WalCheckpoint(_),
+            ) => Ok(vec![]),
         }
     }
 }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
-use sql_generation::model::query::{Create, Insert, Select, predicate::Predicate, update::Update};
+use sql_generation::model::query::{
+    Create, Insert, Select, pragma::CheckpointMode, predicate::Predicate, update::Update,
+};
 
 use crate::model::{Query, QueryDiscriminants};
 
@@ -182,6 +184,11 @@ pub enum Property {
     FaultyQuery {
         query: Query,
     },
+    /// Explicitly drives WAL checkpoints and validates the database afterward.
+    CheckpointStress {
+        mode: CheckpointMode,
+        tables: Vec<String>,
+    },
     /// SavepointRollback wraps random write interactions in a named savepoint,
     /// rolls them back, then checks that the database still matches the shadow
     /// model. This targets pager/WAL/cache-spill bugs where rolled-back page
@@ -232,7 +239,9 @@ impl Property {
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
             | Property::Queries { queries } => Some(queries),
-            Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
+            Property::FsyncNoWait { .. }
+            | Property::FaultyQuery { .. }
+            | Property::CheckpointStress { .. } => None,
             Property::SelectLimit { .. }
             | Property::SelectSelectOptimizer { .. }
             | Property::WhereTrueFalseNull { .. }

--- a/testing/simulator/profiles/io.rs
+++ b/testing/simulator/profiles/io.rs
@@ -13,7 +13,6 @@ pub struct IOProfile {
     pub latency: LatencyProfile,
     #[garde(dive)]
     pub fault: FaultProfile,
-    // TODO: expand here with header corruption options and faults on specific IO operations
 }
 
 impl Default for IOProfile {
@@ -58,7 +57,6 @@ impl Default for LatencyProfile {
 pub struct FaultProfile {
     #[garde(skip)]
     pub enable: bool,
-    // TODO: modify SimIo impls to have a FaultProfile inside so they can skip faults depending on the profile
     #[garde(skip)]
     pub read: bool,
     #[garde(skip)]

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -947,6 +947,7 @@ impl SimulatorEnv {
         self.rng = ChaCha8Rng::seed_from_u64(self.opts.seed);
 
         let latency_prof = &self.profile.io.latency;
+        let fault_profile = self.profile.io.fault.clone();
 
         let io: Arc<dyn SimIO> = match self.io_backend {
             IoBackend::Memory => Arc::new(MemorySimIO::new(
@@ -955,6 +956,7 @@ impl SimulatorEnv {
                 latency_prof.latency_probability,
                 latency_prof.min_tick,
                 latency_prof.max_tick,
+                fault_profile,
             )),
             _ => Arc::new(
                 SimulatorIO::new(
@@ -963,6 +965,7 @@ impl SimulatorEnv {
                     latency_prof.latency_probability,
                     latency_prof.min_tick,
                     latency_prof.max_tick,
+                    fault_profile,
                     self.io_backend,
                 )
                 .unwrap(),
@@ -1176,6 +1179,7 @@ impl SimulatorEnv {
         profile.validate().unwrap();
 
         let latency_prof = &profile.io.latency;
+        let fault_profile = profile.io.fault.clone();
 
         let io_backend = cli_opts.io_backend;
         let io: Arc<dyn SimIO> = match io_backend {
@@ -1185,6 +1189,7 @@ impl SimulatorEnv {
                 latency_prof.latency_probability,
                 latency_prof.min_tick,
                 latency_prof.max_tick,
+                fault_profile,
             )),
             _ => Arc::new(
                 SimulatorIO::new(
@@ -1193,6 +1198,7 @@ impl SimulatorEnv {
                     latency_prof.latency_probability,
                     latency_prof.min_tick,
                     latency_prof.max_tick,
+                    fault_profile,
                     io_backend,
                 )
                 .unwrap(),

--- a/testing/simulator/runner/file.rs
+++ b/testing/simulator/runner/file.rs
@@ -38,6 +38,9 @@ pub(crate) struct SimulatorFile {
     pub(crate) rng: RefCell<ChaCha8Rng>,
 
     pub latency_probability: u8,
+    pub fault_read: bool,
+    pub fault_write: bool,
+    pub fault_sync: bool,
 
     pub sync_completion: RefCell<Option<turso_core::Completion>>,
     pub queued_io: RefCell<Vec<DelayedIo>>,
@@ -70,7 +73,8 @@ impl SimulatorFile {
     pub(crate) fn stats_table(&self) -> String {
         let sum_calls =
             self.nr_pread_calls.get() + self.nr_pwrite_calls.get() + self.nr_sync_calls.get();
-        let sum_faults = self.nr_pread_faults.get() + self.nr_pwrite_faults.get();
+        let sum_faults =
+            self.nr_pread_faults.get() + self.nr_pwrite_faults.get() + self.nr_sync_faults.get();
         let stats_table = [
             "op           calls   faults".to_string(),
             "--------- -------- --------".to_string(),
@@ -87,7 +91,7 @@ impl SimulatorFile {
             format!(
                 "sync      {:8} {:8}",
                 self.nr_sync_calls.get(),
-                0 // No fault counter for sync
+                self.nr_sync_faults.get()
             ),
             "--------- -------- --------".to_string(),
             format!("total     {sum_calls:8} {sum_faults:8}"),
@@ -120,7 +124,7 @@ impl SimulatorFile {
 
 impl File for SimulatorFile {
     fn lock_file(&self, exclusive: bool) -> Result<()> {
-        if self.fault.get() {
+        if self.fault.get() && self.fault_write {
             return Err(turso_core::LimboError::InternalError(
                 FAULT_ERROR_MSG.into(),
             ));
@@ -129,7 +133,7 @@ impl File for SimulatorFile {
     }
 
     fn unlock_file(&self) -> Result<()> {
-        if self.fault.get() {
+        if self.fault.get() && self.fault_write {
             return Err(turso_core::LimboError::InternalError(
                 FAULT_ERROR_MSG.into(),
             ));
@@ -139,7 +143,7 @@ impl File for SimulatorFile {
 
     fn pread(&self, pos: u64, c: turso_core::Completion) -> Result<turso_core::Completion> {
         self.nr_pread_calls.set(self.nr_pread_calls.get() + 1);
-        if self.fault.get() {
+        if self.fault.get() && self.fault_read {
             tracing::debug!("pread fault");
             self.nr_pread_faults.set(self.nr_pread_faults.get() + 1);
             return Err(turso_core::LimboError::InternalError(
@@ -165,7 +169,7 @@ impl File for SimulatorFile {
         c: turso_core::Completion,
     ) -> Result<turso_core::Completion> {
         self.nr_pwrite_calls.set(self.nr_pwrite_calls.get() + 1);
-        if self.fault.get() {
+        if self.fault.get() && self.fault_write {
             tracing::debug!("pwrite fault");
             self.nr_pwrite_faults.set(self.nr_pwrite_faults.get() + 1);
             return Err(turso_core::LimboError::InternalError(
@@ -190,12 +194,12 @@ impl File for SimulatorFile {
         sync_type: turso_core::io::FileSyncType,
     ) -> Result<turso_core::Completion> {
         self.nr_sync_calls.set(self.nr_sync_calls.get() + 1);
-        if self.fault.get() {
-            // TODO: Enable this when https://github.com/tursodatabase/turso/issues/2091 is fixed.
-            tracing::debug!(
-                "ignoring sync fault because it causes false positives with current simulator design"
-            );
-            self.fault.set(false);
+        if self.fault.get() && self.fault_sync {
+            tracing::debug!("sync fault");
+            self.nr_sync_faults.set(self.nr_sync_faults.get() + 1);
+            return Err(turso_core::LimboError::InternalError(
+                FAULT_ERROR_MSG.into(),
+            ));
         }
         let c = if let Some(latency) = self.generate_latency_duration() {
             let cloned_c = c.clone();
@@ -223,7 +227,7 @@ impl File for SimulatorFile {
         c: turso_core::Completion,
     ) -> Result<turso_core::Completion> {
         self.nr_pwrite_calls.set(self.nr_pwrite_calls.get() + 1);
-        if self.fault.get() {
+        if self.fault.get() && self.fault_write {
             tracing::debug!("pwritev fault");
             self.nr_pwrite_faults.set(self.nr_pwrite_faults.get() + 1);
             return Err(turso_core::LimboError::InternalError(
@@ -249,7 +253,7 @@ impl File for SimulatorFile {
     }
 
     fn truncate(&self, len: u64, c: turso_core::Completion) -> Result<turso_core::Completion> {
-        if self.fault.get() {
+        if self.fault.get() && self.fault_write {
             return Err(turso_core::LimboError::InternalError(
                 FAULT_ERROR_MSG.into(),
             ));

--- a/testing/simulator/runner/io.rs
+++ b/testing/simulator/runner/io.rs
@@ -7,7 +7,10 @@ use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use turso_core::{Clock, IO, MonotonicInstant, OpenFlags, PlatformIO, Result, WallClockInstant};
 
-use crate::runner::{SimIO, cli::IoBackend, clock::SimulatorClock, file::SimulatorFile};
+use crate::{
+    profiles::io::FaultProfile,
+    runner::{SimIO, cli::IoBackend, clock::SimulatorClock, file::SimulatorFile},
+};
 
 pub(crate) struct SimulatorIO {
     pub(crate) inner: Box<dyn IO>,
@@ -17,6 +20,7 @@ pub(crate) struct SimulatorIO {
     pub(crate) page_size: usize,
     seed: u64,
     latency_probability: u8,
+    fault_profile: FaultProfile,
     clock: Arc<SimulatorClock>,
 }
 
@@ -30,6 +34,7 @@ impl SimulatorIO {
         latency_probability: u8,
         min_tick: u64,
         max_tick: u64,
+        fault_profile: FaultProfile,
         io_backend: IoBackend,
     ) -> Result<Self> {
         let inner: Box<dyn turso_core::IO> = match io_backend {
@@ -55,6 +60,7 @@ impl SimulatorIO {
             page_size,
             seed,
             latency_probability,
+            fault_profile,
             clock: Arc::new(clock),
         })
     }
@@ -142,6 +148,9 @@ impl IO for SimulatorIO {
             page_size: self.page_size,
             rng: RefCell::new(ChaCha8Rng::seed_from_u64(self.seed)),
             latency_probability: self.latency_probability,
+            fault_read: self.fault_profile.read,
+            fault_write: self.fault_profile.write,
+            fault_sync: self.fault_profile.sync,
             sync_completion: RefCell::new(None),
             queued_io: RefCell::new(Vec::new()),
             clock: self.clock.clone(),

--- a/testing/simulator/runner/memory/file.rs
+++ b/testing/simulator/runner/memory/file.rs
@@ -8,9 +8,12 @@ use rand_chacha::ChaCha8Rng;
 use tracing::{Level, instrument};
 use turso_core::{Completion, File, Result};
 
-use crate::runner::{
-    clock::SimulatorClock,
-    memory::io::{CallbackQueue, Fd, Operation, OperationType},
+use crate::{
+    profiles::io::FaultProfile,
+    runner::{
+        clock::SimulatorClock,
+        memory::io::{CallbackQueue, Fd, Operation, OperationType},
+    },
 };
 
 /// Tracks IO calls and faults for each type of I/O operation
@@ -53,6 +56,7 @@ pub struct MemorySimFile {
     io_tracker: RefCell<IOTracker>,
     pub rng: RefCell<ChaCha8Rng>,
     pub latency_probability: u8,
+    fault_profile: FaultProfile,
     clock: Arc<SimulatorClock>,
     fault: Cell<bool>,
 }
@@ -66,6 +70,7 @@ impl MemorySimFile {
         fd: Fd,
         seed: u64,
         latency_probability: u8,
+        fault_profile: FaultProfile,
         clock: Arc<SimulatorClock>,
     ) -> Self {
         Self {
@@ -76,6 +81,7 @@ impl MemorySimFile {
             io_tracker: RefCell::new(IOTracker::default()),
             rng: RefCell::new(ChaCha8Rng::seed_from_u64(seed)),
             latency_probability,
+            fault_profile,
             clock,
             fault: Cell::new(false),
         }
@@ -131,8 +137,15 @@ impl MemorySimFile {
     }
 
     fn insert_op(&self, op: OperationType) {
-        // FIXME: currently avoid any fsync faults until we correctly define the expected behaviour in the simulator
-        let fault = self.fault.get() && !matches!(op, OperationType::Sync { .. });
+        let fault = self.fault.get()
+            && match op {
+                OperationType::Read { .. } => self.fault_profile.read,
+                OperationType::Write { .. } | OperationType::WriteV { .. } => {
+                    self.fault_profile.write
+                }
+                OperationType::Sync { .. } => self.fault_profile.sync,
+                OperationType::Truncate { .. } => self.fault_profile.write,
+            };
         if fault {
             let mut io_tracker = self.io_tracker.borrow_mut();
             match &op {

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -7,6 +7,7 @@ use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use turso_core::{Clock, Completion, IO, MonotonicInstant, OpenFlags, Result, WallClockInstant};
 
+use crate::profiles::io::FaultProfile;
 use crate::runner::SimIO;
 use crate::runner::clock::SimulatorClock;
 use crate::runner::memory::file::MemorySimFile;
@@ -135,6 +136,7 @@ pub struct MemorySimIO {
     pub page_size: usize,
     seed: u64,
     latency_probability: u8,
+    fault_profile: FaultProfile,
     clock: Arc<SimulatorClock>,
 }
 
@@ -148,6 +150,7 @@ impl MemorySimIO {
         latency_probability: u8,
         min_tick: u64,
         max_tick: u64,
+        fault_profile: FaultProfile,
     ) -> Self {
         let files = RefCell::new(IndexMap::new());
         let rng = RefCell::new(ChaCha8Rng::seed_from_u64(seed));
@@ -159,6 +162,7 @@ impl MemorySimIO {
             page_size,
             seed,
             latency_probability,
+            fault_profile,
             clock: Arc::new(SimulatorClock::new(
                 ChaCha8Rng::seed_from_u64(seed),
                 min_tick,
@@ -256,6 +260,7 @@ impl IO for MemorySimIO {
                 fd.clone(),
                 self.seed,
                 self.latency_probability,
+                self.fault_profile.clone(),
                 self.clock.clone(),
             ));
             files.insert(fd, file.clone());

--- a/testing/simulator/runner/memory/mvcc_recovery.rs
+++ b/testing/simulator/runner/memory/mvcc_recovery.rs
@@ -4,11 +4,19 @@ use std::sync::Arc;
 use anyhow::Result;
 use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
 
+use crate::profiles::io::FaultProfile;
 use crate::runner::SimIO;
 use crate::runner::memory::io::MemorySimIO;
 
 fn make_io(seed: u64, latency_probability: u8) -> Arc<MemorySimIO> {
-    Arc::new(MemorySimIO::new(seed, 4096, latency_probability, 1, 5))
+    Arc::new(MemorySimIO::new(
+        seed,
+        4096,
+        latency_probability,
+        1,
+        5,
+        FaultProfile::default(),
+    ))
 }
 
 fn open_conn(io: Arc<MemorySimIO>, path: &str) -> Result<Arc<Connection>> {

--- a/testing/simulator/runner/memory/statement_abandon.rs
+++ b/testing/simulator/runner/memory/statement_abandon.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
 
+use crate::profiles::io::FaultProfile;
 use crate::runner::SimIO;
 use crate::runner::memory::io::MemorySimIO;
 
@@ -23,8 +24,12 @@ fn make_two_conns(seed: u64) -> Result<(Arc<Connection>, Arc<Connection>, Arc<Me
 
 fn make_io(seed: u64) -> Arc<MemorySimIO> {
     Arc::new(MemorySimIO::new(
-        seed, 4096, 100, // Always schedule operations asynchronously.
-        1, 5,
+        seed,
+        4096,
+        100, // Always schedule operations asynchronously.
+        1,
+        5,
+        FaultProfile::default(),
     ))
 }
 


### PR DESCRIPTION
## Summary
- add `PRAGMA wal_checkpoint(...)` generation to the simulator as a `CheckpointStress` property
- run checkpoint stress through the faulty-query path, then verify table contents and `PRAGMA integrity_check`
- re-enable sync fault injection for platform and memory simulator I/O, honoring `FaultProfile` read/write/sync toggles and reporting sync fault stats

Refs #7045. #2091 is closed, so the old sync-fault workaround can be removed.

## Verification
- `cargo fmt --check`
- `cargo build -q --bin limbo_sim`
- `cargo clippy -q -p limbo_sim --all-targets -- --deny=warnings`
- `cargo test -q -p limbo_sim`
- sync-fault smoke: `RUST_LOG=debug ./target/debug/limbo_sim --disable-bugbase --profile /tmp/turso-sync-fault-profile.json --maximum-tests 180 --minimum-tests 180 --maximum-time 30 --seed 1 --keep-files`
  - observed `PRAGMA wal_checkpoint(TRUNCATE); -- FAULTY QUERY`
  - observed `sync fault` and `PRAGMA wal_checkpoint failed: InternalError("Injected Fault")`
  - stats included `sync             3        3`
  - simulator completed with `simulation succeeded`
