### PR TITLE
core/vdbe: Preserve blob bytes when casting to BLOB

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -877,6 +877,9 @@ impl Value {
             // NONE	Casting a value to a type-name with no affinity causes the value to be converted into a BLOB. Casting to a BLOB consists of first casting the value to TEXT in the encoding of the database connection, then interpreting the resulting byte sequence as a BLOB instead of as TEXT.
             // Historically called NONE, but it's the same as BLOB
             Affinity::Blob => {
+                if let Value::Blob(blob) = self {
+                    return Value::Blob(blob.clone());
+                }
                 // Convert to TEXT first, then interpret as BLOB
                 // TODO: handle encoding
                 let text = self.to_string();
@@ -2440,6 +2443,14 @@ mod tests {
         let input_blob = Value::Blob(vec![0xff]);
         let expected_val = Value::build_text("FF");
         assert_eq!(input_blob.exec_hex(), expected_val);
+    }
+
+    #[test]
+    fn test_cast_blob_preserves_blob_bytes() {
+        let input_blob = Value::Blob(vec![0xd2, 0x64, 0xc0, 0x07, 0xf6, 0x44, 0xe4, 0x59]);
+        let expected = input_blob.clone();
+
+        assert_eq!(input_blob.exec_cast("BLOB"), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix `CAST(blob_value AS BLOB)` so existing BLOB values keep their original bytes instead of being formatted through lossy UTF-8 text first.

The differential oracle found this as a data mutation: an `UPDATE ... SET zv = CAST(zv AS BLOB)` changed stored bytes containing invalid UTF-8 into replacement-character bytes (`EF BF BD`). SQLite preserves the original BLOB bytes.

## Repro

Differential oracle seed that failed before this patch and passes after it:

```sh
cargo run -p differential-fuzzer --bin differential_fuzzer -- -g sql-gen-prop -t 3 -c 6 -n 500 -s 2285030770736237002
```

Original failing statements from the generated SQL:

```sql
INSERT INTO sincere_purchase (zv) VALUES (X'D264C007F644E4592721B14C1768700B9286F5081A18D1CE71071866EFE22F8FB552CBEA7E2282ECEDF2EDF8DA4CCA3ECCEABEAA28A7201D09936FEDD6CCE542300AA3F7E837C160C5AFCD0065');
UPDATE sincere_purchase SET zv = CAST(zv AS BLOB) WHERE 1 = 1 AND 1 = 1;
```

Before the fix, Turso rewrote invalid UTF-8 bytes using replacement bytes while SQLite kept the BLOB unchanged.

## Tests

```sh
cargo test -p turso_core test_cast_blob_preserves_blob_bytes
cargo run -p differential-fuzzer --bin differential_fuzzer -- -g sql-gen-prop -t 3 -c 6 -n 500 -s 2285030770736237002
```
