### PR TITLE
core/mvcc: preempt checkpoint while collecting rows to write_set

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2092,9 +2092,10 @@ mod tests {
         let row_count = COLLECT_PREEMPTION_THRESHOLD + 10;
         for i in 0..row_count as i64 {
             let version = committed_table_row_version(table_id, i);
-            mvstore
-                .rows
-                .insert(RowID::new(table_id, RowKey::Int(i)), Arc::new(RwLock::new(vec![version])));
+            mvstore.rows.insert(
+                RowID::new(table_id, RowKey::Int(i)),
+                Arc::new(RwLock::new(vec![version])),
+            );
         }
 
         // The first chunk fills up before the scan finishes, so it must yield.

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,8 +1,8 @@
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
-    DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, TxTimestampOrID,
-    WriteRowStateMachine, MVCC_META_KEY_PERSISTENT_TX_TS_MAX, MVCC_META_TABLE_NAME,
-    SQLITE_SCHEMA_MVCC_TABLE_ID,
+    DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
+    TxTimestampOrID, WriteRowStateMachine, MVCC_META_KEY_PERSISTENT_TX_TS_MAX,
+    MVCC_META_TABLE_NAME, SQLITE_SCHEMA_MVCC_TABLE_ID,
 };
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
@@ -24,12 +24,17 @@ use crate::{
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::num::NonZeroU64;
+use std::ops::Bound;
 #[cfg(any(test, injected_yields))]
 use strum::EnumCount;
+
+const COLLECT_PREEMPTION_THRESHOLD: usize = 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CheckpointState {
     AcquireLock,
+    CollectTableRows,
+    CollectIndexRows,
     BeginPagerTxn,
     WriteRow {
         write_set_index: usize,
@@ -164,6 +169,9 @@ pub struct CheckpointStateMachine<Clock: LogicalClock> {
     staged_checkpoint_header: Option<DatabaseHeader>,
     /// Guard to avoid restaging page 1 across CommitPagerTxn async retries.
     header_staged_for_commit: bool,
+    collect_table_cursor: Option<RowID>,
+    collect_index_tableid_cursor: Option<MVTableId>,
+    collect_index_key_cursor: Option<Arc<SortableIndexKey>>,
 }
 
 #[cfg(any(test, injected_yields))]
@@ -360,6 +368,9 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             durable_mvcc_metadata,
             staged_checkpoint_header: None,
             header_staged_for_commit: false,
+            collect_table_cursor: None,
+            collect_index_tableid_cursor: None,
+            collect_index_key_cursor: None,
         }
     }
 
@@ -515,14 +526,20 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
     ///    * The row is not a delete (we inserted or changed an existing row), OR
     ///    * The row is a delete AND it exists in the database file already.
     ///      If the row didn't exist in the database file and was deleted, we can simply not write it.
-    fn collect_committed_table_row_versions(&mut self) {
+    fn collect_table_rows(&mut self) -> Option<IOCompletions> {
         // Invariant: RowID ordering is (table_id, row_id) with table_id ascending.
         // Since MV table IDs are negative and sqlite_schema is table_id=-1, iterating
         // in reverse visits sqlite_schema first so CREATE/DROP metadata is applied
         // before user-table rows in this checkpoint pass.
-        for entry in self.mvstore.rows.iter().rev() {
+        let bounds: (Bound<RowID>, Bound<RowID>) = match self.collect_table_cursor.clone() {
+            None => (Bound::Unbounded, Bound::Unbounded),
+            Some(last) => (Bound::Unbounded, Bound::Excluded(last)),
+        };
+        let mut processed = 0;
+        for entry in self.mvstore.rows.range(bounds).rev() {
             let key = entry.key();
             tracing::trace!("collecting {key:?}");
+            self.collect_table_cursor = Some(key.clone());
             if self.destroyed_tables.contains(&key.table_id) {
                 // We won't checkpoint rows for tables that will be destroyed in this checkpoint.
                 // There's two forms of destroyed table:
@@ -650,6 +667,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     self.write_set.push((version, special_write));
                 }
             }
+            processed += 1;
+            if processed >= COLLECT_PREEMPTION_THRESHOLD {
+                return Some(IOCompletions::Single(Completion::new_yield()));
+            }
         }
         // Writing in ascending order of rowid gives us a better chance of using balance-quick algorithm
         // in case of an insert-heavy checkpoint.
@@ -661,6 +682,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 version.0.row.id.row_id.clone(),
             )
         });
+        None
     }
 
     /// Collect all committed index row versions that need to be written to the B-tree.
@@ -670,18 +692,36 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
     /// 2. Either:
     ///    * The row is not a delete (we inserted or changed an existing row), OR
     ///    * The row is a delete AND it exists in the database file already.
-    fn collect_committed_index_row_versions(&mut self) {
-        for entry in self.mvstore.index_rows.iter() {
+    fn collect_index_rows(&mut self) -> Option<IOCompletions> {
+        let outer_bounds: (Bound<MVTableId>, Bound<MVTableId>) =
+            match self.collect_index_tableid_cursor {
+                None => (Bound::Unbounded, Bound::Unbounded),
+                Some(last) if self.collect_index_key_cursor.is_none() => {
+                    (Bound::Excluded(last), Bound::Unbounded)
+                }
+                Some(last) => (Bound::Included(last), Bound::Unbounded),
+            };
+        let mut processed = 0;
+        for entry in self.mvstore.index_rows.range(outer_bounds) {
             let index_id = *entry.key();
 
             // Skip destroyed indexes - we won't checkpoint rows for indexes that will be destroyed
             if self.destroyed_indexes.contains(&index_id) {
+                self.collect_index_tableid_cursor = Some(index_id);
+                self.collect_index_key_cursor = None;
                 continue;
             }
 
             let index_rows_map = entry.value();
-            for entry in index_rows_map.iter() {
+            let inner_bounds: (Bound<Arc<SortableIndexKey>>, Bound<Arc<SortableIndexKey>>) =
+                match self.collect_index_key_cursor.clone() {
+                    None => (Bound::Unbounded, Bound::Unbounded),
+                    Some(last) => (Bound::Excluded(last), Bound::Unbounded),
+                };
+            for entry in index_rows_map.range(inner_bounds) {
                 let versions = entry.value().read();
+                self.collect_index_tableid_cursor = Some(index_id);
+                self.collect_index_key_cursor = Some(entry.key().clone());
 
                 for version in self.maybe_get_checkpointable_versions(&versions, index_id) {
                     let is_delete = version.end.is_some();
@@ -690,8 +730,15 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     // the database file.
                     self.index_write_set.push((index_id, version, is_delete));
                 }
+                processed += 1;
+                if processed >= COLLECT_PREEMPTION_THRESHOLD {
+                    return Some(IOCompletions::Single(Completion::new_yield()));
+                }
             }
+            self.collect_index_tableid_cursor = Some(index_id);
+            self.collect_index_key_cursor = None;
         }
+        None
     }
 
     #[cfg(any(test, debug_assertions))]
@@ -1019,11 +1066,21 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 // Resample after serializing with other checkpoints so already-durable
                 // index deletes are not replayed.
                 self.refresh_checkpoint_bounds();
-
-                self.collect_committed_table_row_versions();
+                self.state = CheckpointState::CollectTableRows;
+                Ok(TransitionResult::Continue)
+            }
+            CheckpointState::CollectTableRows => {
+                if let Some(io) = self.collect_table_rows() {
+                    return Ok(TransitionResult::Io(io));
+                }
                 tracing::debug!("Collected {} committed versions", self.write_set.len());
-
-                self.collect_committed_index_row_versions();
+                self.state = CheckpointState::CollectIndexRows;
+                Ok(TransitionResult::Continue)
+            }
+            CheckpointState::CollectIndexRows => {
+                if let Some(io) = self.collect_index_rows() {
+                    return Ok(TransitionResult::Io(io));
+                }
                 tracing::debug!("Collected {} index row changes", self.index_write_set.len());
                 // Checkpoint boundary is derived from a stable snapshot under the blocking lock:
                 // old durable boundary plus the latest committed tx watermark. This covers both
@@ -1993,7 +2050,7 @@ mod tests {
             .clone();
         mvstore.insert_index_version(index_id, tombstone_key, tombstone_version);
 
-        checkpoint.collect_committed_index_row_versions();
+        while checkpoint.collect_index_rows().is_some() {}
 
         assert!(
             checkpoint.index_write_set.is_empty(),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2057,4 +2057,87 @@ mod tests {
             "a retry checkpoint must not replay a delete whose btree_resident tombstone was already made durable"
         );
     }
+
+    fn committed_table_row_version(table_id: MVTableId, rowid: i64) -> RowVersion {
+        let record = ImmutableRecord::from_values(&[Value::from_i64(rowid)], 1).unwrap();
+        RowVersion {
+            id: 1,
+            begin: Some(TxTimestampOrID::Timestamp(5)),
+            end: None,
+            row: Row::new_table_row(
+                RowID::new(table_id, RowKey::Int(rowid)),
+                record.as_blob().to_vec(),
+                1,
+            ),
+            btree_resident: false,
+        }
+    }
+
+    #[test]
+    fn collect_table_rows_preempts_on_large_scan() {
+        let db = MvccTestDbNoConn::new();
+        let conn = db.connect();
+        let mvstore = db.get_mvcc_store();
+        let pager = conn.pager.load().clone();
+        let mut checkpoint = CheckpointStateMachine::new(
+            pager,
+            mvstore.clone(),
+            conn.clone(),
+            true,
+            conn.get_sync_mode(),
+        );
+
+        // More than one chunk worth of committed rows so collection must preempt.
+        let table_id = MVTableId::from(-2);
+        let row_count = COLLECT_PREEMPTION_THRESHOLD + 10;
+        for i in 0..row_count as i64 {
+            let version = committed_table_row_version(table_id, i);
+            mvstore
+                .rows
+                .insert(RowID::new(table_id, RowKey::Int(i)), Arc::new(RwLock::new(vec![version])));
+        }
+
+        // The first chunk fills up before the scan finishes, so it must yield.
+        let first = checkpoint.collect_table_rows();
+        assert!(
+            first.is_some_and(|io| io.is_explicit_yield()),
+            "scanning more than COLLECT_PREEMPTION_THRESHOLD rows must preempt with an explicit yield"
+        );
+
+        // Resume from the cursor until the scan finishes; every row must still
+        // be collected exactly once across the chunks.
+        while checkpoint.collect_table_rows().is_some() {}
+        assert_eq!(checkpoint.write_set.len(), row_count);
+    }
+
+    #[test]
+    fn collect_index_rows_preempts_on_large_scan() {
+        let db = MvccTestDbNoConn::new();
+        let conn = db.connect();
+        let mvstore = db.get_mvcc_store();
+        let pager = conn.pager.load().clone();
+        let mut checkpoint = CheckpointStateMachine::new(
+            pager,
+            mvstore.clone(),
+            conn.clone(),
+            true,
+            conn.get_sync_mode(),
+        );
+
+        let index_id = MVTableId::from(-7);
+        let row_count = COLLECT_PREEMPTION_THRESHOLD + 10;
+        for i in 0..row_count as i64 {
+            let (key, version) = index_row_version(index_id, "k", i, 1, Some(5), None, false);
+            mvstore.insert_index_version(index_id, key, version);
+        }
+
+        let first = checkpoint.collect_index_rows();
+        assert!(
+            first.is_some_and(|io| io.is_explicit_yield()),
+            "scanning more than COLLECT_PREEMPTION_THRESHOLD index rows must preempt with an explicit yield"
+        );
+
+        while checkpoint.collect_index_rows().is_some() {}
+        assert_eq!(checkpoint.index_write_set.len(), row_count);
+    }
 }


### PR DESCRIPTION
## Description
Checkpoint will iterate the whole list of rows and index rows without ever preempting. This is obviously something that we must do so here it is.

Basically we have two new states `CollectTableRows` and `CollectIndexRows` that simply save the state of current scan during checkpoint. We save the last processed rowid with
`collect_index_outer_cursor` so later we have use `range(Unbounded, last)`. The range is not from [last..] because we iterate backwards with `rev`.



## Description of AI Usage

Seemed like an easy clanker task so I told clanker to use two new states for this and write the code.
