### PR TITLE
dbhash: support encrypted databases

### DIFF
--- a/tools/dbhash/README.md
+++ b/tools/dbhash/README.md
@@ -17,4 +17,7 @@ turso-dbhash --schema-only database.db
 
 # Hash only data (no schema)
 turso-dbhash --without-schema database.db
+
+# Hash an encrypted database
+turso-dbhash --cipher aegis256 --hexkey "<hex-key>" database.db
 ```

--- a/tools/dbhash/README.md
+++ b/tools/dbhash/README.md
@@ -18,6 +18,6 @@ turso-dbhash --schema-only database.db
 # Hash only data (no schema)
 turso-dbhash --without-schema database.db
 
-# Hash an encrypted database
+# Hash an encrypted database; both encryption flags are required
 turso-dbhash --cipher aegis256 --hexkey "<hex-key>" database.db
 ```

--- a/tools/dbhash/src/lib.rs
+++ b/tools/dbhash/src/lib.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 use sha1::{Digest, Sha1};
 use std::num::NonZero;
 use turso_core::{
-    Database, DatabaseOpts, LimboError, OpenFlags, PlatformIO, StepResult, Value, IO,
+    Database, DatabaseOpts, EncryptionKey, EncryptionOpts, LimboError, OpenFlags, PlatformIO,
+    StepResult, Value, IO,
 };
 
 pub use encoder::encode_value;
@@ -26,6 +27,8 @@ pub struct DbHashOptions {
     pub without_schema: bool,
     /// If true, print each value to stderr as it's hashed.
     pub debug_trace: bool,
+    /// Encryption options for opening encrypted databases.
+    pub encryption: Option<EncryptionOpts>,
 }
 
 #[derive(Debug)]
@@ -60,14 +63,24 @@ pub fn hash_database_with_database_opts(
         "`schema_only` and `without_schema` cannot both be true"
     );
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new()?);
+    let database_opts = if options.encryption.is_some() {
+        database_opts.with_encryption(true)
+    } else {
+        database_opts
+    };
+    let encryption_key = options
+        .encryption
+        .as_ref()
+        .map(|opts| EncryptionKey::from_hex_string(&opts.hexkey))
+        .transpose()?;
     let db = Database::open_file_with_flags(
         io.clone(),
         path,
         OpenFlags::default(),
         database_opts,
-        None,
+        options.encryption.clone(),
     )?;
-    let conn = db.connect()?;
+    let conn = db.connect_with_encryption(encryption_key)?;
 
     let mut hasher = Sha1::new();
     let mut tables_hashed = 0;

--- a/tools/dbhash/src/main.rs
+++ b/tools/dbhash/src/main.rs
@@ -1,6 +1,7 @@
 //! turso-dbhash CLI - Compute SHA1 hash of SQLite database content.
 
 use clap::Parser;
+use turso_core::EncryptionOpts;
 use turso_dbhash::{hash_database, DbHashOptions};
 
 #[derive(Parser)]
@@ -26,6 +27,14 @@ struct Args {
     /// Trace hash inputs to stderr
     #[arg(long)]
     debug: bool,
+
+    /// Cipher to use when opening an encrypted database
+    #[arg(long, value_name = "CIPHER", requires = "hexkey")]
+    cipher: Option<String>,
+
+    /// Hex-encoded encryption key for an encrypted database
+    #[arg(long, value_name = "HEXKEY", requires = "cipher")]
+    hexkey: Option<String>,
 }
 
 fn main() {
@@ -41,6 +50,10 @@ fn main() {
         schema_only: args.schema_only,
         without_schema: args.without_schema,
         debug_trace: args.debug,
+        encryption: args.cipher.map(|cipher| EncryptionOpts {
+            cipher,
+            hexkey: args.hexkey.expect("required by clap"),
+        }),
     };
 
     let mut exit_code = 0;

--- a/tools/dbhash/tests/encryption.rs
+++ b/tools/dbhash/tests/encryption.rs
@@ -1,6 +1,9 @@
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
-use tempfile::NamedTempFile;
+use tempfile::TempDir;
 use turso_core::{
     Database, DatabaseOpts, EncryptionKey, EncryptionOpts, OpenFlags, PlatformIO, IO,
 };
@@ -9,6 +12,17 @@ use turso_dbhash::{hash_database, DbHashOptions};
 const CIPHER: &str = "aegis256";
 const HEXKEY: &str = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
 
+struct TestDb {
+    _dir: TempDir,
+    path: PathBuf,
+}
+
+impl TestDb {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
 fn encryption_opts() -> EncryptionOpts {
     EncryptionOpts {
         cipher: CIPHER.to_string(),
@@ -16,9 +30,10 @@ fn encryption_opts() -> EncryptionOpts {
     }
 }
 
-fn create_test_db(encryption: Option<EncryptionOpts>) -> NamedTempFile {
-    let file = NamedTempFile::new().expect("create temp db");
-    let path = file.path().to_str().unwrap();
+fn create_test_db(name: &str, encryption: Option<EncryptionOpts>) -> TestDb {
+    let dir = TempDir::new().expect("create temp dir");
+    let path = dir.path().join(name);
+    let path_str = path.to_str().unwrap();
     let io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("create platform io"));
     let database_opts = if encryption.is_some() {
         DatabaseOpts::new().with_encryption(true)
@@ -30,7 +45,7 @@ fn create_test_db(encryption: Option<EncryptionOpts>) -> NamedTempFile {
         .map(|_| EncryptionKey::from_hex_string(HEXKEY).expect("parse hexkey"));
     let db = Database::open_file_with_flags(
         io.clone(),
-        path,
+        path_str,
         OpenFlags::Create,
         database_opts,
         encryption,
@@ -48,13 +63,13 @@ fn create_test_db(encryption: Option<EncryptionOpts>) -> NamedTempFile {
         io.wait_for_completion(completion).expect("wait for flush");
     }
 
-    file
+    TestDb { _dir: dir, path }
 }
 
 #[test]
 fn hashes_encrypted_database_with_cipher_and_hexkey() {
-    let plain_db = create_test_db(None);
-    let encrypted_db = create_test_db(Some(encryption_opts()));
+    let plain_db = create_test_db("plain.db", None);
+    let encrypted_db = create_test_db("encrypted.db", Some(encryption_opts()));
     let options = DbHashOptions {
         encryption: Some(encryption_opts()),
         ..Default::default()

--- a/tools/dbhash/tests/encryption.rs
+++ b/tools/dbhash/tests/encryption.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use tempfile::NamedTempFile;
+use turso_core::{
+    Database, DatabaseOpts, EncryptionKey, EncryptionOpts, OpenFlags, PlatformIO, IO,
+};
+use turso_dbhash::{hash_database, DbHashOptions};
+
+const CIPHER: &str = "aegis256";
+const HEXKEY: &str = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+fn encryption_opts() -> EncryptionOpts {
+    EncryptionOpts {
+        cipher: CIPHER.to_string(),
+        hexkey: HEXKEY.to_string(),
+    }
+}
+
+fn create_test_db(encryption: Option<EncryptionOpts>) -> NamedTempFile {
+    let file = NamedTempFile::new().expect("create temp db");
+    let path = file.path().to_str().unwrap();
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().expect("create platform io"));
+    let database_opts = if encryption.is_some() {
+        DatabaseOpts::new().with_encryption(true)
+    } else {
+        DatabaseOpts::new()
+    };
+    let encryption_key = encryption
+        .as_ref()
+        .map(|_| EncryptionKey::from_hex_string(HEXKEY).expect("parse hexkey"));
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        path,
+        OpenFlags::Create,
+        database_opts,
+        encryption,
+    )
+    .expect("open db");
+    let conn = db
+        .connect_with_encryption(encryption_key)
+        .expect("connect db");
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT)")
+        .expect("create table");
+    conn.execute("INSERT INTO t(value) VALUES ('alpha'), ('beta')")
+        .expect("insert rows");
+    for completion in conn.cacheflush().expect("flush db") {
+        io.wait_for_completion(completion).expect("wait for flush");
+    }
+
+    file
+}
+
+#[test]
+fn hashes_encrypted_database_with_cipher_and_hexkey() {
+    let plain_db = create_test_db(None);
+    let encrypted_db = create_test_db(Some(encryption_opts()));
+    let options = DbHashOptions {
+        encryption: Some(encryption_opts()),
+        ..Default::default()
+    };
+
+    let plain_result =
+        hash_database(plain_db.path().to_str().unwrap(), &Default::default()).expect("hash plain");
+    let encrypted_result = hash_database(encrypted_db.path().to_str().unwrap(), &options)
+        .expect("hash encrypted database");
+
+    assert_eq!(encrypted_result.hash, plain_result.hash);
+    assert_eq!(encrypted_result.tables_hashed, 1);
+    assert_eq!(encrypted_result.rows_hashed, 2);
+}


### PR DESCRIPTION
## Summary

Fixes #7229.

`turso-dbhash` is used to validate logical database contents, but it previously always opened files without encryption metadata or a connection key. That meant encrypted databases could not be hashed through the tool even when the caller had the cipher and key.

This PR adds encrypted database support to dbhash:

- add `--cipher` and `--hexkey` CLI options
- carry optional `EncryptionOpts` through `DbHashOptions`
- open encrypted databases with encryption enabled and connect with the parsed key
- add regression coverage proving an encrypted database hashes to the same logical content hash as a matching plaintext database
- document the new CLI flags in `tools/dbhash/README.md`

## Verification

- `cargo test -p turso-dbhash`
- `cargo fmt --check`
- `cargo clippy -p turso-dbhash --all-targets -- --deny=warnings`
- `cargo check -p core_tester --test integration_tests`
- `cargo run -q -p turso-dbhash -- --help | rg -- "--cipher|--hexkey|USAGE|Usage"`
- `cargo run -q -p turso-dbhash -- --cipher aegis256 2>&1 | sed -n "1,40p"`