### PR TITLE
core/alter: Clear sqlite_sequence after removing AUTOINCREMENT

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -244,6 +244,51 @@ fn emit_rename_sqlite_sequence_entry(
     });
 }
 
+fn emit_delete_sqlite_sequence_entry(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    database_id: usize,
+    table_name_norm: &str,
+) {
+    let Some(sqlite_sequence) = resolver.with_schema(database_id, |s| {
+        s.get_btree_table(crate::schema::SQLITE_SEQUENCE_TABLE_NAME)
+    }) else {
+        return;
+    };
+
+    let seq_cursor_id = program.alloc_cursor_id(CursorType::BTreeTable(sqlite_sequence.clone()));
+    let sequence_name_reg = program.alloc_register();
+    let row_name_to_delete_reg = program.emit_string8_new_reg(table_name_norm.to_string());
+    program.mark_last_insn_constant();
+
+    program.emit_insn(Insn::OpenWrite {
+        cursor_id: seq_cursor_id,
+        root_page: RegisterOrLiteral::Literal(sqlite_sequence.root_page),
+        db: database_id,
+    });
+
+    program.cursor_loop(seq_cursor_id, |program, _rowid| {
+        program.emit_column_or_rowid(seq_cursor_id, 0, sequence_name_reg);
+
+        let continue_loop_label = program.allocate_label();
+        program.emit_insn(Insn::Ne {
+            lhs: sequence_name_reg,
+            rhs: row_name_to_delete_reg,
+            target_pc: continue_loop_label,
+            flags: CmpInsFlags::default(),
+            collation: None,
+        });
+
+        program.emit_insn(Insn::Delete {
+            cursor_id: seq_cursor_id,
+            table_name: crate::schema::SQLITE_SEQUENCE_TABLE_NAME.to_string(),
+            is_part_of_update: false,
+        });
+
+        program.preassign_label_to_next_insn(continue_loop_label);
+    });
+}
+
 fn literal_default_value(literal: &ast::Literal) -> Result<Value> {
     match literal {
         ast::Literal::Numeric(val) => parse_numeric_literal(val),
@@ -1651,6 +1696,12 @@ pub fn translate_alter_table(
                     (rewrites_physical_layout, Some(replacement_column))
                 }
             };
+            let clears_autoincrement_sequence = !rename
+                && btree.has_autoincrement
+                && btree.columns()[column_index].is_rowid_alias()
+                && replacement_column
+                    .as_ref()
+                    .is_some_and(|column| !column.is_rowid_alias());
 
             let is_making_column_generated = definition
                 .constraints
@@ -2037,6 +2088,11 @@ pub fn translate_alter_table(
                     connection,
                     database_id,
                 );
+            }
+
+            if clears_autoincrement_sequence {
+                let table_name_norm = normalize_ident(table_name);
+                emit_delete_sqlite_sequence_entry(program, resolver, database_id, &table_name_norm);
             }
 
             program.emit_insn(Insn::SetCookie {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13037,6 +13037,14 @@ pub fn op_alter_column(
                 }
             }
         }
+        let clears_autoincrement_sequence = !*rename
+            && btree.has_autoincrement
+            && btree
+                .columns()
+                .get(*column_index)
+                .is_some_and(|column| column.is_rowid_alias())
+            && !new_column.is_rowid_alias();
+
         if *rename {
             btree.columns_mut()[*column_index].name = Some(new_name.clone());
 
@@ -13089,6 +13097,9 @@ pub fn op_alter_column(
         if !*rename {
             // recompute alias from `new_column`
             btree.columns_mut()[*column_index].set_rowid_alias(new_column.is_rowid_alias());
+            if clears_autoincrement_sequence {
+                btree.has_autoincrement = false;
+            }
         }
 
         // Update this table's OWN foreign keys

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -219,6 +219,7 @@ expect {
 }
 
 # Regression test for https://github.com/tursodatabase/turso/issues/6769
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
 test autoinc-alter-column-clears-sequence-row {
     CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT);
     INSERT INTO t(b) VALUES('x'),('y');

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -218,6 +218,26 @@ expect {
     t2|2
 }
 
+# Regression test for https://github.com/tursodatabase/turso/issues/6769
+test autoinc-alter-column-clears-sequence-row {
+    CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT);
+    INSERT INTO t(b) VALUES('x'),('y');
+    ALTER TABLE t ALTER COLUMN a TO a2 TEXT;
+    SELECT COUNT(*) FROM sqlite_sequence WHERE name='t';
+    SELECT sql FROM sqlite_schema WHERE name='t';
+    INSERT INTO t(b) VALUES('z');
+    SELECT COUNT(*) FROM sqlite_sequence WHERE name='t';
+    SELECT a2, b FROM t ORDER BY rowid;
+}
+expect {
+    0
+    CREATE TABLE t (a2 TEXT, b TEXT)
+    0
+    1|x
+    2|y
+    |z
+}
+
 # Test: AUTOINCREMENT fails if the maximum rowid is reached. (Assumes 64-bit rowid)
 @cross-check-integrity
 test autoinc-fail-on-max-rowid {

--- a/tests/integration/query_processing/test_schema_updated.rs
+++ b/tests/integration/query_processing/test_schema_updated.rs
@@ -1,6 +1,7 @@
+use tempfile::TempDir;
 use turso_core::{Result, StatementStatusCounter, Value};
 
-use crate::common::TempDatabase;
+use crate::common::{ExecRows, TempDatabase};
 
 /// Test that SchemaUpdated error reprepares the statement.
 ///
@@ -207,4 +208,108 @@ fn test_deferred_seeks_resize_on_reprepare(tmp_db: TempDatabase) -> Result<()> {
     assert_eq!(results.len(), 3);
 
     Ok(())
+}
+
+/// Regression test for https://github.com/tursodatabase/turso/issues/6769.
+///
+/// ALTER TABLE ... ALTER COLUMN that turns an AUTOINCREMENT rowid alias into a
+/// non-rowid column must persist a consistent state on disk: the table's row in
+/// `sqlite_sequence` is removed and the rewritten `sqlite_schema.sql` no longer
+/// carries the AUTOINCREMENT keyword. After reopening the database, those
+/// invariants must still hold and subsequent inserts must not revive the
+/// sequence row.
+#[test]
+fn test_alter_table_alter_column_clears_autoincrement_reopen() {
+    let path = TempDir::new()
+        .unwrap()
+        .keep()
+        .join("alter_col_autoincrement_clear_reopen.db");
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t(b) VALUES ('x'), ('y')")
+            .unwrap();
+
+        let seq_before: Vec<(String, i64)> =
+            conn.exec_rows("SELECT name, seq FROM sqlite_sequence WHERE name='t'");
+        assert_eq!(
+            seq_before,
+            vec![("t".into(), 2)],
+            "sqlite_sequence should be populated before ALTER"
+        );
+
+        conn.execute("ALTER TABLE t ALTER COLUMN a TO a2 TEXT")
+            .unwrap();
+
+        let schema_has_autoinc: Vec<(i64,)> =
+            conn.exec_rows("SELECT sql LIKE '%AUTOINCREMENT%' FROM sqlite_schema WHERE name='t'");
+        assert_eq!(
+            schema_has_autoinc,
+            vec![(0,)],
+            "AUTOINCREMENT must be gone from sqlite_schema.sql after ALTER COLUMN"
+        );
+
+        let seq_after_alter: Vec<(i64,)> =
+            conn.exec_rows("SELECT COUNT(*) FROM sqlite_sequence WHERE name='t'");
+        assert_eq!(
+            seq_after_alter,
+            vec![(0,)],
+            "sqlite_sequence row must be cleared by ALTER COLUMN"
+        );
+
+        conn.close().unwrap();
+    }
+
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+
+        let schema_has_autoinc: Vec<(i64,)> =
+            conn.exec_rows("SELECT sql LIKE '%AUTOINCREMENT%' FROM sqlite_schema WHERE name='t'");
+        assert_eq!(
+            schema_has_autoinc,
+            vec![(0,)],
+            "persisted sqlite_schema.sql must not contain AUTOINCREMENT after reopen"
+        );
+
+        let seq_after_reopen: Vec<(i64,)> =
+            conn.exec_rows("SELECT COUNT(*) FROM sqlite_sequence WHERE name='t'");
+        assert_eq!(
+            seq_after_reopen,
+            vec![(0,)],
+            "sqlite_sequence row must remain absent after reopen"
+        );
+
+        conn.execute("INSERT INTO t(b) VALUES ('z')").unwrap();
+
+        let seq_after_insert: Vec<(i64,)> =
+            conn.exec_rows("SELECT COUNT(*) FROM sqlite_sequence WHERE name='t'");
+        assert_eq!(
+            seq_after_insert,
+            vec![(0,)],
+            "INSERT after reopen must not recreate the sequence row \
+             (in-memory has_autoincrement must have been cleared)"
+        );
+
+        let rewritten: Vec<(String, String)> =
+            conn.exec_rows("SELECT a2, b FROM t WHERE a2 IS NOT NULL ORDER BY rowid");
+        assert_eq!(
+            rewritten,
+            vec![("1".into(), "x".into()), ("2".into(), "y".into())],
+            "pre-ALTER rows must carry the old rowid as TEXT after the column rewrite"
+        );
+
+        let post_insert: Vec<(i64, String)> =
+            conn.exec_rows("SELECT a2 IS NULL, b FROM t WHERE b='z'");
+        assert_eq!(
+            post_insert,
+            vec![(1, "z".into())],
+            "INSERT after reopen must leave a2 NULL — column is no longer a rowid alias"
+        );
+
+        conn.close().unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #6769.

`ALTER TABLE ... ALTER COLUMN` can remove an `AUTOINCREMENT` rowid alias from a table, but Turso only rewrote the table schema. It left the old row in `sqlite_sequence`, so the database kept stale AUTOINCREMENT metadata for a table whose persisted schema no longer declared AUTOINCREMENT.

This PR keeps the schema rewrite and sequence metadata in sync:

- delete the table's row from `sqlite_sequence` when ALTER COLUMN changes an AUTOINCREMENT rowid alias into a non-rowid column
- clear the in-memory `has_autoincrement` flag for the altered table so later inserts in the same connection do not recreate or update the sequence row
- add SQL regression coverage for the ALTER COLUMN path and the same-connection insert-after-ALTER case

## Bug reproduced

Reproducer:

```sql
.mode list
CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT);
INSERT INTO t(b) VALUES('x'),('y');
ALTER TABLE t ALTER COLUMN a TO a2 TEXT;
SELECT 'seq_after_alter', COUNT(*) FROM sqlite_sequence WHERE name='t';
SELECT 'schema_after_alter', sql FROM sqlite_schema WHERE name='t';
INSERT INTO t(b) VALUES('z');
SELECT 'seq_after_insert', COUNT(*) FROM sqlite_sequence WHERE name='t';
SELECT 'rows', a2, b FROM t ORDER BY rowid;
```

Actual behavior on `origin/main` at `809b4410f`:

```text
seq_after_alter|1
schema_after_alter|CREATE TABLE t (a2 TEXT, b TEXT)
seq_after_insert|1
rows|1|x
rows|2|y
rows||z
```

The schema no longer has an AUTOINCREMENT rowid alias, but `sqlite_sequence` still retains a row for `t`.

Expected behavior, and behavior with this PR:

```text
seq_after_alter|0
schema_after_alter|CREATE TABLE t (a2 TEXT, b TEXT)
seq_after_insert|0
rows|1|x
rows|2|y
rows||z
```

Once `a` becomes plain `a2 TEXT`, the table is no longer an AUTOINCREMENT table. The stored schema and `sqlite_sequence` should agree, and subsequent inserts should not revive the stale sequence row.

## Root cause

The ALTER COLUMN path updated two pieces of table state but missed AUTOINCREMENT metadata:

- `sqlite_schema.sql` was rewritten from `CREATE TABLE t(a INTEGER PRIMARY KEY AUTOINCREMENT, b TEXT)` to `CREATE TABLE t (a2 TEXT, b TEXT)`
- the in-memory column definition was replaced by `a2 TEXT`
- the old `sqlite_sequence` row for `t` was left behind
- the in-memory table still had `has_autoincrement = true`, so later inserts in the same connection could continue treating the table as AUTOINCREMENT despite the rewritten schema

The fix detects the specific state transition: old table has AUTOINCREMENT, the altered column is the rowid alias, and the replacement column is not a rowid alias. In that case it deletes the sequence row and clears the in-memory AUTOINCREMENT flag.

## Verification

- Baseline reproducer against `origin/main` at `809b4410f`: reproduced stale `sqlite_sequence` row (`seq_after_alter|1`, `seq_after_insert|1`)
- Same reproducer on this branch: fixed (`seq_after_alter|0`, `seq_after_insert|0`)
- `cargo fmt --check`
- `make -C testing/sqltests run-filter FILTER='autoinc-alter-column-clears-sequence-row'` -> 1 passed
- `cd testing/sqltests && cargo run --bin test-runner -- run tests/autoincr.sqltest --binary /home/nyasha-hama/dev/contributions/turso/target/debug/tursodb` -> 28 passed
- `git diff --check HEAD~1..HEAD`
- `cargo check -p turso_core`
