### PR TITLE
Fix MVCC checkpoint for transient schema deletes

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -254,6 +254,19 @@ fn sqlite_schema_btree_identity(version: &RowVersion) -> Option<SqliteSchemaBtre
     Some(SqliteSchemaBtreeIdentity { kind, root_page })
 }
 
+fn sqlite_schema_row_has_zero_root_page(version: &RowVersion) -> bool {
+    if version.row.id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID || version.row.payload().is_empty() {
+        return false;
+    }
+
+    let row_data = ImmutableRecord::from_bin_record(version.row.payload().to_vec());
+    let Ok(root_page) = row_data.get_value(3) else {
+        return false;
+    };
+
+    matches!(root_page, ValueRef::Numeric(Numeric::Integer(0)))
+}
+
 fn sqlite_schema_versions_refer_to_btree(lhs: &RowVersion, rhs: &RowVersion) -> bool {
     sqlite_schema_btree_identity(lhs)
         .zip(sqlite_schema_btree_identity(rhs))
@@ -536,6 +549,14 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 // Set to true for schema deletes of never-checkpointed tables/indexes.
                 // These don't need to be written to the B-tree, we just need to track them.
                 let mut skip_write = false;
+
+                if key.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID
+                    && is_delete
+                    && !version.btree_resident
+                    && sqlite_schema_row_has_zero_root_page(&version)
+                {
+                    skip_write = true;
+                }
 
                 if let Some(schema_identity) = sqlite_schema_btree_identity(&version) {
                     let root_page = schema_identity.root_page;

--- a/testing/sqltests/turso-tests/mvcc_feature_compat.sqltest
+++ b/testing/sqltests/turso-tests/mvcc_feature_compat.sqltest
@@ -66,3 +66,17 @@ expect {
     mvcc
     42
 }
+
+test mvcc-checkpoint-skips-never-checkpointed-trigger-delete {
+    PRAGMA journal_mode = 'mvcc';
+    CREATE TABLE t_trigger(id INTEGER PRIMARY KEY, u TEXT UNIQUE, v TEXT);
+    CREATE TRIGGER tr_ai AFTER INSERT ON t_trigger BEGIN SELECT RAISE(ABORT, 'boom'); END;
+    DROP TRIGGER tr_ai;
+    PRAGMA wal_checkpoint(TRUNCATE);
+    PRAGMA integrity_check;
+}
+expect {
+    mvcc
+    0|0|0
+    ok
+}


### PR DESCRIPTION
# NOTICE:

I have allowed maintainer edits on this PR branch.

## Description

Fix MVCC checkpoint handling for sqlite_schema delete tombstones that refer to never-checkpointed schema objects with rootpage 0, such as triggers created and dropped before the first checkpoint.

The checkpoint state machine was attempting to apply those tombstones as physical B-tree deletes even though no pager-resident sqlite_schema row existed yet, producing `MVCC delete: rowid ... not found`.

This adds a regression covering create/drop trigger followed by `PRAGMA wal_checkpoint(TRUNCATE)` and `PRAGMA integrity_check`.

Fixes #6938.

## Motivation and context

A trigger or view has rootpage 0 in sqlite_schema. If it is created and dropped entirely within MVCC before the first checkpoint, its delete tombstone should only affect MVCC history tracking; there is no physical sqlite_schema row to delete from the pager-backed database.

Tests run:

- `cargo check -q -p turso_core --features pure-rust-crypto`
- `cargo run -q -p test-runner -- run testing/sqltests/turso-tests/mvcc_feature_compat.sqltest --backend cli --binary ./target/debug/tursodb --snapshot-mode no --filter mvcc-checkpoint-skips-never-checkpointed-trigger-delete`
- `cargo run -q -p test-runner -- run testing/sqltests/turso-tests/mvcc_feature_compat.sqltest --backend rust --snapshot-mode no --filter mvcc-checkpoint-skips-never-checkpointed-trigger-delete`

## Description of AI Usage

Implemented with Codex. I used it to inspect issue/PR overlap, reproduce the corruption case, make the targeted checkpoint-state-machine change, and run the validation commands above.