### PR TITLE
Add Database.batch() method to JavaScript SDKs

### DIFF
--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -53,6 +53,14 @@ function toBindArgs(params) {
   return [params];
 }
 
+
+/**
+ * Locking mode for `Database.batch(stmts, mode)` and the variants of
+ * `Database.transaction(...)`. When passed to `batch()`, the statements are
+ * wrapped in `BEGIN <mode>` / `COMMIT` (with `ROLLBACK` on failure).
+ */
+export type BatchMode = "deferred" | "immediate" | "exclusive" | "concurrent";
+
 /**
  * A wrapped transaction function. Calling it runs the wrapped function inside a
  * `BEGIN`/`COMMIT` block; the mode properties (`deferred`, `concurrent`, etc.)
@@ -177,6 +185,173 @@ class Database {
     Object.defineProperties(properties.immediate.value, properties);
     Object.defineProperties(properties.exclusive.value, properties);
     return properties.default.value as TransactionFunction<F>;
+  }
+
+  /**
+   * Executes a batch of SQL statements sequentially over this connection.
+   *
+   * By default, batch() is not transactional: each statement runs in its
+   * own autocommit step, so a failure mid-batch leaves earlier successful
+   * statements committed. Pass a `mode` to make the batch atomic — the
+   * statements are wrapped in `BEGIN <mode>` / `COMMIT`, and `ROLLBACK`
+   * runs if any statement fails. When called from inside a
+   * `db.transaction(...)` callback the `mode` argument is ignored and the
+   * surrounding transaction is reused.
+   *
+   * When `mode` is set, `batch()` owns the surrounding
+   * `BEGIN`/`COMMIT`/`ROLLBACK`, so the `statements` array must not
+   * contain its own transaction-control SQL (`BEGIN`, `COMMIT`,
+   * `ROLLBACK`, `SAVEPOINT`, `RELEASE`). The input is not validated
+   * for that — a user-supplied `COMMIT` will close the wrapper
+   * transaction mid-batch and leave earlier statements committed,
+   * defeating the all-or-nothing contract.
+   *
+   * @param statements - An array of SQL strings or `{ sql, args }` objects.
+   * @param mode - When set, wraps the batch in `BEGIN <mode>` / `COMMIT`
+   *   (with `ROLLBACK` on failure). Ignored when already inside a
+   *   transaction.
+   * @returns An object with `rowsAffected` (sum of affected rows) and
+   *   `lastInsertRowid` (rowid of the last successful insert).
+   *
+   * @example
+   * // Plain SQL strings (non-atomic).
+   * await db.batch([
+   *   "INSERT INTO users(name) VALUES ('Alice')",
+   *   "INSERT INTO users(name) VALUES ('Bob')",
+   * ]);
+   *
+   * @example
+   * // Positional and named bind parameters.
+   * await db.batch([
+   *   { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Carol", "carol@example.net"] },
+   *   { sql: "INSERT INTO users(name, email) VALUES (:name, :email)", args: { name: "Dave", email: "dave@example.net" } },
+   * ]);
+   *
+   * @example
+   * // Atomic via the mode parameter.
+   * await db.batch([
+   *   { sql: "INSERT INTO users(name) VALUES (?)", args: ["Eve"] },
+   *   { sql: "INSERT INTO users(name) VALUES (?)", args: ["Frank"] },
+   * ], "immediate");
+   *
+   * @example
+   * // Atomic via the transaction() API for mixed workloads.
+   * const txn = db.transaction(async () => {
+   *   await db.batch([{ sql: "INSERT INTO users(name) VALUES (?)", args: ["Eve"] }]);
+   *   await db.exec("UPDATE counters SET n = n + 1");
+   * });
+   * await txn.immediate();
+   */
+  async batch(
+    statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
+    mode?: BatchMode,
+  ): Promise<{ rowsAffected: number; lastInsertRowid: number | bigint | undefined }> {
+    if (!Array.isArray(statements)) {
+      throw new TypeError("Expected first argument to be an array of statements");
+    }
+    if (!this.connected) {
+      await this.connect();
+    }
+    if (!this.open) {
+      throw new TypeError("The database connection is not open");
+    }
+
+    // Hold execLock across the entire batch so it is observed as a
+    // single unit by other callers on this connection. The helpers
+    // below run their own step loops without re-acquiring the lock.
+    await this.execLock.acquire();
+    try {
+      const runRawSql = async (sql: string) => {
+        const exec = this.db.executor(sql);
+        try {
+          while (true) {
+            const stepResult = exec.stepSync();
+            if (stepResult === STEP_IO) {
+              await this.io();
+              continue;
+            }
+            if (stepResult === STEP_DONE) {
+              break;
+            }
+          }
+        } finally {
+          exec.reset();
+        }
+      };
+
+      const wrap = mode !== undefined && !this._inTransaction;
+      if (wrap) {
+        await runRawSql(`BEGIN ${mode!.toUpperCase()}`);
+        this._inTransaction = true;
+      }
+
+      let rowsAffected = 0;
+      let lastInsertRowid: number | bigint | undefined;
+      try {
+        for (const statement of statements) {
+          const sql = typeof statement === "string" ? statement : statement.sql;
+          const args = typeof statement === "string" ? undefined : statement.args;
+
+          let nativeStmt: NativeStatement;
+          try {
+            nativeStmt = this.db.prepare(sql);
+          } catch (err) {
+            throw convertError(err);
+          }
+          try {
+            if (args !== undefined) {
+              bindParams(nativeStmt, [args]);
+            }
+            const totalChangesBefore = this.db.totalChanges();
+            const lastInsertRowidBefore = this.db.lastInsertRowid();
+            try {
+              while (true) {
+                const stepResult = await nativeStmt.stepSync();
+                if (stepResult === STEP_IO) {
+                  await this.io();
+                  continue;
+                }
+                if (stepResult === STEP_DONE) {
+                  break;
+                }
+                // STEP_ROW results are discarded; batch() does not
+                // surface rows.
+              }
+              if (this.db.totalChanges() !== totalChangesBefore) {
+                rowsAffected += this.db.changes();
+              }
+              // SQLite keeps last_insert_rowid() sticky across
+              // non-INSERT statements, so just checking the value is
+              // not enough — UPDATE/DELETE would inherit a stale
+              // rowid. Use the delta as the per-statement INSERT
+              // signal.
+              const lastInsertRowidAfter = this.db.lastInsertRowid();
+              if (lastInsertRowidAfter !== lastInsertRowidBefore) {
+                lastInsertRowid = lastInsertRowidAfter;
+              }
+            } finally {
+              nativeStmt.reset();
+            }
+          } finally {
+            nativeStmt.finalize();
+          }
+        }
+
+        if (wrap) {
+          await runRawSql("COMMIT");
+          this._inTransaction = false;
+        }
+      } catch (err) {
+        if (wrap) {
+          try { await runRawSql("ROLLBACK"); } catch { /* ignore */ }
+          this._inTransaction = false;
+        }
+        throw err;
+      }
+      return { rowsAffected, lastInsertRowid };
+    } finally {
+      this.execLock.release();
+    }
   }
 
   /**

--- a/docs/javascript-api-reference.md
+++ b/docs/javascript-api-reference.md
@@ -48,6 +48,34 @@ Prepares a SQL statement for execution.
 
 The function returns a `Statement` object.
 
+#### batch(statements, [mode]) ⇒ object
+
+Executes an array of SQL statements over the connection. Each statement is either a SQL string or an object of the form `{ sql, args }`, where `args` is an array of positional bind parameters or an object of named bind parameters.
+
+| Param      | Type                                                                                                                | Description                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| statements | <code>Array&lt;string \| { sql: string, args?: any[] \| Record&lt;string, any&gt; }&gt;</code>                      | The SQL statements to execute as a batch.                                                                                                                         |
+| mode       | <code>"deferred" \| "immediate" \| "exclusive" \| "concurrent"</code>                                               | Optional. When set, the batch is wrapped in `BEGIN <mode>` / `COMMIT` (with `ROLLBACK` on failure). Ignored when already inside a `transaction(...)` callback.    |
+
+Without a `mode`, `batch()` is not transactional: each statement runs in its own autocommit step, so a failure mid-batch leaves earlier successful statements committed. With a `mode`, the batch becomes atomic — on the serverless driver the entire batch (including `BEGIN`, the user statements, `COMMIT`, and a conditional `ROLLBACK`) ships as a single Hrana request, so an atomic batch is still one round-trip.
+
+When `mode` is set, `batch()` owns the surrounding `BEGIN`/`COMMIT`/`ROLLBACK`. Do not include transaction-control SQL (`BEGIN`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`, `RELEASE`) in `statements`; the input is not validated, and a user-supplied `COMMIT` will close the wrapper transaction mid-batch and leave earlier statements committed.
+
+For flexible all-or-nothing work that mixes `batch()` with other calls, wrap them in `transaction(...)` (or one of its `deferred`/`immediate`/`exclusive`/`concurrent` variants):
+
+```js
+const txn = db.transaction(async () => {
+  await db.batch([
+    { sql: "INSERT INTO users(name) VALUES (?)", args: ["Alice"] },
+    { sql: "INSERT INTO users(name) VALUES (?)", args: ["Bob"] },
+  ]);
+  await db.exec("UPDATE counters SET n = n + 1");
+});
+await txn.immediate();
+```
+
+The function returns an object with two properties: `rowsAffected` (the total number of rows affected by all statements) and `lastInsertRowid` (the `rowid` of the last successful insert, or `undefined` if the batch performed no inserts).
+
 #### transaction(function) ⇒ function
 
 This function is currently not supported.

--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -60,6 +60,14 @@ await conn.batch([
   "INSERT INTO users (email) VALUES ('user@example.com')",
   "INSERT INTO users (email) VALUES ('admin@example.com')",
 ]);
+
+// Parameterized batch statements also work
+await conn.transaction(async () => {
+  await conn.batch([
+    { sql: "INSERT INTO users (email) VALUES (?)", args: ["alice@example.com"] },
+    { sql: "INSERT INTO users (email) VALUES (?)", args: ["bob@example.com"] },
+  ]);
+}).concurrent();
 ```
 
 ### libSQL Compatibility Layer

--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -168,3 +168,29 @@ test('Session resets baton after HTTP error', async t => {
   // Baton should be null so the next request starts a fresh stream
   t.is(session['baton'], null);
 });
+
+test('Session.batch encodes named arguments for statement objects', async t => {
+  const session = new Session({ url: 'http://fake-host' });
+  const requests = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url, opts) => {
+    requests.push(JSON.parse(opts.body));
+    return new Response(
+      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 1 })}\n`,
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  await session.batch([
+    { sql: 'INSERT INTO users(name, age) VALUES(:name, :age)', args: { name: 'alice', age: 30 } }
+  ]);
+
+  t.deepEqual(requests[0].batch.steps[0].stmt.args, []);
+  t.deepEqual(requests[0].batch.steps[0].stmt.named_args, [
+    { name: 'name', value: { type: 'text', value: 'alice' } },
+    { name: 'age', value: { type: 'integer', value: '30' } },
+  ]);
+});

--- a/serverless/javascript/src/args.ts
+++ b/serverless/javascript/src/args.ts
@@ -1,3 +1,5 @@
+import { encodeValue, type NamedArg, type Value } from './protocol.js';
+
 /**
  * Normalize execute() arguments into the form session.execute() expects:
  * an array (positional) or a plain object (named). Single non-object/non-array
@@ -41,4 +43,43 @@ export function splitBindParameters(bindParameters: any[]): { params: any; query
     params: bindParameters.length === 1 ? bindParameters[0] : bindParameters,
     queryOptions: undefined,
   };
+}
+
+/**
+ * Encode statement arguments into the protocol's positional/named parameter shape.
+ */
+export function encodeSqlArgs(args: any[] | Record<string, any> = []): { args: Value[]; namedArgs: NamedArg[] } {
+  let positionalArgs: Value[] = [];
+  let namedArgs: NamedArg[] = [];
+
+  if (Array.isArray(args)) {
+    positionalArgs = args.map(encodeValue);
+  } else {
+    const keys = Object.keys(args);
+    const isNumericKeys = keys.length > 0 && keys.every(key => /^\d+$/.test(key));
+
+    if (isNumericKeys) {
+      const sortedKeys = keys.sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
+      const maxIndex = parseInt(sortedKeys[sortedKeys.length - 1], 10);
+      positionalArgs = new Array(maxIndex);
+
+      for (const key of sortedKeys) {
+        const index = parseInt(key, 10) - 1;
+        positionalArgs[index] = encodeValue(args[key]);
+      }
+
+      for (let i = 0; i < positionalArgs.length; i++) {
+        if (positionalArgs[i] === undefined) {
+          positionalArgs[i] = { type: 'null' };
+        }
+      }
+    } else {
+      namedArgs = Object.entries(args).map(([name, value]) => ({
+        name,
+        value: encodeValue(value)
+      }));
+    }
+  }
+
+  return { args: positionalArgs, namedArgs };
 }

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -1,13 +1,20 @@
 import { AsyncLock } from './async-lock.js';
-import { Session, type SessionConfig } from './session.js';
+import { Session, type SessionConfig, type BatchMode } from './session.js';
 import { Statement } from './statement.js';
 import { type QueryOptions } from './protocol.js';
 import { normalizeArgs, splitBindParameters } from './args.js';
+
+export type { BatchMode } from './session.js';
 
 /**
  * Configuration options for connecting to a Turso database.
  */
 export interface Config extends SessionConfig {}
+
+export type BatchStatement = string | {
+  sql: string;
+  args?: any[] | Record<string, any>;
+};
 
 
 /**
@@ -236,28 +243,73 @@ export class Connection {
 
 
   /**
-   * Execute multiple SQL statements in a batch.
-   * 
-   * @param statements - Array of SQL statements to execute
-   * @param mode - Optional transaction mode (currently unused)
-   * @returns Promise resolving to batch execution results
-   * 
+   * Executes a batch of SQL statements over this connection.
+   *
+   * By default, batch() is not transactional: each statement runs in its
+   * own autocommit step, so a failure mid-batch leaves earlier successful
+   * statements committed. Pass a `mode` to make the batch atomic — the
+   * statements are wrapped in `BEGIN <mode>` / `COMMIT` (with `ROLLBACK`
+   * on failure) and dispatched as a single Hrana request, so the whole
+   * batch completes in one round-trip. When called from inside a
+   * `connection.transaction(...)` callback the `mode` argument is ignored
+   * and the surrounding transaction is reused.
+   *
+   * When `mode` is set, `batch()` owns the surrounding
+   * `BEGIN`/`COMMIT`/`ROLLBACK`, so the `statements` array must not
+   * contain its own transaction-control SQL (`BEGIN`, `COMMIT`,
+   * `ROLLBACK`, `SAVEPOINT`, `RELEASE`). The input is not validated
+   * for that — a user-supplied `COMMIT` will close the wrapper
+   * transaction mid-batch and leave earlier statements committed,
+   * defeating the all-or-nothing contract.
+   *
+   * @param statements - An array of SQL strings or `{ sql, args }` objects.
+   * @param mode - When set, makes the batch atomic. Accepts the same
+   *   values as `connection.transaction(...)` variants: `"deferred"`,
+   *   `"immediate"`, `"exclusive"`, `"concurrent"`. Ignored when already
+   *   inside a transaction.
+   * @returns An object with `rowsAffected` (sum of affected rows) and
+   *   `lastInsertRowid` (rowid of the last successful insert).
+   *
    * @example
-   * ```typescript
-   * await client.batch([
-   *   "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)",
-   *   "INSERT INTO users (name) VALUES ('Alice')",
-   *   "INSERT INTO users (name) VALUES ('Bob')"
+   * // Plain SQL strings (non-atomic).
+   * await db.batch([
+   *   "INSERT INTO users(name) VALUES ('Alice')",
+   *   "INSERT INTO users(name) VALUES ('Bob')",
    * ]);
-   * ```
+   *
+   * @example
+   * // Positional and named bind parameters.
+   * await db.batch([
+   *   { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Carol", "carol@example.net"] },
+   *   { sql: "INSERT INTO users(name, email) VALUES (:name, :email)", args: { name: "Dave", email: "dave@example.net" } },
+   * ]);
+   *
+   * @example
+   * // Atomic via the mode parameter.
+   * await db.batch([
+   *   { sql: "INSERT INTO users(name) VALUES (?)", args: ["Eve"] },
+   *   { sql: "INSERT INTO users(name) VALUES (?)", args: ["Frank"] },
+   * ], "immediate");
+   *
+   * @example
+   * // Atomic via the transaction() API for mixed workloads.
+   * const txn = db.transaction(async () => {
+   *   await db.batch([{ sql: "INSERT INTO users(name) VALUES (?)", args: ["Eve"] }]);
+   *   await db.execute("UPDATE counters SET n = n + 1");
+   * });
+   * await txn.immediate();
    */
-  async batch(statements: string[], mode?: string, queryOptions?: QueryOptions): Promise<any> {
+  async batch(statements: BatchStatement[], mode?: BatchMode, queryOptions?: QueryOptions): Promise<any> {
     if (!this.isOpen) {
       throw new TypeError("The database connection is not open");
     }
     await this.execLock.acquire();
     try {
-      return await this.session.batch(statements, queryOptions);
+      // Inside an outer transaction(...) callback the surrounding BEGIN
+      // already opened a transaction on this stream; emitting another
+      // `BEGIN` step would fail, so ignore the user-supplied mode.
+      const effectiveMode = this._inTransaction ? undefined : mode;
+      return await this.session.batch(statements, effectiveMode, queryOptions);
     } finally {
       this.execLock.release();
     }

--- a/serverless/javascript/src/index.ts
+++ b/serverless/javascript/src/index.ts
@@ -1,5 +1,5 @@
 // Turso serverless driver entry point
-export { Connection, connect, type Config } from './connection.js';
+export { Connection, connect, type Config, type BatchStatement } from './connection.js';
 export { Statement } from './statement.js';
 export { Session, type SessionConfig } from './session.js';
 export { DatabaseError, TimeoutError } from './error.js';

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -33,6 +33,14 @@ export interface ExecuteRequest {
   };
 }
 
+export type BatchCondition =
+  | { type: 'ok'; step: number }
+  | { type: 'error'; step: number }
+  | { type: 'not'; cond: BatchCondition }
+  | { type: 'and'; conds: BatchCondition[] }
+  | { type: 'or'; conds: BatchCondition[] }
+  | { type: 'is_autocommit' };
+
 export interface BatchStep {
   stmt: {
     sql: string;
@@ -40,10 +48,7 @@ export interface BatchStep {
     named_args?: NamedArg[];
     want_rows: boolean;
   };
-  condition?: {
-    type: 'ok';
-    step: number;
-  };
+  condition?: BatchCondition;
 }
 
 export interface BatchRequest {

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -1,8 +1,8 @@
 import {
   executeCursor,
   executePipeline,
-  encodeValue,
   decodeValue,
+  type BatchStep,
   type CursorRequest,
   type CursorResponse,
   type CursorEntry,
@@ -12,10 +12,15 @@ import {
   type DescribeRequest,
   type DescribeResult,
   type QueryOptions,
-  type NamedArg,
-  type Value
 } from './protocol.js';
 import { DatabaseError } from './error.js';
+import { encodeSqlArgs } from './args.js';
+
+/**
+ * Locking mode for atomic `batch()` execution. Accepts the same values
+ * as the variants of `Connection.transaction(...)`.
+ */
+export type BatchMode = 'deferred' | 'immediate' | 'exclusive' | 'concurrent';
 
 /**
  * Configuration options for a session.
@@ -131,43 +136,7 @@ export class Session {
    * @returns Promise resolving to the raw response and cursor entries
    */
   async executeRaw(sql: string, args: any[] | Record<string, any> = [], queryOptions?: QueryOptions): Promise<{ response: CursorResponse; entries: AsyncGenerator<CursorEntry> }> {
-    let positionalArgs: Value[] = [];
-    let namedArgs: NamedArg[] = [];
-
-    if (Array.isArray(args)) {
-      positionalArgs = args.map(encodeValue);
-    } else {
-      // Check if this is an object with numeric keys (for ?1, ?2 style parameters)
-      const keys = Object.keys(args);
-      const isNumericKeys = keys.length > 0 && keys.every(key => /^\d+$/.test(key));
-      
-      if (isNumericKeys) {
-        // Convert numeric-keyed object to positional args
-        // Sort keys numerically to ensure correct order
-        const sortedKeys = keys.sort((a, b) => parseInt(a) - parseInt(b));
-        const maxIndex = parseInt(sortedKeys[sortedKeys.length - 1]);
-        
-        // Create array with undefined for missing indices
-        positionalArgs = new Array(maxIndex);
-        for (const key of sortedKeys) {
-          const index = parseInt(key) - 1; // Convert to 0-based index
-          positionalArgs[index] = encodeValue(args[key]);
-        }
-        
-        // Fill any undefined values with null
-        for (let i = 0; i < positionalArgs.length; i++) {
-          if (positionalArgs[i] === undefined) {
-            positionalArgs[i] = { type: 'null' };
-          }
-        }
-      } else {
-        // Convert object with named parameters to NamedArg array
-        namedArgs = Object.entries(args).map(([name, value]) => ({
-          name,
-          value: encodeValue(value)
-        }));
-      }
-    }
+    const encodedArgs = encodeSqlArgs(args);
 
     const request: CursorRequest = {
       baton: this.baton,
@@ -175,8 +144,8 @@ export class Session {
         steps: [{
           stmt: {
             sql,
-            args: positionalArgs,
-            named_args: namedArgs,
+            args: encodedArgs.args,
+            named_args: encodedArgs.namedArgs,
             want_rows: true
           }
         }]
@@ -281,23 +250,88 @@ export class Session {
 
   /**
    * Execute multiple SQL statements in a batch.
-   * 
-   * @param statements - Array of SQL statements to execute
-   * @returns Promise resolving to batch execution results
+   *
+   * When `mode` is set, the batch is sent as a single Hrana request that
+   * also carries `BEGIN <mode>` / `COMMIT` / `ROLLBACK` steps using the
+   * server-side condition chain, giving atomic execution in one round-trip.
+   * When `mode` is omitted, the user statements are sent as-is and run
+   * under autocommit (or whatever transaction is already active on this
+   * stream).
+   *
+   * @param statements - Array of SQL statements to execute.
+   * @param mode - Optional locking mode; when set, the batch executes
+   *   atomically. Accepts the same values as `Database.transaction(...)`
+   *   variants: `"deferred"`, `"immediate"`, `"exclusive"`, `"concurrent"`.
+   * @returns Promise resolving to batch execution results.
    */
-  async batch(statements: string[], queryOptions?: QueryOptions): Promise<any> {
+  async batch(
+    statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
+    mode?: BatchMode,
+    queryOptions?: QueryOptions,
+  ): Promise<any> {
+    const userSteps: BatchStep[] = statements.map(statement => {
+      if (typeof statement === 'string') {
+        return {
+          stmt: { sql: statement, args: [], named_args: [], want_rows: false },
+        };
+      }
+      const encodedArgs = encodeSqlArgs(statement.args ?? []);
+      return {
+        stmt: {
+          sql: statement.sql,
+          args: encodedArgs.args,
+          named_args: encodedArgs.namedArgs,
+          want_rows: false,
+        },
+      };
+    });
+
+    let steps: BatchStep[];
+    let firstUserStepIdx = 0;
+    let lastUserStepIdx = userSteps.length - 1;
+    let beginIdx = -1;
+    let commitIdx = -1;
+    let rollbackIdx = -1;
+    if (mode === undefined) {
+      steps = userSteps;
+    } else {
+      // Atomic batch: BEGIN <mode>, then each user step gated on its
+      // predecessor succeeding, then COMMIT gated on the last user step
+      // succeeding, then ROLLBACK gated on BEGIN having succeeded *and*
+      // COMMIT not having succeeded. The extra ok(BEGIN) guard prevents
+      // ROLLBACK from aborting a transaction the caller opened on this
+      // stream out of band (e.g. via session.execute("BEGIN")).
+      beginIdx = 0;
+      firstUserStepIdx = 1;
+      lastUserStepIdx = userSteps.length; // 1..userSteps.length inclusive
+      commitIdx = lastUserStepIdx + 1;
+      rollbackIdx = commitIdx + 1;
+      steps = [
+        { stmt: { sql: `BEGIN ${mode.toUpperCase()}`, args: [], named_args: [], want_rows: false } },
+        ...userSteps.map((step, i) => ({
+          ...step,
+          condition: { type: 'ok' as const, step: i === 0 ? beginIdx : firstUserStepIdx + i - 1 },
+        })),
+        {
+          stmt: { sql: 'COMMIT', args: [], named_args: [], want_rows: false },
+          condition: { type: 'ok' as const, step: lastUserStepIdx },
+        },
+        {
+          stmt: { sql: 'ROLLBACK', args: [], named_args: [], want_rows: false },
+          condition: {
+            type: 'and' as const,
+            conds: [
+              { type: 'ok' as const, step: beginIdx },
+              { type: 'not' as const, cond: { type: 'ok' as const, step: commitIdx } },
+            ],
+          },
+        },
+      ];
+    }
+
     const request: CursorRequest = {
       baton: this.baton,
-      batch: {
-        steps: statements.map(sql => ({
-          stmt: {
-            sql,
-            args: [],
-            named_args: [],
-            want_rows: false
-          }
-        }))
-      }
+      batch: { steps },
     };
 
     let batchResult;
@@ -316,28 +350,66 @@ export class Session {
 
     let totalRowsAffected = 0;
     let lastInsertRowid: number | undefined;
+    let deferredError: DatabaseError | null = null;
+
+    // step_end entries don't carry a step index on the wire; the Hrana
+    // server only puts `step` on step_begin / step_error. Track the
+    // current step ourselves by watching step_begin so we know which
+    // step_end belongs to a user statement when running in atomic mode.
+    let currentStep: number | undefined;
+    const isUserStep = (step: number | undefined): boolean => {
+      if (mode === undefined) {
+        // Non-atomic batch: every step is a user step.
+        return true;
+      }
+      return step !== undefined && step >= firstUserStepIdx && step <= lastUserStepIdx;
+    };
 
     for await (const entry of entries) {
       switch (entry.type) {
+        case 'step_begin':
+          currentStep = entry.step;
+          break;
         case 'step_end':
-          if (entry.affected_row_count !== undefined) {
-            totalRowsAffected += entry.affected_row_count;
+          if (isUserStep(currentStep)) {
+            if (entry.affected_row_count !== undefined) {
+              totalRowsAffected += entry.affected_row_count;
+            }
+            if (entry.last_insert_rowid !== undefined && entry.last_insert_rowid !== null) {
+              lastInsertRowid = typeof entry.last_insert_rowid === 'number'
+                ? entry.last_insert_rowid
+                : parseInt(entry.last_insert_rowid, 10);
+            }
           }
-          if (entry.last_insert_rowid !== undefined && entry.last_insert_rowid !== null) {
-            lastInsertRowid = typeof entry.last_insert_rowid === 'number'
-              ? entry.last_insert_rowid
-              : parseInt(entry.last_insert_rowid, 10);
-          }
+          currentStep = undefined;
           break;
         case 'step_error':
+          if (mode === undefined) {
+            throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
+          }
+          // Atomic batch: capture the first error from BEGIN, any user
+          // step, or COMMIT and keep draining so ROLLBACK has a chance
+          // to clean up. Errors on the synthetic ROLLBACK step are
+          // suppressed — by the time it runs the transaction has
+          // already been undone and surfacing a ROLLBACK error would
+          // mask the real cause we already captured.
+          if (deferredError === null && entry.step !== rollbackIdx) {
+            deferredError = new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
+          }
+          currentStep = undefined;
+          break;
         case 'error':
           throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
       }
     }
 
+    if (deferredError !== null) {
+      throw deferredError;
+    }
+
     return {
       rowsAffected: totalRowsAffected,
-      lastInsertRowid
+      lastInsertRowid,
     };
   }
 

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -102,6 +102,265 @@ test.serial("Database.exec() after close()", async (t) => {
 });
 
 // ==========================================================================
+// Database.batch()
+// ==========================================================================
+
+test.serial("Database.batch() [bound args]", async (t) => {
+  const db = t.context.db;
+
+  const info = await db.batch([
+    { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Carol", "carol@example.net"] },
+    { sql: "INSERT INTO users(name, email) VALUES (:name, :email)", args: { name: "Dave", email: "dave@example.net" } },
+  ]);
+
+  t.is(info.rowsAffected, 2);
+  t.is(info.lastInsertRowid, 4);
+
+  const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4) ORDER BY id");
+  t.deepEqual(rows, [
+    { name: "Carol", email: "carol@example.net" },
+    { name: "Dave", email: "dave@example.net" },
+  ]);
+});
+
+test.serial("Database.batch() [plain strings]", async (t) => {
+  const db = t.context.db;
+
+  const info = await db.batch([
+    "INSERT INTO users(name, email) VALUES ('Eve', 'eve@example.net')",
+    "INSERT INTO users(name, email) VALUES ('Frank', 'frank@example.net')",
+  ]);
+
+  t.is(info.rowsAffected, 2);
+  t.is(info.lastInsertRowid, 4);
+
+  const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4) ORDER BY id");
+  t.deepEqual(rows, [
+    { name: "Eve", email: "eve@example.net" },
+    { name: "Frank", email: "frank@example.net" },
+  ]);
+});
+
+test.serial("Database.batch() [mixed value types]", async (t) => {
+  const db = t.context.db;
+
+  await db.exec("DROP TABLE IF EXISTS types_batch");
+  await db.exec(`
+    CREATE TABLE types_batch (
+      id INTEGER PRIMARY KEY,
+      i INTEGER,
+      r REAL,
+      s TEXT,
+      b BLOB,
+      n INTEGER
+    )
+  `);
+
+  const blob = Buffer.from([0xDE, 0xAD, 0xBE, 0xEF]);
+
+  const info = await db.batch([
+    {
+      sql: "INSERT INTO types_batch(i, r, s, b, n) VALUES (?, ?, ?, ?, ?)",
+      args: [42, 3.14, "hello", blob, null],
+    },
+    {
+      sql: "INSERT INTO types_batch(i, r, s, b, n) VALUES (:i, :r, :s, :b, :n)",
+      args: { i: -7, r: -0.5, s: "", b: Buffer.alloc(0), n: null },
+    },
+    {
+      sql: "INSERT INTO types_batch(i) VALUES (?)",
+      args: [9007199254740993n],
+    },
+  ]);
+
+  t.is(info.rowsAffected, 3);
+
+  const rows = await db.all("SELECT i, r, s, b, n FROM types_batch ORDER BY id");
+  t.is(rows.length, 3);
+
+  t.is(rows[0].i, 42);
+  t.is(rows[0].r, 3.14);
+  t.is(rows[0].s, "hello");
+  t.deepEqual(rows[0].b, blob);
+  t.is(rows[0].n, null);
+
+  t.is(rows[1].i, -7);
+  t.is(rows[1].r, -0.5);
+  t.is(rows[1].s, "");
+  t.deepEqual(rows[1].b, Buffer.alloc(0));
+  t.is(rows[1].n, null);
+
+  // BigInt is round-tripped as Number when within safe-integer range; for
+  // values above 2^53 we just confirm that the magnitude survived storage.
+  const bigRow = await db.get("SELECT CAST(i AS TEXT) AS i FROM types_batch WHERE id = 3");
+  t.is(bigRow.i, "9007199254740993");
+});
+
+test.serial("Database.batch() [rollback via transaction()]", async (t) => {
+  const db = t.context.db;
+
+  // batch() itself is not transactional; transaction() provides
+  // all-or-nothing semantics around the failing batch.
+  const txn = db.transaction(async () => {
+    return await db.batch([
+      { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Mallory", "mallory@example.net"] },
+      // Duplicate primary key with the row inserted in beforeEach.
+      { sql: "INSERT INTO users(id, name, email) VALUES (1, 'dup', 'dup@example.net')" },
+    ]);
+  });
+
+  await t.throwsAsync(async () => { await txn(); });
+
+  const rows = await db.all("SELECT name FROM users WHERE name = 'Mallory'");
+  t.deepEqual(rows, []);
+});
+
+test.serial("Database.batch() [atomic mode]", async (t) => {
+  const db = t.context.db;
+
+  const info = await db.batch([
+    { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Ivy", "ivy@example.net"] },
+    { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Jay", "jay@example.net"] },
+  ], "immediate");
+
+  t.is(info.rowsAffected, 2);
+  t.is(info.lastInsertRowid, 4);
+
+  const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4) ORDER BY id");
+  t.deepEqual(rows, [
+    { name: "Ivy", email: "ivy@example.net" },
+    { name: "Jay", email: "jay@example.net" },
+  ]);
+});
+
+test.serial("Database.batch() [atomic mode rolls back on failure]", async (t) => {
+  const db = t.context.db;
+
+  await t.throwsAsync(async () => {
+    await db.batch([
+      { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Kelly", "kelly@example.net"] },
+      // Duplicate primary key with the row inserted in beforeEach.
+      { sql: "INSERT INTO users(id, name, email) VALUES (1, 'dup', 'dup@example.net')" },
+    ], "immediate");
+  });
+
+  const rows = await db.all("SELECT name FROM users WHERE name = 'Kelly'");
+  t.deepEqual(rows, []);
+});
+
+test.serial("Database.batch() [concurrent caller waits for atomic batch]", async (t) => {
+  if (process.env.PROVIDER === "serverless") {
+    // Native-only: exercises the connection-level exec lock.
+    t.pass();
+    return;
+  }
+  const db = t.context.db;
+
+  // Kick off an atomic batch that will fail on its second statement
+  // (duplicate primary key), then immediately issue a concurrent INSERT
+  // on the same connection. If batch() does not hold the connection
+  // lock across BEGIN/.../COMMIT, the concurrent insert would interleave
+  // *inside* the batch's transaction and be rolled back along with it.
+  const failingBatch = db.batch([
+    { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["BatchOnly", "batch@example.net"] },
+    { sql: "INSERT INTO users(id, name, email) VALUES (1, 'dup', 'dup@example.net')" },
+  ], "immediate");
+  const concurrentInsert = db.run(
+    "INSERT INTO users(name, email) VALUES (?, ?)",
+    "Concurrent", "concurrent@example.net",
+  );
+
+  await t.throwsAsync(failingBatch);
+  await concurrentInsert;
+
+  const names = (await db.all("SELECT name FROM users ORDER BY id")).map(r => r.name);
+  // BatchOnly is rolled back by the failed atomic batch.
+  t.false(names.includes("BatchOnly"));
+  // The concurrent INSERT ran *after* the batch released the lock, so
+  // it commits via autocommit and is visible.
+  t.true(names.includes("Concurrent"));
+});
+
+test.serial("Database.batch() [atomic mode does not abort manually-opened outer transaction on BEGIN failure]", async (t) => {
+  if (process.env.PROVIDER !== "serverless") {
+    // The native binding emits BEGIN via exec() sequentially and the
+    // failure propagates immediately; this race only exists on the
+    // serverless Hrana-condition-chain path.
+    t.pass();
+    return;
+  }
+  const db = t.context.db;
+
+  // Manually open an outer transaction on the same stream and write a
+  // row inside it.
+  await db.execute("BEGIN");
+  await db.execute("INSERT INTO users(name, email) VALUES ('Outer', 'outer@example.net')");
+
+  // An atomic batch tries to emit BEGIN IMMEDIATE while a transaction
+  // is already open, so the synthetic BEGIN step errors. The atomic
+  // batch must (a) reject so the caller knows nothing committed, and
+  // (b) skip the synthetic ROLLBACK — otherwise it would abort the
+  // outer transaction along with it.
+  await t.throwsAsync(async () => {
+    await db.batch([
+      { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Inner", "inner@example.net"] },
+    ], "immediate");
+  });
+
+  // The outer transaction is still open and can be committed.
+  await db.execute("COMMIT");
+
+  const names = (await db.all("SELECT name FROM users ORDER BY id")).map(r => r.name);
+  t.true(names.includes("Outer"), "outer transaction's INSERT should be visible");
+  t.false(names.includes("Inner"), "atomic batch's INSERT must not have committed");
+});
+
+test.serial("Database.batch() [non-insert batch returns undefined lastInsertRowid]", async (t) => {
+  const db = t.context.db;
+
+  // Seed an INSERT first so the connection has a non-zero lastInsertRowid.
+  await db.run("INSERT INTO users(name, email) VALUES (?, ?)", "Seed", "seed@example.net");
+
+  // Now run a batch that only mutates without inserting. SQLite keeps
+  // last_insert_rowid() sticky across non-INSERT statements, so we
+  // must derive the per-statement INSERT signal from the delta, not
+  // from `changes > 0`.
+  const info = await db.batch([
+    { sql: "UPDATE users SET email = ? WHERE id = 1", args: ["alice2@example.org"] },
+    { sql: "DELETE FROM users WHERE id = 2" },
+  ]);
+
+  t.is(info.rowsAffected, 2);
+  t.is(info.lastInsertRowid, undefined);
+});
+
+
+test.serial("Database.transaction().deferred() [batch]", async (t) => {
+  const db = t.context.db;
+
+  const insertMany = db.transaction(async () => {
+    t.is(db.inTransaction, true);
+    return await db.batch([
+      { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Joey", "joey@example.org"] },
+      { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Sally", "sally@example.org"] },
+      { sql: "INSERT INTO users(name, email) VALUES (:name, :email)", args: { name: "Junior", email: "junior@example.org" } },
+    ]);
+  });
+
+  const info = await insertMany.deferred();
+  t.is(db.inTransaction, false);
+  t.is(info.rowsAffected, 3);
+  t.is(info.lastInsertRowid, 5);
+
+  const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4, 5) ORDER BY id");
+  t.deepEqual(rows, [
+    { name: "Joey", email: "joey@example.org" },
+    { name: "Sally", email: "sally@example.org" },
+    { name: "Junior", email: "junior@example.org" },
+  ]);
+});
+
+// ==========================================================================
 // Database.prepare()
 // ==========================================================================
 


### PR DESCRIPTION
The batch() method executes an array of SQL statements over a single connection and returns aggregated `rowsAffected` and `lastInsertRowid`. Each statement is either a SQL string or a `{ sql, args }` object with positional or named bind parameters; named-args objects are forwarded to the underlying engine as named parameters rather than collapsed via Object.values().

By default the batch is non-transactional: each statement runs in its own autocommit step. Passing a `mode` -- `deferred`, `immediate`, `exclusive`, or `concurrent` -- makes the batch atomic. You can also use `batch()` with the transaction API to make it transactional.

The serverless driver implements atomic batch as a a single SQL over HTTP request. The wire payload chains BEGIN, the user statements, COMMIT, and ROLLBACK as a single batch using the server-side condition operators.