### PR TITLE
optimizer: fix two FULL OUTER JOIN planner bugs

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1041,12 +1041,17 @@ pub fn try_hash_join_access_method(
     {
         return None;
     }
-    // Avoid hash join on self-joins over the same underlying table. The current
-    // implementation assumes distinct build/probe sources; sharing storage can
-    // lead to incorrect matches.
+    // Avoid hash join on self-joins over the same underlying table for INNER /
+    // LEFT joins: a nested-loop with index seek is usually preferred and avoids
+    // double-buffering the table in the hash table. FULL OUTER has no
+    // nested-loop form yet, so it must use hash join even for self-joins.
     let probe_root_page = probe_table.table.btree().expect("table is BTree").root_page;
     let build_root_page = build_table.table.btree().expect("table is BTree").root_page;
-    if build_root_page == probe_root_page {
+    let is_full_outer = probe_table
+        .join_info
+        .as_ref()
+        .is_some_and(|ji| ji.is_full_outer());
+    if build_root_page == probe_root_page && !is_full_outer {
         return None;
     }
     // Explicit INDEXED BY / NOT INDEXED directives must be honored. A hash join

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1099,7 +1099,10 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     .is_some_and(|j| j.is_ordering_constrained())
             })
             .count();
-        if ordering_constrained_count == 0 {
+        let has_full_outer = joined_tables
+            .iter()
+            .any(|t| t.join_info.as_ref().is_some_and(|j| j.is_full_outer()));
+        if ordering_constrained_count == 0 && !has_full_outer {
             None
         } else {
             // map from rhs table index to lhs table index
@@ -1122,6 +1125,25 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                             mask.set(j)?;
                             left_join_illegal_map.insert(i, mask);
                         }
+                    }
+                }
+            }
+            // FULL OUTER acts as a reordering barrier in both directions: tables
+            // originally after a FULL OUTER table cannot be moved before it, or
+            // the planner produces e.g. `(t1 INNER t3) FULL OUTER t2` instead of
+            // the requested `(t1 FULL OUTER t2) INNER t3`, which can leak
+            // NULL-filled probe rows past the inner join.
+            for (k, t) in joined_tables.iter().enumerate() {
+                if !t.join_info.as_ref().is_some_and(|j| j.is_full_outer()) {
+                    continue;
+                }
+                for j in (k + 1)..joined_tables.len() {
+                    if let Some(illegal_lhs) = left_join_illegal_map.get_mut(&k) {
+                        illegal_lhs.set(j)?;
+                    } else {
+                        let mut mask = TableMask::default();
+                        mask.set(j)?;
+                        left_join_illegal_map.insert(k, mask);
                     }
                 }
             }

--- a/testing/sqltests/tests/join/outer_hash_join.sqltest
+++ b/testing/sqltests/tests/join/outer_hash_join.sqltest
@@ -955,15 +955,33 @@ expect {
     |4
 }
 
-# Self-join with FULL OUTER is unsupported (same root page).
-@skip-if sqlite "supported in sqlite"
+# Self-join with FULL OUTER goes through the hash join path (no nested-loop
+# form for FULL OUTER yet). The build and probe cursors share a root page but
+# operate via independent CursorKeys, and the hash table holds copied data.
 @cross-check-integrity
-test full-outer-self-join-errors {
+test full-outer-self-join-equi {
     CREATE TABLE t1(a, b);
-    SELECT a.a, b.a FROM t1 a FULL OUTER JOIN t1 b ON a.a = b.a;
+    INSERT INTO t1 VALUES (1, 'x'), (2, 'y'), (3, 'z');
+    SELECT a.a, b.a FROM t1 a FULL OUTER JOIN t1 b ON a.a = b.a ORDER BY 1, 2;
 }
-expect error {
-    FULL OUTER JOIN requires an equality condition in the ON clause
+expect {
+    1|1
+    2|2
+    3|3
+}
+
+@cross-check-integrity
+test full-outer-self-join-non-equi {
+    CREATE TABLE t1(a);
+    INSERT INTO t1 VALUES (1), (2), (3);
+    SELECT ifnull(a.a, -1), ifnull(b.a, -1) FROM t1 a FULL OUTER JOIN t1 b ON a.a < b.a ORDER BY 1, 2;
+}
+expect {
+    -1|1
+    1|2
+    1|3
+    2|3
+    3|-1
 }
 
 # FULL OUTER with GROUP BY and HAVING.

--- a/testing/sqltests/tests/join/outer_hash_join.sqltest
+++ b/testing/sqltests/tests/join/outer_hash_join.sqltest
@@ -984,6 +984,110 @@ expect {
     3|-1
 }
 
+# Regression: FULL OUTER followed by an INNER JOIN must apply the FULL OUTER
+# first. The planner used to reorder into `(t1 INNER t3) FULL OUTER t2`, which
+# leaked NULL-filled probe rows through the inner join because `t3.c = NULL`
+# fails. Verified the bug by inverting the FULL OUTER barrier in the join-
+# order planner.
+@cross-check-integrity
+test full-outer-then-inner-equi {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(b);
+    CREATE TABLE t3(c);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (2), (3);
+    INSERT INTO t3 VALUES (1), (2);
+    SELECT ifnull(t1.a, -1), ifnull(t2.b, -1), ifnull(t3.c, -1)
+      FROM t1 FULL OUTER JOIN t2 ON t1.a = t2.b
+           JOIN t3 ON t3.c = t1.a
+      ORDER BY 1, 2, 3;
+}
+expect {
+    1|-1|1
+    2|2|2
+}
+
+@cross-check-integrity
+test full-outer-then-inner-non-equi {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(b);
+    CREATE TABLE t3(c);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (1), (3);
+    INSERT INTO t3 VALUES (1), (2);
+    SELECT ifnull(t1.a, -1), ifnull(t2.b, -1), ifnull(t3.c, -1)
+      FROM t1 FULL OUTER JOIN t2 ON t1.a < t2.b
+           JOIN t3 ON t3.c = t1.a
+      ORDER BY 1, 2, 3;
+}
+expect {
+    1|3|1
+    2|3|2
+}
+
+# INNER joins BEFORE a FULL OUTER may still be reordered (the barrier is only
+# in the "anything after a FULL OUTER" direction).
+@cross-check-integrity
+test inner-then-full-outer-reorderable {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(b);
+    CREATE TABLE t3(c);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (1), (2);
+    INSERT INTO t3 VALUES (2), (3);
+    SELECT ifnull(t1.a, -1), ifnull(t2.b, -1), ifnull(t3.c, -1)
+      FROM t1 JOIN t2 ON t1.a = t2.b
+           FULL OUTER JOIN t3 ON t3.c = t1.a
+      ORDER BY 1, 2, 3;
+}
+expect {
+    -1|-1|3
+    1|1|-1
+    2|2|2
+}
+
+# FULL OUTER followed by LEFT JOIN — LEFT JOIN must remain after FULL OUTER.
+@cross-check-integrity
+test full-outer-then-left {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(b);
+    CREATE TABLE t3(c);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (2), (3);
+    INSERT INTO t3 VALUES (1), (3);
+    SELECT ifnull(t1.a, -1), ifnull(t2.b, -1), ifnull(t3.c, -1)
+      FROM t1 FULL OUTER JOIN t2 ON t1.a = t2.b
+           LEFT JOIN t3 ON t3.c = t1.a
+      ORDER BY 1, 2, 3;
+}
+expect {
+    -1|3|-1
+    1|-1|1
+    2|2|-1
+}
+
+# Two INNER joins after a FULL OUTER — both must stay after the FULL OUTER.
+@cross-check-integrity
+test full-outer-then-two-inner {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(b);
+    CREATE TABLE t3(c);
+    CREATE TABLE t4(d);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (2), (3);
+    INSERT INTO t3 VALUES (1), (2);
+    INSERT INTO t4 VALUES (1), (2);
+    SELECT ifnull(t1.a, -1), ifnull(t2.b, -1), ifnull(t3.c, -1), ifnull(t4.d, -1)
+      FROM t1 FULL OUTER JOIN t2 ON t1.a = t2.b
+           JOIN t3 ON t3.c = t1.a
+           JOIN t4 ON t4.d = t3.c
+      ORDER BY 1, 2, 3, 4;
+}
+expect {
+    1|-1|1|1
+    2|2|2|2
+}
+
 # FULL OUTER with GROUP BY and HAVING.
 @cross-check-integrity
 test full-outer-join-group-by-having {


### PR DESCRIPTION
### Bug 1: self-join FULL OUTER rejected
```sql
CREATE TABLE a(x); INSERT INTO a VALUES(1),(2),(3);
SELECT t1.x, t2.x FROM a t1 FULL OUTER JOIN a t2 ON t1.x = t2.x;
-- Parse error: FULL OUTER JOIN requires an equality condition in the ON clause
```

#### Cause
`try_hash_join_access_method` rejects any join whose build and probe tables share a root page. FULL OUTER has no nested-loop fallback, so self-joins fall through to the catch-all "requires an equality condition" error even for equi-joins.

#### Fix
Loosen the restriction for FULL OUTER only: build and probe use independent `CursorKey`s, and the hash table holds copied data, so sharing a root page is safe. INNER/LEFT self-joins continue to prefer nested-loop with index seek (no plan-selection regression).

### Bug 2: `FULL OUTER` chained with `INNER` leaks NULL-filled rows
```sql
SELECT t1.a, t2.b, t3.c
  FROM t1 FULL OUTER JOIN t2 ON t1.a = t2.b
       JOIN t3 ON t3.c = t1.a;
-- emits an extra (NULL, t2.b, NULL) row that SQLite drops
```

#### Cause
The join-order planner only forbids reordering an ordering-constrained RHS (LEFT/FULL/SEMI/ANTI) ahead of its LHS. It does not forbid an *unconstrained* INNER (t3) from being reordered *before* a FULL OUTER (t2) that originally preceded it. The planner ends up emitting `(t1 INNER t3) FULL OUTER t2` instead of `(t1 FULL OUTER t2) INNER t3`. Those are not semantically equivalent: in the requested form, the NULL-filled probe rows from the FULL OUTER fail `t3.c = NULL` and are
dropped; in the reordered form they survive as `(NULL, t2.b, NULL)`.

#### Fix
Treat FULL OUTER as a reordering barrier in both directions: for each FULL OUTER table at position k, every table at position j > k is added to `illegal_lhs[k]`. INNER joins *before* a FULL OUTER remain freely reorderable.