### PR TITLE
Reject AUTOINCREMENT on non-rowid primary keys

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3830,7 +3830,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 let ty = match col_type {
                     Some(data_type) => {
                         let (ty, ei) = type_from_name(&data_type.name);
-                        typename_exactly_integer = ei;
+                        typename_exactly_integer = ei && ty_params.is_empty();
                         ty
                     }
                     None => Type::Null,
@@ -4057,6 +4057,10 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
     }
 
     if has_autoincrement {
+        if !has_rowid {
+            crate::bail_parse_error!("AUTOINCREMENT is not allowed on WITHOUT ROWID tables");
+        }
+
         // only allow integers
         if primary_key_columns.len() != 1 {
             crate::bail_parse_error!("AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY");
@@ -4070,7 +4074,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
         });
 
         if let Some(col) = pk_col {
-            if col.ty() != Type::Integer {
+            if !col.is_rowid_alias() {
                 crate::bail_parse_error!("AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY");
             }
         }

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -275,6 +275,36 @@ test autoinc-fail-on-non-integer-pk {
 expect error {
 }
 
+# Regression tests for https://github.com/tursodatabase/turso/issues/6940
+# AUTOINCREMENT is valid only on a true INTEGER PRIMARY KEY rowid alias.
+@cross-check-integrity
+test autoinc-fail-on-int-pk {
+    CREATE TABLE t(a INT PRIMARY KEY AUTOINCREMENT);
+}
+expect error {
+}
+
+@cross-check-integrity
+test autoinc-fail-on-bigint-pk {
+    CREATE TABLE t(a BIGINT PRIMARY KEY AUTOINCREMENT);
+}
+expect error {
+}
+
+@cross-check-integrity
+test autoinc-fail-on-sized-integer-pk {
+    CREATE TABLE t(a INTEGER(8) PRIMARY KEY AUTOINCREMENT);
+}
+expect error {
+}
+
+@cross-check-integrity
+test autoinc-fail-on-desc-integer-pk {
+    CREATE TABLE t(a INTEGER PRIMARY KEY DESC AUTOINCREMENT);
+}
+expect error {
+}
+
 # Test: An empty INSERT...SELECT does not damage the sequence table. (Ticket #3148)
 @cross-check-integrity
 test autoinc-empty-insert-select-is-safe {


### PR DESCRIPTION
## Summary
- Require AUTOINCREMENT primary key columns to be true rowid aliases instead of any integer-affinity primary key.
- Treat parameterized INTEGER declarations as non-exact for rowid-alias detection.
- Add regression coverage for INT, BIGINT, INTEGER(8), and column-level DESC primary keys with AUTOINCREMENT.

Fixes #6940

## Tests
- make -C testing/sqltests run-rust ARGS="--filter autoinc-* --snapshot-filter __never__"
