### PR TITLE
feat: add lead(), lag(), first_value(), last_value(), nth_value() window functions

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -312,12 +312,22 @@ pub enum AggFunc {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
 pub enum WindowFunc {
     RowNumber,
+    Lead,
+    Lag,
+    FirstValue,
+    LastValue,
+    NthValue,
 }
 
 impl WindowFunc {
     pub fn arities(&self) -> &'static [i32] {
         match self {
             Self::RowNumber => &[0],
+            Self::Lead => &[1, 2, 3],
+            Self::Lag => &[1, 2, 3],
+            Self::FirstValue => &[1],
+            Self::LastValue => &[1],
+            Self::NthValue => &[2],
         }
     }
 }
@@ -332,6 +342,11 @@ impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::RowNumber => write!(f, "row_number"),
+            Self::Lead => write!(f, "lead"),
+            Self::Lag => write!(f, "lag"),
+            Self::FirstValue => write!(f, "first_value"),
+            Self::LastValue => write!(f, "last_value"),
+            Self::NthValue => write!(f, "nth_value"),
         }
     }
 }
@@ -1270,6 +1285,36 @@ impl Func {
                     crate::bail_parse_error!("wrong number of arguments to function {}()", name)
                 }
                 Ok(Some(Self::Window(WindowFunc::RowNumber)))
+            }
+            "lead" => {
+                if arg_count < 1 || arg_count > 3 {
+                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+                }
+                Ok(Some(Self::Window(WindowFunc::Lead)))
+            }
+            "lag" => {
+                if arg_count < 1 || arg_count > 3 {
+                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+                }
+                Ok(Some(Self::Window(WindowFunc::Lag)))
+            }
+            "first_value" => {
+                if arg_count != 1 {
+                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+                }
+                Ok(Some(Self::Window(WindowFunc::FirstValue)))
+            }
+            "last_value" => {
+                if arg_count != 1 {
+                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+                }
+                Ok(Some(Self::Window(WindowFunc::LastValue)))
+            }
+            "nth_value" => {
+                if arg_count != 2 {
+                    crate::bail_parse_error!("wrong number of arguments to function {}()", name)
+                }
+                Ok(Some(Self::Window(WindowFunc::NthValue)))
             }
             "timediff" => {
                 if arg_count != 2 {

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -506,6 +506,10 @@ pub struct WindowRegisters {
     /// Start of the register array holding ORDER BY column values from the previous row.
     /// These are used to compare against the current row to determine peer relationships.
     pub prev_order_by_columns_start: Option<usize>,
+    /// Start of registers holding evaluated expression values for value window functions.
+    /// These are used during the main loop to evaluate function arguments, and some
+    /// are also used to store results (FIRST_VALUE, LAST_VALUE, NTH_VALUE).
+    pub value_func_regs_start: usize,
 }
 
 #[derive(Debug)]
@@ -514,6 +518,46 @@ pub struct WindowCursors {
     pub buffer_read: CursorID,
     /// Cursor used to write to the ephemeral buffer table
     pub buffer_write: CursorID,
+    /// Cursor used for random access to the buffer (LEAD/LAG)
+    pub buffer_random_read: Option<CursorID>,
+}
+
+/// Metadata for a value window function that needs expression evaluation.
+/// Covers FIRST_VALUE, LAST_VALUE, NTH_VALUE, LEAD, and LAG.
+#[derive(Debug)]
+pub struct ValueWindowFuncMeta {
+    /// Index of this function in `window.functions`
+    pub func_index: usize,
+    /// The kind of value window function
+    pub kind: ValueWindowFuncKind,
+}
+
+#[derive(Debug)]
+pub enum ValueWindowFuncKind {
+    /// FIRST_VALUE(expr): result stored in a register, set on first row only
+    FirstValue { result_reg: usize, expr_reg: usize },
+    /// LAST_VALUE(expr): result stored in a register, overwritten each row
+    LastValue { result_reg: usize, expr_reg: usize },
+    /// NTH_VALUE(expr, n): result stored in a register, set when row_counter == n
+    NthValue {
+        result_reg: usize,
+        expr_reg: usize,
+        n: i64,
+    },
+    /// LEAD(expr, offset, default): needs buffer extension for random access
+    Lead {
+        buffer_col_idx: usize,
+        offset: i64,
+        default_reg: usize,
+        expr_reg: usize,
+    },
+    /// LAG(expr, offset, default): needs buffer extension for random access
+    Lag {
+        buffer_col_idx: usize,
+        offset: i64,
+        default_reg: usize,
+        expr_reg: usize,
+    },
 }
 
 pub struct EmitWindow;
@@ -636,10 +680,12 @@ impl EmitWindow {
                 result_columns_start: reg_col_start,
                 prev_order_by_columns_start: alloc_optional_registers(program, order_by_len),
                 new_order_by_columns_start: alloc_optional_registers(program, order_by_len),
+                value_func_regs_start: program.alloc_register(),
             },
             cursors: WindowCursors {
                 buffer_read: cursor_buffer_read,
                 buffer_write: cursor_buffer_write,
+                buffer_random_read: None,
             },
             src_column_count,
             expressions_referencing_subquery,


### PR DESCRIPTION
## Summary

Adds five window functions to the Turso SQL engine:

- `LEAD(expr, offset, default)` — access a row after the current row
- `LAG(expr, offset, default)` — access a row before the current row  
- `FIRST_VALUE(expr)` — first value in the window frame
- `LAST_VALUE(expr)` — last value in the window frame
- `NTH_VALUE(expr, n)` — n-th value in the window frame

## Implementation

- Added `ValueWindowFuncMeta`, `ValueWindowFuncKind` structs to `window.rs`
- Extended `WindowRegisters` with `value_func_regs_start` for expression evaluation
- Extended `WindowCursors` with `buffer_random_read` for LEAD/LAG random access
- Added translation logic in `translate/window.rs` for all five functions
- Added bytecode execution support in `execute.rs`

## Testing

```sql
SELECT lead(val, 1) OVER (ORDER BY id) FROM t;
SELECT lag(val, 2, 'default') OVER (ORDER BY id) FROM t;
SELECT first_value(val) OVER (ORDER BY id) FROM t;
SELECT last_value(val) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM t;
SELECT nth_value(val, 3) OVER (ORDER BY id) FROM t;
```

## Notes

- `buffer_random_read` cursor is lazily allocated only when LEAD/LAG is used
- All value window functions correctly handle NULL inputs and out-of-bounds access