### PR TITLE
core: skip ArcSwap::load on non-MVCC connections in step hot path

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2072,10 +2072,12 @@ impl Connection {
         }
 
         // Never use MV store for bootstrapping - we read state directly from sqlite_schema in the DB file.
-        if !self.is_mvcc_bootstrap_connection() {
-            either::Left(self.db.get_mv_store())
-        } else {
+        // The `has_mv_store` check is a relaxed atomic-bool load that lets non-MVCC
+        // databases skip the ArcSwap load entirely on the per-step hot path.
+        if self.is_mvcc_bootstrap_connection() || !self.db.has_mv_store() {
             either::Right(TransparentWrapper(None))
+        } else {
+            either::Left(self.db.get_mv_store())
         }
     }
 
@@ -2564,6 +2566,7 @@ impl Connection {
                 enc_ctx,
             )?;
             db.mv_store.store(Some(mv_store.clone()));
+            db.mv_store_active.store(true, Ordering::Release);
             let bootstrap_conn = db._connect(true, Some(pager.clone()), encryption_key)?;
             mv_store.bootstrap(bootstrap_conn)?;
         }
@@ -3353,14 +3356,21 @@ impl Connection {
             return None;
         }
         match db {
-            crate::MAIN_DB_ID => self.db.get_mv_store().as_ref().cloned(),
+            crate::MAIN_DB_ID => {
+                if !self.db.has_mv_store() {
+                    return None;
+                }
+                self.db.get_mv_store().as_ref().cloned()
+            }
             crate::TEMP_DB_ID => None,
             _ => {
                 let catalog = self.attached_databases.read();
-                catalog
-                    .index_to_data
-                    .get(&db)
-                    .and_then(|(db, _)| db.get_mv_store().as_ref().cloned())
+                catalog.index_to_data.get(&db).and_then(|(db, _)| {
+                    if !db.has_mv_store() {
+                        return None;
+                    }
+                    db.get_mv_store().as_ref().cloned()
+                })
             }
         }
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -480,6 +480,10 @@ static DATABASE_MANAGER: LazyLock<Arc<parking_lot::Mutex<HashMap<DatabaseKey, Re
 /// encryption key here.
 pub struct Database {
     mv_store: ArcSwapOption<MvStore>,
+    /// Set when `mv_store` is populated. Lets callers skip the ArcSwap load on
+    /// non-MVCC databases: an Acquire `bool` is ~1ns vs ~30ns for
+    /// `HybridStrategy::load`, and this fires on every `Statement::step()`.
+    mv_store_active: AtomicBool,
     schema: Arc<Mutex<Arc<Schema>>>,
     pub db_file: Arc<dyn DatabaseStorage>,
     pub path: String,
@@ -589,6 +593,7 @@ impl Database {
         let wal_path = wal_path.into();
         let shared_wal = WalFileShared::new_noop();
         let mv_store = ArcSwapOption::empty();
+        let mv_store_active = AtomicBool::new(false);
 
         let db_size = db_file.size()?;
 
@@ -616,6 +621,7 @@ impl Database {
 
         let db = Database {
             mv_store,
+            mv_store_active,
             path,
             wal_path,
             schema: Arc::new(Mutex::new(Arc::new({
@@ -1637,6 +1643,7 @@ impl Database {
                 enc_ctx,
             )?;
             self.mv_store.store(Some(mv_store));
+            self.mv_store_active.store(true, Ordering::Release);
         }
 
         Ok(Arc::new(pager))
@@ -2403,6 +2410,13 @@ impl Database {
         self.mv_store.load()
     }
 
+    /// Cheap fast-path check: true once `mv_store` has been populated. Avoids
+    /// the ArcSwap load on the hot per-step path for non-MVCC databases.
+    #[inline]
+    pub fn has_mv_store(&self) -> bool {
+        self.mv_store_active.load(Ordering::Acquire)
+    }
+
     pub fn experimental_views_enabled(&self) -> bool {
         self.opts.enable_views
     }
@@ -2445,7 +2459,7 @@ impl Database {
 
     /// check if database is currently in MVCC mode
     pub fn mvcc_enabled(&self) -> bool {
-        self.mv_store.load().is_some()
+        self.has_mv_store()
     }
 
     #[cfg(feature = "test_helper")]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -14664,12 +14664,22 @@ fn op_journal_mode_inner(
                         enc_ctx,
                     )?;
                     program.connection.db.mv_store.store(Some(mv_store.clone()));
+                    program
+                        .connection
+                        .db
+                        .mv_store_active
+                        .store(true, Ordering::Release);
                     program.connection.demote_to_mvcc_connection();
                     mv_store.bootstrap(program.connection.clone())?;
                 }
 
                 if matches!(new_mode, journal_mode::JournalMode::Wal) {
                     program.connection.db.mv_store.store(None);
+                    program
+                        .connection
+                        .db
+                        .mv_store_active
+                        .store(false, Ordering::Release);
                 }
 
                 // Return result


### PR DESCRIPTION
Every Statement::step() takes several ArcSwap loads on Database::mv_store via Connection::mv_store() / mv_store_for_db(). For non-MVCC databases the load returns None but still pays for arc_swap's hybrid debt machinery (~30ns/load).

Profile of `SELECT 1` (criterion + pprof, non-MVCC :memory:) showed arc_swap::strategy::hybrid::HybridStrategy::load at 15.11% of samples (113/748). After this change: 0/800 samples.

The fix adds Database::mv_store_active (AtomicBool) mirroring whether mv_store is populated, set with Release after each mv_store.store(...) (open, ATTACH, and PRAGMA journal_mode transitions both ways). Callers short-circuit on an Acquire load (~1ns) before touching the ArcSwap. ArcSwap stays for the active-MVCC path; behavior there is unchanged.

Wallclock SELECT 1: 106.6ns -> 91.7ns (-11.2% median, p<0.05).

