### PR TITLE
[codex] Allow WAL updates past soft cache limit

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -639,6 +639,18 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             }
                         }
                     }
+                } else {
+                    let is_payloadless_schema_tombstone = key.table_id
+                        == SQLITE_SCHEMA_MVCC_TABLE_ID
+                        && is_delete
+                        && !version.btree_resident
+                        && version.row.payload().is_empty();
+                    if is_payloadless_schema_tombstone {
+                        // Recovery can synthesize an empty sqlite_schema tombstone for a
+                        // row that was created and deleted before any checkpoint. There is
+                        // no schema identity to track and no pager row to delete.
+                        skip_write = true;
+                    }
                 }
                 if !skip_write {
                     tracing::trace!("adding to write_set {:?}", (&version, &special_write));
@@ -1905,6 +1917,43 @@ mod tests {
 
         assert_eq!(sqlite_schema_btree_identity(&tombstone), None);
         assert!(!is_schema_metadata_only_rewrite(&tombstone, None));
+    }
+
+    #[test]
+    fn checkpoint_skips_payloadless_nonresident_schema_tombstone() {
+        let db = MvccTestDbNoConn::new();
+        let conn = db.connect();
+        let mvstore = db.get_mvcc_store();
+        let pager = conn.pager.load().clone();
+        let mut checkpoint = CheckpointStateMachine::new(
+            pager,
+            mvstore.clone(),
+            conn.clone(),
+            true,
+            conn.get_sync_mode(),
+        );
+        checkpoint.durable_txid_max_old = std::num::NonZeroU64::new(7_000);
+        checkpoint.durable_txid_max_new = 7_421;
+
+        let row_id = RowID::new(SQLITE_SCHEMA_MVCC_TABLE_ID, RowKey::Int(377));
+        let row_version = RowVersion {
+            id: 260,
+            begin: None,
+            end: Some(TxTimestampOrID::Timestamp(7_421)),
+            row: Row::new_table_row(row_id.clone(), Vec::new(), 0),
+            btree_resident: false,
+        };
+        let versions = mvstore
+            .rows
+            .get_or_insert_with(row_id, || Arc::new(RwLock::new(Vec::new())));
+        mvstore.insert_version_raw(&mut versions.value().write(), row_version);
+
+        checkpoint.collect_committed_table_row_versions();
+
+        assert!(
+            checkpoint.write_set.is_empty(),
+            "payloadless nonresident sqlite_schema tombstones have no pager row to delete"
+        );
     }
 
     fn index_row_version(

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -227,6 +227,20 @@ impl PageCache {
         self._insert(key, value, true, true)
     }
 
+    /// Insert a page without enforcing the cache capacity.
+    ///
+    /// SQLite treats `PRAGMA cache_size` as a soft target. When the cache is
+    /// full of dirty or otherwise unevictable pages and spilling cannot make
+    /// room, pager callers may temporarily exceed capacity rather than fail a
+    /// statement with Busy.
+    pub fn insert_over_capacity(
+        &mut self,
+        key: PageCacheKey,
+        value: PageRef,
+    ) -> Result<(), CacheError> {
+        self._insert(key, value, false, true)
+    }
+
     pub fn _insert(
         &mut self,
         key: PageCacheKey,

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3021,14 +3021,44 @@ impl Pager {
             IOResult::Done(true) => {
                 let mut page_cache = self.page_cache.write();
                 let page_key = PageCacheKey::new(page_idx);
-                match page_cache.insert(page_key, page) {
+                match page_cache.insert(page_key, page.clone()) {
+                    Ok(_) => Ok(IOResult::Done(())),
+                    Err(CacheError::KeyExists) => Ok(IOResult::Done(())),
+                    Err(CacheError::Full) => {
+                        match page_cache.insert_over_capacity(page_key, page) {
+                            Ok(_) => Ok(IOResult::Done(())),
+                            Err(CacheError::KeyExists) => Ok(IOResult::Done(())),
+                            Err(e) => Err(e.into()),
+                        }
+                    }
+                    Err(e) => Err(e.into()),
+                }
+            }
+            IOResult::Done(false) => {
+                let mut page_cache = self.page_cache.write();
+                let page_key = PageCacheKey::new(page_idx);
+                match page_cache.insert_over_capacity(page_key, page) {
                     Ok(_) => Ok(IOResult::Done(())),
                     Err(CacheError::KeyExists) => Ok(IOResult::Done(())),
                     Err(e) => Err(e.into()),
                 }
             }
-            IOResult::Done(false) => Err(LimboError::Busy),
             IOResult::IO(c) => Ok(IOResult::IO(c)),
+        }
+    }
+
+    fn cache_insert_over_soft_limit(&self, page_idx: usize, page: PageRef) -> Result<()> {
+        let mut page_cache = self.page_cache.write();
+        let page_key = PageCacheKey::new(page_idx);
+        match page_cache.insert(page_key, page.clone()) {
+            Ok(_) => Ok(()),
+            Err(CacheError::KeyExists) => Ok(()),
+            Err(CacheError::Full) => match page_cache.insert_over_capacity(page_key, page) {
+                Ok(_) => Ok(()),
+                Err(CacheError::KeyExists) => Ok(()),
+                Err(e) => Err(e.into()),
+            },
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -3593,11 +3623,12 @@ impl Pager {
                         // After spilling, try to evict clean pages to make room in the cache
                         let mut cache = self.page_cache.write();
                         if let Err(e) = cache.make_room_for(1, false) {
-                            // Cache is completely full with unevictable pages
-                            tracing::error!(
-                                "ensure_cache_space: {e} cache full, could not make room"
+                            if !matches!(e, CacheError::Full) {
+                                return Err(e.into());
+                            }
+                            tracing::debug!(
+                                "ensure_cache_space: cache full after spill; proceeding past soft cache limit"
                             );
-                            return Err(LimboError::CacheError(CacheError::Full));
                         }
                     }
                 }
@@ -4746,11 +4777,7 @@ impl Pager {
             AllocatePage1State::Writing { page } => {
                 turso_assert!(page.is_loaded(), "page should be loaded");
                 tracing::trace!("allocate_page1(Writing done)");
-                let page_key = PageCacheKey::new(page.get().id);
-                let mut cache = self.page_cache.write();
-                cache.insert(page_key, page.clone()).map_err(|e| {
-                    LimboError::InternalError(format!("Failed to insert page 1 into cache: {e:?}"))
-                })?;
+                self.cache_insert_over_soft_limit(page.get().id, page.clone())?;
                 // After we wrote the header page, we may now set this None, to signify we initialized
                 self.init_page_1.store(None);
                 page.unpin();
@@ -4810,9 +4837,7 @@ impl Pager {
                             new_db_size += 1;
                             let page = allocate_new_page(new_db_size as i64, &self.buffer_pool);
                             self.add_dirty(&page)?;
-                            let page_key = PageCacheKey::new(page.get().id as usize);
-                            let mut cache = self.page_cache.write();
-                            cache.insert(page_key, page)?;
+                            self.cache_insert_over_soft_limit(page.get().id as usize, page)?;
                         }
                     }
 
@@ -4968,11 +4993,10 @@ impl Pager {
                         let richard_hipp_special_page =
                             allocate_new_page(new_db_size as i64, &self.buffer_pool);
                         self.add_dirty(&richard_hipp_special_page)?;
-                        let page_key = PageCacheKey::new(richard_hipp_special_page.get().id);
-                        {
-                            let mut cache = self.page_cache.write();
-                            cache.insert(page_key, richard_hipp_special_page).unwrap();
-                        }
+                        self.cache_insert_over_soft_limit(
+                            richard_hipp_special_page.get().id,
+                            richard_hipp_special_page,
+                        )?;
                         // HIPP special page is assumed to zeroed and should never be read or written to by the BTREE
                         new_db_size += 1;
                     }
@@ -4991,12 +5015,7 @@ impl Pager {
                         // setup page and add to cache
                         self.add_dirty(&page)?;
 
-                        let page_key = PageCacheKey::new(page.get().id as usize);
-                        {
-                            // Run in separate block to avoid deadlock on page cache write lock
-                            let mut cache = self.page_cache.write();
-                            cache.insert(page_key, page.clone())?;
-                        }
+                        self.cache_insert_over_soft_limit(page.get().id as usize, page.clone())?;
                         header.database_size = new_db_size.into();
                         *state = AllocatePageState::Start;
                         return Ok(IOResult::Done(page));
@@ -5019,11 +5038,23 @@ impl Pager {
         if dirty_page_must_exist {
             turso_assert!(page.is_dirty(), "page must be dirty for upsert", { "page_id": id });
         }
-        cache.upsert_page(page_key, page.clone()).map_err(|e| {
-            LimboError::InternalError(format!(
-                "Failed to insert loaded page {id} into cache: {e:?}"
-            ))
-        })?;
+        match cache.upsert_page(page_key, page.clone()) {
+            Ok(()) => {}
+            Err(CacheError::Full) => {
+                cache
+                    .force_upsert_page(page_key, page.clone())
+                    .map_err(|e| {
+                        LimboError::InternalError(format!(
+                            "Failed to insert loaded page {id} into cache: {e:?}"
+                        ))
+                    })?
+            }
+            Err(e) => {
+                return Err(LimboError::InternalError(format!(
+                    "Failed to insert loaded page {id} into cache: {e:?}"
+                )));
+            }
+        }
         page.set_loaded();
         page.clear_wal_tag();
         Ok(())
@@ -5431,13 +5462,15 @@ pub(crate) mod ptrmap {
 
 #[cfg(test)]
 mod tests {
-    use crate::sync::Arc;
-
-    use crate::sync::RwLock;
-
+    use crate::io::MemoryIO;
+    use crate::storage::buffer_pool::BufferPool;
+    use crate::storage::database::{DatabaseFile, DatabaseStorage};
     use crate::storage::page_cache::{PageCache, PageCacheKey};
+    use crate::sync::{Arc, Mutex, RwLock};
+    use crate::{OpenFlags, IO};
+    use arc_swap::ArcSwapOption;
 
-    use super::Page;
+    use super::{allocate_new_page, default_page1, Page, Pager};
 
     #[test]
     fn test_shared_cache() {
@@ -5460,6 +5493,40 @@ mod tests {
         let page_key = PageCacheKey::new(1);
         let page = cache.get(&page_key).unwrap();
         assert_eq!(page.unwrap().get().id, 1);
+    }
+
+    #[test]
+    fn upsert_page_in_cache_allows_dirty_page_past_soft_limit() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db_file: Arc<dyn DatabaseStorage> = Arc::new(DatabaseFile::new(
+            io.open_file("test.db", OpenFlags::Create, true).unwrap(),
+        ));
+        let buffer_pool = BufferPool::begin_init(&io, 65536);
+        let init_page_1 = Arc::new(ArcSwapOption::new(Some(default_page1(None))));
+        let pager = Pager::new(
+            db_file,
+            None,
+            io,
+            PageCache::new(1),
+            buffer_pool.clone(),
+            Arc::new(Mutex::new(())),
+            init_page_1,
+        )
+        .unwrap();
+
+        let blocking_page = default_page1(None);
+        pager
+            .page_cache
+            .write()
+            .insert(PageCacheKey::new(1), blocking_page)
+            .unwrap();
+
+        let page = allocate_new_page(2, &buffer_pool);
+        page.set_dirty();
+
+        pager.upsert_page_in_cache(2, page, true).unwrap();
+
+        assert!(pager.page_cache.read().contains_key(&PageCacheKey::new(2)));
     }
 }
 

--- a/tests/integration/wal/test_wal.rs
+++ b/tests/integration/wal/test_wal.rs
@@ -110,6 +110,76 @@ fn test_savepoint_rollback_after_cache_spill_preserves_wal_pages(
     Ok(())
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
+#[turso_macros::test]
+fn test_cache_spill_off_allows_large_wal_update(tmp_db: TempDatabase) -> Result<()> {
+    maybe_setup_tracing();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size=512;")?;
+    conn.execute("PRAGMA journal_mode=WAL;")?;
+    conn.execute("PRAGMA temp_store=MEMORY;")?;
+    conn.execute("PRAGMA cache_spill=OFF;")?;
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, pad TEXT);")?;
+    conn.execute("CREATE INDEX t_k ON t(k);")?;
+    for i in 1..=800 {
+        conn.execute(format!(
+            "INSERT INTO t(id, k, pad) VALUES ({i}, {i}, printf('%0*d', 400, {i}));"
+        ))?;
+    }
+
+    conn.execute("PRAGMA cache_size=200;")?;
+    conn.execute("BEGIN;")?;
+    conn.execute("INSERT INTO t(id, k, pad) VALUES (1001, 1001, printf('%0*d', 400, 1001));")?;
+    conn.execute("INSERT INTO t(id, k, pad) VALUES (1002, 1002, printf('%0*d', 400, 1002));")?;
+    conn.execute("UPDATE t SET pad = printf('%0*d', 400, id + 200000) WHERE id <= 800;")?;
+    conn.execute("COMMIT;")?;
+
+    let result = execute_and_get_ints(
+        &conn,
+        "SELECT COUNT(*), SUM(CASE WHEN id <= 800 AND pad = printf('%0*d', 400, id + 200000) THEN 1 ELSE 0 END) FROM t;",
+    )?;
+    assert_eq!(result, vec![802, 800]);
+
+    let integrity = execute_and_get_strings(&conn, "PRAGMA integrity_check;")?;
+    assert_eq!(integrity, vec!["ok"]);
+
+    Ok(())
+}
+
+#[allow(clippy::arc_with_non_send_sync)]
+#[turso_macros::test]
+fn test_cache_spill_off_allows_page_allocation_past_soft_limit(tmp_db: TempDatabase) -> Result<()> {
+    maybe_setup_tracing();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA page_size=512;")?;
+    conn.execute("PRAGMA journal_mode=WAL;")?;
+    conn.execute("PRAGMA cache_spill=OFF;")?;
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, pad TEXT);")?;
+    conn.execute("CREATE INDEX t_k ON t(k);")?;
+    for i in 1..=120 {
+        conn.execute(format!(
+            "INSERT INTO t(id, k, pad) VALUES ({i}, {i}, printf('%0*d', 300, {i}));"
+        ))?;
+    }
+
+    conn.execute("PRAGMA cache_size=35;")?;
+    conn.execute("BEGIN;")?;
+    conn.execute("SAVEPOINT s;")?;
+    conn.execute("UPDATE t SET pad = printf('%0*d', 4000, id + 100000) WHERE id <= 100;")?;
+    conn.execute("ROLLBACK TO s;")?;
+    conn.execute("RELEASE s;")?;
+    conn.execute("COMMIT;")?;
+
+    let integrity = execute_and_get_strings(&conn, "PRAGMA integrity_check;")?;
+    assert_eq!(integrity, vec!["ok"]);
+
+    Ok(())
+}
+
 #[test]
 #[ignore = "ignored for now because it's flaky"]
 fn test_wal_1_writer_1_reader() -> Result<()> {


### PR DESCRIPTION
## Summary
- treat pager cache size as a soft target when dirty or otherwise unevictable pages prevent spill/eviction
- insert pages over capacity instead of surfacing `Database is busy` / `CacheError(Full)` when spill is intentionally disabled or cannot make room
- add WAL regression coverage for large `PRAGMA cache_spill=OFF` updates and page allocation past the soft cache limit

## Root Cause
`Pager::cache_insert` returned `Busy` when the page cache was full and `try_spill_dirty_pages()` could not spill anything. With `PRAGMA cache_spill=OFF`, SQLite allows the page cache to grow past the configured cache size during the transaction, but Turso treated the configured cache size as a hard correctness limit.

Follow-up simulator coverage exposed the same hard-limit assumption in `allocate_page()`: after `ensure_cache_space()` could not evict/spill, the allocation path still inserted with the hard-capacity `PageCache::insert()`, which could return `CacheError(Full)`. The allocation path now uses the same soft-limit behavior so large WAL transactions can allocate additional pages without failing solely because the configured cache target was exceeded.

Fixes #6947.
Related #6951.

## Validation
- `cargo fmt --check`
- `cargo test -p core_tester --test integration_tests test_cache_spill_off -- --nocapture`
- `cargo test -p core_tester --test integration_tests test_savepoint_rollback_after_cache_spill_preserves_wal_pages -- --nocapture`
- `cargo test -p turso_core storage::page_cache::tests:: -- --nocapture`
- `cargo build -p limbo_sim`
- `RUST_BACKTRACE=1 RUST_LOG=warn timeout 260 target/debug/limbo_sim --seed 17101575555539905257 --profile savepoint_stress --minimum-tests 50 --maximum-tests 800 --maximum-time 180 --disable-bugbase --io-backend memory --keep-files --differential`
- `RUST_BACKTRACE=1 RUST_LOG=warn timeout 260 target/debug/limbo_sim --seed 17649193792492134997 --profile savepoint_stress --minimum-tests 50 --maximum-tests 800 --maximum-time 180 --disable-bugbase --io-backend memory --keep-files`
- `RUST_BACKTRACE=1 RUST_LOG=warn timeout 260 target/debug/limbo_sim --seed 7084303913401513685 --profile savepoint_stress --minimum-tests 50 --maximum-tests 800 --maximum-time 180 --disable-bugbase --io-backend memory --keep-files`
