### PR TITLE
core/vdbe: refresh ALTER COLUMN CHECK constraints

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13049,6 +13049,23 @@ pub fn op_alter_column(
             }
         } else {
             btree.columns_mut()[*column_index] = new_column.clone();
+            btree.check_constraints.retain(|check| {
+                check
+                    .column
+                    .as_ref()
+                    .is_none_or(|col| !col.eq_ignore_ascii_case(&old_column_name))
+            });
+            for constraint in &definition.constraints {
+                if let ast::ColumnConstraint::Check(expr) = &constraint.constraint {
+                    btree
+                        .check_constraints
+                        .push(crate::schema::CheckConstraint::new(
+                            constraint.name.as_ref(),
+                            expr,
+                            Some(&new_name),
+                        ));
+                }
+            }
         }
 
         btree.prepare_generated_columns()?;

--- a/testing/simulator/runner/memory/alter_column.rs
+++ b/testing/simulator/runner/memory/alter_column.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use turso_core::{Connection, Database, DatabaseOpts, IO, OpenFlags, StepResult};
+
+use crate::runner::memory::io::MemorySimIO;
+
+fn make_io(seed: u64) -> Arc<MemorySimIO> {
+    Arc::new(MemorySimIO::new(seed, 4096, 100, 1, 5))
+}
+
+fn open_conn(io: Arc<MemorySimIO>, path: &str) -> Result<Arc<Connection>> {
+    let db = Database::open_file_with_flags(
+        io as Arc<dyn IO>,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+    )?;
+    Ok(db.connect()?)
+}
+
+fn query_strings(conn: &Arc<Connection>, io: &MemorySimIO, sql: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => io.step()?,
+            StepResult::Row => {
+                let row = stmt.row().expect("row should exist");
+                rows.push(row.get::<String>(0).expect("text column should exist"));
+            }
+            StepResult::Done => return Ok(rows),
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn sim_alter_column_check_is_enforced_before_reopen() -> Result<()> {
+    let seed = 1;
+    let io = make_io(seed);
+    let path = format!("sim_alter_column_check_{seed}.db");
+    let conn = open_conn(io.clone(), &path)?;
+
+    conn.execute("CREATE TABLE t(a INTEGER)")?;
+    conn.execute("ALTER TABLE t ALTER COLUMN a TO b INTEGER CHECK(b > 0)")?;
+
+    let schema = query_strings(
+        &conn,
+        io.as_ref(),
+        "SELECT sql FROM sqlite_schema WHERE name = 't'",
+    )?;
+    assert_eq!(schema, vec!["CREATE TABLE t (b INTEGER CHECK (b > 0))"]);
+
+    let invalid_insert = conn.execute("INSERT INTO t VALUES(-1)");
+    assert!(
+        invalid_insert.is_err(),
+        "ALTER COLUMN must refresh live CHECK metadata before the database is reopened"
+    );
+
+    let integrity = query_strings(&conn, io.as_ref(), "PRAGMA integrity_check")?;
+    assert_eq!(integrity, vec!["ok"]);
+    Ok(())
+}

--- a/testing/simulator/runner/memory/mod.rs
+++ b/testing/simulator/runner/memory/mod.rs
@@ -2,6 +2,8 @@ pub mod file;
 pub mod io;
 
 #[cfg(test)]
+mod alter_column;
+#[cfg(test)]
 mod mvcc_recovery;
 #[cfg(test)]
 mod statement_abandon;

--- a/tests/integration/query_processing/test_alter_table_reopen.rs
+++ b/tests/integration/query_processing/test_alter_table_reopen.rs
@@ -11,6 +11,32 @@
 use crate::common::{ExecRows, TempDatabase};
 use tempfile::TempDir;
 
+#[test]
+fn test_alter_column_check_constraint_enforced_before_reopen() {
+    let db = TempDatabase::new("alter_column_check_constraint_enforced_before_reopen.db");
+    let conn = db.connect_limbo();
+
+    conn.execute("CREATE TABLE t(a INTEGER)").unwrap();
+    conn.execute("ALTER TABLE t ALTER COLUMN a TO b INTEGER CHECK(b > 0)")
+        .unwrap();
+
+    let schema: Vec<(String,)> =
+        conn.exec_rows("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 't'");
+    assert_eq!(
+        schema,
+        vec![("CREATE TABLE t (b INTEGER CHECK (b > 0))".into(),)]
+    );
+
+    let invalid_insert = conn.execute("INSERT INTO t VALUES(-1)");
+    assert!(
+        invalid_insert.is_err(),
+        "ALTER COLUMN must refresh the live CHECK metadata before reopen"
+    );
+
+    let integrity: Vec<(String,)> = conn.exec_rows("PRAGMA integrity_check");
+    assert_eq!(integrity, vec![("ok".into(),)]);
+}
+
 /// After ALTER TABLE DROP COLUMN on an AUTOINCREMENT table, reopen must parse
 /// the persisted schema as AUTOINCREMENT and avoid reusing deleted rowids.
 #[test]


### PR DESCRIPTION
## Summary
- refresh the live BTreeTable CHECK metadata when ALTER COLUMN replaces a column definition
- preserve existing table-level CHECK constraints while removing stale column-level CHECK constraints for the altered column
- add deterministic simulator and integration regressions for same-connection enforcement before reopen

Fixes #6773.

## Tests
- cargo test -p limbo_sim --no-default-features --features turso_core/pure-rust-crypto sim_alter_column_check_is_enforced_before_reopen -- --nocapture
- cargo test -p core_tester --no-default-features --features pure-rust-crypto,test_helper test_alter_column_check_constraint_enforced_before_reopen --test integration_tests -- --nocapture