### PR TITLE
sdk-kit: clarify crates.io descriptions point Rust users to `turso`

### DIFF
--- a/sdk-kit/Cargo.toml
+++ b/sdk-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turso_sdk_kit"
-description = "Turso SDK kit"
+description = "Low-level C ABI for building Turso language bindings. For Rust applications, use the `turso` crate instead."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/sdk-kit/README.md
+++ b/sdk-kit/README.md
@@ -1,5 +1,7 @@
 # Turso SDK kit
 
+> **Building a Rust application?** Use the [`turso`](https://crates.io/crates/turso) crate instead. This crate is the low-level C ABI used to build language bindings; it is not the Rust SDK for end users.
+
 Low-level, SQLite-compatible Turso API to make building SDKs in any language simple and predictable. The core logic is implemented in Rust and exposed through a small, portable C ABI (turso.h), so you can generate language bindings (e.g. via rust-bindgen) without re-implementing database semantics.
 
 Key ideas:

--- a/sync/sdk-kit/Cargo.toml
+++ b/sync/sdk-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turso_sync_sdk_kit"
-description = "Turso sync SDK kit"
+description = "Low-level C ABI for Turso Cloud sync in language bindings. For Rust applications, use the `turso` crate instead."
 version.workspace = true
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
The "Turso SDK kit" / "Turso sync SDK kit" descriptions made these crates look like the Rust SDK to use, especially with a Rust example at the top of the README. Update the descriptions and add a README callout directing Rust applications to the `turso` crate.