### PR TITLE
github: Bump turso_whopper regression-test step timeout to 15 minutes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -346,7 +346,7 @@ jobs:
       - name: Run turso_whopper regression tests
         if: matrix.profile.name == 'in-process'
         run: cargo test -p turso_whopper --test regression_tests
-        timeout-minutes: 5
+        timeout-minutes: 15
       - name: Run turso_whopper (${{ matrix.profile.name }})
         run: |
           cargo build -p turso_whopper --release


### PR DESCRIPTION
The 5-minute step timeout includes compilation, and on partial sccache restores the step times out before tests can run.