### PR TITLE
core/mvcc: check schema cookie during get_commit_timestamp

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1759,15 +1759,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     }
                 }
 
-                if mvcc_store
-                    .last_committed_schema_change_ts
-                    .load(Ordering::Acquire)
-                    > tx.begin_ts
-                {
-                    // Schema changes made after the transaction began always cause a [SchemaConflict] error and the tx must abort.
-                    return Err(LimboError::SchemaConflict);
-                }
-
                 // Atomically generate end_ts and publish Preparing(end_ts) while the
                 // clock lock is held. This closes the TOCTOU window
                 // Consider the example:
@@ -1780,13 +1771,82 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 //
                 // hence we want to guard the timestamp generation by a mutex, only allow next
                 // ts to generate when the previous one is used / discarded
+
+                let write_set_is_empty = tx.write_set.lock().is_empty();
+                let header_write = tx.header_dirty.load(Ordering::Acquire);
+                // Read only is not only exclusive to empty write set, we could be writing the
+                // database header here.
+                let read_only = write_set_is_empty && !header_write;
+
+                let mut schema_conflict = false;
+                let mut exclusive_conflict = false;
+
                 let end_ts = mvcc_store.get_commit_timestamp(|ts| {
                     turso_assert!(
                         ts > tx.begin_ts,
                         "end_ts must be strictly greater than begin_ts"
                     );
-                    tx.state.store(TransactionState::Preparing(ts));
+
+                    // First we check if there is exclusive conflict, if there is then we won't
+                    // commit txn.
+                    if !mvcc_store.is_exclusive_tx(&self.tx_id) && mvcc_store.has_exclusive_tx() {
+                        // A non-CONCURRENT transaction is holding the exclusive lock, we must abort.
+                        turso_assert_reachable!("commit aborted due to exclusive tx conflict");
+                        exclusive_conflict = true;
+                    }
+                    // Now check if we saw schema change which would require reprepare. Let's note
+                    // that we check this right after exlusive tx because we update this before we release
+                    // exclusive lock.
+                    let schema_updated = mvcc_store
+                        .last_committed_schema_change_ts
+                        .load(Ordering::Acquire)
+                        > tx.begin_ts;
+                    // last_committed_schema_ts is not enough, we need to check schema cookie
+                    // is the same because e.g:
+                    // T1 CREATE INDEX
+                    // T1 Yield somewhere in middle of commit
+                    // T1 end_ts = x
+                    // T2 BEGIN CONCURRENT; INSERT (same table); COMMIT
+                    // T2 begin_ts = x+1
+                    // T2 begin_ts > end_ts
+                    //
+                    // Therefore even if exclusive tx (T1) finishes right in time
+                    // we will see schema was not updated because we see an younger timestamp and
+                    // ours is older!
+                    //
+                    let our_cookie = tx.header.read().schema_cookie.get();
+                    let global_cookie = {
+                        let h = mvcc_store.global_header.read();
+                        let h = h.as_ref();
+                        turso_assert!(h.is_some(), "global_header should be initialized");
+                        h.unwrap().schema_cookie.get()
+                    };
+
+                    let header_dirty = tx.header_dirty.load(Ordering::Acquire);
+                    turso_assert!(!header_dirty || mvcc_store.is_exclusive_tx(&tx.tx_id), "header_dirty=true implies that tx is exclusive");
+                    if our_cookie != global_cookie && !header_dirty {
+                        tracing::debug!("cookie mismatch in CommitState::Initial tx({our_cookie}) != global(!{global_cookie})");
+                        schema_conflict = true;
+                    }
+
+                    if schema_updated {
+                        tracing::debug!("schema ts is older than our ts");
+                        // Schema changes made after the transaction began always cause a [SchemaConflict] error and the tx must abort.
+                        schema_conflict = true;
+                    }
+
+                    let can_commit_tx = !(exclusive_conflict || schema_conflict);
+                    if can_commit_tx || read_only {
+                        tx.state.store(TransactionState::Preparing(ts));
+                    }
                 });
+                // We allow reads from happening. Exlusive means there is a single writer.
+                if exclusive_conflict && !read_only {
+                    return Err(LimboError::WriteWriteConflict);
+                }
+                if schema_conflict && !read_only {
+                    return Err(LimboError::SchemaConflict);
+                }
                 tracing::trace!("prepare_tx(tx_id={}, end_ts={})", self.tx_id, end_ts);
                 /* In order to implement serializability, we need the following steps:
                 **
@@ -1871,9 +1931,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                  ** 2. Validate if there are no phantoms by walking the scans from scan_set
                  */
                 tracing::trace!("commit_tx(tx_id={})", self.tx_id);
-                let write_set_is_empty = tx.write_set.lock().is_empty();
                 // Header-only writes must not take this fast path; they need durable log records.
-                if write_set_is_empty && !tx.header_dirty.load(Ordering::Acquire) {
+                if read_only {
                     turso_assert!(
                         tx.commit_dep_set.lock().is_empty(),
                         "MVCC read only transaction should not have commit dependencies on other txns"
@@ -1913,11 +1972,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 Ok(TransitionResult::Continue)
             }
             CommitState::Commit { end_ts } => {
-                if !mvcc_store.is_exclusive_tx(&self.tx_id) && mvcc_store.has_exclusive_tx() {
-                    // A non-CONCURRENT transaction is holding the exclusive lock, we must abort.
-                    turso_assert_reachable!("commit aborted due to exclusive tx conflict");
-                    return Err(LimboError::WriteWriteConflict);
-                }
                 // Check for rowid conflicts before committing (pure optimistic, first-committer-wins)
                 // Ref: Hekaton paper Section 3.2 - validation uses end_ts comparison
                 let tx = mvcc_store

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5526,7 +5526,6 @@ fn test_insert_in_middle_commit_of_create_index_returns_err() {
 
     let conn_a = db.connect();
     let conn_b = db.connect();
-    let mvcc_store = db.get_mvcc_store();
 
     // T1 (conn_a): CREATE INDEX, yielding at `LogRecordPrepared` — the
     // point in the commit pipeline where `end_ts` has been assigned and the

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5507,6 +5507,84 @@ fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     rows
 }
 
+/// Any ddl specially CREATE INDEX must cause SchemaUpdated errors on ongoing INSERTS because
+/// we shouldn't commit an insert without inserting rows to this new index that is being created.
+/// Here we test that case by injecting in the middle of CREATE INDEX's commit and then doing a
+/// regular concurrent insert that will not take into account new index.
+#[test]
+fn test_insert_in_middle_commit_of_create_index_returns_err() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let setup = db.connect();
+        setup
+            .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, c INTEGER)")
+            .unwrap();
+        setup.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+        setup.close().unwrap();
+    }
+
+    let conn_a = db.connect();
+    let conn_b = db.connect();
+    let mvcc_store = db.get_mvcc_store();
+
+    // T1 (conn_a): CREATE INDEX, yielding at `LogRecordPrepared` — the
+    // point in the commit pipeline where `end_ts` has been assigned and the
+    // log record is built, but the global header and
+    // `last_committed_schema_change_ts` haven't been published yet.
+    conn_a.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::LogRecordPrepared.point(),
+    ])));
+    let mut create_idx = conn_a.prepare("CREATE INDEX i ON t(c)").unwrap();
+    let mut yielded = false;
+    for _ in 0..200 {
+        match create_idx.step().unwrap() {
+            StepResult::IO => {
+                yielded = true;
+                break;
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    assert!(
+        yielded,
+        "CREATE INDEX should yield at CommitYieldPoint::LogRecordPrepared"
+    );
+
+    // T2 (conn_b): start a new tx now — its begin_ts will be > T1's end_ts,
+    // but the global schema view still doesn't know about the new index `i`.
+    // The INSERT compiles its bytecode against the stale schema and emits
+    // IdxInsert ops only for the indexes the stale schema knows about.
+    conn_b.execute("BEGIN CONCURRENT").unwrap();
+    conn_b.execute("INSERT INTO t VALUES (2, 20)").unwrap();
+
+    // T1 finishes finalizing the CREATE INDEX. After this point, the global
+    // header carries the new schema_cookie and `last_committed_schema_change_ts`
+    // is bumped to T1's `end_ts`.
+    create_idx.run_ignore_rows().unwrap();
+    drop(create_idx);
+
+    // T2 commits. The schema-conflict check at `CommitState::Initial` compares
+    // `last_committed_schema_change_ts (= T1.end_ts) > tx_b.begin_ts (> T1.end_ts)`
+    // which is FALSE — so no conflict is raised and T2 commits cleanly, even
+    // though its writes never touched the new index.
+
+    let commit_result = conn_b.execute("COMMIT");
+
+    assert!(
+        matches!(
+            commit_result,
+            Err(LimboError::SchemaConflict | LimboError::SchemaUpdated)
+        ),
+        "BUG: tx_b's COMMIT returned {commit_result:?} but should have been \
+         aborted with SchemaConflict/SchemaUpdated. tx_b began with a stale \
+         schema (missing index `i`), so its INSERT silently skipped writing \
+         to that index. Allowing the commit leaves `i` permanently short the \
+         row tx_b wrote."
+    );
+}
+
 /// What this test checks: MVCC transaction visibility and conflict handling follow the intended isolation behavior.
 /// Why this matters: Concurrency bugs are correctness bugs: they create anomalies users can observe as wrong query results.
 #[test]

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1642,7 +1642,7 @@ pub fn test_empty_wal_truncate_checkpoint() {
 }
 
 #[test]
-pub fn test_mvcc_stale_snapshot_after_schema_updated() {
+pub fn test_mvcc_reader_stale_snapshot_after_schema_updated_returns_ok() {
     let _ = env_logger::try_init();
     let db_path = tempfile::NamedTempFile::new().unwrap();
     let (_file, db_path) = db_path.keep().unwrap();
@@ -1659,8 +1659,58 @@ pub fn test_mvcc_stale_snapshot_after_schema_updated() {
         .unwrap();
     // conn1: Start a CONCURRENT transaction
     conn1.execute("BEGIN CONCURRENT").unwrap();
-    // Do something to establish the MVCC snapshot
+    // Do something to establish the MVCC snapshot, we do not write anything so that tx
+    // is read only which would not trigger SchemaUpdated
     conn1.execute("SELECT * FROM t").unwrap();
+    // conn2: Modify schema while conn1's CONCURRENT transaction is active
+    conn2.execute("CREATE TABLE t2 (x)").unwrap();
+    // conn1: Try to COMMIT - should fail with SchemaConflict
+    let commit_result = conn1.execute("COMMIT");
+    assert!(matches!(commit_result, Ok(())));
+
+    // conn2: Insert a row and commit (this happens AFTER conn1's original snapshot)
+    conn2
+        .execute("INSERT INTO t VALUES ('test_key', 'test_value')")
+        .unwrap();
+
+    // conn1: Start a new CONCURRENT transaction
+    // BUG: This should get a fresh MVCC snapshot, but it reuses the old one
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+
+    // conn1: SELECT should see the row inserted by conn2
+    // BUG: Due to stale snapshot, this returns empty result
+    let rows: Vec<(String, String)> = conn1.exec_rows("SELECT * FROM t WHERE key = 'test_key'");
+
+    assert_eq!(
+        rows,
+        vec![("test_key".to_string(), "test_value".to_string())]
+    );
+
+    conn1.execute("COMMIT").unwrap();
+}
+
+#[test]
+pub fn test_mvcc_writer_stale_snapshot_after_schema_updated() {
+    let _ = env_logger::try_init();
+    let db_path = tempfile::NamedTempFile::new().unwrap();
+    let (_file, db_path) = db_path.keep().unwrap();
+    tracing::info!("path: {:?}", db_path);
+    let tmp_db = TempDatabase::builder()
+        .with_db_path(&db_path)
+        .with_mvcc(true)
+        .build();
+    let conn1 = tmp_db.connect_limbo();
+    let conn2 = tmp_db.connect_limbo();
+    // Setup: create initial table
+    conn1
+        .execute("CREATE TABLE t (key TEXT PRIMARY KEY, value TEXT)")
+        .unwrap();
+    // conn1: Start a CONCURRENT transaction
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    // Insert something so that we trigger schema updated
+    conn1
+        .execute("INSERT INTO t VALUES ('foo', 'var')")
+        .unwrap();
     // conn2: Modify schema while conn1's CONCURRENT transaction is active
     conn2.execute("CREATE TABLE t2 (x)").unwrap();
     // conn1: Try to COMMIT - should fail with SchemaConflict


### PR DESCRIPTION
## Description
Copied case where this corruption happens from comments:

T1 CREATE INDEX
T1 Yield somewhere in middle of commit
T1 end_ts = x
T2 BEGIN CONCURRENT; INSERT (same table); COMMIT
T2 begin_ts = x+1
T2 begin_ts > end_ts

Therefore even if exclusive tx (T1) finishes right in time
we will see schema was not updated because we see an younger timestamp and
ours is older!

This basically allowed inserts to a table without acknowledging new index. So we ended up having missing rows in new indexes.


## Description of AI Usage

Got the bug analysis from claude and wrote the solution myself.
