### PR TITLE
simulator: skip SQLite integrity check for MVCC

### DIFF
--- a/testing/simulator/main.rs
+++ b/testing/simulator/main.rs
@@ -530,6 +530,8 @@ fn run_simulation_default(
     if result.error.is_none() {
         if env.opts.disable_integrity_check {
             tracing::info!("skipping integrity check (disabled by configuration)");
+        } else if env.profile.mvcc {
+            tracing::info!("skipping SQLite integrity check for MVCC database");
         } else {
             let ic = integrity_check(&env.get_db_path());
             if let Err(err) = ic {


### PR DESCRIPTION
## Summary

The simulator already avoids inline `PRAGMA integrity_check` checks for MVCC profiles because SQLite/rusqlite cannot read Turso MVCC database files. The final post-run check still used rusqlite unconditionally, which made valid `simple_mvcc` simulations fail with `InternalError("file is not a database")`.

This skips the final SQLite integrity check for MVCC profiles as well.

## Reproduction before fix

```sh
target/debug/limbo_sim --seed 4104947523917507569 --maximum-time 45 --minimum-tests 50 --maximum-tests 500 --io-backend=memory --profile simple_mvcc
# failed: InternalError("file is not a database")
```

The kept `test.db` has a SQLite header but MVCC read/write version bytes (`0xff`), so rusqlite/sqlite3 rejects it before `pragma_integrity_check` can run.

## Validation

```sh
cargo fmt --check
cargo check -p limbo_sim
cargo build -p limbo_sim
cargo test -p limbo_sim
target/debug/limbo_sim --seed 4104947523917507569 --maximum-time 45 --minimum-tests 50 --maximum-tests 500 --io-backend=memory --profile simple_mvcc
target/debug/limbo_sim --seed 16895076595020360911 --maximum-time 45 --minimum-tests 50 --maximum-tests 500 --io-backend=memory --profile simple_mvcc
python3 /Users/jack/Code/githubpr/turso_bounty_hunt.py --repo /Users/jack/Code/turso --runs 3 --per-run-seconds 30 --timeout 90 --modes simple_mvcc,write_heavy_spill,differential
```