### PR TITLE
Match partial indexes in UPSERT conflict targets

### DIFF
--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -257,18 +257,62 @@ fn index_expression_cols(table: &Table, out: &mut ColumnMask, expr: &ast::Expr) 
     });
 }
 
+fn normalize_partial_index_predicate(expr: &ast::Expr, table: &Table) -> ast::Expr {
+    let table_name = normalize_ident(table.get_name());
+    let mut expr = expr.clone();
+    let _ = walk_expr_mut(
+        &mut expr,
+        &mut |e: &mut ast::Expr| -> crate::Result<WalkControl> {
+            match e {
+                ast::Expr::Qualified(t, c) if normalize_ident(t.as_str()) == table_name => {
+                    *e = ast::Expr::Id(c.clone());
+                    Ok(WalkControl::SkipChildren)
+                }
+                ast::Expr::DoublyQualified(_, t, c)
+                    if normalize_ident(t.as_str()) == table_name =>
+                {
+                    *e = ast::Expr::Id(c.clone());
+                    Ok(WalkControl::SkipChildren)
+                }
+                _ => Ok(WalkControl::Continue),
+            }
+        },
+    );
+    expr
+}
+
+fn upsert_target_where_matches_index(
+    target: &ast::UpsertIndex,
+    index: &Index,
+    table: &Table,
+) -> bool {
+    match index.where_clause.as_deref() {
+        None => true,
+        Some(index_where) => target.where_clause.as_deref().is_some_and(|target_where| {
+            exprs_are_equivalent(target_where, index_where)
+                || exprs_are_equivalent(
+                    &normalize_partial_index_predicate(target_where, table),
+                    &normalize_partial_index_predicate(index_where, table),
+                )
+        }),
+    }
+}
+
 /// Match ON CONFLICT target to a UNIQUE index, *ignoring order* but requiring
 /// exact coverage (same column multiset). If the target specifies a COLLATED
 /// column, the collation must match the index column's effective collation.
 /// If the target omits collation, any index collation is accepted.
-/// Partial (WHERE) indexes never match.
+/// Partial (WHERE) indexes match only when the target has the same predicate.
 pub fn upsert_matches_index(upsert: &Upsert, index: &Index, table: &Table) -> bool {
     let Some(target) = upsert.index.as_ref() else {
         return true;
     };
-    // must be a non-partial UNIQUE index with identical arity
-    if !index.unique || index.where_clause.is_some() || target.targets.len() != index.columns.len()
-    {
+    // must be a UNIQUE index with identical arity and matching partial predicate
+    if !index.unique || target.targets.len() != index.columns.len() {
+        return false;
+    }
+
+    if !upsert_target_where_matches_index(target, index, table) {
         return false;
     }
 

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -924,6 +924,74 @@ pub fn upsert_conflict(limbo: TempDatabase) {
 }
 
 #[turso_macros::test]
+pub fn upsert_partial_unique_index_target(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute(
+        "CREATE TABLE t (
+            a TEXT,
+            b TEXT,
+            deleted INTEGER DEFAULT 0
+        )",
+    )
+    .unwrap();
+    conn.execute("CREATE UNIQUE INDEX t_ab_live ON t(a, b) WHERE deleted = 0")
+        .unwrap();
+    conn.execute("INSERT INTO t(a, b, deleted) VALUES ('a', 'b', 0)")
+        .unwrap();
+    conn.execute(
+        "INSERT INTO t(a, b, deleted)
+         VALUES ('a', 'b', 0)
+         ON CONFLICT(a, b) WHERE deleted = 0
+         DO UPDATE SET b = excluded.b",
+    )
+    .unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT a, b, deleted FROM t"),
+        vec![vec![
+            RValue::Text("a".to_string()),
+            RValue::Text("b".to_string()),
+            RValue::Integer(0),
+        ]]
+    );
+
+    conn.execute(
+        "INSERT INTO t(a, b, deleted)
+         VALUES ('a', 'b', 0)
+         ON CONFLICT(a, b) WHERE t.deleted = 0
+         DO UPDATE SET b = excluded.b",
+    )
+    .unwrap();
+
+    let err = conn.execute(
+        "INSERT INTO t(a, b, deleted)
+         VALUES ('a', 'b', 0)
+         ON CONFLICT(a, b) WHERE deleted = 1
+         DO UPDATE SET b = excluded.b",
+    );
+    assert!(err.is_err(), "mismatched partial-index target must fail");
+}
+
+#[turso_macros::test]
+pub fn upsert_conflict_target_where_matches_nonpartial_unique_index(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a INT UNIQUE, v TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'old')").unwrap();
+    conn.execute(
+        "INSERT INTO t VALUES (1, 'new')
+         ON CONFLICT(a) WHERE a = 2
+         DO UPDATE SET v = excluded.v",
+    )
+    .unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT a, v FROM t"),
+        vec![vec![RValue::Integer(1), RValue::Text("new".to_string())]]
+    );
+}
+
+#[turso_macros::test]
 pub fn insert_returning_qualified_quoted_table(limbo: TempDatabase) {
     // Regression: qualified column refs in RETURNING (e.g. "users"."id")
     // failed with `no such table: users` when the table was created with


### PR DESCRIPTION
Fixes #7083

## Summary
- Allow targeted UPSERT conflict clauses to match partial unique indexes when the target WHERE predicate matches the index predicate.
- Normalize target-table-qualified predicate columns before comparing partial-index predicates.
- Keep non-partial unique index matching compatible with SQLite when a conflict target includes a WHERE clause.

## Tests
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p turso_core --features pure-rust-crypto`
- `cargo test -p core_tester --test integration_tests upsert_ --features pure-rust-crypto -- --nocapture`
- `cargo test -p core_tester --test integration_tests --features pure-rust-crypto`