### PR TITLE
Fix generated columns after REPLACE default substitution

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -753,6 +753,11 @@ pub fn translate_insert(
         }
     }
 
+    // NOT NULL default substitution for REPLACE has to run before generated
+    // columns and CHECK constraints. A generated column may depend on a base
+    // column whose explicit NULL is replaced by its DEFAULT.
+    emit_notnull_replace_defaults(program, &ctx, &insertion, resolver)?;
+
     // Make computed virtual columns accessible to CHECK and NOT NULL constraint evaluation
     if insertion.has_virtual_columns() {
         //TODO only compute the necessary virtual columns for CHECK and NOT NULL evaluation
@@ -835,9 +840,9 @@ pub fn translate_insert(
         connection,
         table_references: &mut table_references,
     };
-    // NOT NULL default substitution must happen before index key registers are
-    // copied in preflight constraint checks. Otherwise the index entry gets NULL
-    // while the table row gets the default value, causing integrity_check failures.
+    // NOT NULL handling must happen before index key registers are copied in
+    // preflight constraint checks. Defaults for REPLACE were substituted above
+    // so generated columns and CHECK constraints saw the defaulted row image.
     emit_notnulls(program, &ctx, &insertion, resolver)?;
 
     // Populate register-to-affinity map so partial index WHERE clauses get
@@ -1723,14 +1728,7 @@ fn emit_notnulls(
 
         // Compute effective conflict for this NOT NULL constraint:
         // Statement-level OR clause overrides; otherwise use column's clause.
-        let effective = if ctx.statement_on_conflict.is_some() {
-            ctx.on_conflict
-        } else {
-            column_mapping
-                .column
-                .notnull_conflict_clause
-                .unwrap_or(ResolveType::Abort)
-        };
+        let effective = notnull_effective_conflict(ctx, column_mapping);
         let on_replace = matches!(effective, ResolveType::Replace);
         let on_ignore = matches!(effective, ResolveType::Ignore);
 
@@ -1822,6 +1820,61 @@ fn emit_notnulls(
         }
     }
     Ok(())
+}
+
+fn emit_notnull_replace_defaults(
+    program: &mut ProgramBuilder,
+    ctx: &InsertEmitCtx,
+    insertion: &Insertion,
+    resolver: &Resolver,
+) -> Result<()> {
+    for column_mapping in insertion
+        .col_mappings
+        .iter()
+        .filter(|column_mapping| column_mapping.column.notnull())
+    {
+        if column_mapping.column.is_rowid_alias() {
+            continue;
+        }
+
+        if !matches!(
+            notnull_effective_conflict(ctx, column_mapping),
+            ResolveType::Replace
+        ) {
+            continue;
+        }
+        let Some(default_expr) = column_mapping.column.default.as_ref() else {
+            continue;
+        };
+
+        let skip_label = program.allocate_label();
+        program.emit_insn(Insn::NotNull {
+            reg: column_mapping.register,
+            target_pc: skip_label,
+        });
+        translate_expr_no_constant_opt(
+            program,
+            None,
+            default_expr,
+            column_mapping.register,
+            resolver,
+            NoConstantOptReason::RegisterReuse,
+        )?;
+        program.preassign_label_to_next_insn(skip_label);
+    }
+
+    Ok(())
+}
+
+fn notnull_effective_conflict(ctx: &InsertEmitCtx, column_mapping: &ColMapping<'_>) -> ResolveType {
+    if ctx.statement_on_conflict.is_some() {
+        ctx.on_conflict
+    } else {
+        column_mapping
+            .column
+            .notnull_conflict_clause
+            .unwrap_or(ResolveType::Abort)
+    }
 }
 
 struct BoundInsertResult {

--- a/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default-partial.snap
+++ b/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default-partial.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4               p5  comment
-   0  Init            0  27   0                    0  Start at 27
+   0  Init            0  31   0                    0  Start at 31
    1  OpenWrite       0   2   0                    0  root=2; iDb=0
    2  Integer         1   2   0                    0  r[2]=1
    3  SoftNull        3   0   0                    0
@@ -25,20 +25,24 @@ addr  opcode         p1  p2  p3  p4               p5  comment
   10  NewRowid        0   2   0                    0  r[2]=rowid
   11  NotNull         4  13   0                    0  r[4]!=NULL -> goto 13
   12  Integer        42   4   0                    0  r[4]=42
-  13  HaltIfNull   1299   0   4  t_defaults.val    0
-  14  NotNull         5  16   0                    0  r[5]!=NULL -> goto 16
-  15  String8         0   5   0  unnamed           0  r[5]='unnamed'
-  16  HaltIfNull   1299   0   5  t_defaults.name   0
-  17  NotExists       0  22   2                    0
-  18  Copy            2   1   0                    0  r[1]=r[2]
-  19  SeekRowid       0   1  26                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 26
-  20  Delete          0   0   0  t_defaults        0
-  21  Goto            0  22   0                    0
-  22  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
-  23  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
-  24  Goto            0  25   0                    0
+  13  NotNull         5  15   0                    0  r[5]!=NULL -> goto 15
+  14  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  15  NotNull         4  17   0                    0  r[4]!=NULL -> goto 17
+  16  Integer        42   4   0                    0  r[4]=42
+  17  HaltIfNull   1299   0   4  t_defaults.val    0
+  18  NotNull         5  20   0                    0  r[5]!=NULL -> goto 20
+  19  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  20  HaltIfNull   1299   0   5  t_defaults.name   0
+  21  NotExists       0  26   2                    0
+  22  Copy            2   1   0                    0  r[1]=r[2]
+  23  SeekRowid       0   1  30                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 30
+  24  Delete          0   0   0  t_defaults        0
   25  Goto            0  26   0                    0
-  26  Halt            0   0   0                    0
-  27  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
-  28  String8         0   5   0  unnamed           0  r[5]='unnamed'
-  29  Goto            0   1   0                    0
+  26  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
+  27  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
+  28  Goto            0  29   0                    0
+  29  Goto            0  30   0                    0
+  30  Halt            0   0   0                    0
+  31  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
+  32  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  33  Goto            0   1   0                    0

--- a/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default.snap
+++ b/testing/sqltests/tests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default.snap
@@ -12,7 +12,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4               p5  comment
-   0  Init            0  28   0                    0  Start at 28
+   0  Init            0  32   0                    0  Start at 32
    1  OpenWrite       0   2   0                    0  root=2; iDb=0
    2  Integer         1   2   0                    0  r[2]=1
    3  SoftNull        3   0   0                    0
@@ -26,19 +26,23 @@ addr  opcode         p1  p2  p3  p4               p5  comment
   11  NewRowid        0   2   0                    0  r[2]=rowid
   12  NotNull         4  14   0                    0  r[4]!=NULL -> goto 14
   13  Integer        42   4   0                    0  r[4]=42
-  14  HaltIfNull   1299   0   4  t_defaults.val    0
-  15  NotNull         5  17   0                    0  r[5]!=NULL -> goto 17
-  16  String8         0   5   0  unnamed           0  r[5]='unnamed'
-  17  HaltIfNull   1299   0   5  t_defaults.name   0
-  18  NotExists       0  23   2                    0
-  19  Copy            2   1   0                    0  r[1]=r[2]
-  20  SeekRowid       0   1  27                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 27
-  21  Delete          0   0   0  t_defaults        0
-  22  Goto            0  23   0                    0
-  23  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
-  24  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
-  25  Goto            0  26   0                    0
+  14  NotNull         5  16   0                    0  r[5]!=NULL -> goto 16
+  15  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  16  NotNull         4  18   0                    0  r[4]!=NULL -> goto 18
+  17  Integer        42   4   0                    0  r[4]=42
+  18  HaltIfNull   1299   0   4  t_defaults.val    0
+  19  NotNull         5  21   0                    0  r[5]!=NULL -> goto 21
+  20  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  21  HaltIfNull   1299   0   5  t_defaults.name   0
+  22  NotExists       0  27   2                    0
+  23  Copy            2   1   0                    0  r[1]=r[2]
+  24  SeekRowid       0   1  31                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 31
+  25  Delete          0   0   0  t_defaults        0
   26  Goto            0  27   0                    0
-  27  Halt            0   0   0                    0
-  28  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
-  29  Goto            0   1   0                    0
+  27  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
+  28  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
+  29  Goto            0  30   0                    0
+  30  Goto            0  31   0                    0
+  31  Halt            0   0   0                    0
+  32  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
+  33  Goto            0   1   0                    0

--- a/tests/integration/conflict_resolution.rs
+++ b/tests/integration/conflict_resolution.rs
@@ -2298,6 +2298,76 @@ fn test_ddl_mixed_replace_abort_insert(tmp_db: TempDatabase) -> anyhow::Result<(
     Ok(())
 }
 
+#[turso_macros::test]
+fn test_replace_recomputes_generated_columns_after_defaults(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    let limbo_db = TempDatabase::builder()
+        .with_db_name("generated_column_replace_defaults.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_generated_columns(true))
+        .build();
+    let limbo_conn = limbo_db.connect_limbo();
+    let sqlite_conn = rusqlite::Connection::open_in_memory()?;
+
+    let setup = [
+        "CREATE TABLE t(a NOT NULL DEFAULT 5, b AS(a+1) UNIQUE)",
+        "INSERT INTO t(a) VALUES(5)",
+    ];
+    for sql in setup {
+        limbo_conn.execute(sql)?;
+        sqlite_conn.execute(sql, params![])?;
+    }
+
+    let replace = "REPLACE INTO t(a) VALUES(NULL) RETURNING a,b";
+    let limbo_returning = limbo_exec_rows(&limbo_conn, replace);
+    let sqlite_returning = sqlite_exec_rows(&sqlite_conn, replace);
+    assert_eq!(
+        limbo_returning, sqlite_returning,
+        "RETURNING should expose generated columns after NOT NULL defaults are applied"
+    );
+
+    let verify = "SELECT rowid,a,b FROM t ORDER BY rowid";
+    let limbo_rows = limbo_exec_rows(&limbo_conn, verify);
+    let sqlite_rows = sqlite_exec_rows(&sqlite_conn, verify);
+    assert_eq!(
+        limbo_rows, sqlite_rows,
+        "stored row should match SQLite after REPLACE applies defaults"
+    );
+
+    let indexed_verify = "SELECT rowid FROM t WHERE b = 6 ORDER BY rowid";
+    let limbo_indexed = limbo_exec_rows(&limbo_conn, indexed_verify);
+    let sqlite_indexed = sqlite_exec_rows(&sqlite_conn, indexed_verify);
+    assert_eq!(
+        limbo_indexed, sqlite_indexed,
+        "generated-column UNIQUE index should use the defaulted value"
+    );
+
+    let check_setup = "CREATE TABLE u(a NOT NULL DEFAULT 5, b AS(a+1) CHECK(b=7))";
+    limbo_conn.execute(check_setup)?;
+    sqlite_conn.execute(check_setup, params![])?;
+
+    let check_replace = "REPLACE INTO u(a) VALUES(NULL)";
+    let limbo_check = limbo_try_exec(&limbo_conn, check_replace);
+    let sqlite_check = sqlite_try_exec(&sqlite_conn, check_replace);
+    assert_eq!(
+        limbo_check.is_err(),
+        sqlite_check.is_err(),
+        "CHECK should evaluate generated columns after NOT NULL defaults are applied"
+    );
+
+    let verify_check = "SELECT a,b FROM u";
+    let limbo_check_rows = limbo_exec_rows(&limbo_conn, verify_check);
+    let sqlite_check_rows = sqlite_exec_rows(&sqlite_conn, verify_check);
+    assert_eq!(
+        limbo_check_rows, sqlite_check_rows,
+        "failed CHECK should leave the generated-column table unchanged"
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // FK violations during UPDATE — stmt_journal rollback correctness
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- substitute NOT NULL defaults for effective REPLACE before computing virtual generated columns
- keep the later NOT NULL validation and index preflight ordering intact
- add regression coverage comparing REPLACE RETURNING, generated-column UNIQUE index lookup, and CHECK behavior with SQLite

Fixes #7068.

## Tests
- cargo fmt --all --check
- git diff --check
- cargo check -p turso_core --features pure-rust-crypto
- cargo test -p core_tester --test integration_tests test_replace_recomputes_generated_columns_after_defaults --features pure-rust-crypto -- --nocapture
- cargo test -p core_tester --test integration_tests conflict_resolution:: --features pure-rust-crypto -- --nocapture