### PR TITLE
Roll back atomically when a multi-DB commit hits a WW conflict

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1471,7 +1471,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     /// Returns [LimboError::WriteWriteConflict] when another transaction committed or is
     /// preparing a conflicting version according to first-committer-wins.
     fn check_rowid_for_conflicts(
-        &self,
+        self_tx_id: TxID,
         rowid: &RowID,
         end_ts: u64,
         tx: &Transaction,
@@ -1486,7 +1486,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         let row_versions = row_versions.value();
         let row_versions = row_versions.read();
 
-        self.check_version_conflicts(end_ts, tx, mvcc_store, &row_versions)?;
+        Self::check_version_conflicts(self_tx_id, end_ts, tx, mvcc_store, &row_versions)?;
         Ok(())
     }
 
@@ -1495,7 +1495,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     /// Returns [LimboError::WriteWriteConflict] when another transaction committed or is
     /// preparing a conflicting index version according to first-committer-wins.
     fn check_index_for_conflicts(
-        &self,
+        self_tx_id: TxID,
         rowid: &RowID,
         end_ts: u64,
         tx: &Transaction,
@@ -1545,7 +1545,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
             let row_versions = entry.value();
             let row_versions = row_versions.read();
-            self.check_version_conflicts(end_ts, tx, mvcc_store, &row_versions)?;
+            Self::check_version_conflicts(self_tx_id, end_ts, tx, mvcc_store, &row_versions)?;
         }
 
         Ok(())
@@ -1557,7 +1557,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     /// 1. versions ended by concurrent commits (`end > tx.begin_ts`), and
     /// 2. live versions owned by concurrent transactions (state/ts tie-breaking).
     fn check_version_conflicts(
-        &self,
+        self_tx_id: TxID,
         end_ts: u64,
         tx: &Transaction,
         mvcc_store: &Arc<MvStore<Clock>>,
@@ -1589,7 +1589,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 // the check above at lines 1070-1074. Here we only need to check
                 // in-flight tombstones (end: TxID) from other transactions.
                 if let Some(TxTimestampOrID::TxID(other_tx_id)) = version.end {
-                    if other_tx_id != self.tx_id {
+                    if other_tx_id != self_tx_id {
                         let other_tx = mvcc_store.txs.get(&other_tx_id).expect(
                             "check_version_conflicts: tombstone end TxID not found in txn map",
                         );
@@ -1626,7 +1626,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 }
                 Some(TxTimestampOrID::TxID(end_tx_id)) => {
                     // Deletion not yet finalized; the deleting transaction may still be in Preparing.
-                    if end_tx_id == self.tx_id {
+                    if end_tx_id == self_tx_id {
                         // We deleted this version ourselves, so it cannot conflict with our commit.
                         continue;
                     }
@@ -1661,7 +1661,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             match version.begin {
                 Some(TxTimestampOrID::TxID(other_tx_id)) => {
                     // Skip our own version
-                    if other_tx_id == self.tx_id {
+                    if other_tx_id == self_tx_id {
                         continue;
                     }
                     // Another transaction's uncommitted version - check their state
@@ -2698,9 +2698,9 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
 
                 for (id, _chain) in tx.write_set.lock().iter() {
                     if id.row_id.is_int_key() {
-                        self.check_rowid_for_conflicts(id, *end_ts, tx, mvcc_store)?;
+                        Self::check_rowid_for_conflicts(self.tx_id, id, *end_ts, tx, mvcc_store)?;
                     } else {
-                        self.check_index_for_conflicts(id, *end_ts, tx, mvcc_store)?;
+                        Self::check_index_for_conflicts(self.tx_id, id, *end_ts, tx, mvcc_store)?;
                     }
                 }
 
@@ -4827,6 +4827,32 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         ));
         let state_machine = StateMachine::new(state);
         Ok(state_machine)
+    }
+
+    /// Read-only conflict check used as a pre-commit gate across attached databases:
+    /// detects committed write-write conflicts for `tx_id`'s pending writes so a
+    /// conflict on any DB aborts the multi-DB commit before any DB is finalized.
+    ///
+    /// Passes `end_ts = 0` to the underlying version checks so the lower-end_ts-wins
+    /// branch between two Preparing transactions can never trigger here (concurrent-
+    /// Preparing tie-breaking remains the job of the authoritative per-store
+    /// validation in [CommitState::Commit]).
+    pub fn precheck_write_conflicts(self: &Arc<Self>, tx_id: TxID) -> Result<()> {
+        if !self.is_exclusive_tx(&tx_id) && self.has_exclusive_tx() {
+            return Err(LimboError::WriteWriteConflict);
+        }
+        let Some(tx_entry) = self.txs.get(&tx_id) else {
+            return Ok(());
+        };
+        let tx = tx_entry.value();
+        for (id, _) in tx.write_set.lock().iter() {
+            if id.row_id.is_int_key() {
+                CommitStateMachine::<Clock>::check_rowid_for_conflicts(tx_id, id, 0, tx, self)?;
+            } else {
+                CommitStateMachine::<Clock>::check_index_for_conflicts(tx_id, id, 0, tx, self)?;
+            }
+        }
+        Ok(())
     }
 
     /// Returns true if the transaction can be rolled back (Active or Preparing).

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1974,11 +1974,12 @@ impl Program {
     /// 3. **Attached WAL** — flush dirty pages on attached databases that use WAL
     ///    (e.g. :memory: attached while main is MVCC).
     ///
-    /// **IMPORTANT**: This multi-phase commit is NOT atomic across databases.
-    /// A crash between phases can leave the main and attached databases in
-    /// inconsistent states (main committed, some attached DBs not committed).
-    /// This matches SQLite's WAL mode behavior — cross-file atomicity only
-    /// exists in legacy rollback journal mode, which we do not support.
+    /// **IMPORTANT**: This multi-phase commit is NOT atomic across databases
+    /// in the presence of a crash — a crash between phases can leave main and
+    /// attached DBs inconsistent (main committed, some attached not). Crash
+    /// atomicity across files only exists in SQLite's legacy rollback-journal
+    /// mode, which we do not support. We do however guarantee atomicity on
+    /// **conflict**: a conflict on any DB rolls back all DBs.
     fn commit_txn_mvcc(
         &self,
         pager: Arc<Pager>,
@@ -1992,7 +1993,39 @@ impl Program {
             return Ok(IOResult::Done(()));
         }
 
-        // Phase 1: Commit main DB MVCC transaction
+        // Phase 1: pre-validate WW conflicts across all participating MVCC stores so a
+        // conflict aborts the whole commit before any store has been finalized.
+        if matches!(program_state.commit_state, CommitState::Ready) {
+            let precheck = (|| -> Result<()> {
+                if let Some(tx_id) = conn.get_mv_tx_id() {
+                    mv_store.precheck_write_conflicts(tx_id)?;
+                }
+                let attached: Vec<(usize, u64)> = conn
+                    .attached_mv_txs
+                    .read()
+                    .iter()
+                    .map(|(&d, &(t, _))| (d, t))
+                    .collect();
+                for (db_id, tx_id) in attached {
+                    if let Some(store) = conn.mv_store_for_db(db_id) {
+                        store.precheck_write_conflicts(tx_id)?;
+                    }
+                }
+                Ok(())
+            })();
+            if let Err(e) = precheck {
+                if let Some(tx_id) = conn.get_mv_tx_id() {
+                    mv_store.rollback_tx(tx_id, pager.clone(), &conn, crate::MAIN_DB_ID);
+                }
+                pager.end_read_tx();
+                conn.rollback_attached_mvcc_txs(true);
+                conn.rollback_attached_wal_txns();
+                conn.set_tx_state(TransactionState::None);
+                return Err(e);
+            }
+        }
+
+        // Phase 2: Commit main DB MVCC transaction
         if matches!(program_state.commit_state, CommitState::Ready) {
             if let Some(tx_id) = conn.get_mv_tx_id() {
                 let state_machine = mv_store.commit_tx(tx_id, &conn, crate::MAIN_DB_ID)?;
@@ -2024,7 +2057,7 @@ impl Program {
             }
         }
 
-        // Phase 2: Commit MVCC transactions on attached databases
+        // Phase 3: Commit MVCC transactions on attached databases
         // Resume an in-progress attached MVCC commit
         if matches!(
             program_state.commit_state,
@@ -2099,7 +2132,7 @@ impl Program {
             }
         }
 
-        // Phase 3: Commit WAL transactions on attached databases that don't use MVCC.
+        // Phase 4: Commit WAL transactions on attached databases that don't use MVCC.
         // When the main DB uses MVCC, we route through commit_txn_mvcc, but attached
         // DBs may use WAL mode and need their dirty pages committed via the WAL path.
         if matches!(program_state.commit_state, CommitState::CommittingAttached) {

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1377,3 +1377,37 @@ fn test_mvcc_update_btree_only_row_after_truncate_checkpoint(
 
     Ok(())
 }
+
+#[turso_macros::test]
+fn test_mvcc_multi_db_commit_atomic_on_conflict(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn1 = tmp_db.connect_limbo();
+    conn1.pragma_update("journal_mode", "'mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_atomic.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn1.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn1.execute("CREATE TABLE t(x INTEGER)")?;
+    conn1.execute("CREATE TABLE aux.u(x INTEGER PRIMARY KEY)")?;
+
+    let conn2 = tmp_db.connect_limbo();
+    conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+
+    conn1.execute("BEGIN CONCURRENT")?;
+    conn2.execute("BEGIN CONCURRENT")?;
+    conn1.execute("INSERT INTO t VALUES (1), (2), (3), (4), (5)")?;
+    conn1.execute("INSERT INTO aux.u VALUES (1)")?; // ww conflict, because conn2 commits first
+    conn2.execute("INSERT INTO aux.u VALUES (1)")?;
+    conn2.execute("COMMIT")?;
+
+    // conn1 gets a ww conflict because of its write on aux
+    let conn1_commit = conn1.execute("COMMIT");
+    assert!(matches!(conn1_commit, Err(LimboError::WriteWriteConflict)));
+
+    let observer = tmp_db.connect_limbo();
+    let main_count: Vec<(i64,)> = observer.exec_rows("SELECT COUNT(*) FROM t");
+    // conn1 should roll back in the `main` and `aux` schemas.
+    assert_eq!(main_count, vec![(0,)]);
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

We didn't rollback attached DBs on ww conflicts.

Found while adding MVCC support in the simulator.

## Description of AI Usage

Claude Code