### PR TITLE
Only rollback if auto commit is true

### DIFF
--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1851,3 +1851,20 @@ async fn test_invalid_transaction_state_on_rows_drop() {
     drop(stmt);
     tx.commit().await.unwrap();
 }
+
+#[tokio::test]
+async fn test_invalid_transaction_state_on_rows_drop_mvcc() {
+    const SQL_CREATE: &str = "
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t(v) VALUES (1), (2), (3);";
+    const SQL_QUERY: &str = "SELECT v FROM t;";
+    let (db, _dir) = setup_mvcc_db(SQL_CREATE).await;
+    let mut conn = db.connect().unwrap();
+    let tx = conn.transaction().await.unwrap();
+    let mut stmt = tx.prepare(SQL_QUERY).await.unwrap();
+    let mut rows = stmt.query(()).await.unwrap();
+    let _first = rows.next().await.unwrap();
+    drop(rows);
+    drop(stmt);
+    tx.commit().await.unwrap();
+}

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1829,3 +1829,25 @@ async fn test_autoincrement_blocked_in_mvcc() {
     let count = query_i64(&conn, "SELECT COUNT(*) FROM t").await;
     assert_eq!(count, 1);
 }
+
+#[tokio::test]
+async fn test_invalid_transaction_state_on_rows_drop() {
+    const SQL_CREATE: &str = "
+    CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+    INSERT INTO t(v) VALUES (1), (2), (3);";
+    const SQL_QUERY: &str = "SELECT v FROM t;";
+    let mut conn = turso::Builder::new_local(":memory:")
+        .build()
+        .await
+        .unwrap()
+        .connect()
+        .unwrap();
+    conn.execute_batch(SQL_CREATE).await.unwrap();
+    let tx = conn.transaction().await.unwrap();
+    let mut stmt = tx.prepare(SQL_QUERY).await.unwrap();
+    let mut rows = stmt.query(()).await.unwrap();
+    let _first = rows.next().await.unwrap();
+    drop(rows);
+    drop(stmt);
+    tx.commit().await.unwrap();
+}

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3490,7 +3490,9 @@ pub fn op_transaction_inner(
                                 "nested stmt should not begin a new read transaction"
                             );
                             pager.begin_read_tx()?;
-                            state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                            if conn.get_auto_commit() {
+                                state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                            }
                         }
                         // MVCC reads must refresh WAL change counters to avoid stale page-cache reads.
                         pager.mvcc_refresh_if_db_changed();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3607,7 +3607,11 @@ pub fn op_transaction_inner(
                             "nested stmt should not begin a new read transaction"
                         );
                         pager.begin_read_tx()?;
-                        state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                        // https://github.com/tursodatabase/turso/issues/7106 : If auto-commit is turned off,
+                        // then we shouldn't be setting the auto_txn_cleanup, this will cause errors in case the client explicitly calls commit post a drop of the statement struct
+                        if conn.get_auto_commit() {
+                            state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                        }
                     }
 
                     if !is_secondary_db


### PR DESCRIPTION
Fixes #7106

The reason for the transaction not being active at the `tx.commit()` call is because during the drop of the statement, we observe the following stack trace:
```
 -> Statement::drop
  -> reset_internal
  -> Program::abort
  -> sees auto_txn_cleanup
  -> rolls back whole transaction
  ```
  
  The auto_txn_cleanup in this case was being set at: 
  ```rust
 pager.begin_read_tx()?;
 state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
  ```
  
  Note that this cleanup is unconditional and hence every transaction regardless of whether the auto_commit is set / net sets this cleanup function and that gets called downstream on the statement::drop call. Sqlite seems to have a check before the cleanup:
  
  ```rust
  
    /* If the auto-commit flag is set and this is the only active writer
    ** VM, then we do either a commit or rollback of the current transaction.
    **
    ** Note: This block also runs if one of the special errors handled
    ** above has occurred.
    */
    if( !sqlite3VtabInSync(db)
     && db->autoCommit
     && db->nVdbeWrite==(p->readOnly==0)
    ){
```