### PR TITLE
Add locale-backed collations to Turso

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,16 +2602,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collator"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b521b92a2666061ddda902769d8a4cf730b5c9529a845cc1b69770b12a6c9a71"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections 2.2.0",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_normalizer 2.2.0",
+ "icu_properties 2.2.0",
+ "icu_provider 2.2.0",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038ed8e5817f2059c2f3efb0945ba78d060d3d25e8f1a1bea5139f821a21a2f0"
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
 ]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke 0.8.2",
+ "zerofrom",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections 2.2.0",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider 2.2.0",
+ "potential_utf",
+ "tinystr 0.8.3",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap 0.8.2",
+ "serde",
+ "tinystr 0.8.3",
+ "writeable 0.6.3",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_locid"
@@ -2620,10 +2694,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+ "litemap 0.7.5",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -2635,9 +2709,9 @@ dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -2653,15 +2727,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
+ "icu_collections 1.5.0",
+ "icu_normalizer_data 1.5.0",
+ "icu_properties 1.5.1",
+ "icu_provider 1.5.0",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections 2.2.0",
+ "icu_normalizer_data 2.2.0",
+ "icu_properties 2.2.0",
+ "icu_provider 2.2.0",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -2671,18 +2762,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
 name = "icu_properties"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
+ "icu_properties_data 1.5.0",
+ "icu_provider 1.5.0",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections 2.2.0",
+ "icu_locale_core",
+ "icu_properties_data 2.2.0",
+ "icu_provider 2.2.0",
+ "zerotrie",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -2690,6 +2801,12 @@ name = "icu_properties_data"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
@@ -2701,11 +2818,28 @@ dependencies = [
  "icu_locid",
  "icu_provider_macros",
  "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable 0.6.3",
+ "yoke 0.8.2",
+ "zerofrom",
+ "zerotrie",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -2748,8 +2882,8 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
+ "icu_normalizer 1.5.0",
+ "icu_properties 1.5.1",
 ]
 
 [[package]]
@@ -3297,6 +3431,12 @@ name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4121,6 +4261,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "serde_core",
+ "writeable 0.6.3",
+ "zerovec 0.11.6",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,9 +4653,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -6123,7 +6274,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec 0.11.6",
 ]
 
 [[package]]
@@ -6606,6 +6768,8 @@ dependencies = [
  "fallible-iterator",
  "fastbloom",
  "hex",
+ "icu_collator",
+ "icu_locale",
  "intrusive-collections",
  "io-uring",
  "libc",
@@ -7721,6 +7885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7752,7 +7922,18 @@ checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
- "yoke-derive",
+ "yoke-derive 0.7.5",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive 0.8.2",
  "zerofrom",
 ]
 
@@ -7761,6 +7942,18 @@ name = "yoke-derive"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "synstructure",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7836,14 +8029,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke 0.8.2",
+ "zerofrom",
+ "zerovec 0.11.6",
+]
+
+[[package]]
 name = "zerovec"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
- "yoke",
+ "yoke 0.7.5",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.10.3",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
+ "yoke 0.8.2",
+ "zerofrom",
+ "zerovec-derive 0.11.3",
 ]
 
 [[package]]
@@ -7851,6 +8068,17 @@ name = "zerovec-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -72,6 +72,8 @@ turso_ext = { workspace = true, features = ["core_only"] }
 cfg_block = "0.1.1"
 fallible-iterator = { workspace = true }
 hex = { workspace = true }
+icu_collator = "1.5.0"
+icu_locid = "1.5.0"
 thiserror = { workspace = true }
 regex = { workspace = true }
 regex-syntax = { workspace = true, default-features = false, features = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -72,8 +72,8 @@ turso_ext = { workspace = true, features = ["core_only"] }
 cfg_block = "0.1.1"
 fallible-iterator = { workspace = true }
 hex = { workspace = true }
-icu_collator = "1.5.0"
-icu_locid = "1.5.0"
+icu_collator = "2.2.0"
+icu_locale = "2.2.0"
 thiserror = { workspace = true }
 regex = { workspace = true }
 regex-syntax = { workspace = true, default-features = false, features = [

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4528,7 +4528,11 @@ impl Column {
     #[inline]
     pub const fn collation(&self) -> CollationSeq {
         let v = ((self.raw & COLL_MASK) >> COLL_SHIFT) as u16;
-        CollationSeq::from_storage_bits(v)
+        if v == CollationSeq::Unset.to_bits() {
+            CollationSeq::Binary
+        } else {
+            CollationSeq::from_storage_bits(v)
+        }
     }
 
     #[inline]
@@ -5185,6 +5189,16 @@ mod tests {
         let sql = r#"CREATE TABLE t1 (a INTEGER PRIMARY KEY, b TEXT) WITHOUT ROWID;"#;
         let table = BTreeTable::from_sql(sql, 0)?;
         assert!(!table.has_rowid, "has_rowid should be set to false");
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_column_default_collation_is_effective_binary() -> Result<()> {
+        let sql = r#"CREATE TABLE t1 (a TEXT);"#;
+        let table = BTreeTable::from_sql(sql, 0)?;
+        let column = table.get_column("a").unwrap().1;
+        assert_eq!(column.collation(), CollationSeq::Binary);
+        assert_eq!(column.collation_opt(), None);
         Ok(())
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4653,13 +4653,13 @@ impl Column {
     /// Number of array dimensions (0 = scalar, 1 = `[]`, 2 = `[][]`, etc.)
     #[inline]
     pub const fn array_dimensions(&self) -> u32 {
-        ((self.raw & ARRAY_DIM_MASK) >> ARRAY_DIM_SHIFT) as u32
+        (self.raw & ARRAY_DIM_MASK) >> ARRAY_DIM_SHIFT
     }
 
     #[inline]
     pub fn set_array_dimensions(&mut self, dims: u32) {
         assert!(dims <= 7, "array dimensions must be <= 7");
-        self.raw = (self.raw & !ARRAY_DIM_MASK) | ((dims as u32) << ARRAY_DIM_SHIFT);
+        self.raw = (self.raw & !ARRAY_DIM_MASK) | (dims << ARRAY_DIM_SHIFT);
     }
 
     #[inline]

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4540,8 +4540,7 @@ impl Column {
     #[inline]
     pub const fn set_collation(&mut self, c: Option<CollationSeq>) {
         if let Some(c) = c {
-            self.raw =
-                (self.raw & !COLL_MASK) | ((u32::from(c.to_bits()) << COLL_SHIFT) & COLL_MASK);
+            self.raw = (self.raw & !COLL_MASK) | (((c.to_bits() as u32) << COLL_SHIFT) & COLL_MASK);
         }
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4338,7 +4338,7 @@ pub struct Column {
     pub ty_params: Vec<Box<Expr>>,
     pub default: Option<Box<Expr>>,
     generated_type: GeneratedType,
-    raw: u16,
+    raw: u32,
     explicit_notnull: bool,
     /// ON CONFLICT clause for NOT NULL constraint on this column.
     pub notnull_conflict_clause: Option<ResolveType>,
@@ -4369,26 +4369,26 @@ pub enum GeneratedType {
 }
 
 // flags
-const F_PRIMARY_KEY: u16 = 1;
-const F_ROWID_ALIAS: u16 = 2;
-const F_NOTNULL: u16 = 4;
-const F_UNIQUE: u16 = 8;
-const F_HIDDEN: u16 = 16;
+const F_PRIMARY_KEY: u32 = 1;
+const F_ROWID_ALIAS: u32 = 2;
+const F_NOTNULL: u32 = 4;
+const F_UNIQUE: u32 = 8;
+const F_HIDDEN: u32 = 16;
 
 // pack Type and Collation in the remaining bits
-const TYPE_SHIFT: u16 = 5;
-const TYPE_MASK: u16 = 0b111 << TYPE_SHIFT;
-const COLL_SHIFT: u16 = TYPE_SHIFT + 3;
-const COLL_MASK: u16 = 0b11 << COLL_SHIFT;
+const TYPE_SHIFT: u32 = 5;
+const TYPE_MASK: u32 = 0b111 << TYPE_SHIFT;
+const COLL_SHIFT: u32 = TYPE_SHIFT + 3;
+const COLL_MASK: u32 = 0b1111_1111_1111 << COLL_SHIFT;
 
-// Bits 10-12: base type affinity override for custom type columns.
+// Bits 20-22: base type affinity override for custom type columns.
 // 0 = not set (use ty_str-based affinity), 1-5 = Affinity value + 1
-const BASE_AFF_SHIFT: u16 = COLL_SHIFT + 2;
-const BASE_AFF_MASK: u16 = 0b111 << BASE_AFF_SHIFT;
+const BASE_AFF_SHIFT: u32 = COLL_SHIFT + 12;
+const BASE_AFF_MASK: u32 = 0b111 << BASE_AFF_SHIFT;
 
-// Bits 13-15: array dimensions (0 = scalar, 1-7 = number of [] dimensions)
-const ARRAY_DIM_SHIFT: u16 = 13;
-const ARRAY_DIM_MASK: u16 = 0b111 << ARRAY_DIM_SHIFT;
+// Bits 23-25: array dimensions (0 = scalar, 1-7 = number of [] dimensions)
+const ARRAY_DIM_SHIFT: u32 = BASE_AFF_SHIFT + 3;
+const ARRAY_DIM_MASK: u32 = 0b111 << ARRAY_DIM_SHIFT;
 
 impl Column {
     pub fn affinity(&self) -> Affinity {
@@ -4411,7 +4411,7 @@ impl Column {
     /// This ensures affinity rules use the custom type's BASE type
     /// rather than applying SQLite name-based rules to the type name.
     pub fn set_base_affinity(&mut self, affinity: Affinity) {
-        let v: u16 = match affinity {
+        let v: u32 = match affinity {
             Affinity::Integer => 1,
             Affinity::Text => 2,
             Affinity::Blob => 3,
@@ -4474,10 +4474,10 @@ impl Column {
             }
             None => GeneratedType::NotGenerated,
         };
-        let mut raw = 0u16;
-        raw |= (ty as u16) << TYPE_SHIFT;
+        let mut raw = 0u32;
+        raw |= (ty as u32) << TYPE_SHIFT;
         if let Some(c) = col {
-            raw |= (c as u16) << COLL_SHIFT;
+            raw |= (u32::from(c.to_bits()) << COLL_SHIFT) & COLL_MASK;
         }
         if coldef.primary_key {
             raw |= F_PRIMARY_KEY
@@ -4513,7 +4513,7 @@ impl Column {
 
     #[inline]
     pub const fn set_ty(&mut self, ty: Type) {
-        self.raw = (self.raw & !TYPE_MASK) | (((ty as u16) << TYPE_SHIFT) & TYPE_MASK);
+        self.raw = (self.raw & !TYPE_MASK) | (((ty as u32) << TYPE_SHIFT) & TYPE_MASK);
     }
 
     #[inline]
@@ -4527,20 +4527,21 @@ impl Column {
 
     #[inline]
     pub const fn collation(&self) -> CollationSeq {
-        let v = ((self.raw & COLL_MASK) >> COLL_SHIFT) as u8;
-        CollationSeq::from_bits(v)
+        let v = ((self.raw & COLL_MASK) >> COLL_SHIFT) as u16;
+        CollationSeq::from_storage_bits(v)
     }
 
     #[inline]
     pub const fn has_explicit_collation(&self) -> bool {
-        let v = ((self.raw & COLL_MASK) >> COLL_SHIFT) as u8;
-        v != CollationSeq::Unset as u8
+        let v = ((self.raw & COLL_MASK) >> COLL_SHIFT) as u16;
+        v != CollationSeq::Unset.to_bits()
     }
 
     #[inline]
     pub const fn set_collation(&mut self, c: Option<CollationSeq>) {
         if let Some(c) = c {
-            self.raw = (self.raw & !COLL_MASK) | (((c as u16) << COLL_SHIFT) & COLL_MASK);
+            self.raw =
+                (self.raw & !COLL_MASK) | ((u32::from(c.to_bits()) << COLL_SHIFT) & COLL_MASK);
         }
     }
 
@@ -4655,11 +4656,11 @@ impl Column {
     #[inline]
     pub fn set_array_dimensions(&mut self, dims: u32) {
         assert!(dims <= 7, "array dimensions must be <= 7");
-        self.raw = (self.raw & !ARRAY_DIM_MASK) | ((dims as u16) << ARRAY_DIM_SHIFT);
+        self.raw = (self.raw & !ARRAY_DIM_MASK) | ((dims as u32) << ARRAY_DIM_SHIFT);
     }
 
     #[inline]
-    const fn set_flag(&mut self, mask: u16, val: bool) {
+    const fn set_flag(&mut self, mask: u32, val: bool) {
         if val {
             self.raw |= mask
         } else {

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, str::FromStr as _};
 
 use icu_collator::{options::CollatorOptions, Collator, CollatorBorrowed};
-use icu_locid::Locale;
+use icu_locale::Locale;
 use turso_parser::ast::Expr;
 
 use crate::{

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,8 +1,11 @@
 use std::{cmp::Ordering, str::FromStr as _};
 
+use icu_collator::{options::CollatorOptions, Collator, CollatorBorrowed};
+use icu_locid::Locale;
 use turso_parser::ast::Expr;
 
 use crate::{
+    sync::{LazyLock, RwLock},
     translate::{
         expr::{walk_expr, WalkControl},
         plan::TableReferences,
@@ -10,30 +13,32 @@ use crate::{
     Result,
 };
 
-// TODO: in the future allow user to define collation sequences
-// Will have to meddle with ffi for this
-#[derive(
-    Debug, Clone, Copy, Eq, PartialEq, strum_macros::Display, strum_macros::EnumString, Default,
-)]
-#[strum(ascii_case_insensitive)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 /// **Pre defined collation sequences**\
 /// Collating functions only matter when comparing string values.
 /// Numeric values are always compared numerically, and BLOBs are always compared byte-by-byte using memcmp().
-#[repr(u8)]
 pub enum CollationSeq {
-    Unset = 0,
+    Unset,
     #[default]
-    Binary = 1,
-    NoCase = 2,
-    Rtrim = 3,
+    Binary,
+    NoCase,
+    Rtrim,
+    Locale(LocaleCollationId),
 }
 
 impl CollationSeq {
     pub fn new(collation: &str) -> crate::Result<Self> {
-        CollationSeq::from_str(collation).map_err(|_| {
-            crate::LimboError::ParseError(format!("no such collation sequence: {collation}"))
-        })
+        match collation.to_ascii_lowercase().as_str() {
+            "binary" => return Ok(CollationSeq::Binary),
+            "nocase" => return Ok(CollationSeq::NoCase),
+            "rtrim" => return Ok(CollationSeq::Rtrim),
+            _ => {}
+        }
+        LocaleCollationRegistry::global()
+            .get_or_register(collation)
+            .map(CollationSeq::Locale)
     }
+
     #[inline]
     /// Returns the collation, defaulting to BINARY if unset
     pub const fn from_bits(bits: u8) -> Self {
@@ -50,6 +55,7 @@ impl CollationSeq {
             CollationSeq::Unset | CollationSeq::Binary => Self::binary_cmp(lhs, rhs),
             CollationSeq::NoCase => Self::nocase_cmp(lhs, rhs),
             CollationSeq::Rtrim => Self::rtrim_cmp(lhs, rhs),
+            CollationSeq::Locale(id) => LocaleCollationRegistry::global().compare(*id, lhs, rhs),
         }
     }
 
@@ -68,6 +74,159 @@ impl CollationSeq {
     #[inline(always)]
     fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
         lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
+    }
+
+    #[inline]
+    pub const fn to_bits(self) -> u16 {
+        match self {
+            CollationSeq::Unset => 0,
+            CollationSeq::Binary => 1,
+            CollationSeq::NoCase => 2,
+            CollationSeq::Rtrim => 3,
+            CollationSeq::Locale(id) => id.to_bits(),
+        }
+    }
+
+    #[inline]
+    pub const fn from_storage_bits(bits: u16) -> Self {
+        match bits {
+            0 => CollationSeq::Unset,
+            1 => CollationSeq::Binary,
+            2 => CollationSeq::NoCase,
+            3 => CollationSeq::Rtrim,
+            bits => CollationSeq::Locale(LocaleCollationId::from_bits(bits)),
+        }
+    }
+
+    pub fn hash_key(&self, text: &str) -> Vec<u8> {
+        match self {
+            CollationSeq::Unset | CollationSeq::Binary => text.as_bytes().to_vec(),
+            CollationSeq::NoCase => text.bytes().map(|b| b.to_ascii_lowercase()).collect(),
+            CollationSeq::Rtrim => text.trim_end_matches(' ').as_bytes().to_vec(),
+            CollationSeq::Locale(id) => LocaleCollationRegistry::global().sort_key(*id, text),
+        }
+    }
+}
+
+impl std::fmt::Display for CollationSeq {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CollationSeq::Unset => write!(f, "Unset"),
+            CollationSeq::Binary => write!(f, "Binary"),
+            CollationSeq::NoCase => write!(f, "NoCase"),
+            CollationSeq::Rtrim => write!(f, "Rtrim"),
+            CollationSeq::Locale(id) => {
+                write!(f, "{}", LocaleCollationRegistry::global().name(*id))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct LocaleCollationId(u16);
+
+impl LocaleCollationId {
+    const FIRST_STORAGE_BIT: u16 = 4;
+
+    fn from_index(index: usize) -> Result<Self> {
+        if index > (u16::MAX - Self::FIRST_STORAGE_BIT) as usize {
+            return Err(crate::LimboError::ParseError(
+                "too many locale collation sequences".to_string(),
+            ));
+        }
+        Ok(Self(index as u16))
+    }
+
+    const fn from_bits(bits: u16) -> Self {
+        Self(bits - Self::FIRST_STORAGE_BIT)
+    }
+
+    const fn to_bits(self) -> u16 {
+        self.0 + Self::FIRST_STORAGE_BIT
+    }
+}
+
+struct LocaleCollation {
+    name: String,
+    collator: CollatorBorrowed<'static>,
+}
+
+struct LocaleCollationRegistry {
+    collations: RwLock<Vec<LocaleCollation>>,
+}
+
+impl LocaleCollationRegistry {
+    fn global() -> &'static Self {
+        static REGISTRY: LazyLock<LocaleCollationRegistry> =
+            LazyLock::new(|| LocaleCollationRegistry {
+                collations: RwLock::new(Vec::new()),
+            });
+        &REGISTRY
+    }
+
+    fn get_or_register(&self, name: &str) -> Result<LocaleCollationId> {
+        if let Some(id) = self.find(name) {
+            return Ok(id);
+        }
+
+        let locale = Locale::from_str(name).map_err(|_| {
+            crate::LimboError::ParseError(format!("no such collation sequence: {name}"))
+        })?;
+        let collator =
+            Collator::try_new(locale.into(), CollatorOptions::default()).map_err(|_| {
+                crate::LimboError::ParseError(format!("no such collation sequence: {name}"))
+            })?;
+
+        let mut collations = self.collations.write();
+        if let Some((idx, _)) = collations
+            .iter()
+            .enumerate()
+            .find(|(_, collation)| collation.name.eq_ignore_ascii_case(name))
+        {
+            return LocaleCollationId::from_index(idx);
+        }
+        let id = LocaleCollationId::from_index(collations.len())?;
+        collations.push(LocaleCollation {
+            name: name.to_string(),
+            collator,
+        });
+        Ok(id)
+    }
+
+    fn find(&self, name: &str) -> Option<LocaleCollationId> {
+        self.collations
+            .read()
+            .iter()
+            .enumerate()
+            .find(|(_, collation)| collation.name.eq_ignore_ascii_case(name))
+            .and_then(|(idx, _)| LocaleCollationId::from_index(idx).ok())
+    }
+
+    fn compare(&self, id: LocaleCollationId, lhs: &str, rhs: &str) -> Ordering {
+        self.with_collation(id, |collation| collation.collator.compare(lhs, rhs))
+    }
+
+    fn sort_key(&self, id: LocaleCollationId, text: &str) -> Vec<u8> {
+        self.with_collation(id, |collation| {
+            let mut key = Vec::new();
+            collation
+                .collator
+                .write_sort_key_to(text, &mut key)
+                .expect("Vec collation key sink should be infallible");
+            key
+        })
+    }
+
+    fn name(&self, id: LocaleCollationId) -> String {
+        self.with_collation(id, |collation| collation.name.clone())
+    }
+
+    fn with_collation<T>(&self, id: LocaleCollationId, f: impl FnOnce(&LocaleCollation) -> T) -> T {
+        let collations = self.collations.read();
+        let collation = collations
+            .get(id.0 as usize)
+            .expect("locale collation id should be registered");
+        f(collation)
     }
 }
 
@@ -238,6 +397,42 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_locale_collation_names() {
+        assert!(matches!(
+            CollationSeq::new("fr-FR").unwrap(),
+            CollationSeq::Locale(_)
+        ));
+        assert!(matches!(
+            CollationSeq::new("es-u-co-trad").unwrap(),
+            CollationSeq::Locale(_)
+        ));
+        assert!(matches!(
+            CollationSeq::new("en-u-kf-upper").unwrap(),
+            CollationSeq::Locale(_)
+        ));
+        assert!(matches!(
+            CollationSeq::new("en-US-u-kf-upper").unwrap(),
+            CollationSeq::Locale(_)
+        ));
+        assert!(CollationSeq::new("compile_options").is_err());
+    }
+
+    #[test]
+    fn test_locale_collation_compare() {
+        let traditional_spanish = CollationSeq::new("es-u-co-trad").unwrap();
+        assert_eq!(
+            traditional_spanish.compare_strings("pollo", "polvo"),
+            Ordering::Greater
+        );
+
+        let upper_first = CollationSeq::new("en-u-kf-upper").unwrap();
+        assert_eq!(upper_first.compare_strings("A", "a"), Ordering::Less);
+
+        let upper_first_us = CollationSeq::new("en-US-u-kf-upper").unwrap();
+        assert_eq!(upper_first_us.compare_strings("A", "a"), Ordering::Less);
+    }
 
     #[test]
     fn test_get_collseq_from_expr_single_table_single_column() {

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -92,6 +92,9 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
                     CollationSeq::Binary | CollationSeq::Unset => {
                         hasher.write(text.as_bytes());
                     }
+                    CollationSeq::Locale(_) => {
+                        hasher.write(&collation.hash_key(text.as_str()));
+                    }
                 }
             }
             ValueRef::Blob(blob) => {
@@ -1149,7 +1152,10 @@ impl HashTable {
         metrics: Option<&mut HashJoinMetrics>,
     ) -> Result<HashInsertResult> {
         turso_assert!(
-            matches!(self.state,  HashTableState::Building | HashTableState::Spilled),
+            matches!(
+                self.state,
+                HashTableState::Building | HashTableState::Spilled
+            ),
             "Cannot insert into hash table in unexpected state",
             { "state": format!("{:?}", self.state) }
         );

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -1327,39 +1327,3 @@ test agg_collate_no_leak_with_count {
 expect {
     a|a|2
 }
-
-# ICU locale collations.
-
-test collate_locale_french_tag {
-    SELECT 'e' < char(233) COLLATE 'fr-FR';
-}
-expect {
-    1
-}
-
-test collate_locale_traditional_spanish_tailoring {
-    SELECT 'pollo' > 'polvo' COLLATE 'es-u-co-trad';
-}
-expect {
-    1
-}
-
-test collate_locale_upper_first {
-    SELECT 'A' < 'a' COLLATE 'en-u-kf-upper';
-}
-expect {
-    1
-}
-
-test collate_locale_index_lookup {
-    CREATE TABLE locale_words(id INTEGER PRIMARY KEY, word TEXT);
-    CREATE INDEX locale_words_es_trad ON locale_words(word COLLATE 'es-u-co-trad');
-    INSERT INTO locale_words VALUES (1, 'pollo'), (2, 'polvo'), (3, 'zorro');
-    SELECT id FROM locale_words
-    WHERE word > 'polvo' COLLATE 'es-u-co-trad'
-    ORDER BY id;
-}
-expect {
-    1
-    3
-}

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -1327,3 +1327,39 @@ test agg_collate_no_leak_with_count {
 expect {
     a|a|2
 }
+
+# ICU locale collations.
+
+test collate_locale_french_tag {
+    SELECT 'e' < char(233) COLLATE 'fr-FR';
+}
+expect {
+    1
+}
+
+test collate_locale_traditional_spanish_tailoring {
+    SELECT 'pollo' > 'polvo' COLLATE 'es-u-co-trad';
+}
+expect {
+    1
+}
+
+test collate_locale_upper_first {
+    SELECT 'A' < 'a' COLLATE 'en-u-kf-upper';
+}
+expect {
+    1
+}
+
+test collate_locale_index_lookup {
+    CREATE TABLE locale_words(id INTEGER PRIMARY KEY, word TEXT);
+    CREATE INDEX locale_words_es_trad ON locale_words(word COLLATE 'es-u-co-trad');
+    INSERT INTO locale_words VALUES (1, 'pollo'), (2, 'polvo'), (3, 'zorro');
+    SELECT id FROM locale_words
+    WHERE word > 'polvo' COLLATE 'es-u-co-trad'
+    ORDER BY id;
+}
+expect {
+    1
+    3
+}

--- a/testing/sqltests/turso-tests/collate.sqltest
+++ b/testing/sqltests/turso-tests/collate.sqltest
@@ -1,0 +1,76 @@
+@database :memory:
+
+# ICU locale collations.
+
+test collate_locale_french_tag {
+    SELECT 'e' < char(233) COLLATE 'fr-FR';
+}
+expect {
+    1
+}
+
+test collate_locale_traditional_spanish_tailoring {
+    SELECT 'pollo' > 'polvo' COLLATE 'es-u-co-trad';
+}
+expect {
+    1
+}
+
+test collate_locale_upper_first {
+    SELECT 'A' < 'a' COLLATE 'en-u-kf-upper';
+}
+expect {
+    1
+}
+
+test collate_locale_index_lookup {
+    CREATE TABLE locale_words(id INTEGER PRIMARY KEY, word TEXT);
+    CREATE INDEX locale_words_es_trad ON locale_words(word COLLATE 'es-u-co-trad');
+    INSERT INTO locale_words VALUES (1, 'pollo'), (2, 'polvo'), (3, 'zorro');
+    SELECT id FROM locale_words
+    WHERE word > 'polvo' COLLATE 'es-u-co-trad'
+    ORDER BY id;
+}
+expect {
+    1
+    3
+}
+
+test collate_locale_en_numeric_upper_level2_numbers {
+    WITH values_to_sort(value) AS (
+        VALUES ('10'), ('2'), ('1'), ('20'), ('3')
+    )
+    SELECT value FROM values_to_sort
+    ORDER BY value COLLATE 'en-u-kn-true-kf-upper-ks-level2';
+}
+expect {
+    1
+    2
+    3
+    10
+    20
+}
+
+test collate_locale_en_numeric_upper_level2_case_order {
+    WITH values_to_sort(value) AS (
+        VALUES ('z'), ('a'), ('Z'), ('A')
+    )
+    SELECT value FROM values_to_sort
+    ORDER BY value COLLATE 'en-u-kn-true-kf-upper-ks-level2';
+}
+expect {
+    A
+    a
+    Z
+    z
+}
+
+test collate_locale_en_numeric_upper_level2_o_variants_distinct {
+    SELECT
+        'O' = 'o' COLLATE 'en-u-kn-true-kf-upper-ks-level2',
+        'o' = char(242) COLLATE 'en-u-kn-true-kf-upper-ks-level2',
+        'O' = char(242) COLLATE 'en-u-kn-true-kf-upper-ks-level2';
+}
+expect {
+    0|0|0
+}


### PR DESCRIPTION
## Description

Many other databases expose & support ICU collation (such as being able to collate in a custom locale, or with custom configs on such as upper case first/etc), this is a heavily AI driven attempt at adding the same for Turso.

## Motivation and context

In text editor apps where we support sort by text, we typically want to use collated sorting in the user's locale as well as some expected human behaviors that we can configure via the ICU collator such as upperFirst & accent behavior.

## Description of AI Usage

This was authored by Codex purely. I'm not familiar with the Turso codebase.
