### PR TITLE
core/functions: Allow whitespace in datetime() arguments

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -209,6 +209,8 @@ fn set_to_current(p: &mut DateTime) {
 }
 
 fn parse_date_or_time(value: &str, p: &mut DateTime) -> Result<()> {
+    let value = value.trim();
+
     if parse_yyyy_mm_dd(value, p) {
         return Ok(());
     }
@@ -2575,6 +2577,9 @@ mod tests {
 
         let result = exec_unixepoch(vec![Value::from_f64(2440587.5)]);
         assert_eq!(result, Value::from_i64(0));
+
+        let result = exec_unixepoch(vec![Value::build_text(" 9".to_string())]);
+        assert_eq!(result, Value::from_i64(-210865982400));
     }
 
     #[test]

--- a/testing/sqltests/tests/scalar-functions-datetime.sqltest
+++ b/testing/sqltests/tests/scalar-functions-datetime.sqltest
@@ -653,6 +653,22 @@ expect {
     -62167219200
 }
 
+test unixepoch-trims-time-value-whitespace {
+    SELECT unixepoch(' 9');
+}
+expect {
+    -210865982400
+}
+
+test insert-unixepoch-trims-time-value-whitespace {
+    CREATE TABLE t_unixepoch_whitespace(x);
+    INSERT INTO t_unixepoch_whitespace VALUES (unixepoch(' 9'));
+    SELECT x, typeof(x) FROM t_unixepoch_whitespace;
+}
+expect {
+    -210865982400|integer
+}
+
 test unixepoch-at-millisecond-precision-input-produces-seconds-precision-output {
     SELECT unixepoch('2022-01-27 12:59:28.052');
 }


### PR DESCRIPTION
## Summary

Fix datetime/time-value parsing so inputs with surrounding whitespace are handled before parsing. This matches the differential oracle behavior for values such as `unixepoch(' 9')`, which SQLite treats as Julian day `9` while Turso previously returned `NULL`.

The mismatch was found by the differential fuzzer and can corrupt inserted data because Turso stored `NULL` where SQLite stored `-210865982400`.

Fuzzer reproduction before this fix:

```sh
cargo run -p differential-fuzzer --bin differential_fuzzer -- -n 250 -t 2 -c 4 --generator sql-gen-prop --seed 6154894608632889871
```

Failing statement before fix:

```sql
INSERT INTO temp.engaging_dixon (..., efficient_calladinejones, ...) VALUES (..., UNIXEPOCH(' 9'), ...);
```

## Tests

```sh
cargo test -p turso_core datetime::tests::test_unixepoch_basic_usage --lib
cargo run -p test-runner -- run testing/sqltests/tests/scalar-functions-datetime.sqltest --filter unixepoch-trims-time-value-whitespace
cargo run -p test-runner -- run testing/sqltests/tests/scalar-functions-datetime.sqltest --filter insert-unixepoch-trims-time-value-whitespace
cargo run -p differential-fuzzer --bin differential_fuzzer -- -n 250 -t 2 -c 4 --generator sql-gen-prop --seed 6154894608632889871
cargo fmt --check
git diff --check
```

Contact: nguyenhuyhoangqbx5@gmail.com
