### PR TITLE
Reject CURRENT_* literals in persisted schema expressions

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3500,6 +3500,12 @@ pub(crate) fn validate_generated_expr(expr: &Expr) -> Result<()> {
             bail_parse_error!("bind parameters prohibited in generated columns");
         }
 
+        Expr::Literal(
+            ast::Literal::CurrentDate | ast::Literal::CurrentTime | ast::Literal::CurrentTimestamp,
+        ) => {
+            bail_parse_error!("non-deterministic functions prohibited in generated columns");
+        }
+
         Expr::Subquery(_) | Expr::InSelect { .. } | Expr::Exists(_) | Expr::InTable { .. } => {
             bail_parse_error!("subqueries prohibited in generated columns");
         }
@@ -5091,6 +5097,13 @@ impl Index {
                 return Ok(WalkControl::SkipChildren);
             }
             match e {
+                Expr::Literal(
+                    ast::Literal::CurrentDate
+                    | ast::Literal::CurrentTime
+                    | ast::Literal::CurrentTimestamp,
+                ) => {
+                    ok = false;
+                }
                 Expr::Literal(_) | Expr::RowId { .. } => {}
                 // Unqualified identifier: must be a column of the target table or ROWID
                 Expr::Id(n) => {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -217,7 +217,7 @@ pub fn translate_create_index(
 
     if !idx.validate_where_expr(&table, resolver) {
         crate::bail_parse_error!(
-            "Error: cannot use aggregate, window functions or reference other tables in WHERE clause of CREATE INDEX:\n {}",
+            "Error: cannot use non-deterministic expressions, aggregate/window functions, subqueries, or references to other tables in WHERE clause of CREATE INDEX:\n {}",
             where_clause
                 .as_ref()
                 .expect("where expr has to exist in order to fail")

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -13,6 +13,7 @@ mod pragma;
 mod query_processing;
 mod query_timeout;
 mod queued_io;
+mod schema;
 mod statement_reset;
 mod stmt_journal;
 mod stmt_readonly;

--- a/tests/integration/schema.rs
+++ b/tests/integration/schema.rs
@@ -1,0 +1,41 @@
+use crate::common::TempDatabase;
+use std::sync::Arc;
+
+fn assert_schema_error_contains(conn: &Arc<turso_core::Connection>, sql: &str, expected: &str) {
+    let err = conn
+        .execute(sql)
+        .expect_err("schema statement should have failed");
+    let err = err.to_string();
+    assert!(
+        err.contains(expected),
+        "expected error containing {expected:?}, got {err:?}"
+    );
+}
+
+#[test]
+fn test_generated_columns_reject_current_time_literals() {
+    let opts = turso_core::DatabaseOpts::new().with_generated_columns(true);
+    let db = TempDatabase::builder().with_opts(opts).build();
+    let conn = db.connect_limbo();
+
+    for literal in ["CURRENT_TIME", "CURRENT_DATE", "CURRENT_TIMESTAMP"] {
+        let sql = format!("CREATE TABLE t_{literal}(a, b AS ({literal}))");
+        assert_schema_error_contains(&conn, &sql, "non-deterministic");
+
+        let sql =
+            format!("CREATE TABLE t_nested_{literal}(a, b AS (coalesce({literal}, 'fallback')))");
+        assert_schema_error_contains(&conn, &sql, "non-deterministic");
+    }
+}
+
+#[test]
+fn test_partial_indexes_reject_current_time_literals() {
+    let db = TempDatabase::new_empty();
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t(a)").unwrap();
+
+    for literal in ["CURRENT_TIME", "CURRENT_DATE", "CURRENT_TIMESTAMP"] {
+        let sql = format!("CREATE INDEX i_{literal} ON t(a) WHERE {literal} IS NOT NULL");
+        assert_schema_error_contains(&conn, &sql, "non-deterministic");
+    }
+}


### PR DESCRIPTION
## Summary
- reject `CURRENT_TIME`, `CURRENT_DATE`, and `CURRENT_TIMESTAMP` literals in generated-column expressions
- reject the same non-deterministic literals in partial-index `WHERE` predicates before the schema is persisted
- add integration coverage for generated columns, nested generated expressions, and partial-index predicates

Fixes #7062.
Fixes #6941.

## Tests
- `cargo test -p core_tester --test integration_tests schema:: --features pure-rust-crypto -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p turso_core --features pure-rust-crypto`