### PR TITLE
migrate `order_by.rs` to use fallible vec allocations

### DIFF
--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -37,7 +37,7 @@ impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
 
 impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         #[cfg(not(nightly))]
         {
             Ok(BinaryHeap::with_capacity(capacity))
@@ -88,7 +88,7 @@ impl<T: Clone + Ord> TryClone for BinaryHeap<T> {
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
-        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;
+        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
         #[cfg(nightly)]
         let mut cloned = {
             let alloc = self.allocator().clone();

--- a/core/alloc/collections/boxed.rs
+++ b/core/alloc/collections/boxed.rs
@@ -1,10 +1,24 @@
 use super::{TryClone, TursoBoxExt, TursoNewExt, TursoTryNewExt};
-use crate::alloc::{AllocError, Box, TursoAllocator};
+#[cfg(nightly)]
+use crate::alloc::TursoAllocator;
+use crate::alloc::{AllocError, Box};
 
+#[cfg(not(nightly))]
+fn boxed<T>(value: T) -> Box<T> {
+    Box::new(value)
+}
+
+#[cfg(nightly)]
 fn boxed<T>(value: T) -> Box<T> {
     Box::new_in(value, TursoAllocator)
 }
 
+#[cfg(not(nightly))]
+fn try_boxed<T>(value: T) -> Result<Box<T>, AllocError> {
+    Ok(Box::new(value))
+}
+
+#[cfg(nightly)]
 fn try_boxed<T>(value: T) -> Result<Box<T>, AllocError> {
     Box::try_new_in(value, TursoAllocator)
 }
@@ -25,7 +39,7 @@ impl<T> TursoBoxExt<T> for Box<T> {
     fn into_inner(self) -> T {
         #[cfg(not(nightly))]
         {
-            Box::into_inner(self)
+            *self
         }
         #[cfg(nightly)]
         {

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -21,7 +21,7 @@ where
     K: Eq + Hash,
 {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(HashMap::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -21,7 +21,7 @@ where
     T: Eq + Hash,
 {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(HashSet::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -5,7 +5,7 @@ pub trait TursoAllocExt {
 }
 
 pub trait TursoTryWithCapacityExt: Sized {
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError>;
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError>;
 }
 
 pub trait TursoNewExt<T> {

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -45,7 +45,7 @@ impl<T> TursoVecExt<T> for Vec<T> {
 
 impl<T> TursoTryWithCapacityExt for Vec<T> {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(vec_with_capacity(capacity))
     }
 }
@@ -84,7 +84,7 @@ impl<T: Clone> TryClone for Vec<T> {
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
-        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;
+        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
         #[cfg(nightly)]
         let mut cloned = {
             let alloc = self.allocator().clone();

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -55,7 +55,7 @@ impl<T> TursoVecDequeExt<T> for VecDeque<T> {
 
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(vec_deque_with_capacity(capacity))
     }
 }
@@ -94,7 +94,7 @@ impl<T: Clone> TryClone for VecDeque<T> {
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
-        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;
+        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
         #[cfg(nightly)]
         let mut cloned = {
             let alloc = self.allocator().clone();

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -47,8 +47,9 @@ pub struct TursoAllocator;
 
 pub type Allocator = TursoAllocator;
 
+// TODO: change this to use allocator_api2 Box when we finish migrating callsites
 #[cfg(not(nightly))]
-pub type Box<T> = allocator_api2::boxed::Box<T, TursoAllocator>;
+pub type Box<T> = std::boxed::Box<T>;
 #[cfg(nightly)]
 pub type Box<T> = std::boxed::Box<T, TursoAllocator>;
 

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -105,7 +105,7 @@ macro_rules! __turso_alloc_try_vec {
         (|| {
             let count = $count;
             let mut values =
-                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity(
+                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
                     count,
                 )?;
             values.resize(count, $element);
@@ -115,7 +115,7 @@ macro_rules! __turso_alloc_try_vec {
     ($($element:expr),+ $(,)?) => {{
         (|| {
             let mut values =
-                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity(
+                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
                     $crate::__turso_alloc_vec_count!($($element),+),
                 )?;
             $(values.try_push($element)?;)+

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -275,7 +275,7 @@ fn try_clone_builds_independent_alloc_collections() {
     assert_eq!(cloned.as_slice(), values.as_slice());
     assert_ne!(cloned.as_ptr(), values.as_ptr());
 
-    let boxed = Box::try_new(String::from("turso")).unwrap();
+    let boxed: Box<_> = TursoTryNewExt::try_new(String::from("turso")).unwrap();
     let cloned = boxed.try_clone().unwrap();
     assert_eq!(&*cloned, &*boxed);
 

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -255,11 +255,11 @@ fn iterator_try_unzip_builds_turso_collections() {
 
 #[test]
 fn try_with_capacity_builds_turso_collections() {
-    let values: Vec<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let map: HashMap<usize, usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let set: HashSet<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let queue: VecDeque<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let heap: BinaryHeap<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
+    let values: Vec<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let map: HashMap<usize, usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let set: HashSet<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let queue: VecDeque<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let heap: BinaryHeap<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
 
     assert!(values.capacity() >= 3);
     assert!(map.capacity() >= 3);

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -72,7 +72,7 @@ where
 fn vec_push_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| {
-            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len).unwrap()
         })
         .bench_local_values(|mut values| {
             for value in 0..len {
@@ -117,7 +117,7 @@ fn vec_collect_std(bencher: Bencher, len: usize) {
 fn vec_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len).unwrap();
         TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
         black_box(values)
     });
@@ -136,7 +136,8 @@ fn vec_extend_std(bencher: Bencher, len: usize) {
 fn vec_deque_push_back_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         for value in 0..len {
             values.try_push_back(black_box(value)).unwrap();
         }
@@ -180,7 +181,8 @@ fn vec_deque_collect_std(bencher: Bencher, len: usize) {
 fn vec_deque_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
         black_box(values)
     });
@@ -199,7 +201,8 @@ fn vec_deque_extend_std(bencher: Bencher, len: usize) {
 fn binary_heap_push_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         for value in 0..len {
             values.try_push(black_box(value)).unwrap();
         }
@@ -243,7 +246,8 @@ fn binary_heap_collect_std(bencher: Bencher, len: usize) {
 fn binary_heap_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
         black_box(values)
     });
@@ -262,7 +266,7 @@ fn binary_heap_extend_std(bencher: Bencher, len: usize) {
 fn hash_set_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -309,7 +313,7 @@ fn hash_set_collect_std(bencher: Bencher, len: usize) {
 fn hash_set_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -331,7 +335,7 @@ fn hash_set_extend_std(bencher: Bencher, len: usize) {
 fn hash_map_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -367,7 +371,7 @@ fn hash_map_collect_std(bencher: Bencher, len: usize) {
 fn hash_map_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -431,7 +435,7 @@ fn vec_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn vec_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len).unwrap();
         TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
             .unwrap();
         black_box(values)
@@ -470,7 +474,8 @@ fn vec_deque_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn vec_deque_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
             .unwrap();
         black_box(values)
@@ -509,7 +514,8 @@ fn binary_heap_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn binary_heap_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
             .unwrap();
         black_box(values)
@@ -548,7 +554,7 @@ fn hash_set_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn hash_set_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -594,7 +600,7 @@ fn hash_map_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn hash_map_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -623,7 +629,8 @@ fn vec_non_copy_push_std(bencher: Bencher, len: usize) {
 fn vec_non_copy_push_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| {
-            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap()
         })
         .bench_local_values(|mut values| {
             for value in 0..len {
@@ -669,7 +676,8 @@ fn vec_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(
             &mut values,
             (0..len).map(|value| black_box(NonCopyValue::new(value))),
@@ -694,7 +702,7 @@ fn vec_deque_non_copy_push_back_std(bencher: Bencher, len: usize) {
 fn vec_deque_non_copy_push_back_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
                 .unwrap();
         for value in 0..len {
             values
@@ -739,7 +747,7 @@ fn vec_deque_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn vec_deque_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
                 .unwrap();
         TursoFromIterator::try_extend(
             &mut values,
@@ -765,8 +773,10 @@ fn binary_heap_non_copy_push_std(bencher: Bencher, len: usize) {
 fn binary_heap_non_copy_push_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
-                .unwrap();
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(
+                len,
+            )
+            .unwrap();
         for value in 0..len {
             values
                 .try_push(black_box(NonCopyValue::new(value)))
@@ -810,8 +820,10 @@ fn binary_heap_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn binary_heap_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
-                .unwrap();
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(
+                len,
+            )
+            .unwrap();
         TursoFromIterator::try_extend(
             &mut values,
             (0..len).map(|value| black_box(NonCopyValue::new(value))),
@@ -836,7 +848,7 @@ fn hash_set_non_copy_insert_std(bencher: Bencher, len: usize) {
 fn hash_set_non_copy_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -881,7 +893,7 @@ fn hash_set_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn hash_set_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -912,7 +924,7 @@ fn hash_map_non_copy_insert_std(bencher: Bencher, len: usize) {
 fn hash_map_non_copy_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -977,7 +989,7 @@ fn hash_map_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn hash_map_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -1,5 +1,6 @@
-use crate::sync::Arc;
+use crate::{alloc::TursoVecExt, sync::Arc};
 
+use crate::alloc::*;
 use turso_parser::ast::{self, SortOrder};
 
 use crate::{
@@ -197,13 +198,15 @@ impl EmitOrderBy {
         let has_sequence = (has_group_by && !only_aggs) || use_heap_sort;
 
         let remappings =
-            order_by_deduplicate_result_columns(order_by, result_columns, has_sequence);
+            order_by_deduplicate_result_columns(order_by, result_columns, has_sequence)?;
         let sort_cursor = if use_heap_sort {
             let index_name = format!("heap_sort_{}", program.offset().as_offset_int()); // we don't really care about the name that much, just enough that we don't get name collisions
-            let mut index_columns = Vec::with_capacity(order_by.len() + result_columns.len());
+            let mut index_columns =
+                Vec::try_with_capacity_ext(order_by.len() + result_columns.len())?;
             for (column, order, _nulls) in order_by {
                 let collation = get_collseq_from_expr(column, referenced_tables)?;
                 let pos_in_table = index_columns.len();
+                // Have enough space pre-allocatoed to push without realloc
                 index_columns.push(IndexColumn {
                     name: pos_in_table.to_string(),
                     order: *order,
@@ -211,28 +214,28 @@ impl EmitOrderBy {
                     collation,
                     default: None,
                     expr: None,
-                })
+                });
             }
             let pos_in_table = index_columns.len();
             // add sequence number between ORDER BY columns and result column
-            index_columns.push(IndexColumn {
+            index_columns.try_push(IndexColumn {
                 name: pos_in_table.to_string(),
                 order: SortOrder::Asc,
                 pos_in_table,
                 collation: None,
                 default: None,
                 expr: None,
-            });
+            })?;
             for _ in remappings.iter().filter(|r| !r.deduplicated) {
                 let pos_in_table = index_columns.len();
-                index_columns.push(IndexColumn {
+                index_columns.try_push(IndexColumn {
                     name: pos_in_table.to_string(),
                     order: SortOrder::Asc,
                     pos_in_table,
                     collation: None,
                     default: None,
                     expr: None,
-                })
+                })?;
             }
             let index = Arc::new(Index {
                 name: index_name,
@@ -279,9 +282,9 @@ impl EmitOrderBy {
                 .iter()
                 .map(|(expr, dir, nulls)| {
                     let collation = get_collseq_from_expr(expr, referenced_tables)?;
-                    Ok((*dir, collation, *nulls))
+                    Ok::<_, crate::LimboError>((*dir, collation, *nulls))
                 })
-                .collect::<Result<Vec<_>>>()?;
+                .try_collect::<Result<Vec<_>>>()??;
 
             // Resolve custom type comparators for ORDER BY columns.
             // For types with a `<` operator, the comparator is used for correct sort ordering.
@@ -290,12 +293,12 @@ impl EmitOrderBy {
                 .map(|(expr, _, _)| {
                     custom_type_comparator(expr, referenced_tables, t_ctx.resolver.schema())
                 })
-                .collect();
+                .try_collect()?;
 
             if has_sequence {
                 // sequence column: ascending with BINARY collation, no comparator, no nulls order
                 order_collations_nulls.push((SortOrder::Asc, Some(CollationSeq::default()), None));
-                comparators.push(None);
+                comparators.try_push(None)?;
             }
 
             let key_len = order_collations_nulls.len();
@@ -727,8 +730,9 @@ pub fn order_by_deduplicate_result_columns(
     )],
     result_columns: &[ResultSetColumn],
     has_sequence: bool,
-) -> Vec<OrderByRemapping> {
-    let mut result_column_remapping: Vec<OrderByRemapping> = Vec::new();
+) -> Result<Vec<OrderByRemapping>> {
+    let mut result_column_remapping: Vec<OrderByRemapping> =
+        Vec::try_with_capacity_ext(result_columns.len())?;
     let order_by_len = order_by.len();
     // `sequence_offset` shifts the base index where non-deduped SELECT columns begin,
     // because Sequence sits after ORDER BY keys but before result columns.
@@ -740,6 +744,7 @@ pub fn order_by_deduplicate_result_columns(
             .iter()
             .enumerate()
             .find(|(_, (expr, _, _))| exprs_are_equivalent(expr, &rc.expr));
+        // No need to use `try_push` as we preallocated enough capacity already
         if let Some((j, _)) = found {
             result_column_remapping.push(OrderByRemapping {
                 orderby_sorter_idx: j,
@@ -757,5 +762,5 @@ pub fn order_by_deduplicate_result_columns(
         }
     }
 
-    result_column_remapping
+    Ok(result_column_remapping)
 }


### PR DESCRIPTION
## Description
Also had to change `try_with_capacity` method name because it conflicts with `nightly`

## Motivation and context
Fallible Allocations


## Description of AI Usage
Me and Codex identifying places to change
