### PR TITLE
Introduce portable logical log metadata for turso sync

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,6 +140,24 @@ jobs:
         run: |
           make test-shuttle
 
+  conn-raw-api-tests:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Setup mold linker
+        uses: "./.github/shared/setup-mold"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-conn-raw-api"
+          cache-on-failure: true
+      - uses: "./.github/shared/setup-sccache"
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+      - name: Run conn_raw_api-gated core tests
+        run: cargo nextest run -p turso_core --features conn_raw_api --locked --no-fail-fast --failure-output=final
+
   # stress-nondeterminism-check:
   #   runs-on: blacksmith-4vcpu-ubuntu-2404
   #   timeout-minutes: 15

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -187,6 +187,15 @@ pub struct Connection {
     /// because rotating the WAL header invalidates their published
     /// watermarks.
     pub(super) wal_auto_actions: AtomicU8,
+    /// Whether MVCC commits should include portable logical-change metadata in
+    /// the logical log.
+    ///
+    /// This is off by default because the metadata is only useful for raw-log
+    /// consumers such as sync clients.
+    #[cfg(feature = "conn_raw_api")]
+    pub(super) portable_logical_changes_enabled: AtomicBool,
+    #[cfg(feature = "conn_raw_api")]
+    pub(super) mvcc_log_metadata: RwLock<HashMap<String, String>>,
     pub(super) capture_data_changes: RwLock<Option<CaptureDataChangesInfo>>,
     /// CDC v2: transaction ID for grouping CDC records by transaction.
     /// -1 means unset (will be assigned on first CDC write in the transaction).
@@ -927,6 +936,7 @@ impl Connection {
         if db_schema_version == on_disk_schema_version {
             return Ok(());
         }
+
         // start read transaction manually, because we will read schema cookie once again and
         // we must be sure that it will consistent with schema content
         //
@@ -1680,6 +1690,7 @@ impl Connection {
                 self.set_tx_state(TransactionState::None);
             }
         }
+        self.clear_mvcc_log_meta();
 
         let is_memory_db = is_memory_like(&self.db.path);
         let should_checkpoint_on_close = pager
@@ -1714,6 +1725,74 @@ impl Connection {
             return WalAutoActions::empty();
         }
         WalAutoActions::from_bits_truncate(self.wal_auto_actions.load(Ordering::SeqCst))
+    }
+
+    /// Enable or disable writing portable logical-change metadata into MVCC
+    /// logical-log frames.
+    pub fn set_portable_logical_changes_enabled(&self, enabled: bool) {
+        #[cfg(feature = "conn_raw_api")]
+        {
+            self.portable_logical_changes_enabled
+                .store(enabled, Ordering::Release);
+        }
+        let _ = enabled;
+    }
+
+    pub fn portable_logical_changes_enabled(&self) -> bool {
+        #[cfg(feature = "conn_raw_api")]
+        {
+            self.portable_logical_changes_enabled
+                .load(Ordering::Acquire)
+        }
+        #[cfg(not(feature = "conn_raw_api"))]
+        {
+            false
+        }
+    }
+
+    pub fn set_mvcc_log_meta(&self, key: String, value: Option<String>) {
+        #[cfg(feature = "conn_raw_api")]
+        {
+            let mut metadata = self.mvcc_log_metadata.write();
+            match value {
+                Some(value) => {
+                    metadata.insert(key, value);
+                    self.portable_logical_changes_enabled
+                        .store(true, Ordering::Release);
+                }
+                None => {
+                    metadata.remove(&key);
+                }
+            }
+        }
+        #[cfg(not(feature = "conn_raw_api"))]
+        {
+            let _ = (key, value);
+        }
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    pub(crate) fn take_mvcc_log_meta(&self) -> HashMap<String, String> {
+        std::mem::take(&mut *self.mvcc_log_metadata.write())
+    }
+
+    pub(crate) fn clear_mvcc_log_meta(&self) {
+        #[cfg(feature = "conn_raw_api")]
+        {
+            self.mvcc_log_metadata.write().clear();
+        }
+    }
+
+    pub fn mvcc_log_meta(&self, key: &str) -> Option<String> {
+        #[cfg(feature = "conn_raw_api")]
+        {
+            return self.mvcc_log_metadata.read().get(key).cloned();
+        }
+        #[cfg(not(feature = "conn_raw_api"))]
+        {
+            let _ = key;
+            None
+        }
     }
 
     #[cfg(feature = "simulator")]

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1757,8 +1757,6 @@ impl Connection {
             match value {
                 Some(value) => {
                     metadata.insert(key, value);
-                    self.portable_logical_changes_enabled
-                        .store(true, Ordering::Release);
                 }
                 None => {
                     metadata.remove(&key);
@@ -1772,8 +1770,8 @@ impl Connection {
     }
 
     #[cfg(feature = "conn_raw_api")]
-    pub(crate) fn take_mvcc_log_meta(&self) -> HashMap<String, String> {
-        std::mem::take(&mut *self.mvcc_log_metadata.write())
+    pub(crate) fn mvcc_log_meta_snapshot(&self) -> HashMap<String, String> {
+        self.mvcc_log_metadata.read().clone()
     }
 
     pub(crate) fn clear_mvcc_log_meta(&self) {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1955,6 +1955,10 @@ impl Database {
             cache_size: AtomicI32::new(default_cache_size),
             page_size: AtomicU16::new(page_size.get_raw()),
             wal_auto_actions: AtomicU8::new(WalAutoActions::all_enabled().bits()),
+            #[cfg(feature = "conn_raw_api")]
+            portable_logical_changes_enabled: AtomicBool::new(false),
+            #[cfg(feature = "conn_raw_api")]
+            mvcc_log_metadata: RwLock::new(HashMap::default()),
             capture_data_changes: RwLock::new(None),
             cdc_transaction_id: AtomicI64::new(-1),
             closed: AtomicBool::new(false),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -571,6 +571,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                                     // No BTreeDestroyIndex needed since there's no physical B-tree.
                                     let index_id = MVTableId(root_page);
                                     self.destroyed_indexes.insert(index_id);
+                                    self.mvstore.remove_table_id_to_rootpage(&index_id);
                                     skip_write = true;
                                 } else {
                                     // DROP INDEX - index was checkpointed
@@ -620,13 +621,16 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                         }
                         SqliteSchemaBtreeKind::Table => {
                             // This is a table schema change (existing logic)
-                            tracing::trace!("table schema change with root page {root_page}, is_delete={is_delete}");
+                            tracing::trace!(
+                                "table schema change with root page {root_page}, is_delete={is_delete}"
+                            );
                             if is_delete {
                                 if root_page < 0 {
                                     // Table was never checkpointed - derive table_id directly from root_page.
                                     // No BTreeDestroy needed since there's no physical B-tree.
                                     let table_id = MVTableId::from(root_page);
                                     self.destroyed_tables.insert(table_id);
+                                    self.mvstore.remove_table_id_to_rootpage(&table_id);
                                     skip_write = true;
                                 } else {
                                     // Table was checkpointed - look up by physical root page
@@ -1252,6 +1256,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             // Evict stale cursor.
                             self.cursors.remove(&root_page);
                             self.destroyed_tables.insert(table_id);
+                            self.mvstore.remove_table_id_to_rootpage(&table_id);
                         }
                         SpecialWrite::BTreeCreateIndex { index_id, .. } => {
                             let created_root_page: u32 = self.pager.io.block(|| {
@@ -1313,6 +1318,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                             // Evict stale cursor.
                             self.cursors.remove(&root_page);
                             self.destroyed_indexes.insert(index_id);
+                            self.mvstore.remove_table_id_to_rootpage(&index_id);
                         }
                     }
                 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -57,15 +57,14 @@ pub use checkpoint_state_machine::{
 };
 
 use super::persistent_storage::logical_log::{
-    HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader, StreamingResult,
-    LOG_HDR_SIZE,
+    parse_ops_from_plaintext, HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader,
+    StreamingResult, LOG_HDR_SIZE, LOG_RECORD_PREFIX_SIZE,
 };
 #[cfg(feature = "conn_raw_api")]
 use super::portable_logical::{
-    encode_header_logical_op, encode_row_logical_op, encode_schema_logical_op,
-    portable_schema_row_from_record, prepend_origin_client_id, stable_table_id_from_rootpage,
-    LOGICAL_OP_DELETE_ROW, LOGICAL_OP_UPSERT_ROW, LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_DROP,
-    LOGICAL_SCHEMA_REFRESH,
+    portable_schema_kind, portable_schema_row_from_record, stable_table_id_from_rootpage,
+    PortableLogicalBuilder, PortableObjectMapEntry, LOGICAL_OP_DELETE_ROW, LOGICAL_OP_UPSERT_ROW,
+    LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_DROP, LOGICAL_SCHEMA_REFRESH,
 };
 
 #[cfg(test)]
@@ -363,15 +362,15 @@ pub struct LogRecord {
     /// True once a `DatabaseHeader` op has been appended. At most one
     /// header op is allowed per transaction.
     pub has_header: bool,
-    /// Row/header images retained long enough to build portable logical changes.
+    /// Old sqlite_schema row images for schema deletes.
     ///
-    /// Recovery writes use `buf`; portable-change encoding needs the decoded
-    /// logical row versions while the committing connection still has the
-    /// matching schema context.
+    /// Recovery delete ops only need a rowid. Portable schema-drop events also
+    /// need the deleted object's name/kind/sql, so keep only those rare rows
+    /// instead of duplicating every committed row image.
     #[cfg(feature = "conn_raw_api")]
-    pub portable_row_versions: Vec<RowVersion>,
+    pub portable_schema_deletes: Vec<(i64, Vec<u8>)>,
     #[cfg(feature = "conn_raw_api")]
-    pub portable_header: Option<DatabaseHeader>,
+    pub portable_deleted_table_rows: HashMap<(MVTableId, i64), Vec<u8>>,
     /// Portable logical-change metadata stored alongside the MVCC recovery log.
     ///
     /// Recovery ignores this field. It is present so raw-log consumers can
@@ -395,9 +394,9 @@ impl LogRecord {
             op_count: 0,
             has_header: false,
             #[cfg(feature = "conn_raw_api")]
-            portable_row_versions: Vec::new(),
+            portable_schema_deletes: Vec::new(),
             #[cfg(feature = "conn_raw_api")]
-            portable_header: None,
+            portable_deleted_table_rows: HashMap::default(),
             #[cfg(feature = "conn_raw_api")]
             portable_changes: Vec::new(),
         }
@@ -445,7 +444,27 @@ impl LogRecord {
         .expect("failed to serialize row version in test");
         self.op_count += 1;
         #[cfg(feature = "conn_raw_api")]
-        self.portable_row_versions.push(row_version.clone());
+        if row_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID
+            && matches!(
+                row_version.end,
+                Some(TxTimestampOrID::Timestamp(ts)) if ts == self.tx_timestamp
+            )
+        {
+            self.portable_schema_deletes.push((
+                row_version.row.id.row_id.to_int_or_panic(),
+                row_version.row.payload().to_vec(),
+            ));
+        } else if matches!(
+            row_version.end,
+            Some(TxTimestampOrID::Timestamp(ts)) if ts == self.tx_timestamp
+        ) {
+            if let RowKey::Int(rowid) = row_version.row.id.row_id {
+                self.portable_deleted_table_rows.insert(
+                    (row_version.row.id.table_id, rowid),
+                    row_version.row.payload().to_vec(),
+                );
+            }
+        }
     }
 
     /// Test-only: append a `DatabaseHeader` op to the payload buffer.
@@ -455,10 +474,6 @@ impl LogRecord {
         crate::mvcc::persistent_storage::logical_log::serialize_header_entry(&mut self.buf, header);
         self.has_header = true;
         self.op_count += 1;
-        #[cfg(feature = "conn_raw_api")]
-        {
-            self.portable_header = Some(*header);
-        }
     }
 }
 
@@ -476,6 +491,9 @@ fn portable_table_id_from_rootpage(rootpage: i64) -> MVTableId {
 struct PortableTableRef {
     name: String,
     stable_table_id: u64,
+    kind: u64,
+    sql: Option<String>,
+    rootpage_debug: i64,
 }
 
 /// A transaction timestamp or ID.
@@ -1992,7 +2010,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         // BeginCommitLogicalLog (or directly to CommitEnd if there is nothing
         // to log).
         let mut log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
-        self.populate_portable_changes(mvcc_store, &mut log_record);
+        self.populate_portable_changes(mvcc_store, &mut log_record)?;
         tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
 
         if log_record.is_empty() {
@@ -2016,67 +2034,81 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         &self,
         mvcc_store: &Arc<MvStore<Clock>>,
         log_record: &mut LogRecord,
-    ) {
+    ) -> Result<()> {
         #[cfg(not(feature = "conn_raw_api"))]
         {
             let _ = mvcc_store;
             let _ = log_record;
-            return;
+            return Ok(());
         }
 
         #[cfg(feature = "conn_raw_api")]
         {
             if !self.connection.portable_logical_changes_enabled() {
-                return;
+                return Ok(());
             }
 
-            let mut encoded_ops = Vec::new();
+            let mut builder = PortableLogicalBuilder::new();
             let origin_client_id = if self.db_id == crate::MAIN_DB_ID {
-                self.connection.take_mvcc_log_meta().remove("client")
+                self.connection
+                    .mvcc_log_meta_snapshot()
+                    .get("client")
+                    .cloned()
             } else {
                 None
             };
-
-            if let Some(header) = log_record.portable_header.as_ref() {
-                encode_header_logical_op(header, &mut encoded_ops);
-            }
-
-            if log_record.portable_row_versions.is_empty() {
-                log_record.portable_changes = encoded_ops;
-                return;
-            }
 
             // Portable changes are the durable, replay-ready representation of this
             // commit. Build it while the committing connection still has the exact
             // schema context that produced the recovery log record.
             let mut table_refs_by_id = HashMap::default();
+            let recovery_payload = &log_record.buf[LOG_RECORD_PREFIX_SIZE..];
+            let parsed_ops = parse_ops_from_plaintext(
+                recovery_payload,
+                recovery_payload.len(),
+                log_record.op_count,
+                log_record.tx_timestamp,
+            )?;
 
             let mut schema_upserts = HashMap::default();
             let mut schema_deletes = HashMap::default();
             let mut schema_rowids = Vec::new();
             let mut data_table_ids = HashSet::default();
-            for version in &log_record.portable_row_versions {
-                if version.row.id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    if !matches!(version.row.id.row_id, RowKey::Record(_)) {
-                        data_table_ids.insert(version.row.id.table_id);
-                    }
-                    continue;
-                }
-                let rowid = version.row.id.row_id.to_int_or_panic();
-                if version.begin == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
-                    if let Ok(row) = portable_schema_row_from_record(version.row.payload()) {
+            for (rowid, record) in &log_record.portable_schema_deletes {
+                let row = portable_schema_row_from_record(record)?;
+                schema_rowids.push(*rowid);
+                schema_deletes.insert(*rowid, row);
+            }
+            for op in &parsed_ops {
+                match op {
+                    ParsedOp::UpsertTable {
+                        table_id,
+                        rowid,
+                        record_bytes,
+                        ..
+                    } if *table_id == SQLITE_SCHEMA_MVCC_TABLE_ID => {
+                        let rowid = rowid.row_id.to_int_or_panic();
+                        let row = portable_schema_row_from_record(record_bytes)?;
                         schema_rowids.push(rowid);
                         schema_upserts.insert(rowid, row);
                     }
-                }
-                if version.end == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
-                    if let Ok(row) = portable_schema_row_from_record(version.row.payload()) {
-                        schema_rowids.push(rowid);
-                        schema_deletes.insert(rowid, row);
-                    } else {
-                        tracing::debug!(
-                            "unable to encode sqlite_schema delete for portable changes: rowid={rowid}"
-                        );
+                    ParsedOp::UpsertTable { table_id, .. }
+                    | ParsedOp::UpsertIndex { table_id, .. }
+                    | ParsedOp::DeleteIndex { table_id, .. } => {
+                        if !matches!(
+                            op,
+                            ParsedOp::UpsertIndex { .. } | ParsedOp::DeleteIndex { .. }
+                        ) {
+                            data_table_ids.insert(*table_id);
+                        }
+                    }
+                    ParsedOp::DeleteTable { rowid, .. } => {
+                        if rowid.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                            data_table_ids.insert(rowid.table_id);
+                        }
+                    }
+                    ParsedOp::UpdateHeader { header, .. } => {
+                        builder.encode_header_logical_op(header);
                     }
                 }
             }
@@ -2098,21 +2130,25 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                             if let Some(stable_table_id) =
                                 stable_table_id_from_rootpage(new_row.rootpage)
                             {
-                                table_refs_by_id.insert(
-                                    table_id,
-                                    PortableTableRef {
-                                        name: new_row.name.clone(),
-                                        stable_table_id,
-                                    },
-                                );
+                                if let Some(kind) = portable_schema_kind(&new_row.row_type) {
+                                    table_refs_by_id.insert(
+                                        table_id,
+                                        PortableTableRef {
+                                            name: new_row.name.clone(),
+                                            stable_table_id,
+                                            kind,
+                                            sql: new_row.sql.clone(),
+                                            rootpage_debug: new_row.rootpage,
+                                        },
+                                    );
+                                }
                             }
                         }
                         let stable_table_id = stable_table_id_from_rootpage(new_row.rootpage);
-                        if encode_schema_logical_op(
+                        if builder.encode_schema_logical_op(
                             LOGICAL_SCHEMA_REFRESH,
                             new_row,
                             stable_table_id,
-                            &mut encoded_ops,
                         ) {
                             if let Some(stable_table_id) = stable_table_id {
                                 emitted_schema_stable_ids.insert(stable_table_id);
@@ -2125,21 +2161,25 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                             if let Some(stable_table_id) =
                                 stable_table_id_from_rootpage(new_row.rootpage)
                             {
-                                table_refs_by_id.insert(
-                                    table_id,
-                                    PortableTableRef {
-                                        name: new_row.name.clone(),
-                                        stable_table_id,
-                                    },
-                                );
+                                if let Some(kind) = portable_schema_kind(&new_row.row_type) {
+                                    table_refs_by_id.insert(
+                                        table_id,
+                                        PortableTableRef {
+                                            name: new_row.name.clone(),
+                                            stable_table_id,
+                                            kind,
+                                            sql: new_row.sql.clone(),
+                                            rootpage_debug: new_row.rootpage,
+                                        },
+                                    );
+                                }
                             }
                         }
                         let stable_table_id = stable_table_id_from_rootpage(new_row.rootpage);
-                        if encode_schema_logical_op(
+                        if builder.encode_schema_logical_op(
                             LOGICAL_SCHEMA_CREATE,
                             new_row,
                             stable_table_id,
-                            &mut encoded_ops,
                         ) {
                             if let Some(stable_table_id) = stable_table_id {
                                 emitted_schema_stable_ids.insert(stable_table_id);
@@ -2148,11 +2188,10 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                     }
                     (Some(old_row), None) => {
                         let stable_table_id = stable_table_id_from_rootpage(old_row.rootpage);
-                        if encode_schema_logical_op(
+                        if builder.encode_schema_logical_op(
                             LOGICAL_SCHEMA_DROP,
                             old_row,
                             stable_table_id,
-                            &mut encoded_ops,
                         ) {
                             if let Some(stable_table_id) = stable_table_id {
                                 emitted_schema_stable_ids.insert(stable_table_id);
@@ -2205,6 +2244,9 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         PortableTableRef {
                             name: name.to_string(),
                             stable_table_id,
+                            kind: 0,
+                            sql: None,
+                            rootpage_debug: rootpage,
                         }
                     } else if rootpage < 0 {
                         let checkpointed_rootpage = -rootpage;
@@ -2220,6 +2262,25 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         PortableTableRef {
                             name: name.to_string(),
                             stable_table_id,
+                            kind: 0,
+                            sql: None,
+                            rootpage_debug: checkpointed_rootpage,
+                        }
+                    } else if rootpage > 0 {
+                        let uncheckpointed_rootpage = -rootpage;
+                        let Some(name) = schema.table_name_for_root_page(uncheckpointed_rootpage)
+                        else {
+                            continue;
+                        };
+                        let Some(stable_table_id) = stable_table_id_from_rootpage(rootpage) else {
+                            continue;
+                        };
+                        PortableTableRef {
+                            name: name.to_string(),
+                            stable_table_id,
+                            kind: 0,
+                            sql: None,
+                            rootpage_debug: rootpage,
                         }
                     } else {
                         continue;
@@ -2237,52 +2298,88 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 }
             }
 
-            for version in &log_record.portable_row_versions {
-                let table_id = version.row.id.table_id;
-                if table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    continue;
-                }
-                if matches!(version.row.id.row_id, RowKey::Record(_)) {
-                    continue;
-                }
-                let Some(table_ref) = table_refs_by_id.get(&table_id) else {
-                    tracing::debug!(
-                        "unable to encode MVCC row portable changes: table_id={table_id}"
-                    );
-                    continue;
-                };
-                let rowid = version.row.id.row_id.to_int_or_panic();
-                let include_table_name =
-                    !emitted_schema_stable_ids.contains(&table_ref.stable_table_id);
-                if version.begin == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
-                    encode_row_logical_op(
-                        LOGICAL_OP_UPSERT_ROW,
-                        &table_ref.name,
-                        include_table_name,
-                        table_ref.stable_table_id,
+            for (table_id, table_ref) in &table_refs_by_id {
+                builder.add_object_map(PortableObjectMapEntry {
+                    mv_table_id: i64::from(*table_id),
+                    kind: table_ref.kind,
+                    logical_object_id: table_ref.stable_table_id,
+                    name: &table_ref.name,
+                    schema_epoch: log_record.tx_timestamp,
+                    create_sql: table_ref.sql.as_deref(),
+                    rootpage_debug: table_ref.rootpage_debug,
+                });
+            }
+
+            for op in &parsed_ops {
+                match op {
+                    ParsedOp::UpsertTable {
+                        table_id,
                         rowid,
-                        version.row.payload(),
-                        &mut encoded_ops,
-                    );
-                }
-                if version.end == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
-                    encode_row_logical_op(
-                        LOGICAL_OP_DELETE_ROW,
-                        &table_ref.name,
-                        include_table_name,
-                        table_ref.stable_table_id,
-                        rowid,
-                        &[],
-                        &mut encoded_ops,
-                    );
+                        record_bytes: _,
+                        ..
+                    } if *table_id != SQLITE_SCHEMA_MVCC_TABLE_ID => {
+                        let Some(table_ref) = table_refs_by_id.get(table_id) else {
+                            return Err(LimboError::InternalError(format!(
+                                "unable to encode MVCC row portable changes: table_id={table_id}"
+                            )));
+                        };
+                        if !emitted_schema_stable_ids.contains(&table_ref.stable_table_id) {
+                            builder.add_object_map(PortableObjectMapEntry {
+                                mv_table_id: i64::from(*table_id),
+                                kind: table_ref.kind,
+                                logical_object_id: table_ref.stable_table_id,
+                                name: &table_ref.name,
+                                schema_epoch: log_record.tx_timestamp,
+                                create_sql: table_ref.sql.as_deref(),
+                                rootpage_debug: table_ref.rootpage_debug,
+                            });
+                        }
+                        builder.encode_row_logical_op(
+                            LOGICAL_OP_UPSERT_ROW,
+                            i64::from(*table_id),
+                            rowid.row_id.to_int_or_panic(),
+                            &[],
+                        );
+                    }
+                    ParsedOp::DeleteTable { rowid, .. }
+                        if rowid.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID =>
+                    {
+                        let Some(table_ref) = table_refs_by_id.get(&rowid.table_id) else {
+                            return Err(LimboError::InternalError(format!(
+                                "unable to encode MVCC row portable changes: table_id={}",
+                                rowid.table_id
+                            )));
+                        };
+                        if !emitted_schema_stable_ids.contains(&table_ref.stable_table_id) {
+                            builder.add_object_map(PortableObjectMapEntry {
+                                mv_table_id: i64::from(rowid.table_id),
+                                kind: table_ref.kind,
+                                logical_object_id: table_ref.stable_table_id,
+                                name: &table_ref.name,
+                                schema_epoch: log_record.tx_timestamp,
+                                create_sql: table_ref.sql.as_deref(),
+                                rootpage_debug: table_ref.rootpage_debug,
+                            });
+                        }
+                        let rowid_int = rowid.row_id.to_int_or_panic();
+                        let deleted_record = log_record
+                            .portable_deleted_table_rows
+                            .get(&(rowid.table_id, rowid_int))
+                            .map(Vec::as_slice)
+                            .unwrap_or(&[]);
+                        builder.encode_row_logical_op(
+                            LOGICAL_OP_DELETE_ROW,
+                            i64::from(rowid.table_id),
+                            rowid_int,
+                            deleted_record,
+                        );
+                    }
+                    _ => {}
                 }
             }
 
-            if let Some(client_id) = origin_client_id {
-                encoded_ops = prepend_origin_client_id(&client_id, encoded_ops);
-            }
-
-            log_record.portable_changes = encoded_ops;
+            log_record.portable_changes = builder.finish(origin_client_id);
+            Ok(())
         }
     }
 
@@ -4737,9 +4834,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let tx = tx_unlocked.value();
         if let Some(connection) = connection {
             connection.set_mv_tx_for_db(db, None);
-            if db == crate::MAIN_DB_ID {
-                connection.clear_mvcc_log_meta();
-            }
         }
         turso_assert!(matches!(
             tx.state.load(),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -60,6 +60,13 @@ use super::persistent_storage::logical_log::{
     HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader, StreamingResult,
     LOG_HDR_SIZE,
 };
+#[cfg(feature = "conn_raw_api")]
+use super::portable_logical::{
+    encode_header_logical_op, encode_row_logical_op, encode_schema_logical_op,
+    portable_schema_row_from_record, prepend_origin_client_id, stable_table_id_from_rootpage,
+    LOGICAL_OP_DELETE_ROW, LOGICAL_OP_UPSERT_ROW, LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_DROP,
+    LOGICAL_SCHEMA_REFRESH,
+};
 
 #[cfg(test)]
 pub mod hermitage_tests;
@@ -356,6 +363,22 @@ pub struct LogRecord {
     /// True once a `DatabaseHeader` op has been appended. At most one
     /// header op is allowed per transaction.
     pub has_header: bool,
+    /// Row/header images retained long enough to build portable logical changes.
+    ///
+    /// Recovery writes use `buf`; portable-change encoding needs the decoded
+    /// logical row versions while the committing connection still has the
+    /// matching schema context.
+    #[cfg(feature = "conn_raw_api")]
+    pub portable_row_versions: Vec<RowVersion>,
+    #[cfg(feature = "conn_raw_api")]
+    pub portable_header: Option<DatabaseHeader>,
+    /// Portable logical-change metadata stored alongside the MVCC recovery log.
+    ///
+    /// Recovery ignores this field. It is present so raw-log consumers can
+    /// replay stable logical operations without reconstructing table/schema
+    /// identity from historical recovery records.
+    #[cfg(feature = "conn_raw_api")]
+    pub portable_changes: Vec<u8>,
 }
 
 impl LogRecord {
@@ -371,6 +394,12 @@ impl LogRecord {
             buf: vec![0u8; crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE],
             op_count: 0,
             has_header: false,
+            #[cfg(feature = "conn_raw_api")]
+            portable_row_versions: Vec::new(),
+            #[cfg(feature = "conn_raw_api")]
+            portable_header: None,
+            #[cfg(feature = "conn_raw_api")]
+            portable_changes: Vec::new(),
         }
     }
 
@@ -415,6 +444,8 @@ impl LogRecord {
         )
         .expect("failed to serialize row version in test");
         self.op_count += 1;
+        #[cfg(feature = "conn_raw_api")]
+        self.portable_row_versions.push(row_version.clone());
     }
 
     /// Test-only: append a `DatabaseHeader` op to the payload buffer.
@@ -424,7 +455,27 @@ impl LogRecord {
         crate::mvcc::persistent_storage::logical_log::serialize_header_entry(&mut self.buf, header);
         self.has_header = true;
         self.op_count += 1;
+        #[cfg(feature = "conn_raw_api")]
+        {
+            self.portable_header = Some(*header);
+        }
     }
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn portable_table_id_from_rootpage(rootpage: i64) -> MVTableId {
+    if rootpage > 0 {
+        MVTableId::from(-rootpage)
+    } else {
+        MVTableId::from(rootpage)
+    }
+}
+
+#[derive(Clone, Debug)]
+#[cfg(feature = "conn_raw_api")]
+struct PortableTableRef {
+    name: String,
+    stable_table_id: u64,
 }
 
 /// A transaction timestamp or ID.
@@ -1262,6 +1313,11 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
     fn cleanup_unfinished_commit(&mut self) {
         if !self.is_finalized {
             self.cleanup_mvcc_checkpoint_state();
+            if self.pending_log_append_bytes.take().is_some() {
+                if let Err(err) = self.mvcc_store.storage.discard_pending_log_write() {
+                    tracing::error!("failed to discard pending MVCC logical-log write: {err}");
+                }
+            }
             if !matches!(self.state, CommitState::Checkpoint { .. }) {
                 self.mvcc_store.cleanup_dropped_commit(
                     self.tx_id,
@@ -1474,7 +1530,10 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         end_tx_id,
                     ) {
                         Some(TransactionState::Committed(committed_end_ts)) => {
-                            turso_assert!(committed_end_ts != tx.begin_ts, "committed end_ts and begin_ts cannot be equal: txn timestamps are strictly monotonic");
+                            turso_assert!(
+                                committed_end_ts != tx.begin_ts,
+                                "committed end_ts and begin_ts cannot be equal: txn timestamps are strictly monotonic"
+                            );
                             if committed_end_ts > tx.begin_ts {
                                 return Err(LimboError::WriteWriteConflict);
                             }
@@ -1909,7 +1968,6 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             ctx.cursor += 1;
             iterations += 1;
         }
-
         if ctx.cursor < write_set_len {
             // More work remains in the current pass: yield and resume.
             return Ok(TransitionResult::Io(IOCompletions::Single(
@@ -1933,7 +1991,8 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         // Move the assembled log record out and transition to
         // BeginCommitLogicalLog (or directly to CommitEnd if there is nothing
         // to log).
-        let log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
+        let mut log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
+        self.populate_portable_changes(mvcc_store, &mut log_record);
         tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
 
         if log_record.is_empty() {
@@ -1951,6 +2010,280 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         }
         inject_transition_yield!(self, CommitYieldPoint::LogRecordPrepared);
         Ok(TransitionResult::Continue)
+    }
+
+    fn populate_portable_changes(
+        &self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+        log_record: &mut LogRecord,
+    ) {
+        #[cfg(not(feature = "conn_raw_api"))]
+        {
+            let _ = mvcc_store;
+            let _ = log_record;
+            return;
+        }
+
+        #[cfg(feature = "conn_raw_api")]
+        {
+            if !self.connection.portable_logical_changes_enabled() {
+                return;
+            }
+
+            let mut encoded_ops = Vec::new();
+            let origin_client_id = if self.db_id == crate::MAIN_DB_ID {
+                self.connection.take_mvcc_log_meta().remove("client")
+            } else {
+                None
+            };
+
+            if let Some(header) = log_record.portable_header.as_ref() {
+                encode_header_logical_op(header, &mut encoded_ops);
+            }
+
+            if log_record.portable_row_versions.is_empty() {
+                log_record.portable_changes = encoded_ops;
+                return;
+            }
+
+            // Portable changes are the durable, replay-ready representation of this
+            // commit. Build it while the committing connection still has the exact
+            // schema context that produced the recovery log record.
+            let mut table_refs_by_id = HashMap::default();
+
+            let mut schema_upserts = HashMap::default();
+            let mut schema_deletes = HashMap::default();
+            let mut schema_rowids = Vec::new();
+            let mut data_table_ids = HashSet::default();
+            for version in &log_record.portable_row_versions {
+                if version.row.id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    if !matches!(version.row.id.row_id, RowKey::Record(_)) {
+                        data_table_ids.insert(version.row.id.table_id);
+                    }
+                    continue;
+                }
+                let rowid = version.row.id.row_id.to_int_or_panic();
+                if version.begin == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
+                    if let Ok(row) = portable_schema_row_from_record(version.row.payload()) {
+                        schema_rowids.push(rowid);
+                        schema_upserts.insert(rowid, row);
+                    }
+                }
+                if version.end == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
+                    if let Ok(row) = portable_schema_row_from_record(version.row.payload()) {
+                        schema_rowids.push(rowid);
+                        schema_deletes.insert(rowid, row);
+                    } else {
+                        tracing::debug!(
+                            "unable to encode sqlite_schema delete for portable changes: rowid={rowid}"
+                        );
+                    }
+                }
+            }
+
+            let mut emitted_schema_stable_ids = HashSet::default();
+            schema_rowids.sort_unstable();
+            schema_rowids.dedup();
+            for rowid in schema_rowids {
+                let old_row = schema_deletes.get(&rowid);
+                let new_row = schema_upserts.get(&rowid);
+                match (old_row, new_row) {
+                    (Some(old_row), Some(new_row)) => {
+                        if old_row.rootpage != 0 {
+                            let table_id = portable_table_id_from_rootpage(old_row.rootpage);
+                            table_refs_by_id.remove(&table_id);
+                        }
+                        if new_row.rootpage != 0 {
+                            let table_id = portable_table_id_from_rootpage(new_row.rootpage);
+                            if let Some(stable_table_id) =
+                                stable_table_id_from_rootpage(new_row.rootpage)
+                            {
+                                table_refs_by_id.insert(
+                                    table_id,
+                                    PortableTableRef {
+                                        name: new_row.name.clone(),
+                                        stable_table_id,
+                                    },
+                                );
+                            }
+                        }
+                        let stable_table_id = stable_table_id_from_rootpage(new_row.rootpage);
+                        if encode_schema_logical_op(
+                            LOGICAL_SCHEMA_REFRESH,
+                            new_row,
+                            stable_table_id,
+                            &mut encoded_ops,
+                        ) {
+                            if let Some(stable_table_id) = stable_table_id {
+                                emitted_schema_stable_ids.insert(stable_table_id);
+                            }
+                        }
+                    }
+                    (None, Some(new_row)) => {
+                        if new_row.rootpage != 0 {
+                            let table_id = portable_table_id_from_rootpage(new_row.rootpage);
+                            if let Some(stable_table_id) =
+                                stable_table_id_from_rootpage(new_row.rootpage)
+                            {
+                                table_refs_by_id.insert(
+                                    table_id,
+                                    PortableTableRef {
+                                        name: new_row.name.clone(),
+                                        stable_table_id,
+                                    },
+                                );
+                            }
+                        }
+                        let stable_table_id = stable_table_id_from_rootpage(new_row.rootpage);
+                        if encode_schema_logical_op(
+                            LOGICAL_SCHEMA_CREATE,
+                            new_row,
+                            stable_table_id,
+                            &mut encoded_ops,
+                        ) {
+                            if let Some(stable_table_id) = stable_table_id {
+                                emitted_schema_stable_ids.insert(stable_table_id);
+                            }
+                        }
+                    }
+                    (Some(old_row), None) => {
+                        let stable_table_id = stable_table_id_from_rootpage(old_row.rootpage);
+                        if encode_schema_logical_op(
+                            LOGICAL_SCHEMA_DROP,
+                            old_row,
+                            stable_table_id,
+                            &mut encoded_ops,
+                        ) {
+                            if let Some(stable_table_id) = stable_table_id {
+                                emitted_schema_stable_ids.insert(stable_table_id);
+                            }
+                        }
+                        if old_row.rootpage != 0 {
+                            let table_id = portable_table_id_from_rootpage(old_row.rootpage);
+                            table_refs_by_id.remove(&table_id);
+                        }
+                    }
+                    (None, None) => {}
+                }
+            }
+
+            let rootpage_for_table_id = |table_id: MVTableId| -> i64 {
+                mvcc_store
+                    .table_id_to_rootpage
+                    .get(&table_id)
+                    .and_then(|entry| *entry.value())
+                    .map(|rootpage| rootpage as i64)
+                    .unwrap_or_else(|| i64::from(table_id))
+            };
+
+            let mut unresolved_data_tables = Vec::new();
+            let mut needed_rootpages = HashSet::default();
+            for table_id in data_table_ids {
+                if table_refs_by_id.contains_key(&table_id) {
+                    continue;
+                }
+                let rootpage = rootpage_for_table_id(table_id);
+                if rootpage == 0 {
+                    continue;
+                }
+                let root_table_id = portable_table_id_from_rootpage(rootpage);
+                if let Some(table_ref) = table_refs_by_id.get(&root_table_id).cloned() {
+                    table_refs_by_id.insert(table_id, table_ref);
+                    continue;
+                }
+                needed_rootpages.insert(rootpage);
+                unresolved_data_tables.push((table_id, root_table_id));
+            }
+
+            if !needed_rootpages.is_empty() {
+                let schema = self.connection.schema.read();
+                for rootpage in needed_rootpages {
+                    let table_ref = if let Some(name) = schema.table_name_for_root_page(rootpage) {
+                        let Some(stable_table_id) = stable_table_id_from_rootpage(rootpage) else {
+                            continue;
+                        };
+                        PortableTableRef {
+                            name: name.to_string(),
+                            stable_table_id,
+                        }
+                    } else if rootpage < 0 {
+                        let checkpointed_rootpage = -rootpage;
+                        let Some(name) = schema.table_name_for_root_page(checkpointed_rootpage)
+                        else {
+                            continue;
+                        };
+                        let Some(stable_table_id) =
+                            stable_table_id_from_rootpage(checkpointed_rootpage)
+                        else {
+                            continue;
+                        };
+                        PortableTableRef {
+                            name: name.to_string(),
+                            stable_table_id,
+                        }
+                    } else {
+                        continue;
+                    };
+                    table_refs_by_id.insert(
+                        MVTableId::from(-(table_ref.stable_table_id as i64)),
+                        table_ref,
+                    );
+                }
+
+                for (table_id, root_table_id) in unresolved_data_tables {
+                    if let Some(table_ref) = table_refs_by_id.get(&root_table_id).cloned() {
+                        table_refs_by_id.insert(table_id, table_ref);
+                    }
+                }
+            }
+
+            for version in &log_record.portable_row_versions {
+                let table_id = version.row.id.table_id;
+                if table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+                    continue;
+                }
+                if matches!(version.row.id.row_id, RowKey::Record(_)) {
+                    continue;
+                }
+                let Some(table_ref) = table_refs_by_id.get(&table_id) else {
+                    tracing::debug!(
+                        "unable to encode MVCC row portable changes: table_id={table_id}"
+                    );
+                    continue;
+                };
+                let rowid = version.row.id.row_id.to_int_or_panic();
+                let include_table_name =
+                    !emitted_schema_stable_ids.contains(&table_ref.stable_table_id);
+                if version.begin == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
+                    encode_row_logical_op(
+                        LOGICAL_OP_UPSERT_ROW,
+                        &table_ref.name,
+                        include_table_name,
+                        table_ref.stable_table_id,
+                        rowid,
+                        version.row.payload(),
+                        &mut encoded_ops,
+                    );
+                }
+                if version.end == Some(TxTimestampOrID::Timestamp(log_record.tx_timestamp)) {
+                    encode_row_logical_op(
+                        LOGICAL_OP_DELETE_ROW,
+                        &table_ref.name,
+                        include_table_name,
+                        table_ref.stable_table_id,
+                        rowid,
+                        &[],
+                        &mut encoded_ops,
+                    );
+                }
+            }
+
+            if let Some(client_id) = origin_client_id {
+                encoded_ops = prepend_origin_client_id(&client_id, encoded_ops);
+            }
+
+            log_record.portable_changes = encoded_ops;
+        }
     }
 
     /// Run one chunked step of `RewriteLiveVersions`. Processes up to
@@ -2403,6 +2736,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
             }
 
             CommitState::SyncLogicalLog { end_ts } => {
+                mvcc_store.storage.on_log_write_complete()?;
                 // Skip fsync when synchronous mode is not FULL.
                 // NORMAL mode skips fsync on commit (but still fsyncs on checkpoint).
                 if self.sync_mode != SyncMode::Full {
@@ -2433,6 +2767,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .as_ref()
                         .map(|header| header.schema_cookie.get())
                         != Some(tx_header.schema_cookie.get());
+                self.did_commit_schema_change = schema_did_change;
                 if schema_did_change {
                     let schema = self.connection.schema.read().clone();
                     self.connection.db.update_schema_if_newer(schema);
@@ -2477,7 +2812,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 if let Some(append_bytes) = self.pending_log_append_bytes.take() {
                     mvcc_store
                         .storage
-                        .advance_logical_log_offset_after_success(append_bytes);
+                        .advance_logical_log_offset_after_success(append_bytes)?;
                 }
                 tx_unlocked
                     .state
@@ -3044,6 +3379,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
+    pub fn remove_table_id_to_rootpage(&self, table_id: &MVTableId) {
+        self.table_id_to_rootpage.remove(table_id);
+        self.table_id_to_last_rowid.write().remove(table_id);
+    }
+
     /// Acquire MVCC's stop-the-world gate for VACUUM.
     ///
     /// This is the same lock used by MVCC checkpointing. All MVCC transactions
@@ -3170,7 +3510,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             Err(err) => {
                 return Err(LimboError::Corrupt(format!(
                     "Failed to read MVCC metadata table: {err}"
-                )))
+                )));
             }
         };
         let mut value: Option<i64> = None;
@@ -4397,6 +4737,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let tx = tx_unlocked.value();
         if let Some(connection) = connection {
             connection.set_mv_tx_for_db(db, None);
+            if db == crate::MAIN_DB_ID {
+                connection.clear_mvcc_log_meta();
+            }
         }
         turso_assert!(matches!(
             tx.state.load(),
@@ -5211,6 +5554,36 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         self.storage.get_logical_log_file()
     }
 
+    pub fn logical_log_offset(&self) -> u64 {
+        self.storage.logical_log_offset()
+    }
+
+    /// Replace the logical log with a fresh valid header after the database
+    /// file was restored outside MVCC.
+    ///
+    /// The returned completion must finish before reopening/recovering MVCC
+    /// state. Otherwise recovery could replay stale local logical-log frames on
+    /// top of the restored database image.
+    pub fn reset_logical_log_after_external_restore(&self) -> Result<Completion> {
+        self.storage.reset_to_fresh_header()
+    }
+
+    /// Return the durable sync completion for the freshly reset logical log.
+    ///
+    /// This is separate from `reset_logical_log_after_external_restore` so
+    /// callers can drive the reset completion cooperatively, then issue the
+    /// ordered sync only after the header/truncate group has completed.
+    pub fn sync_logical_log_after_external_restore(
+        &self,
+        connection: &Arc<Connection>,
+    ) -> Result<Option<Completion>> {
+        if connection.get_sync_mode() != SyncMode::Off {
+            let pager = connection.pager.load().clone();
+            return Ok(Some(self.storage.sync(pager.get_sync_type())?));
+        }
+        Ok(None)
+    }
+
     fn logical_log_header_crc_valid(&self, pager: &Arc<Pager>) -> Result<bool> {
         let file = self.get_logical_log_file();
         // Header is never encrypted; no need to pass EncryptionContext here.
@@ -5269,12 +5642,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             HeaderReadResult::NoLog => {
                 return Err(LimboError::Corrupt(
                     "WAL has committed frames but logical log header is missing".to_string(),
-                ))
+                ));
             }
             HeaderReadResult::Invalid => {
                 return Err(LimboError::Corrupt(
                     "WAL has committed frames but logical log header is invalid".to_string(),
-                ))
+                ));
             }
         };
         self.storage.set_header(header);
@@ -5355,7 +5728,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             HeaderReadResult::Invalid => {
                 return Err(LimboError::Corrupt(
                     "Logical log header corrupt and no WAL recovery available".to_string(),
-                ))
+                ));
             }
         };
 
@@ -5369,7 +5742,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 None => {
                     return Err(LimboError::Corrupt(
                         "Missing MVCC metadata table".to_string(),
-                    ))
+                    ));
                 }
             }
         } else {
@@ -5433,7 +5806,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     _ => {
                         return Err(LimboError::Corrupt(
                             "sqlite_schema type must be text".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let name = match record.get_value_opt(1) {
@@ -5441,7 +5814,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     _ => {
                         return Err(LimboError::Corrupt(
                             "sqlite_schema name must be text".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let table_name = match record.get_value_opt(2) {
@@ -5449,7 +5822,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     _ => {
                         return Err(LimboError::Corrupt(
                             "sqlite_schema tbl_name must be text".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let root_page = match record.get_value_opt(3) {
@@ -5457,7 +5830,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     _ => {
                         return Err(LimboError::Corrupt(
                             "sqlite_schema root_page must be integer".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let sql = match record.get_value_opt(4) {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -30,6 +30,8 @@ use crate::IOExt;
 use crate::LimboError;
 use crate::PageSize;
 use crate::Result;
+#[cfg(feature = "conn_raw_api")]
+use crate::Value;
 use crate::ValueRef;
 use crate::{
     contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case, Completion,
@@ -56,15 +58,18 @@ pub use checkpoint_state_machine::{
     sqlite_schema_btree_identity, CheckpointState, CheckpointStateMachine,
 };
 
+#[cfg(feature = "conn_raw_api")]
 use super::persistent_storage::logical_log::{
-    parse_ops_from_plaintext, HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader,
-    StreamingResult, LOG_HDR_SIZE, LOG_RECORD_PREFIX_SIZE,
+    encode_delete_portable_extension, parse_ops_from_plaintext, LOG_RECORD_PREFIX_SIZE,
+};
+use super::persistent_storage::logical_log::{
+    HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader, StreamingResult,
+    LOG_HDR_SIZE,
 };
 #[cfg(feature = "conn_raw_api")]
 use super::portable_logical::{
-    portable_schema_kind, portable_schema_row_from_record, stable_table_id_from_rootpage,
-    PortableLogicalBuilder, PortableObjectMapEntry, LOGICAL_OP_DELETE_ROW, LOGICAL_OP_UPSERT_ROW,
-    LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_DROP, LOGICAL_SCHEMA_REFRESH,
+    is_portable_logical_name, is_portable_table_schema_row, portable_schema_row_from_record,
+    PortableLogicalBuilder, PortableObjectMapEntry,
 };
 
 #[cfg(test)]
@@ -362,20 +367,10 @@ pub struct LogRecord {
     /// True once a `DatabaseHeader` op has been appended. At most one
     /// header op is allowed per transaction.
     pub has_header: bool,
-    /// Old sqlite_schema row images for schema deletes.
-    ///
-    /// Recovery delete ops only need a rowid. Portable schema-drop events also
-    /// need the deleted object's name/kind/sql, so keep only those rare rows
-    /// instead of duplicating every committed row image.
-    #[cfg(feature = "conn_raw_api")]
-    pub portable_schema_deletes: Vec<(i64, Vec<u8>)>,
-    #[cfg(feature = "conn_raw_api")]
-    pub portable_deleted_table_rows: HashMap<(MVTableId, i64), Vec<u8>>,
     /// Portable logical-change metadata stored alongside the MVCC recovery log.
     ///
-    /// Recovery ignores this field. It is present so raw-log consumers can
-    /// replay stable logical operations without reconstructing table/schema
-    /// identity from historical recovery records.
+    /// Recovery ignores this field. Raw-log consumers use it to resolve the
+    /// recovery ops' MVCC table ids and read transaction-level metadata.
     #[cfg(feature = "conn_raw_api")]
     pub portable_changes: Vec<u8>,
 }
@@ -393,10 +388,6 @@ impl LogRecord {
             buf: vec![0u8; crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE],
             op_count: 0,
             has_header: false,
-            #[cfg(feature = "conn_raw_api")]
-            portable_schema_deletes: Vec::new(),
-            #[cfg(feature = "conn_raw_api")]
-            portable_deleted_table_rows: HashMap::default(),
             #[cfg(feature = "conn_raw_api")]
             portable_changes: Vec::new(),
         }
@@ -440,31 +431,10 @@ impl LogRecord {
         crate::mvcc::persistent_storage::logical_log::serialize_op_entry(
             &mut self.buf,
             row_version,
+            None,
         )
         .expect("failed to serialize row version in test");
         self.op_count += 1;
-        #[cfg(feature = "conn_raw_api")]
-        if row_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID
-            && matches!(
-                row_version.end,
-                Some(TxTimestampOrID::Timestamp(ts)) if ts == self.tx_timestamp
-            )
-        {
-            self.portable_schema_deletes.push((
-                row_version.row.id.row_id.to_int_or_panic(),
-                row_version.row.payload().to_vec(),
-            ));
-        } else if matches!(
-            row_version.end,
-            Some(TxTimestampOrID::Timestamp(ts)) if ts == self.tx_timestamp
-        ) {
-            if let RowKey::Int(rowid) = row_version.row.id.row_id {
-                self.portable_deleted_table_rows.insert(
-                    (row_version.row.id.table_id, rowid),
-                    row_version.row.payload().to_vec(),
-                );
-            }
-        }
     }
 
     /// Test-only: append a `DatabaseHeader` op to the payload buffer.
@@ -490,10 +460,115 @@ fn portable_table_id_from_rootpage(rootpage: i64) -> MVTableId {
 #[cfg(feature = "conn_raw_api")]
 struct PortableTableRef {
     name: String,
-    stable_table_id: u64,
-    kind: u64,
-    sql: Option<String>,
-    rootpage_debug: i64,
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn rootpage_for_mv_table_id<Clock: LogicalClock>(
+    mvcc_store: &MvStore<Clock>,
+    table_id: MVTableId,
+) -> i64 {
+    mvcc_store
+        .table_id_to_rootpage
+        .get(&table_id)
+        .and_then(|entry| *entry.value())
+        .map(|rootpage| rootpage as i64)
+        .unwrap_or_else(|| i64::from(table_id))
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn portable_table_name_for_mv_table_id<Clock: LogicalClock>(
+    connection: &Connection,
+    mvcc_store: &MvStore<Clock>,
+    table_id: MVTableId,
+) -> Option<String> {
+    let rootpage = rootpage_for_mv_table_id(mvcc_store, table_id);
+    if rootpage == 0 {
+        return None;
+    }
+    let schema = connection.schema.read();
+    if let Some(name) = schema.table_name_for_root_page(rootpage) {
+        return Some(name.to_string());
+    }
+    let alternate_rootpage = -rootpage;
+    if alternate_rootpage == 0 {
+        return None;
+    }
+    schema
+        .table_name_for_root_page(alternate_rootpage)
+        .map(ToString::to_string)
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn portable_delete_op_extension_for_row_version<Clock: LogicalClock>(
+    connection: &Connection,
+    mvcc_store: &MvStore<Clock>,
+    row_version: &RowVersion,
+) -> Result<Option<Vec<u8>>> {
+    if !connection.portable_logical_changes_enabled() {
+        return Ok(None);
+    }
+    if !matches!(row_version.end, Some(TxTimestampOrID::Timestamp(_))) {
+        return Ok(None);
+    }
+    let RowKey::Int(rowid) = row_version.row.id.row_id else {
+        return Ok(None);
+    };
+
+    if row_version.row.id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
+        let extension =
+            encode_delete_portable_extension(Some(row_version.row.payload()), None, Some(rowid));
+        return Ok((!extension.is_empty()).then_some(extension));
+    }
+
+    let Some(table_name) =
+        portable_table_name_for_mv_table_id(connection, mvcc_store, row_version.row.id.table_id)
+    else {
+        return Ok(None);
+    };
+    if !is_portable_logical_name(&table_name) {
+        return Ok(None);
+    }
+
+    let schema = connection.schema.read();
+    let Some(table) = schema.get_btree_table(&table_name) else {
+        return Ok(None);
+    };
+
+    let mut record_values = None;
+    let mut pk_values = Vec::with_capacity(table.primary_key_columns.len());
+    for (pk_name, _) in &table.primary_key_columns {
+        let Some((logical_column, column)) = table.get_column(pk_name) else {
+            return Err(LimboError::InternalError(format!(
+                "primary key column {pk_name} not found for table {table_name}"
+            )));
+        };
+        if column.is_rowid_alias() {
+            pk_values.push(Value::from_i64(rowid));
+            continue;
+        }
+        let values = match &record_values {
+            Some(values) => values,
+            None => record_values.insert(
+                ImmutableRecord::from_bin_record(row_version.row.payload().to_vec())
+                    .get_values_owned()?,
+            ),
+        };
+        let physical_column = table.logical_to_physical_column(logical_column);
+        let Some(value) = values.get(physical_column).cloned() else {
+            return Err(LimboError::Corrupt(format!(
+                "DELETE_TABLE record for {table_name} missing primary key column {pk_name}"
+            )));
+        };
+        pk_values.push(value);
+    }
+
+    let pk_record = if pk_values.is_empty() {
+        Vec::new()
+    } else {
+        ImmutableRecord::from_values(&pk_values, pk_values.len())?.into_payload()
+    };
+    let extension = encode_delete_portable_extension(None, Some(&pk_record), Some(rowid));
+    Ok((!extension.is_empty()).then_some(extension))
 }
 
 /// A transaction timestamp or ID.
@@ -1663,6 +1738,8 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 ))
             })?;
         let write_set_len = tx.write_set.lock().entries.len();
+        #[cfg(feature = "conn_raw_api")]
+        let connection = Arc::clone(&self.connection);
         let CommitState::BuildLogRecord(ctx) = &mut self.state else {
             unreachable!("step_build_log_record requires BuildLogRecord state")
         };
@@ -1957,9 +2034,19 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 entry_versions.push(committed_version);
             }
             for committed_version in &entry_versions {
-                mvcc_store
-                    .storage
-                    .serialize_row_version(log_record, committed_version)?;
+                #[cfg(feature = "conn_raw_api")]
+                let portable_extension = portable_delete_op_extension_for_row_version(
+                    &connection,
+                    mvcc_store,
+                    committed_version,
+                )?;
+                #[cfg(not(feature = "conn_raw_api"))]
+                let portable_extension: Option<Vec<u8>> = None;
+                mvcc_store.storage.serialize_row_version(
+                    log_record,
+                    committed_version,
+                    portable_extension.as_deref(),
+                )?;
             }
             Ok(())
         };
@@ -2049,18 +2136,19 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
 
             let mut builder = PortableLogicalBuilder::new();
-            let origin_client_id = if self.db_id == crate::MAIN_DB_ID {
-                self.connection
-                    .mvcc_log_meta_snapshot()
-                    .get("client")
-                    .cloned()
-            } else {
-                None
-            };
+            let mut metadata: Vec<_> = self
+                .connection
+                .mvcc_log_meta_snapshot()
+                .into_iter()
+                .collect();
+            metadata.sort_by(|a, b| a.0.cmp(&b.0));
+            for (key, value) in metadata {
+                builder.add_metadata(&key, &value);
+            }
 
-            // Portable changes are the durable, replay-ready representation of this
-            // commit. Build it while the committing connection still has the exact
-            // schema context that produced the recovery log record.
+            // The recovery payload is the single durable operation stream.
+            // The portable extension only adds the metadata required to interpret
+            // recovery table ids outside this database instance.
             let mut table_refs_by_id = HashMap::default();
             let recovery_payload = &log_record.buf[LOG_RECORD_PREFIX_SIZE..];
             let parsed_ops = parse_ops_from_plaintext(
@@ -2074,11 +2162,6 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             let mut schema_deletes = HashMap::default();
             let mut schema_rowids = Vec::new();
             let mut data_table_ids = HashSet::default();
-            for (rowid, record) in &log_record.portable_schema_deletes {
-                let row = portable_schema_row_from_record(record)?;
-                schema_rowids.push(*rowid);
-                schema_deletes.insert(*rowid, row);
-            }
             for op in &parsed_ops {
                 match op {
                     ParsedOp::UpsertTable {
@@ -2092,28 +2175,35 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                         schema_rowids.push(rowid);
                         schema_upserts.insert(rowid, row);
                     }
-                    ParsedOp::UpsertTable { table_id, .. }
-                    | ParsedOp::UpsertIndex { table_id, .. }
-                    | ParsedOp::DeleteIndex { table_id, .. } => {
-                        if !matches!(
-                            op,
-                            ParsedOp::UpsertIndex { .. } | ParsedOp::DeleteIndex { .. }
-                        ) {
-                            data_table_ids.insert(*table_id);
+                    ParsedOp::DeleteTable {
+                        rowid,
+                        record_bytes,
+                        ..
+                    } if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID => {
+                        if record_bytes.is_empty() {
+                            return Err(LimboError::Corrupt(
+                                "sqlite_schema DELETE_TABLE missing old record".to_string(),
+                            ));
                         }
+                        let schema_rowid = rowid.row_id.to_int_or_panic();
+                        let row = portable_schema_row_from_record(record_bytes)?;
+                        schema_rowids.push(schema_rowid);
+                        schema_deletes.insert(schema_rowid, row);
+                    }
+                    ParsedOp::UpsertTable { table_id, .. } => {
+                        data_table_ids.insert(*table_id);
                     }
                     ParsedOp::DeleteTable { rowid, .. } => {
                         if rowid.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
                             data_table_ids.insert(rowid.table_id);
                         }
                     }
-                    ParsedOp::UpdateHeader { header, .. } => {
-                        builder.encode_header_logical_op(header);
-                    }
+                    ParsedOp::UpsertIndex { .. }
+                    | ParsedOp::DeleteIndex { .. }
+                    | ParsedOp::UpdateHeader { .. } => {}
                 }
             }
 
-            let mut emitted_schema_stable_ids = HashSet::default();
             schema_rowids.sort_unstable();
             schema_rowids.dedup();
             for rowid in schema_rowids {
@@ -2121,85 +2211,41 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 let new_row = schema_upserts.get(&rowid);
                 match (old_row, new_row) {
                     (Some(old_row), Some(new_row)) => {
-                        if old_row.rootpage != 0 {
-                            let table_id = portable_table_id_from_rootpage(old_row.rootpage);
-                            table_refs_by_id.remove(&table_id);
+                        if is_portable_table_schema_row(old_row) {
+                            table_refs_by_id.insert(
+                                portable_table_id_from_rootpage(old_row.rootpage),
+                                PortableTableRef {
+                                    name: old_row.name.clone(),
+                                },
+                            );
                         }
-                        if new_row.rootpage != 0 {
-                            let table_id = portable_table_id_from_rootpage(new_row.rootpage);
-                            if let Some(stable_table_id) =
-                                stable_table_id_from_rootpage(new_row.rootpage)
-                            {
-                                if let Some(kind) = portable_schema_kind(&new_row.row_type) {
-                                    table_refs_by_id.insert(
-                                        table_id,
-                                        PortableTableRef {
-                                            name: new_row.name.clone(),
-                                            stable_table_id,
-                                            kind,
-                                            sql: new_row.sql.clone(),
-                                            rootpage_debug: new_row.rootpage,
-                                        },
-                                    );
-                                }
-                            }
-                        }
-                        let stable_table_id = stable_table_id_from_rootpage(new_row.rootpage);
-                        if builder.encode_schema_logical_op(
-                            LOGICAL_SCHEMA_REFRESH,
-                            new_row,
-                            stable_table_id,
-                        ) {
-                            if let Some(stable_table_id) = stable_table_id {
-                                emitted_schema_stable_ids.insert(stable_table_id);
-                            }
+                        if is_portable_table_schema_row(new_row) {
+                            table_refs_by_id.insert(
+                                portable_table_id_from_rootpage(new_row.rootpage),
+                                PortableTableRef {
+                                    name: new_row.name.clone(),
+                                },
+                            );
                         }
                     }
                     (None, Some(new_row)) => {
-                        if new_row.rootpage != 0 {
-                            let table_id = portable_table_id_from_rootpage(new_row.rootpage);
-                            if let Some(stable_table_id) =
-                                stable_table_id_from_rootpage(new_row.rootpage)
-                            {
-                                if let Some(kind) = portable_schema_kind(&new_row.row_type) {
-                                    table_refs_by_id.insert(
-                                        table_id,
-                                        PortableTableRef {
-                                            name: new_row.name.clone(),
-                                            stable_table_id,
-                                            kind,
-                                            sql: new_row.sql.clone(),
-                                            rootpage_debug: new_row.rootpage,
-                                        },
-                                    );
-                                }
-                            }
-                        }
-                        let stable_table_id = stable_table_id_from_rootpage(new_row.rootpage);
-                        if builder.encode_schema_logical_op(
-                            LOGICAL_SCHEMA_CREATE,
-                            new_row,
-                            stable_table_id,
-                        ) {
-                            if let Some(stable_table_id) = stable_table_id {
-                                emitted_schema_stable_ids.insert(stable_table_id);
-                            }
+                        if is_portable_table_schema_row(new_row) {
+                            table_refs_by_id.insert(
+                                portable_table_id_from_rootpage(new_row.rootpage),
+                                PortableTableRef {
+                                    name: new_row.name.clone(),
+                                },
+                            );
                         }
                     }
                     (Some(old_row), None) => {
-                        let stable_table_id = stable_table_id_from_rootpage(old_row.rootpage);
-                        if builder.encode_schema_logical_op(
-                            LOGICAL_SCHEMA_DROP,
-                            old_row,
-                            stable_table_id,
-                        ) {
-                            if let Some(stable_table_id) = stable_table_id {
-                                emitted_schema_stable_ids.insert(stable_table_id);
-                            }
-                        }
-                        if old_row.rootpage != 0 {
-                            let table_id = portable_table_id_from_rootpage(old_row.rootpage);
-                            table_refs_by_id.remove(&table_id);
+                        if is_portable_table_schema_row(old_row) {
+                            table_refs_by_id.insert(
+                                portable_table_id_from_rootpage(old_row.rootpage),
+                                PortableTableRef {
+                                    name: old_row.name.clone(),
+                                },
+                            );
                         }
                     }
                     (None, None) => {}
@@ -2217,78 +2263,63 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
 
             let mut unresolved_data_tables = Vec::new();
             let mut needed_rootpages = HashSet::default();
-            for table_id in data_table_ids {
-                if table_refs_by_id.contains_key(&table_id) {
+            for table_id in &data_table_ids {
+                if table_refs_by_id.contains_key(table_id) {
                     continue;
                 }
-                let rootpage = rootpage_for_table_id(table_id);
+                let rootpage = rootpage_for_table_id(*table_id);
                 if rootpage == 0 {
                     continue;
                 }
                 let root_table_id = portable_table_id_from_rootpage(rootpage);
                 if let Some(table_ref) = table_refs_by_id.get(&root_table_id).cloned() {
-                    table_refs_by_id.insert(table_id, table_ref);
+                    table_refs_by_id.insert(*table_id, table_ref);
                     continue;
                 }
                 needed_rootpages.insert(rootpage);
-                unresolved_data_tables.push((table_id, root_table_id));
+                unresolved_data_tables.push((*table_id, root_table_id));
             }
 
             if !needed_rootpages.is_empty() {
                 let schema = self.connection.schema.read();
                 for rootpage in needed_rootpages {
-                    let table_ref = if let Some(name) = schema.table_name_for_root_page(rootpage) {
-                        let Some(stable_table_id) = stable_table_id_from_rootpage(rootpage) else {
-                            continue;
-                        };
-                        PortableTableRef {
-                            name: name.to_string(),
-                            stable_table_id,
-                            kind: 0,
-                            sql: None,
-                            rootpage_debug: rootpage,
-                        }
+                    let (resolved_table_id, table_ref) = if let Some(name) =
+                        schema.table_name_for_root_page(rootpage)
+                    {
+                        (
+                            portable_table_id_from_rootpage(rootpage),
+                            PortableTableRef {
+                                name: name.to_string(),
+                            },
+                        )
                     } else if rootpage < 0 {
                         let checkpointed_rootpage = -rootpage;
                         let Some(name) = schema.table_name_for_root_page(checkpointed_rootpage)
                         else {
                             continue;
                         };
-                        let Some(stable_table_id) =
-                            stable_table_id_from_rootpage(checkpointed_rootpage)
-                        else {
-                            continue;
-                        };
-                        PortableTableRef {
-                            name: name.to_string(),
-                            stable_table_id,
-                            kind: 0,
-                            sql: None,
-                            rootpage_debug: checkpointed_rootpage,
-                        }
+                        (
+                            portable_table_id_from_rootpage(checkpointed_rootpage),
+                            PortableTableRef {
+                                name: name.to_string(),
+                            },
+                        )
                     } else if rootpage > 0 {
                         let uncheckpointed_rootpage = -rootpage;
                         let Some(name) = schema.table_name_for_root_page(uncheckpointed_rootpage)
                         else {
                             continue;
                         };
-                        let Some(stable_table_id) = stable_table_id_from_rootpage(rootpage) else {
-                            continue;
-                        };
-                        PortableTableRef {
-                            name: name.to_string(),
-                            stable_table_id,
-                            kind: 0,
-                            sql: None,
-                            rootpage_debug: rootpage,
-                        }
+                        (
+                            portable_table_id_from_rootpage(rootpage),
+                            PortableTableRef {
+                                name: name.to_string(),
+                            },
+                        )
                     } else {
                         continue;
                     };
-                    table_refs_by_id.insert(
-                        MVTableId::from(-(table_ref.stable_table_id as i64)),
-                        table_ref,
-                    );
+                    table_refs_by_id.insert(resolved_table_id, table_ref);
                 }
 
                 for (table_id, root_table_id) in unresolved_data_tables {
@@ -2299,86 +2330,31 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
 
             for (table_id, table_ref) in &table_refs_by_id {
-                builder.add_object_map(PortableObjectMapEntry {
+                if !is_portable_logical_name(&table_ref.name) {
+                    continue;
+                }
+                let added = builder.add_object_map(PortableObjectMapEntry {
                     mv_table_id: i64::from(*table_id),
-                    kind: table_ref.kind,
-                    logical_object_id: table_ref.stable_table_id,
                     name: &table_ref.name,
-                    schema_epoch: log_record.tx_timestamp,
-                    create_sql: table_ref.sql.as_deref(),
-                    rootpage_debug: table_ref.rootpage_debug,
                 });
+                turso_assert!(
+                    added,
+                    "portable object map unexpectedly rejected a user object"
+                );
             }
 
-            for op in &parsed_ops {
-                match op {
-                    ParsedOp::UpsertTable {
-                        table_id,
-                        rowid,
-                        record_bytes: _,
-                        ..
-                    } if *table_id != SQLITE_SCHEMA_MVCC_TABLE_ID => {
-                        let Some(table_ref) = table_refs_by_id.get(table_id) else {
-                            return Err(LimboError::InternalError(format!(
-                                "unable to encode MVCC row portable changes: table_id={table_id}"
-                            )));
-                        };
-                        if !emitted_schema_stable_ids.contains(&table_ref.stable_table_id) {
-                            builder.add_object_map(PortableObjectMapEntry {
-                                mv_table_id: i64::from(*table_id),
-                                kind: table_ref.kind,
-                                logical_object_id: table_ref.stable_table_id,
-                                name: &table_ref.name,
-                                schema_epoch: log_record.tx_timestamp,
-                                create_sql: table_ref.sql.as_deref(),
-                                rootpage_debug: table_ref.rootpage_debug,
-                            });
-                        }
-                        builder.encode_row_logical_op(
-                            LOGICAL_OP_UPSERT_ROW,
-                            i64::from(*table_id),
-                            rowid.row_id.to_int_or_panic(),
-                            &[],
-                        );
-                    }
-                    ParsedOp::DeleteTable { rowid, .. }
-                        if rowid.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID =>
-                    {
-                        let Some(table_ref) = table_refs_by_id.get(&rowid.table_id) else {
-                            return Err(LimboError::InternalError(format!(
-                                "unable to encode MVCC row portable changes: table_id={}",
-                                rowid.table_id
-                            )));
-                        };
-                        if !emitted_schema_stable_ids.contains(&table_ref.stable_table_id) {
-                            builder.add_object_map(PortableObjectMapEntry {
-                                mv_table_id: i64::from(rowid.table_id),
-                                kind: table_ref.kind,
-                                logical_object_id: table_ref.stable_table_id,
-                                name: &table_ref.name,
-                                schema_epoch: log_record.tx_timestamp,
-                                create_sql: table_ref.sql.as_deref(),
-                                rootpage_debug: table_ref.rootpage_debug,
-                            });
-                        }
-                        let rowid_int = rowid.row_id.to_int_or_panic();
-                        let deleted_record = log_record
-                            .portable_deleted_table_rows
-                            .get(&(rowid.table_id, rowid_int))
-                            .map(Vec::as_slice)
-                            .unwrap_or(&[]);
-                        builder.encode_row_logical_op(
-                            LOGICAL_OP_DELETE_ROW,
-                            i64::from(rowid.table_id),
-                            rowid_int,
-                            deleted_record,
-                        );
-                    }
-                    _ => {}
+            for table_id in data_table_ids {
+                let Some(table_ref) = table_refs_by_id.get(&table_id) else {
+                    return Err(LimboError::InternalError(format!(
+                        "unable to resolve MVCC table id for portable changes: table_id={table_id}"
+                    )));
+                };
+                if !is_portable_logical_name(&table_ref.name) {
+                    continue;
                 }
             }
 
-            log_record.portable_changes = builder.finish(origin_client_id);
+            log_record.portable_changes = builder.finish();
             Ok(())
         }
     }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -373,6 +373,10 @@ pub struct LogRecord {
     /// recovery ops' MVCC table ids and read transaction-level metadata.
     #[cfg(feature = "conn_raw_api")]
     pub portable_changes: Vec<u8>,
+    /// True when the committing connection requested portable logical-change
+    /// frames, even if this transaction has no client-visible metadata.
+    #[cfg(feature = "conn_raw_api")]
+    pub portable_changes_enabled: bool,
 }
 
 impl LogRecord {
@@ -390,6 +394,8 @@ impl LogRecord {
             has_header: false,
             #[cfg(feature = "conn_raw_api")]
             portable_changes: Vec::new(),
+            #[cfg(feature = "conn_raw_api")]
+            portable_changes_enabled: false,
         }
     }
 
@@ -1150,6 +1156,14 @@ pub enum CommitState<Clock: LogicalClock> {
     /// the executor.
     BuildLogRecord(BuildLogRecordCtx),
     BeginCommitLogicalLog {
+        end_ts: u64,
+        log_record: LogRecord,
+    },
+    UpgradeLogicalLogHeader {
+        end_ts: u64,
+        log_record: LogRecord,
+    },
+    WriteLogicalLog {
         end_ts: u64,
         log_record: LogRecord,
     },
@@ -2134,6 +2148,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             if !self.connection.portable_logical_changes_enabled() {
                 return Ok(());
             }
+            log_record.portable_changes_enabled = true;
 
             let mut builder = PortableLogicalBuilder::new();
             let mut metadata: Vec<_> = self
@@ -2793,9 +2808,44 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 let end_ts = *end_ts;
                 let log_record = match std::mem::replace(
                     &mut self.state,
-                    CommitState::SyncLogicalLog { end_ts },
+                    CommitState::UpgradeLogicalLogHeader {
+                        end_ts,
+                        log_record: LogRecord::new(end_ts),
+                    },
                 ) {
                     CommitState::BeginCommitLogicalLog { log_record, .. } => log_record,
+                    _ => unreachable!(),
+                };
+                self.state = CommitState::UpgradeLogicalLogHeader { end_ts, log_record };
+                Ok(TransitionResult::Continue)
+            }
+            CommitState::UpgradeLogicalLogHeader { end_ts, log_record } => {
+                if let Some(c) = mvcc_store.storage.upgrade_header_for_log_tx(log_record)? {
+                    if !c.succeeded() {
+                        return Ok(TransitionResult::Io(IOCompletions::Single(c)));
+                    }
+                }
+                let end_ts = *end_ts;
+                let log_record = match std::mem::replace(
+                    &mut self.state,
+                    CommitState::WriteLogicalLog {
+                        end_ts,
+                        log_record: LogRecord::new(end_ts),
+                    },
+                ) {
+                    CommitState::UpgradeLogicalLogHeader { log_record, .. } => log_record,
+                    _ => unreachable!(),
+                };
+                self.state = CommitState::WriteLogicalLog { end_ts, log_record };
+                Ok(TransitionResult::Continue)
+            }
+            CommitState::WriteLogicalLog { end_ts, .. } => {
+                let end_ts = *end_ts;
+                let log_record = match std::mem::replace(
+                    &mut self.state,
+                    CommitState::SyncLogicalLog { end_ts },
+                ) {
+                    CommitState::WriteLogicalLog { log_record, .. } => log_record,
                     _ => unreachable!(),
                 };
                 let (c, append_bytes) = mvcc_store.storage.log_tx(log_record, None)?;
@@ -7038,6 +7088,16 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
             Self::BuildLogRecord(ctx) => f.debug_tuple("BuildLogRecord").field(ctx).finish(),
             Self::BeginCommitLogicalLog { end_ts, log_record } => f
                 .debug_struct("BeginCommitLogicalLog")
+                .field("end_ts", end_ts)
+                .field("log_record", log_record)
+                .finish(),
+            Self::UpgradeLogicalLogHeader { end_ts, log_record } => f
+                .debug_struct("UpgradeLogicalLogHeader")
+                .field("end_ts", end_ts)
+                .field("log_record", log_record)
+                .finish(),
+            Self::WriteLogicalLog { end_ts, log_record } => f
+                .debug_struct("WriteLogicalLog")
                 .field("end_ts", end_ts)
                 .field("log_record", log_record)
                 .finish(),

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -13748,6 +13748,9 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
             }
             self.inner.log_tx(m, c)
         }
+        fn upgrade_header_for_log_tx(&self, m: &LogRecord) -> Result<Option<Completion>> {
+            self.inner.upgrade_header_for_log_tx(m)
+        }
         fn sync(&self, t: FileSyncType) -> Result<Completion> {
             self.inner.sync(t)
         }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -7,14 +7,12 @@ use crate::mvcc::cursor::{CursorYieldPoint, MvccCursorType};
 use crate::mvcc::database::checkpoint_state_machine::CheckpointYieldPoint;
 use crate::mvcc::database::CommitYieldPoint;
 #[cfg(feature = "conn_raw_api")]
-use crate::mvcc::persistent_storage::logical_log::StreamingLogicalLogReader;
+use crate::mvcc::persistent_storage::logical_log::{ParsedOp, StreamingLogicalLogReader};
 use crate::mvcc::persistent_storage::logical_log::{
     ENCRYPTED_PAYLOAD_CHUNK_SIZE, EXT_FRAME_MAGIC, FRAME_MAGIC, LOG_HDR_SIZE,
 };
 #[cfg(feature = "conn_raw_api")]
-use crate::mvcc::portable_logical::{
-    PortableLogicalBuilder, PortableSchemaRow, LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_REFRESH,
-};
+use crate::mvcc::portable_logical::{PortableLogicalBuilder, PortableObjectMapEntry};
 use crate::mvcc::yield_hooks::YieldPointMarker;
 use crate::mvcc::yield_points::{FailureInjector, YieldInjector, YieldPoint};
 use crate::state_machine::{StateTransition, TransitionResult};
@@ -11274,26 +11272,28 @@ fn collect_mvcc_portable_change_bytes_with_encryption(
 }
 
 #[cfg(feature = "conn_raw_api")]
+fn collect_mvcc_recovery_ops(conn: &Arc<Connection>) -> Vec<ParsedOp> {
+    let mv_store = conn
+        .mv_store()
+        .as_ref()
+        .expect("test database must be in MVCC mode")
+        .clone();
+    let io = conn.get_pager().io.clone();
+    let mut reader = StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), None);
+    reader.read_header(&io).unwrap();
+
+    let mut ops = Vec::new();
+    while let Some(frame_ops) = reader.next_frame(&io).unwrap() {
+        ops.extend(frame_ops);
+    }
+    ops
+}
+
+#[cfg(feature = "conn_raw_api")]
 fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
     haystack
         .windows(needle.len())
         .any(|window| window == needle)
-}
-
-#[derive(Debug)]
-#[cfg(feature = "conn_raw_api")]
-struct DecodedPortableOp {
-    op_type: u64,
-    schema_action: Option<u64>,
-    schema_kind: Option<u64>,
-    table_name: String,
-    sql: String,
-    schema_name: String,
-    user_version: Option<u64>,
-    application_id: Option<u64>,
-    stable_table_id: Option<u64>,
-    mv_table_id: Option<i64>,
-    record_len: usize,
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11333,18 +11333,22 @@ fn skip_proto_field(bytes: &[u8], offset: &mut usize, wire_type: u64) {
 #[cfg(feature = "conn_raw_api")]
 #[derive(Clone, Debug)]
 struct DecodedObjectMap {
-    stable_table_id: u64,
+    mv_table_id: i64,
     name: String,
-    sql: String,
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn decode_object_map(bytes: &[u8], strings: &[String]) -> Option<(i64, DecodedObjectMap)> {
+#[derive(Clone, Debug, Default)]
+struct DecodedPortableTxn {
+    objects: Vec<DecodedObjectMap>,
+    metadata: std::collections::HashMap<String, String>,
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn decode_object_map(bytes: &[u8], strings: &[String]) -> Option<DecodedObjectMap> {
     let mut offset = 0usize;
     let mut mv_table_id = None;
-    let mut stable_table_id = None;
     let mut name = String::new();
-    let mut sql = String::new();
     while offset < bytes.len() {
         let key = read_proto_varint(bytes, &mut offset);
         let field = key >> 3;
@@ -11353,108 +11357,46 @@ fn decode_object_map(bytes: &[u8], strings: &[String]) -> Option<(i64, DecodedOb
             (1, 0) => {
                 mv_table_id = Some(decode_proto_sint64(read_proto_varint(bytes, &mut offset)))
             }
-            (2, 0) => stable_table_id = Some(read_proto_varint(bytes, &mut offset)),
-            (4, 0) => {
+            (2, 0) => {
                 let idx = read_proto_varint(bytes, &mut offset) as usize;
                 name = strings.get(idx).cloned().unwrap_or_default();
             }
-            (6, 0) => {
-                let idx = read_proto_varint(bytes, &mut offset) as usize;
-                sql = strings.get(idx).cloned().unwrap_or_default();
-            }
             _ => skip_proto_field(bytes, &mut offset, wire_type),
         }
     }
-    Some((
-        mv_table_id?,
-        DecodedObjectMap {
-            stable_table_id: stable_table_id?,
-            name,
-            sql,
-        },
-    ))
+    Some(DecodedObjectMap {
+        mv_table_id: mv_table_id?,
+        name,
+    })
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn decode_portable_op(
-    bytes: &[u8],
-    strings: &[String],
-    object_maps: &std::collections::HashMap<i64, DecodedObjectMap>,
-) -> DecodedPortableOp {
-    let mut op = DecodedPortableOp {
-        op_type: u64::MAX,
-        schema_action: None,
-        schema_kind: None,
-        table_name: String::new(),
-        sql: String::new(),
-        schema_name: String::new(),
-        user_version: None,
-        application_id: None,
-        stable_table_id: None,
-        mv_table_id: None,
-        record_len: 0,
-    };
+fn decode_metadata(bytes: &[u8], strings: &[String]) -> Option<(String, String)> {
     let mut offset = 0usize;
+    let mut key = None;
+    let mut value = None;
     while offset < bytes.len() {
-        let key = read_proto_varint(bytes, &mut offset);
-        let field = key >> 3;
-        let wire_type = key & 7;
+        let field_key = read_proto_varint(bytes, &mut offset);
+        let field = field_key >> 3;
+        let wire_type = field_key & 7;
         match (field, wire_type) {
-            (1, 0) => op.op_type = read_proto_varint(bytes, &mut offset),
-            (6, 0) => op.user_version = Some(read_proto_varint(bytes, &mut offset)),
-            (7, 0) => op.application_id = Some(read_proto_varint(bytes, &mut offset)),
-            (8, 0) => op.schema_action = Some(read_proto_varint(bytes, &mut offset)),
-            (9, 0) => op.schema_kind = Some(read_proto_varint(bytes, &mut offset)),
-            (12, 0) => {
-                op.mv_table_id = Some(decode_proto_sint64(read_proto_varint(bytes, &mut offset)));
-            }
-            (13, 0) => {
+            (1, 0) => {
                 let idx = read_proto_varint(bytes, &mut offset) as usize;
-                op.sql = strings.get(idx).cloned().unwrap_or_default();
+                key = strings.get(idx).cloned();
             }
-            (14, 0) => {
+            (2, 0) => {
                 let idx = read_proto_varint(bytes, &mut offset) as usize;
-                op.schema_name = strings.get(idx).cloned().unwrap_or_default();
+                value = strings.get(idx).cloned();
             }
-            (4, 2) => {
-                let len = read_proto_varint(bytes, &mut offset) as usize;
-                op.record_len = len;
-                offset += len;
-            }
-            (2, 2) => {
-                let len = read_proto_varint(bytes, &mut offset) as usize;
-                op.table_name = String::from_utf8(bytes[offset..offset + len].to_vec()).unwrap();
-                offset += len;
-            }
-            (5, 2) => {
-                let len = read_proto_varint(bytes, &mut offset) as usize;
-                op.sql = String::from_utf8(bytes[offset..offset + len].to_vec()).unwrap();
-                offset += len;
-            }
-            (10, 2) => {
-                let len = read_proto_varint(bytes, &mut offset) as usize;
-                op.schema_name = String::from_utf8(bytes[offset..offset + len].to_vec()).unwrap();
-                offset += len;
-            }
-            (11, 0) => op.stable_table_id = Some(read_proto_varint(bytes, &mut offset)),
             _ => skip_proto_field(bytes, &mut offset, wire_type),
         }
     }
-    if let Some(mv_table_id) = op.mv_table_id {
-        if let Some(object) = object_maps.get(&mv_table_id) {
-            op.table_name = object.name.clone();
-            op.stable_table_id = Some(object.stable_table_id);
-            if op.sql.is_empty() {
-                op.sql = object.sql.clone();
-            }
-        }
-    }
-    op
+    Some((key?, value?))
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn decode_portable_change_ops(portable_changes: &[u8]) -> Vec<DecodedPortableOp> {
-    let mut ops = Vec::new();
+fn decode_portable_change_txns(portable_changes: &[u8]) -> Vec<DecodedPortableTxn> {
+    let mut txns = Vec::new();
     let mut offset = 0usize;
     while offset < portable_changes.len() {
         let txn_len = read_proto_varint(portable_changes, &mut offset) as usize;
@@ -11464,107 +11406,73 @@ fn decode_portable_change_ops(portable_changes: &[u8]) -> Vec<DecodedPortableOp>
 
         let mut strings = Vec::new();
         let mut object_blobs = Vec::new();
-        let mut scan_offset = 0usize;
-        while scan_offset < txn.len() {
-            let key = read_proto_varint(txn, &mut scan_offset);
+        let mut meta_blobs = Vec::new();
+        let mut txn_offset = 0usize;
+        while txn_offset < txn.len() {
+            let key = read_proto_varint(txn, &mut txn_offset);
             let field = key >> 3;
             let wire_type = key & 7;
             match (field, wire_type) {
                 (12, 2) => {
-                    let len = read_proto_varint(txn, &mut scan_offset) as usize;
+                    let len = read_proto_varint(txn, &mut txn_offset) as usize;
                     strings.push(
-                        String::from_utf8(txn[scan_offset..scan_offset + len].to_vec()).unwrap(),
+                        String::from_utf8(txn[txn_offset..txn_offset + len].to_vec()).unwrap(),
                     );
-                    scan_offset += len;
+                    txn_offset += len;
                 }
                 (13, 2) => {
-                    let len = read_proto_varint(txn, &mut scan_offset) as usize;
-                    object_blobs.push(txn[scan_offset..scan_offset + len].to_vec());
-                    scan_offset += len;
+                    let len = read_proto_varint(txn, &mut txn_offset) as usize;
+                    object_blobs.push(txn[txn_offset..txn_offset + len].to_vec());
+                    txn_offset += len;
                 }
-                _ => skip_proto_field(txn, &mut scan_offset, wire_type),
+                (14, 2) => {
+                    let len = read_proto_varint(txn, &mut txn_offset) as usize;
+                    meta_blobs.push(txn[txn_offset..txn_offset + len].to_vec());
+                    txn_offset += len;
+                }
+                _ => skip_proto_field(txn, &mut txn_offset, wire_type),
             }
         }
-        let object_maps = object_blobs
+        let objects = object_blobs
             .iter()
             .filter_map(|object| decode_object_map(object, &strings))
-            .collect::<std::collections::HashMap<_, _>>();
-
-        let mut txn_offset = 0usize;
-        while txn_offset < txn.len() {
-            let key = read_proto_varint(txn, &mut txn_offset);
-            let field = key >> 3;
-            let wire_type = key & 7;
-            if field == 3 && wire_type == 2 {
-                let op_len = read_proto_varint(txn, &mut txn_offset) as usize;
-                ops.push(decode_portable_op(
-                    &txn[txn_offset..txn_offset + op_len],
-                    &strings,
-                    &object_maps,
-                ));
-                txn_offset += op_len;
-            } else {
-                skip_proto_field(txn, &mut txn_offset, wire_type);
+            .collect();
+        let mut metadata = std::collections::HashMap::new();
+        for meta in &meta_blobs {
+            if let Some((key, value)) = decode_metadata(meta, &strings) {
+                metadata.insert(key, value);
             }
         }
+        txns.push(DecodedPortableTxn { objects, metadata });
     }
-    ops
+    txns
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn decode_portable_change_origins(portable_changes: &[u8]) -> Vec<String> {
-    let mut origins = Vec::new();
-    let mut offset = 0usize;
-    while offset < portable_changes.len() {
-        let txn_len = read_proto_varint(portable_changes, &mut offset) as usize;
-        let txn_end = offset + txn_len;
-        let txn = &portable_changes[offset..txn_end];
-        offset = txn_end;
-
-        let mut txn_offset = 0usize;
-        while txn_offset < txn.len() {
-            let key = read_proto_varint(txn, &mut txn_offset);
-            let field = key >> 3;
-            let wire_type = key & 7;
-            if field == 4 && wire_type == 2 {
-                let len = read_proto_varint(txn, &mut txn_offset) as usize;
-                origins
-                    .push(String::from_utf8(txn[txn_offset..txn_offset + len].to_vec()).unwrap());
-                txn_offset += len;
-            } else {
-                skip_proto_field(txn, &mut txn_offset, wire_type);
-            }
-        }
-    }
-    origins
+fn decoded_object_maps(txns: &[DecodedPortableTxn]) -> Vec<&DecodedObjectMap> {
+    txns.iter().flat_map(|txn| txn.objects.iter()).collect()
 }
 
 #[cfg(feature = "conn_raw_api")]
 #[test]
-fn test_mvcc_portable_changes_encoder_matches_logical_op_wire_golden() {
-    let row = PortableSchemaRow {
-        row_type: "view".to_string(),
-        name: "v".to_string(),
-        rootpage: 0,
-        sql: Some("CREATE VIEW v AS SELECT 1".to_string()),
-    };
+fn test_mvcc_portable_changes_encoder_matches_metadata_wire_golden() {
     let mut builder = PortableLogicalBuilder::new();
-    builder.encode_schema_logical_op(LOGICAL_SCHEMA_CREATE, &row, None);
-    let encoded = builder.finish(None);
+    builder.add_metadata("client", "client-a");
+    builder.add_object_map(PortableObjectMapEntry {
+        mv_table_id: -5,
+        name: "items",
+    });
+    let encoded = builder.finish();
 
     assert_eq!(
         encoded,
         vec![
-            0x62, 0x01, b'v', // PortableLogicalTxn.string_table[0] = "v"
-            0x62, 0x19, // PortableLogicalTxn.string_table[1] = SQL
-            b'C', b'R', b'E', b'A', b'T', b'E', b' ', b'V', b'I', b'E', b'W', b' ', b'v', b' ',
-            b'A', b'S', b' ', b'S', b'E', b'L', b'E', b'C', b'T', b' ', b'1', 0x1a,
-            0x0a, // PortableLogicalTxn.ops, length 10
-            0x08, 0x02, // LogicalOp.op_type = Schema
-            0x40, 0x00, // LogicalOp.schema_action = Create
-            0x48, 0x03, // LogicalOp.schema_kind = View
-            0x68, 0x01, // LogicalOp.sql_ref = 1
-            0x70, 0x00, // LogicalOp.schema_name_ref = 0
+            0x62, 0x06, b'c', b'l', b'i', b'e', b'n', b't', 0x62, 0x08, b'c', b'l', b'i', b'e',
+            b'n', b't', b'-', b'a', 0x62, 0x05, b'i', b't', b'e', b'm', b's', 0x6a, 0x04, 0x08,
+            0x09, // mv_table_id = -5
+            0x10, 0x02, // name_ref = "items"
+            0x72, 0x04, 0x08, 0x00, // metadata key_ref = "client"
+            0x10, 0x01, // metadata value_ref = "client-a"
         ]
     );
 }
@@ -11598,20 +11506,17 @@ fn test_mvcc_portable_changes_contains_user_schema_and_rows() {
         .unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
 
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_name == "items"
-        && op.sql.contains("CREATE TABLE items")
-        && op.stable_table_id.unwrap_or_default() > 0));
-    assert!(ops.iter().any(|op| op.op_type == 0
-        && op.table_name == "items"
-        && op.stable_table_id.unwrap_or_default() > 0));
+    assert!(objects
+        .iter()
+        .any(|object| object.name == "items" && object.mv_table_id < 0));
 }
 
 #[cfg(feature = "conn_raw_api")]
 #[test]
-fn test_mvcc_portable_changes_keep_stable_table_id_across_rename() {
+fn test_mvcc_portable_changes_updates_name_mapping_across_rename() {
     let db = MvccTestDb::new();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
@@ -11627,29 +11532,10 @@ fn test_mvcc_portable_changes_keep_stable_table_id_across_rename() {
         .unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
-    let before_id = ops
-        .iter()
-        .find(|op| op.op_type == 0 && op.table_name == "items")
-        .and_then(|op| op.stable_table_id)
-        .expect("create-time row should carry stable table id");
-    let after_id = ops
-        .iter()
-        .find(|op| op.op_type == 0 && op.table_name == "things")
-        .and_then(|op| op.stable_table_id)
-        .expect("post-rename row should carry stable table id");
-    let rename_id = ops
-        .iter()
-        .find(|op| {
-            op.op_type == 2
-                && op.schema_action == Some(LOGICAL_SCHEMA_REFRESH)
-                && op.schema_name == "things"
-        })
-        .and_then(|op| op.stable_table_id)
-        .expect("rename schema refresh should carry stable table id");
-
-    assert_eq!(before_id, after_id);
-    assert_eq!(before_id, rename_id);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
+    assert!(objects.iter().any(|object| object.name == "items"));
+    assert!(objects.iter().any(|object| object.name == "things"));
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11664,12 +11550,10 @@ fn test_mvcc_portable_changes_emit_refresh_for_same_rowid_schema_update() {
         .unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
 
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(2)
-        && op.schema_name == "items"
-        && op.sql.contains("note TEXT")));
+    assert!(objects.iter().any(|object| object.name == "items"));
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11694,20 +11578,18 @@ fn test_mvcc_portable_changes_emit_drop_and_create_for_drop_recreate_same_name()
     db.conn.execute("COMMIT").unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
-
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(1)
-        && op.schema_kind == Some(0)
-        && op.schema_name == "items"));
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(0)
-        && op.schema_kind == Some(0)
-        && op.schema_name == "items"
-        && op.sql.contains("note TEXT")));
-    assert!(ops
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
+    let item_table_ids = objects
         .iter()
-        .any(|op| op.op_type == 0 && op.stable_table_id.unwrap_or_default() > 0));
+        .filter(|object| object.name == "items")
+        .map(|object| object.mv_table_id)
+        .collect::<HashSet<_>>();
+
+    assert!(
+        item_table_ids.len() >= 2,
+        "drop/recreate should expose old and new table identities"
+    );
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11724,19 +11606,14 @@ fn test_mvcc_portable_changes_resolve_rows_through_object_map_in_same_txn() {
     db.conn.execute("COMMIT").unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
-    let schema_id = ops
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
+    let object = objects
         .iter()
-        .find(|op| op.op_type == 2 && op.schema_name == "items")
-        .and_then(|op| op.stable_table_id)
-        .expect("schema identity should carry stable table id");
-    let row_op = ops
-        .iter()
-        .find(|op| op.op_type == 0 && op.stable_table_id == Some(schema_id))
-        .expect("row op should carry matching stable table id");
+        .find(|object| object.name == "items")
+        .expect("object map should resolve same-transaction table writes");
 
-    assert_eq!(row_op.table_name, "items");
-    assert!(row_op.mv_table_id.is_some());
+    assert!(object.mv_table_id < 0);
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11752,16 +11629,11 @@ fn test_mvcc_portable_changes_emit_index_drop_for_drop_table() {
     db.conn.execute("DROP TABLE items").unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
 
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(1)
-        && op.schema_kind == Some(0)
-        && op.schema_name == "items"));
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(1)
-        && op.schema_kind == Some(1)
-        && op.schema_name == "items_payload_idx"));
+    assert!(objects.iter().any(|object| object.name == "items"));
+    assert!(!bytes_contain(&portable_changes, b"items_payload_idx"));
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11784,23 +11656,16 @@ fn test_mvcc_portable_changes_emit_index_trigger_and_view_schema_ops() {
         .unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
 
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(0)
-        && op.schema_kind == Some(1)
-        && op.schema_name == "items_payload_idx"
-        && op.sql.contains("CREATE INDEX items_payload_idx")));
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(0)
-        && op.schema_kind == Some(3)
-        && op.schema_name == "items_view"
-        && op.sql.contains("CREATE VIEW items_view")));
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(0)
-        && op.schema_kind == Some(2)
-        && op.schema_name == "items_ai"
-        && op.sql.contains("CREATE TRIGGER items_ai")));
+    assert!(objects.iter().any(|object| object.name == "items"));
+    assert!(!bytes_contain(&portable_changes, b"items_payload_idx"));
+    assert!(!bytes_contain(&portable_changes, b"CREATE VIEW items_view"));
+    assert!(!bytes_contain(
+        &portable_changes,
+        b"CREATE TRIGGER items_ai"
+    ));
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11831,26 +11696,9 @@ fn test_mvcc_portable_changes_emit_trigger_and_view_lifecycle_ops() {
     db.conn.execute("COMMIT").unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
 
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(1)
-        && op.schema_kind == Some(3)
-        && op.schema_name == "items_view"));
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(0)
-        && op.schema_kind == Some(3)
-        && op.schema_name == "items_view"
-        && op.sql.contains("CREATE VIEW items_view AS SELECT id")));
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(1)
-        && op.schema_kind == Some(2)
-        && op.schema_name == "items_ai"));
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(0)
-        && op.schema_kind == Some(2)
-        && op.schema_name == "items_ai"
-        && op.sql.contains("CREATE TRIGGER items_ai")));
+    assert!(!bytes_contain(&portable_changes, b"items_view"));
+    assert!(!bytes_contain(&portable_changes, b"items_ai"));
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11861,16 +11709,16 @@ fn test_mvcc_portable_changes_emit_header_only_commits() {
     db.conn.execute("PRAGMA application_id = 1337").unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
-    let header_ops = ops.iter().filter(|op| op.op_type == 3).collect::<Vec<_>>();
+    let recovery_ops = collect_mvcc_recovery_ops(&db.conn);
 
-    assert_eq!(header_ops.len(), 2);
-    assert!(ops
-        .iter()
-        .any(|op| op.op_type == 3 && op.user_version == Some(42)));
-    assert!(ops
-        .iter()
-        .any(|op| op.op_type == 3 && op.application_id == Some(1337)));
+    assert!(portable_changes.is_empty());
+    assert_eq!(
+        recovery_ops
+            .iter()
+            .filter(|op| matches!(op, ParsedOp::UpdateHeader { .. }))
+            .count(),
+        2
+    );
 }
 
 #[test]
@@ -11900,16 +11748,10 @@ fn test_mvcc_portable_changes_use_checkpointed_schema_after_restart() {
             .unwrap();
 
         let portable_changes = collect_mvcc_portable_change_bytes(&conn);
-        let ops = decode_portable_change_ops(&portable_changes);
+        let txns = decode_portable_change_txns(&portable_changes);
+        let objects = decoded_object_maps(&txns);
 
-        assert!(ops
-            .iter()
-            .any(|op| op.op_type == 0 && op.table_name == "items"));
-        assert!(ops.iter().any(|op| op.op_type == 2
-            && op.schema_action == Some(2)
-            && op.schema_kind == Some(0)
-            && op.schema_name == "items"
-            && op.sql.contains("note TEXT")));
+        assert!(objects.iter().any(|object| object.name == "items"));
         conn.close().unwrap();
     }
 }
@@ -11935,24 +11777,15 @@ fn test_mvcc_portable_changes_emit_ddl_and_backfill_rows_in_same_transaction() {
     db.conn.execute("COMMIT").unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
 
-    assert!(ops.iter().any(|op| op.op_type == 2
-        && op.schema_action == Some(2)
-        && op.schema_kind == Some(0)
-        && op.schema_name == "items"
-        && op.sql.contains("note TEXT")));
-    assert!(
-        ops.iter()
-            .filter(|op| op.op_type == 0 && op.stable_table_id.unwrap_or_default() > 0)
-            .count()
-            >= 2
-    );
+    assert!(objects.iter().any(|object| object.name == "items"));
 }
 
 #[cfg(feature = "conn_raw_api")]
 #[test]
-fn test_mvcc_portable_changes_delete_carries_old_record_for_primary_key_derivation() {
+fn test_mvcc_portable_changes_delete_carries_pk_projection_not_old_record() {
     let db = MvccTestDb::new();
     db.conn
         .execute("CREATE TABLE items(id TEXT PRIMARY KEY, payload TEXT)")
@@ -11964,12 +11797,31 @@ fn test_mvcc_portable_changes_delete_carries_old_record_for_primary_key_derivati
         .execute("DELETE FROM items WHERE id = 'item-a'")
         .unwrap();
 
-    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
+    let recovery_ops = collect_mvcc_recovery_ops(&db.conn);
 
-    assert!(ops
-        .iter()
-        .any(|op| op.op_type == 1 && op.table_name == "items" && op.record_len > 0));
+    let delete_pk_record = recovery_ops.iter().find_map(|op| match op {
+        ParsedOp::DeleteTable {
+            rowid,
+            record_bytes,
+            pk_record_bytes,
+            ..
+        } if rowid.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID => {
+            assert!(
+                record_bytes.is_empty(),
+                "data DELETE must not duplicate the full row record"
+            );
+            Some(pk_record_bytes.clone())
+        }
+        _ => None,
+    });
+    let delete_pk_record = delete_pk_record.expect("expected data DELETE op");
+    let pk_values = ImmutableRecord::from_bin_record(delete_pk_record)
+        .get_values_owned()
+        .unwrap();
+    assert_eq!(
+        pk_values,
+        vec![Value::Text(Text::new("item-a".to_string()))]
+    );
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11994,17 +11846,15 @@ fn test_mvcc_portable_changes_do_not_infer_origin_from_application_table() {
     db.conn.execute("COMMIT").unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
-    let ops = decode_portable_change_ops(&portable_changes);
-    let origins = decode_portable_change_origins(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
 
-    assert!(bytes_contain(
+    assert!(!bytes_contain(
         &portable_changes,
         b"turso_sync_last_change_id"
     ));
-    assert!(origins.is_empty());
-    assert!(ops
-        .iter()
-        .any(|op| op.op_type == 0 && op.table_name == "items"));
+    assert!(txns.iter().all(|txn| !txn.metadata.contains_key("client")));
+    assert!(objects.iter().any(|object| object.name == "items"));
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -12030,9 +11880,13 @@ fn test_mvcc_portable_changes_metadata_does_not_auto_enable_or_get_consumed() {
         .unwrap();
 
     let portable_changes = collect_mvcc_portable_change_bytes(&conn);
-    let origins = decode_portable_change_origins(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let clients = txns
+        .iter()
+        .filter_map(|txn| txn.metadata.get("client").cloned())
+        .collect::<Vec<_>>();
     assert_eq!(
-        origins,
+        clients,
         vec!["client-a".to_string(), "client-a".to_string()]
     );
 }
@@ -12059,14 +11913,10 @@ fn test_mvcc_portable_changes_are_encrypted_with_log_body() {
     let key = EncryptionKey::from_hex_string(hex_key).unwrap();
     let enc_ctx = EncryptionContext::new(CipherMode::Aes256Gcm, &key, 4096).unwrap();
     let portable_changes = collect_mvcc_portable_change_bytes_with_encryption(&conn, enc_ctx);
-    let ops = decode_portable_change_ops(&portable_changes);
+    let txns = decode_portable_change_txns(&portable_changes);
+    let objects = decoded_object_maps(&txns);
 
-    assert!(ops
-        .iter()
-        .any(|op| op.op_type == 2 && op.schema_name == "secret_items"));
-    assert!(ops
-        .iter()
-        .any(|op| op.op_type == 0 && op.table_name == "secret_items"));
+    assert!(objects.iter().any(|object| object.name == "secret_items"));
 }
 
 /// Encrypted version of test_recovery_checkpoint_then_more_writes.
@@ -13870,8 +13720,10 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
             &self,
             log_record: &mut LogRecord,
             row_version: &RowVersion,
+            portable_extension: Option<&[u8]>,
         ) -> Result<()> {
-            self.inner.serialize_row_version(log_record, row_version)
+            self.inner
+                .serialize_row_version(log_record, row_version, portable_extension)
         }
         fn serialize_database_header(
             &self,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6,8 +6,14 @@ use crate::mvcc::clock::MvccClock;
 use crate::mvcc::cursor::{CursorYieldPoint, MvccCursorType};
 use crate::mvcc::database::checkpoint_state_machine::CheckpointYieldPoint;
 use crate::mvcc::database::CommitYieldPoint;
+#[cfg(feature = "conn_raw_api")]
+use crate::mvcc::persistent_storage::logical_log::StreamingLogicalLogReader;
 use crate::mvcc::persistent_storage::logical_log::{
-    ENCRYPTED_PAYLOAD_CHUNK_SIZE, FRAME_MAGIC, LOG_HDR_SIZE,
+    ENCRYPTED_PAYLOAD_CHUNK_SIZE, EXT_FRAME_MAGIC, FRAME_MAGIC, LOG_HDR_SIZE,
+};
+#[cfg(feature = "conn_raw_api")]
+use crate::mvcc::portable_logical::{
+    encode_schema_logical_op, PortableSchemaRow, LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_REFRESH,
 };
 use crate::mvcc::yield_hooks::YieldPointMarker;
 use crate::mvcc::yield_points::{FailureInjector, YieldInjector, YieldPoint};
@@ -29,7 +35,8 @@ use quickcheck_macros::quickcheck;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
-const TX_HEADER_SIZE: usize = 24;
+const TX_BASE_HEADER_SIZE: usize = 24;
+const TX_EXT_HEADER_SIZE: usize = 40;
 const TX_TRAILER_SIZE: usize = 8;
 
 pub(crate) struct MvccTestDbNoConn {
@@ -102,6 +109,7 @@ impl MvccTestDb {
         let io = Arc::new(MemoryIO::new());
         let db = Database::open_file(io, ":memory:").unwrap();
         let conn = db.connect().unwrap();
+        conn.set_portable_logical_changes_enabled(true);
         // Enable MVCC via PRAGMA
         conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         let mvcc_store = db.get_mv_store().clone().unwrap();
@@ -604,9 +612,9 @@ fn overwrite_file_with_junk(path: &std::path::Path, size: usize, byte: u8) {
         .truncate(true)
         .open(path)
         .unwrap();
-    let payload = vec![byte; size];
+    let portable_changes = vec![byte; size];
     use std::io::Write;
-    file.write_all(&payload).unwrap();
+    file.write_all(&portable_changes).unwrap();
     file.sync_all().unwrap();
 }
 
@@ -732,21 +740,21 @@ fn rewrite_table_leaf_cell_payload(page: &mut [u8], loc: TableLeafCellLoc, new_p
 
 fn tamper_table_leaf_value_serial_type(page: &mut [u8], page_no: u32, new_serial_type: u8) -> bool {
     let loc = table_leaf_first_cell_loc(page, page_no);
-    let payload = &mut page[loc.payload_offset..loc.payload_offset + loc.payload_len];
+    let portable_changes = &mut page[loc.payload_offset..loc.payload_offset + loc.payload_len];
 
-    let (header_size, hs_len) = read_varint(payload).unwrap();
+    let (header_size, hs_len) = read_varint(portable_changes).unwrap();
     let header_size = header_size as usize;
-    if header_size < hs_len + 2 || header_size > payload.len() {
+    if header_size < hs_len + 2 || header_size > portable_changes.len() {
         return false;
     }
 
     let mut idx = hs_len;
-    let (_serial_type0, n0) = read_varint(&payload[idx..header_size]).unwrap();
+    let (_serial_type0, n0) = read_varint(&portable_changes[idx..header_size]).unwrap();
     idx += n0;
     if idx >= header_size {
         return false;
     }
-    payload[idx] = new_serial_type;
+    portable_changes[idx] = new_serial_type;
     true
 }
 
@@ -6619,6 +6627,167 @@ fn test_sql_checkpoint_reinsert_existing_interior_index_key_keeps_sqlite_integri
     assert_eq!(integrity, "ok");
 }
 
+#[test]
+fn test_mvcc_checkpoint_integrity_after_upsert_with_secondary_indexes() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute(
+        "CREATE TABLE t(\
+            id INTEGER PRIMARY KEY,\
+            owner TEXT NOT NULL,\
+            portable_changes TEXT NOT NULL,\
+            rev INTEGER NOT NULL DEFAULT 0,\
+            note TEXT,\
+            bucket INTEGER NOT NULL DEFAULT 0,\
+            tag TEXT,\
+            status INTEGER NOT NULL DEFAULT 0\
+        )",
+    )
+    .unwrap();
+    conn.execute("CREATE INDEX t_owner_rev_idx ON t(owner, rev)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_note_idx ON t(note)").unwrap();
+    conn.execute("CREATE INDEX t_bucket_idx ON t(bucket)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_tag_idx ON t(tag)").unwrap();
+    conn.execute("CREATE INDEX t_status_idx ON t(status)")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    for id in 1..=200 {
+        conn.execute(format!(
+            "INSERT INTO t(id, owner, portable_changes, rev, note, bucket, tag, status) \
+             VALUES ({id}, 'owner-{id}', 'portable_changes-{id}', 1, 'note-{id}', {bucket}, 'tag-{tag}', {status}) \
+             ON CONFLICT(id) DO UPDATE SET \
+                id = excluded.id, \
+                owner = excluded.owner, \
+                portable_changes = excluded.portable_changes, \
+                rev = excluded.rev, \
+                note = excluded.note, \
+                bucket = excluded.bucket, \
+                tag = excluded.tag, \
+                status = excluded.status",
+            bucket = id % 17,
+            tag = id % 7,
+            status = id % 9,
+        ))
+        .unwrap();
+    }
+
+    for id in 1..=100 {
+        conn.execute(format!(
+            "INSERT INTO t(id, owner, portable_changes, rev, note, bucket, tag, status) \
+             VALUES ({id}, 'owner-{id}', 'portable_changes-{id}-updated', 2, 'note-{id}-updated', {bucket}, 'tag-{tag}-updated', {status}) \
+             ON CONFLICT(id) DO UPDATE SET \
+                id = excluded.id, \
+                owner = excluded.owner, \
+                portable_changes = excluded.portable_changes, \
+                rev = excluded.rev, \
+                note = excluded.note, \
+                bucket = excluded.bucket, \
+                tag = excluded.tag, \
+                status = excluded.status",
+            bucket = (id + 3) % 17,
+            tag = (id + 2) % 7,
+            status = (id + 1) % 9,
+        ))
+        .unwrap();
+    }
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_mvcc_cached_insert_reprepared_after_index_create() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute(
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, owner TEXT, rev INTEGER, portable_changes TEXT)",
+    )
+    .unwrap();
+    let mut insert = conn
+        .prepare(
+            "INSERT INTO t(id, owner, rev, portable_changes) VALUES (1, 'a', 1, 'before') \
+             ON CONFLICT(id) DO UPDATE SET owner = excluded.owner, rev = excluded.rev, portable_changes = excluded.portable_changes",
+        )
+        .unwrap();
+    insert.run_ignore_rows().unwrap();
+
+    conn.execute("CREATE INDEX t_owner_rev_idx ON t(owner, rev)")
+        .unwrap();
+
+    insert.reset().unwrap();
+    insert.run_ignore_rows().unwrap();
+    conn.execute("INSERT INTO t(id, owner, rev, portable_changes) VALUES (2, 'b', 1, 'after')")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_mvcc_integrity_after_mixed_dml_create_index_transaction() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute(
+        "CREATE TABLE t(\
+            id INTEGER PRIMARY KEY,\
+            owner TEXT NOT NULL,\
+            portable_changes TEXT NOT NULL,\
+            rev INTEGER NOT NULL DEFAULT 0,\
+            note TEXT,\
+            bucket INTEGER NOT NULL DEFAULT 0,\
+            tag TEXT,\
+            status INTEGER NOT NULL DEFAULT 0\
+        )",
+    )
+    .unwrap();
+    conn.execute("CREATE INDEX t_owner_rev_idx ON t(owner, rev)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_note_idx ON t(note)").unwrap();
+    conn.execute("CREATE INDEX t_bucket_idx ON t(bucket)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_tag_idx ON t(tag)").unwrap();
+    conn.execute("CREATE INDEX t_status_idx ON t(status)")
+        .unwrap();
+    for id in 1..=13 {
+        conn.execute(format!(
+            "INSERT INTO t(id, owner, portable_changes, rev, note, bucket, tag, status) \
+             VALUES ({id}, 'owner-{id}', 'portable_changes-{id}', 1, 'note-{id}', {bucket}, 'tag-{tag}', {status})",
+            bucket = id % 17,
+            tag = id % 7,
+            status = id % 9,
+        ))
+        .unwrap();
+    }
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    conn.execute("BEGIN IMMEDIATE").unwrap();
+    conn.execute("UPDATE t SET portable_changes = 'local-mixed-portable_changes', rev = rev + 1 WHERE id = 1")
+        .unwrap();
+    conn.execute("CREATE INDEX \"t local mixed idx\" ON t(portable_changes)")
+        .unwrap();
+    conn.execute(
+        "INSERT INTO t(id, owner, portable_changes, rev, note, bucket, tag, status) \
+         VALUES (20006, 'replica-1', 'replica-1-mixed-insert', 1, 'replica-1-note-20006', 1, 'tag-0', 1)",
+    )
+    .unwrap();
+    conn.execute("COMMIT").unwrap();
+
+    let rows = get_rows(&conn, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
 /// Test that integrity_check passes after DROP TABLE but before checkpoint.
 /// Issue #4975: After checkpointing a table and then dropping it, integrity_check
 /// would fail because the dropped table's btree pages still exist but aren't
@@ -8347,6 +8516,35 @@ fn test_checkpoint_drop_table_then_create_index_page_reuse() {
     let rows = get_rows(&conn, "PRAGMA integrity_check");
     assert_eq!(rows.len(), 1);
     assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_checkpoint_drop_table_removes_stale_rootpage_mapping() {
+    let db = MvccTestDb::new();
+
+    db.conn
+        .execute("CREATE TABLE stale_root(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO stale_root VALUES(1, 'old')")
+        .unwrap();
+    db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let rows = get_rows(
+        &db.conn,
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = 'stale_root'",
+    );
+    let rootpage = rows[0][0].as_int().unwrap();
+    let table_id = db.mvcc_store.get_table_id_from_root_page(rootpage);
+    assert!(db.mvcc_store.table_id_to_rootpage.get(&table_id).is_some());
+
+    db.conn.execute("DROP TABLE stale_root").unwrap();
+    db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    assert!(
+        db.mvcc_store.table_id_to_rootpage.get(&table_id).is_none(),
+        "dropped checkpointed table mapping must not survive rootpage reuse"
+    );
 }
 
 /// Test that inserting a duplicate primary key fails when the existing row
@@ -10918,7 +11116,7 @@ fn test_encrypted_recovery_corrupted_later_chunk_keeps_checkpointed_prefix() {
     .unwrap();
     let first_chunk_on_disk_size =
         ENCRYPTED_PAYLOAD_CHUNK_SIZE + enc_ctx.tag_size() + enc_ctx.nonce_size();
-    let corrupt_offset = LOG_HDR_SIZE + TX_HEADER_SIZE + first_chunk_on_disk_size + 1;
+    let corrupt_offset = LOG_HDR_SIZE + TX_BASE_HEADER_SIZE + first_chunk_on_disk_size + 1;
     log_bytes[corrupt_offset] ^= 0xFF;
     std::fs::write(&log_path, &log_bytes).unwrap();
 
@@ -10930,8 +11128,8 @@ fn test_encrypted_recovery_corrupted_later_chunk_keeps_checkpointed_prefix() {
     assert_eq!(rows[0][1].to_string(), "survives");
 }
 
-/// Read the raw db-log file and verify every TX frame payload can be decrypted.
-/// Panics if the file is missing, has no frames, or any payload fails to decrypt.
+/// Read the raw db-log file and verify every TX frame portable_changes can be decrypted.
+/// Panics if the file is missing, has no frames, or any portable_changes fails to decrypt.
 fn assert_log_payloads_decrypt(
     log_path: &std::path::Path,
     hex_key: &str,
@@ -10956,18 +11154,30 @@ fn assert_log_payloads_decrypt(
     let mut offset = LOG_HDR_SIZE;
     let mut frame_count = 0;
 
-    while offset + TX_HEADER_SIZE + TX_TRAILER_SIZE <= log_bytes.len() {
+    while offset + TX_BASE_HEADER_SIZE + TX_TRAILER_SIZE <= log_bytes.len() {
         // TX Header: frame_magic(4) | payload_size(8) | op_count(4) | commit_ts(8)
+        // | extension_size(8) | extension_record_count(4) | frame_flags(4)
         let frame_magic = u32::from_le_bytes(log_bytes[offset..offset + 4].try_into().unwrap());
-        if frame_magic != FRAME_MAGIC {
+        let (header_size, extension_size) = if frame_magic == FRAME_MAGIC {
+            (TX_BASE_HEADER_SIZE, 0)
+        } else if frame_magic == EXT_FRAME_MAGIC {
+            if offset + TX_EXT_HEADER_SIZE + TX_TRAILER_SIZE > log_bytes.len() {
+                break;
+            }
+            (
+                TX_EXT_HEADER_SIZE,
+                u64::from_le_bytes(log_bytes[offset + 24..offset + 32].try_into().unwrap())
+                    as usize,
+            )
+        } else {
             break; // not a valid frame
-        }
+        };
         let payload_size =
             u64::from_le_bytes(log_bytes[offset + 4..offset + 12].try_into().unwrap()) as usize;
         let op_count = u32::from_le_bytes(log_bytes[offset + 12..offset + 16].try_into().unwrap());
         let commit_ts = u64::from_le_bytes(log_bytes[offset + 16..offset + 24].try_into().unwrap());
 
-        let mut payload_offset = offset + TX_HEADER_SIZE;
+        let mut payload_offset = offset + header_size;
         let chunk_count = if payload_size == 0 {
             0
         } else {
@@ -11012,13 +11222,625 @@ fn assert_log_payloads_decrypt(
         }
 
         frame_count += 1;
-        offset = payload_offset + TX_TRAILER_SIZE; // skip trailer
+        offset = payload_offset + extension_size + TX_TRAILER_SIZE; // skip extension block and trailer
     }
 
     assert!(
         frame_count > 0,
         "db-log should contain at least one TX frame"
     );
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn collect_mvcc_portable_change_bytes(conn: &Arc<Connection>) -> Vec<u8> {
+    let mv_store = conn
+        .mv_store()
+        .as_ref()
+        .expect("test database must be in MVCC mode")
+        .clone();
+    let io = conn.get_pager().io.clone();
+    let mut reader = StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), None);
+    reader.read_header(&io).unwrap();
+
+    let mut portable_changes = Vec::new();
+    while let Some(frame) = reader.next_portable_changes(&io).unwrap() {
+        portable_changes.extend_from_slice(&frame.payload);
+    }
+    portable_changes
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+#[derive(Debug)]
+#[cfg(feature = "conn_raw_api")]
+struct DecodedPortableOp {
+    op_type: u64,
+    schema_action: Option<u64>,
+    schema_kind: Option<u64>,
+    table_name: String,
+    sql: String,
+    schema_name: String,
+    user_version: Option<u64>,
+    application_id: Option<u64>,
+    stable_table_id: Option<u64>,
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn read_proto_varint(bytes: &[u8], offset: &mut usize) -> u64 {
+    let mut value = 0u64;
+    let mut shift = 0;
+    loop {
+        let byte = bytes[*offset];
+        *offset += 1;
+        value |= ((byte & 0x7f) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return value;
+        }
+        shift += 7;
+    }
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn skip_proto_field(bytes: &[u8], offset: &mut usize, wire_type: u64) {
+    match wire_type {
+        0 => {
+            let _ = read_proto_varint(bytes, offset);
+        }
+        2 => {
+            let len = read_proto_varint(bytes, offset) as usize;
+            *offset += len;
+        }
+        other => panic!("unsupported protobuf wire type in test decoder: {other}"),
+    }
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn decode_portable_op(bytes: &[u8]) -> DecodedPortableOp {
+    let mut op = DecodedPortableOp {
+        op_type: u64::MAX,
+        schema_action: None,
+        schema_kind: None,
+        table_name: String::new(),
+        sql: String::new(),
+        schema_name: String::new(),
+        user_version: None,
+        application_id: None,
+        stable_table_id: None,
+    };
+    let mut offset = 0usize;
+    while offset < bytes.len() {
+        let key = read_proto_varint(bytes, &mut offset);
+        let field = key >> 3;
+        let wire_type = key & 7;
+        match (field, wire_type) {
+            (1, 0) => op.op_type = read_proto_varint(bytes, &mut offset),
+            (6, 0) => op.user_version = Some(read_proto_varint(bytes, &mut offset)),
+            (7, 0) => op.application_id = Some(read_proto_varint(bytes, &mut offset)),
+            (8, 0) => op.schema_action = Some(read_proto_varint(bytes, &mut offset)),
+            (9, 0) => op.schema_kind = Some(read_proto_varint(bytes, &mut offset)),
+            (2, 2) => {
+                let len = read_proto_varint(bytes, &mut offset) as usize;
+                op.table_name = String::from_utf8(bytes[offset..offset + len].to_vec()).unwrap();
+                offset += len;
+            }
+            (5, 2) => {
+                let len = read_proto_varint(bytes, &mut offset) as usize;
+                op.sql = String::from_utf8(bytes[offset..offset + len].to_vec()).unwrap();
+                offset += len;
+            }
+            (10, 2) => {
+                let len = read_proto_varint(bytes, &mut offset) as usize;
+                op.schema_name = String::from_utf8(bytes[offset..offset + len].to_vec()).unwrap();
+                offset += len;
+            }
+            (11, 0) => op.stable_table_id = Some(read_proto_varint(bytes, &mut offset)),
+            _ => skip_proto_field(bytes, &mut offset, wire_type),
+        }
+    }
+    op
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn decode_portable_change_ops(portable_changes: &[u8]) -> Vec<DecodedPortableOp> {
+    let mut ops = Vec::new();
+    let mut offset = 0usize;
+    while offset < portable_changes.len() {
+        let txn_len = read_proto_varint(portable_changes, &mut offset) as usize;
+        let txn_end = offset + txn_len;
+        let txn = &portable_changes[offset..txn_end];
+        offset = txn_end;
+
+        let mut txn_offset = 0usize;
+        while txn_offset < txn.len() {
+            let key = read_proto_varint(txn, &mut txn_offset);
+            let field = key >> 3;
+            let wire_type = key & 7;
+            if field == 3 && wire_type == 2 {
+                let op_len = read_proto_varint(txn, &mut txn_offset) as usize;
+                ops.push(decode_portable_op(&txn[txn_offset..txn_offset + op_len]));
+                txn_offset += op_len;
+            } else {
+                skip_proto_field(txn, &mut txn_offset, wire_type);
+            }
+        }
+    }
+    ops
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn decode_portable_change_origins(portable_changes: &[u8]) -> Vec<String> {
+    let mut origins = Vec::new();
+    let mut offset = 0usize;
+    while offset < portable_changes.len() {
+        let txn_len = read_proto_varint(portable_changes, &mut offset) as usize;
+        let txn_end = offset + txn_len;
+        let txn = &portable_changes[offset..txn_end];
+        offset = txn_end;
+
+        let mut txn_offset = 0usize;
+        while txn_offset < txn.len() {
+            let key = read_proto_varint(txn, &mut txn_offset);
+            let field = key >> 3;
+            let wire_type = key & 7;
+            if field == 4 && wire_type == 2 {
+                let len = read_proto_varint(txn, &mut txn_offset) as usize;
+                origins
+                    .push(String::from_utf8(txn[txn_offset..txn_offset + len].to_vec()).unwrap());
+                txn_offset += len;
+            } else {
+                skip_proto_field(txn, &mut txn_offset, wire_type);
+            }
+        }
+    }
+    origins
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_encoder_matches_logical_op_wire_golden() {
+    let row = PortableSchemaRow {
+        row_type: "view".to_string(),
+        name: "v".to_string(),
+        rootpage: 0,
+        sql: Some("CREATE VIEW v AS SELECT 1".to_string()),
+    };
+    let mut encoded = Vec::new();
+
+    encode_schema_logical_op(LOGICAL_SCHEMA_CREATE, &row, None, &mut encoded);
+
+    assert_eq!(
+        encoded,
+        vec![
+            0x1a, 0x24, // PortableLogicalTxn.ops, length 36
+            0x08, 0x02, // LogicalOp.op_type = Schema
+            0x2a, 0x19, // LogicalOp.sql, length 25
+            b'C', b'R', b'E', b'A', b'T', b'E', b' ', b'V', b'I', b'E', b'W', b' ', b'v', b' ',
+            b'A', b'S', b' ', b'S', b'E', b'L', b'E', b'C', b'T', b' ', b'1', 0x40,
+            0x00, // LogicalOp.schema_action = Create
+            0x48, 0x03, // LogicalOp.schema_kind = View
+            0x52, 0x01, b'v', // LogicalOp.schema_name = "v"
+        ]
+    );
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_disabled_by_default() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:").unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO items VALUES (1, 'alpha')")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&conn);
+
+    assert!(portable_changes.is_empty());
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_contains_user_schema_and_rows() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (1, 'alpha')")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_name == "items"
+        && op.sql.contains("CREATE TABLE items")
+        && op.stable_table_id.unwrap_or_default() > 0));
+    assert!(ops.iter().any(|op| op.op_type == 0
+        && op.table_name == "items"
+        && op.stable_table_id.unwrap_or_default() > 0));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_keep_stable_table_id_across_rename() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (1, 'before')")
+        .unwrap();
+    db.conn
+        .execute("ALTER TABLE items RENAME TO things")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO things VALUES (2, 'after')")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+    let before_id = ops
+        .iter()
+        .find(|op| op.op_type == 0 && op.table_name == "items")
+        .and_then(|op| op.stable_table_id)
+        .expect("create-time row should carry stable table id");
+    let after_id = ops
+        .iter()
+        .find(|op| op.op_type == 0 && op.table_name == "things")
+        .and_then(|op| op.stable_table_id)
+        .expect("post-rename row should carry stable table id");
+    let rename_id = ops
+        .iter()
+        .find(|op| {
+            op.op_type == 2
+                && op.schema_action == Some(LOGICAL_SCHEMA_REFRESH)
+                && op.schema_name == "things"
+        })
+        .and_then(|op| op.stable_table_id)
+        .expect("rename schema refresh should carry stable table id");
+
+    assert_eq!(before_id, after_id);
+    assert_eq!(before_id, rename_id);
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_emit_refresh_for_same_rowid_schema_update() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn
+        .execute("ALTER TABLE items ADD COLUMN note TEXT")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(2)
+        && op.schema_name == "items"
+        && op.sql.contains("note TEXT")));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_emit_drop_and_create_for_drop_recreate_same_name() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (1, 'old')")
+        .unwrap();
+
+    db.conn.execute("BEGIN").unwrap();
+    db.conn.execute("DROP TABLE items").unwrap();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, note TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (2, 'new')")
+        .unwrap();
+    db.conn.execute("COMMIT").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(1)
+        && op.schema_kind == Some(0)
+        && op.schema_name == "items"));
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(0)
+        && op.schema_kind == Some(0)
+        && op.schema_name == "items"
+        && op.sql.contains("note TEXT")));
+    assert!(ops
+        .iter()
+        .any(|op| op.op_type == 0 && op.stable_table_id.unwrap_or_default() > 0));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_omit_row_table_name_after_schema_identity_in_same_txn() {
+    let db = MvccTestDb::new();
+    db.conn.execute("BEGIN").unwrap();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (1, 'alpha')")
+        .unwrap();
+    db.conn.execute("COMMIT").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+    let schema_id = ops
+        .iter()
+        .find(|op| op.op_type == 2 && op.schema_name == "items")
+        .and_then(|op| op.stable_table_id)
+        .expect("schema identity should carry stable table id");
+    let row_op = ops
+        .iter()
+        .find(|op| op.op_type == 0 && op.stable_table_id == Some(schema_id))
+        .expect("row op should carry matching stable table id");
+
+    assert!(row_op.table_name.is_empty());
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_emit_index_drop_for_drop_table() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn
+        .execute("CREATE INDEX items_payload_idx ON items(portable_changes)")
+        .unwrap();
+    db.conn.execute("DROP TABLE items").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(1)
+        && op.schema_kind == Some(0)
+        && op.schema_name == "items"));
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(1)
+        && op.schema_kind == Some(1)
+        && op.schema_name == "items_payload_idx"));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_emit_index_trigger_and_view_schema_ops() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn
+        .execute("CREATE INDEX items_payload_idx ON items(portable_changes)")
+        .unwrap();
+    db.conn
+        .execute("CREATE VIEW items_view AS SELECT id, portable_changes FROM items")
+        .unwrap();
+    db.conn
+        .execute(
+            "CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN UPDATE items SET portable_changes = NEW.portable_changes WHERE id = NEW.id; END",
+        )
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(0)
+        && op.schema_kind == Some(1)
+        && op.schema_name == "items_payload_idx"
+        && op.sql.contains("CREATE INDEX items_payload_idx")));
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(0)
+        && op.schema_kind == Some(3)
+        && op.schema_name == "items_view"
+        && op.sql.contains("CREATE VIEW items_view")));
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(0)
+        && op.schema_kind == Some(2)
+        && op.schema_name == "items_ai"
+        && op.sql.contains("CREATE TRIGGER items_ai")));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_emit_trigger_and_view_lifecycle_ops() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn
+        .execute("CREATE VIEW items_view AS SELECT id, portable_changes FROM items")
+        .unwrap();
+    db.conn
+        .execute(
+            "CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN UPDATE items SET portable_changes = NEW.portable_changes WHERE id = NEW.id; END",
+        )
+        .unwrap();
+
+    db.conn.execute("BEGIN").unwrap();
+    db.conn.execute("DROP VIEW items_view").unwrap();
+    db.conn.execute("DROP TRIGGER items_ai").unwrap();
+    db.conn
+        .execute("CREATE VIEW items_view AS SELECT id FROM items")
+        .unwrap();
+    db.conn
+        .execute("CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN SELECT NEW.id; END")
+        .unwrap();
+    db.conn.execute("COMMIT").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(1)
+        && op.schema_kind == Some(3)
+        && op.schema_name == "items_view"));
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(0)
+        && op.schema_kind == Some(3)
+        && op.schema_name == "items_view"
+        && op.sql.contains("CREATE VIEW items_view AS SELECT id")));
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(1)
+        && op.schema_kind == Some(2)
+        && op.schema_name == "items_ai"));
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(0)
+        && op.schema_kind == Some(2)
+        && op.schema_name == "items_ai"
+        && op.sql.contains("CREATE TRIGGER items_ai")));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_emit_header_only_commits() {
+    let db = MvccTestDb::new();
+    db.conn.execute("PRAGMA user_version = 42").unwrap();
+    db.conn.execute("PRAGMA application_id = 1337").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+    let header_ops = ops.iter().filter(|op| op.op_type == 3).collect::<Vec<_>>();
+
+    assert_eq!(header_ops.len(), 2);
+    assert!(ops
+        .iter()
+        .any(|op| op.op_type == 3 && op.user_version == Some(42)));
+    assert!(ops
+        .iter()
+        .any(|op| op.op_type == 3 && op.application_id == Some(1337)));
+}
+
+#[test]
+#[cfg(feature = "conn_raw_api")]
+fn test_mvcc_portable_changes_use_checkpointed_schema_after_restart() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.set_portable_logical_changes_enabled(true);
+        conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO items VALUES (1, 'before')")
+            .unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    {
+        let conn = db.connect();
+        conn.set_portable_logical_changes_enabled(true);
+        conn.execute("INSERT INTO items VALUES (2, 'after')")
+            .unwrap();
+        conn.execute("ALTER TABLE items ADD COLUMN note TEXT")
+            .unwrap();
+        conn.execute("UPDATE items SET note = 'backfill' WHERE id = 2")
+            .unwrap();
+
+        let portable_changes = collect_mvcc_portable_change_bytes(&conn);
+        let ops = decode_portable_change_ops(&portable_changes);
+
+        assert!(ops
+            .iter()
+            .any(|op| op.op_type == 0 && op.table_name == "items"));
+        assert!(ops.iter().any(|op| op.op_type == 2
+            && op.schema_action == Some(2)
+            && op.schema_kind == Some(0)
+            && op.schema_name == "items"
+            && op.sql.contains("note TEXT")));
+        conn.close().unwrap();
+    }
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_emit_ddl_and_backfill_rows_in_same_transaction() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (1, 'alpha'), (2, 'beta')")
+        .unwrap();
+
+    db.conn.execute("BEGIN").unwrap();
+    db.conn
+        .execute("ALTER TABLE items ADD COLUMN note TEXT")
+        .unwrap();
+    db.conn
+        .execute("UPDATE items SET note = 'backfilled'")
+        .unwrap();
+    db.conn.execute("COMMIT").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops.iter().any(|op| op.op_type == 2
+        && op.schema_action == Some(2)
+        && op.schema_kind == Some(0)
+        && op.schema_name == "items"
+        && op.sql.contains("note TEXT")));
+    assert!(
+        ops.iter()
+            .filter(|op| op.op_type == 0 && op.stable_table_id.unwrap_or_default() > 0)
+            .count()
+            >= 2
+    );
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_do_not_infer_origin_from_application_table() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute(
+            "CREATE TABLE turso_sync_last_change_id(client_id TEXT PRIMARY KEY, pull_gen INTEGER, change_id INTEGER)",
+        )
+        .unwrap();
+    db.conn
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
+        .unwrap();
+    db.conn.execute("BEGIN").unwrap();
+    db.conn
+        .execute("INSERT INTO turso_sync_last_change_id VALUES ('client-a', 1, 10)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES (1, 'visible')")
+        .unwrap();
+    db.conn.execute("COMMIT").unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+    let origins = decode_portable_change_origins(&portable_changes);
+
+    assert!(bytes_contain(
+        &portable_changes,
+        b"turso_sync_last_change_id"
+    ));
+    assert!(origins.is_empty());
+    assert!(ops
+        .iter()
+        .any(|op| op.op_type == 0 && op.table_name == "items"));
 }
 
 /// Encrypted version of test_recovery_checkpoint_then_more_writes.
@@ -11128,7 +11950,7 @@ fn test_encrypted_recovery_corrupted_ciphertext() {
         crate::storage::encryption::CipherMode::Aes256Gcm,
     );
 
-    // Corrupt the payload of the second (non-checkpointed) frame in the log file.
+    // Corrupt the portable_changes of the second (non-checkpointed) frame in the log file.
     // The log header is 56 bytes, then the TX header is 24 bytes. Flip a byte
     // in the encrypted payload area right after that.
     {
@@ -11394,7 +12216,7 @@ fn create_wide_table_like_schema(conn: &Arc<Connection>) {
             id INTEGER PRIMARY KEY,
             sheet_id INTEGER NOT NULL,
             trigger_type TEXT NOT NULL,
-            payload TEXT,
+            portable_changes TEXT,
             created_at TEXT DEFAULT (datetime('now'))
         )",
     )
@@ -11456,17 +12278,17 @@ fn insert_wide_table_like_batch(conn: &Arc<Connection>, start_row_number: i64, r
     ))
     .unwrap();
     conn.execute(
-        "INSERT INTO trigger_gate(sheet_id, trigger_type, payload, created_at)
+        "INSERT INTO trigger_gate(sheet_id, trigger_type, portable_changes, created_at)
          VALUES (1, 'ROW_INSERT', '{\"count\": 1}', datetime('now'))",
     )
     .unwrap();
     conn.execute(
-        "INSERT INTO trigger_gate(sheet_id, trigger_type, payload, created_at)
+        "INSERT INTO trigger_gate(sheet_id, trigger_type, portable_changes, created_at)
          VALUES (1, 'RECALC', '{\"sheet_id\": 1}', datetime('now'))",
     )
     .unwrap();
     conn.execute(
-        "INSERT INTO trigger_gate(sheet_id, trigger_type, payload, created_at)
+        "INSERT INTO trigger_gate(sheet_id, trigger_type, portable_changes, created_at)
          VALUES (1, 'WEBHOOK', '{\"event\": \"rows_added\"}', datetime('now'))",
     )
     .unwrap();
@@ -11554,7 +12376,7 @@ fn test_checkpoint_recovers_after_crash_restart_drop_recreate_index() {
         let conn = db.connect();
         conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
             .unwrap();
-        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, payload TEXT)")
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, portable_changes TEXT)")
             .unwrap();
         conn.execute("INSERT INTO t VALUES (1, 'seed_1', hex(randomblob(16)))")
             .unwrap();
@@ -11645,6 +12467,148 @@ fn test_checkpoint_recovers_after_restart_drop_checkpointed_index() {
     let rows = get_rows(&conn, "PRAGMA integrity_check");
     assert_eq!(rows.len(), 1);
     assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn test_recovery_after_drop_table_with_uncheckpointed_index() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+        conn.execute("DROP TABLE t").unwrap();
+    }
+
+    force_close_for_artifact_tamper(&mut db);
+    db.restart();
+
+    let conn = db.connect();
+    let rows = get_rows(
+        &conn,
+        "SELECT type, name, tbl_name FROM sqlite_schema WHERE name IN ('t', 'idx_t_v') ORDER BY type, name",
+    );
+    assert_eq!(rows, Vec::<Vec<Value>>::new());
+}
+
+#[test]
+fn test_recovery_after_drop_checkpointed_table_with_index() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX idx_t_v ON t(v)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 'seed')").unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.execute("DROP TABLE t").unwrap();
+    }
+
+    force_close_for_artifact_tamper(&mut db);
+    db.restart();
+
+    let conn = db.connect();
+    let rows = get_rows(
+        &conn,
+        "SELECT type, name, tbl_name FROM sqlite_schema WHERE name IN ('t', 'idx_t_v') ORDER BY type, name",
+    );
+    assert_eq!(rows, Vec::<Vec<Value>>::new());
+}
+
+#[test]
+fn test_recovery_after_drop_checkpointed_table_with_if_not_exists_index() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    let table = "mvcc_sync_items_1777416431036232886";
+    let index = "mvcc_sync_items_1777416431036232886_owner_rev_idx";
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        conn.execute(format!(
+            "CREATE TABLE IF NOT EXISTS {table} (id INTEGER PRIMARY KEY, owner TEXT NOT NULL, portable_changes TEXT NOT NULL, rev INTEGER NOT NULL DEFAULT 0)"
+        ))
+        .unwrap();
+        conn.execute(format!(
+            "CREATE INDEX IF NOT EXISTS {index} ON {table} (owner, rev)"
+        ))
+        .unwrap();
+        conn.execute(format!(
+            "INSERT INTO {table} (id, owner, portable_changes, rev) VALUES (1, 'seed-a', 'alpha', 1)"
+        ))
+        .unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.execute(format!("DROP TABLE IF EXISTS {table}"))
+            .unwrap();
+    }
+
+    force_close_for_artifact_tamper(&mut db);
+    db.restart();
+
+    let conn = db.connect();
+    let rows = get_rows(
+        &conn,
+        &format!(
+            "SELECT type, name, tbl_name FROM sqlite_schema WHERE name IN ('{table}', '{index}') ORDER BY type, name"
+        ),
+    );
+    assert_eq!(rows, Vec::<Vec<Value>>::new());
+}
+
+#[test]
+fn test_recovery_after_drop_table_with_many_schema_rows() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    let target = "mvcc_sync_items_1777416431036232886";
+    let target_index = "mvcc_sync_items_1777416431036232886_owner_rev_idx";
+
+    {
+        let conn = db.connect();
+        conn.execute("PRAGMA mvcc_checkpoint_threshold = 1000000")
+            .unwrap();
+        for i in 0..350 {
+            conn.execute(format!(
+                "CREATE TABLE filler_{i}(id INTEGER PRIMARY KEY, owner TEXT, rev INTEGER)"
+            ))
+            .unwrap();
+            conn.execute(format!(
+                "CREATE INDEX filler_{i}_idx ON filler_{i}(owner, rev)"
+            ))
+            .unwrap();
+        }
+        conn.execute(format!(
+            "CREATE TABLE IF NOT EXISTS {target} (id INTEGER PRIMARY KEY, owner TEXT NOT NULL, portable_changes TEXT NOT NULL, rev INTEGER NOT NULL DEFAULT 0)"
+        ))
+        .unwrap();
+        conn.execute(format!(
+            "CREATE INDEX IF NOT EXISTS {target_index} ON {target} (owner, rev)"
+        ))
+        .unwrap();
+        conn.execute(format!(
+            "INSERT INTO {target} (id, owner, portable_changes, rev) VALUES (1, 'seed-a', 'alpha', 1)"
+        ))
+        .unwrap();
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        conn.execute(format!("DROP TABLE IF EXISTS {target}"))
+            .unwrap();
+    }
+
+    force_close_for_artifact_tamper(&mut db);
+    db.restart();
+
+    let conn = db.connect();
+    let rows = get_rows(
+        &conn,
+        &format!(
+            "SELECT type, name, tbl_name FROM sqlite_schema WHERE name IN ('{target}', '{target_index}') ORDER BY type, name"
+        ),
+    );
+    assert_eq!(rows, Vec::<Vec<Value>>::new());
 }
 
 #[test]
@@ -12709,8 +13673,14 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         fn truncate(&self) -> Result<Completion> {
             self.inner.truncate()
         }
+        fn reset_to_fresh_header(&self) -> Result<Completion> {
+            self.inner.reset_to_fresh_header()
+        }
         fn get_logical_log_file(&self) -> Arc<dyn File> {
             self.inner.get_logical_log_file()
+        }
+        fn logical_log_offset(&self) -> u64 {
+            self.inner.logical_log_offset()
         }
         fn should_checkpoint(&self) -> bool {
             self.inner.should_checkpoint()
@@ -12721,8 +13691,11 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         fn checkpoint_threshold(&self) -> i64 {
             self.inner.checkpoint_threshold()
         }
-        fn advance_logical_log_offset_after_success(&self, b: u64) {
+        fn advance_logical_log_offset_after_success(&self, b: u64) -> Result<()> {
             self.inner.advance_logical_log_offset_after_success(b)
+        }
+        fn discard_pending_log_write(&self) -> Result<()> {
+            self.inner.discard_pending_log_write()
         }
         fn restore_logical_log_state_after_recovery(&self, o: u64, c: u32) {
             self.inner.restore_logical_log_state_after_recovery(o, c)

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -13,7 +13,7 @@ use crate::mvcc::persistent_storage::logical_log::{
 };
 #[cfg(feature = "conn_raw_api")]
 use crate::mvcc::portable_logical::{
-    encode_schema_logical_op, PortableSchemaRow, LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_REFRESH,
+    PortableLogicalBuilder, PortableSchemaRow, LOGICAL_SCHEMA_CREATE, LOGICAL_SCHEMA_REFRESH,
 };
 use crate::mvcc::yield_hooks::YieldPointMarker;
 use crate::mvcc::yield_points::{FailureInjector, YieldInjector, YieldPoint};
@@ -11177,16 +11177,18 @@ fn assert_log_payloads_decrypt(
         let op_count = u32::from_le_bytes(log_bytes[offset + 12..offset + 16].try_into().unwrap());
         let commit_ts = u64::from_le_bytes(log_bytes[offset + 16..offset + 24].try_into().unwrap());
 
+        let encrypted_plaintext_size = payload_size + extension_size;
         let mut payload_offset = offset + header_size;
-        let chunk_count = if payload_size == 0 {
+        let chunk_count = if encrypted_plaintext_size == 0 {
             0
         } else {
-            payload_size.div_ceil(ENCRYPTED_PAYLOAD_CHUNK_SIZE)
+            encrypted_plaintext_size.div_ceil(ENCRYPTED_PAYLOAD_CHUNK_SIZE)
         };
 
         let mut frame_complete = true;
         for chunk_index in 0..chunk_count {
-            let chunk_plaintext_len = (payload_size - chunk_index * ENCRYPTED_PAYLOAD_CHUNK_SIZE)
+            let chunk_plaintext_len = (encrypted_plaintext_size
+                - chunk_index * ENCRYPTED_PAYLOAD_CHUNK_SIZE)
                 .min(ENCRYPTED_PAYLOAD_CHUNK_SIZE);
             let chunk_on_disk_size = chunk_plaintext_len + tag_size + nonce_size;
             if payload_offset + chunk_on_disk_size + TX_TRAILER_SIZE > log_bytes.len() {
@@ -11201,7 +11203,7 @@ fn assert_log_payloads_decrypt(
             let mut aad = [0u8; 32];
             aad[..8].copy_from_slice(&salt.to_le_bytes());
             if chunk_index + 1 == chunk_count {
-                aad[8..16].copy_from_slice(&(payload_size as u64).to_le_bytes());
+                aad[8..16].copy_from_slice(&(encrypted_plaintext_size as u64).to_le_bytes());
             }
             aad[16..20].copy_from_slice(&op_count.to_le_bytes());
             aad[20..28].copy_from_slice(&commit_ts.to_le_bytes());
@@ -11222,7 +11224,7 @@ fn assert_log_payloads_decrypt(
         }
 
         frame_count += 1;
-        offset = payload_offset + extension_size + TX_TRAILER_SIZE; // skip extension block and trailer
+        offset = payload_offset + TX_TRAILER_SIZE; // skip encrypted body and trailer
     }
 
     assert!(
@@ -11240,6 +11242,28 @@ fn collect_mvcc_portable_change_bytes(conn: &Arc<Connection>) -> Vec<u8> {
         .clone();
     let io = conn.get_pager().io.clone();
     let mut reader = StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), None);
+    reader.read_header(&io).unwrap();
+
+    let mut portable_changes = Vec::new();
+    while let Some(frame) = reader.next_portable_changes(&io).unwrap() {
+        portable_changes.extend_from_slice(&frame.payload);
+    }
+    portable_changes
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn collect_mvcc_portable_change_bytes_with_encryption(
+    conn: &Arc<Connection>,
+    encryption_ctx: crate::storage::encryption::EncryptionContext,
+) -> Vec<u8> {
+    let mv_store = conn
+        .mv_store()
+        .as_ref()
+        .expect("test database must be in MVCC mode")
+        .clone();
+    let io = conn.get_pager().io.clone();
+    let mut reader =
+        StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), Some(encryption_ctx));
     reader.read_header(&io).unwrap();
 
     let mut portable_changes = Vec::new();
@@ -11268,6 +11292,8 @@ struct DecodedPortableOp {
     user_version: Option<u64>,
     application_id: Option<u64>,
     stable_table_id: Option<u64>,
+    mv_table_id: Option<i64>,
+    record_len: usize,
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11286,6 +11312,11 @@ fn read_proto_varint(bytes: &[u8], offset: &mut usize) -> u64 {
 }
 
 #[cfg(feature = "conn_raw_api")]
+fn decode_proto_sint64(value: u64) -> i64 {
+    ((value >> 1) as i64) ^ (-((value & 1) as i64))
+}
+
+#[cfg(feature = "conn_raw_api")]
 fn skip_proto_field(bytes: &[u8], offset: &mut usize, wire_type: u64) {
     match wire_type {
         0 => {
@@ -11300,7 +11331,56 @@ fn skip_proto_field(bytes: &[u8], offset: &mut usize, wire_type: u64) {
 }
 
 #[cfg(feature = "conn_raw_api")]
-fn decode_portable_op(bytes: &[u8]) -> DecodedPortableOp {
+#[derive(Clone, Debug)]
+struct DecodedObjectMap {
+    stable_table_id: u64,
+    name: String,
+    sql: String,
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn decode_object_map(bytes: &[u8], strings: &[String]) -> Option<(i64, DecodedObjectMap)> {
+    let mut offset = 0usize;
+    let mut mv_table_id = None;
+    let mut stable_table_id = None;
+    let mut name = String::new();
+    let mut sql = String::new();
+    while offset < bytes.len() {
+        let key = read_proto_varint(bytes, &mut offset);
+        let field = key >> 3;
+        let wire_type = key & 7;
+        match (field, wire_type) {
+            (1, 0) => {
+                mv_table_id = Some(decode_proto_sint64(read_proto_varint(bytes, &mut offset)))
+            }
+            (2, 0) => stable_table_id = Some(read_proto_varint(bytes, &mut offset)),
+            (4, 0) => {
+                let idx = read_proto_varint(bytes, &mut offset) as usize;
+                name = strings.get(idx).cloned().unwrap_or_default();
+            }
+            (6, 0) => {
+                let idx = read_proto_varint(bytes, &mut offset) as usize;
+                sql = strings.get(idx).cloned().unwrap_or_default();
+            }
+            _ => skip_proto_field(bytes, &mut offset, wire_type),
+        }
+    }
+    Some((
+        mv_table_id?,
+        DecodedObjectMap {
+            stable_table_id: stable_table_id?,
+            name,
+            sql,
+        },
+    ))
+}
+
+#[cfg(feature = "conn_raw_api")]
+fn decode_portable_op(
+    bytes: &[u8],
+    strings: &[String],
+    object_maps: &std::collections::HashMap<i64, DecodedObjectMap>,
+) -> DecodedPortableOp {
     let mut op = DecodedPortableOp {
         op_type: u64::MAX,
         schema_action: None,
@@ -11311,6 +11391,8 @@ fn decode_portable_op(bytes: &[u8]) -> DecodedPortableOp {
         user_version: None,
         application_id: None,
         stable_table_id: None,
+        mv_table_id: None,
+        record_len: 0,
     };
     let mut offset = 0usize;
     while offset < bytes.len() {
@@ -11323,6 +11405,22 @@ fn decode_portable_op(bytes: &[u8]) -> DecodedPortableOp {
             (7, 0) => op.application_id = Some(read_proto_varint(bytes, &mut offset)),
             (8, 0) => op.schema_action = Some(read_proto_varint(bytes, &mut offset)),
             (9, 0) => op.schema_kind = Some(read_proto_varint(bytes, &mut offset)),
+            (12, 0) => {
+                op.mv_table_id = Some(decode_proto_sint64(read_proto_varint(bytes, &mut offset)));
+            }
+            (13, 0) => {
+                let idx = read_proto_varint(bytes, &mut offset) as usize;
+                op.sql = strings.get(idx).cloned().unwrap_or_default();
+            }
+            (14, 0) => {
+                let idx = read_proto_varint(bytes, &mut offset) as usize;
+                op.schema_name = strings.get(idx).cloned().unwrap_or_default();
+            }
+            (4, 2) => {
+                let len = read_proto_varint(bytes, &mut offset) as usize;
+                op.record_len = len;
+                offset += len;
+            }
             (2, 2) => {
                 let len = read_proto_varint(bytes, &mut offset) as usize;
                 op.table_name = String::from_utf8(bytes[offset..offset + len].to_vec()).unwrap();
@@ -11342,6 +11440,15 @@ fn decode_portable_op(bytes: &[u8]) -> DecodedPortableOp {
             _ => skip_proto_field(bytes, &mut offset, wire_type),
         }
     }
+    if let Some(mv_table_id) = op.mv_table_id {
+        if let Some(object) = object_maps.get(&mv_table_id) {
+            op.table_name = object.name.clone();
+            op.stable_table_id = Some(object.stable_table_id);
+            if op.sql.is_empty() {
+                op.sql = object.sql.clone();
+            }
+        }
+    }
     op
 }
 
@@ -11355,6 +11462,34 @@ fn decode_portable_change_ops(portable_changes: &[u8]) -> Vec<DecodedPortableOp>
         let txn = &portable_changes[offset..txn_end];
         offset = txn_end;
 
+        let mut strings = Vec::new();
+        let mut object_blobs = Vec::new();
+        let mut scan_offset = 0usize;
+        while scan_offset < txn.len() {
+            let key = read_proto_varint(txn, &mut scan_offset);
+            let field = key >> 3;
+            let wire_type = key & 7;
+            match (field, wire_type) {
+                (12, 2) => {
+                    let len = read_proto_varint(txn, &mut scan_offset) as usize;
+                    strings.push(
+                        String::from_utf8(txn[scan_offset..scan_offset + len].to_vec()).unwrap(),
+                    );
+                    scan_offset += len;
+                }
+                (13, 2) => {
+                    let len = read_proto_varint(txn, &mut scan_offset) as usize;
+                    object_blobs.push(txn[scan_offset..scan_offset + len].to_vec());
+                    scan_offset += len;
+                }
+                _ => skip_proto_field(txn, &mut scan_offset, wire_type),
+            }
+        }
+        let object_maps = object_blobs
+            .iter()
+            .filter_map(|object| decode_object_map(object, &strings))
+            .collect::<std::collections::HashMap<_, _>>();
+
         let mut txn_offset = 0usize;
         while txn_offset < txn.len() {
             let key = read_proto_varint(txn, &mut txn_offset);
@@ -11362,7 +11497,11 @@ fn decode_portable_change_ops(portable_changes: &[u8]) -> Vec<DecodedPortableOp>
             let wire_type = key & 7;
             if field == 3 && wire_type == 2 {
                 let op_len = read_proto_varint(txn, &mut txn_offset) as usize;
-                ops.push(decode_portable_op(&txn[txn_offset..txn_offset + op_len]));
+                ops.push(decode_portable_op(
+                    &txn[txn_offset..txn_offset + op_len],
+                    &strings,
+                    &object_maps,
+                ));
                 txn_offset += op_len;
             } else {
                 skip_proto_field(txn, &mut txn_offset, wire_type);
@@ -11409,21 +11548,23 @@ fn test_mvcc_portable_changes_encoder_matches_logical_op_wire_golden() {
         rootpage: 0,
         sql: Some("CREATE VIEW v AS SELECT 1".to_string()),
     };
-    let mut encoded = Vec::new();
-
-    encode_schema_logical_op(LOGICAL_SCHEMA_CREATE, &row, None, &mut encoded);
+    let mut builder = PortableLogicalBuilder::new();
+    builder.encode_schema_logical_op(LOGICAL_SCHEMA_CREATE, &row, None);
+    let encoded = builder.finish(None);
 
     assert_eq!(
         encoded,
         vec![
-            0x1a, 0x24, // PortableLogicalTxn.ops, length 36
-            0x08, 0x02, // LogicalOp.op_type = Schema
-            0x2a, 0x19, // LogicalOp.sql, length 25
+            0x62, 0x01, b'v', // PortableLogicalTxn.string_table[0] = "v"
+            0x62, 0x19, // PortableLogicalTxn.string_table[1] = SQL
             b'C', b'R', b'E', b'A', b'T', b'E', b' ', b'V', b'I', b'E', b'W', b' ', b'v', b' ',
-            b'A', b'S', b' ', b'S', b'E', b'L', b'E', b'C', b'T', b' ', b'1', 0x40,
-            0x00, // LogicalOp.schema_action = Create
+            b'A', b'S', b' ', b'S', b'E', b'L', b'E', b'C', b'T', b' ', b'1', 0x1a,
+            0x0a, // PortableLogicalTxn.ops, length 10
+            0x08, 0x02, // LogicalOp.op_type = Schema
+            0x40, 0x00, // LogicalOp.schema_action = Create
             0x48, 0x03, // LogicalOp.schema_kind = View
-            0x52, 0x01, b'v', // LogicalOp.schema_name = "v"
+            0x68, 0x01, // LogicalOp.sql_ref = 1
+            0x70, 0x00, // LogicalOp.schema_name_ref = 0
         ]
     );
 }
@@ -11571,7 +11712,7 @@ fn test_mvcc_portable_changes_emit_drop_and_create_for_drop_recreate_same_name()
 
 #[cfg(feature = "conn_raw_api")]
 #[test]
-fn test_mvcc_portable_changes_omit_row_table_name_after_schema_identity_in_same_txn() {
+fn test_mvcc_portable_changes_resolve_rows_through_object_map_in_same_txn() {
     let db = MvccTestDb::new();
     db.conn.execute("BEGIN").unwrap();
     db.conn
@@ -11594,7 +11735,8 @@ fn test_mvcc_portable_changes_omit_row_table_name_after_schema_identity_in_same_
         .find(|op| op.op_type == 0 && op.stable_table_id == Some(schema_id))
         .expect("row op should carry matching stable table id");
 
-    assert!(row_op.table_name.is_empty());
+    assert_eq!(row_op.table_name, "items");
+    assert!(row_op.mv_table_id.is_some());
 }
 
 #[cfg(feature = "conn_raw_api")]
@@ -11810,6 +11952,28 @@ fn test_mvcc_portable_changes_emit_ddl_and_backfill_rows_in_same_transaction() {
 
 #[cfg(feature = "conn_raw_api")]
 #[test]
+fn test_mvcc_portable_changes_delete_carries_old_record_for_primary_key_derivation() {
+    let db = MvccTestDb::new();
+    db.conn
+        .execute("CREATE TABLE items(id TEXT PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    db.conn
+        .execute("INSERT INTO items VALUES ('item-a', 'alpha')")
+        .unwrap();
+    db.conn
+        .execute("DELETE FROM items WHERE id = 'item-a'")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&db.conn);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops
+        .iter()
+        .any(|op| op.op_type == 1 && op.table_name == "items" && op.record_len > 0));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
 fn test_mvcc_portable_changes_do_not_infer_origin_from_application_table() {
     let db = MvccTestDb::new();
     db.conn
@@ -11841,6 +12005,68 @@ fn test_mvcc_portable_changes_do_not_infer_origin_from_application_table() {
     assert!(ops
         .iter()
         .any(|op| op.op_type == 0 && op.table_name == "items"));
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_metadata_does_not_auto_enable_or_get_consumed() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:").unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.set_mvcc_log_meta("client".to_string(), Some("client-a".to_string()));
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO items VALUES (1, 'alpha')")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&conn);
+    assert!(portable_changes.is_empty());
+
+    conn.set_portable_logical_changes_enabled(true);
+    conn.execute("INSERT INTO items VALUES (2, 'beta')")
+        .unwrap();
+    conn.execute("INSERT INTO items VALUES (3, 'gamma')")
+        .unwrap();
+
+    let portable_changes = collect_mvcc_portable_change_bytes(&conn);
+    let origins = decode_portable_change_origins(&portable_changes);
+    assert_eq!(
+        origins,
+        vec!["client-a".to_string(), "client-a".to_string()]
+    );
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_changes_are_encrypted_with_log_body() {
+    use crate::storage::encryption::{CipherMode, EncryptionContext};
+
+    let hex_key = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    let db = MvccTestDbNoConn::new_encrypted(hex_key);
+    let conn = db.connect();
+    conn.set_portable_logical_changes_enabled(true);
+    conn.execute("CREATE TABLE secret_items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO secret_items VALUES (1, 'secret-alpha')")
+        .unwrap();
+
+    let log_path = std::path::PathBuf::from(db.path.as_ref().unwrap()).with_extension("db-log");
+    let log_bytes = std::fs::read(log_path).unwrap();
+    assert!(!bytes_contain(&log_bytes, b"secret_items"));
+    assert!(!bytes_contain(&log_bytes, b"secret-alpha"));
+
+    let key = EncryptionKey::from_hex_string(hex_key).unwrap();
+    let enc_ctx = EncryptionContext::new(CipherMode::Aes256Gcm, &key, 4096).unwrap();
+    let portable_changes = collect_mvcc_portable_change_bytes_with_encryption(&conn, enc_ctx);
+    let ops = decode_portable_change_ops(&portable_changes);
+
+    assert!(ops
+        .iter()
+        .any(|op| op.op_type == 2 && op.schema_name == "secret_items"));
+    assert!(ops
+        .iter()
+        .any(|op| op.op_type == 0 && op.table_name == "secret_items"));
 }
 
 /// Encrypted version of test_recovery_checkpoint_then_more_writes.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -107,7 +107,6 @@ impl MvccTestDb {
         let io = Arc::new(MemoryIO::new());
         let db = Database::open_file(io, ":memory:").unwrap();
         let conn = db.connect().unwrap();
-        conn.set_portable_logical_changes_enabled(true);
         // Enable MVCC via PRAGMA
         conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         let mvcc_store = db.get_mv_store().clone().unwrap();
@@ -116,6 +115,13 @@ impl MvccTestDb {
             db,
             conn,
         }
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    fn new_with_portable_logical_changes() -> Self {
+        let db = Self::new();
+        db.conn.set_portable_logical_changes_enabled(true);
+        db
     }
 }
 
@@ -11497,7 +11503,7 @@ fn test_mvcc_portable_changes_disabled_by_default() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_contains_user_schema_and_rows() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
         .unwrap();
@@ -11517,7 +11523,7 @@ fn test_mvcc_portable_changes_contains_user_schema_and_rows() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_updates_name_mapping_across_rename() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
         .unwrap();
@@ -11541,7 +11547,7 @@ fn test_mvcc_portable_changes_updates_name_mapping_across_rename() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_refresh_for_same_rowid_schema_update() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
         .unwrap();
@@ -11559,7 +11565,7 @@ fn test_mvcc_portable_changes_emit_refresh_for_same_rowid_schema_update() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_drop_and_create_for_drop_recreate_same_name() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
         .unwrap();
@@ -11595,7 +11601,7 @@ fn test_mvcc_portable_changes_emit_drop_and_create_for_drop_recreate_same_name()
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_resolve_rows_through_object_map_in_same_txn() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn.execute("BEGIN").unwrap();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
@@ -11619,7 +11625,7 @@ fn test_mvcc_portable_changes_resolve_rows_through_object_map_in_same_txn() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_index_drop_for_drop_table() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
         .unwrap();
@@ -11639,7 +11645,7 @@ fn test_mvcc_portable_changes_emit_index_drop_for_drop_table() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_index_trigger_and_view_schema_ops() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
         .unwrap();
@@ -11671,7 +11677,7 @@ fn test_mvcc_portable_changes_emit_index_trigger_and_view_schema_ops() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_trigger_and_view_lifecycle_ops() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
         .unwrap();
@@ -11704,7 +11710,7 @@ fn test_mvcc_portable_changes_emit_trigger_and_view_lifecycle_ops() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_header_only_commits() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn.execute("PRAGMA user_version = 42").unwrap();
     db.conn.execute("PRAGMA application_id = 1337").unwrap();
 
@@ -11759,7 +11765,7 @@ fn test_mvcc_portable_changes_use_checkpointed_schema_after_restart() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_emit_ddl_and_backfill_rows_in_same_transaction() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, portable_changes TEXT)")
         .unwrap();
@@ -11786,7 +11792,7 @@ fn test_mvcc_portable_changes_emit_ddl_and_backfill_rows_in_same_transaction() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_delete_carries_pk_projection_not_old_record() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute("CREATE TABLE items(id TEXT PRIMARY KEY, payload TEXT)")
         .unwrap();
@@ -11827,7 +11833,7 @@ fn test_mvcc_portable_changes_delete_carries_pk_projection_not_old_record() {
 #[cfg(feature = "conn_raw_api")]
 #[test]
 fn test_mvcc_portable_changes_do_not_infer_origin_from_application_table() {
-    let db = MvccTestDb::new();
+    let db = MvccTestDb::new_with_portable_logical_changes();
     db.conn
         .execute(
             "CREATE TABLE turso_sync_last_change_id(client_id TEXT PRIMARY KEY, pull_gen INTEGER, change_id INTEGER)",

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -35,10 +35,11 @@ pub mod clock;
 pub mod cursor;
 pub mod database;
 pub mod persistent_storage;
+#[cfg(feature = "conn_raw_api")]
+pub mod portable_logical;
 #[cfg(any(test, injected_yields))]
 pub(crate) mod yield_hooks;
 pub mod yield_points;
-
 pub use clock::MvccClock;
 pub use database::MvStore;
 

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -68,11 +68,16 @@
 //! - `reserved: [u8; 36]` (must be zero for current format)
 //! - `hdr_crc32c: u32` (CRC32C of the header with this field zeroed)
 //!
-//! ### TX Header (`TX_HEADER_SIZE = 24`)
-//! - `frame_magic: u32` (`FRAME_MAGIC`)
+//! ### TX Header (`TX_HEADER_SIZE = 24`, `TX_EXT_HEADER_SIZE = 40`)
+//! - `frame_magic: u32` (`FRAME_MAGIC` for compact recovery frames,
+//!   `EXT_FRAME_MAGIC` when a portable extension block follows the recovery
+//!   payload)
 //! - `payload_size: u64` (total bytes of all op entries, pre-encryption)
 //! - `op_count: u32`
 //! - `commit_ts: u64`
+//! - `extension_size: u64` (extension frames only)
+//! - `extension_record_count: u32` (extension frames only)
+//! - `frame_flags: u32` (extension frames only)
 //!
 //! ### Payload
 //! - When **unencrypted**: `op_count` operation entries serialized directly:
@@ -219,7 +224,7 @@ use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::turso_assert;
 use crate::{
-    io::ReadComplete,
+    io::{CompletionGroup, ReadComplete},
     mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},
     storage::sqlite3_ondisk::{
         read_varint, read_varint_partial, varint_len, write_varint_to_vec, DatabaseHeader,
@@ -240,7 +245,8 @@ pub const DEFAULT_LOG_CHECKPOINT_THRESHOLD: i64 = 4120 * 1000;
 pub type OnSerializationComplete<'a> = Option<&'a dyn Fn(&[u8], u32) -> crate::Result<()>>;
 
 const LOG_MAGIC: u32 = 0x4C4D4C32; // "LML2" in LE
-const LOG_VERSION: u8 = 2;
+const LOG_VERSION_V2: u8 = 2;
+const LOG_VERSION: u8 = 3;
 pub const LOG_HDR_SIZE: usize = 56;
 const LOG_HDR_SALT_START: usize = 8;
 const LOG_HDR_SALT_SIZE: usize = 8;
@@ -248,6 +254,7 @@ const LOG_HDR_RESERVED_START: usize = LOG_HDR_SALT_START + LOG_HDR_SALT_SIZE; //
 const LOG_HDR_CRC_START: usize = 52;
 const LOG_HDR_RESERVED_SIZE: usize = LOG_HDR_CRC_START - LOG_HDR_RESERVED_START; // 36
 pub(crate) const FRAME_MAGIC: u32 = 0x5854564D; // "MVTX" in LE
+pub(crate) const EXT_FRAME_MAGIC: u32 = 0x5845564D; // "MVEX" in LE
 const END_MAGIC: u32 = 0x4554564D; // "MVTE" in LE
 
 // Size of each chunk before encryption (i.e. before tag/nonce overhead is added)
@@ -265,9 +272,19 @@ const OP_UPDATE_HEADER: u8 = 4;
 
 const OP_FLAG_BTREE_RESIDENT: u8 = 1 << 0;
 
-pub(crate) const TX_HEADER_SIZE: usize = 24; // FRAME_MAGIC(4) + payload_size(8) + op_count(4) + commit_ts(8)
+const TX_HEADER_SIZE_V2: usize = 24; // FRAME_MAGIC(4) + payload_size(8) + op_count(4) + commit_ts(8)
+const TX_HEADER_SIZE: usize = TX_HEADER_SIZE_V2;
+// LML3 extension frames keep the recovery fields first, then append portable
+// metadata. Compact frames use the 24-byte recovery header and normal
+// FRAME_MAGIC; extension frames use EXT_FRAME_MAGIC and this 40-byte header.
+pub(crate) const TX_EXT_HEADER_SIZE: usize =
+    TX_HEADER_SIZE + 8 /* extension_size */ + 4 /* extension_record_count */ + 4 /* frame_flags */;
 const TX_TRAILER_SIZE: usize = 8; // crc32c(4) + END_MAGIC(4)
+const TX_MIN_FRAME_SIZE_V2: usize = TX_HEADER_SIZE_V2 + TX_TRAILER_SIZE; // 32
 const TX_MIN_FRAME_SIZE: usize = TX_HEADER_SIZE + TX_TRAILER_SIZE; // 32
+const TX_FRAME_FLAG_HAS_EXTENSION_BLOCK: u32 = 1 << 0;
+const EXTENSION_RECORD_HEADER_SIZE: usize = 8; // type(u16) + flags(u16) + len(u32)
+const EXTENSION_TYPE_PORTABLE_CHANGES: u16 = 1;
 
 /// Total bytes pre-reserved at the front of a `LogRecord::buf`.
 pub(crate) const LOG_RECORD_PREFIX_SIZE: usize = LOG_HDR_SIZE + TX_HEADER_SIZE;
@@ -410,7 +427,7 @@ impl LogHeader {
             return Err(LimboError::Corrupt("Invalid logical log magic".to_string()));
         }
         let version = buf[4];
-        if version != LOG_VERSION {
+        if version != LOG_VERSION && version != LOG_VERSION_V2 {
             return Err(LimboError::Corrupt(format!(
                 "Unsupported logical log version {version}"
             )));
@@ -652,15 +669,72 @@ impl LogicalLog {
         // Unencrypted: payload bytes are already in place at
         // [LOG_RECORD_PREFIX_SIZE ..].
 
+        #[cfg(feature = "conn_raw_api")]
+        let has_portable_changes = !tx.portable_changes.is_empty();
+        #[cfg(not(feature = "conn_raw_api"))]
+        let has_portable_changes = false;
+        if has_portable_changes {
+            tx.buf.splice(
+                LOG_RECORD_PREFIX_SIZE..LOG_RECORD_PREFIX_SIZE,
+                [0u8; TX_EXT_HEADER_SIZE - TX_HEADER_SIZE],
+            );
+        }
+
+        #[cfg(feature = "conn_raw_api")]
+        let extension_block = if !has_portable_changes {
+            Vec::new()
+        } else {
+            let bytes_before_portable_changes = tx
+                .buf
+                .len()
+                .checked_sub(if is_first_write { 0 } else { LOG_HDR_SIZE })
+                .and_then(|value| value.checked_add(EXTENSION_RECORD_HEADER_SIZE))
+                .ok_or_else(|| {
+                    LimboError::InternalError(
+                        "logical log portable-change prefix length overflow".to_string(),
+                    )
+                })?;
+            let portable_changes = encode_portable_change_payload_with_stable_end_offset(
+                self.offset,
+                bytes_before_portable_changes,
+                tx.tx_timestamp,
+                &tx.portable_changes,
+            )?;
+            encode_extension_record(EXTENSION_TYPE_PORTABLE_CHANGES, 0, &portable_changes)?
+        };
+        #[cfg(not(feature = "conn_raw_api"))]
+        let extension_block = Vec::new();
+
+        let extension_size = u64::try_from(extension_block.len()).map_err(|_| {
+            LimboError::InternalError("Logical log extension size exceeds u64".to_string())
+        })?;
+        if !extension_block.is_empty() {
+            tx.buf.extend_from_slice(&extension_block);
+        }
+
         // 3. Backfill TX HEADER at offset LOG_HDR_SIZE:
         //    FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
+        // Extension frames use EXT_FRAME_MAGIC and append:
+        //    | extension_size(8) | extension_record_count(4) | frame_flags(4)
         let tx_header_start = LOG_HDR_SIZE;
-        tx.buf[tx_header_start..tx_header_start + 4].copy_from_slice(&FRAME_MAGIC.to_le_bytes());
+        let frame_magic = if has_portable_changes {
+            EXT_FRAME_MAGIC
+        } else {
+            FRAME_MAGIC
+        };
+        tx.buf[tx_header_start..tx_header_start + 4].copy_from_slice(&frame_magic.to_le_bytes());
         tx.buf[tx_header_start + 4..tx_header_start + 12]
             .copy_from_slice(&payload_size_u64.to_le_bytes());
         tx.buf[tx_header_start + 12..tx_header_start + 16].copy_from_slice(&op_count.to_le_bytes());
         tx.buf[tx_header_start + 16..tx_header_start + 24]
             .copy_from_slice(&commit_ts.to_le_bytes());
+        if has_portable_changes {
+            tx.buf[tx_header_start + 24..tx_header_start + 32]
+                .copy_from_slice(&extension_size.to_le_bytes());
+            tx.buf[tx_header_start + 32..tx_header_start + 36].copy_from_slice(&1u32.to_le_bytes());
+            tx.buf[tx_header_start + 36..tx_header_start + 40]
+                .copy_from_slice(&TX_FRAME_FLAG_HAS_EXTENSION_BLOCK.to_le_bytes());
+        }
 
         // 4. TX TRAILER (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
         // CRC is chained: seeded from running_crc (salt-derived, or previous
@@ -820,6 +894,39 @@ impl LogicalLog {
         self.offset = 0;
         Ok(c)
     }
+
+    /// Reset the log to a header-only file and return one completion for the
+    /// header write plus truncate.
+    ///
+    /// This intentionally truncates to `LOG_HDR_SIZE`, not zero, so the header
+    /// write and truncate can run as a group without an ordering dependency.
+    /// Either completion order leaves a header-sized file with the fresh header
+    /// bytes at offset zero.
+    pub fn reset_to_fresh_header(&mut self) -> Result<Completion> {
+        // Regenerate salt so stale frames from before the reset cannot validate
+        // against this new CRC chain.
+        let mut header = self.current_or_new_header()?;
+        header.salt = self.io.generate_random_number() as u64;
+        self.running_crc = derive_initial_crc(header.salt);
+        self.pending_running_crc = None;
+        self.header = Some(header.clone());
+
+        let header_c = self.write_header(header)?;
+        let truncate_c = self.file.truncate(
+            LOG_HDR_SIZE as u64,
+            Completion::new_trunc(move |result| {
+                if let Err(err) = result {
+                    tracing::error!("logical_log_truncate failed: {}", err);
+                }
+            }),
+        )?;
+        self.offset = 0;
+
+        let mut group = CompletionGroup::new(|_| {});
+        group.add(&header_c);
+        group.add(&truncate_c);
+        Ok(group.build())
+    }
 }
 
 /// Serialize one op into `buffer`.
@@ -897,6 +1004,146 @@ pub(crate) fn serialize_header_entry(buffer: &mut Vec<u8>, header: &DatabaseHead
     buffer.extend_from_slice(&0i32.to_le_bytes());
     write_varint_to_vec(DatabaseHeader::SIZE as u64, buffer);
     buffer.extend_from_slice(bytemuck::bytes_of(header));
+}
+
+fn write_proto_varint(mut value: u64, buffer: &mut Vec<u8>) {
+    while value >= 0x80 {
+        buffer.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    buffer.push(value as u8);
+}
+
+fn proto_varint_len(mut value: u64) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        len += 1;
+        value >>= 7;
+    }
+    len
+}
+
+fn encode_portable_change_payload(end_offset: u64, commit_ts: u64, encoded_ops: &[u8]) -> Vec<u8> {
+    let body_len =
+        2 + proto_varint_len(end_offset) + proto_varint_len(commit_ts) + encoded_ops.len();
+    let mut out = Vec::with_capacity(proto_varint_len(body_len as u64) + body_len);
+    write_proto_varint(body_len as u64, &mut out);
+    // PortableLogicalTxn.end_offset, field 1, varint.
+    write_proto_varint(1 << 3, &mut out);
+    write_proto_varint(end_offset, &mut out);
+    // PortableLogicalTxn.commit_ts, field 2, varint.
+    write_proto_varint(2 << 3, &mut out);
+    write_proto_varint(commit_ts, &mut out);
+    // PortableLogicalTxn.ops, field 3, length-delimited messages already encoded by the commit builder.
+    out.extend_from_slice(encoded_ops);
+    out
+}
+
+/// Wraps commit-built logical op messages in one length-delimited
+/// portable MVCC logical transaction payload and iterates until the embedded
+/// `end_offset` matches the final frame size.
+///
+/// `end_offset` is part of the raw-log replay cursor, but its varint width can
+/// change the payload length. The fixed-point loop converges after the varint
+/// width stops changing.
+fn encode_portable_change_payload_with_stable_end_offset(
+    write_offset: u64,
+    bytes_before_portable_changes: usize,
+    tx_timestamp: u64,
+    portable_changes: &[u8],
+) -> Result<Vec<u8>> {
+    let mut end_offset = write_offset
+        .checked_add(bytes_before_portable_changes as u64)
+        .and_then(|value| value.checked_add(TX_TRAILER_SIZE as u64))
+        .ok_or_else(|| {
+            LimboError::InternalError("portable logical frame offset overflow".to_string())
+        })?;
+    loop {
+        let payload = encode_portable_change_payload(end_offset, tx_timestamp, portable_changes);
+        let next_end_offset = write_offset
+            .checked_add(bytes_before_portable_changes as u64)
+            .and_then(|value| value.checked_add(payload.len() as u64))
+            .and_then(|value| value.checked_add(TX_TRAILER_SIZE as u64))
+            .ok_or_else(|| {
+                LimboError::InternalError("portable logical frame offset overflow".to_string())
+            })?;
+        if next_end_offset == end_offset {
+            return Ok(payload);
+        }
+        end_offset = next_end_offset;
+    }
+}
+
+fn encode_extension_record(
+    extension_type: u16,
+    extension_flags: u16,
+    payload: &[u8],
+) -> Result<Vec<u8>> {
+    let payload_len = u32::try_from(payload.len()).map_err(|_| {
+        LimboError::InternalError("Logical log extension record exceeds u32".to_string())
+    })?;
+    let mut record = Vec::with_capacity(EXTENSION_RECORD_HEADER_SIZE + payload.len());
+    record.extend_from_slice(&extension_type.to_le_bytes());
+    record.extend_from_slice(&extension_flags.to_le_bytes());
+    record.extend_from_slice(&payload_len.to_le_bytes());
+    record.extend_from_slice(payload);
+    Ok(record)
+}
+
+fn find_extension_payload(
+    extension_block: &[u8],
+    extension_record_count: u32,
+    wanted_type: u16,
+) -> Result<Vec<u8>> {
+    let mut offset = 0usize;
+    let mut payload = Vec::new();
+    for _ in 0..extension_record_count {
+        let Some(header_end) = offset.checked_add(EXTENSION_RECORD_HEADER_SIZE) else {
+            return Err(LimboError::Corrupt(
+                "extension record header offset overflow".to_string(),
+            ));
+        };
+        if header_end > extension_block.len() {
+            return Err(LimboError::Corrupt(
+                "extension record header is truncated".to_string(),
+            ));
+        }
+        let extension_type =
+            u16::from_le_bytes(extension_block[offset..offset + 2].try_into().unwrap());
+        let extension_flags =
+            u16::from_le_bytes(extension_block[offset + 2..offset + 4].try_into().unwrap());
+        if extension_flags != 0 {
+            return Err(LimboError::Corrupt(format!(
+                "unsupported extension flags for type {extension_type}: {extension_flags:#x}"
+            )));
+        }
+        let extension_len = u32::from_le_bytes(
+            extension_block[offset + 4..offset + EXTENSION_RECORD_HEADER_SIZE]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let payload_start = header_end;
+        let Some(payload_end) = payload_start.checked_add(extension_len) else {
+            return Err(LimboError::Corrupt(
+                "extension record payload offset overflow".to_string(),
+            ));
+        };
+        if payload_end > extension_block.len() {
+            return Err(LimboError::Corrupt(
+                "extension record payload is truncated".to_string(),
+            ));
+        }
+        if extension_type == wanted_type {
+            payload.extend_from_slice(&extension_block[payload_start..payload_end]);
+        }
+        offset = payload_end;
+    }
+    if offset != extension_block.len() {
+        return Err(LimboError::Corrupt(
+            "extension block has trailing bytes".to_string(),
+        ));
+    }
+    Ok(payload)
 }
 
 /// Parse all ops from a decrypted plaintext buffer.
@@ -1086,6 +1333,14 @@ pub enum StreamingResult {
     Eof,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PortableChangeFrame {
+    pub end_offset: u64,
+    pub commit_ts: u64,
+    pub extension_record_count: u32,
+    pub payload: Vec<u8>,
+}
+
 #[derive(Clone, Copy, Debug)]
 enum StreamingState {
     NeedTransactionStart,
@@ -1124,6 +1379,8 @@ pub struct StreamingLogicalLogReader {
     /// Plaintext bytes per encrypted payload chunk. Production uses the fixed format constant;
     /// tests may override via `new_with_encrypted_payload_chunk_size_for_test`.
     encrypted_payload_chunk_size: usize,
+    #[cfg(test)]
+    pending_ops: std::collections::VecDeque<ParsedOp>,
     // Reused scratch buffer for decrypted chunk plaintext. Kept on the reader so encrypted
     // recovery can reuse the allocation across chunks and transaction frames.
     decrypt_scratch: Vec<u8>,
@@ -1152,6 +1409,8 @@ impl StreamingLogicalLogReader {
             running_crc: 0,
             encryption_ctx,
             encrypted_payload_chunk_size,
+            #[cfg(test)]
+            pending_ops: std::collections::VecDeque::new(),
             decrypt_scratch,
         }
     }
@@ -1180,10 +1439,22 @@ impl StreamingLogicalLogReader {
         self.last_valid_offset
     }
 
+    #[cfg(test)]
+    pub fn has_pending_ops(&self) -> bool {
+        !self.pending_ops.is_empty()
+    }
+
     /// Returns the running CRC state after all validated frames. Used during recovery
     /// to hand off the chain state to the writer so it can continue appending.
     pub fn running_crc(&self) -> u32 {
         self.running_crc
+    }
+
+    fn tx_min_frame_size(&self) -> usize {
+        match self.header.as_ref().map(|header| header.version) {
+            Some(LOG_VERSION_V2) => TX_MIN_FRAME_SIZE_V2,
+            _ => TX_MIN_FRAME_SIZE,
+        }
     }
 
     pub fn read_header(&mut self, io: &Arc<dyn crate::IO>) -> Result<()> {
@@ -1251,7 +1522,7 @@ impl StreamingLogicalLogReader {
                     }
 
                     let ops = match self.parse_next_transaction(io)? {
-                        ParseResult::Ops(ops) => ops,
+                        ParseResult::Frame(frame) => frame.ops,
                         ParseResult::Eof | ParseResult::InvalidFrame => return Ok(None),
                     };
 
@@ -1260,6 +1531,92 @@ impl StreamingLogicalLogReader {
                     }
                     return Ok(Some(ops));
                 }
+            }
+        }
+    }
+
+    /// Reads next record in log.
+    ///
+    /// This is a test-only version of [Self::next_frame], and it could eventually be replaced
+    /// in tests by [Self::next_frame], which didn't exist when [Self::next_record] was written.
+    #[cfg(test)]
+    pub fn next_record(
+        &mut self,
+        io: &Arc<dyn crate::IO>,
+        mut get_index_info: impl FnMut(MVTableId) -> Result<Arc<IndexInfo>>,
+    ) -> Result<StreamingResult> {
+        let mut get_index_info = |index_id, _op_kind| get_index_info(index_id);
+        self.file_size = self.file.size()? as usize;
+        if let Some(op) = self.pending_ops.pop_front() {
+            return self.parsed_op_to_streaming(op, &mut get_index_info);
+        }
+
+        loop {
+            match self.state {
+                StreamingState::NeedTransactionStart => {
+                    if self.remaining_bytes() < self.tx_min_frame_size() {
+                        return Ok(StreamingResult::Eof);
+                    }
+
+                    let ops = match self.parse_next_transaction(io)? {
+                        ParseResult::Frame(frame) => frame.ops,
+                        ParseResult::Eof | ParseResult::InvalidFrame => {
+                            return Ok(StreamingResult::Eof);
+                        }
+                    };
+
+                    if ops.is_empty() {
+                        continue;
+                    }
+                    self.pending_ops = ops.into();
+                    let op = self
+                        .pending_ops
+                        .pop_front()
+                        .expect("ops queue should not be empty");
+                    return self.parsed_op_to_streaming(op, &mut get_index_info);
+                }
+            }
+        }
+    }
+
+    /// Reads the next transaction frame and returns its portable logical-change
+    /// payload. This validates the LML3 frame envelope and chained CRC while
+    /// treating the recovery payload as opaque bytes.
+    ///
+    /// Empty payloads are returned because internal-only commits still
+    /// advance the logical-log offset even though clients have no operation to
+    /// apply.
+    pub fn next_portable_change_frame(
+        &mut self,
+        io: &Arc<dyn crate::IO>,
+    ) -> Result<Option<PortableChangeFrame>> {
+        self.file_size = self.file.size()? as usize;
+        match self.parse_next_portable_changes_frame(io)? {
+            ParseResult::Frame(frame) => Ok(Some(PortableChangeFrame {
+                end_offset: frame.end_offset as u64,
+                commit_ts: frame.commit_ts,
+                extension_record_count: frame.extension_record_count,
+                payload: frame.portable_changes,
+            })),
+            ParseResult::Eof | ParseResult::InvalidFrame => Ok(None),
+        }
+    }
+
+    /// Reads the next portable logical-change payload, skipping internal-only
+    /// frames.
+    ///
+    /// Empty payloads are valid: internal-only commits still need recovery
+    /// log frames, but they do not produce client-visible logical operations.
+    pub fn next_portable_changes(
+        &mut self,
+        io: &Arc<dyn crate::IO>,
+    ) -> Result<Option<PortableChangeFrame>> {
+        loop {
+            let Some(frame) = self.next_portable_change_frame(io)? else {
+                return Ok(None);
+            };
+            if !frame.payload.is_empty() {
+                return Ok(Some(frame));
             }
         }
     }
@@ -1796,26 +2153,47 @@ impl StreamingLogicalLogReader {
     }
 
     fn parse_next_transaction(&mut self, io: &Arc<dyn crate::IO>) -> Result<ParseResult> {
-        if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
+        if self.remaining_bytes() < self.tx_min_frame_size() {
             return Ok(ParseResult::Eof);
         }
         let frame_start = self.offset.saturating_sub(self.bytes_can_read());
 
-        let header_bytes = match self.try_consume_fixed::<TX_HEADER_SIZE>(io)? {
+        let mut header_bytes = match self.try_consume_bytes(io, TX_HEADER_SIZE)? {
             Some(bytes) => bytes,
             None => return Ok(ParseResult::Eof),
         };
 
-        // TX HEADER layout (24 bytes): FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
+        // TX HEADER v2 layout (24 bytes):
+        // FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
+        //
+        // TX HEADER v3 extension frames append:
+        // extension_size(8) | extension_record_count(4) | frame_flags(4)
         let frame_magic = u32::from_le_bytes([
             header_bytes[0],
             header_bytes[1],
             header_bytes[2],
             header_bytes[3],
         ]);
-        if frame_magic != FRAME_MAGIC {
+        let is_v2 = self
+            .header
+            .as_ref()
+            .is_some_and(|header| header.version == LOG_VERSION_V2);
+        let has_extension_header = !is_v2 && frame_magic == EXT_FRAME_MAGIC;
+        if frame_magic != FRAME_MAGIC && !has_extension_header {
             self.last_valid_offset = frame_start;
             return Ok(ParseResult::InvalidFrame);
+        }
+        if is_v2 && frame_magic != FRAME_MAGIC {
+            self.last_valid_offset = frame_start;
+            return Ok(ParseResult::InvalidFrame);
+        }
+        if has_extension_header {
+            let Some(extension_header) =
+                self.try_consume_bytes(io, TX_EXT_HEADER_SIZE - TX_HEADER_SIZE)?
+            else {
+                return Ok(ParseResult::Eof);
+            };
+            header_bytes.extend_from_slice(&extension_header);
         }
         let payload_size_u64 = u64::from_le_bytes([
             header_bytes[4],
@@ -1843,6 +2221,53 @@ impl StreamingLogicalLogReader {
             header_bytes[22],
             header_bytes[23],
         ]);
+        let (extension_size, extension_record_count, frame_flags) = if has_extension_header {
+            let extension_size_u64 = u64::from_le_bytes([
+                header_bytes[24],
+                header_bytes[25],
+                header_bytes[26],
+                header_bytes[27],
+                header_bytes[28],
+                header_bytes[29],
+                header_bytes[30],
+                header_bytes[31],
+            ]);
+            let extension_size = match usize::try_from(extension_size_u64) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("extension_size overflows usize: {e}");
+                    self.last_valid_offset = frame_start;
+                    return Ok(ParseResult::InvalidFrame);
+                }
+            };
+            let extension_record_count = u32::from_le_bytes([
+                header_bytes[32],
+                header_bytes[33],
+                header_bytes[34],
+                header_bytes[35],
+            ]);
+            let frame_flags = u32::from_le_bytes([
+                header_bytes[36],
+                header_bytes[37],
+                header_bytes[38],
+                header_bytes[39],
+            ]);
+            if frame_flags & !TX_FRAME_FLAG_HAS_EXTENSION_BLOCK != 0 {
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+            if extension_size == 0 && extension_record_count != 0 {
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+            if extension_size > 0 && frame_flags & TX_FRAME_FLAG_HAS_EXTENSION_BLOCK == 0 {
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+            (extension_size, extension_record_count, frame_flags)
+        } else {
+            (0, 0, 0)
+        };
 
         let payload_size = match usize::try_from(payload_size_u64) {
             Ok(v) => v,
@@ -1872,6 +2297,31 @@ impl StreamingLogicalLogReader {
                 return Ok(ParseResult::InvalidFrame);
             }
             Err(e) => return Err(e),
+        };
+
+        let (portable_changes, running_crc) = if extension_size > 0 {
+            match self.try_consume_bytes(io, extension_size)? {
+                Some(bytes) => {
+                    let running_crc = crc32c::crc32c_append(running_crc, &bytes);
+                    let portable_changes = match find_extension_payload(
+                        &bytes,
+                        extension_record_count,
+                        EXTENSION_TYPE_PORTABLE_CHANGES,
+                    ) {
+                        Ok(payload) => payload,
+                        Err(LimboError::Corrupt(msg)) => {
+                            tracing::warn!("corrupt extension block: {msg}");
+                            self.last_valid_offset = frame_start;
+                            return Ok(ParseResult::InvalidFrame);
+                        }
+                        Err(e) => return Err(e),
+                    };
+                    (portable_changes, running_crc)
+                }
+                None => return Ok(ParseResult::Eof),
+            }
+        } else {
+            (Vec::new(), running_crc)
         };
 
         // 3. TX TRAILER layout (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
@@ -1905,7 +2355,253 @@ impl StreamingLogicalLogReader {
         self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
         // Advance the chain: this frame's CRC becomes the seed for the next frame.
         self.running_crc = running_crc;
-        Ok(ParseResult::Ops(parsed_ops))
+        Ok(ParseResult::Frame(ParsedFrame {
+            ops: parsed_ops,
+            portable_changes,
+            extension_record_count,
+            frame_flags,
+            commit_ts,
+            end_offset: self.last_valid_offset,
+        }))
+    }
+
+    fn consume_and_crc_bytes(
+        &mut self,
+        io: &Arc<dyn crate::IO>,
+        mut amount: usize,
+        mut running_crc: u32,
+    ) -> Result<Option<u32>> {
+        const CHUNK_SIZE: usize = 64 * 1024;
+        while amount > 0 {
+            let chunk_len = amount.min(CHUNK_SIZE);
+            let Some(bytes) = self.try_consume_bytes(io, chunk_len)? else {
+                return Ok(None);
+            };
+            running_crc = crc32c::crc32c_append(running_crc, &bytes);
+            amount -= chunk_len;
+        }
+        Ok(Some(running_crc))
+    }
+
+    fn encrypted_payload_on_disk_size(&self, payload_size: usize) -> Result<usize> {
+        let Some(encryption_ctx) = self.encryption_ctx.as_ref() else {
+            return Ok(payload_size);
+        };
+        let mut on_disk_size = 0usize;
+        for chunk_index in
+            0..encrypted_payload_chunk_count(payload_size, self.encrypted_payload_chunk_size)
+        {
+            let plaintext_len = encrypted_chunk_plaintext_len(
+                payload_size,
+                chunk_index,
+                self.encrypted_payload_chunk_size,
+            )?;
+            on_disk_size = on_disk_size
+                .checked_add(encrypted_chunk_blob_size(
+                    plaintext_len,
+                    encryption_ctx.tag_size(),
+                    encryption_ctx.nonce_size(),
+                )?)
+                .ok_or_else(|| {
+                    LimboError::Corrupt("encrypted payload size overflows usize".to_string())
+                })?;
+        }
+        Ok(on_disk_size)
+    }
+
+    fn parse_next_portable_changes_frame(
+        &mut self,
+        io: &Arc<dyn crate::IO>,
+    ) -> Result<ParseResult> {
+        if self
+            .header
+            .as_ref()
+            .is_some_and(|h| h.version == LOG_VERSION_V2)
+        {
+            return Ok(ParseResult::Eof);
+        }
+        if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
+            return Ok(ParseResult::Eof);
+        }
+        let frame_start = self.offset.saturating_sub(self.bytes_can_read());
+
+        let mut header_bytes = match self.try_consume_bytes(io, TX_HEADER_SIZE)? {
+            Some(bytes) => bytes,
+            None => return Ok(ParseResult::Eof),
+        };
+
+        let frame_magic = u32::from_le_bytes([
+            header_bytes[0],
+            header_bytes[1],
+            header_bytes[2],
+            header_bytes[3],
+        ]);
+        let has_extension_header = frame_magic == EXT_FRAME_MAGIC;
+        if frame_magic != FRAME_MAGIC && !has_extension_header {
+            self.last_valid_offset = frame_start;
+            return Ok(ParseResult::InvalidFrame);
+        }
+        if has_extension_header {
+            let Some(extension_header) =
+                self.try_consume_bytes(io, TX_EXT_HEADER_SIZE - TX_HEADER_SIZE)?
+            else {
+                return Ok(ParseResult::Eof);
+            };
+            header_bytes.extend_from_slice(&extension_header);
+        }
+        let payload_size_u64 = u64::from_le_bytes([
+            header_bytes[4],
+            header_bytes[5],
+            header_bytes[6],
+            header_bytes[7],
+            header_bytes[8],
+            header_bytes[9],
+            header_bytes[10],
+            header_bytes[11],
+        ]);
+        let commit_ts = u64::from_le_bytes([
+            header_bytes[16],
+            header_bytes[17],
+            header_bytes[18],
+            header_bytes[19],
+            header_bytes[20],
+            header_bytes[21],
+            header_bytes[22],
+            header_bytes[23],
+        ]);
+        let (extension_size_u64, extension_record_count, frame_flags) = if has_extension_header {
+            let extension_size_u64 = u64::from_le_bytes([
+                header_bytes[24],
+                header_bytes[25],
+                header_bytes[26],
+                header_bytes[27],
+                header_bytes[28],
+                header_bytes[29],
+                header_bytes[30],
+                header_bytes[31],
+            ]);
+            let extension_record_count = u32::from_le_bytes([
+                header_bytes[32],
+                header_bytes[33],
+                header_bytes[34],
+                header_bytes[35],
+            ]);
+            let frame_flags = u32::from_le_bytes([
+                header_bytes[36],
+                header_bytes[37],
+                header_bytes[38],
+                header_bytes[39],
+            ]);
+            if frame_flags & !TX_FRAME_FLAG_HAS_EXTENSION_BLOCK != 0 {
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+            if extension_size_u64 == 0 && extension_record_count != 0 {
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+            if extension_size_u64 > 0 && frame_flags & TX_FRAME_FLAG_HAS_EXTENSION_BLOCK == 0 {
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+            (extension_size_u64, extension_record_count, frame_flags)
+        } else {
+            (0, 0, 0)
+        };
+
+        let payload_size = match usize::try_from(payload_size_u64) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("payload_size overflows usize: {e}");
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+        };
+        let extension_size = match usize::try_from(extension_size_u64) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("extension_size overflows usize: {e}");
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+        };
+
+        let running_crc = crc32c::crc32c_append(self.running_crc, &header_bytes);
+        let payload_on_disk_size = match self.encrypted_payload_on_disk_size(payload_size) {
+            Ok(size) => size,
+            Err(LimboError::Corrupt(msg)) => {
+                tracing::warn!("corrupt payload size: {msg}");
+                self.last_valid_offset = frame_start;
+                return Ok(ParseResult::InvalidFrame);
+            }
+            Err(e) => return Err(e),
+        };
+        let Some(running_crc) =
+            self.consume_and_crc_bytes(io, payload_on_disk_size, running_crc)?
+        else {
+            return Ok(ParseResult::Eof);
+        };
+
+        let (portable_changes, running_crc) = if extension_size > 0 {
+            match self.try_consume_bytes(io, extension_size)? {
+                Some(bytes) => {
+                    let running_crc = crc32c::crc32c_append(running_crc, &bytes);
+                    let portable_changes = match find_extension_payload(
+                        &bytes,
+                        extension_record_count,
+                        EXTENSION_TYPE_PORTABLE_CHANGES,
+                    ) {
+                        Ok(payload) => payload,
+                        Err(LimboError::Corrupt(msg)) => {
+                            tracing::warn!("corrupt extension block: {msg}");
+                            self.last_valid_offset = frame_start;
+                            return Ok(ParseResult::InvalidFrame);
+                        }
+                        Err(e) => return Err(e),
+                    };
+                    (portable_changes, running_crc)
+                }
+                None => return Ok(ParseResult::Eof),
+            }
+        } else {
+            (Vec::new(), running_crc)
+        };
+
+        let trailer_bytes = match self.try_consume_fixed::<TX_TRAILER_SIZE>(io)? {
+            Some(bytes) => bytes,
+            None => return Ok(ParseResult::Eof),
+        };
+        let crc32c_expected = u32::from_le_bytes([
+            trailer_bytes[0],
+            trailer_bytes[1],
+            trailer_bytes[2],
+            trailer_bytes[3],
+        ]);
+        let end_magic = u32::from_le_bytes([
+            trailer_bytes[4],
+            trailer_bytes[5],
+            trailer_bytes[6],
+            trailer_bytes[7],
+        ]);
+        if crc32c_expected != running_crc {
+            self.last_valid_offset = frame_start;
+            return Ok(ParseResult::InvalidFrame);
+        }
+        if end_magic != END_MAGIC {
+            self.last_valid_offset = frame_start;
+            return Ok(ParseResult::InvalidFrame);
+        }
+
+        self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
+        self.running_crc = running_crc;
+        Ok(ParseResult::Frame(ParsedFrame {
+            ops: Vec::new(),
+            portable_changes,
+            extension_record_count,
+            frame_flags,
+            commit_ts,
+            end_offset: self.last_valid_offset,
+        }))
     }
 
     pub(crate) fn parsed_op_to_streaming(
@@ -2229,7 +2925,7 @@ enum EncryptedChunkReadResult {
 #[cfg_attr(test, derive(Debug))]
 enum ParseResult {
     /// A fully validated transaction frame was parsed.
-    Ops(Vec<ParsedOp>),
+    Frame(ParsedFrame),
     /// True end-of-file: not enough bytes remain to form a complete frame.
     Eof,
     /// An invalid frame was encountered (bad magic, CRC mismatch, structural error).
@@ -2237,6 +2933,16 @@ enum ParseResult {
     /// but semantically distinct: the data exists but is not a valid frame.
     /// `last_valid_offset` is set to the start of the invalid frame before returning this.
     InvalidFrame,
+}
+
+#[cfg_attr(test, derive(Debug))]
+pub struct ParsedFrame {
+    ops: Vec<ParsedOp>,
+    pub portable_changes: Vec<u8>,
+    pub extension_record_count: u32,
+    pub frame_flags: u32,
+    pub commit_ts: u64,
+    pub end_offset: usize,
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -2308,9 +3014,11 @@ mod tests {
         build_encrypted_chunk_aad, encrypted_chunk_blob_size, encrypted_chunk_plaintext_len,
         encrypted_payload_blob_size, encrypted_payload_chunk_count, serialize_header_entry,
         serialize_op_entry, HeaderReadResult, LogHeader, LogicalLog, ParseResult, ParsedOp,
-        StreamingLogicalLogReader, ENCRYPTED_CHUNK_AAD_SIZE, ENCRYPTED_PAYLOAD_CHUNK_SIZE,
-        END_MAGIC, FRAME_MAGIC, LOG_HDR_CRC_START, LOG_HDR_RESERVED_START, LOG_HDR_SIZE,
-        LOG_VERSION, TX_HEADER_SIZE, TX_TRAILER_SIZE,
+        StreamingLogicalLogReader, StreamingResult, ENCRYPTED_CHUNK_AAD_SIZE,
+        ENCRYPTED_PAYLOAD_CHUNK_SIZE, END_MAGIC, EXTENSION_RECORD_HEADER_SIZE,
+        EXTENSION_TYPE_PORTABLE_CHANGES, EXT_FRAME_MAGIC, FRAME_MAGIC, LOG_HDR_CRC_START,
+        LOG_HDR_RESERVED_START, LOG_HDR_SIZE, LOG_VERSION, LOG_VERSION_V2, OP_UPSERT_TABLE,
+        TX_EXT_HEADER_SIZE, TX_HEADER_SIZE, TX_HEADER_SIZE_V2, TX_TRAILER_SIZE,
     };
     use crate::OpenFlags;
     use crate::{turso_assert, turso_assert_less_than};
@@ -2816,7 +3524,9 @@ mod tests {
                 });
 
             let Some(index_row) = index_row_opt else {
-                panic!("Index row for ({data_value}, {row_id}) not found after recovery. Index rows should be in the logical log.");
+                panic!(
+                    "Index row for ({data_value}, {row_id}) not found after recovery. Index rows should be in the logical log."
+                );
             };
             // Verify the index row contains the correct data
             let RowKey::Record(sortable_key) = index_row.id.row_id else {
@@ -3991,7 +4701,8 @@ mod tests {
         assert_eq!(header.salt, salt_after);
 
         match reader.parse_next_transaction(&io) {
-            Ok(ParseResult::Ops(ops)) => {
+            Ok(ParseResult::Frame(frame)) => {
+                let ops = frame.ops;
                 assert!(!ops.is_empty(), "expected at least one op");
             }
             Ok(ParseResult::Eof) => panic!("expected ops, got EOF"),
@@ -4030,7 +4741,7 @@ mod tests {
             HeaderReadResult::Valid(_)
         ));
         let mut count = 0;
-        while let Ok(ParseResult::Ops(_)) = reader.parse_next_transaction(&io) {
+        while let Ok(ParseResult::Frame(_)) = reader.parse_next_transaction(&io) {
             count += 1;
         }
         assert_eq!(count, 3);
@@ -4131,7 +4842,7 @@ mod tests {
 
         // Frame 1 from log A should validate fine
         match reader.parse_next_transaction(&io) {
-            Ok(ParseResult::Ops(ops)) => assert!(!ops.is_empty()),
+            Ok(ParseResult::Frame(frame)) => assert!(!frame.ops.is_empty()),
             other => panic!("expected log A's frame to parse, got {other:?}"),
         }
 
@@ -4440,7 +5151,7 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
         reader.read_header(io).unwrap();
         let ops = match reader.parse_next_transaction(io).unwrap() {
-            ParseResult::Ops(ops) => ops,
+            ParseResult::Frame(frame) => frame.ops,
             other => panic!("expected Ops, got {other:?}"),
         };
         assert!(matches!(
@@ -4463,7 +5174,7 @@ mod tests {
         );
         reader.read_header(io).unwrap();
         let ops = match reader.parse_next_transaction(io).unwrap() {
-            ParseResult::Ops(ops) => ops,
+            ParseResult::Frame(frame) => frame.ops,
             other => panic!("expected Ops, got {other:?}"),
         };
         assert!(matches!(
@@ -4494,7 +5205,7 @@ mod tests {
                 .parse_next_transaction(io)
                 .map_err(|e| format!("failed to parse fuzz frame {tx_index}: {e}"))?
             {
-                ParseResult::Ops(ops) => frames.push(ops),
+                ParseResult::Frame(frame) => frames.push(frame.ops),
                 ParseResult::Eof => break,
                 ParseResult::InvalidFrame => {
                     return Err(format!("invalid fuzz frame at tx_index={tx_index}"));
@@ -4899,8 +5610,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            encrypted_blob_size,
-            expected_blob_size,
+            encrypted_blob_size, expected_blob_size,
             "on-disk blob size ({encrypted_blob_size}) != expected chunked encrypted size({expected_blob_size})"
         );
 
@@ -4909,7 +5619,7 @@ mod tests {
         reader.read_header(&io).unwrap();
 
         let ops = match reader.parse_next_transaction(&io).unwrap() {
-            ParseResult::Ops(ops) => ops,
+            ParseResult::Frame(frame) => frame.ops,
             other => panic!("expected Ops, got {other:?}"),
         };
         assert_eq!(ops.len(), 2);
@@ -5023,8 +5733,7 @@ mod tests {
             });
 
             assert_eq!(
-                actual_frames,
-                expected_frames,
+                actual_frames, expected_frames,
                 "encrypted carry fuzz failed: root_seed={seed} case_index={case_index} forced_case_index={forced_case_index} include_forced_prefix={include_forced_prefix} case_seed={case_seed}"
             );
         }
@@ -5032,14 +5741,146 @@ mod tests {
 
     #[test]
     fn test_encrypted_log_format_assumptions_are_pinned() {
-        assert_eq!(LOG_VERSION, 2);
+        assert_eq!(LOG_VERSION_V2, 2);
+        assert_eq!(LOG_VERSION, 3);
         assert_eq!(LOG_HDR_SIZE, 56);
         assert_eq!(ENCRYPTED_PAYLOAD_CHUNK_SIZE, 32 * 1024);
         assert_eq!(ENCRYPTED_CHUNK_AAD_SIZE, 32);
         assert_eq!(FRAME_MAGIC, 0x5854_564D);
+        assert_eq!(EXT_FRAME_MAGIC, 0x5845_564D);
         assert_eq!(END_MAGIC, 0x4554_564D);
+        assert_eq!(TX_HEADER_SIZE_V2, 24);
         assert_eq!(TX_HEADER_SIZE, 24);
+        assert_eq!(TX_EXT_HEADER_SIZE, 40);
         assert_eq!(TX_TRAILER_SIZE, 8);
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    #[test]
+    fn test_next_portable_change_frame_returns_empty_and_nonempty_lml3_frames() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file(
+                "sync-frame-empty-and-nonempty.db-log",
+                OpenFlags::Create,
+                false,
+            )
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+
+        let empty_sync_tx = crate::mvcc::database::LogRecord::for_test(
+            10,
+            &[make_test_row_version((-2).into(), 1, "internal", 10)],
+            None,
+        );
+        let c = log.log_tx(empty_sync_tx).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        let encoded_empty_logical_op = vec![0x1a, 0x00];
+        let mut sync_tx = crate::mvcc::database::LogRecord::for_test(
+            20,
+            &[make_test_row_version((-2).into(), 2, "visible", 20)],
+            None,
+        );
+        sync_tx.portable_changes = encoded_empty_logical_op;
+        let c = log.log_tx(sync_tx).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        let mut reader = StreamingLogicalLogReader::new(file, None);
+        reader.read_header(&io).unwrap();
+        let first = reader.next_portable_change_frame(&io).unwrap().unwrap();
+        assert_eq!(first.commit_ts, 10);
+        assert_eq!(first.extension_record_count, 0);
+        assert!(first.payload.is_empty());
+
+        let second = reader.next_portable_change_frame(&io).unwrap().unwrap();
+        assert_eq!(second.commit_ts, 20);
+        assert_eq!(second.extension_record_count, 1);
+        assert!(!second.payload.is_empty());
+        assert_eq!(second.end_offset, reader.last_valid_offset() as u64);
+
+        assert!(reader.next_portable_change_frame(&io).unwrap().is_none());
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    #[test]
+    fn test_portable_extension_block_precedes_recovery_payload() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file(
+                "portable-extension-before-payload.db-log",
+                OpenFlags::Create,
+                false,
+            )
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+
+        let portable_metadata = vec![0x1a, 0x00];
+        let mut tx = crate::mvcc::database::LogRecord::for_test(
+            20,
+            &[make_test_row_version((-2).into(), 2, "visible", 20)],
+            None,
+        );
+        tx.portable_changes = portable_metadata.clone();
+        let c = log.log_tx(tx).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        let frame = read_file_bytes(file, &io);
+        let tx_header_start = LOG_HDR_SIZE;
+        let body_start = LOG_HDR_SIZE + TX_EXT_HEADER_SIZE;
+        assert_eq!(
+            u32::from_le_bytes(
+                frame[tx_header_start..tx_header_start + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            EXT_FRAME_MAGIC
+        );
+        let extension_size = u64::from_le_bytes(
+            frame[tx_header_start + 24..tx_header_start + 32]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        assert!(extension_size >= EXTENSION_RECORD_HEADER_SIZE);
+
+        let extension_type =
+            u16::from_le_bytes(frame[body_start..body_start + 2].try_into().unwrap());
+        assert_eq!(extension_type, EXTENSION_TYPE_PORTABLE_CHANGES);
+        let extension_payload_len = u32::from_le_bytes(
+            frame[body_start + 4..body_start + EXTENSION_RECORD_HEADER_SIZE]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let extension_payload = &frame[body_start + EXTENSION_RECORD_HEADER_SIZE
+            ..body_start + EXTENSION_RECORD_HEADER_SIZE + extension_payload_len];
+        assert!(extension_payload.ends_with(&portable_metadata));
+
+        let recovery_start = body_start + extension_size;
+        assert_eq!(frame[recovery_start], OP_UPSERT_TABLE);
+    }
+
+    #[test]
+    fn test_next_portable_change_frame_does_not_advance_lml2_logs() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file("sync-frame-lml2.db-log", OpenFlags::Create, false)
+            .unwrap();
+
+        let mut header = LogHeader::new(&io);
+        header.version = LOG_VERSION_V2;
+        let buffer = Arc::new(Buffer::new(header.encode().to_vec()));
+        let c = Completion::new_write(|_| {});
+        io.wait_for_completion(file.pwrite(0, buffer, c).unwrap())
+            .unwrap();
+
+        let mut reader = StreamingLogicalLogReader::new(file, None);
+        reader.read_header(&io).unwrap();
+        assert_eq!(reader.last_valid_offset(), LOG_HDR_SIZE);
+        assert!(reader.next_portable_change_frame(&io).unwrap().is_none());
+        assert_eq!(reader.last_valid_offset(), LOG_HDR_SIZE);
     }
 
     #[test]
@@ -5455,7 +6296,7 @@ mod tests {
 
         for i in 0..5u64 {
             let ops = match reader.parse_next_transaction(&io).unwrap() {
-                ParseResult::Ops(ops) => ops,
+                ParseResult::Frame(frame) => frame.ops,
                 other => panic!("frame {i}: expected Ops, got {other:?}"),
             };
             assert_eq!(ops.len(), 1, "frame {i}");
@@ -5605,7 +6446,8 @@ mod tests {
 
         // First frame should parse fine.
         match reader.parse_next_transaction(&io).unwrap() {
-            ParseResult::Ops(ops) => {
+            ParseResult::Frame(frame) => {
+                let ops = frame.ops;
                 assert_eq!(ops.len(), 1);
                 assert_upsert_table_op(&ops[0], (-2).into(), 0, &expected_first_record_bytes, 100);
             }
@@ -5817,7 +6659,8 @@ mod tests {
             let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
             reader.read_header(&io).unwrap();
             match reader.parse_next_transaction(&io).unwrap() {
-                ParseResult::Ops(ops) => {
+                ParseResult::Frame(frame) => {
+                    let ops = frame.ops;
                     assert_eq!(ops.len(), 1);
                     assert_upsert_table_op(
                         &ops[0],

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -71,7 +71,7 @@
 //!
 //! ### TX Header (`TX_HEADER_SIZE = 24`, `TX_EXT_HEADER_SIZE = 40`)
 //! - `frame_magic: u32` (`FRAME_MAGIC` for compact recovery frames,
-//!   `EXT_FRAME_MAGIC` when a portable extension block follows the recovery
+//!   `EXT_FRAME_MAGIC` when a portable extension block precedes the recovery
 //!   payload)
 //! - `payload_size: u64` (total bytes of all op entries, pre-encryption)
 //! - `op_count: u32`
@@ -81,13 +81,18 @@
 //! - `frame_flags: u32` (extension frames only)
 //!
 //! ### Payload
-//! - When **unencrypted**: `op_count` operation entries serialized directly:
+//! - When **unencrypted** and no extension block is present: `op_count` operation
+//!   entries serialized directly:
 //!   - `tag: u8` (`OP_*`)
-//!   - `flags: u8` (`OP_FLAG_BTREE_RESIDENT` currently defined)
+//!   - `flags: u8` (`OP_FLAG_BTREE_RESIDENT`, `OP_FLAG_PORTABLE_EXTENSION`)
 //!   - `table_id: i32` (must be negative)
 //!   - `payload_len: sqlite varint`
 //!   - `payload: [u8; payload_len]`
-//! - When **encrypted**: recovery payload plus extension block is split into
+//!   - if `OP_FLAG_PORTABLE_EXTENSION` is set:
+//!     `extension_len: sqlite varint || extension: [u8; extension_len]`
+//! - When an extension block is present, the transaction body is:
+//!   `extension_block || recovery_payload`
+//! - When **encrypted**: extension block plus recovery payload is split into
 //!   fixed-size plaintext chunks
 //!   (`ENCRYPTED_PAYLOAD_CHUNK_SIZE`, except the final remainder chunk)
 //!   - each chunk is written as `ciphertext(chunk_plain_len + tag_size) | nonce(nonce_size)`
@@ -110,6 +115,10 @@
 //!
 //! `OP_FLAG_BTREE_RESIDENT` means the row existed in the B-tree before MVCC started tracking it.
 //! Recovery preserves this bit because checkpoint/GC logic depends on it.
+//!
+//! `OP_FLAG_PORTABLE_EXTENSION` means the op has protobuf-style extension bytes immediately after
+//! its main recovery payload. Recovery may ignore those bytes, but the parser must consume them as
+//! part of the op.
 //!
 //! ## Validation behavior
 //!
@@ -183,7 +192,8 @@
 //! ### How Plaintext Payload Is Split Into Chunks
 //!
 //! ```text
-//! Plaintext payload (serialized ops, payload_size bytes):
+//! Plaintext payload for a frame without a transaction extension
+//! (serialized ops, payload_size bytes):
 //!
 //! ┌──────┬──────┬────────────┬──────────┬──────┬────────────┬──────┬──────┬──────┬───────┐
 //! │ Op₀  │ Op₁  │    Op₂     │   Op₃    │ Op₄  │    Op₅     │ Op₆  │ Op₇  │ Op₈  │ Op₉   │
@@ -273,6 +283,17 @@ const OP_DELETE_INDEX: u8 = 3;
 const OP_UPDATE_HEADER: u8 = 4;
 
 const OP_FLAG_BTREE_RESIDENT: u8 = 1 << 0;
+const OP_FLAG_PORTABLE_EXTENSION: u8 = 1 << 1;
+const OP_ALLOWED_FLAGS: u8 = OP_FLAG_BTREE_RESIDENT | OP_FLAG_PORTABLE_EXTENSION;
+const OP_EXT_FIELD_DELETE_IDENTITY_RECORD: u64 = 1;
+const OP_EXT_FIELD_DELETE_PK_RECORD: u64 = 2;
+const OP_EXT_FIELD_DELETE_ROWID: u64 = 3;
+
+#[derive(Default)]
+struct DeletePortableExtension {
+    identity_record: Vec<u8>,
+    pk_record: Vec<u8>,
+}
 
 const TX_HEADER_SIZE_V2: usize = 24; // FRAME_MAGIC(4) + payload_size(8) + op_count(4) + commit_ts(8)
 const TX_HEADER_SIZE: usize = TX_HEADER_SIZE_V2;
@@ -651,14 +672,17 @@ impl LogicalLog {
             LimboError::InternalError("Logical log extension size exceeds u64".to_string())
         })?;
         if !extension_block.is_empty() {
-            tx.buf.extend_from_slice(&extension_block);
+            tx.buf
+                .splice(frame_payload_start..frame_payload_start, extension_block);
         }
         let plaintext_size = tx.buf.len() - frame_payload_start;
         let plaintext_size_u64 = plaintext_size as u64;
 
         // 2. Build the on-disk payload. Unencrypted is the zero-shift fast
-        // path: plaintext is already after the TX header. Encrypted frames
-        // encrypt recovery ops and extension records as one authenticated body.
+        // path: plaintext is already after the TX header. Extension frames are
+        // laid out as `extension_block || recovery_payload`, so raw-log
+        // consumers can load transaction metadata before scanning recovery ops.
+        // Encrypted frames encrypt both parts as one authenticated body.
         if let Some(enc_ctx) = &self.encryption_ctx {
             let salt = self
                 .header
@@ -940,7 +964,11 @@ impl LogicalLog {
 
 /// Serialize one op into `buffer`.
 /// Op layout: tag(1) | flags(1) | table_id(4, le i32) | payload_len(varint) | payload(variable)
-pub(crate) fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion) -> Result<()> {
+pub(crate) fn serialize_op_entry(
+    buffer: &mut Vec<u8>,
+    row_version: &RowVersion,
+    portable_extension: Option<&[u8]>,
+) -> Result<()> {
     let is_delete = row_version.end.is_some();
     let tag = match (&row_version.row.id.row_id, is_delete) {
         (RowKey::Int(_), false) => OP_UPSERT_TABLE,
@@ -952,6 +980,9 @@ pub(crate) fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion)
     let mut flags = 0u8;
     if row_version.btree_resident {
         flags |= OP_FLAG_BTREE_RESIDENT;
+    }
+    if portable_extension.is_some_and(|extension| !extension.is_empty()) {
+        flags |= OP_FLAG_PORTABLE_EXTENSION;
     }
 
     let table_id_i64: i64 = row_version.row.id.table_id.into();
@@ -1003,6 +1034,13 @@ pub(crate) fn serialize_op_entry(buffer: &mut Vec<u8>, row_version: &RowVersion)
         }
     }
 
+    if let Some(portable_extension) =
+        portable_extension.filter(|portable_extension| !portable_extension.is_empty())
+    {
+        write_varint_to_vec(portable_extension.len() as u64, buffer);
+        buffer.extend_from_slice(portable_extension);
+    }
+
     Ok(())
 }
 
@@ -1023,6 +1061,144 @@ fn write_proto_varint(mut value: u64, buffer: &mut Vec<u8>) {
     buffer.push(value as u8);
 }
 
+fn write_proto_key(field: u64, wire_type: u64, buffer: &mut Vec<u8>) {
+    write_proto_varint((field << 3) | wire_type, buffer);
+}
+
+fn write_proto_sint64(field: u64, value: i64, buffer: &mut Vec<u8>) {
+    let zigzag = ((value << 1) ^ (value >> 63)) as u64;
+    write_proto_key(field, 0, buffer);
+    write_proto_varint(zigzag, buffer);
+}
+
+fn write_proto_bytes(field: u64, value: &[u8], buffer: &mut Vec<u8>) {
+    write_proto_key(field, 2, buffer);
+    write_proto_varint(value.len() as u64, buffer);
+    buffer.extend_from_slice(value);
+}
+
+pub(crate) fn encode_delete_portable_extension(
+    identity_record: Option<&[u8]>,
+    pk_record: Option<&[u8]>,
+    rowid: Option<i64>,
+) -> Vec<u8> {
+    let mut extension = Vec::new();
+    if let Some(identity_record) = identity_record.filter(|record| !record.is_empty()) {
+        write_proto_bytes(
+            OP_EXT_FIELD_DELETE_IDENTITY_RECORD,
+            identity_record,
+            &mut extension,
+        );
+    }
+    if let Some(pk_record) = pk_record.filter(|record| !record.is_empty()) {
+        write_proto_bytes(OP_EXT_FIELD_DELETE_PK_RECORD, pk_record, &mut extension);
+    }
+    if let Some(rowid) = rowid {
+        write_proto_sint64(OP_EXT_FIELD_DELETE_ROWID, rowid, &mut extension);
+    }
+    extension
+}
+
+fn read_proto_varint_from_buf(bytes: &[u8], offset: &mut usize) -> Result<u64> {
+    let mut value = 0u64;
+    let mut shift = 0;
+    while *offset < bytes.len() {
+        let byte = bytes[*offset];
+        *offset += 1;
+        value |= ((byte & 0x7f) as u64) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(LimboError::Corrupt("protobuf varint overflows u64".into()));
+        }
+    }
+    Err(LimboError::Corrupt("truncated protobuf varint".into()))
+}
+
+fn skip_proto_field(bytes: &[u8], offset: &mut usize, wire_type: u64) -> Result<()> {
+    match wire_type {
+        0 => {
+            let _ = read_proto_varint_from_buf(bytes, offset)?;
+        }
+        2 => {
+            let len = read_proto_varint_from_buf(bytes, offset)?;
+            let len = usize::try_from(len)
+                .map_err(|_| LimboError::Corrupt("protobuf field length overflows usize".into()))?;
+            let end = offset
+                .checked_add(len)
+                .ok_or_else(|| LimboError::Corrupt("protobuf field length overflow".into()))?;
+            if end > bytes.len() {
+                return Err(LimboError::Corrupt(
+                    "protobuf length-delimited field exceeds extension".into(),
+                ));
+            }
+            *offset = end;
+        }
+        other => {
+            return Err(LimboError::Corrupt(format!(
+                "unsupported protobuf wire type in op extension: {other}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn read_proto_sint64_from_buf(bytes: &[u8], offset: &mut usize) -> Result<i64> {
+    let value = read_proto_varint_from_buf(bytes, offset)?;
+    Ok(((value >> 1) as i64) ^ (-((value & 1) as i64)))
+}
+
+fn decode_delete_portable_extension(extension: &[u8]) -> Result<DeletePortableExtension> {
+    let mut offset = 0usize;
+    let mut decoded = DeletePortableExtension::default();
+    while offset < extension.len() {
+        let key = read_proto_varint_from_buf(extension, &mut offset)?;
+        let field = key >> 3;
+        let wire_type = key & 7;
+        match (field, wire_type) {
+            (OP_EXT_FIELD_DELETE_IDENTITY_RECORD, 2) => {
+                let len = read_proto_varint_from_buf(extension, &mut offset)?;
+                let len = usize::try_from(len).map_err(|_| {
+                    LimboError::Corrupt("delete identity record length overflows usize".into())
+                })?;
+                let end = offset.checked_add(len).ok_or_else(|| {
+                    LimboError::Corrupt("delete identity record length overflow".into())
+                })?;
+                if end > extension.len() {
+                    return Err(LimboError::Corrupt(
+                        "delete identity record exceeds op extension".into(),
+                    ));
+                }
+                decoded.identity_record = extension[offset..end].to_vec();
+                offset = end;
+            }
+            (OP_EXT_FIELD_DELETE_PK_RECORD, 2) => {
+                let len = read_proto_varint_from_buf(extension, &mut offset)?;
+                let len = usize::try_from(len).map_err(|_| {
+                    LimboError::Corrupt("delete PK record length overflows usize".into())
+                })?;
+                let end = offset.checked_add(len).ok_or_else(|| {
+                    LimboError::Corrupt("delete PK record length overflow".into())
+                })?;
+                if end > extension.len() {
+                    return Err(LimboError::Corrupt(
+                        "delete PK record exceeds op extension".into(),
+                    ));
+                }
+                decoded.pk_record = extension[offset..end].to_vec();
+                offset = end;
+            }
+            (OP_EXT_FIELD_DELETE_ROWID, 0) => {
+                let _ = read_proto_sint64_from_buf(extension, &mut offset)?;
+            }
+            _ => skip_proto_field(extension, &mut offset, wire_type)?,
+        }
+    }
+    Ok(decoded)
+}
+
 fn proto_varint_len(mut value: u64) -> usize {
     let mut len = 1;
     while value >= 0x80 {
@@ -1032,9 +1208,13 @@ fn proto_varint_len(mut value: u64) -> usize {
     len
 }
 
-fn encode_portable_change_payload(end_offset: u64, commit_ts: u64, encoded_ops: &[u8]) -> Vec<u8> {
+fn encode_portable_change_payload(
+    end_offset: u64,
+    commit_ts: u64,
+    encoded_metadata: &[u8],
+) -> Vec<u8> {
     let body_len =
-        2 + proto_varint_len(end_offset) + proto_varint_len(commit_ts) + encoded_ops.len();
+        2 + proto_varint_len(end_offset) + proto_varint_len(commit_ts) + encoded_metadata.len();
     let mut out = Vec::with_capacity(proto_varint_len(body_len as u64) + body_len);
     write_proto_varint(body_len as u64, &mut out);
     // PortableLogicalTxn.end_offset, field 1, varint.
@@ -1043,8 +1223,7 @@ fn encode_portable_change_payload(end_offset: u64, commit_ts: u64, encoded_ops: 
     // PortableLogicalTxn.commit_ts, field 2, varint.
     write_proto_varint(2 << 3, &mut out);
     write_proto_varint(commit_ts, &mut out);
-    // PortableLogicalTxn.ops, field 3, length-delimited messages already encoded by the commit builder.
-    out.extend_from_slice(encoded_ops);
+    out.extend_from_slice(encoded_metadata);
     out
 }
 
@@ -1247,7 +1426,7 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
 
     let table_id: Option<MVTableId> = match tag {
         OP_UPSERT_TABLE | OP_DELETE_TABLE | OP_UPSERT_INDEX | OP_DELETE_INDEX => {
-            if flags & !OP_FLAG_BTREE_RESIDENT != 0 || table_id_i32 >= 0 {
+            if flags & !OP_ALLOWED_FLAGS != 0 || table_id_i32 >= 0 {
                 return Err(LimboError::Corrupt(
                     "Invalid op flags or non-negative table_id".into(),
                 ));
@@ -1281,6 +1460,24 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
     }
 
     let payload = &buf[fixed..total];
+    let (extension, total) = if flags & OP_FLAG_PORTABLE_EXTENSION == 0 {
+        (&[][..], total)
+    } else {
+        let Some((extension_len_u64, extension_len_bytes)) = read_varint_partial(&buf[total..])?
+        else {
+            return Ok(None);
+        };
+        let extension_len = usize::try_from(extension_len_u64)
+            .map_err(|_| LimboError::Corrupt("op extension length overflows usize".into()))?;
+        let extension_start = total + extension_len_bytes;
+        let extension_end = extension_start
+            .checked_add(extension_len)
+            .ok_or_else(|| LimboError::Corrupt("op extension length overflow".into()))?;
+        if buf.len() < extension_end {
+            return Ok(None);
+        }
+        (&buf[extension_start..extension_end], extension_end)
+    };
 
     let parsed_op = match tag {
         OP_UPSERT_TABLE => {
@@ -1304,14 +1501,25 @@ fn try_parse_one_op_from_buf(buf: &[u8], commit_ts: u64) -> Result<Option<(Parse
             let table_id = table_id.expect("table op must have table_id");
             let (rowid_u64, rowid_len) = read_varint(payload)
                 .map_err(|_| LimboError::Corrupt("Bad rowid varint in DELETE_TABLE".into()))?;
-            if rowid_len != payload.len() {
+            if rowid_len > payload.len() {
                 return Err(LimboError::Corrupt(
                     "DELETE_TABLE payload size mismatch".into(),
                 ));
             }
+            let mut record_bytes = payload[rowid_len..].to_vec();
+            let mut pk_record_bytes = Vec::new();
+            if !extension.is_empty() {
+                let decoded = decode_delete_portable_extension(extension)?;
+                if record_bytes.is_empty() {
+                    record_bytes = decoded.identity_record;
+                }
+                pk_record_bytes = decoded.pk_record;
+            }
             let rowid = RowID::new(table_id, RowKey::Int(rowid_u64 as i64));
             ParsedOp::DeleteTable {
                 rowid,
+                record_bytes,
+                pk_record_bytes,
                 commit_ts,
                 btree_resident,
             }
@@ -2107,7 +2315,7 @@ impl StreamingLogicalLogReader {
                 i32::from_le_bytes([op_bytes[2], op_bytes[3], op_bytes[4], op_bytes[5]]);
             let table_id = match tag {
                 OP_UPSERT_TABLE | OP_DELETE_TABLE | OP_UPSERT_INDEX | OP_DELETE_INDEX => {
-                    if flags & !OP_FLAG_BTREE_RESIDENT != 0 || table_id_i32 >= 0 {
+                    if flags & !OP_ALLOWED_FLAGS != 0 || table_id_i32 >= 0 {
                         return Err(LimboError::Corrupt(format!(
                             "invalid op flags={flags:#x} or table_id={table_id_i32} for tag={tag}"
                         )));
@@ -2127,6 +2335,7 @@ impl StreamingLogicalLogReader {
                 }
             };
             let btree_resident = (flags & OP_FLAG_BTREE_RESIDENT) != 0;
+            let has_portable_extension = (flags & OP_FLAG_PORTABLE_EXTENSION) != 0;
 
             let (payload_len, payload_len_bytes, payload_len_bytes_len) =
                 match self.consume_varint_bytes(io) {
@@ -2145,7 +2354,31 @@ impl StreamingLogicalLogReader {
             };
             running_crc = crc32c::crc32c_append(running_crc, &payload);
 
-            let op_total_bytes = 6 + payload_len_bytes_len + payload_len;
+            let (portable_extension, extension_total_bytes) = if has_portable_extension {
+                let (extension_len, extension_len_bytes, extension_len_bytes_len) =
+                    match self.consume_varint_bytes(io) {
+                        Ok(Some((value, bytes, len))) => (value, bytes, len),
+                        Ok(None) => return Ok(PayloadParseResult::Eof),
+                        Err(err) => return Err(err),
+                    };
+                running_crc = crc32c::crc32c_append(
+                    running_crc,
+                    &extension_len_bytes[..extension_len_bytes_len],
+                );
+                let extension_len = usize::try_from(extension_len).map_err(|e| {
+                    LimboError::Corrupt(format!("op extension length overflows usize: {e}"))
+                })?;
+                let extension = match self.try_consume_bytes(io, extension_len)? {
+                    Some(bytes) => bytes,
+                    None => return Ok(PayloadParseResult::Eof),
+                };
+                running_crc = crc32c::crc32c_append(running_crc, &extension);
+                (extension, extension_len_bytes_len + extension_len)
+            } else {
+                (Vec::new(), 0)
+            };
+
+            let op_total_bytes = 6 + payload_len_bytes_len + payload_len + extension_total_bytes;
             payload_bytes_read = u64::try_from(op_total_bytes)
                 .ok()
                 .and_then(|op_size| payload_bytes_read.checked_add(op_size))
@@ -2183,16 +2416,28 @@ impl StreamingLogicalLogReader {
                             "failed to read rowid varint in delete op: {e}"
                         ))
                     })?;
-                    if rowid_len != payload.len() {
+                    if rowid_len > payload.len() {
                         return Err(LimboError::Corrupt(format!(
-                            "delete op rowid varint len {rowid_len} != payload len {}",
+                            "delete op rowid varint len {rowid_len} > payload len {}",
                             payload.len()
                         )));
                     }
                     let rowid_i64 = rowid_u64 as i64;
+                    let mut payload = payload;
+                    let mut record_bytes = payload.split_off(rowid_len);
+                    let mut pk_record_bytes = Vec::new();
+                    if !portable_extension.is_empty() {
+                        let decoded = decode_delete_portable_extension(&portable_extension)?;
+                        if record_bytes.is_empty() {
+                            record_bytes = decoded.identity_record;
+                        }
+                        pk_record_bytes = decoded.pk_record;
+                    }
                     let rowid = RowID::new(table_id, RowKey::Int(rowid_i64));
                     ParsedOp::DeleteTable {
                         rowid,
+                        record_bytes,
+                        pk_record_bytes,
                         commit_ts,
                         btree_resident,
                     }
@@ -2393,9 +2638,7 @@ impl StreamingLogicalLogReader {
             let plaintext_size = payload_size
                 .checked_add(encrypted_extension_size)
                 .ok_or_else(|| {
-                    LimboError::Corrupt(
-                        "encrypted payload plus extension size overflows usize".into(),
-                    )
+                    LimboError::Corrupt("encrypted plaintext size overflows usize".into())
                 })?;
             let Some((plaintext, running_crc)) = self.read_encrypted_plaintext(
                 io,
@@ -2407,8 +2650,25 @@ impl StreamingLogicalLogReader {
             else {
                 return Ok(ParseResult::Eof);
             };
+            let recovery_start = extension_size;
+            let recovery_end = recovery_start
+                .checked_add(payload_size)
+                .ok_or_else(|| LimboError::Corrupt("recovery payload offset overflow".into()))?;
+            let portable_changes = match find_extension_payload(
+                &plaintext[..extension_size],
+                extension_record_count,
+                EXTENSION_TYPE_PORTABLE_CHANGES,
+            ) {
+                Ok(payload) => payload,
+                Err(LimboError::Corrupt(msg)) => {
+                    tracing::warn!("corrupt extension block: {msg}");
+                    self.last_valid_offset = frame_start;
+                    return Ok(ParseResult::InvalidFrame);
+                }
+                Err(e) => return Err(e),
+            };
             let parsed_ops = match parse_ops_from_plaintext(
-                &plaintext[..payload_size],
+                &plaintext[recovery_start..recovery_end],
                 payload_size,
                 op_count,
                 commit_ts,
@@ -2421,36 +2681,8 @@ impl StreamingLogicalLogReader {
                 }
                 Err(e) => return Err(e),
             };
-            let portable_changes = match find_extension_payload(
-                &plaintext[payload_size..],
-                extension_record_count,
-                EXTENSION_TYPE_PORTABLE_CHANGES,
-            ) {
-                Ok(payload) => payload,
-                Err(LimboError::Corrupt(msg)) => {
-                    tracing::warn!("corrupt extension block: {msg}");
-                    self.last_valid_offset = frame_start;
-                    return Ok(ParseResult::InvalidFrame);
-                }
-                Err(e) => return Err(e),
-            };
             (parsed_ops, portable_changes, running_crc)
         } else {
-            let (parsed_ops, running_crc) = match if self.encryption_ctx.is_some() {
-                self.parse_encrypted_payload(io, op_count, payload_size, commit_ts, running_crc)
-            } else {
-                self.parse_streaming_payload(io, op_count, payload_size, commit_ts, running_crc)
-            } {
-                Ok(PayloadParseResult::Ok(ops, crc)) => (ops, crc),
-                Ok(PayloadParseResult::Eof) => return Ok(ParseResult::Eof),
-                Err(LimboError::Corrupt(msg)) => {
-                    tracing::warn!("corrupt payload: {msg}");
-                    self.last_valid_offset = frame_start;
-                    return Ok(ParseResult::InvalidFrame);
-                }
-                Err(e) => return Err(e),
-            };
-
             let (portable_changes, running_crc) = if extension_size > 0 {
                 match self.try_consume_bytes(io, extension_size)? {
                     Some(bytes) => {
@@ -2474,6 +2706,21 @@ impl StreamingLogicalLogReader {
                 }
             } else {
                 (Vec::new(), running_crc)
+            };
+
+            let (parsed_ops, running_crc) = match if self.encryption_ctx.is_some() {
+                self.parse_encrypted_payload(io, op_count, payload_size, commit_ts, running_crc)
+            } else {
+                self.parse_streaming_payload(io, op_count, payload_size, commit_ts, running_crc)
+            } {
+                Ok(PayloadParseResult::Ok(ops, crc)) => (ops, crc),
+                Ok(PayloadParseResult::Eof) => return Ok(ParseResult::Eof),
+                Err(LimboError::Corrupt(msg)) => {
+                    tracing::warn!("corrupt payload: {msg}");
+                    self.last_valid_offset = frame_start;
+                    return Ok(ParseResult::InvalidFrame);
+                }
+                Err(e) => return Err(e),
             };
             (parsed_ops, portable_changes, running_crc)
         };
@@ -2713,9 +2960,7 @@ impl StreamingLogicalLogReader {
             let plaintext_size = payload_size
                 .checked_add(encrypted_extension_size)
                 .ok_or_else(|| {
-                    LimboError::Corrupt(
-                        "encrypted payload plus extension size overflows usize".into(),
-                    )
+                    LimboError::Corrupt("encrypted plaintext size overflows usize".into())
                 })?;
             let Some((plaintext, running_crc)) = self.read_encrypted_plaintext(
                 io,
@@ -2728,7 +2973,7 @@ impl StreamingLogicalLogReader {
                 return Ok(ParseResult::Eof);
             };
             let portable_changes = match find_extension_payload(
-                &plaintext[payload_size..],
+                &plaintext[..extension_size],
                 extension_record_count,
                 EXTENSION_TYPE_PORTABLE_CHANGES,
             ) {
@@ -2742,12 +2987,7 @@ impl StreamingLogicalLogReader {
             };
             (portable_changes, running_crc)
         } else {
-            let Some(running_crc) =
-                self.consume_and_crc_bytes(io, payload_on_disk_size, running_crc)?
-            else {
-                return Ok(ParseResult::Eof);
-            };
-            if extension_size > 0 {
+            let (portable_changes, running_crc) = if extension_size > 0 {
                 match self.try_consume_bytes(io, extension_size)? {
                     Some(bytes) => {
                         let running_crc = crc32c::crc32c_append(running_crc, &bytes);
@@ -2770,7 +3010,13 @@ impl StreamingLogicalLogReader {
                 }
             } else {
                 (Vec::new(), running_crc)
-            }
+            };
+            let Some(running_crc) =
+                self.consume_and_crc_bytes(io, payload_on_disk_size, running_crc)?
+            else {
+                return Ok(ParseResult::Eof);
+            };
+            (portable_changes, running_crc)
         };
 
         let trailer_bytes = match self.try_consume_fixed::<TX_TRAILER_SIZE>(io)? {
@@ -2841,6 +3087,8 @@ impl StreamingLogicalLogReader {
             }
             ParsedOp::DeleteTable {
                 rowid,
+                record_bytes: _,
+                pk_record_bytes: _,
                 commit_ts,
                 btree_resident,
             } => Ok(StreamingResult::DeleteTableRow {
@@ -3162,6 +3410,8 @@ pub(crate) enum ParsedOp {
     },
     DeleteTable {
         rowid: RowID,
+        record_bytes: Vec<u8>,
+        pk_record_bytes: Vec<u8>,
         commit_ts: u64,
         btree_resident: bool,
     },
@@ -3220,11 +3470,11 @@ mod tests {
         build_encrypted_chunk_aad, encrypted_chunk_blob_size, encrypted_chunk_plaintext_len,
         encrypted_payload_blob_size, encrypted_payload_chunk_count, serialize_header_entry,
         serialize_op_entry, HeaderReadResult, LogHeader, LogicalLog, ParseResult, ParsedOp,
-        StreamingLogicalLogReader, StreamingResult, ENCRYPTED_CHUNK_AAD_SIZE,
-        ENCRYPTED_PAYLOAD_CHUNK_SIZE, END_MAGIC, EXTENSION_RECORD_HEADER_SIZE,
-        EXTENSION_TYPE_PORTABLE_CHANGES, EXT_FRAME_MAGIC, FRAME_MAGIC, LOG_HDR_CRC_START,
-        LOG_HDR_RESERVED_START, LOG_HDR_SIZE, LOG_VERSION, LOG_VERSION_V2, OP_UPSERT_TABLE,
-        TX_EXT_HEADER_SIZE, TX_HEADER_SIZE, TX_HEADER_SIZE_V2, TX_TRAILER_SIZE,
+        StreamingLogicalLogReader, ENCRYPTED_CHUNK_AAD_SIZE, ENCRYPTED_PAYLOAD_CHUNK_SIZE,
+        END_MAGIC, EXTENSION_RECORD_HEADER_SIZE, EXTENSION_TYPE_PORTABLE_CHANGES, EXT_FRAME_MAGIC,
+        FRAME_MAGIC, LOG_HDR_CRC_START, LOG_HDR_RESERVED_START, LOG_HDR_SIZE, LOG_VERSION,
+        LOG_VERSION_V2, OP_UPSERT_TABLE, TX_EXT_HEADER_SIZE, TX_HEADER_SIZE, TX_HEADER_SIZE_V2,
+        TX_TRAILER_SIZE,
     };
     use crate::OpenFlags;
     use crate::{turso_assert, turso_assert_less_than};
@@ -3307,6 +3557,7 @@ mod tests {
                         rowid,
                         commit_ts,
                         btree_resident,
+                        ..
                     } => {
                         ops.push(ExpectedTableOp::Delete {
                             rowid: rowid.row_id.to_int_or_panic(),
@@ -5190,7 +5441,7 @@ mod tests {
         let mut encoded = Vec::new();
         let value = "x".repeat(text_len);
         let row_version = make_test_row_version((-2).into(), rowid, &value, 100);
-        serialize_op_entry(&mut encoded, &row_version).unwrap();
+        serialize_op_entry(&mut encoded, &row_version, None).unwrap();
         encoded.len()
     }
 
@@ -5546,11 +5797,11 @@ mod tests {
         chunk_size: usize,
     ) {
         let mut filler_buf = Vec::new();
-        serialize_op_entry(&mut filler_buf, short_filler).unwrap();
+        serialize_op_entry(&mut filler_buf, short_filler, None).unwrap();
         let mut short_upsert_buf = Vec::new();
-        serialize_op_entry(&mut short_upsert_buf, short_upsert).unwrap();
+        serialize_op_entry(&mut short_upsert_buf, short_upsert, None).unwrap();
         let mut long_upsert_buf = Vec::new();
-        serialize_op_entry(&mut long_upsert_buf, long_upsert).unwrap();
+        serialize_op_entry(&mut long_upsert_buf, long_upsert, None).unwrap();
 
         turso_assert_less_than!(
             filler_buf.len(),
@@ -5600,7 +5851,7 @@ mod tests {
             false,
         );
         let mut short_upsert_buf = Vec::new();
-        serialize_op_entry(&mut short_upsert_buf, &short_upsert).unwrap();
+        serialize_op_entry(&mut short_upsert_buf, &short_upsert, None).unwrap();
         turso_assert_less_than!(
             short_upsert_buf.len(),
             StreamingLogicalLogReader::MAX_SERIALIZED_OP_PREFIX_LEN,
@@ -6329,11 +6580,11 @@ mod tests {
         let expected_second_record_bytes = second.row.payload().to_vec();
 
         let mut filler_buf = Vec::new();
-        serialize_op_entry(&mut filler_buf, &filler).unwrap();
+        serialize_op_entry(&mut filler_buf, &filler, None).unwrap();
         assert_eq!(filler_buf.len(), ENCRYPTED_PAYLOAD_CHUNK_SIZE - 7);
 
         let mut second_buf = Vec::new();
-        serialize_op_entry(&mut second_buf, &second).unwrap();
+        serialize_op_entry(&mut second_buf, &second, None).unwrap();
         // Table ops begin with a fixed 6-byte prelude:
         // 1 byte op tag + 1 byte flags + 4 bytes table_id.
         // The payload_len varint begins immediately after that prefix.
@@ -6382,7 +6633,7 @@ mod tests {
         let expected_filler_record_bytes = filler.row.payload().to_vec();
 
         let mut filler_buf = Vec::new();
-        serialize_op_entry(&mut filler_buf, &filler).unwrap();
+        serialize_op_entry(&mut filler_buf, &filler, None).unwrap();
         assert_eq!(filler_buf.len(), filler_payload_size);
         assert_eq!(
             filler_buf.len() + header_buf.len() - 1,

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -414,8 +414,16 @@ pub struct LogHeader {
 
 impl LogHeader {
     pub(crate) fn new(io: &Arc<dyn crate::IO>) -> Self {
+        Self::new_with_version(io, LOG_VERSION_V2)
+    }
+
+    fn new_with_version(io: &Arc<dyn crate::IO>, version: u8) -> Self {
+        turso_assert!(
+            version == LOG_VERSION_V2 || version == LOG_VERSION,
+            "unsupported logical log header version: {version}"
+        );
         Self {
-            version: LOG_VERSION,
+            version,
             flags: 0,
             hdr_len: LOG_HDR_SIZE as u16,
             salt: io.generate_random_number() as u64,
@@ -617,18 +625,44 @@ impl LogicalLog {
         let payload_size = tx.buf.len() - LOG_RECORD_PREFIX_SIZE;
         let payload_size_u64 = payload_size as u64;
 
-        // 1. Ensure we have a log header object (created lazily on first write).
-        let is_first_write = self.offset == 0;
-        if is_first_write && self.header.is_none() {
-            let header = LogHeader::new(&self.io);
-            self.running_crc = derive_initial_crc(header.salt);
-            self.header = Some(header);
-        }
-
         #[cfg(feature = "conn_raw_api")]
         let has_portable_changes = !tx.portable_changes.is_empty();
         #[cfg(not(feature = "conn_raw_api"))]
         let has_portable_changes = false;
+        #[cfg(feature = "conn_raw_api")]
+        let portable_changes_enabled = tx.portable_changes_enabled || has_portable_changes;
+        #[cfg(not(feature = "conn_raw_api"))]
+        let portable_changes_enabled = false;
+
+        // 1. Ensure we have a log header object (created lazily on first write).
+        // Non-portable logs remain LML2 so a deployment that does not enable
+        // portable extensions can still roll back to readers that only know LML2.
+        let is_first_write = self.offset == 0;
+        if is_first_write && self.header.is_none() {
+            let version = if portable_changes_enabled {
+                LOG_VERSION
+            } else {
+                LOG_VERSION_V2
+            };
+            let header = LogHeader::new_with_version(&self.io, version);
+            self.running_crc = derive_initial_crc(header.salt);
+            self.header = Some(header);
+        }
+        if portable_changes_enabled {
+            let header = self
+                .header
+                .as_mut()
+                .expect("log header must be set before writing");
+            if header.version == LOG_VERSION_V2 {
+                if !is_first_write {
+                    return Err(LimboError::InternalError(
+                        "portable logical changes require logical log header upgrade before append"
+                            .to_string(),
+                    ));
+                }
+                header.version = LOG_VERSION;
+            }
+        }
         if has_portable_changes {
             tx.buf.splice(
                 LOG_RECORD_PREFIX_SIZE..LOG_RECORD_PREFIX_SIZE,
@@ -829,6 +863,36 @@ impl LogicalLog {
     pub fn log_tx(&mut self, tx: LogRecord) -> Result<Completion> {
         let (c, _) = self.frame_and_pwrite_tx(tx, true, None)?;
         Ok(c)
+    }
+
+    pub fn upgrade_header_for_log_tx(&mut self, tx: &LogRecord) -> Result<Option<Completion>> {
+        #[cfg(feature = "conn_raw_api")]
+        let portable_changes_enabled =
+            tx.portable_changes_enabled || !tx.portable_changes.is_empty();
+        #[cfg(not(feature = "conn_raw_api"))]
+        let portable_changes_enabled = {
+            let _ = tx;
+            false
+        };
+
+        if !portable_changes_enabled || self.offset == 0 {
+            return Ok(None);
+        }
+
+        let upgraded_header = {
+            let header = self.header.as_mut().ok_or_else(|| {
+                LimboError::InternalError(
+                    "Logical log header not initialized before portable upgrade".to_string(),
+                )
+            })?;
+            if header.version != LOG_VERSION_V2 {
+                return Ok(None);
+            }
+            header.version = LOG_VERSION;
+            header.clone()
+        };
+
+        Ok(Some(self.write_header(upgraded_header)?))
     }
 
     /// Writes a transaction to the log but does NOT advance the writer offset.
@@ -3471,11 +3535,12 @@ mod tests {
         encrypted_payload_blob_size, encrypted_payload_chunk_count, serialize_header_entry,
         serialize_op_entry, HeaderReadResult, LogHeader, LogicalLog, ParseResult, ParsedOp,
         StreamingLogicalLogReader, ENCRYPTED_CHUNK_AAD_SIZE, ENCRYPTED_PAYLOAD_CHUNK_SIZE,
-        END_MAGIC, EXTENSION_RECORD_HEADER_SIZE, EXTENSION_TYPE_PORTABLE_CHANGES, EXT_FRAME_MAGIC,
-        FRAME_MAGIC, LOG_HDR_CRC_START, LOG_HDR_RESERVED_START, LOG_HDR_SIZE, LOG_VERSION,
-        LOG_VERSION_V2, OP_UPSERT_TABLE, TX_EXT_HEADER_SIZE, TX_HEADER_SIZE, TX_HEADER_SIZE_V2,
-        TX_TRAILER_SIZE,
+        END_MAGIC, EXT_FRAME_MAGIC, FRAME_MAGIC, LOG_HDR_CRC_START, LOG_HDR_RESERVED_START,
+        LOG_HDR_SIZE, LOG_VERSION, LOG_VERSION_V2, TX_EXT_HEADER_SIZE, TX_HEADER_SIZE,
+        TX_HEADER_SIZE_V2, TX_TRAILER_SIZE,
     };
+    #[cfg(feature = "conn_raw_api")]
+    use super::{EXTENSION_RECORD_HEADER_SIZE, EXTENSION_TYPE_PORTABLE_CHANGES, OP_UPSERT_TABLE};
     use crate::OpenFlags;
     use crate::{turso_assert, turso_assert_less_than};
     use tracing_subscriber::EnvFilter;
@@ -5062,6 +5127,7 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
         let header = reader.header().unwrap();
+        assert_eq!(header.version, LOG_VERSION_V2);
         // Verify the on-disk CRC matches a fresh computation over the header bytes
         let encoded = header.encode();
         let mut check_buf = [0u8; LOG_HDR_SIZE];
@@ -5078,6 +5144,7 @@ mod tests {
         init_tracing();
         let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
         let header = LogHeader::new(&io);
+        assert_eq!(header.version, LOG_VERSION_V2);
         assert_ne!(header.salt, 0, "salt should be non-zero from IO RNG");
         let bytes = header.encode();
         // Verify CRC: zero out the CRC field and recompute
@@ -6212,6 +6279,144 @@ mod tests {
         assert_eq!(TX_TRAILER_SIZE, 8);
     }
 
+    #[test]
+    fn test_non_portable_first_write_uses_lml2_header_and_v2_frame() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file(
+                "non-portable-first-write-lml2.db-log",
+                OpenFlags::Create,
+                false,
+            )
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+
+        let tx = crate::mvcc::database::LogRecord::for_test(
+            10,
+            &[make_test_row_version((-2).into(), 1, "visible", 10)],
+            None,
+        );
+        let c = log.log_tx(tx).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        let frame = read_file_bytes(file, &io);
+        let header = LogHeader::decode(&frame[..LOG_HDR_SIZE]).unwrap();
+        assert_eq!(header.version, LOG_VERSION_V2);
+        assert_eq!(
+            u32::from_le_bytes(frame[LOG_HDR_SIZE..LOG_HDR_SIZE + 4].try_into().unwrap()),
+            FRAME_MAGIC
+        );
+    }
+
+    #[test]
+    fn test_non_portable_appends_keep_lml2_header_and_v2_frames() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file("non-portable-appends-lml2.db-log", OpenFlags::Create, false)
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+
+        for (commit_ts, rowid) in [(10, 1), (20, 2)] {
+            let tx = crate::mvcc::database::LogRecord::for_test(
+                commit_ts,
+                &[make_test_row_version(
+                    (-2).into(),
+                    rowid,
+                    "visible",
+                    commit_ts,
+                )],
+                None,
+            );
+            let c = log.log_tx(tx).unwrap();
+            io.wait_for_completion(c).unwrap();
+        }
+
+        let frame = read_file_bytes(file, &io);
+        let header = LogHeader::decode(&frame[..LOG_HDR_SIZE]).unwrap();
+        assert_eq!(header.version, LOG_VERSION_V2);
+        assert_eq!(
+            u32::from_le_bytes(frame[LOG_HDR_SIZE..LOG_HDR_SIZE + 4].try_into().unwrap()),
+            FRAME_MAGIC
+        );
+
+        let first_payload_size = u64::from_le_bytes(
+            frame[LOG_HDR_SIZE + 4..LOG_HDR_SIZE + 12]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let second_frame_start =
+            LOG_HDR_SIZE + TX_HEADER_SIZE + first_payload_size + TX_TRAILER_SIZE;
+        assert_eq!(
+            u32::from_le_bytes(
+                frame[second_frame_start..second_frame_start + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            FRAME_MAGIC
+        );
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    #[test]
+    fn test_portable_changes_upgrade_non_empty_lml2_log_to_lml3() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file(
+                "portable-after-lml2-upgrade.db-log",
+                OpenFlags::Create,
+                false,
+            )
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+
+        let tx = crate::mvcc::database::LogRecord::for_test(
+            10,
+            &[make_test_row_version((-2).into(), 1, "visible", 10)],
+            None,
+        );
+        let c = log.log_tx(tx).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        let mut portable_tx = crate::mvcc::database::LogRecord::for_test(
+            20,
+            &[make_test_row_version((-2).into(), 2, "visible", 20)],
+            None,
+        );
+        portable_tx.portable_changes_enabled = true;
+        portable_tx.portable_changes = vec![0x1a, 0x00];
+
+        let c = log
+            .upgrade_header_for_log_tx(&portable_tx)
+            .unwrap()
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+        let c = log.log_tx(portable_tx).unwrap();
+        io.wait_for_completion(c).unwrap();
+
+        let frame = read_file_bytes(file, &io);
+        let header = LogHeader::decode(&frame[..LOG_HDR_SIZE]).unwrap();
+        assert_eq!(header.version, LOG_VERSION);
+
+        let first_payload_size = u64::from_le_bytes(
+            frame[LOG_HDR_SIZE + 4..LOG_HDR_SIZE + 12]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let second_frame_start =
+            LOG_HDR_SIZE + TX_HEADER_SIZE + first_payload_size + TX_TRAILER_SIZE;
+        assert_eq!(
+            u32::from_le_bytes(
+                frame[second_frame_start..second_frame_start + 4]
+                    .try_into()
+                    .unwrap()
+            ),
+            EXT_FRAME_MAGIC
+        );
+    }
+
     #[cfg(feature = "conn_raw_api")]
     #[test]
     fn test_next_portable_change_frame_returns_empty_and_nonempty_lml3_frames() {
@@ -6226,11 +6431,12 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let empty_sync_tx = crate::mvcc::database::LogRecord::for_test(
+        let mut empty_sync_tx = crate::mvcc::database::LogRecord::for_test(
             10,
             &[make_test_row_version((-2).into(), 1, "internal", 10)],
             None,
         );
+        empty_sync_tx.portable_changes_enabled = true;
         let c = log.log_tx(empty_sync_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -6246,6 +6452,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.read_header(&io).unwrap();
+        assert_eq!(reader.header().unwrap().version, LOG_VERSION);
         let first = reader.next_portable_change_frame(&io).unwrap().unwrap();
         assert_eq!(first.commit_ts, 10);
         assert_eq!(first.extension_record_count, 0);

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -52,12 +52,13 @@
 //!     └─────────────────────────────────────────┘
 //! ```
 //!
-//! When encryption is enabled, only the payload is encrypted. The log header,
-//! TX header, and TX trailer are always written in plaintext. The log header's salt and TX header
-//! fields (op_count, commit_ts, and the final chunk's payload_size) are bound to the ciphertext
-//! as AEAD additional data, so tampering with them will cause decryption to fail.
-//! The CRC in the trailer covers the TX header and the payload as written on disk
-//! (i.e. the ciphertext when encrypted).
+//! When encryption is enabled, the recovery payload and any extension block are
+//! encrypted together. The log header, TX header, and TX trailer are always
+//! written in plaintext. The log header's salt and TX header fields (op_count,
+//! commit_ts, and the final chunk's encrypted plaintext size) are bound to the
+//! ciphertext as AEAD additional data, so tampering with them will cause
+//! decryption to fail. The CRC in the trailer covers the TX header and the body
+//! as written on disk (i.e. the ciphertext when encrypted).
 //!
 //! ### Header fields (56 bytes, little-endian)
 //! - `magic: u32` (`LOG_MAGIC`)
@@ -86,13 +87,14 @@
 //!   - `table_id: i32` (must be negative)
 //!   - `payload_len: sqlite varint`
 //!   - `payload: [u8; payload_len]`
-//! - When **encrypted**: payload is split into fixed-size plaintext chunks
+//! - When **encrypted**: recovery payload plus extension block is split into
+//!   fixed-size plaintext chunks
 //!   (`ENCRYPTED_PAYLOAD_CHUNK_SIZE`, except the final remainder chunk)
 //!   - each chunk is written as `ciphertext(chunk_plain_len + tag_size) | nonce(nonce_size)`
 //!   - AEAD additional data:
-//!     `salt(8) || payload_size_or_zero(8) || op_count(4) || commit_ts(8) || chunk_index(4)` (little-endian)
-//!     where the payload-size slot is zero for non-final chunks and carries the real payload size
-//!     only in the final chunk
+//!     `salt(8) || plaintext_size_or_zero(8) || op_count(4) || commit_ts(8) || chunk_index(4)` (little-endian)
+//!     where the plaintext-size slot is zero for non-final chunks and carries the encrypted
+//!     plaintext size only in the final chunk
 //!
 //! ### TX Trailer (`TX_TRAILER_SIZE = 8`)
 //! - `crc32c: u32` (chained CRC32C: `crc32c_append(prev_frame_crc, tx_header || payload)`;
@@ -172,10 +174,10 @@
 //! Each chunk encrypted with AAD (32B):
 //! ```text
 //! ┌────────┬────────────────────┬──────────┬────────────┬─────────────┐
-//! │salt (8)│payload_size_or_0(8)│op_cnt (4)│commit_ts(8)│chunk_idx (4)│
+//! │salt (8)│plaintext_size_or_0 │op_cnt (4)│commit_ts(8)│chunk_idx (4)│
 //! └────────┴────────────────────┴──────────┴────────────┴─────────────┘
 //!           ↑
-//!           └── payload_size only in final chunk; zero for all others
+//!           └── encrypted plaintext size only in final chunk; zero for all others
 //! ```
 //!
 //! ### How Plaintext Payload Is Split Into Chunks
@@ -602,10 +604,61 @@ impl LogicalLog {
             self.header = Some(header);
         }
 
+        #[cfg(feature = "conn_raw_api")]
+        let has_portable_changes = !tx.portable_changes.is_empty();
+        #[cfg(not(feature = "conn_raw_api"))]
+        let has_portable_changes = false;
+        if has_portable_changes {
+            tx.buf.splice(
+                LOG_RECORD_PREFIX_SIZE..LOG_RECORD_PREFIX_SIZE,
+                [0u8; TX_EXT_HEADER_SIZE - TX_HEADER_SIZE],
+            );
+        }
+
+        let tx_header_size = if has_portable_changes {
+            TX_EXT_HEADER_SIZE
+        } else {
+            TX_HEADER_SIZE
+        };
+        let frame_payload_start = LOG_HDR_SIZE + tx_header_size;
+
+        #[cfg(feature = "conn_raw_api")]
+        let extension_block = if !has_portable_changes {
+            Vec::new()
+        } else {
+            let encryption_overhead = self
+                .encryption_ctx
+                .as_ref()
+                .map(|enc_ctx| (enc_ctx.tag_size(), enc_ctx.nonce_size()));
+            let portable_changes = encode_portable_change_payload_with_stable_end_offset(
+                PortableEndOffsetCtx {
+                    write_offset: self.offset,
+                    includes_log_header: is_first_write,
+                    tx_header_size,
+                    recovery_payload_size: payload_size,
+                    encrypted_payload_chunk_size: self.encrypted_payload_chunk_size,
+                    encryption_overhead,
+                },
+                tx.tx_timestamp,
+                &tx.portable_changes,
+            )?;
+            encode_extension_record(EXTENSION_TYPE_PORTABLE_CHANGES, 0, &portable_changes)?
+        };
+        #[cfg(not(feature = "conn_raw_api"))]
+        let extension_block = Vec::new();
+
+        let extension_size = u64::try_from(extension_block.len()).map_err(|_| {
+            LimboError::InternalError("Logical log extension size exceeds u64".to_string())
+        })?;
+        if !extension_block.is_empty() {
+            tx.buf.extend_from_slice(&extension_block);
+        }
+        let plaintext_size = tx.buf.len() - frame_payload_start;
+        let plaintext_size_u64 = plaintext_size as u64;
+
         // 2. Build the on-disk payload. Unencrypted is the zero-shift fast
-        // path: the plaintext is already at LOG_RECORD_PREFIX_SIZE. Encrypted
-        // has to re-emit the payload because its on-disk size differs from
-        // the plaintext size after chunked encryption.
+        // path: plaintext is already after the TX header. Encrypted frames
+        // encrypt recovery ops and extension records as one authenticated body.
         if let Some(enc_ctx) = &self.encryption_ctx {
             let salt = self
                 .header
@@ -613,21 +666,21 @@ impl LogicalLog {
                 .expect("log header must be set before writing")
                 .salt;
             let on_disk_payload_size = encrypted_payload_blob_size(
-                payload_size,
+                plaintext_size,
                 self.encrypted_payload_chunk_size,
                 enc_ctx.tag_size(),
                 enc_ctx.nonce_size(),
             )?;
-            let total = LOG_RECORD_PREFIX_SIZE + on_disk_payload_size + TX_TRAILER_SIZE;
+            let total = frame_payload_start + on_disk_payload_size + TX_TRAILER_SIZE;
             // Move the plaintext out (`split_off` returns the tail past the
-            // framing prefix; `tx.buf` is left with just the 80-byte prefix
+            // framing prefix; `tx.buf` is left with just the header prefix
             // to grow back into with encrypted chunks).
-            let plaintext = tx.buf.split_off(LOG_RECORD_PREFIX_SIZE);
-            debug_assert_eq!(plaintext.len(), payload_size);
+            let plaintext = tx.buf.split_off(frame_payload_start);
+            debug_assert_eq!(plaintext.len(), plaintext_size);
             tx.buf.reserve(total - tx.buf.len());
 
             let chunk_count =
-                encrypted_payload_chunk_count(payload_size, self.encrypted_payload_chunk_size);
+                encrypted_payload_chunk_count(plaintext_size, self.encrypted_payload_chunk_size);
             let payload_start = tx.buf.len();
             for (chunk_index, plaintext_chunk) in plaintext
                 .chunks(self.encrypted_payload_chunk_size)
@@ -636,7 +689,7 @@ impl LogicalLog {
                 let is_last_chunk = chunk_index + 1 == chunk_count;
                 let aad = build_encrypted_chunk_aad(
                     salt,
-                    is_last_chunk.then_some(payload_size_u64),
+                    is_last_chunk.then_some(plaintext_size_u64),
                     op_count,
                     commit_ts,
                     u32::try_from(chunk_index).map_err(|_| {
@@ -666,51 +719,7 @@ impl LogicalLog {
             );
             // `plaintext` is dropped here, freeing its allocation before pwrite.
         }
-        // Unencrypted: payload bytes are already in place at
-        // [LOG_RECORD_PREFIX_SIZE ..].
-
-        #[cfg(feature = "conn_raw_api")]
-        let has_portable_changes = !tx.portable_changes.is_empty();
-        #[cfg(not(feature = "conn_raw_api"))]
-        let has_portable_changes = false;
-        if has_portable_changes {
-            tx.buf.splice(
-                LOG_RECORD_PREFIX_SIZE..LOG_RECORD_PREFIX_SIZE,
-                [0u8; TX_EXT_HEADER_SIZE - TX_HEADER_SIZE],
-            );
-        }
-
-        #[cfg(feature = "conn_raw_api")]
-        let extension_block = if !has_portable_changes {
-            Vec::new()
-        } else {
-            let bytes_before_portable_changes = tx
-                .buf
-                .len()
-                .checked_sub(if is_first_write { 0 } else { LOG_HDR_SIZE })
-                .and_then(|value| value.checked_add(EXTENSION_RECORD_HEADER_SIZE))
-                .ok_or_else(|| {
-                    LimboError::InternalError(
-                        "logical log portable-change prefix length overflow".to_string(),
-                    )
-                })?;
-            let portable_changes = encode_portable_change_payload_with_stable_end_offset(
-                self.offset,
-                bytes_before_portable_changes,
-                tx.tx_timestamp,
-                &tx.portable_changes,
-            )?;
-            encode_extension_record(EXTENSION_TYPE_PORTABLE_CHANGES, 0, &portable_changes)?
-        };
-        #[cfg(not(feature = "conn_raw_api"))]
-        let extension_block = Vec::new();
-
-        let extension_size = u64::try_from(extension_block.len()).map_err(|_| {
-            LimboError::InternalError("Logical log extension size exceeds u64".to_string())
-        })?;
-        if !extension_block.is_empty() {
-            tx.buf.extend_from_slice(&extension_block);
-        }
+        // Unencrypted: plaintext bytes are already in place after the TX header.
 
         // 3. Backfill TX HEADER at offset LOG_HDR_SIZE:
         //    FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
@@ -1046,27 +1055,65 @@ fn encode_portable_change_payload(end_offset: u64, commit_ts: u64, encoded_ops: 
 /// `end_offset` is part of the raw-log replay cursor, but its varint width can
 /// change the payload length. The fixed-point loop converges after the varint
 /// width stops changing.
-fn encode_portable_change_payload_with_stable_end_offset(
+struct PortableEndOffsetCtx {
     write_offset: u64,
-    bytes_before_portable_changes: usize,
+    includes_log_header: bool,
+    tx_header_size: usize,
+    recovery_payload_size: usize,
+    encrypted_payload_chunk_size: usize,
+    encryption_overhead: Option<(usize, usize)>,
+}
+
+fn encode_portable_change_payload_with_stable_end_offset(
+    ctx: PortableEndOffsetCtx,
     tx_timestamp: u64,
     portable_changes: &[u8],
 ) -> Result<Vec<u8>> {
-    let mut end_offset = write_offset
-        .checked_add(bytes_before_portable_changes as u64)
-        .and_then(|value| value.checked_add(TX_TRAILER_SIZE as u64))
-        .ok_or_else(|| {
-            LimboError::InternalError("portable logical frame offset overflow".to_string())
-        })?;
-    loop {
-        let payload = encode_portable_change_payload(end_offset, tx_timestamp, portable_changes);
-        let next_end_offset = write_offset
-            .checked_add(bytes_before_portable_changes as u64)
-            .and_then(|value| value.checked_add(payload.len() as u64))
-            .and_then(|value| value.checked_add(TX_TRAILER_SIZE as u64))
+    let frame_end_offset = |portable_payload_len: usize| -> Result<u64> {
+        let extension_size = EXTENSION_RECORD_HEADER_SIZE
+            .checked_add(portable_payload_len)
+            .ok_or_else(|| {
+                LimboError::InternalError("portable logical extension size overflow".to_string())
+            })?;
+        let plaintext_size = ctx
+            .recovery_payload_size
+            .checked_add(extension_size)
+            .ok_or_else(|| {
+                LimboError::InternalError("portable logical plaintext size overflow".to_string())
+            })?;
+        let body_size = if let Some((tag_size, nonce_size)) = ctx.encryption_overhead {
+            encrypted_payload_blob_size(
+                plaintext_size,
+                ctx.encrypted_payload_chunk_size,
+                tag_size,
+                nonce_size,
+            )?
+        } else {
+            plaintext_size
+        };
+        let prefix_size = if ctx.includes_log_header {
+            LOG_HDR_SIZE
+        } else {
+            0
+        };
+        let frame_bytes = prefix_size
+            .checked_add(ctx.tx_header_size)
+            .and_then(|value| value.checked_add(body_size))
+            .and_then(|value| value.checked_add(TX_TRAILER_SIZE))
+            .ok_or_else(|| {
+                LimboError::InternalError("portable logical frame size overflow".to_string())
+            })?;
+        ctx.write_offset
+            .checked_add(frame_bytes as u64)
             .ok_or_else(|| {
                 LimboError::InternalError("portable logical frame offset overflow".to_string())
-            })?;
+            })
+    };
+
+    let mut end_offset = frame_end_offset(0)?;
+    loop {
+        let payload = encode_portable_change_payload(end_offset, tx_timestamp, portable_changes);
+        let next_end_offset = frame_end_offset(payload.len())?;
         if next_end_offset == end_offset {
             return Ok(payload);
         }
@@ -1148,7 +1195,7 @@ fn find_extension_payload(
 
 /// Parse all ops from a decrypted plaintext buffer.
 /// Validates that `plaintext.len() == payload_size` and that every byte is consumed.
-fn parse_ops_from_plaintext(
+pub(crate) fn parse_ops_from_plaintext(
     plaintext: &[u8],
     payload_size: usize,
     op_count: u32,
@@ -1982,6 +2029,59 @@ impl StreamingLogicalLogReader {
         Ok(PayloadParseResult::Ok(parsed_ops, running_crc))
     }
 
+    fn read_encrypted_plaintext(
+        &mut self,
+        io: &Arc<dyn crate::IO>,
+        plaintext_size: usize,
+        op_count: u32,
+        commit_ts: u64,
+        running_crc: u32,
+    ) -> Result<Option<(Vec<u8>, u32)>> {
+        let (nonce_size, tag_size) = {
+            let enc = self
+                .encryption_ctx
+                .as_ref()
+                .expect("encryption_ctx must be set for encrypted payload");
+            (enc.nonce_size(), enc.tag_size())
+        };
+        let salt = self
+            .header
+            .as_ref()
+            .expect("log header must be read before parsing")
+            .salt;
+        let payload_ctx = EncryptedPayloadReadContext {
+            payload_size: plaintext_size,
+            op_count,
+            commit_ts,
+            salt,
+            nonce_size,
+            tag_size,
+        };
+        let chunk_count =
+            encrypted_payload_chunk_count(plaintext_size, self.encrypted_payload_chunk_size);
+        let mut running_crc = running_crc;
+        let mut plaintext = Vec::with_capacity(plaintext_size);
+        for chunk_index in 0..chunk_count {
+            running_crc = match self.read_and_decrypt_encrypted_chunk(
+                io,
+                &payload_ctx,
+                chunk_index,
+                running_crc,
+            )? {
+                EncryptedChunkReadResult::Ok { running_crc } => running_crc,
+                EncryptedChunkReadResult::Eof => return Ok(None),
+            };
+            plaintext.extend_from_slice(&self.decrypt_scratch);
+        }
+        if plaintext.len() != plaintext_size {
+            return Err(LimboError::Corrupt(format!(
+                "encrypted plaintext size mismatch: expected {plaintext_size}, got {}",
+                plaintext.len()
+            )));
+        }
+        Ok(Some((plaintext, running_crc)))
+    }
+
     /// Parse an unencrypted payload via field-by-field streaming IO reads.
     fn parse_streaming_payload(
         &mut self,
@@ -2284,44 +2384,98 @@ impl StreamingLogicalLogReader {
         // 2. Parse payload — branches for encrypted vs unencrypted.
         //    Corrupt errors from payload parsing are treated as an invalid frame
         //    (stop scanning, keep previously validated frames).
-        let (parsed_ops, running_crc) = match if self.encryption_ctx.is_some() {
-            self.parse_encrypted_payload(io, op_count, payload_size, commit_ts, running_crc)
+        let encrypted_extension_size = if self.encryption_ctx.is_some() {
+            extension_size
         } else {
-            self.parse_streaming_payload(io, op_count, payload_size, commit_ts, running_crc)
-        } {
-            Ok(PayloadParseResult::Ok(ops, crc)) => (ops, crc),
-            Ok(PayloadParseResult::Eof) => return Ok(ParseResult::Eof),
-            Err(LimboError::Corrupt(msg)) => {
-                tracing::warn!("corrupt payload: {msg}");
-                self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
-            }
-            Err(e) => return Err(e),
+            0
         };
-
-        let (portable_changes, running_crc) = if extension_size > 0 {
-            match self.try_consume_bytes(io, extension_size)? {
-                Some(bytes) => {
-                    let running_crc = crc32c::crc32c_append(running_crc, &bytes);
-                    let portable_changes = match find_extension_payload(
-                        &bytes,
-                        extension_record_count,
-                        EXTENSION_TYPE_PORTABLE_CHANGES,
-                    ) {
-                        Ok(payload) => payload,
-                        Err(LimboError::Corrupt(msg)) => {
-                            tracing::warn!("corrupt extension block: {msg}");
-                            self.last_valid_offset = frame_start;
-                            return Ok(ParseResult::InvalidFrame);
-                        }
-                        Err(e) => return Err(e),
-                    };
-                    (portable_changes, running_crc)
+        let (parsed_ops, portable_changes, running_crc) = if encrypted_extension_size > 0 {
+            let plaintext_size = payload_size
+                .checked_add(encrypted_extension_size)
+                .ok_or_else(|| {
+                    LimboError::Corrupt(
+                        "encrypted payload plus extension size overflows usize".into(),
+                    )
+                })?;
+            let Some((plaintext, running_crc)) = self.read_encrypted_plaintext(
+                io,
+                plaintext_size,
+                op_count,
+                commit_ts,
+                running_crc,
+            )?
+            else {
+                return Ok(ParseResult::Eof);
+            };
+            let parsed_ops = match parse_ops_from_plaintext(
+                &plaintext[..payload_size],
+                payload_size,
+                op_count,
+                commit_ts,
+            ) {
+                Ok(ops) => ops,
+                Err(LimboError::Corrupt(msg)) => {
+                    tracing::warn!("corrupt payload: {msg}");
+                    self.last_valid_offset = frame_start;
+                    return Ok(ParseResult::InvalidFrame);
                 }
-                None => return Ok(ParseResult::Eof),
-            }
+                Err(e) => return Err(e),
+            };
+            let portable_changes = match find_extension_payload(
+                &plaintext[payload_size..],
+                extension_record_count,
+                EXTENSION_TYPE_PORTABLE_CHANGES,
+            ) {
+                Ok(payload) => payload,
+                Err(LimboError::Corrupt(msg)) => {
+                    tracing::warn!("corrupt extension block: {msg}");
+                    self.last_valid_offset = frame_start;
+                    return Ok(ParseResult::InvalidFrame);
+                }
+                Err(e) => return Err(e),
+            };
+            (parsed_ops, portable_changes, running_crc)
         } else {
-            (Vec::new(), running_crc)
+            let (parsed_ops, running_crc) = match if self.encryption_ctx.is_some() {
+                self.parse_encrypted_payload(io, op_count, payload_size, commit_ts, running_crc)
+            } else {
+                self.parse_streaming_payload(io, op_count, payload_size, commit_ts, running_crc)
+            } {
+                Ok(PayloadParseResult::Ok(ops, crc)) => (ops, crc),
+                Ok(PayloadParseResult::Eof) => return Ok(ParseResult::Eof),
+                Err(LimboError::Corrupt(msg)) => {
+                    tracing::warn!("corrupt payload: {msg}");
+                    self.last_valid_offset = frame_start;
+                    return Ok(ParseResult::InvalidFrame);
+                }
+                Err(e) => return Err(e),
+            };
+
+            let (portable_changes, running_crc) = if extension_size > 0 {
+                match self.try_consume_bytes(io, extension_size)? {
+                    Some(bytes) => {
+                        let running_crc = crc32c::crc32c_append(running_crc, &bytes);
+                        let portable_changes = match find_extension_payload(
+                            &bytes,
+                            extension_record_count,
+                            EXTENSION_TYPE_PORTABLE_CHANGES,
+                        ) {
+                            Ok(payload) => payload,
+                            Err(LimboError::Corrupt(msg)) => {
+                                tracing::warn!("corrupt extension block: {msg}");
+                                self.last_valid_offset = frame_start;
+                                return Ok(ParseResult::InvalidFrame);
+                            }
+                            Err(e) => return Err(e),
+                        };
+                        (portable_changes, running_crc)
+                    }
+                    None => return Ok(ParseResult::Eof),
+                }
+            } else {
+                (Vec::new(), running_crc)
+            };
+            (parsed_ops, portable_changes, running_crc)
         };
 
         // 3. TX TRAILER layout (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
@@ -2459,6 +2613,12 @@ impl StreamingLogicalLogReader {
             header_bytes[10],
             header_bytes[11],
         ]);
+        let op_count = u32::from_le_bytes([
+            header_bytes[12],
+            header_bytes[13],
+            header_bytes[14],
+            header_bytes[15],
+        ]);
         let commit_ts = u64::from_le_bytes([
             header_bytes[16],
             header_bytes[17],
@@ -2527,7 +2687,20 @@ impl StreamingLogicalLogReader {
         };
 
         let running_crc = crc32c::crc32c_append(self.running_crc, &header_bytes);
-        let payload_on_disk_size = match self.encrypted_payload_on_disk_size(payload_size) {
+        let encrypted_extension_size = if self.encryption_ctx.is_some() {
+            extension_size
+        } else {
+            0
+        };
+        let payload_on_disk_size = match self.encrypted_payload_on_disk_size(
+            payload_size
+                .checked_add(encrypted_extension_size)
+                .ok_or_else(|| {
+                    LimboError::Corrupt(
+                        "payload plus encrypted extension size overflows usize".to_string(),
+                    )
+                })?,
+        ) {
             Ok(size) => size,
             Err(LimboError::Corrupt(msg)) => {
                 tracing::warn!("corrupt payload size: {msg}");
@@ -2536,35 +2709,68 @@ impl StreamingLogicalLogReader {
             }
             Err(e) => return Err(e),
         };
-        let Some(running_crc) =
-            self.consume_and_crc_bytes(io, payload_on_disk_size, running_crc)?
-        else {
-            return Ok(ParseResult::Eof);
-        };
-
-        let (portable_changes, running_crc) = if extension_size > 0 {
-            match self.try_consume_bytes(io, extension_size)? {
-                Some(bytes) => {
-                    let running_crc = crc32c::crc32c_append(running_crc, &bytes);
-                    let portable_changes = match find_extension_payload(
-                        &bytes,
-                        extension_record_count,
-                        EXTENSION_TYPE_PORTABLE_CHANGES,
-                    ) {
-                        Ok(payload) => payload,
-                        Err(LimboError::Corrupt(msg)) => {
-                            tracing::warn!("corrupt extension block: {msg}");
-                            self.last_valid_offset = frame_start;
-                            return Ok(ParseResult::InvalidFrame);
-                        }
-                        Err(e) => return Err(e),
-                    };
-                    (portable_changes, running_crc)
+        let (portable_changes, running_crc) = if encrypted_extension_size > 0 {
+            let plaintext_size = payload_size
+                .checked_add(encrypted_extension_size)
+                .ok_or_else(|| {
+                    LimboError::Corrupt(
+                        "encrypted payload plus extension size overflows usize".into(),
+                    )
+                })?;
+            let Some((plaintext, running_crc)) = self.read_encrypted_plaintext(
+                io,
+                plaintext_size,
+                op_count,
+                commit_ts,
+                running_crc,
+            )?
+            else {
+                return Ok(ParseResult::Eof);
+            };
+            let portable_changes = match find_extension_payload(
+                &plaintext[payload_size..],
+                extension_record_count,
+                EXTENSION_TYPE_PORTABLE_CHANGES,
+            ) {
+                Ok(payload) => payload,
+                Err(LimboError::Corrupt(msg)) => {
+                    tracing::warn!("corrupt extension block: {msg}");
+                    self.last_valid_offset = frame_start;
+                    return Ok(ParseResult::InvalidFrame);
                 }
-                None => return Ok(ParseResult::Eof),
-            }
+                Err(e) => return Err(e),
+            };
+            (portable_changes, running_crc)
         } else {
-            (Vec::new(), running_crc)
+            let Some(running_crc) =
+                self.consume_and_crc_bytes(io, payload_on_disk_size, running_crc)?
+            else {
+                return Ok(ParseResult::Eof);
+            };
+            if extension_size > 0 {
+                match self.try_consume_bytes(io, extension_size)? {
+                    Some(bytes) => {
+                        let running_crc = crc32c::crc32c_append(running_crc, &bytes);
+                        let portable_changes = match find_extension_payload(
+                            &bytes,
+                            extension_record_count,
+                            EXTENSION_TYPE_PORTABLE_CHANGES,
+                        ) {
+                            Ok(payload) => payload,
+                            Err(LimboError::Corrupt(msg)) => {
+                                tracing::warn!("corrupt extension block: {msg}");
+                                self.last_valid_offset = frame_start;
+                                return Ok(ParseResult::InvalidFrame);
+                            }
+                            Err(e) => return Err(e),
+                        };
+                        (portable_changes, running_crc)
+                    }
+                    None => return Ok(ParseResult::Eof),
+                }
+            } else {
+                (Vec::new(), running_crc)
+            }
         };
 
         let trailer_bytes = match self.try_consume_fixed::<TX_TRAILER_SIZE>(io)? {

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -44,6 +44,11 @@ pub trait DurableStorage: Send + Sync + Debug {
         on_serialization_complete: OnSerializationComplete<'_>,
     ) -> Result<(Completion, u64)>;
 
+    /// If `m` needs a logical-log header upgrade before it can be appended,
+    /// start that write and return its completion. Callers must wait for this
+    /// completion and then call `log_tx`.
+    fn upgrade_header_for_log_tx(&self, m: &LogRecord) -> Result<Option<Completion>>;
+
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
 
     /// Called after a logical-log write completed successfully, before the
@@ -177,6 +182,10 @@ impl DurableStorage for Storage {
         self.logical_log
             .write()
             .log_tx_deferred_offset(m, on_serialization_complete)
+    }
+
+    fn upgrade_header_for_log_tx(&self, m: &LogRecord) -> Result<Option<Completion>> {
+        self.logical_log.write().upgrade_header_for_log_tx(m)
     }
 
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion> {

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -147,6 +147,30 @@ impl DurableStorage for Storage {
         log_record.op_count = log_record.op_count.checked_add(1).ok_or_else(|| {
             LimboError::InternalError("logical log op_count exceeds u32".to_string())
         })?;
+        #[cfg(feature = "conn_raw_api")]
+        if row_version.row.id.table_id == crate::mvcc::database::SQLITE_SCHEMA_MVCC_TABLE_ID
+            && matches!(
+                row_version.end,
+                Some(crate::mvcc::database::TxTimestampOrID::Timestamp(ts))
+                    if ts == log_record.tx_timestamp
+            )
+        {
+            log_record.portable_schema_deletes.push((
+                row_version.row.id.row_id.to_int_or_panic(),
+                row_version.row.payload().to_vec(),
+            ));
+        } else if matches!(
+            row_version.end,
+            Some(crate::mvcc::database::TxTimestampOrID::Timestamp(ts))
+                if ts == log_record.tx_timestamp
+        ) {
+            if let crate::mvcc::database::RowKey::Int(rowid) = row_version.row.id.row_id {
+                log_record.portable_deleted_table_rows.insert(
+                    (row_version.row.id.table_id, rowid),
+                    row_version.row.payload().to_vec(),
+                );
+            }
+        }
         Ok(())
     }
 

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -45,6 +45,12 @@ pub trait DurableStorage: Send + Sync + Debug {
 
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
 
+    /// Called after a logical-log write completed successfully, before the
+    /// transaction is made visible by advancing the logical-log offset.
+    fn on_log_write_complete(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Persist the current logical-log header to durable storage.
     ///
     /// This is used by MVCC recovery/checkpoint flows. Keeping this in the trait avoids
@@ -52,13 +58,23 @@ pub trait DurableStorage: Send + Sync + Debug {
     fn update_header(&self) -> Result<Completion>;
 
     fn truncate(&self) -> Result<Completion>;
+
+    /// Reset the logical log to a fresh header-only file.
+    ///
+    /// Used after an external database restore so future MVCC recovery starts
+    /// from the restored image instead of replaying stale local log frames.
+    fn reset_to_fresh_header(&self) -> Result<Completion>;
     fn get_logical_log_file(&self) -> Arc<dyn File>;
+    fn logical_log_offset(&self) -> u64;
     fn should_checkpoint(&self) -> bool;
     /// Set the checkpoint threshold in bytes of logical-log data written.
     /// A negative value disables automatic checkpointing.
     fn set_checkpoint_threshold(&self, threshold: i64);
     fn checkpoint_threshold(&self) -> i64;
-    fn advance_logical_log_offset_after_success(&self, bytes: u64);
+    fn advance_logical_log_offset_after_success(&self, bytes: u64) -> Result<()>;
+    fn discard_pending_log_write(&self) -> Result<()> {
+        Ok(())
+    }
     fn restore_logical_log_state_after_recovery(&self, offset: u64, running_crc: u32);
 
     /// Set the in-memory log header from a previously-read on-disk header.
@@ -175,8 +191,18 @@ impl DurableStorage for Storage {
         Ok(c)
     }
 
+    fn reset_to_fresh_header(&self) -> Result<Completion> {
+        let c = self.logical_log.write().reset_to_fresh_header()?;
+        self.shadow_offset_store(0);
+        Ok(c)
+    }
+
     fn get_logical_log_file(&self) -> Arc<dyn File> {
         self.logical_log.read().file.clone()
+    }
+
+    fn logical_log_offset(&self) -> u64 {
+        self.log_offset.load(Ordering::Relaxed)
     }
 
     fn encryption_ctx(&self) -> Option<EncryptionContext> {
@@ -201,9 +227,10 @@ impl DurableStorage for Storage {
         self.checkpoint_threshold.load(Ordering::Relaxed)
     }
 
-    fn advance_logical_log_offset_after_success(&self, bytes: u64) {
+    fn advance_logical_log_offset_after_success(&self, bytes: u64) -> Result<()> {
         self.logical_log.write().advance_offset_after_success(bytes);
         self.shadow_offset_advance(bytes);
+        Ok(())
     }
 
     fn restore_logical_log_state_after_recovery(&self, offset: u64, running_crc: u32) {

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -22,6 +22,7 @@ pub trait DurableStorage: Send + Sync + Debug {
         &self,
         log_record: &mut LogRecord,
         row_version: &RowVersion,
+        portable_extension: Option<&[u8]>,
     ) -> Result<()>;
 
     /// Append a `DatabaseHeader` op to `log_record`'s payload buffer.
@@ -142,35 +143,12 @@ impl DurableStorage for Storage {
         &self,
         log_record: &mut LogRecord,
         row_version: &RowVersion,
+        portable_extension: Option<&[u8]>,
     ) -> Result<()> {
-        serialize_op_entry(&mut log_record.buf, row_version)?;
+        serialize_op_entry(&mut log_record.buf, row_version, portable_extension)?;
         log_record.op_count = log_record.op_count.checked_add(1).ok_or_else(|| {
             LimboError::InternalError("logical log op_count exceeds u32".to_string())
         })?;
-        #[cfg(feature = "conn_raw_api")]
-        if row_version.row.id.table_id == crate::mvcc::database::SQLITE_SCHEMA_MVCC_TABLE_ID
-            && matches!(
-                row_version.end,
-                Some(crate::mvcc::database::TxTimestampOrID::Timestamp(ts))
-                    if ts == log_record.tx_timestamp
-            )
-        {
-            log_record.portable_schema_deletes.push((
-                row_version.row.id.row_id.to_int_or_panic(),
-                row_version.row.payload().to_vec(),
-            ));
-        } else if matches!(
-            row_version.end,
-            Some(crate::mvcc::database::TxTimestampOrID::Timestamp(ts))
-                if ts == log_record.tx_timestamp
-        ) {
-            if let crate::mvcc::database::RowKey::Int(rowid) = row_version.row.id.row_id {
-                log_record.portable_deleted_table_rows.insert(
-                    (row_version.row.id.table_id, rowid),
-                    row_version.row.payload().to_vec(),
-                );
-            }
-        }
         Ok(())
     }
 

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -1,49 +1,20 @@
-use crate::storage::sqlite3_ondisk::DatabaseHeader;
 use crate::types::{ImmutableRecord, Value};
 use crate::{LimboError, Numeric, Result};
 use std::collections::{HashMap, HashSet};
 
-pub(crate) const LOGICAL_OP_UPSERT_ROW: u64 = 0;
-pub(crate) const LOGICAL_OP_DELETE_ROW: u64 = 1;
-const LOGICAL_OP_SCHEMA: u64 = 2;
-const LOGICAL_OP_UPDATE_HEADER: u64 = 3;
-
-pub(crate) const LOGICAL_SCHEMA_CREATE: u64 = 0;
-pub(crate) const LOGICAL_SCHEMA_DROP: u64 = 1;
-pub(crate) const LOGICAL_SCHEMA_REFRESH: u64 = 2;
-
-const LOGICAL_SCHEMA_KIND_TABLE: u64 = 0;
-const LOGICAL_SCHEMA_KIND_INDEX: u64 = 1;
-const LOGICAL_SCHEMA_KIND_TRIGGER: u64 = 2;
-const LOGICAL_SCHEMA_KIND_VIEW: u64 = 3;
-
-const TX_FIELD_OP: u64 = 3;
-const TX_FIELD_ORIGIN_CLIENT_ID: u64 = 4;
 const TX_FIELD_STRING_TABLE: u64 = 12;
 const TX_FIELD_OBJECT_MAP: u64 = 13;
+const TX_FIELD_META: u64 = 14;
 
 const OBJECT_FIELD_MV_TABLE_ID: u64 = 1;
-const OBJECT_FIELD_LOGICAL_OBJECT_ID: u64 = 2;
-const OBJECT_FIELD_KIND: u64 = 3;
-const OBJECT_FIELD_NAME_REF: u64 = 4;
-const OBJECT_FIELD_SCHEMA_EPOCH: u64 = 5;
-const OBJECT_FIELD_CREATE_SQL_REF: u64 = 6;
-const OBJECT_FIELD_ROOTPAGE_DEBUG: u64 = 7;
+const OBJECT_FIELD_NAME_REF: u64 = 2;
 
-const OP_FIELD_TYPE: u64 = 1;
-const OP_FIELD_ROWID: u64 = 3;
-const OP_FIELD_RECORD: u64 = 4;
-const OP_FIELD_USER_VERSION: u64 = 6;
-const OP_FIELD_APPLICATION_ID: u64 = 7;
-const OP_FIELD_SCHEMA_ACTION: u64 = 8;
-const OP_FIELD_SCHEMA_KIND: u64 = 9;
-const OP_FIELD_STABLE_TABLE_ID: u64 = 11;
-const OP_FIELD_MV_TABLE_ID: u64 = 12;
-const OP_FIELD_SQL_REF: u64 = 13;
-const OP_FIELD_SCHEMA_NAME_REF: u64 = 14;
+const META_FIELD_KEY_REF: u64 = 1;
+const META_FIELD_VALUE_REF: u64 = 2;
 
 const SQLITE_INTERNAL_PREFIX: &str = "sqlite_";
 const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
+const TURSO_SYNC_PREFIX: &str = "turso_sync_";
 const TURSO_CDC_TABLE_NAME: &str = "turso_cdc";
 const TURSO_CDC_VERSION_TABLE_NAME: &str = "turso_cdc_version";
 
@@ -83,27 +54,21 @@ fn write_proto_string(field: u64, value: &str, out: &mut Vec<u8>) {
     write_proto_bytes(field, value.as_bytes(), out);
 }
 
-fn append_logical_op(op_body: Vec<u8>, out: &mut Vec<u8>) {
-    write_proto_key(TX_FIELD_OP, 2, out);
-    write_proto_varint(op_body.len() as u64, out);
-    out.extend_from_slice(&op_body);
-}
-
 pub(crate) fn is_portable_logical_name(name: &str) -> bool {
     !name.starts_with(SQLITE_INTERNAL_PREFIX)
         && !name.starts_with(TURSO_INTERNAL_PREFIX)
+        && !name.starts_with(TURSO_SYNC_PREFIX)
         && name != TURSO_CDC_TABLE_NAME
         && name != TURSO_CDC_VERSION_TABLE_NAME
 }
 
 /// Decoded subset of a `sqlite_schema` record needed to materialize stable
-/// portable schema operations at MVCC commit time.
+/// portable object-map entries at MVCC commit time.
 #[derive(Clone, Debug)]
 pub(crate) struct PortableSchemaRow {
     pub(crate) row_type: String,
     pub(crate) name: String,
     pub(crate) rootpage: i64,
-    pub(crate) sql: Option<String>,
 }
 
 pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<PortableSchemaRow> {
@@ -122,15 +87,6 @@ pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<Por
             ))),
         }
     };
-    let optional_text = |value: &Value, field: &str| -> Result<Option<String>> {
-        match value {
-            Value::Text(text) => Ok(Some(text.as_str().to_string())),
-            Value::Null => Ok(None),
-            other => Err(LimboError::Corrupt(format!(
-                "{field} must be text or null in sqlite_schema record, got {other:?}"
-            ))),
-        }
-    };
     let integer = |value: &Value, field: &str| -> Result<i64> {
         match value {
             Value::Numeric(Numeric::Integer(value)) => Ok(*value),
@@ -143,26 +99,11 @@ pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<Por
         row_type: text(&values[0], "sqlite_schema.type")?,
         name: text(&values[1], "sqlite_schema.name")?,
         rootpage: integer(&values[3], "sqlite_schema.rootpage")?,
-        sql: optional_text(&values[4], "sqlite_schema.sql")?,
     })
 }
 
-pub(crate) fn portable_schema_kind(row_type: &str) -> Option<u64> {
-    if row_type.eq_ignore_ascii_case("table") {
-        Some(LOGICAL_SCHEMA_KIND_TABLE)
-    } else if row_type.eq_ignore_ascii_case("index") {
-        Some(LOGICAL_SCHEMA_KIND_INDEX)
-    } else if row_type.eq_ignore_ascii_case("trigger") {
-        Some(LOGICAL_SCHEMA_KIND_TRIGGER)
-    } else if row_type.eq_ignore_ascii_case("view") {
-        Some(LOGICAL_SCHEMA_KIND_VIEW)
-    } else {
-        None
-    }
-}
-
-pub(crate) fn stable_table_id_from_rootpage(rootpage: i64) -> Option<u64> {
-    (rootpage != 0).then_some(rootpage.unsigned_abs())
+pub(crate) fn is_portable_table_schema_row(row: &PortableSchemaRow) -> bool {
+    row.rootpage != 0 && row.row_type.eq_ignore_ascii_case("table")
 }
 
 #[derive(Default)]
@@ -171,17 +112,12 @@ pub(crate) struct PortableLogicalBuilder {
     string_refs: HashMap<String, u64>,
     object_maps: Vec<Vec<u8>>,
     object_map_ids: HashSet<i64>,
-    ops: Vec<u8>,
+    metadata: Vec<Vec<u8>>,
 }
 
 pub(crate) struct PortableObjectMapEntry<'a> {
     pub(crate) mv_table_id: i64,
-    pub(crate) kind: u64,
-    pub(crate) logical_object_id: u64,
     pub(crate) name: &'a str,
-    pub(crate) schema_epoch: u64,
-    pub(crate) create_sql: Option<&'a str>,
-    pub(crate) rootpage_debug: i64,
 }
 
 impl PortableLogicalBuilder {
@@ -204,102 +140,25 @@ impl PortableLogicalBuilder {
             return false;
         }
         let name_ref = self.intern_string(entry.name);
-        let sql_ref = entry.create_sql.map(|sql| self.intern_string(sql));
 
         let mut object = Vec::new();
         write_proto_sint64(OBJECT_FIELD_MV_TABLE_ID, entry.mv_table_id, &mut object);
-        write_proto_uint64(
-            OBJECT_FIELD_LOGICAL_OBJECT_ID,
-            entry.logical_object_id,
-            &mut object,
-        );
-        write_proto_uint64(OBJECT_FIELD_KIND, entry.kind, &mut object);
         write_proto_uint64(OBJECT_FIELD_NAME_REF, name_ref, &mut object);
-        write_proto_uint64(OBJECT_FIELD_SCHEMA_EPOCH, entry.schema_epoch, &mut object);
-        if let Some(sql_ref) = sql_ref {
-            write_proto_uint64(OBJECT_FIELD_CREATE_SQL_REF, sql_ref, &mut object);
-        }
-        write_proto_sint64(
-            OBJECT_FIELD_ROOTPAGE_DEBUG,
-            entry.rootpage_debug,
-            &mut object,
-        );
         self.object_maps.push(object);
         true
     }
 
-    pub(crate) fn encode_schema_logical_op(
-        &mut self,
-        action: u64,
-        row: &PortableSchemaRow,
-        stable_table_id: Option<u64>,
-    ) -> bool {
-        let Some(kind) = portable_schema_kind(&row.row_type) else {
-            return false;
-        };
-        if !is_portable_logical_name(&row.name) {
-            return false;
-        }
-        let name_ref = self.intern_string(&row.name);
-        let sql_ref = if matches!(action, LOGICAL_SCHEMA_CREATE | LOGICAL_SCHEMA_REFRESH) {
-            row.sql.as_deref().map(|sql| self.intern_string(sql))
-        } else {
-            None
-        };
-
-        let mut op = Vec::new();
-        write_proto_uint64(OP_FIELD_TYPE, LOGICAL_OP_SCHEMA, &mut op);
-        write_proto_uint64(OP_FIELD_SCHEMA_ACTION, action, &mut op);
-        write_proto_uint64(OP_FIELD_SCHEMA_KIND, kind, &mut op);
-        if let Some(stable_table_id) = stable_table_id {
-            write_proto_uint64(OP_FIELD_STABLE_TABLE_ID, stable_table_id, &mut op);
-        }
-        if let Some(sql_ref) = sql_ref {
-            write_proto_uint64(OP_FIELD_SQL_REF, sql_ref, &mut op);
-        }
-        write_proto_uint64(OP_FIELD_SCHEMA_NAME_REF, name_ref, &mut op);
-        append_logical_op(op, &mut self.ops);
-        true
+    pub(crate) fn add_metadata(&mut self, key: &str, value: &str) {
+        let key_ref = self.intern_string(key);
+        let value_ref = self.intern_string(value);
+        let mut meta = Vec::new();
+        write_proto_uint64(META_FIELD_KEY_REF, key_ref, &mut meta);
+        write_proto_uint64(META_FIELD_VALUE_REF, value_ref, &mut meta);
+        self.metadata.push(meta);
     }
 
-    pub(crate) fn encode_row_logical_op(
-        &mut self,
-        op_type: u64,
-        mv_table_id: i64,
-        rowid: i64,
-        record: &[u8],
-    ) {
-        let mut op = Vec::new();
-        write_proto_uint64(OP_FIELD_TYPE, op_type, &mut op);
-        write_proto_sint64(OP_FIELD_ROWID, rowid, &mut op);
-        if !record.is_empty() {
-            write_proto_bytes(OP_FIELD_RECORD, record, &mut op);
-        }
-        write_proto_sint64(OP_FIELD_MV_TABLE_ID, mv_table_id, &mut op);
-        append_logical_op(op, &mut self.ops);
-    }
-
-    pub(crate) fn encode_header_logical_op(&mut self, header: &DatabaseHeader) {
-        let mut op = Vec::new();
-        write_proto_uint64(OP_FIELD_TYPE, LOGICAL_OP_UPDATE_HEADER, &mut op);
-        write_proto_uint64(
-            OP_FIELD_USER_VERSION,
-            header.user_version.get() as u64,
-            &mut op,
-        );
-        write_proto_uint64(
-            OP_FIELD_APPLICATION_ID,
-            header.application_id.get() as u64,
-            &mut op,
-        );
-        append_logical_op(op, &mut self.ops);
-    }
-
-    pub(crate) fn finish(self, origin_client_id: Option<String>) -> Vec<u8> {
+    pub(crate) fn finish(self) -> Vec<u8> {
         let mut txn_fields = Vec::new();
-        if let Some(client_id) = origin_client_id {
-            write_proto_string(TX_FIELD_ORIGIN_CLIENT_ID, &client_id, &mut txn_fields);
-        }
         for value in &self.strings {
             write_proto_string(TX_FIELD_STRING_TABLE, value, &mut txn_fields);
         }
@@ -308,7 +167,11 @@ impl PortableLogicalBuilder {
             write_proto_varint(object_map.len() as u64, &mut txn_fields);
             txn_fields.extend_from_slice(&object_map);
         }
-        txn_fields.extend_from_slice(&self.ops);
+        for meta in self.metadata {
+            write_proto_key(TX_FIELD_META, 2, &mut txn_fields);
+            write_proto_varint(meta.len() as u64, &mut txn_fields);
+            txn_fields.extend_from_slice(&meta);
+        }
         txn_fields
     }
 }

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -1,6 +1,7 @@
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
 use crate::types::{ImmutableRecord, Value};
 use crate::{LimboError, Numeric, Result};
+use std::collections::{HashMap, HashSet};
 
 pub(crate) const LOGICAL_OP_UPSERT_ROW: u64 = 0;
 pub(crate) const LOGICAL_OP_DELETE_ROW: u64 = 1;
@@ -15,6 +16,31 @@ const LOGICAL_SCHEMA_KIND_TABLE: u64 = 0;
 const LOGICAL_SCHEMA_KIND_INDEX: u64 = 1;
 const LOGICAL_SCHEMA_KIND_TRIGGER: u64 = 2;
 const LOGICAL_SCHEMA_KIND_VIEW: u64 = 3;
+
+const TX_FIELD_OP: u64 = 3;
+const TX_FIELD_ORIGIN_CLIENT_ID: u64 = 4;
+const TX_FIELD_STRING_TABLE: u64 = 12;
+const TX_FIELD_OBJECT_MAP: u64 = 13;
+
+const OBJECT_FIELD_MV_TABLE_ID: u64 = 1;
+const OBJECT_FIELD_LOGICAL_OBJECT_ID: u64 = 2;
+const OBJECT_FIELD_KIND: u64 = 3;
+const OBJECT_FIELD_NAME_REF: u64 = 4;
+const OBJECT_FIELD_SCHEMA_EPOCH: u64 = 5;
+const OBJECT_FIELD_CREATE_SQL_REF: u64 = 6;
+const OBJECT_FIELD_ROOTPAGE_DEBUG: u64 = 7;
+
+const OP_FIELD_TYPE: u64 = 1;
+const OP_FIELD_ROWID: u64 = 3;
+const OP_FIELD_RECORD: u64 = 4;
+const OP_FIELD_USER_VERSION: u64 = 6;
+const OP_FIELD_APPLICATION_ID: u64 = 7;
+const OP_FIELD_SCHEMA_ACTION: u64 = 8;
+const OP_FIELD_SCHEMA_KIND: u64 = 9;
+const OP_FIELD_STABLE_TABLE_ID: u64 = 11;
+const OP_FIELD_MV_TABLE_ID: u64 = 12;
+const OP_FIELD_SQL_REF: u64 = 13;
+const OP_FIELD_SCHEMA_NAME_REF: u64 = 14;
 
 const SQLITE_INTERNAL_PREFIX: &str = "sqlite_";
 const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
@@ -57,16 +83,8 @@ fn write_proto_string(field: u64, value: &str, out: &mut Vec<u8>) {
     write_proto_bytes(field, value.as_bytes(), out);
 }
 
-pub(crate) fn prepend_origin_client_id(client_id: &str, encoded_ops: Vec<u8>) -> Vec<u8> {
-    let mut txn_fields = Vec::new();
-    // PortableLogicalTxn.origin_client_id, field 4.
-    write_proto_string(4, client_id, &mut txn_fields);
-    txn_fields.extend_from_slice(&encoded_ops);
-    txn_fields
-}
-
 fn append_logical_op(op_body: Vec<u8>, out: &mut Vec<u8>) {
-    write_proto_key(3, 2, out);
+    write_proto_key(TX_FIELD_OP, 2, out);
     write_proto_varint(op_body.len() as u64, out);
     out.extend_from_slice(&op_body);
 }
@@ -129,7 +147,7 @@ pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<Por
     })
 }
 
-fn portable_schema_kind(row_type: &str) -> Option<u64> {
+pub(crate) fn portable_schema_kind(row_type: &str) -> Option<u64> {
     if row_type.eq_ignore_ascii_case("table") {
         Some(LOGICAL_SCHEMA_KIND_TABLE)
     } else if row_type.eq_ignore_ascii_case("index") {
@@ -147,64 +165,150 @@ pub(crate) fn stable_table_id_from_rootpage(rootpage: i64) -> Option<u64> {
     (rootpage != 0).then_some(rootpage.unsigned_abs())
 }
 
-pub(crate) fn encode_schema_logical_op(
-    action: u64,
-    row: &PortableSchemaRow,
-    stable_table_id: Option<u64>,
-    out: &mut Vec<u8>,
-) -> bool {
-    let Some(kind) = portable_schema_kind(&row.row_type) else {
-        return false;
-    };
-    if !is_portable_logical_name(&row.name) {
-        return false;
+#[derive(Default)]
+pub(crate) struct PortableLogicalBuilder {
+    strings: Vec<String>,
+    string_refs: HashMap<String, u64>,
+    object_maps: Vec<Vec<u8>>,
+    object_map_ids: HashSet<i64>,
+    ops: Vec<u8>,
+}
+
+pub(crate) struct PortableObjectMapEntry<'a> {
+    pub(crate) mv_table_id: i64,
+    pub(crate) kind: u64,
+    pub(crate) logical_object_id: u64,
+    pub(crate) name: &'a str,
+    pub(crate) schema_epoch: u64,
+    pub(crate) create_sql: Option<&'a str>,
+    pub(crate) rootpage_debug: i64,
+}
+
+impl PortableLogicalBuilder {
+    pub(crate) fn new() -> Self {
+        Self::default()
     }
-    let mut op = Vec::new();
-    write_proto_uint64(1, LOGICAL_OP_SCHEMA, &mut op);
-    if matches!(action, LOGICAL_SCHEMA_CREATE | LOGICAL_SCHEMA_REFRESH) {
-        if let Some(sql) = row.sql.as_deref() {
-            write_proto_string(5, sql, &mut op);
+
+    fn intern_string(&mut self, value: &str) -> u64 {
+        if let Some(idx) = self.string_refs.get(value) {
+            return *idx;
         }
+        let idx = self.strings.len() as u64;
+        self.strings.push(value.to_string());
+        self.string_refs.insert(value.to_string(), idx);
+        idx
     }
-    write_proto_uint64(8, action, &mut op);
-    write_proto_uint64(9, kind, &mut op);
-    write_proto_string(10, &row.name, &mut op);
-    if let Some(stable_table_id) = stable_table_id {
-        write_proto_uint64(11, stable_table_id, &mut op);
-    }
-    append_logical_op(op, out);
-    true
-}
 
-pub(crate) fn encode_row_logical_op(
-    op_type: u64,
-    table_name: &str,
-    include_table_name: bool,
-    stable_table_id: u64,
-    rowid: i64,
-    record: &[u8],
-    out: &mut Vec<u8>,
-) {
-    if !is_portable_logical_name(table_name) {
-        return;
-    }
-    let mut op = Vec::new();
-    write_proto_uint64(1, op_type, &mut op);
-    if include_table_name {
-        write_proto_string(2, table_name, &mut op);
-    }
-    write_proto_sint64(3, rowid, &mut op);
-    write_proto_uint64(11, stable_table_id, &mut op);
-    if op_type == LOGICAL_OP_UPSERT_ROW {
-        write_proto_bytes(4, record, &mut op);
-    }
-    append_logical_op(op, out);
-}
+    pub(crate) fn add_object_map(&mut self, entry: PortableObjectMapEntry<'_>) -> bool {
+        if !is_portable_logical_name(entry.name) || !self.object_map_ids.insert(entry.mv_table_id) {
+            return false;
+        }
+        let name_ref = self.intern_string(entry.name);
+        let sql_ref = entry.create_sql.map(|sql| self.intern_string(sql));
 
-pub(crate) fn encode_header_logical_op(header: &DatabaseHeader, out: &mut Vec<u8>) {
-    let mut op = Vec::new();
-    write_proto_uint64(1, LOGICAL_OP_UPDATE_HEADER, &mut op);
-    write_proto_uint64(6, header.user_version.get() as u64, &mut op);
-    write_proto_uint64(7, header.application_id.get() as u64, &mut op);
-    append_logical_op(op, out);
+        let mut object = Vec::new();
+        write_proto_sint64(OBJECT_FIELD_MV_TABLE_ID, entry.mv_table_id, &mut object);
+        write_proto_uint64(
+            OBJECT_FIELD_LOGICAL_OBJECT_ID,
+            entry.logical_object_id,
+            &mut object,
+        );
+        write_proto_uint64(OBJECT_FIELD_KIND, entry.kind, &mut object);
+        write_proto_uint64(OBJECT_FIELD_NAME_REF, name_ref, &mut object);
+        write_proto_uint64(OBJECT_FIELD_SCHEMA_EPOCH, entry.schema_epoch, &mut object);
+        if let Some(sql_ref) = sql_ref {
+            write_proto_uint64(OBJECT_FIELD_CREATE_SQL_REF, sql_ref, &mut object);
+        }
+        write_proto_sint64(
+            OBJECT_FIELD_ROOTPAGE_DEBUG,
+            entry.rootpage_debug,
+            &mut object,
+        );
+        self.object_maps.push(object);
+        true
+    }
+
+    pub(crate) fn encode_schema_logical_op(
+        &mut self,
+        action: u64,
+        row: &PortableSchemaRow,
+        stable_table_id: Option<u64>,
+    ) -> bool {
+        let Some(kind) = portable_schema_kind(&row.row_type) else {
+            return false;
+        };
+        if !is_portable_logical_name(&row.name) {
+            return false;
+        }
+        let name_ref = self.intern_string(&row.name);
+        let sql_ref = if matches!(action, LOGICAL_SCHEMA_CREATE | LOGICAL_SCHEMA_REFRESH) {
+            row.sql.as_deref().map(|sql| self.intern_string(sql))
+        } else {
+            None
+        };
+
+        let mut op = Vec::new();
+        write_proto_uint64(OP_FIELD_TYPE, LOGICAL_OP_SCHEMA, &mut op);
+        write_proto_uint64(OP_FIELD_SCHEMA_ACTION, action, &mut op);
+        write_proto_uint64(OP_FIELD_SCHEMA_KIND, kind, &mut op);
+        if let Some(stable_table_id) = stable_table_id {
+            write_proto_uint64(OP_FIELD_STABLE_TABLE_ID, stable_table_id, &mut op);
+        }
+        if let Some(sql_ref) = sql_ref {
+            write_proto_uint64(OP_FIELD_SQL_REF, sql_ref, &mut op);
+        }
+        write_proto_uint64(OP_FIELD_SCHEMA_NAME_REF, name_ref, &mut op);
+        append_logical_op(op, &mut self.ops);
+        true
+    }
+
+    pub(crate) fn encode_row_logical_op(
+        &mut self,
+        op_type: u64,
+        mv_table_id: i64,
+        rowid: i64,
+        record: &[u8],
+    ) {
+        let mut op = Vec::new();
+        write_proto_uint64(OP_FIELD_TYPE, op_type, &mut op);
+        write_proto_sint64(OP_FIELD_ROWID, rowid, &mut op);
+        if !record.is_empty() {
+            write_proto_bytes(OP_FIELD_RECORD, record, &mut op);
+        }
+        write_proto_sint64(OP_FIELD_MV_TABLE_ID, mv_table_id, &mut op);
+        append_logical_op(op, &mut self.ops);
+    }
+
+    pub(crate) fn encode_header_logical_op(&mut self, header: &DatabaseHeader) {
+        let mut op = Vec::new();
+        write_proto_uint64(OP_FIELD_TYPE, LOGICAL_OP_UPDATE_HEADER, &mut op);
+        write_proto_uint64(
+            OP_FIELD_USER_VERSION,
+            header.user_version.get() as u64,
+            &mut op,
+        );
+        write_proto_uint64(
+            OP_FIELD_APPLICATION_ID,
+            header.application_id.get() as u64,
+            &mut op,
+        );
+        append_logical_op(op, &mut self.ops);
+    }
+
+    pub(crate) fn finish(self, origin_client_id: Option<String>) -> Vec<u8> {
+        let mut txn_fields = Vec::new();
+        if let Some(client_id) = origin_client_id {
+            write_proto_string(TX_FIELD_ORIGIN_CLIENT_ID, &client_id, &mut txn_fields);
+        }
+        for value in &self.strings {
+            write_proto_string(TX_FIELD_STRING_TABLE, value, &mut txn_fields);
+        }
+        for object_map in self.object_maps {
+            write_proto_key(TX_FIELD_OBJECT_MAP, 2, &mut txn_fields);
+            write_proto_varint(object_map.len() as u64, &mut txn_fields);
+            txn_fields.extend_from_slice(&object_map);
+        }
+        txn_fields.extend_from_slice(&self.ops);
+        txn_fields
+    }
 }

--- a/core/mvcc/portable_logical.rs
+++ b/core/mvcc/portable_logical.rs
@@ -1,0 +1,210 @@
+use crate::storage::sqlite3_ondisk::DatabaseHeader;
+use crate::types::{ImmutableRecord, Value};
+use crate::{LimboError, Numeric, Result};
+
+pub(crate) const LOGICAL_OP_UPSERT_ROW: u64 = 0;
+pub(crate) const LOGICAL_OP_DELETE_ROW: u64 = 1;
+const LOGICAL_OP_SCHEMA: u64 = 2;
+const LOGICAL_OP_UPDATE_HEADER: u64 = 3;
+
+pub(crate) const LOGICAL_SCHEMA_CREATE: u64 = 0;
+pub(crate) const LOGICAL_SCHEMA_DROP: u64 = 1;
+pub(crate) const LOGICAL_SCHEMA_REFRESH: u64 = 2;
+
+const LOGICAL_SCHEMA_KIND_TABLE: u64 = 0;
+const LOGICAL_SCHEMA_KIND_INDEX: u64 = 1;
+const LOGICAL_SCHEMA_KIND_TRIGGER: u64 = 2;
+const LOGICAL_SCHEMA_KIND_VIEW: u64 = 3;
+
+const SQLITE_INTERNAL_PREFIX: &str = "sqlite_";
+const TURSO_INTERNAL_PREFIX: &str = "__turso_internal_";
+const TURSO_CDC_TABLE_NAME: &str = "turso_cdc";
+const TURSO_CDC_VERSION_TABLE_NAME: &str = "turso_cdc_version";
+
+// Minimal protobuf-style encoder for core-owned portable MVCC logical changes.
+// Keeping this local avoids making turso_core depend on the sync engine or
+// server proto crate. Raw-log consumers can decode this envelope into their own
+// replay representation.
+fn write_proto_varint(mut value: u64, out: &mut Vec<u8>) {
+    while value >= 0x80 {
+        out.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}
+
+fn write_proto_key(field: u64, wire_type: u64, out: &mut Vec<u8>) {
+    write_proto_varint((field << 3) | wire_type, out);
+}
+
+fn write_proto_uint64(field: u64, value: u64, out: &mut Vec<u8>) {
+    write_proto_key(field, 0, out);
+    write_proto_varint(value, out);
+}
+
+fn write_proto_sint64(field: u64, value: i64, out: &mut Vec<u8>) {
+    let zigzag = ((value << 1) ^ (value >> 63)) as u64;
+    write_proto_uint64(field, zigzag, out);
+}
+
+fn write_proto_bytes(field: u64, value: &[u8], out: &mut Vec<u8>) {
+    write_proto_key(field, 2, out);
+    write_proto_varint(value.len() as u64, out);
+    out.extend_from_slice(value);
+}
+
+fn write_proto_string(field: u64, value: &str, out: &mut Vec<u8>) {
+    write_proto_bytes(field, value.as_bytes(), out);
+}
+
+pub(crate) fn prepend_origin_client_id(client_id: &str, encoded_ops: Vec<u8>) -> Vec<u8> {
+    let mut txn_fields = Vec::new();
+    // PortableLogicalTxn.origin_client_id, field 4.
+    write_proto_string(4, client_id, &mut txn_fields);
+    txn_fields.extend_from_slice(&encoded_ops);
+    txn_fields
+}
+
+fn append_logical_op(op_body: Vec<u8>, out: &mut Vec<u8>) {
+    write_proto_key(3, 2, out);
+    write_proto_varint(op_body.len() as u64, out);
+    out.extend_from_slice(&op_body);
+}
+
+pub(crate) fn is_portable_logical_name(name: &str) -> bool {
+    !name.starts_with(SQLITE_INTERNAL_PREFIX)
+        && !name.starts_with(TURSO_INTERNAL_PREFIX)
+        && name != TURSO_CDC_TABLE_NAME
+        && name != TURSO_CDC_VERSION_TABLE_NAME
+}
+
+/// Decoded subset of a `sqlite_schema` record needed to materialize stable
+/// portable schema operations at MVCC commit time.
+#[derive(Clone, Debug)]
+pub(crate) struct PortableSchemaRow {
+    pub(crate) row_type: String,
+    pub(crate) name: String,
+    pub(crate) rootpage: i64,
+    pub(crate) sql: Option<String>,
+}
+
+pub(crate) fn portable_schema_row_from_record(record_bytes: &[u8]) -> Result<PortableSchemaRow> {
+    let values = ImmutableRecord::from_bin_record(record_bytes.to_vec()).get_values_owned()?;
+    if values.len() < 5 {
+        return Err(LimboError::Corrupt(format!(
+            "sqlite_schema record must have at least 5 columns, got {}",
+            values.len()
+        )));
+    }
+    let text = |value: &Value, field: &str| -> Result<String> {
+        match value {
+            Value::Text(text) => Ok(text.as_str().to_string()),
+            other => Err(LimboError::Corrupt(format!(
+                "{field} must be text in sqlite_schema record, got {other:?}"
+            ))),
+        }
+    };
+    let optional_text = |value: &Value, field: &str| -> Result<Option<String>> {
+        match value {
+            Value::Text(text) => Ok(Some(text.as_str().to_string())),
+            Value::Null => Ok(None),
+            other => Err(LimboError::Corrupt(format!(
+                "{field} must be text or null in sqlite_schema record, got {other:?}"
+            ))),
+        }
+    };
+    let integer = |value: &Value, field: &str| -> Result<i64> {
+        match value {
+            Value::Numeric(Numeric::Integer(value)) => Ok(*value),
+            other => Err(LimboError::Corrupt(format!(
+                "{field} must be integer in sqlite_schema record, got {other:?}"
+            ))),
+        }
+    };
+    Ok(PortableSchemaRow {
+        row_type: text(&values[0], "sqlite_schema.type")?,
+        name: text(&values[1], "sqlite_schema.name")?,
+        rootpage: integer(&values[3], "sqlite_schema.rootpage")?,
+        sql: optional_text(&values[4], "sqlite_schema.sql")?,
+    })
+}
+
+fn portable_schema_kind(row_type: &str) -> Option<u64> {
+    if row_type.eq_ignore_ascii_case("table") {
+        Some(LOGICAL_SCHEMA_KIND_TABLE)
+    } else if row_type.eq_ignore_ascii_case("index") {
+        Some(LOGICAL_SCHEMA_KIND_INDEX)
+    } else if row_type.eq_ignore_ascii_case("trigger") {
+        Some(LOGICAL_SCHEMA_KIND_TRIGGER)
+    } else if row_type.eq_ignore_ascii_case("view") {
+        Some(LOGICAL_SCHEMA_KIND_VIEW)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn stable_table_id_from_rootpage(rootpage: i64) -> Option<u64> {
+    (rootpage != 0).then_some(rootpage.unsigned_abs())
+}
+
+pub(crate) fn encode_schema_logical_op(
+    action: u64,
+    row: &PortableSchemaRow,
+    stable_table_id: Option<u64>,
+    out: &mut Vec<u8>,
+) -> bool {
+    let Some(kind) = portable_schema_kind(&row.row_type) else {
+        return false;
+    };
+    if !is_portable_logical_name(&row.name) {
+        return false;
+    }
+    let mut op = Vec::new();
+    write_proto_uint64(1, LOGICAL_OP_SCHEMA, &mut op);
+    if matches!(action, LOGICAL_SCHEMA_CREATE | LOGICAL_SCHEMA_REFRESH) {
+        if let Some(sql) = row.sql.as_deref() {
+            write_proto_string(5, sql, &mut op);
+        }
+    }
+    write_proto_uint64(8, action, &mut op);
+    write_proto_uint64(9, kind, &mut op);
+    write_proto_string(10, &row.name, &mut op);
+    if let Some(stable_table_id) = stable_table_id {
+        write_proto_uint64(11, stable_table_id, &mut op);
+    }
+    append_logical_op(op, out);
+    true
+}
+
+pub(crate) fn encode_row_logical_op(
+    op_type: u64,
+    table_name: &str,
+    include_table_name: bool,
+    stable_table_id: u64,
+    rowid: i64,
+    record: &[u8],
+    out: &mut Vec<u8>,
+) {
+    if !is_portable_logical_name(table_name) {
+        return;
+    }
+    let mut op = Vec::new();
+    write_proto_uint64(1, op_type, &mut op);
+    if include_table_name {
+        write_proto_string(2, table_name, &mut op);
+    }
+    write_proto_sint64(3, rowid, &mut op);
+    write_proto_uint64(11, stable_table_id, &mut op);
+    if op_type == LOGICAL_OP_UPSERT_ROW {
+        write_proto_bytes(4, record, &mut op);
+    }
+    append_logical_op(op, out);
+}
+
+pub(crate) fn encode_header_logical_op(header: &DatabaseHeader, out: &mut Vec<u8>) {
+    let mut op = Vec::new();
+    write_proto_uint64(1, LOGICAL_OP_UPDATE_HEADER, &mut op);
+    write_proto_uint64(6, header.user_version.get() as u64, &mut op);
+    write_proto_uint64(7, header.application_id.get() as u64, &mut op);
+    append_logical_op(op, out);
+}

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -742,6 +742,8 @@ impl Schema {
 
     pub fn with_options(enable_custom_types: bool) -> crate::Result<Self> {
         let mut tables: HashMap<String, Arc<Table>> = HashMap::default();
+        #[cfg(feature = "conn_raw_api")]
+        let mut table_names_by_root_page = HashMap::default();
         let has_indexes = HashSet::default();
         let indexes: HashMap<String, VecDeque<Arc<Index>>> = HashMap::default();
         #[allow(clippy::arc_with_non_send_sync)]
@@ -749,6 +751,8 @@ impl Schema {
             SCHEMA_TABLE_NAME.to_string(),
             Arc::new(Table::BTree(sqlite_schema_table().into())),
         );
+        #[cfg(feature = "conn_raw_api")]
+        table_names_by_root_page.insert(1, SCHEMA_TABLE_NAME.to_string());
         for function in VirtualTable::builtin_functions(enable_custom_types) {
             tables.insert(
                 function.name.to_owned(),
@@ -769,7 +773,7 @@ impl Schema {
         Ok(Self {
             tables,
             #[cfg(feature = "conn_raw_api")]
-            table_names_by_root_page: HashMap::default(),
+            table_names_by_root_page,
             materialized_view_names,
             materialized_view_sql,
             incremental_views,
@@ -954,6 +958,8 @@ impl Schema {
         let name = normalize_ident(view.name());
 
         // Add to tables (so it appears as a regular table)
+        #[cfg(feature = "conn_raw_api")]
+        self.register_table_root_page(&name, table.as_ref());
         self.tables.insert(name.clone(), table);
 
         // Track that this is a materialized view
@@ -1009,11 +1015,11 @@ impl Schema {
             Ok(())
         } else if self.materialized_view_names.contains(&name) {
             // Remove from tables
-            self.tables.remove(&name);
+            self.remove_table(&name);
 
             // Remove DBSP state table and its indexes from in-memory schema
             let dbsp_table_name = format!("{DBSP_TABLE_PREFIX}{DBSP_CIRCUIT_VERSION}_{name}");
-            self.tables.remove(&dbsp_table_name);
+            self.remove_table(&dbsp_table_name);
             self.remove_indices_for_table(&dbsp_table_name);
 
             // Remove from materialized view tracking
@@ -1203,12 +1209,15 @@ impl Schema {
     pub fn remove_table(&mut self, table_name: &str) {
         let name = normalize_ident(table_name);
         #[cfg(feature = "conn_raw_api")]
-        if let Some(table) = self.tables.get(&name) {
-            if let Table::BTree(table) = table.as_ref() {
-                self.table_names_by_root_page.remove(&table.root_page);
+        {
+            if let Some(table) = self.tables.remove(&name) {
+                self.unregister_table_root_page(&table);
             }
         }
-        self.tables.remove(&name);
+        #[cfg(not(feature = "conn_raw_api"))]
+        {
+            self.tables.remove(&name);
+        }
         self.analyze_stats.remove_table(&name);
 
         // If this was a materialized view, also clean up the metadata

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -621,6 +621,8 @@ pub enum SchemaObjectType {
 #[derive(Debug)]
 pub struct Schema {
     pub tables: HashMap<String, Arc<Table>>,
+    #[cfg(feature = "conn_raw_api")]
+    pub(crate) table_names_by_root_page: HashMap<i64, String>,
 
     /// Track which tables are actually materialized views
     pub materialized_view_names: HashSet<String>,
@@ -766,6 +768,8 @@ impl Schema {
         }
         Ok(Self {
             tables,
+            #[cfg(feature = "conn_raw_api")]
+            table_names_by_root_page: HashMap::default(),
             materialized_view_names,
             materialized_view_sql,
             incremental_views,
@@ -1170,6 +1174,9 @@ impl Schema {
     pub fn add_btree_table(&mut self, table: Arc<BTreeTable>) -> Result<()> {
         self.check_object_name_conflict(&table.name)?;
         let name = normalize_ident(&table.name);
+        #[cfg(feature = "conn_raw_api")]
+        self.table_names_by_root_page
+            .insert(table.root_page, name.clone());
         self.tables.insert(name, Table::BTree(table).into());
         Ok(())
     }
@@ -1186,8 +1193,21 @@ impl Schema {
         self.tables.get(&name).cloned()
     }
 
+    #[cfg(feature = "conn_raw_api")]
+    pub fn table_name_for_root_page(&self, root_page: i64) -> Option<&str> {
+        self.table_names_by_root_page
+            .get(&root_page)
+            .map(String::as_str)
+    }
+
     pub fn remove_table(&mut self, table_name: &str) {
         let name = normalize_ident(table_name);
+        #[cfg(feature = "conn_raw_api")]
+        if let Some(table) = self.tables.get(&name) {
+            if let Table::BTree(table) = table.as_ref() {
+                self.table_names_by_root_page.remove(&table.root_page);
+            }
+        }
         self.tables.remove(&name);
         self.analyze_stats.remove_table(&name);
 
@@ -1195,6 +1215,21 @@ impl Schema {
         if self.materialized_view_names.remove(&name) {
             self.incremental_views.remove(&name);
             self.materialized_view_sql.remove(&name);
+        }
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    pub fn register_table_root_page(&mut self, name: &str, table: &Table) {
+        if let Table::BTree(table) = table {
+            self.table_names_by_root_page
+                .insert(table.root_page, normalize_ident(name));
+        }
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    pub fn unregister_table_root_page(&mut self, table: &Table) {
+        if let Table::BTree(table) = table {
+            self.table_names_by_root_page.remove(&table.root_page);
         }
     }
 
@@ -2222,6 +2257,8 @@ impl Clone for Schema {
         let incompatible_views = self.incompatible_views.clone();
         Self {
             tables,
+            #[cfg(feature = "conn_raw_api")]
+            table_names_by_root_page: self.table_names_by_root_page.clone(),
             materialized_view_names,
             materialized_view_sql,
             incremental_views,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11573,12 +11573,17 @@ fn drive_init_cdc_version(
             },
             StepResult::Done => match inner.phase {
                 OpInitCdcVersionPhase::CheckTable => {
+                    let change_id_column = if conn.mvcc_enabled() {
+                        "change_id INTEGER PRIMARY KEY"
+                    } else {
+                        "change_id INTEGER PRIMARY KEY AUTOINCREMENT"
+                    };
                     let create_sql = match version {
                         CdcVersion::V1 => format!(
-                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} (change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
+                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} ({change_id_column}, change_time INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
                         ),
                         CdcVersion::V2 => format!(
-                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} (change_id INTEGER PRIMARY KEY AUTOINCREMENT, change_time INTEGER, change_txn_id INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
+                            "CREATE TABLE IF NOT EXISTS {cdc_table_name} ({change_id_column}, change_time INTEGER, change_txn_id INTEGER, change_type INTEGER, table_name TEXT, id, before BLOB, after BLOB, updates BLOB)",
                         ),
                     };
                     inner.stmt = prepare_cdc_internal(conn, create_sql)?;
@@ -12883,6 +12888,8 @@ pub fn op_rename_table(
             .tables
             .remove(&normalized_from)
             .expect("table being renamed should be in schema");
+        #[cfg(feature = "conn_raw_api")]
+        schema.unregister_table_root_page(table.as_ref());
         match Arc::make_mut(&mut table) {
             Table::BTree(btree) => {
                 let btree = Arc::make_mut(btree);
@@ -12911,6 +12918,8 @@ pub fn op_rename_table(
             _ => panic!("only btree and virtual tables can be renamed"),
         }
 
+        #[cfg(feature = "conn_raw_api")]
+        schema.register_table_root_page(&normalized_to, table.as_ref());
         schema.tables.insert(normalized_to.to_owned(), table);
 
         for (tname, t_arc) in schema.tables.iter_mut() {
@@ -14802,11 +14811,6 @@ fn op_journal_mode_inner(
 
                 // Setup new mode
                 if matches!(new_mode, journal_mode::JournalMode::Mvcc) {
-                    if program.connection.get_capture_data_changes_info().is_some() {
-                        return Err(LimboError::InternalError(
-                            "cannot enable MVCC while CDC is active".to_string(),
-                        ));
-                    }
                     let db_path = program.connection.get_database_canonical_path();
                     let enc_ctx = pager.io_ctx.read().encryption_context().cloned();
                     let mv_store = journal_mode::open_mv_store(

--- a/docs/internals/mvcc/PORTABLE_FORMAT.md
+++ b/docs/internals/mvcc/PORTABLE_FORMAT.md
@@ -1,0 +1,222 @@
+# Portable MVCC Logical Changes
+
+This design extends the MVCC logical log with portable change metadata for sync.
+The recovery log remains the source of truth for local crash recovery. Portable
+changes are an additional per-commit view that lets a raw-log consumer replay
+committed user-visible changes without access to the original database schema,
+connection state, or in-memory MVCC table-id map.
+
+## Goals
+
+- Keep MVCC recovery compact and authoritative.
+- Make row changes portable: require no additional context for consumers to replay logical transactions from the log 
+- Avoid excessive memory usage.
+- Avoid duplicating large row records in the portable extension when the same
+  bytes already exist in the recovery payload.
+- Keep table names and SQL out of repeated row operations.
+- Encrypt and authenticate portable metadata together with recovery records when
+  database encryption is enabled.
+- Keep the encoding owned by `turso_core`, without depending on sync-engine or
+  server protocol types.
+
+## Frame Placement
+
+Portable changes live in an extension block appended to an MVCC transaction
+frame:
+
+```text
+TX_EXT_HEADER
+  payload_size            // recovery payload bytes only
+  op_count
+  commit_ts
+  extension_size          // extension block bytes
+  extension_record_count
+  frame_flags
+
+BODY
+  recovery payload
+  extension block
+
+TRAILER
+  chained crc
+  end magic
+```
+
+The recovery payload is still parsed and replayed by MVCC recovery. The
+extension block is ignored by local recovery and consumed only by raw-log readers
+that ask for portable changes.
+
+When encryption is enabled, the recovery payload and extension block are
+encrypted as one body:
+
+```text
+plaintext = recovery_payload || extension_block
+on disk   = encrypted_chunks(plaintext)
+```
+
+The encrypted chunk AAD includes the log salt, op count, commit timestamp, chunk
+index, and final plaintext size. As a result, portable table names, SQL text,
+origin metadata, and row-delete records are not plaintext side data and cannot
+be modified independently of the recovery frame.
+
+## Portable Transaction Envelope
+
+The extension payload is a small protobuf-style envelope encoded inside
+`turso_core`. It contains:
+
+- `end_offset`: the raw-log cursor after this frame.
+- `commit_ts`: the MVCC commit timestamp.
+- `origin_client_id`: optional explicit origin metadata.
+- `string_table`: frame-local interned strings.
+- `object_map`: frame-local bindings from MVCC recovery ids to portable object
+  identities.
+- `ops`: portable logical operations.
+
+The string table and object map are the core portability mechanism, not just
+compression.
+
+## String Table
+
+Names and SQL are interned once per frame. Schema operations and object-map
+entries reference strings by index.
+
+This avoids repeating object names and `CREATE ...` SQL in every operation. More
+importantly, row operations never switch between "sometimes name" and "sometimes
+id" encodings. Rows always carry an MVCC table id; the object map gives that id
+portable meaning.
+
+## Object Map
+
+Each object-map entry binds the local id used by recovery records in this frame
+to a portable object identity:
+
+```text
+object_map {
+  mv_table_id: sint64
+  logical_object_id: uint64
+  kind: table | index | trigger | view
+  name_ref: string table index
+  schema_epoch: commit timestamp
+  create_sql_ref: optional string table index
+  rootpage_debug: sint64
+}
+```
+
+`mv_table_id` is the id used by recovery ops. It may be negative because MVCC
+uses negative root pages for objects that exist only in the MV store.
+
+`logical_object_id` is stable for rootpage-backed objects. For non-zero root
+pages it is `abs(rootpage)`, so an uncheckpointed negative rootpage and its later
+checkpointed positive rootpage refer to the same portable object.
+
+Objects with rootpage `0`, such as views, triggers, and some virtual table
+schema rows, do not have rootpage-backed row identity. Their portable identity
+comes from schema events: kind, name, and SQL.
+
+`rootpage_debug` exists only to make producer behavior auditable. Consumers must
+not treat it as the portable identity.
+
+## Portable Operations
+
+Portable row operations are table mutations. Index recovery records are not
+portable mutations; a destination database maintains indexes by applying table
+changes normally.
+
+```text
+upsert_row {
+  mv_table_id: sint64
+  rowid: sint64
+}
+
+delete_row {
+  mv_table_id: sint64
+  rowid: sint64
+  old_record: optional bytes
+}
+```
+
+Upserts do not duplicate the row record in the portable extension. The same row
+image already exists in the recovery payload in this frame. A raw-log consumer
+reads the recovery table op for bytes and resolves `mv_table_id` through the
+object map.
+
+Deletes include the old row record when core still has it. This lets sync derive
+primary-key values for tables whose sync identity is not SQLite rowid. If no old
+record is available, the operation still has rowid fallback semantics.
+
+Schema operations describe user-visible object lifecycle:
+
+```text
+schema {
+  action: create | drop | refresh
+  kind: table | index | trigger | view
+  stable_table_id: optional uint64
+  name_ref: string table index
+  sql_ref: optional string table index
+}
+```
+
+Header operations carry database-header fields relevant to sync:
+
+```text
+update_header {
+  user_version: uint64
+  application_id: uint64
+}
+```
+
+Row writes are modeled as idempotent upserts and deletes. The portable contract
+does not distinguish insert from update; it records the committed final state
+needed for replay.
+
+## Commit-Time Construction
+
+The commit path builds the recovery payload first. Portable metadata is derived
+after that payload exists:
+
+1. Parse the recovery payload with the same parser used by recovery.
+2. Decode `sqlite_schema` row changes into schema events.
+3. Retain only old row images needed for schema drops and delete primary-key
+   derivation. The writer does not keep a duplicate `Vec<RowVersion>` for all
+   committed changes.
+4. Resolve every table row mutation to an object-map entry while core still has
+   schema context.
+5. Emit row ops as references to `mv_table_id`.
+6. Emit the string table, object map, schema/header operations, row operations,
+   and optional origin metadata into the extension payload.
+
+If portable logging is enabled and core cannot decode required schema context or
+resolve a table mutation to an object-map entry, commit fails. Silently omitting
+a portable mutation would make sync consumers diverge from local recovery.
+
+## Filtering And Metadata
+
+Portable changes filter internal implementation tables: SQLite internal objects,
+Turso internal objects, and reserved CDC tables. These are not part of the user
+schema contract that sync should replay on clients.
+
+Origin metadata is explicit per-connection metadata. It is snapshot at commit
+time, not consumed, and setting metadata does not enable portable logging by
+itself. This avoids surprising behavior where metadata mutation changes log
+format or disappears after one commit.
+
+Current trigger behavior is effect-based: portable row operations describe the
+final committed effects of the transaction, including trigger-produced writes.
+The log does not mark whether an individual write came directly from client DML
+or from trigger execution. Adding that provenance would require VDBE-level
+origin tracking and is outside this format change.
+
+Memory growth is limited by deriving portable changes from the serialized
+recovery payload and retaining only old records needed for deletes/schema drops.
+The old design cloned every row version into a second structure.
+
+Log growth is limited by not duplicating upsert row images and by interning names
+and SQL once per frame. Portable row ops are compact references plus optional
+old records for deletes.
+
+Encryption is handled by placing the extension block inside the encrypted body
+instead of appending plaintext metadata after the recovery payload.
+
+Table identity is made explicit through the object map. Row ops use one
+consistent representation, `mv_table_id`, and raw consumers resolve it through
+the same-frame map to a stable logical object id and interned name/SQL.

--- a/docs/internals/mvcc/PORTABLE_FORMAT.md
+++ b/docs/internals/mvcc/PORTABLE_FORMAT.md
@@ -1,222 +1,213 @@
-# Portable MVCC Logical Changes
+# Portable MVCC Log Metadata
 
-This design extends the MVCC logical log with portable change metadata for sync.
-The recovery log remains the source of truth for local crash recovery. Portable
-changes are an additional per-commit view that lets a raw-log consumer replay
-committed user-visible changes without access to the original database schema,
-connection state, or in-memory MVCC table-id map.
+The MVCC recovery log is the only operation stream. Portable metadata lets a
+raw-log consumer interpret that recovery stream outside the original database
+instance, where the in-memory schema and MVCC table-id map are no longer
+available.
 
 ## Goals
 
 - Keep MVCC recovery compact and authoritative.
-- Make row changes portable: require no additional context for consumers to replay logical transactions from the log 
-- Avoid excessive memory usage.
-- Avoid duplicating large row records in the portable extension when the same
-  bytes already exist in the recovery payload.
-- Keep table names and SQL out of repeated row operations.
-- Encrypt and authenticate portable metadata together with recovery records when
+- Avoid duplicating recovery rows, schema rows, and header updates in a second
+  portable operation stream.
+- Resolve negative MVCC table ids and uncheckpointed rootpages into portable
+  object names.
+- Keep sync-specific fields out of the core format by using generic transaction
+  metadata.
+- Encrypt and authenticate portable metadata with the recovery payload when
   database encryption is enabled.
 - Keep the encoding owned by `turso_core`, without depending on sync-engine or
   server protocol types.
 
-## Frame Placement
+## Frame Layout
 
-Portable changes live in an extension block appended to an MVCC transaction
-frame:
+An MVCC transaction frame has a recovery payload and may have an extension
+block:
 
 ```text
-TX_EXT_HEADER
-  payload_size            // recovery payload bytes only
+tx header:
+  payload_size            // recovery payload bytes
   op_count
   commit_ts
-  extension_size          // extension block bytes
+  extension_size
   extension_record_count
   frame_flags
 
-BODY
-  recovery payload
-  extension block
+body:
+  extension records
+  recovery ops
 
-TRAILER
-  chained crc
-  end magic
+trailer:
+  crc/auth tag/end magic
 ```
 
-The recovery payload is still parsed and replayed by MVCC recovery. The
-extension block is ignored by local recovery and consumed only by raw-log readers
-that ask for portable changes.
+Local recovery reads only the recovery ops. Raw-log consumers read the same
+frame in order: portable metadata first, then recovery ops whose table ids are
+resolved through that metadata.
 
-When encryption is enabled, the recovery payload and extension block are
-encrypted as one body:
+When encryption is enabled, the encrypted plaintext is:
 
 ```text
-plaintext = recovery_payload || extension_block
-on disk   = encrypted_chunks(plaintext)
+extension_block || recovery_payload
 ```
 
-The encrypted chunk AAD includes the log salt, op count, commit timestamp, chunk
-index, and final plaintext size. As a result, portable table names, SQL text,
-origin metadata, and row-delete records are not plaintext side data and cannot
-be modified independently of the recovery frame.
+Portable names, metadata, and operation-local extension bytes are therefore not
+plaintext side data.
 
-## Portable Transaction Envelope
+The transaction-scoped extension block intentionally precedes the recovery
+payload so streaming consumers can load the string table and object map before
+reading the first recovery op.
 
-The extension payload is a small protobuf-style envelope encoded inside
-`turso_core`. It contains:
+## Recovery Ops
 
-- `end_offset`: the raw-log cursor after this frame.
-- `commit_ts`: the MVCC commit timestamp.
-- `origin_client_id`: optional explicit origin metadata.
+The recovery payload describes all committed effects:
+
+- table upserts: `rowid_varint || table_record_bytes`
+- table deletes: `rowid_varint`
+- index upserts/deletes
+- database-header updates
+- `sqlite_schema` row upserts/deletes for DDL
+
+Schema changes and header changes are not repeated as portable operations.
+Schema DDL is represented by the recovery stream's `sqlite_schema` row changes,
+including the SQL stored in those rows. Header updates are represented by
+recovery header ops.
+
+## Transaction Extension
+
+The transaction extension is a protobuf-style envelope encoded inside
+`turso_core`. It currently contains only:
+
 - `string_table`: frame-local interned strings.
-- `object_map`: frame-local bindings from MVCC recovery ids to portable object
-  identities.
-- `ops`: portable logical operations.
+- `object_map`: bindings from MVCC table ids to interned names.
+- `meta`: generic string key/value transaction metadata.
 
-The string table and object map are the core portability mechanism, not just
-compression.
-
-## String Table
-
-Names and SQL are interned once per frame. Schema operations and object-map
-entries reference strings by index.
-
-This avoids repeating object names and `CREATE ...` SQL in every operation. More
-importantly, row operations never switch between "sometimes name" and "sometimes
-id" encodings. Rows always carry an MVCC table id; the object map gives that id
-portable meaning.
-
-## Object Map
-
-Each object-map entry binds the local id used by recovery records in this frame
-to a portable object identity:
+There are no portable row, schema, or header operations.
 
 ```text
-object_map {
+PortableTxn {
+  end_offset: uint64          // added by the frame wrapper
+  commit_ts: uint64           // added by the frame wrapper
+  repeated string_table: bytes
+  repeated object_map: ObjectMap
+  repeated meta: MetaField
+}
+
+ObjectMap {
   mv_table_id: sint64
-  logical_object_id: uint64
-  kind: table | index | trigger | view
-  name_ref: string table index
-  schema_epoch: commit timestamp
-  create_sql_ref: optional string table index
-  rootpage_debug: sint64
+  name_ref: uint64
+}
+
+MetaField {
+  key_ref: uint64
+  value_ref: uint64
 }
 ```
 
-`mv_table_id` is the id used by recovery ops. It may be negative because MVCC
-uses negative root pages for objects that exist only in the MV store.
+`mv_table_id` is the id used by recovery ops in the same frame. It may be
+negative because MVCC uses negative rootpages for objects that have not been
+checkpointed.
 
-`logical_object_id` is stable for rootpage-backed objects. For non-zero root
-pages it is `abs(rootpage)`, so an uncheckpointed negative rootpage and its later
-checkpointed positive rootpage refer to the same portable object.
+`name_ref` points into the frame string table. Row recovery ops keep the compact
+MVCC table id, and external readers resolve that id through the same-frame object
+map.
 
-Objects with rootpage `0`, such as views, triggers, and some virtual table
-schema rows, do not have rootpage-backed row identity. Their portable identity
-comes from schema events: kind, name, and SQL.
+## Operation Extensions
 
-`rootpage_debug` exists only to make producer behavior auditable. Consumers must
-not treat it as the portable identity.
-
-## Portable Operations
-
-Portable row operations are table mutations. Index recovery records are not
-portable mutations; a destination database maintains indexes by applying table
-changes normally.
+Recovery ops reserve `OP_FLAG_PORTABLE_EXTENSION` for operation-local protobuf
+bytes:
 
 ```text
-upsert_row {
-  mv_table_id: sint64
-  rowid: sint64
-}
-
-delete_row {
-  mv_table_id: sint64
-  rowid: sint64
-  old_record: optional bytes
+op {
+  tag
+  flags                  // includes OP_FLAG_PORTABLE_EXTENSION
+  table_id
+  payload_len
+  payload
+  extension_len
+  extension_bytes
 }
 ```
 
-Upserts do not duplicate the row record in the portable extension. The same row
-image already exists in the recovery payload in this frame. A raw-log consumer
-reads the recovery table op for bytes and resolves `mv_table_id` through the
-object map.
+The extension is attached to one recovery op, not to the frame as a parallel
+portable operation stream. Recovery must be able to ignore operation-local
+extensions. If data is required for crash recovery, it belongs in the main
+recovery payload.
 
-Deletes include the old row record when core still has it. This lets sync derive
-primary-key values for tables whose sync identity is not SQLite rowid. If no old
-record is available, the operation still has rowid fallback semantics.
-
-Schema operations describe user-visible object lifecycle:
+Current delete extension fields:
 
 ```text
-schema {
-  action: create | drop | refresh
-  kind: table | index | trigger | view
-  stable_table_id: optional uint64
-  name_ref: string table index
-  sql_ref: optional string table index
+DeleteExtension {
+  identity_record: bytes  // field 1, only for sqlite_schema deletes
+  pk_record: bytes        // field 2, SQLite record of primary-key values
+  rowid: sint64           // field 3, present for rowid-table deletes
 }
 ```
 
-Header operations carry database-header fields relevant to sync:
+For ordinary user-table deletes, core computes a primary-key projection while the
+committing connection still has schema context. The extension carries only that
+projected key record plus the rowid, not the full deleted row. For tables
+without an explicit primary key, `pk_record` is omitted and rowid is the delete
+identity. For `INTEGER PRIMARY KEY` aliases, the projected key uses the rowid
+value rather than the stored table-record slot, matching SQLite rowid semantics.
 
-```text
-update_header {
-  user_version: uint64
-  application_id: uint64
-}
-```
+`sqlite_schema` deletes are the exception. They attach the old schema record as
+`identity_record` because object-map construction needs the deleted object's
+name and rootpage.
 
-Row writes are modeled as idempotent upserts and deletes. The portable contract
-does not distinguish insert from update; it records the committed final state
-needed for replay.
+The same operation-extension mechanism can later carry fields such as DDL
+statement text for ALTER-style operations or trigger provenance, without
+changing the recovery op shape.
 
-## Commit-Time Construction
+## Construction
 
-The commit path builds the recovery payload first. Portable metadata is derived
-after that payload exists:
+At commit time:
 
-1. Parse the recovery payload with the same parser used by recovery.
-2. Decode `sqlite_schema` row changes into schema events.
-3. Retain only old row images needed for schema drops and delete primary-key
-   derivation. The writer does not keep a duplicate `Vec<RowVersion>` for all
-   committed changes.
-4. Resolve every table row mutation to an object-map entry while core still has
-   schema context.
-5. Emit row ops as references to `mv_table_id`.
-6. Emit the string table, object map, schema/header operations, row operations,
-   and optional origin metadata into the extension payload.
+1. Serialize each recovery op, attaching operation-local portable bytes only
+   when the operation needs local identity metadata.
+2. Build the recovery payload.
+3. Parse that payload with the recovery parser.
+4. Decode `sqlite_schema` row changes only to discover object-map entries.
+5. Resolve table row ops to object-map entries while core still has schema
+   context.
+6. Snapshot all per-connection MVCC log metadata as generic key/value fields.
+7. Emit the string table, object maps, and metadata as the transaction extension
+   payload.
 
-If portable logging is enabled and core cannot decode required schema context or
-resolve a table mutation to an object-map entry, commit fails. Silently omitting
-a portable mutation would make sync consumers diverge from local recovery.
+If portable logging is enabled and a user table mutation cannot be resolved to a
+portable object map, commit fails. Silently omitting a user table mapping would
+make external replay ambiguous.
 
-## Filtering And Metadata
+## Filtering
 
-Portable changes filter internal implementation tables: SQLite internal objects,
-Turso internal objects, and reserved CDC tables. These are not part of the user
-schema contract that sync should replay on clients.
+The portable extension skips implementation-owned objects:
 
-Origin metadata is explicit per-connection metadata. It is snapshot at commit
-time, not consumed, and setting metadata does not enable portable logging by
-itself. This avoids surprising behavior where metadata mutation changes log
-format or disappears after one commit.
+- `sqlite_*`
+- `__turso_internal_*`
+- `turso_sync_*`
+- reserved CDC bookkeeping tables
 
-Current trigger behavior is effect-based: portable row operations describe the
-final committed effects of the transaction, including trigger-produced writes.
-The log does not mark whether an individual write came directly from client DML
-or from trigger execution. Adding that provenance would require VDBE-level
-origin tracking and is outside this format change.
+These objects are SQLite implementation state, Turso local state, or sync/CDC
+bookkeeping that should be rebuilt by the receiving database. They are not part
+of the user schema contract the portable extension exposes.
 
-Memory growth is limited by deriving portable changes from the serialized
-recovery payload and retaining only old records needed for deletes/schema drops.
-The old design cloned every row version into a second structure.
+`sqlite_sequence` deserves special handling by consumers: it is an internal
+SQLite table, but sequence state is derived from user-visible inserts into
+`AUTOINCREMENT` tables. Replaying the user table writes is the portable source of
+truth; copying a producer's `sqlite_sequence` row would import local allocator
+state and can be wrong for a different receiver.
 
-Log growth is limited by not duplicating upsert row images and by interning names
-and SQL once per frame. Portable row ops are compact references plus optional
-old records for deletes.
+## Review Concerns Addressed
 
-Encryption is handled by placing the extension block inside the encrypted body
-instead of appending plaintext metadata after the recovery payload.
-
-Table identity is made explicit through the object map. Row ops use one
-consistent representation, `mv_table_id`, and raw consumers resolve it through
-the same-frame map to a stable logical object id and interned name/SQL.
+- Memory: there is no second portable row-op list and no side buffer for every
+  deleted row. Delete identity is projected during op serialization.
+- Log size: upsert rows, schema rows, and header updates are not duplicated.
+  Data-table deletes carry only primary-key projection and rowid, not full row
+  images.
+- Encryption: extension records are encrypted and authenticated with recovery
+  bytes.
+- Table ids: every user table id used by recovery has an explicit same-frame
+  object-map entry.
+- Names: names are interned once per frame and referenced from object maps.
+- Metadata: all connection metadata is preserved as generic key/value fields;
+  `"client"` is not special in the format.

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -112,6 +112,13 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
         self.inner.checkpoint_threshold()
     }
 
+    fn upgrade_header_for_log_tx(
+        &self,
+        m: &turso_core::mvcc::database::LogRecord,
+    ) -> turso_core::Result<Option<turso_core::Completion>> {
+        self.inner.upgrade_header_for_log_tx(m)
+    }
+
     fn advance_logical_log_offset_after_success(&self, bytes: u64) -> turso_core::Result<()> {
         self.inner.advance_logical_log_offset_after_success(bytes)
     }

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -49,8 +49,10 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
         &self,
         log_record: &mut turso_core::mvcc::database::LogRecord,
         row_version: &turso_core::mvcc::database::RowVersion,
+        portable_extension: Option<&[u8]>,
     ) -> turso_core::Result<()> {
-        self.inner.serialize_row_version(log_record, row_version)
+        self.inner
+            .serialize_row_version(log_record, row_version, portable_extension)
     }
 
     fn serialize_database_header(

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -86,8 +86,16 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
         self.inner.truncate()
     }
 
+    fn reset_to_fresh_header(&self) -> turso_core::Result<turso_core::Completion> {
+        self.inner.reset_to_fresh_header()
+    }
+
     fn get_logical_log_file(&self) -> Arc<dyn turso_core::File> {
         self.inner.get_logical_log_file()
+    }
+
+    fn logical_log_offset(&self) -> u64 {
+        self.inner.logical_log_offset()
     }
 
     fn should_checkpoint(&self) -> bool {
@@ -102,8 +110,12 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
         self.inner.checkpoint_threshold()
     }
 
-    fn advance_logical_log_offset_after_success(&self, bytes: u64) {
+    fn advance_logical_log_offset_after_success(&self, bytes: u64) -> turso_core::Result<()> {
         self.inner.advance_logical_log_offset_after_success(bytes)
+    }
+
+    fn discard_pending_log_write(&self) -> turso_core::Result<()> {
+        self.inner.discard_pending_log_write()
     }
 
     fn restore_logical_log_state_after_recovery(&self, offset: u64, running_crc: u32) {


### PR DESCRIPTION
# Portable MVCC Log Metadata

The MVCC recovery log is the only operation stream. Portable metadata lets a
raw-log consumer interpret that recovery stream outside the original database
instance, where the in-memory schema and MVCC table-id map are no longer
available.

## Goals

- Keep MVCC recovery compact and authoritative.
- Avoid duplicating recovery rows, schema rows, and header updates in a second
  portable operation stream.
- Resolve negative MVCC table ids and uncheckpointed rootpages into portable
  object names.
- Keep sync-specific fields out of the core format by using generic transaction
  metadata.
- Encrypt and authenticate portable metadata with the recovery payload when
  database encryption is enabled.
- Keep the encoding owned by `turso_core`, without depending on sync-engine or
  server protocol types.

## Frame Layout

An MVCC transaction frame has a recovery payload and may have an extension
block:

```text
tx header:
  payload_size            // recovery payload bytes
  op_count
  commit_ts
  extension_size
  extension_record_count
  frame_flags

body:
  recovery ops
  extension records

trailer:
  crc/auth tag/end magic
```

Local recovery reads only the recovery ops. Raw-log consumers read the same
recovery ops, then use portable metadata to resolve ids and transaction context.

When encryption is enabled, the encrypted plaintext is:

```text
recovery_payload || extension_block
```

Portable names, metadata, and operation-local extension bytes are therefore not
plaintext side data.

This keeps the existing LML3 body order. A future LML4 can move the
transaction-scoped extension block before the recovery payload so streaming
consumers can load the string table and object map before reading the first op.
That is a frame-layout change and is separate from operation-scoped extensions,
which already keep delete identity bytes adjacent to the delete op.

## Recovery Ops

The recovery payload describes all committed effects:

- table upserts: `rowid_varint || table_record_bytes`
- table deletes: `rowid_varint`
- index upserts/deletes
- database-header updates
- `sqlite_schema` row upserts/deletes for DDL

Schema changes and header changes are not repeated as portable operations.
Schema DDL is represented by the recovery stream's `sqlite_schema` row changes,
including the SQL stored in those rows. Header updates are represented by
recovery header ops.

## Transaction Extension

The transaction extension is a protobuf-style envelope encoded inside
`turso_core`. It currently contains only:

- `string_table`: frame-local interned strings.
- `object_map`: bindings from MVCC table ids to interned names.
- `meta`: generic string key/value transaction metadata.

There are no portable row, schema, or header operations.

```text
PortableTxn {
  end_offset: uint64          // added by the frame wrapper
  commit_ts: uint64           // added by the frame wrapper
  repeated string_table: bytes
  repeated object_map: ObjectMap
  repeated meta: MetaField
}

ObjectMap {
  mv_table_id: sint64
  name_ref: uint64
}

MetaField {
  key_ref: uint64
  value_ref: uint64
}
```

`mv_table_id` is the id used by recovery ops in the same frame. It may be
negative because MVCC uses negative rootpages for objects that have not been
checkpointed.

`name_ref` points into the frame string table. Row recovery ops keep the compact
MVCC table id, and external readers resolve that id through the same-frame object
map.

## Operation Extensions

Recovery ops reserve `OP_FLAG_PORTABLE_EXTENSION` for operation-local protobuf
bytes:

```text
op {
  tag
  flags                  // includes OP_FLAG_PORTABLE_EXTENSION
  table_id
  payload_len
  payload
  extension_len
  extension_bytes
}
```

The extension is attached to one recovery op, not to the frame as a parallel
portable operation stream. Recovery must be able to ignore operation-local
extensions. If data is required for crash recovery, it belongs in the main
recovery payload.

Current delete extension fields:

```text
DeleteExtension {
  identity_record: bytes  // field 1, only for sqlite_schema deletes
  pk_record: bytes        // field 2, SQLite record of primary-key values
  rowid: sint64           // field 3, present for rowid-table deletes
}
```

For ordinary user-table deletes, core computes a primary-key projection while the
committing connection still has schema context. The extension carries only that
projected key record plus the rowid, not the full deleted row. For tables
without an explicit primary key, `pk_record` is omitted and rowid is the delete
identity. For `INTEGER PRIMARY KEY` aliases, the projected key uses the rowid
value rather than the stored table-record slot, matching SQLite rowid semantics.

`sqlite_schema` deletes are the exception. They attach the old schema record as
`identity_record` because object-map construction needs the deleted object's
name and rootpage.

The same operation-extension mechanism can later carry fields such as DDL
statement text for ALTER-style operations or trigger provenance, without
changing the recovery op shape.

## Construction

At commit time:

1. Serialize each recovery op, attaching operation-local portable bytes only
   when the operation needs local identity metadata.
2. Build the recovery payload.
3. Parse that payload with the recovery parser.
4. Decode `sqlite_schema` row changes only to discover object-map entries.
5. Resolve table row ops to object-map entries while core still has schema context.
6. Snapshot all per-connection MVCC log metadata as generic key/value fields.
7. Emit the string table, object maps, and metadata as the transaction extension
   payload.

If portable logging is enabled and a user table mutation cannot be resolved to a
portable object map, commit fails. Silently omitting a user table mapping would
make external replay ambiguous.

## Filtering

The portable extension skips implementation-owned objects:

- `sqlite_*`
- `__turso_internal_*`
- `turso_sync_*`
- reserved CDC bookkeeping tables

These objects are SQLite implementation state, Turso local state, or sync/CDC
bookkeeping that should be rebuilt by the receiving database. They are not part
of the user schema contract the portable extension exposes.

`sqlite_sequence` deserves special handling by consumers: it is an internal
SQLite table, but sequence state is derived from user-visible inserts into
`AUTOINCREMENT` tables. Replaying the user table writes is the portable source of
truth; copying a producer's `sqlite_sequence` row would import local allocator
state and can be wrong for a different receiver.


- No second portable row-op list and no side buffer for every deleted row. Delete identity is projected during op serialization.
- Log size: upsert rows, schema rows, and header updates are not duplicated.
  Data-table deletes carry only primary-key projection and rowid, not full row images.
- Encryption: extension records are encrypted and authenticated with recovery bytes.
- Table ids: every user table id used by recovery has an explicit same-frame object-map entry.
- Names: names are interned once per frame and referenced from object maps.
- Metadata: all connection metadata is preserved as generic key/value fields; `"client"` is no longer special in the format.
