### PR TITLE
Fix ignored updates and self-referential updates incorrectly mutating FK violation counters

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -77,13 +77,19 @@ pub fn emit_program_for_compound_select(
                                 .map_err(|_| LimboError::ParseError("invalid limit".to_string()))?;
                             program.emit_insn(Insn::Real { value, dest: reg });
                             program.add_comment(program.offset(), "LIMIT counter");
-                            program.emit_insn(Insn::MustBeInt { reg });
+                            program.emit_insn(Insn::MustBeInt {
+                                reg,
+                                target_pc: None,
+                            });
                         }
                     }
                     _ => {
                         _ = translate_expr(program, None, limit, reg, &right_most_ctx.resolver);
                         program.add_comment(program.offset(), "LIMIT counter");
-                        program.emit_insn(Insn::MustBeInt { reg });
+                        program.emit_insn(Insn::MustBeInt {
+                            reg,
+                            target_pc: None,
+                        });
                     }
                 }
                 Ok::<_, LimboError>(LimitCtx::new_shared(reg))
@@ -120,7 +126,10 @@ pub fn emit_program_for_compound_select(
                     }
                 }
                 program.add_comment(program.offset(), "OFFSET counter");
-                program.emit_insn(Insn::MustBeInt { reg });
+                program.emit_insn(Insn::MustBeInt {
+                    reg,
+                    target_pc: None,
+                });
                 let combined_reg = program.alloc_register();
                 program.add_comment(program.offset(), "OFFSET + LIMIT");
                 program.emit_insn(Insn::OffsetLimit {
@@ -991,13 +1000,19 @@ fn emit_compound_order_by(
                             .map_err(|_| LimboError::ParseError("invalid limit".to_string()))?;
                         program.emit_insn(Insn::Real { value, dest: reg });
                         program.add_comment(program.offset(), "LIMIT counter");
-                        program.emit_insn(Insn::MustBeInt { reg });
+                        program.emit_insn(Insn::MustBeInt {
+                            reg,
+                            target_pc: None,
+                        });
                     }
                 }
                 _ => {
                     _ = translate_expr(program, None, limit_expr, reg, &right_most_ctx.resolver);
                     program.add_comment(program.offset(), "LIMIT counter");
-                    program.emit_insn(Insn::MustBeInt { reg });
+                    program.emit_insn(Insn::MustBeInt {
+                        reg,
+                        target_pc: None,
+                    });
                 }
             }
             Ok::<_, LimboError>(reg)
@@ -1023,7 +1038,10 @@ fn emit_compound_order_by(
                 }
             }
             program.add_comment(program.offset(), "OFFSET counter");
-            program.emit_insn(Insn::MustBeInt { reg });
+            program.emit_insn(Insn::MustBeInt {
+                reg,
+                target_pc: None,
+            });
             if let Some(limit_reg) = limit_ctx {
                 let combined_reg = program.alloc_register();
                 program.add_comment(program.offset(), "OFFSET + LIMIT");

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -342,7 +342,10 @@ pub fn emit_fk_child_decrement_on_delete(
                 dst_reg: tmpi,
                 extra_amount: 0,
             });
-            program.emit_insn(Insn::MustBeInt { reg: tmpi });
+            program.emit_insn(Insn::MustBeInt {
+                reg: tmpi,
+                target_pc: None,
+            });
 
             // NotExists jumps when the parent key is missing, so we decrement there
             let missing = program.allocate_label();

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1629,6 +1629,7 @@ pub(crate) fn init_limit(
                         program.add_comment(program.offset(), "LIMIT counter");
                         program.emit_insn(Insn::MustBeInt {
                             reg: limit_ctx.reg_limit,
+                            target_pc: None,
                         });
                     }
                     _ => unreachable!("parse_numeric_literal only returns Integer or Float"),
@@ -1637,7 +1638,10 @@ pub(crate) fn init_limit(
                     let r = limit_ctx.reg_limit;
 
                     _ = translate_expr(program, None, expr, r, &t_ctx.resolver)?;
-                    program.emit_insn(Insn::MustBeInt { reg: r });
+                    program.emit_insn(Insn::MustBeInt {
+                        reg: r,
+                        target_pc: None,
+                    });
                 }
             }
         }
@@ -1660,7 +1664,10 @@ pub(crate) fn init_limit(
                             value: value.into(),
                             dest: offset_reg,
                         });
-                        program.emit_insn(Insn::MustBeInt { reg: offset_reg });
+                        program.emit_insn(Insn::MustBeInt {
+                            reg: offset_reg,
+                            target_pc: None,
+                        });
                     }
                     _ => unreachable!("parse_numeric_literal only returns Integer or Float"),
                 },
@@ -1669,7 +1676,10 @@ pub(crate) fn init_limit(
                 }
             }
             program.add_comment(program.offset(), "OFFSET counter");
-            program.emit_insn(Insn::MustBeInt { reg: offset_reg });
+            program.emit_insn(Insn::MustBeInt {
+                reg: offset_reg,
+                target_pc: None,
+            });
 
             let combined_reg = program.alloc_register();
             t_ctx.reg_limit_offset_sum = Some(combined_reg);

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -772,6 +772,7 @@ fn emit_update_column_values<'a>(
             )?;
             program.emit_insn(Insn::MustBeInt {
                 reg: rowid_set_clause_reg,
+                target_pc: None,
             });
         }
     }
@@ -817,6 +818,7 @@ fn emit_update_column_values<'a>(
 
                     program.emit_insn(Insn::MustBeInt {
                         reg: rowid_set_clause_reg,
+                        target_pc: None,
                     });
 
                     program.emit_null(target_reg, None);

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1477,59 +1477,21 @@ fn emit_update_insns<'a>(
         )?;
     }
 
-    let mut deferred_new_key_plans = Vec::new();
+    // Build a complete NEW row image for FK code now, while the old cursor is
+    // still positioned. This is only data preparation. FK counters must not be
+    // touched yet because later CHECK/PK/UNIQUE conflict handling may still
+    // decide that `ON CONFLICT IGNORE` makes this row a no-op.
     if connection.foreign_keys_enabled() {
         let rowid_new_reg = effective_rowid_reg;
         if let Some(table_btree) = target_table.table.btree() {
-            let updated_set_columns: ColumnMask = set_clauses
-                .iter()
-                .filter_map(|set_clause| {
-                    (set_clause.column_index != ROWID_SENTINEL).then_some(set_clause.column_index)
-                })
-                .try_collect()?;
             stabilize_new_row_for_fk(
                 program,
                 &table_btree,
-                &updated_set_columns,
+                &updated_column_indices,
                 target_table_cursor_id,
                 start,
                 rowid_new_reg,
             )?;
-            // Child-side FK checks are deferred to AFTER custom type encoding (see below).
-            // This is because child FK checks probe the parent's index which contains
-            // encoded values, so the NEW values must also be encoded.
-
-            // Parent-side NO ACTION/RESTRICT checks must happen BEFORE the update.
-            // This checks that no child rows reference the old parent key values.
-            // CASCADE/SET NULL actions are fired AFTER the update (see below after Insert).
-            if t_ctx.resolver.with_schema(update_database_id, |s| {
-                s.any_resolved_fks_referencing(table_name)
-            }) {
-                let new_key_probe_mode = if any_effective_replace(
-                    program.flags.has_statement_conflict(),
-                    or_conflict,
-                    table_btree.rowid_alias_conflict_clause,
-                    indexes_to_update.iter().map(|idx| idx.on_conflict),
-                ) {
-                    ParentKeyNewProbeMode::AfterReplace
-                } else {
-                    ParentKeyNewProbeMode::BeforeWrite
-                };
-                deferred_new_key_plans = emit_fk_update_parent_actions(
-                    program,
-                    &table_btree,
-                    indexes_to_update.iter(),
-                    target_table_cursor_id,
-                    beg,
-                    start,
-                    rowid_new_reg,
-                    rowid_set_clause_reg,
-                    &updated_set_columns,
-                    new_key_probe_mode,
-                    update_database_id,
-                    &t_ctx.resolver,
-                )?;
-            }
         }
     }
 
@@ -1785,27 +1747,6 @@ fn emit_update_insns<'a>(
                 skip_row_label,
                 Some(&check_constraint_tables),
             )?;
-        }
-    }
-
-    // Child-side FK checks must run AFTER custom type encoding so that NEW values
-    // being probed against the parent's index are encoded (matching the index contents).
-    if connection.foreign_keys_enabled() {
-        if let Some(table_btree) = target_table.table.btree() {
-            if t_ctx.resolver.schema().has_child_fks(table_name) {
-                emit_fk_child_update_counters(
-                    program,
-                    &table_btree,
-                    table_name,
-                    target_table_cursor_id,
-                    start,
-                    effective_rowid_reg,
-                    &affected_columns,
-                    update_database_id,
-                    &t_ctx.resolver,
-                    &layout,
-                )?;
-            }
         }
     }
 
@@ -2148,6 +2089,82 @@ fn emit_update_insns<'a>(
             rowid_reg: beg,
             target_pc: row_not_found_label,
         });
+    }
+
+    // This is the first point where FK counter changes are safe:
+    //
+    // * `ON CONFLICT IGNORE` no-op paths for CHECK/PK/UNIQUE have already
+    //   jumped away. A skipped row must not increment or decrement the single
+    //   deferred FK counter.
+    // * No table or index entry has been rewritten yet. If an immediate FK
+    //   check fails, the statement can stop without leaving partial mutations
+    //   behind.
+    //
+    // Both parent-side and child-side FK checks below run against the
+    // pre-rewrite table image. Self-referential rows therefore need explicit
+    // handling: table scans see OLD values, while the NEW parent/child keys
+    // live in registers until the rewrite.
+    let mut deferred_new_key_plans = Vec::new();
+    if connection.foreign_keys_enabled() {
+        let rowid_new_reg = effective_rowid_reg;
+        if let Some(table_btree) = target_table.table.btree() {
+            // Parent-side checks scan child rows that point at the OLD parent
+            // key. Each match means this update may create a new violation:
+            // RESTRICT halts immediately, while NO ACTION increments the FK
+            // counter so the statement/transaction can fail later if nothing
+            // fixes it.
+            if t_ctx.resolver.with_schema(update_database_id, |s| {
+                s.any_resolved_fks_referencing(table_name)
+            }) {
+                let new_key_probe_mode = if any_effective_replace(
+                    program.flags.has_statement_conflict(),
+                    or_conflict,
+                    table_btree.rowid_alias_conflict_clause,
+                    indexes_to_update.iter().map(|idx| idx.on_conflict),
+                ) {
+                    ParentKeyNewProbeMode::AfterReplace
+                } else {
+                    ParentKeyNewProbeMode::BeforeWrite
+                };
+                deferred_new_key_plans = emit_fk_update_parent_actions(
+                    program,
+                    &table_btree,
+                    indexes_to_update.iter(),
+                    target_table_cursor_id,
+                    beg,
+                    start,
+                    rowid_new_reg,
+                    rowid_set_clause_reg,
+                    &updated_column_indices,
+                    new_key_probe_mode,
+                    update_database_id,
+                    &t_ctx.resolver,
+                )?;
+            }
+        }
+    }
+
+    // Child-side checks answer the opposite question: does the row's NEW child
+    // key have a parent? They also have to run after no-op conflict paths and
+    // before the physical rewrite, for the same counter and rollback reasons as
+    // the parent-side checks above.
+    if connection.foreign_keys_enabled() {
+        if let Some(table_btree) = target_table.table.btree() {
+            if t_ctx.resolver.schema().has_child_fks(table_name) {
+                emit_fk_child_update_counters(
+                    program,
+                    &table_btree,
+                    table_name,
+                    target_table_cursor_id,
+                    start,
+                    effective_rowid_reg,
+                    &affected_columns,
+                    update_database_id,
+                    &t_ctx.resolver,
+                    &layout,
+                )?;
+            }
+        }
     }
 
     // ---- Phase 2: Delete old index entries ----

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -979,10 +979,13 @@ pub fn emit_fk_child_update_counters(
                         dst_reg: rid,
                         extra_amount: 0,
                     });
-                    program.emit_insn(Insn::MustBeInt { reg: rid });
 
                     // If NOT exists => decrement
                     let miss = program.allocate_label();
+                    program.emit_insn(Insn::MustBeInt {
+                        reg: rid,
+                        target_pc: Some(miss),
+                    });
                     program.emit_insn(Insn::NotExists {
                         cursor: pcur,
                         rowid_reg: rid,
@@ -1116,7 +1119,11 @@ pub fn emit_fk_child_update_counters(
                 dst_reg: tmp,
                 extra_amount: 0,
             });
-            program.emit_insn(Insn::MustBeInt { reg: tmp });
+            let violation = program.allocate_label();
+            program.emit_insn(Insn::MustBeInt {
+                reg: tmp,
+                target_pc: Some(violation),
+            });
 
             // Match the rowid lookup semantics before using the same-row fast
             // path. Without the MustBeInt-normalized value, TEXT '2' would not
@@ -1132,7 +1139,6 @@ pub fn emit_fk_child_update_counters(
                 });
             }
 
-            let violation = program.allocate_label();
             program.emit_insn(Insn::NotExists {
                 cursor: pcur,
                 rowid_reg: tmp,

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -35,6 +35,17 @@ pub fn emit_guarded_fk_decrement(
 
 /// Chooses when the parent-side NEW-key probe runs.
 ///
+/// Parent-side FK checks are counter maintenance for child rows that reference
+/// the parent table:
+///
+/// * the OLD-key probe finds children that would become orphans and increments
+///   the FK counter, or halts immediately for RESTRICT;
+/// * the NEW-key probe finds children that this update repairs and decrements
+///   the deferred counter.
+///
+/// Because deferred checks share one aggregate counter, a NEW-key decrement is
+/// only correct if it corresponds to a real unresolved violation.
+///
 /// `BeforeWrite` is correct for plain `UPDATE` and `UPSERT .. DO UPDATE`:
 /// if a child row matches the NEW key, that child is genuinely missing its
 /// parent until this statement creates it.
@@ -73,6 +84,9 @@ fn emit_parent_key_change_probes(
     old_key_start: usize,
     new_key_start: usize,
     n_cols: usize,
+    current_rowid_reg: usize,
+    parent_table: &BTreeTable,
+    updated_positions: &ColumnMask,
     new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
@@ -137,6 +151,9 @@ fn emit_parent_key_change_probes(
         old_key_start,
         new_key_start,
         n_cols,
+        current_rowid_reg,
+        parent_table,
+        updated_positions,
         new_key_probe_mode,
         database_id,
         resolver,
@@ -236,8 +253,75 @@ where
     Ok(())
 }
 
-/// Iterate a table and call `on_match` when all child columns equal the key at `parent_key_start`.
-/// Skips rows where any FK column is NULL. If `self_exclude_rowid` is Some, the row with that rowid is skipped.
+/// Iterate the index entries whose leading columns equal `probe_start`.
+///
+/// Used when an FK parent-side probe needs the matching child rowid, for
+/// example to ignore the row currently being updated in a self-referential FK.
+fn index_scan_match_any<F>(
+    program: &mut ProgramBuilder,
+    icur: usize,
+    probe_start: usize,
+    num_regs: usize,
+    self_exclude_rowid: Option<usize>,
+    mut on_match: F,
+) -> Result<()>
+where
+    F: FnMut(&mut ProgramBuilder) -> Result<()>,
+{
+    let done = program.allocate_label();
+    program.emit_insn(Insn::SeekGE {
+        is_index: true,
+        cursor_id: icur,
+        start_reg: probe_start,
+        num_regs,
+        target_pc: done,
+        eq_only: true,
+    });
+
+    let loop_top = program.allocate_label();
+    program.preassign_label_to_next_insn(loop_top);
+    program.emit_insn(Insn::IdxGT {
+        cursor_id: icur,
+        start_reg: probe_start,
+        num_regs,
+        target_pc: done,
+    });
+
+    let next_row = program.allocate_label();
+    if let Some(parent_rowid) = self_exclude_rowid {
+        let child_rowid = program.alloc_register();
+        program.emit_insn(Insn::IdxRowId {
+            cursor_id: icur,
+            dest: child_rowid,
+        });
+        program.emit_insn(Insn::Eq {
+            lhs: child_rowid,
+            rhs: parent_rowid,
+            target_pc: next_row,
+            flags: CmpInsFlags::default(),
+            collation: None,
+        });
+    }
+
+    on_match(program)?;
+
+    program.preassign_label_to_next_insn(next_row);
+    program.emit_insn(Insn::Next {
+        cursor_id: icur,
+        pc_if_next: loop_top,
+    });
+
+    program.preassign_label_to_next_insn(done);
+    program.emit_insn(Insn::Close { cursor_id: icur });
+    Ok(())
+}
+
+/// Iterate a table and call `on_match` when all child columns equal the key at
+/// `parent_key_start`.
+///
+/// Rows with any NULL FK column do not reference a parent and are ignored. For
+/// self-referential UPDATEs, `self_exclude_rowid` skips the current row when
+/// its old child key is being updated away by the same statement.
 fn table_scan_match_any<F>(
     program: &mut ProgramBuilder,
     child_tbl: &Arc<BTreeTable>,
@@ -292,7 +376,9 @@ where
         program.preassign_label_to_next_insn(cont);
     }
 
-    //self-reference exclusion on rowid
+    // The current row may match the OLD parent key only because it has not been
+    // physically rewritten yet. If the caller knows this row's child key is
+    // changing too, do not count that disappearing old self-reference.
     if let Some(parent_rowid) = self_exclude_rowid {
         let child_rowid = program.alloc_register();
         let skip = program.allocate_label();
@@ -395,11 +481,14 @@ pub fn stabilize_new_row_for_fk(
 }
 
 /// Handles rowid and `INTEGER PRIMARY KEY` parent-key updates.
+#[allow(clippy::too_many_arguments)]
 pub fn emit_rowid_pk_change_check(
     program: &mut ProgramBuilder,
     incoming: &[ResolvedFkRef],
     old_rowid_reg: usize,
     new_rowid_reg: usize,
+    parent_table: &BTreeTable,
+    updated_positions: &ColumnMask,
     new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
@@ -410,6 +499,9 @@ pub fn emit_rowid_pk_change_check(
         old_rowid_reg,
         new_rowid_reg,
         1,
+        old_rowid_reg,
+        parent_table,
+        updated_positions,
         new_key_probe_mode,
         database_id,
         resolver,
@@ -427,6 +519,7 @@ pub fn emit_parent_index_key_change_checks(
     incoming: &[ResolvedFkRef],
     table_btree: &BTreeTable,
     index: &Index,
+    updated_positions: &ColumnMask,
     new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
@@ -506,6 +599,9 @@ pub fn emit_parent_index_key_change_checks(
         old_key,
         new_key,
         idx_len,
+        old_rowid_reg,
+        table_btree,
+        updated_positions,
         new_key_probe_mode,
         database_id,
         resolver,
@@ -523,17 +619,54 @@ pub fn emit_fk_parent_pk_change_counters(
     old_pk_start: usize,
     new_pk_start: usize,
     n_cols: usize,
+    current_rowid_reg: usize,
+    parent_table: &BTreeTable,
+    updated_positions: &ColumnMask,
     new_key_probe_mode: ParentKeyNewProbeMode,
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<()> {
     for fk_ref in incoming {
+        // Self-referential UPDATEs ask two different questions:
+        //
+        // 1. Does removing/changing the OLD parent key orphan a child row?
+        // 2. Does the NEW child key have a parent?
+        //
+        // The child-side code below answers question 2. This parent-side scan
+        // answers question 1 by looking for child rows that still point at the
+        // OLD parent key.
+        //
+        // A single row can be both the parent and the child:
+        //
+        //   UPDATE t SET id = 2, pid = 2 WHERE id = 1
+        //
+        // Before the physical rewrite, the scan still sees this row as
+        // `(id=1,pid=1)`. Counting that old self-reference would add a false
+        // violation because `pid` is being updated away in the same statement.
+        //
+        // Do not exclude the row when only the parent key changes. For
+        // `(id=1,pid=1)`, `UPDATE t SET id=2` leaves `(id=2,pid=1)`, and that
+        // is a real violation. With pre-rewrite FK checks, the NEW child probe
+        // can still see the old parent row in the table. The child-key-changed
+        // condition prevents that stale row from masking a parent-key-only
+        // orphan.
+        let self_exclude_rowid = if fk_ref
+            .child_table
+            .name
+            .eq_ignore_ascii_case(&parent_table.name)
+            && fk_ref.child_key_changed(updated_positions, parent_table)
+        {
+            Some(current_rowid_reg)
+        } else {
+            None
+        };
         emit_fk_parent_key_probe(
             program,
             fk_ref,
             old_pk_start,
             n_cols,
             ParentProbePass::Old,
+            self_exclude_rowid,
             database_id,
             resolver,
         )?;
@@ -545,6 +678,7 @@ pub fn emit_fk_parent_pk_change_counters(
                 new_pk_start,
                 n_cols,
                 ParentProbePass::New,
+                None,
                 database_id,
                 resolver,
             )?;
@@ -586,6 +720,7 @@ pub fn emit_fk_parent_deferred_new_key_probes(
                 plan.new_key_start,
                 plan.new_key_len,
                 ParentProbePass::New,
+                None,
                 database_id,
                 resolver,
             )?;
@@ -613,6 +748,7 @@ fn emit_fk_parent_key_probe(
     parent_key_start: usize,
     n_cols: usize,
     pass: ParentProbePass,
+    self_exclude_rowid: Option<usize>,
     database_id: usize,
     resolver: &Resolver,
 ) -> Result<()> {
@@ -623,7 +759,8 @@ fn emit_fk_parent_key_probe(
 
     let on_match = |p: &mut ProgramBuilder| -> Result<()> {
         match (is_deferred, pass) {
-            // OLD key referenced by a child
+            // OLD key referenced by a child: removing/changing this parent key
+            // creates a violation unless a later statement repairs it.
             (_, ParentProbePass::Old) => {
                 if is_restrict {
                     // RESTRICT: immediate halt
@@ -634,11 +771,10 @@ fn emit_fk_parent_key_probe(
                 }
             }
 
-            // NEW key referenced by a child (cancel one deferred violation)
-            // Note: for RESTRICT, we already halted on OLD pass if child exists,
-            // so this branch only applies to NO ACTION deferred FKs
+            // NEW key referenced by a child: this parent key may repair a
+            // deferred orphan. The decrement is guarded because the aggregate
+            // counter does not know which key originally incremented it.
             (true, ParentProbePass::New) => {
-                // Guard to avoid underflow if OLD pass didn't increment.
                 let skip = p.allocate_label();
                 emit_guarded_fk_decrement(p, skip, fk_ref.fk.deferred);
                 p.preassign_label_to_next_insn(skip);
@@ -649,25 +785,32 @@ fn emit_fk_parent_key_probe(
         Ok(())
     };
 
-    // Prefer exact child index on (child_cols...)
-    let indices: Vec<_> = resolver.with_schema(database_id, |s| {
-        s.get_indices(&child_tbl.name).cloned().collect()
-    });
-    let idx = indices.iter().find(|ix| {
-        ix.columns.len() == child_cols.len()
-            && ix
-                .columns
-                .iter()
-                .zip(child_cols.iter())
-                .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
+    // Prefer an exact child index on (child_cols...). If the current row must
+    // be excluded, scan only the matching index range so the rowid can be
+    // checked before counting the match.
+    let idx = resolver.with_schema(database_id, |s| {
+        s.get_indices(&child_tbl.name)
+            .find(|ix| {
+                ix.columns.len() == child_cols.len()
+                    && ix
+                        .columns
+                        .iter()
+                        .zip(child_cols.iter())
+                        .all(|(ic, cc)| ic.name.eq_ignore_ascii_case(cc))
+            })
+            .cloned()
     });
 
-    if let Some(ix) = idx {
+    if let Some(ix) = idx.as_ref() {
         let icur = open_read_index(program, ix, database_id);
         let probe = copy_with_affinity(program, parent_key_start, n_cols, ix, child_tbl);
 
-        // FOUND => on_match; NOT FOUND => no-op
-        index_probe(program, icur, probe, n_cols, on_match, |_p| Ok(()))?;
+        if self_exclude_rowid.is_some() {
+            index_scan_match_any(program, icur, probe, n_cols, self_exclude_rowid, on_match)?;
+        } else {
+            // FOUND => on_match; NOT FOUND => no-op
+            index_probe(program, icur, probe, n_cols, on_match, |_p| Ok(()))?;
+        }
     } else {
         // Table scan fallback
         table_scan_match_any(
@@ -675,7 +818,7 @@ fn emit_fk_parent_key_probe(
             child_tbl,
             child_cols,
             parent_key_start,
-            None,
+            self_exclude_rowid,
             database_id,
             on_match,
         )?;
@@ -896,6 +1039,10 @@ pub fn emit_fk_child_update_counters(
 
         // Pass 2: NEW tuple handling
         let fk_ok = program.allocate_label();
+        let is_self_ref = fk_ref
+            .child_table
+            .name
+            .eq_ignore_ascii_case(&fk_ref.fk.parent_table);
         for cname in &fk_ref.fk.child_columns {
             let (i, col) = child_tbl.get_column(cname).unwrap();
             let src = if col.is_rowid_alias() {
@@ -907,6 +1054,46 @@ pub fn emit_fk_child_update_counters(
                 reg: src,
                 target_pc: fk_ok,
             });
+        }
+
+        // A child NEW-key check normally probes the parent table before this
+        // row has been written. For a self-reference, the parent it needs may
+        // be this same row's NEW key, which is not in the table yet:
+        //
+        //   UPDATE t SET id = 2, pid = 2 WHERE id = 1
+        //
+        // If NEW child key == this row's NEW parent key, the row will satisfy
+        // itself after the rewrite, so skip the external parent probe. If any
+        // component differs, fall through to the normal parent lookup so
+        // genuinely missing references still fail.
+        //
+        // Rowid parents are handled in the rowid branch below so the child
+        // value can be coerced with MustBeInt before comparison, matching the
+        // rowid lookup path.
+        if is_self_ref && !fk_ref.parent_uses_rowid {
+            let self_mismatch = program.allocate_label();
+            for (idx, &child_pos) in fk_ref.child_pos.iter().enumerate() {
+                let child_reg = if child_tbl.columns()[child_pos].is_rowid_alias() {
+                    new_rowid_reg
+                } else {
+                    layout.to_register(new_start_reg, child_pos)
+                };
+                let parent_pos = fk_ref.parent_pos[idx];
+                let parent_reg = if child_tbl.columns()[parent_pos].is_rowid_alias() {
+                    new_rowid_reg
+                } else {
+                    layout.to_register(new_start_reg, parent_pos)
+                };
+                program.emit_insn(Insn::Ne {
+                    lhs: child_reg,
+                    rhs: parent_reg,
+                    target_pc: self_mismatch,
+                    flags: CmpInsFlags::default().jump_if_null(),
+                    collation: Some(CollationSeq::Binary),
+                });
+            }
+            program.emit_insn(Insn::Goto { target_pc: fk_ok });
+            program.preassign_label_to_next_insn(self_mismatch);
         }
 
         if fk_ref.parent_uses_rowid {
@@ -930,6 +1117,20 @@ pub fn emit_fk_child_update_counters(
                 extra_amount: 0,
             });
             program.emit_insn(Insn::MustBeInt { reg: tmp });
+
+            // Match the rowid lookup semantics before using the same-row fast
+            // path. Without the MustBeInt-normalized value, TEXT '2' would not
+            // match NEW rowid 2 and this valid self-reference would be counted
+            // as a deferred violation.
+            if is_self_ref {
+                program.emit_insn(Insn::Eq {
+                    lhs: tmp,
+                    rhs: new_rowid_reg,
+                    target_pc: fk_ok,
+                    flags: CmpInsFlags::default(),
+                    collation: None,
+                });
+            }
 
             let violation = program.allocate_label();
             program.emit_insn(Insn::NotExists {
@@ -1157,6 +1358,8 @@ pub fn emit_fk_update_parent_actions(
                 &rowid_fks,
                 old_rowid_reg,
                 rowid_set_clause_reg.unwrap_or(old_rowid_reg),
+                table_btree,
+                updated_positions,
                 new_key_probe_mode,
                 database_id,
                 resolver,
@@ -1176,6 +1379,7 @@ pub fn emit_fk_update_parent_actions(
             &check_fks,
             table_btree,
             index.as_ref(),
+            updated_positions,
             new_key_probe_mode,
             database_id,
             resolver,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1198,6 +1198,7 @@ fn emit_check_for_user_provided_rowid(
     program.preassign_label_to_next_insn(must_be_int_label);
     program.emit_insn(Insn::MustBeInt {
         reg: insertion.key_register(),
+        target_pc: None,
     });
 
     program.emit_insn(Insn::Goto {
@@ -3912,7 +3913,11 @@ pub fn emit_fk_child_insert_checks(
                 dst_reg: tmp,
                 extra_amount: 0,
             });
-            program.emit_insn(Insn::MustBeInt { reg: tmp });
+            let violation = program.allocate_label();
+            program.emit_insn(Insn::MustBeInt {
+                reg: tmp,
+                target_pc: Some(violation),
+            });
 
             // If this is a self-reference *and* the child FK equals NEW rowid,
             // the constraint will be satisfied once this row is inserted
@@ -3926,7 +3931,6 @@ pub fn emit_fk_child_insert_checks(
                 });
             }
 
-            let violation = program.allocate_label();
             program.emit_insn(Insn::NotExists {
                 cursor: pcur,
                 rowid_reg: tmp,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3953,8 +3953,61 @@ pub fn emit_fk_child_insert_checks(
                 .parent_unique_index
                 .as_ref()
                 .expect("parent unique index required");
-            let icur = open_read_index(program, idx, database_id);
             let ncols = fk_ref.fk.child_columns.len();
+
+            if is_self_ref {
+                // A self-referential INSERT is checked before the new row has
+                // been written to the parent index. Without a shortcut, even
+                // an exact self-reference would look like a missing parent.
+                // SQLite handles that by comparing the pending INSERT registers
+                // directly before it builds the affinity-coerced index probe.
+                //
+                //   CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER UNIQUE,
+                //                  pk TEXT REFERENCES t(k));
+                //   INSERT INTO t(id, k, pk) VALUES (1, 1, '1');
+                //
+                // In that INSERT image, the child key is pk=TEXT '1' and this
+                // row's parent key is k=INTEGER 1. Those stored values are not
+                // the same, so the same-row shortcut must not fire.
+                //
+                // The normal parent-index probe asks a different question:
+                // "after applying the parent key affinity, does this child key
+                // match some parent row that is already in the index?" That is
+                // why cross-row checks may coerce TEXT '1' to INTEGER 1 before
+                // seeking t(k). For this same-row case there is no parent index
+                // entry yet, so reusing the coerced probe would invent a match
+                // that SQLite rejects.
+                let mismatch = program.allocate_label();
+                for (i, &child_pos) in fk_ref.child_pos.iter().enumerate() {
+                    let child_reg = if child_tbl.columns()[child_pos].is_rowid_alias() {
+                        new_rowid_reg
+                    } else {
+                        layout.to_register(new_start_reg, child_pos)
+                    };
+                    let parent_pos = fk_ref.parent_pos[i];
+                    let parent_reg = if child_tbl.columns()[parent_pos].is_rowid_alias() {
+                        new_rowid_reg
+                    } else {
+                        layout.to_register(new_start_reg, parent_pos)
+                    };
+                    program.emit_insn(Insn::Ne {
+                        lhs: child_reg,
+                        rhs: parent_reg,
+                        target_pc: mismatch,
+                        flags: CmpInsFlags::default().jump_if_null(),
+                        // Keep this as BINARY. Even with
+                        // `k TEXT COLLATE NOCASE UNIQUE, pk TEXT REFERENCES t(k)`,
+                        // SQLite rejects same-row INSERT `(k, pk)=('A', 'a')`;
+                        // NOCASE applies to the later parent-index lookup only.
+                        collation: Some(super::collate::CollationSeq::Binary),
+                    });
+                }
+                // All equal: same-row OK
+                program.emit_insn(Insn::Goto { target_pc: fk_ok });
+                program.preassign_label_to_next_insn(mismatch);
+            }
+
+            let icur = open_read_index(program, idx, database_id);
 
             // Build NEW child probe from child NEW values, apply parent-index affinities.
             let probe = {
@@ -3980,53 +4033,6 @@ pub fn emit_fk_child_insert_checks(
                 }
                 start
             };
-            if is_self_ref {
-                // Determine the parent column order to compare against:
-                let parent_cols: Vec<&str> =
-                    idx.columns.iter().map(|ic| ic.name.as_str()).collect();
-
-                // Build new parent-key image from this same row’s new values, in the index order.
-                let parent_new = program.alloc_registers(ncols);
-                for (i, pname) in parent_cols.iter().enumerate() {
-                    let (pos, col) = child_tbl.get_column(pname).unwrap();
-                    program.emit_insn(Insn::Copy {
-                        src_reg: if col.is_rowid_alias() {
-                            new_rowid_reg
-                        } else {
-                            new_start_reg + pos
-                        },
-                        dst_reg: parent_new + i,
-                        extra_amount: 0,
-                    });
-                }
-                if let Some(cnt) = NonZeroUsize::new(ncols) {
-                    program.emit_insn(Insn::Affinity {
-                        start_reg: parent_new,
-                        count: cnt,
-                        affinities: build_index_affinity_string(idx, &parent_tbl),
-                    });
-                }
-
-                // Compare child probe to NEW parent image column-by-column.
-                let mismatch = program.allocate_label();
-                for i in 0..ncols {
-                    let cont = program.allocate_label();
-                    program.emit_insn(Insn::Eq {
-                        lhs: probe + i,
-                        rhs: parent_new + i,
-                        target_pc: cont,
-                        flags: CmpInsFlags::default().jump_if_null(),
-                        collation: Some(super::collate::CollationSeq::Binary),
-                    });
-                    program.emit_insn(Insn::Goto {
-                        target_pc: mismatch,
-                    });
-                    program.preassign_label_to_next_insn(cont);
-                }
-                // All equal: same-row OK
-                program.emit_insn(Insn::Goto { target_pc: fk_ok });
-                program.preassign_label_to_next_insn(mismatch);
-            }
             index_probe(
                 program,
                 icur,

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -667,7 +667,10 @@ pub fn emit_upsert(
                 dst_reg: r,
                 extra_amount: 0,
             });
-            program.emit_insn(Insn::MustBeInt { reg: r });
+            program.emit_insn(Insn::MustBeInt {
+                reg: r,
+                target_pc: None,
+            });
             new_rowid_reg = Some(r);
         }
     }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1406,6 +1406,12 @@ impl ProgramBuilder {
                 } => {
                     resolve(target_pc, "NotExists")?;
                 }
+                Insn::MustBeInt {
+                    target_pc: Some(target_pc),
+                    ..
+                } => {
+                    resolve(target_pc, "MustBeInt")?;
+                }
                 Insn::Yield {
                     yield_reg: _,
                     end_offset,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10156,31 +10156,40 @@ fn new_rowid_inner(
     }
 }
 
+fn coerce_register_to_integer(state: &mut ProgramState, reg: usize) -> Result<bool> {
+    let converted = match state.registers[reg].get_value() {
+        Value::Numeric(Numeric::Integer(_)) => return Ok(true),
+        Value::Numeric(Numeric::Float(f)) => cast_real_to_integer(f64::from(*f)).ok(),
+        Value::Text(text) => match checked_cast_text_to_numeric(text.as_str(), true) {
+            Ok(Value::Numeric(Numeric::Integer(i))) => Some(i),
+            Ok(Value::Numeric(Numeric::Float(f))) => cast_real_to_integer(f64::from(f)).ok(),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    if let Some(i) = converted {
+        state.registers[reg].set_int(i);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
 pub fn op_must_be_int(
     _program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(MustBeInt { reg }, insn);
-    match &state.registers[*reg].get_value() {
-        Value::Numeric(Numeric::Integer(_)) => {}
-        Value::Numeric(Numeric::Float(f)) => match cast_real_to_integer(f64::from(*f)) {
-            Ok(i) => state.registers[*reg].set_int(i),
-            Err(_) => bail_constraint_error!("datatype mismatch"),
-        },
-        Value::Text(text) => match checked_cast_text_to_numeric(text.as_str(), true) {
-            Ok(Value::Numeric(Numeric::Integer(i))) => state.registers[*reg].set_int(i),
-            Ok(Value::Numeric(Numeric::Float(f))) => match cast_real_to_integer(f64::from(f)) {
-                Ok(i) => state.registers[*reg].set_int(i),
-                Err(_) => bail_constraint_error!("datatype mismatch"),
-            },
-            _ => bail_constraint_error!("datatype mismatch"),
-        },
-        _ => {
-            bail_constraint_error!("datatype mismatch");
+    load_insn!(MustBeInt { reg, target_pc }, insn);
+    if !coerce_register_to_integer(state, *reg)? {
+        if let Some(target_pc) = target_pc {
+            state.pc = target_pc.as_offset_int();
+            return Ok(InsnFunctionStepResult::Step);
         }
-    };
+        bail_constraint_error!("datatype mismatch");
+    }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1492,10 +1492,13 @@ pub fn insn_to_row(
                 0,
                 format!("r[{rowid_reg}]=rowid"),
             ),
-            Insn::MustBeInt { reg } => (
+            Insn::MustBeInt { reg, target_pc } => (
                 "MustBeInt",
                 *reg as i64,
-                0,
+                target_pc
+                    .as_ref()
+                    .map(|target_pc| target_pc.as_offset_int())
+                    .unwrap_or_default() as i64,
                 0,
                 Value::build_text(""),
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1164,6 +1164,7 @@ pub enum Insn {
 
     MustBeInt {
         reg: usize,
+        target_pc: Option<BranchOffset>,
     },
 
     SoftNull {

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -351,6 +351,52 @@ test fk-self-ipk-single-mismatch {
 expect error {
 }
 
+@cross-check-integrity
+test fk-self-ipk-text-child-coerces-rowid-ok {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        rid TEXT REFERENCES t(id)
+    );
+    INSERT INTO t(id, rid) VALUES(1, '1');
+    SELECT typeof(id), typeof(rid), id, rid FROM t;
+}
+expect {
+    integer|text|1|1
+}
+
+@cross-check-integrity
+test fk-deferred-self-ipk-invalid-text-child-is-deferred {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        rid TEXT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    BEGIN;
+    INSERT INTO t(id, rid) VALUES(1, 'abc');
+    SELECT count(*) FROM t;
+    ROLLBACK;
+}
+expect {
+    1
+}
+
+@cross-check-integrity
+test fk-deferred-self-ipk-invalid-blob-child-is-deferred {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        rid BLOB REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    BEGIN;
+    INSERT INTO t(id, rid) VALUES(1, x'31');
+    SELECT count(*) FROM t;
+    ROLLBACK;
+}
+expect {
+    1
+}
+
 # Self-reference on composite PRIMARY KEY: single-row insert should pass
 @cross-check-integrity
 test fk-self-composite-single-ok {

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -767,6 +767,192 @@ expect {
 }
 
 @cross-check-integrity
+test fk-deferred-parent-update-ignore-noop-keeps-violation {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE ON CONFLICT IGNORE);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid,
+        FOREIGN KEY(pid) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (20);
+    INSERT INTO parent VALUES (24);
+    INSERT INTO child VALUES (1, 20);
+    BEGIN;
+    INSERT INTO child VALUES (2, 276);
+    UPDATE parent SET id=20 WHERE id=24;
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-parent-update-or-ignore-noop-keeps-violation {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid,
+        FOREIGN KEY(pid) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (20);
+    INSERT INTO parent VALUES (24);
+    INSERT INTO child VALUES (1, 20);
+    BEGIN;
+    INSERT INTO child VALUES (2, 276);
+    UPDATE OR IGNORE parent SET id=20 WHERE id=24;
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-parent-update-ignore-noop-keeps-old-key-valid {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE ON CONFLICT IGNORE);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid,
+        FOREIGN KEY(pid) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (20);
+    INSERT INTO parent VALUES (24);
+    INSERT INTO child VALUES (1, 24);
+    BEGIN;
+    UPDATE parent SET id=20 WHERE id=24;
+    COMMIT;
+    SELECT id, pid FROM child;
+}
+expect {
+    1|24
+}
+
+@cross-check-integrity
+test fk-deferred-parent-ipk-update-ignore-noop-keeps-violation {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY ON CONFLICT IGNORE);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (20);
+    INSERT INTO parent VALUES (24);
+    INSERT INTO child VALUES (1, 20);
+    BEGIN;
+    INSERT INTO child VALUES (2, 276);
+    UPDATE parent SET id=20 WHERE id=24;
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-parent-update-ignore-notnull-noop-keeps-old-key-valid {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE, nn NOT NULL);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (24, 'ok');
+    INSERT INTO child VALUES (1, 24);
+    BEGIN;
+    UPDATE OR IGNORE parent SET id=99, nn=NULL WHERE id=24;
+    COMMIT;
+    SELECT id, nn FROM parent;
+}
+expect {
+    24|ok
+}
+
+@cross-check-integrity
+test fk-deferred-child-update-ignore-noop-keeps-old-key-valid {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid,
+        u UNIQUE ON CONFLICT IGNORE,
+        FOREIGN KEY(pid) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (1);
+    INSERT INTO child VALUES (1, 1, 10);
+    INSERT INTO child VALUES (2, 1, 20);
+    BEGIN;
+    UPDATE child SET pid=999, u=10 WHERE id=2;
+    COMMIT;
+    SELECT id, pid, u FROM child ORDER BY id;
+}
+expect {
+    1|1|10
+    2|1|20
+}
+
+@cross-check-integrity
+test fk-deferred-child-update-ignore-noop-keeps-violation {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid,
+        u UNIQUE ON CONFLICT IGNORE,
+        FOREIGN KEY(pid) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (1);
+    INSERT INTO child VALUES (1, 1, 10);
+    BEGIN;
+    INSERT INTO child VALUES (2, 999, 20);
+    UPDATE child SET pid=1, u=10 WHERE id=2;
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-child-update-or-ignore-noop-keeps-old-key-valid {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE);
+    CREATE TABLE child(
+        id PRIMARY KEY,
+        pid,
+        u UNIQUE,
+        FOREIGN KEY(pid) REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (1);
+    INSERT INTO child VALUES (1, 1, 10);
+    INSERT INTO child VALUES (2, 1, 20);
+    BEGIN;
+    UPDATE OR IGNORE child SET pid=999, u=10 WHERE id=2;
+    COMMIT;
+    SELECT id, pid, u FROM child ORDER BY id;
+}
+expect {
+    1|1|10
+    2|1|20
+}
+
+@cross-check-integrity
+test fk-deferred-child-ipk-update-ignore-noop-keeps-old-key-valid {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id UNIQUE);
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY ON CONFLICT IGNORE,
+        pid REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES (1);
+    INSERT INTO child VALUES (1, 1);
+    INSERT INTO child VALUES (2, 1);
+    BEGIN;
+    UPDATE child SET id=1, pid=999 WHERE id=2;
+    COMMIT;
+    SELECT id, pid FROM child ORDER BY id;
+}
+expect {
+    1|1
+    2|1
+}
+
+@cross-check-integrity
 test fk-deferred-insert-commit-fails {
     PRAGMA foreign_keys=ON;
     CREATE TABLE p(id INTEGER PRIMARY KEY);
@@ -959,6 +1145,111 @@ test fk-deferred-update-self-ref-id-change-and-fix {
 }
 expect {
     2|2
+}
+
+@cross-check-integrity
+test fk-deferred-update-self-ref-id-and-pid-one-stmt {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id  INTEGER PRIMARY KEY,
+        pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO t VALUES(1, 1);
+    BEGIN;
+    UPDATE t SET id=2, pid=2 WHERE id=1;
+    COMMIT;
+    SELECT id, pid FROM t;
+}
+expect {
+    2|2
+}
+
+@cross-check-integrity
+test fk-deferred-update-self-ref-rowid-affinity-one-stmt {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id  INTEGER PRIMARY KEY,
+        pid TEXT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO t VALUES(1, 1);
+    BEGIN;
+    UPDATE t SET id=2, pid='2' WHERE id=1;
+    COMMIT;
+    SELECT id, typeof(pid), pid FROM t;
+}
+expect {
+    2|text|2
+}
+
+@cross-check-integrity
+test fk-deferred-update-self-ref-indexed-child-key-one-stmt {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id  INTEGER PRIMARY KEY,
+        pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    CREATE INDEX t_pid ON t(pid);
+    INSERT INTO t VALUES(1, 1);
+    BEGIN;
+    UPDATE t SET id=2, pid=2 WHERE id=1;
+    COMMIT;
+    SELECT id, pid FROM t;
+}
+expect {
+    2|2
+}
+
+@cross-check-integrity
+test fk-deferred-update-self-ref-unique-key-one-stmt {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        u  TEXT UNIQUE,
+        pu TEXT REFERENCES t(u) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO t VALUES(1, 'a', 'a');
+    BEGIN;
+    UPDATE t SET u='b', pu='b' WHERE id=1;
+    COMMIT;
+    SELECT u, pu FROM t;
+}
+expect {
+    b|b
+}
+
+@cross-check-integrity
+test fk-deferred-update-self-ref-composite-key-one-stmt {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        a, b,
+        x, y,
+        UNIQUE(a, b),
+        FOREIGN KEY(x, y) REFERENCES t(a, b) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO t VALUES(1, 1, 2, 1, 2);
+    BEGIN;
+    UPDATE t SET a=3, b=4, x=3, y=4 WHERE id=1;
+    COMMIT;
+    SELECT a, b, x, y FROM t;
+}
+expect {
+    3|4|3|4
+}
+
+@cross-check-integrity
+test fk-deferred-update-self-ref-one-stmt-still-fails-if-missing {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id  INTEGER PRIMARY KEY,
+        pid INT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO t VALUES(1, 1);
+    BEGIN;
+    UPDATE t SET id=2, pid=3 WHERE id=1;
+    COMMIT;
+}
+expect error {
 }
 
 @cross-check-integrity

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -503,6 +503,101 @@ expect {
 }
 
 @cross-check-integrity
+test fk-self-unique-parent-affinity-does-not-coerce-same-row-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        k INTEGER UNIQUE,
+        pk TEXT REFERENCES t(k)
+    );
+    INSERT INTO t(id, k, pk) VALUES (1, 1, '1');
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-self-unique-parent-text-does-not-coerce-same-row-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        k TEXT UNIQUE,
+        pk INTEGER REFERENCES t(k)
+    );
+    INSERT INTO t(id, k, pk) VALUES (1, '1', 1);
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-deferred-self-unique-parent-affinity-does-not-coerce-same-row-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        k INTEGER UNIQUE,
+        pk TEXT REFERENCES t(k) DEFERRABLE INITIALLY DEFERRED
+    );
+    BEGIN;
+    INSERT INTO t(id, k, pk) VALUES (1, 1, '1');
+    COMMIT;
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-self-unique-same-row-stored-values-match {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        k INTEGER UNIQUE,
+        pk NUMERIC REFERENCES t(k)
+    );
+    INSERT INTO t(id, k, pk) VALUES (1, 1, '1');
+    SELECT typeof(k), typeof(pk), k, pk FROM t;
+}
+expect {
+    integer|integer|1|1
+}
+
+@cross-check-integrity
+test fk-cross-table-parent-affinity-still-coerces-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(k INTEGER UNIQUE);
+    CREATE TABLE c(pk TEXT REFERENCES p(k));
+    INSERT INTO p VALUES (1);
+    INSERT INTO c VALUES ('1');
+    SELECT typeof(pk), pk FROM c;
+}
+expect {
+    text|1
+}
+
+@cross-check-integrity
+test fk-self-unique-parent-collation-does-not-satisfy-same-row-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE t(
+        id INTEGER PRIMARY KEY,
+        k TEXT COLLATE NOCASE UNIQUE,
+        pk TEXT REFERENCES t(k)
+    );
+    INSERT INTO t(id, k, pk) VALUES (1, 'A', 'a');
+}
+expect error {
+}
+
+@cross-check-integrity
+test fk-cross-table-parent-collation-still-matches-child {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE p(k TEXT COLLATE NOCASE UNIQUE);
+    CREATE TABLE c(pk TEXT REFERENCES p(k));
+    INSERT INTO p VALUES ('A');
+    INSERT INTO c VALUES ('a');
+    SELECT pk FROM c;
+}
+expect {
+    a
+}
+
+@cross-check-integrity
 test fk-self-unique-mismatch {
     PRAGMA foreign_keys=ON;
     CREATE TABLE t(


### PR DESCRIPTION
Closes #7166
Closes #7251

---

## Beef

This PR fixes several problems with FKs leading to COMMITs being incorrectly refused or incorrectly accepted.

## Types of bugs

**Ignored Parent Updates**

- Skipped parent-key updates still ran deferred FK counter maintenance and could incorrectly clear an unrelated existing violation.
- Example:
  ```sql
  CREATE TABLE parent(id UNIQUE ON CONFLICT IGNORE);
  CREATE TABLE child(id PRIMARY KEY, pid REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED);
  INSERT INTO parent VALUES (20), (24);
  INSERT INTO child VALUES (1, 20);

  BEGIN;
  INSERT INTO child VALUES (2, 276); -- real deferred violation
  UPDATE parent SET id = 20 WHERE id = 24; --  ignored due to uniqueness conflict
  COMMIT; -- should fail, but incorrectly passed because
  -- the NEW probe cleared violation due to there being a child ith pid=20
  ```

- Skipped parent-key updates could incorrectly add a deferred violation even though the parent row was not changed.
- Example:
  ```sql
  CREATE TABLE parent(id UNIQUE ON CONFLICT IGNORE);
  CREATE TABLE child(id PRIMARY KEY, pid REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED);
  INSERT INTO parent VALUES (20), (24);
  INSERT INTO child VALUES (1, 24);

  BEGIN;
  UPDATE parent SET id = 20 WHERE id = 24; -- ignored due to uniqueness confict
  COMMIT; -- should pass; child still references parent 24,
  -- but failed because the OLD probe ran too early and marked child.pid=24 with deferred violation
  ```

**Fix for this category:** parent-side FK checks now run only after ignored-row conflict handling has had a chance to skip the row, but still before tables/indexes are actually mutated

**Ignored Child Updates**

- Inverse of the previous one: skipped child-row updates could incorrectly add a deferred violation for a NEW child key that was never written.
- Example:
  ```sql
  CREATE TABLE parent(id UNIQUE);
  CREATE TABLE child(
    id PRIMARY KEY,
    pid REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED,
    u UNIQUE ON CONFLICT IGNORE
  );
  INSERT INTO parent VALUES (1);
  INSERT INTO child VALUES (1, 1, 10), (2, 1, 20);

  BEGIN;
  UPDATE child SET pid = 999, u = 10 WHERE id = 2; -- ignored due to uniqueness conflict
  COMMIT; -- should pass but doesn't; row 2 still has pid=1, there's no violation
  ```

- Skipped child-row updates could incorrectly clear an existing deferred violation even though the child row was not actually updated.
- Example:
  ```sql
  CREATE TABLE parent(id UNIQUE);
  CREATE TABLE child(
    id PRIMARY KEY,
    pid REFERENCES parent(id) DEFERRABLE INITIALLY DEFERRED,
    u UNIQUE ON CONFLICT IGNORE
  );
  INSERT INTO parent VALUES (1);
  INSERT INTO child VALUES (1, 1, 10);

  BEGIN;
  INSERT INTO child VALUES (2, 999, 20); -- real deferred violation
  UPDATE child SET pid = 1, u = 10 WHERE id = 2; -- ignored due to uniqueness conflict
  COMMIT; -- should fail, but incorrectly passed
  ```

*Fix for this category*: same as the parent case - move between IGNORE checks and actual table mutations.

**Self-Referential Deferred Updates**

- A row that updates both its parent key and child key to the same NEW value could fail because FK checks ran before the rewritten row existed.
- Example:
  ```sql
  CREATE TABLE t(id INTEGER PRIMARY KEY, pid REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED);
  INSERT INTO t VALUES (1, 1);

  BEGIN;
  UPDATE t SET id = 2, pid = 2 WHERE id = 1;
  COMMIT; -- should pass, there's no violation since both the child and parent key moved in tandem
  ```

- The same issue existed for rowid affinity coercion.
- Example:
  ```sql
  CREATE TABLE t(id INTEGER PRIMARY KEY, pid TEXT REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED);
  INSERT INTO t VALUES (1, 1);

  BEGIN;
  UPDATE t SET id = 2, pid = '2' WHERE id = 1;
  COMMIT; -- should pass, but didn't after the issue above was fixed due to affinity not being applied
  ```

- The same issue existed for non-rowid UNIQUE parent keys.
- Example:
  ```sql
  CREATE TABLE t(id INTEGER PRIMARY KEY, u TEXT UNIQUE, pu TEXT REFERENCES t(u) DEFERRABLE INITIALLY DEFERRED);
  INSERT INTO t VALUES (1, 'a', 'a');

  BEGIN;
  UPDATE t SET u = 'b', pu = 'b' WHERE id = 1;
  COMMIT; -- should pass
  ```

- The same issue existed for composite parent keys.
- Example:
  ```sql
  CREATE TABLE t(
    id INTEGER PRIMARY KEY,
    a, b, x, y,
    UNIQUE(a, b),
    FOREIGN KEY(x, y) REFERENCES t(a, b) DEFERRABLE INITIALLY DEFERRED
  );
  INSERT INTO t VALUES (1, 1, 2, 1, 2);

  BEGIN;
  UPDATE t SET a = 3, b = 4, x = 3, y = 4 WHERE id = 1;
  COMMIT; -- should pass
  ```

*Fix for this category*: self-referential child checks now recognize when the row’s NEW child key equals its own NEW parent key, with rowid coercion handled before comparison.

**Self-Referential OLD-Key Counting**

- Mirrors the previous one: parent OLD-key scans could count the row’s own disappearing old self-reference as an orphan even though the child key was updated away in the same statement.
- Example:
  ```sql
  CREATE TABLE t(id INTEGER PRIMARY KEY, pid REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED);
  INSERT INTO t VALUES (1, 1);

  BEGIN;
  UPDATE t SET id = 2, pid = 2 WHERE id = 1;
  COMMIT; -- should pass; old pid=1 disappeared with the old id=1
  ```

- But parent-key-only self-reference updates still need to fail.
- Example:
  ```sql
  CREATE TABLE t(id INTEGER PRIMARY KEY, pid REFERENCES t(id) DEFERRABLE INITIALLY DEFERRED);
  INSERT INTO t VALUES (1, 1);

  BEGIN;
  UPDATE t SET id = 2 WHERE id = 1;
  COMMIT; -- should fail; final pid=1 has no parent
  ```

**Fix for this category**: parent OLD-key scans skip the current row only for self-referential FKs whose child key is also changing. Sqlite does this as well.