### PR TITLE
Skip NULL sqlite_sequence names during AUTOINCREMENT scans

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -195,7 +195,7 @@ fn emit_rename_sqlite_sequence_entry(
             lhs: sequence_name_reg,
             rhs: row_name_to_replace_reg,
             target_pc: continue_loop_label,
-            flags: CmpInsFlags::default(),
+            flags: CmpInsFlags::default().jump_if_null(),
             collation: None,
         });
 
@@ -275,7 +275,7 @@ fn emit_delete_sqlite_sequence_entry(
             lhs: sequence_name_reg,
             rhs: row_name_to_delete_reg,
             target_pc: continue_loop_label,
-            flags: CmpInsFlags::default(),
+            flags: CmpInsFlags::default().jump_if_null(),
             collation: None,
         });
 

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1679,7 +1679,7 @@ fn reload_autoincrement_state(program: &mut ProgramBuilder, meta: AutoincMeta) {
         lhs: table_name_reg,
         rhs: name_col_reg,
         target_pc: found_label,
-        flags: Default::default(),
+        flags: CmpInsFlags::default().jump_if_null(),
         collation: None,
     });
 

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -2275,7 +2275,7 @@ pub fn translate_drop_table(
             lhs: seq_table_name_reg,
             rhs: dropped_table_name_reg,
             target_pc: continue_loop_label,
-            flags: CmpInsFlags::default(),
+            flags: CmpInsFlags::default().jump_if_null(),
             collation: None,
         });
 

--- a/testing/sqltests/tests/autoincr.sqltest
+++ b/testing/sqltests/tests/autoincr.sqltest
@@ -218,6 +218,68 @@ expect {
     t2|2
 }
 
+# Regression test for https://github.com/tursodatabase/turso/issues/6966
+@cross-check-integrity
+test autoinc-null-sequence-name-does-not-match-insert {
+    CREATE TABLE t1(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t3(i INTEGER PRIMARY KEY AUTOINCREMENT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL);
+    INSERT INTO t3 VALUES(NULL);
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t2';
+    INSERT INTO t3 VALUES(NULL);
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1|t1|1
+    2||1
+    3|t3|2
+}
+
+@cross-check-integrity
+test autoinc-null-sequence-name-does-not-match-rename {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL);
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t1';
+    ALTER TABLE t2 RENAME TO t3;
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1||1
+    2|t3|1
+}
+
+@cross-check-integrity
+test autoinc-null-sequence-name-does-not-match-drop {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL);
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t1';
+    DROP TABLE t2;
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1||1
+}
+
+@skip-if sqlite "ALTER COLUMN is a Turso extension"
+test autoinc-null-sequence-name-does-not-match-alter-column {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+    INSERT INTO t1 VALUES(NULL);
+    INSERT INTO t2 VALUES(NULL, 'x');
+    UPDATE sqlite_sequence SET name=NULL WHERE name='t1';
+    ALTER TABLE t2 ALTER COLUMN id TO id2 TEXT;
+    SELECT rowid, name, seq FROM sqlite_sequence ORDER BY rowid;
+}
+expect {
+    1||1
+}
+
 # Regression test for https://github.com/tursodatabase/turso/issues/6769
 @skip-if sqlite "ALTER COLUMN is a Turso extension"
 test autoinc-alter-column-clears-sequence-row {


### PR DESCRIPTION
## Summary
- Skip `sqlite_sequence` rows with NULL `name` values when loading AUTOINCREMENT state for inserts.
- Apply the same NULL-skip behavior when renaming, deleting, or dropping `sqlite_sequence` entries.
- Add AUTOINCREMENT regressions for NULL sequence names across insert, rename, drop, and ALTER COLUMN cleanup paths.

Fixes #6966

## Tests
- `cargo fmt --all --check`
- `cargo check -p turso_core --features pure-rust-crypto`
- `test-runner run testing/sqltests/tests/autoincr.sqltest --backend cli --filter "autoinc-*" --snapshot-filter __never__`
- `make -C testing/sqltests run-rust ARGS="--filter autoinc-* --snapshot-filter __never__"`