### PR TITLE
Add core support for advanced .NET APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,7 @@ dependencies = [
  "turso",
  "turso-dbhash",
  "turso_core",
+ "turso_ext",
  "turso_macros",
  "turso_parser",
  "turso_sdk_kit",

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Aggregates.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Aggregates.cs
@@ -17,10 +17,15 @@ public partial class SqliteConnection
         if (step is null)
         {
             _aggregateFunctions.Remove(name);
+            if (_database is not null)
+                TursoBindings.UnregisterFunction(DatabaseHandle, name);
             return;
         }
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        var registration = new AggregateFunctionRegistration(name, argc, isDeterministic, seed, step, resultSelector);
+        _aggregateFunctions[name] = registration;
+        if (_database is not null)
+            _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
     }
 
     private void RegisterAggregateFunctions()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Collations.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Collations.cs
@@ -15,10 +15,15 @@ public partial class SqliteConnection
         if (comparison is null)
         {
             _collations.Remove(name);
+            if (_database is not null)
+                TursoBindings.UnregisterCollation(DatabaseHandle, name);
             return;
         }
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        var registration = new CollationRegistration(name, comparison);
+        _collations[name] = registration;
+        if (_database is not null)
+            _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
     }
 
     private void RegisterCollations()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
@@ -19,10 +19,15 @@ public partial class SqliteConnection
         if (function is null)
         {
             _scalarFunctions.Remove(name);
+            if (_database is not null)
+                TursoBindings.UnregisterFunction(DatabaseHandle, name);
             return;
         }
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        var registration = new ScalarFunctionRegistration(name, argc, isDeterministic, function);
+        _scalarFunctions[name] = registration;
+        if (_database is not null)
+            _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
     }
 
     private void RegisterScalarFunctions()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
@@ -11,8 +11,6 @@ public partial class SqliteConnection : DbConnection
 {
     private const int SQLITE_ERROR = 1;
     private const int SQLITE_CANTOPEN = 14;
-    private const string AdvancedExtensionApisNotSupportedMessage =
-        "SQLite-compatible user-defined functions, aggregates, collations, and extension loading require Turso core managed extension support.";
     private static readonly object SharedMemoryLock = new();
     private static readonly Dictionary<string, int> SharedMemoryReferences = new(StringComparer.OrdinalIgnoreCase);
 
@@ -26,6 +24,8 @@ public partial class SqliteConnection : DbConnection
     private bool _recursiveTriggers;
     private bool _readUncommitted;
     private string? _sharedMemoryPath;
+    private bool _extensionsEnabled;
+    private readonly List<(string File, string? Proc)> _pendingExtensions = [];
 
     public SqliteConnection()
     {
@@ -103,10 +103,12 @@ public partial class SqliteConnection : DbConnection
             _dataSource = filename;
             _readOnly = readOnly;
             _sharedMemoryPath = sharedMemoryPath;
+            ApplyExtensionSettings();
             ApplyConnectionOptions();
             RegisterScalarFunctions();
             RegisterAggregateFunctions();
             RegisterCollations();
+            LoadPendingExtensions();
             OnStateChange(new StateChangeEventArgs(originalState, State));
         }
         catch (TursoException ex)
@@ -312,7 +314,9 @@ public partial class SqliteConnection : DbConnection
 
     public virtual void EnableExtensions(bool enable = true)
     {
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        _extensionsEnabled = enable;
+        if (_database is not null)
+            TursoBindings.EnableLoadExtension(DatabaseHandle, enable);
     }
 
     public virtual void LoadExtension(string file, string? proc = null)
@@ -321,7 +325,13 @@ public partial class SqliteConnection : DbConnection
         if (proc is not null)
             throw new NotSupportedException("Custom extension entry points are not yet supported by the Turso SQLite-compatible provider.");
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        if (_database is null)
+        {
+            _pendingExtensions.Add((file, proc));
+            return;
+        }
+
+        LoadExtensionCore(file, proc);
     }
 
     public virtual void BackupDatabase(SqliteConnection destination)
@@ -432,6 +442,19 @@ public partial class SqliteConnection : DbConnection
             ExecuteNonQuery("PRAGMA foreign_keys = " + (_connectionOptions.ForeignKeys.Value ? "1" : "0") + ";");
         if (_connectionOptions.RecursiveTriggers)
             _recursiveTriggers = true;
+    }
+
+    private void ApplyExtensionSettings()
+    {
+        if (_extensionsEnabled)
+            TursoBindings.EnableLoadExtension(DatabaseHandle, true);
+    }
+
+    private void LoadPendingExtensions()
+    {
+        foreach (var (file, proc) in _pendingExtensions)
+            LoadExtensionCore(file, proc);
+        _pendingExtensions.Clear();
     }
 
     private void LoadExtensionCore(string file, string? proc)

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
@@ -7,9 +7,6 @@ namespace Turso.Raw.Public;
 
 public static class TursoBindings
 {
-    private const string AdvancedExtensionApisMessage =
-        "SQLite-compatible function, aggregate, collation, and extension-loading APIs require Turso core managed extension support.";
-
     public static TursoDatabaseHandle OpenDatabase(string path)
     {
         ArgumentNullException.ThrowIfNull(path);
@@ -58,7 +55,17 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(contextDestructor);
         ArgumentNullException.ThrowIfNull(valueDestructor);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.RegisterScalarFunction(
+            db,
+            name,
+            argc,
+            deterministic,
+            context,
+            callback,
+            contextDestructor,
+            valueDestructor,
+            out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void RegisterAggregateFunction(
@@ -83,7 +90,20 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(aggregateDestructor);
         ArgumentNullException.ThrowIfNull(valueDestructor);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.RegisterAggregateFunction(
+            db,
+            name,
+            argc,
+            deterministic,
+            context,
+            init,
+            step,
+            finalize,
+            contextDestructor,
+            aggregateDestructor,
+            valueDestructor,
+            out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void UnregisterFunction(TursoDatabaseHandle db, string name)
@@ -91,7 +111,8 @@ public static class TursoBindings
         db.ThrowIfInvalid();
         ArgumentNullException.ThrowIfNull(name);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.UnregisterFunction(db, name, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void RegisterCollation(
@@ -106,7 +127,8 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(callback);
         ArgumentNullException.ThrowIfNull(contextDestructor);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.RegisterCollation(db, name, context, callback, contextDestructor, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void UnregisterCollation(TursoDatabaseHandle db, string name)
@@ -114,13 +136,15 @@ public static class TursoBindings
         db.ThrowIfInvalid();
         ArgumentNullException.ThrowIfNull(name);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.UnregisterCollation(db, name, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void EnableLoadExtension(TursoDatabaseHandle db, bool enabled)
     {
         db.ThrowIfInvalid();
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.EnableLoadExtension(db, enabled, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void LoadExtension(TursoDatabaseHandle db, string path)
@@ -128,7 +152,8 @@ public static class TursoBindings
         db.ThrowIfInvalid();
         ArgumentNullException.ThrowIfNull(path);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.LoadExtension(db, path, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void BindParameter(TursoStatementHandle statement, int index, TursoValue parameter)

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Turso.Raw.Public;
 using Turso.Raw.Public.Handles;
 
 namespace Turso.Raw;
@@ -70,6 +71,66 @@ internal static class TursoInterop
 
     [DllImport(DllName, EntryPoint = "turso_connection_deinit", CallingConvention = CallingConvention.Cdecl)]
     public static extern void ConnectionDeinit(IntPtr connection);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_register_scalar_function", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode RegisterScalarFunction(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        int argc,
+        [MarshalAs(UnmanagedType.I1)] bool deterministic,
+        IntPtr context,
+        TursoScalarFunctionCallback callback,
+        TursoContextDestructorCallback contextDestructor,
+        TursoValueDestructorCallback valueDestructor,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_register_aggregate_function", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode RegisterAggregateFunction(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        int argc,
+        [MarshalAs(UnmanagedType.I1)] bool deterministic,
+        IntPtr context,
+        TursoAggregateInitCallback init,
+        TursoAggregateStepCallback step,
+        TursoAggregateFinalCallback finalize,
+        TursoContextDestructorCallback contextDestructor,
+        TursoContextDestructorCallback aggregateDestructor,
+        TursoValueDestructorCallback valueDestructor,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_unregister_function", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode UnregisterFunction(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_register_collation", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode RegisterCollation(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        IntPtr context,
+        TursoCollationCallback callback,
+        TursoContextDestructorCallback contextDestructor,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_unregister_collation", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode UnregisterCollation(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_enable_load_extension", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode EnableLoadExtension(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.I1)] bool enabled,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_load_extension", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode LoadExtension(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path,
+        out IntPtr errorPtr);
 
     [DllImport(DllName, EntryPoint = "turso_connection_prepare_single", CallingConvention = CallingConvention.Cdecl)]
     public static extern TursoStatusCode ConnectionPrepareSingle(

--- a/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
@@ -385,24 +385,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    public void AdvancedApisRequireCoreManagedExtensionSupport()
-    {
-        using var connection = new SqliteConnection("Data Source=:memory:");
-
-        Assert.Throws<NotSupportedException>(() => connection.CreateFunction("test", () => 1L))!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.CreateAggregate<int>("test", value => value))!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.CreateCollation("test", StringComparer.Ordinal.Compare))!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.EnableExtensions())!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.LoadExtension("unknown"))!
-            .Message.Should().Contain("core managed extension support");
-    }
-
-    [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionWorksWhenRegisteredBeforeOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -413,7 +395,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionSupportsVariadicArgumentsAndBlobValues()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -425,7 +406,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionReportsNullForNonNullableParameters()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -439,7 +419,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionPropagatesSqliteExceptionCode()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -453,7 +432,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionCanBeRemoved()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -468,7 +446,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionWorksWhenRegisteredBeforeOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -485,7 +462,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionSupportsVariadicArgumentsAndNoRows()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -498,7 +474,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionPropagatesSqliteExceptionCode()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -514,7 +489,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionFinalizerErrorLeavesConnectionUsable()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -534,7 +508,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionCanBeRemoved()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -550,7 +523,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void CollationWorksWhenRegisteredBeforeOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -561,7 +533,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void CollationStateOverloadCanBeRemoved()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -576,8 +547,7 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
-    public void CustomCollationUnsupportedPathsDoNotFallBackToBinary()
+    public void CustomCollationQueryTimePathsDoNotFallBackToBinary()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
         connection.Open();
@@ -589,14 +559,13 @@ public class SqliteFacadeTests
             .Message.Should().Contain("custom collations are not supported");
 
         connection.ExecuteNonQuery("CREATE TABLE Data(Value TEXT); INSERT INTO Data VALUES ('a'), ('b');");
-        Assert.Throws<SqliteException>(() => connection.ExecuteScalar<string>("SELECT Value FROM Data ORDER BY Value COLLATE reverse_text LIMIT 1;"))!
-            .Message.Should().Contain("custom collations are not supported");
+        connection.ExecuteScalar<string>("SELECT Value FROM Data ORDER BY Value COLLATE reverse_text LIMIT 1;")
+            .Should().Be("b");
         Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery("CREATE INDEX Data_Value_Custom ON Data(Value COLLATE reverse_text);"))!
             .Message.Should().Contain("custom collations are not supported");
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void EnableExtensionsControlsSqlLoadExtension()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -627,7 +596,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void LoadExtensionUsesNativeLoaderEvenWhenSqlFunctionDisabled()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -641,7 +609,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void LoadExtensionWhenClosedRunsOnNextOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -21,6 +21,7 @@ use crate::{
     parse_schema_rows,
     progress::{ProgressHandler, ProgressHandlerCallback},
     refresh_analyze_stats, translate,
+    translate::collate::CollationSeq,
     util::IOExt,
     vdbe, AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
@@ -34,10 +35,10 @@ use crate::{MAIN_DB_ID, TEMP_DB_ID};
 use arc_swap::ArcSwap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
-use std::fmt::Display;
 use std::ops::Deref;
 #[cfg(feature = "simulator")]
 use std::path::Path;
+use std::{cmp::Ordering as CmpOrdering, fmt::Display};
 #[cfg(not(target_family = "wasm"))]
 use tempfile::TempDir;
 use tracing::{instrument, Level};
@@ -206,6 +207,8 @@ pub struct Connection {
     pub(super) full_column_names: AtomicBool,
     /// Deprecated pragma: when ON (default), column refs use just the column name
     pub(super) short_column_names: AtomicBool,
+    /// Per-connection runtime extension loading flag.
+    pub(super) enable_load_extension: AtomicBool,
     pub(crate) mv_tx: RwLock<Option<(crate::mvcc::database::TxID, TransactionMode)>>,
     /// Per-attached-database MVCC transactions.
     /// Main DB uses `mv_tx` above for zero-cost hot path access.
@@ -2871,14 +2874,198 @@ impl Connection {
             .functions
             .values()
             .map(|f| {
-                let is_agg = matches!(f.func, function::ExtFunc::Aggregate { .. });
+                let is_agg = f.func.is_aggregate();
                 let argc = match &f.func {
                     function::ExtFunc::Aggregate { argc, .. } => *argc as i32,
+                    function::ExtFunc::ContextScalar { argc, .. }
+                    | function::ExtFunc::ContextAggregate { argc, .. } => *argc,
                     function::ExtFunc::Scalar(_) => -1,
                 };
                 (f.name.clone(), is_agg, argc)
             })
             .collect()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_external_scalar_function(
+        &self,
+        name: String,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        callback: crate::ContextScalarFunction,
+        context_destructor: Option<crate::ContextDestructor>,
+        value_destructor: Option<crate::ContextValueDestructor>,
+    ) {
+        let normalized_name = crate::util::normalize_ident(&name);
+        self.syms.write().functions.insert(
+            normalized_name.clone(),
+            Arc::new(function::ExternalFunc::new_context_scalar(
+                normalized_name,
+                argc,
+                deterministic,
+                context,
+                callback,
+                context_destructor,
+                value_destructor,
+            )),
+        );
+        self.bump_prepare_context_generation();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_external_aggregate_function(
+        &self,
+        name: String,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        init: crate::ContextAggregateInitFunction,
+        step: crate::ContextAggregateStepFunction,
+        finalize: crate::ContextAggregateFinalFunction,
+        context_destructor: Option<crate::ContextDestructor>,
+        aggregate_destructor: Option<crate::ContextDestructor>,
+        value_destructor: Option<crate::ContextValueDestructor>,
+    ) {
+        let normalized_name = crate::util::normalize_ident(&name);
+        self.syms.write().functions.insert(
+            normalized_name.clone(),
+            Arc::new(function::ExternalFunc::new_context_aggregate(
+                normalized_name,
+                argc,
+                deterministic,
+                context,
+                init,
+                step,
+                finalize,
+                context_destructor,
+                aggregate_destructor,
+                value_destructor,
+            )),
+        );
+        self.bump_prepare_context_generation();
+    }
+
+    pub fn unregister_external_function(&self, name: &str) {
+        let normalized_name = crate::util::normalize_ident(name);
+        self.syms.write().functions.remove(&normalized_name);
+        self.bump_prepare_context_generation();
+    }
+
+    pub fn register_external_collation(
+        &self,
+        name: String,
+        context: usize,
+        callback: crate::ContextCollationFunction,
+        context_destructor: Option<crate::ContextDestructor>,
+    ) {
+        let collation = CollationSeq::register_custom(&name);
+        let normalized_name = crate::util::normalize_ident(&name);
+        self.syms.write().collations.insert(
+            collation.id(),
+            Arc::new(function::ExternalCollation::new(
+                normalized_name,
+                context,
+                callback,
+                context_destructor,
+            )),
+        );
+        self.bump_prepare_context_generation();
+    }
+
+    pub fn unregister_external_collation(&self, name: &str) {
+        if let Some(collation) = CollationSeq::registered_custom(name) {
+            if self
+                .syms
+                .write()
+                .collations
+                .remove(&collation.id())
+                .is_some()
+            {
+                self.bump_prepare_context_generation();
+            }
+        }
+    }
+
+    pub(crate) fn get_external_collation(
+        &self,
+        collation: CollationSeq,
+    ) -> Result<Arc<function::ExternalCollation>> {
+        self.syms
+            .read()
+            .collations
+            .get(&collation.id())
+            .cloned()
+            .ok_or_else(|| {
+                LimboError::ParseError(format!("no such collation sequence: {}", collation.name()))
+            })
+    }
+
+    pub(crate) fn custom_collation_compare(
+        external: &function::ExternalCollation,
+        left: &str,
+        right: &str,
+    ) -> CmpOrdering {
+        let result = unsafe {
+            (external.callback)(
+                external.context,
+                left.as_ptr(),
+                left.len(),
+                right.as_ptr(),
+                right.len(),
+            )
+        };
+        result.cmp(&0)
+    }
+
+    pub(crate) fn external_collation_comparator(
+        external: Arc<function::ExternalCollation>,
+    ) -> crate::vdbe::sorter::SortComparator {
+        Arc::new(move |left, right| match (left, right) {
+            (crate::ValueRef::Text(left), crate::ValueRef::Text(right)) => {
+                Self::custom_collation_compare(&external, left.as_str(), right.as_str())
+            }
+            _ => left.partial_cmp(right).unwrap_or(CmpOrdering::Equal),
+        })
+    }
+
+    pub(crate) fn make_collation_comparator(
+        &self,
+        collation: CollationSeq,
+    ) -> Result<crate::vdbe::sorter::SortComparator> {
+        let external = self.get_external_collation(collation)?;
+        Ok(Self::external_collation_comparator(external))
+    }
+
+    pub(crate) fn compare_with_collation(
+        &self,
+        collation: CollationSeq,
+        left: &str,
+        right: &str,
+    ) -> Result<CmpOrdering> {
+        if collation.is_custom() {
+            let external = self.get_external_collation(collation)?;
+            Ok(Self::custom_collation_compare(&external, left, right))
+        } else {
+            Ok(collation.compare_strings(left, right))
+        }
+    }
+
+    pub fn set_load_extension_enabled(&self, enabled: bool) {
+        self.enable_load_extension.store(enabled, Ordering::Release);
+    }
+
+    pub(crate) fn can_load_extensions(&self) -> bool {
+        self.enable_load_extension.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn compare_external_collation(
+        &self,
+        collation: CollationSeq,
+        left: &str,
+        right: &str,
+    ) -> Result<CmpOrdering> {
+        self.compare_with_collation(collation, left, right)
     }
 
     pub(crate) fn database_ptr(&self) -> usize {
@@ -3344,6 +3531,7 @@ pub type StepResult = vdbe::StepResult;
 #[derive(Default)]
 pub struct SymbolTable {
     pub functions: HashMap<String, Arc<function::ExternalFunc>>,
+    pub collations: HashMap<u32, Arc<function::ExternalCollation>>,
     pub vtabs: HashMap<String, Arc<VirtualTable>>,
     pub vtab_modules: HashMap<String, Arc<crate::ext::VTabImpl>>,
     pub index_methods: HashMap<String, Arc<dyn IndexMethod>>,
@@ -3353,6 +3541,7 @@ impl std::fmt::Debug for SymbolTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SymbolTable")
             .field("functions", &self.functions)
+            .field("collations", &self.collations)
             .finish()
     }
 }
@@ -3383,6 +3572,7 @@ impl SymbolTable {
     pub fn new() -> Self {
         Self {
             functions: HashMap::default(),
+            collations: HashMap::default(),
             vtabs: HashMap::default(),
             vtab_modules: HashMap::default(),
             index_methods: HashMap::default(),
@@ -3391,9 +3581,12 @@ impl SymbolTable {
     pub fn resolve_function(
         &self,
         name: &str,
-        _arg_count: usize,
+        arg_count: usize,
     ) -> Option<Arc<function::ExternalFunc>> {
-        self.functions.get(name).cloned()
+        self.functions
+            .get(&crate::util::normalize_ident(name))
+            .filter(|func| func.func.matches_arg_count(arg_count))
+            .cloned()
     }
 
     pub fn extend(&mut self, other: &SymbolTable) {

--- a/core/function.rs
+++ b/core/function.rs
@@ -2,9 +2,117 @@ use crate::sync::Arc;
 use std::fmt;
 use std::fmt::{Debug, Display};
 use strum::IntoEnumIterator;
-use turso_ext::{FinalizeFunction, InitAggFunction, ScalarFunction, StepFunction};
+use turso_ext::{
+    FinalizeFunction, InitAggFunction, ScalarFunction, StepFunction, Value as ExtValue,
+};
 
-use crate::LimboError;
+use crate::{LimboError, Value};
+
+pub type ContextScalarFunction = unsafe extern "C" fn(
+    context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    result: *mut ContextValue,
+);
+pub type ContextAggregateInitFunction = unsafe extern "C" fn(context: usize) -> usize;
+pub type ContextAggregateStepFunction = unsafe extern "C" fn(
+    context: usize,
+    aggregate_context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    result: *mut ContextValue,
+);
+pub type ContextAggregateFinalFunction =
+    unsafe extern "C" fn(context: usize, aggregate_context: usize, result: *mut ContextValue);
+pub type ContextCollationFunction = unsafe extern "C" fn(
+    context: usize,
+    left_ptr: *const u8,
+    left_len: usize,
+    right_ptr: *const u8,
+    right_len: usize,
+) -> i32;
+pub type ContextDestructor = unsafe extern "C" fn(context: usize);
+pub type ContextValueDestructor = unsafe extern "C" fn(result: *mut ContextValue);
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContextValueType {
+    Null,
+    Integer,
+    Float,
+    Text,
+    Blob,
+    Error,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ContextValueBytes {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union ContextValueData {
+    pub int: i64,
+    pub float: f64,
+    pub bytes: ContextValueBytes,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ContextValue {
+    pub value_type: ContextValueType,
+    pub value: ContextValueData,
+}
+
+impl ContextValue {
+    pub fn null() -> Self {
+        Self {
+            value_type: ContextValueType::Null,
+            value: ContextValueData { int: 0 },
+        }
+    }
+
+    pub fn into_value(self) -> Result<Value, LimboError> {
+        // Text/blob/error payloads are callback-owned; copy them before the
+        // caller invokes the registered value destructor.
+        match self.value_type {
+            ContextValueType::Null => Ok(Value::Null),
+            ContextValueType::Integer => Ok(Value::from_i64(unsafe { self.value.int })),
+            ContextValueType::Float => Ok(Value::from_f64(unsafe { self.value.float })),
+            ContextValueType::Text => {
+                let bytes = unsafe { self.value.bytes };
+                if bytes.ptr.is_null() {
+                    return Ok(Value::Null);
+                }
+                let slice = unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len) };
+                let text = std::str::from_utf8(slice)
+                    .map_err(|err| LimboError::ExtensionError(err.to_string()))?;
+                Ok(Value::build_text(text.to_string()))
+            }
+            ContextValueType::Blob => {
+                let bytes = unsafe { self.value.bytes };
+                if bytes.ptr.is_null() {
+                    return Ok(Value::Blob(Vec::new()));
+                }
+                let slice = unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len) };
+                Ok(Value::Blob(slice.to_vec()))
+            }
+            ContextValueType::Error => {
+                let bytes = unsafe { self.value.bytes };
+                if bytes.ptr.is_null() {
+                    return Err(LimboError::ExtensionError(String::new()));
+                }
+                let slice = unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len) };
+                let message = std::str::from_utf8(slice)
+                    .map_err(|err| LimboError::ExtensionError(err.to_string()))?;
+                Err(LimboError::ExtensionError(message.to_string()))
+            }
+        }
+    }
+}
 
 pub trait Deterministic: std::fmt::Display {
     fn is_deterministic(&self) -> bool;
@@ -15,30 +123,145 @@ pub struct ExternalFunc {
     pub func: ExtFunc,
 }
 
+pub struct ExternalCollation {
+    pub name: String,
+    pub context: usize,
+    pub callback: ContextCollationFunction,
+    pub context_destructor: Option<ContextDestructor>,
+}
+
+impl ExternalCollation {
+    pub fn new(
+        name: String,
+        context: usize,
+        callback: ContextCollationFunction,
+        context_destructor: Option<ContextDestructor>,
+    ) -> Self {
+        Self {
+            name,
+            context,
+            callback,
+            context_destructor,
+        }
+    }
+}
+
+impl Drop for ExternalCollation {
+    fn drop(&mut self) {
+        crate::translate::collate::CollationSeq::unregister_custom(&self.name);
+        if let Some(destructor) = self.context_destructor {
+            unsafe { destructor(self.context) };
+        }
+    }
+}
+
+impl Debug for ExternalCollation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExternalCollation")
+            .field("name", &self.name)
+            .finish()
+    }
+}
+
 impl Deterministic for ExternalFunc {
     fn is_deterministic(&self) -> bool {
-        // external functions can be whatever so let's just default to false
-        false
+        match self.func {
+            ExtFunc::ContextScalar { deterministic, .. }
+            | ExtFunc::ContextAggregate { deterministic, .. } => deterministic,
+            _ => false,
+        }
     }
 }
 
 #[derive(Debug, Clone)]
 pub enum ExtFunc {
     Scalar(ScalarFunction),
+    ContextScalar {
+        context: usize,
+        argc: i32,
+        deterministic: bool,
+        callback: ContextScalarFunction,
+        context_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ContextValueDestructor>,
+    },
     Aggregate {
         argc: usize,
         init: InitAggFunction,
         step: StepFunction,
         finalize: FinalizeFunction,
     },
+    ContextAggregate {
+        context: usize,
+        argc: i32,
+        deterministic: bool,
+        init: ContextAggregateInitFunction,
+        step: ContextAggregateStepFunction,
+        finalize: ContextAggregateFinalFunction,
+        context_destructor: Option<ContextDestructor>,
+        aggregate_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ContextValueDestructor>,
+    },
 }
 
 impl ExtFunc {
-    pub fn agg_args(&self) -> Result<usize, ()> {
-        if let ExtFunc::Aggregate { argc, .. } = self {
-            return Ok(*argc);
+    pub fn agg_args(&self) -> Result<i32, ()> {
+        match self {
+            ExtFunc::Aggregate { argc, .. } => Ok(*argc as i32),
+            ExtFunc::ContextAggregate { argc, .. } => Ok(*argc),
+            _ => Err(()),
         }
-        Err(())
+    }
+
+    pub fn matches_arg_count(&self, arg_count: usize) -> bool {
+        match self {
+            Self::ContextScalar { argc, .. } | Self::ContextAggregate { argc, .. } => {
+                *argc < 0 || *argc as usize == arg_count
+            }
+            Self::Aggregate { argc, .. } => *argc == arg_count,
+            Self::Scalar(_) => true,
+        }
+    }
+
+    pub fn is_aggregate(&self) -> bool {
+        matches!(self, Self::Aggregate { .. } | Self::ContextAggregate { .. })
+    }
+
+    pub fn with_aggregate_arg_count(&self, arg_count: usize) -> Self {
+        match self {
+            Self::ContextAggregate {
+                context,
+                deterministic,
+                init,
+                step,
+                finalize,
+                context_destructor,
+                aggregate_destructor,
+                value_destructor,
+                ..
+            } => Self::ContextAggregate {
+                context: *context,
+                argc: arg_count as i32,
+                deterministic: *deterministic,
+                init: *init,
+                step: *step,
+                finalize: *finalize,
+                context_destructor: *context_destructor,
+                aggregate_destructor: *aggregate_destructor,
+                value_destructor: *value_destructor,
+            },
+            Self::Aggregate {
+                init,
+                step,
+                finalize,
+                ..
+            } => Self::Aggregate {
+                argc: arg_count,
+                init: *init,
+                step: *step,
+                finalize: *finalize,
+            },
+            _ => self.clone(),
+        }
     }
 }
 
@@ -63,6 +286,75 @@ impl ExternalFunc {
                 step: func.1,
                 finalize: func.2,
             },
+        }
+    }
+
+    pub fn new_context_scalar(
+        name: String,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        callback: ContextScalarFunction,
+        context_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ContextValueDestructor>,
+    ) -> Self {
+        Self {
+            name,
+            func: ExtFunc::ContextScalar {
+                context,
+                argc,
+                deterministic,
+                callback,
+                context_destructor,
+                value_destructor,
+            },
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_context_aggregate(
+        name: String,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        init: ContextAggregateInitFunction,
+        step: ContextAggregateStepFunction,
+        finalize: ContextAggregateFinalFunction,
+        context_destructor: Option<ContextDestructor>,
+        aggregate_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ContextValueDestructor>,
+    ) -> Self {
+        Self {
+            name,
+            func: ExtFunc::ContextAggregate {
+                context,
+                argc,
+                deterministic,
+                init,
+                step,
+                finalize,
+                context_destructor,
+                aggregate_destructor,
+                value_destructor,
+            },
+        }
+    }
+}
+
+impl Drop for ExternalFunc {
+    fn drop(&mut self) {
+        match self.func {
+            ExtFunc::ContextScalar {
+                context,
+                context_destructor: Some(context_destructor),
+                ..
+            }
+            | ExtFunc::ContextAggregate {
+                context,
+                context_destructor: Some(context_destructor),
+                ..
+            } => unsafe { context_destructor(context) },
+            _ => {}
         }
     }
 }
@@ -382,7 +674,10 @@ impl AggFunc {
             Self::JsonGroupArray | Self::JsonbGroupArray => 1,
             #[cfg(feature = "json")]
             Self::JsonGroupObject | Self::JsonbGroupObject => 2,
-            Self::External(func) => func.agg_args().unwrap_or(0),
+            Self::External(func) => func
+                .agg_args()
+                .map(|argc| argc.max(0) as usize)
+                .unwrap_or(0),
         }
     }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -127,6 +127,11 @@ use util::parse_schema_rows;
 pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
 pub use error::{io_error, CompletionError, LimboError};
+pub use function::{
+    ContextAggregateFinalFunction, ContextAggregateInitFunction, ContextAggregateStepFunction,
+    ContextCollationFunction, ContextDestructor, ContextScalarFunction, ContextValue,
+    ContextValueBytes, ContextValueData, ContextValueDestructor, ContextValueType,
+};
 #[cfg(all(feature = "fs", target_family = "unix", not(miri)))]
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring", not(miri)))]
@@ -1741,6 +1746,7 @@ impl Database {
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
             full_column_names: AtomicBool::new(false),
             short_column_names: AtomicBool::new(true),
+            enable_load_extension: AtomicBool::new(self.can_load_extensions()),
             fk_pragma: AtomicBool::new(false),
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3913,7 +3913,13 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                             });
                         }
                         ast::ColumnConstraint::Collate { ref collation_name } => {
-                            collation = Some(CollationSeq::new(collation_name.as_str())?);
+                            let collation_seq = CollationSeq::new(collation_name.as_str())?;
+                            if collation_seq.is_custom() {
+                                crate::bail_parse_error!(
+                                    "custom collations are not supported in schema definitions"
+                                );
+                            }
+                            collation = Some(collation_seq);
                         }
                         ast::ColumnConstraint::ForeignKey {
                             clause,
@@ -4703,7 +4709,13 @@ impl TryFrom<&ColumnDefinition> for Column {
                     );
                 }
                 ast::ColumnConstraint::Collate { collation_name } => {
-                    collation.replace(CollationSeq::new(collation_name.as_str())?);
+                    let collation_seq = CollationSeq::new(collation_name.as_str())?;
+                    if collation_seq.is_custom() {
+                        crate::bail_parse_error!(
+                            "custom collations are not supported in schema definitions"
+                        );
+                    }
+                    collation.replace(collation_seq);
                 }
                 ast::ColumnConstraint::Generated { expr, .. } => {
                     generated = Some(expr.clone());
@@ -5068,7 +5080,7 @@ impl Index {
 
     /// Walk the where_clause Expr of a partial index and validate that it doesn't reference any other
     /// tables or use any disallowed constructs.
-    pub fn validate_where_expr(&self, table: &Table, _resolver: &Resolver) -> bool {
+    pub fn validate_where_expr(&self, table: &Table, resolver: &Resolver) -> bool {
         let Some(where_clause) = &self.where_clause else {
             return true;
         };
@@ -5085,6 +5097,10 @@ impl Index {
         let is_deterministic_fn = |name: &str, argc: usize| {
             let n = normalize_ident(name);
             Func::resolve_function(&n, argc).is_ok_and(|f| f.is_some_and(|f| f.is_deterministic()))
+                || resolver
+                    .symbol_table
+                    .resolve_function(&n, argc)
+                    .is_some_and(|f| f.is_deterministic())
         };
 
         let mut ok = true;

--- a/core/storage/buffer_pool.rs
+++ b/core/storage/buffer_pool.rs
@@ -474,11 +474,11 @@ mod arena {
 
 #[cfg(any(not(unix), miri))]
 mod arena {
-    pub fn alloc(len: usize) -> *mut u8 {
+    pub unsafe fn alloc(len: usize) -> *mut u8 {
         let layout = std::alloc::Layout::from_size_align(len, std::mem::size_of::<u8>()).unwrap();
         unsafe { std::alloc::alloc_zeroed(layout) }
     }
-    pub fn dealloc(ptr: *mut u8, len: usize) {
+    pub unsafe fn dealloc(ptr: *mut u8, len: usize) {
         let layout = std::alloc::Layout::from_size_align(len, std::mem::size_of::<u8>()).unwrap();
         unsafe { std::alloc::dealloc(ptr, layout) };
     }

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -1,5 +1,6 @@
 use turso_parser::ast;
 
+use crate::sync::Arc;
 use crate::{
     function::AggFunc,
     schema::Table,
@@ -556,17 +557,22 @@ pub fn translate_aggregation_step(
             target_register
         }
         AggFunc::External(ref func) => {
-            let argc = func.agg_args().map_err(|_| {
+            let registered_argc = func.agg_args().map_err(|_| {
                 LimboError::ExtensionError(
                     "External aggregate function called with wrong number of arguments".to_string(),
                 )
             })?;
-            if argc != num_args {
+            if registered_argc >= 0 && registered_argc as usize != num_args {
                 crate::bail_parse_error!(
                     "External aggregate function called with wrong number of arguments"
                 );
             }
-            let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
+            let argc = num_args;
+            let expr_reg = if argc == 0 {
+                0
+            } else {
+                agg_arg_source.translate(program, referenced_tables, resolver, 0)?
+            };
             for i in 0..argc {
                 if i != 0 {
                     let _ = agg_arg_source.translate(program, referenced_tables, resolver, i)?;
@@ -580,7 +586,13 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::External(func.clone()),
+                func: AggFunc::External(if registered_argc < 0 {
+                    // Variadic registrations store -1, but the VDBE needs the
+                    // concrete call-site arity to slice argument registers.
+                    Arc::new(func.with_aggregate_arg_count(num_args))
+                } else {
+                    func.clone()
+                }),
                 comparator: None,
             });
             target_register

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,4 +1,10 @@
-use std::{cmp::Ordering, str::FromStr as _};
+use std::{
+    cmp::Ordering,
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    str::FromStr as _,
+    sync::{Mutex, OnceLock},
+};
 
 use icu_collator::{options::CollatorOptions, Collator, CollatorBorrowed};
 use icu_locale::Locale;
@@ -13,49 +19,186 @@ use crate::{
     Result,
 };
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 /// **Pre defined collation sequences**\
 /// Collating functions only matter when comparing string values.
 /// Numeric values are always compared numerically, and BLOBs are always compared byte-by-byte using memcmp().
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum CollationSeq {
     Unset,
-    #[default]
     Binary,
     NoCase,
     Rtrim,
     Locale(LocaleCollationId),
+    /// Name/id token for a connection-owned callback. The comparison itself
+    /// must be resolved through `Connection` at runtime.
+    Custom(u32),
 }
+
+#[derive(Default)]
+struct CustomCollations {
+    by_name: HashMap<String, u32>,
+    by_id: HashMap<u32, String>,
+    active_counts: HashMap<u32, usize>,
+}
+
+static CUSTOM_COLLATIONS: OnceLock<Mutex<CustomCollations>> = OnceLock::new();
 
 impl CollationSeq {
     pub fn new(collation: &str) -> crate::Result<Self> {
-        match collation.to_ascii_lowercase().as_str() {
-            "binary" => return Ok(CollationSeq::Binary),
-            "nocase" => return Ok(CollationSeq::NoCase),
-            "rtrim" => return Ok(CollationSeq::Rtrim),
+        match crate::util::normalize_ident(collation).as_str() {
+            "binary" => return Ok(Self::Binary),
+            "nocase" => return Ok(Self::NoCase),
+            "rtrim" => return Ok(Self::Rtrim),
             _ => {}
         }
+
+        if let Some(collation) = Self::active_custom(collation) {
+            return Ok(collation);
+        }
+
         LocaleCollationRegistry::global()
             .get_or_register(collation)
-            .map(CollationSeq::Locale)
+            .map(Self::Locale)
     }
 
     #[inline]
     /// Returns the collation, defaulting to BINARY if unset
     pub const fn from_bits(bits: u8) -> Self {
         match bits {
-            2 => CollationSeq::NoCase,
-            3 => CollationSeq::Rtrim,
-            _ => CollationSeq::Binary,
+            2 => Self::NoCase,
+            3 => Self::Rtrim,
+            _ => Self::Binary,
+        }
+    }
+
+    #[inline]
+    pub const fn to_bits(self) -> u16 {
+        match self {
+            Self::Unset => 0,
+            Self::Binary => 1,
+            Self::NoCase => 2,
+            Self::Rtrim => 3,
+            Self::Locale(id) => id.to_bits(),
+            Self::Custom(_) => 0,
+        }
+    }
+
+    #[inline]
+    pub const fn from_storage_bits(bits: u16) -> Self {
+        match bits {
+            0 => Self::Unset,
+            1 => Self::Binary,
+            2 => Self::NoCase,
+            3 => Self::Rtrim,
+            bits => Self::Locale(LocaleCollationId::from_bits(bits)),
+        }
+    }
+
+    #[inline]
+    pub const fn id(self) -> u32 {
+        match self {
+            Self::Custom(id) => id,
+            _ => self.to_bits() as u32,
+        }
+    }
+
+    #[inline]
+    pub const fn is_custom(self) -> bool {
+        matches!(self, Self::Custom(_))
+    }
+
+    pub fn custom(collation: &str) -> Self {
+        let normalized = crate::util::normalize_ident(collation);
+        let registry = CUSTOM_COLLATIONS.get_or_init(|| Mutex::new(CustomCollations::default()));
+        let mut registry = registry.lock().expect("custom collation registry poisoned");
+        if let Some(id) = registry.by_name.get(&normalized) {
+            return Self::Custom(*id);
+        }
+
+        let mut id = custom_collation_id(&normalized);
+        while id <= 3 || registry.by_id.contains_key(&id) {
+            id = id.wrapping_add(1).max(4);
+        }
+
+        registry.by_name.insert(normalized, id);
+        registry.by_id.insert(id, collation.to_string());
+        Self::Custom(id)
+    }
+
+    pub fn register_custom(collation: &str) -> Self {
+        let collation = Self::custom(collation);
+        let registry = CUSTOM_COLLATIONS.get_or_init(|| Mutex::new(CustomCollations::default()));
+        let mut registry = registry.lock().expect("custom collation registry poisoned");
+        *registry.active_counts.entry(collation.id()).or_insert(0) += 1;
+        collation
+    }
+
+    pub fn unregister_custom(collation: &str) -> Option<Self> {
+        let collation = Self::known_custom(collation)?;
+        Self::release_custom(collation);
+        Some(collation)
+    }
+
+    pub(crate) fn registered_custom(collation: &str) -> Option<Self> {
+        Self::active_custom(collation)
+    }
+
+    fn release_custom(collation: Self) {
+        let registry = CUSTOM_COLLATIONS.get_or_init(|| Mutex::new(CustomCollations::default()));
+        let mut registry = registry.lock().expect("custom collation registry poisoned");
+        if let Some(count) = registry.active_counts.get_mut(&collation.id()) {
+            *count -= 1;
+            if *count == 0 {
+                registry.active_counts.remove(&collation.id());
+            }
+        }
+    }
+
+    fn active_custom(collation: &str) -> Option<Self> {
+        let collation = Self::known_custom(collation)?;
+        let registry = CUSTOM_COLLATIONS.get_or_init(|| Mutex::new(CustomCollations::default()));
+        registry
+            .lock()
+            .expect("custom collation registry poisoned")
+            .active_counts
+            .get(&collation.id())
+            .is_some_and(|count| *count > 0)
+            .then_some(collation)
+    }
+
+    fn known_custom(collation: &str) -> Option<Self> {
+        let normalized = crate::util::normalize_ident(collation);
+        CUSTOM_COLLATIONS
+            .get()
+            .and_then(|registry| registry.lock().ok()?.by_name.get(&normalized).copied())
+            .map(Self::Custom)
+    }
+
+    pub fn name(self) -> String {
+        match self {
+            Self::Unset => "Unset".to_string(),
+            Self::Binary => "Binary".to_string(),
+            Self::NoCase => "NoCase".to_string(),
+            Self::Rtrim => "RTrim".to_string(),
+            Self::Locale(id) => LocaleCollationRegistry::global().name(id),
+            Self::Custom(id) => CUSTOM_COLLATIONS
+                .get()
+                .and_then(|registry| registry.lock().ok()?.by_id.get(&id).cloned())
+                .unwrap_or_else(|| format!("collation_{id}")),
         }
     }
 
     #[inline(always)]
     pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
-        match self {
-            CollationSeq::Unset | CollationSeq::Binary => Self::binary_cmp(lhs, rhs),
-            CollationSeq::NoCase => Self::nocase_cmp(lhs, rhs),
-            CollationSeq::Rtrim => Self::rtrim_cmp(lhs, rhs),
-            CollationSeq::Locale(id) => LocaleCollationRegistry::global().compare(*id, lhs, rhs),
+        match *self {
+            Self::Unset | Self::Binary => Self::binary_cmp(lhs, rhs),
+            Self::NoCase => Self::nocase_cmp(lhs, rhs),
+            Self::Rtrim => Self::rtrim_cmp(lhs, rhs),
+            Self::Locale(id) => LocaleCollationRegistry::global().compare(id, lhs, rhs),
+            // Immutable comparison paths have no connection to fetch the external
+            // callback from. Runtime VDBE paths dispatch custom collations via
+            // `Connection`; schema/index paths reject them before storage.
+            Self::Custom(_) => Self::binary_cmp(lhs, rhs),
         }
     }
 
@@ -76,53 +219,32 @@ impl CollationSeq {
         lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
     }
 
-    #[inline]
-    pub const fn to_bits(self) -> u16 {
-        match self {
-            CollationSeq::Unset => 0,
-            CollationSeq::Binary => 1,
-            CollationSeq::NoCase => 2,
-            CollationSeq::Rtrim => 3,
-            CollationSeq::Locale(id) => id.to_bits(),
-        }
-    }
-
-    #[inline]
-    pub const fn from_storage_bits(bits: u16) -> Self {
-        match bits {
-            0 => CollationSeq::Unset,
-            1 => CollationSeq::Binary,
-            2 => CollationSeq::NoCase,
-            3 => CollationSeq::Rtrim,
-            bits => CollationSeq::Locale(LocaleCollationId::from_bits(bits)),
-        }
-    }
-
     pub fn hash_key(&self, text: &str) -> Vec<u8> {
         match self {
-            CollationSeq::Unset | CollationSeq::Binary => text.as_bytes().to_vec(),
-            CollationSeq::NoCase => text.bytes().map(|b| b.to_ascii_lowercase()).collect(),
-            CollationSeq::Rtrim => text.trim_end_matches(' ').as_bytes().to_vec(),
-            CollationSeq::Locale(id) => LocaleCollationRegistry::global().sort_key(*id, text),
+            Self::Unset | Self::Binary => text.as_bytes().to_vec(),
+            Self::NoCase => text.bytes().map(|b| b.to_ascii_lowercase()).collect(),
+            Self::Rtrim => text.trim_end_matches(' ').as_bytes().to_vec(),
+            Self::Locale(id) => LocaleCollationRegistry::global().sort_key(*id, text),
+            // Hash joins using custom collations are disabled during planning
+            // because the callback is connection-owned and may define arbitrary equality.
+            Self::Custom(_) => text.as_bytes().to_vec(),
         }
+    }
+}
+
+impl Default for CollationSeq {
+    fn default() -> Self {
+        Self::Binary
     }
 }
 
 impl std::fmt::Display for CollationSeq {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CollationSeq::Unset => write!(f, "Unset"),
-            CollationSeq::Binary => write!(f, "Binary"),
-            CollationSeq::NoCase => write!(f, "NoCase"),
-            CollationSeq::Rtrim => write!(f, "Rtrim"),
-            CollationSeq::Locale(id) => {
-                write!(f, "{}", LocaleCollationRegistry::global().name(*id))
-            }
-        }
+        f.write_str(&self.name())
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct LocaleCollationId(u16);
 
 impl LocaleCollationId {
@@ -228,6 +350,12 @@ impl LocaleCollationRegistry {
             .expect("locale collation id should be registered");
         f(collation)
     }
+}
+
+fn custom_collation_id(name: &str) -> u32 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut hasher);
+    ((hasher.finish() as u32) & 0x7fff_fffc).max(4)
 }
 
 /// Every column of every table has an associated collating function. If no collating function is explicitly defined,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -643,7 +643,11 @@ fn extract_collation(expr: &Expr) -> crate::Result<(Option<CollationSeq>, &Expr)
     let mut current = expr;
     let mut coll = None;
     while let Expr::Collate(inner, seq) = current {
-        coll = Some(CollationSeq::new(seq.as_str())?);
+        let collation = CollationSeq::new(seq.as_str())?;
+        if collation.is_custom() {
+            crate::bail_parse_error!("custom collations are not supported in indexes");
+        }
+        coll = Some(collation);
         current = inner.as_ref();
     }
     Ok((coll, current))

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -143,7 +143,7 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
         let use_bloom_filter = self.hash_join_op.use_bloom_filter
             && collations
                 .iter()
-                .all(|c| matches!(c, CollationSeq::Binary | CollationSeq::Unset));
+                .all(|c| matches!(*c, CollationSeq::Binary | CollationSeq::Unset));
 
         let build_table = &self.table_references.joined_tables()[self.hash_join_op.build_table_idx];
         let (payload_columns, payload_signature_columns, use_materialized_keys, allow_seek) =

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -7,6 +7,7 @@ use turso_parser::ast::{self, SortOrder, TableInternalId};
 
 use crate::schema::Schema;
 use crate::stats::AnalyzeStats;
+use crate::translate::collate::CollationSeq;
 use crate::translate::expr::{as_binary_components, walk_expr, WalkControl};
 use crate::translate::optimizer::constraints::{
     convert_to_vtab_constraint, ordered_materialized_key_columns, BinaryExprSide, Constraint,
@@ -975,6 +976,21 @@ pub fn find_equijoin_conditions(
     join_keys
 }
 
+fn expr_uses_custom_collation(expr: &ast::Expr) -> bool {
+    let mut uses_custom = false;
+    let _ = walk_expr(expr, &mut |expr| -> Result<WalkControl> {
+        if let ast::Expr::Collate(_, collation_name) = expr {
+            uses_custom =
+                CollationSeq::new(collation_name.as_str()).is_ok_and(CollationSeq::is_custom);
+            if uses_custom {
+                return Ok(WalkControl::SkipChildren);
+            }
+        }
+        Ok(WalkControl::Continue)
+    });
+    uses_custom
+}
+
 /// Estimate the cost of a hash join between two tables.
 ///
 /// The cost model accounts for:
@@ -1149,6 +1165,14 @@ pub fn try_hash_join_access_method(
 
     // Need at least one equi-join condition
     if join_keys.is_empty() {
+        return None;
+    }
+    // Custom-collated equality depends on a connection-owned callback, so the
+    // hash join planner cannot derive a stable hash/equality pair here.
+    if join_keys.iter().any(|join_key| {
+        expr_uses_custom_collation(join_key.get_build_expr(where_clause))
+            || expr_uses_custom_collation(join_key.get_probe_expr(where_clause))
+    }) {
         return None;
     }
 

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -23,10 +23,7 @@ use crate::{
     util::{exprs_are_equivalent, normalize_ident},
     Result,
 };
-use crate::{
-    function::{AggFunc, ExtFunc},
-    translate::expr::bind_and_rewrite_expr,
-};
+use crate::{function::AggFunc, translate::expr::bind_and_rewrite_expr};
 use crate::{
     translate::plan::{Window, WindowFunction, WindowFunctionKind},
     vdbe::builder::ProgramBuilder,
@@ -263,7 +260,7 @@ pub fn resolve_window_and_aggregate_functions(
                             .resolve_function(name.as_str(), args_count)
                         {
                             let func = AggFunc::External(f.func.clone().into());
-                            if let ExtFunc::Aggregate { .. } = f.as_ref().func {
+                            if f.as_ref().func.is_aggregate() {
                                 if let Some(over_clause) = filter_over.over_clause.as_ref() {
                                     link_with_window(
                                         windows.as_deref_mut(),
@@ -356,7 +353,7 @@ pub fn resolve_window_and_aggregate_functions(
                     None => {
                         if let Some(f) = resolver.symbol_table.resolve_function(name.as_str(), 0) {
                             let func = AggFunc::External(f.func.clone().into());
-                            if let ExtFunc::Aggregate { .. } = f.as_ref().func {
+                            if f.as_ref().func.is_aggregate() {
                                 if let Some(over_clause) = filter_over.over_clause.as_ref() {
                                     link_with_window(
                                         windows.as_deref_mut(),

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -10,6 +10,7 @@ use crate::schema::{
 };
 use crate::stats::STATS_TABLE;
 use crate::storage::pager::CreateBTreeFlags;
+use crate::translate::collate::CollationSeq;
 use crate::translate::emitter::{
     emit_cdc_autocommit_commit, emit_cdc_full_record, emit_cdc_insns, prepare_cdc_if_necessary,
     OperationMode, Resolver,
@@ -751,6 +752,14 @@ fn validate(
                         let expr =
                             translate_ident_to_string_literal(expr).unwrap_or_else(|| expr.clone());
                         validate_default_expr(&expr, col_i)?
+                    }
+                    ast::ColumnConstraint::Collate { collation_name } => {
+                        let collation = CollationSeq::new(collation_name.as_str())?;
+                        if collation.is_custom() {
+                            bail_parse_error!(
+                                "custom collations are not supported in schema definitions"
+                            );
+                        }
                     }
                     _ => {}
                 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -6,6 +6,10 @@ use turso_parser::ast::SortOrder;
 
 use crate::error::LimboError;
 use crate::ext::{ExtValue, ExtValueType};
+use crate::function::{
+    ContextAggregateFinalFunction, ContextAggregateStepFunction, ContextDestructor, ContextValue,
+    ContextValueDestructor,
+};
 use crate::index_method::IndexMethodCursor;
 use crate::numeric::format_float;
 use crate::numeric::nonnan::NonNan;
@@ -486,12 +490,46 @@ impl Value {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct ExternalAggState {
-    pub state: *mut AggCtx,
-    pub argc: usize,
-    pub step_fn: StepFunction,
-    pub finalize_fn: FinalizeFunction,
+#[derive(Clone, PartialEq)]
+pub enum ExternalAggState {
+    Legacy {
+        state: *mut AggCtx,
+        argc: usize,
+        step_fn: StepFunction,
+        finalize_fn: FinalizeFunction,
+    },
+    Context {
+        context: usize,
+        aggregate_context: usize,
+        argc: usize,
+        step_fn: ContextAggregateStepFunction,
+        finalize_fn: ContextAggregateFinalFunction,
+        aggregate_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ContextValueDestructor>,
+    },
+}
+
+impl std::fmt::Debug for ExternalAggState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Legacy { state, argc, .. } => f
+                .debug_struct("Legacy")
+                .field("state", state)
+                .field("argc", argc)
+                .finish_non_exhaustive(),
+            Self::Context {
+                context,
+                aggregate_context,
+                argc,
+                ..
+            } => f
+                .debug_struct("Context")
+                .field("context", context)
+                .field("aggregate_context", aggregate_context)
+                .field("argc", argc)
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 /// Please use Display trait for all limbo output so we have single origin of truth
@@ -717,11 +755,36 @@ pub enum AggContext {
 
 impl AggContext {
     pub fn compute_external(&self) -> Result<Value> {
-        if let Self::External(ext_state) = self {
-            let final_value = unsafe { (ext_state.finalize_fn)(ext_state.state) };
-            Value::from_ffi(final_value)
-        } else {
+        let Self::External(ext_state) = self else {
             panic!("AggContext::compute_external() expected External, found {self:?}");
+        };
+
+        match ext_state {
+            ExternalAggState::Legacy {
+                state, finalize_fn, ..
+            } => {
+                let final_value = unsafe { finalize_fn(*state) };
+                Value::from_ffi(final_value)
+            }
+            ExternalAggState::Context {
+                context,
+                aggregate_context,
+                finalize_fn,
+                aggregate_destructor,
+                value_destructor,
+                ..
+            } => {
+                let mut result = ContextValue::null();
+                unsafe { finalize_fn(*context, *aggregate_context, &mut result) };
+                let value = result.into_value();
+                if let Some(value_destructor) = value_destructor {
+                    unsafe { value_destructor(&mut result) };
+                }
+                if let Some(aggregate_destructor) = aggregate_destructor {
+                    unsafe { aggregate_destructor(*aggregate_context) };
+                }
+                value
+            }
         }
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -21,8 +21,8 @@ use crate::storage::sqlite3_ondisk::{DatabaseHeader, PageSize, RawVersion};
 use crate::translate::collate::CollationSeq;
 use crate::translate::pragma::TURSO_CDC_VERSION_TABLE_NAME;
 use crate::types::{
-    compare_immutable, compare_records_generic, AsValueRef, Extendable, IOCompletions, IOResult,
-    ImmutableRecord, IndexInfo, SeekResult, Text, ValueIterator,
+    compare_immutable, compare_immutable_single, compare_records_generic, AsValueRef, Extendable,
+    IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekResult, Text, ValueIterator,
 };
 use crate::util::{
     escape_sql_string_literal, normalize_ident, rename_identifiers,
@@ -304,16 +304,54 @@ fn compare_with_collation(
     lhs: &Value,
     rhs: &Value,
     collation: Option<CollationSeq>,
+    collation_comparator: &Option<crate::vdbe::sorter::SortComparator>,
 ) -> std::cmp::Ordering {
     match (lhs, rhs) {
         (Value::Text(lhs_text), Value::Text(rhs_text)) => {
-            if let Some(coll) = collation {
+            if let Some(comparator) = collation_comparator {
+                comparator(&lhs.as_ref(), &rhs.as_ref())
+            } else if let Some(coll) = collation {
                 coll.compare_strings(lhs_text.as_str(), rhs_text.as_str())
             } else {
                 lhs.cmp(rhs)
             }
         }
         _ => lhs.cmp(rhs),
+    }
+}
+
+fn compare_with_program_collation<V1, V2>(
+    program: &Program,
+    lhs: V1,
+    rhs: V2,
+    collation: CollationSeq,
+) -> Result<std::cmp::Ordering>
+where
+    V1: AsValueRef,
+    V2: AsValueRef,
+{
+    let lhs = lhs.as_value_ref();
+    let rhs = rhs.as_value_ref();
+    if collation.is_custom() {
+        if let (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) = (lhs, rhs) {
+            return program.connection.compare_external_collation(
+                collation,
+                lhs_text.as_str(),
+                rhs_text.as_str(),
+            );
+        }
+    }
+    Ok(compare_immutable_single(lhs, rhs, collation))
+}
+
+fn comparison_matches_order(op: ComparisonOp, order: std::cmp::Ordering) -> bool {
+    match op {
+        ComparisonOp::Eq => order.is_eq(),
+        ComparisonOp::Ne => !order.is_eq(),
+        ComparisonOp::Lt => order.is_lt(),
+        ComparisonOp::Le => order.is_le(),
+        ComparisonOp::Gt => order.is_gt(),
+        ComparisonOp::Ge => order.is_ge(),
     }
 }
 
@@ -820,7 +858,7 @@ pub fn op_not_null(
 }
 
 pub fn op_comparison(
-    _program: &Program,
+    program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
@@ -981,15 +1019,19 @@ pub fn op_comparison(
         affinity.convert_for_compare(rhs_value),
     );
 
-    let should_jump = op.compare(
-        new_lhs
-            .as_ref()
-            .map_or(Either::Left(lhs_value), Either::Right),
-        new_rhs
-            .as_ref()
-            .map_or(Either::Left(rhs_value), Either::Right),
-        collation,
-    );
+    let lhs_for_compare = new_lhs
+        .as_ref()
+        .map_or(Either::Left(lhs_value), Either::Right);
+    let rhs_for_compare = new_rhs
+        .as_ref()
+        .map_or(Either::Left(rhs_value), Either::Right);
+    let should_jump = if collation.is_custom() {
+        let order =
+            compare_with_program_collation(program, lhs_for_compare, rhs_for_compare, collation)?;
+        comparison_matches_order(op, order)
+    } else {
+        op.compare(lhs_for_compare, rhs_for_compare, collation)
+    };
 
     match (new_lhs, new_rhs) {
         (Some(new_lhs), None) => {
@@ -5937,7 +5979,7 @@ fn update_agg_payload(
                 let payload_ref = payload[0].as_ref();
                 cmp_fn(&arg_ref, &payload_ref)
             } else {
-                compare_with_collation(&arg, &payload[0], Some(collation))
+                compare_with_collation(&arg, &payload[0], Some(collation), comparator)
             };
             let should_update = match func {
                 AggFunc::Max => cmp == Ordering::Greater,
@@ -6127,7 +6169,7 @@ fn finalize_agg_payload(func: &AggFunc, payload: &[Value]) -> Result<Value> {
 }
 
 pub fn op_agg_step(
-    _program: &Program,
+    program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
@@ -6152,11 +6194,29 @@ pub fn op_agg_step(
                     step,
                     finalize,
                     argc,
-                } => Register::Aggregate(AggContext::External(ExternalAggState {
+                } => Register::Aggregate(AggContext::External(ExternalAggState::Legacy {
                     state: unsafe { (init)() },
                     argc: *argc,
                     step_fn: *step,
                     finalize_fn: *finalize,
+                })),
+                ExtFunc::ContextAggregate {
+                    context,
+                    init,
+                    step,
+                    finalize,
+                    argc,
+                    aggregate_destructor,
+                    value_destructor,
+                    ..
+                } => Register::Aggregate(AggContext::External(ExternalAggState::Context {
+                    context: *context,
+                    aggregate_context: unsafe { init(*context) },
+                    argc: (*argc).max(0) as usize,
+                    step_fn: *step,
+                    finalize_fn: *finalize,
+                    aggregate_destructor: *aggregate_destructor,
+                    value_destructor: *value_destructor,
                 })),
                 _ => unreachable!("scalar function called in aggregate context"),
             },
@@ -6169,34 +6229,99 @@ pub fn op_agg_step(
         };
     }
 
-    // Resolve custom type comparator for MIN/MAX if provided
-    let comparator = comparator.as_ref().map(make_sort_comparator);
+    let current_collation = state.current_collation.unwrap_or(CollationSeq::Binary);
+    let comparator = match comparator.as_ref() {
+        Some(comparator) => Some(make_sort_comparator(comparator)),
+        None if current_collation.is_custom() => Some(
+            program
+                .connection
+                .make_collation_comparator(current_collation)?,
+        ),
+        None => None,
+    };
 
     // Step the aggregate
     match func {
         AggFunc::External(_) => {
             // External aggregates use FFI and need special handling
-            let (step_fn, state_ptr, argc) = {
+            let external_state = {
                 let Register::Aggregate(agg) = &state.registers[*acc_reg] else {
                     unreachable!();
                 };
-                let AggContext::External(agg_state) = agg else {
+                let AggContext::External(external_state) = agg else {
                     unreachable!();
                 };
-                (agg_state.step_fn, agg_state.state, agg_state.argc)
+                external_state.clone()
             };
-            if argc == 0 {
-                unsafe { step_fn(state_ptr, 0, std::ptr::null()) };
-            } else {
-                let register_slice = &state.registers[*col..*col + argc];
-                let mut ext_values: Vec<ExtValue> = Vec::with_capacity(argc);
-                for ov in register_slice.iter() {
-                    ext_values.push(ov.get_value().to_ffi());
+
+            match external_state {
+                ExternalAggState::Legacy {
+                    step_fn,
+                    state: state_ptr,
+                    argc,
+                    ..
+                } => {
+                    if argc == 0 {
+                        unsafe { step_fn(state_ptr, 0, std::ptr::null()) };
+                    } else {
+                        let register_slice = &state.registers[*col..*col + argc];
+                        let mut ext_values: Vec<ExtValue> = Vec::with_capacity(argc);
+                        for ov in register_slice.iter() {
+                            ext_values.push(ov.get_value().to_ffi());
+                        }
+                        let argv_ptr = ext_values.as_ptr();
+                        unsafe { step_fn(state_ptr, argc as i32, argv_ptr) };
+                        for ext_value in ext_values {
+                            unsafe { ext_value.__free_internal_type() };
+                        }
+                    }
                 }
-                let argv_ptr = ext_values.as_ptr();
-                unsafe { step_fn(state_ptr, argc as i32, argv_ptr) };
-                for ext_value in ext_values {
-                    unsafe { ext_value.__free_internal_type() };
+                ExternalAggState::Context {
+                    context,
+                    aggregate_context,
+                    argc,
+                    step_fn,
+                    aggregate_destructor,
+                    value_destructor,
+                    ..
+                } => {
+                    let mut ext_values: Vec<ExtValue> = Vec::with_capacity(argc);
+                    if argc != 0 {
+                        let register_slice = &state.registers[*col..*col + argc];
+                        for ov in register_slice.iter() {
+                            ext_values.push(ov.get_value().to_ffi());
+                        }
+                    }
+
+                    let argv_ptr = if ext_values.is_empty() {
+                        std::ptr::null()
+                    } else {
+                        ext_values.as_ptr()
+                    };
+                    let mut result = crate::function::ContextValue::null();
+                    unsafe {
+                        step_fn(
+                            context,
+                            aggregate_context,
+                            argc as i32,
+                            argv_ptr,
+                            &mut result,
+                        )
+                    };
+                    let value = result.into_value();
+                    if let Some(value_destructor) = value_destructor {
+                        unsafe { value_destructor(&mut result) };
+                    }
+                    for ext_value in ext_values {
+                        unsafe { ext_value.__free_internal_type() };
+                    }
+                    if let Err(err) = value {
+                        if let Some(aggregate_destructor) = aggregate_destructor {
+                            unsafe { aggregate_destructor(aggregate_context) };
+                        }
+                        state.registers[*acc_reg].set_value(Value::Null);
+                        return Err(err);
+                    }
                 }
             }
         }
@@ -6230,8 +6355,6 @@ pub fn op_agg_step(
                     }
                     _ => None,
                 };
-                let collation = state.current_collation.unwrap_or(CollationSeq::Binary);
-
                 // Now get mutable borrow on payload
                 let Register::Aggregate(agg) = &mut state.registers[*acc_reg] else {
                     panic!(
@@ -6240,7 +6363,14 @@ pub fn op_agg_step(
                     );
                 };
                 let payload = agg.payload_mut();
-                update_agg_payload(func, arg, maybe_arg2, payload, collation, &comparator)?;
+                update_agg_payload(
+                    func,
+                    arg,
+                    maybe_arg2,
+                    payload,
+                    current_collation,
+                    &comparator,
+                )?;
             }
         }
     };
@@ -6307,6 +6437,37 @@ pub fn op_agg_final(
                     state.registers[dest_reg]
                         .set_blob(json::jsonb::Jsonb::make_empty_obj(1).data());
                 }
+                AggFunc::External(ext_func) => {
+                    let value = match ext_func.as_ref() {
+                        ExtFunc::Aggregate { init, finalize, .. } => {
+                            let state = unsafe { init() };
+                            let final_value = unsafe { finalize(state) };
+                            Value::from_ffi(final_value)?
+                        }
+                        ExtFunc::ContextAggregate {
+                            context,
+                            init,
+                            finalize,
+                            aggregate_destructor,
+                            value_destructor,
+                            ..
+                        } => {
+                            let aggregate_context = unsafe { init(*context) };
+                            let mut result = crate::function::ContextValue::null();
+                            unsafe { finalize(*context, aggregate_context, &mut result) };
+                            let value = result.into_value();
+                            if let Some(value_destructor) = value_destructor {
+                                unsafe { value_destructor(&mut result) };
+                            }
+                            if let Some(aggregate_destructor) = aggregate_destructor {
+                                unsafe { aggregate_destructor(aggregate_context) };
+                            }
+                            value?
+                        }
+                        _ => unreachable!("scalar function called in aggregate context"),
+                    };
+                    state.registers[dest_reg].set_value(value);
+                }
                 _ => {}
             }
         }
@@ -6358,16 +6519,25 @@ pub fn op_sorter_open(
         collations.push(coll.unwrap_or_default());
         nulls_orders.push(*nulls);
     }
-    let comparators = comparators
-        .iter()
-        .map(|c| c.as_ref().map(make_sort_comparator))
-        .collect();
+    let mut sort_comparators = Vec::with_capacity(order_collations_nulls.len());
+    for (idx, (_, coll, _)) in order_collations_nulls.iter().enumerate() {
+        let comparator = match comparators.get(idx).and_then(|c| c.as_ref()) {
+            Some(comparator) => Some(make_sort_comparator(comparator)),
+            None => match coll {
+                Some(collation) if collation.is_custom() => {
+                    Some(program.connection.make_collation_comparator(*collation)?)
+                }
+                _ => None,
+            },
+        };
+        sort_comparators.push(comparator);
+    }
     let temp_store = program.connection.get_temp_store();
     let cursor = Sorter::new(
         &order,
         collations,
         nulls_orders,
-        comparators,
+        sort_comparators,
         max_buffer_size_bytes,
         page_size,
         pager.io.clone(),
@@ -7380,7 +7550,7 @@ pub fn op_function(
             #[cfg(feature = "fs")]
             #[cfg(not(target_family = "wasm"))]
             ScalarFunc::LoadExtension => {
-                if !program.connection.db.can_load_extensions() {
+                if !program.connection.can_load_extensions() {
                     crate::bail_parse_error!("runtime extension loading is disabled");
                 }
                 let extension = &state.registers[*start_reg];
@@ -8138,6 +8308,36 @@ pub fn op_function(
                         }
                     }
                 }
+            }
+            ExtFunc::ContextScalar {
+                context,
+                callback,
+                value_destructor,
+                ..
+            } => {
+                let mut ext_values = Vec::with_capacity(arg_count);
+                if arg_count != 0 {
+                    let register_slice = &state.registers[*start_reg..*start_reg + arg_count];
+                    for ov in register_slice.iter() {
+                        ext_values.push(ov.get_value().to_ffi());
+                    }
+                }
+
+                let argv_ptr = if ext_values.is_empty() {
+                    std::ptr::null()
+                } else {
+                    ext_values.as_ptr()
+                };
+                let mut result = crate::function::ContextValue::null();
+                unsafe { callback(context, arg_count as i32, argv_ptr, &mut result) };
+                let value = result.into_value();
+                if let Some(value_destructor) = value_destructor {
+                    unsafe { value_destructor(&mut result) };
+                }
+                for ext_value in ext_values {
+                    unsafe { ext_value.__free_internal_type() };
+                }
+                state.registers[*dest].set_value(value?);
             }
             _ => unreachable!("aggregate called in scalar context"),
         },

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -81,7 +81,7 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
             ValueRef::Text(text) => {
                 let collation = collations.get(idx).unwrap_or(&CollationSeq::Binary);
                 hasher.write_u8(TEXT_HASH);
-                match collation {
+                match *collation {
                     CollationSeq::NoCase => {
                         hash_text_nocase(&mut hasher, text.as_str());
                     }
@@ -94,6 +94,9 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
                     }
                     CollationSeq::Locale(_) => {
                         hasher.write(&collation.hash_key(text.as_str()));
+                    }
+                    CollationSeq::Custom(_) => {
+                        hasher.write(text.as_bytes());
                     }
                 }
             }

--- a/extensions/core/src/types.rs
+++ b/extensions/core/src/types.rs
@@ -206,7 +206,8 @@ impl TextValue {
     #[cfg(feature = "core_only")]
     fn free(self) {
         if !self.text.is_null() {
-            let _ = unsafe { Box::from_raw(self.text as *mut u8) };
+            let ptr = std::ptr::slice_from_raw_parts_mut(self.text as *mut u8, self.len as usize);
+            let _ = unsafe { Box::from_raw(ptr) };
         }
     }
 
@@ -273,7 +274,8 @@ impl Blob {
     #[cfg(feature = "core_only")]
     fn free(self) {
         if !self.data.is_null() {
-            let _ = unsafe { Box::from_raw(self.data as *mut u8) };
+            let ptr = std::ptr::slice_from_raw_parts_mut(self.data as *mut u8, self.size as usize);
+            let _ = unsafe { Box::from_raw(ptr) };
         }
     }
 }
@@ -520,7 +522,8 @@ impl Value {
             ValueType::Error => {
                 let err_val = Box::from_raw(self.value.error as *mut ErrValue);
                 if !err_val.message.is_null() {
-                    let _ = Box::from_raw(err_val.message);
+                    let message = Box::from_raw(err_val.message);
+                    message.free();
                 }
             }
             _ => {}

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -45,6 +45,98 @@ pub enum turso_type_t {
     TURSO_TYPE_BLOB = 4,
     TURSO_TYPE_NULL = 5,
 }
+pub const turso_context_value_type_t_TURSO_CONTEXT_VALUE_NULL: turso_context_value_type_t = 0;
+pub const turso_context_value_type_t_TURSO_CONTEXT_VALUE_INTEGER: turso_context_value_type_t = 1;
+pub const turso_context_value_type_t_TURSO_CONTEXT_VALUE_FLOAT: turso_context_value_type_t = 2;
+pub const turso_context_value_type_t_TURSO_CONTEXT_VALUE_TEXT: turso_context_value_type_t = 3;
+pub const turso_context_value_type_t_TURSO_CONTEXT_VALUE_BLOB: turso_context_value_type_t = 4;
+pub const turso_context_value_type_t_TURSO_CONTEXT_VALUE_ERROR: turso_context_value_type_t = 5;
+pub type turso_context_value_type_t = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_context_value_bytes_t {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+impl Default for turso_context_value_bytes_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union turso_context_value_data_t {
+    pub int_value: i64,
+    pub float_value: f64,
+    pub bytes: turso_context_value_bytes_t,
+}
+impl Default for turso_context_value_data_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct turso_context_value_t {
+    pub value_type: turso_context_value_type_t,
+    pub value: turso_context_value_data_t,
+}
+impl Default for turso_context_value_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub type turso_scalar_function_callback_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        context: usize,
+        argc: i32,
+        argv: *const ::std::os::raw::c_void,
+        result: *mut turso_context_value_t,
+    ),
+>;
+pub type turso_aggregate_init_callback_t =
+    ::std::option::Option<unsafe extern "C" fn(context: usize) -> usize>;
+pub type turso_aggregate_step_callback_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        context: usize,
+        aggregate_context: usize,
+        argc: i32,
+        argv: *const ::std::os::raw::c_void,
+        result: *mut turso_context_value_t,
+    ),
+>;
+pub type turso_aggregate_final_callback_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        context: usize,
+        aggregate_context: usize,
+        result: *mut turso_context_value_t,
+    ),
+>;
+pub type turso_collation_callback_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        context: usize,
+        left_ptr: *const u8,
+        left_len: usize,
+        right_ptr: *const u8,
+        right_len: usize,
+    ) -> i32,
+>;
+pub type turso_context_destructor_callback_t =
+    ::std::option::Option<unsafe extern "C" fn(context: usize)>;
+pub type turso_value_destructor_callback_t =
+    ::std::option::Option<unsafe extern "C" fn(result: *mut turso_context_value_t)>;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum turso_tracing_level_t {
@@ -180,6 +272,73 @@ unsafe extern "C" {
 unsafe extern "C" {
     #[doc = " Get last insert rowid for the connection or 0 if no inserts happened before"]
     pub fn turso_connection_last_insert_rowid(self_: *const turso_connection_t) -> i64;
+}
+unsafe extern "C" {
+    pub fn turso_connection_register_scalar_function(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        callback: turso_scalar_function_callback_t,
+        context_destructor: turso_context_destructor_callback_t,
+        value_destructor: turso_value_destructor_callback_t,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    pub fn turso_connection_register_aggregate_function(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        init: turso_aggregate_init_callback_t,
+        step: turso_aggregate_step_callback_t,
+        finalize: turso_aggregate_final_callback_t,
+        context_destructor: turso_context_destructor_callback_t,
+        aggregate_destructor: turso_context_destructor_callback_t,
+        value_destructor: turso_value_destructor_callback_t,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    pub fn turso_connection_unregister_function(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    pub fn turso_connection_register_collation(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        context: usize,
+        callback: turso_collation_callback_t,
+        context_destructor: turso_context_destructor_callback_t,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    pub fn turso_connection_unregister_collation(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    pub fn turso_connection_enable_load_extension(
+        self_: *const turso_connection_t,
+        enabled: bool,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    pub fn turso_connection_load_extension(
+        self_: *const turso_connection_t,
+        path: *const ::std::os::raw::c_char,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
 }
 unsafe extern "C" {
     #[doc = " Prepare single statement in a connection"]

--- a/sdk-kit/src/capi.rs
+++ b/sdk-kit/src/capi.rs
@@ -132,6 +132,174 @@ pub extern "C" fn turso_connection_last_insert_rowid(
 }
 
 #[no_mangle]
+pub extern "C" fn turso_connection_register_scalar_function(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    argc: i32,
+    deterministic: bool,
+    context: usize,
+    callback: turso_core::ContextScalarFunction,
+    context_destructor: Option<turso_core::ContextDestructor>,
+    value_destructor: Option<turso_core::ContextValueDestructor>,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.register_external_scalar_function(
+        name.to_string(),
+        argc,
+        deterministic,
+        context,
+        callback,
+        context_destructor,
+        value_destructor,
+    );
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+pub extern "C" fn turso_connection_register_aggregate_function(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    argc: i32,
+    deterministic: bool,
+    context: usize,
+    init: turso_core::ContextAggregateInitFunction,
+    step: turso_core::ContextAggregateStepFunction,
+    finalize: turso_core::ContextAggregateFinalFunction,
+    context_destructor: Option<turso_core::ContextDestructor>,
+    aggregate_destructor: Option<turso_core::ContextDestructor>,
+    value_destructor: Option<turso_core::ContextValueDestructor>,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.register_external_aggregate_function(
+        name.to_string(),
+        argc,
+        deterministic,
+        context,
+        init,
+        step,
+        finalize,
+        context_destructor,
+        aggregate_destructor,
+        value_destructor,
+    );
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+pub extern "C" fn turso_connection_unregister_function(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.unregister_external_function(name);
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+pub extern "C" fn turso_connection_register_collation(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    context: usize,
+    callback: turso_core::ContextCollationFunction,
+    context_destructor: Option<turso_core::ContextDestructor>,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.register_external_collation(name.to_string(), context, callback, context_destructor);
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+pub extern "C" fn turso_connection_unregister_collation(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.unregister_external_collation(name);
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+pub extern "C" fn turso_connection_enable_load_extension(
+    connection: *const c::turso_connection_t,
+    enabled: bool,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.set_load_extension_enabled(enabled);
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+pub extern "C" fn turso_connection_load_extension(
+    connection: *const c::turso_connection_t,
+    path: *const std::ffi::c_char,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let path = match unsafe { str_from_c_str(path) } {
+        Ok(path) => path,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    match connection.load_extension(path) {
+        Ok(()) => c::turso_status_code_t::TURSO_OK,
+        Err(err) => unsafe { err.to_capi(error_opt_out) },
+    }
+}
+
+#[no_mangle]
 #[signature(c)]
 pub extern "C" fn turso_connection_prepare_single(
     connection: *const c::turso_connection_t,

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -831,6 +831,85 @@ impl TursoConnection {
         self.connection.last_insert_rowid()
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_external_scalar_function(
+        &self,
+        name: String,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        callback: turso_core::ContextScalarFunction,
+        context_destructor: Option<turso_core::ContextDestructor>,
+        value_destructor: Option<turso_core::ContextValueDestructor>,
+    ) {
+        self.connection.register_external_scalar_function(
+            name,
+            argc,
+            deterministic,
+            context,
+            callback,
+            context_destructor,
+            value_destructor,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_external_aggregate_function(
+        &self,
+        name: String,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        init: turso_core::ContextAggregateInitFunction,
+        step: turso_core::ContextAggregateStepFunction,
+        finalize: turso_core::ContextAggregateFinalFunction,
+        context_destructor: Option<turso_core::ContextDestructor>,
+        aggregate_destructor: Option<turso_core::ContextDestructor>,
+        value_destructor: Option<turso_core::ContextValueDestructor>,
+    ) {
+        self.connection.register_external_aggregate_function(
+            name,
+            argc,
+            deterministic,
+            context,
+            init,
+            step,
+            finalize,
+            context_destructor,
+            aggregate_destructor,
+            value_destructor,
+        );
+    }
+
+    pub fn unregister_external_function(&self, name: &str) {
+        self.connection.unregister_external_function(name);
+    }
+
+    pub fn register_external_collation(
+        &self,
+        name: String,
+        context: usize,
+        callback: turso_core::ContextCollationFunction,
+        context_destructor: Option<turso_core::ContextDestructor>,
+    ) {
+        self.connection
+            .register_external_collation(name, context, callback, context_destructor);
+    }
+
+    pub fn unregister_external_collation(&self, name: &str) {
+        self.connection.unregister_external_collation(name);
+    }
+
+    pub fn set_load_extension_enabled(&self, enabled: bool) {
+        self.connection.set_load_extension_enabled(enabled);
+    }
+
+    pub fn load_extension(&self, path: &str) -> Result<(), TursoError> {
+        turso_core::resolve_ext_path(path)
+            .and_then(|path| self.connection.load_extension(path))
+            .map_err(TursoError::from)
+    }
+
     /// prepares single SQL statement
     pub fn prepare_single(&self, sql: impl AsRef<str>) -> Result<Box<TursoStatement>, TursoError> {
         let statement = self.connection.prepare(sql)?;

--- a/sdk-kit/turso.h
+++ b/sdk-kit/turso.h
@@ -48,6 +48,43 @@ typedef enum
 
 typedef enum
 {
+    TURSO_CONTEXT_VALUE_NULL = 0,
+    TURSO_CONTEXT_VALUE_INTEGER = 1,
+    TURSO_CONTEXT_VALUE_FLOAT = 2,
+    TURSO_CONTEXT_VALUE_TEXT = 3,
+    TURSO_CONTEXT_VALUE_BLOB = 4,
+    TURSO_CONTEXT_VALUE_ERROR = 5,
+} turso_context_value_type_t;
+
+typedef struct
+{
+    const uint8_t *ptr;
+    size_t len;
+} turso_context_value_bytes_t;
+
+typedef union
+{
+    int64_t int_value;
+    double float_value;
+    turso_context_value_bytes_t bytes;
+} turso_context_value_data_t;
+
+typedef struct
+{
+    turso_context_value_type_t value_type;
+    turso_context_value_data_t value;
+} turso_context_value_t;
+
+typedef void (*turso_scalar_function_callback_t)(uintptr_t context, int32_t argc, const void *argv, turso_context_value_t *result);
+typedef uintptr_t (*turso_aggregate_init_callback_t)(uintptr_t context);
+typedef void (*turso_aggregate_step_callback_t)(uintptr_t context, uintptr_t aggregate_context, int32_t argc, const void *argv, turso_context_value_t *result);
+typedef void (*turso_aggregate_final_callback_t)(uintptr_t context, uintptr_t aggregate_context, turso_context_value_t *result);
+typedef int32_t (*turso_collation_callback_t)(uintptr_t context, const uint8_t *left_ptr, size_t left_len, const uint8_t *right_ptr, size_t right_len);
+typedef void (*turso_context_destructor_callback_t)(uintptr_t context);
+typedef void (*turso_value_destructor_callback_t)(turso_context_value_t *result);
+
+typedef enum
+{
     TURSO_TRACING_LEVEL_ERROR = 1,
     TURSO_TRACING_LEVEL_WARN,
     TURSO_TRACING_LEVEL_INFO,
@@ -164,6 +201,59 @@ bool turso_connection_get_autocommit(const turso_connection_t *self);
 
 /** Get last insert rowid for the connection or 0 if no inserts happened before */
 int64_t turso_connection_last_insert_rowid(const turso_connection_t *self);
+
+turso_status_code_t turso_connection_register_scalar_function(
+    const turso_connection_t *self,
+    const char *name,
+    int32_t argc,
+    bool deterministic,
+    uintptr_t context,
+    turso_scalar_function_callback_t callback,
+    turso_context_destructor_callback_t context_destructor,
+    turso_value_destructor_callback_t value_destructor,
+    const char **error_opt_out);
+
+turso_status_code_t turso_connection_register_aggregate_function(
+    const turso_connection_t *self,
+    const char *name,
+    int32_t argc,
+    bool deterministic,
+    uintptr_t context,
+    turso_aggregate_init_callback_t init,
+    turso_aggregate_step_callback_t step,
+    turso_aggregate_final_callback_t finalize,
+    turso_context_destructor_callback_t context_destructor,
+    turso_context_destructor_callback_t aggregate_destructor,
+    turso_value_destructor_callback_t value_destructor,
+    const char **error_opt_out);
+
+turso_status_code_t turso_connection_unregister_function(
+    const turso_connection_t *self,
+    const char *name,
+    const char **error_opt_out);
+
+turso_status_code_t turso_connection_register_collation(
+    const turso_connection_t *self,
+    const char *name,
+    uintptr_t context,
+    turso_collation_callback_t callback,
+    turso_context_destructor_callback_t context_destructor,
+    const char **error_opt_out);
+
+turso_status_code_t turso_connection_unregister_collation(
+    const turso_connection_t *self,
+    const char *name,
+    const char **error_opt_out);
+
+turso_status_code_t turso_connection_enable_load_extension(
+    const turso_connection_t *self,
+    bool enabled,
+    const char **error_opt_out);
+
+turso_status_code_t turso_connection_load_extension(
+    const turso_connection_t *self,
+    const char *path,
+    const char **error_opt_out);
 
 /** Prepare single statement in a connection */
 turso_status_code_t

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,6 +22,7 @@ path = "fuzz/mod.rs"
 anyhow.workspace = true
 env_logger = { workspace = true }
 turso_core = { workspace = true, features = ["conn_raw_api"] }
+turso_ext.workspace = true
 turso_sdk_kit = { path = "../sdk-kit" }
 turso = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -1,0 +1,742 @@
+use crate::common::{limbo_exec_rows, ExecRows, TempDatabase};
+use rusqlite::types::Value as SqliteValue;
+use serial_test::serial;
+use std::cmp::Ordering;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering as AtomicOrdering},
+    Arc,
+};
+use turso_core::{ContextValue, ContextValueBytes, ContextValueData, ContextValueType, LimboError};
+use turso_ext::{Value as ExtValue, ValueType as ExtValueType};
+
+static SCALAR_VALUE_DROPS: AtomicUsize = AtomicUsize::new(0);
+static AGG_VALUE_DROPS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Default)]
+struct CallbackCounters {
+    calls: AtomicUsize,
+    context_drops: AtomicUsize,
+    aggregate_inits: AtomicUsize,
+    aggregate_steps: AtomicUsize,
+    aggregate_finals: AtomicUsize,
+    aggregate_drops: AtomicUsize,
+}
+
+struct ScalarContext {
+    multiplier: i64,
+    counters: Arc<CallbackCounters>,
+}
+
+struct AggregateContext {
+    counters: Arc<CallbackCounters>,
+}
+
+struct SumState {
+    sum: i64,
+    counters: Arc<CallbackCounters>,
+}
+
+fn integer_result(value: i64) -> ContextValue {
+    ContextValue {
+        value_type: ContextValueType::Integer,
+        value: ContextValueData { int: value },
+    }
+}
+
+fn text_result(bytes: &'static [u8]) -> ContextValue {
+    ContextValue {
+        value_type: ContextValueType::Text,
+        value: ContextValueData {
+            bytes: ContextValueBytes {
+                ptr: bytes.as_ptr(),
+                len: bytes.len(),
+            },
+        },
+    }
+}
+
+fn error_result(bytes: &'static [u8]) -> ContextValue {
+    ContextValue {
+        value_type: ContextValueType::Error,
+        value: ContextValueData {
+            bytes: ContextValueBytes {
+                ptr: bytes.as_ptr(),
+                len: bytes.len(),
+            },
+        },
+    }
+}
+
+unsafe extern "C" fn managed_score(
+    context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const ScalarContext) };
+    ctx.counters.calls.fetch_add(1, AtomicOrdering::SeqCst);
+    let args = if argc <= 0 || argv.is_null() {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(argv, argc as usize) }
+    };
+
+    let int_value = args
+        .first()
+        .and_then(ExtValue::to_integer)
+        .unwrap_or_default();
+    let float_value = args
+        .get(1)
+        .and_then(ExtValue::to_float)
+        .map(|value| value as i64)
+        .unwrap_or_default();
+    let text_len = args
+        .get(2)
+        .and_then(ExtValue::to_text)
+        .map(str::len)
+        .unwrap_or_default() as i64;
+    let blob_len = args
+        .get(3)
+        .and_then(ExtValue::to_blob)
+        .map(|blob| blob.len())
+        .unwrap_or_default() as i64;
+
+    unsafe {
+        *result = integer_result((int_value + float_value + text_len + blob_len) * ctx.multiplier);
+    }
+}
+
+unsafe extern "C" fn managed_label(
+    context: usize,
+    _argc: i32,
+    _argv: *const ExtValue,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const ScalarContext) };
+    ctx.counters.calls.fetch_add(1, AtomicOrdering::SeqCst);
+    unsafe {
+        *result = text_result(b"managed-label");
+    }
+}
+
+unsafe extern "C" fn managed_fail(
+    context: usize,
+    _argc: i32,
+    _argv: *const ExtValue,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const ScalarContext) };
+    ctx.counters.calls.fetch_add(1, AtomicOrdering::SeqCst);
+    unsafe {
+        *result = error_result(b"managed failure");
+    }
+}
+
+unsafe extern "C" fn managed_variadic_score(
+    context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const ScalarContext) };
+    ctx.counters.calls.fetch_add(1, AtomicOrdering::SeqCst);
+    let args = if argc <= 0 || argv.is_null() {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(argv, argc as usize) }
+    };
+
+    let null_count = args
+        .iter()
+        .filter(|arg| arg.value_type() == ExtValueType::Null)
+        .count() as i64;
+    let score = (argc as i64 * 100)
+        + args
+            .first()
+            .and_then(ExtValue::to_integer)
+            .unwrap_or_default()
+        + args
+            .get(1)
+            .and_then(ExtValue::to_float)
+            .map(|value| value as i64)
+            .unwrap_or_default()
+        + args
+            .get(2)
+            .and_then(ExtValue::to_text)
+            .map(str::len)
+            .unwrap_or_default() as i64
+        + args
+            .get(3)
+            .and_then(ExtValue::to_blob)
+            .map(|blob| blob.len())
+            .unwrap_or_default() as i64
+        + null_count;
+    unsafe {
+        *result = integer_result(score * ctx.multiplier);
+    }
+}
+
+unsafe extern "C" fn drop_scalar_context(context: usize) {
+    let context = unsafe { Box::from_raw(context as *mut ScalarContext) };
+    context
+        .counters
+        .context_drops
+        .fetch_add(1, AtomicOrdering::SeqCst);
+}
+
+unsafe extern "C" fn count_scalar_value_drop(_result: *mut ContextValue) {
+    SCALAR_VALUE_DROPS.fetch_add(1, AtomicOrdering::SeqCst);
+}
+
+unsafe extern "C" fn managed_sum_init(context: usize) -> usize {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_inits
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    Box::into_raw(Box::new(SumState {
+        sum: 0,
+        counters: ctx.counters.clone(),
+    })) as usize
+}
+
+unsafe extern "C" fn managed_sum_step(
+    context: usize,
+    aggregate_context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_steps
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    let state = unsafe { &mut *(aggregate_context as *mut SumState) };
+    if argc > 0 && !argv.is_null() {
+        let args = unsafe { std::slice::from_raw_parts(argv, argc as usize) };
+        state.sum += args
+            .first()
+            .and_then(ExtValue::to_integer)
+            .unwrap_or_default();
+    }
+    unsafe {
+        *result = ContextValue::null();
+    }
+}
+
+unsafe extern "C" fn managed_sum_final(
+    context: usize,
+    aggregate_context: usize,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_finals
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    let state = unsafe { &*(aggregate_context as *const SumState) };
+    unsafe {
+        *result = integer_result(state.sum);
+    }
+}
+
+unsafe extern "C" fn managed_variadic_sum_step(
+    context: usize,
+    aggregate_context: usize,
+    argc: i32,
+    argv: *const ExtValue,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_steps
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    let state = unsafe { &mut *(aggregate_context as *mut SumState) };
+    state.sum += argc as i64;
+    if argc > 0 && !argv.is_null() {
+        let args = unsafe { std::slice::from_raw_parts(argv, argc as usize) };
+        state.sum += args.iter().filter_map(ExtValue::to_integer).sum::<i64>();
+    }
+    unsafe {
+        *result = ContextValue::null();
+    }
+}
+
+unsafe extern "C" fn managed_step_fail(
+    context: usize,
+    _aggregate_context: usize,
+    _argc: i32,
+    _argv: *const ExtValue,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_steps
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    unsafe {
+        *result = error_result(b"aggregate step failure");
+    }
+}
+
+unsafe extern "C" fn managed_final_fail(
+    context: usize,
+    _aggregate_context: usize,
+    result: *mut ContextValue,
+) {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_finals
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    unsafe {
+        *result = error_result(b"aggregate final failure");
+    }
+}
+
+unsafe extern "C" fn drop_aggregate_context(context: usize) {
+    let context = unsafe { Box::from_raw(context as *mut AggregateContext) };
+    context
+        .counters
+        .context_drops
+        .fetch_add(1, AtomicOrdering::SeqCst);
+}
+
+unsafe extern "C" fn drop_sum_state(aggregate_context: usize) {
+    let context = unsafe { Box::from_raw(aggregate_context as *mut SumState) };
+    context
+        .counters
+        .aggregate_drops
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    drop(context);
+}
+
+unsafe extern "C" fn count_aggregate_value_drop(_result: *mut ContextValue) {
+    AGG_VALUE_DROPS.fetch_add(1, AtomicOrdering::SeqCst);
+}
+
+fn boxed_scalar_context(multiplier: i64, counters: Arc<CallbackCounters>) -> usize {
+    Box::into_raw(Box::new(ScalarContext {
+        multiplier,
+        counters,
+    })) as usize
+}
+
+fn boxed_aggregate_context(counters: Arc<CallbackCounters>) -> usize {
+    Box::into_raw(Box::new(AggregateContext { counters })) as usize
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_scalar_callbacks_cover_dotnet_create_function_cases(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    SCALAR_VALUE_DROPS.store(0, AtomicOrdering::SeqCst);
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+
+    conn.register_external_scalar_function(
+        "managed_score".to_string(),
+        4,
+        true,
+        boxed_scalar_context(1, counters.clone()),
+        managed_score,
+        Some(drop_scalar_context),
+        None,
+    );
+    conn.register_external_scalar_function(
+        "managed_label".to_string(),
+        0,
+        true,
+        boxed_scalar_context(1, counters.clone()),
+        managed_label,
+        Some(drop_scalar_context),
+        Some(count_scalar_value_drop),
+    );
+    conn.register_external_scalar_function(
+        "managed_fail".to_string(),
+        0,
+        true,
+        boxed_scalar_context(1, counters.clone()),
+        managed_fail,
+        Some(drop_scalar_context),
+        Some(count_scalar_value_drop),
+    );
+
+    let score: Vec<(i64,)> = conn.exec_rows("SELECT managed_score(2, 3.5, 'hi', x'010203')");
+    assert_eq!(score, vec![(10,)]);
+    let label: Vec<(String,)> = conn.exec_rows("SELECT managed_label()");
+    assert_eq!(label, vec![("managed-label".to_string(),)]);
+    let err = conn.execute("SELECT managed_fail()").unwrap_err();
+    assert!(err.to_string().contains("managed failure"));
+    assert_eq!(SCALAR_VALUE_DROPS.load(AtomicOrdering::SeqCst), 2);
+
+    conn.register_external_scalar_function(
+        "managed_score".to_string(),
+        4,
+        true,
+        boxed_scalar_context(10, counters.clone()),
+        managed_score,
+        Some(drop_scalar_context),
+        None,
+    );
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 1);
+    let score: Vec<(i64,)> = conn.exec_rows("SELECT managed_score(1, 2.0, 'a', x'00')");
+    assert_eq!(score, vec![(50,)]);
+
+    conn.unregister_external_function("managed_score");
+    let err = conn
+        .prepare("SELECT managed_score(1, 2.0, 'a', x'00')")
+        .unwrap_err();
+    assert!(err.to_string().contains("no such function"));
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 2);
+
+    conn.unregister_external_function("managed_label");
+    conn.unregister_external_function("managed_fail");
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 4);
+    assert!(counters.calls.load(AtomicOrdering::SeqCst) >= 4);
+    Ok(())
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_scalar_variadic_callbacks_receive_callsite_arguments(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+    conn.register_external_scalar_function(
+        "managed_variadic_score".to_string(),
+        -1,
+        true,
+        boxed_scalar_context(1, counters.clone()),
+        managed_variadic_score,
+        Some(drop_scalar_context),
+        None,
+    );
+
+    let score: Vec<(i64,)> =
+        conn.exec_rows("SELECT managed_variadic_score(1, 3.5, 'A', x'7E57', NULL)");
+    assert_eq!(score, vec![(508,)]);
+
+    conn.unregister_external_function("managed_variadic_score");
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 1);
+    assert_eq!(counters.calls.load(AtomicOrdering::SeqCst), 1);
+    Ok(())
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_aggregate_callbacks_cover_dotnet_create_aggregate_cases(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    AGG_VALUE_DROPS.store(0, AtomicOrdering::SeqCst);
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+    conn.register_external_aggregate_function(
+        "managed_sum".to_string(),
+        1,
+        true,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_sum_step,
+        managed_sum_final,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        Some(count_aggregate_value_drop),
+    );
+
+    conn.execute("CREATE TABLE items(category TEXT, value INTEGER)")?;
+    conn.execute("INSERT INTO items VALUES ('a', 1), ('a', 2), ('a', 2), ('b', 4), ('b', NULL)")?;
+
+    let grouped: Vec<(String, i64)> = conn.exec_rows(
+        "SELECT category, managed_sum(value) FROM items GROUP BY category ORDER BY category",
+    );
+    assert_eq!(grouped, vec![("a".to_string(), 5), ("b".to_string(), 4)]);
+
+    let filtered_distinct: Vec<(i64,)> =
+        conn.exec_rows("SELECT managed_sum(DISTINCT value) FILTER (WHERE value < 3) FROM items");
+    assert_eq!(filtered_distinct, vec![(3,)]);
+
+    let empty: Vec<(i64,)> = conn.exec_rows("SELECT managed_sum(value) FROM items WHERE 0");
+    assert_eq!(empty, vec![(0,)]);
+
+    conn.unregister_external_function("managed_sum");
+    let err = conn
+        .prepare("SELECT managed_sum(value) FROM items")
+        .unwrap_err();
+    assert!(err.to_string().contains("no such function"));
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 1);
+    assert!(counters.aggregate_inits.load(AtomicOrdering::SeqCst) >= 4);
+    assert_eq!(
+        counters.aggregate_inits.load(AtomicOrdering::SeqCst),
+        counters.aggregate_finals.load(AtomicOrdering::SeqCst)
+    );
+    assert_eq!(
+        counters.aggregate_inits.load(AtomicOrdering::SeqCst),
+        counters.aggregate_drops.load(AtomicOrdering::SeqCst)
+    );
+    let aggregate_value_drops = AGG_VALUE_DROPS.load(AtomicOrdering::SeqCst);
+    assert!(aggregate_value_drops >= counters.aggregate_finals.load(AtomicOrdering::SeqCst));
+    assert!(aggregate_value_drops > counters.aggregate_finals.load(AtomicOrdering::SeqCst));
+    Ok(())
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_aggregate_variadic_callbacks_receive_callsite_arg_count(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+    conn.register_external_aggregate_function(
+        "managed_variadic_sum".to_string(),
+        -1,
+        true,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_variadic_sum_step,
+        managed_sum_final,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        None,
+    );
+    conn.execute("CREATE TABLE variadic_items(first INTEGER, second INTEGER)")?;
+    conn.execute("INSERT INTO variadic_items VALUES (1, 2), (3, 4)")?;
+
+    let sum: Vec<(i64,)> =
+        conn.exec_rows("SELECT managed_variadic_sum(first, second) FROM variadic_items");
+    assert_eq!(sum, vec![(14,)]);
+
+    let empty: Vec<(i64,)> =
+        conn.exec_rows("SELECT managed_variadic_sum(first) FROM variadic_items WHERE 0");
+    assert_eq!(empty, vec![(0,)]);
+
+    conn.unregister_external_function("managed_variadic_sum");
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 1);
+    assert_eq!(
+        counters.aggregate_inits.load(AtomicOrdering::SeqCst),
+        counters.aggregate_drops.load(AtomicOrdering::SeqCst)
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_aggregate_errors_leave_connection_usable(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE aggregate_errors(value INTEGER)")?;
+    conn.execute("INSERT INTO aggregate_errors VALUES (1)")?;
+
+    conn.register_external_aggregate_function(
+        "managed_step_fail".to_string(),
+        1,
+        true,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_step_fail,
+        managed_sum_final,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        None,
+    );
+    let err = conn
+        .execute("SELECT managed_step_fail(value) FROM aggregate_errors")
+        .unwrap_err();
+    assert!(err.to_string().contains("aggregate step failure"));
+    let usable: Vec<(i64,)> = conn.exec_rows("SELECT 1");
+    assert_eq!(usable, vec![(1,)]);
+    conn.unregister_external_function("managed_step_fail");
+
+    conn.register_external_aggregate_function(
+        "managed_final_fail".to_string(),
+        1,
+        true,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_sum_step,
+        managed_final_fail,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        None,
+    );
+    let err = conn
+        .execute("SELECT managed_final_fail(value) FROM aggregate_errors")
+        .unwrap_err();
+    assert!(err.to_string().contains("aggregate final failure"));
+    let usable: Vec<(i64,)> = conn.exec_rows("SELECT 1");
+    assert_eq!(usable, vec![(1,)]);
+    conn.unregister_external_function("managed_final_fail");
+
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 2);
+    Ok(())
+}
+
+unsafe extern "C" fn dotnet_nocase_collation(
+    _context: usize,
+    left_ptr: *const u8,
+    left_len: usize,
+    right_ptr: *const u8,
+    right_len: usize,
+) -> i32 {
+    let left = unsafe { std::slice::from_raw_parts(left_ptr, left_len) };
+    let right = unsafe { std::slice::from_raw_parts(right_ptr, right_len) };
+    let left = String::from_utf8_lossy(left).to_ascii_lowercase();
+    let right = String::from_utf8_lossy(right).to_ascii_lowercase();
+    match left.cmp(&right) {
+        Ordering::Less => -1,
+        Ordering::Equal => 0,
+        Ordering::Greater => 1,
+    }
+}
+
+#[turso_macros::test]
+#[serial]
+fn custom_collations_cover_dotnet_create_collation_cases(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_external_collation(
+        "dotnet_nocase".to_string(),
+        0,
+        dotnet_nocase_collation,
+        None,
+    );
+    conn.execute("CREATE TABLE names(value TEXT)")?;
+    conn.execute("INSERT INTO names VALUES ('beta'), ('ALPHA'), ('alpha'), ('Gamma')")?;
+
+    let ordered: Vec<(String,)> =
+        conn.exec_rows("SELECT value FROM names ORDER BY value COLLATE dotnet_nocase, value");
+    assert_eq!(
+        ordered,
+        vec![
+            ("ALPHA".to_string(),),
+            ("alpha".to_string(),),
+            ("beta".to_string(),),
+            ("Gamma".to_string(),)
+        ]
+    );
+
+    let equal_rows: Vec<(String,)> = conn.exec_rows(
+        "SELECT value FROM names WHERE value = 'ALPHA' COLLATE dotnet_nocase ORDER BY value",
+    );
+    assert_eq!(
+        equal_rows,
+        vec![("ALPHA".to_string(),), ("alpha".to_string(),)]
+    );
+    let min_max: Vec<(String, String)> = conn.exec_rows(
+        "SELECT min(value COLLATE dotnet_nocase), max(value COLLATE dotnet_nocase) FROM names",
+    );
+    assert_eq!(min_max, vec![("ALPHA".to_string(), "Gamma".to_string())]);
+
+    let err = conn
+        .execute("CREATE TABLE bad(value TEXT COLLATE dotnet_nocase)")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("custom collations are not supported"));
+    let err = conn
+        .execute("CREATE INDEX bad_idx ON names(value COLLATE dotnet_nocase)")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("custom collations are not supported"));
+
+    conn.execute("CREATE TABLE left_values(value TEXT)")?;
+    conn.execute("CREATE TABLE right_values(value TEXT)")?;
+    for id in 0..100 {
+        let key = format!("key{:02}", id % 10);
+        conn.execute(format!("INSERT INTO left_values VALUES ('{key}')"))?;
+        conn.execute(format!("INSERT INTO right_values VALUES ('{key}')"))?;
+    }
+    let binary_join_sql =
+        "SELECT count(*) FROM left_values AS l JOIN right_values AS r ON l.value = r.value";
+    let explain_rows = limbo_exec_rows(&conn, &format!("EXPLAIN {binary_join_sql}"));
+    let has_hash = explain_rows.iter().any(|row| {
+        row.get(1).is_some_and(|value| {
+            matches!(value, SqliteValue::Text(op) if op == "HashBuild" || op == "HashProbe")
+        })
+    });
+    assert!(has_hash, "expected equivalent binary join to use hash join");
+
+    conn.execute("DELETE FROM right_values")?;
+    for id in 0..100 {
+        let key = format!("KEY{:02}", id % 10);
+        conn.execute(format!("INSERT INTO right_values VALUES ('{key}')"))?;
+    }
+    let join_sql = "SELECT count(*) FROM left_values AS l JOIN right_values AS r \
+        ON l.value = r.value COLLATE dotnet_nocase";
+    let joined: Vec<(i64,)> = conn.exec_rows(join_sql);
+    assert_eq!(joined, vec![(1000,)]);
+    let explain_rows = limbo_exec_rows(&conn, &format!("EXPLAIN {join_sql}"));
+    let has_hash = explain_rows.iter().any(|row| {
+        row.get(1).is_some_and(|value| {
+            matches!(value, SqliteValue::Text(op) if op == "HashBuild" || op == "HashProbe")
+        })
+    });
+    assert!(
+        !has_hash,
+        "custom collations must not use binary-hashed joins"
+    );
+
+    let other_conn = tmp_db.connect_limbo();
+    other_conn.register_external_collation(
+        "dotnet_nocase".to_string(),
+        0,
+        dotnet_nocase_collation,
+        None,
+    );
+    conn.unregister_external_collation("dotnet_nocase");
+    let err = conn
+        .execute("SELECT 'ok' WHERE 'A' = 'a' COLLATE dotnet_nocase")
+        .unwrap_err();
+    assert!(err.to_string().contains("no such collation sequence"));
+    let rows: Vec<(String,)> =
+        other_conn.exec_rows("SELECT 'ok' WHERE 'A' = 'a' COLLATE dotnet_nocase");
+    assert_eq!(rows, vec![("ok".to_string(),)]);
+    other_conn.unregister_external_collation("dotnet_nocase");
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn extension_loading_flag_covers_dotnet_enable_extensions_cases(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    let err = conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+
+    let err = conn
+        .load_extension("definitely_missing_extension")
+        .unwrap_err();
+    assert!(matches!(err, LimboError::ExtensionError(_)));
+    assert!(!err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+
+    conn.set_load_extension_enabled(true);
+    let err = conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+    assert!(matches!(err, LimboError::ExtensionError(_)));
+    assert!(err.to_string().contains("Extension file not found"));
+
+    conn.set_load_extension_enabled(false);
+    let err = conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+
+    let other_conn = tmp_db.connect_limbo();
+    let err = other_conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+    Ok(())
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod common;
 mod conflict_resolution;
 mod custom_types;
 mod database;
+mod external_apis;
 mod functions;
 mod fuzz_transaction;
 mod index_method;


### PR DESCRIPTION
## Summary

This is the Turso core follow-up for the larger .NET/EF Core support work. The .NET test suite exposed several SQLite compatibility gaps that require core/runtime support, so this PR keeps the fixes in Turso core and SDK-kit while avoiding the broader .NET package/facade expansion from the original branch.

- Add managed scalar, aggregate, and collation callback support in core.
- Add external aggregate translator/runtime support, including grouped, filtered, distinct, empty-input, and error paths.
- Add per-connection extension-loading controls and SQL `load_extension(...)` gating.
- Add runtime custom collation dispatch while still rejecting unsupported persistent schema/index custom-collation definitions.
- Expose the new core APIs through the shared `turso_sdk_kit` C ABI.
- Re-enable the merged .NET facade tests that were previously skipped while core managed extension support was unavailable.
- Add Turso-native regression coverage in `tests/integration/external_apis.rs` for the EF Core-discovered behaviors.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -q -p turso_core --features pure-rust-crypto`
- `cargo check -q -p turso_sdk_kit --features pure-rust-crypto`
- `cargo check -q -p core_tester --features pure-rust-crypto --test integration_tests`
- `cargo clippy -q -p turso_core --features pure-rust-crypto --lib -- --deny=warnings`
- `cargo test -q -p core_tester --features pure-rust-crypto --test integration_tests external_apis -- --nocapture`
- `cargo build -q -p turso_sdk_kit --target-dir bindings\dotnet\rs_compiled --target x86_64-pc-windows-msvc`
- `dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj` — 74 total, 73 passed, 1 skipped

No workflow or concurrent-simulator weakening is included.