### PR TITLE
core/mvcc: make MVCC integrity_check reprepare after checkpoint root publication

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1330,17 +1330,48 @@ impl Connection {
         }
         let current_schema = self.schema.read().clone();
         let schema = self.db.schema.lock();
-        if matches!(self.get_tx_state(), TransactionState::None)
-            && self.get_mv_tx().is_none()
-            && self.next_attached_mv_tx().is_none()
-            // In MVCC, checkpoint root publication can replace Database::schema
-            // without changing SQLite's schema cookie. If this connection
-            // still holds an older Schema snapshot, prepared statements must be
-            // invalidated and recompiled against the current roots.
+        if self.has_no_open_transaction_state()
             && (current_schema.schema_version != schema.schema_version
-                || (self.mvcc_enabled() && !Arc::ptr_eq(&current_schema, &schema)))
+                || self.is_same_version_mvcc_shared_schema_replacement(&current_schema, &schema))
         {
             *self.schema.write() = schema.clone();
+            self.bump_prepare_context_generation();
+        }
+    }
+
+    fn has_no_open_transaction_state(&self) -> bool {
+        matches!(self.get_tx_state(), TransactionState::None)
+            && self.get_mv_tx().is_none()
+            && self.next_attached_mv_tx().is_none()
+    }
+
+    fn is_same_version_mvcc_shared_schema_replacement(
+        &self,
+        current_schema: &Arc<Schema>,
+        schema: &Arc<Schema>,
+    ) -> bool {
+        self.mvcc_enabled()
+            && current_schema.schema_version == schema.schema_version
+            && !Arc::ptr_eq(current_schema, schema)
+    }
+
+    pub(crate) fn has_stale_mvcc_shared_schema_before_transaction(&self) -> bool {
+        if !self.has_no_open_transaction_state() {
+            return false;
+        }
+        let current_schema = self.schema.read().clone();
+        let schema = self.db.schema.lock();
+        self.is_same_version_mvcc_shared_schema_replacement(&current_schema, &schema)
+    }
+
+    pub(crate) fn refresh_schema_from_shared_for_reprepare(&self) {
+        let current_schema = self.schema.read().clone();
+        let schema = self.db.schema.lock().clone();
+        if current_schema.schema_version < schema.schema_version
+            || (self.has_no_open_transaction_state()
+                && self.is_same_version_mvcc_shared_schema_replacement(&current_schema, &schema))
+        {
+            *self.schema.write() = schema;
             self.bump_prepare_context_generation();
         }
     }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1330,9 +1330,14 @@ impl Connection {
         }
         let current_schema = self.schema.read().clone();
         let schema = self.db.schema.lock();
+        // MVCC checkpoint can publish physical btree roots into the shared
+        // schema without changing SQLite's schema cookie. If this connection
+        // still has the older schema snapshot, prepared statements must be
+        // invalidated and recompiled with the published roots.
         if self.has_no_open_transaction_state()
             && (current_schema.schema_version != schema.schema_version
-                || self.is_same_version_mvcc_shared_schema_replacement(&current_schema, &schema))
+                || self
+                    .has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema))
         {
             *self.schema.write() = schema.clone();
             self.bump_prepare_context_generation();
@@ -1345,7 +1350,7 @@ impl Connection {
             && self.next_attached_mv_tx().is_none()
     }
 
-    fn is_same_version_mvcc_shared_schema_replacement(
+    fn has_mvcc_schema_snapshot_changed_with_same_version(
         &self,
         current_schema: &Arc<Schema>,
         schema: &Arc<Schema>,
@@ -1355,13 +1360,13 @@ impl Connection {
             && !Arc::ptr_eq(current_schema, schema)
     }
 
-    pub(crate) fn has_stale_mvcc_shared_schema_before_transaction(&self) -> bool {
+    pub(crate) fn mvcc_schema_requires_reprepare_before_tx(&self) -> bool {
         if !self.has_no_open_transaction_state() {
             return false;
         }
         let current_schema = self.schema.read().clone();
         let schema = self.db.schema.lock();
-        self.is_same_version_mvcc_shared_schema_replacement(&current_schema, &schema)
+        self.has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema)
     }
 
     pub(crate) fn refresh_schema_from_shared_for_reprepare(&self) {
@@ -1369,7 +1374,8 @@ impl Connection {
         let schema = self.db.schema.lock().clone();
         if current_schema.schema_version < schema.schema_version
             || (self.has_no_open_transaction_state()
-                && self.is_same_version_mvcc_shared_schema_replacement(&current_schema, &schema))
+                && self
+                    .has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema))
         {
             *self.schema.write() = schema;
             self.bump_prepare_context_generation();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -19,6 +19,7 @@ use crate::storage::sqlite3_ondisk::{
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sync::Mutex;
 use crate::sync::RwLock;
+use crate::vdbe::execute::TransactionYieldPoint;
 use crate::{
     Buffer, Completion, DatabaseOpts, EncryptionKey, LimboError, OpenFlags, StatementStatusCounter,
 };
@@ -2442,6 +2443,148 @@ fn test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0][0].as_int().unwrap(), 1);
     assert_eq!(&rows[0][1].to_string(), "a");
+}
+
+/// Steps:
+/// 1. Create an MVCC database with a table and unique index whose roots are still logical MVCC roots.
+/// 2. Prepare `PRAGMA integrity_check` on a second connection.
+/// 3. Start stepping it, then yield immediately before `OP_Transaction` opens the read transaction.
+/// 4. On the writer connection, insert a row and run `wal_checkpoint(TRUNCATE)` so checkpoint publishes physical roots.
+/// 5. Resume the stale statement; it must force one reprepare and then report `ok`.
+#[test]
+fn test_running_integrity_check_reprepares_after_checkpoint_root_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+
+    let stale_conn = db.connect();
+    let injector = FixedYieldInjector::new([TransactionYieldPoint::BeforeStart.point()]);
+    stale_conn.set_yield_injector(Some(injector.clone()));
+    let mut stale_integrity_check = stale_conn.prepare("PRAGMA integrity_check").unwrap();
+    assert!(
+        matches!(stale_integrity_check.step().unwrap(), crate::StepResult::IO)
+            && injector.is_empty(),
+        "integrity_check should yield before opening its read transaction"
+    );
+
+    writer.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    stale_conn.set_yield_injector(None);
+
+    // The statement has already passed its public step-time schema refresh, but
+    // its transaction has not opened yet. Checkpoint root publication does not
+    // change SQLite's schema cookie, so OP_Transaction must still force a
+    // reprepare before stale bytecode can use the new header with old roots.
+    let rows = stale_integrity_check.run_collect_rows().unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        1
+    );
+}
+
+/// Steps:
+/// 1. Create an MVCC database with a table and unique index whose roots are still logical MVCC roots.
+/// 2. Open a deferred transaction on a second connection without starting its MVCC read transaction yet.
+/// 3. Prepare `PRAGMA integrity_check` inside that deferred transaction.
+/// 4. Start stepping it, then yield immediately before `OP_Transaction` opens the read transaction.
+/// 5. On the writer connection, insert a row and run `wal_checkpoint(TRUNCATE)` so checkpoint publishes physical roots.
+/// 6. Resume the deferred statement; it must force one reprepare, report `ok`, and leave the transaction committable.
+#[test]
+fn test_deferred_begin_integrity_check_reprepares_after_checkpoint_root_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+
+    let stale_conn = db.connect();
+    stale_conn.execute("BEGIN").unwrap();
+
+    let injector = FixedYieldInjector::new([TransactionYieldPoint::BeforeStart.point()]);
+    stale_conn.set_yield_injector(Some(injector.clone()));
+    let mut stale_integrity_check = stale_conn.prepare("PRAGMA integrity_check").unwrap();
+    assert!(
+        matches!(stale_integrity_check.step().unwrap(), crate::StepResult::IO)
+            && injector.is_empty(),
+        "integrity_check should yield before opening its read transaction"
+    );
+
+    writer.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    stale_conn.set_yield_injector(None);
+
+    let rows = stale_integrity_check.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        1
+    );
+
+    stale_conn.execute("COMMIT").unwrap();
+}
+
+/// Steps:
+/// 1. Create an MVCC database with a table and unique index whose roots are still logical MVCC roots.
+/// 2. Prepare `PRAGMA integrity_check` on a second connection and record that it has not reprepared yet.
+/// 3. Record `PRAGMA schema_version` before the checkpoint.
+/// 4. Start stepping the stale statement, then yield immediately before `OP_Transaction` opens the read transaction.
+/// 5. On the writer connection, insert a row and run `wal_checkpoint(TRUNCATE)` so checkpoint publishes physical roots.
+/// 6. Assert the checkpoint did not bump SQLite's schema cookie.
+/// 7. Resume the stale statement; it must force one reprepare and then report `ok`.
+#[test]
+fn test_running_integrity_check_reprepares_without_schema_cookie_bump() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+
+    let stale_conn = db.connect();
+    let injector = FixedYieldInjector::new([TransactionYieldPoint::BeforeStart.point()]);
+    stale_conn.set_yield_injector(Some(injector.clone()));
+    let mut stale_integrity_check = stale_conn.prepare("PRAGMA integrity_check").unwrap();
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        0
+    );
+
+    let schema_version_before = get_rows(&writer, "PRAGMA schema_version")[0][0]
+        .as_int()
+        .unwrap();
+    assert!(
+        matches!(stale_integrity_check.step().unwrap(), crate::StepResult::IO)
+            && injector.is_empty(),
+        "integrity_check should yield before opening its read transaction"
+    );
+
+    writer.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let schema_version_after = get_rows(&writer, "PRAGMA schema_version")[0][0]
+        .as_int()
+        .unwrap();
+    assert_eq!(
+        schema_version_after, schema_version_before,
+        "checkpoint root publication must not change SQLite's schema cookie"
+    );
+
+    stale_conn.set_yield_injector(None);
+    let rows = stale_integrity_check.run_collect_rows().unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        1
+    );
 }
 
 /// What this test checks: Auto-checkpoint post-commit failure does not invalidate committed transaction visibility on restart.

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -561,14 +561,11 @@ impl Statement {
             }
         }
 
-        // if current connection is within a transaction which changed schema - we must use its schema version instead of DB schema version
-        // see test_prepared_stmt_reprepare_ddl_change_txn (plus test_sync_pull_after_local_ddl_and_remote_writes)
-        {
-            let mut conn_schema = conn.schema.write();
-            if conn_schema.schema_version < conn.db.schema.lock().schema_version {
-                *conn_schema = conn.db.clone_schema();
-            }
-        }
+        // Refresh from shared schema only when shared is newer; this preserves a
+        // connection-local schema that is ahead of shared. An MVCC checkpoint can
+        // publish new btree roots without bumping the schema cookie, so
+        // same-version reprepare still refreshes it.
+        conn.refresh_schema_from_shared_for_reprepare();
         let new_program = {
             let mut parser = Parser::new(self.program.sql.as_bytes());
             let cmd = parser.next_cmd()?;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3387,6 +3387,17 @@ pub fn op_transaction_inner(
                     return Err(LimboError::ReadOnly);
                 }
 
+                // Fast path: if checkpoint root publication already replaced the
+                // shared schema, force reprepare before opening any transaction state.
+                if *db == crate::MAIN_DB_ID
+                    && mv_store.is_some()
+                    && conn.has_stale_mvcc_shared_schema_before_transaction()
+                {
+                    tracing::debug!(
+                        "MVCC shared schema changed without a schema-cookie change; force reprepare"
+                    );
+                    return Err(LimboError::SchemaUpdated);
+                }
                 #[cfg(any(test, injected_yields))]
                 {
                     if let Some(IOResult::IO(io)) =
@@ -3551,6 +3562,19 @@ pub fn op_transaction_inner(
                         if !has_existing_mv_tx {
                             match begin_mvcc_tx(mv_store, &pager, tx_mode, None) {
                                 Ok(tx_id) => {
+                                    // Check again in case checkpoint published roots after the
+                                    // previous check and before this transaction was protected.
+                                    if conn.has_stale_mvcc_shared_schema_before_transaction() {
+                                        tracing::debug!(
+                                            "MVCC shared schema changed while starting transaction; force reprepare"
+                                        );
+                                        mv_store.rollback_tx(tx_id, pager.clone(), &conn, *db);
+                                        if started_read_tx {
+                                            pager.end_read_tx();
+                                            state.auto_txn_cleanup = TxnCleanup::None;
+                                        }
+                                        return Err(LimboError::SchemaUpdated);
+                                    }
                                     program
                                         .connection
                                         .set_mv_tx_for_db(*db, Some((tx_id, *tx_mode)));

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3391,7 +3391,7 @@ pub fn op_transaction_inner(
                 // shared schema, force reprepare before opening any transaction state.
                 if *db == crate::MAIN_DB_ID
                     && mv_store.is_some()
-                    && conn.has_stale_mvcc_shared_schema_before_transaction()
+                    && conn.mvcc_schema_requires_reprepare_before_tx()
                 {
                     tracing::debug!(
                         "MVCC shared schema changed without a schema-cookie change; force reprepare"
@@ -3564,7 +3564,7 @@ pub fn op_transaction_inner(
                                 Ok(tx_id) => {
                                     // Check again in case checkpoint published roots after the
                                     // previous check and before this transaction was protected.
-                                    if conn.has_stale_mvcc_shared_schema_before_transaction() {
+                                    if conn.mvcc_schema_requires_reprepare_before_tx() {
                                         tracing::debug!(
                                             "MVCC shared schema changed while starting transaction; force reprepare"
                                         );

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3161,6 +3161,23 @@ pub enum OpTransactionState {
     BeginStatement,
 }
 
+#[cfg(any(test, injected_yields))]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TransactionYieldPoint {
+    BeforeStart,
+}
+
+#[cfg(any(test, injected_yields))]
+impl crate::mvcc::yield_hooks::YieldPointMarker for TransactionYieldPoint {
+    const POINT_COUNT: u8 = 1;
+
+    fn ordinal(self) -> u8 {
+        match self {
+            TransactionYieldPoint::BeforeStart => 0,
+        }
+    }
+}
+
 pub fn op_transaction(
     program: &Program,
     state: &mut ProgramState,
@@ -3368,6 +3385,20 @@ pub fn op_transaction_inner(
                 let mut started_secondary_tx = false;
                 if write && conn.is_readonly(*db) {
                     return Err(LimboError::ReadOnly);
+                }
+
+                #[cfg(any(test, injected_yields))]
+                {
+                    if let Some(IOResult::IO(io)) =
+                        crate::mvcc::yield_hooks::maybe_inject_io_yield::<(), _>(
+                            conn.yield_injector().as_ref(),
+                            0,
+                            *db as u64,
+                            TransactionYieldPoint::BeforeStart,
+                        )
+                    {
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
                 }
 
                 // 1. We try to upgrade current version


### PR DESCRIPTION
## Description

Fixes a stale prepared-statement path where MVCC checkpoint root publication can update shared schema

## Motivation and context

A prepared `PRAGMA integrity_check` could pass its initial schema refresh, then yield before opening its MVCC read transaction. If another connection checkpointed in that window, the statement could resume with bytecode compiled against old logical roots while reading a database/header with newly published physical roots, causing false integrity errors like `Page N: never used`.

The bug needs two connections.

  1. `conn1` prepares `PRAGMA integrity_check`.
  2. The prepared bytecode captures the current schema roots. In this MVCC path, newly created tables/indexes can be represented by negative logical root ids before checkpoint. The checkpoint later publishes their real positive btree root pages into the shared schema.
  3. `conn1` starts stepping the statement, but assume the thread pauses before starting MVCC read transaction.
  4. `conn2` inserts data and runs an MVCC checkpoint.
  5. That checkpoint publishes real physical btree roots into the shared schema, but it does not bump SQLite's `schema_version`. (Otherwise the bump could have noticed by the `conn1`)
  6. `conn1` resumes. Since the schema cookie did not change, the old code did not reprepare the statement.
  7. `conn1` now runs `integrity_check` using stale roots against a database that has new physical roots.
  8. Pages belonging to the new roots are not marked as reachable by the stale bytecode, so `integrity_check` reports false corruption like `Page N: never used`.

This patch comes with [regression tests](https://github.com/tursodatabase/turso/actions/runs/26170956616/job/76988529523?pr=7157#logs):

```rust
cargo test -p turso_core test_running_integrity_check_reprepares_after_checkpoint_root_publish -- --nocapture
cargo test -p turso_core test_deferred_begin_integrity_check_reprepares_after_checkpoint_root_publish -- --nocapture
cargo test -p turso_core test_running_integrity_check_reprepares_without_schema_cookie_bump -- --nocapture

thread 'mvcc::database::tests::test_running_integrity_check_reprepares_after_checkpoint_root_publish' panicked at core/mvcc/database/tests.rs:2484:5:
assertion `left == right` failed
  left: "*** in database main ***\nPage 3: never used\nPage 4: never used"
 right: "ok"

test mvcc::database::tests::test_running_integrity_check_reprepares_after_checkpoint_root_publish ... FAILED

thread 'mvcc::database::tests::test_deferred_begin_integrity_check_reprepares_after_checkpoint_root_publish' panicked at core/mvcc/database/tests.rs:2525:5:
assertion `left == right` failed
  left: "*** in database main ***\nPage 3: never used\nPage 4: never used"
 right: "ok"

test mvcc::database::tests::test_deferred_begin_integrity_check_reprepares_after_checkpoint_root_publish ... FAILED

thread 'mvcc::database::tests::test_running_integrity_check_reprepares_without_schema_cookie_bump' panicked at core/mvcc/database/tests.rs:2583:5:
assertion `left == right` failed
  left: "*** in database main ***\nPage 3: never used\nPage 4: never used"
 right: "ok"

test mvcc::database::tests::test_running_integrity_check_reprepares_without_schema_cookie_bump ... FAILED
```

This bug was found by Antithesis.

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
