### PR TITLE
simulator: enable sync faults

### DIFF
--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -819,8 +819,6 @@ impl InteractionType {
                 .collect();
 
             loop {
-                let syncing = env.io.syncing();
-
                 // Decide faults independently per database
                 let main_fault = env.rng.random_bool(current_prob);
                 let aux_prob = (current_prob * 0.5).min(1.0);
@@ -831,8 +829,7 @@ impl InteractionType {
                 }
                 let any_fault = fault_pairs.iter().any(|(_, f)| *f);
 
-                // TODO: avoid for now injecting faults when syncing
-                if any_fault && !syncing {
+                if any_fault {
                     env.io.inject_fault_selective(&fault_pairs);
                 }
 

--- a/testing/simulator/runner/file.rs
+++ b/testing/simulator/runner/file.rs
@@ -70,7 +70,8 @@ impl SimulatorFile {
     pub(crate) fn stats_table(&self) -> String {
         let sum_calls =
             self.nr_pread_calls.get() + self.nr_pwrite_calls.get() + self.nr_sync_calls.get();
-        let sum_faults = self.nr_pread_faults.get() + self.nr_pwrite_faults.get();
+        let sum_faults =
+            self.nr_pread_faults.get() + self.nr_pwrite_faults.get() + self.nr_sync_faults.get();
         let stats_table = [
             "op           calls   faults".to_string(),
             "--------- -------- --------".to_string(),
@@ -87,7 +88,7 @@ impl SimulatorFile {
             format!(
                 "sync      {:8} {:8}",
                 self.nr_sync_calls.get(),
-                0 // No fault counter for sync
+                self.nr_sync_faults.get()
             ),
             "--------- -------- --------".to_string(),
             format!("total     {sum_calls:8} {sum_faults:8}"),
@@ -191,11 +192,11 @@ impl File for SimulatorFile {
     ) -> Result<turso_core::Completion> {
         self.nr_sync_calls.set(self.nr_sync_calls.get() + 1);
         if self.fault.get() {
-            // TODO: Enable this when https://github.com/tursodatabase/turso/issues/2091 is fixed.
-            tracing::debug!(
-                "ignoring sync fault because it causes false positives with current simulator design"
-            );
-            self.fault.set(false);
+            tracing::debug!("sync fault");
+            self.nr_sync_faults.set(self.nr_sync_faults.get() + 1);
+            return Err(turso_core::LimboError::InternalError(
+                FAULT_ERROR_MSG.into(),
+            ));
         }
         let c = if let Some(latency) = self.generate_latency_duration() {
             let cloned_c = c.clone();

--- a/testing/simulator/runner/memory/file.rs
+++ b/testing/simulator/runner/memory/file.rs
@@ -131,8 +131,7 @@ impl MemorySimFile {
     }
 
     fn insert_op(&self, op: OperationType) {
-        // FIXME: currently avoid any fsync faults until we correctly define the expected behaviour in the simulator
-        let fault = self.fault.get() && !matches!(op, OperationType::Sync { .. });
+        let fault = self.fault.get();
         if fault {
             let mut io_tracker = self.io_tracker.borrow_mut();
             match &op {


### PR DESCRIPTION
## Summary

- enable simulator sync/fsync faults now that #2091 has defined the fsync failure behavior
- count sync faults in the platform simulator backend stats
- allow the memory simulator backend to abort sync completions under fault injection
- let `FaultyQuery` inject faults while a sync is pending instead of skipping those windows

Closes #4976

## Verification

- `cargo fmt -p limbo_sim --check`
- `cargo check -p limbo_sim`
- `cargo clippy -p limbo_sim --all-targets -- -D warnings`
- `cargo test -p limbo_sim`
- `cargo run -p limbo_sim -- --seed 1 -n 120 -k 30 --maximum-time 30 --io-backend memory --disable-bugbase --disable-integrity-check --keep-files`
- `cargo run -p limbo_sim -- --seed 2 -n 120 -k 30 --maximum-time 30 --io-backend memory --disable-bugbase --disable-integrity-check --keep-files`
- `cargo run -p limbo_sim -- --seed 4 -n 120 -k 30 --maximum-time 30 --io-backend default --disable-bugbase --disable-integrity-check --keep-files`

/claim #4976
