### PR TITLE
core/vdbe: fix scalar function coercion persistence

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -332,11 +332,10 @@ impl Value {
     where
         F: Fn(&mut [u8]),
     {
-        let length = match self {
-            Value::Numeric(Numeric::Integer(i)) => *i,
-            Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-            Value::Text(t) => t.as_str().parse().unwrap_or(1),
-            _ => 1,
+        let length = match Numeric::from_value(self) {
+            Some(Numeric::Integer(i)) => i,
+            Some(Numeric::Float(f)) => real_to_i64(f64::from(f)),
+            None => 1,
         }
         .max(1);
 
@@ -654,7 +653,8 @@ impl Value {
                     _ => Value::Null,
                 },
                 Some(ignore) => match ignore {
-                    Value::Text(_) => {
+                    Value::Null => Value::Null,
+                    _ => {
                         let input = self.to_string();
                         let ignore = ignore.to_string();
                         let mut chars = input.chars().peekable();
@@ -688,7 +688,6 @@ impl Value {
                             out.push(((hi << 4) | lo) as u8);
                         }
                     }
-                    _ => Value::Null,
                 },
             },
         }
@@ -793,7 +792,17 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
+        let fmt = Value::build_text(format!("%.{precision}f"));
+        let formatted = crate::functions::printf::exec_printf(&[
+            crate::vdbe::Register::Value(fmt),
+            crate::vdbe::Register::Value(Value::from_f64(f)),
+        ])
+        .expect("round() printf formatting should not fail");
+        let Value::Text(formatted) = formatted else {
+            return Value::Null;
+        };
+
+        let f: f64 = crate::numeric::str_to_f64(formatted.as_str())
             .expect("formatted float should always parse successfully")
             .into();
 
@@ -815,7 +824,11 @@ impl Value {
                     Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
                     _ => std::borrow::Cow::Owned(p.to_string()),
                 };
-                let p_str = pat_cow.as_ref();
+                let p_str = pat_cow
+                    .as_ref()
+                    .split_once('\0')
+                    .map(|(prefix, _)| prefix)
+                    .unwrap_or_else(|| pat_cow.as_ref());
                 match trim_type {
                     TrimType::All => text_cow.trim_matches(|c| p_str.contains(c)),
                     TrimType::Left => text_cow.trim_start_matches(|c| p_str.contains(c)),
@@ -846,11 +859,10 @@ impl Value {
     }
 
     pub fn exec_zeroblob(&self) -> Result<Value> {
-        let length: i64 = match self {
-            Value::Numeric(Numeric::Integer(i)) => *i,
-            Value::Numeric(Numeric::Float(f)) => f64::from(*f) as i64,
-            Value::Text(s) => s.as_str().parse().unwrap_or(0),
-            _ => 0,
+        let length: i64 = match Numeric::from_value(self) {
+            Some(Numeric::Integer(i)) => i,
+            Some(Numeric::Float(f)) => f64::from(f) as i64,
+            None => 0,
         }
         .max(0);
 
@@ -1317,18 +1329,15 @@ impl Value {
             return Value::Null;
         }
 
-        let separator = match registers
+        let Some(separator) = registers
             .next()
             .expect("registers should have at least one element after length check")
-        {
-            Value::Null | Value::Blob(_) => return Value::Null,
-            v => format!("{v}"),
+            .cast_text()
+        else {
+            return Value::Null;
         };
 
-        let parts = registers.filter_map(|val| match val {
-            Value::Text(_) | Value::Numeric(_) => Some(format!("{val}")),
-            _ => None,
-        });
+        let parts = registers.filter_map(|val| val.cast_text());
 
         let result = parts.collect::<Vec<_>>().join(&separator);
         Value::build_text(result)
@@ -1337,22 +1346,31 @@ impl Value {
     pub fn exec_char<'a, T: Iterator<Item = &'a Self>>(values: T) -> Self {
         let result: String = values
             .filter_map(|x| match x {
-                Value::Numeric(Numeric::Integer(i)) => {
-                    // Convert integer to Unicode codepoint.
-                    // For invalid codepoints (negative, surrogates, or > U+10FFFF),
-                    // output U+FFFD (replacement character) to match SQLite behavior.
-                    if *i >= 0 {
-                        Some(char::from_u32(*i as u32).unwrap_or('\u{FFFD}'))
-                    } else {
-                        Some('\u{FFFD}')
-                    }
+                Value::Numeric(Numeric::Integer(i)) => Some(sqlite_char_from_i64(*i)),
+                Value::Numeric(Numeric::Float(f)) => {
+                    Some(sqlite_char_from_i64(real_to_i64(f64::from(*f))))
                 }
-                // NULL arguments produce NUL characters to match SQLite behavior.
-                Value::Null => Some('\0'),
-                _ => None,
+                Value::Text(_) | Value::Blob(_) => Numeric::from_value(x).map(|numeric| {
+                    sqlite_char_from_i64(match numeric {
+                        Numeric::Integer(i) => i,
+                        Numeric::Float(f) => real_to_i64(f64::from(f)),
+                    })
+                }),
+                Value::Null => {
+                    // NULL arguments produce NUL characters to match SQLite behavior.
+                    Some('\0')
+                }
             })
             .collect();
         Value::build_text(result)
+    }
+}
+
+fn sqlite_char_from_i64(i: i64) -> char {
+    if i >= 0 {
+        char::from_u32(i as u32).unwrap_or('\u{FFFD}')
+    } else {
+        '\u{FFFD}'
     }
 }
 
@@ -2323,6 +2341,18 @@ mod tests {
         let input_float = Value::from_f64(123.5);
         let expected_text = Value::build_text("123.5");
         assert_eq!(input_float.exec_trim(None), expected_text);
+
+        let input_nul = Value::build_text("\0abc\0");
+        let pattern_nul = Value::build_text("\0");
+        assert_eq!(input_nul.exec_trim(Some(&pattern_nul)), input_nul);
+
+        let input_nul_terminated_pattern = Value::build_text("x\0abc\0x");
+        let pattern_nul_terminated = Value::build_text("x\0");
+        let expected_nul_terminated = Value::build_text("\0abc\0");
+        assert_eq!(
+            input_nul_terminated_pattern.exec_trim(Some(&pattern_nul_terminated)),
+            expected_nul_terminated
+        );
     }
 
     #[test]
@@ -2480,6 +2510,10 @@ mod tests {
         let expected = Value::Blob(vec![0xaa, 0xbb, 0xcc]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text("-"))), expected);
 
+        let input = Value::build_text("aa-bb");
+        let expected = Value::Blob(vec![0xaa, 0xbb]);
+        assert_eq!(input.exec_unhex(Some(&Value::Blob(vec![b'-']))), expected);
+
         let input = Value::build_text("aa bb");
         let expected = Value::Blob(vec![0xaa, 0xbb]);
         assert_eq!(input.exec_unhex(Some(&Value::build_text(" "))), expected);
@@ -2551,7 +2585,19 @@ mod tests {
                     .iter()
                     .map(|reg| reg.get_value())
             ),
-            Value::build_text("")
+            Value::build_text("\0")
+        );
+        assert_eq!(
+            Value::exec_char(
+                [
+                    Register::Value(Value::from_f64(65.9)),
+                    Register::Value(Value::build_text("65suffix")),
+                    Register::Value(Value::Blob(b"65suffix".to_vec())),
+                ]
+                .iter()
+                .map(|reg| reg.get_value())
+            ),
+            Value::build_text("AAA")
         );
     }
 
@@ -2645,6 +2691,14 @@ mod tests {
                 expected_len: 5,
             },
             TestCase {
+                input: Value::build_text("3.9suffix"),
+                expected_len: 3,
+            },
+            TestCase {
+                input: Value::Blob(b"3.9suffix".to_vec()),
+                expected_len: 3,
+            },
+            TestCase {
                 input: Value::build_text("0"),
                 expected_len: 1,
             },
@@ -2695,6 +2749,16 @@ mod tests {
         let input_val = Value::from_f64(123.456);
         let precision_val = Value::from_i64(2);
         let expected_val = Value::from_f64(123.46);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(-2.3);
         assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
 
         let input_val = Value::from_f64(123.456);
@@ -3018,6 +3082,10 @@ mod tests {
         let expected = Value::Blob(vec![0; 5]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
+        let input = Value::build_text("5.9suffix");
+        let expected = Value::Blob(vec![0; 5]);
+        assert_eq!(input.exec_zeroblob().unwrap(), expected);
+
         let input = Value::build_text("-5");
         let expected = Value::Blob(vec![]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
@@ -3032,6 +3100,10 @@ mod tests {
 
         let input = Value::Blob(vec![1]);
         let expected = Value::Blob(vec![]);
+        assert_eq!(input.exec_zeroblob().unwrap(), expected);
+
+        let input = Value::Blob(b"5.9suffix".to_vec());
+        let expected = Value::Blob(vec![0; 5]);
         assert_eq!(input.exec_zeroblob().unwrap(), expected);
 
         // Test TooBig error

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -193,10 +193,10 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | ---------------------------- | ------ | ------- |
 | abs(X)                       | No     |         |
 | changes()                    | No     |         |
-| char(X1,X2,...,XN)           | No     |         |
+| char(X1,X2,...,XN)           | Partial | ScalarFunctionPersistence covers persisted numeric coercion edge cases |
 | coalesce(X,Y,...)            | No     |         |
 | concat(X,...)                | No     |         |
-| concat_ws(SEP,X,...)         | No     |         |
+| concat_ws(SEP,X,...)         | Partial | ScalarFunctionPersistence covers persisted blob coercion edge cases |
 | format(FORMAT,...)           | No     |         |
 | glob(X,Y)                    | No     |         |
 | hex(X)                       | No     |         |
@@ -213,7 +213,7 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | load_extension(X,Y)          | No     |         |
 | lower(X)                     | No     |         |
 | ltrim(X)                     | No     |         |
-| ltrim(X,Y)                   | No     |         |
+| ltrim(X,Y)                   | Partial | ScalarFunctionPersistence covers persisted NUL trim-set edge cases |
 | max(X,Y,...)                 | No     |         |
 | min(X,Y,...)                 | No     |         |
 | nullif(X,Y)                  | No     |         |
@@ -221,12 +221,12 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | printf(FORMAT,...)           | No     |         |
 | quote(X)                     | No     |         |
 | random()                     | No     |         |
-| randomblob(N)                | No     |         |
+| randomblob(N)                | Partial | ScalarFunctionPersistence covers persisted numeric coercion edge cases |
 | replace(X,Y,Z)               | No     |         |
-| round(X)                     | No     |         |
-| round(X,Y)                   | No     |         |
+| round(X)                     | Partial | ScalarFunctionPersistence covers persisted half-tie edge cases |
+| round(X,Y)                   | Partial | ScalarFunctionPersistence covers persisted half-tie edge cases |
 | rtrim(X)                     | No     |         |
-| rtrim(X,Y)                   | No     |         |
+| rtrim(X,Y)                   | Partial | ScalarFunctionPersistence covers persisted NUL trim-set edge cases |
 | sign(X)                      | No     |         |
 | soundex(X)                   | No     |         |
 | sqlite_compileoption_get(N)  | No     |         |
@@ -240,14 +240,14 @@ Feature support of [sqlite expr syntax](https://www.sqlite.org/lang_expr.html).
 | substring(X,Y)               | No     |         |
 | total_changes()              | No     |         |
 | trim(X)                      | No     |         |
-| trim(X,Y)                    | No     |         |
+| trim(X,Y)                    | Partial | ScalarFunctionPersistence covers persisted NUL trim-set edge cases |
 | typeof(X)                    | No     |         |
 | unhex(X)                     | No     |         |
-| unhex(X,Y)                   | No     |         |
+| unhex(X,Y)                   | Partial | ScalarFunctionPersistence covers persisted blob ignore-set edge case |
 | unicode(X)                   | No     |         |
 | unlikely(X)                  | No     |         |
 | upper(X)                     | No     |         |
-| zeroblob(N)                  | No     |         |
+| zeroblob(N)                  | Partial | ScalarFunctionPersistence covers persisted numeric coercion edge cases |
 
 #### Mathematical functions
 

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -6,6 +6,7 @@
 //! an optimization issue that is good to point out for the future
 
 use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 use rand::distr::{Distribution, weighted::WeightedIndex};
 use sql_generation::{
@@ -38,7 +39,7 @@ use crate::{
         metrics::Remaining,
         property::{InteractiveQueryInfo, Property, PropertyDiscriminants},
     },
-    runner::env::SimulatorEnv,
+    runner::env::{SimConnection, SimulatorEnv},
 };
 
 type PropertyQueryGenFunc<'a, R, G> =
@@ -247,6 +248,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::ScalarFunctionPersistence
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => {
                 unreachable!("No extensional queries")
@@ -1201,6 +1203,20 @@ impl Property {
                 ),
                 ].into_iter().map(InteractionBuilder::with_interaction).collect()
             }
+            Property::ScalarFunctionPersistence => {
+                let table_prefix = format!("sim_scalar_persistence_{}", id.get());
+                let assertion = Assertion::new(
+                    "scalar function persisted writes should match SQLite".to_string(),
+                    move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
+                        assert_scalar_function_persistence(env, connection_index, &table_prefix)
+                    },
+                    vec![],
+                );
+
+                vec![InteractionBuilder::with_interaction(
+                    InteractionType::Assertion(assertion),
+                )]
+            }
             Property::Queries { queries } => queries
                 .clone()
                 .into_iter()
@@ -1678,6 +1694,15 @@ fn property_savepoint_rollback<R: rand::Rng + ?Sized>(
     }
 }
 
+fn property_scalar_function_persistence<R: rand::Rng + ?Sized>(
+    _rng: &mut R,
+    _query_distr: &QueryDistribution,
+    _ctx: &impl GenerationContext,
+    _mvcc: bool,
+) -> Property {
+    Property::ScalarFunctionPersistence
+}
+
 fn property_table_has_expected_content<R: rand::Rng + ?Sized>(
     rng: &mut R,
     _query_distr: &QueryDistribution,
@@ -1899,6 +1924,9 @@ impl PropertyDiscriminants {
             PropertyDiscriminants::InsertValuesSelect => property_insert_values_select,
             PropertyDiscriminants::ReadYourUpdatesBack => property_read_your_updates_back,
             PropertyDiscriminants::SavepointRollback => property_savepoint_rollback,
+            PropertyDiscriminants::ScalarFunctionPersistence => {
+                property_scalar_function_persistence
+            }
             PropertyDiscriminants::TableHasExpectedContent => property_table_has_expected_content,
             PropertyDiscriminants::AllTableHaveExpectedContent => {
                 property_all_tables_have_expected_content
@@ -1954,6 +1982,13 @@ impl PropertyDiscriminants {
                     && ctx.tables().iter().any(|table| !table.name.contains('.'))
                 {
                     remaining.insert + remaining.update + remaining.delete
+                } else {
+                    0
+                }
+            }
+            PropertyDiscriminants::ScalarFunctionPersistence => {
+                if !env.opts.disable_scalar_function_persistence {
+                    remaining.select.max(1)
                 } else {
                     0
                 }
@@ -2059,6 +2094,9 @@ impl PropertyDiscriminants {
                 QueryCapabilities::SELECT.union(QueryCapabilities::UPDATE)
             }
             PropertyDiscriminants::SavepointRollback => QueryCapabilities::INSERT,
+            PropertyDiscriminants::ScalarFunctionPersistence => {
+                QueryCapabilities::SELECT.union(QueryCapabilities::INSERT)
+            }
             PropertyDiscriminants::TableHasExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::AllTableHaveExpectedContent => QueryCapabilities::SELECT,
             PropertyDiscriminants::DoubleCreateFailure => QueryCapabilities::CREATE,
@@ -2141,6 +2179,232 @@ impl<'a> ArbitraryFrom<&PropertyDistribution<'a>> for Property {
         property_distr: &PropertyDistribution<'a>,
     ) -> Self {
         property_distr.sample(rng, conn_ctx)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScalarPersistenceCase {
+    name: &'static str,
+    expression: &'static str,
+    expected: [&'static str; 4],
+}
+
+const SCALAR_PERSISTENCE_CASES: &[ScalarPersistenceCase] = &[
+    ScalarPersistenceCase {
+        name: "round_positive_half_tie",
+        expression: "round(2.25, 1)",
+        expected: ["real", "2.3", "3", "322E33"],
+    },
+    ScalarPersistenceCase {
+        name: "round_negative_half_tie",
+        expression: "round(-2.25, 1)",
+        expected: ["real", "-2.3", "4", "2D322E33"],
+    },
+    ScalarPersistenceCase {
+        name: "zeroblob_text_numeric_prefix",
+        expression: "zeroblob('3.9suffix')",
+        expected: ["blob", "X'000000'", "3", "000000"],
+    },
+    ScalarPersistenceCase {
+        name: "zeroblob_blob_numeric_prefix",
+        expression: "zeroblob(x'332E39737566666978')",
+        expected: ["blob", "X'000000'", "3", "000000"],
+    },
+    ScalarPersistenceCase {
+        name: "randomblob_text_numeric_prefix_length",
+        expression: "length(randomblob('3.9suffix'))",
+        expected: ["integer", "3", "1", "33"],
+    },
+    ScalarPersistenceCase {
+        name: "randomblob_blob_numeric_prefix_length",
+        expression: "length(randomblob(x'332E39737566666978'))",
+        expected: ["integer", "3", "1", "33"],
+    },
+    ScalarPersistenceCase {
+        name: "char_real_truncates",
+        expression: "char(65.9)",
+        expected: ["text", "'A'", "1", "41"],
+    },
+    ScalarPersistenceCase {
+        name: "char_text_numeric_prefix",
+        expression: "char('65suffix')",
+        expected: ["text", "'A'", "1", "41"],
+    },
+    ScalarPersistenceCase {
+        name: "char_blob_numeric_prefix",
+        expression: "char(x'3635737566666978')",
+        expected: ["text", "'A'", "1", "41"],
+    },
+    ScalarPersistenceCase {
+        name: "concat_ws_blob_separator",
+        expression: "concat_ws(x'2D', 'a', 'b')",
+        expected: ["text", "'a-b'", "3", "612D62"],
+    },
+    ScalarPersistenceCase {
+        name: "concat_ws_blob_value",
+        expression: "concat_ws('-', 'a', x'42')",
+        expected: ["text", "'a-B'", "3", "612D42"],
+    },
+    ScalarPersistenceCase {
+        name: "unhex_blob_ignore_set",
+        expression: "unhex('41-42', x'2D')",
+        expected: ["blob", "X'4142'", "2", "4142"],
+    },
+    ScalarPersistenceCase {
+        name: "trim_nul_pattern",
+        expression: "trim(char(0) || 'abc' || char(0), char(0))",
+        expected: ["text", "''", "0", "0061626300"],
+    },
+    ScalarPersistenceCase {
+        name: "ltrim_nul_pattern",
+        expression: "ltrim(char(0) || 'abc' || char(0), char(0))",
+        expected: ["text", "''", "0", "0061626300"],
+    },
+    ScalarPersistenceCase {
+        name: "rtrim_nul_pattern",
+        expression: "rtrim(char(0) || 'abc' || char(0), char(0))",
+        expected: ["text", "''", "0", "0061626300"],
+    },
+];
+
+fn assert_scalar_function_persistence(
+    env: &mut SimulatorEnv,
+    connection_index: usize,
+    table_prefix: &str,
+) -> turso_core::Result<Result<(), String>> {
+    let mut failures = Vec::new();
+
+    for (idx, case) in SCALAR_PERSISTENCE_CASES.iter().enumerate() {
+        let table = format!("{table_prefix}_{idx}");
+        let setup = [
+            format!("DROP TABLE IF EXISTS {table}"),
+            format!("CREATE TABLE {table}(v)"),
+            format!("INSERT INTO {table} VALUES({})", case.expression),
+        ];
+        let select = format!("SELECT typeof(v), quote(v), length(v), hex(v) FROM {table}");
+        let cleanup = format!("DROP TABLE IF EXISTS {table}");
+
+        let rows = match &mut env.connections[connection_index] {
+            SimConnection::LimboConnection(conn) => {
+                query_scalar_persistence_limbo(conn, &setup, &select, &cleanup)?
+            }
+            SimConnection::SQLiteConnection(conn) => {
+                query_scalar_persistence_sqlite(conn, &setup, &select, &cleanup)?
+            }
+            SimConnection::Disconnected => {
+                return Err(LimboError::InternalError(
+                    "connection is disconnected during scalar-function assertion".into(),
+                ));
+            }
+        };
+
+        let expected = vec![
+            case.expected
+                .iter()
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>(),
+        ];
+        if rows != expected {
+            failures.push(format!(
+                "{} persisted unexpected state: expected {:?}, got {:?}",
+                case.name, expected, rows
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        return Ok(Err(failures.join("; ")));
+    }
+
+    Ok(Ok(()))
+}
+
+fn query_scalar_persistence_limbo(
+    conn: &Arc<turso_core::Connection>,
+    setup: &[String; 3],
+    select: &str,
+    cleanup: &str,
+) -> turso_core::Result<Vec<Vec<String>>> {
+    for statement in setup {
+        conn.execute(statement)?;
+    }
+
+    let result = (|| -> turso_core::Result<Vec<Vec<String>>> {
+        let mut rows = conn.query(select)?.ok_or_else(|| {
+            LimboError::InternalError("scalar-function assertion query returned no rows".into())
+        })?;
+        let mut out = Vec::new();
+        rows.run_with_row_callback(|row| {
+            out.push(row.get_values().map(value_to_state_cell).collect());
+            Ok(())
+        })?;
+        Ok(out)
+    })();
+
+    let cleanup_result = conn.execute(cleanup);
+    match (result, cleanup_result) {
+        (Ok(rows), Ok(())) => Ok(rows),
+        (Err(err), _) => Err(err),
+        (Ok(_), Err(err)) => Err(err),
+    }
+}
+
+fn query_scalar_persistence_sqlite(
+    conn: &rusqlite::Connection,
+    setup: &[String; 3],
+    select: &str,
+    cleanup: &str,
+) -> turso_core::Result<Vec<Vec<String>>> {
+    for statement in setup {
+        conn.execute(statement, [])
+            .map_err(|err| LimboError::InternalError(err.to_string()))?;
+    }
+
+    let result = (|| -> rusqlite::Result<Vec<Vec<String>>> {
+        let mut stmt = conn.prepare(select)?;
+        let rows = stmt.query_map([], |row| {
+            (0..4)
+                .map(|idx| row.get_ref(idx).map(sqlite_value_to_state_cell))
+                .collect::<rusqlite::Result<Vec<_>>>()
+        })?;
+        rows.collect()
+    })();
+
+    let cleanup_result = conn.execute(cleanup, []);
+    match (result, cleanup_result) {
+        (Ok(rows), Ok(_)) => Ok(rows),
+        (Err(err), _) | (_, Err(err)) => Err(LimboError::InternalError(err.to_string())),
+    }
+}
+
+fn value_to_state_cell(value: &types::Value) -> String {
+    match value {
+        types::Value::Null => "NULL".to_string(),
+        types::Value::Numeric(Numeric::Integer(i)) => i.to_string(),
+        types::Value::Numeric(Numeric::Float(f)) => f.to_string(),
+        types::Value::Text(text) => text.as_str().to_string(),
+        types::Value::Blob(blob) => blob
+            .iter()
+            .map(|byte| format!("{byte:02X}"))
+            .collect::<Vec<_>>()
+            .join(""),
+    }
+}
+
+fn sqlite_value_to_state_cell(value: rusqlite::types::ValueRef<'_>) -> String {
+    match value {
+        rusqlite::types::ValueRef::Null => "NULL".to_string(),
+        rusqlite::types::ValueRef::Integer(i) => i.to_string(),
+        rusqlite::types::ValueRef::Real(f) => {
+            let value = turso_core::Value::from_f64(f);
+            value.to_string()
+        }
+        rusqlite::types::ValueRef::Text(text) => String::from_utf8_lossy(text).into_owned(),
+        rusqlite::types::ValueRef::Blob(blob) => blob
+            .iter()
+            .map(|byte| format!("{byte:02X}"))
+            .collect::<Vec<_>>()
+            .join(""),
     }
 }
 

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -191,6 +191,12 @@ pub enum Property {
         tables: Vec<String>,
         write_kinds: Vec<QueryDiscriminants>,
     },
+    /// ScalarFunctionPersistence verifies that built-in scalar functions store
+    /// SQLite-compatible bytes when their results are materialized into a table.
+    /// This intentionally uses concrete edge cases that the general expression
+    /// generator does not currently model, such as decimal half-ties,
+    /// numeric-prefix zeroblob arguments, and NUL trim patterns.
+    ScalarFunctionPersistence,
     /// Property used to subsititute a property with its queries only
     Queries {
         queries: Vec<Query>,
@@ -238,6 +244,7 @@ impl Property {
             | Property::WhereTrueFalseNull { .. }
             | Property::UnionAllPreservesCardinality { .. }
             | Property::ReadYourUpdatesBack { .. }
+            | Property::ScalarFunctionPersistence
             | Property::TableHasExpectedContent { .. }
             | Property::AllTableHaveExpectedContent { .. } => None,
         }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -151,6 +151,12 @@ pub struct SimulatorCLI {
         default_value_t = false
     )]
     pub disable_savepoint_rollback: bool,
+    #[clap(
+        long,
+        help = "disable Scalar-Function-Persistence Property",
+        default_value_t = false
+    )]
+    pub disable_scalar_function_persistence: bool,
     #[clap(long, help = "disable FsyncNoWait Property", default_value_t = true)]
     pub disable_fsync_no_wait: bool,
     #[clap(long, help = "disable FaultyQuery Property")]

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1105,6 +1105,7 @@ impl SimulatorEnv {
             disable_union_all_preserves_cardinality: cli_opts
                 .disable_union_all_preserves_cardinality,
             disable_savepoint_rollback: cli_opts.disable_savepoint_rollback,
+            disable_scalar_function_persistence: cli_opts.disable_scalar_function_persistence,
             disable_fsync_no_wait: cli_opts.disable_fsync_no_wait,
             disable_faulty_query: cli_opts.disable_faulty_query,
             page_size: 4096, // TODO: randomize this too
@@ -1443,6 +1444,7 @@ pub(crate) struct SimulatorOpts {
     pub(crate) disable_where_true_false_null: bool,
     pub(crate) disable_union_all_preserves_cardinality: bool,
     pub(crate) disable_savepoint_rollback: bool,
+    pub(crate) disable_scalar_function_persistence: bool,
     pub(crate) disable_fsync_no_wait: bool,
     pub(crate) disable_faulty_query: bool,
     pub(crate) disable_reopen_database: bool,

--- a/testing/sqltests/tests/scalar-functions.sqltest
+++ b/testing/sqltests/tests/scalar-functions.sqltest
@@ -63,6 +63,20 @@ expect {
     ab,bc,cd
 }
 
+test concat_ws-blob-separator {
+    select concat_ws(x'2d', 'a', 'b');
+}
+expect {
+    a-b
+}
+
+test concat_ws-blob-value {
+    select concat_ws('-', 'a', x'42');
+}
+expect {
+    a-B
+}
+
 # Regression test: CONCAT with complex first argument that allocates internal registers
 test concat-complex-first-arg {
     select concat((1 IN (2,3)), 'hello', 'world')
@@ -551,6 +565,13 @@ expect {
     X'AABBCC'
 }
 
+test unhex-blob-ignore-set {
+    SELECT quote(unhex('41-42', x'2d'));
+}
+expect {
+    X'4142'
+}
+
 test unhex-space-separated {
     SELECT quote(unhex('aa bb', ' '));
 }
@@ -623,6 +644,20 @@ expect {
     Limbo
 }
 
+test trim-nul-pattern-preserves-text {
+    SELECT hex(trim(char(0) || 'abc' || char(0), char(0)));
+}
+expect {
+    0061626300
+}
+
+test trim-nul-terminated-pattern {
+    SELECT hex(trim('x' || char(0) || 'abc' || char(0) || 'x', 'x' || char(0)));
+}
+expect {
+    0061626300
+}
+
 test ltrim {
     SELECT ltrim('   Limbo    ');
 }
@@ -680,6 +715,13 @@ test ltrim-no-match-pattern {
 }
 expect {
     Limbo
+}
+
+test ltrim-nul-pattern-preserves-text {
+    SELECT hex(ltrim(char(0) || 'abc' || char(0), char(0)));
+}
+expect {
+    0061626300
 }
 
 test rtrim {
@@ -741,6 +783,13 @@ expect {
     Limbo
 }
 
+test rtrim-nul-pattern-preserves-text {
+    SELECT hex(rtrim(char(0) || 'abc' || char(0), char(0)));
+}
+expect {
+    0061626300
+}
+
 # TRIM always returns TEXT, even for numeric inputs.
 # This is important for expression indexes that use TRIM on numeric columns.
 test trim-integer-returns-text {
@@ -793,6 +842,32 @@ test round-float-with-precision {
 }
 expect {
     123.46
+}
+
+test round-float-half-away-positive {
+    SELECT round(2.25, 1);
+}
+expect {
+    2.3
+}
+
+test round-float-half-away-negative {
+    SELECT round(-2.25, 1);
+}
+expect {
+    -2.3
+}
+
+test round-float-half-away-persistent-update {
+    CREATE TABLE round_regression(id INT PRIMARY KEY, r REAL, v REAL);
+    INSERT INTO round_regression(id, r) VALUES(1, -2.25), (2, -2.35), (3, 2.25);
+    UPDATE round_regression SET v = round(r, 1);
+    SELECT id, typeof(v), quote(v) FROM round_regression ORDER BY id;
+}
+expect {
+    1|real|-2.3
+    2|real|-2.4
+    3|real|2.3
 }
 
 test round-float-with-text-precision {
@@ -1599,6 +1674,27 @@ expect {
     2
 }
 
+test randomblob-text-numeric-prefix {
+    SELECT length(randomblob('3.9suffix'));
+}
+expect {
+    3
+}
+
+test randomblob-blob-numeric-prefix {
+    SELECT length(randomblob(x'332e39737566666978'));
+}
+expect {
+    3
+}
+
+test char-numeric-coercions {
+    SELECT char(65.9), char('65suffix'), char(x'3635737566666978');
+}
+expect {
+    A|A|A
+}
+
 test zeroblob-int-0 {
     SELECT zeroblob(0) = x'';
 }
@@ -1615,6 +1711,20 @@ expect {
 
 test zeroblob-str-3 {
     SELECT zeroblob('3') = x'000000';
+}
+expect {
+    1
+}
+
+test zeroblob-str-float-prefix {
+    SELECT zeroblob('3.9suffix') = x'000000';
+}
+expect {
+    1
+}
+
+test zeroblob-blob-float-prefix {
+    SELECT zeroblob(x'332E39737566666978') = x'000000';
 }
 expect {
     1


### PR DESCRIPTION
This PR is closed and should not be reviewed as-is.

The useful part is the minimal SQLite compatibility repro:

```sql
CREATE TABLE out(v);
INSERT INTO out VALUES(zeroblob('3.9suffix'));
PRAGMA integrity_check;
SELECT typeof(v), quote(v), length(v), hex(v) FROM out;
```

SQLite 3.51.0 returns:

```text
ok
blob|X'000000'|3|000000
```

Turso v0.6.1 (`76af5a1250cd`) and current main (`7db53cd27dba`) return:

```text
ok
blob|X''|0|
```

Expected: `zeroblob('3.9suffix')` should follow SQLite's numeric-prefix
coercion and persist a 3-byte zero blob.

Actual: Turso persists an empty blob while `PRAGMA integrity_check` reports
`ok`.

The patch in this closed PR was an attempted fix for this scalar-function
numeric coercion mismatch. Given the trust-gate closure, the minimal repro above
is the actionable artifact.
