### PR TITLE
Resolve row-value generated column collations

### DIFF
--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -4,6 +4,7 @@ use turso_parser::ast::Expr;
 
 use crate::{
     translate::{
+        emitter::Resolver,
         expr::{walk_expr, WalkControl},
         plan::TableReferences,
     },
@@ -98,7 +99,7 @@ pub fn get_collseq_from_expr(
     top_expr: &Expr,
     referenced_tables: &TableReferences,
 ) -> Result<Option<CollationSeq>> {
-    let (explicit, column) = get_collseq_parts_from_expr(top_expr, referenced_tables)?;
+    let (explicit, column) = get_collseq_parts_from_expr(top_expr, referenced_tables, None)?;
     Ok(explicit.or(column))
 }
 
@@ -162,13 +163,23 @@ pub fn resolve_comparison_collseq(
     rhs_expr: &Expr,
     referenced_tables: &TableReferences,
 ) -> Result<CollationSeq> {
-    let (lhs_explicit, lhs_column) = get_collseq_parts_from_expr(lhs_expr, referenced_tables)?;
-    let (rhs_explicit, rhs_column) = get_collseq_parts_from_expr(rhs_expr, referenced_tables)?;
-    Ok(lhs_explicit
-        .or(rhs_explicit)
-        .or(lhs_column)
-        .or(rhs_column)
-        .unwrap_or(CollationSeq::Binary))
+    Ok(
+        resolve_comparison_collseq_opt(lhs_expr, rhs_expr, referenced_tables, None)?
+            .unwrap_or(CollationSeq::Binary),
+    )
+}
+
+pub fn resolve_comparison_collseq_opt(
+    lhs_expr: &Expr,
+    rhs_expr: &Expr,
+    referenced_tables: &TableReferences,
+    resolver: Option<&Resolver>,
+) -> Result<Option<CollationSeq>> {
+    let (lhs_explicit, lhs_column) =
+        get_collseq_parts_from_expr(lhs_expr, referenced_tables, resolver)?;
+    let (rhs_explicit, rhs_column) =
+        get_collseq_parts_from_expr(rhs_expr, referenced_tables, resolver)?;
+    Ok(lhs_explicit.or(rhs_explicit).or(lhs_column).or(rhs_column))
 }
 
 /// Returns (explicit_collation, column_collation) from a single expression.
@@ -178,6 +189,7 @@ pub fn resolve_comparison_collseq(
 fn get_collseq_parts_from_expr(
     top_expr: &Expr,
     referenced_tables: &TableReferences,
+    resolver: Option<&Resolver>,
 ) -> Result<(Option<CollationSeq>, Option<CollationSeq>)> {
     let mut maybe_column_collseq = None;
     let mut maybe_explicit_collseq = None;
@@ -194,6 +206,17 @@ fn get_collseq_parts_from_expr(
                 return Ok(WalkControl::SkipChildren);
             }
             Expr::Column { table, column, .. } => {
+                if table.is_self_table() {
+                    if resolver.is_some_and(|r| r.has_self_table_context()) {
+                        if maybe_column_collseq.is_none() {
+                            maybe_column_collseq =
+                                resolver.and_then(|r| r.self_table_collation_opt(*column));
+                        }
+                        return Ok(WalkControl::Continue);
+                    } else {
+                        return Err(crate::LimboError::ParseError("table not found".to_string()));
+                    }
+                }
                 let (_, table_ref) = referenced_tables
                     .find_table_by_internal_id(*table)
                     .ok_or_else(|| crate::LimboError::ParseError("table not found".to_string()))?;
@@ -206,6 +229,13 @@ fn get_collseq_parts_from_expr(
                 return Ok(WalkControl::Continue);
             }
             Expr::RowId { table, .. } => {
+                if table.is_self_table() {
+                    if resolver.is_some_and(|r| r.has_self_table_context()) {
+                        return Ok(WalkControl::Continue);
+                    } else {
+                        return Err(crate::LimboError::ParseError("table not found".to_string()));
+                    }
+                }
                 let (_, table_ref) = referenced_tables
                     .find_table_by_internal_id(*table)
                     .ok_or_else(|| crate::LimboError::ParseError("table not found".to_string()))?;

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -185,36 +185,58 @@ pub struct Resolver<'a> {
 struct SelfTableScope {
     context: SelfTableContext,
     affinities: Option<Arc<[Affinity]>>,
+    collations: Option<Arc<[Option<CollationSeq>]>>,
 }
 
 impl SelfTableScope {
     fn new(context: SelfTableContext) -> Self {
-        let affinities = match &context {
-            SelfTableContext::ForDML { table, .. } => Some(
-                table
-                    .columns()
-                    .iter()
-                    .map(|c| c.affinity_with_strict(table.is_strict))
-                    .collect(),
+        let (affinities, collations) = match &context {
+            SelfTableContext::ForDML { table, .. } => (
+                Some(
+                    table
+                        .columns()
+                        .iter()
+                        .map(|c| c.affinity_with_strict(table.is_strict))
+                        .collect(),
+                ),
+                Some(table.columns().iter().map(|c| c.collation_opt()).collect()),
             ),
             SelfTableContext::ForSelect {
                 table_ref_id,
                 referenced_tables,
-            } => referenced_tables
-                .find_table_by_internal_id(*table_ref_id)
-                .and_then(|(_, table_ref)| table_ref.btree())
-                .map(|btree| {
-                    btree
-                        .columns()
-                        .iter()
-                        .map(|c| c.affinity_with_strict(btree.is_strict))
-                        .collect()
-                }),
+            } => {
+                let Some((_, table_ref)) =
+                    referenced_tables.find_table_by_internal_id(*table_ref_id)
+                else {
+                    return Self {
+                        context,
+                        affinities: None,
+                        collations: None,
+                    };
+                };
+                (
+                    table_ref.btree().map(|btree| {
+                        btree
+                            .columns()
+                            .iter()
+                            .map(|c| c.affinity_with_strict(btree.is_strict))
+                            .collect()
+                    }),
+                    Some(
+                        table_ref
+                            .columns()
+                            .iter()
+                            .map(|c| c.collation_opt())
+                            .collect(),
+                    ),
+                )
+            }
         };
 
         Self {
             context,
             affinities,
+            collations,
         }
     }
 
@@ -222,6 +244,12 @@ impl SelfTableScope {
         self.affinities
             .as_ref()
             .and_then(|affinities| affinities.get(column).copied())
+    }
+
+    fn collation_opt(&self, column: usize) -> Option<CollationSeq> {
+        self.collations
+            .as_ref()
+            .and_then(|collations| collations.get(column).copied().flatten())
     }
 
     fn column_type_str(&self, column: usize) -> Option<String> {
@@ -373,11 +401,22 @@ impl<'a> Resolver<'a> {
         f(ctx.as_ref())
     }
 
+    pub(crate) fn has_self_table_context(&self) -> bool {
+        self.self_table_scope.borrow().is_some()
+    }
+
     pub(crate) fn self_table_affinity(&self, column: usize) -> Option<Affinity> {
         self.self_table_scope
             .borrow()
             .as_ref()
             .and_then(|scope| scope.affinity(column))
+    }
+
+    pub(crate) fn self_table_collation_opt(&self, column: usize) -> Option<CollationSeq> {
+        self.self_table_scope
+            .borrow()
+            .as_ref()
+            .and_then(|scope| scope.collation_opt(column))
     }
 
     pub(crate) fn self_table_column_type_str(&self, column: usize) -> Option<String> {

--- a/core/translate/expr/binary.rs
+++ b/core/translate/expr/binary.rs
@@ -422,7 +422,7 @@ pub(super) fn row_component_affinity_collation(
     let rhs_for_cmp = row_value_component_expr(rhs_expr, idx)?.unwrap_or(rhs_expr);
     Ok((
         comparison_affinity(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver),
-        comparison_collation(lhs_for_cmp, rhs_for_cmp, referenced_tables)?,
+        comparison_collation(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver)?,
     ))
 }
 
@@ -444,20 +444,46 @@ pub(super) fn comparison_collation(
     lhs_expr: &Expr,
     rhs_expr: &Expr,
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Result<Option<CollationSeq>> {
     if let Some(tables) = referenced_tables {
-        let lhs_collation = get_collseq_from_expr(lhs_expr, tables)?;
-        if lhs_collation.is_some() {
-            return Ok(lhs_collation);
-        }
-        return get_collseq_from_expr(rhs_expr, tables);
+        return resolve_comparison_collseq_opt(lhs_expr, rhs_expr, tables, resolver);
     }
 
     let lhs_collation = explicit_collation(lhs_expr)?;
     if lhs_collation.is_some() {
         return Ok(lhs_collation);
     }
-    explicit_collation(rhs_expr)
+    let rhs_collation = explicit_collation(rhs_expr)?;
+    if rhs_collation.is_some() {
+        return Ok(rhs_collation);
+    }
+
+    let lhs_collation = self_table_collation(lhs_expr, resolver)?;
+    if lhs_collation.is_some() {
+        return Ok(lhs_collation);
+    }
+    self_table_collation(rhs_expr, resolver)
+}
+
+fn self_table_collation(expr: &Expr, resolver: Option<&Resolver>) -> Result<Option<CollationSeq>> {
+    let Some(resolver) = resolver.filter(|r| r.has_self_table_context()) else {
+        return Ok(None);
+    };
+    let mut found = None;
+    walk_expr(expr, &mut |e| -> Result<WalkControl> {
+        match e {
+            Expr::Collate(_, _) => Ok(WalkControl::SkipChildren),
+            Expr::Column { table, column, .. } if table.is_self_table() => {
+                if found.is_none() {
+                    found = resolver.self_table_collation_opt(*column);
+                }
+                Ok(WalkControl::Continue)
+            }
+            _ => Ok(WalkControl::Continue),
+        }
+    })?;
+    Ok(found)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -4,7 +4,7 @@ use crate::turso_assert;
 use tracing::{instrument, Level};
 use turso_parser::ast::{self, Expr, ResolveType, SubqueryType, TableInternalId, UnaryOperator};
 
-use super::collate::{get_collseq_from_expr, CollationSeq};
+use super::collate::{resolve_comparison_collseq_opt, CollationSeq};
 use super::emitter::Resolver;
 use super::optimizer::Optimizable;
 use super::plan::TableReferences;

--- a/tests/integration/query_processing/test_ddl.rs
+++ b/tests/integration/query_processing/test_ddl.rs
@@ -249,3 +249,26 @@ fn test_prepared_stmt_reprepare_ddl_change_txn(tmp_db: TempDatabase) -> anyhow::
 
     Ok(())
 }
+
+#[test]
+fn test_generated_column_row_value_resolves_columns() -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_generated_columns(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute(
+        "CREATE TABLE t(
+            a TEXT COLLATE NOCASE,
+            b AS ((a, 1) < ('B', 2)),
+            c AS ((a, 1) = ('B' COLLATE BINARY, 1))
+        )",
+    )?;
+    conn.execute("INSERT INTO t(a) VALUES ('b'), ('c')")?;
+
+    let rows: Vec<(String, i64, i64)> = conn.exec_rows("SELECT a, b, c FROM t ORDER BY rowid");
+    assert_eq!(rows, vec![("b".to_string(), 1, 0), ("c".to_string(), 0, 0)]);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Resolve generated-column `SELF_TABLE` column collations while translating row-value comparison components.
- Preserve explicit `COLLATE` precedence before declared column collations.
- Add regression coverage for row-value generated columns with column references and collation-sensitive comparisons.

Fixes #7066

## Tests

- `cargo test -p core_tester --test integration_tests test_generated_column_row_value_resolves_columns --features pure-rust-crypto -- --nocapture`
- `cargo test -p core_tester --test integration_tests query_processing::test_ddl --features pure-rust-crypto -- --nocapture`
- `cargo test -p turso_core translate::collate --features pure-rust-crypto -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p turso_core --features pure-rust-crypto`