### PR TITLE
core/mvcc: Don't commit suspended previous root statement

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6545,6 +6545,70 @@ fn test_integrity_check_after_drop_index_before_checkpoint() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+#[test]
+fn test_interrupted_drop_table_rolls_back_schema_table_and_indexes() {
+    let io = Arc::new(MemoryIO::new());
+    let path = ":memory:interrupted-drop-table-schema-rollback";
+    let db = Database::open_file(io.clone(), path).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+
+    conn.execute("CREATE TABLE repro_target(c0 INTEGER, c1 REAL)")
+        .unwrap();
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_repro_target_c0 \
+         ON repro_target (c0) WHERE c1 IS NULL",
+    )
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let target_schema_rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'repro_target' ORDER BY rowid",
+    );
+    assert_eq!(target_schema_rows.len(), 2);
+    assert_eq!(target_schema_rows[0][0].to_string(), "table");
+    assert_eq!(target_schema_rows[0][1].to_string(), "repro_target");
+    assert_eq!(target_schema_rows[1][0].to_string(), "index");
+    assert_eq!(target_schema_rows[1][1].to_string(), "idx_repro_target_c0");
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        CursorYieldPoint::NextStart.point()
+    ])));
+
+    let mut drop_stmt = conn.prepare("DROP TABLE repro_target").unwrap();
+    match drop_stmt.step().unwrap() {
+        crate::StepResult::IO => {}
+        other => panic!("expected injected IO yield while dropping repro_target; got {other:?}"),
+    }
+    conn.set_yield_injector(None);
+
+    let rows = get_rows(&conn, "SELECT 1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "1");
+
+    drop(drop_stmt);
+    drop(conn);
+    drop(db);
+
+    // Reopening used to fail here because the same-connection SELECT could
+    // commit the interrupted DROP TABLE's partial sqlite_schema delete.
+    let db = Database::open_file(io, path).unwrap();
+    let conn = db.connect().unwrap();
+    let target_schema_rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'repro_target' ORDER BY rowid",
+    );
+    assert_eq!(target_schema_rows.len(), 2);
+    assert_eq!(target_schema_rows[0][0].to_string(), "table");
+    assert_eq!(target_schema_rows[0][1].to_string(), "repro_target");
+    assert_eq!(target_schema_rows[1][0].to_string(), "index");
+    assert_eq!(target_schema_rows[1][1].to_string(), "idx_repro_target_c0");
+}
+
 /// What this test checks: Rollback/savepoint behavior restores exactly the intended state when statements or transactions fail.
 /// Why this matters: Partial rollback mistakes leave data in impossible intermediate states.
 #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2870,6 +2870,7 @@ pub fn halt(
 ) -> Result<InsnFunctionStepResult> {
     let mv_store = program.connection.mv_store();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
+    let owns_auto_txn = state.owns_auto_txn();
 
     // Check if we're resuming from a FAIL commit I/O wait.
     // If pending_fail_error is set, we were in the middle of committing partial changes
@@ -2945,7 +2946,7 @@ pub fn halt(
         // For FAIL mode with autocommit, commit partial changes before returning error.
         // This matches SQLite behavior where FAIL keeps changes made before the error.
         // Note: ON CONFLICT FAIL does NOT apply to FK violations, so we check for those first.
-        if program.resolve_type == ResolveType::Fail && auto_commit {
+        if program.resolve_type == ResolveType::Fail && owns_auto_txn {
             // Check for immediate FK violations - FK errors don't respect ON CONFLICT
             if program.connection.foreign_keys_enabled()
                 && state.get_fk_immediate_violations_during_stmt() > 0
@@ -2976,7 +2977,11 @@ pub fn halt(
         return Err(error);
     }
 
-    tracing::trace!("halt(auto_commit={})", auto_commit);
+    tracing::trace!(
+        "halt(auto_commit={}, owns_auto_txn={})",
+        auto_commit,
+        owns_auto_txn
+    );
 
     // Check for immediate foreign key violations.
     // Any immediate violation causes the statement subtransaction to roll back.
@@ -2995,7 +3000,7 @@ pub fn halt(
     if auto_commit {
         // In autocommit mode, a statement that leaves deferred violations must fail here,
         // and it also ends the transaction.
-        if program.connection.foreign_keys_enabled() {
+        if owns_auto_txn && program.connection.foreign_keys_enabled() {
             let deferred_violations = program
                 .connection
                 .fk_deferred_violations
@@ -3017,19 +3022,34 @@ pub fn halt(
             }
         }
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
-        vtab_commit_all(&program.connection)?;
-        index_method_pre_commit_all(state, pager)?;
-        let result = program
-            .commit_txn(pager.clone(), state, mv_store.as_ref(), false)
-            .map(Into::into);
-        // Apply deferred CDC state and reset CDC txn ID after successful commit
-        if matches!(result, Ok(InsnFunctionStepResult::Done)) {
+        if owns_auto_txn {
+            vtab_commit_all(&program.connection)?;
+            index_method_pre_commit_all(state, pager)?;
+            let result = program
+                .commit_txn(pager.clone(), state, mv_store.as_ref(), false)
+                .map(Into::into);
+            // Apply deferred CDC state and reset CDC txn ID after successful commit
+            if matches!(result, Ok(InsnFunctionStepResult::Done)) {
+                if let Some(cdc_info) = state.pending_cdc_info.take() {
+                    program.connection.set_capture_data_changes_info(cdc_info);
+                }
+                program.connection.set_cdc_transaction_id(-1);
+            }
+            result
+        } else {
+            // Another root statement may own the implicit autocommit
+            // transaction. This statement can finish, but must not commit or
+            // roll back connection-level state it did not start.
             if let Some(cdc_info) = state.pending_cdc_info.take() {
                 program.connection.set_capture_data_changes_info(cdc_info);
             }
-            program.connection.set_cdc_transaction_id(-1);
+            if program.change_cnt_on {
+                program
+                    .connection
+                    .set_changes(state.n_change.load(Ordering::SeqCst));
+            }
+            Ok(InsnFunctionStepResult::Done)
         }
-        result
     } else {
         // Even if deferred violations are present, the statement subtransaction completes successfully when
         // it is part of an interactive transaction.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -887,6 +887,14 @@ impl ProgramState {
         self.subprogram_stmt_cache.clear();
     }
 
+    /// Whether this statement owns the implicit autocommit transaction it is
+    /// about to finish, including re-entry while its commit is in progress.
+    #[inline]
+    pub(crate) fn owns_auto_txn(&self) -> bool {
+        self.auto_txn_cleanup == TxnCleanup::RollbackTxn
+            || !matches!(self.commit_state, CommitState::Ready)
+    }
+
     #[inline]
     pub fn record_rows_read(&mut self, count: u64) {
         self.metrics.rows_read = self.metrics.rows_read.saturating_add(count);
@@ -2296,6 +2304,7 @@ impl Program {
         }
         // Errors from nested statements are handled by the parent statement.
         if !self.connection.is_nested_stmt() && !self.is_trigger_subprogram() {
+            let owns_auto_txn = state.owns_auto_txn();
             if err.is_some() && !pager.is_checkpointing() {
                 // For ON CONFLICT FAIL, do NOT rollback the statement savepoint —
                 // changes made before the error should persist.
@@ -2336,7 +2345,7 @@ impl Program {
                 // FK errors always behave like ABORT: rollback statement,
                 // rollback transaction in autocommit mode.
                 Some(LimboError::ForeignKeyConstraint(_)) => {
-                    if self.connection.get_auto_commit() {
+                    if owns_auto_txn {
                         self.rollback_current_txn(pager);
                     }
                     self.connection.set_changes_without_total(0);
@@ -2372,7 +2381,7 @@ impl Program {
                                     "Failed to release statement savepoint during abort",
                                 );
                             }
-                            if self.connection.get_auto_commit() {
+                            if owns_auto_txn {
                                 // Autocommit FAIL: commit partial changes.
                                 // This matches halt()'s FAIL+autocommit path.
                                 let mv_store = self.connection.mv_store();
@@ -2421,7 +2430,7 @@ impl Program {
                             }
                         }
                         _ => {
-                            if self.connection.get_auto_commit() {
+                            if owns_auto_txn {
                                 self.rollback_current_txn(pager);
                             }
                         }
@@ -2446,7 +2455,9 @@ impl Program {
                         self.rollback_current_txn(pager);
                     }
                     TxnCleanup::RollbackSavepoint => {
-                        if err.is_none() && !pager.is_checkpointing() {
+                        if owns_auto_txn {
+                            self.rollback_current_txn(pager);
+                        } else if err.is_none() && !pager.is_checkpointing() {
                             if let Err(end_stmt_err) = state.end_statement(
                                 &self.connection,
                                 pager,
@@ -2461,7 +2472,7 @@ impl Program {
                         }
                     }
                     TxnCleanup::None => {
-                        if err.is_some() {
+                        if owns_auto_txn || (!self.connection.get_auto_commit() && err.is_some()) {
                             self.rollback_current_txn(pager);
                         }
                     }

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -1,5 +1,9 @@
+use std::sync::Arc;
+
 use crate::common::{limbo_exec_rows, TempDatabase};
+use crate::queued_io::QueuedIo;
 use turso_core::vdbe::StepResult;
+use turso_core::{Database, LimboError};
 
 /// Helper: step a statement through IO until it returns Row or Done.
 fn step_blocking(stmt: &mut turso_core::Statement) -> turso_core::Result<StepResult> {
@@ -92,6 +96,42 @@ fn returning_delete_drop_after_partial_read_commits(tmp_db: TempDatabase) -> any
     Ok(())
 }
 
+#[turso_macros::test]
+fn unrelated_runtime_error_does_not_rollback_open_returning_statement(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE pending (id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE overflow (x INTEGER)")?;
+    conn.execute("INSERT INTO overflow VALUES (9223372036854775807), (1)")?;
+
+    {
+        let mut owner =
+            conn.prepare("INSERT INTO pending VALUES (1, 'a'), (2, 'b') RETURNING id")?;
+        let result = step_blocking(&mut owner)?;
+        assert!(
+            matches!(result, StepResult::Row),
+            "expected Row, got {result:?}"
+        );
+
+        let err = conn
+            .execute("SELECT sum(x) FROM overflow")
+            .expect_err("sum overflow should fail");
+        assert!(matches!(err, LimboError::IntegerOverflow), "{err:?}");
+    }
+
+    let rows = limbo_exec_rows(&conn, "SELECT id FROM pending ORDER BY id");
+    let ids: Vec<i64> = rows
+        .iter()
+        .map(|row| match &row[0] {
+            rusqlite::types::Value::Integer(i) => *i,
+            other => panic!("expected integer, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(ids, vec![1, 2]);
+    Ok(())
+}
+
 /// Plain INSERT (no RETURNING): runs to completion via step(), then drop.
 /// This is the normal case — Halt commits the transaction.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);")]
@@ -113,6 +153,33 @@ fn plain_insert_step_to_done_commits(tmp_db: TempDatabase) -> anyhow::Result<()>
         other => panic!("expected integer, got {other:?}"),
     };
     assert_eq!(count, 2);
+    Ok(())
+}
+
+#[test]
+fn dropping_explicit_commit_waiting_on_io_rolls_back_transaction() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file(io, "queued-explicit-commit-drop.db")?;
+    let conn = db.connect()?;
+
+    conn.execute("CREATE TABLE t(x INTEGER)")?;
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (1)")?;
+
+    {
+        let mut commit = conn.prepare("COMMIT")?;
+        assert!(matches!(commit.step()?, StepResult::IO));
+    }
+
+    conn.execute("INSERT INTO t VALUES (2)")?;
+
+    let mut stmt = conn.prepare("SELECT x FROM t ORDER BY x")?;
+    let mut values = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        values.push(row.get::<i64>(0)?);
+        Ok(())
+    })?;
+    assert_eq!(values, vec![2]);
     Ok(())
 }
 


### PR DESCRIPTION
## Description

In SQLite and Turso, multiple concurrent statements on a connection can participate in the same implicit transaction. In that case, participating statements must not commit effects from other statements.

The `Halt` opcode (called on drop) was not doing the correct check to see if the aborted statement was the owning statement, so in some cases a statement could commit partial effects from another incomplete statement on the same transaction.

## Description of AI Usage

Codex