### PR TITLE
core/mvcc: Skip transient view and trigger deletes during MVCC checkpoint

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -467,11 +467,16 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 });
             // - It is a delete, AND some version of the row exists in the database file.
             let is_delete_and_exists_in_db_file = end_ts.is_some() && exists_in_db_file;
-            // - It is a delete of a sqlite_schema row that hasn't been checkpointed yet. We need to
-            //   return these even if they don't exist in the DB file so we can track destroyed
-            //   tables/indexes and skip their data rows.
+            // - It is a delete of an uncheckpointed sqlite_schema row for a
+            //   table or index. The schema row itself is not in the DB file, but
+            //   checkpoint still needs it so it can remember that the table or
+            //   index was destroyed and skip that object's data/index rows.
+            //   Views and triggers have rootpage=0, so their uncheckpointed
+            //   deletes can be ignored here: there is no B-tree to destroy, and
+            //   deleting a missing sqlite_schema row would be wrong.
             let is_schema_delete = table_id == SQLITE_SCHEMA_MVCC_TABLE_ID
                 && !exists_in_db_file
+                && sqlite_schema_btree_identity(version).is_some()
                 && self
                     .durable_txid_max_old
                     .is_none_or(|txid_max_old| end_ts.is_some_and(|e| e > u64::from(txid_max_old)));

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8891,6 +8891,72 @@ fn test_checkpoint_skips_uncheckpointed_view_and_trigger_deletes_after_recovery(
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+#[test]
+fn test_checkpoint_deletes_checkpointed_view_and_trigger_schema_rows_after_recovery() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT)")
+            .unwrap();
+        conn.execute("CREATE VIEW v_t AS SELECT id, b FROM t")
+            .unwrap();
+        conn.execute(
+            "CREATE TRIGGER tr_t_ai AFTER INSERT ON t
+             BEGIN
+               UPDATE t SET b = NEW.b || '_tr' WHERE id = NEW.id;
+             END",
+        )
+        .unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    {
+        let conn = db.connect();
+        let rows = get_rows(
+            &conn,
+            "SELECT type, name FROM sqlite_schema WHERE name NOT LIKE '__turso%' ORDER BY rowid",
+        );
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0][0].to_string(), "table");
+        assert_eq!(rows[0][1].to_string(), "t");
+        assert_eq!(rows[1][0].to_string(), "view");
+        assert_eq!(rows[1][1].to_string(), "v_t");
+        assert_eq!(rows[2][0].to_string(), "trigger");
+        assert_eq!(rows[2][1].to_string(), "tr_t_ai");
+        conn.close().unwrap();
+    }
+
+    db.get_mvcc_store().set_checkpoint_threshold(-1);
+    {
+        let conn = db.connect();
+        conn.execute("DROP VIEW v_t").unwrap();
+        conn.execute("DROP TRIGGER tr_t_ai").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    let rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema WHERE name NOT LIKE '__turso%' ORDER BY rowid",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "table");
+    assert_eq!(rows[0][1].to_string(), "t");
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
 /// Reproducer: DROP TABLE ghost data after restart without explicit checkpoint.
 /// Session 1: create + insert + checkpoint. Session 2: drop. Session 3: reopen.
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8845,6 +8845,52 @@ fn test_alter_table_rename_with_unique_constraint_panics_on_restart() {
     }
 }
 
+#[test]
+fn test_checkpoint_skips_uncheckpointed_view_and_trigger_deletes_after_recovery() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT)")
+            .unwrap();
+        conn.execute("CREATE VIEW v_t AS SELECT id, b FROM t")
+            .unwrap();
+        conn.execute(
+            "CREATE TRIGGER tr_t_ai AFTER INSERT ON t
+             BEGIN
+               UPDATE t SET b = NEW.b || '_tr' WHERE id = NEW.id;
+             END",
+        )
+        .unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    {
+        db.get_mvcc_store().set_checkpoint_threshold(-1);
+        let conn = db.connect();
+        conn.execute("BEGIN").unwrap();
+        conn.execute("DROP VIEW v_t").unwrap();
+        conn.execute("DROP TRIGGER tr_t_ai").unwrap();
+        conn.execute("COMMIT").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema WHERE name NOT LIKE '__turso%' ORDER BY rowid",
+    );
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "table");
+    assert_eq!(rows[0][1].to_string(), "t");
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
 /// Reproducer: DROP TABLE ghost data after restart without explicit checkpoint.
 /// Session 1: create + insert + checkpoint. Session 2: drop. Session 3: reopen.
 #[test]


### PR DESCRIPTION
MVCC checkpoint needs uncheckpointed sqlite_schema deletes for tables and indexes because those rows identify B-trees whose data/index rows must be skipped after the object is destroyed. That rule does not apply to views and triggers: their sqlite_schema rows have rootpage=0, were not written to the db file, and have no B-tree to destroy.

Filter the special sqlite_schema delete path through sqlite_schema_btree_identity so only table/index rows participate. The regression creates an uncheckpointed view and trigger, drops both after recovery, then runs checkpoint and verifies sqlite_schema plus integrity_check.