### PR TITLE
fix: accept uuid blobs in strict uuid columns

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -669,7 +669,7 @@ fn bootstrap_builtin_types(registry: &mut HashMap<String, Arc<TypeDef>>) -> crat
 
     let type_sqls: &[&str] = &[
         #[cfg(feature = "uuid")]
-        "CREATE TYPE uuid(value text) BASE blob ENCODE uuid_blob(value) DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
+        "CREATE TYPE uuid(value any) BASE blob ENCODE uuid_blob(value) DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
         "CREATE TYPE boolean(value any) BASE integer ENCODE boolean_to_int(value) DECODE CASE WHEN value THEN 1 ELSE 0 END OPERATOR '<'",
         #[cfg(feature = "json")]
         "CREATE TYPE json(value text) BASE text ENCODE json(value) DECODE value",

--- a/core/uuid.rs
+++ b/core/uuid.rs
@@ -133,11 +133,23 @@ fn uuid_str(args: &[Value]) -> Value {
 
 #[scalar(name = "uuid_blob")]
 fn uuid_blob(&self, args: &[Value]) -> Value {
-    let Some(text) = args.first().and_then(|a| a.to_text()) else {
+    let Some(value) = args.first() else {
         return Value::error_with_message(
             "wrong number of arguments to function uuid_blob()".into(),
         );
     };
+
+    if let Some(blob) = value.to_blob() {
+        return match uuid::Uuid::from_slice(&blob) {
+            Ok(_) => Value::from_blob(blob),
+            Err(_) => Value::null(),
+        };
+    }
+
+    let Some(text) = value.to_text() else {
+        return Value::null();
+    };
+
     match uuid::Uuid::parse_str(text) {
         Ok(uuid) => Value::from_blob(uuid.as_bytes().to_vec()),
         Err(_) => Value::null(),

--- a/testing/sqltests/turso-tests/custom_types.sqltest
+++ b/testing/sqltests/turso-tests/custom_types.sqltest
@@ -314,7 +314,7 @@ expect {
     smallint(value integer)|integer|CASE WHEN value BETWEEN - 32768 AND 32767 THEN value ELSE RAISE (ABORT, 'integer out of range for smallint') END|value||'<'
     time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE time (value) END|value||'<'
     timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE datetime (value) END|value||'<'
-    uuid(value text)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
+    uuid(value any)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }
 
@@ -345,7 +345,7 @@ expect {
     test_uint(value any)|text|test_uint_encode (value)|test_uint_decode (value)|0|'+' test_uint_add
     time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE time (value) END|value||'<'
     timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE datetime (value) END|value||'<'
-    uuid(value text)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
+    uuid(value any)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }
 

--- a/tests/integration/custom_types.rs
+++ b/tests/integration/custom_types.rs
@@ -3,6 +3,44 @@ mod tests {
     use crate::common::{ExecRows, TempDatabase};
     use tempfile::TempDir;
 
+    #[test]
+    fn test_builtin_uuid_type_accepts_generated_uuid_blob() {
+        let db = TempDatabase::builder()
+            .with_opts(
+                turso_core::DatabaseOpts::new()
+                    .with_custom_types(true)
+                    .with_encryption(true),
+            )
+            .build();
+        let conn = db.connect_limbo();
+
+        conn.execute(
+            "CREATE TABLE events (
+                id uuid PRIMARY KEY,
+                name varchar(100),
+                event_date date,
+                is_active boolean DEFAULT 1,
+                metadata json
+            ) STRICT",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO events VALUES (
+                uuid4(),
+                'Product Launch',
+                '2025-03-15',
+                1,
+                '{\"venue\": \"online\"}'
+            )",
+        )
+        .unwrap();
+
+        let rows: Vec<(String, String)> = conn.exec_rows("SELECT id, name FROM events");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0.len(), 36);
+        assert_eq!(rows[0].1, "Product Launch");
+    }
+
     /// Custom types must be loaded from __turso_internal_types when reopening
     /// a database. Without this, SELECT returns raw encoded values and PRAGMA
     /// list_types omits user-defined types.


### PR DESCRIPTION
# NOTICE:
<!--
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->

## Description

Fixes #6221.

This updates the built-in `uuid` custom type so STRICT `uuid` columns can accept UUID helper functions such as `uuid4()` and `uuid7()`, which produce 16-byte BLOB values. `uuid_blob()` now also passes through valid UUID BLOBs while continuing to parse text UUID input.

## Motivation and context

The documented STRICT-table example fails today because `uuid` declares `value text`, so the pre-encode type check rejects the BLOB returned by `uuid4()` before the UUID encoder can handle it.

This keeps text UUID input working and allows generated UUID BLOBs to pass through the same validation path before being stored as the UUID type's BLOB base representation.

## Tests

```bash
cargo test -p core_tester --test integration_tests custom_types::tests::test_builtin_uuid_type_accepts_generated_uuid_blob -- --nocapture
cargo test -p core_tester --test integration_tests custom_types -- --nocapture
cargo test -p core_tester --test integration_tests functions::test_uuid -- --nocapture
cargo fmt --check
cargo run --bin tursodb -- --quiet --experimental-custom-types ':memory:' "CREATE TABLE events (id uuid PRIMARY KEY, name varchar(100), event_date date, is_active boolean DEFAULT 1, metadata json) STRICT; INSERT INTO events VALUES (uuid4(), 'Product Launch', '2025-03-15', 1, '{\"venue\": \"online\"}'); SELECT length(id), name FROM events;"
```

## Description of AI Usage

Implemented with AI assistance under human direction. The agent helped triage open income-oriented candidates, reproduce this issue locally, add a regression test, make the minimal code change, and run the verification commands above. I reviewed the diff and test output before submitting.
