### PR TITLE
core: open with absolute path

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1781,16 +1781,7 @@ impl Connection {
     }
 
     pub fn get_database_canonical_path(&self) -> String {
-        if self.db.is_in_memory_db() {
-            // For in-memory databases, SQLite shows empty string
-            String::new()
-        } else {
-            // For file databases, try show the full absolute path if that doesn't fail
-            match std::fs::canonicalize(&self.db.path) {
-                Ok(abs_path) => abs_path.to_string_lossy().to_string(),
-                Err(_) => self.db.path.to_string(),
-            }
-        }
+        self.db.get_database_canonical_path()
     }
 
     /// Check if a specific attached database is read only or not, by its index

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1618,10 +1618,11 @@ impl Database {
         pager.set_schema_cookie(None);
 
         if open_mv_store {
+            let canonical_path = self.get_database_canonical_path();
             let enc_ctx = pager.io_ctx.read().encryption_context().cloned();
             let mv_store = journal_mode::open_mv_store(
                 self.io.clone(),
-                &self.path,
+                &canonical_path,
                 self.open_flags,
                 self.durable_storage.clone(),
                 enc_ctx,
@@ -1630,6 +1631,19 @@ impl Database {
         }
 
         Ok(Arc::new(pager))
+    }
+
+    pub fn get_database_canonical_path(&self) -> String {
+        if self.is_in_memory_db() {
+            // For in-memory databases, SQLite shows empty string
+            String::new()
+        } else {
+            // For file databases, try show the full absolute path if that doesn't fail
+            match std::fs::canonicalize(&self.path) {
+                Ok(abs_path) => abs_path.to_string_lossy().to_string(),
+                Err(_) => self.db.path.to_string(),
+            }
+        }
     }
 
     #[instrument(skip_all, level = Level::INFO)]

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1641,7 +1641,7 @@ impl Database {
             // For file databases, try show the full absolute path if that doesn't fail
             match std::fs::canonicalize(&self.path) {
                 Ok(abs_path) => abs_path.to_string_lossy().to_string(),
-                Err(_) => self.db.path.to_string(),
+                Err(_) => self.path.to_string(),
             }
         }
     }

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -24,6 +24,12 @@ impl Default for IOFaultConfig {
     }
 }
 
+fn canonical_key(path: &str) -> String {
+    std::fs::canonicalize(path)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string())
+}
+
 pub struct SimulatorIO {
     files: Mutex<Vec<(String, Arc<SimulatorFile>)>>,
     file_sizes: Arc<Mutex<HashMap<String, u64>>>,
@@ -125,9 +131,10 @@ impl IO for SimulatorIO {
             .fetch_add(duration.as_micros() as u64, Ordering::SeqCst);
     }
     fn open_file(&self, path: &str, _flags: OpenFlags, _create_new: bool) -> Result<Arc<dyn File>> {
+        let lookup_key = canonical_key(path);
         {
             let files = self.files.lock().unwrap();
-            if let Some((_, file)) = files.iter().find(|f| f.0 == path) {
+            if let Some((_, file)) = files.iter().find(|f| f.0 == lookup_key) {
                 return Ok(file.clone());
             }
         }
@@ -137,9 +144,10 @@ impl IO for SimulatorIO {
             self.file_sizes.clone(),
             self.pending.clone(),
         ));
+        let insert_key = canonical_key(path);
 
         let mut files = self.files.lock().unwrap();
-        files.push((path.to_string(), file.clone()));
+        files.push((insert_key, file.clone()));
 
         Ok(file as Arc<dyn File>)
     }
@@ -149,8 +157,9 @@ impl IO for SimulatorIO {
     }
 
     fn remove_file(&self, path: &str) -> Result<()> {
+        let key = canonical_key(path);
         let mut files = self.files.lock().unwrap();
-        files.retain(|(p, _)| p != path);
+        files.retain(|(p, _)| p != &key);
 
         if !self.keep_files {
             let _ = std::fs::remove_file(path);


### PR DESCRIPTION
## Description

Whopper was finding issues while reopening a database that had log frames because when we reopened the database, in `SimulatorIO::open_file` we would not use canonical (absolute) path, meaning we would open two different files.

## Description of AI Usage

Got the analysis from clanker
