### PR TITLE
Gate custom benchmark iterations for CodSpeed

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -19,6 +19,23 @@ use turso_core::{Database, LimboError, PlatformIO, StepResult};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(not(feature = "codspeed"))]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter_custom(|$iters| $body)
+    };
+}
+
+#[cfg(feature = "codspeed")]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter(|| {
+            let $iters = 1;
+            $body
+        })
+    };
+}
+
 fn rusqlite_open() -> rusqlite::Connection {
     let sqlite_conn = rusqlite::Connection::open("../testing/system/testing.db").unwrap();
     sqlite_conn
@@ -124,7 +141,7 @@ fn bench_alter(criterion: &mut Criterion) {
         let io = Arc::new(PlatformIO::new().unwrap());
         let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             (0..iters)
                 .map(|_| {
                     conn.execute("CREATE TABLE x(a)").unwrap();
@@ -143,7 +160,7 @@ fn bench_alter(criterion: &mut Criterion) {
     if enable_rusqlite {
         group.bench_function(BenchmarkId::new("sqlite_rename_table", ""), |b| {
             let conn = rusqlite::Connection::open("../testing/system/schema_5k.db").unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 (0..iters)
                     .map(|_| {
                         conn.execute("CREATE TABLE x(a)", ()).unwrap();
@@ -169,7 +186,7 @@ fn bench_alter(criterion: &mut Criterion) {
         let io = Arc::new(PlatformIO::new().unwrap());
         let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             (0..iters)
                 .map(|_| {
                     conn.execute("CREATE TABLE x(a)").unwrap();
@@ -188,7 +205,7 @@ fn bench_alter(criterion: &mut Criterion) {
     if enable_rusqlite {
         group.bench_function(BenchmarkId::new("sqlite_rename_column", ""), |b| {
             let conn = rusqlite::Connection::open("../testing/system/schema_5k.db").unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 (0..iters)
                     .map(|_| {
                         conn.execute("CREATE TABLE x(a)", ()).unwrap();
@@ -215,7 +232,7 @@ fn bench_alter(criterion: &mut Criterion) {
         let io = Arc::new(PlatformIO::new().unwrap());
         let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             (0..iters)
                 .map(|_| {
                     conn.execute("CREATE TABLE x(a)").unwrap();
@@ -234,7 +251,7 @@ fn bench_alter(criterion: &mut Criterion) {
     if enable_rusqlite {
         group.bench_function(BenchmarkId::new("sqlite_add_column", ""), |b| {
             let conn = rusqlite::Connection::open("../testing/system/schema_5k.db").unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 (0..iters)
                     .map(|_| {
                         conn.execute("CREATE TABLE x(a)", ()).unwrap();
@@ -260,7 +277,7 @@ fn bench_alter(criterion: &mut Criterion) {
         let io = Arc::new(PlatformIO::new().unwrap());
         let db = Database::open_file(io, "../testing/system/schema_5k.db").unwrap();
         let conn = db.connect().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             (0..iters)
                 .map(|_| {
                     conn.execute("CREATE TABLE x(a, b)").unwrap();
@@ -279,7 +296,7 @@ fn bench_alter(criterion: &mut Criterion) {
     if enable_rusqlite {
         group.bench_function(BenchmarkId::new("sqlite_drop_column", ""), |b| {
             let conn = rusqlite::Connection::open("../testing/system/schema_5k.db").unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 (0..iters)
                     .map(|_| {
                         conn.execute("CREATE TABLE x(a, b)", ()).unwrap();

--- a/core/benches/create_index_benchmark.rs
+++ b/core/benches/create_index_benchmark.rs
@@ -41,6 +41,23 @@ use turso_core::{Database, PlatformIO, StepResult};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(not(feature = "codspeed"))]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter_custom(|$iters| $body)
+    };
+}
+
+#[cfg(feature = "codspeed")]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter(|| {
+            let $iters = 1;
+            $body
+        })
+    };
+}
+
 /// Step a statement to completion, draining IO callbacks.
 fn run_to_completion(
     stmt: &mut turso_core::Statement,
@@ -164,6 +181,10 @@ fn row_counts() -> Vec<usize> {
     v
 }
 
+fn should_bench_create_index_turso(row_count: usize) -> bool {
+    !(cfg!(feature = "codspeed") && row_count > 100_000)
+}
+
 /// Benchmark CREATE INDEX on an already-populated table.
 ///
 /// Indexes the non-monotonic `val` column to force a real sort + B-tree build
@@ -206,49 +227,51 @@ fn bench_create_index(criterion: &mut Criterion) {
         group.warm_up_time(warm_up);
         group.measurement_time(measurement);
 
-        // ---- Turso total latency ----
-        {
-            let temp_dir = tempfile::tempdir().unwrap();
-            let (db, conn) = open_turso(&temp_dir);
-            populate_turso(&db, &conn, row_count);
+        if should_bench_create_index_turso(row_count) {
+            // ---- Turso total latency ----
+            {
+                let temp_dir = tempfile::tempdir().unwrap();
+                let (db, conn) = open_turso(&temp_dir);
+                populate_turso(&db, &conn, row_count);
 
-            group.bench_function(BenchmarkId::new("turso_total", row_count), |b| {
-                b.iter_custom(|iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for _ in 0..iters {
-                        let start = std::time::Instant::now();
-                        exec_turso(&conn, &db, "BEGIN");
-                        exec_turso(&conn, &db, "CREATE INDEX idx_val ON t(val)");
-                        exec_turso(&conn, &db, "COMMIT");
-                        total += start.elapsed();
-                        // Restore the un-indexed state for the next sample.
-                        exec_turso(&conn, &db, "DROP INDEX idx_val");
-                    }
-                    total
+                group.bench_function(BenchmarkId::new("turso_total", row_count), |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = std::time::Instant::now();
+                            exec_turso(&conn, &db, "BEGIN");
+                            exec_turso(&conn, &db, "CREATE INDEX idx_val ON t(val)");
+                            exec_turso(&conn, &db, "COMMIT");
+                            total += start.elapsed();
+                            // Restore the un-indexed state for the next sample.
+                            exec_turso(&conn, &db, "DROP INDEX idx_val");
+                        }
+                        total
+                    });
                 });
-            });
-        }
+            }
 
-        // ---- Turso commit latency ----
-        {
-            let temp_dir = tempfile::tempdir().unwrap();
-            let (db, conn) = open_turso(&temp_dir);
-            populate_turso(&db, &conn, row_count);
+            // ---- Turso commit latency ----
+            {
+                let temp_dir = tempfile::tempdir().unwrap();
+                let (db, conn) = open_turso(&temp_dir);
+                populate_turso(&db, &conn, row_count);
 
-            group.bench_function(BenchmarkId::new("turso_commit_only", row_count), |b| {
-                b.iter_custom(|iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for _ in 0..iters {
-                        exec_turso(&conn, &db, "BEGIN");
-                        exec_turso(&conn, &db, "CREATE INDEX idx_val ON t(val)");
-                        let start = std::time::Instant::now();
-                        exec_turso(&conn, &db, "COMMIT");
-                        total += start.elapsed();
-                        exec_turso(&conn, &db, "DROP INDEX idx_val");
-                    }
-                    total
+                group.bench_function(BenchmarkId::new("turso_commit_only", row_count), |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            exec_turso(&conn, &db, "BEGIN");
+                            exec_turso(&conn, &db, "CREATE INDEX idx_val ON t(val)");
+                            let start = std::time::Instant::now();
+                            exec_turso(&conn, &db, "COMMIT");
+                            total += start.elapsed();
+                            exec_turso(&conn, &db, "DROP INDEX idx_val");
+                        }
+                        total
+                    });
                 });
-            });
+            }
         }
 
         // ---- sqlite ----
@@ -258,7 +281,7 @@ fn bench_create_index(criterion: &mut Criterion) {
             populate_rusqlite(&conn, row_count);
 
             group.bench_function(BenchmarkId::new("sqlite", row_count), |b| {
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -288,6 +311,10 @@ fn bench_create_index_commit(criterion: &mut Criterion) {
     group.sampling_mode(SamplingMode::Flat);
 
     for &row_count in &row_counts() {
+        if !should_bench_create_index_turso(row_count) {
+            continue;
+        }
+
         group.throughput(Throughput::Elements(row_count as u64));
         let samples = match row_count {
             n if n <= 10_000 => 30,
@@ -320,7 +347,7 @@ fn bench_create_index_commit(criterion: &mut Criterion) {
             group.bench_function(
                 BenchmarkId::new("turso_create_index_commit", row_count),
                 |b| {
-                    b.iter_custom(|iters| {
+                    iter_custom_or_iter!(b, |iters| {
                         let mut total = std::time::Duration::ZERO;
                         for _ in 0..iters {
                             let start = std::time::Instant::now();
@@ -345,7 +372,7 @@ fn bench_create_index_commit(criterion: &mut Criterion) {
             populate_rusqlite(&conn, row_count);
 
             group.bench_function(BenchmarkId::new("sqlite", row_count), |b| {
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();

--- a/core/benches/fts_benchmark.rs
+++ b/core/benches/fts_benchmark.rs
@@ -23,6 +23,23 @@ use turso_core::{Database, DatabaseOpts, OpenFlags, PlatformIO, StepResult};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(not(feature = "codspeed"))]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter_custom(|$iters| $body)
+    };
+}
+
+#[cfg(feature = "codspeed")]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter(|| {
+            let $iters = 1;
+            $body
+        })
+    };
+}
+
 /// Helper to execute a statement to completion, stepping through IO.
 fn run_to_completion(
     stmt: &mut turso_core::Statement,
@@ -141,7 +158,7 @@ fn bench_fts_cold_query(criterion: &mut Criterion) {
         group.bench_function(
             BenchmarkId::new("cold_query", format!("{row_count}_rows")),
             |b| {
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         // Fresh connection = no cached directory
@@ -189,7 +206,7 @@ fn bench_fts_warm_query(criterion: &mut Criterion) {
         group.bench_function(
             BenchmarkId::new("warm_query", format!("{row_count}_rows")),
             |b| {
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -242,7 +259,7 @@ fn bench_fts_query_selectivity(criterion: &mut Criterion) {
         let sql = format!("SELECT id, title FROM docs WHERE (title, body) MATCH '{query_term}'");
 
         group.bench_function(BenchmarkId::new("selectivity", name), |b| {
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
@@ -278,7 +295,7 @@ fn bench_fts_insert_then_query(criterion: &mut Criterion) {
         group.bench_function(
             BenchmarkId::new("insert_query", format!("{row_count}_rows")),
             |b| {
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();

--- a/core/benches/triggers.rs
+++ b/core/benches/triggers.rs
@@ -16,6 +16,23 @@ use turso_core::{Database, PlatformIO, StepResult};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(not(feature = "codspeed"))]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter_custom(|$iters| $body)
+    };
+}
+
+#[cfg(feature = "codspeed")]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter(|| {
+            let $iters = 1;
+            $body
+        })
+    };
+}
+
 fn run_to_completion(
     stmt: &mut turso_core::Statement,
     db: &Arc<Database>,
@@ -104,7 +121,7 @@ fn bench_multirow_insert_with_trigger(criterion: &mut Criterion) {
                 let mut insert_stmt = conn.prepare(&values).unwrap();
                 let mut del_src = conn.query("DELETE FROM src").unwrap().unwrap();
                 let mut del_audit = conn.query("DELETE FROM audit").unwrap().unwrap();
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -130,7 +147,7 @@ fn bench_multirow_insert_with_trigger(criterion: &mut Criterion) {
                 BenchmarkId::new("sqlite", format!("{row_count}_rows")),
                 |b| {
                     let mut stmt = sqlite_conn.prepare(&values).unwrap();
-                    b.iter_custom(|iters| {
+                    iter_custom_or_iter!(b, |iters| {
                         let mut total = std::time::Duration::ZERO;
                         for _ in 0..iters {
                             let start = std::time::Instant::now();
@@ -203,7 +220,7 @@ fn bench_wide_table_sparse_trigger(criterion: &mut Criterion) {
                 let mut insert_stmt = conn.prepare(&values).unwrap();
                 let mut del1 = conn.query("DELETE FROM wide").unwrap().unwrap();
                 let mut del2 = conn.query("DELETE FROM audit_wide").unwrap().unwrap();
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -229,7 +246,7 @@ fn bench_wide_table_sparse_trigger(criterion: &mut Criterion) {
                 BenchmarkId::new("sqlite", format!("{col_count}_cols")),
                 |b| {
                     let mut stmt = sqlite_conn.prepare(&values).unwrap();
-                    b.iter_custom(|iters| {
+                    iter_custom_or_iter!(b, |iters| {
                         let mut total = std::time::Duration::ZERO;
                         for _ in 0..iters {
                             let start = std::time::Instant::now();
@@ -332,7 +349,7 @@ fn bench_multiple_triggers(criterion: &mut Criterion) {
                     .iter()
                     .map(|t| conn.query(format!("DELETE FROM {t}")).unwrap().unwrap())
                     .collect();
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -358,7 +375,7 @@ fn bench_multiple_triggers(criterion: &mut Criterion) {
                 BenchmarkId::new("sqlite", format!("{trigger_count}_triggers")),
                 |b| {
                     let mut stmt = sqlite_conn.prepare(&values).unwrap();
-                    b.iter_custom(|iters| {
+                    iter_custom_or_iter!(b, |iters| {
                         let mut total = std::time::Duration::ZERO;
                         for _ in 0..iters {
                             let start = std::time::Instant::now();
@@ -423,7 +440,7 @@ fn bench_trigger_overhead(criterion: &mut Criterion) {
             } else {
                 None
             };
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
@@ -453,7 +470,7 @@ fn bench_trigger_overhead(criterion: &mut Criterion) {
                 } else {
                     "DELETE FROM src"
                 };
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -507,7 +524,7 @@ fn bench_before_trigger(criterion: &mut Criterion) {
             |b| {
                 let mut insert_stmt = conn.prepare(&values).unwrap();
                 let mut del = conn.query("DELETE FROM src").unwrap().unwrap();
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -531,7 +548,7 @@ fn bench_before_trigger(criterion: &mut Criterion) {
                 BenchmarkId::new("sqlite", format!("{row_count}_rows")),
                 |b| {
                     let mut stmt = sqlite_conn.prepare(&values).unwrap();
-                    b.iter_custom(|iters| {
+                    iter_custom_or_iter!(b, |iters| {
                         let mut total = std::time::Duration::ZERO;
                         for _ in 0..iters {
                             let start = std::time::Instant::now();

--- a/core/benches/write_perf_benchmark.rs
+++ b/core/benches/write_perf_benchmark.rs
@@ -27,6 +27,23 @@ use turso_core::{Database, PlatformIO, StepResult};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+#[cfg(not(feature = "codspeed"))]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter_custom(|$iters| $body)
+    };
+}
+
+#[cfg(feature = "codspeed")]
+macro_rules! iter_custom_or_iter {
+    ($b:expr, |$iters:ident| $body:block) => {
+        $b.iter(|| {
+            let $iters = 1;
+            $body
+        })
+    };
+}
+
 /// Helper to execute a statement to completion
 fn run_to_completion(
     stmt: &mut turso_core::Statement,
@@ -148,7 +165,7 @@ fn bench_index_impact(criterion: &mut Criterion) {
         group.bench_function(BenchmarkId::new("limbo", name), |b| {
             let mut insert_stmt = conn.prepare(&values).unwrap();
             let mut delete_stmt = conn.query("DELETE FROM test").unwrap().unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
@@ -170,7 +187,7 @@ fn bench_index_impact(criterion: &mut Criterion) {
 
             group.bench_function(BenchmarkId::new("sqlite", name), |b| {
                 let mut stmt = sqlite_conn.prepare(&values).unwrap();
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -227,7 +244,7 @@ fn bench_transaction_size(criterion: &mut Criterion) {
             let mut insert_stmt = conn.prepare(&values).unwrap();
             let mut delete_stmt = conn.query("DELETE FROM test").unwrap().unwrap();
 
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
@@ -255,7 +272,7 @@ fn bench_transaction_size(criterion: &mut Criterion) {
             );
 
             group.bench_function(BenchmarkId::new("sqlite", format!("{tx_size}_rows")), |b| {
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
@@ -328,7 +345,7 @@ fn bench_key_pattern(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo", "sequential_keys"), |b| {
         let mut stmt = conn.prepare(&seq_values).unwrap();
         let mut delete_stmt = conn.query("DELETE FROM test").unwrap().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             let mut total = std::time::Duration::ZERO;
             for _ in 0..iters {
                 let start = std::time::Instant::now();
@@ -353,7 +370,7 @@ fn bench_key_pattern(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo", "random_keys"), |b| {
         let mut stmt = conn.prepare(&rand_values).unwrap();
         let mut delete_stmt = conn.query("DELETE FROM test").unwrap().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             let mut total = std::time::Duration::ZERO;
             for _ in 0..iters {
                 let start = std::time::Instant::now();
@@ -377,7 +394,7 @@ fn bench_key_pattern(criterion: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("sqlite", "sequential_keys"), |b| {
             let mut stmt = sqlite_conn.prepare(&seq_values).unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
@@ -398,7 +415,7 @@ fn bench_key_pattern(criterion: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("sqlite", "random_keys"), |b| {
             let mut stmt = sqlite_conn.prepare(&rand_values).unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
@@ -531,7 +548,7 @@ fn bench_delete_performance(criterion: &mut Criterion) {
     let conn = db.connect().unwrap();
 
     group.bench_function(BenchmarkId::new("limbo", "range_delete"), |b| {
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             let mut total = std::time::Duration::ZERO;
             for _ in 0..iters {
                 // Re-insert data
@@ -561,7 +578,7 @@ fn bench_delete_performance(criterion: &mut Criterion) {
         );
 
         group.bench_function(BenchmarkId::new("sqlite", "range_delete"), |b| {
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     // Re-insert data
@@ -624,7 +641,7 @@ fn bench_large_transaction_commit(criterion: &mut Criterion) {
         group.bench_function(
             BenchmarkId::new("limbo", format!("{row_count}_rows")),
             |b| {
-                b.iter_custom(|iters| {
+                iter_custom_or_iter!(b, |iters| {
                     let mut total = std::time::Duration::ZERO;
                     for _ in 0..iters {
                         // BEGIN
@@ -661,7 +678,7 @@ fn bench_large_transaction_commit(criterion: &mut Criterion) {
             group.bench_function(
                 BenchmarkId::new("sqlite", format!("{row_count}_rows")),
                 |b| {
-                    b.iter_custom(|iters| {
+                    iter_custom_or_iter!(b, |iters| {
                         let mut total = std::time::Duration::ZERO;
                         for _ in 0..iters {
                             sqlite_conn.execute("BEGIN", []).unwrap();
@@ -715,7 +732,7 @@ fn bench_fsync_overhead(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo", "sync_FULL"), |b| {
         let mut insert_stmt = conn.prepare(&values).unwrap();
         let mut delete_stmt = conn.query("DELETE FROM test").unwrap().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             let mut total = std::time::Duration::ZERO;
             for _ in 0..iters {
                 let start = std::time::Instant::now();
@@ -741,7 +758,7 @@ fn bench_fsync_overhead(criterion: &mut Criterion) {
     group.bench_function(BenchmarkId::new("limbo", "sync_OFF"), |b| {
         let mut insert_stmt = conn.prepare(&values).unwrap();
         let mut delete_stmt = conn.query("DELETE FROM test").unwrap().unwrap();
-        b.iter_custom(|iters| {
+        iter_custom_or_iter!(b, |iters| {
             let mut total = std::time::Duration::ZERO;
             for _ in 0..iters {
                 let start = std::time::Instant::now();
@@ -765,7 +782,7 @@ fn bench_fsync_overhead(criterion: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("sqlite", "sync_FULL"), |b| {
             let mut stmt = sqlite_conn.prepare(&values).unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();
@@ -796,7 +813,7 @@ fn bench_fsync_overhead(criterion: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("sqlite", "sync_OFF"), |b| {
             let mut stmt = sqlite_conn.prepare(&values).unwrap();
-            b.iter_custom(|iters| {
+            iter_custom_or_iter!(b, |iters| {
                 let mut total = std::time::Duration::ZERO;
                 for _ in 0..iters {
                     let start = std::time::Instant::now();


### PR DESCRIPTION
## Description
Codspeed in simulation mode does not support custom iterations as it runs the benchmark only once. Also made   the bigger create index benches local only for now as it was timing out codspeed.
<img width="1392" height="830" alt="image" src="https://github.com/user-attachments/assets/d149168a-ff2b-4f77-8200-02552983fa4e" />


## Description of AI Usage
Do the mechanical change
