### PR TITLE
core/mvcc: Add per-connection extension loading

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -206,6 +206,8 @@ pub struct Connection {
     pub(super) full_column_names: AtomicBool,
     /// Deprecated pragma: when ON (default), column refs use just the column name
     pub(super) short_column_names: AtomicBool,
+    /// Per-connection runtime extension loading flag.
+    pub(super) enable_load_extension: AtomicBool,
     pub(crate) mv_tx: RwLock<Option<(crate::mvcc::database::TxID, TransactionMode)>>,
     /// Per-attached-database MVCC transactions.
     /// Main DB uses `mv_tx` above for zero-cost hot path access.
@@ -1862,6 +1864,14 @@ impl Connection {
 
     pub fn get_auto_commit(&self) -> bool {
         self.auto_commit.load(Ordering::SeqCst)
+    }
+
+    pub fn set_load_extension_enabled(&self, enabled: bool) {
+        self.enable_load_extension.store(enabled, Ordering::Release);
+    }
+
+    pub(crate) fn can_load_extensions(&self) -> bool {
+        self.enable_load_extension.load(Ordering::Acquire)
     }
 
     pub fn reparse_schema_after_extension_load(self: &Arc<Connection>) -> Result<()> {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1741,6 +1741,7 @@ impl Database {
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
             full_column_names: AtomicBool::new(false),
             short_column_names: AtomicBool::new(true),
+            enable_load_extension: AtomicBool::new(self.can_load_extensions()),
             fk_pragma: AtomicBool::new(false),
             fk_deferred_violations: AtomicIsize::new(0),
             n_active_writes: AtomicI32::new(0),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7380,7 +7380,7 @@ pub fn op_function(
             #[cfg(feature = "fs")]
             #[cfg(not(target_family = "wasm"))]
             ScalarFunc::LoadExtension => {
-                if !program.connection.db.can_load_extensions() {
+                if !program.connection.can_load_extensions() {
                     crate::bail_parse_error!("runtime extension loading is disabled");
                 }
                 let extension = &state.registers[*start_reg];

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -1,0 +1,62 @@
+use crate::common::TempDatabase;
+use turso_core::LimboError;
+
+#[turso_macros::test]
+fn sql_extension_loading_is_disabled_by_default(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    let err = conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+
+    assert!(err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn sql_extension_loading_flag_is_per_connection(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let enabled_conn = tmp_db.connect_limbo();
+    let disabled_conn = tmp_db.connect_limbo();
+
+    enabled_conn.set_load_extension_enabled(true);
+    let err = enabled_conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+    assert!(matches!(err, LimboError::ExtensionError(_)));
+    assert!(err.to_string().contains("Extension file not found"));
+
+    let err = disabled_conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+
+    enabled_conn.set_load_extension_enabled(false);
+    let err = enabled_conn
+        .execute("SELECT load_extension('definitely_missing_extension')")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+    Ok(())
+}
+
+#[turso_macros::test]
+fn direct_connection_extension_loading_bypasses_sql_flag(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+
+    let err = conn
+        .load_extension("definitely_missing_extension")
+        .unwrap_err();
+
+    assert!(matches!(err, LimboError::ExtensionError(_)));
+    assert!(!err
+        .to_string()
+        .contains("runtime extension loading is disabled"));
+    Ok(())
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod common;
 mod conflict_resolution;
 mod custom_types;
 mod database;
+mod external_apis;
 mod functions;
 mod fuzz_transaction;
 mod index_method;


### PR DESCRIPTION
## Summary
- Split focused core runtime extension-loading support out of PR #7154.
- Source commit: `cf0cee96201dc015109b7034c52f3f083aad166e`.
- Adds per-connection SQL `load_extension()` enable/disable state while keeping direct native `Connection::load_extension()` behavior available.
- Keeps the diff limited to core extension-loading plumbing and focused Turso-native Rust integration tests.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check -q -p core_tester --features pure-rust-crypto --test integration_tests`
- `cargo test -q -p core_tester --features pure-rust-crypto --test integration_tests extension_loading -- --nocapture` (3 passed)