### PR TITLE
github: Bump `test-limbo` timeout to 30 minutes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -291,7 +291,7 @@ jobs:
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -314,7 +314,6 @@ jobs:
       - uses: "./.github/shared/install_sqlite"
       - name: Test
         run: make test
-        timeout-minutes: 20
 
   concurrent-simulator:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
Recent `test-limbo` runs on main commonly take 15–19 minutes, repeatedly brushing the 20-minute cap. Bump up the timeout to 30 minutes, and drop the test runner specific timeout.