### PR TITLE
Fix UPSERT OR REPLACE statement rollback analysis

### DIFF
--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -150,6 +150,9 @@ pub(crate) fn set_insert_stmt_journal_flags(
     let has_check = !table.check_constraints.is_empty();
     let may_abort = has_triggers
         || has_fks
+        // SQLite treats the DO UPDATE arm of an UPSERT as ABORT, even when
+        // the outer INSERT policy is OR REPLACE.
+        || (has_upsert && matches!(statement_conflict, ResolveType::Replace))
         || constraint_may_abort(
             has_statement_conflict,
             statement_conflict,

--- a/tests/integration/stmt_journal.rs
+++ b/tests/integration/stmt_journal.rs
@@ -185,6 +185,35 @@ fn insert_fk_violation_in_tx_rolls_back_row(tmp_db: TempDatabase) -> anyhow::Res
     Ok(())
 }
 
+/// Regression: DO UPDATE in an UPSERT always aborts on a secondary UNIQUE
+/// violation, even when the outer INSERT policy is OR REPLACE. The statement
+/// journal must roll back any index changes made before that abort.
+#[turso_macros::test]
+fn insert_or_replace_upsert_unique_abort_rolls_back_indexes(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode=WAL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, u TEXT UNIQUE, a TEXT UNIQUE)")?;
+    conn.execute("INSERT INTO t VALUES(1,'u1','a1'),(2,'u2','a2')")?;
+
+    conn.execute("BEGIN")?;
+    let result = conn.execute(
+        "INSERT OR REPLACE INTO t(u,a) VALUES('u1','a2') \
+         ON CONFLICT(u) DO UPDATE SET a=excluded.a",
+    );
+    assert!(result.is_err(), "UPSERT should fail with UNIQUE violation");
+
+    let integrity = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(integrity, vec!["ok"]);
+    conn.execute("COMMIT")?;
+    let integrity = query_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(integrity, vec!["ok"]);
+    let rows = query_rows(&conn, "SELECT id,u,a FROM t ORDER BY id");
+    assert_eq!(rows, vec!["1|u1|a1", "2|u2|a2"]);
+    Ok(())
+}
+
 // ──────────────────────────────────────────────────────────
 // UPDATE
 // ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- treat UPSERT DO UPDATE as an ABORT-capable path when the outer INSERT policy is OR REPLACE
- keep the statement journal enabled so secondary-index changes roll back on a later UNIQUE violation
- add regression coverage for issue #6859

Fixes #6859

## Tests
- cargo test -p core_tester --test integration_tests insert_or_replace_upsert_unique_abort_rolls_back_indexes -- --nocapture
- cargo test -p core_tester --test integration_tests stmt_journal -- --nocapture
- cargo fmt --check