### PR TITLE
 core/mvcc: fix logical logging for transient same-tx rows and btrees

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -992,6 +992,20 @@ pub struct BuildLogRecordCtx {
     pub schema_process: bool,
 }
 
+fn version_begin_is_tx(row_version: &RowVersion, tx_id: TxID) -> bool {
+    matches!(
+        row_version.begin,
+        Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+    )
+}
+
+fn version_end_is_tx(row_version: &RowVersion, tx_id: TxID) -> bool {
+    matches!(
+        row_version.end,
+        Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
+    )
+}
+
 /// Iteration state for the chunked `RewriteLiveVersions` step.
 #[derive(Debug)]
 pub struct RewriteLiveVersionsCtx {
@@ -1546,16 +1560,17 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
 
         // Returns Some(row_version) if our tx contributed to it and if we must therefore log it.
         let our_committed_image = |row_version: &RowVersion| -> Option<RowVersion> {
-            let our_begin = matches!(
-                row_version.begin,
-                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
-            );
-            let our_end = matches!(
-                row_version.end,
-                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
-            );
+            let our_begin = version_begin_is_tx(row_version, tx_id);
+            let our_end = version_end_is_tx(row_version, tx_id);
             if !our_begin && !our_end {
                 // row_version belongs to another tx
+                return None;
+            }
+            if our_begin && our_end && !row_version.btree_resident {
+                // This non-B-tree-resident version was born and died in this
+                // transaction, so it has no durable row-level effect. Logging
+                // it as a delete would lose the begin side and make recovery
+                // think an older row was removed.
                 return None;
             }
             let mut committed = row_version.clone();

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -990,6 +990,13 @@ pub struct BuildLogRecordCtx {
     /// data-row pass. Schema rows are emitted first so log replay sees
     /// CREATE TABLE before related INSERTs.
     pub schema_process: bool,
+    /// B-tree ids created and dropped by this transaction before commit.
+    /// Their schema rows and contents have no durable net effect unless a
+    /// same-transaction schema row for the same btree survives.
+    pub created_deleted_btree_ids: HashSet<MVTableId>,
+    /// B-tree ids with a same-transaction schema row that survives commit.
+    /// These disqualify earlier insert/delete schema rewrites for the same id.
+    pub created_live_btree_ids: HashSet<MVTableId>,
 }
 
 fn version_begin_is_tx(row_version: &RowVersion, tx_id: TxID) -> bool {
@@ -1004,6 +1011,100 @@ fn version_end_is_tx(row_version: &RowVersion, tx_id: TxID) -> bool {
         row_version.end,
         Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
     )
+}
+
+// Extract the MVCC B-tree id from a sqlite_schema row version.
+//
+// This only returns Some(id) when all of the following are true:
+// - the row belongs to sqlite_schema;
+// - the row has a payload;
+// - sqlite_schema.type is "table" or "index";
+// - sqlite_schema.rootpage is a negative integer.
+//
+// A negative rootpage means the table/index exists only as an MVCC logical
+// B-tree id and has not yet been checkpointed into a real positive root page
+// in the database file.
+//
+// For example, this sqlite_schema row:
+//
+//   type = "index"
+//   name = "idx_t_v"
+//   tbl_name = "t"
+//   rootpage = -4
+//   sql = "CREATE INDEX idx_t_v ON t(v)"
+//
+// returns Some(MVTableId(-4)).
+//
+// A normal checkpointed schema row with rootpage = 7 returns None, because
+// this fix only concerns never-checkpointed transient B-trees.
+fn uncheckpointed_schema_btree_id(row_version: &RowVersion) -> Option<MVTableId> {
+    if row_version.row.id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
+        return None;
+    }
+
+    let payload = row_version.row.payload();
+    if payload.is_empty() {
+        return None;
+    }
+
+    let record = ImmutableRecord::from_bin_record(payload.to_vec());
+    let Some(ValueRef::Text(row_type)) = record.get_value_opt(0) else {
+        return None;
+    };
+    if !matches!(row_type.as_str(), "table" | "index") {
+        return None;
+    }
+
+    let Some(ValueRef::Numeric(Numeric::Integer(root_page))) = record.get_value_opt(3) else {
+        return None;
+    };
+    if root_page < 0 {
+        Some(MVTableId::from(root_page))
+    } else {
+        None
+    }
+}
+
+// Track whether this transaction's uncheckpointed schema B-tree survives commit.
+//
+// Example:
+//
+//   BEGIN;
+//   CREATE INDEX idx_t_v ON t(v); -- sqlite_schema.rootpage = -4
+//   DROP INDEX idx_t_v;
+//   COMMIT;
+//
+// The index schema row has begin=TxID(tx_id) and end=TxID(tx_id), so -4 is added
+// to created_deleted_btree_ids. Later in BuildLogRecord, index content rows with
+// table_id -4 are skipped because the B-tree has no surviving schema row.
+//
+// For a metadata rewrite that keeps the same B-tree alive, such as:
+//
+//   BEGIN;
+//   CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); -- rootpage = -3
+//   ALTER TABLE t RENAME TO t2;
+//   COMMIT;
+//
+// one schema version for -3 may be created and ended, while another same-tx
+// schema version for -3 survives. That puts -3 in created_live_btree_ids too,
+// preventing data rows for the surviving B-tree from being skipped.
+fn track_schema_btree_lifetime(
+    tx_id: TxID,
+    row_version: &RowVersion,
+    created_deleted_btree_ids: &mut HashSet<MVTableId>,
+    created_live_btree_ids: &mut HashSet<MVTableId>,
+) {
+    let Some(btree_id) = uncheckpointed_schema_btree_id(row_version) else {
+        return;
+    };
+    if !version_begin_is_tx(row_version, tx_id) {
+        return;
+    }
+    if version_end_is_tx(row_version, tx_id) {
+        created_deleted_btree_ids.insert(btree_id);
+    } else {
+        created_live_btree_ids.insert(btree_id);
+    }
 }
 
 /// Iteration state for the chunked `RewriteLiveVersions` step.
@@ -1602,15 +1703,54 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             Some(committed)
         };
 
-        let collect_versions = |row_versions: &Arc<RwLock<Vec<RowVersion>>>,
-                                log_record: &mut LogRecord| {
-            for row_version in row_versions.read().iter() {
-                if let Some(mut committed_version) = our_committed_image(row_version) {
-                    canonicalize_table_id(&mut committed_version);
-                    mvcc_store.insert_version_raw(&mut log_record.row_versions, committed_version);
+        // During the schema pass, collect lifetime information only from
+        // sqlite_schema row-version chains already selected by `process`.
+        // For example, CREATE INDEX idx_t_v followed by DROP INDEX idx_t_v
+        // records the index rootpage/id in created_deleted_btree_ids before
+        // the later data pass sees any index content rows for that id.
+        let track_schema_btree_lifetimes =
+            |row_versions: &Arc<RwLock<Vec<RowVersion>>>,
+             created_deleted_btree_ids: &mut HashSet<MVTableId>,
+             created_live_btree_ids: &mut HashSet<MVTableId>| {
+                for row_version in row_versions.read().iter() {
+                    track_schema_btree_lifetime(
+                        tx_id,
+                        row_version,
+                        created_deleted_btree_ids,
+                        created_live_btree_ids,
+                    );
                 }
-            }
-        };
+            };
+
+        // Emit committed row versions for the current pass. The transient
+        // B-tree sets are complete before the data pass starts, so index rows
+        // created by CREATE INDEX idx_t_v and invalidated by DROP INDEX idx_t_v
+        // can be skipped even though DROP INDEX does not mark every index row
+        // with an end timestamp.
+        let collect_versions =
+            |row_versions: &Arc<RwLock<Vec<RowVersion>>>,
+             log_record: &mut LogRecord,
+             created_deleted_btree_ids: &HashSet<MVTableId>,
+             created_live_btree_ids: &HashSet<MVTableId>| {
+                for row_version in row_versions.read().iter() {
+                    if let Some(mut committed_version) = our_committed_image(row_version) {
+                        let btree_created_and_dropped = created_deleted_btree_ids
+                            .contains(&committed_version.row.id.table_id)
+                            && !created_live_btree_ids.contains(&committed_version.row.id.table_id);
+                        if btree_created_and_dropped {
+                            turso_assert!(
+                                !committed_version.btree_resident,
+                                "same-transaction created/dropped btree row cannot be btree-resident",
+                                { "row_id": &committed_version.row.id }
+                            );
+                            continue;
+                        }
+                        canonicalize_table_id(&mut committed_version);
+                        mvcc_store
+                            .insert_version_raw(&mut log_record.row_versions, committed_version);
+                    }
+                }
+            };
 
         // Process schema rows (sqlite_schema) before data rows so that during log
         // replay the table_id_to_rootpage map is populated before data row inserts
@@ -1630,7 +1770,19 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
                 !is_schema
             };
             if process {
-                collect_versions(row_versions, &mut ctx.log_record);
+                if ctx.schema_process {
+                    track_schema_btree_lifetimes(
+                        row_versions,
+                        &mut ctx.created_deleted_btree_ids,
+                        &mut ctx.created_live_btree_ids,
+                    );
+                }
+                collect_versions(
+                    row_versions,
+                    &mut ctx.log_record,
+                    &ctx.created_deleted_btree_ids,
+                    &ctx.created_live_btree_ids,
+                );
             }
             ctx.cursor += 1;
             iterations += 1;
@@ -2078,6 +2230,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     log_record,
                     cursor: 0,
                     schema_process: true,
+                    created_deleted_btree_ids: HashSet::default(),
+                    created_live_btree_ids: HashSet::default(),
                 });
                 return Ok(TransitionResult::Continue);
             }

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1109,6 +1109,179 @@ fn test_create_rename_insert_same_tx_recover_then_checkpoint(
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum TransientIndexTiming {
+    None,
+    BeforeRowChanges,
+    AfterTransientInserts,
+    AfterDeletes,
+}
+
+impl TransientIndexTiming {
+    fn suffix(self) -> &'static str {
+        match self {
+            Self::None => "no_idx",
+            Self::BeforeRowChanges => "idx_before",
+            Self::AfterTransientInserts => "idx_after_inserts",
+            Self::AfterDeletes => "idx_after_deletes",
+        }
+    }
+}
+
+/// Deterministic matrix for same-transaction row and transient-index effects.
+/// Each case is recovered and then checkpointed so logical-log replay and
+/// B-tree persistence both see the same net state.
+#[turso_macros::test]
+fn test_mvcc_same_tx_row_and_index_lifecycle_matrix(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.pragma_update("journal_mode", "'mvcc'")?;
+    }
+    drop(db);
+
+    let index_timings = [
+        TransientIndexTiming::None,
+        TransientIndexTiming::BeforeRowChanges,
+        TransientIndexTiming::AfterTransientInserts,
+        TransientIndexTiming::AfterDeletes,
+    ];
+    let mut case_id = 0;
+
+    for transient_rows in [false, true] {
+        for update_delete_existing in [false, true] {
+            for index_timing in index_timings {
+                case_id += 1;
+                let table = format!(
+                    "mvcc_same_tx_{}_{}_{}",
+                    if transient_rows {
+                        "transient"
+                    } else {
+                        "stable"
+                    },
+                    if update_delete_existing {
+                        "delete_existing"
+                    } else {
+                        "keep_existing"
+                    },
+                    index_timing.suffix()
+                );
+                let base_index = format!("{table}_base_idx");
+                let transient_index = format!("{table}_tmp_idx");
+                let label = format!(
+                    "case {case_id}: transient_rows={transient_rows}, update_delete_existing={update_delete_existing}, index_timing={}",
+                    index_timing.suffix()
+                );
+
+                {
+                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let conn = db.connect()?;
+                    conn.pragma_update("journal_mode", "'mvcc'")?;
+                    conn.execute(format!(
+                        "CREATE TABLE {table}(id INTEGER PRIMARY KEY, v TEXT)"
+                    ))?;
+                    conn.execute(format!(
+                        "INSERT INTO {table} VALUES (1, 'original'), (2, 'keep')"
+                    ))?;
+                    conn.execute(format!("CREATE INDEX {base_index} ON {table}(v)"))?;
+                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+                }
+
+                {
+                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let conn = db.connect()?;
+                    conn.pragma_update("journal_mode", "'mvcc'")?;
+
+                    let create_drop_transient_index = || -> anyhow::Result<()> {
+                        conn.execute(format!("CREATE INDEX {transient_index} ON {table}(v)"))?;
+                        conn.execute(format!("DROP INDEX {transient_index}"))?;
+                        Ok(())
+                    };
+
+                    conn.execute("BEGIN")?;
+                    if matches!(index_timing, TransientIndexTiming::BeforeRowChanges) {
+                        create_drop_transient_index()?;
+                    }
+                    if transient_rows {
+                        conn.execute(format!(
+                            "INSERT INTO {table} VALUES (10, 'temp_10'), (11, 'temp_11')"
+                        ))?;
+                    }
+                    if matches!(index_timing, TransientIndexTiming::AfterTransientInserts) {
+                        create_drop_transient_index()?;
+                    }
+                    if update_delete_existing {
+                        conn.execute(format!("UPDATE {table} SET v = 'updated' WHERE id = 1"))?;
+                        conn.execute(format!("DELETE FROM {table} WHERE id = 1"))?;
+                    }
+                    if transient_rows {
+                        conn.execute(format!("DELETE FROM {table} WHERE id IN (10, 11)"))?;
+                    }
+                    if matches!(index_timing, TransientIndexTiming::AfterDeletes) {
+                        create_drop_transient_index()?;
+                    }
+                    conn.execute("COMMIT")?;
+                }
+
+                for checkpoint_after_recovery in [true, false] {
+                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let conn = db.connect()?;
+
+                    let rows_sql = format!("SELECT id, v FROM {table} ORDER BY id");
+                    let rows: Vec<(i64, String)> = conn.exec_rows(&rows_sql);
+                    let expected_rows = if update_delete_existing {
+                        vec![(2, "keep".to_string())]
+                    } else {
+                        vec![(1, "original".to_string()), (2, "keep".to_string())]
+                    };
+                    assert_eq!(rows, expected_rows, "{label}");
+
+                    let index_names_sql = format!(
+                        "SELECT name FROM sqlite_schema \
+                         WHERE type = 'index' AND tbl_name = '{table}' ORDER BY name"
+                    );
+                    let index_names: Vec<(String,)> = conn.exec_rows(&index_names_sql);
+                    assert_eq!(index_names, vec![(base_index.clone(),)], "{label}");
+
+                    let original_ids_sql = format!(
+                        "SELECT id FROM {table} INDEXED BY {base_index} \
+                         WHERE v = 'original' ORDER BY id"
+                    );
+                    let original_ids: Vec<(i64,)> = conn.exec_rows(&original_ids_sql);
+                    let expected_original_ids = if update_delete_existing {
+                        Vec::new()
+                    } else {
+                        vec![(1,)]
+                    };
+                    assert_eq!(original_ids, expected_original_ids, "{label}");
+
+                    let updated_ids_sql = format!(
+                        "SELECT id FROM {table} INDEXED BY {base_index} \
+                         WHERE v = 'updated' ORDER BY id"
+                    );
+                    let updated_ids: Vec<(i64,)> = conn.exec_rows(&updated_ids_sql);
+                    assert_eq!(updated_ids, Vec::<(i64,)>::new(), "{label}");
+
+                    let transient_ids_sql = format!(
+                        "SELECT id FROM {table} INDEXED BY {base_index} \
+                         WHERE v IN ('temp_10', 'temp_11') ORDER BY id"
+                    );
+                    let transient_ids: Vec<(i64,)> = conn.exec_rows(&transient_ids_sql);
+                    assert_eq!(transient_ids, Vec::<(i64,)>::new(), "{label}");
+
+                    if checkpoint_after_recovery {
+                        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Same-tx create + insert + drop: data rows reference a table_id whose schema
 /// entry is created and destroyed in the same transaction.
 #[turso_macros::test]

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1037,6 +1037,78 @@ fn test_create_drop_index_same_tx_recover_then_checkpoint(db: TempDatabase) -> a
     Ok(())
 }
 
+/// Same-tx CREATE INDEX + DROP INDEX on an already-populated table.
+/// The transient index contents must not be replayed after its schema row is
+/// removed before commit.
+#[turso_macros::test]
+fn test_create_drop_populated_index_same_tx_recover_then_checkpoint(
+    db: TempDatabase,
+) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+        conn.execute("create table t(id integer primary key, v text)")?;
+        conn.execute("insert into t values (1, 'one'), (2, 'two')")?;
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+        conn.execute("begin")?;
+        conn.execute("create index idx_t_v on t(v)")?;
+        conn.execute("drop index idx_t_v")?;
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let conn = db.connect()?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    let rows: Vec<(i64, String)> = conn.exec_rows("select id, v from t order by id");
+    assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
+
+    Ok(())
+}
+
+/// CREATE TABLE followed by RENAME in the same transaction creates and deletes
+/// a schema row for a B-tree id that still survives under a new schema row.
+/// Rows for the surviving table must remain durable after recovery.
+#[turso_macros::test]
+fn test_create_rename_insert_same_tx_recover_then_checkpoint(
+    db: TempDatabase,
+) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+
+        conn.execute("begin")?;
+        conn.execute("create table t(id integer primary key, v text)")?;
+        conn.execute("alter table t rename to t2")?;
+        conn.execute("insert into t2 values (1, 'one'), (2, 'two')")?;
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    {
+        let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+        let conn = db.connect()?;
+        let rows: Vec<(i64, String)> = conn.exec_rows("select id, v from t2 order by id");
+        assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    }
+
+    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let conn = db.connect()?;
+    let rows: Vec<(i64, String)> = conn.exec_rows("select id, v from t2 order by id");
+    assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
+
+    Ok(())
+}
+
 /// Same-tx create + insert + drop: data rows reference a table_id whose schema
 /// entry is created and destroyed in the same transaction.
 #[turso_macros::test]

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1006,6 +1006,37 @@ fn test_create_drop_index_same_tx_recover(db: TempDatabase) -> anyhow::Result<()
     Ok(())
 }
 
+/// Same-tx CREATE INDEX + DROP INDEX followed by recovery and a checkpoint.
+/// Replay must not turn the transient sqlite_schema row into a durable delete
+/// for a row that was never checkpointed to the btree.
+#[turso_macros::test]
+fn test_create_drop_index_same_tx_recover_then_checkpoint(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+        conn.execute("create table t(id integer primary key, v text)")?;
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+        conn.execute("begin")?;
+        conn.execute("create index idx_t_v on t(v)")?;
+        conn.execute("drop index idx_t_v")?;
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let conn = db.connect()?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    let rows: Vec<(i64,)> = conn.exec_rows("select count(*) from t");
+    assert_eq!(rows, vec![(0,)]);
+
+    Ok(())
+}
+
 /// Same-tx create + insert + drop: data rows reference a table_id whose schema
 /// entry is created and destroyed in the same transaction.
 #[turso_macros::test]
@@ -1126,6 +1157,53 @@ fn test_mvcc_update_btree_only_row_after_truncate_checkpoint(
 
     let rows: Vec<(String, i64)> = conn.exec_rows("SELECT key, length(value) FROM quint_corrupt");
     assert_eq!(rows, vec![("k0".to_string(), 32)]);
+
+    Ok(())
+}
+
+/// Upserting then deleting a B-tree-resident row in one transaction must log the
+/// delete, otherwise recovery resurrects the old pager row.
+#[turso_macros::test]
+fn test_mvcc_upsert_then_delete_btree_resident_row_recover(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.pragma_update("journal_mode", "'mvcc'")?;
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")?;
+        conn.execute("INSERT INTO t VALUES (1, 'original')")?;
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    }
+    drop(db);
+
+    {
+        let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+        let conn = db.connect()?;
+        conn.pragma_update("journal_mode", "'mvcc'")?;
+        let rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t");
+        assert_eq!(rows, vec![(1, "original".to_string())]);
+        conn.execute("BEGIN")?;
+        conn.execute(
+            "INSERT INTO t VALUES (1, 'updated') \
+             ON CONFLICT(id) DO UPDATE SET v = excluded.v",
+        )?;
+        conn.execute("DELETE FROM t WHERE id = 1")?;
+        conn.execute("COMMIT")?;
+    }
+
+    {
+        let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+        let conn = db.connect()?;
+        let rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t");
+        assert_eq!(rows, Vec::<(i64, String)>::new());
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    }
+
+    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let conn = db.connect()?;
+    let rows: Vec<(i64, String)> = conn.exec_rows("SELECT id, v FROM t");
+    assert_eq!(rows, Vec::<(i64, String)>::new());
 
     Ok(())
 }


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
