### PR TITLE
bindings/js/sync: bump concurrent-actions-consistency timeout to 30s

### DIFF
--- a/bindings/javascript/sync/packages/native/promise.test.ts
+++ b/bindings/javascript/sync/packages/native/promise.test.ts
@@ -271,7 +271,7 @@ test('concurrent-actions-consistency', async ({ server }) => {
         }
     }
     await Promise.all([pull(100), push(100), run(200)]);
-})
+}, 30_000)
 
 test('simple-db', async () => {
     const db = new Database({ path: ':memory:' });


### PR DESCRIPTION
The test runs 200 sequential UPDATEs each sleeping 10-20ms (~3s floor) alongside 100 concurrent pulls and pushes, which routinely exceeds vitest's 5000ms default in CI.