### PR TITLE
introduce ImmutableRecordRef to reduce cloning

### DIFF
--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -12,7 +12,9 @@ use crate::storage::btree::CursorTrait;
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::translate::plan::ColumnMask;
-use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult, ValueRef};
+use crate::types::{
+    IOResult, ImmutableRecord, ImmutableRecordRef, SeekKey, SeekOp, SeekResult, ValueRef,
+};
 use crate::{return_and_restore_if_io, return_if_io, LimboError, Result, Value};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::BTreeMap;
@@ -1009,7 +1011,7 @@ impl AggregateState {
     }
 
     pub fn from_blob(blob: &[u8]) -> Result<(Self, Vec<Value>)> {
-        let record = ImmutableRecord::from_bin_record(blob.to_vec());
+        let record = ImmutableRecordRef::from_bin_record(blob);
         let mut all_values: Vec<Value> = record.get_values_owned()?;
 
         if all_values.is_empty() {

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -10,7 +10,7 @@ use crate::numeric::Numeric;
 use crate::storage::btree::CursorTrait;
 use crate::sync::Arc;
 use crate::sync::Mutex;
-use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult};
+use crate::types::{IOResult, ImmutableRecord, ImmutableRecordRef, SeekKey, SeekOp, SeekResult};
 use crate::{return_and_restore_if_io, return_if_io, Result, Value};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -545,9 +545,7 @@ impl JoinOperator {
 }
 
 fn deserialize_hashable_row(blob: &[u8]) -> Result<HashableRow> {
-    use crate::types::ImmutableRecord;
-
-    let record = ImmutableRecord::from_bin_record(blob.to_vec());
+    let record = ImmutableRecordRef::from_bin_record(blob);
     let all_values: Vec<Value> = record.get_values_owned()?;
 
     if all_values.is_empty() {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -16,7 +16,7 @@ use crate::storage::wal::{CheckpointMode, TursoRwLock, WalAutoActions};
 use crate::sync::atomic::Ordering;
 use crate::sync::Arc;
 use crate::sync::RwLock;
-use crate::types::{IOCompletions, IOResult, ImmutableRecord};
+use crate::types::{IOCompletions, IOResult, ImmutableRecord, ImmutableRecordRef};
 use crate::{turso_assert, turso_assert_eq};
 use crate::{
     CheckpointResult, Completion, Connection, IOExt, LimboError, Numeric, Pager, Result, SyncMode,
@@ -229,7 +229,7 @@ fn sqlite_schema_btree_identity(version: &RowVersion) -> Option<SqliteSchemaBtre
         return None;
     }
 
-    let row_data = ImmutableRecord::from_bin_record(version.row.payload().to_vec());
+    let row_data = ImmutableRecordRef::from_bin_record(version.row.payload());
     let Ok((col0, col3)) = row_data.get_two_values(0, 3) else {
         return None;
     };
@@ -1288,8 +1288,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                                     "row version not found in write set".to_string(),
                                 )
                             })?;
-                        let record =
-                            ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
+                        let record = ImmutableRecordRef::from_bin_record(row_version.row.payload());
 
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
@@ -1323,8 +1322,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                                     "row version not found in write set".to_string(),
                                 )
                             })?;
-                        let record =
-                            ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
+                        let record = ImmutableRecordRef::from_bin_record(row_version.row.payload());
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
                         let record = ImmutableRecord::from_values(&values, values.len());

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -22,9 +22,9 @@ use crate::translate::plan::IterationDirection;
 use crate::types::compare_immutable;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
-use crate::types::ImmutableRecord;
 use crate::types::IndexInfo;
 use crate::types::SeekResult;
+use crate::types::{ImmutableRecord, ImmutableRecordRef};
 use crate::File;
 use crate::IOExt;
 use crate::LimboError;
@@ -5240,8 +5240,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     }
                     let is_schema_row = rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID;
                     if is_schema_row {
-                        let row_data = row.payload().to_vec();
-                        let record = ImmutableRecord::from_bin_record(row_data);
+                        let record = ImmutableRecordRef::from_bin_record(row.payload());
                         if record.column_count() < 5 {
                             return Err(LimboError::Corrupt(format!(
                                 "sqlite_schema row must have at least 5 columns, got {}",
@@ -5310,7 +5309,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             )));
                         }
                         let rowid_int = rowid.row_id.to_int_or_panic();
-                        schema_rows.insert(rowid_int, record);
+                        schema_rows.insert(
+                            rowid_int,
+                            ImmutableRecord::from_bin_record(row.payload().to_vec()),
+                        );
                         needs_schema_rebuild.set(true);
                     } else if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
                         // Data row references a table_id not yet in the map. This can happen

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -19,6 +19,7 @@ use crate::storage::sqlite3_ondisk::{
 use crate::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use crate::sync::Mutex;
 use crate::sync::RwLock;
+use crate::types::ImmutableRecordRef;
 use crate::vdbe::execute::TransactionYieldPoint;
 use crate::{
     Buffer, Completion, DatabaseOpts, EncryptionKey, LimboError, OpenFlags, StatementStatusCounter,
@@ -775,7 +776,7 @@ fn tamper_db_metadata_row_value(db_path: &str, metadata_root_page: u32, new_valu
     let mut page = read_db_page(db_path, metadata_root_page, page_size);
     let loc = table_leaf_first_cell_loc(&page, metadata_root_page);
     let payload = &page[loc.payload_offset..loc.payload_offset + loc.payload_len];
-    let record = ImmutableRecord::from_bin_record(payload.to_vec());
+    let record = ImmutableRecordRef::from_bin_record(payload);
     let key = record
         .get_value_opt(0)
         .expect("metadata key column missing");
@@ -804,7 +805,7 @@ fn tamper_db_metadata_row_value_by_key(
     let mut updated = false;
     for loc in table_leaf_cell_locs(&page, metadata_root_page) {
         let payload = &page[loc.payload_offset..loc.payload_offset + loc.payload_len];
-        let record = ImmutableRecord::from_bin_record(payload.to_vec());
+        let record = ImmutableRecordRef::from_bin_record(payload);
         let key = record
             .get_value_opt(0)
             .expect("metadata key column missing");
@@ -847,7 +848,7 @@ fn tamper_db_metadata_row_key(db_path: &str, metadata_root_page: u32, new_key: &
     let mut page = read_db_page(db_path, metadata_root_page, page_size);
     let loc = table_leaf_first_cell_loc(&page, metadata_root_page);
     let payload = &page[loc.payload_offset..loc.payload_offset + loc.payload_len];
-    let record = ImmutableRecord::from_bin_record(payload.to_vec());
+    let record = ImmutableRecordRef::from_bin_record(payload);
     let value = record
         .get_value_opt(1)
         .expect("metadata value column missing");

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1961,8 +1961,7 @@ impl StreamingLogicalLogReader {
                 // Compute column_count from the serialized record so recovered rows keep
                 // the same shape metadata as non-recovered rows.
                 let column_count =
-                    crate::types::ImmutableRecord::from_bin_record(record_bytes.clone())
-                        .column_count();
+                    crate::types::ImmutableRecordRef::from_bin_record(&record_bytes).column_count();
                 let row = Row::new_table_row(
                     RowID::new(table_id, rowid.row_id.clone()),
                     record_bytes,
@@ -2332,7 +2331,7 @@ mod tests {
         storage::sqlite3_ondisk::{
             read_varint, read_varint_partial, varint_len, write_varint, DatabaseHeader,
         },
-        types::{ImmutableRecord, IndexInfo, Text},
+        types::{ImmutableRecord, ImmutableRecordRef, IndexInfo, Text},
         Buffer, Completion, LimboError, Value, ValueRef,
     };
 
@@ -2543,7 +2542,7 @@ mod tests {
             .read(tx, &RowID::new((-100).into(), RowKey::Int(1)))
             .unwrap()
             .unwrap();
-        let record = ImmutableRecord::from_bin_record(row.payload().to_vec());
+        let record = ImmutableRecordRef::from_bin_record(row.payload());
         let foo = record.iter().unwrap().next().unwrap().unwrap();
         let ValueRef::Text(foo) = foo else {
             unreachable!()
@@ -2621,7 +2620,7 @@ mod tests {
         for (rowid, value) in &values {
             let tx = mvcc_store.begin_tx(pager.clone()).unwrap();
             let row = mvcc_store.read(tx, rowid).unwrap().unwrap();
-            let record = ImmutableRecord::from_bin_record(row.payload().to_vec());
+            let record = ImmutableRecordRef::from_bin_record(row.payload());
             let foo = record.iter().unwrap().next().unwrap().unwrap();
             let ValueRef::Text(foo) = foo else {
                 unreachable!()
@@ -2740,7 +2739,7 @@ mod tests {
         let tx = mvcc_store.begin_tx(pager.clone()).unwrap();
         for present_rowid in present_rowids {
             let row = mvcc_store.read(tx, &present_rowid).unwrap().unwrap();
-            let record = ImmutableRecord::from_bin_record(row.payload().to_vec());
+            let record = ImmutableRecordRef::from_bin_record(row.payload());
             let foo = record.iter().unwrap().next().unwrap().unwrap();
             let ValueRef::Text(foo) = foo else {
                 unreachable!()
@@ -2820,7 +2819,7 @@ mod tests {
                 .read(tx, &RowID::new(table_id, RowKey::Int(row_id)))
                 .unwrap()
                 .expect("Table row should exist");
-            let record = ImmutableRecord::from_bin_record(row.payload().to_vec());
+            let record = ImmutableRecordRef::from_bin_record(row.payload());
             let values = record.get_values().unwrap();
             let data_value = values.get(1).expect("Should have data column");
             let ValueRef::Text(data_text) = data_value else {

--- a/core/types.rs
+++ b/core/types.rs
@@ -935,76 +935,613 @@ impl<'a> TryFrom<ValueRef<'a>> for &'a str {
     }
 }
 
-/// This struct serves the purpose of not allocating multiple vectors of bytes if not needed.
-/// A value in a record that has already been serialized can stay serialized and what this struct offsers
-/// is easy acces to each value which point to the payload.
-/// The name might be contradictory as it is immutable in the sense that you cannot modify the values without modifying the payload.
-pub struct ImmutableRecord {
-    // We have to be super careful with this buffer since we make values point to the payload we need to take care reallocations
-    // happen in a controlled manner. If we realocate with values that should be correct, they will now point to undefined data.
-    // We don't use pin here because it would make it imposible to reuse the buffer if we need to push a new record in the same struct.
-    //
-    // payload is the Vec<u8> but in order to use Register which holds ImmutableRecord as a Value - we store Vec<u8> as Value::Blob
-    payload: Value,
-}
+mod immutable_record {
+    use super::*;
 
-// SAFETY: all ImmutableRecord instances are intended to be used in a single thread
-// by a single connection.
-unsafe impl Send for ImmutableRecord {}
-unsafe impl Sync for ImmutableRecord {}
+    /// This struct serves the purpose of not allocating multiple vectors of bytes if not needed.
+    /// A value in a record that has already been serialized can stay serialized and what this struct offsers
+    /// is easy acces to each value which point to the payload.
+    /// The name might be contradictory as it is immutable in the sense that you cannot modify the values without modifying the payload.
+    pub struct ImmutableRecord {
+        // We have to be super careful with this buffer since we make values point to the payload we need to take care reallocations
+        // happen in a controlled manner. If we realocate with values that should be correct, they will now point to undefined data.
+        // We don't use pin here because it would make it imposible to reuse the buffer if we need to push a new record in the same struct.
+        //
+        // payload is the Vec<u8> but in order to use Register which holds ImmutableRecord as a Value - we store Vec<u8> as Value::Blob
+        payload: Value,
+    }
 
-impl Clone for ImmutableRecord {
-    fn clone(&self) -> Self {
-        Self {
-            payload: self.payload.clone(),
+    // SAFETY: all ImmutableRecord instances are intended to be used in a single thread
+    // by a single connection.
+    unsafe impl Send for ImmutableRecord {}
+    unsafe impl Sync for ImmutableRecord {}
+
+    impl Clone for ImmutableRecord {
+        fn clone(&self) -> Self {
+            Self {
+                payload: self.payload.clone(),
+            }
+        }
+    }
+
+    impl PartialEq for ImmutableRecord {
+        fn eq(&self, other: &Self) -> bool {
+            self.payload == other.payload // Only compare payload, ignore cursor state
+        }
+    }
+
+    impl Eq for ImmutableRecord {}
+
+    impl PartialOrd for ImmutableRecord {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Ord for ImmutableRecord {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.payload.cmp(&other.payload) // Only compare payload, ignore cursor state
+        }
+    }
+
+    impl std::fmt::Debug for ImmutableRecord {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match &self.payload {
+                Value::Blob(bytes) => {
+                    let preview = if bytes.len() > 20 {
+                        format!("{:?} ... ({} bytes total)", &bytes[..20], bytes.len())
+                    } else {
+                        format!("{bytes:?}")
+                    };
+                    write!(f, "ImmutableRecord {{ payload: {preview} }}")
+                }
+                Value::Text(s) => {
+                    let string = s.as_str();
+                    let preview = if string.len() > 20 {
+                        format!("{:?} ... ({} chars total)", &string[..20], string.len())
+                    } else {
+                        format!("{string:?}")
+                    };
+                    write!(f, "ImmutableRecord {{ payload: {preview} }}")
+                }
+                other => write!(f, "ImmutableRecord {{ payload: {other:?} }}"),
+            }
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct ImmutableRecordRef<'a> {
+        payload: &'a [u8],
+    }
+
+    impl std::fmt::Debug for ImmutableRecordRef<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let bytes = self.payload;
+            let preview = if bytes.len() > 20 {
+                format!("{:?} ... ({} bytes total)", &bytes[..20], bytes.len())
+            } else {
+                format!("{bytes:?}")
+            };
+            write!(f, "ImmutableRecordRef {{ payload: {preview} }}")
+        }
+    }
+
+    struct AppendWriter<'a> {
+        buf: &'a mut Vec<u8>,
+        pos: usize,
+        buf_capacity_start: usize,
+        buf_ptr_start: *const u8,
+    }
+
+    impl<'a> AppendWriter<'a> {
+        fn new(buf: &'a mut Vec<u8>, pos: usize) -> Self {
+            let buf_ptr_start = buf.as_ptr();
+            let buf_capacity_start = buf.capacity();
+            Self {
+                buf,
+                pos,
+                buf_capacity_start,
+                buf_ptr_start,
+            }
+        }
+
+        #[inline]
+        fn extend_from_slice(&mut self, slice: &[u8]) {
+            self.buf[self.pos..self.pos + slice.len()].copy_from_slice(slice);
+            self.pos += slice.len();
+        }
+
+        fn assert_finish_capacity(&self) {
+            // let's make sure we didn't reallocate anywhere else
+            assert_eq!(self.buf_capacity_start, self.buf.capacity());
+            assert_eq!(self.buf_ptr_start, self.buf.as_ptr());
+        }
+    }
+
+    #[inline(always)]
+    fn iter(payload: &[u8]) -> Result<ValueIterator<'_>, LimboError> {
+        ValueIterator::new(payload)
+    }
+
+    fn values(payload: &[u8]) -> Result<Vec<ValueRef<'_>>> {
+        let iter = iter(payload)?;
+        let mut values = Vec::with_capacity(iter.size_hint().0);
+        for value in iter {
+            values.push(value?);
+        }
+        Ok(values)
+    }
+
+    fn values_range(payload: &[u8], range: std::ops::Range<usize>) -> Result<Vec<ValueRef<'_>>> {
+        let mut iter = iter(payload)?;
+        let mut values = Vec::with_capacity(range.end - range.start);
+        if let Some(value) = iter.nth(range.start) {
+            values.push(value?);
+        } else {
+            return Ok(values);
+        }
+        for _ in range.start + 1..range.end {
+            if let Some(value) = iter.next() {
+                values.push(value?);
+            } else {
+                break;
+            }
+        }
+        Ok(values)
+    }
+
+    fn two_values(
+        payload: &[u8],
+        idx1: usize,
+        idx2: usize,
+    ) -> Result<(ValueRef<'_>, ValueRef<'_>)> {
+        let mut iter = iter(payload)?;
+        let val1 = iter.nth(idx1);
+        let val2 = iter.nth(idx2 - idx1 - 1);
+        match (val1, val2) {
+            (Some(v1), Some(v2)) => Ok((v1?, v2?)),
+            _ => Err(LimboError::InternalError("index out of bound".to_string())),
+        }
+    }
+
+    fn three_values(
+        payload: &[u8],
+        idx1: usize,
+        idx2: usize,
+        idx3: usize,
+    ) -> Result<(ValueRef<'_>, ValueRef<'_>, ValueRef<'_>)> {
+        let mut iter = iter(payload)?;
+        let val1 = iter.nth(idx1);
+        let val2 = iter.nth(idx2 - idx1 - 1);
+        let val3 = iter.nth(idx3 - idx2 - 1);
+        match (val1, val2, val3) {
+            (Some(v1), Some(v2), Some(v3)) => Ok((v1?, v2?, v3?)),
+            _ => Err(LimboError::InternalError("index out of bound".to_string())),
+        }
+    }
+
+    fn four_values(
+        payload: &[u8],
+        idx1: usize,
+        idx2: usize,
+        idx3: usize,
+        idx4: usize,
+    ) -> Result<(ValueRef<'_>, ValueRef<'_>, ValueRef<'_>, ValueRef<'_>)> {
+        let mut iter = iter(payload)?;
+        let val1 = iter.nth(idx1);
+        let val2 = iter.nth(idx2 - idx1 - 1);
+        let val3 = iter.nth(idx3 - idx2 - 1);
+        let val4 = iter.nth(idx4 - idx3 - 1);
+        match (val1, val2, val3, val4) {
+            (Some(v1), Some(v2), Some(v3), Some(v4)) => Ok((v1?, v2?, v3?, v4?)),
+            _ => Err(LimboError::InternalError("index out of bound".to_string())),
+        }
+    }
+
+    fn values_owned(payload: &[u8]) -> Result<Vec<Value>> {
+        let iter = iter(payload).expect("Failed to create payload iterator");
+        let mut values = Vec::with_capacity(iter.size_hint().0);
+        for value in iter {
+            values.push(value?.to_owned());
+        }
+        Ok(values)
+    }
+
+    fn values_owned_range(payload: &[u8], range: std::ops::Range<usize>) -> Result<Vec<Value>> {
+        let mut iter = iter(payload).expect("Failed to create payload iterator");
+        let mut values = Vec::with_capacity(range.end - range.start);
+        if let Some(value) = iter.nth(range.start) {
+            values.push(value?.to_owned());
+        } else {
+            return Ok(values);
+        }
+        for _ in range.start + 1..range.end {
+            if let Some(value) = iter.next() {
+                values.push(value?.to_owned());
+            } else {
+                break;
+            }
+        }
+        Ok(values)
+    }
+
+    fn contains_null(payload: &[u8]) -> Result<bool> {
+        let (header_size, header_varint_len) = read_varint(payload)?;
+        let header_size = header_size as usize;
+
+        if header_size > payload.len() || header_varint_len > payload.len() {
+            return Err(LimboError::Corrupt(
+                "Payload too small for indicated header size".into(),
+            ));
+        }
+
+        let mut header = &payload[header_varint_len..header_size];
+
+        while !header.is_empty() {
+            let (serial_type, bytes_read) = read_varint(header)?;
+            if serial_type == 0 {
+                return Ok(true);
+            }
+            header = &header[bytes_read..];
+        }
+
+        Ok(false)
+    }
+
+    fn last_value(payload: &[u8]) -> Option<Result<ValueRef<'_>>> {
+        if unlikely(payload.is_empty()) {
+            return Some(Err(LimboError::InternalError(
+                "Record is invalidated".into(),
+            )));
+        }
+        let iter = match iter(payload) {
+            Ok(it) => it,
+            Err(e) => return Some(Err(e)),
+        };
+        iter.last()
+    }
+
+    fn first_value(payload: &[u8]) -> Result<ValueRef<'_>> {
+        if unlikely(payload.is_empty()) {
+            return Err(LimboError::InternalError("Record is invalidated".into()));
+        }
+        match iter(payload)?.next() {
+            Some(v) => v,
+            None => Err(LimboError::InternalError("Record has no columns".into())),
+        }
+    }
+
+    fn value(payload: &[u8], idx: usize) -> Result<ValueRef<'_>> {
+        if unlikely(payload.is_empty()) {
+            return Err(LimboError::InternalError("Record is invalidated".into()));
+        }
+        let mut iter = iter(payload)?;
+        iter.nth(idx)
+            .transpose()?
+            .ok_or_else(|| LimboError::InternalError("Index out of bounds".into()))
+    }
+
+    fn value_opt(payload: &[u8], idx: usize) -> Option<ValueRef<'_>> {
+        let mut iter = match iter(payload) {
+            Ok(it) => it,
+            Err(_) => {
+                mark_unlikely();
+                return None;
+            }
+        };
+        match iter.nth(idx) {
+            Some(Ok(v)) => Some(v),
+            _ => {
+                mark_unlikely();
+                None
+            }
+        }
+    }
+
+    fn column_count(payload: &[u8]) -> usize {
+        iter(payload).map(|it| it.count()).unwrap_or_default()
+    }
+
+    impl ImmutableRecord {
+        // Don't use this in performance critical paths, prefer using `iter()` instead
+        pub fn get_values(&self) -> Result<Vec<ValueRef<'_>>> {
+            values(self.get_payload())
+        }
+
+        // Don't use this in performance critical paths, prefer using `iter()` instead
+        pub fn get_values_range(&self, range: std::ops::Range<usize>) -> Result<Vec<ValueRef<'_>>> {
+            values_range(self.get_payload(), range)
+        }
+
+        // Idx values must be sorted ascending
+        pub fn get_two_values(
+            &self,
+            idx1: usize,
+            idx2: usize,
+        ) -> Result<(ValueRef<'_>, ValueRef<'_>)> {
+            two_values(self.get_payload(), idx1, idx2)
+        }
+
+        // Idx values must be sorted ascending
+        pub fn get_three_values(
+            &self,
+            idx1: usize,
+            idx2: usize,
+            idx3: usize,
+        ) -> Result<(ValueRef<'_>, ValueRef<'_>, ValueRef<'_>)> {
+            three_values(self.get_payload(), idx1, idx2, idx3)
+        }
+
+        // Idx values must be sorted ascending
+        pub fn get_four_values(
+            &self,
+            idx1: usize,
+            idx2: usize,
+            idx3: usize,
+            idx4: usize,
+        ) -> Result<(ValueRef<'_>, ValueRef<'_>, ValueRef<'_>, ValueRef<'_>)> {
+            four_values(self.get_payload(), idx1, idx2, idx3, idx4)
+        }
+
+        // Don't use this in performance critical paths, prefer using `iter()` instead
+        pub fn get_values_owned(&self) -> Result<Vec<Value>> {
+            values_owned(self.get_payload())
+        }
+
+        // Don't use this in performance critical paths, prefer using `iter()` instead
+        pub fn get_values_owned_range(&self, range: std::ops::Range<usize>) -> Result<Vec<Value>> {
+            values_owned_range(self.get_payload(), range)
+        }
+
+        #[inline(always)]
+        pub fn iter(&self) -> Result<ValueIterator<'_>, LimboError> {
+            iter(self.get_payload())
+        }
+
+        #[inline]
+        /// Returns true if the record contains any NULL values.
+        /// This is an optimization that only examines the header (serial types)
+        /// without deserializing the data section.
+        pub fn contains_null(&self) -> Result<bool> {
+            contains_null(self.get_payload())
+        }
+
+        #[inline]
+        pub fn last_value(&self) -> Option<Result<ValueRef<'_>>> {
+            last_value(self.get_payload())
+        }
+
+        #[inline]
+        pub fn first_value(&self) -> Result<ValueRef<'_>> {
+            first_value(self.get_payload())
+        }
+
+        #[inline]
+        pub fn get_value(&self, idx: usize) -> Result<ValueRef<'_>> {
+            value(self.get_payload(), idx)
+        }
+
+        #[inline]
+        pub fn get_value_opt(&self, idx: usize) -> Option<ValueRef<'_>> {
+            value_opt(self.get_payload(), idx)
+        }
+
+        pub fn column_count(&self) -> usize {
+            column_count(self.get_payload())
+        }
+    }
+
+    impl<'a> ImmutableRecordRef<'a> {
+        #[inline(always)]
+        pub fn iter(&self) -> Result<ValueIterator<'a>, LimboError> {
+            iter(self.payload)
+        }
+
+        pub fn get_values(&self) -> Result<Vec<ValueRef<'a>>> {
+            values(self.payload)
+        }
+
+        pub fn get_two_values(
+            &self,
+            idx1: usize,
+            idx2: usize,
+        ) -> Result<(ValueRef<'a>, ValueRef<'a>)> {
+            two_values(self.payload, idx1, idx2)
+        }
+
+        pub fn get_values_owned(&self) -> Result<Vec<Value>> {
+            values_owned(self.payload)
+        }
+
+        #[inline]
+        pub fn get_value_opt(&self, idx: usize) -> Option<ValueRef<'a>> {
+            value_opt(self.payload, idx)
+        }
+
+        pub fn column_count(&self) -> usize {
+            column_count(self.payload)
+        }
+    }
+
+    impl ImmutableRecord {
+        pub fn new(payload_capacity: usize) -> Self {
+            Self {
+                payload: Value::Blob(Vec::with_capacity(payload_capacity)),
+            }
+        }
+
+        pub const fn from_bin_record(payload: Vec<u8>) -> Self {
+            Self {
+                payload: Value::Blob(payload),
+            }
+        }
+
+        pub fn as_record_ref(&self) -> ImmutableRecordRef<'_> {
+            ImmutableRecordRef::from_bin_record(self.get_payload())
+        }
+
+        pub fn from_registers<'a, I: Iterator<Item = &'a Register> + Clone>(
+            // we need to accept both &[Register] and &[&Register] values - that's why non-trivial signature
+            //
+            // std::slice::Iter under the hood just stores pointer and length of slice and also implements a Clone which just copy those meta-values
+            // (without copying the data itself)
+            registers: impl IntoIterator<Item = &'a Register, IntoIter = I>,
+            len: usize,
+        ) -> Self {
+            Self::from_values(registers.into_iter().map(|x| x.get_value()), len)
+        }
+
+        pub fn from_values<'a>(
+            values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
+            len: usize,
+        ) -> Self {
+            let mut serials = Vec::with_capacity(len);
+            let mut size_header = 0;
+            let mut size_values = 0;
+
+            let mut serial_type_buf = [0; 9];
+            // write serial types
+            for value in values.clone() {
+                let serial_type = SerialType::from(value.as_value_ref());
+                let n = write_varint(&mut serial_type_buf[0..], serial_type.into());
+                serials.push((serial_type_buf, n));
+
+                let value_size = serial_type.size();
+
+                size_header += n;
+                size_values += value_size;
+            }
+
+            let header_size = Record::calc_header_size(size_header);
+
+            // 1. write header size
+            let mut buf = Vec::new();
+            buf.reserve_exact(header_size + size_values);
+            assert_eq!(buf.capacity(), header_size + size_values);
+            let n = write_varint(&mut serial_type_buf, header_size as u64);
+
+            buf.resize(buf.capacity(), 0);
+            let mut writer = AppendWriter::new(&mut buf, 0);
+            writer.extend_from_slice(&serial_type_buf[..n]);
+
+            // 2. Write serial
+            for (value, n) in serials {
+                writer.extend_from_slice(&value[..n]);
+            }
+
+            // write content
+            for value in values {
+                let value = value.as_value_ref();
+                match value {
+                    ValueRef::Null => {}
+                    ValueRef::Numeric(Numeric::Integer(i)) => {
+                        let serial_type = SerialType::from(value);
+                        match serial_type.kind() {
+                            SerialTypeKind::ConstInt0 | SerialTypeKind::ConstInt1 => {}
+                            SerialTypeKind::I8 => {
+                                writer.extend_from_slice(&(i as i8).to_be_bytes())
+                            }
+                            SerialTypeKind::I16 => {
+                                writer.extend_from_slice(&(i as i16).to_be_bytes())
+                            }
+                            SerialTypeKind::I24 => {
+                                writer.extend_from_slice(&(i as i32).to_be_bytes()[1..])
+                            } // remove most significant byte
+                            SerialTypeKind::I32 => {
+                                writer.extend_from_slice(&(i as i32).to_be_bytes())
+                            }
+                            SerialTypeKind::I48 => writer.extend_from_slice(&i.to_be_bytes()[2..]), // remove 2 most significant bytes
+                            SerialTypeKind::I64 => writer.extend_from_slice(&i.to_be_bytes()),
+                            other => panic!("Serial type is not an integer: {other:?}"),
+                        }
+                    }
+                    ValueRef::Numeric(Numeric::Float(f)) => {
+                        let fval: f64 = f.into();
+                        writer.extend_from_slice(&fval.to_be_bytes());
+                    }
+                    ValueRef::Text(t) => {
+                        writer.extend_from_slice(t.value.as_bytes());
+                    }
+                    ValueRef::Blob(b) => {
+                        writer.extend_from_slice(b);
+                    }
+                };
+            }
+
+            writer.assert_finish_capacity();
+            Self {
+                payload: Value::Blob(buf),
+            }
+        }
+
+        #[inline]
+        pub fn into_payload(self) -> Vec<u8> {
+            match self.payload {
+                Value::Blob(b) => b,
+                _ => panic!("payload must be a blob"),
+            }
+        }
+
+        #[inline]
+        pub const fn as_blob(&self) -> &Vec<u8> {
+            match &self.payload {
+                Value::Blob(b) => b,
+                _ => panic!("payload must be a blob"),
+            }
+        }
+
+        #[inline]
+        pub const fn as_blob_mut(&mut self) -> &mut Vec<u8> {
+            match &mut self.payload {
+                Value::Blob(b) => b,
+                _ => panic!("payload must be a blob"),
+            }
+        }
+
+        #[inline]
+        pub const fn as_blob_value(&self) -> &Value {
+            &self.payload
+        }
+
+        #[inline]
+        pub fn start_serialization(&mut self, payload: &[u8]) {
+            self.as_blob_mut().extend_from_slice(payload);
+        }
+
+        #[inline]
+        pub fn invalidate(&mut self) {
+            self.as_blob_mut().clear();
+        }
+
+        #[inline]
+        pub const fn is_invalidated(&self) -> bool {
+            self.as_blob().is_empty()
+        }
+
+        #[inline]
+        pub fn get_payload(&self) -> &[u8] {
+            self.as_blob()
+        }
+    }
+
+    impl<'a> ImmutableRecordRef<'a> {
+        pub const fn from_bin_record(payload: &'a [u8]) -> Self {
+            Self { payload }
+        }
+
+        #[inline]
+        pub const fn get_payload(&self) -> &'a [u8] {
+            self.payload
+        }
+
+        #[inline]
+        pub const fn is_invalidated(&self) -> bool {
+            self.payload.is_empty()
         }
     }
 }
 
-impl PartialEq for ImmutableRecord {
-    fn eq(&self, other: &Self) -> bool {
-        self.payload == other.payload // Only compare payload, ignore cursor state
-    }
-}
-
-impl Eq for ImmutableRecord {}
-
-impl PartialOrd for ImmutableRecord {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ImmutableRecord {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.payload.cmp(&other.payload) // Only compare payload, ignore cursor state
-    }
-}
-
-impl std::fmt::Debug for ImmutableRecord {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.payload {
-            Value::Blob(bytes) => {
-                let preview = if bytes.len() > 20 {
-                    format!("{:?} ... ({} bytes total)", &bytes[..20], bytes.len())
-                } else {
-                    format!("{bytes:?}")
-                };
-                write!(f, "ImmutableRecord {{ payload: {preview} }}")
-            }
-            Value::Text(s) => {
-                let string = s.as_str();
-                let preview = if string.len() > 20 {
-                    format!("{:?} ... ({} chars total)", &string[..20], string.len())
-                } else {
-                    format!("{string:?}")
-                };
-                write!(f, "ImmutableRecord {{ payload: {preview} }}")
-            }
-            other => write!(f, "ImmutableRecord {{ payload: {other:?} }}"),
-        }
-    }
-}
+pub use immutable_record::{ImmutableRecord, ImmutableRecordRef};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Record {
@@ -1039,388 +1576,6 @@ impl Record {
 
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
-    }
-}
-struct AppendWriter<'a> {
-    buf: &'a mut Vec<u8>,
-    pos: usize,
-    buf_capacity_start: usize,
-    buf_ptr_start: *const u8,
-}
-
-impl<'a> AppendWriter<'a> {
-    pub fn new(buf: &'a mut Vec<u8>, pos: usize) -> Self {
-        let buf_ptr_start = buf.as_ptr();
-        let buf_capacity_start = buf.capacity();
-        Self {
-            buf,
-            pos,
-            buf_capacity_start,
-            buf_ptr_start,
-        }
-    }
-
-    #[inline]
-    pub fn extend_from_slice(&mut self, slice: &[u8]) {
-        self.buf[self.pos..self.pos + slice.len()].copy_from_slice(slice);
-        self.pos += slice.len();
-    }
-
-    fn assert_finish_capacity(&self) {
-        // let's make sure we didn't reallocate anywhere else
-        assert_eq!(self.buf_capacity_start, self.buf.capacity());
-        assert_eq!(self.buf_ptr_start, self.buf.as_ptr());
-    }
-}
-
-impl ImmutableRecord {
-    pub fn new(payload_capacity: usize) -> Self {
-        Self {
-            payload: Value::Blob(Vec::with_capacity(payload_capacity)),
-        }
-    }
-
-    pub const fn from_bin_record(payload: Vec<u8>) -> Self {
-        Self {
-            payload: Value::Blob(payload),
-        }
-    }
-
-    // Don't use this in performance critical paths, prefer using `iter()` instead
-    pub fn get_values(&self) -> Result<Vec<ValueRef<'_>>> {
-        let iter = self.iter()?;
-        let mut values = Vec::with_capacity(iter.size_hint().0);
-        for value in iter {
-            values.push(value?);
-        }
-        Ok(values)
-    }
-
-    // Don't use this in performance critical paths, prefer using `iter()` instead
-    pub fn get_values_range(&self, range: std::ops::Range<usize>) -> Result<Vec<ValueRef<'_>>> {
-        let mut iter = self.iter()?;
-        let mut values = Vec::with_capacity(range.end - range.start);
-        // advance to start
-        if let Some(value) = iter.nth(range.start) {
-            values.push(value?);
-        } else {
-            return Ok(values);
-        }
-        // collect rest
-        for _ in range.start + 1..range.end {
-            if let Some(value) = iter.next() {
-                values.push(value?);
-            } else {
-                break;
-            }
-        }
-        Ok(values)
-    }
-
-    // Idx values must be sorted ascending
-    pub fn get_two_values(&self, idx1: usize, idx2: usize) -> Result<(ValueRef<'_>, ValueRef<'_>)> {
-        let mut iter = self.iter()?;
-        let val1 = iter.nth(idx1);
-        let val2 = iter.nth(idx2 - idx1 - 1); // idx2 - idx1 - 1 because we already advanced to idx1
-        match (val1, val2) {
-            (Some(v1), Some(v2)) => Ok((v1?, v2?)),
-            _ => Err(LimboError::InternalError("index out of bound".to_string())),
-        }
-    }
-
-    // Idx values must be sorted ascending
-    pub fn get_three_values(
-        &self,
-        idx1: usize,
-        idx2: usize,
-        idx3: usize,
-    ) -> Result<(ValueRef<'_>, ValueRef<'_>, ValueRef<'_>)> {
-        let mut iter = self.iter()?;
-        let val1 = iter.nth(idx1);
-        let val2 = iter.nth(idx2 - idx1 - 1); // idx2 - idx1 - 1 because we already advanced to idx1
-        let val3 = iter.nth(idx3 - idx2 - 1); // idx3 - idx2 - 1 because we already advanced to idx2
-        match (val1, val2, val3) {
-            (Some(v1), Some(v2), Some(v3)) => Ok((v1?, v2?, v3?)),
-            _ => Err(LimboError::InternalError("index out of bound".to_string())),
-        }
-    }
-
-    // Idx values must be sorted ascending
-    pub fn get_four_values(
-        &self,
-        idx1: usize,
-        idx2: usize,
-        idx3: usize,
-        idx4: usize,
-    ) -> Result<(ValueRef<'_>, ValueRef<'_>, ValueRef<'_>, ValueRef<'_>)> {
-        let mut iter = self.iter()?;
-        let val1 = iter.nth(idx1);
-        let val2 = iter.nth(idx2 - idx1 - 1); // idx2 - idx1 - 1 because we already advanced to idx1
-        let val3 = iter.nth(idx3 - idx2 - 1); // idx3 - idx2 - 1 because we already advanced to idx2
-        let val4 = iter.nth(idx4 - idx3 - 1); // idx4 - idx3 - 1 because we already advanced to idx3
-        match (val1, val2, val3, val4) {
-            (Some(v1), Some(v2), Some(v3), Some(v4)) => Ok((v1?, v2?, v3?, v4?)),
-            _ => Err(LimboError::InternalError("index out of bound".to_string())),
-        }
-    }
-
-    // Don't use this in performance critical paths, prefer using `iter()` instead
-    pub fn get_values_owned(&self) -> Result<Vec<Value>> {
-        let iter = self.iter().expect("Failed to create payload iterator");
-        let mut values = Vec::with_capacity(iter.size_hint().0);
-        for value in iter {
-            values.push(value?.to_owned());
-        }
-        Ok(values)
-    }
-
-    // Don't use this in performance critical paths, prefer using `iter()` instead
-    pub fn get_values_owned_range(&self, range: std::ops::Range<usize>) -> Result<Vec<Value>> {
-        let mut iter = self.iter().expect("Failed to create payload iterator");
-        let mut values = Vec::with_capacity(range.end - range.start);
-        // advance to start
-        if let Some(value) = iter.nth(range.start) {
-            values.push(value?.to_owned());
-        } else {
-            return Ok(values);
-        }
-        // collect rest
-        for _ in range.start + 1..range.end {
-            if let Some(value) = iter.next() {
-                values.push(value?.to_owned());
-            } else {
-                break;
-            }
-        }
-        Ok(values)
-    }
-
-    pub fn from_registers<'a, I: Iterator<Item = &'a Register> + Clone>(
-        // we need to accept both &[Register] and &[&Register] values - that's why non-trivial signature
-        //
-        // std::slice::Iter under the hood just stores pointer and length of slice and also implements a Clone which just copy those meta-values
-        // (without copying the data itself)
-        registers: impl IntoIterator<Item = &'a Register, IntoIter = I>,
-        len: usize,
-    ) -> Self {
-        Self::from_values(registers.into_iter().map(|x| x.get_value()), len)
-    }
-
-    pub fn from_values<'a>(
-        values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
-        len: usize,
-    ) -> Self {
-        let mut serials = Vec::with_capacity(len);
-        let mut size_header = 0;
-        let mut size_values = 0;
-
-        let mut serial_type_buf = [0; 9];
-        // write serial types
-        for value in values.clone() {
-            let serial_type = SerialType::from(value.as_value_ref());
-            let n = write_varint(&mut serial_type_buf[0..], serial_type.into());
-            serials.push((serial_type_buf, n));
-
-            let value_size = serial_type.size();
-
-            size_header += n;
-            size_values += value_size;
-        }
-
-        let header_size = Record::calc_header_size(size_header);
-
-        // 1. write header size
-        let mut buf = Vec::new();
-        buf.reserve_exact(header_size + size_values);
-        assert_eq!(buf.capacity(), header_size + size_values);
-        let n = write_varint(&mut serial_type_buf, header_size as u64);
-
-        buf.resize(buf.capacity(), 0);
-        let mut writer = AppendWriter::new(&mut buf, 0);
-        writer.extend_from_slice(&serial_type_buf[..n]);
-
-        // 2. Write serial
-        for (value, n) in serials {
-            writer.extend_from_slice(&value[..n]);
-        }
-
-        // write content
-        for value in values {
-            let value = value.as_value_ref();
-            match value {
-                ValueRef::Null => {}
-                ValueRef::Numeric(Numeric::Integer(i)) => {
-                    let serial_type = SerialType::from(value);
-                    match serial_type.kind() {
-                        SerialTypeKind::ConstInt0 | SerialTypeKind::ConstInt1 => {}
-                        SerialTypeKind::I8 => writer.extend_from_slice(&(i as i8).to_be_bytes()),
-                        SerialTypeKind::I16 => writer.extend_from_slice(&(i as i16).to_be_bytes()),
-                        SerialTypeKind::I24 => {
-                            writer.extend_from_slice(&(i as i32).to_be_bytes()[1..])
-                        } // remove most significant byte
-                        SerialTypeKind::I32 => writer.extend_from_slice(&(i as i32).to_be_bytes()),
-                        SerialTypeKind::I48 => writer.extend_from_slice(&i.to_be_bytes()[2..]), // remove 2 most significant bytes
-                        SerialTypeKind::I64 => writer.extend_from_slice(&i.to_be_bytes()),
-                        other => panic!("Serial type is not an integer: {other:?}"),
-                    }
-                }
-                ValueRef::Numeric(Numeric::Float(f)) => {
-                    let fval: f64 = f.into();
-                    writer.extend_from_slice(&fval.to_be_bytes());
-                }
-                ValueRef::Text(t) => {
-                    writer.extend_from_slice(t.value.as_bytes());
-                }
-                ValueRef::Blob(b) => {
-                    writer.extend_from_slice(b);
-                }
-            };
-        }
-
-        writer.assert_finish_capacity();
-        Self {
-            payload: Value::Blob(buf),
-        }
-    }
-
-    #[inline]
-    pub fn into_payload(self) -> Vec<u8> {
-        match self.payload {
-            Value::Blob(b) => b,
-            _ => panic!("payload must be a blob"),
-        }
-    }
-
-    #[inline]
-    pub const fn as_blob(&self) -> &Vec<u8> {
-        match &self.payload {
-            Value::Blob(b) => b,
-            _ => panic!("payload must be a blob"),
-        }
-    }
-
-    #[inline]
-    pub const fn as_blob_mut(&mut self) -> &mut Vec<u8> {
-        match &mut self.payload {
-            Value::Blob(b) => b,
-            _ => panic!("payload must be a blob"),
-        }
-    }
-
-    #[inline]
-    pub const fn as_blob_value(&self) -> &Value {
-        &self.payload
-    }
-
-    #[inline]
-    pub fn start_serialization(&mut self, payload: &[u8]) {
-        self.as_blob_mut().extend_from_slice(payload);
-    }
-
-    #[inline]
-    pub fn invalidate(&mut self) {
-        self.as_blob_mut().clear();
-    }
-
-    #[inline]
-    pub const fn is_invalidated(&self) -> bool {
-        self.as_blob().is_empty()
-    }
-
-    #[inline]
-    pub fn get_payload(&self) -> &[u8] {
-        self.as_blob()
-    }
-
-    #[inline(always)]
-    pub fn iter(&self) -> Result<ValueIterator<'_>, LimboError> {
-        ValueIterator::new(self.get_payload())
-    }
-
-    #[inline]
-    /// Returns true if the record contains any NULL values.
-    /// This is an optimization that only examines the header (serial types)
-    /// without deserializing the data section.
-    pub fn contains_null(&self) -> Result<bool> {
-        let payload = self.get_payload();
-        let (header_size, header_varint_len) = read_varint(payload)?;
-        let header_size = header_size as usize;
-
-        if header_size > payload.len() || header_varint_len > payload.len() {
-            return Err(LimboError::Corrupt(
-                "Payload too small for indicated header size".into(),
-            ));
-        }
-
-        let mut header = &payload[header_varint_len..header_size];
-
-        while !header.is_empty() {
-            let (serial_type, bytes_read) = read_varint(header)?;
-            if serial_type == 0 {
-                return Ok(true);
-            }
-            header = &header[bytes_read..];
-        }
-
-        Ok(false)
-    }
-
-    #[inline]
-    pub fn last_value(&self) -> Option<Result<ValueRef<'_>>> {
-        if unlikely(self.is_invalidated()) {
-            return Some(Err(LimboError::InternalError(
-                "Record is invalidated".into(),
-            )));
-        }
-        let iter = match self.iter() {
-            Ok(it) => it,
-            Err(e) => return Some(Err(e)),
-        };
-        iter.last()
-    }
-
-    #[inline]
-    pub fn first_value(&self) -> Result<ValueRef<'_>> {
-        if unlikely(self.is_invalidated()) {
-            return Err(LimboError::InternalError("Record is invalidated".into()));
-        }
-        match self.iter()?.next() {
-            Some(v) => v,
-            None => Err(LimboError::InternalError("Record has no columns".into())),
-        }
-    }
-
-    #[inline]
-    pub fn get_value(&self, idx: usize) -> Result<ValueRef<'_>> {
-        if unlikely(self.is_invalidated()) {
-            return Err(LimboError::InternalError("Record is invalidated".into()));
-        }
-        let mut iter = self.iter()?;
-        iter.nth(idx)
-            .transpose()?
-            .ok_or_else(|| LimboError::InternalError("Index out of bounds".into()))
-    }
-
-    #[inline]
-    pub fn get_value_opt(&self, idx: usize) -> Option<ValueRef<'_>> {
-        let mut iter = match self.iter() {
-            Ok(it) => it,
-            Err(_) => {
-                mark_unlikely();
-                return None;
-            }
-        };
-        match iter.nth(idx) {
-            Some(Ok(v)) => Some(v),
-            _ => {
-                mark_unlikely();
-                None
-            }
-        }
-    }
-
-    pub fn column_count(&self) -> usize {
-        self.iter().map(|it| it.count()).unwrap_or_default()
     }
 }
 
@@ -3170,6 +3325,19 @@ mod tests {
     fn create_record(values: Vec<Value>) -> ImmutableRecord {
         let registers: Vec<Register> = values.into_iter().map(Register::Value).collect();
         ImmutableRecord::from_registers(&registers, registers.len())
+    }
+
+    #[test]
+    fn immutable_record_ref_borrows_bin_record_payload() {
+        let expected_values = vec![Value::from_i64(42), Value::build_text("borrowed")];
+        let record = create_record(expected_values.clone());
+        let payload = record.get_payload();
+
+        let borrowed = ImmutableRecordRef::from_bin_record(payload);
+
+        assert_eq!(borrowed.get_payload().as_ptr(), payload.as_ptr());
+        assert_eq!(borrowed.column_count(), 2);
+        assert_eq!(borrowed.get_values_owned().unwrap(), expected_values);
     }
 
     fn create_index_info(

--- a/sync/engine/src/types.rs
+++ b/sync/engine/src/types.rs
@@ -582,8 +582,10 @@ pub enum SyncEngineIoResult {
     IO,
 }
 
-pub fn parse_bin_record(bin_record: Vec<u8>) -> Result<Vec<turso_core::Value>> {
-    match turso_core::types::ImmutableRecord::from_bin_record(bin_record).get_values_owned() {
+pub fn parse_bin_record(bin_record: impl AsRef<[u8]>) -> Result<Vec<turso_core::Value>> {
+    match turso_core::types::ImmutableRecordRef::from_bin_record(bin_record.as_ref())
+        .get_values_owned()
+    {
         Ok(values) => Ok(values),
         Err(err) => Err(Error::DatabaseTapeError(format!(
             "unable to parse bin record: {err}"


### PR DESCRIPTION
## Description

We were cloning entire payloads, just to give ownership to `ImmutableRecord`, but it doesn't need it. So I'm introducing a `ImmutableRecordRef` type that borrows from a slice of bytes.

## Description of AI Usage

Codex