### PR TITLE
sqlite3: Respect `n_byte` length in `sqlite3_prepare_{v2,v3}`

### DIFF
--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -802,7 +802,7 @@ pub unsafe extern "C" fn sqlite3_context_db_handle(context: *mut ffi::c_void) ->
 pub unsafe extern "C" fn sqlite3_prepare_v2(
     raw_db: *mut sqlite3,
     sql: *const ffi::c_char,
-    _len: ffi::c_int,
+    n_byte: ffi::c_int,
     out_stmt: *mut *mut sqlite3_stmt,
     tail: *mut *const ffi::c_char,
 ) -> ffi::c_int {
@@ -811,8 +811,22 @@ pub unsafe extern "C" fn sqlite3_prepare_v2(
     }
     let db: &mut sqlite3 = &mut *raw_db;
     let mut db = db.inner.lock().unwrap();
-    let sql_cstr = CStr::from_ptr(sql);
-    let sql_str = match sql_cstr.to_str() {
+    // SQLite C-API contract (https://www.sqlite.org/c3ref/prepare.html):
+    //   If nByte is negative, zSql is read up to the first zero terminator.
+    //   If nByte is positive, it is the number of bytes read from zSql.
+    // Without this branch, the function unconditionally walks until NUL — over-reads
+    // any non-NUL-terminated Rust `&str` passed by rusqlite/libsqlite3-sys, producing
+    // misleading parse errors from neighbouring memory.
+    let sql_bytes: &[u8] = if n_byte < 0 {
+        CStr::from_ptr(sql).to_bytes()
+    } else {
+        let bounded = std::slice::from_raw_parts(sql as *const u8, n_byte as usize);
+        bounded
+            .iter()
+            .position(|&b| b == 0)
+            .map_or(bounded, |i| &bounded[..i])
+    };
+    let sql_str = match std::str::from_utf8(sql_bytes) {
         Ok(s) => s,
         Err(_) => {
             db.err_code = SQLITE_MISUSE;

--- a/sqlite3/tests/compat/mod.rs
+++ b/sqlite3/tests/compat/mod.rs
@@ -271,6 +271,90 @@ mod tests {
         }
     }
 
+    // Per SQLite spec (https://www.sqlite.org/c3ref/prepare.html):
+    //   "If nByte is positive, it is the number of bytes read from zSql."
+    // Consumers like rusqlite/libsqlite3-sys pass non-NUL-terminated &str slices with
+    // explicit positive nByte. The three tests below cover the contract:
+    //   - positive nByte respects the bound (no over-read past the slice)
+    //   - negative nByte keeps the read-until-NUL behavior
+    //   - NUL within the bound truncates (per spec)
+    // Each test actively sets up the failure mode (garbage bytes after the bound, or
+    // a "should-not-be-seen" suffix after an embedded NUL) so an over-reading impl
+    // would produce a parser error rather than silently passing.
+
+    #[test]
+    fn test_prepare_v2_n_byte_positive_no_nul() {
+        unsafe {
+            let mut db = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            // 8 bytes of valid SQL followed by 4 bytes of garbage. n_byte = 8.
+            // An over-reading impl would walk past the bound, hit \xff, and error.
+            let sql_and_garbage: &[u8] = b"SELECT 1\xff\xff\xff\xff";
+            let mut stmt = ptr::null_mut();
+            let rc = sqlite3_prepare_v2(
+                db,
+                sql_and_garbage.as_ptr() as *const libc::c_char,
+                8,
+                &mut stmt,
+                ptr::null_mut(),
+            );
+            assert_eq!(
+                rc, SQLITE_OK,
+                "prepare_v2 must respect positive n_byte (no over-read)"
+            );
+            assert!(!stmt.is_null());
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_prepare_v2_n_byte_negative_uses_nul() {
+        // Regression: n_byte = -1 path must still read until NUL terminator.
+        unsafe {
+            let mut db = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            let mut stmt = ptr::null_mut();
+            let rc = sqlite3_prepare_v2(db, c"SELECT 1".as_ptr(), -1, &mut stmt, ptr::null_mut());
+            assert_eq!(rc, SQLITE_OK);
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_prepare_v2_n_byte_truncates_at_embedded_nul() {
+        // Spec: "the SQL text is read up to the first zero terminator or the nByte-th
+        // byte, whichever comes first." Embedded NUL within the bound must truncate.
+        unsafe {
+            let mut db = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+
+            // NUL at offset 8; bound is 20 (claims more). Reader must stop at NUL.
+            // If under-truncating, parser sees "GARBAGE_AFTER_NUL" and errors out.
+            let sql: &[u8] = b"SELECT 1\x00GARBAGE_AFTER_NUL";
+            let mut stmt = ptr::null_mut();
+            let rc = sqlite3_prepare_v2(
+                db,
+                sql.as_ptr() as *const libc::c_char,
+                20,
+                &mut stmt,
+                ptr::null_mut(),
+            );
+            assert_eq!(
+                rc, SQLITE_OK,
+                "embedded NUL within bound must truncate, not over-read"
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
     #[test]
     fn test_sqlite3_bind_int() {
         unsafe {


### PR DESCRIPTION
## Summary

Fixes #7100 — `sqlite3_prepare_v2` / `_v3` ignore the `nByte` parameter and read until the first NUL byte, regardless of caller intent.

Per the [SQLite C-API spec](https://www.sqlite.org/c3ref/prepare.html):
> If nByte is negative, then zSql is read up to the first zero terminator.
> If nByte is positive, then it is the number of bytes read from zSql.

The previous impl declared the parameter as `_len: c_int` (underscore-prefixed → intentionally unused) and unconditionally called `CStr::from_ptr`, walking until NUL regardless of `nByte`.

## How this surfaces

Any binding that passes Rust `&str` slices with `sql.len()` as `nByte` — i.e. `rusqlite` + `libsqlite3-sys` and anything built on safe Rust string types — over-reads past the slice into neighbouring memory until a NUL appears. Observable as misleading parse errors like:

- `near 'q': syntax error`
- `expected = sign '!' at offset 24`
- `non-terminated literal ''OFF''' at offset 19`

The exact char depends on what happens to live after the slice in allocator memory — deterministic per-build but mystifying.

## Reproducer

Discovered while linking [garage](https://git.deuxfleurs.fr/Deuxfleurs/garage) (S3-compatible object store, v2.3) against `turso_sqlite3` as a libsqlite3 drop-in. The first `PRAGMA journal_mode=WAL` on `Connection::open()` exploded because rusqlite's prepare path is:

```rust
// rusqlite/src/inner_connection.rs:213-220
let c_sql = sql.as_bytes().as_ptr().cast::<c_char>();
let len = c_int::try_from(sql.len())?;
ffi::sqlite3_prepare_v3(self.db(), c_sql, len, flags.bits(), &mut c_stmt, ...);
```

`c_sql` is a Rust slice — **not** NUL-terminated.

Reproducer files (Zig smoke + shim + verify orchestrator): https://github.com/wommy/turso-garage-poc (link placeholder if desired) — but the included compat tests reproduce the bug at the C API directly.

## Fix

`sqlite3/src/lib.rs:802-838` — branch on the sign of `nByte`:
- **negative** → original `CStr::from_ptr` path (read until NUL)
- **non-negative** → bounded slice via `std::slice::from_raw_parts(sql, nByte)`, truncated at first NUL within the bound (per spec — *"whichever comes first"*)

UTF-8 decode + downstream prepare flow unchanged.

## Tests

Three regression tests added in `sqlite3/tests/compat/mod.rs`:

1. **`test_prepare_v2_n_byte_positive_no_nul`** — non-NUL-terminated buffer + 4 sentinel bytes of `\xff` past the bound. An over-reading impl would hit garbage and parser-error; correct impl produces `SQLITE_OK`.
2. **`test_prepare_v2_n_byte_negative_uses_nul`** — `nByte = -1` regression check; CStr path must still work.
3. **`test_prepare_v2_n_byte_truncates_at_embedded_nul`** — NUL at offset 8, bound = 20. Under-truncate path would parse `"GARBAGE_AFTER_NUL"` (non-SQL) and error; correct impl stops at NUL.

Each test actively constructs the failure mode — survivorship / belt-and-suspenders style — so a regression can't silently pass.

## Verification

Patch applied + Turso rebuilt locally; garage S3 server runs cleanly against the patched `libsqlite3.so`, including end-to-end PUT/GET round-trip with `blake3` hash match.

```
PUT  /bench/turso-v1-smoke/...  status=200  26.3ms  64KB
GET  /bench/turso-v1-smoke/...  status=200   6.8ms  64KB
blake3 PUT == blake3 GET ✓
```

Closes #7100.