### PR TITLE
Forward NULL arguments to table-valued functions

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -32,7 +32,6 @@ use crate::{
     vdbe::builder::ProgramBuilder,
 };
 use smallvec::SmallVec;
-use turso_parser::ast::Literal::Null;
 use turso_parser::ast::{
     self, As, Expr, FromClause, JoinType, Materialized, Over, QualifiedName, Select,
     TableInternalId, With,
@@ -1160,14 +1159,9 @@ fn transform_args_into_where_terms(
                 column: i,
                 is_rowid_alias: col.is_rowid_alias(),
             };
-            let expr = match arg_expr.as_ref() {
-                Expr::Literal(Null) => Expr::IsNull(Box::new(column_expr)),
-                other => Expr::Binary(
-                    column_expr.into(),
-                    ast::Operator::Equals,
-                    other.clone().into(),
-                ),
-            };
+            // Positional TVF arguments must stay equality constraints so NULL
+            // arguments are forwarded through VFilter instead of becoming residual predicates.
+            let expr = Expr::Binary(column_expr.into(), ast::Operator::Equals, arg_expr.clone());
             predicates.push(expr);
         }
     }

--- a/tests/integration/query_timeout.rs
+++ b/tests/integration/query_timeout.rs
@@ -1,4 +1,5 @@
-use crate::common::TempDatabase;
+use crate::common::{limbo_exec_rows, TempDatabase};
+use rusqlite::types::Value as RValue;
 use std::time::Duration;
 use turso_core::vdbe::StepResult;
 
@@ -40,6 +41,28 @@ fn query_timeout_allows_short_running_query(tmp_db: TempDatabase) -> anyhow::Res
     assert!(
         matches!(result, StepResult::Done),
         "expected done, got {result:?}"
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn query_timeout_allows_generate_series_null_stop(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.set_query_timeout(Duration::from_millis(10));
+
+    let mut stmt = conn.prepare("SELECT count(*) FROM generate_series(1, NULL);")?;
+    let result = run_until_terminal(&mut stmt)?;
+    assert!(
+        matches!(result, StepResult::Done),
+        "expected NULL stop to produce an empty series without scanning, got {result:?}"
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT count(*) FROM generate_series(1, NULL);"),
+        vec![vec![RValue::Integer(0)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT * FROM generate_series(1, NULL) LIMIT 5;"),
+        Vec::<Vec<RValue>>::new()
     );
     Ok(())
 }


### PR DESCRIPTION
Fixes #6086

## Summary
- Preserve positional table-valued function arguments as equality constraints, including NULL literals.
- Let explicit NULL arguments reach virtual table filtering instead of becoming residual IS NULL predicates.
- Add regression coverage showing generate_series(1, NULL) finishes immediately and returns an empty result set.

## Tests
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p turso_core --features pure-rust-crypto`
- `cargo test -p core_tester --test integration_tests query_timeout --features pure-rust-crypto -- --nocapture`
- `cargo test -p core_tester --test integration_tests test_pragma_module_list_generate_series --features pure-rust-crypto -- --nocapture`
- `cargo test -p core_tester --test integration_tests --features pure-rust-crypto`