### PR TITLE
revert: make all fallible functions use current infallible methods for now

### DIFF
--- a/.claude/skills/allocator-migration/SKILL.md
+++ b/.claude/skills/allocator-migration/SKILL.md
@@ -171,4 +171,26 @@ Before allocator-sensitive commits, also check the nightly cfg build:
 RUSTFLAGS="--cfg nightly" cargo +nightly check -p turso_core
 ```
 
+For allocator collection performance work, use the Divan comparison script. It
+runs the `alloc_collections` bench by default and prints a sorted std-vs-Turso
+comparison table:
+
+```bash
+scripts/compare-divan-std-turso.py --run
+```
+
+To exercise the nightly allocator paths, run:
+
+```bash
+scripts/compare-divan-std-turso.py --run --nightly
+```
+
+Useful variants:
+
+```bash
+scripts/compare-divan-std-turso.py --run --bench-filter hash_map --filter hash_map
+scripts/compare-divan-std-turso.py --run --save-output /tmp/alloc_collections.txt
+scripts/compare-divan-std-turso.py /tmp/alloc_collections.txt
+```
+
 Run focused tests only when the touched code path is risky, behavior changed, or compilation is not enough to validate the migration.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -195,6 +195,10 @@ harness = false
 required-features = ["bench"]
 
 [[bench]]
+name = "alloc_collections"
+harness = false
+
+[[bench]]
 name = "hash_spill_benchmark"
 harness = false
 required-features = ["bench"]

--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -1,7 +1,5 @@
-use super::{
-    TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoFromIterator, TursoTryWithCapacityExt,
-};
-use crate::alloc::{BinaryHeap, TryReserveError};
+use super::*;
+use crate::alloc::*;
 
 #[cfg(not(nightly))]
 fn binary_heap<T: Ord>() -> BinaryHeap<T> {
@@ -29,9 +27,39 @@ impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
 
 impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push(value);
         Ok(())
+    }
+}
+
+impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
+    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+        let mut values = <Self as TursoAllocExt>::new();
+        values.try_reserve(capacity)?;
+        Ok(values)
+    }
+}
+
+// For these 2 impls we use std::vec because on `stable` we can't use allocator on BinaryHeap, but on nightly we can
+impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
+    fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        // We use std::vec here because on stable we dont have allocators for BinaryHeap. On Nightly, we create a Vec with the TursoAllocator
+        #[cfg(nightly)]
+        let mut values = super::vec::vec();
+        #[cfg(not(nightly))]
+        let mut values = std::vec::Vec::new();
+        values.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            // We already reserved enough space above so no panics should happen
+            values.push(value);
+        }
+        Ok(BinaryHeap::from(values))
     }
 
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
@@ -40,38 +68,15 @@ impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
     {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
+        let mut values = std::mem::take(self).into_vec();
+        values.try_reserve(upper.unwrap_or(lower))?;
         for value in iter {
-            self.try_push(value)?;
+            // We already reserved enough space above so no panics should happen
+            values.push(value);
         }
+
+        *self = BinaryHeap::from(values);
         Ok(())
-    }
-}
-
-impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
-        Ok(values)
-    }
-}
-
-impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
-    fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            values.try_push(value)?;
-        }
-        Ok(values)
     }
 }
 
@@ -86,9 +91,7 @@ impl<T: Clone + Ord> TryClone for BinaryHeap<T> {
             let alloc = self.allocator().clone();
             Self::new_in(alloc)
         };
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
         cloned.extend(self.iter().cloned());
         Ok(cloned)
     }

--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -2,17 +2,18 @@ use super::*;
 use crate::alloc::*;
 
 #[cfg(not(nightly))]
-fn binary_heap<T: Ord>() -> BinaryHeap<T> {
-    std::collections::BinaryHeap::new()
+const fn binary_heap<T: Ord>() -> BinaryHeap<T> {
+    BinaryHeap::new()
 }
 
 #[cfg(nightly)]
-fn binary_heap<T: Ord>() -> BinaryHeap<T> {
-    std::collections::BinaryHeap::new_in(crate::alloc::TursoAllocator)
+const fn binary_heap<T: Ord>() -> BinaryHeap<T> {
+    BinaryHeap::new_in(crate::alloc::TursoAllocator)
 }
 
 #[cfg(not(nightly))]
 impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
+    #[inline(always)]
     fn new() -> Self {
         binary_heap()
     }
@@ -20,70 +21,63 @@ impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
 
 #[cfg(nightly)]
 impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
+    #[inline(always)]
     fn new() -> Self {
         binary_heap()
     }
 }
 
 impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
+    #[inline(always)]
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push(value);
         Ok(())
     }
 }
 
 impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        #[cfg(not(nightly))]
+        {
+            Ok(BinaryHeap::with_capacity(capacity))
+        }
+        #[cfg(nightly)]
+        {
+            Ok(BinaryHeap::with_capacity_in(
+                capacity,
+                crate::alloc::TursoAllocator,
+            ))
+        }
     }
 }
 
 // For these 2 impls we use std::vec because on `stable` we can't use allocator on BinaryHeap, but on nightly we can
 impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        // We use std::vec here because on stable we dont have allocators for BinaryHeap. On Nightly, we create a Vec with the TursoAllocator
-        #[cfg(nightly)]
-        let mut values = super::vec::vec();
         #[cfg(not(nightly))]
-        let mut values = std::vec::Vec::new();
-        values.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_reserve(1)?;
-                values.push(value);
-            }
+        {
+            Ok(iter.into_iter().collect())
         }
-        Ok(BinaryHeap::from(values))
+        #[cfg(nightly)]
+        {
+            // We use std::vec here because on stable we dont have allocators for BinaryHeap. On Nightly, we create a Vec with the TursoAllocator
+            let mut values = super::vec::vec();
+            values.extend(iter);
+            Ok(BinaryHeap::from(values))
+        }
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let mut values = std::mem::take(self).into_vec();
-        values.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_reserve(1)?;
-                values.push(value);
-            }
-        }
-
-        *self = BinaryHeap::from(values);
+        self.extend(iter);
         Ok(())
     }
 }
@@ -91,6 +85,7 @@ impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
 impl<T: Clone + Ord> TryClone for BinaryHeap<T> {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;

--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -55,9 +55,13 @@ impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
         #[cfg(not(nightly))]
         let mut values = std::vec::Vec::new();
         values.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            // We already reserved enough space above so no panics should happen
-            values.push(value);
+        if upper.is_some() {
+            values.extend(iter);
+        } else {
+            for value in iter {
+                values.try_reserve(1)?;
+                values.push(value);
+            }
         }
         Ok(BinaryHeap::from(values))
     }
@@ -70,9 +74,13 @@ impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
         let (lower, upper) = iter.size_hint();
         let mut values = std::mem::take(self).into_vec();
         values.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            // We already reserved enough space above so no panics should happen
-            values.push(value);
+        if upper.is_some() {
+            values.extend(iter);
+        } else {
+            for value in iter {
+                values.try_reserve(1)?;
+                values.push(value);
+            }
         }
 
         *self = BinaryHeap::from(values);

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -57,7 +57,7 @@ where
 
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
-        let mut cloned = Self::with_hasher(self.hasher().clone());
+        let mut cloned = Self::with_hasher(*self.hasher());
         cloned.try_reserve(self.len())?;
         // TODO: have a `TryClone` boundary for K and V here instead of `Clone`
         cloned.extend(self.iter().map(|(key, value)| (key.clone(), value.clone())));

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -52,8 +52,14 @@ where
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for (key, value) in iter {
-            TursoHashMapExt::try_insert(&mut values, key, value)?;
+        if upper.is_some() {
+            for (key, value) in iter {
+                values.insert(key, value);
+            }
+        } else {
+            for (key, value) in iter {
+                TursoHashMapExt::try_insert(&mut values, key, value)?;
+            }
         }
         Ok(values)
     }
@@ -65,8 +71,14 @@ where
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for (key, value) in iter {
-            TursoHashMapExt::try_insert(self, key, value)?;
+        if upper.is_some() {
+            for (key, value) in iter {
+                self.insert(key, value);
+            }
+        } else {
+            for (key, value) in iter {
+                TursoHashMapExt::try_insert(self, key, value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -53,9 +53,7 @@ where
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for (key, value) in iter {
-                values.insert(key, value);
-            }
+            values.extend(iter);
         } else {
             for (key, value) in iter {
                 TursoHashMapExt::try_insert(&mut values, key, value)?;
@@ -72,9 +70,7 @@ where
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
         if upper.is_some() {
-            for (key, value) in iter {
-                self.insert(key, value);
-            }
+            self.extend(iter);
         } else {
             for (key, value) in iter {
                 TursoHashMapExt::try_insert(self, key, value)?;

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -22,22 +22,8 @@ where
     S: BuildHasher,
 {
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         Ok(self.insert(key, value))
-    }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = (K, V)>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for (key, value) in iter {
-            TursoHashMapExt::try_insert(self, key, value)?;
-        }
-        Ok(())
     }
 }
 
@@ -48,9 +34,7 @@ where
 {
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
+        values.try_reserve(capacity)?;
         Ok(values)
     }
 }
@@ -73,6 +57,19 @@ where
         }
         Ok(values)
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for (key, value) in iter {
+            TursoHashMapExt::try_insert(self, key, value)?;
+        }
+        Ok(())
+    }
 }
 
 impl<K, V, S> TryClone for HashMap<K, V, S>
@@ -85,9 +82,8 @@ where
 
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
+        // TODO: have a `TryClone` boundary for K and V here instead of `Clone`
         cloned.extend(self.iter().map(|(key, value)| (key.clone(), value.clone())));
         Ok(cloned)
     }

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -1,93 +1,61 @@
 use std::hash::{BuildHasher, Hash};
 
-use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoHashMapExt, TursoTryWithCapacityExt};
+use rustc_hash::FxBuildHasher;
+
+use super::{TryClone, TursoFromIterator, TursoHashMapExt, TursoTryWithCapacityExt};
 use crate::alloc::{HashMap, TryReserveError};
-
-fn hash_map_with_hasher<K, V, S>(hasher: S) -> HashMap<K, V, S> {
-    std::collections::HashMap::with_hasher(hasher)
-}
-
-impl<K, V, S> TursoAllocExt for HashMap<K, V, S>
-where
-    S: Default,
-{
-    fn new() -> Self {
-        hash_map_with_hasher(S::default())
-    }
-}
 
 impl<K, V, S> TursoHashMapExt<K, V> for HashMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
+    #[inline(always)]
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, TryReserveError> {
-        self.try_reserve(1)?;
         Ok(self.insert(key, value))
     }
 }
 
-impl<K, V, S> TursoTryWithCapacityExt for HashMap<K, V, S>
+impl<K, V> TursoTryWithCapacityExt for HashMap<K, V>
 where
     K: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        Ok(HashMap::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }
 
-impl<K, V, S> TursoFromIterator<(K, V)> for HashMap<K, V, S>
+impl<K, V> TursoFromIterator<(K, V)> for HashMap<K, V>
 where
     K: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for (key, value) in iter {
-                TursoHashMapExt::try_insert(&mut values, key, value)?;
-            }
-        }
-        Ok(values)
+        Ok(iter.into_iter().collect())
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            self.extend(iter);
-        } else {
-            for (key, value) in iter {
-                TursoHashMapExt::try_insert(self, key, value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
 
-impl<K, V, S> TryClone for HashMap<K, V, S>
+impl<K, V> TryClone for HashMap<K, V>
 where
     K: Clone + Eq + Hash,
     V: Clone,
-    S: BuildHasher + Clone,
 {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
         cloned.try_reserve(self.len())?;

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -53,9 +53,7 @@ where
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for value in iter {
-                values.insert(value);
-            }
+            values.extend(iter);
         } else {
             for value in iter {
                 TursoHashSetExt::try_insert(&mut values, value)?;
@@ -72,9 +70,7 @@ where
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
         if upper.is_some() {
-            for value in iter {
-                self.insert(value);
-            }
+            self.extend(iter);
         } else {
             for value in iter {
                 TursoHashSetExt::try_insert(self, value)?;

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -22,22 +22,8 @@ where
     S: BuildHasher,
 {
     fn try_insert(&mut self, value: T) -> Result<bool, TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         Ok(self.insert(value))
-    }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for value in iter {
-            TursoHashSetExt::try_insert(self, value)?;
-        }
-        Ok(())
     }
 }
 
@@ -48,9 +34,7 @@ where
 {
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
+        values.try_reserve(capacity)?;
         Ok(values)
     }
 }
@@ -73,6 +57,19 @@ where
         }
         Ok(values)
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            TursoHashSetExt::try_insert(self, value)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T, S> TryClone for HashSet<T, S>
@@ -84,9 +81,7 @@ where
 
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
         cloned.extend(self.iter().cloned());
         Ok(cloned)
     }

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -52,8 +52,14 @@ where
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            TursoHashSetExt::try_insert(&mut values, value)?;
+        if upper.is_some() {
+            for value in iter {
+                values.insert(value);
+            }
+        } else {
+            for value in iter {
+                TursoHashSetExt::try_insert(&mut values, value)?;
+            }
         }
         Ok(values)
     }
@@ -65,8 +71,14 @@ where
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            TursoHashSetExt::try_insert(self, value)?;
+        if upper.is_some() {
+            for value in iter {
+                self.insert(value);
+            }
+        } else {
+            for value in iter {
+                TursoHashSetExt::try_insert(self, value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -1,81 +1,49 @@
 use std::hash::{BuildHasher, Hash};
 
-use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoHashSetExt, TursoTryWithCapacityExt};
+use rustc_hash::FxBuildHasher;
+
+use super::{TryClone, TursoFromIterator, TursoHashSetExt, TursoTryWithCapacityExt};
 use crate::alloc::{HashSet, TryReserveError};
-
-fn hash_set_with_hasher<T, S>(hasher: S) -> HashSet<T, S> {
-    std::collections::HashSet::with_hasher(hasher)
-}
-
-impl<T, S> TursoAllocExt for HashSet<T, S>
-where
-    S: Default,
-{
-    fn new() -> Self {
-        hash_set_with_hasher(S::default())
-    }
-}
 
 impl<T, S> TursoHashSetExt<T> for HashSet<T, S>
 where
     T: Eq + Hash,
     S: BuildHasher,
 {
+    #[inline(always)]
     fn try_insert(&mut self, value: T) -> Result<bool, TryReserveError> {
-        self.try_reserve(1)?;
         Ok(self.insert(value))
     }
 }
 
-impl<T, S> TursoTryWithCapacityExt for HashSet<T, S>
+impl<T> TursoTryWithCapacityExt for HashSet<T>
 where
     T: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        Ok(HashSet::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }
 
-impl<T, S> TursoFromIterator<T> for HashSet<T, S>
+impl<T> TursoFromIterator<T> for HashSet<T>
 where
     T: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                TursoHashSetExt::try_insert(&mut values, value)?;
-            }
-        }
-        Ok(values)
+        Ok(iter.into_iter().collect())
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            self.extend(iter);
-        } else {
-            for value in iter {
-                TursoHashSetExt::try_insert(self, value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
@@ -87,6 +55,7 @@ where
 {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
         cloned.try_reserve(self.len())?;

--- a/core/alloc/collections/iterator.rs
+++ b/core/alloc/collections/iterator.rs
@@ -10,7 +10,7 @@ where
         I: IntoIterator<Item = Option<T>>,
     {
         let mut saw_none = false;
-        let values = C::try_from_iter(iter.into_iter().scan((), |(), item| match item {
+        let values = C::try_from_iter(iter.into_iter().map_while(|item| match item {
             Some(value) => Some(value),
             None => {
                 saw_none = true;
@@ -32,7 +32,7 @@ where
             return Ok(());
         };
         let mut saw_none = false;
-        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+        values.try_extend(iter.into_iter().map_while(|item| match item {
             Some(value) => Some(value),
             None => {
                 saw_none = true;
@@ -56,7 +56,7 @@ where
         I: IntoIterator<Item = Result<T, E>>,
     {
         let mut error = None;
-        let values = C::try_from_iter(iter.into_iter().scan((), |(), item| match item {
+        let values = C::try_from_iter(iter.into_iter().map_while(|item| match item {
             Ok(value) => Some(value),
             Err(err) => {
                 error = Some(F::from(err));
@@ -78,7 +78,7 @@ where
             return Ok(());
         };
         let mut error = None;
-        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+        values.try_extend(iter.into_iter().map_while(|item| match item {
             Ok(value) => Some(value),
             Err(err) => {
                 error = Some(F::from(err));

--- a/core/alloc/collections/iterator.rs
+++ b/core/alloc/collections/iterator.rs
@@ -17,11 +17,28 @@ where
                 None
             }
         }))?;
+        if saw_none { Ok(None) } else { Ok(Some(values)) }
+    }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = Option<T>>,
+    {
+        let Some(values) = self else {
+            return Ok(());
+        };
+        let mut saw_none = false;
+        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+            Some(value) => Some(value),
+            None => {
+                saw_none = true;
+                None
+            }
+        }))?;
         if saw_none {
-            Ok(None)
-        } else {
-            Ok(Some(values))
+            *self = None;
         }
+        Ok(())
     }
 }
 
@@ -48,6 +65,154 @@ where
             Ok(Ok(values))
         }
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = Result<T, E>>,
+    {
+        let Ok(values) = self else {
+            return Ok(());
+        };
+        let mut error = None;
+        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+            Ok(value) => Some(value),
+            Err(err) => {
+                error = Some(F::from(err));
+                None
+            }
+        }))?;
+        if let Some(error) = error {
+            *self = Err(error);
+        }
+        Ok(())
+    }
 }
 
 impl<I: Iterator> TursoIteratorExt for I {}
+
+macro_rules! impl_tuple_from_iterator {
+    ($(($ty:ident, $from_ty:ident, $item:ident, $collection:ident)),+) => {
+        impl<$($ty,)+ $($from_ty,)+> TursoFromIterator<($($ty,)+)> for ($($from_ty,)+)
+        where
+            $($from_ty: TursoFromIterator<$ty>,)+
+        {
+            fn try_from_iter<Iter>(iter: Iter) -> Result<Self, TryReserveError>
+            where
+                Iter: IntoIterator<Item = ($($ty,)+)>,
+            {
+                let mut values = ($($from_ty::try_from_iter(std::iter::empty())?,)+);
+                values.try_extend(iter)?;
+                Ok(values)
+            }
+
+            fn try_extend<Iter>(&mut self, iter: Iter) -> Result<(), TryReserveError>
+            where
+                Iter: IntoIterator<Item = ($($ty,)+)>,
+            {
+                let ($($collection,)+) = self;
+                for ($($item,)+) in iter {
+                    $($collection.try_extend(std::iter::once($item))?;)+
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_tuple_from_iterator!((A, FromA, a, from_a));
+impl_tuple_from_iterator!((A, FromA, a, from_a), (B, FromB, b, from_b));
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i),
+    (J, FromJ, j, from_j)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i),
+    (J, FromJ, j, from_j),
+    (K, FromK, k, from_k)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i),
+    (J, FromJ, j, from_j),
+    (K, FromK, k, from_k),
+    (L, FromL, l, from_l)
+);

--- a/core/alloc/collections/iterator.rs
+++ b/core/alloc/collections/iterator.rs
@@ -17,7 +17,11 @@ where
                 None
             }
         }))?;
-        if saw_none { Ok(None) } else { Ok(Some(values)) }
+        if saw_none {
+            Ok(None)
+        } else {
+            Ok(Some(values))
+        }
     }
 
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -53,6 +53,7 @@ pub trait TursoFromIterator<T>: Sized {
 }
 
 pub trait TursoIteratorExt: Iterator + Sized {
+    #[inline]
     fn try_collect<C>(self) -> Result<C, TryReserveError>
     where
         C: TursoFromIterator<Self::Item>,
@@ -60,6 +61,7 @@ pub trait TursoIteratorExt: Iterator + Sized {
         C::try_from_iter(self)
     }
 
+    #[inline]
     fn try_unzip<A, B, FromA, FromB>(self) -> Result<(FromA, FromB), TryReserveError>
     where
         (FromA, FromB): TursoFromIterator<(A, B)>,

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -23,42 +23,31 @@ pub trait TursoBoxExt<T>: Sized {
 pub trait TursoVecExt<T>: Sized {
     fn with_capacity(capacity: usize) -> Self;
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoHashMapExt<K, V>: Sized {
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = (K, V)>;
 }
 
 pub trait TursoHashSetExt<T>: Sized {
     fn try_insert(&mut self, value: T) -> Result<bool, TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoVecDequeExt<T>: Sized {
     fn try_push_back(&mut self, value: T) -> Result<(), TryReserveError>;
     fn try_push_front(&mut self, value: T) -> Result<(), TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoBinaryHeapExt<T>: Sized {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoFromIterator<T>: Sized {
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = T>;
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>;
 }
@@ -69,6 +58,14 @@ pub trait TursoIteratorExt: Iterator + Sized {
         C: TursoFromIterator<Self::Item>,
     {
         C::try_from_iter(self)
+    }
+
+    fn try_unzip<A, B, FromA, FromB>(self) -> Result<(FromA, FromB), TryReserveError>
+    where
+        (FromA, FromB): TursoFromIterator<(A, B)>,
+        Self: Iterator<Item = (A, B)>,
+    {
+        <(FromA, FromB) as TursoFromIterator<(A, B)>>::try_from_iter(self)
     }
 }
 

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -21,7 +21,7 @@ impl<T> TursoVecExt<T> for Vec<T> {
     }
 
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push(value);
         Ok(())
     }
@@ -32,9 +32,7 @@ impl<T> TursoTryWithCapacityExt for Vec<T> {
         #[cfg(not(nightly))]
         {
             let mut values = vec();
-            values
-                .try_reserve(capacity)
-                .map_err(TryReserveError::from)?;
+            values.try_reserve(capacity)?;
             Ok(values)
         }
         #[cfg(nightly)]
@@ -55,9 +53,7 @@ impl<T> TursoFromIterator<T> for Vec<T> {
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for value in iter {
-                values.push(value);
-            }
+            values.extend(iter);
         } else {
             for value in iter {
                 values.try_push(value)?;

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -1,83 +1,79 @@
 use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoTryWithCapacityExt, TursoVecExt};
-use crate::alloc::{TryReserveError, TursoAllocator, Vec};
+#[cfg(nightly)]
+use crate::alloc::TursoAllocator;
+use crate::alloc::{TryReserveError, Vec};
 
-pub(super) fn vec<T>() -> Vec<T> {
+#[cfg(not(nightly))]
+pub(super) const fn vec<T>() -> Vec<T> {
+    Vec::new()
+}
+
+#[cfg(nightly)]
+pub(super) const fn vec<T>() -> Vec<T> {
     Vec::new_in(TursoAllocator)
 }
 
+#[cfg(not(nightly))]
+fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
+    Vec::with_capacity(capacity)
+}
+
+#[cfg(nightly)]
 fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
     Vec::with_capacity_in(capacity, TursoAllocator)
 }
 
 impl<T> TursoAllocExt for Vec<T> {
+    #[inline(always)]
     fn new() -> Self {
         vec()
     }
 }
 
 impl<T> TursoVecExt<T> for Vec<T> {
+    #[inline(always)]
     fn with_capacity(capacity: usize) -> Self {
         vec_with_capacity(capacity)
     }
 
+    #[inline(always)]
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push(value);
         Ok(())
     }
 }
 
 impl<T> TursoTryWithCapacityExt for Vec<T> {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        #[cfg(not(nightly))]
-        {
-            let mut values = vec();
-            values.try_reserve(capacity)?;
-            Ok(values)
-        }
-        #[cfg(nightly)]
-        {
-            std::vec::Vec::try_with_capacity_in(capacity, TursoAllocator)
-                .map_err(TryReserveError::from)
-        }
+        Ok(vec_with_capacity(capacity))
     }
 }
 
 impl<T> TursoFromIterator<T> for Vec<T> {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_push(value)?;
-            }
+        #[cfg(not(nightly))]
+        {
+            Ok(iter.into_iter().collect())
         }
-        Ok(values)
+        #[cfg(nightly)]
+        {
+            let mut values = vec();
+            values.extend(iter);
+            Ok(values)
+        }
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            for value in iter {
-                self.push(value);
-            }
-        } else {
-            for value in iter {
-                self.try_push(value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
@@ -85,6 +81,7 @@ impl<T> TursoFromIterator<T> for Vec<T> {
 impl<T: Clone> TryClone for Vec<T> {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -54,8 +54,14 @@ impl<T> TursoFromIterator<T> for Vec<T> {
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            values.try_push(value)?;
+        if upper.is_some() {
+            for value in iter {
+                values.push(value);
+            }
+        } else {
+            for value in iter {
+                values.try_push(value)?;
+            }
         }
         Ok(values)
     }
@@ -67,8 +73,14 @@ impl<T> TursoFromIterator<T> for Vec<T> {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            self.try_push(value)?;
+        if upper.is_some() {
+            for value in iter {
+                self.push(value);
+            }
+        } else {
+            for value in iter {
+                self.try_push(value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -1,7 +1,7 @@
 use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoTryWithCapacityExt, TursoVecExt};
 use crate::alloc::{TryReserveError, TursoAllocator, Vec};
 
-fn vec<T>() -> Vec<T> {
+pub(super) fn vec<T>() -> Vec<T> {
     Vec::new_in(TursoAllocator)
 }
 
@@ -23,20 +23,6 @@ impl<T> TursoVecExt<T> for Vec<T> {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
         self.try_reserve(1).map_err(TryReserveError::from)?;
         self.push(value);
-        Ok(())
-    }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for value in iter {
-            self.try_push(value)?;
-        }
         Ok(())
     }
 }
@@ -72,6 +58,19 @@ impl<T> TursoFromIterator<T> for Vec<T> {
             values.try_push(value)?;
         }
         Ok(values)
+    }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            self.try_push(value)?;
+        }
+        Ok(())
     }
 }
 

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -60,8 +60,14 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            values.try_push_back(value)?;
+        if upper.is_some() {
+            for value in iter {
+                values.push_back(value);
+            }
+        } else {
+            for value in iter {
+                values.try_push_back(value)?;
+            }
         }
         Ok(values)
     }
@@ -73,8 +79,14 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            self.try_push_back(value)?;
+        if upper.is_some() {
+            for value in iter {
+                self.push_back(value);
+            }
+        } else {
+            for value in iter {
+                self.try_push_back(value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -29,13 +29,13 @@ impl<T> TursoAllocExt for VecDeque<T> {
 
 impl<T> TursoVecDequeExt<T> for VecDeque<T> {
     fn try_push_back(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push_back(value);
         Ok(())
     }
 
     fn try_push_front(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push_front(value);
         Ok(())
     }
@@ -44,9 +44,7 @@ impl<T> TursoVecDequeExt<T> for VecDeque<T> {
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
+        values.try_reserve(capacity)?;
         Ok(values)
     }
 }
@@ -61,9 +59,7 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for value in iter {
-                values.push_back(value);
-            }
+            values.extend(iter);
         } else {
             for value in iter {
                 values.try_push_back(value)?;
@@ -80,9 +76,7 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
         if upper.is_some() {
-            for value in iter {
-                self.push_back(value);
-            }
+            self.extend(iter);
         } else {
             for value in iter {
                 self.try_push_back(value)?;

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -4,17 +4,28 @@ use super::{
 use crate::alloc::{TryReserveError, VecDeque};
 
 #[cfg(not(nightly))]
-fn vec_deque<T>() -> VecDeque<T> {
+const fn vec_deque<T>() -> VecDeque<T> {
     std::collections::VecDeque::new()
 }
 
 #[cfg(nightly)]
-fn vec_deque<T>() -> VecDeque<T> {
+const fn vec_deque<T>() -> VecDeque<T> {
     std::collections::VecDeque::new_in(crate::alloc::TursoAllocator)
 }
 
 #[cfg(not(nightly))]
+fn vec_deque_with_capacity<T>(capacity: usize) -> VecDeque<T> {
+    std::collections::VecDeque::with_capacity(capacity)
+}
+
+#[cfg(nightly)]
+fn vec_deque_with_capacity<T>(capacity: usize) -> VecDeque<T> {
+    std::collections::VecDeque::with_capacity_in(capacity, crate::alloc::TursoAllocator)
+}
+
+#[cfg(not(nightly))]
 impl<T> TursoAllocExt for VecDeque<T> {
+    #[inline(always)]
     fn new() -> Self {
         vec_deque()
     }
@@ -22,66 +33,57 @@ impl<T> TursoAllocExt for VecDeque<T> {
 
 #[cfg(nightly)]
 impl<T> TursoAllocExt for VecDeque<T> {
+    #[inline(always)]
     fn new() -> Self {
         vec_deque()
     }
 }
 
 impl<T> TursoVecDequeExt<T> for VecDeque<T> {
+    #[inline(always)]
     fn try_push_back(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push_back(value);
         Ok(())
     }
 
+    #[inline(always)]
     fn try_push_front(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push_front(value);
         Ok(())
     }
 }
 
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        Ok(vec_deque_with_capacity(capacity))
     }
 }
 
 impl<T> TursoFromIterator<T> for VecDeque<T> {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_push_back(value)?;
-            }
+        #[cfg(not(nightly))]
+        {
+            Ok(iter.into_iter().collect())
         }
-        Ok(values)
+        #[cfg(nightly)]
+        {
+            let mut values = super::vec::vec();
+            values.extend(iter);
+            Ok(Self::from(values))
+        }
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            self.extend(iter);
-        } else {
-            for value in iter {
-                self.try_push_back(value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
@@ -89,6 +91,7 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
 impl<T: Clone> TryClone for VecDeque<T> {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -39,20 +39,6 @@ impl<T> TursoVecDequeExt<T> for VecDeque<T> {
         self.push_front(value);
         Ok(())
     }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for value in iter {
-            self.try_push_back(value)?;
-        }
-        Ok(())
-    }
 }
 
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
@@ -79,6 +65,19 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         }
         Ok(values)
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            self.try_push_back(value)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T: Clone> TryClone for VecDeque<T> {
@@ -92,9 +91,7 @@ impl<T: Clone> TryClone for VecDeque<T> {
             let alloc = self.allocator().clone();
             Self::new_in(alloc)
         };
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
         cloned.extend(self.iter().cloned());
         Ok(cloned)
     }

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -1,8 +1,7 @@
 //! Turso-owned allocation namespace.
 //!
-//! Stable builds use `allocator-api2` where it has allocator-aware types and
-//! fall back to `std` for collections that do not have stable allocator-aware
-//! equivalents. Builds compiled with `--cfg nightly` use Rust's unstable
+//! Stable builds use `std` collections where allocator parameters are not
+//! available. Builds compiled with `--cfg nightly` use Rust's unstable
 //! `allocator_api` collection parameters.
 
 use std::fmt;
@@ -54,7 +53,7 @@ pub type Box<T> = allocator_api2::boxed::Box<T, TursoAllocator>;
 pub type Box<T> = std::boxed::Box<T, TursoAllocator>;
 
 #[cfg(not(nightly))]
-pub type Vec<T> = allocator_api2::vec::Vec<T, TursoAllocator>;
+pub type Vec<T> = std::vec::Vec<T>;
 #[cfg(nightly)]
 pub type Vec<T> = std::vec::Vec<T, TursoAllocator>;
 

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -44,7 +44,7 @@ fn try_extend_accepts_iterators_without_upper_bounds() {
 
 #[test]
 fn hash_map_try_insert_and_extend_reserve_before_mutation() {
-    let mut values: HashMap<&str, usize> = TursoAllocExt::new();
+    let mut values: HashMap<&str, usize> = HashMap::default();
 
     assert_eq!(
         TursoHashMapExt::try_insert(&mut values, "one", 1).unwrap(),
@@ -63,7 +63,7 @@ fn hash_map_try_insert_and_extend_reserve_before_mutation() {
 
 #[test]
 fn hash_set_try_insert_and_extend_reserve_before_mutation() {
-    let mut values: HashSet<usize> = TursoAllocExt::new();
+    let mut values: HashSet<usize> = HashSet::default();
 
     assert!(TursoHashSetExt::try_insert(&mut values, 1).unwrap());
     assert!(!TursoHashSetExt::try_insert(&mut values, 1).unwrap());

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -110,6 +110,15 @@ fn iterator_try_collect_builds_turso_vec() {
 }
 
 #[test]
+fn try_extend_extends_existing_collection() {
+    let mut values = try_vec![1].unwrap();
+
+    values.try_extend([2, 3]).unwrap();
+
+    assert_eq!(values.as_slice(), &[1, 2, 3]);
+}
+
+#[test]
 fn try_vec_macro_builds_turso_vecs() {
     let empty: Vec<usize> = try_vec![].unwrap();
     let repeated: Vec<_> = try_vec![7; 3].unwrap();
@@ -197,6 +206,51 @@ fn iterator_try_collect_accepts_try_vec_results() {
 
     assert_eq!(values[0].as_slice(), &[false]);
     assert_eq!(values[1].as_slice(), &[false, false]);
+}
+
+#[test]
+fn tuple_try_extend_extends_both_collections() {
+    let mut values: (Vec<_>, VecDeque<_>) = (Vec::new(), VecDeque::new());
+
+    values
+        .try_extend([(1, "one"), (2, "two"), (3, "three")])
+        .unwrap();
+
+    assert_eq!(values.0.as_slice(), &[1, 2, 3]);
+    assert_eq!(
+        values.1.into_iter().collect::<std::vec::Vec<_>>(),
+        ["one", "two", "three"]
+    );
+}
+
+#[test]
+fn tuple_try_collect_builds_three_collections() {
+    let (numbers, words, flags): (Vec<_>, VecDeque<_>, Vec<_>) =
+        [(1, "one", true), (2, "two", false), (3, "three", true)]
+            .into_iter()
+            .try_collect()
+            .unwrap();
+
+    assert_eq!(numbers.as_slice(), &[1, 2, 3]);
+    assert_eq!(
+        words.into_iter().collect::<std::vec::Vec<_>>(),
+        ["one", "two", "three"]
+    );
+    assert_eq!(flags.as_slice(), &[true, false, true]);
+}
+
+#[test]
+fn iterator_try_unzip_builds_turso_collections() {
+    let (numbers, words): (Vec<_>, VecDeque<_>) = [(1, "one"), (2, "two"), (3, "three")]
+        .into_iter()
+        .try_unzip()
+        .unwrap();
+
+    assert_eq!(numbers.as_slice(), &[1, 2, 3]);
+    assert_eq!(
+        words.into_iter().collect::<std::vec::Vec<_>>(),
+        ["one", "two", "three"]
+    );
 }
 
 #[test]

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -1,0 +1,763 @@
+use divan::{black_box, AllocProfiler, Bencher};
+use mimalloc::MiMalloc;
+use rustc_hash::FxBuildHasher;
+use turso_core::alloc::{
+    self, TursoBinaryHeapExt, TursoFromIterator, TursoHashMapExt, TursoHashSetExt,
+    TursoIteratorExt, TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt,
+};
+
+#[global_allocator]
+static ALLOC: AllocProfiler<MiMalloc> = AllocProfiler::new(MiMalloc);
+
+#[cfg(not(feature = "codspeed"))]
+const SAMPLE_COUNT: u32 = 1000;
+
+#[cfg(not(feature = "codspeed"))]
+fn main() {
+    divan::Divan::default().sample_count(SAMPLE_COUNT).main();
+}
+
+#[cfg(feature = "codspeed")]
+fn main() {
+    divan::main();
+}
+
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct NonCopyValue {
+    id: usize,
+    payload: [usize; 4],
+}
+
+impl NonCopyValue {
+    fn new(id: usize) -> Self {
+        Self {
+            id,
+            payload: [
+                id,
+                id.wrapping_mul(3),
+                id.rotate_left(7),
+                id ^ 0x9e37_79b9_7f4a_7c15,
+            ],
+        }
+    }
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_push_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| {
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+        })
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values.try_push(black_box(value)).unwrap();
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_push_std(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| std::vec::Vec::with_capacity(len))
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values.push(black_box(value));
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::Vec<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len).map(black_box).collect::<std::vec::Vec<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::vec::Vec::with_capacity(len);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_push_back_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        for value in 0..len {
+            values.try_push_back(black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_push_back_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        for value in 0..len {
+            values.push_back(black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::VecDeque<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .collect::<std::collections::VecDeque<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_push_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        for value in 0..len {
+            values.try_push(black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_push_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        for value in 0..len {
+            values.push(black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::BinaryHeap<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .collect::<std::collections::BinaryHeap<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashSetExt::try_insert(&mut values, black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::HashSet<_, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .collect::<std::collections::HashSet<_, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashMapExt::try_insert(&mut values, black_box(value), black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| (black_box(value), black_box(value)))
+            .try_collect::<alloc::HashMap<_, _, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| (black_box(value), black_box(value)))
+            .collect::<std::collections::HashMap<_, _, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| (black_box(value), black_box(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(|value| (black_box(value), black_box(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(black_box(value), black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_push_std(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| std::vec::Vec::with_capacity(len))
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values.push(black_box(NonCopyValue::new(value)));
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_push_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| {
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+        })
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values
+                    .try_push(black_box(NonCopyValue::new(value)))
+                    .unwrap();
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::vec::Vec<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::Vec<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::vec::Vec::with_capacity(len);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_push_back_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        for value in 0..len {
+            values.push_back(black_box(NonCopyValue::new(value)));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_push_back_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        for value in 0..len {
+            values
+                .try_push_back(black_box(NonCopyValue::new(value)))
+                .unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::collections::VecDeque<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::VecDeque<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_push_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        for value in 0..len {
+            values.push(black_box(NonCopyValue::new(value)));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_push_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        for value in 0..len {
+            values
+                .try_push(black_box(NonCopyValue::new(value)))
+                .unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::collections::BinaryHeap<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::BinaryHeap<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(black_box(NonCopyValue::new(value)));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashSetExt::try_insert(&mut values, black_box(NonCopyValue::new(value))).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::collections::HashSet<_, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::HashSet<_, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(
+                black_box(NonCopyValue::new(value)),
+                black_box(NonCopyValue::new(value.wrapping_mul(3))),
+            );
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashMapExt::try_insert(
+                &mut values,
+                black_box(NonCopyValue::new(value)),
+                black_box(NonCopyValue::new(value.wrapping_mul(3))),
+            )
+            .unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| {
+                (
+                    black_box(NonCopyValue::new(value)),
+                    black_box(NonCopyValue::new(value.wrapping_mul(3))),
+                )
+            })
+            .collect::<std::collections::HashMap<_, _, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| {
+                (
+                    black_box(NonCopyValue::new(value)),
+                    black_box(NonCopyValue::new(value.wrapping_mul(3))),
+                )
+            })
+            .try_collect::<alloc::HashMap<_, _, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(|value| {
+            (
+                black_box(NonCopyValue::new(value)),
+                black_box(NonCopyValue::new(value.wrapping_mul(3))),
+            )
+        }));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| {
+                (
+                    black_box(NonCopyValue::new(value)),
+                    black_box(NonCopyValue::new(value.wrapping_mul(3))),
+                )
+            }),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -42,6 +42,32 @@ impl NonCopyValue {
     }
 }
 
+struct LowerBoundOnly<I> {
+    iter: I,
+}
+
+impl<I> LowerBoundOnly<I> {
+    fn new(iter: I) -> Self {
+        Self { iter }
+    }
+}
+
+impl<I> Iterator for LowerBoundOnly<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, _) = self.iter.size_hint();
+        (lower, None)
+    }
+}
+
 #[divan::bench(args = [64, 1_024, 16_384])]
 fn vec_push_turso(bencher: Bencher, len: usize) {
     bencher
@@ -370,6 +396,213 @@ fn hash_map_insert_std(bencher: Bencher, len: usize) {
         for value in 0..len {
             values.insert(black_box(value), black_box(value));
         }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box)).collect::<std::vec::Vec<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::Vec<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::vec::Vec::with_capacity(len);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values =
+            LowerBoundOnly::new((0..len).map(black_box)).collect::<std::collections::VecDeque<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::VecDeque<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .collect::<std::collections::BinaryHeap<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::BinaryHeap<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .collect::<std::collections::HashSet<_, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::HashSet<_, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values =
+            LowerBoundOnly::new((0..len).map(|value| (black_box(value), black_box(value))))
+                .collect::<std::collections::HashMap<_, _, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values =
+            LowerBoundOnly::new((0..len).map(|value| (black_box(value), black_box(value))))
+                .try_collect::<alloc::HashMap<_, _, FxBuildHasher>>()
+                .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend(LowerBoundOnly::new(
+            (0..len).map(|value| (black_box(value), black_box(value))),
+        ));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            LowerBoundOnly::new((0..len).map(|value| (black_box(value), black_box(value)))),
+        )
+        .unwrap();
         black_box(values)
     });
 }

--- a/scripts/compare-divan-std-turso.py
+++ b/scripts/compare-divan-std-turso.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Compare Divan benchmark pairs named *_std and *_turso."""
+
+import argparse
+import csv
+import os
+import re
+import subprocess
+import sys
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+BENCH_RE = re.compile(
+    r"^.*[\u251c\u2570]\u2500\s*"
+    r"([A-Za-z0-9_]+_(?:std|turso))\s*(?:[|\u2502]|$)"
+)
+SIZE_RE = re.compile(r"[\u251c\u2570]\u2500\s*([0-9][0-9_,]*)\s+(.+?)\s*$")
+
+
+def strip_ansi(line):
+    return ANSI_RE.sub("", line)
+
+
+def parse_duration_ns(value):
+    value = value.strip()
+    match = re.search(r"([0-9.]+)\s*(ns|us|\u00b5s|ms|s)", value)
+    if not match:
+        return None
+
+    amount = float(match.group(1))
+    unit = match.group(2)
+    if unit == "ns":
+        return amount
+    if unit in ("us", "\u00b5s"):
+        return amount * 1_000
+    if unit == "ms":
+        return amount * 1_000_000
+    if unit == "s":
+        return amount * 1_000_000_000
+    return None
+
+
+def parse_size_and_median(parts):
+    for index, part in enumerate(parts):
+        size_match = SIZE_RE.search(part)
+        if not size_match:
+            continue
+
+        median_index = index + 2
+        if len(parts) <= median_index:
+            return None
+
+        median = parts[median_index].strip()
+        median_ns = parse_duration_ns(median)
+        if median_ns is None:
+            return None
+
+        size = int(size_match.group(1).replace("_", "").replace(",", ""))
+        return size, median, median_ns
+
+    return None
+
+
+def parse_bench_lines(lines):
+    benches = {}
+    current = None
+
+    for raw_line in lines:
+        line = strip_ansi(raw_line.rstrip("\n"))
+
+        bench_match = BENCH_RE.search(line)
+        if bench_match:
+            current = bench_match.group(1)
+            benches.setdefault(current, {})
+            continue
+
+        if current is None:
+            continue
+
+        parts = line.split("\u2502")
+        if len(parts) < 3:
+            parts = line.split("|")
+        if len(parts) < 3:
+            continue
+
+        size_and_median = parse_size_and_median(parts)
+        if size_and_median is None:
+            continue
+        size, median, median_ns = size_and_median
+
+        benches[current][size] = {
+            "median": median,
+            "median_ns": median_ns,
+        }
+
+    return benches
+
+
+def parse_benches(path):
+    with open(path, encoding="utf-8") as bench_file:
+        return parse_bench_lines(bench_file)
+
+
+def run_bench(args):
+    command = [
+        "cargo",
+        "bench",
+        "-p",
+        args.package,
+        "--bench",
+        args.bench,
+    ]
+    if args.nightly:
+        command[0:1] = ["cargo", "+nightly"]
+    if args.bench_filter:
+        command.append(args.bench_filter)
+
+    print(f"Running: {' '.join(command)}", file=sys.stderr)
+    env = os.environ.copy()
+    if args.nightly:
+        rustflags = env.get("RUSTFLAGS")
+        env["RUSTFLAGS"] = (
+            f"{rustflags} --cfg nightly" if rustflags else "--cfg nightly"
+        )
+    result = subprocess.run(
+        command,
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    if args.save_output:
+        with open(args.save_output, "w", encoding="utf-8") as output_file:
+            output_file.write(result.stdout)
+
+    return parse_bench_lines(result.stdout.splitlines())
+
+
+def paired_rows(benches, name_filter):
+    bases = sorted(
+        {
+            name.rsplit("_", 1)[0]
+            for name in benches
+            if name.endswith("_std") or name.endswith("_turso")
+        }
+    )
+
+    rows = []
+    pattern = re.compile(name_filter) if name_filter else None
+    for base in bases:
+        if pattern and not pattern.search(base):
+            continue
+
+        std = benches.get(f"{base}_std")
+        turso = benches.get(f"{base}_turso")
+        if not std or not turso:
+            continue
+
+        for size in sorted(set(std) & set(turso)):
+            std_ns = std[size]["median_ns"]
+            turso_ns = turso[size]["median_ns"]
+            ratio = turso_ns / std_ns
+            delta = ((turso_ns - std_ns) / std_ns) * 100
+            if ratio < 0.97:
+                winner = "turso"
+            elif ratio > 1.03:
+                winner = "std"
+            else:
+                winner = "parity"
+
+            rows.append(
+                {
+                    "benchmark": base,
+                    "size": size,
+                    "std_median": std[size]["median"],
+                    "turso_median": turso[size]["median"],
+                    "ratio": ratio,
+                    "delta": delta,
+                    "winner": winner,
+                }
+            )
+
+    winner_order = {"std": 0, "parity": 1, "turso": 2}
+    return sorted(
+        rows,
+        key=lambda row: (
+            winner_order[row["winner"]],
+            -row["delta"],
+            row["benchmark"],
+            row["size"],
+        ),
+    )
+
+
+def print_markdown(rows):
+    print("| benchmark | size | std median | turso median | turso/std | delta | winner |")
+    print("|---|---:|---:|---:|---:|---:|---|")
+    for row in rows:
+        print(
+            "| {benchmark} | {size} | {std_median} | {turso_median} | "
+            "{ratio:.2f}x | {delta:+.1f}% | {winner} |".format(**row)
+        )
+    counts = winner_counts(rows)
+    print()
+    print(
+        f"Summary: std={counts['std']}, parity={counts['parity']}, "
+        f"turso={counts['turso']}"
+    )
+
+
+def winner_counts(rows):
+    counts = {"std": 0, "parity": 0, "turso": 0}
+    for row in rows:
+        counts[row["winner"]] += 1
+    return counts
+
+
+def print_csv(rows):
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "benchmark",
+            "size",
+            "std_median",
+            "turso_median",
+            "ratio",
+            "delta",
+            "winner",
+        ],
+    )
+    writer.writeheader()
+    for row in rows:
+        csv_row = dict(row)
+        csv_row["ratio"] = f"{row['ratio']:.4f}"
+        csv_row["delta"] = f"{row['delta']:.2f}"
+        writer.writerow(csv_row)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare Divan benchmark output for *_std and *_turso pairs."
+    )
+    parser.add_argument(
+        "bench_output",
+        nargs="?",
+        help="Path to captured cargo bench output. Omit when using --run.",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run cargo bench before printing the comparison table.",
+    )
+    parser.add_argument(
+        "--package",
+        default="turso_core",
+        help="Cargo package to bench when using --run.",
+    )
+    parser.add_argument(
+        "--bench",
+        default="alloc_collections",
+        help="Cargo bench target to run when using --run.",
+    )
+    parser.add_argument(
+        "--bench-filter",
+        help="Optional benchmark name filter passed to cargo bench when using --run.",
+    )
+    parser.add_argument(
+        "--nightly",
+        action="store_true",
+        help="Run cargo bench with +nightly and RUSTFLAGS='--cfg nightly'.",
+    )
+    parser.add_argument(
+        "--save-output",
+        help="Save raw Divan stdout to this path when using --run.",
+    )
+    parser.add_argument(
+        "--filter",
+        help="Only include benchmark base names matching this regular expression",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "csv"),
+        default="markdown",
+        help="Output format",
+    )
+    args = parser.parse_args()
+
+    if args.run:
+        benches = run_bench(args)
+    elif args.bench_output:
+        benches = parse_benches(args.bench_output)
+    else:
+        parser.error("provide bench_output or use --run")
+
+    rows = paired_rows(benches, args.filter)
+    if args.format == "csv":
+        print_csv(rows)
+    else:
+        print_markdown(rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
See below some of my discussion with @LeMikaelF, but essentially the std lib can have faster impls due to specialization and being able to access the inner struct with some private methods. This means you can have up to 4 times slower implementations if you just try to do the trivial thing here. So for now, I will first focus on just doing the migration of changing functions signatures in core and making sure we call fallible allocation methods. 

Then after the migration, I can focus on making sure that the methods here can be as fast as possible. Of course there will be some overhead because we will be checking for the allocation failure which is something the standard library does not. 

I also added some benchmarks to compare the impls for the future.

## Motivation and context
Ergonomic fallible allocation

## Description of AI Usage
Codex did the boilerplate