### PR TITLE
core/mvcc: add MVCC recovery regression cases

### DIFF
--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1006,6 +1006,217 @@ fn test_create_drop_index_same_tx_recover(db: TempDatabase) -> anyhow::Result<()
     Ok(())
 }
 
+/// CREATE TABLE followed by RENAME in the same transaction creates and deletes
+/// a schema row for a B-tree id that still survives under a new schema row.
+/// Rows for the surviving table must remain durable after recovery.
+#[turso_macros::test]
+fn test_create_rename_insert_same_tx_recover_then_checkpoint(
+    db: TempDatabase,
+) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.execute("pragma journal_mode = 'mvcc'")?;
+
+        conn.execute("begin")?;
+        conn.execute("create table t(id integer primary key, v text)")?;
+        conn.execute("alter table t rename to t2")?;
+        conn.execute("insert into t2 values (1, 'one'), (2, 'two')")?;
+        conn.execute("commit")?;
+    }
+    drop(db);
+
+    {
+        let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+        let conn = db.connect()?;
+        let rows: Vec<(i64, String)> = conn.exec_rows("select id, v from t2 order by id");
+        assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    }
+
+    let db = Database::open_file(io, path.to_str().unwrap())?;
+    let conn = db.connect()?;
+    let rows: Vec<(i64, String)> = conn.exec_rows("select id, v from t2 order by id");
+    assert_eq!(rows, vec![(1, "one".to_string()), (2, "two".to_string())]);
+
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum TransientIndexTiming {
+    None,
+    BeforeRowChanges,
+    AfterTransientInserts,
+    AfterDeletes,
+}
+
+impl TransientIndexTiming {
+    fn suffix(self) -> &'static str {
+        match self {
+            Self::None => "no_idx",
+            Self::BeforeRowChanges => "idx_before",
+            Self::AfterTransientInserts => "idx_after_inserts",
+            Self::AfterDeletes => "idx_after_deletes",
+        }
+    }
+}
+
+/// Deterministic matrix for same-transaction row and transient-index effects.
+/// Each case is recovered and then checkpointed so logical-log replay and
+/// B-tree persistence both see the same net state.
+#[turso_macros::test]
+fn test_mvcc_same_tx_row_and_index_lifecycle_matrix(db: TempDatabase) -> anyhow::Result<()> {
+    let path = db.path.clone();
+    let io = db.io.clone();
+
+    {
+        let conn = db.connect_limbo();
+        conn.pragma_update("journal_mode", "'mvcc'")?;
+    }
+    drop(db);
+
+    let index_timings = [
+        TransientIndexTiming::None,
+        TransientIndexTiming::BeforeRowChanges,
+        TransientIndexTiming::AfterTransientInserts,
+        TransientIndexTiming::AfterDeletes,
+    ];
+    let mut case_id = 0;
+
+    for transient_rows in [false, true] {
+        for update_delete_existing in [false, true] {
+            for index_timing in index_timings {
+                case_id += 1;
+                let table = format!(
+                    "mvcc_same_tx_{}_{}_{}",
+                    if transient_rows {
+                        "transient"
+                    } else {
+                        "stable"
+                    },
+                    if update_delete_existing {
+                        "delete_existing"
+                    } else {
+                        "keep_existing"
+                    },
+                    index_timing.suffix()
+                );
+                let base_index = format!("{table}_base_idx");
+                let transient_index = format!("{table}_tmp_idx");
+                let label = format!(
+                    "case {case_id}: transient_rows={transient_rows}, update_delete_existing={update_delete_existing}, index_timing={}",
+                    index_timing.suffix()
+                );
+
+                {
+                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let conn = db.connect()?;
+                    conn.pragma_update("journal_mode", "'mvcc'")?;
+                    conn.execute(format!(
+                        "CREATE TABLE {table}(id INTEGER PRIMARY KEY, v TEXT)"
+                    ))?;
+                    conn.execute(format!(
+                        "INSERT INTO {table} VALUES (1, 'original'), (2, 'keep')"
+                    ))?;
+                    conn.execute(format!("CREATE INDEX {base_index} ON {table}(v)"))?;
+                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+                }
+
+                {
+                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let conn = db.connect()?;
+                    conn.pragma_update("journal_mode", "'mvcc'")?;
+
+                    let create_drop_transient_index = || -> anyhow::Result<()> {
+                        conn.execute(format!("CREATE INDEX {transient_index} ON {table}(v)"))?;
+                        conn.execute(format!("DROP INDEX {transient_index}"))?;
+                        Ok(())
+                    };
+
+                    conn.execute("BEGIN")?;
+                    if matches!(index_timing, TransientIndexTiming::BeforeRowChanges) {
+                        create_drop_transient_index()?;
+                    }
+                    if transient_rows {
+                        conn.execute(format!(
+                            "INSERT INTO {table} VALUES (10, 'temp_10'), (11, 'temp_11')"
+                        ))?;
+                    }
+                    if matches!(index_timing, TransientIndexTiming::AfterTransientInserts) {
+                        create_drop_transient_index()?;
+                    }
+                    if update_delete_existing {
+                        conn.execute(format!("UPDATE {table} SET v = 'updated' WHERE id = 1"))?;
+                        conn.execute(format!("DELETE FROM {table} WHERE id = 1"))?;
+                    }
+                    if transient_rows {
+                        conn.execute(format!("DELETE FROM {table} WHERE id IN (10, 11)"))?;
+                    }
+                    if matches!(index_timing, TransientIndexTiming::AfterDeletes) {
+                        create_drop_transient_index()?;
+                    }
+                    conn.execute("COMMIT")?;
+                }
+
+                for checkpoint_after_recovery in [true, false] {
+                    let db = Database::open_file(io.clone(), path.to_str().unwrap())?;
+                    let conn = db.connect()?;
+
+                    let rows_sql = format!("SELECT id, v FROM {table} ORDER BY id");
+                    let rows: Vec<(i64, String)> = conn.exec_rows(&rows_sql);
+                    let expected_rows = if update_delete_existing {
+                        vec![(2, "keep".to_string())]
+                    } else {
+                        vec![(1, "original".to_string()), (2, "keep".to_string())]
+                    };
+                    assert_eq!(rows, expected_rows, "{label}");
+
+                    let index_names_sql = format!(
+                        "SELECT name FROM sqlite_schema \
+                         WHERE type = 'index' AND tbl_name = '{table}' ORDER BY name"
+                    );
+                    let index_names: Vec<(String,)> = conn.exec_rows(&index_names_sql);
+                    assert_eq!(index_names, vec![(base_index.clone(),)], "{label}");
+
+                    let original_ids_sql = format!(
+                        "SELECT id FROM {table} INDEXED BY {base_index} \
+                         WHERE v = 'original' ORDER BY id"
+                    );
+                    let original_ids: Vec<(i64,)> = conn.exec_rows(&original_ids_sql);
+                    let expected_original_ids = if update_delete_existing {
+                        Vec::new()
+                    } else {
+                        vec![(1,)]
+                    };
+                    assert_eq!(original_ids, expected_original_ids, "{label}");
+
+                    let updated_ids_sql = format!(
+                        "SELECT id FROM {table} INDEXED BY {base_index} \
+                         WHERE v = 'updated' ORDER BY id"
+                    );
+                    let updated_ids: Vec<(i64,)> = conn.exec_rows(&updated_ids_sql);
+                    assert_eq!(updated_ids, Vec::<(i64,)>::new(), "{label}");
+
+                    let transient_ids_sql = format!(
+                        "SELECT id FROM {table} INDEXED BY {base_index} \
+                         WHERE v IN ('temp_10', 'temp_11') ORDER BY id"
+                    );
+                    let transient_ids: Vec<(i64,)> = conn.exec_rows(&transient_ids_sql);
+                    assert_eq!(transient_ids, Vec::<(i64,)>::new(), "{label}");
+
+                    if checkpoint_after_recovery {
+                        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Same-tx create + insert + drop: data rows reference a table_id whose schema
 /// entry is created and destroyed in the same transaction.
 #[turso_macros::test]


### PR DESCRIPTION
## Description

I was working on a PR earlier https://github.com/tursodatabase/turso/pull/7224 but the bug got fixed in main by another PR. So I am just keeping the tests around (these aren;t present in main).

These tests check mvcc recovery logic, especially those bugs arising due to rollback in the same txn. The actual PR and bug fixes you can see here https://github.com/tursodatabase/turso/pull/7218