### PR TITLE
fix: avoid overflow in op_sorter_open when cache_size is i32::MIN

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6317,7 +6317,7 @@ pub fn op_sorter_open(
 
     // Set the buffer size threshold to be roughly the same as the limit configured for the page-cache.
     let max_buffer_size_bytes = if cache_size < 0 {
-        (cache_size.abs() * 1024) as usize
+        (cache_size.unsigned_abs() as usize).saturating_mul(1024)
     } else {
         (cache_size as usize) * page_size
     };

--- a/tests/integration/pragma.rs
+++ b/tests/integration/pragma.rs
@@ -391,6 +391,26 @@ fn test_pragma_cache_size_min_value(db: TempDatabase) {
     assert_eq!(*value, 200);
 }
 
+#[turso_macros::test(mvcc)]
+fn test_pragma_cache_size_i32_min_order_by(db: TempDatabase) {
+    let conn = db.connect_limbo();
+
+    // Regression for #7150: ORDER BY must not panic when cache_size is at i32::MIN.
+    // The pragma stores the raw KB-mode value verbatim, so op_sorter_open later
+    // reads i32::MIN back via get_cache_size(). Computing abs() on i32::MIN overflows.
+    let i32_min = i32::MIN as i64;
+    let query = format!("PRAGMA cache_size = {i32_min}");
+    conn.execute(&query).unwrap();
+    conn.execute("CREATE TABLE items (id TEXT)").unwrap();
+    conn.execute("INSERT INTO items VALUES ('b'), ('a')")
+        .unwrap();
+
+    let rows = limbo_exec_rows(&conn, "SELECT id FROM items ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0], vec![RValue::Text("a".to_string())]);
+    assert_eq!(rows[1], vec![RValue::Text("b".to_string())]);
+}
+
 #[turso_macros::test]
 fn test_pragma_wal_checkpoint_targets_attached_database(db: TempDatabase) {
     let conn = db.connect_limbo();


### PR DESCRIPTION
Fixes #7150.

`op_sorter_open` derives the sorter buffer threshold from `cache_size.abs() * 1024` when the pragma is in KB-mode (negative). With `PRAGMA cache_size = -2147483648`, `i32::MIN.abs()` overflows because `|i32::MIN|` does not fit in `i32`, and any subsequent `ORDER BY` panics with "attempt to negate with overflow" in debug builds.

The cast lives at `core/vdbe/execute.rs:6320`. `update_cache_size` in `core/translate/pragma.rs` already guards the i64 case with `checked_abs` (from #5258), but the `as i32` cast at line 1757 lets `i32::MIN` survive into storage, and `op_sorter_open` reads it back through `get_cache_size()`. Fixing at the sorter site keeps the existing storage shape and matches where the arithmetic actually happens.

Switch to `unsigned_abs()` for the magnitude and `saturating_mul(1024)` to also guard u32 → usize on 32-bit targets.

Regression test exercises the full repro path: set the pragma to `i32::MIN`, insert two rows, run `SELECT ... ORDER BY`. Without the fix it panics in both standard and mvcc variants; with the fix the rows come back sorted.