### PR TITLE
fix(alter): reject ALTER COLUMN to generated when column is indexed

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1691,6 +1691,31 @@ pub fn translate_alter_table(
                         "must have at least one non-generated column".to_string(),
                     ));
                 }
+
+                // Converting an indexed column to a generated column would leave the
+                // secondary index entries pointing at the old stored values while the
+                // rewritten rows reflect the new generated values, corrupting the index
+                // (issue #7077). Reject the operation until index rebuild is supported.
+                let old_column = &btree.columns()[column_index];
+                if old_column.unique()
+                    || btree.unique_sets.iter().any(|set| {
+                        set.columns
+                            .iter()
+                            .any(|(name, _)| name == &normalize_ident(from))
+                    })
+                {
+                    return Err(LimboError::ParseError(format!(
+                        "cannot alter column \"{from}\" to a generated column: column has a UNIQUE constraint"
+                    )));
+                }
+                for index in table_indexes.iter() {
+                    if index.columns.iter().any(|col| col.pos_in_table == column_index) {
+                        return Err(LimboError::ParseError(format!(
+                            "cannot alter column \"{from}\" to a generated column: column is referenced in index \"{}\"",
+                            index.name
+                        )));
+                    }
+                }
             }
 
             let rewritten_table = if rewrites_physical_layout {

--- a/testing/sqltests/turso-tests/alter_column.sqltest
+++ b/testing/sqltests/turso-tests/alter_column.sqltest
@@ -717,3 +717,41 @@ expect {
     a2|a2c2|c2
     ok
 }
+
+# Issue #7077: Converting a column with a UNIQUE constraint to a generated
+# column must be rejected. The row-rewrite path does not rebuild secondary
+# indexes, so allowing the operation would leave the autoindex pointing at the
+# old stored values while DELETE/UPDATE use the new generated values, producing
+# "Corrupt database: IdxDelete: no matching index entry found".
+test fail-alter-column-to-generated-when-inline-unique {
+    CREATE TABLE p (a, b UNIQUE);
+    INSERT INTO p VALUES(1, 10);
+    ALTER TABLE p ALTER COLUMN b TO g AS (a + 1);
+}
+expect error {
+    cannot alter column "b" to a generated column: column has a UNIQUE constraint
+}
+
+# Same protection via an explicit CREATE INDEX (not an inline UNIQUE).
+test fail-alter-column-to-generated-when-explicitly-indexed {
+    CREATE TABLE q (a, b);
+    CREATE INDEX idx_q_b ON q (b);
+    INSERT INTO q VALUES(1, 10);
+    ALTER TABLE q ALTER COLUMN b TO g AS (a + 1);
+}
+expect error {
+    cannot alter column "b" to a generated column: column is referenced in index "idx_q_b"
+}
+
+# Altering an un-indexed column to generated must still work (no regression).
+test alter-column-to-generated-unindexed-ok {
+    CREATE TABLE r (a, b UNIQUE, c);
+    INSERT INTO r VALUES(1, 10, 99);
+    ALTER TABLE r ALTER COLUMN c TO g AS (a + 1);
+    SELECT a, b, g FROM r;
+    PRAGMA integrity_check;
+}
+expect {
+    1|10|2
+    ok
+}


### PR DESCRIPTION
## Summary

Fixes #7077 — data corruption when converting an indexed column to a generated column.

### Root cause

`emit_rewrite_table_rows` rewrites every table page so each row computes the new generated value, but it never touches secondary indexes. Those index entries still hold the old stored column value. Any subsequent `DELETE` or `UPDATE` issues an `IdxDelete` against the key the index actually contains (old value), which no longer matches any index entry → **"Corrupt database: IdxDelete: no matching index entry found"**.

### Fix

Guard the `is_making_column_generated` path with the same checks DROP COLUMN already uses:

- Inline `UNIQUE` constraint on the column → error
- Column appears in a multi-column unique set → error  
- Column is covered by any explicit secondary index → error

This mirrors the conservative approach taken for DROP COLUMN and avoids the corruption until a proper index-rebuild / REINDEX path is implemented.

### Tests

Three new sqltests in `alter_column.sqltest`:

| Test | Expectation |
|---|---|
| `fail-alter-column-to-generated-when-inline-unique` | parse error (UNIQUE constraint) |
| `fail-alter-column-to-generated-when-explicitly-indexed` | parse error (referenced in index) |
| `alter-column-to-generated-unindexed-ok` | succeeds; non-indexed column converts cleanly |

All existing `alter-column` tests continue to pass.

---

> This fix was developed as part of a Turso bug bounty submission.