### PR TITLE
Reject invalid generated column syntax

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -3669,14 +3669,15 @@ impl<'a> Parser<'a> {
         let typ = match self.peek()? {
             Some(tok) => match tok.token_type.fallback_id_if_ok() {
                 TK_ID => {
-                    let tok = eat_assert!(self, TK_ID);
                     let s = from_bytes(tok.as_bytes());
                     if s.eq_ignore_ascii_case("STORED") {
+                        eat_assert!(self, TK_ID);
                         Some(GeneratedColumnType::Stored)
                     } else if s.eq_ignore_ascii_case("VIRTUAL") {
+                        eat_assert!(self, TK_ID);
                         Some(GeneratedColumnType::Virtual)
                     } else {
-                        None
+                        return Err(Error::Custom(format!("unknown generated column type: {s}")));
                     }
                 }
                 _ => None,
@@ -3693,6 +3694,8 @@ impl<'a> Parser<'a> {
     ) -> Result<Vec<NamedColumnConstraint>> {
         let mut result = vec![];
         let mut has_primary_key = false;
+        let mut has_default = false;
+        let mut has_generated = false;
 
         loop {
             let name = match self.peek()? {
@@ -3749,6 +3752,12 @@ impl<'a> Parser<'a> {
             match self.peek()? {
                 Some(tok) => match tok.token_type {
                     TK_DEFAULT => {
+                        if has_generated {
+                            return Err(Error::Custom(
+                                "generated columns cannot have a DEFAULT value".to_owned(),
+                            ));
+                        }
+                        has_default = true;
                         result.push(NamedColumnConstraint {
                             name,
                             constraint: self.parse_default_column_constraint()?,
@@ -3813,6 +3822,17 @@ impl<'a> Parser<'a> {
                         });
                     }
                     TK_GENERATED | TK_AS => {
+                        if has_generated {
+                            return Err(Error::Custom(
+                                "multiple generated column clauses on a single column".to_owned(),
+                            ));
+                        }
+                        if has_default {
+                            return Err(Error::Custom(
+                                "generated columns cannot have a DEFAULT value".to_owned(),
+                            ));
+                        }
+                        has_generated = true;
                         result.push(NamedColumnConstraint {
                             name,
                             constraint: self.parse_generated_column_constraint()?,

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -13,6 +13,7 @@ mod pragma;
 mod query_processing;
 mod query_timeout;
 mod queued_io;
+mod schema;
 mod statement_reset;
 mod stmt_journal;
 mod stmt_readonly;

--- a/tests/integration/schema.rs
+++ b/tests/integration/schema.rs
@@ -1,0 +1,58 @@
+use crate::common::TempDatabase;
+use turso_core::DatabaseOpts;
+
+fn generated_columns_db() -> TempDatabase {
+    TempDatabase::builder()
+        .with_opts(DatabaseOpts::new().with_generated_columns(true))
+        .build()
+}
+
+fn assert_schema_rejected(sql: &str) {
+    let db = generated_columns_db();
+    let conn = db.connect_limbo();
+    let err = conn
+        .execute(sql)
+        .expect_err("schema statement should be rejected");
+    assert!(
+        err.to_string().contains("generated")
+            || err.to_string().contains("DEFAULT")
+            || err.to_string().contains("syntax"),
+        "unexpected error: {err}"
+    );
+}
+
+#[turso_macros::test]
+fn test_generated_columns_reject_default_clause(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    assert_schema_rejected("CREATE TABLE t(a, b DEFAULT 5 AS (a + 1))");
+
+    let db = generated_columns_db();
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t(a)")?;
+    conn.execute("ALTER TABLE t ADD COLUMN b DEFAULT 5 AS (a + 1)")
+        .expect_err("ALTER ADD generated column with DEFAULT should be rejected");
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_generated_columns_reject_unknown_type_tokens(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    assert_schema_rejected("CREATE TABLE t(a, b AS (a) WAT)");
+    assert_schema_rejected("CREATE TABLE t(a, b AS (a + 1) HIDDEN, c)");
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_generated_columns_reject_duplicate_generated_clauses(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    assert_schema_rejected("CREATE TABLE t(a, b, c AS (a + 1) AS (a + 2))");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- reject unknown generated-column type tokens after `AS (...)`
- reject duplicate generated-column clauses on the same column
- reject `DEFAULT` clauses on generated columns for both `CREATE TABLE` and `ALTER TABLE ADD COLUMN`
- add focused integration coverage for the invalid generated-column syntax cases

Fixes #7058.
Fixes #7059.
Fixes #7060.

## Tests
- `cargo test -p core_tester --test integration_tests schema:: --features pure-rust-crypto -- --nocapture`
- `cargo test -p turso_parser`
- `cargo fmt --all --check`
- `git diff --cached --check`
- `cargo check -p turso_core --features pure-rust-crypto`