### PR TITLE
core: raise recursion_limit to 256 for FromRepr on Insn

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2,6 +2,7 @@
     nightly,
     feature(allocator_api, btreemap_alloc, clone_from_ref, try_with_capacity)
 )]
+#![recursion_limit = "256"]
 
 pub mod alloc;
 pub mod busy;


### PR DESCRIPTION
The `Insn` enum in `core/vdbe/insn.rs` currently has ~195 variants and derives `FromRepr` via `EnumDiscriminants`. The const-eval query chain that the compiler walks to type-check the generated per-variant discriminant constants is right at the edge of the default 128-deep `recursion_limit`. Under certain nightly-rustc flag combinations it overflows.

Specifically: the minimum reproducer is `cargo +nightly build --release` on a crate depending on `turso_core` with

```
RUSTFLAGS="-Zthreads=N -Zlocation-detail=none"   (N >= 2)
```

producing:

```
error: queries overflow the depth limit!
  = note: query depth increased by 130 when simplifying constant for
    the type system `vdbe::insn::<impl at vdbe/insn.rs:235:55>
    ::from_repr::HashDistinct_DISCRIMINANT`
```

Either flag alone fits inside the 128 budget. Together they push past it. The flags are orthogonal in intent: `-Zthreads=N` enables parallel rustc (build-time win on multi-core), `-Zlocation-detail=none` strips `#[track_caller]` location info from generated code (binary-size reduction). Neither is exotic; both turn up in any sufficiently optimization-conscious release build that targets nightly. Their interaction inflating const-eval query depth by ~30 layers for `caller_location` const-folding is arguably a rustc-side issue worth filing separately, but the fix on our side is the one-liner the compiler itself suggests:

```
#![recursion_limit = "256"]
```

Properties:
- compile-time-only; no runtime effect, generated code byte-identical
- no effect on stable Rust builds (don't approach the limit)
- no effect on single-threaded nightly builds (same)
- defensive against `Insn` growing further: every new opcode adds more discriminant queries

This pattern (raising `recursion_limit` for crates with large `EnumDiscriminants`-derived enums) is used in `serde_derive`, `clap`, `syn`, and others. The compiler explicitly suggests this exact line in the error path; see the rust reference, "Limits" attribute section.

Context: I hit this while trying to integrate Turso with an unnamed JavaScript runtime recently written in Rust (ported from a different language). The host crate passes both `-Zthreads=N` and `-Zlocation-detail=none` for the reasons above. Currently working around it with a local patch on the vendored `turso_core` copy; filing this so the workaround can be dropped once a patched release is on crates.io.

