### PR TITLE
Fix RENAME COLUMN with TEMP trigger on main table

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -2439,13 +2439,11 @@ fn rewrite_trigger_sql_for_column_rename(
     // Get the trigger's owning table to check unqualified column references
     let trigger_table_name_raw = tbl_name.name.as_str();
     let trigger_table_name = normalize_ident(trigger_table_name_raw);
-    let trigger_table = resolver
-        .with_schema(trigger_database_id, |schema| {
-            schema.get_btree_table(&trigger_table_name)
-        })
-        .ok_or_else(|| {
-            LimboError::ParseError(format!("trigger table not found: {trigger_table_name}"))
-        })?;
+    let trigger_table =
+        resolve_trigger_command_table_for_alter(resolver, trigger_database_id, &trigger_table_name)
+            .ok_or_else(|| {
+                LimboError::ParseError(format!("trigger table not found: {trigger_table_name}"))
+            })?;
 
     // Check if this trigger references the column being renamed
     // We need to check if the column exists in the table being renamed

--- a/tests/integration/trigger.rs
+++ b/tests/integration/trigger.rs
@@ -972,6 +972,26 @@ fn test_alter_table_rename_column_propagates_to_multiple_triggers(db: TempDataba
 }
 
 #[turso_macros::test(mvcc)]
+fn test_alter_table_rename_column_with_temp_trigger_on_main_table(db: TempDatabase) {
+    let conn = db.connect_limbo();
+
+    conn.execute("CREATE TABLE t (a INTEGER, b INTEGER)")
+        .unwrap();
+    conn.execute(
+        "CREATE TEMP TRIGGER tr BEFORE INSERT ON t BEGIN
+         SELECT 1;
+        END",
+    )
+    .unwrap();
+
+    conn.execute("ALTER TABLE t RENAME COLUMN a TO c").unwrap();
+    conn.execute("INSERT INTO t(c, b) VALUES (1, 2)").unwrap();
+
+    let columns: Vec<(String,)> = conn.exec_rows("SELECT name FROM pragma_table_info('t')");
+    assert_eq!(columns, vec![("c".to_string(),), ("b".to_string(),)]);
+}
+
+#[turso_macros::test(mvcc)]
 fn test_alter_table_drop_column_fails_with_old_reference_in_update_trigger(db: TempDatabase) {
     let conn = db.connect_limbo();
 


### PR DESCRIPTION
## Summary
- Resolve a TEMP trigger's owning table through the temp-then-main lookup during ALTER TABLE RENAME COLUMN
- Preserve SQLite-compatible behavior for TEMP triggers created on main tables
- Add a regression covering the reduced fuzzer repro in normal and MVCC modes

## Repro
```sql
CREATE TABLE t(a INTEGER, b INTEGER);
CREATE TEMP TRIGGER tr BEFORE INSERT ON t BEGIN SELECT 1; END;
ALTER TABLE t RENAME COLUMN a TO c;
```

SQLite accepts this. Before this patch Turso failed with:

```text
Parse error: error in trigger tr after rename column: trigger table not found: t
```

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p core_tester --test integration_tests test_alter_table_rename_column_with_temp_trigger_on_main_table -- --nocapture
- cargo test -p core_tester --test integration_tests test_alter_table_rename_column_propagates_to_multiple_triggers -- --nocapture
- target/debug/tursodb :memory: "CREATE TABLE t(a INTEGER, b INTEGER); CREATE TEMP TRIGGER tr BEFORE INSERT ON t BEGIN SELECT 1; END; ALTER TABLE t RENAME COLUMN a TO c;"
- ./target/debug/differential_fuzzer --seed 17904652130988522302 --keep-files
