### PR TITLE
Convert `BitSet` and callers that use it to propagate fallible allocation errors

### DIFF
--- a/.claude/skills/allocator-migration/SKILL.md
+++ b/.claude/skills/allocator-migration/SKILL.md
@@ -171,4 +171,26 @@ Before allocator-sensitive commits, also check the nightly cfg build:
 RUSTFLAGS="--cfg nightly" cargo +nightly check -p turso_core
 ```
 
+For allocator collection performance work, use the Divan comparison script. It
+runs the `alloc_collections` bench by default and prints a sorted std-vs-Turso
+comparison table:
+
+```bash
+scripts/compare-divan-std-turso.py --run
+```
+
+To exercise the nightly allocator paths, run:
+
+```bash
+scripts/compare-divan-std-turso.py --run --nightly
+```
+
+Useful variants:
+
+```bash
+scripts/compare-divan-std-turso.py --run --bench-filter hash_map --filter hash_map
+scripts/compare-divan-std-turso.py --run --save-output /tmp/alloc_collections.txt
+scripts/compare-divan-std-turso.py /tmp/alloc_collections.txt
+```
+
 Run focused tests only when the touched code path is risky, behavior changed, or compilation is not enough to validate the migration.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -195,6 +195,10 @@ harness = false
 required-features = ["bench"]
 
 [[bench]]
+name = "alloc_collections"
+harness = false
+
+[[bench]]
 name = "hash_spill_benchmark"
 harness = false
 required-features = ["bench"]

--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -1,7 +1,5 @@
-use super::{
-    TryClone, TursoAllocExt, TursoBinaryHeapExt, TursoFromIterator, TursoTryWithCapacityExt,
-};
-use crate::alloc::{BinaryHeap, TryReserveError};
+use super::*;
+use crate::alloc::*;
 
 #[cfg(not(nightly))]
 fn binary_heap<T: Ord>() -> BinaryHeap<T> {
@@ -29,9 +27,39 @@ impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
 
 impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push(value);
         Ok(())
+    }
+}
+
+impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
+    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+        let mut values = <Self as TursoAllocExt>::new();
+        values.try_reserve(capacity)?;
+        Ok(values)
+    }
+}
+
+// For these 2 impls we use std::vec because on `stable` we can't use allocator on BinaryHeap, but on nightly we can
+impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
+    fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        // We use std::vec here because on stable we dont have allocators for BinaryHeap. On Nightly, we create a Vec with the TursoAllocator
+        #[cfg(nightly)]
+        let mut values = super::vec::vec();
+        #[cfg(not(nightly))]
+        let mut values = std::vec::Vec::new();
+        values.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            // We already reserved enough space above so no panics should happen
+            values.push(value);
+        }
+        Ok(BinaryHeap::from(values))
     }
 
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
@@ -40,38 +68,15 @@ impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
     {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
+        let mut values = std::mem::take(self).into_vec();
+        values.try_reserve(upper.unwrap_or(lower))?;
         for value in iter {
-            self.try_push(value)?;
+            // We already reserved enough space above so no panics should happen
+            values.push(value);
         }
+
+        *self = BinaryHeap::from(values);
         Ok(())
-    }
-}
-
-impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
-        Ok(values)
-    }
-}
-
-impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
-    fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            values.try_push(value)?;
-        }
-        Ok(values)
     }
 }
 
@@ -86,9 +91,7 @@ impl<T: Clone + Ord> TryClone for BinaryHeap<T> {
             let alloc = self.allocator().clone();
             Self::new_in(alloc)
         };
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
         cloned.extend(self.iter().cloned());
         Ok(cloned)
     }

--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -2,17 +2,18 @@ use super::*;
 use crate::alloc::*;
 
 #[cfg(not(nightly))]
-fn binary_heap<T: Ord>() -> BinaryHeap<T> {
-    std::collections::BinaryHeap::new()
+const fn binary_heap<T: Ord>() -> BinaryHeap<T> {
+    BinaryHeap::new()
 }
 
 #[cfg(nightly)]
-fn binary_heap<T: Ord>() -> BinaryHeap<T> {
-    std::collections::BinaryHeap::new_in(crate::alloc::TursoAllocator)
+const fn binary_heap<T: Ord>() -> BinaryHeap<T> {
+    BinaryHeap::new_in(crate::alloc::TursoAllocator)
 }
 
 #[cfg(not(nightly))]
 impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
+    #[inline(always)]
     fn new() -> Self {
         binary_heap()
     }
@@ -20,70 +21,63 @@ impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
 
 #[cfg(nightly)]
 impl<T: Ord> TursoAllocExt for BinaryHeap<T> {
+    #[inline(always)]
     fn new() -> Self {
         binary_heap()
     }
 }
 
 impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
+    #[inline(always)]
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push(value);
         Ok(())
     }
 }
 
 impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        #[cfg(not(nightly))]
+        {
+            Ok(BinaryHeap::with_capacity(capacity))
+        }
+        #[cfg(nightly)]
+        {
+            Ok(BinaryHeap::with_capacity_in(
+                capacity,
+                crate::alloc::TursoAllocator,
+            ))
+        }
     }
 }
 
 // For these 2 impls we use std::vec because on `stable` we can't use allocator on BinaryHeap, but on nightly we can
 impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        // We use std::vec here because on stable we dont have allocators for BinaryHeap. On Nightly, we create a Vec with the TursoAllocator
-        #[cfg(nightly)]
-        let mut values = super::vec::vec();
         #[cfg(not(nightly))]
-        let mut values = std::vec::Vec::new();
-        values.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_reserve(1)?;
-                values.push(value);
-            }
+        {
+            Ok(iter.into_iter().collect())
         }
-        Ok(BinaryHeap::from(values))
+        #[cfg(nightly)]
+        {
+            // We use std::vec here because on stable we dont have allocators for BinaryHeap. On Nightly, we create a Vec with the TursoAllocator
+            let mut values = super::vec::vec();
+            values.extend(iter);
+            Ok(BinaryHeap::from(values))
+        }
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let mut values = std::mem::take(self).into_vec();
-        values.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_reserve(1)?;
-                values.push(value);
-            }
-        }
-
-        *self = BinaryHeap::from(values);
+        self.extend(iter);
         Ok(())
     }
 }
@@ -91,6 +85,7 @@ impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
 impl<T: Clone + Ord> TryClone for BinaryHeap<T> {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;

--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -55,9 +55,13 @@ impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
         #[cfg(not(nightly))]
         let mut values = std::vec::Vec::new();
         values.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            // We already reserved enough space above so no panics should happen
-            values.push(value);
+        if upper.is_some() {
+            values.extend(iter);
+        } else {
+            for value in iter {
+                values.try_reserve(1)?;
+                values.push(value);
+            }
         }
         Ok(BinaryHeap::from(values))
     }
@@ -70,9 +74,13 @@ impl<T: Ord> TursoFromIterator<T> for BinaryHeap<T> {
         let (lower, upper) = iter.size_hint();
         let mut values = std::mem::take(self).into_vec();
         values.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            // We already reserved enough space above so no panics should happen
-            values.push(value);
+        if upper.is_some() {
+            values.extend(iter);
+        } else {
+            for value in iter {
+                values.try_reserve(1)?;
+                values.push(value);
+            }
         }
 
         *self = BinaryHeap::from(values);

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -57,7 +57,7 @@ where
 
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
-        let mut cloned = Self::with_hasher(self.hasher().clone());
+        let mut cloned = Self::with_hasher(*self.hasher());
         cloned.try_reserve(self.len())?;
         // TODO: have a `TryClone` boundary for K and V here instead of `Clone`
         cloned.extend(self.iter().map(|(key, value)| (key.clone(), value.clone())));

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -52,8 +52,14 @@ where
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for (key, value) in iter {
-            TursoHashMapExt::try_insert(&mut values, key, value)?;
+        if upper.is_some() {
+            for (key, value) in iter {
+                values.insert(key, value);
+            }
+        } else {
+            for (key, value) in iter {
+                TursoHashMapExt::try_insert(&mut values, key, value)?;
+            }
         }
         Ok(values)
     }
@@ -65,8 +71,14 @@ where
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for (key, value) in iter {
-            TursoHashMapExt::try_insert(self, key, value)?;
+        if upper.is_some() {
+            for (key, value) in iter {
+                self.insert(key, value);
+            }
+        } else {
+            for (key, value) in iter {
+                TursoHashMapExt::try_insert(self, key, value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -53,9 +53,7 @@ where
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for (key, value) in iter {
-                values.insert(key, value);
-            }
+            values.extend(iter);
         } else {
             for (key, value) in iter {
                 TursoHashMapExt::try_insert(&mut values, key, value)?;
@@ -72,9 +70,7 @@ where
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
         if upper.is_some() {
-            for (key, value) in iter {
-                self.insert(key, value);
-            }
+            self.extend(iter);
         } else {
             for (key, value) in iter {
                 TursoHashMapExt::try_insert(self, key, value)?;

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -22,22 +22,8 @@ where
     S: BuildHasher,
 {
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         Ok(self.insert(key, value))
-    }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = (K, V)>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for (key, value) in iter {
-            TursoHashMapExt::try_insert(self, key, value)?;
-        }
-        Ok(())
     }
 }
 
@@ -48,9 +34,7 @@ where
 {
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
+        values.try_reserve(capacity)?;
         Ok(values)
     }
 }
@@ -73,6 +57,19 @@ where
         }
         Ok(values)
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for (key, value) in iter {
+            TursoHashMapExt::try_insert(self, key, value)?;
+        }
+        Ok(())
+    }
 }
 
 impl<K, V, S> TryClone for HashMap<K, V, S>
@@ -85,9 +82,8 @@ where
 
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
+        // TODO: have a `TryClone` boundary for K and V here instead of `Clone`
         cloned.extend(self.iter().map(|(key, value)| (key.clone(), value.clone())));
         Ok(cloned)
     }

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -1,93 +1,61 @@
 use std::hash::{BuildHasher, Hash};
 
-use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoHashMapExt, TursoTryWithCapacityExt};
+use rustc_hash::FxBuildHasher;
+
+use super::{TryClone, TursoFromIterator, TursoHashMapExt, TursoTryWithCapacityExt};
 use crate::alloc::{HashMap, TryReserveError};
-
-fn hash_map_with_hasher<K, V, S>(hasher: S) -> HashMap<K, V, S> {
-    std::collections::HashMap::with_hasher(hasher)
-}
-
-impl<K, V, S> TursoAllocExt for HashMap<K, V, S>
-where
-    S: Default,
-{
-    fn new() -> Self {
-        hash_map_with_hasher(S::default())
-    }
-}
 
 impl<K, V, S> TursoHashMapExt<K, V> for HashMap<K, V, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
+    #[inline(always)]
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, TryReserveError> {
-        self.try_reserve(1)?;
         Ok(self.insert(key, value))
     }
 }
 
-impl<K, V, S> TursoTryWithCapacityExt for HashMap<K, V, S>
+impl<K, V> TursoTryWithCapacityExt for HashMap<K, V>
 where
     K: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        Ok(HashMap::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }
 
-impl<K, V, S> TursoFromIterator<(K, V)> for HashMap<K, V, S>
+impl<K, V> TursoFromIterator<(K, V)> for HashMap<K, V>
 where
     K: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for (key, value) in iter {
-                TursoHashMapExt::try_insert(&mut values, key, value)?;
-            }
-        }
-        Ok(values)
+        Ok(iter.into_iter().collect())
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            self.extend(iter);
-        } else {
-            for (key, value) in iter {
-                TursoHashMapExt::try_insert(self, key, value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
 
-impl<K, V, S> TryClone for HashMap<K, V, S>
+impl<K, V> TryClone for HashMap<K, V>
 where
     K: Clone + Eq + Hash,
     V: Clone,
-    S: BuildHasher + Clone,
 {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
         cloned.try_reserve(self.len())?;

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -53,9 +53,7 @@ where
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for value in iter {
-                values.insert(value);
-            }
+            values.extend(iter);
         } else {
             for value in iter {
                 TursoHashSetExt::try_insert(&mut values, value)?;
@@ -72,9 +70,7 @@ where
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
         if upper.is_some() {
-            for value in iter {
-                self.insert(value);
-            }
+            self.extend(iter);
         } else {
             for value in iter {
                 TursoHashSetExt::try_insert(self, value)?;

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -22,22 +22,8 @@ where
     S: BuildHasher,
 {
     fn try_insert(&mut self, value: T) -> Result<bool, TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         Ok(self.insert(value))
-    }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for value in iter {
-            TursoHashSetExt::try_insert(self, value)?;
-        }
-        Ok(())
     }
 }
 
@@ -48,9 +34,7 @@ where
 {
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
+        values.try_reserve(capacity)?;
         Ok(values)
     }
 }
@@ -73,6 +57,19 @@ where
         }
         Ok(values)
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            TursoHashSetExt::try_insert(self, value)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T, S> TryClone for HashSet<T, S>
@@ -84,9 +81,7 @@ where
 
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
         cloned.extend(self.iter().cloned());
         Ok(cloned)
     }

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -52,8 +52,14 @@ where
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            TursoHashSetExt::try_insert(&mut values, value)?;
+        if upper.is_some() {
+            for value in iter {
+                values.insert(value);
+            }
+        } else {
+            for value in iter {
+                TursoHashSetExt::try_insert(&mut values, value)?;
+            }
         }
         Ok(values)
     }
@@ -65,8 +71,14 @@ where
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            TursoHashSetExt::try_insert(self, value)?;
+        if upper.is_some() {
+            for value in iter {
+                self.insert(value);
+            }
+        } else {
+            for value in iter {
+                TursoHashSetExt::try_insert(self, value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -1,81 +1,49 @@
 use std::hash::{BuildHasher, Hash};
 
-use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoHashSetExt, TursoTryWithCapacityExt};
+use rustc_hash::FxBuildHasher;
+
+use super::{TryClone, TursoFromIterator, TursoHashSetExt, TursoTryWithCapacityExt};
 use crate::alloc::{HashSet, TryReserveError};
-
-fn hash_set_with_hasher<T, S>(hasher: S) -> HashSet<T, S> {
-    std::collections::HashSet::with_hasher(hasher)
-}
-
-impl<T, S> TursoAllocExt for HashSet<T, S>
-where
-    S: Default,
-{
-    fn new() -> Self {
-        hash_set_with_hasher(S::default())
-    }
-}
 
 impl<T, S> TursoHashSetExt<T> for HashSet<T, S>
 where
     T: Eq + Hash,
     S: BuildHasher,
 {
+    #[inline(always)]
     fn try_insert(&mut self, value: T) -> Result<bool, TryReserveError> {
-        self.try_reserve(1)?;
         Ok(self.insert(value))
     }
 }
 
-impl<T, S> TursoTryWithCapacityExt for HashSet<T, S>
+impl<T> TursoTryWithCapacityExt for HashSet<T>
 where
     T: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        Ok(HashSet::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }
 
-impl<T, S> TursoFromIterator<T> for HashSet<T, S>
+impl<T> TursoFromIterator<T> for HashSet<T>
 where
     T: Eq + Hash,
-    S: BuildHasher + Default,
 {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                TursoHashSetExt::try_insert(&mut values, value)?;
-            }
-        }
-        Ok(values)
+        Ok(iter.into_iter().collect())
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            self.extend(iter);
-        } else {
-            for value in iter {
-                TursoHashSetExt::try_insert(self, value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
@@ -87,6 +55,7 @@ where
 {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         let mut cloned = Self::with_hasher(self.hasher().clone());
         cloned.try_reserve(self.len())?;

--- a/core/alloc/collections/iterator.rs
+++ b/core/alloc/collections/iterator.rs
@@ -10,7 +10,7 @@ where
         I: IntoIterator<Item = Option<T>>,
     {
         let mut saw_none = false;
-        let values = C::try_from_iter(iter.into_iter().scan((), |(), item| match item {
+        let values = C::try_from_iter(iter.into_iter().map_while(|item| match item {
             Some(value) => Some(value),
             None => {
                 saw_none = true;
@@ -32,7 +32,7 @@ where
             return Ok(());
         };
         let mut saw_none = false;
-        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+        values.try_extend(iter.into_iter().map_while(|item| match item {
             Some(value) => Some(value),
             None => {
                 saw_none = true;
@@ -56,7 +56,7 @@ where
         I: IntoIterator<Item = Result<T, E>>,
     {
         let mut error = None;
-        let values = C::try_from_iter(iter.into_iter().scan((), |(), item| match item {
+        let values = C::try_from_iter(iter.into_iter().map_while(|item| match item {
             Ok(value) => Some(value),
             Err(err) => {
                 error = Some(F::from(err));
@@ -78,7 +78,7 @@ where
             return Ok(());
         };
         let mut error = None;
-        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+        values.try_extend(iter.into_iter().map_while(|item| match item {
             Ok(value) => Some(value),
             Err(err) => {
                 error = Some(F::from(err));

--- a/core/alloc/collections/iterator.rs
+++ b/core/alloc/collections/iterator.rs
@@ -17,11 +17,28 @@ where
                 None
             }
         }))?;
+        if saw_none { Ok(None) } else { Ok(Some(values)) }
+    }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = Option<T>>,
+    {
+        let Some(values) = self else {
+            return Ok(());
+        };
+        let mut saw_none = false;
+        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+            Some(value) => Some(value),
+            None => {
+                saw_none = true;
+                None
+            }
+        }))?;
         if saw_none {
-            Ok(None)
-        } else {
-            Ok(Some(values))
+            *self = None;
         }
+        Ok(())
     }
 }
 
@@ -48,6 +65,154 @@ where
             Ok(Ok(values))
         }
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = Result<T, E>>,
+    {
+        let Ok(values) = self else {
+            return Ok(());
+        };
+        let mut error = None;
+        values.try_extend(iter.into_iter().scan((), |(), item| match item {
+            Ok(value) => Some(value),
+            Err(err) => {
+                error = Some(F::from(err));
+                None
+            }
+        }))?;
+        if let Some(error) = error {
+            *self = Err(error);
+        }
+        Ok(())
+    }
 }
 
 impl<I: Iterator> TursoIteratorExt for I {}
+
+macro_rules! impl_tuple_from_iterator {
+    ($(($ty:ident, $from_ty:ident, $item:ident, $collection:ident)),+) => {
+        impl<$($ty,)+ $($from_ty,)+> TursoFromIterator<($($ty,)+)> for ($($from_ty,)+)
+        where
+            $($from_ty: TursoFromIterator<$ty>,)+
+        {
+            fn try_from_iter<Iter>(iter: Iter) -> Result<Self, TryReserveError>
+            where
+                Iter: IntoIterator<Item = ($($ty,)+)>,
+            {
+                let mut values = ($($from_ty::try_from_iter(std::iter::empty())?,)+);
+                values.try_extend(iter)?;
+                Ok(values)
+            }
+
+            fn try_extend<Iter>(&mut self, iter: Iter) -> Result<(), TryReserveError>
+            where
+                Iter: IntoIterator<Item = ($($ty,)+)>,
+            {
+                let ($($collection,)+) = self;
+                for ($($item,)+) in iter {
+                    $($collection.try_extend(std::iter::once($item))?;)+
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_tuple_from_iterator!((A, FromA, a, from_a));
+impl_tuple_from_iterator!((A, FromA, a, from_a), (B, FromB, b, from_b));
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i),
+    (J, FromJ, j, from_j)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i),
+    (J, FromJ, j, from_j),
+    (K, FromK, k, from_k)
+);
+impl_tuple_from_iterator!(
+    (A, FromA, a, from_a),
+    (B, FromB, b, from_b),
+    (C, FromC, c, from_c),
+    (D, FromD, d, from_d),
+    (E, FromE, e, from_e),
+    (F, FromF, f, from_f),
+    (G, FromG, g, from_g),
+    (H, FromH, h, from_h),
+    (I, FromI, i, from_i),
+    (J, FromJ, j, from_j),
+    (K, FromK, k, from_k),
+    (L, FromL, l, from_l)
+);

--- a/core/alloc/collections/iterator.rs
+++ b/core/alloc/collections/iterator.rs
@@ -17,7 +17,11 @@ where
                 None
             }
         }))?;
-        if saw_none { Ok(None) } else { Ok(Some(values)) }
+        if saw_none {
+            Ok(None)
+        } else {
+            Ok(Some(values))
+        }
     }
 
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -53,6 +53,7 @@ pub trait TursoFromIterator<T>: Sized {
 }
 
 pub trait TursoIteratorExt: Iterator + Sized {
+    #[inline]
     fn try_collect<C>(self) -> Result<C, TryReserveError>
     where
         C: TursoFromIterator<Self::Item>,
@@ -60,6 +61,7 @@ pub trait TursoIteratorExt: Iterator + Sized {
         C::try_from_iter(self)
     }
 
+    #[inline]
     fn try_unzip<A, B, FromA, FromB>(self) -> Result<(FromA, FromB), TryReserveError>
     where
         (FromA, FromB): TursoFromIterator<(A, B)>,

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -23,42 +23,31 @@ pub trait TursoBoxExt<T>: Sized {
 pub trait TursoVecExt<T>: Sized {
     fn with_capacity(capacity: usize) -> Self;
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoHashMapExt<K, V>: Sized {
     fn try_insert(&mut self, key: K, value: V) -> Result<Option<V>, TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = (K, V)>;
 }
 
 pub trait TursoHashSetExt<T>: Sized {
     fn try_insert(&mut self, value: T) -> Result<bool, TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoVecDequeExt<T>: Sized {
     fn try_push_back(&mut self, value: T) -> Result<(), TryReserveError>;
     fn try_push_front(&mut self, value: T) -> Result<(), TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoBinaryHeapExt<T>: Sized {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>;
 }
 
 pub trait TursoFromIterator<T>: Sized {
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
+    where
+        I: IntoIterator<Item = T>;
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>;
 }
@@ -69,6 +58,14 @@ pub trait TursoIteratorExt: Iterator + Sized {
         C: TursoFromIterator<Self::Item>,
     {
         C::try_from_iter(self)
+    }
+
+    fn try_unzip<A, B, FromA, FromB>(self) -> Result<(FromA, FromB), TryReserveError>
+    where
+        (FromA, FromB): TursoFromIterator<(A, B)>,
+        Self: Iterator<Item = (A, B)>,
+    {
+        <(FromA, FromB) as TursoFromIterator<(A, B)>>::try_from_iter(self)
     }
 }
 

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -21,7 +21,7 @@ impl<T> TursoVecExt<T> for Vec<T> {
     }
 
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push(value);
         Ok(())
     }
@@ -32,9 +32,7 @@ impl<T> TursoTryWithCapacityExt for Vec<T> {
         #[cfg(not(nightly))]
         {
             let mut values = vec();
-            values
-                .try_reserve(capacity)
-                .map_err(TryReserveError::from)?;
+            values.try_reserve(capacity)?;
             Ok(values)
         }
         #[cfg(nightly)]
@@ -55,9 +53,7 @@ impl<T> TursoFromIterator<T> for Vec<T> {
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for value in iter {
-                values.push(value);
-            }
+            values.extend(iter);
         } else {
             for value in iter {
                 values.try_push(value)?;

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -1,83 +1,79 @@
 use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoTryWithCapacityExt, TursoVecExt};
-use crate::alloc::{TryReserveError, TursoAllocator, Vec};
+#[cfg(nightly)]
+use crate::alloc::TursoAllocator;
+use crate::alloc::{TryReserveError, Vec};
 
-pub(super) fn vec<T>() -> Vec<T> {
+#[cfg(not(nightly))]
+pub(super) const fn vec<T>() -> Vec<T> {
+    Vec::new()
+}
+
+#[cfg(nightly)]
+pub(super) const fn vec<T>() -> Vec<T> {
     Vec::new_in(TursoAllocator)
 }
 
+#[cfg(not(nightly))]
+fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
+    Vec::with_capacity(capacity)
+}
+
+#[cfg(nightly)]
 fn vec_with_capacity<T>(capacity: usize) -> Vec<T> {
     Vec::with_capacity_in(capacity, TursoAllocator)
 }
 
 impl<T> TursoAllocExt for Vec<T> {
+    #[inline(always)]
     fn new() -> Self {
         vec()
     }
 }
 
 impl<T> TursoVecExt<T> for Vec<T> {
+    #[inline(always)]
     fn with_capacity(capacity: usize) -> Self {
         vec_with_capacity(capacity)
     }
 
+    #[inline(always)]
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push(value);
         Ok(())
     }
 }
 
 impl<T> TursoTryWithCapacityExt for Vec<T> {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        #[cfg(not(nightly))]
-        {
-            let mut values = vec();
-            values.try_reserve(capacity)?;
-            Ok(values)
-        }
-        #[cfg(nightly)]
-        {
-            std::vec::Vec::try_with_capacity_in(capacity, TursoAllocator)
-                .map_err(TryReserveError::from)
-        }
+        Ok(vec_with_capacity(capacity))
     }
 }
 
 impl<T> TursoFromIterator<T> for Vec<T> {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_push(value)?;
-            }
+        #[cfg(not(nightly))]
+        {
+            Ok(iter.into_iter().collect())
         }
-        Ok(values)
+        #[cfg(nightly)]
+        {
+            let mut values = vec();
+            values.extend(iter);
+            Ok(values)
+        }
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            for value in iter {
-                self.push(value);
-            }
-        } else {
-            for value in iter {
-                self.try_push(value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
@@ -85,6 +81,7 @@ impl<T> TursoFromIterator<T> for Vec<T> {
 impl<T: Clone> TryClone for Vec<T> {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -54,8 +54,14 @@ impl<T> TursoFromIterator<T> for Vec<T> {
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            values.try_push(value)?;
+        if upper.is_some() {
+            for value in iter {
+                values.push(value);
+            }
+        } else {
+            for value in iter {
+                values.try_push(value)?;
+            }
         }
         Ok(values)
     }
@@ -67,8 +73,14 @@ impl<T> TursoFromIterator<T> for Vec<T> {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            self.try_push(value)?;
+        if upper.is_some() {
+            for value in iter {
+                self.push(value);
+            }
+        } else {
+            for value in iter {
+                self.try_push(value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -1,7 +1,7 @@
 use super::{TryClone, TursoAllocExt, TursoFromIterator, TursoTryWithCapacityExt, TursoVecExt};
 use crate::alloc::{TryReserveError, TursoAllocator, Vec};
 
-fn vec<T>() -> Vec<T> {
+pub(super) fn vec<T>() -> Vec<T> {
     Vec::new_in(TursoAllocator)
 }
 
@@ -23,20 +23,6 @@ impl<T> TursoVecExt<T> for Vec<T> {
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
         self.try_reserve(1).map_err(TryReserveError::from)?;
         self.push(value);
-        Ok(())
-    }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for value in iter {
-            self.try_push(value)?;
-        }
         Ok(())
     }
 }
@@ -72,6 +58,19 @@ impl<T> TursoFromIterator<T> for Vec<T> {
             values.try_push(value)?;
         }
         Ok(values)
+    }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            self.try_push(value)?;
+        }
+        Ok(())
     }
 }
 

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -60,8 +60,14 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let (lower, upper) = iter.size_hint();
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        for value in iter {
-            values.try_push_back(value)?;
+        if upper.is_some() {
+            for value in iter {
+                values.push_back(value);
+            }
+        } else {
+            for value in iter {
+                values.try_push_back(value)?;
+            }
         }
         Ok(values)
     }
@@ -73,8 +79,14 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let iter = iter.into_iter();
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
-        for value in iter {
-            self.try_push_back(value)?;
+        if upper.is_some() {
+            for value in iter {
+                self.push_back(value);
+            }
+        } else {
+            for value in iter {
+                self.try_push_back(value)?;
+            }
         }
         Ok(())
     }

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -29,13 +29,13 @@ impl<T> TursoAllocExt for VecDeque<T> {
 
 impl<T> TursoVecDequeExt<T> for VecDeque<T> {
     fn try_push_back(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push_back(value);
         Ok(())
     }
 
     fn try_push_front(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1).map_err(TryReserveError::from)?;
+        self.try_reserve(1)?;
         self.push_front(value);
         Ok(())
     }
@@ -44,9 +44,7 @@ impl<T> TursoVecDequeExt<T> for VecDeque<T> {
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
         let mut values = <Self as TursoAllocExt>::new();
-        values
-            .try_reserve(capacity)
-            .map_err(TryReserveError::from)?;
+        values.try_reserve(capacity)?;
         Ok(values)
     }
 }
@@ -61,9 +59,7 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let capacity = upper.unwrap_or(lower);
         let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
         if upper.is_some() {
-            for value in iter {
-                values.push_back(value);
-            }
+            values.extend(iter);
         } else {
             for value in iter {
                 values.try_push_back(value)?;
@@ -80,9 +76,7 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         let (lower, upper) = iter.size_hint();
         self.try_reserve(upper.unwrap_or(lower))?;
         if upper.is_some() {
-            for value in iter {
-                self.push_back(value);
-            }
+            self.extend(iter);
         } else {
             for value in iter {
                 self.try_push_back(value)?;

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -4,17 +4,28 @@ use super::{
 use crate::alloc::{TryReserveError, VecDeque};
 
 #[cfg(not(nightly))]
-fn vec_deque<T>() -> VecDeque<T> {
+const fn vec_deque<T>() -> VecDeque<T> {
     std::collections::VecDeque::new()
 }
 
 #[cfg(nightly)]
-fn vec_deque<T>() -> VecDeque<T> {
+const fn vec_deque<T>() -> VecDeque<T> {
     std::collections::VecDeque::new_in(crate::alloc::TursoAllocator)
 }
 
 #[cfg(not(nightly))]
+fn vec_deque_with_capacity<T>(capacity: usize) -> VecDeque<T> {
+    std::collections::VecDeque::with_capacity(capacity)
+}
+
+#[cfg(nightly)]
+fn vec_deque_with_capacity<T>(capacity: usize) -> VecDeque<T> {
+    std::collections::VecDeque::with_capacity_in(capacity, crate::alloc::TursoAllocator)
+}
+
+#[cfg(not(nightly))]
 impl<T> TursoAllocExt for VecDeque<T> {
+    #[inline(always)]
     fn new() -> Self {
         vec_deque()
     }
@@ -22,66 +33,57 @@ impl<T> TursoAllocExt for VecDeque<T> {
 
 #[cfg(nightly)]
 impl<T> TursoAllocExt for VecDeque<T> {
+    #[inline(always)]
     fn new() -> Self {
         vec_deque()
     }
 }
 
 impl<T> TursoVecDequeExt<T> for VecDeque<T> {
+    #[inline(always)]
     fn try_push_back(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push_back(value);
         Ok(())
     }
 
+    #[inline(always)]
     fn try_push_front(&mut self, value: T) -> Result<(), TryReserveError> {
-        self.try_reserve(1)?;
         self.push_front(value);
         Ok(())
     }
 }
 
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
+    #[inline(always)]
     fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
-        let mut values = <Self as TursoAllocExt>::new();
-        values.try_reserve(capacity)?;
-        Ok(values)
+        Ok(vec_deque_with_capacity(capacity))
     }
 }
 
 impl<T> TursoFromIterator<T> for VecDeque<T> {
+    #[inline(always)]
     fn try_from_iter<I>(iter: I) -> Result<Self, TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        let capacity = upper.unwrap_or(lower);
-        let mut values = <Self as TursoTryWithCapacityExt>::try_with_capacity(capacity)?;
-        if upper.is_some() {
-            values.extend(iter);
-        } else {
-            for value in iter {
-                values.try_push_back(value)?;
-            }
+        #[cfg(not(nightly))]
+        {
+            Ok(iter.into_iter().collect())
         }
-        Ok(values)
+        #[cfg(nightly)]
+        {
+            let mut values = super::vec::vec();
+            values.extend(iter);
+            Ok(Self::from(values))
+        }
     }
 
+    #[inline(always)]
     fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
     where
         I: IntoIterator<Item = T>,
     {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))?;
-        if upper.is_some() {
-            self.extend(iter);
-        } else {
-            for value in iter {
-                self.try_push_back(value)?;
-            }
-        }
+        self.extend(iter);
         Ok(())
     }
 }
@@ -89,6 +91,7 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
 impl<T: Clone> TryClone for VecDeque<T> {
     type Error = TryReserveError;
 
+    #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
         let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -39,20 +39,6 @@ impl<T> TursoVecDequeExt<T> for VecDeque<T> {
         self.push_front(value);
         Ok(())
     }
-
-    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let iter = iter.into_iter();
-        let (lower, upper) = iter.size_hint();
-        self.try_reserve(upper.unwrap_or(lower))
-            .map_err(TryReserveError::from)?;
-        for value in iter {
-            self.try_push_back(value)?;
-        }
-        Ok(())
-    }
 }
 
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
@@ -79,6 +65,19 @@ impl<T> TursoFromIterator<T> for VecDeque<T> {
         }
         Ok(values)
     }
+
+    fn try_extend<I>(&mut self, iter: I) -> Result<(), TryReserveError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter();
+        let (lower, upper) = iter.size_hint();
+        self.try_reserve(upper.unwrap_or(lower))?;
+        for value in iter {
+            self.try_push_back(value)?;
+        }
+        Ok(())
+    }
 }
 
 impl<T: Clone> TryClone for VecDeque<T> {
@@ -92,9 +91,7 @@ impl<T: Clone> TryClone for VecDeque<T> {
             let alloc = self.allocator().clone();
             Self::new_in(alloc)
         };
-        cloned
-            .try_reserve(self.len())
-            .map_err(TryReserveError::from)?;
+        cloned.try_reserve(self.len())?;
         cloned.extend(self.iter().cloned());
         Ok(cloned)
     }

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -1,8 +1,7 @@
 //! Turso-owned allocation namespace.
 //!
-//! Stable builds use `allocator-api2` where it has allocator-aware types and
-//! fall back to `std` for collections that do not have stable allocator-aware
-//! equivalents. Builds compiled with `--cfg nightly` use Rust's unstable
+//! Stable builds use `std` collections where allocator parameters are not
+//! available. Builds compiled with `--cfg nightly` use Rust's unstable
 //! `allocator_api` collection parameters.
 
 use std::fmt;
@@ -54,7 +53,7 @@ pub type Box<T> = allocator_api2::boxed::Box<T, TursoAllocator>;
 pub type Box<T> = std::boxed::Box<T, TursoAllocator>;
 
 #[cfg(not(nightly))]
-pub type Vec<T> = allocator_api2::vec::Vec<T, TursoAllocator>;
+pub type Vec<T> = std::vec::Vec<T>;
 #[cfg(nightly)]
 pub type Vec<T> = std::vec::Vec<T, TursoAllocator>;
 

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -44,7 +44,7 @@ fn try_extend_accepts_iterators_without_upper_bounds() {
 
 #[test]
 fn hash_map_try_insert_and_extend_reserve_before_mutation() {
-    let mut values: HashMap<&str, usize> = TursoAllocExt::new();
+    let mut values: HashMap<&str, usize> = HashMap::default();
 
     assert_eq!(
         TursoHashMapExt::try_insert(&mut values, "one", 1).unwrap(),
@@ -63,7 +63,7 @@ fn hash_map_try_insert_and_extend_reserve_before_mutation() {
 
 #[test]
 fn hash_set_try_insert_and_extend_reserve_before_mutation() {
-    let mut values: HashSet<usize> = TursoAllocExt::new();
+    let mut values: HashSet<usize> = HashSet::default();
 
     assert!(TursoHashSetExt::try_insert(&mut values, 1).unwrap());
     assert!(!TursoHashSetExt::try_insert(&mut values, 1).unwrap());

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -110,6 +110,15 @@ fn iterator_try_collect_builds_turso_vec() {
 }
 
 #[test]
+fn try_extend_extends_existing_collection() {
+    let mut values = try_vec![1].unwrap();
+
+    values.try_extend([2, 3]).unwrap();
+
+    assert_eq!(values.as_slice(), &[1, 2, 3]);
+}
+
+#[test]
 fn try_vec_macro_builds_turso_vecs() {
     let empty: Vec<usize> = try_vec![].unwrap();
     let repeated: Vec<_> = try_vec![7; 3].unwrap();
@@ -197,6 +206,51 @@ fn iterator_try_collect_accepts_try_vec_results() {
 
     assert_eq!(values[0].as_slice(), &[false]);
     assert_eq!(values[1].as_slice(), &[false, false]);
+}
+
+#[test]
+fn tuple_try_extend_extends_both_collections() {
+    let mut values: (Vec<_>, VecDeque<_>) = (Vec::new(), VecDeque::new());
+
+    values
+        .try_extend([(1, "one"), (2, "two"), (3, "three")])
+        .unwrap();
+
+    assert_eq!(values.0.as_slice(), &[1, 2, 3]);
+    assert_eq!(
+        values.1.into_iter().collect::<std::vec::Vec<_>>(),
+        ["one", "two", "three"]
+    );
+}
+
+#[test]
+fn tuple_try_collect_builds_three_collections() {
+    let (numbers, words, flags): (Vec<_>, VecDeque<_>, Vec<_>) =
+        [(1, "one", true), (2, "two", false), (3, "three", true)]
+            .into_iter()
+            .try_collect()
+            .unwrap();
+
+    assert_eq!(numbers.as_slice(), &[1, 2, 3]);
+    assert_eq!(
+        words.into_iter().collect::<std::vec::Vec<_>>(),
+        ["one", "two", "three"]
+    );
+    assert_eq!(flags.as_slice(), &[true, false, true]);
+}
+
+#[test]
+fn iterator_try_unzip_builds_turso_collections() {
+    let (numbers, words): (Vec<_>, VecDeque<_>) = [(1, "one"), (2, "two"), (3, "three")]
+        .into_iter()
+        .try_unzip()
+        .unwrap();
+
+    assert_eq!(numbers.as_slice(), &[1, 2, 3]);
+    assert_eq!(
+        words.into_iter().collect::<std::vec::Vec<_>>(),
+        ["one", "two", "three"]
+    );
 }
 
 #[test]

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -1,0 +1,763 @@
+use divan::{black_box, AllocProfiler, Bencher};
+use mimalloc::MiMalloc;
+use rustc_hash::FxBuildHasher;
+use turso_core::alloc::{
+    self, TursoBinaryHeapExt, TursoFromIterator, TursoHashMapExt, TursoHashSetExt,
+    TursoIteratorExt, TursoTryWithCapacityExt, TursoVecDequeExt, TursoVecExt,
+};
+
+#[global_allocator]
+static ALLOC: AllocProfiler<MiMalloc> = AllocProfiler::new(MiMalloc);
+
+#[cfg(not(feature = "codspeed"))]
+const SAMPLE_COUNT: u32 = 1000;
+
+#[cfg(not(feature = "codspeed"))]
+fn main() {
+    divan::Divan::default().sample_count(SAMPLE_COUNT).main();
+}
+
+#[cfg(feature = "codspeed")]
+fn main() {
+    divan::main();
+}
+
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct NonCopyValue {
+    id: usize,
+    payload: [usize; 4],
+}
+
+impl NonCopyValue {
+    fn new(id: usize) -> Self {
+        Self {
+            id,
+            payload: [
+                id,
+                id.wrapping_mul(3),
+                id.rotate_left(7),
+                id ^ 0x9e37_79b9_7f4a_7c15,
+            ],
+        }
+    }
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_push_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| {
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+        })
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values.try_push(black_box(value)).unwrap();
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_push_std(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| std::vec::Vec::with_capacity(len))
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values.push(black_box(value));
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::Vec<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len).map(black_box).collect::<std::vec::Vec<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::vec::Vec::with_capacity(len);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_push_back_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        for value in 0..len {
+            values.try_push_back(black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_push_back_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        for value in 0..len {
+            values.push_back(black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::VecDeque<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .collect::<std::collections::VecDeque<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_push_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        for value in 0..len {
+            values.try_push(black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_push_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        for value in 0..len {
+            values.push(black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::BinaryHeap<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .collect::<std::collections::BinaryHeap<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashSetExt::try_insert(&mut values, black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .try_collect::<alloc::HashSet<_, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(black_box)
+            .collect::<std::collections::HashSet<_, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(black_box));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashMapExt::try_insert(&mut values, black_box(value), black_box(value)).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| (black_box(value), black_box(value)))
+            .try_collect::<alloc::HashMap<_, _, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| (black_box(value), black_box(value)))
+            .collect::<std::collections::HashMap<_, _, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| (black_box(value), black_box(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(|value| (black_box(value), black_box(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(black_box(value), black_box(value));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_push_std(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| std::vec::Vec::with_capacity(len))
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values.push(black_box(NonCopyValue::new(value)));
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_push_turso(bencher: Bencher, len: usize) {
+    bencher
+        .with_inputs(|| {
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+        })
+        .bench_local_values(|mut values| {
+            for value in 0..len {
+                values
+                    .try_push(black_box(NonCopyValue::new(value)))
+                    .unwrap();
+            }
+            black_box(values)
+        });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::vec::Vec<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::Vec<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::vec::Vec::with_capacity(len);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_push_back_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        for value in 0..len {
+            values.push_back(black_box(NonCopyValue::new(value)));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_push_back_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        for value in 0..len {
+            values
+                .try_push_back(black_box(NonCopyValue::new(value)))
+                .unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::collections::VecDeque<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::VecDeque<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_push_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        for value in 0..len {
+            values.push(black_box(NonCopyValue::new(value)));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_push_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        for value in 0..len {
+            values
+                .try_push(black_box(NonCopyValue::new(value)))
+                .unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::collections::BinaryHeap<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::BinaryHeap<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+                .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(black_box(NonCopyValue::new(value)));
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashSetExt::try_insert(&mut values, black_box(NonCopyValue::new(value))).unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .collect::<std::collections::HashSet<_, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| black_box(NonCopyValue::new(value)))
+            .try_collect::<alloc::HashSet<_, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(|value| black_box(NonCopyValue::new(value))));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| black_box(NonCopyValue::new(value))),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_insert_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        for value in 0..len {
+            values.insert(
+                black_box(NonCopyValue::new(value)),
+                black_box(NonCopyValue::new(value.wrapping_mul(3))),
+            );
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_insert_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        for value in 0..len {
+            TursoHashMapExt::try_insert(
+                &mut values,
+                black_box(NonCopyValue::new(value)),
+                black_box(NonCopyValue::new(value.wrapping_mul(3))),
+            )
+            .unwrap();
+        }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_collect_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| {
+                (
+                    black_box(NonCopyValue::new(value)),
+                    black_box(NonCopyValue::new(value.wrapping_mul(3))),
+                )
+            })
+            .collect::<std::collections::HashMap<_, _, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_collect_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = (0..len)
+            .map(|value| {
+                (
+                    black_box(NonCopyValue::new(value)),
+                    black_box(NonCopyValue::new(value.wrapping_mul(3))),
+                )
+            })
+            .try_collect::<alloc::HashMap<_, _, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_extend_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend((0..len).map(|value| {
+            (
+                black_box(NonCopyValue::new(value)),
+                black_box(NonCopyValue::new(value.wrapping_mul(3))),
+            )
+        }));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_non_copy_extend_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            (0..len).map(|value| {
+                (
+                    black_box(NonCopyValue::new(value)),
+                    black_box(NonCopyValue::new(value.wrapping_mul(3))),
+                )
+            }),
+        )
+        .unwrap();
+        black_box(values)
+    });
+}

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -42,6 +42,32 @@ impl NonCopyValue {
     }
 }
 
+struct LowerBoundOnly<I> {
+    iter: I,
+}
+
+impl<I> LowerBoundOnly<I> {
+    fn new(iter: I) -> Self {
+        Self { iter }
+    }
+}
+
+impl<I> Iterator for LowerBoundOnly<I>
+where
+    I: Iterator,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, _) = self.iter.size_hint();
+        (lower, None)
+    }
+}
+
 #[divan::bench(args = [64, 1_024, 16_384])]
 fn vec_push_turso(bencher: Bencher, len: usize) {
     bencher
@@ -370,6 +396,213 @@ fn hash_map_insert_std(bencher: Bencher, len: usize) {
         for value in 0..len {
             values.insert(black_box(value), black_box(value));
         }
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box)).collect::<std::vec::Vec<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::Vec<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::vec::Vec::with_capacity(len);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values =
+            LowerBoundOnly::new((0..len).map(black_box)).collect::<std::collections::VecDeque<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::VecDeque<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::VecDeque::with_capacity(len);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn vec_deque_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .collect::<std::collections::BinaryHeap<_>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::BinaryHeap<_>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::BinaryHeap::with_capacity(len);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn binary_heap_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .collect::<std::collections::HashSet<_, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values = LowerBoundOnly::new((0..len).map(black_box))
+            .try_collect::<alloc::HashSet<_, FxBuildHasher>>()
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashSet::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend(LowerBoundOnly::new((0..len).map(black_box)));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_set_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
+            .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values =
+            LowerBoundOnly::new((0..len).map(|value| (black_box(value), black_box(value))))
+                .collect::<std::collections::HashMap<_, _, FxBuildHasher>>();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_collect_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let values =
+            LowerBoundOnly::new((0..len).map(|value| (black_box(value), black_box(value))))
+                .try_collect::<alloc::HashMap<_, _, FxBuildHasher>>()
+                .unwrap();
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_unknown_upper_std(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values = std::collections::HashMap::with_capacity_and_hasher(len, FxBuildHasher);
+        values.extend(LowerBoundOnly::new(
+            (0..len).map(|value| (black_box(value), black_box(value))),
+        ));
+        black_box(values)
+    });
+}
+
+#[divan::bench(args = [64, 1_024, 16_384])]
+fn hash_map_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
+    bencher.bench_local(|| {
+        let mut values =
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+                len,
+            )
+            .unwrap();
+        TursoFromIterator::try_extend(
+            &mut values,
+            LowerBoundOnly::new((0..len).map(|value| (black_box(value), black_box(value)))),
+        )
+        .unwrap();
         black_box(values)
     });
 }

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -291,7 +291,7 @@ impl AggregateFunction {
             _ => {
                 return Err(LimboError::InternalError(format!(
                     "Unknown aggregate type code: {type_code:?}"
-                )))
+                )));
             }
         };
 
@@ -827,7 +827,7 @@ impl AggregateState {
             _ => {
                 return Err(LimboError::InternalError(format!(
                     "Expected Integer for aggregate count, got {num_aggregates:?}"
-                )))
+                )));
             }
         };
         cursor += 1;
@@ -927,7 +927,7 @@ impl AggregateState {
                         _ => {
                             return Err(LimboError::InternalError(format!(
                                 "Expected Float for AVG sum, got {sum:?}"
-                            )))
+                            )));
                         }
                     };
                     cursor += 1;
@@ -940,7 +940,7 @@ impl AggregateState {
                         _ => {
                             return Err(LimboError::InternalError(format!(
                                 "Expected Integer for AVG count, got {count:?}"
-                            )))
+                            )));
                         }
                     };
                     cursor += 1;
@@ -1024,12 +1024,12 @@ impl AggregateState {
             Value::Numeric(Numeric::Integer(n)) => {
                 return Err(LimboError::InternalError(format!(
                     "Negative group key count: {n}"
-                )))
+                )));
             }
             other => {
                 return Err(LimboError::InternalError(format!(
                     "Expected Integer for group key count, got {other:?}"
-                )))
+                )));
             }
         };
 
@@ -1408,7 +1408,7 @@ impl AggregateOperator {
                 AggregateFunction::CountDistinct(col_idx)
                 | AggregateFunction::SumDistinct(col_idx)
                 | AggregateFunction::AvgDistinct(col_idx) => {
-                    distinct_columns.set(*col_idx);
+                    distinct_columns.set(*col_idx)?;
                 }
                 _ => {}
             }

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -708,7 +708,7 @@ impl AggregateEvalState {
                         existing_groups,
                         old_values,
                         pre_existing_groups,
-                    );
+                    )?;
 
                     *self = AggregateEvalState::Done {
                         output: (output_delta, computed_states),
@@ -1062,7 +1062,7 @@ impl AggregateState {
         aggregates: &[AggregateFunction],
         _column_names: &[String], // No longer needed
         distinct_transitions: &HashMap<usize, DistinctTransition>,
-    ) {
+    ) -> Result<()> {
         // Update COUNT
         self.count += weight as i64;
 
@@ -1089,7 +1089,7 @@ impl AggregateState {
                                 TransitionType::Removed => current_count - 1,
                             };
                             self.distinct_counts.insert(*col_idx, new_count);
-                            processed_counts.set(*col_idx);
+                            processed_counts.set(*col_idx)?;
                         }
                     }
                 }
@@ -1105,7 +1105,7 @@ impl AggregateState {
                                 TransitionType::Removed => current_count - 1,
                             };
                             self.distinct_counts.insert(*col_idx, new_count);
-                            processed_counts.set(*col_idx);
+                            processed_counts.set(*col_idx)?;
                         }
 
                         // Update sum if not already processed
@@ -1123,7 +1123,7 @@ impl AggregateState {
                                 TransitionType::Removed => current_sum - value_as_float,
                             };
                             self.distinct_sums.insert(*col_idx, new_sum);
-                            processed_sums.set(*col_idx);
+                            processed_sums.set(*col_idx)?;
                         }
                     }
                 }
@@ -1177,6 +1177,7 @@ impl AggregateState {
                 }
             }
         }
+        Ok(())
     }
 
     /// Convert aggregate state to output values
@@ -1501,7 +1502,7 @@ impl AggregateOperator {
         existing_groups: &mut HashMap<String, AggregateState>,
         old_values: &mut HashMap<String, Vec<Value>>,
         pre_existing_groups: &HashSet<String>,
-    ) -> MergeResult {
+    ) -> Result<MergeResult> {
         let mut output_delta = Delta::new();
         let mut temp_keys: HashMap<String, Vec<Value>> = HashMap::default();
 
@@ -1558,7 +1559,7 @@ impl AggregateOperator {
                 &self.aggregates,
                 &self.input_column_names,
                 &distinct_transitions,
-            );
+            )?;
         }
 
         // Generate output delta from temporary states and collect final states
@@ -1627,7 +1628,7 @@ impl AggregateOperator {
             }
         }
 
-        (output_delta, final_states)
+        Ok((output_delta, final_states))
     }
 
     /// Extract distinct values from delta changes for batch tracking

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2762,31 +2762,33 @@ impl BTreeTable {
         table: &Arc<BTreeTable>,
         schema: &Schema,
         only_columns: Option<&ColumnMask>,
-    ) -> Arc<BTreeTable> {
+    ) -> Result<Arc<BTreeTable>> {
         let has_virtual = table.has_virtual_columns();
         let has_custom = table
             .columns
             .iter()
             .any(|c| c.is_array() || schema.get_type_def(&c.ty_str, table.is_strict).is_some());
         if !has_custom && !has_virtual {
-            return Arc::clone(table);
+            return Ok(Arc::clone(table));
         }
         let mut modified = (**table).clone();
         let remapped_only_columns = if has_virtual {
-            let remapped = only_columns.map(|only| {
-                let mut new_set = ColumnMask::default();
-                let mut physical = 0usize;
-                for (orig, col) in modified.columns.iter().enumerate() {
-                    if col.is_virtual_generated() {
-                        continue;
+            let remapped = only_columns
+                .map(|only| {
+                    let mut new_set = ColumnMask::default();
+                    let mut physical = 0usize;
+                    for (orig, col) in modified.columns.iter().enumerate() {
+                        if col.is_virtual_generated() {
+                            continue;
+                        }
+                        if only.get(orig) {
+                            new_set.set(physical)?;
+                        }
+                        physical += 1;
                     }
-                    if only.get(orig) {
-                        new_set.set(physical);
-                    }
-                    physical += 1;
-                }
-                new_set
-            });
+                    Ok::<_, LimboError>(new_set)
+                })
+                .transpose()?;
             modified.columns.retain(|c| !c.is_virtual_generated());
             modified.has_virtual_columns = false;
             remapped
@@ -2809,7 +2811,7 @@ impl BTreeTable {
                 col.ty_str = type_def.value_input_type().to_uppercase();
             }
         }
-        Arc::new(modified)
+        Ok(Arc::new(modified))
     }
 
     /// Override column type metadata for custom type columns so that
@@ -6153,7 +6155,7 @@ mod tests {
         )?;
         let mut expected = t.columns_affected_by_update([0])?;
         let b_mask = t.columns_affected_by_update([1])?;
-        expected.union_with(&b_mask);
+        expected.union_with(&b_mask).unwrap();
         let union_mask = t.columns_affected_by_update([0, 1])?;
         assert_eq!(indices(&union_mask), indices(&expected));
         Ok(())

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,3 +1,4 @@
+use crate::alloc::TursoFromIterator;
 use crate::function::{Deterministic, Func};
 use crate::incremental::view::IncrementalView;
 use crate::incremental::{compiler::DBSP_CIRCUIT_VERSION, operator::create_dbsp_state_index};
@@ -2558,7 +2559,7 @@ impl GeneratedColGraph {
                     col.name.as_deref().unwrap_or("?")
                 );
             }
-            let direct_mask: ColumnMask = ColumnMask::from_iter(direct.iter());
+            let direct_mask: ColumnMask = ColumnMask::try_from_iter(direct.iter())?;
             direct_deps[j].union_with(&direct_mask);
             for i in direct.iter() {
                 direct_dependents[i].set(j);

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1509,7 +1509,13 @@ impl Schema {
             let mut pk_index_added = false;
             for unique_set in &table.unique_sets {
                 if unique_set.is_primary_key {
-                    assert!(table.primary_key_columns.len() == unique_set.columns.len(), "trying to add a {}-column primary key index for table {}, but the table has {} primary key columns", unique_set.columns.len(), table.name, table.primary_key_columns.len());
+                    assert!(
+                        table.primary_key_columns.len() == unique_set.columns.len(),
+                        "trying to add a {}-column primary key index for table {}, but the table has {} primary key columns",
+                        unique_set.columns.len(),
+                        table.name,
+                        table.primary_key_columns.len()
+                    );
                     // Add composite primary key index
                     assert!(
                         !pk_index_added,
@@ -1585,7 +1591,11 @@ impl Schema {
             // In MVCC mode during recovery, not all automatic index schema rows might be visible yet
             // during incremental schema reparsing, so we may have extra entries
             if !mvcc_enabled {
-                assert!(automatic_indexes.is_empty(), "all automatic indexes parsed from sqlite_schema should have been consumed, but {} remain", automatic_indexes.len());
+                assert!(
+                    automatic_indexes.is_empty(),
+                    "all automatic indexes parsed from sqlite_schema should have been consumed, but {} remain",
+                    automatic_indexes.len()
+                );
             }
         }
         Ok(())
@@ -1750,7 +1760,9 @@ impl Schema {
                                     // This will cause populate_materialized_views to skip this view
                                     tracing::warn!(
                                         "Skipping materialized view '{}' - has version {} but current version is {}. DROP and recreate the view to use it.",
-                                        view_name, stored_version, DBSP_CIRCUIT_VERSION
+                                        view_name,
+                                        stored_version,
+                                        DBSP_CIRCUIT_VERSION
                                     );
                                     // We can't track incompatible views here since we're in handle_schema_row
                                     // which doesn't have mutable access to self
@@ -2560,9 +2572,9 @@ impl GeneratedColGraph {
                 );
             }
             let direct_mask: ColumnMask = ColumnMask::try_from_iter(direct.iter())?;
-            direct_deps[j].union_with(&direct_mask);
+            direct_deps[j].union_with(&direct_mask)?;
             for i in direct.iter() {
-                direct_dependents[i].set(j);
+                direct_dependents[i].set(j)?;
                 in_degree[j] += 1;
             }
         }
@@ -2598,7 +2610,7 @@ impl GeneratedColGraph {
             dependencies[j] = direct_deps[j].clone();
             for i in direct_deps[j].iter() {
                 let snapshot = dependencies[i].clone();
-                dependencies[j].union_with(&snapshot);
+                dependencies[j].union_with(&snapshot)?;
             }
         }
 
@@ -2608,7 +2620,7 @@ impl GeneratedColGraph {
             dependents[i] = direct_dependents[i].clone();
             for j in direct_dependents[i].iter() {
                 let snapshot = dependents[j].clone();
-                dependents[i].union_with(&snapshot);
+                dependents[i].union_with(&snapshot)?;
             }
         }
 
@@ -3235,10 +3247,10 @@ impl BTreeTable {
         let graph = self.column_graph()?;
         let mut affected = ColumnMask::default();
         for i in updated_cols {
-            affected.set(i);
+            affected.set(i)?;
             if i < graph.dependents.len() {
                 let snapshot = graph.dependents[i].clone();
-                affected.union_with(&snapshot);
+                affected.union_with(&snapshot)?;
             }
         }
         Ok(affected)
@@ -3252,12 +3264,12 @@ impl BTreeTable {
         let mut deps = ColumnMask::default();
         for j in targets {
             if !self.columns[j].is_virtual_generated() {
-                deps.set(j);
+                deps.set(j)?;
                 continue;
             }
             for i in graph.dependencies[j].iter() {
                 if !self.columns[i].is_virtual_generated() {
-                    deps.set(i);
+                    deps.set(i)?;
                 }
             }
         }
@@ -3404,16 +3416,16 @@ fn collect_column_dependencies_of_gencol(expr: &Expr, columns: &[Column], out: &
     let _ = walk_expr(expr, &mut |e| {
         match e {
             Expr::Column { table, column, .. } if table.is_self_table() => {
-                out.set(*column);
+                out.set(*column)?;
             }
             Expr::Id(name) | Expr::Name(name) => {
                 if let Some(idx) = find_column_index_by_name(columns, name.as_str()) {
-                    out.set(idx);
+                    out.set(idx)?;
                 }
             }
             Expr::Qualified(_, col) | Expr::DoublyQualified(_, _, col) => {
                 if let Some(idx) = find_column_index_by_name(columns, col.as_str()) {
-                    out.set(idx);
+                    out.set(idx)?;
                 }
             }
             Expr::Subquery(_)

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -13,6 +13,7 @@ use turso_parser::{
     parser::Parser,
 };
 
+use crate::alloc::TursoIteratorExt;
 use crate::{
     busy::BusyHandlerState,
     parameters,
@@ -547,7 +548,7 @@ impl Statement {
             .iter()
             .chain(self.program.prepared.read_databases.iter())
             .filter(|&id| id != crate::MAIN_DB_ID)
-            .collect();
+            .try_collect()?;
         for db_id in &attached_db_ids {
             // Discard any connection-local schema changes for this non-main DB
             // (temp or attached) so the re-translate reads the committed schema.

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -723,8 +723,8 @@ pub fn translate_alter_table(
     } = alter;
     let database_id = resolver.resolve_existing_table_database_id_qualified(&qualified_name)?;
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
-    program.begin_write_operation();
+    program.begin_write_on_database(database_id, schema_cookie)?;
+    program.begin_write_operation()?;
     let table_name = qualified_name.name.as_str();
     // For attached databases, qualify sqlite_schema with the database name
     // so that the UPDATE targets the correct database's schema table.
@@ -1464,7 +1464,7 @@ pub fn translate_alter_table(
 
             let temp_schema_version = if !temp_triggers_to_rewrite.is_empty() {
                 let schema_cookie = resolver.with_schema(crate::TEMP_DB_ID, |s| s.schema_version);
-                program.begin_write_on_database(crate::TEMP_DB_ID, schema_cookie);
+                program.begin_write_on_database(crate::TEMP_DB_ID, schema_cookie)?;
                 Some(schema_cookie)
             } else {
                 None
@@ -1879,7 +1879,7 @@ pub fn translate_alter_table(
                     .any(|(db, _, _)| *db == crate::TEMP_DB_ID);
             let temp_schema_version = if has_temp_rewrites {
                 let schema_cookie = resolver.with_schema(crate::TEMP_DB_ID, |s| s.schema_version);
-                program.begin_write_on_database(crate::TEMP_DB_ID, schema_cookie);
+                program.begin_write_on_database(crate::TEMP_DB_ID, schema_cookie)?;
                 Some(schema_cookie)
             } else {
                 None

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2208,7 +2208,7 @@ fn translate_rename_virtual_table(
     database_id: usize,
 ) -> Result<()> {
     let schema_version = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_operation();
+    program.begin_write_operation()?;
     let vtab_cur = program.alloc_cursor_id(CursorType::VirtualTable(vtab));
     program.emit_insn(Insn::VOpen {
         cursor_id: vtab_cur,

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -149,8 +149,8 @@ pub fn translate_analyze(
     // epilogue emits a Transaction instruction (which starts the MVCC
     // exclusive transaction required by OpenWrite on sqlite_schema).
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
-    program.begin_write_operation();
+    program.begin_write_on_database(database_id, schema_cookie)?;
+    program.begin_write_operation()?;
 
     // This is emitted early because SQLite does, and thus generated VDBE matches a bit closer.
     let null_reg = program.alloc_register();

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -91,7 +91,7 @@ pub fn translate_delete(
     )?;
 
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
 
     let mut delete_plan = prepare_delete_plan(
         program,

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -22,6 +22,7 @@ use super::{
     trigger_exec::{get_triggers_including_temp, has_triggers_including_temp},
     window::WindowMetadata,
 };
+use crate::alloc::TursoIteratorExt;
 use crate::instrument;
 use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
@@ -523,20 +524,21 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub(crate) fn attached_database_ids_in_search_order(&self) -> BitSet {
-        self.attached_databases
+    pub(crate) fn attached_database_ids_in_search_order(&self) -> Result<BitSet> {
+        Ok(self
+            .attached_databases
             .read()
             .index_to_data
             .keys()
             .copied()
-            .collect()
+            .try_collect()?)
     }
 
     fn resolve_unqualified_existing_database_id<F>(
         &self,
         object_name: &str,
         schema_contains_object: F,
-    ) -> usize
+    ) -> Result<usize>
     where
         F: Fn(&Schema, &str) -> bool,
     {
@@ -548,24 +550,24 @@ impl<'a> Resolver<'a> {
                 schema_contains_object(schema, object_name)
             })
         {
-            return crate::TEMP_DB_ID;
+            return Ok(crate::TEMP_DB_ID);
         }
 
         if self.with_schema(crate::MAIN_DB_ID, |schema| {
             schema_contains_object(schema, object_name)
         }) {
-            return crate::MAIN_DB_ID;
+            return Ok(crate::MAIN_DB_ID);
         }
 
-        for database_id in self.attached_database_ids_in_search_order() {
+        for database_id in self.attached_database_ids_in_search_order()? {
             if self.with_schema(database_id, |schema| {
                 schema_contains_object(schema, object_name)
             }) {
-                return database_id;
+                return Ok(database_id);
             }
         }
 
-        crate::MAIN_DB_ID
+        Ok(crate::MAIN_DB_ID)
     }
 
     fn schema_has_table_like_object(schema: &Schema, table_name: &str) -> bool {
@@ -618,20 +620,20 @@ impl<'a> Resolver<'a> {
                 return Ok(ctx.database_id);
             }
 
-            return Ok(self.resolve_unqualified_existing_database_id(
+            return self.resolve_unqualified_existing_database_id(
                 table_name,
                 Self::schema_has_table_like_object,
-            ));
+            );
         }
 
         if let Some(database_id) = Self::resolve_schema_table_database_id(table_name) {
             return Ok(database_id);
         }
 
-        Ok(self.resolve_unqualified_existing_database_id(
+        self.resolve_unqualified_existing_database_id(
             table_name,
             Self::schema_has_table_like_object,
-        ))
+        )
     }
 
     pub(crate) fn resolve_existing_index_database_id(
@@ -643,7 +645,7 @@ impl<'a> Resolver<'a> {
         }
 
         let index_name = normalize_ident(qualified_name.name.as_str());
-        Ok(self.resolve_unqualified_existing_database_id(&index_name, Self::schema_has_index))
+        self.resolve_unqualified_existing_database_id(&index_name, Self::schema_has_index)
     }
 
     pub(crate) fn resolve_existing_trigger_database_id(
@@ -655,7 +657,7 @@ impl<'a> Resolver<'a> {
         }
 
         let trigger_name = qualified_name.name.as_str();
-        Ok(self.resolve_unqualified_existing_database_id(trigger_name, Self::schema_has_trigger))
+        self.resolve_unqualified_existing_database_id(trigger_name, Self::schema_has_trigger)
     }
 
     /// Resolve database ID from a qualified name
@@ -1719,8 +1721,8 @@ pub(crate) fn emit_columns_and_dependencies(
     let target_base = program.alloc_registers(targets.len());
     let extra_base = {
         let mut dependencies_not_in_targets: ColumnMask = dependencies.clone();
-        let target_mask = targets.iter().copied().collect();
-        dependencies_not_in_targets -= &target_mask;
+        let target_mask = targets.iter().copied().try_collect()?;
+        dependencies_not_in_targets.union_with(&target_mask)?;
 
         let extra_count = dependencies_not_in_targets.count();
 

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alloc::{TursoFromIterator, TursoIteratorExt},
     emit_explain,
     schema::{BTreeCharacteristics, BTreeTable},
     sync::Arc,
@@ -594,7 +595,7 @@ fn prune_join_order_for_materialized_inputs(
             continue;
         }
         if matches!(input.mode, MaterializedBuildInputMode::KeyPayload { .. }) {
-            tables_to_remove.extend(input.prefix_tables.iter());
+            tables_to_remove.try_extend(input.prefix_tables.iter())?;
         }
     }
 
@@ -677,7 +678,10 @@ fn materialization_prefix(
         });
     }
 
-    let mut included_tables: TableMask = prefix_join_order.iter().map(|m| m.original_idx).collect();
+    let mut included_tables: TableMask = prefix_join_order
+        .iter()
+        .map(|m| m.original_idx)
+        .try_collect()?;
     for member in prefix_join_order.iter() {
         let table_ref = &plan.table_references.joined_tables()[member.original_idx];
         if let Operation::HashJoin(hash_join_op) = &table_ref.op {
@@ -785,7 +789,7 @@ fn build_materialized_build_input_plan(
     // Bitmask of tables that are actually in the prefix join order for
     // this materialization subplan. Anything that depends on other tables
     // cannot be evaluated during those table scans.
-    let join_prefix_mask: TableMask = join_order.iter().map(|m| m.original_idx).collect();
+    let join_prefix_mask: TableMask = join_order.iter().map(|m| m.original_idx).try_collect()?;
 
     // Clone WHERE terms for the materialization subplan. We cannot reuse the
     // parent plan's consumed flags because the optimizer may have consumed

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -335,7 +335,7 @@ pub(crate) fn emit_materialized_build_inputs(
     for table in plan.table_references.joined_tables().iter() {
         if let Operation::HashJoin(hash_join_op) = &table.op {
             let build_table = &plan.table_references.joined_tables()[hash_join_op.build_table_idx];
-            hash_tables_to_keep_open.set(build_table.internal_id.into());
+            hash_tables_to_keep_open.set(build_table.internal_id.into())?;
         }
     }
 
@@ -350,7 +350,7 @@ pub(crate) fn emit_materialized_build_inputs(
             {
                 continue;
             }
-            seen_build_tables.set(hash_join_op.build_table_idx);
+            seen_build_tables.set(hash_join_op.build_table_idx)?;
 
             let probe_table_idx = hash_join_op.probe_table_idx;
             let probe_pos = plan
@@ -585,7 +585,7 @@ fn prune_join_order_for_materialized_inputs(
     for member in plan.join_order.iter() {
         let table = &plan.table_references.joined_tables()[member.original_idx];
         if let Operation::HashJoin(hash_join_op) = &table.op {
-            build_tables_in_plan.set(hash_join_op.build_table_idx);
+            build_tables_in_plan.set(hash_join_op.build_table_idx)?;
         }
     }
 
@@ -685,7 +685,7 @@ fn materialization_prefix(
     for member in prefix_join_order.iter() {
         let table_ref = &plan.table_references.joined_tables()[member.original_idx];
         if let Operation::HashJoin(hash_join_op) = &table_ref.op {
-            included_tables.set(hash_join_op.build_table_idx);
+            included_tables.set(hash_join_op.build_table_idx)?;
         }
     }
     Ok((prefix_join_order, included_tables))

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1704,7 +1704,7 @@ fn emit_update_insns<'a>(
                     &btree_table,
                     t_ctx.resolver.schema(),
                     Some(&set_col_indices),
-                ),
+                )?,
             });
 
             // Encode only SET clause columns. Non-SET columns were read from disk

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1,5 +1,6 @@
 use super::gencol::compute_virtual_columns;
 use super::TranslateCtx;
+use crate::alloc::TursoIteratorExt;
 use crate::schema::{Column, ColumnLayout, GeneratedType, Table};
 use crate::translate::insert::halt_desc_and_on_error;
 use crate::translate::plan::ColumnMask;
@@ -1151,7 +1152,7 @@ fn emit_update_insns<'a>(
     let updated_column_indices: ColumnMask = set_clauses
         .iter()
         .map(|set_clause| set_clause.column_index)
-        .collect();
+        .try_collect()?;
     let has_any_update_triggers = if let Some(btree_table) = target_table.table.btree() {
         has_triggers_including_temp(
             &t_ctx.resolver,
@@ -1485,7 +1486,7 @@ fn emit_update_insns<'a>(
                 .filter_map(|set_clause| {
                     (set_clause.column_index != ROWID_SENTINEL).then_some(set_clause.column_index)
                 })
-                .collect();
+                .try_collect()?;
             stabilize_new_row_for_fk(
                 program,
                 &table_btree,
@@ -1691,7 +1692,7 @@ fn emit_update_insns<'a>(
             let set_col_indices: ColumnMask = set_clauses
                 .iter()
                 .map(|set_clause| set_clause.column_index)
-                .collect();
+                .try_collect()?;
 
             // Pre-encode TypeCheck: validate SET column input types.
             // Non-SET columns hold encoded values from disk, so skip them (ANY).

--- a/core/translate/expression_index.rs
+++ b/core/translate/expression_index.rs
@@ -71,7 +71,7 @@ pub fn single_table_column_usage(expr: &ast::Expr) -> Option<(TableInternalId, C
             } else {
                 table_id = Some(*table);
             }
-            columns.set(*column);
+            columns.set(*column)?;
         }
         Ok(WalkControl::Continue)
     });

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -123,7 +123,7 @@ pub fn translate_create_index(
     program.extend(&opts);
 
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
 
     // Check if the index is being created on a valid btree table and
     // the name is globally unique in the schema.
@@ -939,7 +939,7 @@ pub fn translate_drop_index(
     program.extend(&opts);
 
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
 
     // Find the index in Schema
     let mut maybe_index = None;

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -653,7 +653,7 @@ pub fn translate_insert(
                 ctx.table,
                 resolver.schema(),
                 None,
-            ),
+            )?,
         });
 
         // Encode values for columns with custom types.

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -326,7 +326,7 @@ pub fn translate_insert(
     let cdc_table = prepare_cdc_if_necessary(program, resolver.schema(), table.get_name())?;
 
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
 
     let mut table_references = TableReferences::new(
         vec![JoinedTable {

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -462,8 +462,8 @@ pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
     let has_gosub = gosub.is_some();
     let allowed_tables = {
         let mut m = TableMask::default();
-        m.set(build_table_idx);
-        m.set(probe_table_idx);
+        m.set(build_table_idx)?;
+        m.set(probe_table_idx)?;
         // When there's a gosub wrapping inner tables, we must also allow
         // conditions that reference outer tables (those appearing before the
         // hash join probe in the join order), since their cursors are valid
@@ -475,7 +475,7 @@ pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
                 .position(|j| j.original_idx == probe_table_idx)
                 .expect("probe table must be in join order");
             for join in &plan.join_order[..probe_pos] {
-                m.set(join.original_idx);
+                m.set(join.original_idx)?;
             }
         }
         m

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::alloc::TursoIteratorExt;
 use crate::schema::GeneratedType;
 use crate::translate::emitter::HashLabels;
 use crate::translate::plan::ColumnUsedMask;
@@ -158,7 +159,7 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
                     );
                     let payload_signature_columns: ColumnUsedMask = (0..payload_columns.len())
                         .map(|i| *payload_num_keys + i)
-                        .collect();
+                        .try_collect()?;
                     (
                         payload_columns.clone(),
                         payload_signature_columns,
@@ -340,8 +341,9 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
         }
 
         if !config.use_materialized_keys {
-            let build_only_mask: TableMask =
-                [planner.hash_join_op.build_table_idx].into_iter().collect();
+            let build_only_mask: TableMask = [planner.hash_join_op.build_table_idx]
+                .into_iter()
+                .try_collect()?;
             for cond in planner.predicates.iter() {
                 if cond.from_outer_join.is_some() {
                     // OUTER JOIN predicates must stay on the right-table loop

--- a/core/translate/main_loop/init.rs
+++ b/core/translate/main_loop/init.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::alloc::TursoIteratorExt;
 
 pub fn init_distinct(program: &mut ProgramBuilder, plan: &SelectPlan) -> Result<DistinctCtx> {
     let collations = plan
@@ -90,7 +91,7 @@ impl InitLoop {
         let mut required_tables: TableMask = join_order
             .iter()
             .map(|member| member.original_idx)
-            .collect();
+            .try_collect()?;
         for table in tables.joined_tables().iter() {
             if let Operation::HashJoin(hash_join_op) = &table.op {
                 required_tables.set(hash_join_op.build_table_idx);

--- a/core/translate/main_loop/init.rs
+++ b/core/translate/main_loop/init.rs
@@ -106,7 +106,7 @@ impl InitLoop {
             let schema_cookie = t_ctx
                 .resolver
                 .with_schema(table.database_id, |s| s.schema_version);
-            program.begin_read_on_database(table.database_id, schema_cookie);
+            program.begin_read_on_database(table.database_id, schema_cookie)?;
             // Initialize bookkeeping for OUTER JOIN
             if let Some(join_info) = table.join_info.as_ref() {
                 if join_info.is_outer() {

--- a/core/translate/main_loop/init.rs
+++ b/core/translate/main_loop/init.rs
@@ -94,7 +94,7 @@ impl InitLoop {
             .try_collect()?;
         for table in tables.joined_tables().iter() {
             if let Operation::HashJoin(hash_join_op) = &table.op {
-                required_tables.set(hash_join_op.build_table_idx);
+                required_tables.set(hash_join_op.build_table_idx)?;
             }
         }
 

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -408,7 +408,7 @@ pub fn translate_inner(
 
     // Indicate write operations so that in the epilogue we can emit the correct type of transaction
     if is_write {
-        program.begin_write_operation();
+        program.begin_write_operation()?;
     }
 
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -413,7 +413,7 @@ pub fn translate_inner(
 
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction
     if is_select && !program.table_references.is_empty() {
-        program.begin_read_operation();
+        program.begin_read_operation()?;
     }
 
     Ok(())

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -240,7 +240,7 @@ pub(super) fn choose_best_btree_candidate(
 
     // Build a mask for the rhs table itself.
     let mut rhs_table_mask = TableMask::default();
-    rhs_table_mask.set(rhs_table_idx);
+    rhs_table_mask.set(rhs_table_idx)?;
 
     // Estimate cost for each candidate index (including the rowid index) and
     // keep the best candidate.

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -821,7 +821,7 @@ fn find_best_access_method_for_btree(
             best_access_method.cost,
             &lhs_mask,
             analyze_stats,
-        ) {
+        )? {
             best_access_method = multi_idx_method;
         }
 
@@ -838,7 +838,7 @@ fn find_best_access_method_for_btree(
             best_access_method.cost,
             &lhs_mask,
             analyze_stats,
-        ) {
+        )? {
             best_access_method = multi_idx_and_method;
         }
     }

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -5,6 +5,7 @@ use smallvec::SmallVec;
 use turso_ext::{ConstraintInfo, ConstraintUsage, ResultCode};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
+use crate::alloc::TursoIteratorExt;
 use crate::schema::Schema;
 use crate::stats::AnalyzeStats;
 use crate::translate::expr::{as_binary_components, walk_expr, WalkControl};
@@ -209,7 +210,7 @@ pub(super) fn choose_best_btree_candidate(
     input_cardinality: f64,
     base_row_count: RowCountEstimate,
     params: &CostModelParams,
-) -> Option<ChosenBtreeCandidate> {
+) -> Result<Option<ChosenBtreeCandidate>> {
     // Seed the baseline with a table scan only if a rowid candidate exists
     // (i.e. no INDEXED BY has removed it). Otherwise start at infinite cost
     // so the forced index candidate always wins.
@@ -378,7 +379,7 @@ pub(super) fn choose_best_btree_candidate(
                 .flatten()
                 {
                     let c = &rhs_constraints.constraints[idx];
-                    mask = mask.iter().chain(c.lhs_mask.iter()).collect();
+                    mask = mask.iter().chain(c.lhs_mask.iter()).try_collect()?;
                 }
             }
             mask
@@ -388,7 +389,7 @@ pub(super) fn choose_best_btree_candidate(
         let allowed_mask: TableMask = loop_prereq_mask
             .iter()
             .chain(rhs_table_mask.iter())
-            .collect();
+            .try_collect()?;
 
         // Collect which constraint positions are consumed by the index seek.
         let consumed: SmallVec<[usize; 8]> = usable_constraint_refs
@@ -452,7 +453,7 @@ pub(super) fn choose_best_btree_candidate(
         }
     }
 
-    Some(best_choice)
+    Ok(Some(best_choice))
 }
 
 fn consumed_where_terms_from_constraint_refs(
@@ -727,7 +728,7 @@ fn find_best_access_method_for_btree(
         .iter()
         .take(join_order.len() - 1)
         .map(|member| member.original_idx)
-        .collect();
+        .try_collect()?;
     let best = choose_best_btree_candidate(
         rhs_table,
         rhs_constraints,
@@ -740,7 +741,7 @@ fn find_best_access_method_for_btree(
         input_cardinality,
         base_row_count,
         params,
-    )
+    )?
     .expect("btree candidate selection must always consider the rowid candidate");
 
     let estimated_rows_per_outer_row = if best.constraint_refs.is_empty() {
@@ -853,7 +854,7 @@ fn find_best_access_method_for_vtab(
     base_row_count: RowCountEstimate,
     params: &CostModelParams,
 ) -> Result<Option<AccessMethod>> {
-    let vtab_constraints = convert_to_vtab_constraint(constraints, join_order);
+    let vtab_constraints = convert_to_vtab_constraint(constraints, join_order)?;
 
     // TODO: get proper order_by information to pass to the vtab.
     // maybe encode more info on t_ctx? we need: [col_idx , is_descending]
@@ -1478,7 +1479,7 @@ fn find_best_access_method_for_subquery(
         &rhs_constraints.constraints,
         &temp_constraint_refs,
         join_order,
-    );
+    )?;
 
     let has_search_constraints = !usable_constraint_refs.is_empty();
     if !has_search_constraints {

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -644,7 +644,11 @@ pub fn constraints_from_where_clause(
                 let estimated_values = rhs.len() as f64;
                 let mut rhs_mask = TableMask::default();
                 for rhs_expr in rhs.iter() {
-                    rhs_mask |= &table_mask_from_expr(rhs_expr, table_references, subqueries)?;
+                    rhs_mask.union_with(&table_mask_from_expr(
+                        rhs_expr,
+                        table_references,
+                        subqueries,
+                    )?)?;
                 }
                 let table_stats = schema
                     .analyze_stats

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1,3 +1,4 @@
+use crate::alloc::TursoIteratorExt;
 use crate::{
     schema::{Column, Index, Schema},
     translate::{
@@ -1131,7 +1132,7 @@ pub fn usable_constraints_for_join_order<'a>(
     constraints: &'a [Constraint],
     refs: &'a [ConstraintRef],
     join_order: &[JoinOrderMember],
-) -> Vec<RangeConstraintRef> {
+) -> Result<Vec<RangeConstraintRef>> {
     turso_debug_assert!(refs.is_sorted_by_key(|x| x.index_col_pos));
 
     let table_idx = join_order.last().unwrap().original_idx;
@@ -1139,8 +1140,13 @@ pub fn usable_constraints_for_join_order<'a>(
         .iter()
         .take(join_order.len() - 1)
         .map(|j| j.original_idx)
-        .collect();
-    usable_constraints_for_lhs_mask(constraints, refs, &lhs_mask, table_idx)
+        .try_collect()?;
+    Ok(usable_constraints_for_lhs_mask(
+        constraints,
+        refs,
+        &lhs_mask,
+        table_idx,
+    ))
 }
 
 /// Order synthetic key columns for a materialized subquery seek index.
@@ -1422,14 +1428,14 @@ fn estimate_bound_expr_selectivity(
 pub fn convert_to_vtab_constraint(
     constraints: &[Constraint],
     join_order: &[JoinOrderMember],
-) -> Vec<ConstraintInfo> {
+) -> Result<Vec<ConstraintInfo>> {
     let table_idx = join_order.last().unwrap().original_idx;
     let lhs_mask: TableMask = join_order
         .iter()
         .take(join_order.len() - 1)
         .map(|j| j.original_idx)
-        .collect();
-    constraints
+        .try_collect()?;
+    let constraints = constraints
         .iter()
         .enumerate()
         .filter_map(|(i, constraint)| {
@@ -1447,7 +1453,8 @@ pub fn convert_to_vtab_constraint(
                 index: i,
             })
         })
-        .collect()
+        .collect();
+    Ok(constraints)
 }
 
 fn to_ext_constraint_op(op: &ConstraintOperator) -> Option<ConstraintOp> {

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1,4 +1,4 @@
-use crate::{turso_assert_eq, turso_assert_greater_than};
+use crate::{alloc::TryReserveError, turso_assert_eq, turso_assert_greater_than};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use smallvec::SmallVec;
@@ -12,6 +12,7 @@ use super::{
     order::OrderTarget,
     AvailableIndexes, IndexMethodCandidate,
 };
+use crate::alloc::TursoIteratorExt;
 use crate::{
     schema::Schema,
     stats::AnalyzeStats,
@@ -204,8 +205,10 @@ pub fn join_lhs_and_rhs<'a>(
     {
         if constraint_refs.is_empty() {
             // Check if there are usable constraints that will create an ephemeral index
-            let lhs_mask_for_ephemeral: TableMask =
-                lhs.map_or_else(TableMask::default, |l| l.table_numbers().collect());
+            let lhs_mask_for_ephemeral: TableMask = match lhs {
+                Some(l) => l.table_numbers().try_collect()?,
+                None => TableMask::default(),
+            };
             let has_usable_constraints = rhs_constraints.constraints.iter().any(|c| {
                 c.usable
                     && c.table_col_pos.is_some()
@@ -226,7 +229,10 @@ pub fn join_lhs_and_rhs<'a>(
     let mut best_access_method = method;
 
     // Reuse for hash cost and output cardinality computation
-    let lhs_mask = lhs.map_or_else(TableMask::default, |l| l.table_numbers().collect());
+    let lhs_mask = match lhs {
+        Some(l) => l.table_numbers().try_collect()?,
+        None => TableMask::default(),
+    };
 
     // Self-constraints are conditions comparing columns within the same table
     // (e.g., t.col1 < t.col2). Include them in selectivity since they filter rows.
@@ -271,7 +277,7 @@ pub fn join_lhs_and_rhs<'a>(
     if let Some(lhs) = lhs {
         let rhs_table_idx = join_order.last().unwrap().original_idx;
         let last_lhs_table_idx = join_order[join_order.len() - 2].original_idx;
-        let lhs_table_numbers: TableMask = lhs.table_numbers().collect();
+        let lhs_table_numbers: TableMask = lhs.table_numbers().try_collect()?;
 
         let rhs_has_selective_seek = matches!(
             best_access_method.params,
@@ -394,7 +400,7 @@ pub fn join_lhs_and_rhs<'a>(
                             }
                         })
                     })
-                    .collect()
+                    .try_collect()?
             };
 
             let build_has_prior_constraints = {
@@ -835,7 +841,10 @@ fn build_self_constraint_selectivity(
     build_constraints: &TableConstraints,
     build_table_idx: usize,
 ) -> f64 {
-    let build_only_mask: TableMask = [build_table_idx].into_iter().collect();
+    let build_only_mask: TableMask = [build_table_idx]
+        .into_iter()
+        .try_collect()
+        .expect("does not heap allocate with just a single value");
     let mut selectivity = 1.0;
     let mut saw_constraint = false;
     for constraint in build_constraints.constraints.iter() {
@@ -1124,6 +1133,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     // Try to join each single table to each other table.
     for subset_size in 2..=num_tables {
         for mask in generate_join_bitmasks(num_tables, subset_size) {
+            let mask = mask?;
             // Keep track of the best way to join this subset of tables per possible last table.
             // This preserves alternative join orders that may be more expensive for the subset
             // but enable cheaper joins when adding more tables.
@@ -1166,7 +1176,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                 };
 
                 // Stable iteration keeps tie-breaks consistent across runs.
-                let lhs_keys: TableMask = lhs_variants.keys().copied().collect();
+                let lhs_keys: TableMask = lhs_variants.keys().copied().try_collect()?;
                 for lhs_key in &lhs_keys {
                     let lhs = &lhs_variants[&lhs_key];
                     // Build a JoinOrder out of the table bitmask under consideration.
@@ -1388,7 +1398,7 @@ pub fn compute_greedy_join_order<'a>(
         })
         .collect();
 
-    let mut remaining: TableMask = (0..num_tables).collect();
+    let mut remaining: TableMask = (0..num_tables).try_collect()?;
     let mut join_order: Vec<JoinOrderMember> = Vec::with_capacity(num_tables);
 
     // Pick starting table: prefer tables with high "hub score" (referenced by many constraints).
@@ -1433,7 +1443,7 @@ pub fn compute_greedy_join_order<'a>(
 
     // Greedily add remaining tables, always picking lowest marginal cost.
     while !remaining.is_empty() {
-        let current_mask: TableMask = join_order.iter().map(|m| m.original_idx).collect();
+        let current_mask: TableMask = join_order.iter().map(|m| m.original_idx).try_collect()?;
 
         // Placeholder for candidate evaluation (avoids cloning)
         join_order.push(JoinOrderMember::default());
@@ -1752,14 +1762,17 @@ impl JoinBitmaskIter {
 }
 
 impl Iterator for JoinBitmaskIter {
-    type Item = TableMask;
+    type Item = Result<TableMask, TryReserveError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.current >= self.max_exclusive {
             return None;
         }
 
-        let result = self.current.into();
+        let result = match TableMask::try_from(self.current) {
+            Ok(res) => res,
+            Err(e) => return Some(Err(e)),
+        };
 
         // Gosper's hack: compute next k-bit combination in lexicographic order
         let c = self.current & (!self.current + 1); // rightmost set bit
@@ -1768,7 +1781,7 @@ impl Iterator for JoinBitmaskIter {
         let ones = (ones >> 2) / c; // right-adjust shifted bits
         self.current = r | ones; // form the next combination
 
-        Some(result)
+        Some(Ok(result))
     }
 }
 
@@ -1814,14 +1827,15 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_bitmasks() {
-        let bitmasks = generate_join_bitmasks(4, 2).collect::<Vec<_>>();
-        assert!(bitmasks.contains(&0b0011.into())); // {0,1}
-        assert!(bitmasks.contains(&0b0101.into())); // {0,2}
-        assert!(bitmasks.contains(&0b0110.into())); // {1,2}
-        assert!(bitmasks.contains(&0b1001.into())); // {0,3}
-        assert!(bitmasks.contains(&0b1010.into())); // {1,3}
-        assert!(bitmasks.contains(&0b1100.into())); // {2,3}
+    fn test_generate_bitmasks() -> std::result::Result<(), TryReserveError> {
+        let bitmasks = generate_join_bitmasks(4, 2).collect::<std::result::Result<Vec<_>, _>>()?;
+        assert!(bitmasks.contains(&TableMask::try_from(0b0011u128)?)); // {0,1}
+        assert!(bitmasks.contains(&TableMask::try_from(0b0101u128)?)); // {0,2}
+        assert!(bitmasks.contains(&TableMask::try_from(0b0110u128)?)); // {1,2}
+        assert!(bitmasks.contains(&TableMask::try_from(0b1001u128)?)); // {0,3}
+        assert!(bitmasks.contains(&TableMask::try_from(0b1010u128)?)); // {1,3}
+        assert!(bitmasks.contains(&TableMask::try_from(0b1100u128)?)); // {2,3}
+        Ok(())
     }
 
     #[test]

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -238,7 +238,7 @@ pub fn join_lhs_and_rhs<'a>(
     // (e.g., t.col1 < t.col2). Include them in selectivity since they filter rows.
     let rhs_self_mask = {
         let mut m = TableMask::default();
-        m.set(rhs_table_number);
+        m.set(rhs_table_number)?;
         m
     };
 
@@ -1050,7 +1050,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     // there were no other tables.
     for i in 0..num_tables {
         let mut mask = TableMask::default();
-        mask.set(i);
+        mask.set(i)?;
         let table_ref = &joined_tables[i];
         join_order[0] = JoinOrderMember {
             table_id: table_ref.internal_id,
@@ -1116,10 +1116,10 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     {
                         // bitwise OR the masks
                         if let Some(illegal_lhs) = left_join_illegal_map.get_mut(&i) {
-                            illegal_lhs.set(j);
+                            illegal_lhs.set(j)?;
                         } else {
                             let mut mask = TableMask::default();
-                            mask.set(j);
+                            mask.set(j)?;
                             left_join_illegal_map.insert(i, mask);
                         }
                     }

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1392,18 +1392,18 @@ pub fn compute_greedy_join_order<'a>(
         .map(|(j, _)| {
             let mut required = TableMask::default();
             for k in 0..j {
-                required.set(k);
+                required.set(k)?;
             }
-            (j, required)
+            Ok((j, required))
         })
-        .collect();
+        .collect::<Result<_>>()?;
 
     let mut remaining: TableMask = (0..num_tables).try_collect()?;
     let mut join_order: Vec<JoinOrderMember> = Vec::with_capacity(num_tables);
 
     // Pick starting table: prefer tables with high "hub score" (referenced by many constraints).
     let first_idx =
-        find_best_starting_table(num_tables, constraints, base_table_rows, &left_join_deps);
+        find_best_starting_table(num_tables, constraints, base_table_rows, &left_join_deps)?;
     let first_table = &joined_tables[first_idx];
     join_order.push(JoinOrderMember {
         table_id: first_table.internal_id,
@@ -1566,7 +1566,7 @@ fn find_best_starting_table(
     constraints: &[TableConstraints],
     base_table_rows: &[RowCountEstimate],
     left_join_deps: &HashMap<usize, TableMask>,
-) -> usize {
+) -> Result<usize> {
     // hub_score[t] = count of usable constraints on OTHER tables that reference t.
     // If we join t first, each such constraint becomes usable for an index lookup.
     let mut hub_score = vec![0usize; num_tables];
@@ -1591,7 +1591,7 @@ fn find_best_starting_table(
         // Self-constraints compare columns within the same table (e.g., t.col1 < t.col2).
         let self_mask = {
             let mut m = TableMask::default();
-            m.set(t);
+            m.set(t)?;
             m
         };
 
@@ -1611,7 +1611,7 @@ fn find_best_starting_table(
     }
 
     // Table 0 can never be outer join RHS, so best is always Some.
-    best.expect("no valid starting table").0
+    Ok(best.expect("no valid starting table").0)
 }
 
 /// Specialized version of [compute_best_join_order] that just joins tables in the order they are given

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -8,6 +8,7 @@ use super::{
         WhereTerm,
     },
 };
+use crate::alloc::TursoIteratorExt;
 use crate::schema::GeneratedType;
 use crate::translate::expression_index::expression_index_column_usage;
 use crate::translate::plan::{BitSet, ColumnMask, MultiIndexBranchAccess};
@@ -985,7 +986,7 @@ fn update_write_set_reason(
             .set_clauses
             .iter()
             .map(|set_clause| set_clause.column_index)
-            .collect();
+            .try_collect()?;
         let database_id = table_ref.database_id;
         if has_triggers_including_temp(
             resolver,
@@ -2113,7 +2114,7 @@ fn optimize_table_access(
                     }
                 })
             })
-            .unzip();
+            .try_unzip()?;
     #[cfg(debug_assertions)]
     {
         let mut probe_tables: TableMask = TableMask::default();
@@ -2162,7 +2163,7 @@ fn optimize_table_access(
     let hash_join_build_only_tables: TableMask = hash_join_build_tables
         .iter()
         .filter(|table_idx| !hash_join_probe_tables.get(*table_idx))
-        .collect();
+        .try_collect()?;
 
     let best_join_order: Vec<JoinOrderMember> = best_table_numbers
         .iter()
@@ -2267,7 +2268,7 @@ fn optimize_table_access(
                     let unique_col_positions: BitSet = usable
                         .iter()
                         .map(|(_, c)| c.table_col_pos.expect("table_col_pos was Some above"))
-                        .collect();
+                        .try_collect()?;
                     // Map each usable constraint to a ConstraintRef.
                     // Multiple constraints with the same table_col_pos share the same index_col_pos.
                     let mut temp_constraint_refs: Vec<ConstraintRef> = usable
@@ -2289,7 +2290,7 @@ fn optimize_table_access(
                         &table_constraints.constraints,
                         &temp_constraint_refs,
                         &best_join_order[..=join_order_pos],
-                    );
+                    )?;
 
                     if usable_constraint_refs.is_empty() {
                         table_references.joined_tables_mut()[table_idx].op =
@@ -2599,12 +2600,12 @@ fn optimize_table_access(
         let prior_mask = best_join_order[..probe_pos]
             .iter()
             .map(|member| member.original_idx)
-            .collect();
+            .try_collect()?;
         let join_key_indices: BitSet = hash_join_op
             .join_keys
             .iter()
             .map(|key| key.where_clause_idx)
-            .collect();
+            .try_collect()?;
         let build_constraints = &constraints_per_table[hash_join_op.build_table_idx];
         let mut has_prior_constraints = false;
         for constraint in build_constraints.constraints.iter() {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1088,7 +1088,7 @@ fn collect_subquery_ids_from_exprs<'a>(
     let mut ids = BitSet::<turso_parser::ast::TableInternalId>::default();
     let mut collector = |e: &ast::Expr| -> Result<WalkControl> {
         if let ast::Expr::SubqueryResult { subquery_id, .. } = e {
-            ids.set(*subquery_id);
+            ids.set(*subquery_id)?;
         }
         Ok(WalkControl::Continue)
     };
@@ -1113,7 +1113,7 @@ fn collect_update_phase_subquery_ids(
         plan.returning
             .iter()
             .flat_map(|returning| returning.iter().map(|column| &column.expr)),
-    )?);
+    )?)?;
     Ok(ids)
 }
 
@@ -2146,7 +2146,7 @@ fn optimize_table_access(
                         "hash join build/probe tables are not adjacent in join order"
                     );
                 }
-                probe_tables.set(*probe_table_idx);
+                probe_tables.set(*probe_table_idx)?;
                 build_tables.insert(*build_table_idx, *materialize_build_input);
             }
         }

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -6,6 +6,7 @@
 //! union/intersection-specific decomposition, costing, and residual handling on
 //! top.
 
+use crate::alloc::TursoIteratorExt;
 use crate::schema::{Index, Schema};
 use crate::stats::AnalyzeStats;
 use crate::translate::expr::expr_references_any_subquery;
@@ -28,6 +29,7 @@ use crate::translate::plan::{
     UnionBranchPrePostFilters, WhereTerm,
 };
 use crate::translate::planner::{table_mask_from_expr, TableMask};
+use crate::Result;
 use smallvec::SmallVec;
 use std::sync::Arc;
 use turso_macros::turso_assert_eq;
@@ -334,7 +336,7 @@ fn choose_multi_index_branch_access(
     base_row_count: RowCountEstimate,
     analyze_stats: &AnalyzeStats,
     params: &CostModelParams,
-) -> crate::Result<Option<MultiIdxBranch>> {
+) -> Result<Option<MultiIdxBranch>> {
     let chosen_seek = choose_best_btree_candidate(
         rhs_table,
         table_constraints,
@@ -347,7 +349,7 @@ fn choose_multi_index_branch_access(
         1.0,
         base_row_count,
         params,
-    );
+    )?;
 
     let mut best_branch = chosen_seek
         .as_ref()
@@ -447,7 +449,7 @@ fn partition_residual_multi_or_exprs(
     lhs_mask: &TableMask,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
-) -> Option<MultiOrResidualPrePostFilters> {
+) -> Result<Option<MultiOrResidualPrePostFilters>> {
     let mut consumed = vec![false; branch_terms.len()];
     match access {
         MultiIdxBranchAccess::Seek {
@@ -480,22 +482,22 @@ fn partition_residual_multi_or_exprs(
         }
         let expr = &term.expr;
         if expr_references_any_subquery(expr) {
-            return None;
+            return Ok(None);
         }
-        let mask = table_mask_from_expr(expr, table_references, subqueries).ok()?;
+        let mask = table_mask_from_expr(expr, table_references, subqueries)?;
         if lhs_mask.contains_all_set_bits_of(&mask) {
             pre_filter_exprs.push(expr.clone());
         } else {
-            post_mask |= &mask;
+            post_mask.union_with(&mask)?;
             post_filter_exprs.push(expr.clone());
         }
     }
 
-    Some(MultiOrResidualPrePostFilters {
+    Ok(Some(MultiOrResidualPrePostFilters {
         pre_filter_exprs,
         post_filter_exprs,
         post_mask,
-    })
+    }))
 }
 
 /// Estimate selectivity for a residual predicate that remains after a branch
@@ -913,7 +915,7 @@ pub fn consider_multi_index_union(
     best_cost: Cost,
     lhs_mask: &TableMask,
     analyze_stats: &AnalyzeStats,
-) -> Option<AccessMethod> {
+) -> Result<Option<AccessMethod>> {
     for (where_term_idx, term) in where_clause.iter().enumerate() {
         if term.consumed {
             continue;
@@ -936,22 +938,22 @@ pub fn consider_multi_index_union(
         else {
             continue;
         };
-        allowed_mask.set(rhs_idx);
+        allowed_mask.set(rhs_idx)?;
 
         // Each disjunct is replanned with branch-local `TableConstraints`, so
         // compound conjuncts can reuse the same compound-seek analysis as
         // ordinary btree access.
-        let branches: Option<Vec<_>> = disjuncts
+        let branches: Result<Option<Vec<MultiIdxBranch>>> = disjuncts
             .into_iter()
             .map(|disjunct_expr| {
                 let Ok(disjunct_expr) = crate::translate::expr::unwrap_parens(disjunct_expr) else {
-                    return None;
+                    return Ok(None);
                 };
                 let conjuncts = flatten_and_expr(disjunct_expr)
                     .into_iter()
                     .cloned()
                     .collect::<Vec<_>>();
-                let (synthetic_where_terms, table_constraints) =
+                let Some((synthetic_where_terms, table_constraints)) =
                     get_table_local_constraints_for_branch(
                         &conjuncts,
                         term.from_outer_join,
@@ -962,8 +964,11 @@ pub fn consider_multi_index_union(
                         schema,
                         params,
                     )
-                    .ok()?;
-                let mut chosen = choose_multi_index_branch_access(
+                    .ok()
+                else {
+                    return Ok(None);
+                };
+                let Some(mut chosen) = choose_multi_index_branch_access(
                     rhs_table,
                     &table_constraints,
                     &synthetic_where_terms,
@@ -974,30 +979,35 @@ pub fn consider_multi_index_union(
                     base_row_count,
                     analyze_stats,
                     params,
-                )
-                .ok()??;
+                )?
+                else {
+                    return Ok(None);
+                };
                 // Partition residuals in a single pass: pre-filters reference
                 // only outer (lhs) tables and can short-circuit the branch
                 // before the index seek; post-filters reference the target
                 // table and are evaluated after the seek.
-                let partitioned_pre_post = partition_residual_multi_or_exprs(
+                let Some(partitioned_pre_post) = partition_residual_multi_or_exprs(
                     &synthetic_where_terms,
                     &chosen.access,
                     lhs_mask,
                     table_references,
                     subqueries,
-                )?;
+                )?
+                else {
+                    return Ok(None);
+                };
                 if !allowed_mask.contains_all_set_bits_of(&partitioned_pre_post.post_mask) {
-                    return None;
+                    return Ok(None);
                 }
                 chosen.union_prepost_filters = Some(UnionBranchPrePostFilters {
                     requires_table_cursor: partitioned_pre_post.post_mask.get(rhs_idx),
                     pre_filter_exprs: partitioned_pre_post.pre_filter_exprs,
                     post_filter_exprs: partitioned_pre_post.post_filter_exprs,
                 });
-                Some(chosen)
+                Ok(Some(chosen))
             })
-            .collect();
+            .collect()?;
 
         let Some(branches) = branches else {
             continue;
@@ -1017,11 +1027,11 @@ pub fn consider_multi_index_union(
             params,
             best_cost,
         ) {
-            return Some(access_method);
+            return Ok(Some(access_method));
         }
     }
 
-    None
+    Ok(None)
 }
 
 /// Analyze top-level AND terms for AND-by-intersection optimization.
@@ -1043,8 +1053,8 @@ pub fn consider_multi_index_intersection(
     best_cost: Cost,
     lhs_mask: &TableMask,
     analyze_stats: &AnalyzeStats,
-) -> Option<AccessMethod> {
-    let decomposition = analyze_and_terms_for_multi_index(
+) -> Result<Option<AccessMethod>> {
+    let Some(decomposition) = analyze_and_terms_for_multi_index(
         rhs_table,
         where_clause,
         available_indexes,
@@ -1052,10 +1062,12 @@ pub fn consider_multi_index_intersection(
         subqueries,
         schema,
         params,
-    )?;
+    ) else {
+        return Ok(None);
+    };
 
     if decomposition.branches.len() < 2 {
-        return None;
+        return Ok(None);
     }
 
     let all_usable = decomposition
@@ -1063,7 +1075,7 @@ pub fn consider_multi_index_intersection(
         .iter()
         .all(|b| lhs_mask.contains_all_set_bits_of(&b.constraint.lhs_mask));
     if !all_usable {
-        return None;
+        return Ok(None);
     }
 
     let branches: Vec<_> = decomposition
@@ -1112,10 +1124,14 @@ pub fn consider_multi_index_intersection(
         .collect();
 
     let where_term_idx = decomposition.term_indices[0];
-    let additional_consumed_terms: BitSet =
-        decomposition.term_indices.iter().skip(1).copied().collect();
+    let additional_consumed_terms: BitSet = decomposition
+        .term_indices
+        .iter()
+        .skip(1)
+        .copied()
+        .try_collect()?;
 
-    evaluate_multi_index_branches(
+    Ok(evaluate_multi_index_branches(
         branches,
         SetOperation::Intersection {
             additional_consumed_terms,
@@ -1130,7 +1146,7 @@ pub fn consider_multi_index_intersection(
         input_cardinality,
         params,
         best_cost,
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -1139,6 +1155,7 @@ mod tests {
         consider_multi_index_intersection, consider_multi_index_union, AnalyzeStats,
         MultiIndexBranchParams,
     };
+    use crate::alloc::TursoIteratorExt;
     use crate::{
         schema::{
             BTreeCharacteristics, BTreeTable, ColDef, Column, Index, IndexColumn, Schema, Table,
@@ -1418,7 +1435,7 @@ mod tests {
 
         let table_references = TableReferences::new(joined_tables, vec![]);
         let base_row_count = RowCountEstimate::hardcoded_fallback(&DEFAULT_PARAMS);
-        let lhs_mask: TableMask = [LINK].into_iter().collect();
+        let lhs_mask: TableMask = [LINK].into_iter().try_collect().unwrap();
 
         let access_method = consider_multi_index_union(
             &table_references.joined_tables()[ITEM],
@@ -1433,7 +1450,8 @@ mod tests {
             Cost(f64::INFINITY),
             &lhs_mask,
             &AnalyzeStats::default(),
-        );
+        )
+        .unwrap();
 
         assert!(
             access_method.is_none(),
@@ -1522,6 +1540,7 @@ mod tests {
             &TableMask::default(),
             &AnalyzeStats::default(),
         )
+        .unwrap()
         .expect("rowid and secondary-index terms should be eligible for intersection");
 
         let branches = assert_is_multi_index(&access_method);
@@ -1694,7 +1713,7 @@ mod tests {
         }];
 
         let table_references = TableReferences::new(joined_tables, vec![]);
-        let lhs_mask = [LINK].into_iter().collect();
+        let lhs_mask = [LINK].into_iter().try_collect().unwrap();
         let base_row_count = RowCountEstimate::hardcoded_fallback(&DEFAULT_PARAMS);
 
         let access_method = consider_multi_index_union(
@@ -1711,6 +1730,7 @@ mod tests {
             &lhs_mask,
             &AnalyzeStats::default(),
         )
+        .unwrap()
         .expect("compound OR branches should produce a multi-index union");
 
         let branches = assert_is_multi_index(&access_method);
@@ -1837,7 +1857,7 @@ mod tests {
         };
 
         let table_references = TableReferences::new(joined_tables, vec![]);
-        let lhs_mask = [LINK].into_iter().collect();
+        let lhs_mask = [LINK].into_iter().try_collect().unwrap();
         let base_row_count = RowCountEstimate::hardcoded_fallback(&DEFAULT_PARAMS);
 
         let without_residual = consider_multi_index_union(
@@ -1854,6 +1874,7 @@ mod tests {
             &lhs_mask,
             &AnalyzeStats::default(),
         )
+        .unwrap()
         .expect("plain OR branches should produce a multi-index union");
 
         let with_residual = consider_multi_index_union(
@@ -1870,6 +1891,7 @@ mod tests {
             &lhs_mask,
             &AnalyzeStats::default(),
         )
+        .unwrap()
         .expect("residual-filtered OR branches should still produce a multi-index union");
 
         assert!(

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -943,7 +943,7 @@ pub fn consider_multi_index_union(
         // Each disjunct is replanned with branch-local `TableConstraints`, so
         // compound conjuncts can reuse the same compound-seek analysis as
         // ordinary btree access.
-        let branches: Result<Option<Vec<MultiIdxBranch>>> = disjuncts
+        let branches = disjuncts
             .into_iter()
             .map(|disjunct_expr| {
                 let Ok(disjunct_expr) = crate::translate::expr::unwrap_parens(disjunct_expr) else {
@@ -1007,7 +1007,7 @@ pub fn consider_multi_index_union(
                 });
                 Ok(Some(chosen))
             })
-            .collect()?;
+            .collect::<Result<_>>()?;
 
         let Some(branches) = branches else {
             continue;

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alloc::{self, TursoAllocExt},
     function::{AggFunc, WindowFunc},
     schema::{
         BTreeTable, ColDef, Column, FromClauseSubquery, Index, Schema, Table, Type, ROWID_SENTINEL,
@@ -1507,17 +1508,19 @@ pub struct ColumnMask {
 }
 
 impl ColumnMask {
-    pub fn set(&mut self, idx: usize) {
+    pub fn set(&mut self, idx: usize) -> Result<(), alloc::TryReserveError> {
         if idx == ROWID_SENTINEL {
             self.has_rowid_sentinel = true;
         } else {
-            self.bitset.set(idx);
+            self.bitset.set(idx)?;
         }
+        Ok(())
     }
 
-    pub fn union_with(&mut self, other: &ColumnMask) {
-        self.bitset.union_with(&other.bitset);
+    pub fn union_with(&mut self, other: &ColumnMask) -> Result<(), alloc::TryReserveError> {
+        self.bitset.union_with(&other.bitset)?;
         self.has_rowid_sentinel |= other.has_rowid_sentinel;
+        Ok(())
     }
 
     pub fn get(&self, idx: usize) -> bool {
@@ -1549,21 +1552,23 @@ impl std::ops::SubAssign<&Self> for ColumnMask {
     }
 }
 
-impl FromIterator<usize> for ColumnMask {
-    fn from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Self {
+impl alloc::TursoFromIterator<usize> for ColumnMask {
+    fn try_from_iter<I: IntoIterator<Item = usize>>(
+        iter: I,
+    ) -> Result<Self, alloc::TryReserveError> {
         let mut mask = ColumnMask::default();
-        for idx in iter {
-            mask.set(idx);
-        }
-        mask
+        mask.try_extend(iter)?;
+        Ok(mask)
     }
-}
 
-impl Extend<usize> for ColumnMask {
-    fn extend<I: IntoIterator<Item = usize>>(&mut self, iter: I) {
+    fn try_extend<I: IntoIterator<Item = usize>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), alloc::TryReserveError> {
         for idx in iter {
-            self.set(idx);
+            self.set(idx)?;
         }
+        Ok(())
     }
 }
 
@@ -1619,7 +1624,7 @@ impl IntoIterator for ColumnMask {
 pub struct BitSet<T = usize> {
     inline: u64,
     /// invariant: `overflow` is `None` iff no bits ≥ 64 are set.
-    overflow: Option<Vec<u64>>,
+    overflow: Option<alloc::Vec<u64>>,
     _phantom: PhantomData<fn() -> T>,
 }
 
@@ -1702,19 +1707,21 @@ impl<T: From<usize>> BitSet<T>
 where
     usize: From<T>,
 {
-    pub fn set(&mut self, index: T) {
+    pub fn set(&mut self, index: T) -> Result<(), alloc::TryReserveError> {
         let index: usize = index.into();
         if index < Self::INLINE_BITS {
             self.inline |= 1 << index;
         } else {
             let overflow_idx = (index - Self::INLINE_BITS) / 64;
             let bit = (index - Self::INLINE_BITS) % 64;
-            let overflow = self.overflow.get_or_insert_with(Vec::new);
+            let overflow = self.overflow.get_or_insert_with(alloc::Vec::new);
             if overflow_idx >= overflow.len() {
+                overflow.try_reserve(overflow_idx + 1 - overflow.len())?;
                 overflow.resize(overflow_idx + 1, 0);
             }
             overflow[overflow_idx] |= 1 << bit;
         }
+        Ok(())
     }
 
     pub fn get(&self, index: T) -> bool {
@@ -1811,17 +1818,19 @@ where
         }
     }
 
-    pub fn union_with(&mut self, other: &Self) {
+    pub fn union_with(&mut self, other: &Self) -> Result<(), alloc::TryReserveError> {
         self.inline |= other.inline;
         if let Some(other_ov) = &other.overflow {
-            let self_ov = self.overflow.get_or_insert_with(Vec::new);
+            let self_ov = self.overflow.get_or_insert_with(alloc::Vec::new);
             if self_ov.len() < other_ov.len() {
+                self_ov.try_reserve(other_ov.len() - self_ov.len())?;
                 self_ov.resize(other_ov.len(), 0);
             }
             for (s, &o) in self_ov.iter_mut().zip(other_ov.iter()) {
                 *s |= o;
             }
         }
+        Ok(())
     }
 
     pub fn iter(&self) -> BitSetIter<T, &Self> {
@@ -1910,53 +1919,43 @@ where
     }
 }
 
-impl<T> std::ops::BitOrAssign<&Self> for BitSet<T> {
-    fn bitor_assign(&mut self, rhs: &Self) {
-        self.inline |= rhs.inline;
-        if let Some(rhs_ov) = &rhs.overflow {
-            let self_ov = self.overflow.get_or_insert_with(Vec::new);
-            if self_ov.len() < rhs_ov.len() {
-                self_ov.resize(rhs_ov.len(), 0);
-            }
-            for (s, &r) in self_ov.iter_mut().zip(rhs_ov.iter()) {
-                *s |= r;
-            }
-        }
-    }
-}
-
-impl<T: From<usize>> FromIterator<T> for BitSet<T>
+impl<T: From<usize>> alloc::TursoFromIterator<T> for BitSet<T>
 where
     usize: From<T>,
 {
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+    fn try_from_iter<I: IntoIterator<Item = T>>(iter: I) -> Result<Self, alloc::TryReserveError> {
         let mut set = Self::default();
+        set.try_extend(iter)?;
+        Ok(set)
+    }
+
+    fn try_extend<I: IntoIterator<Item = T>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), alloc::TryReserveError> {
         for index in iter {
-            set.set(index);
+            self.set(index)?;
         }
-        set
+        Ok(())
     }
 }
 
-impl<T: From<usize>> Extend<T> for BitSet<T>
-where
-    usize: From<T>,
-{
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        for index in iter {
-            self.set(index);
-        }
-    }
-}
+impl<T> TryFrom<u128> for BitSet<T> {
+    type Error = alloc::TryReserveError;
 
-impl<T> From<u128> for BitSet<T> {
-    fn from(from: u128) -> Self {
+    fn try_from(from: u128) -> Result<Self, Self::Error> {
+        use crate::alloc::*;
+
         let high = (from >> 64) as u64;
-        Self {
+        let overflow = match high != 0 {
+            true => Some(alloc::try_vec![high]?),
+            false => None,
+        };
+        Ok(Self {
             inline: from as u64,
-            overflow: (high != 0).then(|| vec![high]),
+            overflow,
             _phantom: PhantomData,
-        }
+        })
     }
 }
 
@@ -3377,24 +3376,29 @@ fn resolve_outer_ref_loop(
 
 #[cfg(test)]
 mod tests {
+    use crate::alloc::TursoFromIterator;
+
     use super::*;
     use rand_chacha::{
         rand_core::{RngCore, SeedableRng},
         ChaCha8Rng,
     };
 
+    type TestResult = std::result::Result<(), alloc::TryReserveError>;
+
     #[test]
-    fn test_column_used_mask_empty() {
+    fn test_column_used_mask_empty() -> TestResult {
         let mask = ColumnUsedMask::default();
         assert!(mask.is_empty());
 
         let mut mask2 = ColumnUsedMask::default();
-        mask2.set(0);
+        mask2.set(0)?;
         assert!(!mask2.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_set_and_get() {
+    fn test_column_used_mask_set_and_get() -> TestResult {
         let mut mask = ColumnUsedMask::default();
 
         let max_columns = 10000;
@@ -3409,7 +3413,7 @@ mod tests {
         for i in 0..max_columns {
             if rng.next_u32() % 3 == 0 {
                 set_indices.push(i);
-                mask.set(i);
+                mask.set(i)?;
             }
         }
 
@@ -3424,10 +3428,11 @@ mod tests {
                 assert!(!mask.get(i), "Expected bit {i} to not be set");
             }
         }
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_subset_relationship() {
+    fn test_column_used_mask_subset_relationship() -> TestResult {
         let mut full_mask = ColumnUsedMask::default();
         let mut subset_mask = ColumnUsedMask::default();
 
@@ -3442,9 +3447,9 @@ mod tests {
         // Create a pattern where subset has fewer bits
         for i in 0..max_columns {
             if rng.next_u32() % 5 == 0 {
-                full_mask.set(i);
+                full_mask.set(i)?;
                 if i % 2 == 0 {
-                    subset_mask.set(i);
+                    subset_mask.set(i)?;
                 }
             }
         }
@@ -3458,13 +3463,14 @@ mod tests {
         // A mask contains itself
         assert!(full_mask.contains_all_set_bits_of(&full_mask));
         assert!(subset_mask.contains_all_set_bits_of(&subset_mask));
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_empty_subset() {
+    fn test_column_used_mask_empty_subset() -> TestResult {
         let mut mask = ColumnUsedMask::default();
         for i in (0..1000).step_by(7) {
-            mask.set(i);
+            mask.set(i)?;
         }
 
         let empty_mask = ColumnUsedMask::default();
@@ -3472,17 +3478,18 @@ mod tests {
         // Empty mask is subset of everything
         assert!(mask.contains_all_set_bits_of(&empty_mask));
         assert!(empty_mask.contains_all_set_bits_of(&empty_mask));
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_sparse_indices() {
+    fn test_column_used_mask_sparse_indices() -> TestResult {
         let mut sparse_mask = ColumnUsedMask::default();
 
         // Test with very sparse, large indices
         let sparse_indices = vec![0, 137, 1042, 5389, 10000, 50000, 100000, 500000, 1000000];
 
         for &idx in &sparse_indices {
-            sparse_mask.set(idx);
+            sparse_mask.set(idx)?;
         }
 
         for &idx in &sparse_indices {
@@ -3496,23 +3503,24 @@ mod tests {
         }
 
         assert!(!sparse_mask.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_clear() {
+    fn test_column_used_mask_clear() -> TestResult {
         let mut mask = ColumnUsedMask::default();
 
         // Test inline clear
-        mask.set(5);
-        mask.set(10);
+        mask.set(5)?;
+        mask.set(10)?;
         assert!(mask.get(5));
         mask.clear(5);
         assert!(!mask.get(5));
         assert!(mask.get(10));
 
         // Test overflow clear
-        mask.set(100);
-        mask.set(200);
+        mask.set(100)?;
+        mask.set(200)?;
         assert!(mask.get(100));
         mask.clear(100);
         assert!(!mask.get(100));
@@ -3521,50 +3529,52 @@ mod tests {
         // Clear non-existent bit should be no-op
         mask.clear(999);
         assert!(!mask.get(999));
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_is_only() {
+    fn test_column_used_mask_is_only() -> TestResult {
         // Test inline is_only
         let mut mask = ColumnUsedMask::default();
-        mask.set(5);
+        mask.set(5)?;
         assert!(mask.is_only(5));
         assert!(!mask.is_only(0));
         assert!(!mask.is_only(100));
 
-        mask.set(10);
+        mask.set(10)?;
         assert!(!mask.is_only(5));
         assert!(!mask.is_only(10));
 
         // Test overflow is_only
         let mut mask2 = ColumnUsedMask::default();
-        mask2.set(100);
+        mask2.set(100)?;
         assert!(mask2.is_only(100));
         assert!(!mask2.is_only(0));
         assert!(!mask2.is_only(50));
 
-        mask2.set(200);
+        mask2.set(200)?;
         assert!(!mask2.is_only(100));
 
         // Test empty mask
         let empty = ColumnUsedMask::default();
         assert!(!empty.is_only(0));
         assert!(!empty.is_only(100));
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_subtract() {
+    fn test_column_used_mask_subtract() -> TestResult {
         let mut mask1 = ColumnUsedMask::default();
         let mut mask2 = ColumnUsedMask::default();
 
         // Set up mask1 with inline and overflow bits
         for i in [1, 5, 10, 63, 64, 100, 200] {
-            mask1.set(i);
+            mask1.set(i)?;
         }
 
         // Set up mask2 with some overlapping bits
         for i in [5, 10, 100] {
-            mask2.set(i);
+            mask2.set(i)?;
         }
 
         mask1.subtract(&mask2);
@@ -3579,15 +3589,16 @@ mod tests {
         assert!(!mask1.get(5));
         assert!(!mask1.get(10));
         assert!(!mask1.get(100));
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_iter() {
+    fn test_column_used_mask_iter() -> TestResult {
         let mut mask = ColumnUsedMask::default();
         let indices = vec![0, 5, 63, 64, 65, 127, 128, 200, 1000];
 
         for &i in &indices {
-            mask.set(i);
+            mask.set(i)?;
         }
 
         let collected: Vec<usize> = mask.iter().collect();
@@ -3596,24 +3607,25 @@ mod tests {
         // Empty mask iter
         let empty = ColumnUsedMask::default();
         assert_eq!(empty.iter().count(), 0);
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_bitor_assign() {
+    fn test_column_used_mask_bitor_assign() -> TestResult {
         let mut mask1 = ColumnUsedMask::default();
         let mut mask2 = ColumnUsedMask::default();
 
         // Inline bits
-        mask1.set(1);
-        mask1.set(5);
-        mask2.set(5);
-        mask2.set(10);
+        mask1.set(1)?;
+        mask1.set(5)?;
+        mask2.set(5)?;
+        mask2.set(10)?;
 
         // Overflow bits
-        mask1.set(100);
-        mask2.set(200);
+        mask1.set(100)?;
+        mask2.set(200)?;
 
-        mask1 |= &mask2;
+        mask1.union_with(&mask2)?;
 
         assert!(mask1.get(1));
         assert!(mask1.get(5));
@@ -3627,15 +3639,16 @@ mod tests {
         assert!(mask2.get(10));
         assert!(!mask2.get(100));
         assert!(mask2.get(200));
+        Ok(())
     }
 
     #[test]
-    fn test_column_used_mask_boundary_conditions() {
+    fn test_column_used_mask_boundary_conditions() -> TestResult {
         let mut mask = ColumnUsedMask::default();
 
         // Test at inline/overflow boundary
-        mask.set(63); // last inline bit
-        mask.set(64); // first overflow bit
+        mask.set(63)?; // last inline bit
+        mask.set(64)?; // first overflow bit
 
         assert!(mask.get(63));
         assert!(mask.get(64));
@@ -3644,16 +3657,17 @@ mod tests {
 
         // Test is_only at boundary
         let mut mask2 = ColumnUsedMask::default();
-        mask2.set(63);
+        mask2.set(63)?;
         assert!(mask2.is_only(63));
 
         let mut mask3 = ColumnUsedMask::default();
-        mask3.set(64);
+        mask3.set(64)?;
         assert!(mask3.is_only(64));
+        Ok(())
     }
 
     #[test]
-    fn test_column_mask_rowid_sentinel() {
+    fn test_column_mask_rowid_sentinel() -> TestResult {
         // ColumnMask stores `usize::MAX` (ROWID_SENTINEL) in an out-of-band bool
         // so that the underlying dense BitSet never sees it. The small API surface
         // that ColumnMask exposes must all honor the sentinel consistently.
@@ -3661,17 +3675,17 @@ mod tests {
         // set / get round-trip on the sentinel alone
         let mut mask = ColumnMask::default();
         assert!(!mask.get(usize::MAX));
-        mask.set(usize::MAX);
+        mask.set(usize::MAX)?;
         assert!(mask.get(usize::MAX));
         assert_eq!(mask.count(), 1);
 
         // sentinel coexists with dense bits
         let mut mixed = ColumnMask::default();
-        mixed.set(0);
-        mixed.set(63);
-        mixed.set(64); // crosses into overflow
-        mixed.set(500);
-        mixed.set(usize::MAX);
+        mixed.set(0)?;
+        mixed.set(63)?;
+        mixed.set(64)?; // crosses into overflow
+        mixed.set(500)?;
+        mixed.set(usize::MAX)?;
         assert!(mixed.get(0));
         assert!(mixed.get(63));
         assert!(mixed.get(64));
@@ -3685,15 +3699,19 @@ mod tests {
         // count() and iter().count() must agree
         assert_eq!(mixed.count(), (&mixed).into_iter().count());
 
-        // FromIterator round-trip through the sentinel
-        let built: ColumnMask = [0usize, 63, 64, 500, usize::MAX].into_iter().collect();
+        // fallible collection round-trip through the sentinel
+        let built = ColumnMask::try_from_iter([0usize, 63, 64, 500, usize::MAX])?;
         assert_eq!(built, mixed);
-        let round: ColumnMask = (&mixed).into_iter().collect();
+        let round = ColumnMask::try_from_iter(&mixed)?;
         assert_eq!(round, mixed);
+        let mut extended = ColumnMask::default();
+        extended.try_extend([0usize, 63, 64, 500, usize::MAX])?;
+        assert_eq!(extended, mixed);
 
         // owned IntoIterator (used by flat_map in the UPDATE emitter)
         let mixed_owned: Vec<usize> = mixed.clone().into_iter().collect();
         assert_eq!(mixed_owned, vec![0, 63, 64, 500, usize::MAX]);
+        Ok(())
     }
 
     fn rng_from_env_or_time() -> (ChaCha8Rng, u64) {
@@ -3747,7 +3765,7 @@ mod tests {
     }
 
     #[test]
-    fn test_column_used_mask_fuzz() {
+    fn test_column_used_mask_fuzz() -> TestResult {
         fn pick_index(rng: &mut ChaCha8Rng, max_index: u32) -> usize {
             (rng.next_u32() % max_index) as usize
         }
@@ -3768,7 +3786,7 @@ mod tests {
             match op {
                 0..=2 => {
                     // Set (more frequent)
-                    mask.set(idx);
+                    mask.set(idx)?;
                     reference.set(idx);
                 }
                 3 => {
@@ -3806,7 +3824,7 @@ mod tests {
                     let mut other_ref = ReferenceMask::new();
                     for _ in 0..(rng.next_u32() % 20) {
                         let other_idx = pick_index(&mut rng, max_index);
-                        other_mask.set(other_idx);
+                        other_mask.set(other_idx)?;
                         other_ref.set(other_idx);
                     }
                     assert_eq!(
@@ -3821,10 +3839,10 @@ mod tests {
                     let mut other_ref = ReferenceMask::new();
                     for _ in 0..(rng.next_u32() % 20) {
                         let other_idx = pick_index(&mut rng, max_index);
-                        other_mask.set(other_idx);
+                        other_mask.set(other_idx)?;
                         other_ref.set(other_idx);
                     }
-                    mask |= &other_mask;
+                    mask.union_with(&other_mask)?;
                     reference.bitor_assign(&other_ref);
                 }
                 9 => {
@@ -3833,7 +3851,7 @@ mod tests {
                     let mut other_ref = ReferenceMask::new();
                     for _ in 0..(rng.next_u32() % 20) {
                         let other_idx = pick_index(&mut rng, max_index);
-                        other_mask.set(other_idx);
+                        other_mask.set(other_idx)?;
                         other_ref.set(other_idx);
                     }
                     mask.subtract(&other_mask);
@@ -3846,22 +3864,23 @@ mod tests {
         // Final verification: iter should produce same results
         let mask_set: std::collections::BTreeSet<usize> = mask.iter().collect();
         assert_eq!(mask_set, reference.0, "final iter mismatch, seed={seed}");
+        Ok(())
     }
 
     #[test]
-    fn test_bitset_properties_fuzz() {
+    fn test_bitset_properties_fuzz() -> TestResult {
         fn sample_other(
             rng: &mut ChaCha8Rng,
             max_index: usize,
-        ) -> (BitSet, std::collections::BTreeSet<usize>) {
+        ) -> Result<(BitSet, std::collections::BTreeSet<usize>), alloc::TryReserveError> {
             let mut m = BitSet::default();
             let mut r = std::collections::BTreeSet::new();
             for _ in 0..(rng.next_u32() % 20) {
                 let i = (rng.next_u32() as usize) % max_index;
-                m.set(i);
+                m.set(i)?;
                 r.insert(i);
             }
-            (m, r)
+            Ok((m, r))
         }
 
         let (mut rng, seed) = rng_from_env_or_time();
@@ -3879,7 +3898,7 @@ mod tests {
             match op {
                 0..=3 => {
                     // Set (weighted to grow the set)
-                    mask.set(idx);
+                    mask.set(idx)?;
                     reference.insert(idx);
                 }
                 4 => {
@@ -3906,7 +3925,7 @@ mod tests {
                 }
                 7 => {
                     // intersects() agrees with BTreeSet intersection
-                    let (other_mask, other_ref) = sample_other(&mut rng, max_index);
+                    let (other_mask, other_ref) = sample_other(&mut rng, max_index)?;
                     let expected = reference.intersection(&other_ref).next().is_some();
                     assert_eq!(
                         mask.intersects(&other_mask),
@@ -3921,14 +3940,14 @@ mod tests {
                     );
                 }
                 8 => {
-                    // FromIterator: building a fresh BitSet from the reference
+                    // Fallible collection: building a fresh BitSet from the reference
                     // must compare equal to the mask.
-                    let built: BitSet = reference.iter().copied().collect();
-                    assert_eq!(built, mask, "step={step} seed={seed} op=FromIterator");
+                    let built = BitSet::try_from_iter(reference.iter().copied())?;
+                    assert_eq!(built, mask, "step={step} seed={seed} op=try_from_iter");
                 }
                 9 => {
-                    // iter() -> collect::<BitSet>() round trip is the identity
-                    let round: BitSet = mask.iter().collect();
+                    // iter() -> try_from_iter() round trip is the identity
+                    let round = BitSet::try_from_iter(mask.iter())?;
                     assert_eq!(round, mask, "step={step} seed={seed} op=iter-roundtrip");
 
                     // iter() yields bits in strictly increasing order, matching the reference
@@ -3946,55 +3965,55 @@ mod tests {
                     );
                 }
                 10 => {
-                    // From<u128>: sample a random u128, verify per-bit and count
+                    // TryFrom<u128>: sample a random u128, verify per-bit and count
                     let val = ((rng.next_u32() as u128) << 96)
                         | ((rng.next_u32() as u128) << 64)
                         | ((rng.next_u32() as u128) << 32)
                         | (rng.next_u32() as u128);
-                    let bs = BitSet::from(val);
+                    let bs = BitSet::try_from(val)?;
                     assert_eq!(
                         bs.count(),
                         val.count_ones() as usize,
-                        "step={step} seed={seed} From<u128>({val:#x}) count"
+                        "step={step} seed={seed} TryFrom<u128>({val:#x}) count"
                     );
                     for i in 0..128 {
                         let expected = (val >> i) & 1 != 0;
                         assert_eq!(
                             bs.get(i),
                             expected,
-                            "step={step} seed={seed} From<u128>({val:#x}) get({i})"
+                            "step={step} seed={seed} TryFrom<u128>({val:#x}) get({i})"
                         );
                     }
                     // Path equivalence: same bits via set() must compare equal
                     let mut manual = BitSet::default();
                     for i in 0..128 {
                         if (val >> i) & 1 != 0 {
-                            manual.set(i);
+                            manual.set(i)?;
                         }
                     }
                     assert_eq!(
                         bs, manual,
-                        "step={step} seed={seed} From<u128>({val:#x}) vs manual"
+                        "step={step} seed={seed} TryFrom<u128>({val:#x}) vs manual"
                     );
-                    // From<u128>(0) must equal default (equality anchor)
+                    // TryFrom<u128>(0) must equal default (equality anchor)
                     assert_eq!(
-                        BitSet::<usize>::from(0u128),
+                        BitSet::<usize>::try_from(0u128)?,
                         BitSet::<usize>::default(),
-                        "step={step} seed={seed} From<u128>(0) != default"
+                        "step={step} seed={seed} TryFrom<u128>(0) != default"
                     );
                 }
                 11 => {
                     // SubAssign (delegates to subtract)
-                    let (other_mask, other_ref) = sample_other(&mut rng, max_index);
+                    let (other_mask, other_ref) = sample_other(&mut rng, max_index)?;
                     mask -= &other_mask;
                     for i in &other_ref {
                         reference.remove(i);
                     }
                 }
                 12 => {
-                    // BitOrAssign
-                    let (other_mask, other_ref) = sample_other(&mut rng, max_index);
-                    mask |= &other_mask;
+                    // union_with
+                    let (other_mask, other_ref) = sample_other(&mut rng, max_index)?;
+                    mask.union_with(&other_mask)?;
                     for i in other_ref {
                         reference.insert(i);
                     }
@@ -4015,7 +4034,7 @@ mod tests {
                 }
                 14 => {
                     // Cross-method: contains_all(other) && !other.is_empty() => intersects(other)
-                    let (other_mask, other_ref) = sample_other(&mut rng, max_index);
+                    let (other_mask, other_ref) = sample_other(&mut rng, max_index)?;
                     if mask.contains_all_set_bits_of(&other_mask) && !other_ref.is_empty() {
                         assert!(
                             mask.intersects(&other_mask),
@@ -4048,18 +4067,19 @@ mod tests {
             reference.len(),
             "final count mismatch, seed={seed}"
         );
+        Ok(())
     }
 
     #[test]
-    fn test_bitset_with_table_internal_id() {
+    fn test_bitset_with_table_internal_id() -> TestResult {
         let a = TableInternalId::from(3);
         let b = TableInternalId::from(70); // exercises overflow path
         let c = TableInternalId::from(200);
 
         let mut mask: BitSet<TableInternalId> = BitSet::default();
-        mask.set(a);
-        mask.set(b);
-        mask.set(c);
+        mask.set(a)?;
+        mask.set(b)?;
+        mask.set(c)?;
 
         assert!(mask.get(a));
         assert!(mask.get(b));
@@ -4075,15 +4095,19 @@ mod tests {
         let collected: Vec<TableInternalId> = (&mask).into_iter().collect();
         assert_eq!(collected, vec![a, c]);
 
-        // FromIterator<TableInternalId> works.
-        let rebuilt: BitSet<TableInternalId> = [a, c].into_iter().collect();
+        // Fallible collection preserves TableInternalId.
+        let rebuilt = BitSet::<TableInternalId>::try_from_iter([a, c])?;
         assert_eq!(rebuilt, mask);
+        let mut extended = BitSet::<TableInternalId>::default();
+        extended.try_extend([a, c])?;
+        assert_eq!(extended, mask);
+        Ok(())
     }
 
     #[test]
-    fn test_column_mask_sub_assign() {
-        let mut a: ColumnMask = [1, 3, ROWID_SENTINEL].into_iter().collect();
-        let b: ColumnMask = [3, ROWID_SENTINEL].into_iter().collect();
+    fn test_column_mask_sub_assign() -> TestResult {
+        let mut a = ColumnMask::try_from_iter([1, 3, ROWID_SENTINEL])?;
+        let b = ColumnMask::try_from_iter([3, ROWID_SENTINEL])?;
         a -= &b;
         assert!(a.get(1));
         assert!(!a.get(3));
@@ -4091,12 +4115,13 @@ mod tests {
         assert_eq!(a.count(), 1);
 
         // Subtracting without rowid sentinel leaves it intact
-        let mut a: ColumnMask = [2, 4, ROWID_SENTINEL].into_iter().collect();
-        let b: ColumnMask = [2].into_iter().collect();
+        let mut a = ColumnMask::try_from_iter([2, 4, ROWID_SENTINEL])?;
+        let b = ColumnMask::try_from_iter([2])?;
         a -= &b;
         assert!(!a.get(2));
         assert!(a.get(4));
         assert!(a.get(ROWID_SENTINEL));
         assert_eq!(a.count(), 2);
+        Ok(())
     }
 }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1157,8 +1157,9 @@ impl OuterQueryReference {
     }
 
     /// Marks a column as used; used means that the column is referenced in the query.
-    pub fn mark_column_used(&mut self, column_index: usize) {
-        self.col_used_mask.set(column_index);
+    pub fn mark_column_used(&mut self, column_index: usize) -> Result<()> {
+        self.col_used_mask.set(column_index)?;
+        Ok(())
     }
 
     /// Whether the OuterQueryReference is used by the current query scope.
@@ -1441,7 +1442,9 @@ impl TableReferences {
         } else if let Some(outer_query_ref) =
             self.find_outer_query_ref_by_internal_id_mut(internal_id)
         {
-            outer_query_ref.mark_column_used(column_index);
+            outer_query_ref
+                .mark_column_used(column_index)
+                .expect("TODO: alloc error");
         } else {
             panic!("table with internal id {internal_id} not found in table references");
         }
@@ -2393,7 +2396,7 @@ impl JoinedTable {
             self.column_use_counts.resize(index + 1, 0);
         }
         self.column_use_counts[index] += 1;
-        self.col_used_mask.set(index);
+        self.col_used_mask.set(index).expect("TODO: alloc error");
     }
 
     /// Clear any previously registered expression index usages.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alloc::{self, TursoAllocExt},
+    alloc::{self, TursoAllocExt, TursoFromIterator, TursoIteratorExt},
     function::{AggFunc, WindowFunc},
     schema::{
         BTreeTable, ColDef, Column, FromClauseSubquery, Index, Schema, Table, Type, ROWID_SENTINEL,
@@ -1088,25 +1088,25 @@ pub struct JoinedTable {
 }
 
 impl JoinedTable {
-    pub fn using_dedup_hidden_cols(&self) -> ColumnMask {
-        self.join_info
-            .as_ref()
-            .map(|join_info| {
-                self.table
-                    .columns()
+    pub fn using_dedup_hidden_cols(&self) -> Result<ColumnMask> {
+        let Some(join_info) = self.join_info.as_ref() else {
+            return Ok(ColumnMask::default());
+        };
+        let col_mask = self
+            .table
+            .columns()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, col)| {
+                let col_name = col.name.as_deref()?;
+                join_info
+                    .using
                     .iter()
-                    .enumerate()
-                    .filter_map(|(idx, col)| {
-                        let col_name = col.name.as_deref()?;
-                        join_info
-                            .using
-                            .iter()
-                            .any(|using_col| using_col.as_str().eq_ignore_ascii_case(col_name))
-                            .then_some(idx)
-                    })
-                    .collect()
+                    .any(|using_col| using_col.as_str().eq_ignore_ascii_case(col_name))
+                    .then_some(idx)
             })
-            .unwrap_or_default()
+            .try_collect()?;
+        Ok(col_mask)
     }
 }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1,5 +1,5 @@
 use crate::{
-    alloc::{self, TursoAllocExt, TursoFromIterator, TursoIteratorExt},
+    alloc::{self, TursoIteratorExt},
     function::{AggFunc, WindowFunc},
     schema::{
         BTreeTable, ColDef, Column, FromClauseSubquery, Index, Schema, Table, Type, ROWID_SENTINEL,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -524,7 +524,7 @@ fn plan_cte(
             identifier: referenced_table.identifier.clone(),
             internal_id: referenced_table.internal_id,
             table: referenced_table.table.clone(),
-            using_dedup_hidden_cols: referenced_table.using_dedup_hidden_cols(),
+            using_dedup_hidden_cols: referenced_table.using_dedup_hidden_cols()?,
             col_used_mask: ColumnUsedMask::default(),
             cte_select: None,
             cte_explicit_columns: vec![],

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1497,7 +1497,7 @@ pub fn table_mask_from_expr(
                     .iter()
                     .position(|t| t.internal_id == *table)
                 {
-                    mask.set(table_idx);
+                    mask.set(table_idx)?;
                 } else if table_references
                     .find_outer_query_ref_by_internal_id(*table)
                     .is_none()
@@ -1525,7 +1525,7 @@ pub fn table_mask_from_expr(
                                 .iter()
                                 .position(|t| t.internal_id == *outer_ref_id)
                             {
-                                mask.set(table_idx);
+                                mask.set(table_idx)?;
                             }
                         }
                     }
@@ -1543,7 +1543,7 @@ pub fn table_mask_from_expr(
                                 .iter()
                                 .position(|t| t.internal_id == *outer_ref_id)
                             {
-                                mask.set(table_idx);
+                                mask.set(table_idx)?;
                             }
                         }
                     }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -281,13 +281,13 @@ pub fn translate_pragma(
         TransactionMode::None => {}
         TransactionMode::Read => {
             let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-            program.begin_read_on_database(database_id, schema_cookie);
-            program.begin_read_operation();
+            program.begin_read_on_database(database_id, schema_cookie)?;
+            program.begin_read_operation()?;
         }
         TransactionMode::Write => {
             let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-            program.begin_write_on_database(database_id, schema_cookie);
-            program.begin_write_operation();
+            program.begin_write_on_database(database_id, schema_cookie)?;
+            program.begin_write_operation()?;
         }
         TransactionMode::Concurrent => {
             program.begin_concurrent_operation();

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1,6 +1,7 @@
 //! VDBE bytecode generation for pragma statements.
 //! More info: https://www.sqlite.org/pragma.html.
 
+use crate::alloc::TursoIteratorExt;
 use crate::sync::Arc;
 use crate::turso_soft_unreachable;
 use chrono::Datelike;
@@ -47,19 +48,20 @@ fn parse_max_errors_from_value(value: &Option<Expr>) -> usize {
     }
 }
 
-fn visible_database_ids_for_table_list(connection: &crate::Connection) -> BitSet {
+fn visible_database_ids_for_table_list(connection: &crate::Connection) -> crate::Result<BitSet> {
+    use crate::alloc::*;
     let mut ids = BitSet::default();
     ids.set(crate::MAIN_DB_ID);
     ids.set(crate::TEMP_DB_ID);
-    ids.extend(
+    ids.try_extend(
         connection
             .attached_databases()
             .read()
             .index_to_data
             .keys()
             .copied(),
-    );
-    ids
+    )?;
+    Ok(ids)
 }
 
 fn display_table_list_name(database_id: usize, name: &str) -> String {
@@ -1228,9 +1230,9 @@ fn query_pragma(
             program.alloc_registers(5);
 
             let database_ids = if schema_was_explicit {
-                [database_id].into_iter().collect::<BitSet>()
+                [database_id].into_iter().try_collect::<BitSet>()?
             } else {
-                visible_database_ids_for_table_list(connection.as_ref())
+                visible_database_ids_for_table_list(connection.as_ref())?
             };
             for current_database_id in &database_ids {
                 let database_name = connection

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -51,8 +51,8 @@ fn parse_max_errors_from_value(value: &Option<Expr>) -> usize {
 fn visible_database_ids_for_table_list(connection: &crate::Connection) -> crate::Result<BitSet> {
     use crate::alloc::*;
     let mut ids = BitSet::default();
-    ids.set(crate::MAIN_DB_ID);
-    ids.set(crate::TEMP_DB_ID);
+    ids.set(crate::MAIN_DB_ID)?;
+    ids.set(crate::TEMP_DB_ID)?;
     ids.try_extend(
         connection
             .attached_databases()

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1121,7 +1121,7 @@ pub fn translate_create_table(
         resolver.resolve_database_id(&tbl_name)?
     };
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
     let normalized_tbl_name = normalize_ident(tbl_name.name.as_str());
     validate(&body, &normalized_tbl_name, resolver, connection)?;
 
@@ -1790,7 +1790,7 @@ pub fn translate_drop_table(
     program.extend(&opts);
 
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
 
     let Some(table) = resolver.with_schema(database_id, |s| s.get_table(name)) else {
         if if_exists {
@@ -1942,7 +1942,7 @@ pub fn translate_drop_table(
 
         if !trigger_names_to_drop.is_empty() {
             let temp_schema_cookie = resolver.with_schema(crate::TEMP_DB_ID, |s| s.schema_version);
-            program.begin_write_on_database(crate::TEMP_DB_ID, temp_schema_cookie);
+            program.begin_write_on_database(crate::TEMP_DB_ID, temp_schema_cookie)?;
             let temp_schema_table =
                 resolver.with_schema(crate::TEMP_DB_ID, |s| s.get_btree_table(SQLITE_TABLEID));
             if let Some(temp_schema_table) = temp_schema_table {

--- a/core/translate/stmt_journal.rs
+++ b/core/translate/stmt_journal.rs
@@ -180,6 +180,7 @@ pub(crate) fn set_update_stmt_journal_flags(
     resolver: &Resolver,
     connection: &crate::sync::Arc<crate::Connection>,
 ) -> Result<()> {
+    use crate::alloc::*;
     let target_table = &plan.target_table;
     let Some(btree_table) = target_table.btree() else {
         return Ok(()); // Virtual table — keep conservative defaults.
@@ -190,7 +191,7 @@ pub(crate) fn set_update_stmt_journal_flags(
         .set_clauses
         .iter()
         .map(|set_clause| set_clause.column_index)
-        .collect();
+        .try_collect()?;
     let has_triggers = has_triggers_including_temp(
         resolver,
         database_id,

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashMap as HashMap;
 use turso_parser::ast::{self, SortOrder, SubqueryType};
 
 use crate::{
+    alloc::TursoIteratorExt,
     emit_explain,
     schema::{BTreeCharacteristics, BTreeTable, Column, Index, IndexColumn, Table},
     translate::{
@@ -308,7 +309,7 @@ pub fn plan_subqueries_from_select_plan(
     }
 
     // LIMIT and OFFSET cannot reference columns from the outer query
-    let get_outer_query_refs = |_: &TableReferences| vec![];
+    let get_outer_query_refs = |_: &TableReferences| Ok(crate::alloc::try_vec![]?);
     {
         let mut subquery_parser = get_subquery_parser(
             program,
@@ -519,7 +520,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
     // including nested cases where a subquery inside a subquery references columns from its parent's parent
     // and so on.
     let get_outer_query_refs = |referenced_tables: &TableReferences| {
-        referenced_tables
+        let outer_refs = referenced_tables
             .joined_tables()
             .iter()
             .map(|t| {
@@ -528,39 +529,38 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     Table::FromClauseSubquery(subq) => subq.cte_id(),
                     _ => None,
                 };
-                OuterQueryReference {
+                let outer_ref = OuterQueryReference {
                     table: t.table.clone(),
                     identifier: t.identifier.clone(),
                     internal_id: t.internal_id,
-                    using_dedup_hidden_cols: t.using_dedup_hidden_cols(),
+                    using_dedup_hidden_cols: t.using_dedup_hidden_cols()?,
                     col_used_mask: ColumnUsedMask::default(),
                     cte_select: None,
-                    cte_explicit_columns: vec![],
+                    cte_explicit_columns: Vec::new(),
                     cte_id,
                     cte_definition_only: false,
                     rowid_referenced: false,
                     scope_depth: 0,
-                }
+                };
+                Ok::<_, crate::LimboError>(outer_ref)
             })
-            .chain(
-                referenced_tables
-                    .outer_query_refs()
-                    .iter()
-                    .map(|t| OuterQueryReference {
-                        table: t.table.clone(),
-                        identifier: t.identifier.clone(),
-                        internal_id: t.internal_id,
-                        using_dedup_hidden_cols: t.using_dedup_hidden_cols.clone(),
-                        col_used_mask: ColumnUsedMask::default(),
-                        cte_select: t.cte_select.clone(),
-                        cte_explicit_columns: t.cte_explicit_columns.clone(),
-                        cte_id: t.cte_id, // Preserve CTE ID from outer query refs
-                        cte_definition_only: t.cte_definition_only,
-                        rowid_referenced: false,
-                        scope_depth: t.scope_depth + 1,
-                    }),
-            )
-            .collect::<Vec<_>>()
+            .chain(referenced_tables.outer_query_refs().iter().map(|t| {
+                Ok(OuterQueryReference {
+                    table: t.table.clone(),
+                    identifier: t.identifier.clone(),
+                    internal_id: t.internal_id,
+                    using_dedup_hidden_cols: t.using_dedup_hidden_cols.clone(),
+                    col_used_mask: ColumnUsedMask::default(),
+                    cte_select: t.cte_select.clone(),
+                    cte_explicit_columns: t.cte_explicit_columns.clone(),
+                    cte_id: t.cte_id, // Preserve CTE ID from outer query refs
+                    cte_definition_only: t.cte_definition_only,
+                    rowid_referenced: false,
+                    scope_depth: t.scope_depth + 1,
+                })
+            }))
+            .try_collect::<Result<crate::alloc::Vec<_>>>()??;
+        Ok(outer_refs)
     };
 
     let mut subquery_parser = get_subquery_parser(
@@ -589,7 +589,8 @@ fn get_subquery_parser<'a>(
     referenced_tables: &'a mut TableReferences,
     resolver: &'a Resolver,
     connection: &'a Arc<Connection>,
-    get_outer_query_refs: impl Fn(&TableReferences) -> Vec<OuterQueryReference> + 'a,
+    get_outer_query_refs: impl Fn(&TableReferences) -> Result<crate::alloc::Vec<OuterQueryReference>>
+        + 'a,
     position: SubqueryPosition,
     origin: SubqueryOrigin,
     allow_correlated: bool,
@@ -612,7 +613,7 @@ fn get_subquery_parser<'a>(
                 let outer_query_refs = {
                     crate::stack::trace_stack!("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
-                };
+                }?;
 
                 let result_reg = program.alloc_register();
                 let subquery_type = SubqueryType::Exists { result_reg };
@@ -662,7 +663,7 @@ fn get_subquery_parser<'a>(
                 let outer_query_refs = {
                     crate::stack::trace_stack!("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
-                };
+                }?;
 
                 let result_expr = ast::Expr::SubqueryResult {
                     subquery_id,
@@ -773,7 +774,7 @@ fn get_subquery_parser<'a>(
                 let outer_query_refs = {
                     crate::stack::trace_stack!("get_outer_refs");
                     get_outer_query_refs(referenced_tables)
-                };
+                }?;
 
                 let ast::Expr::InSelect { lhs, not, rhs } = ({
                     crate::stack::trace_stack!("take_in_select_expr");
@@ -998,12 +999,16 @@ fn update_column_used_masks(
                     }
                     joined_table.column_use_counts[col_idx] += 1;
                 }
-                joined_table.col_used_mask |= &child_outer_query_ref.col_used_mask;
+                joined_table
+                    .col_used_mask
+                    .union_with(&child_outer_query_ref.col_used_mask)?;
             }
             if let Some(outer_query_ref) = table_refs
                 .find_outer_query_ref_by_internal_id_mut(child_outer_query_ref.internal_id)
             {
-                outer_query_ref.col_used_mask |= &child_outer_query_ref.col_used_mask;
+                outer_query_ref
+                    .col_used_mask
+                    .union_with(&child_outer_query_ref.col_used_mask)?;
             }
         }
 
@@ -1233,7 +1238,7 @@ pub fn emit_from_clause_subqueries(
         .iter()
         .map(|member| member.original_idx)
         .collect();
-    let visit_set: TableMask = visit_order.iter().copied().collect();
+    let visit_set: TableMask = visit_order.iter().copied().try_collect()?;
     for table in tables.joined_tables().iter() {
         if let Operation::HashJoin(hash_join_op) = &table.op {
             let build_idx = hash_join_op.build_table_idx;
@@ -1248,7 +1253,7 @@ pub fn emit_from_clause_subqueries(
         .iter()
         .filter(|m| m.is_outer)
         .map(|m| m.original_idx)
-        .collect();
+        .try_collect()?;
 
     for table_index in visit_order {
         let table_reference = &mut tables.joined_tables_mut()[table_index];

--- a/core/translate/transaction.rs
+++ b/core/translate/transaction.rs
@@ -45,7 +45,7 @@ pub fn translate_tx_begin(
                 tx_mode: TransactionMode::Write,
                 schema_cookie: temp_schema_cookie,
             });
-            for db_id in resolver.attached_database_ids_in_search_order() {
+            for db_id in resolver.attached_database_ids_in_search_order()? {
                 let cookie = resolver.with_schema(db_id, |s| s.schema_version);
                 program.emit_insn(Insn::Transaction {
                     db: db_id,
@@ -73,7 +73,7 @@ pub fn translate_tx_begin(
                 tx_mode: TransactionMode::Write,
                 schema_cookie: temp_schema_cookie,
             });
-            for db_id in resolver.attached_database_ids_in_search_order() {
+            for db_id in resolver.attached_database_ids_in_search_order()? {
                 let cookie = resolver.with_schema(db_id, |s| s.schema_version);
                 program.emit_insn(Insn::Transaction {
                     db: db_id,

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -125,8 +125,8 @@ pub fn translate_create_trigger(
     }
 
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
-    program.begin_write_operation();
+    program.begin_write_on_database(database_id, schema_cookie)?;
+    program.begin_write_operation()?;
 
     // Temp-backed triggers follow SQLite's looser name-resolution rules and may
     // access objects across schemas. Ordinary triggers stay schema-local.
@@ -475,8 +475,8 @@ pub fn translate_drop_trigger(
 ) -> Result<()> {
     let database_id = resolver.resolve_existing_trigger_database_id(trigger_name)?;
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
-    program.begin_write_operation();
+    program.begin_write_on_database(database_id, schema_cookie)?;
+    program.begin_write_operation()?;
     let normalized_trigger_name = normalize_ident(trigger_name.name.as_str());
 
     // Check if trigger exists

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -636,7 +636,7 @@ fn execute_trigger_commands(
             program.begin_write_operation();
         } else {
             let schema_cookie = resolver.with_schema(db_id, |s| s.schema_version);
-            program.begin_write_on_database(db_id, schema_cookie);
+            program.begin_write_on_database(db_id, schema_cookie)?;
         }
     }
     for db_id in &subprogram_prepared.read_databases {
@@ -644,10 +644,10 @@ fn execute_trigger_commands(
             continue;
         }
         if db_id == crate::MAIN_DB_ID {
-            program.begin_read_operation();
+            program.begin_read_operation()?;
         } else {
             let schema_cookie = resolver.with_schema(db_id, |s| s.schema_version);
-            program.begin_read_on_database(db_id, schema_cookie);
+            program.begin_read_on_database(db_id, schema_cookie)?;
         }
     }
 

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -633,7 +633,7 @@ fn execute_trigger_commands(
     // before OP_Program enters the subprogram.
     for db_id in &subprogram_prepared.write_databases {
         if db_id == crate::MAIN_DB_ID {
-            program.begin_write_operation();
+            program.begin_write_operation()?;
         } else {
             let schema_cookie = resolver.with_schema(db_id, |s| s.schema_version);
             program.begin_write_on_database(db_id, schema_cookie)?;

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -262,7 +262,7 @@ fn prepare_update_plan(
         bail_parse_error!("UPDATE of WITHOUT ROWID tables is not supported");
     }
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
     validate_update(
         schema,
         &body,

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -542,9 +542,10 @@ fn collect_indexes_to_update(
     read_scope_tables: &mut TableReferences,
     resolver: &Resolver,
 ) -> crate::Result<Vec<Arc<crate::schema::Index>>> {
-    let indexes: Vec<_> = resolver.with_schema(database_id, |s| {
-        s.get_indices(table_name).cloned().collect()
-    });
+    use crate::alloc::TursoIteratorExt;
+    let indexes: crate::alloc::Vec<_> = resolver.with_schema(database_id, |s| {
+        s.get_indices(table_name).cloned().try_collect()
+    })?;
     let target_table_ref = read_scope_tables
         .joined_tables()
         .first()
@@ -553,8 +554,9 @@ fn collect_indexes_to_update(
     let rowid_alias_used = set_clauses.iter().any(|set| {
         set.column_index == ROWID_SENTINEL || columns[set.column_index].is_rowid_alias()
     });
-    let updated_cols: Option<ColumnMask> =
-        (!rowid_alias_used).then(|| set_clauses.iter().map(|set| set.column_index).collect());
+    let updated_cols: Option<ColumnMask> = (!rowid_alias_used)
+        .then(|| set_clauses.iter().map(|set| set.column_index).try_collect())
+        .transpose()?;
     let affected_cols = match (table.btree(), updated_cols.as_ref()) {
         (Some(bt), Some(updated)) => Some(bt.columns_affected_by_update(updated)?),
         (None, Some(updated)) => Some(updated.clone()),
@@ -571,7 +573,7 @@ fn collect_indexes_to_update(
             if let Some(expr) = col.expr.as_ref() {
                 let cols_used =
                     expression_index_column_usage(expr.as_ref(), target_table_ref, resolver)?;
-                expression_cols_used |= &cols_used;
+                expression_cols_used.union_with(&cols_used);
 
                 if !must_update
                     && affected_cols.as_ref().is_some_and(|affected_cols| {

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -573,7 +573,7 @@ fn collect_indexes_to_update(
             if let Some(expr) = col.expr.as_ref() {
                 let cols_used =
                     expression_index_column_usage(expr.as_ref(), target_table_ref, resolver)?;
-                expression_cols_used.union_with(&cols_used);
+                expression_cols_used.union_with(&cols_used)?;
 
                 if !must_update
                     && affected_cols.as_ref().is_some_and(|affected_cols| {

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use turso_parser::ast::{self, TriggerEvent, TriggerTime, Upsert};
 
 use super::emitter::gencol::compute_virtual_columns;
+use crate::alloc::TursoIteratorExt;
 use crate::error::SQLITE_CONSTRAINT_PRIMARYKEY;
 use crate::schema::{BTreeTable, ColumnLayout, IndexColumn, ROWID_SENTINEL};
 use crate::translate::emitter::{emit_check_constraints, emit_make_record, UpdateRowSource};
@@ -228,7 +229,7 @@ fn index_expression_cols(table: &Table, out: &mut ColumnMask, expr: &ast::Expr) 
         match e {
             Expr::Id(n) => {
                 if let Some((i, _)) = table.get_column_by_name(&normalize_ident(n.as_str())) {
-                    out.set(i);
+                    out.set(i)?;
                 } else if ROWID_STRS
                     .iter()
                     .any(|r| r.eq_ignore_ascii_case(n.as_str()))
@@ -237,7 +238,7 @@ fn index_expression_cols(table: &Table, out: &mut ColumnMask, expr: &ast::Expr) 
                         .btree()
                         .and_then(|t| t.get_rowid_alias_column().map(|(p, _)| p))
                     {
-                        out.set(rowid_pos);
+                        out.set(rowid_pos)?;
                     }
                 }
             }
@@ -250,7 +251,7 @@ fn index_expression_cols(table: &Table, out: &mut ColumnMask, expr: &ast::Expr) 
                     }
                 }
             }
-            Expr::Column { column, .. } => out.set(*column),
+            Expr::Column { column, .. } => out.set(*column)?,
             _ => {}
         }
         Ok(WalkControl::Continue)
@@ -686,8 +687,10 @@ pub fn emit_upsert(
     // Fire BEFORE UPDATE triggers
     let upsert_database_id = ctx.database_id;
     let preserved_old_registers: Option<Vec<usize>> = if let Some(btree_table) = table.btree() {
-        let updated_column_indices: ColumnMask =
-            set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
+        let updated_column_indices: ColumnMask = set_pairs
+            .iter()
+            .map(|(col_idx, _)| *col_idx)
+            .try_collect()?;
         let relevant_before_update_triggers = get_triggers_including_temp(
             resolver,
             upsert_database_id,
@@ -798,7 +801,10 @@ pub fn emit_upsert(
     } else {
         None
     };
-    let updated_positions: ColumnMask = set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
+    let updated_positions: ColumnMask = set_pairs
+        .iter()
+        .map(|(col_idx, _)| *col_idx)
+        .try_collect()?;
     if let Some(bt) = table.btree() {
         if connection.foreign_keys_enabled() {
             let rowid_new_reg = new_rowid_reg.unwrap_or(ctx.conflict_rowid_reg);
@@ -1231,8 +1237,10 @@ pub fn emit_upsert(
 
     // Fire AFTER UPDATE triggers
     if let (Some(btree_table), Some(old_regs)) = (table.btree(), preserved_old_registers) {
-        let updated_column_indices: ColumnMask =
-            set_pairs.iter().map(|(col_idx, _)| *col_idx).collect();
+        let updated_column_indices: ColumnMask = set_pairs
+            .iter()
+            .map(|(col_idx, _)| *col_idx)
+            .try_collect()?;
         let relevant_triggers = get_triggers_including_temp(
             resolver,
             upsert_database_id,

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -619,7 +619,7 @@ pub fn emit_upsert(
                     &bt,
                     resolver.schema(),
                     None,
-                ),
+                )?,
             });
 
             // Encode ALL columns. Both non-SET columns (decoded from disk above)

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -213,7 +213,7 @@ fn referenced_index_cols(idx: &Index, table: &Table) -> crate::Result<ColumnMask
         if let Some(expr) = &ic.expr {
             index_expression_cols(table, &mut referenced_cols, expr);
         } else {
-            referenced_cols.set(ic.pos_in_table);
+            referenced_cols.set(ic.pos_in_table)?;
         }
     }
     match table.btree() {
@@ -247,7 +247,7 @@ fn index_expression_cols(table: &Table, out: &mut ColumnMask, expr: &ast::Expr) 
                 let tname = normalize_ident(table.get_name());
                 if nsn.eq_ignore_ascii_case(&tname) {
                     if let Some((i, _)) = table.get_column_by_name(&normalize_ident(c.as_str())) {
-                        out.set(i);
+                        out.set(i)?;
                     }
                 }
             }

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -174,7 +174,7 @@ fn collect_changed_cols(
             if c.is_rowid_alias() {
                 rowid_changed = true;
             } else {
-                cols_changed.set(*col_idx);
+                cols_changed.set(*col_idx).expect("TODO: alloc error");
             }
         }
     }
@@ -323,7 +323,7 @@ pub fn upsert_matches_index(upsert: &Upsert, index: &Index, table: &Table) -> bo
         }
 
         if let Some(i) = found {
-            matched.set(i);
+            matched.set(i).expect("TODO: alloc error");
         } else {
             return false;
         }

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -61,7 +61,7 @@ pub fn translate_create_materialized_view(
 ) -> Result<()> {
     let database_id = resolver.resolve_database_id(view_name)?;
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
     let normalized_view_name = normalize_ident(view_name.name.as_str());
 
     // Validate the view can be created and extract its columns
@@ -297,7 +297,7 @@ pub fn translate_create_view(
 ) -> Result<()> {
     let database_id = resolver.resolve_database_id(view_name)?;
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
     let normalized_view_name = normalize_ident(view_name.name.as_str());
 
     validate_create_view(resolver, database_id, &normalized_view_name)?;
@@ -385,7 +385,7 @@ pub fn translate_drop_view(
 ) -> Result<()> {
     let database_id = resolver.resolve_database_id(view_name)?;
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
-    program.begin_write_on_database(database_id, schema_cookie);
+    program.begin_write_on_database(database_id, schema_cookie)?;
     let normalized_view_name = normalize_ident(view_name.name.as_str());
 
     // Check if view exists (either regular or materialized)

--- a/core/util.rs
+++ b/core/util.rs
@@ -4978,8 +4978,7 @@ pub mod tests {
 
     #[test]
     fn test_rewrite_trigger_cmd_table_refs_expr_subquery_branch() {
-        let sql =
-            "CREATE TEMP TRIGGER trg AFTER INSERT ON temp.old BEGIN SELECT EXISTS(SELECT 1 FROM temp.old); END";
+        let sql = "CREATE TEMP TRIGGER trg AFTER INSERT ON temp.old BEGIN SELECT EXISTS(SELECT 1 FROM temp.old); END";
         let mut parser = Parser::new(sql.as_bytes());
         let cmd = parser
             .next_cmd()

--- a/core/util.rs
+++ b/core/util.rs
@@ -647,7 +647,7 @@ pub fn try_capture_parameters_column_agnostic(
                 continue;
             }
             if exprs_are_equivalent(pattern_col, query_col) {
-                matched_pattern_indices.set(i);
+                matched_pattern_indices.set(i).expect("TODO: alloc error");
                 found_match = true;
                 break;
             }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,4 +1,5 @@
-use crate::{turso_assert, turso_assert_eq, turso_debug_assert};
+use crate::{alloc, turso_assert, turso_assert_eq, turso_debug_assert, Result};
+
 use rustc_hash::FxHashMap as HashMap;
 use tracing::{instrument, Level};
 use turso_parser::ast::{self, ResolveType, SortOrder, TableInternalId};
@@ -1625,37 +1626,47 @@ impl ProgramBuilder {
     }
 
     /// Tries to mirror: https://github.com/sqlite/sqlite/blob/e77e589a35862f6ac9c4141cfd1beb2844b84c61/src/build.c#L5379
-    pub fn begin_write_operation(&mut self) {
+    pub fn begin_write_operation(&mut self) -> Result<(), alloc::TryReserveError> {
         self.txn_mode = TransactionMode::Write;
-        self.write_databases.set(crate::MAIN_DB_ID);
+        self.write_databases.set(crate::MAIN_DB_ID)
     }
 
     /// Begin a write operation on a specific database (for attached databases).
-    pub fn begin_write_on_database(&mut self, database_id: usize, schema_cookie: u32) {
+    pub fn begin_write_on_database(
+        &mut self,
+        database_id: usize,
+        schema_cookie: u32,
+    ) -> Result<(), alloc::TryReserveError> {
         self.txn_mode = TransactionMode::Write;
-        self.write_databases.set(database_id);
+        self.write_databases.set(database_id)?;
         self.write_database_cookies
             .insert(database_id, schema_cookie);
+        Ok(())
     }
 
-    pub fn begin_read_operation(&mut self) {
+    pub fn begin_read_operation(&mut self) -> Result<(), alloc::TryReserveError> {
         // Just override the transaction mode when it is None
         if matches!(self.txn_mode, TransactionMode::None) {
             self.txn_mode = TransactionMode::Read;
         }
-        self.read_databases.set(crate::MAIN_DB_ID);
+        self.read_databases.set(crate::MAIN_DB_ID)
     }
 
     /// Begin a read operation on a specific attached database.
     /// This ensures a Transaction instruction is emitted for the attached pager
     /// so that a WAL read lock is acquired.
-    pub fn begin_read_on_database(&mut self, database_id: usize, schema_cookie: u32) {
+    pub fn begin_read_on_database(
+        &mut self,
+        database_id: usize,
+        schema_cookie: u32,
+    ) -> Result<(), alloc::TryReserveError> {
         if matches!(self.txn_mode, TransactionMode::None) {
             self.txn_mode = TransactionMode::Read;
         }
-        self.read_databases.set(database_id);
+        self.read_databases.set(database_id)?;
         self.read_database_cookies
             .insert(database_id, schema_cookie);
+        Ok(())
     }
 
     pub const fn begin_concurrent_operation(&mut self) {

--- a/scripts/compare-divan-std-turso.py
+++ b/scripts/compare-divan-std-turso.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Compare Divan benchmark pairs named *_std and *_turso."""
+
+import argparse
+import csv
+import os
+import re
+import subprocess
+import sys
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+BENCH_RE = re.compile(
+    r"^.*[\u251c\u2570]\u2500\s*"
+    r"([A-Za-z0-9_]+_(?:std|turso))\s*(?:[|\u2502]|$)"
+)
+SIZE_RE = re.compile(r"[\u251c\u2570]\u2500\s*([0-9][0-9_,]*)\s+(.+?)\s*$")
+
+
+def strip_ansi(line):
+    return ANSI_RE.sub("", line)
+
+
+def parse_duration_ns(value):
+    value = value.strip()
+    match = re.search(r"([0-9.]+)\s*(ns|us|\u00b5s|ms|s)", value)
+    if not match:
+        return None
+
+    amount = float(match.group(1))
+    unit = match.group(2)
+    if unit == "ns":
+        return amount
+    if unit in ("us", "\u00b5s"):
+        return amount * 1_000
+    if unit == "ms":
+        return amount * 1_000_000
+    if unit == "s":
+        return amount * 1_000_000_000
+    return None
+
+
+def parse_size_and_median(parts):
+    for index, part in enumerate(parts):
+        size_match = SIZE_RE.search(part)
+        if not size_match:
+            continue
+
+        median_index = index + 2
+        if len(parts) <= median_index:
+            return None
+
+        median = parts[median_index].strip()
+        median_ns = parse_duration_ns(median)
+        if median_ns is None:
+            return None
+
+        size = int(size_match.group(1).replace("_", "").replace(",", ""))
+        return size, median, median_ns
+
+    return None
+
+
+def parse_bench_lines(lines):
+    benches = {}
+    current = None
+
+    for raw_line in lines:
+        line = strip_ansi(raw_line.rstrip("\n"))
+
+        bench_match = BENCH_RE.search(line)
+        if bench_match:
+            current = bench_match.group(1)
+            benches.setdefault(current, {})
+            continue
+
+        if current is None:
+            continue
+
+        parts = line.split("\u2502")
+        if len(parts) < 3:
+            parts = line.split("|")
+        if len(parts) < 3:
+            continue
+
+        size_and_median = parse_size_and_median(parts)
+        if size_and_median is None:
+            continue
+        size, median, median_ns = size_and_median
+
+        benches[current][size] = {
+            "median": median,
+            "median_ns": median_ns,
+        }
+
+    return benches
+
+
+def parse_benches(path):
+    with open(path, encoding="utf-8") as bench_file:
+        return parse_bench_lines(bench_file)
+
+
+def run_bench(args):
+    command = [
+        "cargo",
+        "bench",
+        "-p",
+        args.package,
+        "--bench",
+        args.bench,
+    ]
+    if args.nightly:
+        command[0:1] = ["cargo", "+nightly"]
+    if args.bench_filter:
+        command.append(args.bench_filter)
+
+    print(f"Running: {' '.join(command)}", file=sys.stderr)
+    env = os.environ.copy()
+    if args.nightly:
+        rustflags = env.get("RUSTFLAGS")
+        env["RUSTFLAGS"] = (
+            f"{rustflags} --cfg nightly" if rustflags else "--cfg nightly"
+        )
+    result = subprocess.run(
+        command,
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+    if args.save_output:
+        with open(args.save_output, "w", encoding="utf-8") as output_file:
+            output_file.write(result.stdout)
+
+    return parse_bench_lines(result.stdout.splitlines())
+
+
+def paired_rows(benches, name_filter):
+    bases = sorted(
+        {
+            name.rsplit("_", 1)[0]
+            for name in benches
+            if name.endswith("_std") or name.endswith("_turso")
+        }
+    )
+
+    rows = []
+    pattern = re.compile(name_filter) if name_filter else None
+    for base in bases:
+        if pattern and not pattern.search(base):
+            continue
+
+        std = benches.get(f"{base}_std")
+        turso = benches.get(f"{base}_turso")
+        if not std or not turso:
+            continue
+
+        for size in sorted(set(std) & set(turso)):
+            std_ns = std[size]["median_ns"]
+            turso_ns = turso[size]["median_ns"]
+            ratio = turso_ns / std_ns
+            delta = ((turso_ns - std_ns) / std_ns) * 100
+            if ratio < 0.97:
+                winner = "turso"
+            elif ratio > 1.03:
+                winner = "std"
+            else:
+                winner = "parity"
+
+            rows.append(
+                {
+                    "benchmark": base,
+                    "size": size,
+                    "std_median": std[size]["median"],
+                    "turso_median": turso[size]["median"],
+                    "ratio": ratio,
+                    "delta": delta,
+                    "winner": winner,
+                }
+            )
+
+    winner_order = {"std": 0, "parity": 1, "turso": 2}
+    return sorted(
+        rows,
+        key=lambda row: (
+            winner_order[row["winner"]],
+            -row["delta"],
+            row["benchmark"],
+            row["size"],
+        ),
+    )
+
+
+def print_markdown(rows):
+    print("| benchmark | size | std median | turso median | turso/std | delta | winner |")
+    print("|---|---:|---:|---:|---:|---:|---|")
+    for row in rows:
+        print(
+            "| {benchmark} | {size} | {std_median} | {turso_median} | "
+            "{ratio:.2f}x | {delta:+.1f}% | {winner} |".format(**row)
+        )
+    counts = winner_counts(rows)
+    print()
+    print(
+        f"Summary: std={counts['std']}, parity={counts['parity']}, "
+        f"turso={counts['turso']}"
+    )
+
+
+def winner_counts(rows):
+    counts = {"std": 0, "parity": 0, "turso": 0}
+    for row in rows:
+        counts[row["winner"]] += 1
+    return counts
+
+
+def print_csv(rows):
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "benchmark",
+            "size",
+            "std_median",
+            "turso_median",
+            "ratio",
+            "delta",
+            "winner",
+        ],
+    )
+    writer.writeheader()
+    for row in rows:
+        csv_row = dict(row)
+        csv_row["ratio"] = f"{row['ratio']:.4f}"
+        csv_row["delta"] = f"{row['delta']:.2f}"
+        writer.writerow(csv_row)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare Divan benchmark output for *_std and *_turso pairs."
+    )
+    parser.add_argument(
+        "bench_output",
+        nargs="?",
+        help="Path to captured cargo bench output. Omit when using --run.",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Run cargo bench before printing the comparison table.",
+    )
+    parser.add_argument(
+        "--package",
+        default="turso_core",
+        help="Cargo package to bench when using --run.",
+    )
+    parser.add_argument(
+        "--bench",
+        default="alloc_collections",
+        help="Cargo bench target to run when using --run.",
+    )
+    parser.add_argument(
+        "--bench-filter",
+        help="Optional benchmark name filter passed to cargo bench when using --run.",
+    )
+    parser.add_argument(
+        "--nightly",
+        action="store_true",
+        help="Run cargo bench with +nightly and RUSTFLAGS='--cfg nightly'.",
+    )
+    parser.add_argument(
+        "--save-output",
+        help="Save raw Divan stdout to this path when using --run.",
+    )
+    parser.add_argument(
+        "--filter",
+        help="Only include benchmark base names matching this regular expression",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "csv"),
+        default="markdown",
+        help="Output format",
+    )
+    args = parser.parse_args()
+
+    if args.run:
+        benches = run_bench(args)
+    elif args.bench_output:
+        benches = parse_benches(args.bench_output)
+    else:
+        parser.error("provide bench_output or use --run")
+
+    rows = paired_rows(benches, args.filter)
+    if args.format == "csv":
+        print_csv(rows)
+    else:
+        print_markdown(rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
Changed `BitSet` to start propagating allocation errors for the underlying overflow vector. This PR attempts to be mostly a mechanical change where we change function signatures to add a `Result` type and just propagate errors with `?`. Kinda inevitable, `Result` types spread like a virus which meant that a lot of files have to be touched. But no logic should have changed here, just error propagation.

Depends on https://github.com/tursodatabase/turso/pull/7134
## Motivation and context
Start handling allocation errors


## Description of AI Usage
Small, mostly for some mechanical things
