### PR TITLE
testing/simulator: fix drop index accounting in query profile

### DIFF
--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -73,7 +73,7 @@ impl Remaining {
             .unwrap_or_default();
 
         let mut remaining_drop_index = total_drop_index
-            .checked_sub(stats.alter_table_count)
+            .checked_sub(stats.drop_index_count)
             .unwrap_or_default();
 
         if mvcc {

--- a/testing/simulator/profiles/query.rs
+++ b/testing/simulator/profiles/query.rs
@@ -63,6 +63,7 @@ impl QueryProfile {
             + self.delete_weight
             + self.drop_table_weight
             + self.alter_table_weight
+            + self.drop_index
             + self.pragma_weight
     }
 }


### PR DESCRIPTION
Two related bugs in the simulator's drop-index weighting:

- `Remaining::new` subtracted `alter_table_count` instead of `drop_index_count` when computing how many drop-index ops remained.
- `QueryProfile::total_weight` omitted `drop_index`, so the total was under-counted and weighted picks across query kinds were skewed.

Forked from #7006 by Codex.