### PR TITLE
core/statement: return busy stmt step if another write tx exists

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8744,6 +8744,72 @@ fn test_close_persists_drop_table() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+#[test]
+fn test_cant_commit_interrupted_drop_table() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let io = Arc::new(MemoryIO::new());
+    let path = ":memory:interrupted-drop-table-schema-rollback";
+    let db = Database::open_file(io.clone(), path).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+
+    conn.execute("CREATE TABLE repro_target(c0 INTEGER, c1 REAL)")
+        .unwrap();
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_repro_target_c0 \
+         ON repro_target (c0) WHERE c1 IS NULL",
+    )
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let target_schema_rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'repro_target' ORDER BY rowid",
+    );
+    assert_eq!(target_schema_rows.len(), 2);
+    assert_eq!(target_schema_rows[0][0].to_string(), "table");
+    assert_eq!(target_schema_rows[0][1].to_string(), "repro_target");
+    assert_eq!(target_schema_rows[1][0].to_string(), "index");
+    assert_eq!(target_schema_rows[1][1].to_string(), "idx_repro_target_c0");
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        CursorYieldPoint::NextStart.point()
+    ])));
+
+    let mut drop_stmt = conn.prepare("DROP TABLE repro_target").unwrap();
+    match drop_stmt.step().unwrap() {
+        crate::StepResult::IO => {}
+        other => panic!("expected injected IO yield while dropping repro_target; got {other:?}"),
+    }
+    conn.set_yield_injector(None);
+    tracing::info!("yielded pere");
+
+    let mut select_1 = conn.prepare("SELECT 1").unwrap();
+    let res = select_1.run_collect_rows();
+    assert!(matches!(res, Err(LimboError::Busy)));
+
+    drop(drop_stmt);
+    drop(conn);
+    drop(db);
+
+    // FIXME this fails with
+    // called `Result::unwrap()` on an `Err` value: Corrupt("sqlite_schema contains index for missing table 'repro_target': rootpage=3 sql=CREATE UNIQUE INDEX IF NOT EXISTS idx_repro_target_c0 ON repro_target (c0) WHERE c1 IS NULL")
+    let db = Database::open_file(io, path).unwrap();
+    let conn = db.connect().unwrap();
+    let target_schema_rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'repro_target' ORDER BY rowid",
+    );
+    assert_eq!(target_schema_rows.len(), 2);
+    assert_eq!(target_schema_rows[0][0].to_string(), "table");
+    assert_eq!(target_schema_rows[0][1].to_string(), "repro_target");
+    assert_eq!(target_schema_rows[1][0].to_string(), "index");
+    assert_eq!(target_schema_rows[1][1].to_string(), "idx_repro_target_c0");
+}
+
 /// Reproducer: DROP INDEX ghost pages after restart without explicit checkpoint.
 /// Session 1: create table + index + insert + checkpoint. Session 2: drop index. Session 3: reopen.
 #[test]

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -284,6 +284,14 @@ impl Statement {
 
     fn _step(&mut self, waker: Option<&Waker>) -> Result<StepResult> {
         if !self.counted_as_active_root && matches!(self.origin, StatementOrigin::Root) {
+            let conn = self.program.connection.clone();
+            // There is another statement running with write tx open. Let's not allow this statement
+            // from running because it could commit changes from other statement.
+            let has_write_tx = matches!(conn.get_tx_state(), TransactionState::Write { .. })
+                || matches!(conn.get_mv_tx(), Some((_, TransactionMode::Write)));
+            if has_write_tx && conn.n_active_root_statements.load(Ordering::SeqCst) > 0 {
+                return Err(LimboError::Busy);
+            }
             self.program
                 .connection
                 .n_active_root_statements


### PR DESCRIPTION
## Description

Interrupting a write tx and then starting another statement in the **same connection** is an anti pattern that could lead to corruption. In this case, running `select 1` after interrupting the `DROP TABLE` query cause the `select 1` to commit unfinished changes from `DROP TABLE`.

This fix makes it so that we cannot run an statement while another one is running and its on write mode.



## Description of AI Usage

Test was written by Mikael using a clanker which already provided the analysis, so I just had to write this code :)