### PR TITLE
github: Use Playwright container for wasm browser tests

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -213,20 +213,22 @@ jobs:
         node:
           - "20"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Image ships node 20 + chromium + firefox + system deps. Bump the tag
+    # whenever the `playwright` dep in bindings/javascript/yarn.lock changes.
+    container:
+      image: mcr.microsoft.com/playwright:v1.60.0-jammy
+    # GitHub mounts /github/home (uid 1001) as $HOME, but the image runs as
+    # root — Firefox refuses to launch unless HOME is root-owned.
+    env:
+      HOME: /root
     steps:
       - uses: actions/checkout@v4
-      - name: Setup node
-        uses: useblacksmith/setup-node@v5
-        with:
-          node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: yarn install
       - name: Build common
         run: yarn workspace @tursodatabase/database-common build
       - name: Build wasm-common
         run: yarn workspace @tursodatabase/database-wasm-common build
-      - name: Install playwright with deps
-        run: yarn workspace @tursodatabase/database-wasm playwright install --with-deps
       - name: Download all DB artifacts
         uses: actions/download-artifact@v4
         with:
@@ -303,12 +305,18 @@ jobs:
         node:
           - "20"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Image ships node 20 + chromium + firefox + system deps. Bump the tag
+    # whenever the `playwright` dep in bindings/javascript/yarn.lock changes.
+    container:
+      image: mcr.microsoft.com/playwright:v1.60.0-jammy
+    # GitHub mounts /github/home (uid 1001) as $HOME, but the image runs as
+    # root — Firefox refuses to launch unless HOME is root-owned.
+    env:
+      HOME: /root
     steps:
       - uses: actions/checkout@v4
-      - name: Setup node
-        uses: useblacksmith/setup-node@v5
-        with:
-          node-version: ${{ matrix.node }}
+      - name: Install build toolchain
+        run: apt-get update && apt-get install -y --no-install-recommends build-essential
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Setup mold linker
@@ -329,8 +337,6 @@ jobs:
         run: yarn workspace @tursodatabase/database-wasm-common build
       - name: Build sync common
         run: yarn workspace @tursodatabase/sync-common build
-      - name: Install playwright with deps
-        run: yarn workspace @tursodatabase/sync-wasm playwright install --with-deps
       - name: Download all DB artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Switch to Playwright container to avoid reinstalling packages for every run.