### PR TITLE
Fix invalid CTE ORDER BY subquery resolution before UPDATE mutation

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -692,6 +692,9 @@ fn prepare_one_select_plan(
                 let rowid_alias_col = joined
                     .btree()
                     .and_then(|t| t.get_rowid_alias_column().map(|(idx, _)| idx));
+                let elided_tail_needs_subquery_resolution = plan.order_by[1..]
+                    .iter()
+                    .any(|(expr, _, _)| expr_contains_scalar_or_exists_subquery(expr));
 
                 let first_is_rowid = match plan.order_by[0].0.as_ref() {
                     ast::Expr::Column { table, column, .. } => {
@@ -700,7 +703,7 @@ fn prepare_one_select_plan(
                     ast::Expr::RowId { table, .. } => *table == table_id,
                     _ => false,
                 };
-                if first_is_rowid {
+                if first_is_rowid && !elided_tail_needs_subquery_resolution {
                     plan.order_by.truncate(1);
                 }
             }
@@ -1493,6 +1496,125 @@ fn select_has_non_from_subqueries(
         }
     }
 
+    false
+}
+
+fn expr_contains_scalar_or_exists_subquery(expr: &Expr) -> bool {
+    // SQLite still resolves scalar/EXISTS subqueries in ORDER BY terms that are
+    // later elided by a leading rowid sort key.  Keep those terms around until
+    // subquery planning has validated names.  Row-value arity checks for IN
+    // subqueries are intentionally still elided for compatibility with existing
+    // SQLite behavior.
+    let mut stack = vec![expr];
+    while let Some(node) = stack.pop() {
+        match node {
+            Expr::Subquery(_) | Expr::Exists(_) => return true,
+            Expr::InSelect { lhs, .. } => {
+                stack.push(lhs.as_ref());
+            }
+            Expr::Between {
+                lhs, start, end, ..
+            } => {
+                stack.push(lhs.as_ref());
+                stack.push(start.as_ref());
+                stack.push(end.as_ref());
+            }
+            Expr::Binary(lhs, _, rhs) => {
+                stack.push(rhs.as_ref());
+                stack.push(lhs.as_ref());
+            }
+            Expr::Case {
+                base,
+                when_then_pairs,
+                else_expr,
+            } => {
+                if let Some(expr) = else_expr.as_deref() {
+                    stack.push(expr);
+                }
+                for (when_expr, then_expr) in when_then_pairs.iter().rev() {
+                    stack.push(then_expr.as_ref());
+                    stack.push(when_expr.as_ref());
+                }
+                if let Some(base_expr) = base.as_deref() {
+                    stack.push(base_expr);
+                }
+            }
+            Expr::Cast { expr, .. }
+            | Expr::Collate(expr, _)
+            | Expr::IsNull(expr)
+            | Expr::NotNull(expr)
+            | Expr::Unary(_, expr) => {
+                stack.push(expr.as_ref());
+            }
+            Expr::FunctionCall {
+                args,
+                order_by,
+                filter_over,
+                ..
+            } => {
+                push_function_tail_exprs(&mut stack, filter_over);
+                for sorted in order_by.iter().rev() {
+                    stack.push(sorted.expr.as_ref());
+                }
+                for arg in args.iter().rev() {
+                    stack.push(arg.as_ref());
+                }
+            }
+            Expr::FunctionCallStar { filter_over, .. } => {
+                push_function_tail_exprs(&mut stack, filter_over);
+            }
+            Expr::InList { lhs, rhs, .. } => {
+                for item in rhs.iter().rev() {
+                    stack.push(item.as_ref());
+                }
+                stack.push(lhs.as_ref());
+            }
+            Expr::InTable { lhs, args, .. } => {
+                for arg in args.iter().rev() {
+                    stack.push(arg.as_ref());
+                }
+                stack.push(lhs.as_ref());
+            }
+            Expr::Like {
+                lhs, rhs, escape, ..
+            } => {
+                if let Some(escape_expr) = escape.as_deref() {
+                    stack.push(escape_expr);
+                }
+                stack.push(rhs.as_ref());
+                stack.push(lhs.as_ref());
+            }
+            Expr::Parenthesized(exprs) => {
+                for expr in exprs.iter().rev() {
+                    stack.push(expr.as_ref());
+                }
+            }
+            Expr::Raise(_, raise_expr) => {
+                if let Some(expr) = raise_expr.as_deref() {
+                    stack.push(expr);
+                }
+            }
+            Expr::SubqueryResult { lhs, .. } => {
+                if let Some(expr) = lhs.as_deref() {
+                    stack.push(expr);
+                }
+            }
+            Expr::Array { .. } | Expr::Subscript { .. } => {
+                unreachable!("Array and Subscript are desugared into function calls by the parser")
+            }
+            Expr::Column { .. }
+            | Expr::DoublyQualified(_, _, _)
+            | Expr::Id(_)
+            | Expr::Literal(_)
+            | Expr::Name(_)
+            | Expr::Qualified(_, _)
+            | Expr::FieldAccess { .. }
+            | Expr::Register(_)
+            | Expr::RowId { .. }
+            | Expr::Variable(_)
+            | Expr::Default => {}
+        }
+    }
     false
 }
 

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -358,6 +358,28 @@ pub fn plan_subqueries_from_select_plan(
     Ok(())
 }
 
+fn plan_subqueries_from_plan(
+    program: &mut ProgramBuilder,
+    plan: &mut Plan,
+    resolver: &Resolver,
+    connection: &Arc<Connection>,
+) -> Result<()> {
+    match plan {
+        Plan::Select(select_plan) => {
+            plan_subqueries_from_select_plan(program, select_plan, resolver, connection)
+        }
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            for (select_plan, _) in left {
+                plan_subqueries_from_select_plan(program, select_plan, resolver, connection)?;
+            }
+            plan_subqueries_from_select_plan(program, right_most, resolver, connection)
+        }
+        Plan::Delete(_) | Plan::Update(_) => Ok(()),
+    }
+}
+
 /// Compute query plans for subqueries in a DML statement's WHERE clause.
 /// This is used by DELETE and UPDATE statements which only have subqueries in the WHERE clause.
 /// Similar to [plan_subqueries_from_select_plan] but only handles the WHERE clause
@@ -642,6 +664,7 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
+                plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
                 optimize_select_plan(&mut plan, resolver)?;
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
@@ -694,6 +717,7 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
+                plan_subqueries_from_select_plan(program, &mut plan, resolver, connection)?;
                 optimize_select_plan(&mut plan, resolver)?;
                 let reg_count = plan.result_columns.len();
                 let reg_start = program.alloc_registers(reg_count);
@@ -789,6 +813,8 @@ fn get_subquery_parser<'a>(
                     QueryDestination::Unset,
                     connection,
                 )?;
+                let mut plan = plan;
+                plan_subqueries_from_plan(program, &mut plan, resolver, connection)?;
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
                         optimize_select_plan(&mut select_plan, resolver)?;

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -863,6 +863,73 @@ fn test_insert_with_column_names(tmp_db: TempDatabase) -> anyhow::Result<()> {
 }
 
 #[turso_macros::test()]
+fn update_rejects_invalid_cte_column_before_mutation(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE x(a, b)")?;
+    conn.execute("INSERT INTO x(a) VALUES (1)")?;
+    conn.execute("CREATE TABLE z(q INTEGER, p INTEGER)")?;
+    conn.execute("CREATE TABLE y(id INTEGER PRIMARY KEY, d INTEGER)")?;
+
+    let result = conn.execute(
+        "UPDATE x
+         SET b = 1
+         WHERE
+           1 OR (
+             SELECT d
+             FROM y
+             ORDER BY
+               id,
+               MAX(
+                 0,
+                 d,
+                 EXISTS (
+                   WITH c AS (
+                     SELECT *
+                     FROM z
+                     WHERE p
+                   )
+                   SELECT DISTINCT c0
+                   FROM c
+                   WHERE c0
+                   ORDER BY c0
+                 )
+               )
+             LIMIT 1
+           )
+         RETURNING a, b",
+    );
+
+    let error = result.expect_err("invalid CTE column should be rejected");
+    match error {
+        LimboError::ParseError(message) => assert_eq!(message, "no such column: c0"),
+        other => panic!("unexpected error for invalid CTE column: {other}"),
+    }
+
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT a, b FROM x"),
+        vec![vec![RValue::Integer(1), RValue::Null]],
+        "invalid UPDATE must not mutate rows"
+    );
+
+    Ok(())
+}
+
+#[turso_macros::test()]
+fn order_by_rowid_still_elides_in_select_arity_check(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b)")?;
+    conn.execute("INSERT INTO t VALUES (1, 10)")?;
+
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT b FROM t ORDER BY id, b IN (SELECT id, b FROM t) LIMIT 1",
+    );
+
+    assert_eq!(rows, vec![vec![RValue::Integer(10)]]);
+    Ok(())
+}
+
+#[turso_macros::test()]
 pub fn delete_search_op_ignore_nulls(limbo: TempDatabase) {
     let conn = limbo.db.connect().unwrap();
     for sql in [


### PR DESCRIPTION
## Summary

- Fixes a SQLite compatibility/data-mutation bug from #7146 where an invalid nested CTE column inside an ORDER BY tail could be skipped when the leading rowid sort key was elided, allowing a short-circuited UPDATE to mutate data.
- Recursively plans nested subqueries during WHERE-clause subquery planning so name-resolution errors surface before execution.
- Preserves existing rowid ORDER BY elision behavior for IN-select arity checks, matching current SQLite-compatible behavior.

## Repro / impact

SQLite rejects the reduced repro with `no such column: c0` and leaves `x.b` NULL. Before this patch, Turso accepted the UPDATE and returned/mutated `b=1`.

This is the fix path for issue #7146, reduced from differential fuzzer seed `4142201962884420057`. It appears to fit the simulator challenge class because invalid SQL can mutate data, but I will leave bounty classification to maintainers.

## Validation

- `cargo fmt --check`
- `cargo test -q -p core_tester --test integration_tests update_rejects_invalid_cte_column_before_mutation`
- `cargo test -q -p core_tester --test integration_tests order_by_rowid_still_elides_in_select_arity_check`
- `sqlite3 :memory: < /Users/sravansridhar/Documents/money_27/proof/turso_invalid_cte_update_repro.sql`
- `target/debug/tursodb :memory: < /Users/sravansridhar/Documents/money_27/proof/turso_invalid_cte_update_repro.sql`

Note: a broader unscoped `cargo test -q update_rejects_invalid_cte_column_before_mutation` hits the local macOS `py-turso` environment's missing `libpython3.12.dylib`, so I used the package-targeted integration test commands above for verification.
