### PR TITLE
refactor `Extendable` trait to use Result for fallible allocations

### DIFF
--- a/.claude/skills/allocator-migration/SKILL.md
+++ b/.claude/skills/allocator-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: allocator-migration
-description: Use when migrating Turso core code to crate::alloc, allocator-api2, cfg(nightly) allocator aliases, fallible collection APIs, try_vec!, try_collect, or LimboError::OutOfMemory handling. Covers import style, allocator-aware aliases, stable/nightly boundaries, shuttle Arc compatibility, and how to keep allocator foundation commits separate from module migrations.
+description: Use when migrating Turso core code to crate::alloc, allocator-api2, cfg(nightly) allocator aliases, fallible collection APIs, try_vec!, try_collect, or LimboError::OutOfMemory handling. Covers import style, allocator-aware aliases, stable/nightly boundaries, shuttle Arc compatibility, and how to keep allocator foundation commits separate from module migrations. Read this when changing code that does allocations.
 ---
 
 # Turso Allocator Migration

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,8 @@ inherits = "release-official"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(shuttle)', 'cfg(antithesis)', 'cfg(nightly)'] }
+# For now allow this for the allocator api migration
+unstable_name_collisions = "allow"
 
 [workspace.lints.clippy]
 or_fun_call = "deny"

--- a/bindings/java/rs_src/turso_statement.rs
+++ b/bindings/java/rs_src/turso_statement.rs
@@ -158,9 +158,16 @@ pub extern "system" fn Java_tech_turso_core_TursoStatement_bindNull<'local>(
         }
     };
 
-    stmt.stmt
-        .bind_at(NonZero::new(position as usize).unwrap(), Value::Null);
-    SQLITE_OK
+    match stmt
+        .stmt
+        .bind_at(NonZero::new(position as usize).unwrap(), Value::Null)
+    {
+        Ok(()) => SQLITE_OK,
+        Err(e) => {
+            set_err_msg_and_throw_exception(&mut env, obj, SQLITE_ERROR, e.to_string());
+            SQLITE_ERROR
+        }
+    }
 }
 
 #[no_mangle]
@@ -179,11 +186,16 @@ pub extern "system" fn Java_tech_turso_core_TursoStatement_bindLong<'local>(
         }
     };
 
-    stmt.stmt.bind_at(
+    match stmt.stmt.bind_at(
         NonZero::new(position as usize).unwrap(),
         Value::from_i64(value),
-    );
-    SQLITE_OK
+    ) {
+        Ok(()) => SQLITE_OK,
+        Err(e) => {
+            set_err_msg_and_throw_exception(&mut env, obj, SQLITE_ERROR, e.to_string());
+            SQLITE_ERROR
+        }
+    }
 }
 
 #[no_mangle]
@@ -202,11 +214,16 @@ pub extern "system" fn Java_tech_turso_core_TursoStatement_bindDouble<'local>(
         }
     };
 
-    stmt.stmt.bind_at(
+    match stmt.stmt.bind_at(
         NonZero::new(position as usize).unwrap(),
         Value::from_f64(value),
-    );
-    SQLITE_OK
+    ) {
+        Ok(()) => SQLITE_OK,
+        Err(e) => {
+            set_err_msg_and_throw_exception(&mut env, obj, SQLITE_ERROR, e.to_string());
+            SQLITE_ERROR
+        }
+    }
 }
 
 #[no_mangle]
@@ -230,11 +247,16 @@ pub extern "system" fn Java_tech_turso_core_TursoStatement_bindText<'local>(
         Err(_) => return SQLITE_ERROR,
     };
 
-    stmt.stmt.bind_at(
+    match stmt.stmt.bind_at(
         NonZero::new(position as usize).unwrap(),
         Value::build_text(text),
-    );
-    SQLITE_OK
+    ) {
+        Ok(()) => SQLITE_OK,
+        Err(e) => {
+            set_err_msg_and_throw_exception(&mut env, obj, SQLITE_ERROR, e.to_string());
+            SQLITE_ERROR
+        }
+    }
 }
 
 #[no_mangle]
@@ -258,9 +280,16 @@ pub extern "system" fn Java_tech_turso_core_TursoStatement_bindBlob<'local>(
         Err(_) => return SQLITE_ERROR,
     };
 
-    stmt.stmt
-        .bind_at(NonZero::new(position as usize).unwrap(), Value::Blob(blob));
-    SQLITE_OK
+    match stmt
+        .stmt
+        .bind_at(NonZero::new(position as usize).unwrap(), Value::Blob(blob))
+    {
+        Ok(()) => SQLITE_OK,
+        Err(e) => {
+            set_err_msg_and_throw_exception(&mut env, obj, SQLITE_ERROR, e.to_string());
+            SQLITE_ERROR
+        }
+    }
 }
 
 #[no_mangle]

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -793,7 +793,8 @@ impl Statement {
             .borrow_mut()
             .as_mut()
             .ok_or_else(|| create_generic_error("statement has been finalized"))?
-            .bind_at(non_zero_idx, turso_value);
+            .bind_at(non_zero_idx, turso_value)
+            .map_err(|err| create_generic_error(&err.to_string()))?;
         Ok(())
     }
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -563,7 +563,9 @@ impl Limbo {
         let mut last_stmt_metrics = None;
         for mut output in runner {
             if let Ok(Some(ref mut stmt)) = output {
-                self.apply_parameter_bindings(stmt);
+                if let Err(err) = self.apply_parameter_bindings(stmt) {
+                    output = Err(err);
+                }
             }
             if self
                 .print_query_result(input, &mut output, stats.as_mut())
@@ -589,19 +591,20 @@ impl Limbo {
         }
     }
 
-    fn apply_parameter_bindings(&self, stmt: &mut Statement) {
+    fn apply_parameter_bindings(&self, stmt: &mut Statement) -> Result<(), LimboError> {
         for binding in &self.parameter_bindings {
             if let Some(index) = binding.index {
                 if stmt.parameters().has_slot(index) {
-                    stmt.bind_at(index, binding.value.clone());
+                    stmt.bind_at(index, binding.value.clone())?;
                 }
                 continue;
             }
 
             if let Some(index) = stmt.parameter_index(&binding.name) {
-                stmt.bind_at(index, binding.value.clone());
+                stmt.bind_at(index, binding.value.clone())?;
             }
         }
+        Ok(())
     }
 
     fn handle_parameter_command(&mut self, args: ParameterArgs) -> Result<(), String> {

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -231,7 +231,15 @@ impl TursoSyncServer {
 
         for (i, arg) in req.stmt.args.iter().enumerate() {
             let core_value = convert_value_to_core(arg);
-            stmt.bind_at(std::num::NonZero::new(i + 1).unwrap(), core_value);
+            if let Err(err) = stmt.bind_at(std::num::NonZero::new(i + 1).unwrap(), core_value) {
+                error!("Failed to bind statement argument: {}", err);
+                return StreamResult::Error {
+                    error: Error {
+                        message: err.to_string(),
+                        code: "BIND_ERROR".to_string(),
+                    },
+                };
+            }
         }
 
         let want_rows = req.stmt.want_rows.unwrap_or(true);
@@ -395,7 +403,7 @@ impl TursoSyncServer {
 
         for (i, arg) in step.stmt.args.iter().enumerate() {
             let core_value = convert_value_to_core(arg);
-            stmt.bind_at(std::num::NonZero::new(i + 1).unwrap(), core_value);
+            stmt.bind_at(std::num::NonZero::new(i + 1).unwrap(), core_value)?;
         }
 
         let want_rows = step.stmt.want_rows.unwrap_or(true);

--- a/core/alloc/collections/binary_heap.rs
+++ b/core/alloc/collections/binary_heap.rs
@@ -37,7 +37,7 @@ impl<T: Ord> TursoBinaryHeapExt<T> for BinaryHeap<T> {
 
 impl<T: Ord> TursoTryWithCapacityExt for BinaryHeap<T> {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         #[cfg(not(nightly))]
         {
             Ok(BinaryHeap::with_capacity(capacity))
@@ -88,7 +88,7 @@ impl<T: Clone + Ord> TryClone for BinaryHeap<T> {
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
-        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;
+        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
         #[cfg(nightly)]
         let mut cloned = {
             let alloc = self.allocator().clone();

--- a/core/alloc/collections/boxed.rs
+++ b/core/alloc/collections/boxed.rs
@@ -1,10 +1,24 @@
 use super::{TryClone, TursoBoxExt, TursoNewExt, TursoTryNewExt};
-use crate::alloc::{AllocError, Box, TursoAllocator};
+#[cfg(nightly)]
+use crate::alloc::TursoAllocator;
+use crate::alloc::{AllocError, Box};
 
+#[cfg(not(nightly))]
+fn boxed<T>(value: T) -> Box<T> {
+    Box::new(value)
+}
+
+#[cfg(nightly)]
 fn boxed<T>(value: T) -> Box<T> {
     Box::new_in(value, TursoAllocator)
 }
 
+#[cfg(not(nightly))]
+fn try_boxed<T>(value: T) -> Result<Box<T>, AllocError> {
+    Ok(Box::new(value))
+}
+
+#[cfg(nightly)]
 fn try_boxed<T>(value: T) -> Result<Box<T>, AllocError> {
     Box::try_new_in(value, TursoAllocator)
 }
@@ -25,7 +39,7 @@ impl<T> TursoBoxExt<T> for Box<T> {
     fn into_inner(self) -> T {
         #[cfg(not(nightly))]
         {
-            Box::into_inner(self)
+            *self
         }
         #[cfg(nightly)]
         {

--- a/core/alloc/collections/hash_map.rs
+++ b/core/alloc/collections/hash_map.rs
@@ -21,7 +21,7 @@ where
     K: Eq + Hash,
 {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(HashMap::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }

--- a/core/alloc/collections/hash_set.rs
+++ b/core/alloc/collections/hash_set.rs
@@ -21,7 +21,7 @@ where
     T: Eq + Hash,
 {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(HashSet::with_capacity_and_hasher(capacity, FxBuildHasher))
     }
 }

--- a/core/alloc/collections/traits.rs
+++ b/core/alloc/collections/traits.rs
@@ -5,7 +5,7 @@ pub trait TursoAllocExt {
 }
 
 pub trait TursoTryWithCapacityExt: Sized {
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError>;
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError>;
 }
 
 pub trait TursoNewExt<T> {

--- a/core/alloc/collections/vec.rs
+++ b/core/alloc/collections/vec.rs
@@ -45,7 +45,7 @@ impl<T> TursoVecExt<T> for Vec<T> {
 
 impl<T> TursoTryWithCapacityExt for Vec<T> {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(vec_with_capacity(capacity))
     }
 }
@@ -84,7 +84,7 @@ impl<T: Clone> TryClone for Vec<T> {
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
-        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;
+        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
         #[cfg(nightly)]
         let mut cloned = {
             let alloc = self.allocator().clone();

--- a/core/alloc/collections/vec_deque.rs
+++ b/core/alloc/collections/vec_deque.rs
@@ -55,7 +55,7 @@ impl<T> TursoVecDequeExt<T> for VecDeque<T> {
 
 impl<T> TursoTryWithCapacityExt for VecDeque<T> {
     #[inline(always)]
-    fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError> {
+    fn try_with_capacity_ext(capacity: usize) -> Result<Self, TryReserveError> {
         Ok(vec_deque_with_capacity(capacity))
     }
 }
@@ -94,7 +94,7 @@ impl<T: Clone> TryClone for VecDeque<T> {
     #[inline(always)]
     fn try_clone(&self) -> Result<Self, Self::Error> {
         #[cfg(not(nightly))]
-        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity(self.len())?;
+        let mut cloned = <Self as TursoTryWithCapacityExt>::try_with_capacity_ext(self.len())?;
         #[cfg(nightly)]
         let mut cloned = {
             let alloc = self.allocator().clone();

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -47,8 +47,9 @@ pub struct TursoAllocator;
 
 pub type Allocator = TursoAllocator;
 
+// TODO: change this to use allocator_api2 Box when we finish migrating callsites
 #[cfg(not(nightly))]
-pub type Box<T> = allocator_api2::boxed::Box<T, TursoAllocator>;
+pub type Box<T> = std::boxed::Box<T>;
 #[cfg(nightly)]
 pub type Box<T> = std::boxed::Box<T, TursoAllocator>;
 

--- a/core/alloc/mod.rs
+++ b/core/alloc/mod.rs
@@ -105,7 +105,7 @@ macro_rules! __turso_alloc_try_vec {
         (|| {
             let count = $count;
             let mut values =
-                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity(
+                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
                     count,
                 )?;
             values.resize(count, $element);
@@ -115,7 +115,7 @@ macro_rules! __turso_alloc_try_vec {
     ($($element:expr),+ $(,)?) => {{
         (|| {
             let mut values =
-                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity(
+                <$crate::alloc::Vec<_> as $crate::alloc::TursoTryWithCapacityExt>::try_with_capacity_ext(
                     $crate::__turso_alloc_vec_count!($($element),+),
                 )?;
             $(values.try_push($element)?;)+

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -275,7 +275,7 @@ fn try_clone_builds_independent_alloc_collections() {
     assert_eq!(cloned.as_slice(), values.as_slice());
     assert_ne!(cloned.as_ptr(), values.as_ptr());
 
-    let boxed = Box::try_new(String::from("turso")).unwrap();
+    let boxed: Box<_> = TursoTryNewExt::try_new(String::from("turso")).unwrap();
     let cloned = boxed.try_clone().unwrap();
     assert_eq!(&*cloned, &*boxed);
 

--- a/core/alloc/tests.rs
+++ b/core/alloc/tests.rs
@@ -255,11 +255,11 @@ fn iterator_try_unzip_builds_turso_collections() {
 
 #[test]
 fn try_with_capacity_builds_turso_collections() {
-    let values: Vec<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let map: HashMap<usize, usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let set: HashSet<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let queue: VecDeque<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
-    let heap: BinaryHeap<usize> = TursoTryWithCapacityExt::try_with_capacity(3).unwrap();
+    let values: Vec<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let map: HashMap<usize, usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let set: HashSet<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let queue: VecDeque<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
+    let heap: BinaryHeap<usize> = TursoTryWithCapacityExt::try_with_capacity_ext(3).unwrap();
 
     assert!(values.capacity() >= 3);
     assert!(map.capacity() >= 3);

--- a/core/benches/alloc_collections.rs
+++ b/core/benches/alloc_collections.rs
@@ -72,7 +72,7 @@ where
 fn vec_push_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| {
-            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len).unwrap()
         })
         .bench_local_values(|mut values| {
             for value in 0..len {
@@ -117,7 +117,7 @@ fn vec_collect_std(bencher: Bencher, len: usize) {
 fn vec_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len).unwrap();
         TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
         black_box(values)
     });
@@ -136,7 +136,8 @@ fn vec_extend_std(bencher: Bencher, len: usize) {
 fn vec_deque_push_back_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         for value in 0..len {
             values.try_push_back(black_box(value)).unwrap();
         }
@@ -180,7 +181,8 @@ fn vec_deque_collect_std(bencher: Bencher, len: usize) {
 fn vec_deque_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
         black_box(values)
     });
@@ -199,7 +201,8 @@ fn vec_deque_extend_std(bencher: Bencher, len: usize) {
 fn binary_heap_push_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         for value in 0..len {
             values.try_push(black_box(value)).unwrap();
         }
@@ -243,7 +246,8 @@ fn binary_heap_collect_std(bencher: Bencher, len: usize) {
 fn binary_heap_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, (0..len).map(black_box)).unwrap();
         black_box(values)
     });
@@ -262,7 +266,7 @@ fn binary_heap_extend_std(bencher: Bencher, len: usize) {
 fn hash_set_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -309,7 +313,7 @@ fn hash_set_collect_std(bencher: Bencher, len: usize) {
 fn hash_set_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -331,7 +335,7 @@ fn hash_set_extend_std(bencher: Bencher, len: usize) {
 fn hash_map_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -367,7 +371,7 @@ fn hash_map_collect_std(bencher: Bencher, len: usize) {
 fn hash_map_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -431,7 +435,7 @@ fn vec_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn vec_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::Vec<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len).unwrap();
         TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
             .unwrap();
         black_box(values)
@@ -470,7 +474,8 @@ fn vec_deque_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn vec_deque_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::VecDeque<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
             .unwrap();
         black_box(values)
@@ -509,7 +514,8 @@ fn binary_heap_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn binary_heap_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::BinaryHeap<usize> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(&mut values, LowerBoundOnly::new((0..len).map(black_box)))
             .unwrap();
         black_box(values)
@@ -548,7 +554,7 @@ fn hash_set_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn hash_set_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -594,7 +600,7 @@ fn hash_map_extend_unknown_upper_std(bencher: Bencher, len: usize) {
 fn hash_map_extend_unknown_upper_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<usize, usize, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -623,7 +629,8 @@ fn vec_non_copy_push_std(bencher: Bencher, len: usize) {
 fn vec_non_copy_push_turso(bencher: Bencher, len: usize) {
     bencher
         .with_inputs(|| {
-            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap()
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap()
         })
         .bench_local_values(|mut values| {
             for value in 0..len {
@@ -669,7 +676,8 @@ fn vec_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn vec_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len).unwrap();
+            <alloc::Vec<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
+                .unwrap();
         TursoFromIterator::try_extend(
             &mut values,
             (0..len).map(|value| black_box(NonCopyValue::new(value))),
@@ -694,7 +702,7 @@ fn vec_deque_non_copy_push_back_std(bencher: Bencher, len: usize) {
 fn vec_deque_non_copy_push_back_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
                 .unwrap();
         for value in 0..len {
             values
@@ -739,7 +747,7 @@ fn vec_deque_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn vec_deque_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
+            <alloc::VecDeque<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(len)
                 .unwrap();
         TursoFromIterator::try_extend(
             &mut values,
@@ -765,8 +773,10 @@ fn binary_heap_non_copy_push_std(bencher: Bencher, len: usize) {
 fn binary_heap_non_copy_push_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
-                .unwrap();
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(
+                len,
+            )
+            .unwrap();
         for value in 0..len {
             values
                 .try_push(black_box(NonCopyValue::new(value)))
@@ -810,8 +820,10 @@ fn binary_heap_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn binary_heap_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity(len)
-                .unwrap();
+            <alloc::BinaryHeap<NonCopyValue> as TursoTryWithCapacityExt>::try_with_capacity_ext(
+                len,
+            )
+            .unwrap();
         TursoFromIterator::try_extend(
             &mut values,
             (0..len).map(|value| black_box(NonCopyValue::new(value))),
@@ -836,7 +848,7 @@ fn hash_set_non_copy_insert_std(bencher: Bencher, len: usize) {
 fn hash_set_non_copy_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -881,7 +893,7 @@ fn hash_set_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn hash_set_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashSet<NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -912,7 +924,7 @@ fn hash_map_non_copy_insert_std(bencher: Bencher, len: usize) {
 fn hash_map_non_copy_insert_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();
@@ -977,7 +989,7 @@ fn hash_map_non_copy_extend_std(bencher: Bencher, len: usize) {
 fn hash_map_non_copy_extend_turso(bencher: Bencher, len: usize) {
     bencher.bench_local(|| {
         let mut values =
-            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity(
+            <alloc::HashMap<NonCopyValue, NonCopyValue, FxBuildHasher> as TursoTryWithCapacityExt>::try_with_capacity_ext(
                 len,
             )
             .unwrap();

--- a/core/benches/hash_spill_benchmark.rs
+++ b/core/benches/hash_spill_benchmark.rs
@@ -30,7 +30,7 @@ fn create_hash_table(mem_budget: usize) -> HashTable {
         track_matched: false,
         partition_count: None,
     };
-    HashTable::new(config, io)
+    HashTable::new(config, io).unwrap()
 }
 
 /// Insert entries with integer keys and no payload
@@ -159,17 +159,21 @@ fn bench_build_and_probe(c: &mut Criterion) {
                     for i in 0..count {
                         let key = vec![Value::Numeric(Numeric::Integer(i as i64))];
                         if ht.has_spilled() {
-                            let partition_idx = ht.partition_for_keys(&key);
+                            let partition_idx = ht.partition_for_keys(&key).unwrap();
                             if !ht.is_partition_loaded(partition_idx) {
                                 while let Ok(IOResult::IO(_)) =
                                     ht.load_spilled_partition(partition_idx, None)
                                 {
                                 }
                             }
-                            if ht.probe_partition(partition_idx, &key, None).is_some() {
+                            if ht
+                                .probe_partition(partition_idx, &key, None)
+                                .unwrap()
+                                .is_some()
+                            {
                                 found += 1;
                             }
-                        } else if ht.probe(key, None).is_some() {
+                        } else if ht.probe(key, None).unwrap().is_some() {
                             found += 1;
                         }
                     }
@@ -193,17 +197,21 @@ fn bench_build_and_probe(c: &mut Criterion) {
                     for i in 0..count {
                         let key = vec![Value::from_i64(i as i64)];
                         if ht.has_spilled() {
-                            let partition_idx = ht.partition_for_keys(&key);
+                            let partition_idx = ht.partition_for_keys(&key).unwrap();
                             if !ht.is_partition_loaded(partition_idx) {
                                 while let Ok(IOResult::IO(_)) =
                                     ht.load_spilled_partition(partition_idx, None)
                                 {
                                 }
                             }
-                            if ht.probe_partition(partition_idx, &key, None).is_some() {
+                            if ht
+                                .probe_partition(partition_idx, &key, None)
+                                .unwrap()
+                                .is_some()
+                            {
                                 found += 1;
                             }
-                        } else if ht.probe(key, None).is_some() {
+                        } else if ht.probe(key, None).unwrap().is_some() {
                             found += 1;
                         }
                     }
@@ -239,7 +247,7 @@ fn bench_text_key_hashing(c: &mut Criterion) {
                         track_matched: false,
                         partition_count: None,
                     };
-                    let mut ht = HashTable::new(config, io);
+                    let mut ht = HashTable::new(config, io).unwrap();
                     insert_text_key_entries(&mut ht, count);
                     let _ = ht.finalize_build(None);
                     black_box(ht.has_spilled())
@@ -263,7 +271,7 @@ fn bench_text_key_hashing(c: &mut Criterion) {
                         track_matched: false,
                         partition_count: None,
                     };
-                    let mut ht = HashTable::new(config, io);
+                    let mut ht = HashTable::new(config, io).unwrap();
                     insert_text_key_entries(&mut ht, count);
                     let _ = ht.finalize_build(None);
                     black_box(ht.has_spilled())

--- a/core/ext/vtab_xconnect.rs
+++ b/core/ext/vtab_xconnect.rs
@@ -41,10 +41,13 @@ pub unsafe extern "C" fn execute(
                 if arg_count > 0 {
                     let args_slice = &mut std::slice::from_raw_parts_mut(args, arg_count as usize);
                     for (i, val) in args_slice.iter_mut().enumerate() {
-                        stmt.bind_at(
+                        if let Err(err) = stmt.bind_at(
                             NonZeroUsize::new(i + 1).unwrap(),
                             Value::from_ffi(std::mem::take(val)).unwrap_or(Value::Null),
-                        );
+                        ) {
+                            tracing::error!("execute: failed to bind argument: {:?}", err);
+                            return ResultCode::Error;
+                        }
                     }
                 }
                 let result = stmt.run_with_row_callback(|_| {
@@ -139,7 +142,10 @@ pub unsafe extern "C" fn stmt_bind_args_fn(ctx: *mut Stmt, idx: i32, arg: ExtVal
         tracing::error!("stmt_bind_args_fn: invalid index");
         return ResultCode::Error;
     };
-    stmt_ctx.bind_at(idx, owned_val);
+    if let Err(err) = stmt_ctx.bind_at(idx, owned_val) {
+        tracing::error!("stmt_bind_args_fn: failed to bind arg: {:?}", err);
+        return ResultCode::Error;
+    }
     ResultCode::OK
 }
 

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -822,8 +822,9 @@ impl Statement {
         self.program.parameters.index(name)
     }
 
-    pub fn bind_at(&mut self, index: NonZero<usize>, value: Value) {
-        self.state.bind_at(index, value);
+    pub fn bind_at(&mut self, index: NonZero<usize>, value: Value) -> Result<()> {
+        self.state.bind_at(index, value)?;
+        Ok(())
     }
 
     pub fn clear_bindings(&mut self) {

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -1,5 +1,6 @@
-use crate::sync::Arc;
+use crate::{alloc::TursoVecExt, sync::Arc};
 
+use crate::alloc::*;
 use turso_parser::ast::{self, SortOrder};
 
 use crate::{
@@ -197,13 +198,15 @@ impl EmitOrderBy {
         let has_sequence = (has_group_by && !only_aggs) || use_heap_sort;
 
         let remappings =
-            order_by_deduplicate_result_columns(order_by, result_columns, has_sequence);
+            order_by_deduplicate_result_columns(order_by, result_columns, has_sequence)?;
         let sort_cursor = if use_heap_sort {
             let index_name = format!("heap_sort_{}", program.offset().as_offset_int()); // we don't really care about the name that much, just enough that we don't get name collisions
-            let mut index_columns = Vec::with_capacity(order_by.len() + result_columns.len());
+            let mut index_columns =
+                Vec::try_with_capacity_ext(order_by.len() + result_columns.len())?;
             for (column, order, _nulls) in order_by {
                 let collation = get_collseq_from_expr(column, referenced_tables)?;
                 let pos_in_table = index_columns.len();
+                // Have enough space pre-allocatoed to push without realloc
                 index_columns.push(IndexColumn {
                     name: pos_in_table.to_string(),
                     order: *order,
@@ -211,28 +214,28 @@ impl EmitOrderBy {
                     collation,
                     default: None,
                     expr: None,
-                })
+                });
             }
             let pos_in_table = index_columns.len();
             // add sequence number between ORDER BY columns and result column
-            index_columns.push(IndexColumn {
+            index_columns.try_push(IndexColumn {
                 name: pos_in_table.to_string(),
                 order: SortOrder::Asc,
                 pos_in_table,
                 collation: None,
                 default: None,
                 expr: None,
-            });
+            })?;
             for _ in remappings.iter().filter(|r| !r.deduplicated) {
                 let pos_in_table = index_columns.len();
-                index_columns.push(IndexColumn {
+                index_columns.try_push(IndexColumn {
                     name: pos_in_table.to_string(),
                     order: SortOrder::Asc,
                     pos_in_table,
                     collation: None,
                     default: None,
                     expr: None,
-                })
+                })?;
             }
             let index = Arc::new(Index {
                 name: index_name,
@@ -279,9 +282,9 @@ impl EmitOrderBy {
                 .iter()
                 .map(|(expr, dir, nulls)| {
                     let collation = get_collseq_from_expr(expr, referenced_tables)?;
-                    Ok((*dir, collation, *nulls))
+                    Ok::<_, crate::LimboError>((*dir, collation, *nulls))
                 })
-                .collect::<Result<Vec<_>>>()?;
+                .try_collect::<Result<Vec<_>>>()??;
 
             // Resolve custom type comparators for ORDER BY columns.
             // For types with a `<` operator, the comparator is used for correct sort ordering.
@@ -290,12 +293,12 @@ impl EmitOrderBy {
                 .map(|(expr, _, _)| {
                     custom_type_comparator(expr, referenced_tables, t_ctx.resolver.schema())
                 })
-                .collect();
+                .try_collect()?;
 
             if has_sequence {
                 // sequence column: ascending with BINARY collation, no comparator, no nulls order
                 order_collations_nulls.push((SortOrder::Asc, Some(CollationSeq::default()), None));
-                comparators.push(None);
+                comparators.try_push(None)?;
             }
 
             let key_len = order_collations_nulls.len();
@@ -727,8 +730,9 @@ pub fn order_by_deduplicate_result_columns(
     )],
     result_columns: &[ResultSetColumn],
     has_sequence: bool,
-) -> Vec<OrderByRemapping> {
-    let mut result_column_remapping: Vec<OrderByRemapping> = Vec::new();
+) -> Result<Vec<OrderByRemapping>> {
+    let mut result_column_remapping: Vec<OrderByRemapping> =
+        Vec::try_with_capacity_ext(result_columns.len())?;
     let order_by_len = order_by.len();
     // `sequence_offset` shifts the base index where non-deduped SELECT columns begin,
     // because Sequence sits after ORDER BY keys but before result columns.
@@ -740,6 +744,7 @@ pub fn order_by_deduplicate_result_columns(
             .iter()
             .enumerate()
             .find(|(_, (expr, _, _))| exprs_are_equivalent(expr, &rc.expr));
+        // No need to use `try_push` as we preallocated enough capacity already
         if let Some((j, _)) = found {
             result_column_remapping.push(OrderByRemapping {
                 orderby_sorter_idx: j,
@@ -757,5 +762,5 @@ pub fn order_by_deduplicate_result_columns(
         }
     }
 
-    result_column_remapping
+    Ok(result_column_remapping)
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -4,6 +4,8 @@ use either::Either;
 use turso_ext::{AggCtx, FinalizeFunction, StepFunction};
 use turso_parser::ast::SortOrder;
 
+use crate::alloc::vec;
+use crate::alloc::*;
 use crate::error::LimboError;
 use crate::ext::{ExtValue, ExtValueType};
 use crate::index_method::IndexMethodCursor;
@@ -132,12 +134,12 @@ impl<'a> Deref for TextRef<'a> {
 }
 
 pub trait Extendable<T> {
-    fn do_extend(&mut self, other: &T);
+    fn do_extend(&mut self, other: &T) -> Result<()>;
 }
 
 impl<T: AnyText> Extendable<T> for Text {
     #[inline(always)]
-    fn do_extend(&mut self, other: &T) {
+    fn do_extend(&mut self, other: &T) -> Result<()> {
         let other_str = other.as_ref();
         match &mut self.value {
             Cow::Owned(s) => {
@@ -162,12 +164,13 @@ impl<T: AnyText> Extendable<T> for Text {
             }
         }
         self.subtype = other.subtype();
+        Ok(())
     }
 }
 
 impl<T: AnyBlob> Extendable<T> for Vec<u8> {
     #[inline(always)]
-    fn do_extend(&mut self, other: &T) {
+    fn do_extend(&mut self, other: &T) -> Result<()> {
         let other_slice = other.as_slice();
         let needed = other_slice.len();
         if self.capacity() >= needed {
@@ -183,8 +186,11 @@ impl<T: AnyBlob> Extendable<T> for Vec<u8> {
             }
         } else {
             self.clear();
+            // Reserve mores space to extend the slice
+            self.try_reserve(self.len().abs_diff(needed))?;
             self.extend_from_slice(other_slice);
         }
+        Ok(())
     }
 }
 
@@ -3196,6 +3202,7 @@ impl WalFrameInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;
 
     #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6653,7 +6653,7 @@ pub fn op_rowset_add(
 
     let rowset = state.rowsets.entry(*rowset_reg).or_default();
 
-    rowset.insert(rowid);
+    rowset.insert(rowid)?;
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -6755,7 +6755,7 @@ pub fn op_rowset_test(
         state.pc = pc_if_found.as_offset_int();
     } else {
         if *batch != -1 {
-            rowset.insert(rowid);
+            rowset.insert(rowid)?;
         }
         state.pc += 1;
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2165,7 +2165,7 @@ pub fn op_array_decode(
             return Ok(InsnFunctionStepResult::Step);
         }
     };
-    state.registers[*reg].set_text(Text::new(text));
+    state.registers[*reg].set_text(Text::new(text))?;
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -4493,7 +4493,7 @@ pub fn op_program(
                     let value = state.registers[parent_reg].get_value().clone();
                     let param_index = NonZero::<usize>::new(param_idx + 1)
                         .expect("param_idx + 1 should be non-zero");
-                    statement.bind_at(param_index, value);
+                    statement.bind_at(param_index, value)?;
                 }
 
                 *state.active_op_state.program() = OpProgramState::Step {
@@ -4644,7 +4644,7 @@ pub fn op_string8(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(String8 { value, dest }, insn);
-    state.registers[*dest].set_text(Text::new(value.clone()));
+    state.registers[*dest].set_text(Text::new(value.clone()))?;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -4656,7 +4656,7 @@ pub fn op_blob(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Blob { value, dest }, insn);
-    state.registers[*dest].set_blob(value.clone());
+    state.registers[*dest].set_blob(value.clone())?;
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -6346,21 +6346,21 @@ pub fn op_agg_final(
                 }
                 #[cfg(feature = "json")]
                 AggFunc::JsonGroupArray => {
-                    state.registers[dest_reg].set_text(Text::json("[]".to_string()));
+                    state.registers[dest_reg].set_text(Text::json("[]".to_string()))?;
                 }
                 #[cfg(feature = "json")]
                 AggFunc::JsonbGroupArray => {
                     state.registers[dest_reg]
-                        .set_blob(json::jsonb::Jsonb::make_empty_array(1).data());
+                        .set_blob(json::jsonb::Jsonb::make_empty_array(1).data())?;
                 }
                 #[cfg(feature = "json")]
                 AggFunc::JsonGroupObject => {
-                    state.registers[dest_reg].set_text(Text::json("{}".to_string()));
+                    state.registers[dest_reg].set_text(Text::json("{}".to_string()))?;
                 }
                 #[cfg(feature = "json")]
                 AggFunc::JsonbGroupObject => {
                     state.registers[dest_reg]
-                        .set_blob(json::jsonb::Jsonb::make_empty_obj(1).data());
+                        .set_blob(json::jsonb::Jsonb::make_empty_obj(1).data())?;
                 }
                 _ => {}
             }
@@ -7400,18 +7400,18 @@ pub fn op_function(
             }
             ScalarFunc::TursoVersion => {
                 if !program.connection.is_db_initialized() {
-                    state.registers[*dest].set_text(Text::new(info::build::PKG_VERSION));
+                    state.registers[*dest].set_text(Text::new(info::build::PKG_VERSION))?;
                 } else {
                     let version_integer =
                         return_if_io!(pager.with_header(|header| header.version_number)).get()
                             as i64;
                     let version = execute_turso_version(version_integer);
-                    state.registers[*dest].set_text(Text::new(version));
+                    state.registers[*dest].set_text(Text::new(version))?;
                 }
             }
             ScalarFunc::SqliteVersion => {
                 let version = execute_sqlite_version();
-                state.registers[*dest].set_text(Text::new(version));
+                state.registers[*dest].set_text(Text::new(version))?;
             }
             ScalarFunc::SqliteSourceId => {
                 let src_id = format!(
@@ -7419,7 +7419,7 @@ pub fn op_function(
                     info::build::BUILT_TIME_SQLITE,
                     info::build::GIT_COMMIT_HASH.unwrap_or("unknown")
                 );
-                state.registers[*dest].set_text(Text::new(src_id));
+                state.registers[*dest].set_text(Text::new(src_id))?;
             }
             ScalarFunc::Replace => {
                 assert_eq!(arg_count, 3);
@@ -8827,12 +8827,12 @@ pub fn op_function(
             };
 
             state.registers[*dest].set_value(r#type.clone());
-            state.registers[*dest + 1].set_text(Text::from(new_name));
-            state.registers[*dest + 2].set_text(Text::from(new_tbl_name));
+            state.registers[*dest + 1].set_text(Text::from(new_name))?;
+            state.registers[*dest + 2].set_text(Text::from(new_tbl_name))?;
             state.registers[*dest + 3].set_int(*root_page);
 
             if let Some(new_sql) = new_sql {
-                state.registers[*dest + 4].set_text(Text::from(new_sql));
+                state.registers[*dest + 4].set_text(Text::from(new_sql))?;
             } else {
                 state.registers[*dest + 4].set_value(sql.clone());
             }
@@ -8931,7 +8931,7 @@ pub fn op_function(
                             &before_str,
                             &after_str,
                         );
-                        state.registers[*dest].set_text(Text::new(highlighted));
+                        state.registers[*dest].set_text(Text::new(highlighted))?;
                     }
                 }
             }
@@ -14515,7 +14515,7 @@ fn op_journal_mode_inner(
                 // If no new mode specified, just return current mode
                 let Some(mode_str) = new_mode else {
                     let ret: &'static str = prev_mode.into();
-                    state.registers[*dest].set_text(Text::new(ret));
+                    state.registers[*dest].set_text(Text::new(ret))?;
                     state.pc += 1;
                     return Ok(InsnFunctionStepResult::Step);
                 };
@@ -14526,7 +14526,7 @@ fn op_journal_mode_inner(
                     Ok(mode) if mode.supported() => mode,
                     _ => {
                         let ret: &'static str = prev_mode.into();
-                        state.registers[*dest].set_text(Text::new(ret));
+                        state.registers[*dest].set_text(Text::new(ret))?;
                         state.pc += 1;
                         return Ok(InsnFunctionStepResult::Step);
                     }
@@ -14535,14 +14535,14 @@ fn op_journal_mode_inner(
                 // If same mode, just return
                 if prev_mode == new_mode {
                     let ret: &'static str = new_mode.into();
-                    state.registers[*dest].set_text(Text::new(ret));
+                    state.registers[*dest].set_text(Text::new(ret))?;
                     state.pc += 1;
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
                 if *db != crate::MAIN_DB_ID {
                     let ret: &'static str = prev_mode.into();
-                    state.registers[*dest].set_text(Text::new(ret));
+                    state.registers[*dest].set_text(Text::new(ret))?;
                     state.pc += 1;
                     return Ok(InsnFunctionStepResult::Step);
                 }
@@ -14678,7 +14678,7 @@ fn op_journal_mode_inner(
 
                 // Return result
                 let ret: &'static str = new_mode.into();
-                state.registers[*dest].set_text(Text::new(ret));
+                state.registers[*dest].set_text(Text::new(ret))?;
                 state.pc += 1;
 
                 return Ok(InsnFunctionStepResult::Step);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13512,21 +13512,20 @@ pub fn op_hash_build(
     } else {
         data.mem_budget
     };
-    state
-        .hash_tables
-        .entry(data.hash_table_id)
-        .or_insert_with(|| {
-            let config = HashTableConfig {
-                initial_buckets: 1024,
-                mem_budget,
-                num_keys: data.num_keys,
-                collations: data.collations.clone(),
-                temp_store,
-                track_matched: data.track_matched,
-                partition_count: None,
-            };
-            HashTable::new(config, pager.io.clone())
-        });
+    if let std::collections::hash_map::Entry::Vacant(e) =
+        state.hash_tables.entry(data.hash_table_id)
+    {
+        let config = HashTableConfig {
+            initial_buckets: 1024,
+            mem_budget,
+            num_keys: data.num_keys,
+            collations: data.collations.clone(),
+            temp_store,
+            track_matched: data.track_matched,
+            partition_count: None,
+        };
+        e.insert(HashTable::new(config, pager.io.clone())?);
+    }
 
     // Read pre-computed key values directly from registers
     while op_state.key_idx < data.num_keys {
@@ -13617,21 +13616,24 @@ pub fn op_hash_distinct(
     } else {
         DEFAULT_MEM_BUDGET
     };
+    if let std::collections::hash_map::Entry::Vacant(e) =
+        state.hash_tables.entry(data.hash_table_id)
+    {
+        let config = HashTableConfig {
+            initial_buckets: 1024,
+            mem_budget,
+            num_keys: data.num_keys,
+            collations: data.collations.clone(),
+            temp_store,
+            track_matched: false,
+            partition_count: None,
+        };
+        e.insert(HashTable::new(config, pager.io.clone())?);
+    }
     let hash_table = state
         .hash_tables
-        .entry(data.hash_table_id)
-        .or_insert_with(|| {
-            let config = HashTableConfig {
-                initial_buckets: 1024,
-                mem_budget,
-                num_keys: data.num_keys,
-                collations: data.collations.clone(),
-                temp_store,
-                track_matched: false,
-                partition_count: None,
-            };
-            HashTable::new(config, pager.io.clone())
-        });
+        .get_mut(&data.hash_table_id)
+        .expect("hash table exists");
 
     let key_values = &mut state.distinct_key_values;
     key_values.clear();
@@ -13753,8 +13755,10 @@ pub fn op_hash_probe(
     // For spilled hash tables, either buffer main-loop probe rows for grace
     // processing or probe a partition that grace logic already loaded.
     if hash_table.has_spilled() {
-        let partition_idx =
-            partition_idx.unwrap_or_else(|| hash_table.partition_for_keys(&probe_keys));
+        let partition_idx = match partition_idx {
+            Some(partition_idx) => partition_idx,
+            None => hash_table.partition_for_keys(&probe_keys)?,
+        };
 
         // Main probe loop: buffer probe rows targeting spilled build partitions.
         if let Some(rowid_reg) = probe_rowid_reg {
@@ -13807,7 +13811,7 @@ pub fn op_hash_probe(
             partition_idx,
             &probe_keys,
             Some(&mut state.metrics.hash_join),
-        ) {
+        )? {
             Some(entry) => {
                 state.registers[dest_reg].set_int(entry.rowid);
                 write_hash_payload_to_registers(
@@ -13828,7 +13832,7 @@ pub fn op_hash_probe(
         }
     } else {
         // Non-spilled hash table, use normal probe
-        match hash_table.probe(probe_keys, Some(&mut state.metrics.hash_join)) {
+        match hash_table.probe(probe_keys, Some(&mut state.metrics.hash_join))? {
             Some(entry) => {
                 state.registers[dest_reg].set_int(entry.rowid);
                 write_hash_payload_to_registers(
@@ -13871,7 +13875,7 @@ pub fn op_hash_next(
         mark_unlikely();
         LimboError::InternalError(format!("Hash table not found with ID: {hash_table_id}"))
     })?;
-    match hash_table.next_match() {
+    match hash_table.next_match()? {
         Some(entry) => {
             state.registers[*dest_reg].set_int(entry.rowid);
             write_hash_payload_to_registers(
@@ -13912,7 +13916,7 @@ pub fn op_hash_clear(
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(HashClear { hash_table_id }, insn);
     if let Some(hash_table) = state.hash_tables.get_mut(hash_table_id) {
-        hash_table.clear();
+        hash_table.clear()?;
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -14103,7 +14107,7 @@ pub fn op_hash_grace_init(
     }
 
     // Initialize grace processing
-    if !hash_table.grace_begin() {
+    if !hash_table.grace_begin()? {
         state.pc = target_pc.as_offset_int();
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -15258,7 +15262,7 @@ mod tests {
             track_matched: false,
             ..Default::default()
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         for i in 0..1024 {
             match ht
@@ -15279,11 +15283,11 @@ mod tests {
         let probe_key = (0..1024)
             .map(|i| vec![Value::from_i64(i)])
             .find(|key| {
-                let partition_idx = ht.partition_for_keys(key);
+                let partition_idx = ht.partition_for_keys(key).unwrap();
                 !ht.is_partition_loaded(partition_idx)
             })
             .expect("expected an unloaded spilled partition");
-        let partition_idx = ht.partition_for_keys(&probe_key);
+        let partition_idx = ht.partition_for_keys(&probe_key).unwrap();
 
         (ht, probe_key, partition_idx)
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6427,7 +6427,7 @@ pub fn op_sorter_open(
         page_size,
         pager.io.clone(),
         temp_store,
-    );
+    )?;
     let cursors = &mut state.cursors;
     cursors
         .get_mut(*cursor_id)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1836,13 +1836,13 @@ pub fn op_column(
                                 Value::Text(new_text),
                                 Register::Value(Value::Text(existing_text)),
                             ) => {
-                                existing_text.do_extend(new_text);
+                                existing_text.do_extend(new_text)?;
                             }
                             (
                                 Value::Blob(new_blob),
                                 Register::Value(Value::Blob(existing_blob)),
                             ) => {
-                                existing_blob.do_extend(new_blob);
+                                existing_blob.do_extend(new_blob)?;
                             }
                             _ => {
                                 state.registers[*dest].set_value(default.clone());
@@ -2135,7 +2135,7 @@ pub fn op_array_encode(
 
     // Serialize coerced elements as a native record-format BLOB
     let record = ImmutableRecord::from_values(&coerced_elements, coerced_elements.len());
-    state.registers[*reg].set_blob(record.into_payload());
+    state.registers[*reg].set_blob(record.into_payload())?;
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -2631,7 +2631,7 @@ pub fn op_array_set_element(
     let mut elements = array_values_from_blob(blob)?;
     if idx >= elements.len() {
         // Out-of-bounds: preserve original array unchanged
-        state.registers[*dest].set_blob(blob.clone());
+        state.registers[*dest].set_blob(blob.clone())?;
     } else {
         elements[idx] = new_val;
         state.registers[*dest].set_value(values_to_record_blob(&elements));
@@ -7637,7 +7637,7 @@ pub fn op_function(
                     _ => 0,
                 };
                 let accum = StatAccum::new(n_col);
-                state.registers[*dest].set_blob(accum.to_bytes());
+                state.registers[*dest].set_blob(accum.to_bytes())?;
             }
             ScalarFunc::StatPush => {
                 // stat_push(accum_blob, i_chng): Push a row into the accumulator
@@ -12504,7 +12504,7 @@ pub fn op_integrity_check(
                 errors.truncate(*max_errors);
                 let message = format_integrity_check_result(errors);
                 match message {
-                    Some(msg) => state.registers[*message_register].set_text(Text::new(msg)),
+                    Some(msg) => state.registers[*message_register].set_text(Text::new(msg))?,
                     None => state.registers[*message_register].set_null(),
                 };
                 state.active_op_state.clear();
@@ -12562,7 +12562,7 @@ pub fn op_integrity_check(
             errors.truncate(*max_errors);
             let message = format_integrity_check_result(errors);
             match message {
-                Some(msg) => state.registers[*message_register].set_text(Text::new(msg)),
+                Some(msg) => state.registers[*message_register].set_text(Text::new(msg))?,
                 None => state.registers[*message_register].set_null(),
             };
             state.active_op_state.clear();

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -1,3 +1,5 @@
+use crate::alloc::vec;
+use crate::alloc::*;
 use crate::turso_assert;
 use crate::{
     error::LimboError,
@@ -15,9 +17,7 @@ use crate::{
 };
 use branches::{mark_unlikely, unlikely};
 use rapidhash::fast::RapidHasher;
-use std::cmp::Ordering;
-use std::hash::Hasher;
-use std::{cell::RefCell, collections::VecDeque};
+use std::{cell::RefCell, cmp::Ordering, hash::Hasher};
 use turso_macros::{turso_assert_eq, AtomicEnum};
 
 const DEFAULT_SEED: u64 = 1337;
@@ -234,7 +234,7 @@ pub(crate) enum HashInsertResult {
 }
 
 impl HashEntry {
-    const fn new(hash: u64, key_values: Vec<Value>, rowid: i64) -> Self {
+    fn new(hash: u64, key_values: Vec<Value>, rowid: i64) -> Self {
         Self {
             hash,
             key_values,
@@ -372,7 +372,8 @@ impl HashEntry {
     /// Serialize this entry to bytes for disk storage.
     /// Format: [hash:8][rowid:8][num_keys:varint][keys...][num_payload:varint][payload...]
     /// Each value is: [type:1][len:varint (for text/blob)][data]
-    fn serialize(&self, buf: &mut Vec<u8>) {
+    fn serialize(&self, buf: &mut Vec<u8>) -> Result<()> {
+        buf.try_reserve(self.serialized_size())?;
         buf.extend_from_slice(&self.hash.to_le_bytes());
         buf.extend_from_slice(&self.rowid.to_le_bytes());
 
@@ -390,6 +391,7 @@ impl HashEntry {
         for value in &self.payload_values {
             Self::serialize_value(value, buf, varint_buf);
         }
+        Ok(())
     }
 
     /// Helper to serialize a single Value to bytes.
@@ -439,9 +441,10 @@ impl HashEntry {
         let (num_keys, varint_len) = read_varint(&buf[offset..])?;
         offset += varint_len;
 
-        let mut key_values = Vec::with_capacity(num_keys as usize);
+        let mut key_values = Vec::try_with_capacity_ext(num_keys as usize)?;
         for _ in 0..num_keys {
             let (value, consumed) = Self::deserialize_value(&buf[offset..])?;
+            // Preallocated enough already
             key_values.push(value);
             offset += consumed;
         }
@@ -450,9 +453,10 @@ impl HashEntry {
         let (num_payload, varint_len) = read_varint(&buf[offset..])?;
         offset += varint_len;
 
-        let mut payload_values = Vec::with_capacity(num_payload as usize);
+        let mut payload_values = Vec::try_with_capacity_ext(num_payload as usize)?;
         for _ in 0..num_payload {
             let (value, consumed) = Self::deserialize_value(&buf[offset..])?;
+            // Preallocated enough already
             payload_values.push(value);
             offset += consumed;
         }
@@ -514,9 +518,11 @@ impl HashEntry {
                 // SAFETY: We serialized this data ourselves, so it should be valid UTF-8.
                 // Skipping validation here for performance in the spill/reload path.
                 // Doing checked utf8 construction here is a massive performance hit.
-                let s = unsafe {
-                    String::from_utf8_unchecked(buf[offset..offset + str_len as usize].to_vec())
-                };
+                let bytes: Vec<_> = buf[offset..offset + str_len as usize]
+                    .iter()
+                    .copied()
+                    .try_collect()?;
+                let s = unsafe { String::from_utf8_unchecked(bytes) };
                 offset += str_len as usize;
                 Value::Text(s.into())
             }
@@ -528,7 +534,10 @@ impl HashEntry {
                         "HashEntry: buffer too small for blob".to_string(),
                     ));
                 }
-                let b = buf[offset..offset + blob_len as usize].to_vec();
+                let b: Vec<_> = buf[offset..offset + blob_len as usize]
+                    .iter()
+                    .copied()
+                    .try_collect()?;
                 offset += blob_len as usize;
                 Value::Blob(b)
             }
@@ -577,28 +586,15 @@ pub struct HashBucket {
 }
 
 impl HashBucket {
-    const fn new() -> Self {
+    fn new() -> Self {
         Self {
             entries: Vec::new(),
         }
     }
 
-    fn insert(&mut self, entry: HashEntry) {
-        self.entries.push(entry);
-    }
-
-    fn find_matches<'a>(
-        &'a self,
-        hash: u64,
-        probe_keys: &[ValueRef],
-        collations: &[CollationSeq],
-    ) -> Vec<&'a HashEntry> {
-        self.entries
-            .iter()
-            .filter(|entry| {
-                entry.hash == hash && keys_equal(&entry.key_values, probe_keys, collations)
-            })
-            .collect()
+    fn insert(&mut self, entry: HashEntry) -> Result<()> {
+        self.entries.try_push(entry)?;
+        Ok(())
     }
 
     const fn is_empty(&self) -> bool {
@@ -693,12 +689,13 @@ impl SpilledPartition {
     }
 
     /// Add a new chunk of data to this partition
-    fn add_chunk(&mut self, file_offset: u64, size_bytes: usize, num_entries: usize) {
-        self.chunks.push(SpillChunk {
+    fn add_chunk(&mut self, file_offset: u64, size_bytes: usize, num_entries: usize) -> Result<()> {
+        self.chunks.try_push(SpillChunk {
             file_offset,
             size_bytes,
             num_entries,
-        });
+        })?;
+        Ok(())
     }
 
     /// Get total size in bytes across all chunks
@@ -744,16 +741,17 @@ struct PartitionBuffer {
 }
 
 impl PartitionBuffer {
-    const fn new() -> Self {
+    fn new() -> Self {
         Self {
             entries: Vec::new(),
             mem_used: 0,
         }
     }
 
-    fn insert(&mut self, entry: HashEntry) {
+    fn insert(&mut self, entry: HashEntry) -> Result<()> {
         self.mem_used += entry.size_bytes();
-        self.entries.push(entry);
+        self.entries.try_push(entry)?;
+        Ok(())
     }
 
     fn clear(&mut self) {
@@ -822,7 +820,7 @@ impl SpillState {
         Ok(SpillState {
             partition_buffers: (0..partitioning.count)
                 .map(|_| PartitionBuffer::new())
-                .collect(),
+                .try_collect()?,
             partitions: Vec::new(),
             next_spill_offset: 0,
             temp_file: TempFile::with_temp_store(io, temp_store)?,
@@ -872,7 +870,7 @@ impl ProbeSpillState {
         Ok(Self {
             partition_buffers: (0..partitioning.count)
                 .map(|_| PartitionBuffer::new())
-                .collect(),
+                .try_collect()?,
             partitions: Vec::new(),
             next_spill_offset: 0,
             temp_file: TempFile::with_temp_store(io, temp_store)?,
@@ -1043,15 +1041,15 @@ enum ParseChunkResult {
 
 impl HashTable {
     /// Create a new hash table.
-    pub fn new(config: HashTableConfig, io: Arc<dyn IO>) -> Self {
+    pub fn new(config: HashTableConfig, io: Arc<dyn IO>) -> Result<Self> {
         let num_buckets = config.initial_buckets;
-        let buckets = (0..num_buckets).map(|_| HashBucket::new()).collect();
+        let buckets = (0..num_buckets).map(|_| HashBucket::new()).try_collect()?;
         let matched_bits = if config.track_matched {
-            (0..num_buckets).map(|_| Vec::new()).collect()
+            (0..num_buckets).map(|_| Vec::new()).try_collect()?
         } else {
             Vec::new()
         };
-        Self {
+        Ok(Self {
             initial_buckets: config.initial_buckets,
             buckets,
             num_entries: 0,
@@ -1079,7 +1077,7 @@ impl HashTable {
             partition_count_override: config.partition_count,
             probe_spill_state: None,
             grace_state: None,
-        }
+        })
     }
 
     /// Get the current state of the hash table.
@@ -1168,7 +1166,11 @@ impl HashTable {
         }
 
         // Compute hash of the join keys using collations
-        let key_refs: Vec<ValueRef> = pending.key_values.iter().map(|v| v.as_ref()).collect();
+        let key_refs: Vec<ValueRef> = pending
+            .key_values
+            .iter()
+            .map(|value| value.as_ref())
+            .try_collect()?;
         let hash = hash_join_key(&key_refs, &self.collations);
         let entry_size = HashEntry::size_from_values(&pending.key_values, &pending.payload_values);
 
@@ -1185,7 +1187,7 @@ impl HashTable {
                 let partition_count = self.choose_partition_count(entry_size);
                 let partitioning = Partitioning::new(partition_count);
                 self.spill_state = Some(SpillState::new(&self.io, self.temp_store, partitioning)?);
-                self.redistribute_to_partitions();
+                self.redistribute_to_partitions()?;
                 self.state = HashTableState::Spilled;
             };
 
@@ -1219,16 +1221,16 @@ impl HashTable {
             };
             let spill_state = self.spill_state.as_mut().expect("spill state must exist");
             // In spilled mode, insert into partition buffer
-            spill_state.partition_buffers[partition_idx].insert(entry);
+            spill_state.partition_buffers[partition_idx].insert(entry)?;
         } else {
             // Normal mode, insert into hash bucket
             let bucket_idx = (hash as usize) % self.buckets.len();
             if self.buckets[bucket_idx].entries.is_empty() {
-                self.non_empty_buckets.push(bucket_idx);
+                self.non_empty_buckets.try_push(bucket_idx)?;
             }
-            self.buckets[bucket_idx].insert(entry);
+            self.buckets[bucket_idx].insert(entry)?;
             if self.track_matched {
-                self.matched_bits[bucket_idx].push(false);
+                self.matched_bits[bucket_idx].try_push(false)?;
             }
         }
 
@@ -1310,9 +1312,9 @@ impl HashTable {
                 let spill_state = self.spill_state.as_mut().expect("spill state exists");
                 spill_state.partition_buffers[partition_idx].insert(HashEntry::new(
                     hash,
-                    key_values.to_vec(),
+                    key_values.iter().cloned().try_collect()?,
                     0,
-                ));
+                ))?;
             }
             self.num_entries += 1;
             self.mem_used += entry_size;
@@ -1336,23 +1338,27 @@ impl HashTable {
                 let partition_count = self.choose_partition_count(entry_size);
                 let partitioning = Partitioning::new(partition_count);
                 self.spill_state = Some(SpillState::new(&self.io, self.temp_store, partitioning)?);
-                self.redistribute_to_partitions();
+                self.redistribute_to_partitions()?;
                 self.state = HashTableState::Spilled;
             }
             return self.insert_distinct(key_values, key_refs, metrics);
         }
 
         if self.buckets[bucket_idx].entries.is_empty() {
-            self.non_empty_buckets.push(bucket_idx);
+            self.non_empty_buckets.try_push(bucket_idx)?;
         }
-        self.buckets[bucket_idx].insert(HashEntry::new(hash, key_values.to_vec(), 0));
+        self.buckets[bucket_idx].insert(HashEntry::new(
+            hash,
+            key_values.iter().cloned().try_collect()?,
+            0,
+        ))?;
         self.num_entries += 1;
         self.mem_used += entry_size;
         Ok(IOResult::Done(true))
     }
 
     /// Clear all entries and reset spill state.
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self) -> Result<()> {
         if self.num_entries == 0 && self.spill_state.is_none() {
             self.state = HashTableState::Building;
             self.current_probe_keys = None;
@@ -1365,14 +1371,14 @@ impl HashTable {
             self.non_empty_buckets.clear();
             self.probe_spill_state = None;
             self.grace_state = None;
-            return;
+            return Ok(());
         }
 
         if self.spill_state.is_some() {
             // Drop spilled partitions and reset buckets.
             self.spill_state = None;
             let bucket_count = self.initial_buckets.max(1);
-            self.buckets = (0..bucket_count).map(|_| HashBucket::new()).collect();
+            self.buckets = (0..bucket_count).map(|_| HashBucket::new()).try_collect()?;
             self.non_empty_buckets.clear();
         } else {
             for &idx in &self.non_empty_buckets {
@@ -1391,10 +1397,11 @@ impl HashTable {
         self.current_spill_partition_idx = 0;
         self.loaded_partitions_lru.borrow_mut().clear();
         self.loaded_partitions_mem = 0;
+        Ok(())
     }
 
     /// Redistribute existing bucket entries into partition buffers for grace hash join.
-    fn redistribute_to_partitions(&mut self) {
+    fn redistribute_to_partitions(&mut self) -> Result<()> {
         let partitioning = {
             let spill_state = self.spill_state.as_ref().expect("spill state must exist");
             spill_state.partitioning
@@ -1406,11 +1413,12 @@ impl HashTable {
                     .as_mut()
                     .expect("spill state must exist")
                     .partition_buffers[partition_idx]
-                    .insert(entry);
+                    .insert(entry)?;
             }
         }
         // Clear in-memory matched bits; spilled partitions will have their own.
         self.matched_bits.clear();
+        Ok(())
     }
 
     /// Return the next partition which should be spilled to disk, for simplicity,
@@ -1442,10 +1450,11 @@ impl HashTable {
 
         // Phase 1: Calculate sizes and cache them to avoid recomputation
         let num_entries = partition.entries.len();
-        let mut entry_sizes = Vec::with_capacity(num_entries);
+        let mut entry_sizes = Vec::try_with_capacity_ext(num_entries)?;
         let mut total_size = 0usize;
         for entry in &partition.entries {
             let entry_size = entry.serialized_size();
+            // Preallocated enough already
             entry_sizes.push(entry_size);
             total_size += varint_len(entry_size as u64) + entry_size;
         }
@@ -1471,7 +1480,7 @@ impl HashTable {
 
         // Find existing partition or create new one
         let io_state = if let Some(existing) = spill_state.find_partition_mut(partition_idx) {
-            existing.add_chunk(file_offset, data_size, num_entries);
+            existing.add_chunk(file_offset, data_size, num_entries)?;
             if let Some(metrics) = metrics.as_deref_mut() {
                 metrics.spill_bytes_written =
                     metrics.spill_bytes_written.saturating_add(data_size as u64);
@@ -1486,7 +1495,7 @@ impl HashTable {
             existing.io_state.clone()
         } else {
             let mut new_partition = SpilledPartition::new(partition_idx);
-            new_partition.add_chunk(file_offset, data_size, num_entries);
+            new_partition.add_chunk(file_offset, data_size, num_entries)?;
             if let Some(metrics) = metrics {
                 metrics.spill_bytes_written =
                     metrics.spill_bytes_written.saturating_add(data_size as u64);
@@ -1499,7 +1508,7 @@ impl HashTable {
                     .max(new_partition.total_size_bytes() as u64);
             }
             let io_state = new_partition.io_state.clone();
-            spill_state.partitions.push(new_partition);
+            spill_state.partitions.try_push(new_partition)?;
             io_state
         };
 
@@ -1555,7 +1564,7 @@ impl HashTable {
             entry_sizes: Vec<usize>,
         }
 
-        let mut metas = Vec::with_capacity(partition_indices.len());
+        let mut metas = Vec::try_with_capacity_ext(partition_indices.len())?;
         let mut total_size = 0usize;
 
         for &partition_idx in partition_indices {
@@ -1564,21 +1573,22 @@ impl HashTable {
                 continue;
             }
 
-            let mut entry_sizes = Vec::with_capacity(partition.entries.len());
+            let mut entry_sizes = Vec::try_with_capacity_ext(partition.entries.len())?;
             let mut partition_size = 0usize;
             for entry in &partition.entries {
                 let entry_size = entry.serialized_size();
+                // Preallocated enough
                 entry_sizes.push(entry_size);
                 partition_size += varint_len(entry_size as u64) + entry_size;
             }
 
-            metas.push(PartitionMeta {
+            metas.try_push(PartitionMeta {
                 idx: partition_idx,
                 num_entries: partition.entries.len(),
                 data_size: partition_size,
                 mem_freed: partition.mem_used,
                 entry_sizes,
-            });
+            })?;
             total_size += partition_size;
         }
 
@@ -1593,9 +1603,10 @@ impl HashTable {
         let base_file_offset = spill_state.next_spill_offset;
 
         // Track where each partition's data starts in the buffer
-        let mut partition_offsets = Vec::with_capacity(metas.len());
+        let mut partition_offsets = Vec::try_with_capacity_ext(metas.len())?;
 
         for meta in &metas {
+            // Preallocated enough already
             partition_offsets.push(offset);
             let partition = &spill_state.partition_buffers[meta.idx];
 
@@ -1609,7 +1620,7 @@ impl HashTable {
 
         // Update partition metadata and clear buffers
         let mut total_mem_freed = 0usize;
-        let mut io_states = Vec::with_capacity(metas.len());
+        let mut io_states = Vec::try_with_capacity_ext(metas.len())?;
 
         for (meta, &partition_offset) in metas.iter().zip(partition_offsets.iter()) {
             let file_offset = base_file_offset + partition_offset as u64;
@@ -1619,7 +1630,7 @@ impl HashTable {
 
             // Find existing partition or create new one
             let io_state = if let Some(existing) = spill_state.find_partition_mut(meta.idx) {
-                existing.add_chunk(file_offset, meta.data_size, meta.num_entries);
+                existing.add_chunk(file_offset, meta.data_size, meta.num_entries)?;
                 if let Some(metrics) = metrics.as_deref_mut() {
                     metrics.spill_bytes_written = metrics
                         .spill_bytes_written
@@ -1635,7 +1646,7 @@ impl HashTable {
                 existing.io_state.clone()
             } else {
                 let mut new_partition = SpilledPartition::new(meta.idx);
-                new_partition.add_chunk(file_offset, meta.data_size, meta.num_entries);
+                new_partition.add_chunk(file_offset, meta.data_size, meta.num_entries)?;
                 if let Some(metrics) = metrics.as_deref_mut() {
                     metrics.spill_bytes_written = metrics
                         .spill_bytes_written
@@ -1649,12 +1660,12 @@ impl HashTable {
                         .max(new_partition.total_size_bytes() as u64);
                 }
                 let io_state = new_partition.io_state.clone();
-                spill_state.partitions.push(new_partition);
+                spill_state.partitions.try_push(new_partition)?;
                 io_state
             };
 
             io_state.set(SpillIOState::WaitingForWrite);
-            io_states.push(io_state);
+            io_states.try_push(io_state)?;
         }
 
         // Submit single I/O write
@@ -1713,14 +1724,14 @@ impl HashTable {
             .enumerate()
             .filter(|(_, p)| !p.is_empty())
             .map(|(idx, p)| (idx, p.mem_used))
-            .collect();
+            .try_collect()?;
         candidates.sort_by(|a, b| b.1.cmp(&a.1)); // Sort descending by mem_used
 
         for (partition_idx, mem_used) in candidates {
             if projected_mem_used + entry_size <= self.mem_budget {
                 break;
             }
-            partitions_to_spill.push(partition_idx);
+            partitions_to_spill.try_push(partition_idx)?;
             projected_mem_used -= mem_used;
         }
 
@@ -1732,15 +1743,15 @@ impl HashTable {
     }
 
     /// Convert a never-spilled partition buffer into in-memory buckets for probing.
-    fn materialize_partition_in_memory(&mut self, partition_idx: usize) {
+    fn materialize_partition_in_memory(&mut self, partition_idx: usize) -> Result<()> {
         let spill_state = self.spill_state.as_mut().expect("spill state must exist");
         if spill_state.find_partition(partition_idx).is_some() {
-            return;
+            return Ok(());
         }
 
         let partition_buffer = &mut spill_state.partition_buffers[partition_idx];
         if partition_buffer.is_empty() {
-            return;
+            return Ok(());
         }
 
         let entries = std::mem::take(&mut partition_buffer.entries);
@@ -1749,19 +1760,17 @@ impl HashTable {
         partition_buffer.mem_used = 0;
 
         let bucket_count = entries.len().next_power_of_two().max(64);
-        let mut buckets = (0..bucket_count)
-            .map(|_| HashBucket::new())
-            .collect::<Vec<_>>();
+        let mut buckets: Vec<_> = (0..bucket_count).map(|_| HashBucket::new()).try_collect()?;
         for entry in entries {
             let bucket_idx = (entry.hash as usize) % bucket_count;
-            buckets[bucket_idx].insert(entry);
+            buckets[bucket_idx].insert(entry)?;
         }
 
         let matched_bits = if self.track_matched {
             buckets
                 .iter()
                 .map(|b| vec![false; b.entries.len()])
-                .collect()
+                .try_collect()?
         } else {
             Vec::new()
         };
@@ -1770,7 +1779,8 @@ impl HashTable {
         partition.buckets = buckets;
         partition.matched_bits = matched_bits;
         partition.resident_mem = 0;
-        spill_state.partitions.push(partition);
+        spill_state.partitions.try_push(partition)?;
+        Ok(())
     }
 
     /// Finalize the build phase and prepare for probing.
@@ -1808,9 +1818,9 @@ impl HashTable {
                         continue;
                     }
                     if spill_state.find_partition(partition_idx).is_some() {
-                        spill_targets.push(partition_idx);
+                        spill_targets.try_push(partition_idx)?;
                     } else {
-                        materialize_targets.push(partition_idx);
+                        materialize_targets.try_push(partition_idx)?;
                     }
                 }
             }
@@ -1825,7 +1835,7 @@ impl HashTable {
                 }
             }
             for partition_idx in materialize_targets {
-                self.materialize_partition_in_memory(partition_idx);
+                self.materialize_partition_in_memory(partition_idx)?;
             }
         }
         self.current_spill_partition_idx = 0;
@@ -1840,7 +1850,7 @@ impl HashTable {
         &mut self,
         probe_keys: Vec<Value>,
         metrics: Option<&mut HashJoinMetrics>,
-    ) -> Option<&HashEntry> {
+    ) -> Result<Option<&HashEntry>> {
         turso_assert!(
             self.state == HashTableState::Probing,
             "Cannot probe hash table in unexpected state",
@@ -1851,12 +1861,15 @@ impl HashTable {
         if has_null_key(&probe_keys) {
             self.current_probe_keys = Some(probe_keys);
             self.current_probe_hash = None;
-            return None;
+            return Ok(None);
         }
 
         // Compute hash of probe keys using collations
         let hash = {
-            let key_refs: Vec<ValueRef> = probe_keys.iter().map(|v| v.as_ref()).collect();
+            let key_refs: Vec<ValueRef> = probe_keys
+                .iter()
+                .map(|value| value.as_ref())
+                .try_collect()?;
             hash_join_key(&key_refs, &self.collations)
         };
         self.current_probe_keys = Some(probe_keys);
@@ -1878,9 +1891,11 @@ impl HashTable {
 
             let bucket_idx = {
                 let spill_state = self.spill_state.as_ref().expect("spill state must exist");
-                let partition = spill_state.find_partition(target_partition)?;
+                let Some(partition) = spill_state.find_partition(target_partition) else {
+                    return Ok(None);
+                };
                 if partition.buckets.is_empty() {
-                    return None;
+                    return Ok(None);
                 }
                 (hash as usize) % partition.buckets.len()
             };
@@ -1895,9 +1910,11 @@ impl HashTable {
                     .expect("probe keys were set")
                     .iter()
                     .map(|v| v.as_ref())
-                    .collect();
+                    .try_collect()?;
                 let spill_state = self.spill_state.as_ref().expect("spill state must exist");
-                let partition = spill_state.find_partition(target_partition)?;
+                let Some(partition) = spill_state.find_partition(target_partition) else {
+                    return Ok(None);
+                };
                 let bucket = &partition.buckets[bucket_idx];
                 let mut found = None;
                 for (idx, entry) in bucket.entries.iter().enumerate() {
@@ -1914,11 +1931,13 @@ impl HashTable {
             if let Some(idx) = match_idx {
                 self.probe_entry_idx = idx + 1;
                 let spill_state = self.spill_state.as_ref().expect("spill state must exist");
-                let partition = spill_state.find_partition(target_partition)?;
+                let Some(partition) = spill_state.find_partition(target_partition) else {
+                    return Ok(None);
+                };
                 let bucket = &partition.buckets[bucket_idx];
-                return bucket.entries.get(idx);
+                return Ok(bucket.entries.get(idx));
             }
-            None
+            Ok(None)
         } else {
             // Normal mode - search in hash buckets
             let bucket_idx = (hash as usize) % self.buckets.len();
@@ -1930,7 +1949,7 @@ impl HashTable {
                     .expect("probe keys were set")
                     .iter()
                     .map(|v| v.as_ref())
-                    .collect();
+                    .try_collect()?;
                 let bucket = &self.buckets[bucket_idx];
                 let mut found = None;
                 for (idx, entry) in bucket.entries.iter().enumerate() {
@@ -1946,14 +1965,14 @@ impl HashTable {
 
             if let Some(idx) = match_idx {
                 self.probe_entry_idx = idx + 1;
-                return self.buckets[bucket_idx].entries.get(idx);
+                return Ok(self.buckets[bucket_idx].entries.get(idx));
             }
-            None
+            Ok(None)
         }
     }
 
     /// Get the next matching entry for the current probe keys.
-    pub fn next_match(&mut self) -> Option<&HashEntry> {
+    pub fn next_match(&mut self) -> Result<Option<&HashEntry>> {
         turso_assert!(
             self.state == HashTableState::Probing || self.state == HashTableState::GraceProcessing,
             "Cannot get next match in unexpected state",
@@ -1961,8 +1980,10 @@ impl HashTable {
         );
 
         turso_assert!(self.current_probe_keys.is_some(), "probe keys must be set");
-        let probe_keys = self.current_probe_keys.as_ref()?;
-        let key_refs: Vec<ValueRef> = probe_keys.iter().map(|v| v.as_ref()).collect();
+        let Some(probe_keys) = self.current_probe_keys.as_ref() else {
+            return Ok(None);
+        };
+        let key_refs: Vec<ValueRef> = probe_keys.iter().map(|v| v.as_ref()).try_collect()?;
         let hash = match self.current_probe_hash {
             Some(h) => h,
             None => {
@@ -1976,9 +1997,11 @@ impl HashTable {
             let partition_idx = self.current_spill_partition_idx;
 
             turso_assert_eq!(partition_idx, self.partition_index(hash));
-            let partition = spill_state.find_partition(partition_idx)?;
+            let Some(partition) = spill_state.find_partition(partition_idx) else {
+                return Ok(None);
+            };
             if partition.buckets.is_empty() {
-                return None;
+                return Ok(None);
             }
 
             let bucket = &partition.buckets[self.probe_bucket_idx];
@@ -1988,10 +2011,10 @@ impl HashTable {
                 if entry.hash == hash && keys_equal(&entry.key_values, &key_refs, &self.collations)
                 {
                     self.probe_entry_idx = idx + 1;
-                    return Some(entry);
+                    return Ok(Some(entry));
                 }
             }
-            None
+            Ok(None)
         } else {
             // non-spilled case, seach in main buckets
             let bucket = &self.buckets[self.probe_bucket_idx];
@@ -2001,10 +2024,10 @@ impl HashTable {
                 {
                     // update probe entry index for next call
                     self.probe_entry_idx = idx + 1;
-                    return Some(entry);
+                    return Ok(Some(entry));
                 }
             }
-            None
+            Ok(None)
         }
     }
 
@@ -2271,7 +2294,7 @@ impl HashTable {
                                 let total_entries = spilled.total_num_entries();
                                 let bucket_count = total_entries.next_power_of_two().max(64);
                                 spilled.buckets =
-                                    (0..bucket_count).map(|_| HashBucket::new()).collect();
+                                    (0..bucket_count).map(|_| HashBucket::new()).try_collect()?;
                                 spilled.parsed_entries = 0;
                                 spilled.partial_entry.clear();
                             }
@@ -2404,9 +2427,11 @@ impl HashTable {
             let data_guard = partition.read_buffer.read();
             let data = &data_guard[..data_len];
             let parse_buf = if partition.partial_entry.is_empty() {
-                data.to_vec()
+                data.iter().copied().try_collect()?
             } else {
-                let mut combined = Vec::with_capacity(partition.partial_entry.len() + data.len());
+                let mut combined =
+                    Vec::try_with_capacity_ext(partition.partial_entry.len() + data.len())?;
+                // Preallocated enough already
                 combined.extend_from_slice(&partition.partial_entry);
                 combined.extend_from_slice(data);
                 combined
@@ -2424,12 +2449,18 @@ impl HashTable {
                 else {
                     partition
                         .partial_entry
+                        .try_reserve(parse_buf.len() - offset)?;
+                    partition
+                        .partial_entry
                         .extend_from_slice(&parse_buf[offset..]);
                     break;
                 };
 
                 let total_needed = varint_size + entry_len as usize;
                 if offset + total_needed > parse_buf.len() {
+                    partition
+                        .partial_entry
+                        .try_reserve(parse_buf.len() - offset)?;
                     partition
                         .partial_entry
                         .extend_from_slice(&parse_buf[offset..]);
@@ -2445,7 +2476,7 @@ impl HashTable {
                 );
 
                 let bucket_idx = (entry.hash as usize) % partition.buckets.len();
-                partition.buckets[bucket_idx].insert(entry);
+                partition.buckets[bucket_idx].insert(entry)?;
                 partition.parsed_entries += 1;
                 offset += total_needed;
             }
@@ -2471,7 +2502,7 @@ impl HashTable {
                         .buckets
                         .iter()
                         .map(|b| vec![false; b.entries.len()])
-                        .collect();
+                        .try_collect()?;
                 }
                 partition.state = PartitionState::Loaded;
                 partition.resident_mem = Self::partition_bucket_mem(&partition.buckets);
@@ -2497,28 +2528,32 @@ impl HashTable {
         partition_idx: usize,
         probe_keys: &[Value],
         metrics: Option<&mut HashJoinMetrics>,
-    ) -> Option<&HashEntry> {
+    ) -> Result<Option<&HashEntry>> {
         // Skip probing if any key is NULL - NULL can never match anything in SQL
         if has_null_key(probe_keys) {
-            self.current_probe_keys = Some(probe_keys.to_vec());
+            self.current_probe_keys = Some(probe_keys.iter().cloned().try_collect()?);
             self.current_probe_hash = None;
-            return None;
+            return Ok(None);
         }
 
-        let key_refs: Vec<ValueRef> = probe_keys.iter().map(|v| v.as_ref()).collect();
+        let key_refs: Vec<ValueRef> = probe_keys.iter().map(|v| v.as_ref()).try_collect()?;
         let hash = hash_join_key(&key_refs, &self.collations);
 
         // Store probe keys for subsequent next_match calls
-        self.current_probe_keys = Some(probe_keys.to_vec());
+        self.current_probe_keys = Some(probe_keys.iter().cloned().try_collect()?);
         self.current_probe_hash = Some(hash);
 
         self.record_probe_call(metrics);
         self.touch_partition_lru(partition_idx);
-        let spill_state = self.spill_state.as_ref()?;
-        let partition = spill_state.find_partition(partition_idx)?;
+        let Some(spill_state) = self.spill_state.as_ref() else {
+            return Ok(None);
+        };
+        let Some(partition) = spill_state.find_partition(partition_idx) else {
+            return Ok(None);
+        };
 
         if !partition.is_loaded() || partition.buckets.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let bucket_idx = (hash as usize) % partition.buckets.len();
@@ -2530,21 +2565,21 @@ impl HashTable {
         for (idx, entry) in bucket.entries.iter().enumerate() {
             if entry.hash == hash && keys_equal(&entry.key_values, &key_refs, &self.collations) {
                 self.probe_entry_idx = idx + 1;
-                return Some(entry);
+                return Ok(Some(entry));
             }
         }
-        None
+        Ok(None)
     }
 
     /// Get the partition index for a given probe key hash.
-    pub fn partition_for_keys(&self, probe_keys: &[Value]) -> usize {
+    pub fn partition_for_keys(&self, probe_keys: &[Value]) -> Result<usize> {
         turso_assert!(
             self.spill_state.is_some(),
             "partition_for_keys requires spill state"
         );
-        let key_refs: Vec<ValueRef> = probe_keys.iter().map(|v| v.as_ref()).collect();
+        let key_refs: Vec<ValueRef> = probe_keys.iter().map(|v| v.as_ref()).try_collect()?;
         let hash = hash_join_key(&key_refs, &self.collations);
-        self.partition_index(hash)
+        Ok(self.partition_index(hash))
     }
 
     /// Returns true if the hash table has spilled to disk.
@@ -2659,7 +2694,7 @@ impl HashTable {
             )?);
         }
 
-        let key_refs: Vec<ValueRef> = key_values.iter().map(|v| v.as_ref()).collect();
+        let key_refs: Vec<ValueRef> = key_values.iter().map(|v| v.as_ref()).try_collect()?;
         let hash = hash_join_key(&key_refs, &self.collations);
         let partition_idx = partitioning.index(hash);
 
@@ -2671,7 +2706,7 @@ impl HashTable {
             .as_mut()
             .expect("probe spill state just initialized");
 
-        probe_state.partition_buffers[partition_idx].insert(entry);
+        probe_state.partition_buffers[partition_idx].insert(entry)?;
         probe_state.mem_used += entry_size;
 
         if let Some(metrics) = metrics {
@@ -2729,10 +2764,10 @@ impl HashTable {
 
         // Calculate total serialized size
         let mut total_size = 0usize;
-        let mut entry_sizes = Vec::with_capacity(partition.entries.len());
+        let mut entry_sizes = Vec::try_with_capacity_ext(partition.entries.len())?;
         for entry in &partition.entries {
             let s = entry.serialized_size();
-            entry_sizes.push(s);
+            entry_sizes.try_push(s)?;
             total_size += varint_len(s as u64) + s;
         }
 
@@ -2754,13 +2789,13 @@ impl HashTable {
 
         // Record chunk
         let io_state = if let Some(existing) = probe_state.find_partition_mut(partition_idx) {
-            existing.add_chunk(file_offset, total_size, num_entries);
+            existing.add_chunk(file_offset, total_size, num_entries)?;
             existing.io_state.clone()
         } else {
             let mut new_partition = SpilledPartition::new(partition_idx);
-            new_partition.add_chunk(file_offset, total_size, num_entries);
+            new_partition.add_chunk(file_offset, total_size, num_entries)?;
             let io_state = new_partition.io_state.clone();
-            probe_state.partitions.push(new_partition);
+            probe_state.partitions.try_push(new_partition)?;
             io_state
         };
 
@@ -2818,7 +2853,7 @@ impl HashTable {
                 continue;
             }
             if probe_state.find_partition(partition_idx).is_some() {
-                flush_targets.push(partition_idx);
+                flush_targets.try_push(partition_idx)?;
             }
         }
 
@@ -2840,9 +2875,9 @@ impl HashTable {
 
     /// Initialize grace processing. Builds partition list, frees in-memory build partitions.
     /// Returns true if there are partitions to process. No IO.
-    pub fn grace_begin(&mut self) -> bool {
+    pub fn grace_begin(&mut self) -> Result<bool> {
         if self.probe_spill_state.is_none() || self.spill_state.is_none() {
-            return false;
+            return Ok(false);
         }
 
         // Build list of partitions that were spilled on the build side
@@ -2853,11 +2888,11 @@ impl HashTable {
                 .iter()
                 .filter(|p| !p.chunks.is_empty())
                 .map(|p| p.partition_idx)
-                .collect()
+                .try_collect()?
         };
 
         if partitions_to_process.is_empty() {
-            return false;
+            return Ok(false);
         }
 
         // Free in-memory build partitions -- initial probe is done with them
@@ -2883,7 +2918,7 @@ impl HashTable {
         }
 
         self.state = HashTableState::GraceProcessing;
-        true
+        Ok(true)
     }
 
     /// Load build partition at current index + first probe chunk. IO-blocking.
@@ -3166,7 +3201,7 @@ impl HashTable {
 
             let data_guard = partition.read_buffer.read();
             let data = &data_guard[..data_len];
-            let mut entries = Vec::with_capacity(expected_entries);
+            let mut entries = Vec::try_with_capacity_ext(expected_entries)?;
             let mut offset = 0;
             while offset < data_len {
                 let Some((entry_len, varint_size)) = read_varint_partial(&data[offset..])? else {
@@ -3183,7 +3218,7 @@ impl HashTable {
                 let start = offset + varint_size;
                 let end = start + entry_len as usize;
                 let (entry, _consumed) = HashEntry::deserialize(&data[start..end])?;
-                entries.push(entry);
+                entries.try_push(entry)?;
                 offset += total_needed;
             }
             drop(data_guard);
@@ -3230,6 +3265,7 @@ impl HashTable {
 #[cfg(test)]
 mod hashtests {
     use super::*;
+    use crate::alloc::vec;
     use crate::io::Buffer;
     use crate::MemoryIO;
 
@@ -3326,7 +3362,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert some entries (late materialization - only store rowids)
         let key1 = vec![Value::from_i64(1)];
@@ -3338,21 +3374,21 @@ mod hashtests {
         let _ = ht.finalize_build(None);
 
         // Probe for key1
-        let result = ht.probe(key1, None);
+        let result = ht.probe(key1, None).unwrap();
         assert!(result.is_some());
         let entry1 = result.unwrap();
         assert_eq!(entry1.key_values[0].as_ref(), ValueRef::from_i64(1));
         assert_eq!(entry1.rowid, 100);
 
         // Probe for key2
-        let result = ht.probe(key2, None);
+        let result = ht.probe(key2, None).unwrap();
         assert!(result.is_some());
         let entry2 = result.unwrap();
         assert_eq!(entry2.key_values[0].as_ref(), ValueRef::from_i64(2));
         assert_eq!(entry2.rowid, 200);
 
         // Probe for non-existent key
-        let result = ht.probe(vec![Value::from_i64(999)], None);
+        let result = ht.probe(vec![Value::from_i64(999)], None).unwrap();
         assert!(result.is_none());
     }
 
@@ -3368,7 +3404,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert multiple entries (late materialization - only store rowids)
         for i in 0..10 {
@@ -3380,7 +3416,7 @@ mod hashtests {
 
         // Verify all entries can be found
         for i in 0..10 {
-            let result = ht.probe(vec![Value::from_i64(i)], None);
+            let result = ht.probe(vec![Value::from_i64(i)], None).unwrap();
             assert!(result.is_some());
             let entry = result.unwrap();
             assert_eq!(entry.key_values[0].as_ref(), ValueRef::from_i64(i));
@@ -3400,7 +3436,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert multiple entries with the same key
         let key = vec![Value::from_i64(42)];
@@ -3411,21 +3447,21 @@ mod hashtests {
         let _ = ht.finalize_build(None);
 
         // Probe should return first match
-        let result = ht.probe(key, None);
+        let result = ht.probe(key, None).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().rowid, 1000);
 
         // next_match should return additional matches
-        let result2 = ht.next_match();
+        let result2 = ht.next_match().unwrap();
         assert!(result2.is_some());
         assert_eq!(result2.unwrap().rowid, 1001);
 
-        let result3 = ht.next_match();
+        let result3 = ht.next_match().unwrap();
         assert!(result3.is_some());
         assert_eq!(result3.unwrap().rowid, 1002);
 
         // No more matches
-        let result4 = ht.next_match();
+        let result4 = ht.next_match().unwrap();
         assert!(result4.is_none());
     }
 
@@ -3444,7 +3480,7 @@ mod hashtests {
         );
 
         let mut buf = Vec::new();
-        entry.serialize(&mut buf);
+        entry.serialize(&mut buf).unwrap();
 
         let (deserialized, consumed) = HashEntry::deserialize(&buf).unwrap();
         assert_eq!(consumed, buf.len());
@@ -3484,7 +3520,7 @@ mod hashtests {
 
         // Serialize using the Vec-based method
         let mut vec_buf = Vec::new();
-        entry.serialize(&mut vec_buf);
+        entry.serialize(&mut vec_buf).unwrap();
 
         // Serialize using the slice-based method
         let size = entry.serialized_size();
@@ -3544,13 +3580,13 @@ mod hashtests {
         assert_eq!(partition.total_num_entries(), 0);
 
         // Add first chunk
-        partition.add_chunk(0, 1000, 50);
+        partition.add_chunk(0, 1000, 50).unwrap();
         assert_eq!(partition.chunks.len(), 1);
         assert_eq!(partition.total_size_bytes(), 1000);
         assert_eq!(partition.total_num_entries(), 50);
 
         // Add second chunk
-        partition.add_chunk(1000, 500, 25);
+        partition.add_chunk(1000, 500, 25).unwrap();
         assert_eq!(partition.chunks.len(), 2);
         assert_eq!(partition.total_size_bytes(), 1500);
         assert_eq!(partition.total_num_entries(), 75);
@@ -3574,7 +3610,7 @@ mod hashtests {
             track_matched: false,
             partition_count: Some(64),
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
         insert_many_force_spill(&mut ht, 0, 1024);
         let _ = ht.finalize_build(None).unwrap();
         assert!(ht.has_spilled());
@@ -3595,7 +3631,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
         insert_many_force_spill(&mut ht, 0, 1024);
         let _ = ht.finalize_build(None).unwrap();
         assert!(ht.has_spilled());
@@ -3619,7 +3655,7 @@ mod hashtests {
             track_matched: false,
             partition_count: Some(16),
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         let key = vec![Value::from_i64(1)];
         for i in 0..2048 {
@@ -3635,7 +3671,7 @@ mod hashtests {
         }
         assert!(ht.has_spilled());
 
-        let partition_idx = ht.partition_for_keys(&key);
+        let partition_idx = ht.partition_for_keys(&key).unwrap();
         {
             let spill_state = ht.spill_state.as_ref().expect("spill state exists");
             let partition = spill_state
@@ -3647,11 +3683,14 @@ mod hashtests {
         while let IOResult::IO(_) = ht.load_spilled_partition(partition_idx, None).unwrap() {}
         assert!(ht.is_partition_loaded(partition_idx));
 
-        let entry = ht.probe_partition(partition_idx, &key, None).unwrap();
+        let entry = ht
+            .probe_partition(partition_idx, &key, None)
+            .unwrap()
+            .unwrap();
         assert_eq!(entry.rowid, 0);
 
         let mut matches = 1usize;
-        while ht.next_match().is_some() {
+        while ht.next_match().unwrap().is_some() {
             matches += 1;
         }
         assert_eq!(matches, 2048);
@@ -3669,12 +3708,12 @@ mod hashtests {
             track_matched: false,
             partition_count: Some(16),
         };
-        let mut ht = HashTable::new(config, io.clone());
+        let mut ht = HashTable::new(config, io.clone()).unwrap();
         let partitioning = Partitioning::new(16);
         let temp_file = TempFile::with_temp_store(&io, crate::TempStore::Default).unwrap();
 
         let mut partition = SpilledPartition::new(0);
-        partition.add_chunk(0, 0, 0);
+        partition.add_chunk(0, 0, 0).unwrap();
 
         let spill_state = SpillState {
             partition_buffers: (0..partitioning.count)
@@ -3704,11 +3743,11 @@ mod hashtests {
             track_matched: false,
             partition_count: Some(16),
         };
-        let mut ht = HashTable::new(config, io.clone());
+        let mut ht = HashTable::new(config, io.clone()).unwrap();
 
         let entry = HashEntry::new(1, vec![Value::from_i64(1)], 7);
         let mut buf = Vec::new();
-        entry.serialize(&mut buf);
+        entry.serialize(&mut buf).unwrap();
         let truncated = &buf[..buf.len() - 1];
 
         let temp_file = TempFile::with_temp_store(&io, crate::TempStore::Default).unwrap();
@@ -3723,7 +3762,7 @@ mod hashtests {
 
         let partitioning = Partitioning::new(16);
         let mut partition = SpilledPartition::new(0);
-        partition.add_chunk(0, truncated.len(), 1);
+        partition.add_chunk(0, truncated.len(), 1).unwrap();
 
         let spill_state = SpillState {
             partition_buffers: (0..partitioning.count)
@@ -3833,7 +3872,7 @@ mod hashtests {
         let entry = HashEntry::new(123, vec![Value::from_i64(1), Value::Text("abc".into())], 42);
 
         let mut buf = Vec::new();
-        entry.serialize(&mut buf);
+        entry.serialize(&mut buf).unwrap();
 
         // Cut off the buffer mid-entry
         let truncated = &buf[..buf.len() - 2];
@@ -3849,7 +3888,7 @@ mod hashtests {
     fn test_hash_entry_deserialization_garbage_type_tag() {
         let entry = HashEntry::new(1, vec![Value::from_i64(10)], 7);
         let mut buf = Vec::new();
-        entry.serialize(&mut buf);
+        entry.serialize(&mut buf).unwrap();
 
         // Compute the exact offset of the *first* type tag.
         // Layout: [0..8] hash | [8..16] rowid | varint(num_keys) | type | payload...
@@ -3888,7 +3927,7 @@ mod hashtests {
             track_matched: false,
             ..Default::default()
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert enough fat rows to exceed budget and force spills
         insert_many_force_spill(&mut ht, 0, 1024);
@@ -3898,7 +3937,7 @@ mod hashtests {
 
         // Pick a key and find its partition
         let probe_key = vec![Value::from_i64(10)];
-        let partition_idx = ht.partition_for_keys(&probe_key);
+        let partition_idx = ht.partition_for_keys(&probe_key).unwrap();
 
         // Load that partition into memory
         match ht.load_spilled_partition(partition_idx, None).unwrap() {
@@ -3912,7 +3951,7 @@ mod hashtests {
         );
 
         // Probe via partition API
-        let entry = ht.probe_partition(partition_idx, &probe_key, None);
+        let entry = ht.probe_partition(partition_idx, &probe_key, None).unwrap();
         assert!(entry.is_some()); // here
         assert_eq!(entry.unwrap().rowid, 10);
     }
@@ -3930,7 +3969,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert two disjoint key ranges that will hash to different partitions
         insert_many_force_spill(&mut ht, 0, 256);
@@ -3941,8 +3980,8 @@ mod hashtests {
 
         let key_a = vec![Value::from_i64(1)];
         let key_b = vec![Value::from_i64(10_001)];
-        let pa = ht.partition_for_keys(&key_a);
-        let pb = ht.partition_for_keys(&key_b);
+        let pa = ht.partition_for_keys(&key_a).unwrap();
+        let pb = ht.partition_for_keys(&key_b).unwrap();
         assert_ne!(pa, pb);
 
         // Load partition A
@@ -3974,7 +4013,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         let key = vec![Value::from_i64(42)];
         for i in 0..1024 {
@@ -3989,7 +4028,7 @@ mod hashtests {
         }
 
         assert!(ht.has_spilled());
-        let partition_idx = ht.partition_for_keys(&key);
+        let partition_idx = ht.partition_for_keys(&key).unwrap();
 
         match ht.load_spilled_partition(partition_idx, None).unwrap() {
             IOResult::Done(()) => {}
@@ -3998,15 +4037,18 @@ mod hashtests {
         assert!(ht.is_partition_loaded(partition_idx));
 
         // First probe should give us the first rowid
-        let entry1 = ht.probe_partition(partition_idx, &key, None).unwrap();
+        let entry1 = ht
+            .probe_partition(partition_idx, &key, None)
+            .unwrap()
+            .unwrap();
         assert_eq!(entry1.rowid, 1000);
 
         // Then iterate through the rest with next_match
         for i in 0..1023 {
-            let next = ht.next_match().unwrap();
+            let next = ht.next_match().unwrap().unwrap();
             assert_eq!(next.rowid, 1001 + i);
         }
-        assert!(ht.next_match().is_none());
+        assert!(ht.next_match().unwrap().is_none());
     }
 
     #[test]
@@ -4021,7 +4063,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert entries with payload values (simulating cached result columns)
         let key1 = vec![Value::from_i64(1)];
@@ -4043,7 +4085,7 @@ mod hashtests {
         let _ = ht.finalize_build(None);
 
         // Probe and verify payload is returned correctly
-        let result = ht.probe(key1, None);
+        let result = ht.probe(key1, None).unwrap();
         assert!(result.is_some());
         let entry1 = result.unwrap();
         assert_eq!(entry1.rowid, 100);
@@ -4053,7 +4095,7 @@ mod hashtests {
         assert_eq!(entry1.payload_values[1], Value::from_i64(30));
         assert_eq!(entry1.payload_values[2], Value::from_f64(1000.50));
 
-        let result = ht.probe(key2, None);
+        let result = ht.probe(key2, None).unwrap();
         assert!(result.is_some());
         let entry2 = result.unwrap();
         assert_eq!(entry2.rowid, 200);
@@ -4075,7 +4117,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert entry with NULL values in payload
         let key = vec![Value::from_i64(1)];
@@ -4084,7 +4126,7 @@ mod hashtests {
 
         let _ = ht.finalize_build(None);
 
-        let result = ht.probe(key, None);
+        let result = ht.probe(key, None).unwrap();
         assert!(result.is_some());
         let entry = result.unwrap();
         assert_eq!(entry.payload_values.len(), 3);
@@ -4107,7 +4149,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert entry with NULL key - should be silently skipped
         let null_key = vec![Value::Null, Value::from_i64(1)];
@@ -4127,16 +4169,16 @@ mod hashtests {
         assert_eq!(ht.num_entries, 1);
 
         // Probing with NULL key should return None
-        let result = ht.probe(null_key, None);
+        let result = ht.probe(null_key, None).unwrap();
         assert!(result.is_none());
 
         // Probing with valid key should return the entry
-        let result = ht.probe(valid_key, None);
+        let result = ht.probe(valid_key, None).unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().rowid, 200);
 
         // Probing with NULL in second position should also return None
-        let result = ht.probe(null_key2, None);
+        let result = ht.probe(null_key2, None).unwrap();
         assert!(result.is_none());
     }
 
@@ -4152,7 +4194,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert entry with blob payload
         let key = vec![Value::from_i64(1)];
@@ -4162,7 +4204,7 @@ mod hashtests {
 
         let _ = ht.finalize_build(None);
 
-        let result = ht.probe(key, None);
+        let result = ht.probe(key, None).unwrap();
         assert!(result.is_some());
         let entry = result.unwrap();
         assert_eq!(entry.payload_values.len(), 2);
@@ -4182,7 +4224,7 @@ mod hashtests {
             track_matched: false,
             partition_count: None,
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         // Insert multiple entries with the same key but different payloads
         let key = vec![Value::from_i64(42)];
@@ -4214,7 +4256,7 @@ mod hashtests {
         let _ = ht.finalize_build(None);
 
         // First probe should return first match
-        let result = ht.probe(key, None);
+        let result = ht.probe(key, None).unwrap();
         assert!(result.is_some());
         let entry1 = result.unwrap();
         assert_eq!(entry1.rowid, 100);
@@ -4222,18 +4264,18 @@ mod hashtests {
         assert_eq!(entry1.payload_values[1], Value::from_i64(1));
 
         // next_match should return subsequent matches with their payloads
-        let entry2 = ht.next_match().unwrap();
+        let entry2 = ht.next_match().unwrap().unwrap();
         assert_eq!(entry2.rowid, 200);
         assert_eq!(entry2.payload_values[0], Value::Text("second".into()));
         assert_eq!(entry2.payload_values[1], Value::from_i64(2));
 
-        let entry3 = ht.next_match().unwrap();
+        let entry3 = ht.next_match().unwrap().unwrap();
         assert_eq!(entry3.rowid, 300);
         assert_eq!(entry3.payload_values[0], Value::Text("third".into()));
         assert_eq!(entry3.payload_values[1], Value::from_i64(3));
 
         // No more matches
-        assert!(ht.next_match().is_none());
+        assert!(ht.next_match().unwrap().is_none());
     }
 
     #[test]
@@ -4253,7 +4295,7 @@ mod hashtests {
         );
 
         let mut buf = Vec::new();
-        entry.serialize(&mut buf);
+        entry.serialize(&mut buf).unwrap();
 
         let (deserialized, bytes_consumed) = HashEntry::deserialize(&buf).unwrap();
         assert_eq!(bytes_consumed, buf.len());
@@ -4293,7 +4335,7 @@ mod hashtests {
 
         // Serialization should still work
         let mut buf = Vec::new();
-        entry.serialize(&mut buf);
+        entry.serialize(&mut buf).unwrap();
 
         let (deserialized, _) = HashEntry::deserialize(&buf).unwrap();
         assert!(!deserialized.has_payload());
@@ -4336,7 +4378,7 @@ mod hashtests {
             track_matched: false,
             ..Default::default()
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
         for (rowid, keys) in build_keys {
             let payload_values = if payload {
                 vec![Value::Text(format!("payload_{rowid}").into())]
@@ -4355,7 +4397,7 @@ mod hashtests {
         let _ = ht.finalize_probe_spill(None).unwrap();
         let mut matches = Vec::new();
 
-        if !ht.grace_begin() {
+        if !ht.grace_begin().unwrap() {
             return matches;
         }
 
@@ -4380,20 +4422,23 @@ mod hashtests {
                 // Use probe_partition + next_match to find build matches
                 let key_values = entry.key_values;
                 let probe_rowid = entry.probe_rowid;
-                let partition_idx = ht.partition_for_keys(&key_values);
+                let partition_idx = ht.partition_for_keys(&key_values).unwrap();
 
                 if ht
                     .probe_partition(partition_idx, &key_values, None)
+                    .unwrap()
                     .is_some()
                 {
                     // First match from probe_partition
-                    let build_entry = ht.probe_partition(partition_idx, &key_values, None);
+                    let build_entry = ht
+                        .probe_partition(partition_idx, &key_values, None)
+                        .unwrap();
                     // Re-probe to get entry again
                     if let Some(build_entry) = build_entry {
                         matches.push((build_entry.rowid, probe_rowid));
                     }
                     // Get additional matches via next_match
-                    while let Some(build_entry) = ht.next_match() {
+                    while let Some(build_entry) = ht.next_match().unwrap() {
                         matches.push((build_entry.rowid, probe_rowid));
                     }
                 }
@@ -4418,7 +4463,7 @@ mod hashtests {
         let mut buffered = 0;
         for i in 0..200 {
             let key = vec![Value::from_i64(i)];
-            let partition_idx = ht.partition_for_keys(&key);
+            let partition_idx = ht.partition_for_keys(&key).unwrap();
             if !ht.is_partition_loaded(partition_idx) {
                 let _ = ht.buffer_probe_row(key, i + 1000, None).unwrap();
                 buffered += 1;
@@ -4457,7 +4502,7 @@ mod hashtests {
             track_matched: false,
             ..Default::default()
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
         for i in 0..10 {
             let _ = ht.insert(vec![Value::from_i64(i)], i, vec![], None);
         }
@@ -4466,7 +4511,7 @@ mod hashtests {
 
         // grace_begin should return false since nothing was spilled
         assert!(
-            !ht.grace_begin(),
+            !ht.grace_begin().unwrap(),
             "grace_begin should return false when nothing spilled"
         );
     }
@@ -4489,7 +4534,7 @@ mod hashtests {
         let mut buffered_keys = Vec::new();
         for i in 0..100 {
             let key = vec![Value::from_i64(i)];
-            let partition_idx = ht.partition_for_keys(&key);
+            let partition_idx = ht.partition_for_keys(&key).unwrap();
             if !ht.is_partition_loaded(partition_idx) {
                 let _ = ht.buffer_probe_row(key, i + 500, None).unwrap();
                 buffered_keys.push(i);
@@ -4518,7 +4563,7 @@ mod hashtests {
         // Buffer probe rows with non-matching keys
         for i in 1000..1050 {
             let key = vec![Value::from_i64(i)];
-            let partition_idx = ht.partition_for_keys(&key);
+            let partition_idx = ht.partition_for_keys(&key).unwrap();
             if !ht.is_partition_loaded(partition_idx) {
                 let _ = ht.buffer_probe_row(key, i, None).unwrap();
             }
@@ -4543,7 +4588,7 @@ mod hashtests {
         // Buffer a probe row with NULL key - should be skipped
         let null_key = vec![Value::Null];
         // NULL keys can't match, so we just verify no crash
-        let partition_idx = ht.partition_for_keys(&[Value::from_i64(0)]);
+        let partition_idx = ht.partition_for_keys(&[Value::from_i64(0)]).unwrap();
         if !ht.is_partition_loaded(partition_idx) {
             // Buffer with a valid key to ensure grace processing runs
             let _ = ht
@@ -4555,7 +4600,10 @@ mod hashtests {
 
         let _ = ht.finalize_probe_spill(None).unwrap();
         // Should not crash; NULL key entries should return from grace_next_probe_entry
-        assert!(ht.grace_begin(), "should have partitions to process");
+        assert!(
+            ht.grace_begin().unwrap(),
+            "should have partitions to process"
+        );
         loop {
             match ht.grace_load_current_partition(None).unwrap() {
                 IOResult::Done(true) => {}
@@ -4591,7 +4639,7 @@ mod hashtests {
         let mut buffered = 0;
         for i in 0..200 {
             let key = vec![Value::from_i64(i)];
-            let partition_idx = ht.partition_for_keys(&key);
+            let partition_idx = ht.partition_for_keys(&key).unwrap();
             if !ht.is_partition_loaded(partition_idx) {
                 let _ = ht.buffer_probe_row(key, i + 1000, None).unwrap();
                 buffered += 1;
@@ -4599,7 +4647,10 @@ mod hashtests {
         }
 
         let _ = ht.finalize_probe_spill(None).unwrap();
-        assert!(ht.grace_begin(), "should have partitions to process");
+        assert!(
+            ht.grace_begin().unwrap(),
+            "should have partitions to process"
+        );
 
         let mut match_count = 0;
         loop {
@@ -4617,8 +4668,11 @@ mod hashtests {
                     break;
                 };
                 let key_values = entry.key_values;
-                let partition_idx = ht.partition_for_keys(&key_values);
-                if let Some(build_entry) = ht.probe_partition(partition_idx, &key_values, None) {
+                let partition_idx = ht.partition_for_keys(&key_values).unwrap();
+                if let Some(build_entry) = ht
+                    .probe_partition(partition_idx, &key_values, None)
+                    .unwrap()
+                {
                     // Check payload was correctly round-tripped
                     let expected_payload = format!("payload_{}", build_entry.rowid);
                     assert_eq!(build_entry.payload_values.len(), 1);
@@ -4648,7 +4702,7 @@ mod hashtests {
             track_matched: true,
             partition_count: Some(4),
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         for i in 0..400 {
             let key = vec![Value::from_i64(i)];
@@ -4659,7 +4713,7 @@ mod hashtests {
 
         let mut keys_by_partition = std::collections::BTreeMap::<usize, Vec<i64>>::new();
         for i in 0..400 {
-            let partition_idx = ht.partition_for_keys(&[Value::from_i64(i)]);
+            let partition_idx = ht.partition_for_keys(&[Value::from_i64(i)]).unwrap();
             keys_by_partition.entry(partition_idx).or_default().push(i);
         }
 
@@ -4694,7 +4748,7 @@ mod hashtests {
                 .unwrap();
         }
         let _ = ht.finalize_probe_spill(None).unwrap();
-        assert!(ht.grace_begin(), "should enter grace");
+        assert!(ht.grace_begin().unwrap(), "should enter grace");
 
         match ht.grace_load_current_partition(None).unwrap() {
             IOResult::Done(true) => {}
@@ -4716,13 +4770,14 @@ mod hashtests {
             let Some(entry) = entry else {
                 break;
             };
-            let partition_idx = ht.partition_for_keys(&entry.key_values);
+            let partition_idx = ht.partition_for_keys(&entry.key_values).unwrap();
             if ht
                 .probe_partition(partition_idx, &entry.key_values, None)
+                .unwrap()
                 .is_some()
             {
                 ht.mark_current_matched();
-                while ht.next_match().is_some() {
+                while ht.next_match().unwrap().is_some() {
                     ht.mark_current_matched();
                 }
             }
@@ -4789,7 +4844,7 @@ mod hashtests {
             track_matched: true,
             partition_count: Some(16),
         };
-        let mut ht = HashTable::new(config, io);
+        let mut ht = HashTable::new(config, io).unwrap();
 
         let mut next_rowid = 0i64;
         while !ht.has_spilled() {
@@ -4800,7 +4855,7 @@ mod hashtests {
         }
 
         let partition_keys: std::collections::BTreeMap<usize, Vec<i64>> = (0..4096)
-            .map(|i| (ht.partition_for_keys(&[Value::from_i64(i)]), i))
+            .map(|i| (ht.partition_for_keys(&[Value::from_i64(i)]).unwrap(), i))
             .fold(
                 std::collections::BTreeMap::new(),
                 |mut acc, (partition, key)| {
@@ -4883,7 +4938,7 @@ mod hashtests {
 
         let probe_key = (0..400)
             .map(|i| vec![Value::from_i64(i)])
-            .find(|key| ht.partition_for_keys(key) == spilled_partition)
+            .find(|key| ht.partition_for_keys(key).unwrap() == spilled_partition)
             .expect("spilled partition should have at least one key");
         let _ = ht.buffer_probe_row(probe_key, 10_000, None).unwrap();
         assert!(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -286,10 +286,10 @@ impl Register {
     /// Set the value of the register to a Text,
     /// reusing Register::Value(Value::Text(_)) buffer if possible.
     #[inline]
-    pub fn set_text(&mut self, val: Text) {
+    pub fn set_text(&mut self, val: Text) -> Result<()> {
         match self {
             Register::Value(Value::Text(existing)) => {
-                existing.do_extend(&val);
+                existing.do_extend(&val)?;
             }
             Register::Value(other_value_kind) => {
                 *other_value_kind = Value::Text(val);
@@ -298,15 +298,16 @@ impl Register {
                 *self = Register::Value(Value::Text(val));
             }
         }
+        Ok(())
     }
 
     /// Set the value of the register to a blob,
     /// reusing Register::Value(Value::Blob(_)) buffer if possible.
     #[inline]
-    pub fn set_blob(&mut self, val: Vec<u8>) {
+    pub fn set_blob(&mut self, val: Vec<u8>) -> Result<()> {
         match self {
             Register::Value(Value::Blob(existing)) => {
-                existing.do_extend(&val);
+                existing.do_extend(&val)?;
             }
             Register::Value(other_value_kind) => {
                 *other_value_kind = Value::Blob(val);
@@ -315,6 +316,7 @@ impl Register {
                 *self = Register::Value(Value::Blob(val));
             }
         }
+        Ok(())
     }
 
     // Set the value of the register to NULL,
@@ -789,7 +791,7 @@ impl ProgramState {
         matches!(self.execution_state, ProgramExecutionState::Interrupting)
     }
 
-    pub fn bind_at(&mut self, index: NonZero<usize>, value: Value) {
+    pub fn bind_at(&mut self, index: NonZero<usize>, value: Value) -> Result<()> {
         let i = index.get() - 1;
         if i >= self.parameters.len() {
             self.parameters.resize(i + 1, Value::Null);
@@ -803,10 +805,11 @@ impl ProgramState {
             (Value::Numeric(Numeric::Float(existing)), Value::Numeric(Numeric::Float(new))) => {
                 *existing = new
             }
-            (Value::Text(existing), Value::Text(new)) => existing.do_extend(&new),
-            (Value::Blob(existing), Value::Blob(new)) => existing.do_extend(&new),
+            (Value::Text(existing), Value::Text(new)) => existing.do_extend(&new)?,
+            (Value::Blob(existing), Value::Blob(new)) => existing.do_extend(&new)?,
             (slot, value) => *slot = value,
         }
+        Ok(())
     }
 
     pub fn clear_bindings(&mut self) {
@@ -2825,10 +2828,14 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 let blob_data = &data[..content_size];
                 match dest {
                     Register::Value(Value::Blob(existing_blob)) => {
-                        existing_blob.do_extend(&blob_data);
+                        if let Err(err) = existing_blob.do_extend(&blob_data) {
+                            return Some(Err(err));
+                        }
                     }
                     _ => {
-                        dest.set_blob(blob_data.to_vec());
+                        if let Err(err) = dest.set_blob(blob_data.to_vec()) {
+                            return Some(Err(err));
+                        }
                     }
                 }
             }
@@ -2855,7 +2862,9 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 };
                 match dest {
                     Register::Value(Value::Text(existing_text)) => {
-                        existing_text.do_extend(&text_str);
+                        if let Err(err) = existing_text.do_extend(&text_str) {
+                            return Some(Err(err));
+                        }
                     }
                     _ => {
                         dest.set_text(Text::new(text_str.to_string()));

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2867,7 +2867,9 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                         }
                     }
                     _ => {
-                        dest.set_text(Text::new(text_str.to_string()));
+                        if let Err(err) = dest.set_text(Text::new(text_str.to_string())) {
+                            return Some(Err(err));
+                        }
                     }
                 }
             }

--- a/core/vdbe/rowset.rs
+++ b/core/vdbe/rowset.rs
@@ -27,7 +27,9 @@
 
 use branches::mark_unlikely;
 
+use crate::alloc::*;
 use crate::turso_assert;
+use crate::Result;
 use std::collections::BTreeSet;
 
 /// The mode of usage for a RowSet.
@@ -79,12 +81,13 @@ impl RowSet {
     /// # Panics
     ///
     /// Panics if `smallest()` extraction has already started.
-    pub fn insert(&mut self, rowid: i64) {
+    pub fn insert(&mut self, rowid: i64) -> Result<()> {
         turso_assert!(
             !matches!(self.mode, RowSetMode::Smallest { .. }),
             "cannot insert after smallest() has been used"
         );
-        self.fresh.push(rowid);
+        self.fresh.try_push(rowid)?;
+        Ok(())
     }
 
     /// Tests if the rowid exists in the set, with batch-based consolidation.
@@ -140,8 +143,7 @@ impl RowSet {
             "cannot call smallest() after test() has been used"
         );
         if matches!(self.mode, RowSetMode::Unset) {
-            let mut v = Vec::with_capacity(self.fresh.len());
-            v.append(&mut self.fresh);
+            let mut v = std::mem::take(&mut self.fresh);
             v.sort_unstable();
             v.dedup();
             v.reverse();
@@ -199,9 +201,9 @@ mod tests {
     fn test_insert_and_test() {
         let mut rowset = RowSet::new();
 
-        rowset.insert(10);
-        rowset.insert(20);
-        rowset.insert(30);
+        rowset.insert(10).unwrap();
+        rowset.insert(20).unwrap();
+        rowset.insert(30).unwrap();
 
         assert!(!rowset.test(10, 0));
         assert!(!rowset.test(20, 0));
@@ -218,14 +220,14 @@ mod tests {
         let mut rowset = RowSet::new();
 
         // Insert values into batch 0 (first set)
-        rowset.insert(10);
-        rowset.insert(20);
+        rowset.insert(10).unwrap();
+        rowset.insert(20).unwrap();
         // Batch 0 doesn't test for membership (guaranteed not to contain values)
         assert!(!rowset.test(10, 0));
 
         // Insert more values (still in fresh, not consolidated yet)
-        rowset.insert(30);
-        rowset.insert(40);
+        rowset.insert(30).unwrap();
+        rowset.insert(40).unwrap();
 
         // Test with batch 1: triggers consolidation of fresh values (10, 20, 30, 40)
         // All should be found after consolidation
@@ -236,7 +238,7 @@ mod tests {
         assert!(!rowset.test(50, 1));
 
         // Insert value 50 (goes to fresh, not consolidated yet)
-        rowset.insert(50);
+        rowset.insert(50).unwrap();
 
         // Test with same batch (1): no new consolidation, so 50 not found yet
         assert!(rowset.test(10, 1));
@@ -250,11 +252,11 @@ mod tests {
     fn test_smallest_extraction() {
         let mut rowset = RowSet::new();
 
-        rowset.insert(30);
-        rowset.insert(10);
-        rowset.insert(50);
-        rowset.insert(20);
-        rowset.insert(40);
+        rowset.insert(30).unwrap();
+        rowset.insert(10).unwrap();
+        rowset.insert(50).unwrap();
+        rowset.insert(20).unwrap();
+        rowset.insert(40).unwrap();
 
         assert_eq!(rowset.smallest(), Some(10));
         assert_eq!(rowset.smallest(), Some(20));
@@ -269,11 +271,11 @@ mod tests {
     fn test_smallest_with_duplicates() {
         let mut rowset = RowSet::new();
 
-        rowset.insert(10);
-        rowset.insert(20);
-        rowset.insert(10);
-        rowset.insert(30);
-        rowset.insert(20);
+        rowset.insert(10).unwrap();
+        rowset.insert(20).unwrap();
+        rowset.insert(10).unwrap();
+        rowset.insert(30).unwrap();
+        rowset.insert(20).unwrap();
 
         assert_eq!(rowset.smallest(), Some(10));
         assert_eq!(rowset.smallest(), Some(20));
@@ -284,11 +286,11 @@ mod tests {
     #[test]
     fn test_insert_after_smallest_panics() {
         let mut rowset = RowSet::new();
-        rowset.insert(10);
+        rowset.insert(10).unwrap();
         rowset.smallest();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            rowset.insert(20);
+            rowset.insert(20).unwrap();
         }));
         assert!(result.is_err());
     }
@@ -296,7 +298,7 @@ mod tests {
     #[test]
     fn test_test_after_smallest_panics() {
         let mut rowset = RowSet::new();
-        rowset.insert(10);
+        rowset.insert(10).unwrap();
         rowset.smallest();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -308,7 +310,7 @@ mod tests {
     #[test]
     fn test_smallest_after_test_panics() {
         let mut rowset = RowSet::new();
-        rowset.insert(10);
+        rowset.insert(10).unwrap();
         rowset.test(10, 1);
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -320,11 +322,11 @@ mod tests {
     #[test]
     fn test_batch_zero_allows_smallest() {
         let mut rowset = RowSet::new();
-        rowset.insert(10);
-        rowset.insert(20);
-        rowset.insert(30);
-        rowset.insert(5);
-        rowset.insert(15);
+        rowset.insert(10).unwrap();
+        rowset.insert(20).unwrap();
+        rowset.insert(30).unwrap();
+        rowset.insert(5).unwrap();
+        rowset.insert(15).unwrap();
 
         assert_eq!(rowset.smallest(), Some(5));
         assert_eq!(rowset.smallest(), Some(10));
@@ -345,8 +347,8 @@ mod tests {
     fn test_batch_zero_semantics() {
         let mut rowset = RowSet::new();
 
-        rowset.insert(10);
-        rowset.insert(20);
+        rowset.insert(10).unwrap();
+        rowset.insert(20).unwrap();
 
         assert!(!rowset.test(10, 0));
         assert!(!rowset.test(20, 0));
@@ -360,11 +362,11 @@ mod tests {
         let mut rowset = RowSet::new();
 
         // Insert and consolidate with batch 1
-        rowset.insert(10);
+        rowset.insert(10).unwrap();
         assert!(rowset.test(10, 1));
 
         // Insert more (goes to fresh)
-        rowset.insert(20);
+        rowset.insert(20).unwrap();
 
         // Test with batch -1 (final set): consolidates fresh values
         // Both 10 (already consolidated) and 20 (now consolidated) should be found
@@ -381,11 +383,11 @@ mod tests {
     fn test_negative_values() {
         let mut rowset = RowSet::new();
 
-        rowset.insert(-10);
-        rowset.insert(-5);
-        rowset.insert(0);
-        rowset.insert(5);
-        rowset.insert(10);
+        rowset.insert(-10).unwrap();
+        rowset.insert(-5).unwrap();
+        rowset.insert(0).unwrap();
+        rowset.insert(5).unwrap();
+        rowset.insert(10).unwrap();
 
         assert!(rowset.test(-10, 1));
         assert!(rowset.test(-5, 1));
@@ -409,10 +411,10 @@ mod tests {
         let large3 = i64::MIN;
         let large4 = i64::MIN + 1;
 
-        rowset.insert(large1);
-        rowset.insert(large2);
-        rowset.insert(large3);
-        rowset.insert(large4);
+        rowset.insert(large1).unwrap();
+        rowset.insert(large2).unwrap();
+        rowset.insert(large3).unwrap();
+        rowset.insert(large4).unwrap();
 
         assert!(rowset.test(large1, 1));
         assert!(rowset.test(large2, 1));
@@ -441,7 +443,7 @@ mod tests {
             let num_inserts = 100 + (rng.next_u64() % 900) as usize;
             for _ in 0..num_inserts {
                 let value = rng.next_u64() as i64;
-                rowset.insert(value);
+                rowset.insert(value).unwrap();
                 inserted.insert(value);
             }
 
@@ -490,7 +492,7 @@ mod tests {
 
                 for _ in 0..num_values {
                     let value = rng.next_u64() as i64;
-                    rowset.insert(value);
+                    rowset.insert(value).unwrap();
                     batch_values.push(value);
                 }
 
@@ -538,7 +540,7 @@ mod tests {
                     0 => {
                         // Insert a random value
                         let value = rng.next_u64() as i64;
-                        rowset.insert(value);
+                        rowset.insert(value).unwrap();
                         all_values.insert(value);
                     }
                     _ => {
@@ -622,7 +624,7 @@ mod tests {
                 // Insert values for this batch
                 for _ in 0..batch_inserts {
                     let value = rng.next_u64() as i64;
-                    rowset.insert(value);
+                    rowset.insert(value).unwrap();
                     reference.insert(value);
                     batch_values.push(value);
                 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -6,10 +6,10 @@ use crate::sync::RwLock;
 use crate::sync::{atomic, Arc};
 use bumpalo::Bump;
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd, Reverse};
-use std::collections::BinaryHeap;
 use std::ptr::NonNull;
 use std::rc::Rc;
 
+use crate::alloc::*;
 use crate::io::TempFile;
 use crate::types::{IOCompletions, ValueIterator};
 use crate::{
@@ -106,28 +106,27 @@ impl Sorter {
         min_chunk_read_buffer_size_bytes: usize,
         io: Arc<dyn IO>,
         temp_store: crate::TempStore,
-    ) -> Self {
+    ) -> Result<Self> {
         turso_assert_eq!(order.len(), collations.len());
-        Self {
+        let index_key_info = order
+            .iter()
+            .zip(collations)
+            .zip(nulls_orders)
+            .map(|((order, collation), nulls)| KeyInfo {
+                sort_order: *order,
+                collation,
+                nulls_order: nulls,
+            })
+            .try_collect()?;
+        let this = Self {
             arena: Bump::new(),
             records: Vec::new(),
             current: None,
             key_len: order.len(),
-            index_key_info: Rc::new(
-                order
-                    .iter()
-                    .zip(collations)
-                    .zip(nulls_orders)
-                    .map(|((order, collation), nulls)| KeyInfo {
-                        sort_order: *order,
-                        collation,
-                        nulls_order: nulls,
-                    })
-                    .collect(),
-            ),
+            index_key_info: Rc::new(index_key_info),
             comparators: Rc::new(comparators),
             chunks: Vec::new(),
-            chunk_heap: BinaryHeap::new(),
+            chunk_heap: TursoAllocExt::new(),
             max_buffer_size: max_buffer_size_bytes,
             current_buffer_size: 0,
             min_chunk_read_buffer_size: min_chunk_read_buffer_size_bytes,
@@ -140,7 +139,8 @@ impl Sorter {
             init_chunk_heap_state: InitChunkHeapState::Start,
             pending_completion: None,
             temp_store,
-        }
+        };
+        Ok(this)
     }
 
     pub const fn is_empty(&self) -> bool {
@@ -289,9 +289,9 @@ impl Sorter {
                         &self.index_key_info,
                         &self.comparators,
                     )?;
-                    let record_ref = self.arena.alloc(sortable_record);
-                    // SAFETY: arena.alloc returns a valid, aligned, non-null pointer
-                    self.records.push(NonNull::from(record_ref));
+                    let record_ref = self.arena.try_alloc(sortable_record)?;
+                    // SAFETY: try_alloc returns a valid, aligned, non-null pointer.
+                    self.records.try_push(NonNull::from(record_ref))?;
                     self.current_buffer_size += payload_size;
                     self.max_payload_size_in_buffer =
                         self.max_payload_size_in_buffer.max(payload_size);
@@ -331,7 +331,7 @@ impl Sorter {
                     )),
                     "chunks should have been read"
                 );
-                self.chunk_heap.reserve(self.chunks.len());
+                self.chunk_heap.try_reserve(self.chunks.len())?;
                 // TODO: blocking will be unnecessary here with IO completions
                 let mut group = CompletionGroup::new(|_| {});
                 for chunk_idx in 0..self.chunks.len() {
@@ -388,7 +388,7 @@ impl Sorter {
 
         match chunk.next()? {
             ChunkNextResult::Done(Some(record)) => {
-                self.chunk_heap.push((
+                self.chunk_heap.try_push((
                     Reverse(Box::new(BoxedSortableRecord::new(
                         record,
                         self.key_len,
@@ -396,7 +396,7 @@ impl Sorter {
                         self.comparators.clone(),
                     )?)),
                     chunk_idx,
-                ));
+                ))?;
                 Ok(None)
             }
             ChunkNextResult::Done(None) => Ok(None),
@@ -433,17 +433,18 @@ impl Sorter {
         // Pre-compute varint lengths for record sizes to determine the total buffer size.
         // SAFETY: All pointers are valid because they are allocated in the arena,
         // and the arena hasn't been reset.
-        let mut record_size_lengths = Vec::with_capacity(self.records.len());
+        let mut record_size_lengths = Vec::try_with_capacity_ext(self.records.len())?;
         for ptr in self.records.iter() {
             let record_size = unsafe { ptr.as_ref().payload().len() };
             let size_len = varint_len(record_size as u64);
+            // Enough space was preallocated to `push` instead of `try_push`
             record_size_lengths.push(size_len);
             chunk_size += size_len + record_size;
         }
 
-        let mut chunk = SortedChunk::new(chunk_file, self.next_chunk_offset, chunk_buffer_size);
+        let mut chunk = SortedChunk::new(chunk_file, self.next_chunk_offset, chunk_buffer_size)?;
         let c = chunk.write(&self.records, record_size_lengths, chunk_size)?;
-        self.chunks.push(chunk);
+        self.chunks.try_push(chunk)?;
 
         self.records.clear();
         self.arena.reset();
@@ -526,18 +527,18 @@ enum ChunkNextResult {
 }
 
 impl SortedChunk {
-    fn new(file: Arc<dyn File>, start_offset: usize, buffer_size: usize) -> Self {
-        Self {
+    fn new(file: Arc<dyn File>, start_offset: usize, buffer_size: usize) -> Result<Self> {
+        Ok(Self {
             file,
             start_offset: start_offset as u64,
             chunk_size: 0,
-            buffer: Arc::new(RwLock::new(vec![0; buffer_size])),
+            buffer: Arc::new(RwLock::new(try_vec![0; buffer_size]?)),
             buffer_len: Arc::new(atomic::AtomicUsize::new(0)),
             records: Vec::new(),
             io_state: Arc::new(RwLock::new(SortedChunkIOState::None)),
             total_bytes_read: Arc::new(atomic::AtomicUsize::new(0)),
             next_state: NextState::Start,
-        }
+        })
     }
 
     fn buffer_len(&self) -> usize {
@@ -600,7 +601,7 @@ impl SortedChunk {
                             );
                             buffer_offset += record_size;
 
-                            self.records.push(record);
+                            self.records.try_push(record)?;
                         }
                         if buffer_offset < buffer_len {
                             buffer.copy_within(buffer_offset..buffer_len, 0);
@@ -768,12 +769,12 @@ impl ArenaSortableRecord {
         index_key_info: &[KeyInfo],
         comparators: &[Option<SortComparator>],
     ) -> Result<Self> {
-        let payload = arena.alloc_slice_copy(record.get_payload());
+        let payload = arena.try_alloc_slice_copy(record.get_payload())?;
 
         let mut payload_iter = ValueIterator::new(payload)?;
 
-        let mut key_values =
-            bumpalo::collections::Vec::with_capacity_in(payload_iter.clone().count(), arena);
+        let mut key_values = bumpalo::collections::Vec::new_in(arena);
+        key_values.try_reserve(payload_iter.clone().count())?;
         for _ in 0..key_len {
             let value = match payload_iter.next() {
                 Some(Ok(v)) => v,
@@ -895,7 +896,7 @@ impl BoxedSortableRecord {
         comparators: Rc<Vec<Option<SortComparator>>>,
     ) -> Result<Self> {
         let mut value_iterator = record.iter()?;
-        let mut key_values = Vec::with_capacity(key_len);
+        let mut key_values = Vec::try_with_capacity_ext(key_len)?;
         let mut deserialization_error = None;
 
         for _ in 0..key_len {
@@ -903,6 +904,7 @@ impl BoxedSortableRecord {
                 Some(Ok(value)) => {
                     // SAFETY: value points into record which lives as long as this struct
                     let value: ValueRef<'static> = unsafe { std::mem::transmute(value) };
+                    // Preallocated enough space
                     key_values.push(value);
                 }
                 Some(Err(err)) => {
@@ -1036,14 +1038,15 @@ mod tests {
         for _ in 0..attempts {
             let mut sorter = Sorter::new(
                 &[SortOrder::Asc],
-                vec![CollationSeq::Binary],
-                vec![None],
-                vec![None],
+                try_vec![CollationSeq::Binary].unwrap(),
+                try_vec![None].unwrap(),
+                try_vec![None].unwrap(),
                 256,
                 64,
                 io.clone(),
                 crate::TempStore::Default,
-            );
+            )
+            .unwrap();
 
             let num_records = 1000 + rng.next_u64() % 2000;
             let num_records = num_records as i64;
@@ -1053,7 +1056,7 @@ mod tests {
 
             let mut initial_records = Vec::with_capacity(num_records as usize);
             for i in (0..num_records).rev() {
-                let mut values = vec![Value::from_i64(i)];
+                let mut values = try_vec![Value::from_i64(i)].unwrap();
                 values.append(&mut generate_values(&mut rng, &value_types));
                 let record = ImmutableRecord::from_values(&values, values.len());
 

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -789,7 +789,7 @@ pub(crate) fn vacuum_target_build_step(
                     for (i, value) in row.get_values().cloned().enumerate() {
                         let index =
                             std::num::NonZero::new(i + 1).expect("i + 1 is always non-zero");
-                        target_insert_stmt.bind_at(index, value);
+                        target_insert_stmt.bind_at(index, value)?;
                     }
 
                     state.phase = VacuumTargetBuildPhase::StepTargetInsert {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1095,7 +1095,7 @@ impl TursoStatement {
                 "bind index {index} is out of bounds"
             )));
         }
-        stmt.bind_at(index, value);
+        stmt.bind_at(index, value)?;
         Ok(())
     }
     /// named parameter position.

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -1533,6 +1533,20 @@ fn sqlite3_bind_index_in_range(stmt: &sqlite3_stmt, idx: ffi::c_int) -> Option<N
     }
 }
 
+unsafe fn sqlite3_bind_result(
+    stmt: &mut sqlite3_stmt,
+    result: Result<(), LimboError>,
+) -> ffi::c_int {
+    match result {
+        Ok(()) => SQLITE_OK,
+        Err(err) => {
+            let db = &mut *stmt.db;
+            let mut inner = db.inner.lock().unwrap();
+            set_db_err(&mut inner, err)
+        }
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_bind_parameter_name(
     stmt: *mut sqlite3_stmt,
@@ -1584,8 +1598,8 @@ pub unsafe extern "C" fn sqlite3_bind_null(stmt: *mut sqlite3_stmt, idx: ffi::c_
         return SQLITE_RANGE;
     };
 
-    stmt.stmt.bind_at(index, Value::Null);
-    SQLITE_OK
+    let result = stmt.stmt.bind_at(index, Value::Null);
+    sqlite3_bind_result(stmt, result)
 }
 
 #[no_mangle]
@@ -1611,9 +1625,8 @@ pub unsafe extern "C" fn sqlite3_bind_int64(
         return SQLITE_RANGE;
     };
 
-    stmt.stmt.bind_at(index, Value::from_i64(val));
-
-    SQLITE_OK
+    let result = stmt.stmt.bind_at(index, Value::from_i64(val));
+    sqlite3_bind_result(stmt, result)
 }
 
 #[no_mangle]
@@ -1630,9 +1643,8 @@ pub unsafe extern "C" fn sqlite3_bind_double(
         return SQLITE_RANGE;
     };
 
-    stmt.stmt.bind_at(index, Value::from_f64(val));
-
-    SQLITE_OK
+    let result = stmt.stmt.bind_at(index, Value::from_f64(val));
+    sqlite3_bind_result(stmt, result)
 }
 
 #[no_mangle]
@@ -1651,8 +1663,8 @@ pub unsafe extern "C" fn sqlite3_bind_text(
         return SQLITE_RANGE;
     };
     if text.is_null() {
-        stmt_ref.stmt.bind_at(index, Value::Null);
-        return SQLITE_OK;
+        let result = stmt_ref.stmt.bind_at(index, Value::Null);
+        return sqlite3_bind_result(stmt_ref, result);
     }
 
     let static_ptr = std::ptr::null();
@@ -1676,15 +1688,27 @@ pub unsafe extern "C" fn sqlite3_bind_text(
 
     if ptr_val == transient_ptr {
         let val = Value::from_text(str_value);
-        stmt_ref.stmt.bind_at(index, val);
+        let result = stmt_ref.stmt.bind_at(index, val);
+        let rc = sqlite3_bind_result(stmt_ref, result);
+        if rc != SQLITE_OK {
+            return rc;
+        }
     } else if ptr_val == static_ptr {
         let slice = std::slice::from_raw_parts(text as *const u8, str_value.len());
         let val = Value::from_text(std::str::from_utf8(slice).unwrap());
-        stmt_ref.stmt.bind_at(index, val);
+        let result = stmt_ref.stmt.bind_at(index, val);
+        let rc = sqlite3_bind_result(stmt_ref, result);
+        if rc != SQLITE_OK {
+            return rc;
+        }
     } else {
         let slice = std::slice::from_raw_parts(text as *const u8, str_value.len());
         let val = Value::from_text(std::str::from_utf8(slice).unwrap());
-        stmt_ref.stmt.bind_at(index, val);
+        let result = stmt_ref.stmt.bind_at(index, val);
+        let rc = sqlite3_bind_result(stmt_ref, result);
+        if rc != SQLITE_OK {
+            return rc;
+        }
 
         stmt_ref
             .destructors
@@ -1710,15 +1734,19 @@ pub unsafe extern "C" fn sqlite3_bind_blob(
         return SQLITE_RANGE;
     };
     if blob.is_null() {
-        stmt_ref.stmt.bind_at(index, Value::Null);
-        return SQLITE_OK;
+        let result = stmt_ref.stmt.bind_at(index, Value::Null);
+        return sqlite3_bind_result(stmt_ref, result);
     }
 
     let slice_blob = std::slice::from_raw_parts(blob as *const u8, len as usize).to_vec();
 
     let val_blob = Value::from_blob(slice_blob);
 
-    stmt_ref.stmt.bind_at(index, val_blob);
+    let result = stmt_ref.stmt.bind_at(index, val_blob);
+    let rc = sqlite3_bind_result(stmt_ref, result);
+    if rc != SQLITE_OK {
+        return rc;
+    }
 
     if let Some(destructor_fn) = destructor {
         let ptr_val = destructor_fn as *const ffi::c_void;

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -708,7 +708,7 @@ pub async fn has_table<Ctx>(
     stmt.bind_at(
         1.try_into().unwrap(),
         Value::Text(Text::new(table_name.to_string())),
-    );
+    )?;
 
     let count = match run_stmt_expect_one_row(coro, &mut stmt).await? {
         Some(row) => row[0]
@@ -725,7 +725,7 @@ pub async fn count_local_changes<Ctx>(
     change_id: i64,
 ) -> Result<i64> {
     let mut stmt = conn.prepare("SELECT COUNT(*) FROM turso_cdc WHERE change_id > ?")?;
-    stmt.bind_at(1.try_into().unwrap(), Value::from_i64(change_id));
+    stmt.bind_at(1.try_into().unwrap(), Value::from_i64(change_id))?;
 
     let count = match run_stmt_expect_one_row(coro, &mut stmt).await? {
         Some(row) => row[0]
@@ -752,21 +752,21 @@ pub async fn update_last_change_id<Ctx>(
     select_stmt.bind_at(
         1.try_into().unwrap(),
         turso_core::Value::Text(turso_core::types::Text::new(client_id.to_string())),
-    );
+    )?;
     let row = run_stmt_expect_one_row(coro, &mut select_stmt).await?;
     tracing::info!("update_last_change_id(client_id={client_id}): selected client row if any");
 
     if row.is_some() {
         let mut update_stmt = conn.prepare(TURSO_SYNC_UPDATE_LAST_CHANGE_ID)?;
-        update_stmt.bind_at(1.try_into().unwrap(), turso_core::Value::from_i64(pull_gen));
+        update_stmt.bind_at(1.try_into().unwrap(), turso_core::Value::from_i64(pull_gen))?;
         update_stmt.bind_at(
             2.try_into().unwrap(),
             turso_core::Value::from_i64(change_id),
-        );
+        )?;
         update_stmt.bind_at(
             3.try_into().unwrap(),
             turso_core::Value::Text(turso_core::types::Text::new(client_id.to_string())),
-        );
+        )?;
         run_stmt_ignore_rows(coro, &mut update_stmt).await?;
         tracing::info!("update_last_change_id(client_id={client_id}): updated row for the client");
     } else {
@@ -774,12 +774,12 @@ pub async fn update_last_change_id<Ctx>(
         update_stmt.bind_at(
             1.try_into().unwrap(),
             turso_core::Value::Text(turso_core::types::Text::new(client_id.to_string())),
-        );
-        update_stmt.bind_at(2.try_into().unwrap(), turso_core::Value::from_i64(pull_gen));
+        )?;
+        update_stmt.bind_at(2.try_into().unwrap(), turso_core::Value::from_i64(pull_gen))?;
         update_stmt.bind_at(
             3.try_into().unwrap(),
             turso_core::Value::from_i64(change_id),
-        );
+        )?;
         run_stmt_ignore_rows(coro, &mut update_stmt).await?;
         tracing::info!(
             "update_last_change_id(client_id={client_id}): inserted new row for the client"
@@ -806,7 +806,7 @@ pub async fn read_last_change_id<Ctx>(
     select_last_change_id_stmt.bind_at(
         1.try_into().unwrap(),
         Value::Text(Text::new(client_id.to_string())),
-    );
+    )?;
 
     match run_stmt_expect_one_row(coro, &mut select_last_change_id_stmt).await? {
         Some(row) => {

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -489,7 +489,7 @@ impl DatabaseChangesIterator {
         query_stmt.bind_at(
             1.try_into().unwrap(),
             turso_core::Value::from_i64(change_id_filter),
-        );
+        )?;
 
         let mut last_change_id = None;
         while let Some(row) = run_stmt_once(coro, query_stmt).await? {
@@ -547,7 +547,7 @@ async fn replay_stmt<Ctx>(
 ) -> Result<()> {
     stmt.reset()?;
     for (i, value) in values.into_iter().enumerate() {
-        stmt.bind_at((i + 1).try_into().unwrap(), value);
+        stmt.bind_at((i + 1).try_into().unwrap(), value)?;
     }
     exec_stmt(coro, stmt).await?;
     Ok(())

--- a/tests/integration/query_processing/test_read_path.rs
+++ b/tests/integration/query_processing/test_read_path.rs
@@ -9,7 +9,7 @@ fn test_statement_reset_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     let mut stmt = conn.prepare("select ?")?;
 
-    stmt.bind_at(1.try_into()?, Value::from_i64(1));
+    stmt.bind_at(1.try_into()?, Value::from_i64(1))?;
     stmt.run_with_row_callback(|row| {
         assert_eq!(
             *row.get::<&Value>(0).unwrap(),
@@ -21,7 +21,7 @@ fn test_statement_reset_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     stmt.reset()?;
 
-    stmt.bind_at(1.try_into()?, Value::from_i64(2));
+    stmt.bind_at(1.try_into()?, Value::from_i64(2))?;
 
     stmt.run_with_row_callback(|row| {
         assert_eq!(
@@ -41,14 +41,14 @@ fn test_statement_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
 
     let mut stmt = conn.prepare("select ?, ?1, :named, ?3, ?4")?;
 
-    stmt.bind_at(1.try_into()?, Value::build_text("hello"));
+    stmt.bind_at(1.try_into()?, Value::build_text("hello"))?;
 
     let i = stmt.parameters().index(":named").unwrap();
-    stmt.bind_at(i, Value::from_i64(42));
+    stmt.bind_at(i, Value::from_i64(42))?;
 
-    stmt.bind_at(3.try_into()?, Value::from_blob(vec![0x1, 0x2, 0x3]));
+    stmt.bind_at(3.try_into()?, Value::from_blob(vec![0x1, 0x2, 0x3]))?;
 
-    stmt.bind_at(4.try_into()?, Value::from_f64(0.5));
+    stmt.bind_at(4.try_into()?, Value::from_f64(0.5))?;
 
     assert_eq!(stmt.parameters().count(), 4);
 
@@ -142,7 +142,7 @@ fn test_insert_parameter_remap(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let args = [Value::from_i64(111), Value::from_i64(222)];
     for (i, arg) in args.iter().enumerate() {
         let idx = i + 1;
-        ins.bind_at(idx.try_into()?, arg.clone());
+        ins.bind_at(idx.try_into()?, arg.clone())?;
     }
     ins.run_with_row_callback(|_| panic!("Unexpected row"))?;
 
@@ -196,7 +196,7 @@ fn test_insert_parameter_remap_all_params(tmp_db: TempDatabase) -> anyhow::Resul
     ];
     for (i, value) in values.iter().enumerate() {
         let idx = i + 1;
-        ins.bind_at(idx.try_into()?, value.clone());
+        ins.bind_at(idx.try_into()?, value.clone())?;
     }
 
     // execute the insert (no rows returned)
@@ -249,7 +249,7 @@ fn test_insert_parameter_multiple_remap_backwards(tmp_db: TempDatabase) -> anyho
     ];
     for (i, value) in values.iter().enumerate() {
         let idx = i + 1;
-        ins.bind_at(idx.try_into()?, value.clone());
+        ins.bind_at(idx.try_into()?, value.clone())?;
     }
 
     // execute the insert (no rows returned)
@@ -302,7 +302,7 @@ fn test_insert_parameter_multiple_no_remap(tmp_db: TempDatabase) -> anyhow::Resu
     ];
     for (i, value) in values.iter().enumerate() {
         let idx = i + 1;
-        ins.bind_at(idx.try_into()?, value.clone());
+        ins.bind_at(idx.try_into()?, value.clone())?;
     }
 
     // execute the insert (no rows returned)
@@ -357,7 +357,7 @@ fn test_insert_parameter_multiple_row(tmp_db: TempDatabase) -> anyhow::Result<()
     ];
     for (i, value) in values.iter().enumerate() {
         let idx = i + 1;
-        ins.bind_at(idx.try_into()?, value.clone());
+        ins.bind_at(idx.try_into()?, value.clone())?;
     }
 
     // execute the insert (no rows returned)
@@ -396,8 +396,8 @@ fn test_bind_parameters_update_query(tmp_db: TempDatabase) -> anyhow::Result<()>
     ins.run_with_row_callback(|_| panic!("unexpected row"))?;
 
     let mut ins = conn.prepare("update test set a = ? where b = ?;")?;
-    ins.bind_at(1.try_into()?, Value::from_i64(222));
-    ins.bind_at(2.try_into()?, Value::build_text("test1"));
+    ins.bind_at(1.try_into()?, Value::from_i64(222))?;
+    ins.bind_at(2.try_into()?, Value::build_text("test1"))?;
 
     ins.run_with_row_callback(|_| panic!("unexpected row"))?;
 
@@ -421,9 +421,9 @@ fn test_bind_parameters_update_query_multiple_where(tmp_db: TempDatabase) -> any
     ins.run_with_row_callback(|_| panic!("unexpected row"))?;
 
     let mut ins = conn.prepare("update test set a = ? where b = ? and c = 4 and d = ?;")?;
-    ins.bind_at(1.try_into()?, Value::from_i64(222));
-    ins.bind_at(2.try_into()?, Value::build_text("test1"));
-    ins.bind_at(3.try_into()?, Value::from_i64(5));
+    ins.bind_at(1.try_into()?, Value::from_i64(222))?;
+    ins.bind_at(2.try_into()?, Value::build_text("test1"))?;
+    ins.bind_at(3.try_into()?, Value::from_i64(5))?;
     ins.run_with_row_callback(|_| panic!("unexpected row"))?;
 
     let mut sel = conn.prepare("select a, b, c, d from test;")?;
@@ -455,8 +455,8 @@ fn test_bind_parameters_update_rowid_alias(tmp_db: TempDatabase) -> anyhow::Resu
     })?;
 
     let mut ins = conn.prepare("update test set name = ? where id = ?;")?;
-    ins.bind_at(1.try_into()?, Value::build_text("updated"));
-    ins.bind_at(2.try_into()?, Value::from_i64(1));
+    ins.bind_at(1.try_into()?, Value::build_text("updated"))?;
+    ins.bind_at(2.try_into()?, Value::from_i64(1))?;
     ins.run_with_row_callback(|_| panic!("unexpected row"))?;
 
     let mut sel = conn.prepare("select id, name from test;")?;
@@ -495,10 +495,10 @@ fn test_bind_parameters_update_rowid_alias_seek_rowid(tmp_db: TempDatabase) -> a
     })?;
 
     let mut ins = conn.prepare("update test set name = ? where id < ? AND age between ? and ?;")?;
-    ins.bind_at(1.try_into()?, Value::build_text("updated"));
-    ins.bind_at(2.try_into()?, Value::from_i64(2));
-    ins.bind_at(3.try_into()?, Value::from_i64(3));
-    ins.bind_at(4.try_into()?, Value::from_i64(5));
+    ins.bind_at(1.try_into()?, Value::build_text("updated"))?;
+    ins.bind_at(2.try_into()?, Value::from_i64(2))?;
+    ins.bind_at(3.try_into()?, Value::from_i64(3))?;
+    ins.bind_at(4.try_into()?, Value::from_i64(5))?;
     ins.run_with_row_callback(|_| panic!("unexpected row"))?;
 
     let mut sel = conn.prepare("select name from test;")?;
@@ -529,10 +529,10 @@ fn test_bind_parameters_delete_rowid_alias_seek_out_of_order(
 
     let mut ins =
         conn.prepare("delete from test where age between ? and ? AND id > ? AND name = ?;")?;
-    ins.bind_at(1.try_into()?, Value::from_i64(10));
-    ins.bind_at(2.try_into()?, Value::from_i64(12));
-    ins.bind_at(3.try_into()?, Value::from_i64(4));
-    ins.bind_at(4.try_into()?, Value::build_text("test"));
+    ins.bind_at(1.try_into()?, Value::from_i64(10))?;
+    ins.bind_at(2.try_into()?, Value::from_i64(12))?;
+    ins.bind_at(3.try_into()?, Value::from_i64(4))?;
+    ins.bind_at(4.try_into()?, Value::build_text("test"))?;
     ins.run_with_row_callback(|_| panic!("unexpected row"))?;
 
     let mut sel = conn.prepare("select name from test;")?;
@@ -672,8 +672,8 @@ fn test_offset_limit_bind(tmp_db: TempDatabase) -> anyhow::Result<()> {
         (1, 1, vec![vec![turso_core::Value::from_i64(4)]]),
     ] {
         let mut stmt = conn.prepare("SELECT * FROM test LIMIT ? OFFSET ?")?;
-        stmt.bind_at(1.try_into()?, Value::from_i64(limit));
-        stmt.bind_at(2.try_into()?, Value::from_i64(offset));
+        stmt.bind_at(1.try_into()?, Value::from_i64(limit))?;
+        stmt.bind_at(2.try_into()?, Value::from_i64(offset))?;
 
         let mut rows = Vec::new();
         stmt.run_with_row_callback(|row| {
@@ -697,11 +697,11 @@ fn test_upsert_parameters_order(tmp_db: TempDatabase) -> anyhow::Result<()> {
     conn.execute("INSERT INTO test VALUES (1, 2), (3, 4)")?;
     let mut stmt =
         conn.prepare("INSERT INTO test VALUES (?, ?), (?, ?) ON CONFLICT DO UPDATE SET v = ?")?;
-    stmt.bind_at(1.try_into()?, Value::from_i64(1));
-    stmt.bind_at(2.try_into()?, Value::from_i64(20));
-    stmt.bind_at(3.try_into()?, Value::from_i64(3));
-    stmt.bind_at(4.try_into()?, Value::from_i64(40));
-    stmt.bind_at(5.try_into()?, Value::from_i64(66));
+    stmt.bind_at(1.try_into()?, Value::from_i64(1))?;
+    stmt.bind_at(2.try_into()?, Value::from_i64(20))?;
+    stmt.bind_at(3.try_into()?, Value::from_i64(3))?;
+    stmt.bind_at(4.try_into()?, Value::from_i64(40))?;
+    stmt.bind_at(5.try_into()?, Value::from_i64(66))?;
     stmt.run_with_row_callback(|_| panic!("unexpected row"))?;
 
     let mut rows = Vec::new();
@@ -755,7 +755,7 @@ fn test_stmt_reset(tmp_db: TempDatabase) -> anyhow::Result<()> {
     let mut stmt1 = conn1.prepare("INSERT INTO test VALUES (?)").unwrap();
     for _ in 0..3 {
         stmt1.reset()?;
-        stmt1.bind_at(1.try_into().unwrap(), Value::Blob(vec![0u8; 1024]));
+        stmt1.bind_at(1.try_into().unwrap(), Value::Blob(vec![0u8; 1024]))?;
         loop {
             match stmt1.step().unwrap() {
                 StepResult::Done => break,
@@ -770,7 +770,7 @@ fn test_stmt_reset(tmp_db: TempDatabase) -> anyhow::Result<()> {
         .unwrap();
 
     stmt1.reset()?;
-    stmt1.bind_at(1.try_into().unwrap(), Value::Blob(vec![0u8; 1024]));
+    stmt1.bind_at(1.try_into().unwrap(), Value::Blob(vec![0u8; 1024]))?;
     loop {
         match stmt1.step().unwrap() {
             StepResult::Done => break,
@@ -922,11 +922,13 @@ fn test_eval_param_only_once(tmp_db: TempDatabase) {
     stmt.bind_at(
         1.try_into().unwrap(),
         turso_core::Value::from_i64(100_000_000),
-    );
+    )
+    .unwrap();
     stmt.bind_at(
         2.try_into().unwrap(),
         turso_core::Value::from_i64(100_000_000),
-    );
+    )
+    .unwrap();
     let start_time = std::time::Instant::now();
     stmt.run_with_row_callback(|row| {
         let values = row.get_values().cloned().collect::<Vec<_>>();
@@ -1020,8 +1022,8 @@ fn test_bind_in_exists_subquery(tmp_db: TempDatabase) -> anyhow::Result<()> {
         stmt.parameters().has_slot(2.try_into().unwrap()),
         "parameter ?2 should be registered"
     );
-    stmt.bind_at(1.try_into()?, Value::from_i64(42));
-    stmt.bind_at(2.try_into()?, Value::from_i64(1));
+    stmt.bind_at(1.try_into()?, Value::from_i64(42))?;
+    stmt.bind_at(2.try_into()?, Value::from_i64(1))?;
     let mut turso_rows = Vec::new();
     stmt.run_with_row_callback(|row| {
         turso_rows.push(row.get::<&Value>(2).unwrap().clone());

--- a/tools/dbhash/src/lib.rs
+++ b/tools/dbhash/src/lib.rs
@@ -115,7 +115,7 @@ fn get_table_names(
     stmt.bind_at(
         NonZero::new(1).unwrap(),
         Value::from_text(like_pattern.to_string()),
-    );
+    )?;
     let mut names = Vec::new();
 
     loop {
@@ -201,7 +201,7 @@ fn hash_schema(
     stmt.bind_at(
         NonZero::new(1).unwrap(),
         Value::from_text(like_pattern.to_string()),
-    );
+    )?;
     hash_rows(&mut stmt, io, hasher, debug)?;
     Ok(())
 }


### PR DESCRIPTION
## Description
Well the title says it. This change also affected `bind` as it now returns a possible AllocationError

## Motivation and context
Fallible Allocations


## Description of AI Usage
Helping with boilerplate