### PR TITLE
translate: fix RETURNING column names for quoted identifiers

### DIFF
--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -139,11 +139,9 @@ pub fn process_returning_clause(
 ) -> Result<Vec<ResultSetColumn>> {
     let mut result_columns = Vec::with_capacity(returning.len());
 
-    let alias_to_string = |alias: &ast::As| alias.name().as_str().to_string();
-
     for rc in returning.iter_mut() {
         match rc {
-            ast::ResultColumn::Expr(expr, alias) => {
+            ast::ResultColumn::Expr(expr, maybe_as) => {
                 bind_and_rewrite_expr(
                     expr,
                     Some(table_references),
@@ -160,10 +158,20 @@ pub fn process_returning_clause(
                     );
                 }
 
+                let (alias, implicit_column_name) = match maybe_as {
+                    Some(ast::As::As(name)) | Some(ast::As::Elided(name)) => {
+                        (Some(name.as_str().to_string()), None)
+                    }
+                    Some(ast::As::ImplicitColumnName(name)) => {
+                        (None, Some(name.as_str().to_string()))
+                    }
+                    None => (None, None),
+                };
+
                 result_columns.push(ResultSetColumn {
                     expr: expr.as_ref().clone(),
-                    alias: alias.as_ref().map(alias_to_string),
-                    implicit_column_name: None,
+                    alias,
+                    implicit_column_name,
                     contains_aggregates: false,
                 });
             }

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -946,6 +946,23 @@ pub fn insert_returning_qualified_quoted_table(limbo: TempDatabase) {
 }
 
 #[turso_macros::test]
+pub fn returning_quoted_column_name(limbo: TempDatabase) {
+    let conn = limbo.db.connect().unwrap();
+    conn.execute("CREATE TABLE counters (id INTEGER PRIMARY KEY, name TEXT)")
+        .unwrap();
+
+    let stmt = conn
+        .prepare("INSERT INTO counters (name) VALUES ('test') RETURNING `id`")
+        .unwrap();
+    assert_eq!(stmt.get_column_name(0), "id");
+
+    let stmt = conn
+        .prepare(r#"INSERT INTO counters (name) VALUES ('test') RETURNING "id""#)
+        .unwrap();
+    assert_eq!(stmt.get_column_name(0), "id");
+}
+
+#[turso_macros::test]
 pub fn concurrent_writes_over_single_connection(limbo: TempDatabase) {
     const COUNT: usize = 16;
     let conn = limbo.db.connect().unwrap();


### PR DESCRIPTION
## Description

Fixes #7084. Quoted column identifiers in `RETURNING` (e.g. `` `id` `` or
`"id"`) returned the verbatim quoted text from `get_column_name` instead
of the dequoted column name, which broke GORM and any caller using
`database/sql`'s `Rows.Columns()`.

Adds a regression test covering both backtick- and double-quote–quoted
column references in `INSERT ... RETURNING`.

## Motivation and context

`process_returning_clause` in `core/translate/expr/emission.rs`
unconditionally assigned every `ast::As` variant to
`ResultSetColumn.alias`. Since `Statement::get_column_name` returns the
alias first — before any column-resolution logic runs — the verbatim
quoted text (e.g. `` `id` ``) leaked all the way out to the public API,
bypassing the dequoting that would normally happen when resolving an
`Expr::Column` to its schema name.

`translate_select` already handles this correctly: only `As::As` and
`As::Elided` populate `alias`, while `As::ImplicitColumnName` populates
the separate `implicit_column_name` field. For column references,
`get_column_name` then resolves to the schema column name (dequoted)
rather than echoing the user's quoted text.

This change aligns `process_returning_clause` with that pattern. No
parser, type, or binding changes are required.

Fixes #7084.

## Description of AI Usage

Used Claude Code (Opus 4.7 / Sonnet 4.6) collaboratively throughout:

- **Investigation:** asked Claude to trace the path from
  `RETURNING` parsing through `process_returning_clause` to
  `get_column_name`, and compare against the `SELECT` path in
  `translate_select`. The fix (route `ImplicitColumnName` to
  `implicit_column_name` instead of `alias`) came out of that
  comparison.
- **Drafting:** Claude drafted the initial diff in `emission.rs` and the
  regression test in `test_write_path.rs`, matching the existing
  `insert_returning_qualified_quoted_table` test pattern.
- **Validation:** I ran `cargo test`, `cargo fmt`, `cargo clippy
  --deny=warnings`, and a CLI sanity check (`tursodb :memory: 'INSERT
  ... RETURNING "id"'`) myself and confirmed the regression test fails
  on `main` and passes with the fix.
I reviewed every change before committing and understand the code
paths involved.
