### PR TITLE
core/translate/optimizer: allow hash join for FULL OUTER JOIN on rowid/PK equijoins

### DIFF
--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -482,7 +482,16 @@ pub fn join_lhs_and_rhs<'a>(
             // Eligibility gate: prefer nested-loop when uses a selective probe seek.
             // Probe->build chaining is only allowed when the
             // build input is materialized from the join prefix.
-            let allow_hash_join = !rhs_has_selective_seek
+            //
+            // A FULL OUTER JOIN can only run as a hash join (the unmatched-build
+            // scan has no nested-loop form), so a selective probe seek must not
+            // disable it. A rowid/PRIMARY KEY join column always has such a seek,
+            // which otherwise leaves the join with no plan.
+            let rhs_is_full_outer = rhs_table_reference
+                .join_info
+                .as_ref()
+                .is_some_and(|ji| ji.is_full_outer());
+            let allow_hash_join = (!rhs_has_selective_seek || rhs_is_full_outer)
                 && !probe_table_is_prior_build
                 && (!build_has_prior_constraints || build_has_rowid)
                 && !chaining_across_outer;

--- a/sqlite/conformance/sqlite-sqltests/join/outer_hash_join.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join/outer_hash_join.sqltest
@@ -229,6 +229,25 @@ expect {
     2|y||
 }
 
+# Regression: FULL OUTER JOIN on rowid-alias (INTEGER PRIMARY KEY) columns. The
+# probe side has a selective rowid seek available, which previously disabled the
+# hash join and left the FULL OUTER JOIN with no plan, wrongly rejecting it as
+# "requires an equality condition in the ON clause".
+@cross-check-integrity
+test full-outer-join-primary-key {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, b);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, d);
+    INSERT INTO t1 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+    INSERT INTO t2 VALUES (2, 'a'), (4, 'b');
+    SELECT t1.id, t1.b, t2.id, t2.d FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.id ORDER BY coalesce(t1.id, t2.id);
+}
+expect {
+    1|x||
+    2|y|2|a
+    3|z||
+    ||4|b
+}
+
 @cross-check-integrity
 test full-outer-join-count {
     CREATE TABLE t1(a, b);


### PR DESCRIPTION
### What's wrong

`FULL OUTER JOIN` on `INTEGER PRIMARY KEY` (rowid-alias) columns is rejected, even though the `ON` clause is an equality:

```sql
CREATE TABLE a(id INTEGER PRIMARY KEY);
CREATE TABLE b(id INTEGER PRIMARY KEY);
SELECT * FROM a FULL OUTER JOIN b ON a.id = b.id;
-- Parse error: FULL OUTER JOIN requires an equality condition in the ON clause
```

The same query on non-indexed columns works, and SQLite accepts both.

### Cause

A `FULL OUTER JOIN` can only run as a hash join (the unmatched-build scan has no nested-loop form). The eligibility gate in `optimizer/join.rs` disables the hash join whenever the probe side has a selective seek (`rhs_has_selective_seek`) — and a rowid/PK join column always has a rowid seek. So the join finds no plan and falls through to the catch-all "requires an equality condition" error.

### Fix

Keep the hash join for a `FULL OUTER JOIN` even when a selective probe seek exists. INNER/LEFT/RIGHT joins are unchanged.

### Tests

Added `full-outer-join-primary-key` to `outer_hash_join.sqltest` (`@cross-check-integrity`, so it is validated against SQLite). Confirmed it fails without this change (the same parse error) and passes with it; the full `outer_hash_join` suite (98 tests) passes.

### Not included

Non-equality `FULL OUTER JOIN` (e.g. `ON a.x < b.x`) is still rejected — that needs a non-hash execution path and is a separate change (related: #5788). Planning to look at that next.
