### PR TITLE
Add recovery-heavy profile to Whopper

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -470,6 +470,11 @@ enum DatabaseKey {
 static DATABASE_MANAGER: LazyLock<Arc<parking_lot::Mutex<HashMap<DatabaseKey, RegistryEntry>>>> =
     LazyLock::new(|| Arc::new(parking_lot::Mutex::new(HashMap::default())));
 
+#[cfg(feature = "simulator")]
+pub fn clear_database_registry() {
+    DATABASE_MANAGER.lock().clear();
+}
+
 /// The `Database` object contains per database file state that is shared
 /// between multiple connections.
 ///

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -10,6 +10,7 @@ use sql_generation::{
 };
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write;
 use std::ops::Bound;
 use std::sync::Arc;
 use tracing::{debug, error, trace};
@@ -266,6 +267,40 @@ pub struct WhopperOpts {
     /// On each idle step, each profile fires with the given probability (0.0–1.0).
     /// If none fires, regular workloads run instead.
     pub chaotic_profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>,
+    /// Schema-generation bias.
+    pub schema_bias: SchemaBias,
+    /// If true, MVCC's auto-checkpoint is disabled on the Database immediately after open.
+    /// Recovery bugs need uncheckpointed schema rows to remain in the logical log to exercise recovery.
+    pub disable_mvcc_auto_checkpoint: bool,
+    /// If false, don't close connections before dropping them
+    pub close_connections_gracefully: bool,
+    /// Probabilty of a reopen fault.
+    pub reopen_probability: f64,
+}
+
+/// Schema-generation bias
+#[derive(Debug, Clone)]
+pub struct SchemaBias {
+    /// Probability that a generated table uses a non-integer PRIMARY KEY
+    pub non_rowid_pk_prob: f64,
+    /// Probability that a column is UNIQUE (autoindex)
+    pub unique_col_prob: f64,
+    pub num_tables_range: std::ops::RangeInclusive<u32>,
+    pub num_columns_range: std::ops::RangeInclusive<u32>,
+    /// Initial rows per table. Rows are guaranteed unique, so that INSERTs won't fail.
+    pub initial_rows_per_table: u32,
+}
+
+impl Default for SchemaBias {
+    fn default() -> Self {
+        Self {
+            non_rowid_pk_prob: 0.0,
+            unique_col_prob: 0.3,
+            num_tables_range: 1..=5,
+            num_columns_range: 2..=8,
+            initial_rows_per_table: 0,
+        }
+    }
 }
 
 impl Default for WhopperOpts {
@@ -283,6 +318,10 @@ impl Default for WhopperOpts {
             workloads: vec![],
             properties: vec![],
             chaotic_profiles: vec![],
+            schema_bias: SchemaBias::default(),
+            disable_mvcc_auto_checkpoint: false,
+            close_connections_gracefully: true,
+            reopen_probability: 0.0,
         }
     }
 }
@@ -310,6 +349,22 @@ impl WhopperOpts {
             max_steps: 1_000_000,
             cosmic_ray_probability: 0.0001,
             ..Default::default()
+        }
+    }
+
+    pub fn recovery_heavy() -> Self {
+        Self {
+            schema_bias: SchemaBias {
+                non_rowid_pk_prob: 0.5,
+                unique_col_prob: 0.5,
+                num_tables_range: 1..=2,
+                num_columns_range: 2..=4,
+                initial_rows_per_table: 3,
+            },
+            disable_mvcc_auto_checkpoint: true,
+            close_connections_gracefully: false,
+            reopen_probability: 0.1,
+            ..Self::fast()
         }
     }
 
@@ -499,6 +554,10 @@ pub struct Whopper {
     pub stats: Stats,
     /// Chaotic workload profiles: (probability, name, profile).
     chaotic_profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>,
+    /// Setting this to true sets `pramga mvcc_checkpoint_threshold = -1` (disabled).
+    disable_mvcc_auto_checkpoint: bool,
+    /// If false, drop fiber connections without first closing them.
+    close_connections_gracefully: bool,
 }
 
 impl Whopper {
@@ -521,7 +580,15 @@ impl Whopper {
         let io = Arc::new(SimulatorIO::new(opts.keep_files, io_rng, fault_config));
         let file_sizes = io.file_sizes();
 
-        let db_path = format!("whopper-{}-{}.db", seed, std::process::id());
+        // Use an absolute path to match `PRAGMA journal_mode = 'mvcc'` (which canonicalizes the
+        // path), otherwise recovery is a no-op, because SimulatorIO's file cache is keyed on the
+        // path string, and an absolute/relative mismatch will make it think that there was no
+        // existing logical log.
+        let db_path = std::env::current_dir()?
+            .join(format!("whopper-{}-{}.db", seed, std::process::id()))
+            .to_str()
+            .unwrap()
+            .to_string();
         let wal_path = format!("{db_path}-wal");
 
         let encryption_opts = if opts.enable_encryption {
@@ -559,7 +626,7 @@ impl Whopper {
             bootstrap_conn.execute("PRAGMA journal_mode = 'mvcc'")?;
         }
 
-        let schema = create_initial_schema(&mut rng);
+        let schema = create_initial_schema(&mut rng, &opts.schema_bias);
         let tables = schema.iter().map(|t| t.table.clone()).collect::<Vec<_>>();
         for create_table in &schema {
             let sql = create_table.to_string();
@@ -572,6 +639,15 @@ impl Whopper {
             let sql = create_index.to_string();
             debug!("{}", sql);
             bootstrap_conn.execute(&sql)?;
+        }
+
+        if opts.schema_bias.initial_rows_per_table > 0 {
+            for create_table in &schema {
+                for row_idx in 0..opts.schema_bias.initial_rows_per_table {
+                    let sql = seed_insert_sql(&create_table.table, row_idx);
+                    bootstrap_conn.execute(&sql)?;
+                }
+            }
         }
 
         // Create Elle tables if configured
@@ -625,6 +701,8 @@ impl Whopper {
             seed,
             stats: Stats::default(),
             chaotic_profiles: opts.chaotic_profiles,
+            disable_mvcc_auto_checkpoint: opts.disable_mvcc_auto_checkpoint,
+            close_connections_gracefully: opts.close_connections_gracefully,
         };
 
         whopper.open_connections()?;
@@ -807,7 +885,9 @@ impl Whopper {
                     | turso_core::LimboError::BusySnapshot
                     | turso_core::LimboError::WriteWriteConflict
                     | turso_core::LimboError::CommitDependencyAborted
-                    | turso_core::LimboError::InvalidArgument(..) => {
+                    | turso_core::LimboError::InvalidArgument(..)
+                    | turso_core::LimboError::Constraint(..)
+                    | turso_core::LimboError::ForeignKeyConstraint(..) => {
                         if ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit() {
                             ctx.fiber.current_op = Some(Operation::Rollback);
                         } else {
@@ -1101,16 +1181,19 @@ impl Whopper {
         {
             let fibers = self.context.fibers.drain(..).collect::<Vec<_>>();
             for fiber in fibers {
-                // Drop statement first
                 drop(fiber.statement.into_inner());
-                // Close and drop connection
-                if let Err(e) = fiber.connection.close() {
-                    debug!("Error closing connection during restart: {}", e);
+                if self.close_connections_gracefully {
+                    if let Err(e) = fiber.connection.close() {
+                        debug!("Error closing connection during restart: {}", e);
+                    }
                 }
                 drop(fiber.connection);
             }
             // All fibers are now dropped, database Arc should be released
         }
+
+        // Without this, the Database object is never dropped and recovery never happens
+        turso_core::clear_database_registry();
 
         // Reopen connections (creates new Database instance)
         self.open_connections()?;
@@ -1133,6 +1216,12 @@ impl Whopper {
             self.encryption_opts.clone(),
         )
         .map_err(|e| anyhow::anyhow!("Database open failed: {}", e))?;
+
+        if self.disable_mvcc_auto_checkpoint {
+            if let Some(mv_store) = db.get_mv_store().as_ref() {
+                mv_store.set_checkpoint_threshold(-1);
+            }
+        }
 
         for i in 0..self.max_connections {
             let conn = db
@@ -1215,25 +1304,63 @@ pub fn create_initial_indexes(rng: &mut ChaCha8Rng, tables: &[Table]) -> Vec<Cre
     indexes
 }
 
-pub fn create_initial_schema(rng: &mut ChaCha8Rng) -> Vec<Create> {
+fn seed_insert_sql(table: &Table, row_idx: u32) -> String {
+    let mut sql = format!("INSERT INTO {} VALUES (", table.name);
+    let mut first = true;
+    for col in &table.columns {
+        if !first {
+            sql.push_str(", ");
+        }
+        first = false;
+        // use unique values to avoid UNIQUE or PRIMARY KEY constraint violations
+        match col.column_type {
+            ColumnType::Integer => {
+                let _ = write!(sql, "{}", row_idx as i64);
+            }
+            ColumnType::Float => {
+                let _ = write!(sql, "{}.0", row_idx);
+            }
+            ColumnType::Text => {
+                let _ = write!(sql, "'seed_{}_{}'", col.name, row_idx);
+            }
+            ColumnType::Blob => {
+                let _ = write!(sql, "x'{:08x}'", row_idx);
+            }
+        }
+    }
+    sql.push(')');
+    sql
+}
+
+pub fn create_initial_schema(rng: &mut ChaCha8Rng, bias: &SchemaBias) -> Vec<Create> {
     let mut schema = Vec::new();
 
-    // Generate random number of tables (1-5)
-    let num_tables = rng.random_range(1..=5);
+    let num_tables = rng.random_range(bias.num_tables_range.clone());
 
     for i in 0..num_tables {
         let table_name = format!("table_{i}");
 
-        // Generate random number of columns (2-8)
-        let num_columns = rng.random_range(2..=8);
+        let num_columns = rng.random_range(bias.num_columns_range.clone());
         let mut columns = Vec::new();
 
-        // TODO: there is no proper unique generation yet in whopper, so disable primary keys for now
-        columns.push(Column {
-            name: "id".to_string(),
-            column_type: ColumnType::Integer,
-            constraints: vec![],
-        });
+        let id_column = if rng.random_bool(bias.non_rowid_pk_prob) {
+            Column {
+                name: "id".to_string(),
+                column_type: ColumnType::Text,
+                constraints: vec![ColumnConstraint::PrimaryKey {
+                    order: None,
+                    conflict_clause: None,
+                    auto_increment: false,
+                }],
+            }
+        } else {
+            Column {
+                name: "id".to_string(),
+                column_type: ColumnType::Integer,
+                constraints: vec![],
+            }
+        };
+        columns.push(id_column);
 
         // Add random columns
         for j in 1..num_columns {
@@ -1242,11 +1369,7 @@ pub fn create_initial_schema(rng: &mut ChaCha8Rng) -> Vec<Create> {
                 1 => ColumnType::Text,
                 _ => ColumnType::Float,
             };
-
-            // FIXME: before sql_generation did not incorporate ColumnConstraint into the sql string
-            // now it does and it the simulation here fails `whopper` with UNIQUE CONSTRAINT ERROR
-            // 20% chance of unique
-            let constraints = if rng.random_bool(0.0) {
+            let constraints = if rng.random_bool(bias.unique_col_prob) {
                 vec![ColumnConstraint::Unique(None)]
             } else {
                 Vec::new()

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -1318,13 +1318,13 @@ fn seed_insert_sql(table: &Table, row_idx: u32) -> String {
                 let _ = write!(sql, "{}", row_idx as i64);
             }
             ColumnType::Float => {
-                let _ = write!(sql, "{}.0", row_idx);
+                let _ = write!(sql, "{row_idx}.0");
             }
             ColumnType::Text => {
                 let _ = write!(sql, "'seed_{}_{}'", col.name, row_idx);
             }
             ColumnType::Blob => {
-                let _ = write!(sql, "x'{:08x}'", row_idx);
+                let _ = write!(sql, "x'{row_idx:08x}'");
             }
         }
     }

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -42,8 +42,9 @@ struct Args {
     /// Number of connections opened inside each worker process in multiprocess mode.
     #[arg(long, default_value_t = 1)]
     connections_per_process: usize,
-    #[arg(long, default_value_t = 0.0)]
-    reopen_probability: f64,
+    /// Reopen probability per step.
+    #[arg(long)]
+    reopen_probability: Option<f64>,
     /// Max steps
     #[arg(long)]
     max_steps: Option<usize>,
@@ -249,6 +250,8 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
         println!("cosmic ray probability = {}", opts.cosmic_ray_probability);
     }
 
+    let reopen_probability = args.reopen_probability.unwrap_or(opts.reopen_probability);
+
     let mut whopper = Whopper::new(opts)?;
 
     let max_steps = whopper.max_steps;
@@ -260,7 +263,7 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     progress_index += 1;
 
     while !whopper.is_done() {
-        if whopper.rng.random_bool(args.reopen_probability) {
+        if whopper.rng.random_bool(reopen_probability) {
             whopper.reopen().unwrap();
         }
         match whopper.step()? {
@@ -381,6 +384,7 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         "fast" => WhopperOpts::fast(),
         "chaos" => WhopperOpts::chaos(),
         "ragnarök" | "ragnarok" => WhopperOpts::ragnarok(),
+        "recovery-heavy" => WhopperOpts::recovery_heavy(),
         mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
     };
 

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -277,7 +277,7 @@ impl MultiprocessWhopper {
                 conn.execute("PRAGMA journal_mode = 'mvcc'")?;
             }
 
-            let schema = create_initial_schema(&mut rng);
+            let schema = create_initial_schema(&mut rng, &crate::SchemaBias::default());
             let tables = schema.iter().map(|t| t.table.clone()).collect::<Vec<_>>();
             for create_table in &schema {
                 conn.execute(create_table.to_string())?;
@@ -307,7 +307,7 @@ impl MultiprocessWhopper {
 
         // Build initial simulator state from the schema we just created
         let mut schema_rng = ChaCha8Rng::seed_from_u64(seed);
-        let schema = create_initial_schema(&mut schema_rng);
+        let schema = create_initial_schema(&mut schema_rng, &crate::SchemaBias::default());
         let tables = schema.iter().map(|t| t.table.clone()).collect::<Vec<_>>();
         let indexes = create_initial_indexes(&mut schema_rng, &tables);
         let indexes_vec: Vec<(String, String)> = indexes

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -4,14 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 use turso_core::{Connection, Database, DatabaseOpts, IO, LimboError, OpenFlags};
 use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
-use turso_whopper::{
-    multiprocess_platform_io,
-    workloads::{
-        BeginWorkload, CommitWorkload, CreateIndexWorkload, CreateSimpleTableWorkload,
-        DeleteWorkload, DropIndexWorkload, IntegrityCheckWorkload, RollbackWorkload,
-        SimpleInsertWorkload, SimpleSelectWorkload, UpdateWorkload, WalCheckpointWorkload,
-    },
-};
+use turso_whopper::multiprocess_platform_io;
 
 fn wait_for_file(path: &Path) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
@@ -472,13 +465,6 @@ fn probe_simple_kv_length_via_fresh_worker(
 }
 
 #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
-fn advance_seeded_whopper_to_step(whopper: &mut MultiprocessWhopper, step_after_execution: usize) {
-    while whopper.current_step < step_after_execution {
-        whopper.step().expect("seeded whopper step");
-    }
-}
-
-#[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
 #[test]
 fn multiprocess_restart_reuses_persisted_tshm_without_disk_scan() {
     let mut whopper = create_multiprocess_whopper(2);
@@ -694,59 +680,45 @@ fn multiprocess_committed_large_row_survives_repeated_restarts() -> anyhow::Resu
 
 #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
 #[test]
-fn multiprocess_seed_8849519299024683634_localizes_schema_loss_boundary() {
-    configure_worker_exe();
-    let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
-        seed: Some(8849519299024683634),
-        enable_mvcc: false,
-        process_count: 16,
-        connections_per_process: 1,
-        max_steps: 72,
-        elle_tables: vec![],
-        workloads: vec![
-            (10, Box::new(IntegrityCheckWorkload)),
-            (5, Box::new(WalCheckpointWorkload)),
-            (10, Box::new(CreateSimpleTableWorkload)),
-            (20, Box::new(SimpleSelectWorkload)),
-            (20, Box::new(SimpleInsertWorkload)),
-            (15, Box::new(UpdateWorkload)),
-            (15, Box::new(DeleteWorkload)),
-            (2, Box::new(CreateIndexWorkload)),
-            (2, Box::new(DropIndexWorkload)),
-            (30, Box::new(BeginWorkload)),
-            (10, Box::new(CommitWorkload)),
-            (10, Box::new(RollbackWorkload)),
-        ],
-        properties: vec![],
-        chaotic_profiles: vec![],
-        kill_probability: 0.0,
-        restart_probability: 0.05,
-        history_output: None,
-        keep_files: true,
-    })
-    .expect("create seeded multiprocess whopper");
+fn multiprocess_committed_table_schema_survives_repeated_restarts() -> anyhow::Result<()> {
+    let mut whopper = create_multiprocess_whopper_with_keep(1, true);
+    let db_path = whopper.db_path().to_path_buf();
+    let table_name = "table_name";
+    let key = "key_name";
+    let value_len: i64 = 874;
 
-    advance_seeded_whopper_to_step(&mut whopper, 67);
-    assert!(
-        probe_table_rootpage_via_fresh_worker(&whopper, "simple_kv_9842").is_some(),
-        "simple_kv_9842 should still exist for a fresh opener immediately after the step 66 restart",
-    );
+    whopper.execute_sql_direct(
+        0,
+        format!("create table {table_name}(key text primary key, value text not null)"),
+    )??;
+
+    whopper.execute_sql_direct(
+        0,
+        format!(
+            "insert into {table_name}(key, value) values ('{key}', printf('%0*d', {value_len}, 1))"
+        ),
+    )??;
+
+    assert!(probe_table_rootpage_via_fresh_worker(&whopper, table_name).is_some());
     assert_eq!(
-        probe_simple_kv_length_via_fresh_worker(&whopper, "simple_kv_9842", "key_6095"),
-        Some(874),
-        "baseline row should still be visible for a fresh opener immediately after the step 66 restart",
+        probe_simple_kv_length_via_fresh_worker(&whopper, table_name, key),
+        Some(value_len)
     );
 
-    advance_seeded_whopper_to_step(&mut whopper, 70);
-    assert!(
-        probe_table_rootpage_via_fresh_worker(&whopper, "simple_kv_9842").is_some(),
-        "simple_kv_9842 disappeared from sqlite_schema by the step 70 restart; cohort_telemetries={:?}",
-        whopper.worker_startup_telemetries(),
-    );
+    for _restart in 1..=3 {
+        whopper.restart_all_workers_preserve_files().unwrap();
+        assert!(probe_table_rootpage_via_fresh_worker(&whopper, table_name).is_some());
+        assert_eq!(
+            probe_simple_kv_length_via_fresh_worker(&whopper, table_name, key),
+            Some(value_len)
+        );
+    }
 
-    whopper
-        .finalize()
-        .expect("finalize seeded multiprocess whopper");
+    let db_str = db_path.to_str().unwrap();
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(format!("{db_str}-wal"));
+    let _ = std::fs::remove_file(format!("{db_str}-tshm"));
+    Ok(())
 }
 
 #[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]


### PR DESCRIPTION
## Description

Adds a new `--mode recovery-heavy` profile to whopper biased toward catching MVCC schema-recovery bugs (https://github.com/tursodatabase/turso/pull/6628). The profile is composed of:

- SchemaBias struct on WhopperOpts with knobs for ipk_prob (probability of TEXT/BLOB PRIMARY KEY → non-rowid PK auto-index), unique_col_autoindex_prob, num_tables_range, num_columns_range, and seed_rows_per_table. Defaults match existing fast/chaos/ragnarok behavior; recovery-bugs sets aggressive values.
- disable_mvcc_auto_checkpoint flag → calls MvStore::set_checkpoint_threshold(-1) so schema CREATE rows stay in the logical log for replay rather than being flushed early to the on-disk btree.
- crash_like_reopen flag → drops fiber connections without graceful close to preserve uncheckpointed log state across reopens.
- default_reopen_probability field → CLI fallback when --reopen-probability is not pinned explicitly.
- create_initial_schema honors SchemaBias for both single-process and multiprocess paths; multiprocess uses the default bias.
- seed_insert_sql produces deterministic per-table seed rows so the simulator's read/write workloads have actual data to operate on (prevents tables from staying empty when the random INSERT generator collides on UNIQUE).

## Description of AI Usage

Mostly CC