### PR TITLE
core/mvcc: skip transient schema deletes during checkpoint

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -639,6 +639,19 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             }
                         }
                     }
+                } else {
+                    let is_transient_schema_tombstone = key.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID
+                        && is_delete
+                        && !version.btree_resident
+                        && version.row.column_count == 0;
+                    if is_transient_schema_tombstone {
+                        // A payloadless, non-B-tree-resident sqlite_schema delete is a tombstone
+                        // recovered for a schema row that was inserted and deleted before any
+                        // checkpoint. `column_count == 0` means recovery had no pre-delete schema
+                        // record to preserve; `!btree_resident` means no sqlite_schema pager row
+                        // ever existed. Checkpoint can retire that logical tombstone locally.
+                        skip_write = true;
+                    }
                 }
                 if !skip_write {
                     tracing::trace!("adding to write_set {:?}", (&version, &special_write));

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5016,6 +5016,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             })?;
         }
         let mut index_infos: HashMap<MVTableId, Arc<IndexInfo>> = HashMap::default();
+        let mut transient_schema_index_ids: HashSet<MVTableId> = HashSet::default();
 
         // Track whether we have pending schema changes that need a rebuild.
         // We defer rebuild_schema() until all consecutive schema rows have been
@@ -5154,17 +5155,30 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         .map(|value| value as i64)
                         .unwrap_or_else(|| i64::from(index_id)); // this can be negative for non-checkpointed indexes
 
-                    let index = schema
+                    let found_index = schema
                         .indexes
                         .values()
                         .flatten()
-                        .find(|idx| idx.root_page == root_page)
-                        .ok_or_else(|| {
-                            LimboError::InternalError(format!(
+                        .find(|idx| idx.root_page == root_page);
+                    let index = match found_index {
+                        Some(index) => IndexInfo::new_from_index(index),
+                        None if root_page < 0 => {
+                            // This index was created and dropped before being checkpointed.
+                            // The logical log can still contain its index-row operations, but
+                            // the rebuilt schema intentionally has no entry for the negative
+                            // root page. The streaming log reader needs some index metadata to
+                            // decode the key payload before the match arm below can skip it, so
+                            // use throwaway default metadata and mark the index id as transient.
+                            transient_schema_index_ids.insert(index_id);
+                            IndexInfo::default()
+                        }
+                        None => {
+                            return Err(LimboError::InternalError(format!(
                                 "Index with root page {root_page} not found in schema",
-                            ))
-                        })?;
-                    let index_info = Arc::new(IndexInfo::new_from_index(index));
+                            )));
+                        }
+                    };
+                    let index_info = Arc::new(index);
                     index_infos.insert(index_id, index_info.clone());
                     Ok(index_info)
                 }
@@ -5396,6 +5410,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     if commit_ts <= replay_cutoff_ts {
                         continue;
                     }
+                    if transient_schema_index_ids.contains(&rowid.table_id) {
+                        continue;
+                    }
                     let version_id = self.get_version_id();
                     let row_version = RowVersion {
                         id: version_id,
@@ -5417,6 +5434,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 } => {
                     max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
                     if commit_ts <= replay_cutoff_ts {
+                        continue;
+                    }
+                    if transient_schema_index_ids.contains(&rowid.table_id) {
                         continue;
                     }
                     let RowKey::Record(sortable_key) = rowid.row_id.clone() else {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8781,6 +8781,52 @@ fn test_close_persists_drop_index() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+/// Reproducer: CREATE INDEX followed by DROP INDEX in the same transaction
+/// leaves a deleted sqlite_schema row that was never checkpointed into the
+/// B-tree. After restart, checkpoint must retire the transient index metadata
+/// without trying to delete that absent sqlite_schema row from the pager.
+#[test]
+fn test_checkpoint_skips_same_tx_create_drop_index_schema_delete() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'seed')").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+        conn.execute("BEGIN").unwrap();
+        conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+        conn.execute("DROP INDEX idx_t_v").unwrap();
+        conn.execute("COMMIT").unwrap();
+    }
+
+    db.restart();
+
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND name = 'idx_t_v'",
+    );
+    assert_eq!(rows.len(), 0);
+
+    let rows = get_rows(&conn, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    assert_eq!(rows[0][1].to_string(), "seed");
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
 #[test]
 fn test_partial_commit_visibility_bug() {
     use crate::sync::atomic::{AtomicBool, AtomicU64, Ordering};


### PR DESCRIPTION
## Summary

- skip transient index rows during MVCC recovery when an index was created and dropped before it was checkpointed
- skip empty non-btree `sqlite_schema` delete tombstones during checkpoint because no pager row exists to delete
- add a regression test for same-transaction `CREATE INDEX` / `DROP INDEX` across restart and checkpoint

## Notes

This is a follow-up from simulator seed `2719369063341430976`, which was also seen in CI on #7145. The seed is a separate MVCC schema tombstone issue, not part of the WAL-tail recovery logic in that PR.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p turso_core mvcc::database::tests::test_checkpoint_skips_same_tx_create_drop_index_schema_delete -- --nocapture`
- `cargo test -p turso_core mvcc::database::tests:: -- --quiet`
- `cargo clippy -p turso_core --lib --tests --locked -- --deny=warnings`
- `cargo build -p turso_whopper --release`
- `SEED=2719369063341430976 RUST_BACKTRACE=1 timeout 240 ./target/release/turso_whopper --mode fast --reopen-probability 0.01 --enable-mvcc --max-steps 8841`
- `SEED=2719369063341430976 RUST_BACKTRACE=1 timeout 300 ./target/release/turso_whopper --mode fast --reopen-probability 0.01 --enable-mvcc`
