### PR TITLE
core/translate/optimizer: support non-equijoin FULL OUTER JOIN

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1147,8 +1147,11 @@ pub fn try_hash_join_access_method(
         "hash-join equi-join keys"
     );
 
-    // Need at least one equi-join condition
-    if join_keys.is_empty() {
+    // A hash join normally needs at least one equi-join condition. A FULL OUTER
+    // JOIN is the exception: it has no nested-loop form, so when the ON clause has
+    // no equality (e.g. `a.x < b.x`) we still build a single-bucket hash join and
+    // let the predicate apply as a residual, rather than rejecting the query.
+    if join_keys.is_empty() && hash_join_type != HashJoinType::FullOuter {
         return None;
     }
 

--- a/testing/sqltests/tests/join/outer_hash_join.sqltest
+++ b/testing/sqltests/tests/join/outer_hash_join.sqltest
@@ -465,15 +465,21 @@ expect {
     4|y|a
 }
 
-@skip-if sqlite "supported in sqlite"
+# A non-equality ON clause is supported: FULL OUTER falls back to a single-bucket
+# hash join with the predicate applied as a residual, emitting unmatched rows on
+# both sides.
 @cross-check-integrity
-test full-outer-join-non-equi-errors {
+test full-outer-join-non-equi {
     CREATE TABLE t1(a);
     CREATE TABLE t2(b);
-    SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.a > t2.b;
+    INSERT INTO t1 VALUES (2), (8);
+    INSERT INTO t2 VALUES (5), (10);
+    SELECT ifnull(t1.a, -1), ifnull(t2.b, -1) FROM t1 FULL OUTER JOIN t2 ON t1.a > t2.b ORDER BY 1, 2;
 }
-expect error {
-    FULL OUTER JOIN requires an equality condition in the ON clause
+expect {
+    -1|10
+    2|-1
+    8|5
 }
 
 @skip-if sqlite "supported in sqlite"
@@ -487,15 +493,19 @@ expect error {
     FULL OUTER JOIN requires an equality condition in the ON clause
 }
 
-@skip-if sqlite "supported in sqlite"
+# With no ON clause every pair matches, so FULL OUTER degenerates to a cross
+# product (no unmatched rows on either side).
 @cross-check-integrity
-test full-outer-join-no-on-clause-errors {
+test full-outer-join-no-on-clause {
     CREATE TABLE t1(a);
     CREATE TABLE t2(b);
-    SELECT * FROM t1 FULL OUTER JOIN t2;
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (3);
+    SELECT ifnull(t1.a, -1), ifnull(t2.b, -1) FROM t1 FULL OUTER JOIN t2 ORDER BY 1, 2;
 }
-expect error {
-    FULL OUTER JOIN requires an equality condition in the ON clause
+expect {
+    1|3
+    2|3
 }
 
 @cross-check-integrity
@@ -1576,4 +1586,22 @@ expect {
     2|-1
     3|-1
     4|-1
+}
+
+# Regression: non-equijoin FULL OUTER JOIN preserves duplicate and multi-match
+# rows (the ON predicate is applied as a residual inside a single-bucket hash join).
+@cross-check-integrity
+test full-outer-join-non-equijoin-duplicates {
+    CREATE TABLE a(x);
+    CREATE TABLE b(x);
+    INSERT INTO a VALUES (1), (2), (3);
+    INSERT INTO b VALUES (2), (2), (5);
+    SELECT ifnull(a.x, -1), ifnull(b.x, -1) FROM a FULL OUTER JOIN b ON a.x < b.x ORDER BY 1, 2;
+}
+expect {
+    1|2
+    1|2
+    1|5
+    2|5
+    3|5
 }


### PR DESCRIPTION
Fixes #5788.

### What's wrong

`FULL OUTER JOIN` with a non-equality `ON` clause (or no `ON` clause) is rejected, even though SQLite supports both:

```sql
CREATE TABLE a(x); CREATE TABLE b(x);
SELECT * FROM a FULL OUTER JOIN b ON a.x < b.x;
-- Parse error: FULL OUTER JOIN requires an equality condition in the ON clause
```

### Cause

`FULL OUTER JOIN` is only ever planned as a hash join, and a hash join needs an equi-join key. With no equality in the `ON` clause there is no key, so no plan is found and the catch-all "requires an equality condition" error fires.

### Fix

Allow an empty-key hash join for `FULL OUTER`: the build side hashes into a single bucket and the `ON` predicate is applied as the residual the hash join already supports. The existing hash-join matched-build tracking and unmatched-row emission handle `FULL OUTER`, so unmatched rows come out correctly on both sides. `INNER`/`LEFT`/`RIGHT` are unchanged — they still prefer a nested-loop seek when there is no equi-join key.

### Tests

Converted the two `*-errors` sqltests (non-equi `ON`, no `ON` clause) into cross-checked positive tests, and added a duplicate/multi-match case. All cross-check against SQLite, and I verified they fail without this change. `FULL OUTER JOIN USING(...)` remains a separate unsupported case.
