### PR TITLE
Fix recursive FK cascades causing stack overflow

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -28,6 +28,7 @@ use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
     EXPR_INDEX_SENTINEL,
 };
+use crate::translate::fkeys::RecursiveFkActionCompileStack;
 use crate::translate::plan::ColumnMask;
 use crate::vdbe::{
     affinity::Affinity,
@@ -180,6 +181,13 @@ pub struct Resolver<'a> {
     /// (e.g. via a nested sub-program), update this field on that
     /// path or switch to a live read.
     has_temp_schema: bool,
+    /// Foreign-key action programs currently being compiled by this resolver.
+    ///
+    /// This is shared with forked resolvers because `translate_inner` can fork
+    /// the resolver while compiling generated foreign-key action SQL. Without
+    /// shared state, a self-referential `ON DELETE CASCADE` could fail to see
+    /// that its own action program is already being built.
+    pub(super) recursive_fk_action_compile_stack: RecursiveFkActionCompileStack,
 }
 
 #[derive(Clone)]
@@ -286,6 +294,7 @@ impl<'a> Resolver<'a> {
             dqs_dml,
             trigger_context: None,
             has_temp_schema,
+            recursive_fk_action_compile_stack: RecursiveFkActionCompileStack::default(),
         }
     }
 
@@ -314,6 +323,7 @@ impl<'a> Resolver<'a> {
             dqs_dml: self.dqs_dml,
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
+            recursive_fk_action_compile_stack: self.recursive_fk_action_compile_stack.clone(),
         }
     }
 
@@ -334,6 +344,7 @@ impl<'a> Resolver<'a> {
             dqs_dml: self.dqs_dml,
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
+            recursive_fk_action_compile_stack: self.recursive_fk_action_compile_stack.clone(),
         }
     }
 

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -28,7 +28,7 @@ use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
     EXPR_INDEX_SENTINEL,
 };
-use crate::translate::fkeys::RecursiveFkActionCompileStack;
+use crate::translate::fkeys::FkActionCompileStack;
 use crate::translate::plan::ColumnMask;
 use crate::vdbe::{
     affinity::Affinity,
@@ -187,7 +187,7 @@ pub struct Resolver<'a> {
     /// the resolver while compiling generated foreign-key action SQL. Without
     /// shared state, a self-referential `ON DELETE CASCADE` could fail to see
     /// that its own action program is already being built.
-    pub(super) recursive_fk_action_compile_stack: RecursiveFkActionCompileStack,
+    pub(super) fk_action_compile_stack: FkActionCompileStack,
 }
 
 #[derive(Clone)]
@@ -294,7 +294,7 @@ impl<'a> Resolver<'a> {
             dqs_dml,
             trigger_context: None,
             has_temp_schema,
-            recursive_fk_action_compile_stack: RecursiveFkActionCompileStack::default(),
+            fk_action_compile_stack: FkActionCompileStack::default(),
         }
     }
 
@@ -323,7 +323,7 @@ impl<'a> Resolver<'a> {
             dqs_dml: self.dqs_dml,
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
-            recursive_fk_action_compile_stack: self.recursive_fk_action_compile_stack.clone(),
+            fk_action_compile_stack: self.fk_action_compile_stack.clone(),
         }
     }
 
@@ -344,7 +344,7 @@ impl<'a> Resolver<'a> {
             dqs_dml: self.dqs_dml,
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
-            recursive_fk_action_compile_stack: self.recursive_fk_action_compile_stack.clone(),
+            fk_action_compile_stack: self.fk_action_compile_stack.clone(),
         }
     }
 

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -7,15 +7,125 @@ use crate::translate::plan::ColumnMask;
 use crate::{
     error::SQLITE_CONSTRAINT_FOREIGNKEY,
     schema::{BTreeTable, ColumnLayout, ForeignKey, Index, ResolvedFkRef},
+    sync::{Arc, OnceLock, Weak},
     translate::{collate::CollationSeq, emitter::Resolver, planner::ROWID_STRS},
     vdbe::{
         builder::{CursorType, DmlColumnContext, QueryMode},
-        insn::{CmpInsFlags, Insn},
-        BranchOffset,
+        insn::{CmpInsFlags, Insn, Subprogram},
+        BranchOffset, PreparedProgram,
     },
     Connection, LimboError, Result,
 };
-use std::{num::NonZero, num::NonZeroUsize, sync::Arc};
+use std::{cell::RefCell, num::NonZero, num::NonZeroUsize, rc::Rc};
+
+/// Tracks foreign-key action programs that are currently being compiled.
+///
+/// This is needed when generated foreign-key action SQL reaches the same
+/// foreign-key action again before the first copy has finished compiling.
+///
+/// Example: in `t(id PRIMARY KEY, parent REFERENCES t(id) ON DELETE CASCADE)`,
+/// deleting row `1` runs an action that deletes row `2`. Deleting row `2` must
+/// run the same action again to delete row `3`. While compiling that action,
+/// this stack lets the nested delete emit a call back to the action program
+/// already being built.
+///
+/// A two-table cycle needs the same mechanism: table `a` cascades to `b`, and
+/// `b` cascades back to `a`.
+#[derive(Clone, Default)]
+pub(super) struct RecursiveFkActionCompileStack(
+    Rc<RefCell<Vec<RecursiveFkActionCompileStackEntry>>>,
+);
+
+/// One foreign-key action program that is currently being compiled.
+struct RecursiveFkActionCompileStackEntry {
+    /// The foreign key whose action program is being compiled.
+    foreign_key: Arc<ForeignKey>,
+    /// Whether the action started from a parent delete or a parent key update.
+    parent_change: FkActionParentChange,
+    /// The place where the finished action program will be stored.
+    ///
+    /// Recursive calls emitted during compilation hold a clone of this slot.
+    prepared_program_slot: Arc<OnceLock<Weak<PreparedProgram>>>,
+}
+
+impl RecursiveFkActionCompileStack {
+    /// Find the unfinished action program for this foreign key and parent row change.
+    ///
+    /// Returning `Some` means the compiler is re-entering the same FK action.
+    /// The caller should emit a recursive call to that in-progress program
+    /// instead of compiling another copy of the action.
+    fn program_being_compiled_for(
+        &self,
+        foreign_key: &Arc<ForeignKey>,
+        parent_change: FkActionParentChange,
+    ) -> Option<Arc<OnceLock<Weak<PreparedProgram>>>> {
+        self.0
+            .borrow()
+            .iter()
+            .find(|compiling| {
+                compiling.parent_change == parent_change
+                    && Arc::ptr_eq(&compiling.foreign_key, foreign_key)
+            })
+            .map(|compiling| compiling.prepared_program_slot.clone())
+    }
+
+    /// Remember that a foreign-key action program is being compiled.
+    ///
+    /// The returned guard removes the entry from the stack when compilation
+    /// ends, including when compilation returns an error.
+    fn push_compile_stack_entry(
+        &self,
+        foreign_key: Arc<ForeignKey>,
+        parent_change: FkActionParentChange,
+    ) -> RecursiveFkActionCompileStackGuard {
+        let program = Arc::new(OnceLock::new());
+        self.0
+            .borrow_mut()
+            .push(RecursiveFkActionCompileStackEntry {
+                foreign_key,
+                parent_change,
+                prepared_program_slot: program.clone(),
+            });
+        RecursiveFkActionCompileStackGuard {
+            compile_stack: self.clone(),
+            prepared_program_slot: program,
+        }
+    }
+}
+
+/// Removes a foreign-key action program from the compile stack when compilation ends.
+struct RecursiveFkActionCompileStackGuard {
+    compile_stack: RecursiveFkActionCompileStack,
+    prepared_program_slot: Arc<OnceLock<Weak<PreparedProgram>>>,
+}
+
+impl Drop for RecursiveFkActionCompileStackGuard {
+    fn drop(&mut self) {
+        let ended = self
+            .compile_stack
+            .0
+            .borrow_mut()
+            .pop()
+            .expect("foreign-key action compilation stack underflow");
+        debug_assert!(Arc::ptr_eq(
+            &ended.prepared_program_slot,
+            &self.prepared_program_slot
+        ));
+    }
+}
+
+/// The parent-row change that started a foreign-key action.
+///
+/// Delete and update actions are different generated programs. A recursive
+/// delete action must call the in-progress delete action, not an update action
+/// for the same foreign key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FkActionParentChange {
+    /// The parent row was deleted.
+    Delete,
+    /// The parent key was updated.
+    Update,
+}
 
 #[inline]
 pub fn emit_guarded_fk_decrement(
@@ -1210,6 +1320,19 @@ impl FkActionContext {
             new_key_registers: Some(new_key_registers),
         }
     }
+
+    /// Return which generated action program this context runs.
+    ///
+    /// Delete actions only have old parent key values. Update actions have old
+    /// and new parent key values. The recursive compile stack uses this to keep
+    /// delete and update action programs separate for the same foreign key.
+    fn parent_change_that_runs_action(&self) -> FkActionParentChange {
+        if self.new_key_registers.is_some() {
+            FkActionParentChange::Update
+        } else {
+            FkActionParentChange::Delete
+        }
+    }
 }
 
 /// Context for compiling FK action subprograms - maps parameter indices to column values
@@ -1331,48 +1454,112 @@ fn emit_key_change_check(
 /// Common options for FK action subprogram builders.
 const FK_SUBPROGRAM_OPTS: ProgramBuilderOpts = ProgramBuilderOpts::new(2, 32, 4);
 
-/// Compile and emit an FK action as a sub-program.
-/// This is the common implementation for CASCADE DELETE, SET NULL, SET DEFAULT, and CASCADE UPDATE.
+/// Emit the `Program` instruction that runs a foreign-key action subprogram.
+///
+/// For a normal action, `subprogram` is a finished generated action program.
+/// For a recursive action, it points to the action program currently being
+/// compiled. The parent key registers are passed as SQL parameters to the
+/// generated action statement.
+fn emit_fk_action_program_insn(
+    program: &mut ProgramBuilder,
+    ctx: &FkActionContext,
+    subprogram: Subprogram,
+    action_subprogram_context: &FkSubprogramContext,
+) {
+    // Foreign-key action subprograms can't contain RAISE(IGNORE), so ignore_jump_target
+    // is a no-op that resolves to the next instruction (just falls through).
+    let mut param_registers = ctx.old_key_registers.to_vec();
+    if action_subprogram_context.new_param_start.is_some() {
+        let new_regs = ctx
+            .new_key_registers
+            .as_ref()
+            .expect("new key registers required for update cascade params");
+        param_registers.extend(new_regs.iter().copied());
+    }
+
+    let ignore_jump_target = program.allocate_label();
+    program.emit_insn(Insn::Program {
+        param_registers,
+        program: subprogram,
+        ignore_jump_target,
+    });
+    program.preassign_label_to_next_insn(ignore_jump_target);
+}
+
+/// Compile and emit a foreign-key action as a subprogram.
+///
+/// This is the common implementation for CASCADE DELETE, SET NULL, SET DEFAULT,
+/// and CASCADE UPDATE. The recursive case is handled before compiling a new
+/// subprogram: if the same foreign-key action is already being compiled, this
+/// emits a call to that in-progress program instead of compiling forever.
+///
+/// This is required for self-referential cascades and foreign-key cycles. In
+/// both cases, the generated action SQL can fire the same action again before
+/// the first action program has finished compiling.
+#[allow(clippy::too_many_arguments)]
 fn emit_fk_action_subprogram(
     program: &mut ProgramBuilder,
     resolver: &mut Resolver,
     connection: &Arc<Connection>,
     stmt: ast::Stmt,
     ctx: &FkActionContext,
+    foreign_key: Arc<ForeignKey>,
     description: &'static str,
+    action_subprogram_context: &FkSubprogramContext,
 ) -> Result<()> {
+    let parent_change = ctx.parent_change_that_runs_action();
+    let recursive_fk_action_compile_stack = resolver.recursive_fk_action_compile_stack.clone();
+    if let Some(recursive_action_program) =
+        recursive_fk_action_compile_stack.program_being_compiled_for(&foreign_key, parent_change)
+    {
+        assert!(
+            program.flags.is_subprogram(),
+            "recursive foreign-key action calls must be emitted from a foreign-key action subprogram"
+        );
+        emit_fk_action_program_insn(
+            program,
+            ctx,
+            Subprogram::RecursiveFkActionBeingCompiled(recursive_action_program),
+            action_subprogram_context,
+        );
+        return Ok(());
+    }
+
     let mut subprogram_builder = ProgramBuilder::new_for_subprogram(
         QueryMode::Normal,
         program.capture_data_changes_info().clone(),
         FK_SUBPROGRAM_OPTS,
     );
-    subprogram_builder.prologue();
-    translate_inner(
-        stmt,
-        resolver,
-        &mut subprogram_builder,
-        connection,
-        description,
-    )?;
-    subprogram_builder.epilogue(resolver.schema());
-    let built_subprogram = subprogram_builder.build(connection.clone(), true, description)?;
+    let built_subprogram = {
+        let compile_stack_entry =
+            recursive_fk_action_compile_stack.push_compile_stack_entry(foreign_key, parent_change);
+        (|| -> Result<_> {
+            subprogram_builder.prologue();
+            translate_inner(
+                stmt,
+                resolver,
+                &mut subprogram_builder,
+                connection,
+                description,
+            )?;
+            subprogram_builder.epilogue(resolver.schema());
+            let built_subprogram =
+                subprogram_builder.build(connection.clone(), true, description)?;
+            let prepared_subprogram = built_subprogram.prepared().clone();
+            compile_stack_entry
+                .prepared_program_slot
+                .set(Arc::downgrade(&prepared_subprogram))
+                .expect("foreign-key action subprogram should be set exactly once");
+            Ok(prepared_subprogram)
+        })()
+    }?;
 
-    // Build param_registers: OLD key register indices, then optionally NEW key register indices
-    let mut param_registers: Vec<usize> = ctx.old_key_registers.to_vec();
-
-    if let Some(new_regs) = &ctx.new_key_registers {
-        param_registers.extend(new_regs.iter().copied());
-    }
-
-    // FK action subprograms can't contain RAISE(IGNORE), so ignore_jump_target
-    // is a no-op that resolves to the next instruction (just falls through).
-    let ignore_jump_target = program.allocate_label();
-    program.emit_insn(Insn::Program {
-        param_registers,
-        program: built_subprogram.prepared().clone(),
-        ignore_jump_target,
-    });
-    program.preassign_label_to_next_insn(ignore_jump_target);
+    emit_fk_action_program_insn(
+        program,
+        ctx,
+        Subprogram::PreparedProgram(built_subprogram),
+        action_subprogram_context,
+    );
 
     Ok(())
 }
@@ -1576,7 +1763,9 @@ fn fire_fk_cascade_delete(
         connection,
         stmt,
         ctx,
+        fk_ref.fk.clone(),
         "fk cascade delete",
+        &subprog_ctx,
     )
 }
 
@@ -1603,7 +1792,16 @@ fn fire_fk_set_null(
         &subprog_ctx,
         db_name.as_deref(),
     );
-    emit_fk_action_subprogram(program, resolver, connection, stmt, ctx, "fk set null")
+    emit_fk_action_subprogram(
+        program,
+        resolver,
+        connection,
+        stmt,
+        ctx,
+        fk_ref.fk.clone(),
+        "fk set null",
+        &subprog_ctx,
+    )
 }
 
 /// Compile and emit an FK SET DEFAULT action as a sub-program.
@@ -1629,7 +1827,16 @@ fn fire_fk_set_default(
         &subprog_ctx,
         db_name.as_deref(),
     );
-    emit_fk_action_subprogram(program, resolver, connection, stmt, ctx, "fk set default")
+    emit_fk_action_subprogram(
+        program,
+        resolver,
+        connection,
+        stmt,
+        ctx,
+        fk_ref.fk.clone(),
+        "fk set default",
+        &subprog_ctx,
+    )
 }
 
 /// Compile and emit an FK CASCADE UPDATE action as a sub-program.
@@ -1662,7 +1869,9 @@ fn fire_fk_cascade_update(
         connection,
         stmt,
         ctx,
+        fk_ref.fk.clone(),
         "fk cascade update",
+        &subprog_ctx,
     )
 }
 

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -32,12 +32,10 @@ use std::{cell::RefCell, num::NonZero, num::NonZeroUsize, rc::Rc};
 /// A two-table cycle needs the same mechanism: table `a` cascades to `b`, and
 /// `b` cascades back to `a`.
 #[derive(Clone, Default)]
-pub(super) struct RecursiveFkActionCompileStack(
-    Rc<RefCell<Vec<RecursiveFkActionCompileStackEntry>>>,
-);
+pub(super) struct FkActionCompileStack(Rc<RefCell<Vec<FkActionCompileStackEntry>>>);
 
 /// One foreign-key action program that is currently being compiled.
-struct RecursiveFkActionCompileStackEntry {
+struct FkActionCompileStackEntry {
     /// The foreign key whose action program is being compiled.
     foreign_key: Arc<ForeignKey>,
     /// Whether the action started from a parent delete or a parent key update.
@@ -45,16 +43,16 @@ struct RecursiveFkActionCompileStackEntry {
     /// The place where the finished action program will be stored.
     ///
     /// Recursive calls emitted during compilation hold a clone of this slot.
-    prepared_program_slot: Arc<OnceLock<Weak<PreparedProgram>>>,
+    slot: Arc<OnceLock<Weak<PreparedProgram>>>,
 }
 
-impl RecursiveFkActionCompileStack {
+impl FkActionCompileStack {
     /// Find the unfinished action program for this foreign key and parent row change.
     ///
     /// Returning `Some` means the compiler is re-entering the same FK action.
     /// The caller should emit a recursive call to that in-progress program
     /// instead of compiling another copy of the action.
-    fn program_being_compiled_for(
+    fn find(
         &self,
         foreign_key: &Arc<ForeignKey>,
         parent_change: FkActionParentChange,
@@ -62,55 +60,49 @@ impl RecursiveFkActionCompileStack {
         self.0
             .borrow()
             .iter()
-            .find(|compiling| {
-                compiling.parent_change == parent_change
-                    && Arc::ptr_eq(&compiling.foreign_key, foreign_key)
+            .find(|entry| {
+                entry.parent_change == parent_change && Arc::ptr_eq(&entry.foreign_key, foreign_key)
             })
-            .map(|compiling| compiling.prepared_program_slot.clone())
+            .map(|entry| entry.slot.clone())
     }
 
     /// Remember that a foreign-key action program is being compiled.
     ///
     /// The returned guard removes the entry from the stack when compilation
     /// ends, including when compilation returns an error.
-    fn push_compile_stack_entry(
+    fn push(
         &self,
         foreign_key: Arc<ForeignKey>,
         parent_change: FkActionParentChange,
-    ) -> RecursiveFkActionCompileStackGuard {
-        let program = Arc::new(OnceLock::new());
-        self.0
-            .borrow_mut()
-            .push(RecursiveFkActionCompileStackEntry {
-                foreign_key,
-                parent_change,
-                prepared_program_slot: program.clone(),
-            });
-        RecursiveFkActionCompileStackGuard {
-            compile_stack: self.clone(),
-            prepared_program_slot: program,
+    ) -> FkActionCompileStackGuard {
+        let slot = Arc::new(OnceLock::new());
+        self.0.borrow_mut().push(FkActionCompileStackEntry {
+            foreign_key,
+            parent_change,
+            slot: slot.clone(),
+        });
+        FkActionCompileStackGuard {
+            stack: self.clone(),
+            slot,
         }
     }
 }
 
 /// Removes a foreign-key action program from the compile stack when compilation ends.
-struct RecursiveFkActionCompileStackGuard {
-    compile_stack: RecursiveFkActionCompileStack,
-    prepared_program_slot: Arc<OnceLock<Weak<PreparedProgram>>>,
+struct FkActionCompileStackGuard {
+    stack: FkActionCompileStack,
+    slot: Arc<OnceLock<Weak<PreparedProgram>>>,
 }
 
-impl Drop for RecursiveFkActionCompileStackGuard {
+impl Drop for FkActionCompileStackGuard {
     fn drop(&mut self) {
         let ended = self
-            .compile_stack
+            .stack
             .0
             .borrow_mut()
             .pop()
             .expect("foreign-key action compilation stack underflow");
-        debug_assert!(Arc::ptr_eq(
-            &ended.prepared_program_slot,
-            &self.prepared_program_slot
-        ));
+        debug_assert!(Arc::ptr_eq(&ended.slot, &self.slot));
     }
 }
 
@@ -1326,7 +1318,7 @@ impl FkActionContext {
     /// Delete actions only have old parent key values. Update actions have old
     /// and new parent key values. The recursive compile stack uses this to keep
     /// delete and update action programs separate for the same foreign key.
-    fn parent_change_that_runs_action(&self) -> FkActionParentChange {
+    fn parent_change(&self) -> FkActionParentChange {
         if self.new_key_registers.is_some() {
             FkActionParentChange::Update
         } else {
@@ -1454,38 +1446,6 @@ fn emit_key_change_check(
 /// Common options for FK action subprogram builders.
 const FK_SUBPROGRAM_OPTS: ProgramBuilderOpts = ProgramBuilderOpts::new(2, 32, 4);
 
-/// Emit the `Program` instruction that runs a foreign-key action subprogram.
-///
-/// For a normal action, `subprogram` is a finished generated action program.
-/// For a recursive action, it points to the action program currently being
-/// compiled. The parent key registers are passed as SQL parameters to the
-/// generated action statement.
-fn emit_fk_action_program_insn(
-    program: &mut ProgramBuilder,
-    ctx: &FkActionContext,
-    subprogram: Subprogram,
-    action_subprogram_context: &FkSubprogramContext,
-) {
-    // Foreign-key action subprograms can't contain RAISE(IGNORE), so ignore_jump_target
-    // is a no-op that resolves to the next instruction (just falls through).
-    let mut param_registers = ctx.old_key_registers.to_vec();
-    if action_subprogram_context.new_param_start.is_some() {
-        let new_regs = ctx
-            .new_key_registers
-            .as_ref()
-            .expect("new key registers required for update cascade params");
-        param_registers.extend(new_regs.iter().copied());
-    }
-
-    let ignore_jump_target = program.allocate_label();
-    program.emit_insn(Insn::Program {
-        param_registers,
-        program: subprogram,
-        ignore_jump_target,
-    });
-    program.preassign_label_to_next_insn(ignore_jump_target);
-}
-
 /// Compile and emit a foreign-key action as a subprogram.
 ///
 /// This is the common implementation for CASCADE DELETE, SET NULL, SET DEFAULT,
@@ -1496,7 +1456,6 @@ fn emit_fk_action_program_insn(
 /// This is required for self-referential cascades and foreign-key cycles. In
 /// both cases, the generated action SQL can fire the same action again before
 /// the first action program has finished compiling.
-#[allow(clippy::too_many_arguments)]
 fn emit_fk_action_subprogram(
     program: &mut ProgramBuilder,
     resolver: &mut Resolver,
@@ -1505,61 +1464,54 @@ fn emit_fk_action_subprogram(
     ctx: &FkActionContext,
     foreign_key: Arc<ForeignKey>,
     description: &'static str,
-    action_subprogram_context: &FkSubprogramContext,
 ) -> Result<()> {
-    let parent_change = ctx.parent_change_that_runs_action();
-    let recursive_fk_action_compile_stack = resolver.recursive_fk_action_compile_stack.clone();
-    if let Some(recursive_action_program) =
-        recursive_fk_action_compile_stack.program_being_compiled_for(&foreign_key, parent_change)
-    {
+    let parent_change = ctx.parent_change();
+    let compile_stack = resolver.fk_action_compile_stack.clone();
+
+    let subprogram = if let Some(slot) = compile_stack.find(&foreign_key, parent_change) {
         assert!(
             program.flags.is_subprogram(),
             "recursive foreign-key action calls must be emitted from a foreign-key action subprogram"
         );
-        emit_fk_action_program_insn(
-            program,
-            ctx,
-            Subprogram::RecursiveFkActionBeingCompiled(recursive_action_program),
-            action_subprogram_context,
+        Subprogram::Pending(slot)
+    } else {
+        let mut subprogram_builder = ProgramBuilder::new_for_subprogram(
+            QueryMode::Normal,
+            program.capture_data_changes_info().clone(),
+            FK_SUBPROGRAM_OPTS,
         );
-        return Ok(());
+        let entry = compile_stack.push(foreign_key, parent_change);
+        subprogram_builder.prologue();
+        translate_inner(
+            stmt,
+            resolver,
+            &mut subprogram_builder,
+            connection,
+            description,
+        )?;
+        subprogram_builder.epilogue(resolver.schema());
+        let built = subprogram_builder.build(connection.clone(), true, description)?;
+        let prepared = built.prepared().clone();
+        entry
+            .slot
+            .set(Arc::downgrade(&prepared))
+            .expect("foreign-key action subprogram should be set exactly once");
+        Subprogram::PreparedProgram(prepared)
+    };
+
+    // Foreign-key action subprograms can't contain RAISE(IGNORE), so ignore_jump_target
+    // is a no-op that resolves to the next instruction (just falls through).
+    let mut param_registers = ctx.old_key_registers.to_vec();
+    if let Some(new_regs) = &ctx.new_key_registers {
+        param_registers.extend(new_regs.iter().copied());
     }
-
-    let mut subprogram_builder = ProgramBuilder::new_for_subprogram(
-        QueryMode::Normal,
-        program.capture_data_changes_info().clone(),
-        FK_SUBPROGRAM_OPTS,
-    );
-    let built_subprogram = {
-        let compile_stack_entry =
-            recursive_fk_action_compile_stack.push_compile_stack_entry(foreign_key, parent_change);
-        (|| -> Result<_> {
-            subprogram_builder.prologue();
-            translate_inner(
-                stmt,
-                resolver,
-                &mut subprogram_builder,
-                connection,
-                description,
-            )?;
-            subprogram_builder.epilogue(resolver.schema());
-            let built_subprogram =
-                subprogram_builder.build(connection.clone(), true, description)?;
-            let prepared_subprogram = built_subprogram.prepared().clone();
-            compile_stack_entry
-                .prepared_program_slot
-                .set(Arc::downgrade(&prepared_subprogram))
-                .expect("foreign-key action subprogram should be set exactly once");
-            Ok(prepared_subprogram)
-        })()
-    }?;
-
-    emit_fk_action_program_insn(
-        program,
-        ctx,
-        Subprogram::PreparedProgram(built_subprogram),
-        action_subprogram_context,
-    );
+    let ignore_jump_target = program.allocate_label();
+    program.emit_insn(Insn::Program {
+        param_registers,
+        program: subprogram,
+        ignore_jump_target,
+    });
+    program.preassign_label_to_next_insn(ignore_jump_target);
 
     Ok(())
 }
@@ -1765,7 +1717,6 @@ fn fire_fk_cascade_delete(
         ctx,
         fk_ref.fk.clone(),
         "fk cascade delete",
-        &subprog_ctx,
     )
 }
 
@@ -1800,7 +1751,6 @@ fn fire_fk_set_null(
         ctx,
         fk_ref.fk.clone(),
         "fk set null",
-        &subprog_ctx,
     )
 }
 
@@ -1835,7 +1785,6 @@ fn fire_fk_set_default(
         ctx,
         fk_ref.fk.clone(),
         "fk set default",
-        &subprog_ctx,
     )
 }
 
@@ -1871,7 +1820,6 @@ fn fire_fk_cascade_update(
         ctx,
         fk_ref.fk.clone(),
         "fk cascade update",
-        &subprog_ctx,
     )
 }
 

--- a/core/translate/trigger_exec.rs
+++ b/core/translate/trigger_exec.rs
@@ -13,7 +13,7 @@ use crate::translate::{
 };
 use crate::util::normalize_ident;
 use crate::vdbe::affinity::Affinity;
-use crate::vdbe::insn::Insn;
+use crate::vdbe::insn::{Insn, Subprogram};
 use crate::vdbe::BranchOffset;
 use crate::{bail_parse_error, QueryMode, Result};
 use std::cell::RefCell;
@@ -681,7 +681,7 @@ fn execute_trigger_commands(
 
     program.emit_insn(Insn::Program {
         param_registers,
-        program: built_subprogram.prepared().clone(),
+        program: Subprogram::PreparedProgram(built_subprogram.prepared().clone()),
         ignore_jump_target,
     });
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4452,6 +4452,7 @@ pub fn op_program(
         },
         insn
     );
+    let subprogram = subprogram.prepared_program()?;
     loop {
         match std::mem::take(state.active_op_state.program()) {
             OpProgramState::Start => {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -956,19 +956,27 @@ pub fn insn_to_row(
             Insn::Program {
                 param_registers,
                 ignore_jump_target,
-                ..
-            } => (
-                "Program",
-                // P1: first parent register that contains a param
-                param_registers.first().copied().unwrap_or(0) as i64,
-                // P2: ignore jump target (for RAISE(IGNORE))
-                ignore_jump_target.as_debug_int() as i64,
-                // P3: number of registers that contain params
-                param_registers.len() as i64,
-                Value::build_text(program.sql.clone()),
-                0,
-                format!("subprogram={}", program.sql),
-            ),
+                program: subprogram,
+            } => {
+                let sql = subprogram
+                    .prepared_program()
+                    .expect("Program subprogram should be resolved before EXPLAIN")
+                    .sql
+                    .clone();
+                let comment = format!("subprogram={sql}");
+                (
+                    "Program",
+                    // P1: first parent register that contains a param
+                    param_registers.first().copied().unwrap_or(0) as i64,
+                    // P2: ignore jump target (for RAISE(IGNORE))
+                    ignore_jump_target.as_debug_int() as i64,
+                    // P3: number of registers that contain params
+                    param_registers.len() as i64,
+                    Value::build_text(sql),
+                    0,
+                    comment,
+                )
+            }
             Insn::ResetCount => (
                 "ResetCount",
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -39,37 +39,24 @@ pub enum Subprogram {
     /// from `t`, so it must call the same action program that is being built.
     /// The slot is filled after compilation finishes. The stored reference is
     /// weak so the finished program does not own itself.
-    RecursiveFkActionBeingCompiled(Arc<OnceLock<Weak<PreparedProgram>>>),
+    Pending(Arc<OnceLock<Weak<PreparedProgram>>>),
 }
 
 impl Subprogram {
     /// Return the finished program that `Insn::Program` should run.
     ///
-    /// `RecursiveFkActionBeingCompiled` must have been filled during
-    /// compilation before execution reaches the instruction. If it has not been
-    /// filled, compilation emitted a recursive foreign-key action call without
-    /// connecting it to the finished action program.
+    /// `Pending` must have been filled during compilation before execution
+    /// reaches the instruction. If it has not been filled, compilation emitted
+    /// a recursive foreign-key action call without connecting it to the
+    /// finished action program.
     pub(super) fn prepared_program(&self) -> crate::Result<Arc<PreparedProgram>> {
         match self {
             Self::PreparedProgram(program) => Ok(program.clone()),
-            Self::RecursiveFkActionBeingCompiled(program) => {
-                program.get().and_then(Weak::upgrade).ok_or_else(|| {
-                    crate::LimboError::InternalError(
-                        "recursive foreign-key action subprogram was not resolved".into(),
-                    )
-                })
-            }
-        }
-    }
-
-    /// Return whether the finished program is read-only.
-    ///
-    /// A recursive foreign-key action is treated as writable while it is still
-    /// being compiled. Foreign-key actions can modify child rows.
-    fn is_readonly(&self) -> bool {
-        match self {
-            Self::PreparedProgram(program) => program.is_readonly(),
-            Self::RecursiveFkActionBeingCompiled(_) => false,
+            Self::Pending(program) => program.get().and_then(Weak::upgrade).ok_or_else(|| {
+                crate::LimboError::InternalError(
+                    "recursive foreign-key action subprogram was not resolved".into(),
+                )
+            }),
         }
     }
 }
@@ -2110,7 +2097,12 @@ impl Insn {
             | Self::JournalMode { .. }
             | Self::Vacuum { .. } => false,
             Self::MaxPgcnt { new_max, .. } => *new_max == 0,
-            Self::Program { program, .. } => program.is_readonly(),
+            // A recursive foreign-key action is treated as writable while it's still being
+            // compiled; only fully-prepared subprograms can declare themselves read-only.
+            Self::Program { program, .. } => match program {
+                Subprogram::PreparedProgram(p) => p.is_readonly(),
+                Subprogram::Pending(_) => false,
+            },
             _ => true,
         }
     }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1,7 +1,4 @@
-use std::{
-    num::{NonZero, NonZeroUsize},
-    sync::Arc,
-};
+use std::num::{NonZero, NonZeroUsize};
 
 /// Convert a usize to u16 for instruction fields (registers, counts).
 /// Panics if the value exceeds u16::MAX.
@@ -14,6 +11,7 @@ use super::{execute, AggFunc, BranchOffset, CursorID, FuncCtx, InsnFunction, Pag
 use crate::{
     schema::{BTreeTable, CheckConstraint, Column, ForeignKey, Index},
     storage::{pager::CreateBTreeFlags, wal::CheckpointMode},
+    sync::{Arc, OnceLock, Weak},
     translate::{collate::CollationSeq, emitter::TransactionMode},
     types::KeyInfo,
     vdbe::affinity::Affinity,
@@ -23,6 +21,58 @@ use strum::EnumCount;
 use strum_macros::{EnumDiscriminants, FromRepr, VariantArray};
 use turso_macros::Description;
 use turso_parser::ast::{ResolveType, SortOrder};
+
+/// The program run by an `Insn::Program` instruction.
+///
+/// Most callers already have a finished trigger or foreign-key action program.
+/// Recursive foreign-key actions are different: while compiling one action
+/// program, the generated SQL can need to emit a call back to that same action
+/// program before it has finished compiling.
+#[derive(Debug, Clone)]
+pub enum Subprogram {
+    /// A finished trigger or foreign-key action program.
+    PreparedProgram(Arc<PreparedProgram>),
+    /// A recursive foreign-key action program that is still being compiled.
+    ///
+    /// Example: `t(id PRIMARY KEY, parent REFERENCES t(id) ON DELETE CASCADE)`.
+    /// The action that deletes child rows from `t` can itself delete more rows
+    /// from `t`, so it must call the same action program that is being built.
+    /// The slot is filled after compilation finishes. The stored reference is
+    /// weak so the finished program does not own itself.
+    RecursiveFkActionBeingCompiled(Arc<OnceLock<Weak<PreparedProgram>>>),
+}
+
+impl Subprogram {
+    /// Return the finished program that `Insn::Program` should run.
+    ///
+    /// `RecursiveFkActionBeingCompiled` must have been filled during
+    /// compilation before execution reaches the instruction. If it has not been
+    /// filled, compilation emitted a recursive foreign-key action call without
+    /// connecting it to the finished action program.
+    pub(super) fn prepared_program(&self) -> crate::Result<Arc<PreparedProgram>> {
+        match self {
+            Self::PreparedProgram(program) => Ok(program.clone()),
+            Self::RecursiveFkActionBeingCompiled(program) => {
+                program.get().and_then(Weak::upgrade).ok_or_else(|| {
+                    crate::LimboError::InternalError(
+                        "recursive foreign-key action subprogram was not resolved".into(),
+                    )
+                })
+            }
+        }
+    }
+
+    /// Return whether the finished program is read-only.
+    ///
+    /// A recursive foreign-key action is treated as writable while it is still
+    /// being compiled. Foreign-key actions can modify child rows.
+    fn is_readonly(&self) -> bool {
+        match self {
+            Self::PreparedProgram(program) => program.is_readonly(),
+            Self::RecursiveFkActionBeingCompiled(_) => false,
+        }
+    }
+}
 
 /// Known custom type comparator functions for sorting and MIN/MAX aggregates.
 /// These replace heap-allocated String names with a compact enum.
@@ -798,7 +848,7 @@ pub enum Insn {
         can_fallthrough: bool,
     },
 
-    /// Invoke a trigger subprogram.
+    /// Invoke a trigger or foreign-key action subprogram.
     ///
     /// According to SQLite documentation (https://sqlite.org/opcode.html):
     /// "The Program opcode invokes the trigger subprogram. The Program instruction
@@ -810,7 +860,7 @@ pub enum Insn {
         /// At runtime, values are copied from these parent registers into
         /// the child statement's parameters via bind_at.
         param_registers: Vec<usize>,
-        program: Arc<PreparedProgram>,
+        program: Subprogram,
         /// Jump target when RAISE(IGNORE) fires in the subprogram.
         /// Points to the "skip this row" address in the parent program.
         ignore_jump_target: BranchOffset,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1230,8 +1230,24 @@ macro_rules! get_cursor {
 pub struct ExplainState {
     /// Subprograms queued for explain output, processed after the parent program finishes.
     pending: std::collections::VecDeque<Arc<PreparedProgram>>,
+    /// Prepared subprograms that have already been queued for explain output.
+    ///
+    /// Recursive foreign-key action programs can contain a `Program` instruction
+    /// that calls the same prepared program again. Without this set, EXPLAIN
+    /// keeps printing the same subprogram forever.
+    queued_subprograms: std::collections::HashSet<usize>,
     /// The subprogram currently being explained, if any.
     current: Option<Arc<PreparedProgram>>,
+}
+
+impl ExplainState {
+    /// Queue a subprogram for EXPLAIN output if this statement has not queued it before.
+    fn queue_subprogram_once(&mut self, subprogram: Arc<PreparedProgram>) {
+        let subprogram_id = Arc::as_ptr(&subprogram) as usize;
+        if self.queued_subprograms.insert(subprogram_id) {
+            self.pending.push_back(subprogram);
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1445,10 +1461,11 @@ impl Program {
         let (row, subprogram) = if let Some(ref current) = explain_state.current {
             let (insn, _) = &current.insns[pc];
             let sub = if let Insn::Program {
-                program: prepared, ..
+                program: subprogram,
+                ..
             } = insn
             {
-                Some(prepared.clone())
+                Some(subprogram.prepared_program()?)
             } else {
                 None
             };
@@ -1461,10 +1478,11 @@ impl Program {
         } else {
             let (insn, _) = &self.insns[pc];
             let sub = if let Insn::Program {
-                program: prepared, ..
+                program: subprogram,
+                ..
             } = insn
             {
-                Some(prepared.clone())
+                Some(subprogram.prepared_program()?)
             } else {
                 None
             };
@@ -1476,7 +1494,7 @@ impl Program {
             (insn_to_row_with_comment(self, insn, comment), sub)
         };
         if let Some(sub) = subprogram {
-            explain_state.pending.push_back(sub);
+            explain_state.queue_subprogram_once(sub);
         }
         let (opcode, p1, p2, p3, p4, p5, comment) = row;
 

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -1795,6 +1795,149 @@ expect {
     0
 }
 
+# ON DELETE CASCADE - self-referential chain
+@cross-check-integrity
+test fk-cascade-delete-self-referential-chain {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON DELETE CASCADE);
+    INSERT INTO t VALUES(1,NULL),(2,1),(3,2);
+    DELETE FROM t WHERE id=1;
+    SELECT id, pid FROM t ORDER BY id;
+}
+expect {
+}
+
+# ON DELETE CASCADE - longer self-referential chain
+@cross-check-integrity
+test fk-cascade-delete-self-referential-long-chain {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON DELETE CASCADE);
+    INSERT INTO t VALUES
+        (1,NULL),(2,1),(3,2),(4,3),(5,4),(6,5),
+        (7,6),(8,7),(9,8),(10,9),(11,10),(12,11);
+    DELETE FROM t WHERE id=1;
+    SELECT count(*) FROM t;
+}
+expect {
+    0
+}
+
+# ON DELETE CASCADE - composite self-referential chain
+@cross-check-integrity
+test fk-cascade-delete-self-referential-composite-chain {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        a INTEGER,
+        b INTEGER,
+        pa INTEGER,
+        pb INTEGER,
+        PRIMARY KEY(a,b),
+        FOREIGN KEY(pa,pb) REFERENCES t(a,b) ON DELETE CASCADE
+    );
+    INSERT INTO t VALUES(1,1,NULL,NULL),(2,2,1,1),(3,3,2,2);
+    DELETE FROM t WHERE a=1 AND b=1;
+    SELECT count(*) FROM t;
+}
+expect {
+    0
+}
+
+# ON DELETE CASCADE - two self references to the same table
+@cross-check-integrity
+test fk-cascade-delete-self-referential-two-fks {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        p1 INTEGER REFERENCES t(id) ON DELETE CASCADE,
+        p2 INTEGER REFERENCES t(id) ON DELETE CASCADE
+    );
+    INSERT INTO t VALUES(1,NULL,NULL),(2,1,NULL),(3,NULL,1),(4,2,3);
+    DELETE FROM t WHERE id=1;
+    SELECT count(*) FROM t;
+}
+expect {
+    0
+}
+
+# ON DELETE CASCADE - deferred self-referential chain
+@cross-check-integrity
+test fk-cascade-delete-self-referential-deferred {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        pid INTEGER REFERENCES t(id) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO t VALUES(1,NULL),(2,1),(3,2);
+    BEGIN;
+    DELETE FROM t WHERE id=1;
+    SELECT count(*) FROM t;
+    COMMIT;
+    SELECT count(*) FROM t;
+}
+expect {
+    0
+    0
+}
+
+# ON DELETE CASCADE - more than one root row starts a self-referential cascade
+@cross-check-integrity
+test fk-cascade-delete-self-referential-multi-root {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON DELETE CASCADE);
+    INSERT INTO t VALUES(1,NULL),(2,1),(3,2),(10,NULL),(11,10);
+    DELETE FROM t WHERE id IN (1,10);
+    SELECT count(*) FROM t;
+}
+expect {
+    0
+}
+
+# EXPLAIN should print the recursive FK action once and then stop.
+test fk-cascade-delete-self-referential-explain-terminates {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON DELETE CASCADE);
+    EXPLAIN DELETE FROM t WHERE id=1;
+}
+expect pattern {
+    Program
+}
+
+# ON DELETE CASCADE - two tables cascade into each other
+@cross-check-integrity
+test fk-cascade-delete-two-table-cycle {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON DELETE CASCADE);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON DELETE CASCADE);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    DELETE FROM a WHERE id=1;
+    SELECT count(*) FROM a;
+    SELECT count(*) FROM b;
+}
+expect {
+    0
+    0
+}
+
+# ON DELETE CASCADE - three tables cascade into a cycle
+@cross-check-integrity
+test fk-cascade-delete-three-table-cycle {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, cid INTEGER REFERENCES c(id) ON DELETE CASCADE);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON DELETE CASCADE);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON DELETE CASCADE);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    INSERT INTO c VALUES(3,2);
+    UPDATE a SET cid=3 WHERE id=1;
+    DELETE FROM a WHERE id=1;
+    SELECT (SELECT count(*) FROM a),(SELECT count(*) FROM b),(SELECT count(*) FROM c);
+}
+expect {
+    0|0|0
+}
+
 # Basic ON UPDATE CASCADE - single child row
 @cross-check-integrity
 test fk-cascade-update-basic {
@@ -1825,6 +1968,37 @@ expect {
     10|99
     11|99
     12|99
+}
+
+# ON UPDATE CASCADE - self-referential hierarchy
+@cross-check-integrity
+test fk-cascade-update-self-referential-chain {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON UPDATE CASCADE);
+    INSERT INTO t VALUES(1,NULL),(2,1),(3,2);
+    UPDATE t SET id=id+10 WHERE id=1;
+    SELECT id, pid FROM t ORDER BY id;
+}
+expect {
+    2|11
+    3|2
+    11|
+}
+
+# ON UPDATE CASCADE - two tables update each other
+@cross-check-integrity
+test fk-cascade-update-two-table-cycle {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON UPDATE CASCADE);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON UPDATE CASCADE);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    UPDATE a SET id=10 WHERE id=1;
+    SELECT a.id,a.bid,b.id,b.aid FROM a,b;
+}
+expect {
+    10|2|2|10
 }
 
 # ON UPDATE CASCADE - composite key
@@ -1891,6 +2065,22 @@ expect {
     1||
 }
 
+# ON DELETE SET NULL - two tables clear each other's references
+@cross-check-integrity
+test fk-setnull-delete-two-table-cycle {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON DELETE SET NULL);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON DELETE SET NULL);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    DELETE FROM a WHERE id=1;
+    SELECT id, aid FROM b ORDER BY id;
+}
+expect {
+    2|
+}
+
 # Basic ON UPDATE SET NULL
 @cross-check-integrity
 test fk-setnull-update-basic {
@@ -1904,6 +2094,82 @@ test fk-setnull-update-basic {
 }
 expect {
     10|
+}
+
+# ON UPDATE SET NULL - two tables clear each other's references
+@cross-check-integrity
+test fk-setnull-update-two-table-cycle {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON UPDATE SET NULL);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON UPDATE SET NULL);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    UPDATE a SET id=10 WHERE id=1;
+    SELECT a.id,a.bid,b.id,b.aid FROM a,b;
+}
+expect {
+    10|2|2|
+}
+
+# ON DELETE SET DEFAULT - two tables reset each other's references to NULL
+@cross-check-integrity
+test fk-setdefault-delete-two-table-cycle-null-default {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER DEFAULT NULL REFERENCES b(id) ON DELETE SET DEFAULT);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER DEFAULT NULL REFERENCES a(id) ON DELETE SET DEFAULT);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    DELETE FROM a WHERE id=1;
+    SELECT id, aid FROM b ORDER BY id;
+}
+expect {
+    2|
+}
+
+# ON UPDATE SET DEFAULT - two tables reset each other's references to NULL
+@cross-check-integrity
+test fk-setdefault-update-two-table-cycle-null-default {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER DEFAULT NULL REFERENCES b(id) ON UPDATE SET DEFAULT);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER DEFAULT NULL REFERENCES a(id) ON UPDATE SET DEFAULT);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    UPDATE a SET id=10 WHERE id=1;
+    SELECT a.id,a.bid,b.id,b.aid FROM a,b;
+}
+expect {
+    10|2|2|
+}
+
+# ON DELETE SET DEFAULT - two-table cycle fails when the default has no parent row
+@cross-check-integrity
+test fk-setdefault-delete-two-table-cycle-missing-default-fails {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER DEFAULT 999 REFERENCES b(id) ON DELETE SET DEFAULT);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER DEFAULT 999 REFERENCES a(id) ON DELETE SET DEFAULT);
+    INSERT INTO a(id,bid) VALUES(1,NULL);
+    INSERT INTO b(id,aid) VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    DELETE FROM a WHERE id=1;
+}
+expect error {
+}
+
+# ON UPDATE SET DEFAULT - two-table cycle fails when the default has no parent row
+@cross-check-integrity
+test fk-setdefault-update-two-table-cycle-missing-default-fails {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER DEFAULT 999 REFERENCES b(id) ON UPDATE SET DEFAULT);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER DEFAULT 999 REFERENCES a(id) ON UPDATE SET DEFAULT);
+    INSERT INTO a(id,bid) VALUES(1,NULL);
+    INSERT INTO b(id,aid) VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    UPDATE a SET id=10 WHERE id=1;
+}
+expect error {
 }
 
 # ON DELETE CASCADE with ON UPDATE NO ACTION

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -1892,6 +1892,21 @@ expect {
     0
 }
 
+# ON DELETE CASCADE - multi-row parent delete on adjacent rows of a self-ref chain.
+# Each deleted root row references the next, so the parent scan and the cascade
+# target overlapping rows.
+@cross-check-integrity
+test fk-cascade-delete-self-referential-adjacent-rows {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES t(id) ON DELETE CASCADE);
+    INSERT INTO t VALUES(1,NULL),(2,1),(3,2),(4,3),(5,4),(6,5),(7,6),(8,7);
+    DELETE FROM t WHERE id BETWEEN 1 AND 4;
+    SELECT count(*) FROM t;
+}
+expect {
+    0
+}
+
 # EXPLAIN should print the recursive FK action once and then stop.
 test fk-cascade-delete-self-referential-explain-terminates {
     PRAGMA foreign_keys=ON;
@@ -1936,6 +1951,70 @@ test fk-cascade-delete-three-table-cycle {
 }
 expect {
     0|0|0
+}
+
+# Two-table cycle with mixed cascade actions: a->b ON DELETE CASCADE,
+# b->a ON UPDATE CASCADE. Verifies the (fk, parent_change) compile-stack
+# key distinguishes ON DELETE from ON UPDATE for the same FK pair.
+@cross-check-integrity
+test fk-cascade-mixed-actions-two-table-cycle {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON DELETE CASCADE);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON UPDATE CASCADE);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    UPDATE a SET id=10 WHERE id=1;
+    SELECT 'after-update', a.id, a.bid, b.id, b.aid FROM a, b;
+    DELETE FROM b WHERE id=2;
+    SELECT 'after-delete-a', count(*) FROM a;
+    SELECT 'after-delete-b', count(*) FROM b;
+}
+expect {
+    after-update|10|2|2|10
+    after-delete-a|0
+    after-delete-b|0
+}
+
+# RESTRICT in a two-table cycle: must report a constraint violation rather
+# than recurse. The RESTRICT action does not emit a cascade
+# subprogram, but the cycle topology should not confuse the planner.
+@cross-check-integrity
+test fk-restrict-two-table-cycle {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE a(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id) ON DELETE RESTRICT);
+    CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id) ON DELETE RESTRICT);
+    INSERT INTO a VALUES(1,NULL);
+    INSERT INTO b VALUES(2,1);
+    UPDATE a SET bid=2 WHERE id=1;
+    DELETE FROM a WHERE id=1;
+}
+expect error {
+}
+
+# Cascade fires a trigger that issues an UPDATE that fires another cascade.
+# Exercises the interaction between fkeys.rs (cascade emission) and trigger_exec.rs.
+@cross-check-integrity
+test fk-cascade-trigger-cascade {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(id INTEGER PRIMARY KEY);
+    CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id) ON UPDATE CASCADE);
+    CREATE TABLE gc(id INTEGER PRIMARY KEY, cid INTEGER REFERENCES c(id) ON UPDATE CASCADE);
+    CREATE TRIGGER tr AFTER UPDATE OF pid ON c BEGIN
+      UPDATE c SET id = id + 100 WHERE id = NEW.id;
+    END;
+    INSERT INTO p VALUES(1);
+    INSERT INTO c VALUES(10, 1);
+    INSERT INTO gc VALUES(20, 10);
+    UPDATE p SET id=99 WHERE id=1;
+    SELECT 'p', id FROM p;
+    SELECT 'c', id, pid FROM c;
+    SELECT 'gc', id, cid FROM gc;
+}
+expect {
+    p|99
+    c|110|99
+    gc|20|110
 }
 
 # Basic ON UPDATE CASCADE - single child row

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -2230,10 +2230,10 @@ mod fuzz_tests {
         println!("fk_cascade_actions_fuzz complete (seed {seed})");
     }
 
-    // Fuzz test for recursive CASCADE (A->B->C chains)
+    // Fuzz test for recursive CASCADE chains, self-references, and FK cycles.
     #[turso_macros::test(mvcc)]
-    pub fn fk_recursive_cascade_fuzz(db: TempDatabase) {
-        let (mut rng, seed) = helpers::init_fuzz_test("fk_recursive_cascade_fuzz");
+    pub fn fk_recursive_fk_action_fuzz(db: TempDatabase) {
+        let (mut rng, seed) = helpers::init_fuzz_test("fk_recursive_fk_action_fuzz");
 
         let builder = helpers::builder_from_db(&db);
 
@@ -2241,7 +2241,7 @@ mod fuzz_tests {
         const INNER_ITERS: usize = 200;
 
         for outer in 0..OUTER_ITERS {
-            println!("fk_recursive_cascade_fuzz {}/{}", outer + 1, OUTER_ITERS);
+            println!("fk_recursive_fk_action_fuzz {}/{}", outer + 1, OUTER_ITERS);
 
             let limbo_db = builder.clone().build();
             let sqlite_db = builder.clone().build();
@@ -2278,6 +2278,31 @@ mod fuzz_tests {
             );
             limbo_exec_rows(&limbo, &s);
             sqlite.execute(&s, params![]).unwrap();
+
+            for stmt in [
+                "CREATE TABLE self_fk(id INTEGER PRIMARY KEY, pid INT, \
+                 FOREIGN KEY(pid) REFERENCES self_fk(id) ON DELETE CASCADE ON UPDATE CASCADE)",
+                "CREATE TABLE cycle_a(id INTEGER PRIMARY KEY, bid INT, \
+                 FOREIGN KEY(bid) REFERENCES cycle_b(id) ON DELETE CASCADE ON UPDATE CASCADE)",
+                "CREATE TABLE cycle_b(id INTEGER PRIMARY KEY, aid INT, \
+                 FOREIGN KEY(aid) REFERENCES cycle_a(id) ON DELETE CASCADE ON UPDATE CASCADE)",
+                "CREATE TABLE null_a(id INTEGER PRIMARY KEY, bid INT, \
+                 FOREIGN KEY(bid) REFERENCES null_b(id) ON DELETE SET NULL ON UPDATE SET NULL)",
+                "CREATE TABLE null_b(id INTEGER PRIMARY KEY, aid INT, \
+                 FOREIGN KEY(aid) REFERENCES null_a(id) ON DELETE SET NULL ON UPDATE SET NULL)",
+                "CREATE TABLE default_a(id INTEGER PRIMARY KEY, bid INT DEFAULT NULL, \
+                 FOREIGN KEY(bid) REFERENCES default_b(id) ON DELETE SET DEFAULT ON UPDATE SET DEFAULT)",
+                "CREATE TABLE default_b(id INTEGER PRIMARY KEY, aid INT DEFAULT NULL, \
+                 FOREIGN KEY(aid) REFERENCES default_a(id) ON DELETE SET DEFAULT ON UPDATE SET DEFAULT)",
+                "CREATE TABLE bad_default_a(id INTEGER PRIMARY KEY, bid INT DEFAULT 999, \
+                 FOREIGN KEY(bid) REFERENCES bad_default_b(id) ON DELETE SET DEFAULT ON UPDATE SET DEFAULT)",
+                "CREATE TABLE bad_default_b(id INTEGER PRIMARY KEY, aid INT DEFAULT 999, \
+                 FOREIGN KEY(aid) REFERENCES bad_default_a(id) ON DELETE SET DEFAULT ON UPDATE SET DEFAULT)",
+            ] {
+                let stmt = log_and_exec(stmt);
+                limbo_exec_rows(&limbo, &stmt);
+                sqlite.execute(&stmt, params![]).unwrap();
+            }
 
             // Seed grandparents
             let mut gp_ids = std::collections::HashSet::new();
@@ -2319,9 +2344,29 @@ mod fuzz_tests {
                 }
             }
 
-            // Fuzz mutations on the hierarchy
+            for stmt in [
+                "INSERT INTO self_fk VALUES (1,NULL),(2,1),(3,2),(4,3),(10,NULL),(11,10)",
+                "INSERT INTO cycle_a VALUES (1,NULL)",
+                "INSERT INTO cycle_b VALUES (2,1)",
+                "UPDATE cycle_a SET bid=2 WHERE id=1",
+                "INSERT INTO null_a VALUES (1,NULL)",
+                "INSERT INTO null_b VALUES (2,1)",
+                "UPDATE null_a SET bid=2 WHERE id=1",
+                "INSERT INTO default_a VALUES (1,NULL)",
+                "INSERT INTO default_b VALUES (2,1)",
+                "UPDATE default_a SET bid=2 WHERE id=1",
+                "INSERT INTO bad_default_a(id,bid) VALUES (1,NULL)",
+                "INSERT INTO bad_default_b(id,aid) VALUES (2,1)",
+                "UPDATE bad_default_a SET bid=2 WHERE id=1",
+            ] {
+                let stmt = log_and_exec(stmt);
+                limbo_exec_rows(&limbo, &stmt);
+                sqlite.execute(&stmt, params![]).unwrap();
+            }
+
+            // Fuzz mutations on the hierarchy, self-reference, and cycles.
             for _ in 0..INNER_ITERS {
-                let op = rng.random_range(0..12);
+                let op = rng.random_range(0..30);
                 let stmt = match op {
                     // DELETE grandparent (should cascade to parent and child)
                     0 | 1 => {
@@ -2431,7 +2476,7 @@ mod fuzz_tests {
                         }
                     }
                     // UPSERT on parent that updates value (doesn't change FK key)
-                    _ => {
+                    11 => {
                         if let Some(id) = p_ids.iter().choose(&mut rng).cloned() {
                             if let Some(gp_id) = gp_ids.iter().choose(&mut rng) {
                                 let new_v = rng.random_range(0..=100);
@@ -2445,59 +2490,94 @@ mod fuzz_tests {
                             continue;
                         }
                     }
+                    // DELETE a self-referential cascade root.
+                    12 => "DELETE FROM self_fk WHERE id=1".to_string(),
+                    // DELETE more than one self-referential cascade root.
+                    13 => "DELETE FROM self_fk WHERE id IN (1,10)".to_string(),
+                    // UPDATE a self-referential cascade root.
+                    14 => "UPDATE self_fk SET id=id+100 WHERE id=1".to_string(),
+                    // Try to rebuild the root of the self-referential graph.
+                    15 => "INSERT OR IGNORE INTO self_fk VALUES(1,NULL)".to_string(),
+                    // Try to rebuild one child in the self-referential graph.
+                    16 => "INSERT OR IGNORE INTO self_fk VALUES(2,1)".to_string(),
+                    // DELETE one side of a two-table cascade cycle.
+                    17 => "DELETE FROM cycle_a WHERE id=1".to_string(),
+                    // UPDATE one side of a two-table cascade cycle.
+                    18 => "UPDATE cycle_a SET id=10 WHERE id=1".to_string(),
+                    // Try to rebuild the first row in the two-table cascade cycle.
+                    19 => "INSERT OR IGNORE INTO cycle_a VALUES(1,NULL)".to_string(),
+                    // Try to rebuild the second row in the two-table cascade cycle.
+                    20 => "INSERT OR IGNORE INTO cycle_b VALUES(2,1)".to_string(),
+                    // Try to link the rebuilt two-table cascade cycle.
+                    21 => "UPDATE cycle_a SET bid=2 WHERE id=1".to_string(),
+                    // DELETE through a SET NULL cycle.
+                    22 => "DELETE FROM null_a WHERE id=1".to_string(),
+                    // UPDATE through a SET NULL cycle.
+                    23 => "UPDATE null_a SET id=10 WHERE id=1".to_string(),
+                    // DELETE through a SET DEFAULT cycle whose default is NULL.
+                    24 => "DELETE FROM default_a WHERE id=1".to_string(),
+                    // UPDATE through a SET DEFAULT cycle whose default is NULL.
+                    25 => "UPDATE default_a SET id=10 WHERE id=1".to_string(),
+                    // DELETE through a SET DEFAULT cycle whose default breaks the FK.
+                    26 => "DELETE FROM bad_default_a WHERE id=1".to_string(),
+                    // UPDATE through a SET DEFAULT cycle whose default breaks the FK.
+                    27 => "UPDATE bad_default_a SET id=10 WHERE id=1".to_string(),
+                    // INSERT a missing self-reference. Both engines must reject it.
+                    28 => "INSERT INTO self_fk(id,pid) VALUES(30,999)".to_string(),
+                    // INSERT a missing cycle reference. Both engines must reject it.
+                    _ => "INSERT INTO cycle_a VALUES(30,999)".to_string(),
                 };
 
                 let stmt = log_and_exec(&stmt);
                 let sres = sqlite.execute(&stmt, params![]);
                 let lres = limbo_exec_rows_fallible(&limbo_db, &limbo, &stmt);
+                let context = format!(
+                    "recursive FK action fuzz\nseed: {seed}\nouter: {}\nlast stmt: {stmt}",
+                    outer + 1
+                );
+                helpers::assert_outcome_parity(&sres, &lres, &stmt, &context);
 
-                match (sres, lres) {
-                    (Ok(_), Ok(_)) => {
-                        // Verify state parity
-                        let s_gp = sqlite_exec_rows(&sqlite, "SELECT id,v FROM gp ORDER BY id");
-                        let l_gp = limbo_exec_rows(&limbo, "SELECT id,v FROM gp ORDER BY id");
-                        let s_p = sqlite_exec_rows(&sqlite, "SELECT id,gp_id,v FROM p ORDER BY id");
-                        let l_p = limbo_exec_rows(&limbo, "SELECT id,gp_id,v FROM p ORDER BY id");
-                        let s_c = sqlite_exec_rows(&sqlite, "SELECT id,p_id,v FROM c ORDER BY id");
-                        let l_c = limbo_exec_rows(&limbo, "SELECT id,p_id,v FROM c ORDER BY id");
-
-                        if s_gp != l_gp || s_p != l_p || s_c != l_c {
-                            eprintln!("\n=== Recursive CASCADE fuzz failure ===");
-                            eprintln!("seed: {seed}, outer: {}", outer + 1);
-                            eprintln!("last stmt: {stmt}");
-                            eprintln!("sqlite gp: {s_gp:?}");
-                            eprintln!("limbo  gp: {l_gp:?}");
-                            eprintln!("sqlite p: {s_p:?}");
-                            eprintln!("limbo  p: {l_p:?}");
-                            eprintln!("sqlite c: {s_c:?}");
-                            eprintln!("limbo  c: {l_c:?}");
-                            let mut file =
-                                std::fs::File::create("fk_recursive_cascade_fuzz.sql").unwrap();
-                            for s in stmts.iter() {
-                                let _ = file.write_fmt(format_args!("{s};\n"));
-                            }
-                            file.flush().unwrap();
-                            panic!("Recursive CASCADE mismatch");
-                        }
-                    }
-                    (Err(_), Err(_)) => {}
-                    (ok_sqlite, ok_limbo) => {
-                        eprintln!("\n=== Recursive CASCADE outcome mismatch ===");
-                        eprintln!("seed: {seed}");
-                        eprintln!("sqlite: {ok_sqlite:?}, limbo: {ok_limbo:?}");
-                        eprintln!("stmt: {stmt}");
+                for (table, query) in [
+                    ("gp", "SELECT id,v FROM gp ORDER BY id"),
+                    ("p", "SELECT id,gp_id,v FROM p ORDER BY id"),
+                    ("c", "SELECT id,p_id,v FROM c ORDER BY id"),
+                    ("self_fk", "SELECT id,pid FROM self_fk ORDER BY id"),
+                    ("cycle_a", "SELECT id,bid FROM cycle_a ORDER BY id"),
+                    ("cycle_b", "SELECT id,aid FROM cycle_b ORDER BY id"),
+                    ("null_a", "SELECT id,bid FROM null_a ORDER BY id"),
+                    ("null_b", "SELECT id,aid FROM null_b ORDER BY id"),
+                    ("default_a", "SELECT id,bid FROM default_a ORDER BY id"),
+                    ("default_b", "SELECT id,aid FROM default_b ORDER BY id"),
+                    (
+                        "bad_default_a",
+                        "SELECT id,bid FROM bad_default_a ORDER BY id",
+                    ),
+                    (
+                        "bad_default_b",
+                        "SELECT id,aid FROM bad_default_b ORDER BY id",
+                    ),
+                ] {
+                    let sqlite_rows = sqlite_exec_rows(&sqlite, query);
+                    let limbo_rows = limbo_exec_rows(&limbo, query);
+                    if sqlite_rows != limbo_rows {
+                        eprintln!("\n=== Recursive FK fuzz failure ===");
+                        eprintln!("seed: {seed}, outer: {}", outer + 1);
+                        eprintln!("last stmt: {stmt}");
+                        eprintln!("table: {table}");
+                        eprintln!("sqlite rows: {sqlite_rows:?}");
+                        eprintln!("limbo  rows: {limbo_rows:?}");
                         let mut file =
-                            std::fs::File::create("fk_recursive_cascade_fuzz.sql").unwrap();
+                            std::fs::File::create("fk_recursive_fk_action_fuzz.sql").unwrap();
                         for s in stmts.iter() {
                             let _ = file.write_fmt(format_args!("{s};\n"));
                         }
                         file.flush().unwrap();
-                        panic!("Recursive CASCADE outcome mismatch");
+                        panic!("Recursive FK state mismatch");
                     }
                 }
             }
         }
-        println!("fk_recursive_cascade_fuzz complete (seed {seed})");
+        println!("fk_recursive_fk_action_fuzz complete (seed {seed})");
     }
 
     #[turso_macros::test(mvcc)]


### PR DESCRIPTION
## Le broblem:

FK actions are compiled into subprograms. A self-referential cascade, or a cycle between two tables, can reach the same action again while that action is still being compiled, resulting in stack overflow.

## Le fix:

Track the fk action programs currently being compiled in the resolver. When compilation re-enters the same foreign-key action, emit a Program instruction that points at the in-progress action slot instead of compiling another copy. Fill that slot with a weak reference after the action program is built so the program can call itself without owning itself.