### PR TITLE
Add core custom collation support

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -21,6 +21,7 @@ use crate::{
     parse_schema_rows,
     progress::{ProgressHandler, ProgressHandlerCallback},
     refresh_analyze_stats, translate,
+    translate::collate::CollationSeq,
     util::IOExt,
     vdbe, AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
@@ -34,6 +35,7 @@ use crate::{MAIN_DB_ID, TEMP_DB_ID};
 use arc_swap::ArcSwap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::SmallVec;
+use std::cmp::Ordering as CmpOrdering;
 use std::fmt::Display;
 use std::ops::Deref;
 #[cfg(feature = "simulator")]
@@ -2933,6 +2935,103 @@ impl Connection {
             .collect()
     }
 
+    pub fn register_external_collation(
+        &self,
+        name: String,
+        context: usize,
+        callback: crate::ContextCollationFunction,
+        context_destructor: Option<crate::ContextDestructor>,
+    ) {
+        let collation = CollationSeq::custom(&name);
+        let normalized_name = crate::util::normalize_ident(&name);
+        self.syms.write().collations.insert(
+            collation.id(),
+            Arc::new(function::ExternalCollation::new(
+                normalized_name,
+                context,
+                callback,
+                context_destructor,
+            )),
+        );
+        self.bump_prepare_context_generation();
+    }
+
+    pub fn unregister_external_collation(&self, name: &str) {
+        if let Some(collation) = CollationSeq::known_custom(name) {
+            if self
+                .syms
+                .write()
+                .collations
+                .remove(&collation.id())
+                .is_some()
+            {
+                self.bump_prepare_context_generation();
+            }
+        }
+    }
+
+    pub(crate) fn get_external_collation(
+        &self,
+        collation: CollationSeq,
+    ) -> Result<Arc<function::ExternalCollation>> {
+        self.syms
+            .read()
+            .collations
+            .get(&collation.id())
+            .cloned()
+            .ok_or_else(|| {
+                LimboError::ParseError(format!("no such collation sequence: {}", collation.name()))
+            })
+    }
+
+    pub(crate) fn custom_collation_compare(
+        external: &function::ExternalCollation,
+        left: &str,
+        right: &str,
+    ) -> CmpOrdering {
+        let result = unsafe {
+            (external.callback)(
+                external.context,
+                left.as_ptr(),
+                left.len(),
+                right.as_ptr(),
+                right.len(),
+            )
+        };
+        result.cmp(&0)
+    }
+
+    pub(crate) fn external_collation_comparator(
+        external: Arc<function::ExternalCollation>,
+    ) -> crate::vdbe::sorter::SortComparator {
+        Arc::new(move |left, right| {
+            Ok(match (left, right) {
+                (crate::ValueRef::Text(left), crate::ValueRef::Text(right)) => {
+                    Self::custom_collation_compare(&external, left.as_str(), right.as_str())
+                }
+                _ => left.partial_cmp(right).unwrap_or(CmpOrdering::Equal),
+            })
+        })
+    }
+
+    pub(crate) fn make_collation_comparator(
+        &self,
+        collation: CollationSeq,
+    ) -> Result<crate::vdbe::sorter::SortComparator> {
+        let external = self.get_external_collation(collation)?;
+        Ok(Self::external_collation_comparator(external))
+    }
+
+    pub(crate) fn compare_external_collation(
+        &self,
+        collation: CollationSeq,
+        left: &str,
+        right: &str,
+    ) -> Result<CmpOrdering> {
+        let external = self.get_external_collation(collation)?;
+        Ok(Self::custom_collation_compare(&external, left, right))
+    }
+
     pub(crate) fn database_ptr(&self) -> usize {
         Arc::as_ptr(&self.db) as usize
     }
@@ -3396,6 +3495,7 @@ pub type StepResult = vdbe::StepResult;
 #[derive(Default)]
 pub struct SymbolTable {
     pub functions: HashMap<String, Arc<function::ExternalFunc>>,
+    pub collations: HashMap<u32, Arc<function::ExternalCollation>>,
     pub vtabs: HashMap<String, Arc<VirtualTable>>,
     pub vtab_modules: HashMap<String, Arc<crate::ext::VTabImpl>>,
     pub index_methods: HashMap<String, Arc<dyn IndexMethod>>,
@@ -3405,6 +3505,7 @@ impl std::fmt::Debug for SymbolTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SymbolTable")
             .field("functions", &self.functions)
+            .field("collations", &self.collations)
             .finish()
     }
 }
@@ -3435,6 +3536,7 @@ impl SymbolTable {
     pub fn new() -> Self {
         Self {
             functions: HashMap::default(),
+            collations: HashMap::default(),
             vtabs: HashMap::default(),
             vtab_modules: HashMap::default(),
             index_methods: HashMap::default(),
@@ -3456,9 +3558,19 @@ impl SymbolTable {
             .filter(|func| func.func.matches_arg_count(arg_count))
     }
 
+    pub fn resolve_collation(&self, name: &str) -> Option<CollationSeq> {
+        let collation = CollationSeq::known_custom(name)?;
+        self.collations
+            .contains_key(&collation.id())
+            .then_some(collation)
+    }
+
     pub fn extend(&mut self, other: &SymbolTable) {
         for (name, func) in &other.functions {
             self.functions.insert(name.clone(), func.clone());
+        }
+        for (id, collation) in &other.collations {
+            self.collations.insert(*id, collation.clone());
         }
         for (name, vtab) in &other.vtabs {
             self.vtabs.insert(name.clone(), vtab.clone());

--- a/core/function.rs
+++ b/core/function.rs
@@ -9,6 +9,14 @@ use turso_ext::{
 
 use crate::LimboError;
 
+pub type ContextCollationFunction = unsafe extern "C" fn(
+    context: usize,
+    left_ptr: *const u8,
+    left_len: usize,
+    right_ptr: *const u8,
+    right_len: usize,
+) -> i32;
+
 pub trait Deterministic: std::fmt::Display {
     fn is_deterministic(&self) -> bool;
 }
@@ -16,6 +24,45 @@ pub trait Deterministic: std::fmt::Display {
 pub struct ExternalFunc {
     pub name: String,
     pub func: ExtFunc,
+}
+
+pub struct ExternalCollation {
+    pub name: String,
+    pub context: usize,
+    pub callback: ContextCollationFunction,
+    pub context_destructor: Option<ContextDestructor>,
+}
+
+impl ExternalCollation {
+    pub fn new(
+        name: String,
+        context: usize,
+        callback: ContextCollationFunction,
+        context_destructor: Option<ContextDestructor>,
+    ) -> Self {
+        Self {
+            name,
+            context,
+            callback,
+            context_destructor,
+        }
+    }
+}
+
+impl Drop for ExternalCollation {
+    fn drop(&mut self) {
+        if let Some(destructor) = self.context_destructor {
+            unsafe { destructor(self.context) };
+        }
+    }
+}
+
+impl Debug for ExternalCollation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExternalCollation")
+            .field("name", &self.name)
+            .finish()
+    }
 }
 
 impl Deterministic for ExternalFunc {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -128,6 +128,7 @@ use util::parse_schema_rows;
 pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
 pub use error::{io_error, CompletionError, LimboError};
+pub use function::ContextCollationFunction;
 #[cfg(all(feature = "fs", target_family = "unix", not(miri)))]
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring", not(miri)))]
@@ -154,6 +155,7 @@ pub use storage::{
     wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
 };
 pub use translate::expr::{walk_expr_mut, WalkControl};
+pub use turso_ext::ContextDestructor;
 pub use turso_macros::{
     turso_assert, turso_assert_all, turso_assert_eq, turso_assert_greater_than,
     turso_assert_greater_than_or_equal, turso_assert_less_than, turso_assert_less_than_or_equal,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3928,7 +3928,13 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                             });
                         }
                         ast::ColumnConstraint::Collate { ref collation_name } => {
-                            collation = Some(CollationSeq::new(collation_name.as_str())?);
+                            let collation_seq = CollationSeq::new(collation_name.as_str())?;
+                            if collation_seq.is_custom() {
+                                crate::bail_parse_error!(
+                                    "custom collations are not supported in schema definitions"
+                                );
+                            }
+                            collation = Some(collation_seq);
                         }
                         ast::ColumnConstraint::ForeignKey {
                             clause,
@@ -4718,7 +4724,13 @@ impl TryFrom<&ColumnDefinition> for Column {
                     );
                 }
                 ast::ColumnConstraint::Collate { collation_name } => {
-                    collation.replace(CollationSeq::new(collation_name.as_str())?);
+                    let collation_seq = CollationSeq::new(collation_name.as_str())?;
+                    if collation_seq.is_custom() {
+                        crate::bail_parse_error!(
+                            "custom collations are not supported in schema definitions"
+                        );
+                    }
+                    collation.replace(collation_seq);
                 }
                 ast::ColumnConstraint::Generated { expr, .. } => {
                     generated = Some(expr.clone());

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -181,10 +181,11 @@ pub(crate) fn emit_collseq_if_needed(
     program: &mut ProgramBuilder,
     referenced_tables: &TableReferences,
     expr: &ast::Expr,
+    resolver: &Resolver,
 ) {
     // Check if this is a column expression with explicit COLLATE clause
     if let ast::Expr::Collate(_, collation_name) = expr {
-        if let Ok(collation) = CollationSeq::new(collation_name.as_str()) {
+        if let Ok(collation) = resolver.resolve_collation(collation_name.as_str()) {
             program.emit_insn(Insn::CollSeq {
                 reg: None,
                 collation,
@@ -426,7 +427,7 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr);
+            emit_collseq_if_needed(program, referenced_tables, expr, resolver);
             let comparator =
                 super::order_by::custom_type_comparator(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {
@@ -445,7 +446,7 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             let expr = &agg_arg_source.arg_at(0);
-            emit_collseq_if_needed(program, referenced_tables, expr);
+            emit_collseq_if_needed(program, referenced_tables, expr, resolver);
             let comparator =
                 super::order_by::custom_type_comparator(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -1,11 +1,17 @@
-use std::{cmp::Ordering, str::FromStr as _};
+use std::{
+    cmp::Ordering,
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    str::FromStr as _,
+};
 
 use icu_collator::{options::CollatorOptions, Collator, CollatorBorrowed};
 use icu_locale::Locale;
 use turso_parser::ast::Expr;
 
 use crate::{
-    sync::{LazyLock, RwLock},
+    connection::SymbolTable,
+    sync::{LazyLock, Mutex, RwLock},
     translate::{
         expr::{walk_expr, WalkControl},
         plan::TableReferences,
@@ -13,49 +19,147 @@ use crate::{
     Result,
 };
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 /// **Pre defined collation sequences**\
 /// Collating functions only matter when comparing string values.
 /// Numeric values are always compared numerically, and BLOBs are always compared byte-by-byte using memcmp().
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum CollationSeq {
     Unset,
-    #[default]
     Binary,
     NoCase,
     Rtrim,
     Locale(LocaleCollationId),
+    /// Name/id token for a connection-owned callback. The comparison itself
+    /// must be resolved through `Connection` at runtime.
+    Custom(u32),
 }
+
+#[derive(Default)]
+struct CustomCollationNames {
+    // Custom collation callbacks are connection-local. This process-wide table
+    // only interns names so bytecode can carry compact `CollationSeq::Custom`
+    // tokens and resolve the callback through the active connection at runtime.
+    by_name: HashMap<String, u32>,
+    by_id: HashMap<u32, String>,
+}
+
+static CUSTOM_COLLATION_NAMES: LazyLock<Mutex<CustomCollationNames>> =
+    LazyLock::new(|| Mutex::new(CustomCollationNames::default()));
 
 impl CollationSeq {
     pub fn new(collation: &str) -> crate::Result<Self> {
-        match collation.to_ascii_lowercase().as_str() {
-            "binary" => return Ok(CollationSeq::Binary),
-            "nocase" => return Ok(CollationSeq::NoCase),
-            "rtrim" => return Ok(CollationSeq::Rtrim),
+        match crate::util::normalize_ident(collation).as_str() {
+            "binary" => return Ok(Self::Binary),
+            "nocase" => return Ok(Self::NoCase),
+            "rtrim" => return Ok(Self::Rtrim),
             _ => {}
         }
+
         LocaleCollationRegistry::global()
             .get_or_register(collation)
-            .map(CollationSeq::Locale)
+            .map(Self::Locale)
     }
 
     #[inline]
     /// Returns the collation, defaulting to BINARY if unset
     pub const fn from_bits(bits: u8) -> Self {
         match bits {
-            2 => CollationSeq::NoCase,
-            3 => CollationSeq::Rtrim,
-            _ => CollationSeq::Binary,
+            2 => Self::NoCase,
+            3 => Self::Rtrim,
+            _ => Self::Binary,
+        }
+    }
+
+    #[inline]
+    pub const fn to_bits(self) -> u16 {
+        match self {
+            Self::Unset => 0,
+            Self::Binary => 1,
+            Self::NoCase => 2,
+            Self::Rtrim => 3,
+            Self::Locale(id) => id.to_bits(),
+            Self::Custom(_) => 0,
+        }
+    }
+
+    #[inline]
+    pub const fn from_storage_bits(bits: u16) -> Self {
+        match bits {
+            0 => Self::Unset,
+            1 => Self::Binary,
+            2 => Self::NoCase,
+            3 => Self::Rtrim,
+            bits => Self::Locale(LocaleCollationId::from_bits(bits)),
+        }
+    }
+
+    #[inline]
+    pub const fn id(self) -> u32 {
+        match self {
+            Self::Custom(id) => id,
+            _ => self.to_bits() as u32,
+        }
+    }
+
+    #[inline]
+    pub const fn is_custom(self) -> bool {
+        matches!(self, Self::Custom(_))
+    }
+
+    pub fn custom(collation: &str) -> Self {
+        let normalized = crate::util::normalize_ident(collation);
+        let mut registry = CUSTOM_COLLATION_NAMES.lock();
+        if let Some(id) = registry.by_name.get(&normalized) {
+            return Self::Custom(*id);
+        }
+
+        let mut id = custom_collation_id(&normalized);
+        while id <= 3 || registry.by_id.contains_key(&id) {
+            id = id.wrapping_add(1).max(4);
+        }
+
+        registry.by_name.insert(normalized, id);
+        registry.by_id.insert(id, collation.to_string());
+        Self::Custom(id)
+    }
+
+    pub(crate) fn known_custom(collation: &str) -> Option<Self> {
+        let normalized = crate::util::normalize_ident(collation);
+        CUSTOM_COLLATION_NAMES
+            .lock()
+            .by_name
+            .get(&normalized)
+            .copied()
+            .map(Self::Custom)
+    }
+
+    pub fn name(self) -> String {
+        match self {
+            Self::Unset => "Unset".to_string(),
+            Self::Binary => "Binary".to_string(),
+            Self::NoCase => "NoCase".to_string(),
+            Self::Rtrim => "RTrim".to_string(),
+            Self::Locale(id) => LocaleCollationRegistry::global().name(id),
+            Self::Custom(id) => CUSTOM_COLLATION_NAMES
+                .lock()
+                .by_id
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| format!("collation_{id}")),
         }
     }
 
     #[inline(always)]
     pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
-        match self {
-            CollationSeq::Unset | CollationSeq::Binary => Self::binary_cmp(lhs, rhs),
-            CollationSeq::NoCase => Self::nocase_cmp(lhs, rhs),
-            CollationSeq::Rtrim => Self::rtrim_cmp(lhs, rhs),
-            CollationSeq::Locale(id) => LocaleCollationRegistry::global().compare(*id, lhs, rhs),
+        match *self {
+            Self::Unset | Self::Binary => Self::binary_cmp(lhs, rhs),
+            Self::NoCase => Self::nocase_cmp(lhs, rhs),
+            Self::Rtrim => Self::rtrim_cmp(lhs, rhs),
+            Self::Locale(id) => LocaleCollationRegistry::global().compare(id, lhs, rhs),
+            // Immutable comparison paths have no connection to fetch the external
+            // callback from. Runtime VDBE paths dispatch custom collations via
+            // `Connection`; schema/index paths reject them before storage.
+            Self::Custom(_) => Self::binary_cmp(lhs, rhs),
         }
     }
 
@@ -76,53 +180,42 @@ impl CollationSeq {
         lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
     }
 
-    #[inline]
-    pub const fn to_bits(self) -> u16 {
-        match self {
-            CollationSeq::Unset => 0,
-            CollationSeq::Binary => 1,
-            CollationSeq::NoCase => 2,
-            CollationSeq::Rtrim => 3,
-            CollationSeq::Locale(id) => id.to_bits(),
-        }
-    }
-
-    #[inline]
-    pub const fn from_storage_bits(bits: u16) -> Self {
-        match bits {
-            0 => CollationSeq::Unset,
-            1 => CollationSeq::Binary,
-            2 => CollationSeq::NoCase,
-            3 => CollationSeq::Rtrim,
-            bits => CollationSeq::Locale(LocaleCollationId::from_bits(bits)),
-        }
-    }
-
     pub fn hash_key(&self, text: &str) -> Vec<u8> {
         match self {
-            CollationSeq::Unset | CollationSeq::Binary => text.as_bytes().to_vec(),
-            CollationSeq::NoCase => text.bytes().map(|b| b.to_ascii_lowercase()).collect(),
-            CollationSeq::Rtrim => text.trim_end_matches(' ').as_bytes().to_vec(),
-            CollationSeq::Locale(id) => LocaleCollationRegistry::global().sort_key(*id, text),
+            Self::Unset | Self::Binary => text.as_bytes().to_vec(),
+            Self::NoCase => text.bytes().map(|b| b.to_ascii_lowercase()).collect(),
+            Self::Rtrim => text.trim_end_matches(' ').as_bytes().to_vec(),
+            Self::Locale(id) => LocaleCollationRegistry::global().sort_key(*id, text),
+            // Hash joins using custom collations are disabled during planning
+            // because the callback is connection-owned and may define arbitrary equality.
+            Self::Custom(_) => text.as_bytes().to_vec(),
         }
+    }
+}
+
+fn resolve_collation_name(
+    collation: &str,
+    symbol_table: Option<&SymbolTable>,
+) -> Result<CollationSeq> {
+    if let Some(collation) = symbol_table.and_then(|syms| syms.resolve_collation(collation)) {
+        return Ok(collation);
+    }
+    CollationSeq::new(collation)
+}
+
+impl Default for CollationSeq {
+    fn default() -> Self {
+        Self::Binary
     }
 }
 
 impl std::fmt::Display for CollationSeq {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CollationSeq::Unset => write!(f, "Unset"),
-            CollationSeq::Binary => write!(f, "Binary"),
-            CollationSeq::NoCase => write!(f, "NoCase"),
-            CollationSeq::Rtrim => write!(f, "Rtrim"),
-            CollationSeq::Locale(id) => {
-                write!(f, "{}", LocaleCollationRegistry::global().name(*id))
-            }
-        }
+        f.write_str(&self.name())
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct LocaleCollationId(u16);
 
 impl LocaleCollationId {
@@ -230,6 +323,12 @@ impl LocaleCollationRegistry {
     }
 }
 
+fn custom_collation_id(name: &str) -> u32 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut hasher);
+    ((hasher.finish() as u32) & 0x7fff_fffc).max(4)
+}
+
 /// Every column of every table has an associated collating function. If no collating function is explicitly defined,
 /// then the collating function defaults to BINARY.
 /// The COLLATE clause of the column definition is used to define alternative collating functions for a column.
@@ -257,7 +356,16 @@ pub fn get_collseq_from_expr(
     top_expr: &Expr,
     referenced_tables: &TableReferences,
 ) -> Result<Option<CollationSeq>> {
-    let (explicit, column) = get_collseq_parts_from_expr(top_expr, referenced_tables)?;
+    get_collseq_from_expr_with_symbols(top_expr, referenced_tables, None)
+}
+
+pub fn get_collseq_from_expr_with_symbols(
+    top_expr: &Expr,
+    referenced_tables: &TableReferences,
+    symbol_table: Option<&SymbolTable>,
+) -> Result<Option<CollationSeq>> {
+    let (explicit, column) =
+        get_collseq_parts_from_expr_with_symbols(top_expr, referenced_tables, symbol_table)?;
     Ok(explicit.or(column))
 }
 
@@ -269,9 +377,10 @@ pub fn get_collseq_from_expr(
 /// column translation records that fact in `ProgramBuilder::curr_collation_ctx()`.
 /// Synthetic expressions such as aggregates must opt out by storing `None` in
 /// the cache entry instead of calling this helper.
-pub fn get_expr_collation_ctx(
+pub fn get_expr_collation_ctx_with_symbols(
     top_expr: &Expr,
     referenced_tables: &TableReferences,
+    symbol_table: Option<&SymbolTable>,
 ) -> Result<Option<(CollationSeq, bool)>> {
     let mut maybe_column_collseq = None;
     let mut maybe_explicit_collseq = None;
@@ -280,8 +389,9 @@ pub fn get_expr_collation_ctx(
         match expr {
             Expr::Collate(_, seq) => {
                 if maybe_explicit_collseq.is_none() {
-                    maybe_explicit_collseq =
-                        Some(CollationSeq::new(seq.as_str()).unwrap_or_default());
+                    maybe_explicit_collseq = Some(
+                        resolve_collation_name(seq.as_str(), symbol_table).unwrap_or_default(),
+                    );
                 }
                 return Ok(WalkControl::SkipChildren);
             }
@@ -316,13 +426,25 @@ pub fn get_expr_collation_ctx(
 /// 1. Explicit COLLATE operator on either side wins (LHS takes precedence)
 /// 2. Column with defined collation on either side wins (LHS takes precedence)
 /// 3. Otherwise BINARY
+#[cfg(test)]
 pub fn resolve_comparison_collseq(
     lhs_expr: &Expr,
     rhs_expr: &Expr,
     referenced_tables: &TableReferences,
 ) -> Result<CollationSeq> {
-    let (lhs_explicit, lhs_column) = get_collseq_parts_from_expr(lhs_expr, referenced_tables)?;
-    let (rhs_explicit, rhs_column) = get_collseq_parts_from_expr(rhs_expr, referenced_tables)?;
+    resolve_comparison_collseq_with_symbols(lhs_expr, rhs_expr, referenced_tables, None)
+}
+
+pub fn resolve_comparison_collseq_with_symbols(
+    lhs_expr: &Expr,
+    rhs_expr: &Expr,
+    referenced_tables: &TableReferences,
+    symbol_table: Option<&SymbolTable>,
+) -> Result<CollationSeq> {
+    let (lhs_explicit, lhs_column) =
+        get_collseq_parts_from_expr_with_symbols(lhs_expr, referenced_tables, symbol_table)?;
+    let (rhs_explicit, rhs_column) =
+        get_collseq_parts_from_expr_with_symbols(rhs_expr, referenced_tables, symbol_table)?;
     Ok(lhs_explicit
         .or(rhs_explicit)
         .or(lhs_column)
@@ -334,9 +456,10 @@ pub fn resolve_comparison_collseq(
 /// Explicit collation comes from COLLATE operators; column collation comes from
 /// column definitions. These are kept separate to allow proper precedence resolution
 /// in binary comparisons.
-fn get_collseq_parts_from_expr(
+fn get_collseq_parts_from_expr_with_symbols(
     top_expr: &Expr,
     referenced_tables: &TableReferences,
+    symbol_table: Option<&SymbolTable>,
 ) -> Result<(Option<CollationSeq>, Option<CollationSeq>)> {
     let mut maybe_column_collseq = None;
     let mut maybe_explicit_collseq = None;
@@ -346,8 +469,9 @@ fn get_collseq_parts_from_expr(
             Expr::Collate(_, seq) => {
                 // Only store the first (leftmost) COLLATE operator we find
                 if maybe_explicit_collseq.is_none() {
-                    maybe_explicit_collseq =
-                        Some(CollationSeq::new(seq.as_str()).unwrap_or_default());
+                    maybe_explicit_collseq = Some(
+                        resolve_collation_name(seq.as_str(), symbol_table).unwrap_or_default(),
+                    );
                 }
                 // Skip children since we've found a COLLATE operator
                 return Ok(WalkControl::SkipChildren);

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1,7 +1,7 @@
 // This module contains code for emitting bytecode instructions for SQL query execution.
 // It handles translating high-level SQL operations into low-level bytecode that can be executed by the virtual machine.
 use super::{
-    collate::{get_expr_collation_ctx, CollationSeq},
+    collate::{get_expr_collation_ctx_with_symbols, CollationSeq},
     compound_select::emit_program_for_compound_select,
     emitter::{
         delete::emit_program_for_delete, select::emit_program_for_select,
@@ -491,9 +491,20 @@ impl<'a> Resolver<'a> {
         needs_decode: bool,
         referenced_tables: &TableReferences,
     ) -> Result<()> {
-        let collation = get_expr_collation_ctx(expr.as_ref(), referenced_tables)?;
+        let collation = get_expr_collation_ctx_with_symbols(
+            expr.as_ref(),
+            referenced_tables,
+            Some(self.symbol_table),
+        )?;
         self.cache_expr_reg(expr, reg, needs_decode, collation);
         Ok(())
+    }
+
+    pub fn resolve_collation(&self, name: &str) -> Result<CollationSeq> {
+        if let Some(collation) = self.symbol_table.resolve_collation(name) {
+            return Ok(collation);
+        }
+        CollationSeq::new(name)
     }
 
     /// Returns the register, decode flag, and collation metadata for a previously translated expression.

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -191,7 +191,7 @@ pub fn emit_query<'a>(
     }
 
     let distinct_ctx = if let Distinctness::Distinct { .. } = &plan.distinctness {
-        Some(init_distinct(program, plan)?)
+        Some(init_distinct(program, plan, &t_ctx.resolver)?)
     } else {
         None
     };

--- a/core/translate/expr/binary.rs
+++ b/core/translate/expr/binary.rs
@@ -422,16 +422,24 @@ pub(super) fn row_component_affinity_collation(
     let rhs_for_cmp = row_value_component_expr(rhs_expr, idx)?.unwrap_or(rhs_expr);
     Ok((
         comparison_affinity(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver),
-        comparison_collation(lhs_for_cmp, rhs_for_cmp, referenced_tables)?,
+        comparison_collation(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver)?,
     ))
 }
 
-pub(super) fn explicit_collation(expr: &Expr) -> Result<Option<CollationSeq>> {
+pub(super) fn explicit_collation(
+    expr: &Expr,
+    resolver: Option<&Resolver>,
+) -> Result<Option<CollationSeq>> {
     let mut found = None;
     walk_expr(expr, &mut |e| -> Result<WalkControl> {
         if let Expr::Collate(_, seq) = e {
             if found.is_none() {
-                found = Some(CollationSeq::new(seq.as_str()).unwrap_or_default());
+                let collation = match resolver {
+                    Some(resolver) => resolver.resolve_collation(seq.as_str()),
+                    None => CollationSeq::new(seq.as_str()),
+                }
+                .unwrap_or_default();
+                found = Some(collation);
             }
             return Ok(WalkControl::SkipChildren);
         }
@@ -444,20 +452,22 @@ pub(super) fn comparison_collation(
     lhs_expr: &Expr,
     rhs_expr: &Expr,
     referenced_tables: Option<&TableReferences>,
+    resolver: Option<&Resolver>,
 ) -> Result<Option<CollationSeq>> {
     if let Some(tables) = referenced_tables {
-        let lhs_collation = get_collseq_from_expr(lhs_expr, tables)?;
+        let symbol_table = resolver.map(|resolver| resolver.symbol_table);
+        let lhs_collation = get_collseq_from_expr_with_symbols(lhs_expr, tables, symbol_table)?;
         if lhs_collation.is_some() {
             return Ok(lhs_collation);
         }
-        return get_collseq_from_expr(rhs_expr, tables);
+        return get_collseq_from_expr_with_symbols(rhs_expr, tables, symbol_table);
     }
 
-    let lhs_collation = explicit_collation(lhs_expr)?;
+    let lhs_collation = explicit_collation(lhs_expr, resolver)?;
     if lhs_collation.is_some() {
         return Ok(lhs_collation);
     }
-    explicit_collation(rhs_expr)
+    explicit_collation(rhs_expr, resolver)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -4,7 +4,7 @@ use crate::turso_assert;
 use tracing::{instrument, Level};
 use turso_parser::ast::{self, Expr, ResolveType, SubqueryType, TableInternalId, UnaryOperator};
 
-use super::collate::{get_collseq_from_expr, CollationSeq};
+use super::collate::{get_collseq_from_expr_with_symbols, CollationSeq};
 use super::emitter::Resolver;
 use super::optimizer::Optimizable;
 use super::plan::TableReferences;

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -644,7 +644,7 @@ pub fn translate_expr(
             // First translate inner expr, then set the curr collation. If we set curr collation before,
             // it may be overwritten later by inner translate.
             translate_expr(program, referenced_tables, expr, target_register, resolver)?;
-            let collation = CollationSeq::new(collation.as_str())?;
+            let collation = resolver.resolve_collation(collation.as_str())?;
             program.set_collation(Some((collation, true)));
             Ok(target_register)
         }

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -20,7 +20,7 @@ use crate::translate::{
 use crate::{
     emit_explain,
     schema::PseudoCursorType,
-    translate::collate::{get_collseq_from_expr, CollationSeq},
+    translate::collate::{get_collseq_from_expr_with_symbols, CollationSeq},
     util::exprs_are_equivalent,
     vdbe::{
         builder::{CursorType, ProgramBuilder},
@@ -168,7 +168,11 @@ impl EmitGroupBy {
                 .zip(sort_order.iter())
                 .zip(group_by.nulls_order.iter())
                 .map(|((expr, ord), nulls)| {
-                    let collation = get_collseq_from_expr(expr, &plan.table_references)?;
+                    let collation = get_collseq_from_expr_with_symbols(
+                        expr,
+                        &plan.table_references,
+                        Some(t_ctx.resolver.symbol_table),
+                    )?;
                     Ok((*ord, collation, *nulls))
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -641,7 +645,11 @@ pub fn group_by_process_single_group(
         .enumerate()
         .take(group_by.exprs.len())
     {
-        let maybe_collation = get_collseq_from_expr(&group_by.exprs[i], &plan.table_references)?;
+        let maybe_collation = get_collseq_from_expr_with_symbols(
+            &group_by.exprs[i],
+            &plan.table_references,
+            Some(t_ctx.resolver.symbol_table),
+        )?;
         c.collation = maybe_collation.unwrap_or_default();
     }
 

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -145,7 +145,7 @@ pub fn translate_create_index(
     if !tbl.has_rowid {
         bail_parse_error!("CREATE INDEX on WITHOUT ROWID tables is not supported");
     }
-    let columns = resolve_sorted_columns(&tbl, &columns)?;
+    let columns = resolve_sorted_columns_with_resolver(&tbl, &columns, Some(resolver))?;
 
     // Block CREATE INDEX on non-orderable custom type columns and STRUCT/UNION columns
     for col in &columns {
@@ -599,10 +599,18 @@ pub fn resolve_sorted_columns(
     table: &BTreeTable,
     cols: &[SortedColumn],
 ) -> crate::Result<Vec<IndexColumn>> {
+    resolve_sorted_columns_with_resolver(table, cols, None)
+}
+
+fn resolve_sorted_columns_with_resolver(
+    table: &BTreeTable,
+    cols: &[SortedColumn],
+    resolver: Option<&Resolver>,
+) -> crate::Result<Vec<IndexColumn>> {
     let mut resolved = Vec::with_capacity(cols.len());
     for sc in cols {
         let order = sc.order.unwrap_or(SortOrder::Asc);
-        let (explicit_collation, base_expr) = extract_collation(sc.expr.as_ref())?;
+        let (explicit_collation, base_expr) = extract_collation(sc.expr.as_ref(), resolver)?;
         // Unwrap parentheses for column resolution (SQLite treats (('col')) same as 'col')
         let unwrapped_expr = unwrap_parens(base_expr)?;
         if let Some((pos, column_name, column)) = resolve_index_column(unwrapped_expr, table) {
@@ -639,11 +647,21 @@ pub fn resolve_sorted_columns(
 /// Extracts collation sequence from an expression if it is a Collate expression.
 /// Given the example: `col1 COLLATE NOCASE` / Expr::Collation(Expr::Id(col1), CollationSeq)
 /// returns (Some(CollationSeq), Expr::Id(col1))
-fn extract_collation(expr: &Expr) -> crate::Result<(Option<CollationSeq>, &Expr)> {
+fn extract_collation<'a>(
+    expr: &'a Expr,
+    resolver: Option<&Resolver>,
+) -> crate::Result<(Option<CollationSeq>, &'a Expr)> {
     let mut current = expr;
     let mut coll = None;
     while let Expr::Collate(inner, seq) = current {
-        coll = Some(CollationSeq::new(seq.as_str())?);
+        let collation = match resolver {
+            Some(resolver) => resolver.resolve_collation(seq.as_str())?,
+            None => CollationSeq::new(seq.as_str())?,
+        };
+        if collation.is_custom() {
+            crate::bail_parse_error!("custom collations are not supported in indexes");
+        }
+        coll = Some(collation);
         current = inner.as_ref();
     }
     Ok((coll, current))

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -251,7 +251,12 @@ fn emit_loop_source<'a>(
                     None
                 };
 
-                emit_collseq_if_needed(program, &plan.table_references, &min_max.argument);
+                emit_collseq_if_needed(
+                    program,
+                    &plan.table_references,
+                    &min_max.argument,
+                    &t_ctx.resolver,
+                );
                 let comparator = custom_type_comparator(
                     &min_max.argument,
                     &plan.table_references,

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -136,15 +136,20 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
                         join_key.get_build_expr(self.predicates),
                     ),
                 };
-                resolve_comparison_collseq(original_lhs, original_rhs, self.table_references)
-                    .unwrap_or(CollationSeq::Binary)
+                resolve_comparison_collseq_with_symbols(
+                    original_lhs,
+                    original_rhs,
+                    self.table_references,
+                    Some(self.t_ctx.resolver.symbol_table),
+                )
+                .unwrap_or(CollationSeq::Binary)
             })
             .collect();
 
         let use_bloom_filter = self.hash_join_op.use_bloom_filter
             && collations
                 .iter()
-                .all(|c| matches!(c, CollationSeq::Binary | CollationSeq::Unset));
+                .all(|c| matches!(*c, CollationSeq::Binary | CollationSeq::Unset));
 
         let build_table = &self.table_references.joined_tables()[self.hash_join_op.build_table_idx];
         let (payload_columns, payload_signature_columns, use_materialized_keys, allow_seek) =

--- a/core/translate/main_loop/init.rs
+++ b/core/translate/main_loop/init.rs
@@ -1,13 +1,21 @@
 use super::*;
 use crate::alloc::TursoIteratorExt;
 
-pub fn init_distinct(program: &mut ProgramBuilder, plan: &SelectPlan) -> Result<DistinctCtx> {
+pub fn init_distinct(
+    program: &mut ProgramBuilder,
+    plan: &SelectPlan,
+    resolver: &Resolver,
+) -> Result<DistinctCtx> {
     let collations = plan
         .result_columns
         .iter()
         .map(|col| {
-            get_collseq_from_expr(&col.expr, &plan.table_references)
-                .map(|c| c.unwrap_or(CollationSeq::Binary))
+            get_collseq_from_expr_with_symbols(
+                &col.expr,
+                &plan.table_references,
+                Some(resolver.symbol_table),
+            )
+            .map(|c| c.unwrap_or(CollationSeq::Binary))
         })
         .collect::<Result<Vec<_>>>()?;
     let hash_table_id = program.alloc_hash_table_id();
@@ -66,9 +74,12 @@ impl InitLoop {
                 1,
                 "DISTINCT aggregate functions must have exactly one argument"
             );
-            let collations =
-                vec![get_collseq_from_expr(&agg.original_expr, tables)?
-                    .unwrap_or(CollationSeq::Binary)];
+            let collations = vec![get_collseq_from_expr_with_symbols(
+                &agg.original_expr,
+                tables,
+                Some(t_ctx.resolver.symbol_table),
+            )?
+            .unwrap_or(CollationSeq::Binary)];
             let hash_table_id = program.alloc_hash_table_id();
             agg.distinctness = Distinctness::Distinct {
                 ctx: Some(DistinctCtx {

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -25,7 +25,10 @@ use crate::{
     emit_explain,
     schema::{Index, IndexColumn, Table},
     translate::{
-        collate::{get_collseq_from_expr, resolve_comparison_collseq, CollationSeq},
+        collate::{
+            get_collseq_from_expr_with_symbols, resolve_comparison_collseq_with_symbols,
+            CollationSeq,
+        },
         emitter::{prepare_cdc_if_necessary, HashCtx},
         expr::comparison_affinity,
         planner::{table_mask_from_expr, TableMask},

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -8,6 +8,7 @@ use turso_parser::ast::{self, SortOrder, TableInternalId};
 use crate::alloc::TursoIteratorExt;
 use crate::schema::Schema;
 use crate::stats::AnalyzeStats;
+use crate::translate::collate::CollationSeq;
 use crate::translate::expr::{as_binary_components, walk_expr, WalkControl};
 use crate::translate::optimizer::constraints::{
     convert_to_vtab_constraint, ordered_materialized_key_columns, BinaryExprSide, Constraint,
@@ -976,6 +977,20 @@ pub fn find_equijoin_conditions(
     join_keys
 }
 
+fn expr_uses_custom_collation(expr: &ast::Expr) -> bool {
+    let mut uses_custom = false;
+    let _ = walk_expr(expr, &mut |expr| -> Result<WalkControl> {
+        if let ast::Expr::Collate(_, collation_name) = expr {
+            uses_custom = CollationSeq::known_custom(collation_name.as_str()).is_some();
+            if uses_custom {
+                return Ok(WalkControl::SkipChildren);
+            }
+        }
+        Ok(WalkControl::Continue)
+    });
+    uses_custom
+}
+
 /// Estimate the cost of a hash join between two tables.
 ///
 /// The cost model accounts for:
@@ -1158,6 +1173,14 @@ pub fn try_hash_join_access_method(
     // no equality (e.g. `a.x < b.x`) we still build a single-bucket hash join and
     // let the predicate apply as a residual, rather than rejecting the query.
     if join_keys.is_empty() && hash_join_type != HashJoinType::FullOuter {
+        return None;
+    }
+    // Custom-collated equality depends on a connection-owned callback, so the
+    // hash join planner cannot derive a stable hash/equality pair here.
+    if join_keys.iter().any(|join_key| {
+        expr_uses_custom_collation(join_key.get_build_expr(where_clause))
+            || expr_uses_custom_collation(join_key.get_probe_expr(where_clause))
+    }) {
         return None;
     }
 

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -7,7 +7,7 @@ use crate::{
     emit_explain,
     schema::{Index, IndexColumn, PseudoCursorType, Schema},
     translate::{
-        collate::{get_collseq_from_expr, CollationSeq},
+        collate::{get_collseq_from_expr_with_symbols, CollationSeq},
         group_by::is_orderby_agg_or_const,
         plan::Aggregate,
     },
@@ -204,7 +204,11 @@ impl EmitOrderBy {
             let mut index_columns =
                 Vec::try_with_capacity_ext(order_by.len() + result_columns.len())?;
             for (column, order, _nulls) in order_by {
-                let collation = get_collseq_from_expr(column, referenced_tables)?;
+                let collation = get_collseq_from_expr_with_symbols(
+                    column,
+                    referenced_tables,
+                    Some(t_ctx.resolver.symbol_table),
+                )?;
                 let pos_in_table = index_columns.len();
                 // Have enough space pre-allocatoed to push without realloc
                 index_columns.push(IndexColumn {
@@ -281,7 +285,11 @@ impl EmitOrderBy {
             )> = order_by
                 .iter()
                 .map(|(expr, dir, nulls)| {
-                    let collation = get_collseq_from_expr(expr, referenced_tables)?;
+                    let collation = get_collseq_from_expr_with_symbols(
+                        expr,
+                        referenced_tables,
+                        Some(t_ctx.resolver.symbol_table),
+                    )?;
                     Ok::<_, crate::LimboError>((*dir, collation, *nulls))
                 })
                 .try_collect::<Result<Vec<_>>>()??;

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -752,6 +752,14 @@ fn validate(
                             translate_ident_to_string_literal(expr).unwrap_or_else(|| expr.clone());
                         validate_default_expr(&expr, col_i)?
                     }
+                    ast::ColumnConstraint::Collate { collation_name } => {
+                        let collation = resolver.resolve_collation(collation_name.as_str())?;
+                        if collation.is_custom() {
+                            bail_parse_error!(
+                                "custom collations are not supported in schema definitions"
+                            );
+                        }
+                    }
                     _ => {}
                 }
             }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -21,8 +21,8 @@ use crate::storage::sqlite3_ondisk::{DatabaseHeader, PageSize, RawVersion};
 use crate::translate::collate::CollationSeq;
 use crate::translate::pragma::TURSO_CDC_VERSION_TABLE_NAME;
 use crate::types::{
-    compare_immutable, compare_records_generic, AsValueRef, Extendable, IOCompletions, IOResult,
-    ImmutableRecord, IndexInfo, SeekResult, Text, ValueIterator,
+    compare_immutable, compare_immutable_single, compare_records_generic, AsValueRef, Extendable,
+    IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekResult, Text, ValueIterator,
 };
 use crate::util::{
     escape_sql_string_literal, normalize_ident, rename_identifiers,
@@ -310,16 +310,54 @@ fn compare_with_collation(
     lhs: &Value,
     rhs: &Value,
     collation: Option<CollationSeq>,
-) -> std::cmp::Ordering {
-    match (lhs, rhs) {
+    collation_comparator: &Option<crate::vdbe::sorter::SortComparator>,
+) -> Result<std::cmp::Ordering> {
+    Ok(match (lhs, rhs) {
         (Value::Text(lhs_text), Value::Text(rhs_text)) => {
-            if let Some(coll) = collation {
+            if let Some(comparator) = collation_comparator {
+                comparator(&lhs.as_ref(), &rhs.as_ref())?
+            } else if let Some(coll) = collation {
                 coll.compare_strings(lhs_text.as_str(), rhs_text.as_str())
             } else {
                 lhs.cmp(rhs)
             }
         }
         _ => lhs.cmp(rhs),
+    })
+}
+
+fn compare_with_program_collation<V1, V2>(
+    program: &Program,
+    lhs: V1,
+    rhs: V2,
+    collation: CollationSeq,
+) -> Result<std::cmp::Ordering>
+where
+    V1: AsValueRef,
+    V2: AsValueRef,
+{
+    let lhs = lhs.as_value_ref();
+    let rhs = rhs.as_value_ref();
+    if collation.is_custom() {
+        if let (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) = (lhs, rhs) {
+            return program.connection.compare_external_collation(
+                collation,
+                lhs_text.as_str(),
+                rhs_text.as_str(),
+            );
+        }
+    }
+    Ok(compare_immutable_single(lhs, rhs, collation))
+}
+
+fn comparison_matches_order(op: ComparisonOp, order: std::cmp::Ordering) -> bool {
+    match op {
+        ComparisonOp::Eq => order.is_eq(),
+        ComparisonOp::Ne => !order.is_eq(),
+        ComparisonOp::Lt => order.is_lt(),
+        ComparisonOp::Le => order.is_le(),
+        ComparisonOp::Gt => order.is_gt(),
+        ComparisonOp::Ge => order.is_ge(),
     }
 }
 
@@ -826,7 +864,7 @@ pub fn op_not_null(
 }
 
 pub fn op_comparison(
-    _program: &Program,
+    program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
@@ -987,15 +1025,19 @@ pub fn op_comparison(
         affinity.convert_for_compare(rhs_value),
     );
 
-    let should_jump = op.compare(
-        new_lhs
-            .as_ref()
-            .map_or(Either::Left(lhs_value), Either::Right),
-        new_rhs
-            .as_ref()
-            .map_or(Either::Left(rhs_value), Either::Right),
-        collation,
-    );
+    let lhs_for_compare = new_lhs
+        .as_ref()
+        .map_or(Either::Left(lhs_value), Either::Right);
+    let rhs_for_compare = new_rhs
+        .as_ref()
+        .map_or(Either::Left(rhs_value), Either::Right);
+    let should_jump = if collation.is_custom() {
+        let order =
+            compare_with_program_collation(program, lhs_for_compare, rhs_for_compare, collation)?;
+        comparison_matches_order(op, order)
+    } else {
+        op.compare(lhs_for_compare, rhs_for_compare, collation)
+    };
 
     match (new_lhs, new_rhs) {
         (Some(new_lhs), None) => {
@@ -5998,7 +6040,7 @@ fn update_agg_payload(
                 let payload_ref = payload[0].as_ref();
                 cmp_fn(&arg_ref, &payload_ref)?
             } else {
-                compare_with_collation(&arg, &payload[0], Some(collation))
+                compare_with_collation(&arg, &payload[0], Some(collation), comparator)?
             };
             let should_update = match func {
                 AggFunc::Max => cmp == Ordering::Greater,
@@ -6188,7 +6230,7 @@ fn finalize_agg_payload(func: &AggFunc, payload: &[Value]) -> Result<Value> {
 }
 
 pub fn op_agg_step(
-    _program: &Program,
+    program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
@@ -6237,8 +6279,16 @@ pub fn op_agg_step(
         };
     }
 
-    // Resolve custom type comparator for MIN/MAX if provided
-    let comparator = comparator.as_ref().map(make_sort_comparator).transpose()?;
+    let current_collation = state.current_collation.unwrap_or(CollationSeq::Binary);
+    let comparator = match comparator.as_ref() {
+        Some(comparator) => Some(make_sort_comparator(comparator)?),
+        None if current_collation.is_custom() => Some(
+            program
+                .connection
+                .make_collation_comparator(current_collation)?,
+        ),
+        None => None,
+    };
 
     // Step the aggregate
     match func {
@@ -6320,8 +6370,6 @@ pub fn op_agg_step(
                     }
                     _ => None,
                 };
-                let collation = state.current_collation.unwrap_or(CollationSeq::Binary);
-
                 // Now get mutable borrow on payload
                 let Register::Aggregate(agg) = &mut state.registers[*acc_reg] else {
                     panic!(
@@ -6330,7 +6378,14 @@ pub fn op_agg_step(
                     );
                 };
                 let payload = agg.payload_mut();
-                update_agg_payload(func, arg, maybe_arg2, payload, collation, &comparator)?;
+                update_agg_payload(
+                    func,
+                    arg,
+                    maybe_arg2,
+                    payload,
+                    current_collation,
+                    &comparator,
+                )?;
             }
         }
     };
@@ -6475,16 +6530,25 @@ pub fn op_sorter_open(
         collations.push(coll.unwrap_or_default());
         nulls_orders.push(*nulls);
     }
-    let comparators = comparators
-        .iter()
-        .map(|c| c.as_ref().map(make_sort_comparator).transpose())
-        .collect::<Result<_>>()?;
+    let mut sort_comparators = Vec::with_capacity(order_collations_nulls.len());
+    for (idx, (_, coll, _)) in order_collations_nulls.iter().enumerate() {
+        let comparator = match comparators.get(idx).and_then(|c| c.as_ref()) {
+            Some(comparator) => Some(make_sort_comparator(comparator)?),
+            None => match coll {
+                Some(collation) if collation.is_custom() => {
+                    Some(program.connection.make_collation_comparator(*collation)?)
+                }
+                _ => None,
+            },
+        };
+        sort_comparators.push(comparator);
+    }
     let temp_store = program.connection.get_temp_store();
     let cursor = Sorter::new(
         &order,
         collations,
         nulls_orders,
-        comparators,
+        sort_comparators,
         max_buffer_size_bytes,
         page_size,
         pager.io.clone(),

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -81,7 +81,7 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
             ValueRef::Text(text) => {
                 let collation = collations.get(idx).unwrap_or(&CollationSeq::Binary);
                 hasher.write_u8(TEXT_HASH);
-                match collation {
+                match *collation {
                     CollationSeq::NoCase => {
                         hash_text_nocase(&mut hasher, text.as_str());
                     }
@@ -94,6 +94,11 @@ fn hash_join_key(key_values: &[ValueRef], collations: &[CollationSeq]) -> u64 {
                     }
                     CollationSeq::Locale(_) => {
                         hasher.write(&collation.hash_key(text.as_str()));
+                    }
+                    CollationSeq::Custom(_) => {
+                        unreachable!(
+                            "custom collations are rejected before hash table construction"
+                        )
                     }
                 }
             }
@@ -1042,6 +1047,17 @@ enum ParseChunkResult {
 impl HashTable {
     /// Create a new hash table.
     pub fn new(config: HashTableConfig, io: Arc<dyn IO>) -> Result<Self> {
+        if config
+            .collations
+            .iter()
+            .any(|collation| collation.is_custom())
+        {
+            // Custom collation equality is a connection-owned callback. Hash tables do
+            // not carry connection context, so hash/equality cannot be made consistent here.
+            return Err(LimboError::InternalError(
+                "custom collations are not supported by hash tables".to_string(),
+            ));
+        }
         let num_buckets = config.initial_buckets;
         let buckets = (0..num_buckets).map(|_| HashBucket::new()).try_collect()?;
         let matched_bits = if config.track_matched {
@@ -3268,6 +3284,22 @@ mod hashtests {
     use crate::alloc::vec;
     use crate::io::Buffer;
     use crate::MemoryIO;
+
+    #[test]
+    fn test_hash_table_rejects_custom_collations() {
+        let io = Arc::new(MemoryIO::new());
+        let config = HashTableConfig {
+            collations: vec![CollationSeq::custom("hash_table_custom")],
+            ..Default::default()
+        };
+        let err = match HashTable::new(config, io) {
+            Ok(_) => panic!("custom-collated hash table should be rejected"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("custom collations are not supported by hash tables"));
+    }
 
     #[test]
     fn test_hash_function_consistency() {

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -2,6 +2,7 @@ use crate::common::{limbo_exec_rows, ExecRows, TempDatabase};
 use rusqlite::types::Value as SqliteValue;
 use serial_test::serial;
 use std::{
+    cmp::Ordering,
     ffi::CString,
     os::raw::c_void,
     sync::{
@@ -743,5 +744,155 @@ fn managed_aggregate_errors_leave_connection_usable(tmp_db: TempDatabase) -> any
         counters.aggregate_inits.load(AtomicOrdering::SeqCst),
         counters.aggregate_drops.load(AtomicOrdering::SeqCst)
     );
+    Ok(())
+}
+
+unsafe extern "C" fn dotnet_nocase_collation(
+    _context: usize,
+    left_ptr: *const u8,
+    left_len: usize,
+    right_ptr: *const u8,
+    right_len: usize,
+) -> i32 {
+    let left = unsafe { std::slice::from_raw_parts(left_ptr, left_len) };
+    let right = unsafe { std::slice::from_raw_parts(right_ptr, right_len) };
+    let left = String::from_utf8_lossy(left).to_ascii_lowercase();
+    let right = String::from_utf8_lossy(right).to_ascii_lowercase();
+    match left.cmp(&right) {
+        Ordering::Less => -1,
+        Ordering::Equal => 0,
+        Ordering::Greater => 1,
+    }
+}
+
+unsafe extern "C" fn dotnet_case_sensitive_collation(
+    _context: usize,
+    left_ptr: *const u8,
+    left_len: usize,
+    right_ptr: *const u8,
+    right_len: usize,
+) -> i32 {
+    let left = unsafe { std::slice::from_raw_parts(left_ptr, left_len) };
+    let right = unsafe { std::slice::from_raw_parts(right_ptr, right_len) };
+    match left.cmp(right) {
+        Ordering::Less => -1,
+        Ordering::Equal => 0,
+        Ordering::Greater => 1,
+    }
+}
+
+#[turso_macros::test]
+#[serial]
+fn custom_collations_cover_dotnet_create_collation_cases(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.register_external_collation(
+        "dotnet_nocase".to_string(),
+        0,
+        dotnet_nocase_collation,
+        None,
+    );
+    conn.execute("CREATE TABLE names(value TEXT)")?;
+    conn.execute("INSERT INTO names VALUES ('beta'), ('ALPHA'), ('alpha'), ('Gamma')")?;
+
+    let ordered: Vec<(String,)> =
+        conn.exec_rows("SELECT value FROM names ORDER BY value COLLATE dotnet_nocase, value");
+    assert_eq!(
+        ordered,
+        vec![
+            ("ALPHA".to_string(),),
+            ("alpha".to_string(),),
+            ("beta".to_string(),),
+            ("Gamma".to_string(),)
+        ]
+    );
+
+    let equal_rows: Vec<(String,)> = conn.exec_rows(
+        "SELECT value FROM names WHERE value = 'ALPHA' COLLATE dotnet_nocase ORDER BY value",
+    );
+    assert_eq!(
+        equal_rows,
+        vec![("ALPHA".to_string(),), ("alpha".to_string(),)]
+    );
+
+    let min_max: Vec<(String, String)> = conn.exec_rows(
+        "SELECT min(value COLLATE dotnet_nocase), max(value COLLATE dotnet_nocase) FROM names",
+    );
+    assert_eq!(min_max, vec![("ALPHA".to_string(), "Gamma".to_string())]);
+
+    let err = conn
+        .execute("CREATE TABLE bad(value TEXT COLLATE dotnet_nocase)")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("custom collations are not supported"));
+    let err = conn
+        .execute("CREATE INDEX bad_idx ON names(value COLLATE dotnet_nocase)")
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("custom collations are not supported"));
+
+    conn.execute("CREATE TABLE left_values(value TEXT)")?;
+    conn.execute("CREATE TABLE right_values(value TEXT)")?;
+    for id in 0..100 {
+        let key = format!("key{:02}", id % 10);
+        conn.execute(format!("INSERT INTO left_values VALUES ('{key}')"))?;
+        conn.execute(format!("INSERT INTO right_values VALUES ('{key}')"))?;
+    }
+    let binary_join_sql =
+        "SELECT count(*) FROM left_values AS l JOIN right_values AS r ON l.value = r.value";
+    let explain_rows = limbo_exec_rows(&conn, &format!("EXPLAIN {binary_join_sql}"));
+    let has_hash = explain_rows.iter().any(|row| {
+        row.get(1).is_some_and(|value| {
+            matches!(value, SqliteValue::Text(op) if op == "HashBuild" || op == "HashProbe")
+        })
+    });
+    assert!(has_hash, "expected equivalent binary join to use hash join");
+
+    conn.execute("DELETE FROM right_values")?;
+    for id in 0..100 {
+        let key = format!("KEY{:02}", id % 10);
+        conn.execute(format!("INSERT INTO right_values VALUES ('{key}')"))?;
+    }
+    let join_sql = "SELECT count(*) FROM left_values AS l JOIN right_values AS r \
+        ON l.value = r.value COLLATE dotnet_nocase";
+    let joined: Vec<(i64,)> = conn.exec_rows(join_sql);
+    assert_eq!(joined, vec![(1000,)]);
+    let explain_rows = limbo_exec_rows(&conn, &format!("EXPLAIN {join_sql}"));
+    let has_hash = explain_rows.iter().any(|row| {
+        row.get(1).is_some_and(|value| {
+            matches!(value, SqliteValue::Text(op) if op == "HashBuild" || op == "HashProbe")
+        })
+    });
+    assert!(
+        !has_hash,
+        "custom collations must not use binary-hashed joins"
+    );
+
+    let other_conn = tmp_db.connect_limbo();
+    other_conn.register_external_collation(
+        "dotnet_nocase".to_string(),
+        0,
+        dotnet_case_sensitive_collation,
+        None,
+    );
+    let rows: Vec<(String,)> = conn.exec_rows("SELECT 'ok' WHERE 'A' = 'a' COLLATE dotnet_nocase");
+    assert_eq!(rows, vec![("ok".to_string(),)]);
+    let rows: Vec<(String,)> =
+        other_conn.exec_rows("SELECT 'ok' WHERE 'A' = 'a' COLLATE dotnet_nocase");
+    assert_eq!(rows, Vec::<(String,)>::new());
+
+    conn.unregister_external_collation("dotnet_nocase");
+    let err = conn
+        .execute("SELECT 'ok' WHERE 'A' = 'a' COLLATE dotnet_nocase")
+        .unwrap_err();
+    assert!(err.to_string().contains("no such collation sequence"));
+    let rows: Vec<(String,)> =
+        other_conn.exec_rows("SELECT 'ok' WHERE 'A' = 'A' COLLATE dotnet_nocase");
+    assert_eq!(rows, vec![("ok".to_string(),)]);
+    other_conn.unregister_external_collation("dotnet_nocase");
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add connection-owned custom collation registration/unregistration in core
- Route runtime comparisons, sorters, and min/max through connection custom collation callbacks
- Reject custom collations in persistent schema/index definitions and avoid hash joins for custom-collated equality
- Add focused integration coverage for ordering/equality/min-max, unregister behavior, multiple connections using the same name, schema/index rejection, and hash-join avoidance

## Validation
- `cargo fmt --check`
- `git diff --check` including new test file
- `cargo check -q -p core_tester --features pure-rust-crypto --test integration_tests`
- `cargo test -q -p core_tester --features pure-rust-crypto --test integration_tests custom_collations_cover_dotnet_create_collation_cases -- --nocapture`

## Known validation blocker
- `cargo clippy -q -p core_tester --features pure-rust-crypto --test integration_tests -- --deny=warnings` is blocked by unrelated existing `unused_unsafe` errors in `core\storage\buffer_pool.rs` lines 356 and 386.