### PR TITLE
More mvcc fixerinos

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -467,11 +467,16 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 });
             // - It is a delete, AND some version of the row exists in the database file.
             let is_delete_and_exists_in_db_file = end_ts.is_some() && exists_in_db_file;
-            // - It is a delete of a sqlite_schema row that hasn't been checkpointed yet. We need to
-            //   return these even if they don't exist in the DB file so we can track destroyed
-            //   tables/indexes and skip their data rows.
+            // - It is a delete of an uncheckpointed sqlite_schema row for a
+            //   table or index. The schema row itself is not in the DB file, but
+            //   checkpoint still needs it so it can remember that the table or
+            //   index was destroyed and skip that object's data/index rows.
+            //   Views and triggers have rootpage=0, so their uncheckpointed
+            //   deletes can be ignored here: there is no B-tree to destroy, and
+            //   deleting a missing sqlite_schema row would be wrong.
             let is_schema_delete = table_id == SQLITE_SCHEMA_MVCC_TABLE_ID
                 && !exists_in_db_file
+                && sqlite_schema_btree_identity(version).is_some()
                 && self
                     .durable_txid_max_old
                     .is_none_or(|txid_max_old| end_ts.is_some_and(|e| e > u64::from(txid_max_old)));

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -55,7 +55,8 @@ pub mod checkpoint_state_machine;
 pub use checkpoint_state_machine::{CheckpointState, CheckpointStateMachine};
 
 use super::persistent_storage::logical_log::{
-    HeaderReadResult, StreamingLogicalLogReader, StreamingResult, LOG_HDR_SIZE,
+    HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader, StreamingResult,
+    LOG_HDR_SIZE,
 };
 
 #[cfg(test)]
@@ -1525,6 +1526,117 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         };
         let end_ts = ctx.end_ts;
 
+        // A sqlite_schema row that is inserted and deleted inside one
+        // transaction does not always mean the underlying table or index was
+        // inserted and deleted. ALTER TABLE can rewrite sqlite_schema several
+        // times for an existing root page. We only treat a root page as
+        // transaction-local when it has no schema row before the transaction and
+        // no schema row after it.
+        let schema_btree_root_page = |row_version: &RowVersion| -> Result<Option<i64>> {
+            let record = ImmutableRecord::from_bin_record(row_version.row.payload().to_vec());
+            if record.column_count() < 5 {
+                return Err(LimboError::Corrupt(format!(
+                    "sqlite_schema row must have at least 5 columns, got {}",
+                    record.column_count()
+                )));
+            }
+            let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
+                return Err(LimboError::Corrupt(
+                    "sqlite_schema type must be text".to_string(),
+                ));
+            };
+            if !matches!(row_type.as_str(), "table" | "index") {
+                return Ok(None);
+            }
+            let Some(ValueRef::Numeric(Numeric::Integer(root_page))) = record.get_value_opt(3)
+            else {
+                turso_assert_reachable!(
+                    "malformed sqlite_schema root_page while committing MVCC logical log"
+                );
+                return Err(LimboError::Corrupt(
+                    "sqlite_schema root_page must be integer".to_string(),
+                ));
+            };
+            if root_page == 0 {
+                return Ok(None);
+            }
+            Ok(Some(root_page))
+        };
+
+        let is_our_begin = |row_version: &RowVersion| {
+            matches!(
+                row_version.begin,
+                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+            )
+        };
+        let is_our_end = |row_version: &RowVersion| {
+            matches!(
+                row_version.end,
+                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+            )
+        };
+
+        let mut btree_ids_created_and_dropped_in_tx: HashSet<MVTableId> = HashSet::default();
+        let mut btree_ids_removed_from_schema_by_tx: HashSet<MVTableId> = HashSet::default();
+        {
+            let write_set = tx.write_set.lock();
+            let frame_writes_schema = write_set
+                .entries
+                .iter()
+                .any(|(id, _)| id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID);
+
+            // Decoding sqlite_schema records is only needed for DDL frames.
+            // Normal DML frames do not touch sqlite_schema, so avoid parsing
+            // schema records while committing the common path.
+            if frame_writes_schema {
+                let mut schema_roots_created_and_deleted_in_tx: HashSet<i64> = HashSet::default();
+                let mut schema_roots_deleted_by_tx: HashSet<i64> = HashSet::default();
+                let mut schema_roots_present_before_tx: HashSet<i64> = HashSet::default();
+                let mut schema_roots_present_after_tx: HashSet<i64> = HashSet::default();
+
+                for (id, row_versions) in &write_set.entries {
+                    if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                        continue;
+                    }
+                    for row_version in row_versions.read().iter() {
+                        let Some(root_page) = schema_btree_root_page(row_version)? else {
+                            continue;
+                        };
+                        let our_begin = is_our_begin(row_version);
+                        let our_end = is_our_end(row_version);
+                        if !our_begin {
+                            schema_roots_present_before_tx.insert(root_page);
+                        }
+                        if our_end {
+                            schema_roots_deleted_by_tx.insert(root_page);
+                        }
+                        if !our_end {
+                            schema_roots_present_after_tx.insert(root_page);
+                        }
+                        if our_begin && our_end && !row_version.btree_resident {
+                            schema_roots_created_and_deleted_in_tx.insert(root_page);
+                        }
+                    }
+                }
+
+                for root_page in schema_roots_deleted_by_tx {
+                    if !schema_roots_present_after_tx.contains(&root_page) {
+                        btree_ids_removed_from_schema_by_tx
+                            .insert(mvcc_store.get_table_id_from_root_page(root_page));
+                    }
+                }
+
+                for root_page in schema_roots_created_and_deleted_in_tx {
+                    if !schema_roots_present_before_tx.contains(&root_page)
+                        && !schema_roots_present_after_tx.contains(&root_page)
+                    {
+                        btree_ids_created_and_dropped_in_tx
+                            .insert(mvcc_store.get_table_id_from_root_page(root_page));
+                    }
+                }
+            }
+        }
+
         // Remap a table_id to its canonical form for the log. After checkpoint,
         // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
         // (e.g. -58). On recovery, bootstrap reconstructs the map using
@@ -1558,6 +1670,31 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 // row_version belongs to another tx
                 return None;
             }
+            if btree_ids_created_and_dropped_in_tx.contains(&row_version.row.id.table_id) {
+                // This table or index has no sqlite_schema row before the
+                // transaction and no sqlite_schema row after it. It was created
+                // and dropped inside this commit, so its table/index entries do
+                // not change durable state.
+                return None;
+            }
+            if btree_ids_removed_from_schema_by_tx.contains(&row_version.row.id.table_id)
+                && our_begin
+                && !our_end
+            {
+                // This transaction created or rewrote an entry for a table or
+                // index that is gone from sqlite_schema by COMMIT. Example:
+                // UPDATE writes a new entry into idx_old, then DROP INDEX
+                // idx_old runs before COMMIT. Keep deletes for entries that
+                // existed before the transaction, but do not log new entries
+                // that cannot exist after the transaction.
+                return None;
+            }
+            if our_begin && our_end && !row_version.btree_resident {
+                // This entry was created and deleted by this transaction before it
+                // ever reached the database file. Replaying it after restart would
+                // have no durable effect.
+                return None;
+            }
             let mut committed = row_version.clone();
             if our_begin {
                 // New version is valid STARTING FROM the committing
@@ -1589,19 +1726,135 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
 
         let collect_versions = |row_versions: &Arc<RwLock<Vec<RowVersion>>>,
                                 log_record: &mut LogRecord| {
-            for row_version in row_versions.read().iter() {
+            // `log_record.row_versions` is the logical transaction log. Recovery
+            // replays it in this order. `insert_version_raw` is for the versions
+            // of one MVCC entry: one table row, one sqlite_schema row, or one
+            // index entry. Its timestamp sort is correct for that one entry, but
+            // it is not a rule for ordering the whole transaction.
+            //
+            // Example: the db file already has table t, index idx, and
+            // t(rowid=1). One transaction runs `DELETE FROM t`, then
+            // `ALTER TABLE t ADD COLUMN x`. ALTER TABLE records a DELETE for the
+            // old sqlite_schema row for t and an UPSERT for the replacement row.
+            // DELETE FROM t records a DELETE for t(rowid=1) and a DELETE_INDEX
+            // for the idx entry that pointed at that row. The schema DELETE,
+            // table-row DELETE, and DELETE_INDEX are all for entries already in
+            // the db file, so their `begin` is None. Sorting the whole
+            // transaction with `insert_version_raw` can put those three deletes
+            // before the schema UPSERT:
+            // `[DELETE schema(t), DELETE t(rowid=1), DELETE_INDEX idx(rowid=1),
+            //   UPSERT schema(t)]`.
+            //
+            // Index log ops contain serialized index keys, not CREATE INDEX SQL.
+            // Recovery now decodes every index op using schema snapshots for the
+            // whole transaction frame, so it does not install a half-updated
+            // schema while the frame is still being replayed. The writer still
+            // must not scramble a sqlite_schema DELETE+UPSERT pair with unrelated
+            // table/index entries; keeping each write-set entry together gives
+            // recovery a frame whose final schema can be understood.
+            //
+            // The filtering below has four separate jobs:
+            //
+            // 1. Omit all entries for a table/index root page that had no
+            //    sqlite_schema row before this transaction and has no
+            //    sqlite_schema row after it. Example: CREATE INDEX followed by
+            //    DROP INDEX in one transaction.
+            // 2. Omit inserts and updates for a table/index root page that is
+            //    removed from sqlite_schema by this transaction. Example:
+            //    UPDATE writes a new entry into idx_old, then DROP INDEX
+            //    idx_old runs before COMMIT. The old index-entry deletes still
+            //    matter, but new entries for idx_old cannot survive the frame.
+            // 3. Omit one version that was created and deleted by this
+            //    transaction before it reached the database file. Such a version
+            //    does not change durable state, and recovery may not have enough
+            //    schema information to decode a delete for it.
+            // 4. If this entry has a delete for the row that already existed in
+            //    the database file, do not also log a same-transaction
+            //    create/delete replacement for the same write-set entry. Example:
+            //    ALTER TABLE rewrites an index sqlite_schema row, then DROP INDEX
+            //    deletes that replacement in the same transaction. The durable
+            //    change is one delete of the original sqlite_schema row.
+            //
+            // What the code below does after that filtering:
+            // - look only at this one write-set entry (`row_versions`);
+            // - copy the versions written or ended by the committing transaction;
+            // - if this same entry appears twice with the same
+            //   `begin=Timestamp(...)`, keep the later one, because recovery should
+            //   not replay an intermediate value for the same table row,
+            //   sqlite_schema row, or index entry;
+            // - append those versions to `log_record.row_versions` without sorting
+            //   them against versions from other write-set entries.
+            let mut per_entry_versions: Vec<RowVersion> = Vec::new();
+            let row_versions = row_versions.read();
+            let has_delete_for_db_file_row = row_versions.iter().any(|row_version| {
+                let our_begin = matches!(
+                    row_version.begin,
+                    Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+                );
+                let our_end = matches!(
+                    row_version.end,
+                    Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+                );
+                !our_begin && our_end && row_version.btree_resident
+            });
+            for row_version in row_versions.iter() {
+                let our_begin = matches!(
+                    row_version.begin,
+                    Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+                );
+                let our_end = matches!(
+                    row_version.end,
+                    Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+                );
+                if has_delete_for_db_file_row && our_begin && our_end && row_version.btree_resident
+                {
+                    continue;
+                }
                 if let Some(mut committed_version) = our_committed_image(row_version) {
                     canonicalize_table_id(&mut committed_version);
-                    mvcc_store.insert_version_raw(&mut log_record.row_versions, committed_version);
+                    let replaces_last = per_entry_versions.last().is_some_and(|last| {
+                        last.row.id == committed_version.row.id
+                            && matches!(
+                                (&last.begin, &committed_version.begin),
+                                (
+                                    Some(TxTimestampOrID::Timestamp(existing)),
+                                    Some(TxTimestampOrID::Timestamp(new))
+                                ) if existing == new
+                            )
+                    });
+                    if replaces_last {
+                        *per_entry_versions
+                            .last_mut()
+                            .expect("last version checked above") = committed_version;
+                        continue;
+                    }
+                    #[cfg(debug_assertions)]
+                    {
+                        let same_row_and_begin = |existing: &RowVersion| {
+                            existing.row.id == committed_version.row.id
+                                && matches!(
+                                    (&existing.begin, &committed_version.begin),
+                                    (
+                                        Some(TxTimestampOrID::Timestamp(existing)),
+                                        Some(TxTimestampOrID::Timestamp(new))
+                                    ) if existing == new
+                                )
+                        };
+                        turso_assert!(
+                            !per_entry_versions.iter().any(same_row_and_begin),
+                            "one write-set entry produced non-adjacent log versions with the same row id and commit timestamp"
+                        );
+                    }
+                    per_entry_versions.push(committed_version);
                 }
             }
+            log_record.row_versions.append(&mut per_entry_versions);
         };
 
-        // Process schema rows (sqlite_schema) before data rows so that during log
-        // replay the table_id_to_rootpage map is populated before data row inserts
-        // reference it. `tx.write_set` is sorted by table_id descending (most
-        // negative first), which would otherwise place data table rows
-        // (e.g. table_id=-3) before schema rows (table_id=-1).
+        // Process schema rows (sqlite_schema) before data/index rows so that
+        // replay sees table_id_to_rootpage updates before row ops reference
+        // those ids. `tx.write_set` preserves first-touch order, so mixed DDL
+        // and DML in one transaction cannot rely on write-set order alone.
         let mut iterations = 0;
 
         let write_set = tx.write_set.lock();
@@ -5069,314 +5322,495 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 Ok(())
             })?;
         }
-        let mut index_infos: HashMap<MVTableId, Arc<IndexInfo>> = HashMap::default();
-
-        // Track whether we have pending schema changes that need a rebuild.
-        // We defer rebuild_schema() until all consecutive schema rows have been
-        // inserted, because an intermediate rebuild (e.g. after inserting the
-        // renamed table row but before inserting the renamed index row) can see
-        // an inconsistent state and panic in populate_indices().
-        // Cell is used so the get_index_info closure can flush the pending rebuild.
-        let needs_schema_rebuild = std::cell::Cell::new(false);
-
-        let rebuild_schema =
-            |connection: &Arc<Connection>, schema_rows: &HashMap<i64, ImmutableRecord>| {
-                let pager = connection.pager.load().clone();
-                let cookie = self
-                    .global_header
-                    .read()
-                    .as_ref()
-                    .map(|header| header.schema_cookie.get())
-                    .unwrap_or(
-                        pager
-                            .io
-                            .block(|| pager.with_header(|header| header.schema_cookie))?
-                            .get(),
-                    );
-                let mut fresh = Schema::new();
-                fresh.generated_columns_enabled =
-                    connection.db.experimental_generated_columns_enabled();
-                fresh.schema_version = cookie;
-                let mut from_sql_indexes = Vec::with_capacity(10);
-                let mut automatic_indices: HashMap<String, Vec<(String, i64)>> = HashMap::default();
-                let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
-                let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();
-                let mut materialized_view_info: HashMap<String, (String, i64)> = HashMap::default();
-                let syms = connection.syms.read();
-                let mv_store = connection.db.get_mv_store().clone();
-
-                let mut sorted_rowids: Vec<i64> = schema_rows.keys().copied().collect();
-                sorted_rowids.sort_unstable();
-                for rowid in &sorted_rowids {
-                    let record = &schema_rows[rowid];
-                    let ty = match record.get_value_opt(0) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema type must be text".to_string(),
-                            ))
-                        }
-                    };
-                    let name = match record.get_value_opt(1) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema name must be text".to_string(),
-                            ))
-                        }
-                    };
-                    let table_name = match record.get_value_opt(2) {
-                        Some(ValueRef::Text(v)) => v.as_str(),
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema tbl_name must be text".to_string(),
-                            ))
-                        }
-                    };
-                    let root_page = match record.get_value_opt(3) {
-                        Some(ValueRef::Numeric(Numeric::Integer(v))) => v,
-                        _ => {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema root_page must be integer".to_string(),
-                            ))
-                        }
-                    };
-                    let sql = match record.get_value_opt(4) {
-                        Some(ValueRef::Text(v)) => Some(v.as_str()),
-                        _ => None,
-                    };
-                    let attached_resolver = |alias: &str| -> Option<usize> {
-                        connection
-                            .attached_databases()
-                            .read()
-                            .get_database_by_name(&crate::util::normalize_ident(alias))
-                            .map(|(idx, _)| idx)
-                    };
-                    fresh.handle_schema_row(
-                        ty,
-                        name,
-                        table_name,
-                        root_page,
-                        sql,
-                        &syms,
-                        &mut from_sql_indexes,
-                        &mut automatic_indices,
-                        &mut dbsp_state_roots,
-                        &mut dbsp_state_index_roots,
-                        &mut materialized_view_info,
-                        &attached_resolver,
-                    )?;
-                }
-                fresh.populate_indices(
-                    &syms,
-                    from_sql_indexes,
-                    automatic_indices,
-                    mv_store.is_some(),
-                )?;
-                fresh.populate_materialized_views(
-                    materialized_view_info,
-                    dbsp_state_roots,
-                    dbsp_state_index_roots,
-                )?;
-                Self::rehydrate_table_valued_functions(
-                    &mut fresh,
-                    &preserved_table_valued_functions,
+        let build_schema = |schema_rows: &HashMap<i64, ImmutableRecord>| -> Result<Arc<Schema>> {
+            let pager = connection.pager.load().clone();
+            let cookie = self
+                .global_header
+                .read()
+                .as_ref()
+                .map(|header| header.schema_cookie.get())
+                .unwrap_or(
+                    pager
+                        .io
+                        .block(|| pager.with_header(|header| header.schema_cookie))?
+                        .get(),
                 );
+            let mut fresh = Schema::new();
+            fresh.generated_columns_enabled =
+                connection.db.experimental_generated_columns_enabled();
+            fresh.schema_version = cookie;
+            let mut from_sql_indexes = Vec::with_capacity(10);
+            let mut automatic_indices: HashMap<String, Vec<(String, i64)>> = HashMap::default();
+            let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
+            let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();
+            let mut materialized_view_info: HashMap<String, (String, i64)> = HashMap::default();
+            let syms = connection.syms.read();
+            let mv_store = connection.db.get_mv_store().clone();
 
-                let fresh = Arc::new(fresh);
-                *connection.schema.write() = fresh.clone();
-                *connection.db.schema.lock() = fresh;
-                Ok(())
-            };
+            let mut sorted_rowids: Vec<i64> = schema_rows.keys().copied().collect();
+            sorted_rowids.sort_unstable();
+            for rowid in &sorted_rowids {
+                let record = &schema_rows[rowid];
+                let ty = match record.get_value_opt(0) {
+                    Some(ValueRef::Text(v)) => v.as_str(),
+                    _ => {
+                        return Err(LimboError::Corrupt(
+                            "sqlite_schema type must be text".to_string(),
+                        ))
+                    }
+                };
+                let name = match record.get_value_opt(1) {
+                    Some(ValueRef::Text(v)) => v.as_str(),
+                    _ => {
+                        return Err(LimboError::Corrupt(
+                            "sqlite_schema name must be text".to_string(),
+                        ))
+                    }
+                };
+                let table_name = match record.get_value_opt(2) {
+                    Some(ValueRef::Text(v)) => v.as_str(),
+                    _ => {
+                        return Err(LimboError::Corrupt(
+                            "sqlite_schema tbl_name must be text".to_string(),
+                        ))
+                    }
+                };
+                let root_page = match record.get_value_opt(3) {
+                    Some(ValueRef::Numeric(Numeric::Integer(v))) => v,
+                    _ => {
+                        return Err(LimboError::Corrupt(
+                            "sqlite_schema root_page must be integer".to_string(),
+                        ))
+                    }
+                };
+                let sql = match record.get_value_opt(4) {
+                    Some(ValueRef::Text(v)) => Some(v.as_str()),
+                    _ => None,
+                };
+                let attached_resolver = |alias: &str| -> Option<usize> {
+                    connection
+                        .attached_databases()
+                        .read()
+                        .get_database_by_name(&crate::util::normalize_ident(alias))
+                        .map(|(idx, _)| idx)
+                };
+                fresh.handle_schema_row(
+                    ty,
+                    name,
+                    table_name,
+                    root_page,
+                    sql,
+                    &syms,
+                    &mut from_sql_indexes,
+                    &mut automatic_indices,
+                    &mut dbsp_state_roots,
+                    &mut dbsp_state_index_roots,
+                    &mut materialized_view_info,
+                    &attached_resolver,
+                )?;
+            }
+            fresh.populate_indices(
+                &syms,
+                from_sql_indexes,
+                automatic_indices,
+                mv_store.is_some(),
+            )?;
+            fresh.populate_materialized_views(
+                materialized_view_info,
+                dbsp_state_roots,
+                dbsp_state_index_roots,
+            )?;
+            Self::rehydrate_table_valued_functions(&mut fresh, &preserved_table_valued_functions);
+
+            Ok(Arc::new(fresh))
+        };
+
+        let install_schema = |schema: Arc<Schema>| {
+            *connection.schema.write() = schema.clone();
+            *connection.db.schema.lock() = schema;
+        };
+
+        let root_page_for_index = |index_id: MVTableId| -> i64 {
+            self.table_id_to_rootpage
+                .get(&index_id)
+                .and_then(|entry| *entry.value())
+                .map(|value| value as i64)
+                .unwrap_or_else(|| i64::from(index_id))
+        };
+
+        let find_index_info = |schema: &Schema, root_page: i64| -> Option<Arc<IndexInfo>> {
+            schema
+                .indexes
+                .values()
+                .flatten()
+                .find(|idx| idx.root_page == root_page)
+                .map(|idx| Arc::new(IndexInfo::new_from_index(idx.as_ref())))
+        };
+
+        let schema_has_index_root = |schema: &Schema, root_page: i64| -> bool {
+            schema
+                .indexes
+                .values()
+                .flatten()
+                .any(|idx| idx.root_page == root_page)
+        };
+
+        let parsed_op_commit_ts = |op: &ParsedOp| match op {
+            ParsedOp::UpsertTable { commit_ts, .. }
+            | ParsedOp::DeleteTable { commit_ts, .. }
+            | ParsedOp::UpsertIndex { commit_ts, .. }
+            | ParsedOp::DeleteIndex { commit_ts, .. }
+            | ParsedOp::UpdateHeader { commit_ts, .. } => *commit_ts,
+        };
+
+        let mut current_schema = connection.schema.read().clone();
+        let mut index_infos: HashMap<(MVTableId, IndexOpKind), Arc<IndexInfo>> = HashMap::default();
 
         loop {
-            let mut get_index_info = |index_id: MVTableId| -> Result<Arc<IndexInfo>> {
-                if let Some(index_info) = index_infos.get(&index_id) {
-                    Ok(index_info.clone())
-                } else {
-                    // Flush any pending schema rebuild so we can see newly created indexes.
-                    if needs_schema_rebuild.get() {
-                        rebuild_schema(&connection, &schema_rows)?;
-                        index_infos.clear();
-                        needs_schema_rebuild.set(false);
-                    }
-                    let schema = connection.schema.read();
-                    let root_page = self
-                        .table_id_to_rootpage
-                        .get(&index_id)
-                        .and_then(|entry| *entry.value())
-                        .map(|value| value as i64)
-                        .unwrap_or_else(|| i64::from(index_id)); // this can be negative for non-checkpointed indexes
-
-                    let index = schema
-                        .indexes
-                        .values()
-                        .flatten()
-                        .find(|idx| idx.root_page == root_page)
-                        .ok_or_else(|| {
-                            LimboError::InternalError(format!(
-                                "Index with root page {root_page} not found in schema",
-                            ))
-                        })?;
-                    let index_info = Arc::new(IndexInfo::new_from_index(index));
-                    index_infos.insert(index_id, index_info.clone());
-                    Ok(index_info)
-                }
+            // Read one committed transaction at a time. This is important for
+            // schema recovery: a single transaction can contain both sqlite_schema
+            // changes and index-row changes, and the index-row log records do not
+            // carry CREATE INDEX SQL. They carry only the serialized index key
+            // bytes plus the index root page encoded as an MVCC table id. To turn
+            // those bytes back into an index row, recovery needs IndexInfo from a
+            // schema that is valid for this transaction frame.
+            let Some(frame) = reader.next_frame(&pager.io)? else {
+                let recovered_offset = reader.last_valid_offset() as u64;
+                let recovered_running_crc = reader.running_crc();
+                self.storage.restore_logical_log_state_after_recovery(
+                    recovered_offset,
+                    recovered_running_crc,
+                );
+                break;
             };
-            let next_rec = reader.next_record(&pager.io, &mut get_index_info)?;
 
-            tracing::trace!("next_rec {next_rec:?}");
+            let frame_commit_ts = parsed_op_commit_ts(
+                frame
+                    .first()
+                    .expect("next_frame should not return an empty frame"),
+            );
+            max_commit_ts_seen = max_commit_ts_seen.max(frame_commit_ts);
+            if frame_commit_ts <= replay_cutoff_ts {
+                continue;
+            }
 
-            match next_rec {
-                StreamingResult::UpsertTableRow {
-                    row,
-                    rowid,
-                    commit_ts,
-                    btree_resident,
-                } => {
-                    max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
-                    if commit_ts <= replay_cutoff_ts {
-                        continue;
-                    }
-                    let is_schema_row = rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID;
-                    if is_schema_row {
-                        let row_data = row.payload().to_vec();
-                        let record = ImmutableRecord::from_bin_record(row_data);
+            // Work out what sqlite_schema will look like after this transaction,
+            // before applying any row/index changes from the transaction.
+            //
+            // Why this is necessary:
+            // - CREATE INDEX can log index-entry inserts in the same frame as the
+            //   sqlite_schema insert for the new index. Those index-entry inserts
+            //   need the post-frame schema.
+            // - DROP INDEX can log DELETE_INDEX entries for b-tree index entries
+            //   that existed before the transaction. Those deletes still need the
+            //   pre-frame schema, because the final schema no longer has idx.
+            // - ALTER TABLE can delete and reinsert the same table's sqlite_schema
+            //   row while also logging table/index DML. Installing the schema after
+            //   only the delete would create an impossible in-between schema:
+            //   sqlite_schema may still contain idx while the table row for t is
+            //   temporarily absent.
+            //
+            // So recovery stages sqlite_schema into `schema_rows_after`, builds a
+            // post-frame Schema from that staged map, and keeps the installed
+            // `current_schema` unchanged until every op in the frame has replayed.
+            // Most transaction frames do not change sqlite_schema, so clone the
+            // schema row map only if this frame actually writes sqlite_schema.
+            let mut schema_rows_after: Option<HashMap<i64, ImmutableRecord>> = None;
+            for parsed_op in &frame {
+                match parsed_op {
+                    ParsedOp::UpsertTable {
+                        rowid,
+                        record_bytes,
+                        ..
+                    } if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID => {
+                        let schema_rows_after =
+                            schema_rows_after.get_or_insert_with(|| schema_rows.clone());
+                        let record = ImmutableRecord::from_bin_record(record_bytes.clone());
                         if record.column_count() < 5 {
                             return Err(LimboError::Corrupt(format!(
                                 "sqlite_schema row must have at least 5 columns, got {}",
                                 record.column_count()
                             )));
                         }
-                        let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema type must be text".to_string(),
-                            ));
-                        };
-                        let row_type = row_type.as_str();
-                        let val = match record.get_value_opt(3) {
-                            Some(v) => v,
-                            None => {
-                                return Err(LimboError::InternalError(
-                                    "Expected at least 5 columns in sqlite_schema".to_string(),
-                                ));
-                            }
-                        };
-                        let ValueRef::Numeric(crate::numeric::Numeric::Integer(root_page)) = val
-                        else {
-                            panic!("Expected integer value for root page, got {val:?}");
-                        };
-                        let sql = match record.get_value_opt(4) {
-                            Some(ValueRef::Text(v)) => Some(v.as_str()),
-                            _ => None,
-                        };
-                        let is_virtual_table = row_type == "table"
-                            && sql.is_some_and(|sql| {
-                                contains_ignore_ascii_case!(sql.as_bytes(), b"create virtual")
-                            });
-                        let has_btree = match row_type {
-                            "index" => true,
-                            "table" => !is_virtual_table,
-                            _ => false,
-                        };
-                        if has_btree {
-                            if root_page == 0 {
-                                return Err(LimboError::Corrupt(format!(
-                                    "sqlite_schema root_page=0 for btree {row_type}"
-                                )));
-                            }
-                            if root_page < 0 {
-                                let table_id = self.get_table_id_from_root_page(root_page);
-                                if let Some(entry) = self.table_id_to_rootpage.get(&table_id) {
-                                    if let Some(value) = *entry.value() {
-                                        panic!("Logical log contains an insertion of a sqlite_schema record that has both a negative root page and a positive root page: {root_page} & {value}");
-                                    }
-                                }
-                                self.insert_table_id_to_rootpage(table_id, None);
-                            } else {
-                                dropped_root_pages.remove(&root_page);
-                                let table_id = self.get_table_id_from_root_page(root_page);
-                                let Some(entry) = self.table_id_to_rootpage.get(&table_id) else {
-                                    panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");
-                                };
-                                let Some(value) = *entry.value() else {
-                                    panic!("Logical log contains root page reference {root_page} that does not have a root page in the table_id_to_rootpage map");
-                                };
-                                turso_assert_eq!(value, root_page as u64, "logical log root page does not match table_id_to_rootpage map", { "root_page": root_page, "map_value": value });
-                            }
-                        } else if root_page != 0 {
-                            return Err(LimboError::Corrupt(format!(
-                                "sqlite_schema root_page must be 0 for {row_type}, got {root_page}"
-                            )));
-                        }
-                        let rowid_int = rowid.row_id.to_int_or_panic();
-                        schema_rows.insert(rowid_int, record);
-                        needs_schema_rebuild.set(true);
-                    } else if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
-                        // Data row references a table_id not yet in the map. This can happen
-                        // with logs written before the schema-first serialization fix: in a
-                        // same-transaction CREATE TABLE + INSERT + DROP TABLE, data rows were
-                        // serialized before the schema INSERT that registers the table_id.
-                        // The schema INSERT (or DELETE) for this table will follow later in
-                        // this transaction frame, so we register the table_id now.
-                        self.insert_table_id_to_rootpage(rowid.table_id, None);
+                        schema_rows_after.insert(rowid.row_id.to_int_or_panic(), record);
+                    }
+                    ParsedOp::DeleteTable { rowid, .. }
+                        if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID =>
+                    {
+                        let schema_rows_after =
+                            schema_rows_after.get_or_insert_with(|| schema_rows.clone());
+                        schema_rows_after.remove(&rowid.row_id.to_int_or_panic());
+                    }
+                    _ => {}
+                }
+            }
+
+            let frame_changes_schema = schema_rows_after.is_some();
+            let schema_after = match schema_rows_after.as_ref() {
+                Some(schema_rows_after) => Some(build_schema(schema_rows_after)?),
+                None => None,
+            };
+
+            if frame_changes_schema {
+                // Cached IndexInfo values are tied to a specific schema. Clear
+                // before decoding a schema-changing frame so this frame chooses
+                // from its own before/after schema pair.
+                index_infos.clear();
+            }
+
+            {
+                let should_skip_index_op = |parsed_op: &ParsedOp| -> bool {
+                    if !frame_changes_schema {
+                        return false;
                     }
 
-                    let version_id = self.get_version_id();
-                    let row_version = RowVersion {
-                        id: version_id,
-                        begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                        end: None,
-                        row: row.clone(),
-                        btree_resident,
-                    };
-                    {
-                        let versions = self.rows.get_or_insert_with(rowid.clone(), || {
-                            Arc::new(RwLock::new(Vec::new()))
-                        });
-                        let mut versions = versions.value().write();
-                        self.insert_version_raw(&mut versions, row_version);
+                    match parsed_op {
+                        ParsedOp::UpsertIndex { table_id, .. } => {
+                            let root_page = root_page_for_index(*table_id);
+                            let Some(schema_after) = schema_after.as_ref() else {
+                                return false;
+                            };
+                            !schema_has_index_root(schema_after, root_page)
+                        }
+                        ParsedOp::DeleteIndex { table_id, .. } => {
+                            let root_page = root_page_for_index(*table_id);
+                            !schema_has_index_root(&current_schema, root_page)
+                        }
+                        _ => false,
                     }
-                    let allocator = self.get_rowid_allocator(&rowid.table_id);
-                    allocator.insert_row_id_maybe_update(rowid.row_id.to_int_or_panic());
-                }
-                StreamingResult::DeleteTableRow {
-                    rowid,
-                    commit_ts,
-                    btree_resident,
-                } => {
-                    max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
-                    if commit_ts <= replay_cutoff_ts {
+                };
+
+                let mut get_index_info = |index_id: MVTableId,
+                                          op_kind: IndexOpKind|
+                 -> Result<Arc<IndexInfo>> {
+                    if let Some(index_info) = index_infos.get(&(index_id, op_kind)) {
+                        return Ok(index_info.clone());
+                    }
+
+                    let root_page = root_page_for_index(index_id);
+                    let before = find_index_info(&current_schema, root_page);
+                    let after = schema_after
+                        .as_ref()
+                        .and_then(|schema| find_index_info(schema, root_page));
+
+                    // The logical log tells us whether an index entry is being
+                    // inserted or deleted, but it stores only encoded key bytes
+                    // plus the index root page. The recovery loop below skips
+                    // index ops that cannot affect the final state of this
+                    // frame before those bytes are decoded. For the remaining
+                    // ops, pick the schema view that owns the entry at the
+                    // frame boundary:
+                    //
+                    // - UPSERT_INDEX writes an entry that survives after the
+                    //   transaction. In a schema-changing frame, the index must
+                    //   exist in the post-frame schema.
+                    // - DELETE_INDEX removes an entry that existed before the
+                    //   transaction. In a schema-changing frame, the index must
+                    //   exist in the pre-frame schema.
+                    // - If the frame does not change schema, `current_schema` is
+                    //   both the before and after schema.
+                    let index_info = match op_kind {
+                        IndexOpKind::Upsert if schema_after.is_some() => after,
+                        IndexOpKind::Delete if schema_after.is_some() => before,
+                        IndexOpKind::Upsert | IndexOpKind::Delete => before,
+                    }
+                    .ok_or_else(|| {
+                        let expected_schema = match op_kind {
+                            IndexOpKind::Upsert if schema_after.is_some() => "post-frame",
+                            IndexOpKind::Delete if schema_after.is_some() => "pre-frame",
+                            IndexOpKind::Upsert | IndexOpKind::Delete => "current",
+                        };
+                        LimboError::InternalError(format!(
+                            "Index with root page {root_page} not found in {expected_schema} schema while recovering logical log",
+                        ))
+                    })?;
+                    index_infos.insert((index_id, op_kind), index_info.clone());
+                    Ok(index_info)
+                };
+
+                for parsed_op in frame {
+                    // Some index writes are real while the transaction is
+                    // running, but have no meaning at either durable boundary.
+                    //
+                    // Example: UPDATE a row so it writes a new entry into
+                    // idx_old, then DROP INDEX idx_old before COMMIT. The
+                    // UPSERT_INDEX for idx_old is not part of the database
+                    // after the transaction, and the post-frame schema no
+                    // longer has CREATE INDEX text for idx_old. Decoding it
+                    // against the pre-frame schema would preserve an index
+                    // entry for an index that was dropped. Decoding it against
+                    // the post-frame schema is impossible. The correct action
+                    // is to skip it.
+                    //
+                    // The opposite case is a DELETE_INDEX for an index created
+                    // earlier in the same frame. There was no pre-frame index
+                    // entry in the database file, so that delete also has no
+                    // durable work to do.
+                    if should_skip_index_op(&parsed_op) {
                         continue;
                     }
-                    if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
-                        // See comment in UpsertTableRow: old logs may have data rows
-                        // serialized before the schema INSERT that registers the table_id.
-                        self.insert_table_id_to_rootpage(rowid.table_id, None);
-                    }
-                    let tombstone_row = if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                        let rowid_int = rowid.row_id.to_int_or_panic();
-                        if let Some(record) = schema_rows.get(&rowid_int) {
-                            // Preserve the pre-delete sqlite_schema record in recovered
-                            // tombstones so checkpoint can still recover B-tree identity.
-                            Row::new_table_row(
-                                rowid.clone(),
-                                record.as_blob().clone(),
-                                record.column_count(),
-                            )
-                        } else {
-                            Row::new_table_row(rowid.clone(), Vec::new(), 0)
+
+                    let next_rec = reader.parsed_op_to_streaming(parsed_op, &mut get_index_info)?;
+
+                    tracing::trace!("next_rec {next_rec:?}");
+
+                    match next_rec {
+                        StreamingResult::UpsertTableRow {
+                            row,
+                            rowid,
+                            commit_ts,
+                            btree_resident,
+                        } => {
+                            max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
+                            if commit_ts <= replay_cutoff_ts {
+                                continue;
+                            }
+                            let is_schema_row = rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID;
+                            if is_schema_row {
+                                let row_data = row.payload().to_vec();
+                                let record = ImmutableRecord::from_bin_record(row_data);
+                                if record.column_count() < 5 {
+                                    return Err(LimboError::Corrupt(format!(
+                                        "sqlite_schema row must have at least 5 columns, got {}",
+                                        record.column_count()
+                                    )));
+                                }
+                                let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
+                                    return Err(LimboError::Corrupt(
+                                        "sqlite_schema type must be text".to_string(),
+                                    ));
+                                };
+                                let row_type = row_type.as_str();
+                                let val = match record.get_value_opt(3) {
+                                    Some(v) => v,
+                                    None => {
+                                        return Err(LimboError::InternalError(
+                                            "Expected at least 5 columns in sqlite_schema"
+                                                .to_string(),
+                                        ));
+                                    }
+                                };
+                                let ValueRef::Numeric(crate::numeric::Numeric::Integer(root_page)) =
+                                    val
+                                else {
+                                    panic!("Expected integer value for root page, got {val:?}");
+                                };
+                                let sql = match record.get_value_opt(4) {
+                                    Some(ValueRef::Text(v)) => Some(v.as_str()),
+                                    _ => None,
+                                };
+                                let is_virtual_table = row_type == "table"
+                                    && sql.is_some_and(|sql| {
+                                        contains_ignore_ascii_case!(
+                                            sql.as_bytes(),
+                                            b"create virtual"
+                                        )
+                                    });
+                                let has_btree = match row_type {
+                                    "index" => true,
+                                    "table" => !is_virtual_table,
+                                    _ => false,
+                                };
+                                if has_btree {
+                                    if root_page == 0 {
+                                        return Err(LimboError::Corrupt(format!(
+                                            "sqlite_schema root_page=0 for btree {row_type}"
+                                        )));
+                                    }
+                                    if root_page < 0 {
+                                        let table_id = self.get_table_id_from_root_page(root_page);
+                                        if let Some(entry) =
+                                            self.table_id_to_rootpage.get(&table_id)
+                                        {
+                                            if let Some(value) = *entry.value() {
+                                                panic!("Logical log contains an insertion of a sqlite_schema record that has both a negative root page and a positive root page: {root_page} & {value}");
+                                            }
+                                        }
+                                        self.insert_table_id_to_rootpage(table_id, None);
+                                    } else {
+                                        dropped_root_pages.remove(&root_page);
+                                        let table_id = self.get_table_id_from_root_page(root_page);
+                                        let Some(entry) = self.table_id_to_rootpage.get(&table_id)
+                                        else {
+                                            panic!("Logical log contains root page reference {root_page} that does not exist in the table_id_to_rootpage map");
+                                        };
+                                        let Some(value) = *entry.value() else {
+                                            panic!("Logical log contains root page reference {root_page} that does not have a root page in the table_id_to_rootpage map");
+                                        };
+                                        turso_assert_eq!(value, root_page as u64, "logical log root page does not match table_id_to_rootpage map", { "root_page": root_page, "map_value": value });
+                                    }
+                                } else if root_page != 0 {
+                                    return Err(LimboError::Corrupt(format!(
+                                "sqlite_schema root_page must be 0 for {row_type}, got {root_page}"
+                            )));
+                                }
+                                let rowid_int = rowid.row_id.to_int_or_panic();
+                                schema_rows.insert(rowid_int, record);
+                            } else if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
+                                // Data row references a table_id not yet in the map. This can happen
+                                // with logs written before the schema-first serialization fix: in a
+                                // same-transaction CREATE TABLE + INSERT + DROP TABLE, data rows were
+                                // serialized before the schema INSERT that registers the table_id.
+                                // The schema INSERT (or DELETE) for this table will follow later in
+                                // this transaction frame, so we register the table_id now.
+                                self.insert_table_id_to_rootpage(rowid.table_id, None);
+                            }
+
+                            let version_id = self.get_version_id();
+                            let row_version = RowVersion {
+                                id: version_id,
+                                begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
+                                end: None,
+                                row: row.clone(),
+                                btree_resident,
+                            };
+                            {
+                                let versions = self.rows.get_or_insert_with(rowid.clone(), || {
+                                    Arc::new(RwLock::new(Vec::new()))
+                                });
+                                let mut versions = versions.value().write();
+                                self.insert_version_raw(&mut versions, row_version);
+                            }
+                            let allocator = self.get_rowid_allocator(&rowid.table_id);
+                            allocator.insert_row_id_maybe_update(rowid.row_id.to_int_or_panic());
                         }
-                    } else {
-                        Row::new_table_row(rowid.clone(), Vec::new(), 0)
-                    };
-                    if let Some(versions) = self.rows.get(&rowid) {
-                        // Row exists in memory — try to find the current (non-ended) version
-                        // that was committed before this delete, and mark it as ended. If no
-                        // such version exists (e.g. it was already GC'd or this is a B-tree
-                        // resident row not yet in memory), insert a tombstone instead.
-                        let mut versions = versions.value().write();
-                        if let Some(existing) = versions.iter_mut().rev().find(|rv| {
+                        StreamingResult::DeleteTableRow {
+                            rowid,
+                            commit_ts,
+                            btree_resident,
+                        } => {
+                            max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
+                            if commit_ts <= replay_cutoff_ts {
+                                continue;
+                            }
+                            if self.table_id_to_rootpage.get(&rowid.table_id).is_none() {
+                                // See comment in UpsertTableRow: old logs may have data rows
+                                // serialized before the schema INSERT that registers the table_id.
+                                self.insert_table_id_to_rootpage(rowid.table_id, None);
+                            }
+                            let tombstone_row = if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                                let rowid_int = rowid.row_id.to_int_or_panic();
+                                if let Some(record) = schema_rows.get(&rowid_int) {
+                                    // Preserve the pre-delete sqlite_schema record in recovered
+                                    // tombstones so checkpoint can still recover B-tree identity.
+                                    Row::new_table_row(
+                                        rowid.clone(),
+                                        record.as_blob().clone(),
+                                        record.column_count(),
+                                    )
+                                } else {
+                                    Row::new_table_row(rowid.clone(), Vec::new(), 0)
+                                }
+                            } else {
+                                Row::new_table_row(rowid.clone(), Vec::new(), 0)
+                            };
+                            if let Some(versions) = self.rows.get(&rowid) {
+                                // Row exists in memory — try to find the current (non-ended) version
+                                // that was committed before this delete, and mark it as ended. If no
+                                // such version exists (e.g. it was already GC'd or this is a B-tree
+                                // resident row not yet in memory), insert a tombstone instead.
+                                let mut versions = versions.value().write();
+                                if let Some(existing) = versions.iter_mut().rev().find(|rv| {
                             rv.end.is_none()
                                 && matches!(rv.begin, Some(TxTimestampOrID::Timestamp(b)) if b < commit_ts)
                         }) {
@@ -5392,137 +5826,149 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             };
                             self.insert_version_raw(&mut versions, row_version);
                         }
-                    } else {
-                        let version_id = self.get_version_id();
-                        let row_version = RowVersion {
-                            id: version_id,
-                            begin: None,
-                            end: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                            row: tombstone_row,
+                            } else {
+                                let version_id = self.get_version_id();
+                                let row_version = RowVersion {
+                                    id: version_id,
+                                    begin: None,
+                                    end: Some(TxTimestampOrID::Timestamp(commit_ts)),
+                                    row: tombstone_row,
+                                    btree_resident,
+                                };
+                                let versions = self.rows.get_or_insert_with(rowid.clone(), || {
+                                    Arc::new(RwLock::new(Vec::new()))
+                                });
+                                let mut versions = versions.value().write();
+                                self.insert_version_raw(&mut versions, row_version);
+                            }
+                            if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                                let rowid_int = rowid.row_id.to_int_or_panic();
+                                let Some(record) = schema_rows.get(&rowid_int) else {
+                                    // this can happen if a row in sqlite_schema was inserted and then
+                                    // deleted in the same transaction (ex: a CREATE TABLE followed by a DROP TABLE)
+                                    continue;
+                                };
+                                if record.column_count() < 5 {
+                                    return Err(LimboError::Corrupt(format!(
+                                        "sqlite_schema row must have at least 5 columns, got {}",
+                                        record.column_count()
+                                    )));
+                                }
+                                let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
+                                    return Err(LimboError::Corrupt(
+                                        "sqlite_schema type must be text".to_string(),
+                                    ));
+                                };
+                                let row_type = row_type.as_str();
+                                let Some(ValueRef::Numeric(Numeric::Integer(root_page))) =
+                                    record.get_value_opt(3)
+                                else {
+                                    return Err(LimboError::Corrupt(
+                                        "sqlite_schema root_page must be integer".to_string(),
+                                    ));
+                                };
+                                if (row_type == "table" || row_type == "index") && root_page > 0 {
+                                    dropped_root_pages.insert(root_page);
+                                }
+                                schema_rows.remove(&rowid_int);
+                            }
+                        }
+                        StreamingResult::UpsertIndexRow {
+                            row,
+                            rowid,
+                            commit_ts,
                             btree_resident,
-                        };
-                        let versions = self.rows.get_or_insert_with(rowid.clone(), || {
-                            Arc::new(RwLock::new(Vec::new()))
-                        });
-                        let mut versions = versions.value().write();
-                        self.insert_version_raw(&mut versions, row_version);
-                    }
-                    if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                        let rowid_int = rowid.row_id.to_int_or_panic();
-                        let Some(record) = schema_rows.get(&rowid_int) else {
-                            // this can happen if a row in sqlite_schema was inserted and then
-                            // deleted in the same transaction (ex: a CREATE TABLE followed by a DROP TABLE)
-                            continue;
-                        };
-                        if record.column_count() < 5 {
-                            return Err(LimboError::Corrupt(format!(
-                                "sqlite_schema row must have at least 5 columns, got {}",
-                                record.column_count()
-                            )));
+                        } => {
+                            max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
+                            if commit_ts <= replay_cutoff_ts {
+                                continue;
+                            }
+                            let version_id = self.get_version_id();
+                            let row_version = RowVersion {
+                                id: version_id,
+                                begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
+                                end: None,
+                                row: row.clone(),
+                                btree_resident,
+                            };
+                            let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
+                                panic!("Index writes must be to a record");
+                            };
+                            self.insert_index_version(
+                                rowid.table_id,
+                                Arc::new(sortable_key),
+                                row_version,
+                            );
                         }
-                        let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema type must be text".to_string(),
-                            ));
-                        };
-                        let row_type = row_type.as_str();
-                        let Some(ValueRef::Numeric(Numeric::Integer(root_page))) =
-                            record.get_value_opt(3)
-                        else {
-                            return Err(LimboError::Corrupt(
-                                "sqlite_schema root_page must be integer".to_string(),
-                            ));
-                        };
-                        if (row_type == "table" || row_type == "index") && root_page > 0 {
-                            dropped_root_pages.insert(root_page);
-                        }
-                        schema_rows.remove(&rowid_int);
-                        needs_schema_rebuild.set(true);
-                    }
-                }
-                StreamingResult::UpsertIndexRow {
-                    row,
-                    rowid,
-                    commit_ts,
-                    btree_resident,
-                } => {
-                    max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
-                    if commit_ts <= replay_cutoff_ts {
-                        continue;
-                    }
-                    let version_id = self.get_version_id();
-                    let row_version = RowVersion {
-                        id: version_id,
-                        begin: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                        end: None,
-                        row: row.clone(),
-                        btree_resident,
-                    };
-                    let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
-                        panic!("Index writes must be to a record");
-                    };
-                    self.insert_index_version(rowid.table_id, Arc::new(sortable_key), row_version);
-                }
-                StreamingResult::DeleteIndexRow {
-                    row,
-                    rowid,
-                    commit_ts,
-                    btree_resident,
-                } => {
-                    max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
-                    if commit_ts <= replay_cutoff_ts {
-                        continue;
-                    }
-                    let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
-                        panic!("Index writes must be to a record");
-                    };
-                    let sortable_key =
-                        self.get_or_create_index_key_arc(rowid.table_id, sortable_key);
-                    if let Some(index_map) = self.index_rows.get(&rowid.table_id) {
-                        if let Some(versions) = index_map.value().get(&sortable_key) {
-                            let mut versions = versions.value().write();
-                            if let Some(existing) = versions.iter_mut().rev().find(|rv| {
+                        StreamingResult::DeleteIndexRow {
+                            row,
+                            rowid,
+                            commit_ts,
+                            btree_resident,
+                        } => {
+                            max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
+                            if commit_ts <= replay_cutoff_ts {
+                                continue;
+                            }
+                            let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
+                                panic!("Index writes must be to a record");
+                            };
+                            let sortable_key =
+                                self.get_or_create_index_key_arc(rowid.table_id, sortable_key);
+                            if let Some(index_map) = self.index_rows.get(&rowid.table_id) {
+                                if let Some(versions) = index_map.value().get(&sortable_key) {
+                                    let mut versions = versions.value().write();
+                                    if let Some(existing) = versions.iter_mut().rev().find(|rv| {
                                 rv.end.is_none()
                                     && matches!(rv.begin, Some(TxTimestampOrID::Timestamp(b)) if b < commit_ts)
                             }) {
                                 existing.end = Some(TxTimestampOrID::Timestamp(commit_ts));
                                 continue;
                             }
+                                }
+                            }
+                            let version_id = self.get_version_id();
+                            let row_version = RowVersion {
+                                id: version_id,
+                                begin: None,
+                                end: Some(TxTimestampOrID::Timestamp(commit_ts)),
+                                row: row.clone(),
+                                btree_resident,
+                            };
+                            self.insert_index_version(rowid.table_id, sortable_key, row_version);
+                        }
+                        StreamingResult::UpdateHeader { header, commit_ts } => {
+                            max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
+                            if commit_ts <= replay_cutoff_ts {
+                                continue;
+                            }
+                            // Recovery applies only post-boundary header ops; the same value is later
+                            // staged to pager page-1 during checkpoint.
+                            self.global_header.write().replace(header);
+                        }
+                        StreamingResult::Eof => {
+                            unreachable!("next_frame does not return EOF records");
                         }
                     }
-                    let version_id = self.get_version_id();
-                    let row_version = RowVersion {
-                        id: version_id,
-                        begin: None,
-                        end: Some(TxTimestampOrID::Timestamp(commit_ts)),
-                        row: row.clone(),
-                        btree_resident,
-                    };
-                    self.insert_index_version(rowid.table_id, sortable_key, row_version);
-                }
-                StreamingResult::UpdateHeader { header, commit_ts } => {
-                    max_commit_ts_seen = max_commit_ts_seen.max(commit_ts);
-                    if commit_ts <= replay_cutoff_ts {
-                        continue;
-                    }
-                    // Recovery applies only post-boundary header ops; the same value is later
-                    // staged to pager page-1 during checkpoint.
-                    self.global_header.write().replace(header);
-                }
-                StreamingResult::Eof => {
-                    let recovered_offset = reader.last_valid_offset() as u64;
-                    let recovered_running_crc = reader.running_crc();
-                    self.storage.restore_logical_log_state_after_recovery(
-                        recovered_offset,
-                        recovered_running_crc,
-                    );
-                    break;
                 }
             }
-        }
-        // Flush any remaining pending schema rebuild after processing all log records.
-        if needs_schema_rebuild.get() {
-            rebuild_schema(&connection, &schema_rows)?;
+
+            if frame_changes_schema {
+                // Now that all table and index ops from this transaction have
+                // been replayed, publish the frame's final schema. No later index
+                // op from this frame can observe a half-applied sqlite_schema.
+                let schema_rows_after =
+                    schema_rows_after.expect("schema_rows_after must exist when schema changed");
+                let schema_after = schema_after
+                    .expect("schema_after must exist when frame_changes_schema is true");
+                schema_rows = schema_rows_after;
+                install_schema(schema_after.clone());
+                current_schema = schema_after;
+                // The frame may have decoded DROP INDEX entries using the
+                // pre-frame schema. Do not carry those IndexInfo values into
+                // later frames after current_schema has changed.
+                index_infos.clear();
+            }
         }
 
         assert!(

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9367,6 +9367,52 @@ fn test_schema_rewrites_do_not_drop_table_versions_from_recovery_log() {
     }
 }
 
+#[test]
+fn test_checkpoint_skips_uncheckpointed_view_and_trigger_deletes_after_recovery() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT)")
+            .unwrap();
+        conn.execute("CREATE VIEW v_t AS SELECT id, b FROM t")
+            .unwrap();
+        conn.execute(
+            "CREATE TRIGGER tr_t_ai AFTER INSERT ON t
+             BEGIN
+               UPDATE t SET b = NEW.b || '_tr' WHERE id = NEW.id;
+             END",
+        )
+        .unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("DROP VIEW v_t").unwrap();
+        conn.execute("DROP TRIGGER tr_t_ai").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema WHERE name NOT LIKE '__turso%' ORDER BY rowid",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "table");
+    assert_eq!(rows[0][1].to_string(), "t");
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
 /// Updating a row that already exists in the db file creates an MVCC
 /// replacement version. If the same transaction deletes that row, recovery must
 /// not replay both the old-row delete and a second delete for the replacement:

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8845,6 +8845,608 @@ fn test_alter_table_rename_with_unique_constraint_panics_on_restart() {
     }
 }
 
+/// Reproducer for "sqlite_schema contains index for missing table 't'".
+///
+/// A single transaction deletes a row from t and then runs
+/// `ALTER TABLE t ADD COLUMN`. The deleted row already exists in the db file,
+/// and idx already has an entry for it. The log therefore contains a
+/// DELETE_INDEX op for that one idx entry; it is not deleting idx itself.
+/// ADD COLUMN is used because it is a small way to get the general shape that
+/// matters here: a schema-row DELETE plus a replacement schema-row UPSERT in the
+/// same transaction as table/index row changes.
+///
+/// The old BuildLogRecord path inserted every committed version into one log
+/// vector with `insert_version_raw`. That helper is only valid for one entry in
+/// the MVCC maps, but the log vector is replayed in serialized order. Since the
+/// old sqlite_schema row for t is already in the db file, ALTER TABLE logs its
+/// DELETE with `begin=None` and its replacement UPSERT with `begin=end_ts`.
+/// Sorting every touched entry together could replay the schema DELETE, row
+/// DELETE, and index-entry DELETE before the schema UPSERT for t's new CREATE
+/// TABLE text.
+///
+/// During replay, the table schema DELETE removes t from `schema_rows` and sets
+/// `needs_schema_rebuild=true`. The following DELETE_INDEX op calls
+/// `get_index_info` to resolve idx's key format before the table schema UPSERT
+/// has been decoded. `get_index_info` sees `needs_schema_rebuild=true` and calls
+/// `rebuild_schema(&schema_rows)`, so `populate_indices` sees t missing while
+/// the btree-loaded idx schema row is still present and reports
+/// "sqlite_schema contains index for missing table".
+///
+/// Recovery must decode index ops with schema metadata chosen for the whole
+/// transaction frame, not with a schema rebuilt halfway through the frame.
+#[test]
+fn test_alter_add_column_with_index_dml_does_not_corrupt_on_reopen() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(v INTEGER)").unwrap();
+        conn.execute("CREATE INDEX idx ON t(v)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("DELETE FROM t").unwrap();
+        conn.execute("ALTER TABLE t ADD COLUMN x INTEGER").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+    db.restart();
+    let conn = db.connect();
+    let names: Vec<String> = get_rows(&conn, "SELECT name FROM sqlite_schema ORDER BY rowid")
+        .iter()
+        .map(|r| r[0].to_string())
+        .collect();
+    assert!(
+        names.contains(&"t".to_string()),
+        "'t' table missing from sqlite_schema after reopen; got {names:?}"
+    );
+    assert!(
+        names.contains(&"idx".to_string()),
+        "index missing from sqlite_schema after reopen; got {names:?}"
+    );
+}
+
+/// Reproducer for `Index with root page ... not found in schema`.
+///
+/// A single transaction deletes a row from t and then drops idx. The deleted row
+/// already exists in the db file, and idx already has an entry for it. The log
+/// therefore contains a DELETE_INDEX op for that one idx entry, plus a
+/// sqlite_schema DELETE for idx itself.
+///
+/// This is the opposite side of the ALTER TABLE ADD COLUMN case above. The
+/// index-entry DELETE needs the old idx schema row in order to decode the index
+/// key. If BuildLogRecord writes the sqlite_schema DELETE before the
+/// DELETE_INDEX op, recovery removes idx from `schema_rows`, rebuilds
+/// `connection.schema`, then cannot resolve idx's root page when decoding the
+/// later DELETE_INDEX op.
+///
+/// This is why frame recovery chooses schema metadata from the whole frame.
+/// CREATE INDEX insert ops need the final schema; DROP INDEX delete ops need
+/// the old schema for entries that existed before the transaction.
+#[test]
+fn test_delete_then_drop_index_with_index_dml_replays_on_reopen() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(v INTEGER)").unwrap();
+        conn.execute("CREATE INDEX idx ON t(v)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("DELETE FROM t").unwrap();
+        conn.execute("DROP INDEX idx").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+    db.restart();
+    let conn = db.connect();
+    let names: Vec<String> = get_rows(&conn, "SELECT name FROM sqlite_schema ORDER BY rowid")
+        .iter()
+        .map(|r| r[0].to_string())
+        .collect();
+    assert!(
+        names.contains(&"t".to_string()),
+        "'t' table missing from sqlite_schema after reopen; got {names:?}"
+    );
+    assert!(
+        !names.contains(&"idx".to_string()),
+        "dropped index still present in sqlite_schema after reopen; got {names:?}"
+    );
+    let rows = get_rows(&conn, "SELECT v FROM t");
+    assert!(
+        rows.is_empty(),
+        "deleted row should stay deleted after reopen; got {rows:?}"
+    );
+}
+
+/// A transient index created and dropped in one transaction should leave no
+/// logical-log index work behind.
+///
+/// CREATE INDEX writes sqlite_schema and index entries with `begin=tx_id`.
+/// DROP INDEX ends those same versions before commit. Those entries never
+/// reached the db file, so recovery cannot depend on their schema existing
+/// before or after the frame. The writer must omit them instead of logging a
+/// log op for an index that has no durable schema row.
+#[test]
+fn test_create_then_drop_index_in_one_tx_replays_on_reopen() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(v INTEGER)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1)").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("CREATE INDEX idx ON t(v)").unwrap();
+        conn.execute("DROP INDEX idx").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+    db.restart();
+    let conn = db.connect();
+    let names: Vec<String> = get_rows(&conn, "SELECT name FROM sqlite_schema ORDER BY rowid")
+        .iter()
+        .map(|r| r[0].to_string())
+        .collect();
+    assert!(
+        names.contains(&"t".to_string()),
+        "'t' table missing from sqlite_schema after reopen; got {names:?}"
+    );
+    assert!(
+        !names.contains(&"idx".to_string()),
+        "transient index should not remain in sqlite_schema after reopen; got {names:?}"
+    );
+    let rows = get_rows(&conn, "SELECT v FROM t ORDER BY v");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+/// These cases came from an adversarial DDL/DML matrix. They did not find a
+/// failure, but they cover schema-before/schema-after combinations that the
+/// frame-level recovery code must keep working: dropped indexes, newly-created
+/// indexes, table recreation, and both checkpointed and uncheckpointed base
+/// schemas.
+#[test]
+fn test_schema_frame_recovery_drop_index_with_remaining_index_matrix() {
+    for checkpoint_base in [false, true] {
+        let mut db = MvccTestDbNoConn::new_with_random_db();
+        {
+            let conn = db.connect();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)")
+                .unwrap();
+            conn.execute("CREATE INDEX idx_a ON t(a)").unwrap();
+            conn.execute("CREATE INDEX idx_b ON t(b)").unwrap();
+            conn.execute("INSERT INTO t VALUES (1, 10, 100)").unwrap();
+            conn.execute("INSERT INTO t VALUES (2, 20, 200)").unwrap();
+            conn.execute("INSERT INTO t VALUES (3, 30, 300)").unwrap();
+            if checkpoint_base {
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+            }
+            conn.close().unwrap();
+        }
+        {
+            db.get_mvcc_store().set_checkpoint_threshold(-1);
+            let conn = db.connect();
+            conn.execute("BEGIN").unwrap();
+            conn.execute("DELETE FROM t WHERE id = 1").unwrap();
+            conn.execute("DROP INDEX idx_a").unwrap();
+            conn.execute("UPDATE t SET b = 250 WHERE id = 2").unwrap();
+            conn.execute("INSERT INTO t VALUES (4, 40, 400)").unwrap();
+            conn.execute("COMMIT").unwrap();
+            conn.close().unwrap();
+        }
+
+        db.restart();
+        let conn = db.connect();
+        let names: Vec<String> = get_rows(
+            &conn,
+            "SELECT name FROM sqlite_schema WHERE tbl_name = 't' ORDER BY rowid",
+        )
+        .iter()
+        .map(|r| r[0].to_string())
+        .collect();
+        assert!(names.contains(&"t".to_string()), "table missing: {names:?}");
+        assert!(
+            !names.contains(&"idx_a".to_string()),
+            "dropped idx_a still present after reopen: {names:?}"
+        );
+        assert!(
+            names.contains(&"idx_b".to_string()),
+            "remaining idx_b missing after reopen: {names:?}"
+        );
+        let rows = get_rows(
+            &conn,
+            "SELECT id, b FROM t INDEXED BY idx_b WHERE b >= 250 ORDER BY b",
+        );
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0][0].as_int().unwrap(), 2);
+        assert_eq!(rows[0][1].as_int().unwrap(), 250);
+        assert_eq!(rows[1][0].as_int().unwrap(), 3);
+        assert_eq!(rows[1][1].as_int().unwrap(), 300);
+        assert_eq!(rows[2][0].as_int().unwrap(), 4);
+        assert_eq!(rows[2][1].as_int().unwrap(), 400);
+        let rows = get_rows(&conn, "PRAGMA integrity_check");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(&rows[0][0].to_string(), "ok");
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+
+        db.restart();
+        let conn = db.connect();
+        let rows = get_rows(
+            &conn,
+            "SELECT id, b FROM t INDEXED BY idx_b WHERE b >= 250 ORDER BY b",
+        );
+        assert_eq!(rows.len(), 3);
+    }
+}
+
+#[test]
+fn test_schema_frame_recovery_create_index_with_mixed_dml_matrix() {
+    for checkpoint_base in [false, true] {
+        let mut db = MvccTestDbNoConn::new_with_random_db();
+        {
+            let conn = db.connect();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)")
+                .unwrap();
+            conn.execute("CREATE INDEX idx_a ON t(a)").unwrap();
+            conn.execute("INSERT INTO t VALUES (1, 10, 100)").unwrap();
+            conn.execute("INSERT INTO t VALUES (2, 20, 200)").unwrap();
+            conn.execute("INSERT INTO t VALUES (3, 30, 300)").unwrap();
+            if checkpoint_base {
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+            }
+            conn.close().unwrap();
+        }
+        {
+            db.get_mvcc_store().set_checkpoint_threshold(-1);
+            let conn = db.connect();
+            conn.execute("BEGIN").unwrap();
+            conn.execute("UPDATE t SET a = 21 WHERE id = 2").unwrap();
+            conn.execute("INSERT INTO t VALUES (4, 40, 400)").unwrap();
+            conn.execute("DELETE FROM t WHERE id = 1").unwrap();
+            conn.execute("CREATE INDEX idx_b ON t(b)").unwrap();
+            conn.execute("UPDATE t SET b = 333 WHERE id = 3").unwrap();
+            conn.execute("COMMIT").unwrap();
+            conn.close().unwrap();
+        }
+
+        db.restart();
+        let conn = db.connect();
+        let names: Vec<String> = get_rows(
+            &conn,
+            "SELECT name FROM sqlite_schema WHERE tbl_name = 't' ORDER BY rowid",
+        )
+        .iter()
+        .map(|r| r[0].to_string())
+        .collect();
+        assert!(
+            names.contains(&"idx_a".to_string()),
+            "idx_a missing: {names:?}"
+        );
+        assert!(
+            names.contains(&"idx_b".to_string()),
+            "idx_b missing: {names:?}"
+        );
+        let rows = get_rows(
+            &conn,
+            "SELECT id, b FROM t INDEXED BY idx_b WHERE b >= 200 ORDER BY b",
+        );
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0][0].as_int().unwrap(), 2);
+        assert_eq!(rows[0][1].as_int().unwrap(), 200);
+        assert_eq!(rows[1][0].as_int().unwrap(), 3);
+        assert_eq!(rows[1][1].as_int().unwrap(), 333);
+        assert_eq!(rows[2][0].as_int().unwrap(), 4);
+        assert_eq!(rows[2][1].as_int().unwrap(), 400);
+        let rows = get_rows(&conn, "PRAGMA integrity_check");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(&rows[0][0].to_string(), "ok");
+    }
+}
+
+#[test]
+fn test_schema_frame_recovery_drop_recreate_table_indexes_matrix() {
+    for checkpoint_base in [false, true] {
+        let mut db = MvccTestDbNoConn::new_with_random_db();
+        {
+            let conn = db.connect();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER)")
+                .unwrap();
+            conn.execute("CREATE INDEX idx_a ON t(a)").unwrap();
+            conn.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+            conn.execute("INSERT INTO t VALUES (2, 20)").unwrap();
+            if checkpoint_base {
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+            }
+            conn.close().unwrap();
+        }
+        {
+            db.get_mvcc_store().set_checkpoint_threshold(-1);
+            let conn = db.connect();
+            conn.execute("BEGIN").unwrap();
+            conn.execute("DELETE FROM t WHERE id = 1").unwrap();
+            conn.execute("DROP TABLE t").unwrap();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT, c INTEGER)")
+                .unwrap();
+            conn.execute("CREATE INDEX idx_c ON t(c)").unwrap();
+            conn.execute("INSERT INTO t VALUES (1, 'new', 30)").unwrap();
+            conn.execute("INSERT INTO t VALUES (2, 'next', 40)")
+                .unwrap();
+            conn.execute("UPDATE t SET c = 45 WHERE id = 2").unwrap();
+            conn.execute("COMMIT").unwrap();
+            conn.close().unwrap();
+        }
+
+        db.restart();
+        let conn = db.connect();
+        let names: Vec<String> = get_rows(
+            &conn,
+            "SELECT name FROM sqlite_schema WHERE tbl_name = 't' ORDER BY rowid",
+        )
+        .iter()
+        .map(|r| r[0].to_string())
+        .collect();
+        assert!(names.contains(&"t".to_string()), "table missing: {names:?}");
+        assert!(
+            !names.contains(&"idx_a".to_string()),
+            "old idx_a still present after recreate: {names:?}"
+        );
+        assert!(
+            names.contains(&"idx_c".to_string()),
+            "new idx_c missing after recreate: {names:?}"
+        );
+        let rows = get_rows(&conn, "SELECT id, b, c FROM t INDEXED BY idx_c ORDER BY c");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0][0].as_int().unwrap(), 1);
+        assert_eq!(rows[0][1].to_string(), "new");
+        assert_eq!(rows[0][2].as_int().unwrap(), 30);
+        assert_eq!(rows[1][0].as_int().unwrap(), 2);
+        assert_eq!(rows[1][1].to_string(), "next");
+        assert_eq!(rows[1][2].as_int().unwrap(), 45);
+        let rows = get_rows(&conn, "PRAGMA integrity_check");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(&rows[0][0].to_string(), "ok");
+    }
+}
+
+#[test]
+fn test_schema_frame_recovery_same_name_partial_index_redefinition() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER)")
+            .unwrap();
+        conn.execute("CREATE INDEX idx_common ON t(a) WHERE a >= 20")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 10, 100)").unwrap();
+        conn.execute("INSERT INTO t VALUES (2, 20, 200)").unwrap();
+        conn.execute("INSERT INTO t VALUES (3, 30, 300)").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("UPDATE t SET a = 25 WHERE id = 2").unwrap();
+        conn.execute("DROP INDEX idx_common").unwrap();
+        conn.execute("CREATE INDEX idx_common ON t(b) WHERE b >= 250")
+            .unwrap();
+        conn.execute("UPDATE t SET b = 275 WHERE id = 2").unwrap();
+        conn.execute("INSERT INTO t VALUES (4, 40, 400)").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let sql_rows = get_rows(
+        &conn,
+        "SELECT sql FROM sqlite_schema WHERE name = 'idx_common'",
+    );
+    assert_eq!(sql_rows.len(), 1);
+    let index_sql = sql_rows[0][0].to_string();
+    assert!(
+        index_sql.contains("ON t (b)") && index_sql.contains("WHERE b >= 250"),
+        "idx_common should be recreated on b with the partial predicate; got {index_sql}"
+    );
+    let rows = get_rows(
+        &conn,
+        "SELECT id, b FROM t INDEXED BY idx_common WHERE b >= 250 ORDER BY b",
+    );
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+    assert_eq!(rows[0][1].as_int().unwrap(), 275);
+    assert_eq!(rows[1][0].as_int().unwrap(), 3);
+    assert_eq!(rows[1][1].as_int().unwrap(), 300);
+    assert_eq!(rows[2][0].as_int().unwrap(), 4);
+    assert_eq!(rows[2][1].as_int().unwrap(), 400);
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_schema_rewrites_do_not_drop_table_versions_from_recovery_log() {
+    for checkpoint_base in [false, true] {
+        let mut db = MvccTestDbNoConn::new_with_random_db();
+        {
+            let conn = db.connect();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, note TEXT)")
+                .unwrap();
+            conn.execute("CREATE INDEX idx_a ON t(a)").unwrap();
+            conn.execute("CREATE INDEX idx_b ON t(b)").unwrap();
+            conn.execute("CREATE UNIQUE INDEX idx_note ON t(note)")
+                .unwrap();
+            conn.execute("INSERT INTO t VALUES(1, 10, 100, 'n1')")
+                .unwrap();
+            conn.execute("INSERT INTO t VALUES(2, 20, 200, 'n2')")
+                .unwrap();
+            conn.execute("INSERT INTO t VALUES(3, 30, 300, 'n3')")
+                .unwrap();
+            if checkpoint_base {
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+            }
+            conn.close().unwrap();
+        }
+
+        db.restart();
+        {
+            db.get_mvcc_store().set_checkpoint_threshold(-1);
+            let conn = db.connect();
+            conn.execute("BEGIN").unwrap();
+            conn.execute("ALTER TABLE t RENAME TO tt").unwrap();
+            conn.execute("ALTER TABLE tt RENAME COLUMN note TO label")
+                .unwrap();
+            conn.execute("UPDATE tt SET a = a + 12 WHERE id = 1")
+                .unwrap();
+            conn.execute("ALTER TABLE tt ADD COLUMN c INTEGER DEFAULT 5")
+                .unwrap();
+            conn.execute("UPDATE tt SET c = a + b WHERE id = 2")
+                .unwrap();
+            conn.execute("CREATE INDEX idx_label ON tt(label)").unwrap();
+            conn.execute(
+                "INSERT INTO tt(id,a,b,label,c) VALUES(4, 40, 472, 'n4', 912)
+                 ON CONFLICT(id) DO UPDATE
+                 SET a = excluded.a, b = excluded.b, label = excluded.label, c = excluded.c",
+            )
+            .unwrap();
+            conn.execute("DROP INDEX idx_b").unwrap();
+            conn.execute("COMMIT").unwrap();
+            conn.close().unwrap();
+        }
+
+        db.restart();
+        let conn = db.connect();
+        let table_rows = get_rows(&conn, "SELECT id, a, b, label, c FROM tt ORDER BY id");
+        assert_eq!(table_rows.len(), 4, "checkpoint_base={checkpoint_base}");
+        assert_eq!(table_rows[0][0].as_int().unwrap(), 1);
+        assert_eq!(table_rows[0][1].as_int().unwrap(), 22);
+        assert_eq!(table_rows[0][4].as_int().unwrap(), 5);
+        assert_eq!(table_rows[1][0].as_int().unwrap(), 2);
+        assert_eq!(table_rows[1][2].as_int().unwrap(), 200);
+        assert_eq!(table_rows[1][4].as_int().unwrap(), 220);
+        assert_eq!(table_rows[2][0].as_int().unwrap(), 3);
+        assert_eq!(table_rows[2][4].as_int().unwrap(), 5);
+        assert_eq!(table_rows[3][0].as_int().unwrap(), 4);
+        assert_eq!(table_rows[3][1].as_int().unwrap(), 40);
+        assert_eq!(table_rows[3][3].to_string(), "n4");
+        assert_eq!(table_rows[3][4].as_int().unwrap(), 912);
+
+        let indexed_rows = get_rows(
+            &conn,
+            "SELECT id, label FROM tt INDEXED BY idx_label WHERE label >= 'n1' ORDER BY label, id",
+        );
+        assert_eq!(indexed_rows.len(), 4, "checkpoint_base={checkpoint_base}");
+        assert_eq!(indexed_rows[3][0].as_int().unwrap(), 4);
+        assert_eq!(indexed_rows[3][1].to_string(), "n4");
+
+        let rows = get_rows(&conn, "PRAGMA integrity_check");
+        assert_eq!(rows.len(), 1, "checkpoint_base={checkpoint_base}");
+        assert_eq!(&rows[0][0].to_string(), "ok");
+    }
+}
+
+/// Updating a row that already exists in the db file creates an MVCC
+/// replacement version. If the same transaction deletes that row, recovery must
+/// not replay both the old-row delete and a second delete for the replacement:
+/// only the old row ever existed in the db file.
+#[test]
+fn test_btree_resident_update_then_delete_checkpoints_after_reopen() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER)")
+            .unwrap();
+        conn.execute("CREATE INDEX idx_v ON t(v)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+        conn.execute("INSERT INTO t VALUES (2, 20)").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("UPDATE t SET v = 15 WHERE id = 1").unwrap();
+        conn.execute("DELETE FROM t WHERE id = 1").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let rows = get_rows(&conn, "SELECT id, v FROM t INDEXED BY idx_v ORDER BY v");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+    assert_eq!(rows[0][1].as_int().unwrap(), 20);
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
+#[test]
+fn test_schema_frame_recovery_rename_column_then_drop_index_checkpoints_after_reopen() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX i_b ON t(b)").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("ALTER TABLE t RENAME COLUMN b TO bb").unwrap();
+        conn.execute("DROP INDEX i_b").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let schema_rows = get_rows(
+        &conn,
+        "SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE name NOT LIKE '__turso%' ORDER BY rowid",
+    );
+    assert_eq!(schema_rows.len(), 1);
+    assert_eq!(schema_rows[0][0].to_string(), "table");
+    assert_eq!(schema_rows[0][1].to_string(), "t");
+    assert_eq!(schema_rows[0][2].to_string(), "t");
+    assert_eq!(
+        schema_rows[0][3].to_string(),
+        "CREATE TABLE t (a INTEGER PRIMARY KEY, bb TEXT)"
+    );
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
 /// Reproducer: DROP TABLE ghost data after restart without explicit checkpoint.
 /// Session 1: create + insert + checkpoint. Session 2: drop. Session 3: reopen.
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -16,7 +16,7 @@ use crate::storage::sqlite3_ondisk::{
     checksum_wal, read_varint, write_varint, DatabaseHeader, WalHeader, WAL_FRAME_HEADER_SIZE,
     WAL_HEADER_SIZE,
 };
-use crate::sync::atomic::{AtomicBool, Ordering};
+use crate::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use crate::sync::Mutex;
 use crate::sync::RwLock;
 use crate::{
@@ -11871,6 +11871,156 @@ fn test_read_lock_leak_deferred_then_concurrent() {
     // After the error, SELECT should work without panicking
     let rows = get_rows(&conn1, "SELECT * FROM t1");
     assert_eq!(rows.len(), 1);
+}
+
+#[test]
+fn test_schema_change_succeeds_while_concurrent_writer_aborts_at_commit() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, c TEXT)")
+        .unwrap();
+    setup.execute("INSERT INTO t VALUES(1, 'a')").unwrap();
+    setup.close().unwrap();
+
+    let ddl = db.connect();
+    let writer = db.connect();
+    writer.execute("BEGIN CONCURRENT").unwrap();
+    writer
+        .execute("UPDATE t SET c = 'writer' WHERE id = 1")
+        .unwrap();
+
+    ddl.execute("ALTER TABLE t ADD COLUMN extra INTEGER")
+        .unwrap();
+
+    let commit_err = writer
+        .execute("COMMIT")
+        .expect_err("writer snapshot predates committed schema change");
+    assert!(matches!(commit_err, LimboError::SchemaConflict));
+    assert!(
+        writer.get_auto_commit(),
+        "SchemaConflict should roll back the stale writer transaction"
+    );
+
+    let verify = db.connect();
+    let columns = get_rows(&verify, "PRAGMA table_info(t)");
+    let column_names: Vec<String> = columns.iter().map(|row| row[1].to_string()).collect();
+    assert_eq!(column_names, vec!["id", "c", "extra"]);
+    let rows = get_rows(&verify, "SELECT id, c, extra FROM t");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][1].to_string(), "a");
+    assert!(matches!(&rows[0][2], crate::types::Value::Null));
+}
+
+#[test]
+fn test_create_index_succeeds_while_concurrent_writer_aborts_at_commit() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, c TEXT, keep INTEGER)")
+        .unwrap();
+    setup.execute("INSERT INTO t VALUES(1, 'a', 10)").unwrap();
+    setup.execute("INSERT INTO t VALUES(2, 'b', 20)").unwrap();
+    setup.close().unwrap();
+
+    let writer = db.connect();
+    writer.execute("BEGIN CONCURRENT").unwrap();
+    writer.execute("INSERT INTO t VALUES(3, 'c', 30)").unwrap();
+
+    let ddl = db.connect();
+    ddl.execute("CREATE INDEX idx_t_c ON t(c)").unwrap();
+
+    let commit_err = writer
+        .execute("COMMIT")
+        .expect_err("writer snapshot predates committed schema change");
+    assert!(matches!(commit_err, LimboError::SchemaConflict));
+    assert!(writer.get_auto_commit());
+
+    let verify = db.connect();
+    let rows = get_rows(&verify, "SELECT id, c, keep FROM t ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    let indexes = get_rows(
+        &verify,
+        "SELECT name FROM sqlite_schema WHERE type = 'index' AND name = 'idx_t_c'",
+    );
+    assert_eq!(indexes.len(), 1);
+    let rows = get_rows(&verify, "PRAGMA integrity_check");
+    assert_eq!(rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_exclusive_update_conflicts_with_concurrent_delete_without_replacing_marker() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, text TEXT)")
+        .unwrap();
+    setup
+        .execute("INSERT INTO t VALUES(1, 'original')")
+        .unwrap();
+    setup.close().unwrap();
+
+    let concurrent = db.connect();
+    let exclusive = db.connect();
+    concurrent.execute("BEGIN CONCURRENT").unwrap();
+    concurrent.execute("DELETE FROM t WHERE id = 1").unwrap();
+
+    let update_err = exclusive
+        .execute("UPDATE t SET text = 'exclusive' WHERE id = 1")
+        .expect_err("exclusive writer must not replace another transaction's delete marker");
+    assert!(matches!(update_err, LimboError::WriteWriteConflict));
+    assert!(exclusive.get_auto_commit());
+
+    let rows = get_rows(&concurrent, "SELECT * FROM t");
+    assert!(
+        rows.is_empty(),
+        "concurrent tx should still see its own delete"
+    );
+    concurrent.execute("COMMIT").unwrap();
+    assert!(
+        concurrent.get_auto_commit(),
+        "concurrent transaction should remain usable after rejected exclusive write"
+    );
+
+    let rows = get_rows(&exclusive, "SELECT id, text FROM t");
+    assert!(rows.is_empty());
+}
+
+#[test]
+fn test_explicit_delete_conflicts_with_concurrent_delete_without_replacing_marker() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, text TEXT)")
+        .unwrap();
+    setup
+        .execute("INSERT INTO t VALUES(1, 'original')")
+        .unwrap();
+    setup.execute("INSERT INTO t VALUES(2, 'keep')").unwrap();
+    setup.close().unwrap();
+
+    let concurrent = db.connect();
+    let exclusive = db.connect();
+    concurrent.execute("BEGIN CONCURRENT").unwrap();
+    concurrent.execute("DELETE FROM t WHERE id = 1").unwrap();
+
+    exclusive.execute("BEGIN").unwrap();
+    let rows = get_rows(&exclusive, "SELECT * FROM t ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    let delete_err = exclusive
+        .execute("DELETE FROM t WHERE id = 1")
+        .expect_err("exclusive delete must conflict instead of stealing row marker");
+    assert!(matches!(delete_err, LimboError::WriteWriteConflict));
+    assert!(exclusive.get_auto_commit());
+
+    let rows = get_rows(&concurrent, "SELECT * FROM t ORDER BY id");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+
+    concurrent.execute("COMMIT").unwrap();
+    let rows = get_rows(&exclusive, "SELECT id, text FROM t ORDER BY id");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
 }
 
 /// Regression for #6754: dropping a Statement that paused mid-IO inside

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1263,12 +1263,51 @@ impl StreamingLogicalLogReader {
         self.last_valid_offset = LOG_HDR_SIZE;
     }
 
+    /// Reads the next complete transaction frame.
+    ///
+    /// Recovery needs the whole frame so it can decide which schema snapshot
+    /// should decode each index op. `next_record` keeps the older one-op-at-a-time
+    /// API for tests and other callers. This is only a different API shape over
+    /// the same parser: `parse_next_transaction` still owns EOF handling,
+    /// torn-tail detection, `last_valid_offset`, and the chained CRC update.
+    ///
+    /// Empty parsed frames are skipped, so callers that receive Some(frame) can
+    /// rely on `frame` being non-empty.
+    pub(crate) fn next_frame(&mut self, io: &Arc<dyn crate::IO>) -> Result<Option<Vec<ParsedOp>>> {
+        if !self.pending_ops.is_empty() {
+            return Err(LimboError::InternalError(
+                "next_frame cannot be mixed with next_record on the same reader".to_string(),
+            ));
+        }
+
+        loop {
+            match self.state {
+                StreamingState::NeedTransactionStart => {
+                    if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
+                        return Ok(None);
+                    }
+
+                    let ops = match self.parse_next_transaction(io)? {
+                        ParseResult::Ops(ops) => ops,
+                        ParseResult::Eof | ParseResult::InvalidFrame => return Ok(None),
+                    };
+
+                    if ops.is_empty() {
+                        continue;
+                    }
+                    return Ok(Some(ops));
+                }
+            }
+        }
+    }
+
     /// Reads next record in log.
     pub fn next_record(
         &mut self,
         io: &Arc<dyn crate::IO>,
         mut get_index_info: impl FnMut(MVTableId) -> Result<Arc<IndexInfo>>,
     ) -> Result<StreamingResult> {
+        let mut get_index_info = |index_id, _op_kind| get_index_info(index_id);
         if let Some(op) = self.pending_ops.pop_front() {
             return self.parsed_op_to_streaming(op, &mut get_index_info);
         }
@@ -1945,10 +1984,10 @@ impl StreamingLogicalLogReader {
         Ok(ParseResult::Ops(parsed_ops))
     }
 
-    fn parsed_op_to_streaming(
+    pub(crate) fn parsed_op_to_streaming(
         &self,
         parsed_op: ParsedOp,
-        get_index_info: &mut impl FnMut(MVTableId) -> Result<Arc<IndexInfo>>,
+        get_index_info: &mut impl FnMut(MVTableId, IndexOpKind) -> Result<Arc<IndexInfo>>,
     ) -> Result<StreamingResult> {
         match parsed_op {
             ParsedOp::UpsertTable {
@@ -1992,7 +2031,7 @@ impl StreamingLogicalLogReader {
             } => {
                 let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
                 let column_count = key_record.column_count();
-                let index_info = get_index_info(table_id)?;
+                let index_info = get_index_info(table_id, IndexOpKind::Upsert)?;
                 let key = SortableIndexKey::new_from_record(key_record, index_info);
                 let rowid = RowID::new(table_id, RowKey::Record(key));
                 let row = Row::new_index_row(rowid.clone(), column_count);
@@ -2011,7 +2050,7 @@ impl StreamingLogicalLogReader {
             } => {
                 let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
                 let column_count = key_record.column_count();
-                let index_info = get_index_info(table_id)?;
+                let index_info = get_index_info(table_id, IndexOpKind::Delete)?;
                 let key = SortableIndexKey::new_from_record(key_record, index_info);
                 let rowid = RowID::new(table_id, RowKey::Record(key));
                 let row = Row::new_index_row(rowid.clone(), column_count);
@@ -2278,7 +2317,7 @@ enum ParseResult {
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
-enum ParsedOp {
+pub(crate) enum ParsedOp {
     UpsertTable {
         table_id: MVTableId,
         rowid: RowID,
@@ -2307,6 +2346,12 @@ enum ParsedOp {
         header: DatabaseHeader,
         commit_ts: u64,
     },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum IndexOpKind {
+    Upsert,
+    Delete,
 }
 
 #[cfg(test)]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2341,6 +2341,13 @@ impl Program {
                 // Schema updated errors do not cause a rollback; the statement will be reprepared and retried,
                 // and the caller is expected to handle transaction cleanup explicitly if needed.
                 Some(LimboError::SchemaUpdated) => {}
+                Some(LimboError::WriteWriteConflict | LimboError::SchemaConflict) => {
+                    // These MVCC errors mean the current transaction cannot
+                    // commit. Roll it back even if this statement opened a
+                    // statement savepoint, as DDL does.
+                    self.rollback_current_txn(pager);
+                    self.connection.set_changes_without_total(0);
+                }
                 // Foreign key constraint errors: ON CONFLICT does NOT apply to FK violations.
                 // FK errors always behave like ABORT: rollback statement,
                 // rollback transaction in autocommit mode.

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1664,7 +1664,7 @@ pub fn test_mvcc_reader_stale_snapshot_after_schema_updated_returns_ok() {
     conn1.execute("SELECT * FROM t").unwrap();
     // conn2: Modify schema while conn1's CONCURRENT transaction is active
     conn2.execute("CREATE TABLE t2 (x)").unwrap();
-    // conn1: Try to COMMIT - should fail with SchemaConflict
+    // conn1: A read-only transaction can commit even though the schema changed.
     let commit_result = conn1.execute("COMMIT");
     assert!(matches!(commit_result, Ok(())));
 
@@ -1673,12 +1673,11 @@ pub fn test_mvcc_reader_stale_snapshot_after_schema_updated_returns_ok() {
         .execute("INSERT INTO t VALUES ('test_key', 'test_value')")
         .unwrap();
 
-    // conn1: Start a new CONCURRENT transaction
-    // BUG: This should get a fresh MVCC snapshot, but it reuses the old one
+    // conn1: Start a new CONCURRENT transaction. It must get a fresh
+    // snapshot after the earlier transaction committed.
     conn1.execute("BEGIN CONCURRENT").unwrap();
 
-    // conn1: SELECT should see the row inserted by conn2
-    // BUG: Due to stale snapshot, this returns empty result
+    // conn1: SELECT should see the row inserted by conn2.
     let rows: Vec<(String, String)> = conn1.exec_rows("SELECT * FROM t WHERE key = 'test_key'");
 
     assert_eq!(
@@ -1711,9 +1710,9 @@ pub fn test_mvcc_writer_stale_snapshot_after_schema_updated() {
     conn1
         .execute("INSERT INTO t VALUES ('foo', 'var')")
         .unwrap();
-    // conn2: Modify schema while conn1's CONCURRENT transaction is active
+    // conn2: Modify schema while conn1's CONCURRENT transaction is active.
     conn2.execute("CREATE TABLE t2 (x)").unwrap();
-    // conn1: Try to COMMIT - should fail with SchemaConflict
+    // conn1: COMMIT should fail because its writer snapshot predates the schema change.
     let commit_result = conn1.execute("COMMIT");
     assert!(matches!(commit_result, Err(LimboError::SchemaConflict)));
 
@@ -1722,12 +1721,11 @@ pub fn test_mvcc_writer_stale_snapshot_after_schema_updated() {
         .execute("INSERT INTO t VALUES ('test_key', 'test_value')")
         .unwrap();
 
-    // conn1: Start a new CONCURRENT transaction
-    // BUG: This should get a fresh MVCC snapshot, but it reuses the old one
+    // conn1: Start a new CONCURRENT transaction. It must get a fresh
+    // snapshot after the earlier transaction committed.
     conn1.execute("BEGIN CONCURRENT").unwrap();
 
-    // conn1: SELECT should see the row inserted by conn2
-    // BUG: Due to stale snapshot, this returns empty result
+    // conn1: SELECT should see the row inserted by conn2.
     let rows: Vec<(String, String)> = conn1.exec_rows("SELECT * FROM t WHERE key = 'test_key'");
 
     assert_eq!(


### PR DESCRIPTION
## Beef

This PR fixes three MVCC bugs.

## Bugs and fixes

### 1. Replay schema-changing log frames as whole transactions

Recovery used to replay one log op at a time and rebuild schema in the middle of a transaction. That broke when one transaction mixed DDL and indexed-row writes.

Example: `DELETE FROM t` plus `ALTER TABLE t ADD COLUMN x` could make recovery briefly see the index for `t` while the table row for `t` was missing, then fail with `sqlite_schema contains index for missing table` -- this is because ALTER TABLE is a sequence of a sqlite_schema delete and insert.

Recovery now reads one transaction frame at a time, works out the schema before and after that frame, decodes index ops with the right schema, and installs the new schema after the whole frame is replayed.

### 2. Don’t checkpoint fake deletes for views/triggers

Checkpoint needs dropped table/index schema rows because those objects have B-trees. Views and triggers do not. They have `rootpage = 0`.

The checkpoint path now keeps this special delete handling only for real table/index B-trees. Dropped views/triggers no longer create bogus checkpoint work.

### 3. Clean up writers after schema conflicts

A schema change can commit while a `BEGIN CONCURRENT` writer is active. If that writer later commits with a stale schema snapshot, it gets `SchemaConflict`.

The bug was that the connection could keep the failed MVCC transaction around. The next transaction on that connection could then reuse stale state.

`SchemaConflict` and `WriteWriteConflict` now roll back the current MVCC transaction, so the connection is clean afterward.
