### PR TITLE
Fix RETURNING implicit column names

### DIFF
--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -139,8 +139,6 @@ pub fn process_returning_clause(
 ) -> Result<Vec<ResultSetColumn>> {
     let mut result_columns = Vec::with_capacity(returning.len());
 
-    let alias_to_string = |alias: &ast::As| alias.name().as_str().to_string();
-
     for rc in returning.iter_mut() {
         match rc {
             ast::ResultColumn::Expr(expr, alias) => {
@@ -160,10 +158,20 @@ pub fn process_returning_clause(
                     );
                 }
 
+                let (alias, implicit_column_name) = match &alias {
+                    Some(ast::As::As(name)) | Some(ast::As::Elided(name)) => {
+                        (Some(name.as_str().to_string()), None)
+                    }
+                    Some(ast::As::ImplicitColumnName(name)) => {
+                        (None, Some(name.as_str().to_string()))
+                    }
+                    None => (None, None),
+                };
+
                 result_columns.push(ResultSetColumn {
                     expr: expr.as_ref().clone(),
-                    alias: alias.as_ref().map(alias_to_string),
-                    implicit_column_name: None,
+                    alias,
+                    implicit_column_name,
                     contains_aggregates: false,
                 });
             }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -709,6 +709,16 @@ mod tests {
         let columns = stmt.num_columns();
         assert_eq!(columns, 0);
 
+        let stmt = conn.prepare(
+            "insert into \"test\" (\"foo\", \"bar\", \"baz\") values (1, 2, 3) \
+             returning \"test\".\"foo\", \"bar\", baz as explicit_baz;",
+        )?;
+        let columns = stmt.num_columns();
+        assert_eq!(columns, 3);
+        assert_eq!(stmt.get_column_name(0), "foo");
+        assert_eq!(stmt.get_column_name(1), "bar");
+        assert_eq!(stmt.get_column_name(2), "explicit_baz");
+
         let stmt = conn.prepare("delete from test where foo = 1")?;
         let columns = stmt.num_columns();
         assert_eq!(columns, 0);


### PR DESCRIPTION
Fixes #7115.

## Summary
- treat parser-generated implicit column names in RETURNING like SELECT result names, not user aliases
- keep explicit RETURNING aliases unchanged
- add regression coverage for quoted and qualified RETURNING column references

## Test
```powershell
cargo test -p core_tester --test integration_tests common::tests::test_statement_columns -- --nocapture
cargo fmt --check
cargo build -p turso_cli --bin tursodb
```