### PR TITLE
Reject RAISE in generated column schemas

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3500,6 +3500,10 @@ pub(crate) fn validate_generated_expr(expr: &Expr) -> Result<()> {
             bail_parse_error!("bind parameters prohibited in generated columns");
         }
 
+        Expr::Raise(_, _) => {
+            bail_parse_error!("RAISE() may only be used within a trigger-program");
+        }
+
         Expr::Subquery(_) | Expr::InSelect { .. } | Expr::Exists(_) | Expr::InTable { .. } => {
             bail_parse_error!("subqueries prohibited in generated columns");
         }

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -1,4 +1,5 @@
 use crate::common::{ExecRows, TempDatabase};
+use turso_core::DatabaseOpts;
 
 #[turso_macros::test(init_sql = "CREATE TABLE t (a, b);")]
 fn test_fail_drop_indexed_column(tmp_db: TempDatabase) -> anyhow::Result<()> {
@@ -213,6 +214,40 @@ fn test_create_table_without_rowid_rejects_autoincrement(
             .contains("AUTOINCREMENT is not allowed on WITHOUT ROWID tables"),
         "Expected error message about AUTOINCREMENT"
     );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_generated_column_rejects_raise_at_schema_creation(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    drop(tmp_db);
+
+    let db = TempDatabase::builder()
+        .with_opts(DatabaseOpts::new().with_generated_columns(true))
+        .build();
+    let conn = db.connect_limbo();
+
+    for sql in [
+        "CREATE TABLE t(a, b AS (RAISE(IGNORE)))",
+        "CREATE TABLE t(a, b AS (CASE WHEN a IS NULL THEN RAISE(ABORT, 'bad') ELSE a END))",
+    ] {
+        let err = conn
+            .execute(sql)
+            .expect_err("RAISE() is only valid in trigger programs");
+        assert!(
+            err.to_string().contains("RAISE()"),
+            "unexpected error: {err}"
+        );
+    }
+
+    let rows: Vec<(String,)> =
+        conn.exec_rows("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 't'");
+    assert!(
+        rows.is_empty(),
+        "invalid generated column schema should not be persisted"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Reject `RAISE()` while validating generated-column expressions during schema creation and alteration paths.
- Cover direct `RAISE()` usage and `RAISE()` nested inside a `CASE` expression.
- Assert invalid generated-column schemas are not persisted.

Fixes #7063

## Tests

- `cargo test -p core_tester --test integration_tests test_generated_column_rejects_raise_at_schema_creation --features pure-rust-crypto -- --nocapture`
- `cargo test -p core_tester --test integration_tests query_processing::test_ddl --features pure-rust-crypto -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p turso_core --features pure-rust-crypto`