### PR TITLE
serverless/javascript: fix server-side stream leak on one-shot queries

### DIFF
--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -59,7 +59,6 @@ export class Connection {
   private session: Session;
   private isOpen: boolean = true;
   private defaultSafeIntegerMode: boolean = false;
-  private _inTransaction: boolean = false;
   private execLock: AsyncLock = new AsyncLock();
 
   constructor(config: Config) {
@@ -71,16 +70,23 @@ export class Connection {
     
     // Define inTransaction property
     Object.defineProperty(this, 'inTransaction', {
-      get: () => this._inTransaction,
+      get: () => this.session.isStreamOpen,
       enumerable: true
     });
   }
 
   /**
-   * Whether the database is currently in a transaction.
+   * Whether the database is currently inside a transaction.
+   *
+   * Derived from the server's view: if the server is keeping a stream open
+   * for us, we're not in autocommit. This catches BEGIN/COMMIT correctly and
+   * mirrors how `sqlite3_get_autocommit()` is exposed on the native bindings.
+   * (Strictly, a non-null baton can also mean stored SQL or pragma side-
+   * effects; we don't use stored SQL and pragma side-effects are rare enough
+   * that treating them as "stateful" is acceptable.)
    */
   get inTransaction(): boolean {
-    return this._inTransaction;
+    return this.session.isStreamOpen;
   }
 
   /**
@@ -318,15 +324,12 @@ export class Connection {
     const wrapTxn = (mode: string) => {
       return async (...bindParameters: any[]) => {
         await db.exec("BEGIN " + mode);
-        db._inTransaction = true;
         try {
           const result = await fn(...bindParameters);
           await db.exec("COMMIT");
-          db._inTransaction = false;
           return result;
         } catch (err) {
           await db.exec("ROLLBACK");
-          db._inTransaction = false;
           throw err;
         }
       };

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -79,6 +79,11 @@ export interface PipelineRequest {
   requests: (ExecuteRequest | BatchRequest | SequenceRequest | CloseRequest | DescribeRequest)[];
 }
 
+export interface BatchResult {
+  step_results: Array<ExecuteResult | null>;
+  step_errors: Array<{ message: string; code: string } | null>;
+}
+
 export interface PipelineResponse {
   baton: string | null;
   base_url: string | null;
@@ -86,7 +91,7 @@ export interface PipelineResponse {
     type: 'ok' | 'error';
     response?: {
       type: 'execute' | 'batch' | 'sequence' | 'close' | 'describe';
-      result?: ExecuteResult | DescribeResult;
+      result?: ExecuteResult | DescribeResult | BatchResult;
     };
     error?: {
       message: string;

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -7,6 +7,11 @@ import {
   type CursorResponse,
   type CursorEntry,
   type PipelineRequest,
+  type PipelineResponse,
+  type ExecuteRequest,
+  type ExecuteResult,
+  type BatchRequest,
+  type BatchResult,
   type SequenceRequest,
   type CloseRequest,
   type DescribeRequest,
@@ -58,6 +63,19 @@ export class Session {
     this.baseUrl = normalizeUrl(config.url);
   }
 
+  /**
+   * Whether the server is currently keeping a stream open for this session.
+   *
+   * Per the Hrana V2/V3 spec, the server returns a baton in every pipeline
+   * response: a non-null baton means the server kept the stream alive (it's
+   * inside a transaction, has stored SQL, or has pragma side-effects); a null
+   * baton means the server closed the stream because the connection state is
+   * back to a clean autocommit slate.
+   */
+  get isStreamOpen(): boolean {
+    return this.baton !== null;
+  }
+
   private createAbortSignal(queryOptions?: QueryOptions): AbortSignal | undefined {
     const timeout = queryOptions?.queryTimeout ?? this.config.defaultQueryTimeout;
     if (timeout != null && timeout > 0) {
@@ -67,23 +85,28 @@ export class Session {
   }
 
   /**
-   * Describe a SQL statement to get its column metadata.
-   * 
-   * @param sql - The SQL statement to describe
-   * @returns Promise resolving to the statement description
+   * Send a pipeline request, propagating baton and base_url from the response.
+   * The server returns baton: null when the stream can be closed; we just trust
+   * that and store whatever comes back.
    */
-  async describe(sql: string, queryOptions?: QueryOptions): Promise<DescribeResult> {
+  private async sendPipeline(
+    requests: PipelineRequest['requests'],
+    queryOptions?: QueryOptions,
+  ): Promise<PipelineResponse> {
     const request: PipelineRequest = {
       baton: this.baton,
-      requests: [{
-        type: "describe",
-        sql: sql
-      } as DescribeRequest]
+      requests,
     };
 
     let response;
     try {
-      response = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
+      response = await executePipeline(
+        this.baseUrl,
+        this.config.authToken,
+        request,
+        this.config.remoteEncryptionKey,
+        this.createAbortSignal(queryOptions),
+      );
     } catch (e) {
       this.baton = null;
       throw e;
@@ -93,15 +116,24 @@ export class Session {
     if (response.base_url) {
       this.baseUrl = response.base_url;
     }
+    return response;
+  }
 
-    // Check for errors in the response
+  /**
+   * Describe a SQL statement to get its column metadata.
+   */
+  async describe(sql: string, queryOptions?: QueryOptions): Promise<DescribeResult> {
+    const response = await this.sendPipeline(
+      [{ type: 'describe', sql } as DescribeRequest],
+      queryOptions,
+    );
+
     if (response.results && response.results[0]) {
       const result = response.results[0];
-      if (result.type === "error") {
+      if (result.type === 'error') {
         throw new DatabaseError(result.error?.message || 'Describe execution failed', result.error?.code);
       }
-
-      if (result.response?.type === "describe" && result.response.result) {
+      if (result.response?.type === 'describe' && result.response.result) {
         return result.response.result as DescribeResult;
       }
     }
@@ -111,63 +143,49 @@ export class Session {
 
   /**
    * Execute a SQL statement and return all results.
-   * 
-   * @param sql - The SQL statement to execute
-   * @param args - Optional array of parameter values or object with named parameters
-   * @param safeIntegers - Whether to return integers as BigInt
-   * @returns Promise resolving to the complete result set
+   *
+   * Uses the /v3/pipeline endpoint so the server runs its auto-close check
+   * and closes the stream itself (returning baton: null) when the connection
+   * is back in autocommit. The /v3/cursor endpoint does NOT run that check
+   * and would leak a stream on the server for every one-shot SELECT.
    */
   async execute(sql: string, args: any[] | Record<string, any> = [], safeIntegers: boolean = false, queryOptions?: QueryOptions): Promise<any> {
-    const { response, entries } = await this.executeRaw(sql, args, queryOptions);
-    const result = await this.processCursorEntries(entries, safeIntegers);
-    return result;
+    const { positionalArgs, namedArgs } = this.encodeArgs(args);
+
+    const executeReq: ExecuteRequest = {
+      type: 'execute',
+      stmt: {
+        sql,
+        args: positionalArgs,
+        named_args: namedArgs,
+        want_rows: true,
+      },
+    };
+
+    const response = await this.sendPipeline([executeReq], queryOptions);
+
+    if (response.results && response.results[0]) {
+      const result = response.results[0];
+      if (result.type === 'error') {
+        throw new DatabaseError(result.error?.message || 'SQL execution failed', result.error?.code);
+      }
+      if (result.response?.type === 'execute' && result.response.result) {
+        return this.processExecuteResult(result.response.result as ExecuteResult, safeIntegers);
+      }
+    }
+
+    throw new DatabaseError('Unexpected execute response');
   }
 
   /**
-   * Execute a SQL statement and return the raw response and entries.
-   * 
-   * @param sql - The SQL statement to execute
-   * @param args - Optional array of parameter values or object with named parameters
-   * @returns Promise resolving to the raw response and cursor entries
+   * Execute a SQL statement and stream results via the /v3/cursor endpoint.
+   *
+   * The cursor endpoint always returns a baton — it doesn't run the
+   * auto-close check — so the leftover baton will be cleaned up by the next
+   * pipeline call when the server re-evaluates stream state.
    */
   async executeRaw(sql: string, args: any[] | Record<string, any> = [], queryOptions?: QueryOptions): Promise<{ response: CursorResponse; entries: AsyncGenerator<CursorEntry> }> {
-    let positionalArgs: Value[] = [];
-    let namedArgs: NamedArg[] = [];
-
-    if (Array.isArray(args)) {
-      positionalArgs = args.map(encodeValue);
-    } else {
-      // Check if this is an object with numeric keys (for ?1, ?2 style parameters)
-      const keys = Object.keys(args);
-      const isNumericKeys = keys.length > 0 && keys.every(key => /^\d+$/.test(key));
-      
-      if (isNumericKeys) {
-        // Convert numeric-keyed object to positional args
-        // Sort keys numerically to ensure correct order
-        const sortedKeys = keys.sort((a, b) => parseInt(a) - parseInt(b));
-        const maxIndex = parseInt(sortedKeys[sortedKeys.length - 1]);
-        
-        // Create array with undefined for missing indices
-        positionalArgs = new Array(maxIndex);
-        for (const key of sortedKeys) {
-          const index = parseInt(key) - 1; // Convert to 0-based index
-          positionalArgs[index] = encodeValue(args[key]);
-        }
-        
-        // Fill any undefined values with null
-        for (let i = 0; i < positionalArgs.length; i++) {
-          if (positionalArgs[i] === undefined) {
-            positionalArgs[i] = { type: 'null' };
-          }
-        }
-      } else {
-        // Convert object with named parameters to NamedArg array
-        namedArgs = Object.entries(args).map(([name, value]) => ({
-          name,
-          value: encodeValue(value)
-        }));
-      }
-    }
+    const { positionalArgs, namedArgs } = this.encodeArgs(args);
 
     const request: CursorRequest = {
       baton: this.baton,
@@ -177,10 +195,10 @@ export class Session {
             sql,
             args: positionalArgs,
             named_args: namedArgs,
-            want_rows: true
-          }
-        }]
-      }
+            want_rows: true,
+          },
+        }],
+      },
     };
 
     let result;
@@ -196,8 +214,35 @@ export class Session {
     if (response.base_url) {
       this.baseUrl = response.base_url;
     }
-
     return { response, entries };
+  }
+
+  /**
+   * Convert an ExecuteResult from the pipeline endpoint into the same row/
+   * column shape that processCursorEntries returns from the cursor endpoint.
+   */
+  private processExecuteResult(execResult: ExecuteResult, safeIntegers: boolean): any {
+    const columns = execResult.cols.map(col => col.name);
+    const columnTypes = execResult.cols.map(col => col.decltype || '');
+    const rows = execResult.rows.map(row => {
+      const decodedRow = row.map(value => decodeValue(value, safeIntegers));
+      return this.createRowObject(decodedRow, columns);
+    });
+
+    let lastInsertRowid: number | undefined;
+    if (execResult.last_insert_rowid !== undefined && execResult.last_insert_rowid !== null) {
+      lastInsertRowid = typeof execResult.last_insert_rowid === 'number'
+        ? execResult.last_insert_rowid
+        : parseInt(execResult.last_insert_rowid as string, 10);
+    }
+
+    return {
+      columns,
+      columnTypes,
+      rows,
+      rowsAffected: execResult.affected_row_count,
+      lastInsertRowid,
+    };
   }
 
   /**
@@ -280,99 +325,79 @@ export class Session {
   }
 
   /**
-   * Execute multiple SQL statements in a batch.
-   * 
-   * @param statements - Array of SQL statements to execute
-   * @returns Promise resolving to batch execution results
+   * Execute multiple SQL statements in a batch. Uses the /v3/pipeline endpoint
+   * (see `execute` for why) so the server's auto-close logic applies.
    */
   async batch(statements: string[], queryOptions?: QueryOptions): Promise<any> {
-    const request: CursorRequest = {
-      baton: this.baton,
+    const batchReq: BatchRequest = {
+      type: 'batch',
       batch: {
         steps: statements.map(sql => ({
           stmt: {
             sql,
             args: [],
             named_args: [],
-            want_rows: false
-          }
-        }))
-      }
+            want_rows: false,
+          },
+        })),
+      },
     };
 
-    let batchResult;
-    try {
-      batchResult = await executeCursor(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
-    } catch (e) {
-      this.baton = null;
-      throw e;
+    const response = await this.sendPipeline([batchReq], queryOptions);
+
+    if (response.results && response.results[0]) {
+      const result = response.results[0];
+      if (result.type === 'error') {
+        throw new DatabaseError(result.error?.message || 'Batch execution failed', result.error?.code);
+      }
+      if (result.response?.type === 'batch' && result.response.result) {
+        return this.processBatchResult(result.response.result as BatchResult);
+      }
     }
 
-    const { response, entries } = batchResult;
-    this.baton = response.baton;
-    if (response.base_url) {
-      this.baseUrl = response.base_url;
-    }
+    throw new DatabaseError('Unexpected batch response');
+  }
 
+  private processBatchResult(batchResult: BatchResult): any {
     let totalRowsAffected = 0;
     let lastInsertRowid: number | undefined;
 
-    for await (const entry of entries) {
-      switch (entry.type) {
-        case 'step_end':
-          if (entry.affected_row_count !== undefined) {
-            totalRowsAffected += entry.affected_row_count;
-          }
-          if (entry.last_insert_rowid !== undefined && entry.last_insert_rowid !== null) {
-            lastInsertRowid = typeof entry.last_insert_rowid === 'number'
-              ? entry.last_insert_rowid
-              : parseInt(entry.last_insert_rowid, 10);
-          }
-          break;
-        case 'step_error':
-        case 'error':
-          throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
+    for (let i = 0; i < batchResult.step_results.length; i++) {
+      const stepError = batchResult.step_errors[i];
+      if (stepError) {
+        throw new DatabaseError(stepError.message || 'Batch execution failed', stepError.code);
+      }
+      const stepResult = batchResult.step_results[i];
+      if (stepResult) {
+        totalRowsAffected += stepResult.affected_row_count;
+        if (stepResult.last_insert_rowid !== undefined && stepResult.last_insert_rowid !== null) {
+          lastInsertRowid = typeof stepResult.last_insert_rowid === 'number'
+            ? stepResult.last_insert_rowid
+            : parseInt(stepResult.last_insert_rowid as string, 10);
+        }
       }
     }
 
     return {
       rowsAffected: totalRowsAffected,
-      lastInsertRowid
+      lastInsertRowid,
     };
   }
 
   /**
    * Execute a sequence of SQL statements separated by semicolons.
-   * 
+   *
    * @param sql - SQL string containing multiple statements separated by semicolons
-   * @returns Promise resolving when all statements are executed
    */
   async sequence(sql: string, queryOptions?: QueryOptions): Promise<void> {
-    const request: PipelineRequest = {
-      baton: this.baton,
-      requests: [{
-        type: "sequence",
-        sql: sql
-      } as SequenceRequest]
-    };
+    const response = await this.sendPipeline(
+      [{ type: 'sequence', sql } as SequenceRequest],
+      queryOptions,
+    );
 
-    let seqResponse;
-    try {
-      seqResponse = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
-    } catch (e) {
-      this.baton = null;
-      throw e;
-    }
-
-    this.baton = seqResponse.baton;
-    if (seqResponse.base_url) {
-      this.baseUrl = seqResponse.base_url;
-    }
-
-    // Check for errors in the response
-    if (seqResponse.results && seqResponse.results[0]) {
-      const result = seqResponse.results[0];
-      if (result.type === "error") {
+    if (response.results && response.results[0]) {
+      const result = response.results[0];
+      if (result.type === 'error') {
         throw new DatabaseError(result.error?.message || 'Sequence execution failed', result.error?.code);
       }
     }
@@ -405,5 +430,40 @@ export class Session {
     // Reset local state
     this.baton = null;
     this.baseUrl = '';
+  }
+
+  /**
+   * Encode arguments (positional array or named-parameter object) into the
+   * positional/named Value arrays the Hrana protocol expects.
+   */
+  private encodeArgs(args: any[] | Record<string, any>): { positionalArgs: Value[]; namedArgs: NamedArg[] } {
+    if (Array.isArray(args)) {
+      return { positionalArgs: args.map(encodeValue), namedArgs: [] };
+    }
+
+    const keys = Object.keys(args);
+    const isNumericKeys = keys.length > 0 && keys.every(key => /^\d+$/.test(key));
+
+    if (isNumericKeys) {
+      const sortedKeys = keys.sort((a, b) => parseInt(a) - parseInt(b));
+      const maxIndex = parseInt(sortedKeys[sortedKeys.length - 1]);
+      const positionalArgs: Value[] = new Array(maxIndex);
+      for (const key of sortedKeys) {
+        const index = parseInt(key) - 1;
+        positionalArgs[index] = encodeValue(args[key]);
+      }
+      for (let i = 0; i < positionalArgs.length; i++) {
+        if (positionalArgs[i] === undefined) {
+          positionalArgs[i] = { type: 'null' };
+        }
+      }
+      return { positionalArgs, namedArgs: [] };
+    }
+
+    const namedArgs: NamedArg[] = Object.entries(args).map(([name, value]) => ({
+      name,
+      value: encodeValue(value),
+    }));
+    return { positionalArgs: [], namedArgs };
   }
 }

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -157,6 +157,21 @@ test.serial("Database.pragma() after close()", async (t) => {
 // Database.transaction()
 // ==========================================================================
 
+test.serial("Connection is in autocommit after a one-shot query", async (t) => {
+  const db = t.context.db;
+  // After a stateless query (no BEGIN, no pragma side-effects) the connection
+  // must report autocommit — `inTransaction` is false. On native backends
+  // this maps directly to `sqlite3_get_autocommit()`; on the serverless
+  // driver this requires the HTTP server to have closed the stream and the
+  // driver to honor that signal (baton: null per the Hrana spec). A leaked
+  // baton would leave `inTransaction` true even though the connection is in
+  // autocommit, lying about connection state to user code.
+  const stmt = await db.prepare("SELECT 1 AS n");
+  await stmt.get();
+  t.false(db.inTransaction,
+    "inTransaction should be false after a stateless one-shot query");
+});
+
 test.serial("Database.transaction()", async (t) => {
   const db = t.context.db;
 


### PR DESCRIPTION
execute() and batch() routed through /v3/cursor, which always returns a
baton and does not run the server's is_stateless() auto-close check, so
every one-shot SELECT kept a stream alive on the server. Route them
through /v3/pipeline instead and trust the server's baton: null signal
that the stream has been closed. executeRaw() still uses /v3/cursor for
streaming; the leftover baton is reset by the next pipeline call when
the server re-evaluates stream state.

Derive Connection.inTransaction from session.baton state rather than a
local flag toggled by transaction(). The server's view is authoritative
and this catches BEGIN/COMMIT correctly, matching how the native
bindings expose sqlite3_get_autocommit().

Add a conformance test asserting inTransaction is false after a
stateless one-shot query — trivially true on the native backends, and
the user-visible signal that the serverless leak is fixed.
