### PR TITLE
bindings/python: enable PyO3 abi3-py310 for a single cross-version wheel

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           working-directory: ${{ env.working-directory }}
           target: ${{ matrix.target }}
-          args: --profile release-official --out dist --find-interpreter
+          args: --profile release-official --out dist
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -192,7 +192,7 @@ jobs:
         with:
           working-directory: ${{ env.working-directory }}
           target: ${{ matrix.target }}
-          args: --profile release-official --out dist --find-interpreter
+          args: --profile release-official --out dist
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,9 +18,9 @@ crate-type = ["cdylib"]
 anyhow = "1.0"
 turso_sdk_kit = { workspace = true }
 turso_sync_sdk_kit = { workspace = true }
-pyo3 = { version = "0.28.2", features = ["anyhow"] }
+pyo3 = { version = "0.28.2", features = ["anyhow", "abi3-py310"] }
 
 [build-dependencies]
 version_check = "0.9.5"
 # used where logic has to be version/distribution specific, e.g. pypy
-pyo3-build-config = { version = "0.28.2" }
+pyo3-build-config = { version = "0.28.2", features = ["abi3-py310"] }


### PR DESCRIPTION
Using the stable ABI lets one wheel target Python 3.10 and every newer 3.x, replacing the per-minor-version matrix. Drops --find-interpreter from the release wheel builds so maturin emits one cp310-abi3 wheel per platform instead of one per interpreter.