### PR TITLE
Fix stale WAL disk scan clearing shared frame index

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1416,6 +1416,21 @@ impl ShmWalCoordination {
         Self::install_local_snapshot(&mut shared, snapshot, snapshot.page_size != 0);
     }
 
+    fn sync_local_from_authority_after_stale_disk_scan(
+        &self,
+        snapshot: SharedWalCoordinationHeader,
+    ) {
+        let mut shared = self.shared.write();
+        Self::install_local_snapshot(&mut shared, snapshot, snapshot.page_size != 0);
+        // The local frame cache still belongs to the disk scan we decided not
+        // to trust. Do not let a later same-process connection rebuild the
+        // authority from that stale cache after we adopt the authority snapshot.
+        shared
+            .metadata
+            .loaded_from_disk_scan
+            .store(false, Ordering::Release);
+    }
+
     fn sync_authority_from_local(&self) {
         self.authority
             .install_snapshot(self.local_authority_snapshot());
@@ -1425,6 +1440,10 @@ impl ShmWalCoordination {
         let mut shared = self.shared.write();
         Self::install_local_snapshot(&mut shared, snapshot, true);
         shared.metadata.initialized.store(false, Ordering::Release);
+        shared
+            .metadata
+            .loaded_from_disk_scan
+            .store(false, Ordering::Release);
         shared.runtime.frame_cache.lock().clear();
         shared.runtime.overflow_fallback_coverage.lock().clear();
     }
@@ -1468,11 +1487,11 @@ impl ShmWalCoordination {
         }
         if Self::local_scan_cannot_disprove_zero_frame_authority(authority_snapshot, local_snapshot)
         {
-            self.sync_local_from_authority(authority_snapshot);
+            self.sync_local_from_authority_after_stale_disk_scan(authority_snapshot);
             return;
         }
         if Self::local_scan_cannot_disprove_positive_authority(authority_snapshot, local_snapshot) {
-            self.sync_local_from_authority(authority_snapshot);
+            self.sync_local_from_authority_after_stale_disk_scan(authority_snapshot);
             return;
         }
         if Self::authority_matches_local_wal_scan(authority_snapshot, local_snapshot) {
@@ -1505,7 +1524,7 @@ impl ShmWalCoordination {
         // frame index — it is maintained by writers and must not be replaced
         // with a potentially incomplete reconstruction.
         if Self::authority_is_same_or_newer_generation(authority_snapshot, local_snapshot) {
-            self.sync_local_from_authority(authority_snapshot);
+            self.sync_local_from_authority_after_stale_disk_scan(authority_snapshot);
             if authority_snapshot.checkpoint_seq == local_snapshot.checkpoint_seq
                 && self.authority.frame_index_overflowed()
             {
@@ -7358,6 +7377,65 @@ pub mod test {
             .load(Ordering::Acquire));
         let reopened_coordination = ShmWalCoordination::new(reopened_shared, reopened_authority);
         assert_eq!(reopened_coordination.find_frame(7, 0, 1, None), Some(1));
+    }
+
+    #[cfg(host_shared_wal)]
+    #[test]
+    fn test_shm_coordination_stale_disk_scan_adoption_does_not_clear_frame_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-stale-scan-adopt.db-wal");
+        let shm_path = dir.path().join("test-stale-scan-adopt.db-tshm");
+        let io = shared_wal_test_io();
+        let authoritative = write_test_wal_with_single_commit_frame(&io, &wal_path);
+
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        authority.install_snapshot(authoritative);
+        authority.record_frame(7, 1);
+        assert_eq!(authority.find_frame(7, 0, 1, None), Some(1));
+
+        let stale_file = io
+            .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
+            .unwrap();
+        let stale_shared = WalFileShared::new_shared(stale_file).unwrap();
+        {
+            let mut shared = stale_shared.write();
+            shared
+                .metadata
+                .loaded_from_disk_scan
+                .store(true, Ordering::Release);
+            shared.metadata.max_frame.store(0, Ordering::Release);
+            shared.metadata.nbackfills.store(0, Ordering::Release);
+            shared.metadata.last_checksum = (11, 13);
+            let mut header = shared.metadata.wal_header.lock();
+            header.page_size = authoritative.page_size;
+            header.checkpoint_seq = authoritative.checkpoint_seq.wrapping_sub(1);
+            header.salt_1 = authoritative.salt_1.wrapping_sub(1);
+            header.salt_2 = authoritative.salt_2.wrapping_sub(1);
+            header.checksum_1 = 11;
+            header.checksum_2 = 13;
+        }
+
+        let first_coordination = ShmWalCoordination::new(stale_shared.clone(), authority.clone());
+        assert_eq!(first_coordination.load_snapshot().max_frame, 1);
+        assert!(
+            !stale_shared
+                .read()
+                .metadata
+                .loaded_from_disk_scan
+                .load(Ordering::Acquire),
+            "adopting a newer authority from a stale local scan must stop treating the empty local cache as a disk scan"
+        );
+        assert_eq!(authority.find_frame(7, 0, 1, None), Some(1));
+        drop(first_coordination);
+
+        let second_coordination = ShmWalCoordination::new(stale_shared, authority.clone());
+        assert_eq!(
+            second_coordination.find_frame(7, 0, 1, None),
+            Some(1),
+            "a second connection must not clear the authoritative frame index using the stale local cache"
+        );
+        assert_eq!(authority.iter_latest_frames(0, 1), vec![(7, 1)]);
     }
 
     #[cfg(host_shared_wal)]

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -30,7 +30,7 @@ struct Args {
     #[command(subcommand)]
     subcommand: Option<SubCmd>,
 
-    /// Simulation mode (fast, chaos, ragnarök/ragnarok)
+    /// Simulation mode (fast, chaos, wal_stress, ragnarök/ragnarok)
     #[arg(long, default_value = "fast")]
     mode: String,
     /// Max connections
@@ -157,6 +157,7 @@ fn run_multiprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     }
     let base_max_steps = match args.mode.as_str() {
         "fast" => 100_000,
+        "wal_stress" => 250_000,
         "chaos" => 10_000_000,
         "ragnarök" | "ragnarok" => 1_000_000,
         mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),
@@ -345,6 +346,31 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
         let et = vec![(table_name.to_string(), create_sql.to_string())];
 
         (w, p, et, chaotic)
+    } else if args.mode == "wal_stress" {
+        let w: Vec<(u32, Box<dyn Workload>)> = vec![
+            (30, Box::new(IntegrityCheckWorkload)),
+            (25, Box::new(WalCheckpointModeWorkload { mode: "TRUNCATE" })),
+            (25, Box::new(WalCheckpointModeWorkload { mode: "RESTART" })),
+            (10, Box::new(WalCheckpointModeWorkload { mode: "PASSIVE" })),
+            (8, Box::new(CreateSimpleTableWorkload)),
+            (8, Box::new(SimpleSelectWorkload)),
+            (12, Box::new(SimpleInsertWorkload)),
+            (45, Box::new(LargeSimpleInsertWorkload)),
+            (5, Box::new(UpdateWorkload)),
+            (5, Box::new(DeleteWorkload)),
+            (2, Box::new(CreateIndexWorkload)),
+            (2, Box::new(DropIndexWorkload)),
+            (15, Box::new(BeginWorkload)),
+            (20, Box::new(CommitWorkload)),
+            (3, Box::new(RollbackWorkload)),
+        ];
+
+        let p: Vec<Box<dyn Property>> = vec![
+            Box::new(IntegrityCheckProperty),
+            Box::new(SimpleKeysDoNotDisappear::new()),
+        ];
+
+        (w, p, vec![], vec![])
     } else {
         let w: Vec<(u32, Box<dyn Workload>)> = vec![
             (10, Box::new(IntegrityCheckWorkload)),
@@ -379,6 +405,7 @@ type BuildArtifacts = (WorkerWorkloads, PropertyList, TableSchemas, ChaosProfile
 fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
     let mut base_opts = match args.mode.as_str() {
         "fast" => WhopperOpts::fast(),
+        "wal_stress" => WhopperOpts::fast().with_max_steps(250_000),
         "chaos" => WhopperOpts::chaos(),
         "ragnarök" | "ragnarok" => WhopperOpts::ragnarok(),
         mode => return Err(anyhow::anyhow!("Unknown mode: {}", mode)),

--- a/testing/concurrent-simulator/regression_tests.rs
+++ b/testing/concurrent-simulator/regression_tests.rs
@@ -6,10 +6,12 @@ use turso_core::{Connection, Database, DatabaseOpts, IO, LimboError, OpenFlags};
 use turso_whopper::multiprocess::{MultiprocessOpts, MultiprocessWhopper};
 use turso_whopper::{
     multiprocess_platform_io,
+    properties::{IntegrityCheckProperty, SimpleKeysDoNotDisappear},
     workloads::{
         BeginWorkload, CommitWorkload, CreateIndexWorkload, CreateSimpleTableWorkload,
-        DeleteWorkload, DropIndexWorkload, IntegrityCheckWorkload, RollbackWorkload,
-        SimpleInsertWorkload, SimpleSelectWorkload, UpdateWorkload, WalCheckpointWorkload,
+        DeleteWorkload, DropIndexWorkload, IntegrityCheckWorkload, LargeSimpleInsertWorkload,
+        RollbackWorkload, SimpleInsertWorkload, SimpleSelectWorkload, UpdateWorkload,
+        WalCheckpointModeWorkload, WalCheckpointWorkload,
     },
 };
 
@@ -1135,5 +1137,51 @@ fn multiprocess_restart_rebuilds_from_disk_after_restart_checkpoint_changes_gene
         "conservative reopen after RESTART-generation checkpoint churn should preserve both generations of rows"
     );
 
+    whopper.finalize().expect("finalize multiprocess whopper");
+}
+
+#[cfg(all(any(unix, target_os = "windows"), target_pointer_width = "64"))]
+#[test]
+fn multiprocess_wal_stress_preserves_rows_after_stale_disk_scan_reopen() {
+    configure_worker_exe();
+    let mut whopper = MultiprocessWhopper::new(MultiprocessOpts {
+        seed: Some(7512),
+        enable_mvcc: false,
+        process_count: 2,
+        connections_per_process: 2,
+        max_steps: 1403,
+        elle_tables: vec![],
+        workloads: vec![
+            (30, Box::new(IntegrityCheckWorkload)),
+            (25, Box::new(WalCheckpointModeWorkload { mode: "TRUNCATE" })),
+            (25, Box::new(WalCheckpointModeWorkload { mode: "RESTART" })),
+            (10, Box::new(WalCheckpointModeWorkload { mode: "PASSIVE" })),
+            (8, Box::new(CreateSimpleTableWorkload)),
+            (8, Box::new(SimpleSelectWorkload)),
+            (12, Box::new(SimpleInsertWorkload)),
+            (45, Box::new(LargeSimpleInsertWorkload)),
+            (5, Box::new(UpdateWorkload)),
+            (5, Box::new(DeleteWorkload)),
+            (2, Box::new(CreateIndexWorkload)),
+            (2, Box::new(DropIndexWorkload)),
+            (15, Box::new(BeginWorkload)),
+            (20, Box::new(CommitWorkload)),
+            (3, Box::new(RollbackWorkload)),
+        ],
+        properties: vec![
+            Box::new(IntegrityCheckProperty),
+            Box::new(SimpleKeysDoNotDisappear::new()),
+        ],
+        chaotic_profiles: vec![],
+        kill_probability: 0.04,
+        restart_probability: 0.04,
+        history_output: None,
+        keep_files: false,
+    })
+    .expect("create multiprocess whopper");
+
+    while !whopper.is_done() {
+        whopper.step().expect("step should succeed");
+    }
     whopper.finalize().expect("finalize multiprocess whopper");
 }

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -146,6 +146,29 @@ impl Workload for SimpleInsertWorkload {
     }
 }
 
+/// Execute a larger INSERT into a random simple table to grow WAL frames quickly.
+pub struct LargeSimpleInsertWorkload;
+
+impl Workload for LargeSimpleInsertWorkload {
+    fn generate(&self, ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        if ctx.sim_state.simple_tables.is_empty() {
+            return None;
+        }
+        let table_name = match ctx.sim_state.simple_tables.pick(rng) {
+            Some((name, _)) => name.clone(),
+            None => return None,
+        };
+        let key = format!("large_key_{}", rng.random_range(0..1_000_000));
+        let value_length = rng.random_range(32 * 1024..256 * 1024);
+
+        Some(Operation::SimpleInsert {
+            table_name,
+            key,
+            value_length,
+        })
+    }
+}
+
 /// Execute a SELECT query (works in both Idle and InTx states).
 pub struct SelectWorkload;
 
@@ -248,6 +271,22 @@ impl Workload for WalCheckpointWorkload {
             .expect("array is not empty");
         Some(Operation::WalCheckpoint {
             mode: mode.to_string(),
+        })
+    }
+}
+
+/// Run WAL checkpoint with a fixed mode.
+pub struct WalCheckpointModeWorkload {
+    pub mode: &'static str,
+}
+
+impl Workload for WalCheckpointModeWorkload {
+    fn generate(&self, ctx: &WorkloadContext, _rng: &mut ChaCha8Rng) -> Option<Operation> {
+        if *ctx.fiber_state != FiberState::Idle {
+            return None;
+        }
+        Some(Operation::WalCheckpoint {
+            mode: self.mode.to_string(),
         })
     }
 }


### PR DESCRIPTION
## Summary

This PR is intended as a Turso Challenge submission for a data-loss/corruption-class bug found with deterministic multiprocess WAL stress testing.

It fixes a multiprocess WAL reopen path where a stale local disk scan could clear the authoritative shared WAL frame index after the process had already adopted the `.tshm` authority snapshot.

When a local disk scan is stale and the shared authority is same-or-newer, the connection correctly adopts the authority snapshot. However, the local `loaded_from_disk_scan` flag remained set. A later same-process connection could then treat the already-overridden local frame cache as a trustworthy disk scan and rebuild the `.tshm` frame index from an empty/stale cache. In stress runs this caused acknowledged autocommit inserts to disappear after a cohort restart even though `PRAGMA integrity_check` still returned `ok`.

This patch clears the disk-scan marker when adopting the authority over a stale local scan, preserving the authoritative frame index for later same-process connections.

## Reproduction

Before the fix, the seeded multiprocess WAL stress case could lose rows inserted by successful autocommit statements after a cohort restart. The new regression exercises that path with seed `7512` and verifies that tracked simple-table keys do not disappear.

## Tests

- `cargo test -p turso_core test_shm_coordination -- --nocapture`
- `cargo test -p turso_whopper -- --nocapture`
- `SEED=7512 RUST_LOG=warn ./target/debug/turso_whopper --mode wal_stress --multiprocess --processes 2 --connections-per-process 2 --max-steps 1403 --kill-probability 0.04 --restart-probability 0.04`
