### PR TITLE
Propagate immutable record allocation errors

### DIFF
--- a/core/benches/mvcc_benchmark.rs
+++ b/core/benches/mvcc_benchmark.rs
@@ -101,7 +101,7 @@ fn bench(c: &mut Criterion) {
     });
 
     let db = bench_db();
-    let record = ImmutableRecord::from_values(&vec![Value::Text(Text::new("World"))], 1);
+    let record = ImmutableRecord::from_values(&vec![Value::Text(Text::new("World"))], 1).unwrap();
     let record_data = record.as_blob();
     group.bench_function("begin_tx-update-commit_tx", |b| {
         b.to_async(FuturesExecutor).iter(|| async {

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -556,8 +556,10 @@ impl AggregateEvalState {
                         ];
 
                         // Create an immutable record for the index key
-                        let index_record =
-                            ImmutableRecord::from_values(&index_key_values, index_key_values.len());
+                        let index_record = ImmutableRecord::from_values(
+                            &index_key_values,
+                            index_key_values.len(),
+                        )?;
 
                         // Seek in the index to find if this row exists
                         let seek_result = return_if_io!(cursors.index_cursor.seek(
@@ -999,15 +1001,15 @@ impl AggregateState {
         Ok(state)
     }
 
-    fn to_blob(&self, aggregates: &[AggregateFunction], group_key: &[Value]) -> Vec<u8> {
+    fn to_blob(&self, aggregates: &[AggregateFunction], group_key: &[Value]) -> Result<Vec<u8>> {
         let mut all_values = Vec::new();
         // Store the group key size first
         all_values.push(Value::from_i64(group_key.len() as i64));
         all_values.extend_from_slice(group_key);
         all_values.extend(self.to_value_vector(aggregates));
 
-        let record = ImmutableRecord::from_values(&all_values, all_values.len());
-        record.as_blob().clone()
+        let record = ImmutableRecord::from_values(&all_values, all_values.len())?;
+        Ok(record.as_blob().clone())
     }
 
     pub fn from_blob(blob: &[u8]) -> Result<(Self, Vec<Value>)> {
@@ -1897,7 +1899,7 @@ impl IncrementalOperator for AggregateOperator {
                         let weight = if agg_state.count == 0 { -1 } else { 1 };
 
                         // Serialize the aggregate state (only for regular aggregates, not plain DISTINCT)
-                        let state_blob = agg_state.to_blob(&self.aggregates, group_key);
+                        let state_blob = agg_state.to_blob(&self.aggregates, group_key)?;
                         let blob_value = Value::Blob(state_blob);
 
                         // Build the aggregate storage format: [operator_id, zset_hash, element_id, value, weight]
@@ -2468,7 +2470,7 @@ impl ScanState {
                         zset_hash.to_value(),
                         current_candidate.clone(),
                     ];
-                    let index_record = ImmutableRecord::from_values(&index_key, index_key.len());
+                    let index_record = ImmutableRecord::from_values(&index_key, index_key.len())?;
 
                     let seek_op = if *is_min {
                         SeekOp::GT // For MIN, seek greater than current
@@ -2722,7 +2724,7 @@ impl FetchDistinctState {
                         zset_hash.to_value(),
                         element_id.to_value(),
                     ];
-                    let index_record = ImmutableRecord::from_values(&index_key, index_key.len());
+                    let index_record = ImmutableRecord::from_values(&index_key, index_key.len())?;
 
                     let seek_result = return_if_io!(cursors.index_cursor.seek(
                         SeekKey::IndexKey(&index_record),
@@ -2985,7 +2987,7 @@ impl DistinctPersistState {
                         count: *weight as i64,
                         ..Default::default()
                     };
-                    let weight_blob = weight_state.to_blob(&[], &[]);
+                    let weight_blob = weight_state.to_blob(&[], &[])?;
 
                     let record_values = vec![
                         Value::from_i64(storage_id),

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -127,7 +127,7 @@ impl WriteRowView {
 
                     // Create an ImmutableRecord from the values
                     let immutable_record =
-                        ImmutableRecord::from_values(&record_values, record_values.len());
+                        ImmutableRecord::from_values(&record_values, record_values.len())?;
                     let btree_key = BTreeKey::new_table_rowid(key_i64, Some(&immutable_record));
 
                     // Mark as Done before insert to avoid retry on I/O

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -47,7 +47,7 @@ fn read_next_join_row(
         ],
     };
 
-    let index_record = ImmutableRecord::from_values(&index_key_values, index_key_values.len());
+    let index_record = ImmutableRecord::from_values(&index_key_values, index_key_values.len())?;
 
     // Use GE (>=) for initial seek with NULL, GT (>) for continuation
     let seek_op = if last_element_hash.is_none() {
@@ -570,15 +570,15 @@ fn deserialize_hashable_row(blob: &[u8]) -> Result<HashableRow> {
     Ok(HashableRow::new(rowid, values))
 }
 
-fn serialize_hashable_row(row: &HashableRow) -> Vec<u8> {
+fn serialize_hashable_row(row: &HashableRow) -> Result<Vec<u8>> {
     use crate::types::ImmutableRecord;
 
     let mut all_values = Vec::with_capacity(row.values.len() + 1);
     all_values.push(Value::from_i64(row.rowid));
     all_values.extend_from_slice(&row.values);
 
-    let record = ImmutableRecord::from_values(&all_values, all_values.len());
-    record.as_blob().clone()
+    let record = ImmutableRecord::from_values(&all_values, all_values.len())?;
+    Ok(record.as_blob().clone())
 }
 
 impl IncrementalOperator for JoinOperator {
@@ -649,7 +649,7 @@ impl IncrementalOperator for JoinOperator {
                     ];
 
                     // The record values: we'll store the serialized row as a blob
-                    let row_blob = serialize_hashable_row(row);
+                    let row_blob = serialize_hashable_row(row)?;
                     let record_values = vec![
                         Value::from_i64(self.left_storage_id()),
                         zset_hash.to_value(),
@@ -697,7 +697,7 @@ impl IncrementalOperator for JoinOperator {
                     ];
 
                     // The record values: we'll store the serialized row as a blob
-                    let row_blob = serialize_hashable_row(row);
+                    let row_blob = serialize_hashable_row(row)?;
                     let record_values = vec![
                         Value::from_i64(self.right_storage_id()),
                         zset_hash.to_value(),

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -113,7 +113,7 @@ impl WriteRow {
                     // First, seek in the index to find if the row exists
                     let index_values = index_key.clone();
                     let index_record =
-                        ImmutableRecord::from_values(&index_values, index_values.len());
+                        ImmutableRecord::from_values(&index_values, index_values.len())?;
 
                     let res = return_if_io!(cursors.index_cursor.seek(
                         SeekKey::IndexKey(&index_record),
@@ -241,7 +241,7 @@ impl WriteRow {
 
                     // Create an ImmutableRecord from the values
                     let immutable_record =
-                        ImmutableRecord::from_values(&complete_record, complete_record.len());
+                        ImmutableRecord::from_values(&complete_record, complete_record.len())?;
                     let btree_key = BTreeKey::new_table_rowid(rowid_val, Some(&immutable_record));
 
                     // Transition to InsertIndex state after table insertion
@@ -256,7 +256,7 @@ impl WriteRow {
 
                     // Create the index record with the rowid appended
                     let index_record =
-                        ImmutableRecord::from_values(&index_values, index_values.len());
+                        ImmutableRecord::from_values(&index_values, index_values.len())?;
                     let index_btree_key = BTreeKey::new_index_key(&index_record);
 
                     // Mark as Done before index insert to avoid retry on I/O
@@ -273,7 +273,7 @@ impl WriteRow {
 
                     // Create an ImmutableRecord from the values
                     let immutable_record =
-                        ImmutableRecord::from_values(&complete_record, complete_record.len());
+                        ImmutableRecord::from_values(&complete_record, complete_record.len())?;
                     let btree_key = BTreeKey::new_table_rowid(*rowid, Some(&immutable_record));
 
                     // Mark as Done before insert to avoid retry on I/O

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -703,7 +703,8 @@ impl HybridBTreeDirectory {
                 Value::Blob(vec![]),
             ],
             Self::CHUNK_LEN,
-        );
+        )
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         // Blocking seek to first chunk
         loop {
@@ -1994,7 +1995,7 @@ impl FtsCursor {
                             Value::Blob(vec![]),
                         ],
                         3,
-                    );
+                    )?;
 
                     let seek_result =
                         return_if_io!(cursor
@@ -2179,7 +2180,7 @@ impl FtsCursor {
                             Value::Blob(chunk_data.to_vec()),
                         ],
                         3,
-                    );
+                    )?;
 
                     // Seek to find the correct position using GE (not eq_only)
                     // This positions the cursor at or after where the record should be inserted
@@ -2264,7 +2265,7 @@ impl FtsCursor {
                             Value::Blob(vec![]),
                         ],
                         3,
-                    );
+                    )?;
 
                     let _result =
                         return_if_io!(cursor

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -590,7 +590,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             Value::from_i64(*rowid),
                         ],
                         3,
-                    );
+                    )?;
                     tracing::debug!(
                         "insert_state: seek: component={}, sum={}, rowid={}",
                         position,
@@ -649,7 +649,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         ));
                     };
                     let position = v.as_f32_sparse().idx[*idx];
-                    let key = ImmutableRecord::from_values(&[Value::from_i64(position as i64)], 1);
+                    let key = ImmutableRecord::from_values(&[Value::from_i64(position as i64)], 1)?;
                     self.insert_state = VectorSparseInvertedIndexInsertState::SeekStats {
                         vector: vector.take(),
                         sum: *sum,
@@ -705,7 +705,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                                     Value::from_f64(value),
                                 ],
                                 4,
-                            );
+                            )?;
                             self.insert_state = VectorSparseInvertedIndexInsertState::UpdateStats {
                                 vector: vector.take(),
                                 sum: *sum,
@@ -746,7 +746,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             Value::from_f64(value.max(component.max)),
                         ],
                         4,
-                    );
+                    )?;
                     self.insert_state = VectorSparseInvertedIndexInsertState::UpdateStats {
                         vector: vector.take(),
                         sum: *sum,
@@ -842,7 +842,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             Value::from_i64(*rowid),
                         ],
                         3,
-                    );
+                    )?;
                     self.delete_state = VectorSparseInvertedIndexDeleteState::SeekInverted {
                         vector: vector.take(),
                         idx: *idx,
@@ -934,7 +934,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         ));
                     };
                     let position = v.as_f32_sparse().idx[*idx];
-                    let key = ImmutableRecord::from_values(&[Value::from_i64(position as i64)], 1);
+                    let key = ImmutableRecord::from_values(&[Value::from_i64(position as i64)], 1)?;
                     self.delete_state = VectorSparseInvertedIndexDeleteState::SeekStats {
                         vector: vector.take(),
                         sum: *sum,
@@ -1003,7 +1003,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             Value::from_f64(component.max),
                         ],
                         4,
-                    );
+                    )?;
                     self.delete_state = VectorSparseInvertedIndexDeleteState::UpdateStats {
                         vector: vector.take(),
                         sum: *sum,
@@ -1153,7 +1153,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         *key = Some(ImmutableRecord::from_values(
                             &[Value::from_i64(position as i64)],
                             1,
-                        ));
+                        )?);
                     }
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
@@ -1298,7 +1298,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         *key = Some(ImmutableRecord::from_values(
                             &[Value::from_i64(c.position as i64)],
                             1,
-                        ));
+                        )?);
                         *component = Some(c.position);
                     }
                     let Some(k) = key.as_ref() else {

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -414,9 +414,9 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                         return Ok(IOResult::Done(None));
                     };
                     {
-                        let record = self.get_immutable_record_or_create();
+                        let record = self.get_immutable_record_or_create()?;
                         record.invalidate();
-                        record.start_serialization(row.payload());
+                        record.start_serialization(row.payload())?;
                     }
 
                     let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
@@ -506,9 +506,11 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
         }
     }
 
-    fn get_immutable_record_or_create(&mut self) -> &mut ImmutableRecord {
-        self.reusable_immutable_record
-            .get_or_insert_with(|| ImmutableRecord::new(1024))
+    fn get_immutable_record_or_create(&mut self) -> Result<&mut ImmutableRecord> {
+        if self.reusable_immutable_record.is_none() {
+            self.reusable_immutable_record = Some(ImmutableRecord::new(1024)?);
+        }
+        Ok(self.reusable_immutable_record.as_mut().unwrap())
     }
 
     fn get_current_pos(&self) -> CursorPosition {
@@ -1163,7 +1165,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
         registers: &[Register],
         op: SeekOp,
     ) -> Result<IOResult<SeekResult>> {
-        let record = make_record(registers, &0, &registers.len());
+        let record = make_record(registers, &0, &registers.len())?;
         self.seek(SeekKey::IndexKey(&record), op)
     }
 
@@ -1811,7 +1813,9 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
     }
 
     fn invalidate_record(&mut self) {
-        self.get_immutable_record_or_create().invalidate();
+        if let Some(record) = self.reusable_immutable_record.as_mut() {
+            record.invalidate();
+        }
     }
 
     fn has_rowid(&self) -> bool {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -984,7 +984,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 Value::from_i64(new_i64),
             ],
             2,
-        );
+        )?;
         let row = Row::new_table_row(
             RowID::new(table_id, RowKey::Int(1)),
             record.get_payload().to_vec(),
@@ -1292,7 +1292,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
-                        let record = ImmutableRecord::from_values(&values, values.len());
+                        let record = ImmutableRecord::from_values(&values, values.len())?;
                         row_version.row.data = Some(record.get_payload().to_owned());
                         row_version.clone()
                     };
@@ -1325,7 +1325,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                         let record = ImmutableRecordRef::from_bin_record(row_version.row.payload());
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
-                        let record = ImmutableRecord::from_values(&values, values.len());
+                        let record = ImmutableRecord::from_values(&values, values.len())?;
                         row_version.row.data = Some(record.get_payload().to_owned());
                         row_version.clone()
                     };
@@ -1820,7 +1820,8 @@ mod tests {
                 Value::build_text(format!("sql:{entry_type}:{name}:{root_page}")),
             ],
             5,
-        );
+        )
+        .unwrap();
         RowVersion {
             id: 1,
             begin: begin.map(TxTimestampOrID::Timestamp),
@@ -1942,7 +1943,8 @@ mod tests {
                 Value::from_i64(rowid),
             ],
             2,
-        );
+        )
+        .unwrap();
         let sortable_key = SortableIndexKey::new_from_record(key_record, index_info);
         let key_arc = Arc::new(sortable_key.clone());
         let row = Row::new_index_row(RowID::new(index_id, RowKey::Record(sortable_key)), 2);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -127,12 +127,12 @@ impl SortableIndexKey {
         Self { key, metadata }
     }
 
-    pub fn new_from_values(values: Vec<ValueRef>, metadata: Arc<IndexInfo>) -> Self {
+    pub fn new_from_values(values: Vec<ValueRef>, metadata: Arc<IndexInfo>) -> Result<Self> {
         let len = values.len();
-        Self {
-            key: ImmutableRecord::from_values(values, len),
+        Ok(Self {
+            key: ImmutableRecord::from_values(values, len)?,
             metadata,
-        }
+        })
     }
 
     fn compare(&self, other: &Self) -> Result<std::cmp::Ordering> {
@@ -2638,8 +2638,8 @@ impl StateTransition for WriteRowStateMachine {
                     None
                 } else {
                     let row_data = self.row.data.as_ref().expect("table rows should have data");
-                    let mut record = ImmutableRecord::new(row_data.len());
-                    record.start_serialization(row_data);
+                    let mut record = ImmutableRecord::new(row_data.len())?;
+                    record.start_serialization(row_data)?;
                     Some(record)
                 };
                 if self.requires_seek {
@@ -5384,7 +5384,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let values = (1..=5)
                     .map(|i| row.get_value(i).clone())
                     .collect::<Vec<_>>();
-                schema_rows.insert(rowid, ImmutableRecord::from_values(&values, values.len()));
+                schema_rows.insert(rowid, ImmutableRecord::from_values(&values, values.len())?);
                 Ok(())
             })?;
         }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -530,7 +530,8 @@ impl MvccTestDbNoConn {
 }
 
 pub(crate) fn generate_simple_string_row(table_id: MVTableId, id: i64, data: &str) -> Row {
-    let record = ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1);
+    let record =
+        ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1).unwrap();
     Row::new_table_row(
         RowID::new(table_id, RowKey::Int(id)),
         record.as_blob().to_vec(),
@@ -539,7 +540,7 @@ pub(crate) fn generate_simple_string_row(table_id: MVTableId, id: i64, data: &st
 }
 
 pub(crate) fn generate_simple_string_record(data: &str) -> ImmutableRecord {
-    ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1)
+    ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1).unwrap()
 }
 
 fn advance_checkpoint_until_wal_has_commit_frame(
@@ -789,7 +790,8 @@ fn tamper_db_metadata_row_value(db_path: &str, metadata_root_page: u32, new_valu
             Value::from_i64(new_value),
         ],
         2,
-    );
+    )
+    .unwrap();
     rewrite_table_leaf_cell_payload(&mut page, loc, new_record.as_blob());
     write_db_page(db_path, metadata_root_page, page_size, &page);
 }
@@ -821,7 +823,8 @@ fn tamper_db_metadata_row_value_by_key(
                 Value::from_i64(new_value),
             ],
             2,
-        );
+        )
+        .unwrap();
         rewrite_table_leaf_cell_payload(&mut page, loc, new_record.as_blob());
         updated = true;
     }
@@ -861,7 +864,8 @@ fn tamper_db_metadata_row_key(db_path: &str, metadata_root_page: u32, new_key: &
             Value::from_i64(value),
         ],
         2,
-    );
+    )
+    .unwrap();
     rewrite_table_leaf_cell_payload(&mut page, loc, new_record.as_blob());
     write_db_page(db_path, metadata_root_page, page_size, &page);
 }
@@ -3817,7 +3821,8 @@ fn setup_test_db() -> (MvccTestDb, u64, MVTableId, i64) {
 
     for (row_id, data) in test_rows.iter() {
         let id = RowID::new(table_id, RowKey::Int(*row_id));
-        let record = ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1);
+        let record =
+            ImmutableRecord::from_values(&[Value::Text(Text::new(data.to_string()))], 1).unwrap();
         let row = Row::new_table_row(id, record.as_blob().to_vec(), 1);
         db.mvcc_store.insert(tx_id, row).unwrap();
     }
@@ -3853,7 +3858,7 @@ fn setup_lazy_db(initial_keys: &[i64]) -> (MvccTestDb, u64, MVTableId, i64) {
     for i in initial_keys {
         let id = RowID::new(table_id, RowKey::Int(*i));
         let data = format!("row{i}");
-        let record = ImmutableRecord::from_values(&[Value::Text(Text::new(data))], 1);
+        let record = ImmutableRecord::from_values(&[Value::Text(Text::new(data))], 1).unwrap();
         let row = Row::new_table_row(id, record.as_blob().to_vec(), 1);
         db.mvcc_store.insert(tx_id, row).unwrap();
     }
@@ -5480,7 +5485,8 @@ fn write_synthetic_row(db: &MvccTestDbNoConn, value: &str) {
             )),
         ],
         5,
-    );
+    )
+    .unwrap();
     mvcc_store
         .insert(
             tx_id,
@@ -5593,8 +5599,8 @@ fn test_delete_with_conn() {
 }
 
 fn get_record_value(row: &Row) -> ImmutableRecord {
-    let mut record = ImmutableRecord::new(1024);
-    record.start_serialization(row.payload());
+    let mut record = ImmutableRecord::new(1024).unwrap();
+    record.start_serialization(row.payload()).unwrap();
     record
 }
 
@@ -6501,7 +6507,8 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     )));
 
     for key in 1..=600 {
-        let record = ImmutableRecord::from_values(&[Value::from_i64(key), Value::from_i64(key)], 2);
+        let record =
+            ImmutableRecord::from_values(&[Value::from_i64(key), Value::from_i64(key)], 2).unwrap();
         let seek_result = run_pager_until_done(
             || {
                 cursor.write().seek(
@@ -6526,7 +6533,8 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     pager.begin_read_tx().unwrap();
     let mut interior_key = None;
     for key in 1..=600 {
-        let record = ImmutableRecord::from_values(&[Value::from_i64(key), Value::from_i64(key)], 2);
+        let record =
+            ImmutableRecord::from_values(&[Value::from_i64(key), Value::from_i64(key)], 2).unwrap();
         let seek_result = run_pager_until_done(
             || {
                 cursor.write().seek(
@@ -6554,7 +6562,8 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     let record = ImmutableRecord::from_values(
         &[Value::from_i64(interior_key), Value::from_i64(interior_key)],
         2,
-    );
+    )
+    .unwrap();
     let row_key = SortableIndexKey::new_from_record(record, index_info);
     let row = Row::new_index_row(
         RowID::new(MVTableId::new(-42), RowKey::Record(row_key)),

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -2527,7 +2527,8 @@ mod tests {
                     )), // sql
                 ],
                 5,
-            );
+            )
+            .unwrap();
             mvcc_store
                 .insert(
                     tx_id,
@@ -2598,7 +2599,8 @@ mod tests {
                     )), // sql
                 ],
                 5,
-            );
+            )
+            .unwrap();
             mvcc_store
                 .insert(
                     tx_id,
@@ -2711,7 +2713,8 @@ mod tests {
                     )), // sql
                 ],
                 5,
-            );
+            )
+            .unwrap();
             mvcc_store
                 .insert(
                     tx_id,
@@ -2854,7 +2857,8 @@ mod tests {
                     Value::from_i64(row_id),
                 ],
                 2,
-            );
+            )
+            .unwrap();
             let sortable_key = SortableIndexKey::new_from_record(key_record, index_info.clone());
             let index_rowid = RowID::new(index_id, RowKey::Record(sortable_key));
 
@@ -4261,7 +4265,8 @@ mod tests {
                 Value::from_i64(rowid),
             ],
             2,
-        );
+        )
+        .unwrap();
         let sortable_key = SortableIndexKey::new_from_record(
             key_record,
             Arc::new(IndexInfo {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1039,13 +1039,13 @@ impl BTreeCursor {
             }
             let payload_swap = std::mem::take(payload);
 
-            let mut reuse_immutable = self.get_immutable_record_or_create();
+            let mut reuse_immutable = self.get_immutable_record_or_create()?;
             reuse_immutable.as_mut().unwrap().invalidate();
 
             reuse_immutable
                 .as_mut()
                 .unwrap()
-                .start_serialization(&payload_swap);
+                .start_serialization(&payload_swap)?;
 
             self.read_overflow_state.take();
             break Ok(IOResult::Done(()));
@@ -1682,14 +1682,14 @@ impl BTreeCursor {
                 return Ok(ControlFlow::Break(res));
             }
         } else {
-            self.get_immutable_record_or_create()
+            self.get_immutable_record_or_create()?
                 .as_mut()
                 .unwrap()
                 .invalidate();
-            self.get_immutable_record_or_create()
+            self.get_immutable_record_or_create()?
                 .as_mut()
                 .unwrap()
-                .start_serialization(payload);
+                .start_serialization(payload)?;
         };
 
         let (target_leaf_page_is_in_left_subtree, is_eq) = {
@@ -2118,14 +2118,14 @@ impl BTreeCursor {
                 return Ok(ControlFlow::Break(IOResult::IO(io)));
             }
         } else {
-            self.get_immutable_record_or_create()
+            self.get_immutable_record_or_create()?
                 .as_mut()
                 .unwrap()
                 .invalidate();
-            self.get_immutable_record_or_create()
+            self.get_immutable_record_or_create()?
                 .as_mut()
                 .unwrap()
-                .start_serialization(payload);
+                .start_serialization(payload)?;
         };
 
         let (cmp, found) = self.compare_with_current_record(
@@ -4909,14 +4909,14 @@ impl BTreeCursor {
         Ok(())
     }
 
-    fn get_immutable_record_or_create(&mut self) -> Option<&mut ImmutableRecord> {
+    fn get_immutable_record_or_create(&mut self) -> Result<Option<&mut ImmutableRecord>> {
         let reusable_immutable_record = &mut self.reusable_immutable_record;
         if reusable_immutable_record.is_none() {
             let page_size = self.pager.get_page_size_unchecked().get();
-            let record = ImmutableRecord::new(page_size as usize);
+            let record = ImmutableRecord::new(page_size as usize)?;
             reusable_immutable_record.replace(record);
         }
-        reusable_immutable_record.as_mut()
+        Ok(reusable_immutable_record.as_mut())
     }
 
     fn get_immutable_record(&self) -> Option<&ImmutableRecord> {
@@ -5154,14 +5154,14 @@ impl CursorTrait for BTreeCursor {
         if let Some(next_page) = first_overflow_page {
             return_if_io!(self.process_overflow_read(payload, next_page, payload_size))
         } else {
-            self.get_immutable_record_or_create()
+            self.get_immutable_record_or_create()?
                 .as_mut()
                 .unwrap()
                 .invalidate();
-            self.get_immutable_record_or_create()
+            self.get_immutable_record_or_create()?
                 .as_mut()
                 .unwrap()
-                .start_serialization(payload);
+                .start_serialization(payload)?;
         };
 
         Ok(IOResult::Done(self.reusable_immutable_record.as_ref()))
@@ -5750,10 +5750,9 @@ impl CursorTrait for BTreeCursor {
 
     #[inline]
     fn invalidate_record(&mut self) {
-        self.get_immutable_record_or_create()
-            .as_mut()
-            .unwrap()
-            .invalidate();
+        if let Some(record) = self.reusable_immutable_record.as_mut() {
+            record.invalidate();
+        }
     }
 
     #[inline]
@@ -8422,7 +8421,7 @@ mod tests {
         val: Value,
     ) -> Result<(), LimboError> {
         let regs = &[Register::Value(val)];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
 
         run_until_done(
             || {
@@ -8454,7 +8453,7 @@ mod tests {
 
         let header_size = 8;
         let regs = &[Register::Value(Value::from_i64(1))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let payload = add_record(1, 0, page.clone(), record, &conn);
         let page_contents = page.get_contents();
         assert_eq!(page_contents.cell_count(), 1);
@@ -8485,7 +8484,7 @@ mod tests {
         let usable_space = 4096;
         for i in 0..3 {
             let regs = &[Register::Value(Value::from_i64(i as i64))];
-            let record = ImmutableRecord::from_registers(regs, regs.len());
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             let payload = add_record(i, i, page.clone(), record, &conn);
             assert_eq!(page_contents.cell_count(), i + 1);
             let free = compute_free_space(page_contents, usable_space).unwrap();
@@ -8732,7 +8731,7 @@ mod tests {
 
         // Create a record with the large payload
         let regs = &[Register::Value(Value::Blob(large_payload))];
-        let large_record = ImmutableRecord::from_registers(regs, regs.len());
+        let large_record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
 
         // Create cursor for the table
         let mut cursor = BTreeCursor::new_table(pager.clone(), root_page, num_columns);
@@ -8785,7 +8784,7 @@ mod tests {
         // Create a smaller record to overwrite with
         let small_payload = vec![b'Y'; 100]; // Much smaller payload
         let regs = &[Register::Value(Value::Blob(small_payload.clone()))];
-        let small_record = ImmutableRecord::from_registers(regs, regs.len());
+        let small_record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
 
         // Seek to the existing record
         run_until_done(
@@ -8904,7 +8903,7 @@ mod tests {
                 )
                 .unwrap();
                 let regs = &[Register::Value(Value::Blob(vec![0; *size]))];
-                let value = ImmutableRecord::from_registers(regs, regs.len());
+                let value = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
                 tracing::info!("insert key:{}", key);
                 run_until_done(
                     || cursor.insert(&BTreeKey::new_table_rowid(*key, Some(&value))),
@@ -9001,7 +9000,7 @@ mod tests {
                 )
                 .unwrap();
                 let regs = &[Register::Value(Value::Blob(vec![0; size]))];
-                let value = ImmutableRecord::from_registers(regs, regs.len());
+                let value = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
                 let btree_before = if do_validate {
                     format_btree(pager.clone(), root_page, 0)
                 } else {
@@ -9140,10 +9139,10 @@ mod tests {
                     .iter()
                     .map(|col| Register::Value(Value::from_i64(*col)))
                     .collect::<Vec<_>>();
-                let value = ImmutableRecord::from_registers(&regs, regs.len());
+                let value = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
                 run_until_done(
                     || {
-                        let record = ImmutableRecord::from_registers(&regs, regs.len());
+                        let record = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
                         let key = SeekKey::IndexKey(&record);
                         cursor.seek(key, SeekOp::GE { eq_only: true })
                     },
@@ -9174,7 +9173,9 @@ mod tests {
                             .map(|col| Register::Value(Value::from_i64(*col)))
                             .collect::<Vec<_>>();
                         cursor.seek(
-                            SeekKey::IndexKey(&ImmutableRecord::from_registers(&regs, regs.len())),
+                            SeekKey::IndexKey(
+                                &ImmutableRecord::from_registers(&regs, regs.len()).unwrap(),
+                            ),
                             SeekOp::GE { eq_only: true },
                         )
                     },
@@ -9326,11 +9327,12 @@ mod tests {
                     expected_keys.push(key.clone());
 
                     let regs = vec![Register::Value(Value::Blob(key))];
-                    let value = ImmutableRecord::from_registers(&regs, regs.len());
+                    let value = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
 
                     let seek_result = run_until_done(
                         || {
-                            let record = ImmutableRecord::from_registers(&regs, regs.len());
+                            let record =
+                                ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
                             let key = SeekKey::IndexKey(&record);
                             cursor.seek(key, SeekOp::GE { eq_only: true })
                         },
@@ -9356,7 +9358,7 @@ mod tests {
                         }
 
                         let regs = vec![Register::Value(Value::Blob(key_to_delete.clone()))];
-                        let record = ImmutableRecord::from_registers(&regs, regs.len());
+                        let record = ImmutableRecord::from_registers(&regs, regs.len()).unwrap();
 
                         // Seek to the key to delete
                         let seek_result = run_until_done(
@@ -9417,7 +9419,9 @@ mod tests {
                 || {
                     let regs = vec![Register::Value(Value::Blob(key.clone()))];
                     cursor.seek(
-                        SeekKey::IndexKey(&ImmutableRecord::from_registers(&regs, regs.len())),
+                        SeekKey::IndexKey(
+                            &ImmutableRecord::from_registers(&regs, regs.len()).unwrap(),
+                        ),
                         SeekOp::GE { eq_only: true },
                     )
                 },
@@ -9497,7 +9501,7 @@ mod tests {
         let total_cells = 10;
         for i in 0..total_cells {
             let regs = &[Register::Value(Value::from_i64(i as i64))];
-            let record = ImmutableRecord::from_registers(regs, regs.len());
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             let payload = add_record(i, i, page.clone(), record, &conn);
             assert_eq!(page_contents.cell_count(), i + 1);
             let free = compute_free_space(page_contents, usable_space).unwrap();
@@ -10250,7 +10254,7 @@ mod tests {
         let usable_space = 4096;
         for i in 0..3 {
             let regs = &[Register::Value(Value::from_i64(i as i64))];
-            let record = ImmutableRecord::from_registers(regs, regs.len());
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             let payload = add_record(i, i, page.clone(), record, &conn);
             assert_eq!(page_contents.cell_count(), i + 1);
             let free = compute_free_space(page_contents, usable_space).unwrap();
@@ -10292,7 +10296,7 @@ mod tests {
         let total_cells = 10;
         for i in 0..total_cells {
             let regs = &[Register::Value(Value::from_i64(i as i64))];
-            let record = ImmutableRecord::from_registers(regs, regs.len());
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             let payload = add_record(i, i, page.clone(), record, &conn);
             assert_eq!(page_contents.cell_count(), i + 1);
             let free = compute_free_space(page_contents, usable_space).unwrap();
@@ -10348,7 +10352,7 @@ mod tests {
                     let cell_idx = rng.next_u64() as usize % (page_contents.cell_count() + 1);
                     let free = compute_free_space(page_contents, usable_space).unwrap();
                     let regs = &[Register::Value(Value::from_i64(i as i64))];
-                    let record = ImmutableRecord::from_registers(regs, regs.len());
+                    let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
                     let mut payload: Vec<u8> = Vec::new();
                     let mut fill_cell_payload_state = FillCellPayloadState::Start;
                     run_until_done(
@@ -10431,7 +10435,7 @@ mod tests {
                         let cell_idx = rng.next_u64() as usize % (page_contents.cell_count() + 1);
                         let free = compute_free_space(page_contents, usable_space).unwrap();
                         let regs = &[Register::Value(Value::from_i64(i))];
-                        let record = ImmutableRecord::from_registers(regs, regs.len());
+                        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
                         let mut payload: Vec<u8> = Vec::new();
                         let mut fill_cell_payload_state = FillCellPayloadState::Start;
                         run_until_done(
@@ -10591,7 +10595,7 @@ mod tests {
         let usable_space = 4096;
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let payload = add_record(0, 0, page.clone(), record, &conn);
         let free = compute_free_space(page_contents, usable_space).unwrap();
         assert_eq!(free, 4096 - payload.len() - 2 - header_size);
@@ -10608,7 +10612,7 @@ mod tests {
         let usable_space = 4096;
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let payload = add_record(0, 0, page.clone(), record, &conn);
 
         assert_eq!(page_contents.cell_count(), 1);
@@ -10633,7 +10637,7 @@ mod tests {
             Register::Value(Value::from_i64(0)),
             Register::Value(Value::Text(Text::new("aaaaaaaa"))),
         ];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(0, 0, page.clone(), record, &conn);
 
         assert_eq!(page_contents.cell_count(), 1);
@@ -10641,7 +10645,7 @@ mod tests {
         assert_eq!(page_contents.cell_count(), 0);
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let payload = add_record(0, 0, page.clone(), record, &conn);
         assert_eq!(page_contents.cell_count(), 1);
 
@@ -10664,7 +10668,7 @@ mod tests {
             Register::Value(Value::from_i64(0)),
             Register::Value(Value::Text(Text::new("aaaaaaaa"))),
         ];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(0, 0, page.clone(), record, &conn);
 
         for _ in 0..100 {
@@ -10673,7 +10677,7 @@ mod tests {
             assert_eq!(page_contents.cell_count(), 0);
 
             let regs = &[Register::Value(Value::from_i64(0))];
-            let record = ImmutableRecord::from_registers(regs, regs.len());
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             let payload = add_record(0, 0, page.clone(), record, &conn);
             assert_eq!(page_contents.cell_count(), 1);
 
@@ -10694,13 +10698,13 @@ mod tests {
         let usable_space = 4096;
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let payload = add_record(0, 0, page.clone(), record, &conn);
         let regs = &[Register::Value(Value::from_i64(1))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(1, 1, page.clone(), record, &conn);
         let regs = &[Register::Value(Value::from_i64(2))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(2, 2, page.clone(), record, &conn);
 
         drop_cell(page_contents, 1, usable_space).unwrap();
@@ -10720,24 +10724,24 @@ mod tests {
         let usable_space = 4096;
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(0, 0, page.clone(), record, &conn);
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(0, 0, page.clone(), record, &conn);
         drop_cell(page_contents, 0, usable_space).unwrap();
 
         defragment_page(page_contents, usable_space, 4).unwrap();
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(0, 1, page.clone(), record, &conn);
 
         drop_cell(page_contents, 0, usable_space).unwrap();
 
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let _ = add_record(0, 1, page.clone(), record, &conn);
     }
 
@@ -10750,7 +10754,7 @@ mod tests {
         let usable_space = 4096;
         let insert = |pos, page| {
             let regs = &[Register::Value(Value::from_i64(0))];
-            let record = ImmutableRecord::from_registers(regs, regs.len());
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             let _ = add_record(0, pos, page, record, &conn);
         };
         let drop = |pos, page| {
@@ -10791,7 +10795,7 @@ mod tests {
         let usable_space = 4096;
         let insert = |pos, page| {
             let regs = &[Register::Value(Value::from_i64(0))];
-            let record = ImmutableRecord::from_registers(regs, regs.len());
+            let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             let _ = add_record(0, pos, page, record, &conn);
         };
         let drop = |pos, page| {
@@ -10801,7 +10805,7 @@ mod tests {
             defragment_page(page, usable_space, 4).unwrap();
         };
         let regs = &[Register::Value(Value::from_i64(0))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let mut payload: Vec<u8> = Vec::new();
         let mut fill_cell_payload_state = FillCellPayloadState::Start;
         run_until_done(
@@ -10847,7 +10851,7 @@ mod tests {
             let mut cursor = BTreeCursor::new_table(pager.clone(), root_page, num_columns);
             tracing::info!("INSERT INTO t VALUES ({});", i,);
             let regs = &[Register::Value(Value::from_i64(i))];
-            let value = ImmutableRecord::from_registers(regs, regs.len());
+            let value = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             tracing::trace!("before insert {}", i);
             run_until_done(
                 || {
@@ -10887,7 +10891,7 @@ mod tests {
         let page = get_page(2);
         let usable_space = 4096;
         let regs = &[Register::Value(Value::Blob(vec![0; 3600]))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let mut payload: Vec<u8> = Vec::new();
         let mut fill_cell_payload_state = FillCellPayloadState::Start;
         run_until_done(
@@ -10933,7 +10937,7 @@ mod tests {
         for i in 1..=10000 {
             let mut cursor = BTreeCursor::new_table(pager.clone(), root_page, num_columns);
             let regs = &[Register::Value(Value::Text(Text::new("hello world")))];
-            let value = ImmutableRecord::from_registers(regs, regs.len());
+            let value = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
 
             run_until_done(
                 || {
@@ -11012,7 +11016,7 @@ mod tests {
             let mut cursor = BTreeCursor::new_table(pager.clone(), root_page, num_columns);
             tracing::info!("INSERT INTO t VALUES ({});", i,);
             let regs = &[Register::Value(Value::Text(Text::new(huge_text.clone())))];
-            let value = ImmutableRecord::from_registers(regs, regs.len());
+            let value = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
             tracing::trace!("before insert {}", i);
             tracing::debug!(
                 "=========== btree before ===========\n{}\n\n",
@@ -11136,7 +11140,7 @@ mod tests {
     fn insert_cell(cell_idx: u64, size: u16, page: PageRef, pager: Arc<Pager>) {
         let mut payload = Vec::new();
         let regs = &[Register::Value(Value::Blob(vec![0; size as usize]))];
-        let record = ImmutableRecord::from_registers(regs, regs.len());
+        let record = ImmutableRecord::from_registers(regs, regs.len()).unwrap();
         let mut fill_cell_payload_state = FillCellPayloadState::Start;
         let contents = page.get_contents();
         run_until_done(

--- a/core/types.rs
+++ b/core/types.rs
@@ -1071,16 +1071,13 @@ mod immutable_record {
 
     fn values(payload: &[u8]) -> Result<Vec<ValueRef<'_>>> {
         let iter = iter(payload)?;
-        let mut values = Vec::with_capacity(iter.size_hint().0);
-        for value in iter {
-            values.push(value?);
-        }
+        let values = iter.try_collect::<Result<_>>()??;
         Ok(values)
     }
 
     fn values_range(payload: &[u8], range: std::ops::Range<usize>) -> Result<Vec<ValueRef<'_>>> {
         let mut iter = iter(payload)?;
-        let mut values = Vec::with_capacity(range.end - range.start);
+        let mut values = Vec::try_with_capacity_ext(range.end - range.start)?;
         if let Some(value) = iter.nth(range.start) {
             values.push(value?);
         } else {
@@ -1146,16 +1143,15 @@ mod immutable_record {
 
     fn values_owned(payload: &[u8]) -> Result<Vec<Value>> {
         let iter = iter(payload).expect("Failed to create payload iterator");
-        let mut values = Vec::with_capacity(iter.size_hint().0);
-        for value in iter {
-            values.push(value?.to_owned());
-        }
+        let values = iter
+            .map(|v| Ok::<_, LimboError>(v?.to_owned()))
+            .try_collect::<Result<_>>()??;
         Ok(values)
     }
 
     fn values_owned_range(payload: &[u8], range: std::ops::Range<usize>) -> Result<Vec<Value>> {
         let mut iter = iter(payload).expect("Failed to create payload iterator");
-        let mut values = Vec::with_capacity(range.end - range.start);
+        let mut values = Vec::try_with_capacity_ext(range.end - range.start)?;
         if let Some(value) = iter.nth(range.start) {
             values.push(value?.to_owned());
         } else {
@@ -1370,10 +1366,10 @@ mod immutable_record {
     }
 
     impl ImmutableRecord {
-        pub fn new(payload_capacity: usize) -> Self {
-            Self {
-                payload: Value::Blob(Vec::with_capacity(payload_capacity)),
-            }
+        pub fn new(payload_capacity: usize) -> Result<Self> {
+            Ok(Self {
+                payload: Value::Blob(Vec::try_with_capacity_ext(payload_capacity)?),
+            })
         }
 
         pub const fn from_bin_record(payload: Vec<u8>) -> Self {
@@ -1393,15 +1389,15 @@ mod immutable_record {
             // (without copying the data itself)
             registers: impl IntoIterator<Item = &'a Register, IntoIter = I>,
             len: usize,
-        ) -> Self {
+        ) -> Result<Self> {
             Self::from_values(registers.into_iter().map(|x| x.get_value()), len)
         }
 
         pub fn from_values<'a>(
             values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
             len: usize,
-        ) -> Self {
-            let mut serials = Vec::with_capacity(len);
+        ) -> Result<Self> {
+            let mut serials = Vec::try_with_capacity_ext(len)?;
             let mut size_header = 0;
             let mut size_values = 0;
 
@@ -1421,8 +1417,7 @@ mod immutable_record {
             let header_size = Record::calc_header_size(size_header);
 
             // 1. write header size
-            let mut buf = Vec::new();
-            buf.reserve_exact(header_size + size_values);
+            let mut buf = Vec::try_with_capacity_ext(header_size + size_values)?;
             assert_eq!(buf.capacity(), header_size + size_values);
             let n = write_varint(&mut serial_type_buf, header_size as u64);
 
@@ -1475,9 +1470,9 @@ mod immutable_record {
             }
 
             writer.assert_finish_capacity();
-            Self {
+            Ok(Self {
                 payload: Value::Blob(buf),
-            }
+            })
         }
 
         #[inline]
@@ -1510,8 +1505,11 @@ mod immutable_record {
         }
 
         #[inline]
-        pub fn start_serialization(&mut self, payload: &[u8]) {
-            self.as_blob_mut().extend_from_slice(payload);
+        pub fn start_serialization(&mut self, payload: &[u8]) -> Result<()> {
+            let blob = self.as_blob_mut();
+            blob.try_reserve(payload.len())?;
+            blob.extend_from_slice(payload);
+            Ok(())
         }
 
         #[inline]
@@ -3331,7 +3329,7 @@ mod tests {
 
     fn create_record(values: Vec<Value>) -> ImmutableRecord {
         let registers: Vec<Register> = values.into_iter().map(Register::Value).collect();
-        ImmutableRecord::from_registers(&registers, registers.len())
+        ImmutableRecord::from_registers(&registers, registers.len()).unwrap()
     }
 
     #[test]
@@ -4192,7 +4190,7 @@ mod tests {
         for num_values in 1..=10 {
             let values: Vec<Value> = (0..num_values).map(|i| Value::from_i64(i as i64)).collect();
 
-            let record = ImmutableRecord::from_values(&values, values.len());
+            let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
             let cnt = record.column_count();
             assert_eq!(
                 cnt, num_values,

--- a/core/vdbe/array.rs
+++ b/core/vdbe/array.rs
@@ -144,8 +144,10 @@ fn parse_pg_text_array(text: &str) -> Option<Vec<Value>> {
 }
 
 /// Pack values into a record-format array blob.
-pub(crate) fn values_to_record_blob(values: &[Value]) -> Value {
-    Value::Blob(ImmutableRecord::from_values(values, values.len()).into_payload())
+pub(crate) fn values_to_record_blob(values: &[Value]) -> Result<Value> {
+    Ok(Value::Blob(
+        ImmutableRecord::from_values(values, values.len())?.into_payload(),
+    ))
 }
 
 /// Serialize a record-format array blob to PostgreSQL text representation.
@@ -248,17 +250,17 @@ pub(crate) fn compute_array_length(val: &Value) -> Option<i64> {
     }
 }
 
-pub(crate) fn exec_array_append(arr: &Value, elem: &Value) -> Value {
+pub(crate) fn exec_array_append(arr: &Value, elem: &Value) -> Result<Value> {
     let Some(mut elements) = array_values_from_any(arr) else {
-        return Value::Null;
+        return Ok(Value::Null);
     };
     elements.push(elem.clone());
     values_to_record_blob(&elements)
 }
 
-pub(crate) fn exec_array_prepend(arr: &Value, elem: &Value) -> Value {
+pub(crate) fn exec_array_prepend(arr: &Value, elem: &Value) -> Result<Value> {
     let Some(elements) = array_values_from_any(arr) else {
-        return Value::Null;
+        return Ok(Value::Null);
     };
     // Build new vec with elem first — avoids O(n) shift from Vec::insert(0, ...)
     let mut result = Vec::with_capacity(elements.len() + 1);
@@ -267,26 +269,26 @@ pub(crate) fn exec_array_prepend(arr: &Value, elem: &Value) -> Value {
     values_to_record_blob(&result)
 }
 
-pub(crate) fn exec_array_cat(a: &Value, b: &Value) -> Value {
+pub(crate) fn exec_array_cat(a: &Value, b: &Value) -> Result<Value> {
     if matches!(a, Value::Null) || matches!(b, Value::Null) {
-        return Value::Null;
+        return Ok(Value::Null);
     }
     let Some(mut elems_a) = array_values_from_any(a) else {
-        return Value::Null;
+        return Ok(Value::Null);
     };
     let Some(elems_b) = array_values_from_any(b) else {
-        return Value::Null;
+        return Ok(Value::Null);
     };
     elems_a.extend(elems_b);
     values_to_record_blob(&elems_a)
 }
 
-pub(crate) fn exec_array_remove(arr: &Value, target: &Value) -> Value {
+pub(crate) fn exec_array_remove(arr: &Value, target: &Value) -> Result<Value> {
     if matches!(arr, Value::Null) {
-        return Value::Null;
+        return Ok(Value::Null);
     }
     let Some(elements) = array_values_from_any(arr) else {
-        return Value::Null;
+        return Ok(Value::Null);
     };
     let result: Vec<Value> = elements.into_iter().filter(|e| e != target).collect();
     values_to_record_blob(&result)
@@ -345,12 +347,12 @@ fn array_find_streaming(
     None
 }
 
-pub(crate) fn exec_array_slice(arr: &Value, start: &Value, end: &Value) -> Value {
+pub(crate) fn exec_array_slice(arr: &Value, start: &Value, end: &Value) -> Result<Value> {
     if matches!(arr, Value::Null) {
-        return Value::Null;
+        return Ok(Value::Null);
     }
     let Some(elements) = array_values_from_any(arr) else {
-        return Value::Null;
+        return Ok(Value::Null);
     };
     // PG convention: 1-based inclusive bounds
     let start_idx = match start {
@@ -375,10 +377,10 @@ pub(crate) fn exec_string_to_array(
     text: &Value,
     delimiter: &Value,
     null_str: Option<&Value>,
-) -> Value {
+) -> Result<Value> {
     let text_str = match text {
         Value::Text(t) => t.as_str().to_string(),
-        Value::Null => return Value::Null,
+        Value::Null => return Ok(Value::Null),
         other => other.to_string(),
     };
 
@@ -557,9 +559,9 @@ pub(crate) fn make_array_from_registers(
     registers: &[super::Register],
     start_reg: usize,
     count: usize,
-) -> Value {
-    let record = ImmutableRecord::from_registers(&registers[start_reg..start_reg + count], count);
-    Value::Blob(record.into_payload())
+) -> Result<Value> {
+    let record = ImmutableRecord::from_registers(&registers[start_reg..start_reg + count], count)?;
+    Ok(Value::Blob(record.into_payload()))
 }
 
 /// Element-wise comparison of two record-format array blobs.
@@ -625,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_compute_array_length_valid_array() {
-        let blob = values_to_record_blob(&[Value::from_i64(1), Value::from_i64(2)]);
+        let blob = values_to_record_blob(&[Value::from_i64(1), Value::from_i64(2)]).unwrap();
         assert_eq!(compute_array_length(&blob), Some(2));
     }
 
@@ -642,8 +644,9 @@ mod tests {
             Value::from_i64(3),
             Value::from_i64(2),
             Value::from_i64(1),
-        ]);
-        let result = exec_array_remove(&arr, &Value::from_i64(2));
+        ])
+        .unwrap();
+        let result = exec_array_remove(&arr, &Value::from_i64(2)).unwrap();
         let Value::Blob(blob) = &result else {
             panic!("Expected Blob");
         };
@@ -698,7 +701,7 @@ mod tests {
 
     #[test]
     fn test_string_to_array_null_delimiter_splits_chars() {
-        let result = exec_string_to_array(&Value::build_text("hello"), &Value::Null, None);
+        let result = exec_string_to_array(&Value::build_text("hello"), &Value::Null, None).unwrap();
         let Value::Blob(blob) = &result else {
             panic!("Expected Blob, got {result:?}");
         };
@@ -715,7 +718,8 @@ mod tests {
             Value::from_i64(10),
             Value::from_i64(20),
             Value::from_i64(30),
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             exec_array_contains(&arr, &Value::from_i64(20)),
             Value::from_i64(1)
@@ -732,7 +736,8 @@ mod tests {
             Value::from_i64(10),
             Value::from_i64(20),
             Value::from_i64(30),
-        ]);
+        ])
+        .unwrap();
         // 1-based: element 20 is at position 2
         assert_eq!(
             exec_array_position(&arr, &Value::from_i64(20)),
@@ -747,7 +752,8 @@ mod tests {
             Value::from_i64(10),
             Value::from_i64(20),
             Value::from_i64(30),
-        ]);
+        ])
+        .unwrap();
         // array_find_streaming with impossible predicate should return None
         let Value::Blob(blob) = &arr else {
             panic!("Expected Blob");
@@ -758,7 +764,7 @@ mod tests {
     #[test]
     fn test_dc4_array_remove_null_returns_null() {
         assert_eq!(
-            exec_array_remove(&Value::Null, &Value::from_i64(1)),
+            exec_array_remove(&Value::Null, &Value::from_i64(1)).unwrap(),
             Value::Null
         );
     }
@@ -766,16 +772,19 @@ mod tests {
     #[test]
     fn test_dc4_array_slice_null_returns_null() {
         assert_eq!(
-            exec_array_slice(&Value::Null, &Value::from_i64(0), &Value::from_i64(2)),
+            exec_array_slice(&Value::Null, &Value::from_i64(0), &Value::from_i64(2)).unwrap(),
             Value::Null,
         );
     }
 
     #[test]
     fn test_dc4_array_cat_null_returns_null() {
-        assert_eq!(exec_array_cat(&Value::Null, &Value::Null), Value::Null);
         assert_eq!(
-            exec_array_cat(&Value::Null, &Value::from_i64(1)),
+            exec_array_cat(&Value::Null, &Value::Null).unwrap(),
+            Value::Null
+        );
+        assert_eq!(
+            exec_array_cat(&Value::Null, &Value::from_i64(1)).unwrap(),
             Value::Null,
         );
     }
@@ -783,7 +792,8 @@ mod tests {
     #[test]
     fn test_serialize_array_from_blob() {
         let arr =
-            values_to_record_blob(&[Value::from_i64(1), Value::build_text("hello"), Value::Null]);
+            values_to_record_blob(&[Value::from_i64(1), Value::build_text("hello"), Value::Null])
+                .unwrap();
         let Value::Blob(blob) = &arr else {
             panic!("Expected Blob");
         };
@@ -799,7 +809,7 @@ mod tests {
             Register::Value(Value::build_text("two")),
             Register::Value(Value::from_i64(3)),
         ];
-        let result = make_array_from_registers(&registers, 0, 3);
+        let result = make_array_from_registers(&registers, 0, 3).unwrap();
         let Value::Blob(blob) = &result else {
             panic!("Expected Blob");
         };

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -200,12 +200,14 @@ fn value_to_bigdecimal(val: &Value) -> Result<bigdecimal::BigDecimal> {
 }
 
 /// Create a sort comparator closure from a SortComparatorType enum.
-fn make_sort_comparator(cmp_type: &SortComparatorType) -> crate::vdbe::sorter::SortComparator {
+fn make_sort_comparator(
+    cmp_type: &SortComparatorType,
+) -> Result<crate::vdbe::sorter::SortComparator> {
     use std::cmp::Ordering;
-    match cmp_type {
+    let cmp: crate::vdbe::sorter::SortComparator = match cmp_type {
         SortComparatorType::NumericLt => {
-            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Ordering {
-                match (a, b) {
+            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Result<Ordering> {
+                let res = match (a, b) {
                     (ValueRef::Null, ValueRef::Null) => Ordering::Equal,
                     (ValueRef::Null, _) => Ordering::Less,
                     (_, ValueRef::Null) => Ordering::Greater,
@@ -218,27 +220,29 @@ fn make_sort_comparator(cmp_type: &SortComparatorType) -> crate::vdbe::sorter::S
                             _ => a.partial_cmp(b).unwrap_or(Ordering::Equal),
                         }
                     }
-                }
+                };
+                Ok(res)
             })
         }
         SortComparatorType::StringReverse => {
-            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Ordering {
+            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Result<Ordering> {
                 fn reverse_str(v: &ValueRef) -> String {
                     match v {
                         ValueRef::Text(t) => t.to_string().chars().rev().collect(),
                         _ => String::new(),
                     }
                 }
-                match (a, b) {
+                let res = match (a, b) {
                     (ValueRef::Null, ValueRef::Null) => Ordering::Equal,
                     (ValueRef::Null, _) => Ordering::Less,
                     (_, ValueRef::Null) => Ordering::Greater,
                     _ => reverse_str(a).cmp(&reverse_str(b)),
-                }
+                };
+                Ok(res)
             })
         }
         SortComparatorType::TestUintLt => {
-            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Ordering {
+            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Result<Ordering> {
                 fn to_u64(v: &ValueRef) -> Option<u64> {
                     match v {
                         ValueRef::Null => None,
@@ -253,7 +257,7 @@ fn make_sort_comparator(cmp_type: &SortComparatorType) -> crate::vdbe::sorter::S
                         _ => None,
                     }
                 }
-                match (a, b) {
+                let res = match (a, b) {
                     (ValueRef::Null, ValueRef::Null) => Ordering::Equal,
                     (ValueRef::Null, _) => Ordering::Less,
                     (_, ValueRef::Null) => Ordering::Greater,
@@ -261,12 +265,13 @@ fn make_sort_comparator(cmp_type: &SortComparatorType) -> crate::vdbe::sorter::S
                         (Some(a), Some(b)) => a.cmp(&b),
                         _ => a.partial_cmp(b).unwrap_or(Ordering::Equal),
                     },
-                }
+                };
+                Ok(res)
             })
         }
         SortComparatorType::ArrayLt => {
-            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Ordering {
-                match (a, b) {
+            std::sync::Arc::new(|a: &ValueRef, b: &ValueRef| -> Result<Ordering> {
+                let res = match (a, b) {
                     (ValueRef::Null, ValueRef::Null) => Ordering::Equal,
                     (ValueRef::Null, _) => Ordering::Less,
                     (_, ValueRef::Null) => Ordering::Greater,
@@ -279,8 +284,8 @@ fn make_sort_comparator(cmp_type: &SortComparatorType) -> crate::vdbe::sorter::S
                         let b_vals = crate::vdbe::array::parse_text_array(b_text);
                         match (a_vals, b_vals) {
                             (Some(av), Some(bv)) => {
-                                let a_blob = crate::vdbe::array::values_to_record_blob(&av);
-                                let b_blob = crate::vdbe::array::values_to_record_blob(&bv);
+                                let a_blob = crate::vdbe::array::values_to_record_blob(&av)?;
+                                let b_blob = crate::vdbe::array::values_to_record_blob(&bv)?;
                                 if let (Value::Blob(ab), Value::Blob(bb)) = (&a_blob, &b_blob) {
                                     crate::vdbe::array::compare_arrays(ab, bb)
                                         .unwrap_or(Ordering::Equal)
@@ -292,10 +297,12 @@ fn make_sort_comparator(cmp_type: &SortComparatorType) -> crate::vdbe::sorter::S
                         }
                     }
                     _ => a.partial_cmp(b).unwrap_or(Ordering::Equal),
-                }
+                };
+                Ok(res)
             })
         }
-    }
+    };
+    Ok(cmp)
 }
 
 /// Compare two values using the specified collation for text values.
@@ -2134,7 +2141,7 @@ pub fn op_array_encode(
     }
 
     // Serialize coerced elements as a native record-format BLOB
-    let record = ImmutableRecord::from_values(&coerced_elements, coerced_elements.len());
+    let record = ImmutableRecord::from_values(&coerced_elements, coerced_elements.len())?;
     state.registers[*reg].set_blob(record.into_payload())?;
 
     state.pc += 1;
@@ -2282,7 +2289,7 @@ pub fn op_make_array(
         &state.registers,
         *start_reg,
         *count,
-    ));
+    )?);
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -2325,7 +2332,7 @@ pub fn op_make_array_dynamic(
         &state.registers,
         *start_reg,
         count,
-    ));
+    )?);
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -2386,7 +2393,7 @@ pub fn op_union_pack(
     );
 
     let record =
-        ImmutableRecord::from_registers(std::slice::from_ref(&state.registers[*value_reg]), 1);
+        ImmutableRecord::from_registers(std::slice::from_ref(&state.registers[*value_reg]), 1)?;
     let record_bytes = record.into_payload();
 
     // Format: [tag_index: 1 byte][record bytes]
@@ -2564,17 +2571,17 @@ pub fn op_array_concat(
             let mut elems_a = array_values_from_blob(lb)?;
             let elems_b = array_values_from_blob(rb)?;
             elems_a.extend(elems_b);
-            values_to_record_blob(&elems_a)
+            values_to_record_blob(&elems_a)?
         }
         (Value::Blob(lb), _) => {
             let mut elems = array_values_from_blob(lb)?;
             elems.push(rhs_ref.clone());
-            values_to_record_blob(&elems)
+            values_to_record_blob(&elems)?
         }
         (_, Value::Blob(rb)) => {
             let mut elems = array_values_from_blob(rb)?;
             elems.insert(0, lhs_ref.clone());
-            values_to_record_blob(&elems)
+            values_to_record_blob(&elems)?
         }
         _ => {
             // Neither is an array blob — fall back to string concat
@@ -2634,7 +2641,7 @@ pub fn op_array_set_element(
         state.registers[*dest].set_blob(blob.clone())?;
     } else {
         elements[idx] = new_val;
-        state.registers[*dest].set_value(values_to_record_blob(&elements));
+        state.registers[*dest].set_value(values_to_record_blob(&elements)?);
     }
 
     state.pc += 1;
@@ -2662,7 +2669,7 @@ pub fn op_array_slice(
     let start_val = state.registers[*start_reg].get_value().clone();
     let end_val = state.registers[*end_reg].get_value().clone();
 
-    let result = exec_array_slice(&arr_val, &start_val, &end_val);
+    let result = exec_array_slice(&arr_val, &start_val, &end_val)?;
     state.registers[*dest].set_value(result);
 
     state.pc += 1;
@@ -2705,7 +2712,7 @@ pub fn op_make_record(
         }
     }
 
-    let record = make_record(&state.registers, &start_reg, &count);
+    let record = make_record(&state.registers, &start_reg, &count)?;
     state.registers[dest_reg] = Register::Record(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -5990,7 +5997,7 @@ fn update_agg_payload(
             let cmp = if let Some(ref cmp_fn) = comparator {
                 let arg_ref = arg.as_ref();
                 let payload_ref = payload[0].as_ref();
-                cmp_fn(&arg_ref, &payload_ref)
+                cmp_fn(&arg_ref, &payload_ref)?
             } else {
                 compare_with_collation(&arg, &payload[0], Some(collation))
             };
@@ -6146,7 +6153,7 @@ fn finalize_agg_payload(func: &AggFunc, payload: &[Value]) -> Result<Value> {
                 )));
             } else {
                 let elements = &payload[1..1 + count];
-                Value::Blob(ImmutableRecord::from_values(elements, count).into_payload())
+                Value::Blob(ImmutableRecord::from_values(elements, count)?.into_payload())
             }
         }
         AggFunc::External(_) => {
@@ -6225,7 +6232,7 @@ pub fn op_agg_step(
     }
 
     // Resolve custom type comparator for MIN/MAX if provided
-    let comparator = comparator.as_ref().map(make_sort_comparator);
+    let comparator = comparator.as_ref().map(make_sort_comparator).transpose()?;
 
     // Step the aggregate
     match func {
@@ -6415,8 +6422,8 @@ pub fn op_sorter_open(
     }
     let comparators = comparators
         .iter()
-        .map(|c| c.as_ref().map(make_sort_comparator))
-        .collect();
+        .map(|c| c.as_ref().map(make_sort_comparator).transpose())
+        .collect::<Result<_>>()?;
     let temp_store = program.connection.get_temp_store();
     let cursor = Sorter::new(
         &order,
@@ -8008,25 +8015,25 @@ pub fn op_function(
                 check_arg_count!(arg_count, 2);
                 let arr_val = state.registers[*start_reg].get_value().clone();
                 let elem_val = state.registers[*start_reg + 1].get_value().clone();
-                state.registers[*dest].set_value(exec_array_append(&arr_val, &elem_val));
+                state.registers[*dest].set_value(exec_array_append(&arr_val, &elem_val)?);
             }
             ScalarFunc::ArrayPrepend => {
                 check_arg_count!(arg_count, 2);
                 let elem_val = state.registers[*start_reg].get_value().clone();
                 let arr_val = state.registers[*start_reg + 1].get_value().clone();
-                state.registers[*dest].set_value(exec_array_prepend(&arr_val, &elem_val));
+                state.registers[*dest].set_value(exec_array_prepend(&arr_val, &elem_val)?);
             }
             ScalarFunc::ArrayCat => {
                 check_arg_count!(arg_count, 2);
                 let a_val = state.registers[*start_reg].get_value().clone();
                 let b_val = state.registers[*start_reg + 1].get_value().clone();
-                state.registers[*dest].set_value(exec_array_cat(&a_val, &b_val));
+                state.registers[*dest].set_value(exec_array_cat(&a_val, &b_val)?);
             }
             ScalarFunc::ArrayRemove => {
                 check_arg_count!(arg_count, 2);
                 let arr_val = state.registers[*start_reg].get_value().clone();
                 let target = state.registers[*start_reg + 1].get_value().clone();
-                state.registers[*dest].set_value(exec_array_remove(&arr_val, &target));
+                state.registers[*dest].set_value(exec_array_remove(&arr_val, &target)?);
             }
             ScalarFunc::ArrayContains => {
                 check_arg_count!(arg_count, 2);
@@ -8053,7 +8060,7 @@ pub fn op_function(
                 let arr_val = state.registers[*start_reg].get_value().clone();
                 let start_idx = state.registers[*start_reg + 1].get_value().clone();
                 let end_idx = state.registers[*start_reg + 2].get_value().clone();
-                let result = exec_array_slice(&arr_val, &start_idx, &end_idx);
+                let result = exec_array_slice(&arr_val, &start_idx, &end_idx)?;
                 state.registers[*dest].set_value(result);
             }
             ScalarFunc::StringToArray => {
@@ -8068,7 +8075,7 @@ pub fn op_function(
                     &text,
                     &delimiter,
                     null_str.as_ref(),
-                ));
+                )?);
             }
             ScalarFunc::ArrayToString => {
                 let arr_val = state.registers[*start_reg].get_value().clone();
@@ -9301,7 +9308,7 @@ pub fn op_insert(
                             Register::Record(r) => std::borrow::Cow::Borrowed(r),
                             Register::Value(value) => {
                                 let values = [value];
-                                let record = ImmutableRecord::from_values(values, values.len());
+                                let record = ImmutableRecord::from_values(values, values.len())?;
                                 std::borrow::Cow::Owned(record)
                             }
                             Register::Aggregate(..) => {
@@ -9323,7 +9330,7 @@ pub fn op_insert(
                         Register::Record(r) => std::borrow::Cow::Borrowed(r),
                         Register::Value(value) => {
                             let values = [value];
-                            let record = ImmutableRecord::from_values(values, values.len());
+                            let record = ImmutableRecord::from_values(values, values.len())?;
                             std::borrow::Cow::Owned(record)
                         }
                         Register::Aggregate(..) => {
@@ -9419,7 +9426,7 @@ pub fn op_insert(
                         Register::Record(r) => std::borrow::Cow::Borrowed(r),
                         Register::Value(value) => {
                             let values = [value];
-                            let record = ImmutableRecord::from_values(values, values.len());
+                            let record = ImmutableRecord::from_values(values, values.len())?;
                             std::borrow::Cow::Owned(record)
                         }
                         Register::Aggregate(..) => {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2521,7 +2521,7 @@ pub(crate) fn make_record(
     registers: &[Register],
     start_reg: &usize,
     count: &usize,
-) -> ImmutableRecord {
+) -> Result<ImmutableRecord> {
     let regs = &registers[*start_reg..*start_reg + *count];
     ImmutableRecord::from_registers(regs, regs.len())
 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -25,7 +25,7 @@ use crate::{io_yield_one, return_if_io, CompletionError};
 /// A custom comparison function for sorting custom type columns.
 /// Takes two value references and returns an Ordering.
 /// Used when a custom type defines a `<` operator for correct sort behavior.
-pub type SortComparator = Arc<dyn Fn(&ValueRef, &ValueRef) -> Ordering + Send + Sync>;
+pub type SortComparator = Arc<dyn Fn(&ValueRef, &ValueRef) -> Result<Ordering> + Send + Sync>;
 
 #[derive(Debug, Clone, Copy)]
 enum SortState {
@@ -216,10 +216,10 @@ impl Sorter {
                     match &mut self.current {
                         Some(record) => {
                             record.invalidate();
-                            record.start_serialization(payload);
+                            record.start_serialization(payload)?;
                         }
                         None => {
-                            self.current = Some(arena_record.to_immutable_record());
+                            self.current = Some(arena_record.to_immutable_record()?);
                         }
                     }
 
@@ -240,7 +240,7 @@ impl Sorter {
                     match &mut self.current {
                         Some(record) => {
                             record.invalidate();
-                            record.start_serialization(payload);
+                            record.start_serialization(payload)?;
                         }
                         None => {
                             self.current = Some(boxed_record.record);
@@ -595,10 +595,10 @@ impl SortedChunk {
                             }
                             buffer_offset += bytes_read;
 
-                            let mut record = ImmutableRecord::new(record_size);
+                            let mut record = ImmutableRecord::new(record_size)?;
                             record.start_serialization(
                                 &buffer[buffer_offset..buffer_offset + record_size],
-                            );
+                            )?;
                             buffer_offset += record_size;
 
                             self.records.try_push(record)?;
@@ -807,11 +807,11 @@ impl ArenaSortableRecord {
     }
 
     /// Create an ImmutableRecord by copying payload bytes out of the arena.
-    fn to_immutable_record(&self) -> ImmutableRecord {
+    fn to_immutable_record(&self) -> Result<ImmutableRecord> {
         let payload = self.payload();
-        let mut record = ImmutableRecord::new(payload.len());
-        record.start_serialization(payload);
-        record
+        let mut record = ImmutableRecord::new(payload.len())?;
+        record.start_serialization(payload)?;
+        Ok(record)
     }
 }
 
@@ -831,7 +831,7 @@ impl Ord for ArenaSortableRecord {
             .enumerate()
         {
             let cmp = if let Some(Some(comparator)) = comparators.get(i) {
-                comparator(&self_val, &other_val)
+                comparator(&self_val, &other_val).expect("Memory allocation failed here")
             } else {
                 match (self_val, other_val) {
                     (ValueRef::Text(left), ValueRef::Text(right)) => {
@@ -947,7 +947,7 @@ impl Ord for BoxedSortableRecord {
             .enumerate()
         {
             let cmp = if let Some(Some(comparator)) = self.comparators.get(i) {
-                comparator(&self_val, &other_val)
+                comparator(&self_val, &other_val).expect("Memory allocation failed here")
             } else {
                 match (self_val, other_val) {
                     (ValueRef::Text(left), ValueRef::Text(right)) => {
@@ -1058,7 +1058,7 @@ mod tests {
             for i in (0..num_records).rev() {
                 let mut values = try_vec![Value::from_i64(i)].unwrap();
                 values.append(&mut generate_values(&mut rng, &value_types));
-                let record = ImmutableRecord::from_values(&values, values.len());
+                let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
 
                 io.block(|| sorter.insert(&record))
                     .expect("Failed to insert the record");

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -107,6 +107,7 @@ fn record<const N: usize>(values: [Value; N]) -> Vec<u8> {
         })
         .collect::<Vec<_>>();
     ImmutableRecord::from_values(&values, values.len())
+        .unwrap()
         .get_payload()
         .to_vec()
 }


### PR DESCRIPTION
## Description
Changed certain `immutable_record` methods to return an error as they can allocate. Changes are really mostly syntactic. There were 2 `Ord` impls though that needed to have an `expect` there as we cannot return errors from that trait. 

## Motivation and context
Fallible allocations


## Description of AI Usage
AI for boilerplate
