### PR TITLE
core/fts: Fix ngram tokenizer casing

### DIFF
--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1893,7 +1893,10 @@ impl FtsCursor {
         // Register "ngram" tokenizer - 2-3 character n-grams for substring matching
         // Using prefix=false for full n-gram (not just prefix)
         if let Ok(ngram) = NgramTokenizer::new(2, 3, false) {
-            tokenizers.register("ngram", ngram);
+            let analyzer = TextAnalyzer::builder(ngram)
+                .filter(tantivy::tokenizer::LowerCaser)
+                .build();
+            tokenizers.register("ngram", analyzer);
         }
     }
 

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -2232,7 +2232,12 @@ impl FtsCursor {
         // Using prefix=false for full n-gram (not just prefix)
         let (min_gram, max_gram) = self.ngram_window;
         if let Ok(ngram) = NgramTokenizer::new(min_gram, max_gram, false) {
-            tokenizers.register("ngram", ngram);
+            // Lowercase the n-grams so matching is case-insensitive, like the
+            // other tokenizers.
+            let analyzer = TextAnalyzer::builder(ngram)
+                .filter(tantivy::tokenizer::LowerCaser)
+                .build();
+            tokenizers.register("ngram", analyzer);
         }
     }
 

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -1121,6 +1121,17 @@ fn test_fts_ngram_tokenizer(tmp_db: TempDatabase) {
     // With ngram(2,3), "Pho" generates ngrams that should match ngrams in "iPhone"
     assert!(!rows.is_empty());
 
+    // Ngram should also follow the default/simple tokenizer case-insensitive behavior
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT id FROM products WHERE fts_match(name, 'pho')",
+    );
+    assert_eq!(rows.len(), 1);
+    match &rows[0][0] {
+        rusqlite::types::Value::Integer(i) => assert_eq!(*i, 1),
+        _ => panic!("Expected integer"),
+    }
+
     // Search for "Gal" should match "Galaxy"
     let rows = limbo_exec_rows(
         &conn,

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -1132,6 +1132,17 @@ fn test_fts_ngram_tokenizer(tmp_db: TempDatabase) {
     // With ngram(2,3), "Pho" generates ngrams that should match ngrams in "iPhone"
     assert!(!rows.is_empty());
 
+    // Ngram should also follow the default/simple tokenizer case-insensitive behavior
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT id FROM products WHERE fts_match(name, 'pho')",
+    );
+    assert_eq!(rows.len(), 1);
+    match &rows[0][0] {
+        rusqlite::types::Value::Integer(i) => assert_eq!(*i, 1),
+        _ => panic!("Expected integer"),
+    }
+
     // Search for "Gal" should match "Galaxy"
     let rows = limbo_exec_rows(
         &conn,


### PR DESCRIPTION
## Summary
- apply `LowerCaser` to the registered `ngram` FTS tokenizer
- add a regression that lowercase `pho` matches indexed mixed-case `iPhone` content

Closes #7012.

## Validation
- `cargo test -p core_tester --test integration_tests test_fts_ngram_tokenizer -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --timeout 30`

Broader FTS/integration suites were not run.