### PR TITLE
testing/simulator: don't panic from SimulatorFile::drop

### DIFF
--- a/testing/simulator/runner/file.rs
+++ b/testing/simulator/runner/file.rs
@@ -270,7 +270,12 @@ impl File for SimulatorFile {
 
 impl Drop for SimulatorFile {
     fn drop(&mut self) {
-        self.inner.unlock_file().expect("Failed to unlock file");
+        // Best-effort unlock during cleanup. We must not panic from `drop` —
+        // it aborts the process if a panic is already in flight, which masks
+        // the original failure. On Windows in particular, `UnlockFileEx` on
+        // an already-unlocked region returns ERROR_NOT_LOCKED (os error 158),
+        // which is not a real error for our cleanup purposes.
+        let _ = self.inner.unlock_file();
     }
 }
 


### PR DESCRIPTION
## Description

`SimulatorFile::drop` previously called `unlock_file().expect(...)`, which made it panic on any unlock error. On Windows this triggers immediately: `UnlockFileEx` against an already-unlocked region returns `FALSE` with `GetLastError() == ERROR_NOT_LOCKED (158)`, which the Windows VFS in `core/io/windows.rs` surfaces as a `LockingError`. The result is that `cargo run --bin limbo_sim` aborts during plan generation on a stock Windows host with:

```
Failed to unlock file: LockingError("Failed to release file lock: 段已解除锁定。 (os error 158)")
```

Panicking from `Drop` is also bad on any platform: if a panic is already unwinding, a second panic in `drop` aborts the process and masks the original failure — exactly the kind of original failure the simulator exists to surface.

Change: best-effort unlock in `Drop` — ignore the result. Behaviorally a no-op on Unix (the working case already returned `Ok`), and turns the Windows `ERROR_NOT_LOCKED` into a silent successful cleanup.

After this change the simulator runs to completion on Windows. Reproduced on Windows 11 + Rust 1.88.0 (MSVC, VS2022 Community); `cargo run --bin limbo_sim -- --differential -t 60 -n 1000 -k 200` now finishes with `simulation succeeded` instead of panicking during plan generation.

## Motivation and context

Unblocks running the deterministic simulator on Windows hosts. Without this fix the simulator cannot reach the first interaction on Windows, so the existing `cfg(target_os = "windows")` branches under `testing/simulator/runner/` are effectively dead code on a real Windows machine.

## Description of AI Usage

Written with Claude (Anthropic, Claude Code CLI) helping navigate the codebase and diagnose the Windows error path. The change was reviewed and is understood by me before submission.
