### PR TITLE
simulator: stress WAL checkpoints

### DIFF
--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    WalCheckpoint(WalCheckpointMode),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,6 +14,14 @@ pub enum VacuumMode {
     None,
     Incremental,
     Full,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WalCheckpointMode {
+    Passive,
+    Full,
+    Restart,
+    Truncate,
 }
 
 impl Display for Pragma {
@@ -31,6 +40,15 @@ impl Display for Pragma {
             Pragma::ForeignKeyList(table_name) => {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
+            }
+            Pragma::WalCheckpoint(mode) => {
+                let mode = match mode {
+                    WalCheckpointMode::Passive => "PASSIVE",
+                    WalCheckpointMode::Full => "FULL",
+                    WalCheckpointMode::Restart => "RESTART",
+                    WalCheckpointMode::Truncate => "TRUNCATE",
+                };
+                write!(f, "PRAGMA wal_checkpoint({mode})")
             }
         }
     }

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -154,7 +154,7 @@ simulator covers and tests.
 | PRAGMA vdbe_listing              | No         |                                                  |
 | PRAGMA vdbe_trace                | No         |                                                  |
 | PRAGMA wal_autocheckpoint        | No         |                                                  |
-| PRAGMA wal_checkpoint            | No         |                                                  |
+| PRAGMA wal_checkpoint            | Partial    | Covered by WalCheckpointStress property.         |
 | PRAGMA writable_schema           | No         |                                                  |
 
 ### Expressions

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -14,6 +14,7 @@ use sql_generation::{
         query::{
             Create, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
+            pragma::Pragma,
             predicate::Predicate,
             select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
             transaction::{Begin, Commit, Rollback},
@@ -28,7 +29,10 @@ use turso_parser::ast::{self, Distinctness};
 
 use crate::{
     common::print_diff,
-    generation::{Shadow, WeightedDistribution, query::QueryDistribution},
+    generation::{
+        Shadow, WeightedDistribution,
+        query::{QueryDistribution, random_wal_checkpoint_mode},
+    },
     model::{
         Query, QueryCapabilities, QueryDiscriminants, ReleaseSavepoint, ResultSet,
         RollbackToSavepoint, Savepoint,
@@ -228,10 +232,12 @@ impl Property {
                     }
                 }
             }
-            Property::SavepointRollback { .. } => {
+            Property::SavepointRollback { .. } | Property::WalCheckpointStress { .. } => {
                 |rng: &mut R, ctx: &G, _query_distr: &QueryDistribution, property: &Property| {
-                    let Property::SavepointRollback { write_kinds, .. } = property else {
-                        unreachable!()
+                    let write_kinds = match property {
+                        Property::SavepointRollback { write_kinds, .. }
+                        | Property::WalCheckpointStress { write_kinds, .. } => write_kinds,
+                        _ => unreachable!(),
                     };
                     random_main_table_write(rng, ctx, write_kinds)
                 }
@@ -1233,6 +1239,23 @@ impl Property {
                 interactions.push(assert_integrity_check(tables, connection_index));
                 interactions
             }
+            Property::WalCheckpointStress {
+                queries,
+                tables,
+                mode,
+                ..
+            } => {
+                let mut interactions = Vec::with_capacity(queries.len() + 2 + tables.len() * 2);
+                interactions.extend(queries.clone().into_iter().map(|query| {
+                    InteractionBuilder::with_interaction(InteractionType::Query(query))
+                }));
+                interactions.push(InteractionBuilder::with_interaction(
+                    InteractionType::Query(Query::Pragma(Pragma::WalCheckpoint(mode.clone()))),
+                ));
+                interactions.extend(assert_all_table_values(tables, connection_index));
+                interactions.push(assert_integrity_check(tables, connection_index));
+                interactions
+            }
         };
 
         assert!(!interactions.is_empty());
@@ -1417,7 +1440,7 @@ fn random_main_table_delete<R: rand::Rng + ?Sized>(rng: &mut R, table: &Table) -
 fn assert_integrity_check(tables: &[String], connection_index: usize) -> InteractionBuilder {
     let tables = tables.to_vec();
     InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
-        "PRAGMA integrity_check should be ok after savepoint rollback".to_string(),
+        "PRAGMA integrity_check should be ok".to_string(),
         move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
             let result = run_integrity_check(env, connection_index)?;
             if result == "ok" {
@@ -1678,6 +1701,41 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_wal_checkpoint_stress<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    query_distr: &QueryDistribution,
+    ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    let tables = ctx
+        .tables()
+        .iter()
+        .filter(|table| !table.name.contains('.'))
+        .map(|table| table.name.clone())
+        .collect::<Vec<_>>();
+    assert!(!tables.is_empty());
+    let write_kinds = query_distr
+        .positive_items()
+        .filter(|query| {
+            matches!(
+                query,
+                QueryDiscriminants::Insert
+                    | QueryDiscriminants::Update
+                    | QueryDiscriminants::Delete
+            )
+        })
+        .collect::<Vec<_>>();
+    assert!(!write_kinds.is_empty());
+    let amount = rng.random_range(1..=3);
+
+    Property::WalCheckpointStress {
+        queries: std::iter::repeat_n(Query::Placeholder, amount).collect(),
+        tables,
+        write_kinds,
+        mode: random_wal_checkpoint_mode(rng),
+    }
+}
+
 fn property_table_has_expected_content<R: rand::Rng + ?Sized>(
     rng: &mut R,
     _query_distr: &QueryDistribution,
@@ -1899,6 +1957,7 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
             PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
+            PropertyDiscriminants::WalCheckpointStress => property_wal_checkpoint_stress,
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
@@ -1954,6 +2013,18 @@ impl PropertyDiscriminants {
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
                     remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::WalCheckpointStress => {
+                let remaining_writes = remaining.insert + remaining.update + remaining.delete;
+                if !env.profile.mvcc
+                    && remaining.pragma_count > 0
+                    && remaining_writes > 0
+                    && ctx.tables().iter().any(|table| !table.name.contains('.'))
+                {
+                    remaining.pragma_count.saturating_mul(8)
                 } else {
                     0
                 }
@@ -2059,6 +2130,7 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::WalCheckpointStress => QueryCapabilities::SELECT,
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -13,7 +13,7 @@ use sql_generation::{
         query::{
             Create, CreateIndex, Delete, DropIndex, Insert, Select,
             alter_table::AlterTable,
-            pragma::{Pragma, VacuumMode},
+            pragma::{Pragma, VacuumMode, WalCheckpointMode},
             update::Update,
         },
         table::Table,
@@ -84,6 +84,10 @@ fn random_create_index<R: rand::Rng + ?Sized>(
 }
 
 fn random_pragma<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationContext) -> Query {
+    if rng.random_bool(0.25) {
+        return Query::Pragma(Pragma::WalCheckpoint(random_wal_checkpoint_mode(rng)));
+    }
+
     if !conn_ctx.tables().is_empty() && rng.random_bool(0.5) {
         let table = conn_ctx.tables().choose(rng).unwrap();
         return Query::Pragma(Pragma::ForeignKeyList(table.name.clone()));
@@ -98,6 +102,17 @@ fn random_pragma<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationC
     let mode = ALL_MODES.choose(rng).unwrap();
 
     Query::Pragma(Pragma::AutoVacuumMode(mode.clone()))
+}
+
+pub(crate) fn random_wal_checkpoint_mode<R: rand::Rng + ?Sized>(rng: &mut R) -> WalCheckpointMode {
+    const ALL_MODES: [WalCheckpointMode; 4] = [
+        WalCheckpointMode::Passive,
+        WalCheckpointMode::Full,
+        WalCheckpointMode::Restart,
+        WalCheckpointMode::Truncate,
+    ];
+
+    ALL_MODES.choose(rng).unwrap().clone()
 }
 
 fn random_alter_table<R: rand::Rng + ?Sized>(

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -468,7 +468,9 @@ impl Shadow for Query {
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
-            Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(
+                Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_) | Pragma::WalCheckpoint(_),
+            ) => Ok(vec![]),
         }
     }
 }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
-use sql_generation::model::query::{Create, Insert, Select, predicate::Predicate, update::Update};
+use sql_generation::model::query::{
+    Create, Insert, Select, pragma::WalCheckpointMode, predicate::Predicate, update::Update,
+};
 
 use crate::model::{Query, QueryDiscriminants};
 
@@ -191,6 +193,14 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// WalCheckpointStress drives WAL checkpoint frame promotion explicitly,
+    /// then verifies table contents and structural integrity.
+    WalCheckpointStress {
+        queries: Vec<Query>,
+        tables: Vec<String>,
+        write_kinds: Vec<QueryDiscriminants>,
+        mode: WalCheckpointMode,
+    },
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -220,6 +230,7 @@ impl Property {
                 | Property::DeleteSelect { .. }
                 | Property::DropSelect { .. }
                 | Property::SavepointRollback { .. }
+                | Property::WalCheckpointStress { .. }
                 | Property::Queries { .. }
         )
     }
@@ -231,6 +242,7 @@ impl Property {
             | Property::DeleteSelect { queries, .. }
             | Property::DropSelect { queries, .. }
             | Property::SavepointRollback { queries, .. }
+            | Property::WalCheckpointStress { queries, .. }
             | Property::Queries { queries } => Some(queries),
             Property::FsyncNoWait { .. } | Property::FaultyQuery { .. } => None,
             Property::SelectLimit { .. }


### PR DESCRIPTION
## Summary
- add `PRAGMA wal_checkpoint(...)` to the simulator query model with randomized PASSIVE/FULL/RESTART/TRUNCATE modes
- add a `WalCheckpointStress` property that runs random main-database writes, checkpoints the WAL, then checks table contents against the shadow model and runs `PRAGMA integrity_check`
- update simulator coverage for `PRAGMA wal_checkpoint`

## Scope
This addresses Phase 1 of #7045: explicitly driving checkpoint code paths during simulator runs. It intentionally does not implement Phase 2 / sync-fault injection; that remains dependent on the upstream fault-injection false-positive work tracked in #2091.

## Validation
- `nix develop --extra-experimental-features "nix-command flakes" --command cargo fmt --check`
- `git diff --check`
- `nix develop --extra-experimental-features "nix-command flakes" --command cargo check -p limbo_sim`
- `nix develop --extra-experimental-features "nix-command flakes" --command cargo test -p limbo_sim`
- `RUST_LOG=error nix develop --extra-experimental-features "nix-command flakes" --command cargo run --bin limbo_sim -- --seed 7045 -n 300 -k 120 -t 25 --disable-bugbase --profile write_heavy --io-backend memory --keep-files`

The smoke run generated `WalCheckpointStress` blocks containing writes followed by `PRAGMA wal_checkpoint(TRUNCATE)` and `PRAGMA wal_checkpoint(RESTART)`, then table-content assertions and `PRAGMA integrity_check`.

Addresses Phase 1 of #7045.