### PR TITLE
core/mvcc: Guard global_header write against out-of-order commits

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2220,25 +2220,22 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
 
                 inject_transition_yield!(self, CommitYieldPoint::BeforeGlobalHeaderUpdate);
 
-                // Since we assign a commit timestamp and then we drive the commit to completion,
-                // it is totally possible for so an older transaction can finish after a newer one.
-                // In such case, we should not let older commit to set lower value than previous.
-                // This value is used in checkpointing as a watermark boundary, and an incorrect
-                // lower value can cause data loss / corruption.
-                let prev_committed_ts = mvcc_store
-                    .last_committed_tx_ts
-                    .fetch_max(*end_ts, Ordering::AcqRel);
-                // Guard the global_header write with the same monotonicity rule.
-                // Out-of-order completion (older end_ts finishing after a newer one) would
-                // otherwise regress global_header.schema_cookie below the latest committed
-                // value, breaking later `maybe_reparse_schema` cookie comparisons against
-                // `db.schema` and stranding readers in a redundant disk-reparse loop that
-                // takes commit deps on still-Preparing writers.
-                if prev_committed_ts <= *end_ts {
-                    mvcc_store
-                        .global_header
-                        .write()
-                        .replace(*tx_unlocked.header.read());
+                let tx_header = *tx_unlocked.header.read();
+                {
+                    // Hold the header lock across the watermark update and header
+                    // publish so the guard decision and replacement are serialized.
+                    let mut global_header = mvcc_store.global_header.write();
+                    // Since we assign a commit timestamp and then we drive the commit to completion,
+                    // it is totally possible for so an older transaction can finish after a newer one.
+                    // In such case, we should not let older commit to set lower value than previous.
+                    // This value is used in checkpointing as a watermark boundary, and an incorrect
+                    // lower value can cause data loss / corruption.
+                    let last_committed_ts = mvcc_store
+                        .last_committed_tx_ts
+                        .fetch_max(*end_ts, Ordering::AcqRel);
+                    if last_committed_ts <= *end_ts {
+                        global_header.replace(tx_header);
+                    }
                 }
                 if self.did_commit_schema_change {
                     mvcc_store

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2215,11 +2215,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
 
                 mvcc_store.unlock_commit_lock_if_held(tx_unlocked);
 
-                mvcc_store
-                    .global_header
-                    .write()
-                    .replace(*tx_unlocked.header.read());
-
                 inject_transition_yield!(
                     self,
                     CommitYieldPoint::BeforeCommittedTimestampWatermarkUpdate
@@ -2230,9 +2225,21 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // In such case, we should not let older commit to set lower value than previous.
                 // This value is used in checkpointing as a watermark boundary, and an incorrect
                 // lower value can cause data loss / corruption.
-                mvcc_store
+                let prev_committed_ts = mvcc_store
                     .last_committed_tx_ts
                     .fetch_max(*end_ts, Ordering::AcqRel);
+                // Guard the global_header write with the same monotonicity rule.
+                // Out-of-order completion (older end_ts finishing after a newer one) would
+                // otherwise regress global_header.schema_cookie below the latest committed
+                // value, breaking later `maybe_reparse_schema` cookie comparisons against
+                // `db.schema` and stranding readers in a redundant disk-reparse loop that
+                // takes commit deps on still-Preparing writers.
+                if prev_committed_ts <= *end_ts {
+                    mvcc_store
+                        .global_header
+                        .write()
+                        .replace(*tx_unlocked.header.read());
+                }
                 if self.did_commit_schema_change {
                     mvcc_store
                         .last_committed_schema_change_ts

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1041,7 +1041,10 @@ pub(crate) enum CommitYieldPoint {
     /// `LogRecordPrepared` to bracket the BuildLogRecord chunked yields.
     BuildLogRecordStart,
     LogRecordPrepared,
-    BeforeCommittedTimestampWatermarkUpdate,
+    /// Fires after commit dependencies are released and the commit lock is
+    /// dropped, but before publishing the cached global header / committed
+    /// timestamp watermark.
+    BeforeGlobalHeaderUpdate,
     BeforeFinishCommittedTx,
     /// Boundary right after `remove_tx` runs but before the connection cache
     /// is cleared by the caller at vdbe/mod.rs. Used for failure injection
@@ -2215,10 +2218,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
 
                 mvcc_store.unlock_commit_lock_if_held(tx_unlocked);
 
-                inject_transition_yield!(
-                    self,
-                    CommitYieldPoint::BeforeCommittedTimestampWatermarkUpdate
-                );
+                inject_transition_yield!(self, CommitYieldPoint::BeforeGlobalHeaderUpdate);
 
                 // Since we assign a commit timestamp and then we drive the commit to completion,
                 // it is totally possible for so an older transaction can finish after a newer one.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -2912,7 +2912,7 @@ fn test_checkpoint_stale_boundary_does_not_replay_checkpointed_create_table_afte
             .execute("UPDATE s SET v = 'older_commit' WHERE id = 1")
             .unwrap();
         older.set_yield_injector(Some(FixedYieldInjector::new([
-            CommitYieldPoint::BeforeCommittedTimestampWatermarkUpdate.point(),
+            CommitYieldPoint::BeforeGlobalHeaderUpdate.point(),
         ])));
         let mut older_commit = older.prepare("COMMIT").unwrap();
         assert!(
@@ -11968,38 +11968,13 @@ fn test_auto_rowid_after_negative_explicit_rowid_uses_next_negative() {
     assert_eq!(rows[1][0].as_int().unwrap(), -4);
     assert_eq!(rows[1][1].to_string(), "auto");
 }
-/// Regression: out-of-order MVCC commit completion must not regress
-/// `mvcc_store.global_header.schema_cookie`.
+/// Regression: out-of-order MVCC commit finalization must not let an older
+/// transaction replace `global_header` with a stale header.
 ///
-/// `CommitStateMachine::FinalizeCommit` writes `global_header` with the
-/// committing tx's header. Two commits that interleave (older end_ts
-/// reaches FinalizeCommit *after* a newer one with a bumped cookie)
-/// would otherwise overwrite the latest cookie with a stale value.
-///
-/// Once `global_header.schema_cookie` regresses below
-/// `db.schema.schema_version`, `maybe_reparse_schema`'s early-exit fails
-/// on every subsequent statement — it triggers a disk reparse, the inner
-/// `SELECT * FROM sqlite_schema` speculatively reads any still-Preparing
-/// writer's row (Hekaton §2.7), registers a commit dependency, and the
-/// single-threaded reparse loop in `Statement::run_with_row_callback`
-/// parks in `WaitForDependencies` forever. This is the deadlock seed
-/// 4729871996470817193 hit in whopper MVCC soak.
-///
-/// Repro shape:
-/// - tx_a: CONCURRENT update, pinned at `LogRecordPrepared` (in
-///   BuildLogRecord state, end_ts already assigned but commit not yet
-///   logged).
-/// - tx_b: exclusive DDL (CREATE TABLE) ran end-to-end while tx_a is
-///   paused. tx_b acquired a newer end_ts and bumped the cookie; its
-///   `FinalizeCommit` writes the new cookie into `global_header`.
-/// - tx_a resumes, runs through to `FinalizeCommit`. Its tx_header
-///   carries the OLD cookie. Without the guard,
-///   `global_header.write().replace(...)` regresses the cookie.
-///
-/// The fix in `FinalizeCommit` reorders
-/// `last_committed_tx_ts.fetch_max(end_ts)` before the `global_header`
-/// write and only writes when `prev_committed_ts <= *end_ts` — i.e. only
-/// when our commit is still the most recent.
+/// tx_a is paused in FinalizeCommit after it has been marked Committed but
+/// before publishing its header/watermark. tx_b then commits newer DDL and
+/// publishes a bumped schema cookie. When tx_a resumes, its older header must
+/// not move `global_header.schema_cookie` backward.
 #[test]
 fn test_global_header_cookie_no_regression_on_out_of_order_finalize() {
     let db = MvccTestDbNoConn::new_with_random_db();
@@ -12033,7 +12008,7 @@ fn test_global_header_cookie_no_regression_on_out_of_order_finalize() {
     let tx_a_id = conn_a.get_mv_tx_id().expect("tx_a should be active");
 
     conn_a.set_yield_injector(Some(FixedYieldInjector::new([
-        CommitYieldPoint::BeforeCommittedTimestampWatermarkUpdate.point(),
+        CommitYieldPoint::BeforeGlobalHeaderUpdate.point(),
     ])));
     let mut commit_a = conn_a.prepare("COMMIT").unwrap();
     let mut yielded = false;
@@ -12049,7 +12024,7 @@ fn test_global_header_cookie_no_regression_on_out_of_order_finalize() {
     }
     assert!(
         yielded,
-        "tx_a's COMMIT should yield at BeforeCommittedTimestampWatermarkUpdate"
+        "tx_a's COMMIT should yield before publishing global_header"
     );
     assert!(
         matches!(
@@ -12097,4 +12072,77 @@ fn test_global_header_cookie_no_regression_on_out_of_order_finalize() {
     );
 }
 
+/// Regression: the same stale `global_header` overwrite can lose user-visible
+/// database-header state, not just regress the internal schema cookie.
+///
+/// `PRAGMA user_version` is committed through the MVCC header path. If an older
+/// transaction resumes after that newer header-only commit and overwrites
+/// `global_header` with its stale header snapshot, users observe the committed
+/// user_version move backward.
+#[test]
+fn test_global_header_regression_would_lose_committed_user_version() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let setup = db.connect();
+        setup
+            .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        setup.execute("PRAGMA user_version = 7").unwrap();
+        setup
+            .execute("INSERT INTO t VALUES (1, 'initial')")
+            .unwrap();
+        setup.close().unwrap();
+    }
 
+    let older = db.connect();
+    let header_writer = db.connect();
+    let observer = db.connect();
+
+    older.execute("BEGIN CONCURRENT").unwrap();
+    older
+        .execute("UPDATE t SET v = 'older' WHERE id = 1")
+        .unwrap();
+    older.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::BeforeGlobalHeaderUpdate.point(),
+    ])));
+    let mut older_commit = older.prepare("COMMIT").unwrap();
+    let mut yielded_older = false;
+    for _ in 0..200 {
+        match older_commit.step().unwrap() {
+            StepResult::IO => {
+                yielded_older = true;
+                break;
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    assert!(
+        yielded_older,
+        "older COMMIT should yield before publishing global_header"
+    );
+
+    header_writer.execute("BEGIN").unwrap();
+    header_writer.execute("PRAGMA user_version = 42").unwrap();
+    header_writer.execute("COMMIT").unwrap();
+
+    let rows = get_rows(&observer, "PRAGMA user_version");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0][0].as_int().unwrap(),
+        42,
+        "newer header-only commit should publish user_version before older resumes"
+    );
+
+    older.set_yield_injector(None);
+    older_commit.run_ignore_rows().unwrap();
+    drop(older_commit);
+
+    let rows = get_rows(&observer, "PRAGMA user_version");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0][0].as_int().unwrap(),
+        42,
+        "older out-of-order FinalizeCommit regressed committed PRAGMA user_version"
+    );
+}

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -11968,3 +11968,133 @@ fn test_auto_rowid_after_negative_explicit_rowid_uses_next_negative() {
     assert_eq!(rows[1][0].as_int().unwrap(), -4);
     assert_eq!(rows[1][1].to_string(), "auto");
 }
+/// Regression: out-of-order MVCC commit completion must not regress
+/// `mvcc_store.global_header.schema_cookie`.
+///
+/// `CommitStateMachine::FinalizeCommit` writes `global_header` with the
+/// committing tx's header. Two commits that interleave (older end_ts
+/// reaches FinalizeCommit *after* a newer one with a bumped cookie)
+/// would otherwise overwrite the latest cookie with a stale value.
+///
+/// Once `global_header.schema_cookie` regresses below
+/// `db.schema.schema_version`, `maybe_reparse_schema`'s early-exit fails
+/// on every subsequent statement — it triggers a disk reparse, the inner
+/// `SELECT * FROM sqlite_schema` speculatively reads any still-Preparing
+/// writer's row (Hekaton §2.7), registers a commit dependency, and the
+/// single-threaded reparse loop in `Statement::run_with_row_callback`
+/// parks in `WaitForDependencies` forever. This is the deadlock seed
+/// 4729871996470817193 hit in whopper MVCC soak.
+///
+/// Repro shape:
+/// - tx_a: CONCURRENT update, pinned at `LogRecordPrepared` (in
+///   BuildLogRecord state, end_ts already assigned but commit not yet
+///   logged).
+/// - tx_b: exclusive DDL (CREATE TABLE) ran end-to-end while tx_a is
+///   paused. tx_b acquired a newer end_ts and bumped the cookie; its
+///   `FinalizeCommit` writes the new cookie into `global_header`.
+/// - tx_a resumes, runs through to `FinalizeCommit`. Its tx_header
+///   carries the OLD cookie. Without the guard,
+///   `global_header.write().replace(...)` regresses the cookie.
+///
+/// The fix in `FinalizeCommit` reorders
+/// `last_committed_tx_ts.fetch_max(end_ts)` before the `global_header`
+/// write and only writes when `prev_committed_ts <= *end_ts` — i.e. only
+/// when our commit is still the most recent.
+#[test]
+fn test_global_header_cookie_no_regression_on_out_of_order_finalize() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let setup = db.connect();
+        setup
+            .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        setup
+            .execute("INSERT INTO t VALUES (1, 'initial')")
+            .unwrap();
+        setup.close().unwrap();
+    }
+    let mvcc_store = db.get_mvcc_store();
+    let cookie_before = mvcc_store
+        .with_header(|h| h.schema_cookie.get(), None)
+        .unwrap();
+
+    let conn_a = db.connect();
+    let conn_b = db.connect();
+
+    // tx_a: CONCURRENT update. Pin its commit inside FinalizeCommit, after
+    // CommitEnd has already marked the tx Committed but before the
+    // watermark / global_header writes. tx_a is no longer Preparing at the
+    // yield, so `acquire_exclusive_tx`'s `has_preparing_tx_other_than` check
+    // lets tx_b take the slot.
+    conn_a.execute("BEGIN CONCURRENT").unwrap();
+    conn_a
+        .execute("UPDATE t SET v = 'a-mod' WHERE id = 1")
+        .unwrap();
+    let tx_a_id = conn_a.get_mv_tx_id().expect("tx_a should be active");
+
+    conn_a.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::BeforeCommittedTimestampWatermarkUpdate.point(),
+    ])));
+    let mut commit_a = conn_a.prepare("COMMIT").unwrap();
+    let mut yielded = false;
+    for _ in 0..200 {
+        match commit_a.step().unwrap() {
+            StepResult::IO => {
+                yielded = true;
+                break;
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    assert!(
+        yielded,
+        "tx_a's COMMIT should yield at BeforeCommittedTimestampWatermarkUpdate"
+    );
+    assert!(
+        matches!(
+            mvcc_store
+                .txs
+                .get(&tx_a_id)
+                .expect("tx_a should be tracked")
+                .value()
+                .state
+                .load(),
+            TransactionState::Committed(_)
+        ),
+        "tx_a should be Committed (set by CommitEnd) by the time we yield in FinalizeCommit"
+    );
+
+    // tx_b: exclusive DDL. tx_a is Committed so `acquire_exclusive_tx`
+    // does not see a Preparing other-than. tx_b runs end-to-end and its
+    // FinalizeCommit writes the bumped cookie into global_header.
+    conn_b.execute("BEGIN").unwrap();
+    conn_b.execute("CREATE TABLE foo(x INTEGER)").unwrap();
+    conn_b.execute("COMMIT").unwrap();
+    let cookie_after_b = mvcc_store
+        .with_header(|h| h.schema_cookie.get(), None)
+        .unwrap();
+    assert!(
+        cookie_after_b > cookie_before,
+        "tx_b's CREATE TABLE should bump global_header.schema_cookie \
+         (before={cookie_before} after_b={cookie_after_b})"
+    );
+
+    // Resume tx_a. Its FinalizeCommit's global_header write must not
+    // overwrite tx_b's newer cookie.
+    conn_a.set_yield_injector(None);
+    commit_a.run_ignore_rows().unwrap();
+    drop(commit_a);
+
+    let cookie_final = mvcc_store
+        .with_header(|h| h.schema_cookie.get(), None)
+        .unwrap();
+    assert_eq!(
+        cookie_final, cookie_after_b,
+        "global_header.schema_cookie regressed after older tx_a finalized \
+         after newer DDL tx_b — before={cookie_before} after_b={cookie_after_b} \
+         final={cookie_final}"
+    );
+}
+
+


### PR DESCRIPTION
## Motivation and context

MVCC commits can finalize out of commit-timestamp order. We already protect
last_committed_tx_ts with fetch_max(end_ts), but global_header was updated as a
separate operation. That left a race where an older finalizing commit could
overwrite a newer commit's header, regressing schema_cookie or other header
fields.

When the cached header goes backwards, connections believe the database schema
on disk is older than the schema already published in memory. They repeatedly
try to reload schema state that is already current. Under a single-threaded
executor, that reload can wait on another transaction that never gets a chance
to run, turning the stale header into a permanent hang. This can cause data loss
and/or corruption.

Fix this by holding the global_header write lock across both the watermark
fetch_max and the conditional header replacement. The latest-committer decision
and cached-header publish are now one serialized critical section.

This patch comes with regression tests:

```rust
 running 2 tests
  test mvcc::database::tests::test_global_header_regression_would_lose_committed_user_version ... FAILED
  test mvcc::database::tests::test_global_header_cookie_no_regression_on_out_of_order_finalize ... FAILED

  failures:

  ---- mvcc::database::tests::test_global_header_regression_would_lose_committed_user_version stdout ----
  thread 'mvcc::database::tests::test_global_header_regression_would_lose_committed_user_version' panicked at core/mvcc/database/tests.rs:12143:5:
  assertion `left == right` failed: older out-of-order FinalizeCommit regressed committed PRAGMA user_version
    left: 7
   right: 42

  ---- mvcc::database::tests::test_global_header_cookie_no_regression_on_out_of_order_finalize stdout ----
  thread 'mvcc::database::tests::test_global_header_cookie_no_regression_on_out_of_order_finalize' panicked at core/mvcc/database/tests.rs:12067:5:
  assertion `left == right` failed: global_header.schema_cookie regressed after older tx_a finalized after newer DDL tx_b — before=2 after_b=3 final=2
    left: 2
   right: 3

  failures:
      mvcc::database::tests::test_global_header_cookie_no_regression_on_out_of_order_finalize
      mvcc::database::tests::test_global_header_regression_would_lose_committed_user_version
```