### PR TITLE
Fix aggregate FILTER IN-subquery scheduling

### DIFF
--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -14,7 +14,8 @@ use crate::{
             emit_program_for_select_with_resolver, emit_query,
         },
         expr::{
-            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr_mut, WalkControl,
+            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr, walk_expr_mut,
+            WalkControl,
         },
         optimizer::optimize_select_plan,
         plan::{
@@ -345,7 +346,7 @@ pub fn plan_subqueries_from_select_plan(
         recollect_aggregates(plan, resolver)?;
     }
 
-    assign_select_subquery_eval_phases(plan);
+    assign_select_subquery_eval_phases(plan)?;
     mark_shared_cte_materialization_requirements(
         &mut plan.table_references,
         &mut plan.non_from_clause_subqueries,
@@ -1969,18 +1970,38 @@ pub fn emit_non_from_clause_subqueries_for_eval_at(
     )
 }
 
-fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) {
+fn aggregate_step_subquery_ids(plan: &SelectPlan) -> Result<Vec<ast::TableInternalId>> {
+    let mut ids = Vec::new();
+    for agg in &plan.aggregates {
+        for expr in agg.args.iter().chain(agg.filter_expr.as_ref().into_iter()) {
+            walk_expr(expr, &mut |expr| -> Result<WalkControl> {
+                if let ast::Expr::SubqueryResult { subquery_id, .. } = expr {
+                    ids.push(*subquery_id);
+                }
+                Ok(WalkControl::Continue)
+            })?;
+        }
+    }
+    Ok(ids)
+}
+
+fn assign_select_subquery_eval_phases(plan: &mut SelectPlan) -> Result<()> {
     let has_grouped_output = plan
         .group_by
         .as_ref()
         .is_some_and(|group_by| !group_by.exprs.is_empty());
+    let aggregate_step_subqueries = aggregate_step_subquery_ids(plan)?;
 
     for subquery in plan.non_from_clause_subqueries.iter_mut() {
         subquery.eval_phase = match subquery.origin {
+            _ if aggregate_step_subqueries.contains(&subquery.internal_id) => {
+                SubqueryEvalPhase::BeforeLoop
+            }
             SubqueryOrigin::SelectHaving | SubqueryOrigin::SelectOrderBy if has_grouped_output => {
                 SubqueryEvalPhase::GroupedOutput
             }
             _ => subquery.origin.phase_floor(),
         };
     }
+    Ok(())
 }

--- a/testing/sqltests/tests/agg-functions/memory.sqltest
+++ b/testing/sqltests/tests/agg-functions/memory.sqltest
@@ -319,6 +319,15 @@ expect {
 }
 
 @cross-check-integrity
+test filter-with-in-subquery-in-having {
+    SELECT 1
+    GROUP BY 1
+    HAVING COUNT(*) FILTER (WHERE 1 IN (SELECT 2)) = 1;
+}
+expect {
+}
+
+@cross-check-integrity
 test filter-group-by-multiple-groups {
     CREATE TABLE t(val INTEGER, a TEXT, b TEXT);
     INSERT INTO t VALUES (1, 'x', 'p'), (2, 'x', 'q'), (3, 'y', 'p'), (4, 'y', 'q');


### PR DESCRIPTION
## Summary
- evaluate subqueries used inside aggregate arguments and FILTER predicates before aggregate steps can probe them
- keep grouped-output scheduling for HAVING/ORDER BY subqueries that are not used during accumulation
- add a regression for `COUNT(*) FILTER (WHERE 1 IN (SELECT 2))` in HAVING

Fixes #6807.

## Root Cause
Subqueries found while planning HAVING were promoted to the grouped-output phase when the query had GROUP BY output. That is too late for subqueries nested inside aggregate FILTER predicates, because the filter runs during row accumulation before grouped-output bytecode opens the ephemeral IN cursor.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo run -p test-runner -- run testing/sqltests/tests/agg-functions/memory.sqltest --filter filter-with-in-subquery-in-having --snapshot-mode no`
- `cargo run -p test-runner -- run testing/sqltests/tests/agg-functions/memory.sqltest --filter filter-with-subquery-in-condition --snapshot-mode no`