### PR TITLE
simulator: drive wal_checkpoint in SavepointRollback properties

### DIFF
--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    WalCheckpoint(WalCheckpointMode),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -13,6 +14,14 @@ pub enum VacuumMode {
     None,
     Incremental,
     Full,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WalCheckpointMode {
+    Passive,
+    Full,
+    Restart,
+    Truncate,
 }
 
 impl Display for Pragma {
@@ -31,6 +40,15 @@ impl Display for Pragma {
             Pragma::ForeignKeyList(table_name) => {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
+            }
+            Pragma::WalCheckpoint(mode) => {
+                let mode = match mode {
+                    WalCheckpointMode::Passive => "PASSIVE",
+                    WalCheckpointMode::Full => "FULL",
+                    WalCheckpointMode::Restart => "RESTART",
+                    WalCheckpointMode::Truncate => "TRUNCATE",
+                };
+                write!(f, "PRAGMA wal_checkpoint({mode})")
             }
         }
     }

--- a/testing/simulator/COVERAGE.md
+++ b/testing/simulator/COVERAGE.md
@@ -154,7 +154,7 @@ simulator covers and tests.
 | PRAGMA vdbe_listing              | No         |                                                  |
 | PRAGMA vdbe_trace                | No         |                                                  |
 | PRAGMA wal_autocheckpoint        | No         |                                                  |
-| PRAGMA wal_checkpoint            | No         |                                                  |
+| PRAGMA wal_checkpoint            | Partial    | Driven by SavepointRollback intermediary queries |
 | PRAGMA writable_schema           | No         |                                                  |
 
 ### Expressions

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -14,6 +14,7 @@ use sql_generation::{
         query::{
             Create, Delete, Drop, Insert, Select,
             alter_table::{AlterTable, AlterTableType},
+            pragma::{Pragma, WalCheckpointMode},
             predicate::Predicate,
             select::{CompoundOperator, CompoundSelect, ResultColumn, SelectBody, SelectInner},
             transaction::{Begin, Commit, Rollback},
@@ -233,6 +234,15 @@ impl Property {
                     let Property::SavepointRollback { write_kinds, .. } = property else {
                         unreachable!()
                     };
+                    if rng.random_bool(0.30) {
+                        let mode = match rng.random_range(0..4) {
+                            0 => WalCheckpointMode::Passive,
+                            1 => WalCheckpointMode::Full,
+                            2 => WalCheckpointMode::Restart,
+                            _ => WalCheckpointMode::Truncate,
+                        };
+                        return Some(Query::Pragma(Pragma::WalCheckpoint(mode)));
+                    }
                     random_main_table_write(rng, ctx, write_kinds)
                 }
             }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -468,7 +468,11 @@ impl Shadow for Query {
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
-            Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(
+                Pragma::AutoVacuumMode(_)
+                | Pragma::ForeignKeyList(_)
+                | Pragma::WalCheckpoint(_),
+            ) => Ok(vec![]),
         }
     }
 }


### PR DESCRIPTION
## Summary
- add PRAGMA wal_checkpoint(...) support to simulator Pragma model
- drive checkpoint execution from SavepointRollback intermediary queries (30% chance, random mode: PASSIVE/FULL/RESTART/TRUNCATE)
- update simulator shadow handling for the new pragma variant
- update coverage doc to reflect partial wal_checkpoint coverage

## Why
Issue #7045 points out that DST rarely exercises WAL checkpoint paths. This patch introduces lightweight checkpoint pressure inside an existing write-heavy property while preserving current assertions (ssert_all_table_values + integrity_check).

## Validation
- attempted: cargo test -p limbo_sim --no-run
- blocked in this environment by missing clang-cl.exe (toolchain issue on Windows)
