### PR TITLE
fix: graceful handling of FTS Drop after committed transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.1 -- 2026-05-22
+
+### Fixed
+
+* Apply virtual gen-col affinity in OLD probe and NEW key (Mikaël Francoeur)
+* core/mvcc: make MVCC integrity_check reprepare after checkpoint root publication (Avinash Sajjanshetty)
+* core/mvcc: rollback savepoint on abandoned statement (Pere Diaz Bou)
+* core/mvcc: check schema cookie during get_commit_timestamp (Pere Diaz Bou)
+* core/mvcc: yield on big serialization of transaction (Pere Diaz Bou)
+* core/mvcc: preserve rowid allocator watermark (Avinash Sajjanshetty)
+* core/mvcc: Rollback abandoned MVCC commits on cleanup (Mikaël Francoeur)
+* core/mvcc: fix MVCC checkpoint duplicate index entries for interior index keys (Avinash Sajjanshetty)
+
 ## 0.6.0 -- 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_tester"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1612,7 +1612,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "differential-fuzzer"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_completion"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "mimalloc",
  "turso_ext",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_crypto"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_csv"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "csv",
  "mimalloc",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_fuzzy"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "mimalloc",
  "turso_ext",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_ipaddr"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "ipnetwork",
  "mimalloc",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_percentile"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "mimalloc",
  "turso_ext",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_regexp"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "mimalloc",
  "regex",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_sim"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_sqlite_test_ext"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "cc",
 ]
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "py-turso"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "pyo3",
@@ -5502,7 +5502,7 @@ checksum = "d372029cb5195f9ab4e4b9aef550787dce78b124fcaee8d82519925defcd6f0d"
 
 [[package]]
 name = "sql_gen"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "proptest",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "sql_gen_prop"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "proptest",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "sql_generation"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "anyhow",
@@ -6488,7 +6488,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turso"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6513,7 +6513,7 @@ dependencies = [
 
 [[package]]
 name = "turso-dbhash"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "clap",
  "hex",
@@ -6524,14 +6524,14 @@ dependencies = [
 
 [[package]]
 name = "turso-dotnet"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "turso_core",
 ]
 
 [[package]]
 name = "turso-java"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "jni",
  "thiserror 2.0.16",
@@ -6540,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "turso_cli"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "aegis",
  "aes",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "getrandom 0.4.2",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "turso_ext_tests"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -6681,7 +6681,7 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6690,7 +6690,7 @@ dependencies = [
 
 [[package]]
 name = "turso_node"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "napi",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "bitflags 2.9.4",
  "codspeed-criterion-compat",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -6737,7 +6737,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit_macros"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6746,7 +6746,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sqlite3"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "turso_stress"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "antithesis_sdk",
  "clap",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_engine"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6807,7 +6807,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_js"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "genawaiter",
  "napi",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_sdk_kit"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -6839,7 +6839,7 @@ dependencies = [
 
 [[package]]
 name = "turso_whopper"
-version = "0.6.1-pre.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_tester"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1612,7 +1612,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "differential-fuzzer"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_completion"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "mimalloc",
  "turso_ext",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_crypto"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "blake3",
  "data-encoding",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_csv"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "csv",
  "mimalloc",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_fuzzy"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "mimalloc",
  "turso_ext",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_ipaddr"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "ipnetwork",
  "mimalloc",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_percentile"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "mimalloc",
  "turso_ext",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_regexp"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "mimalloc",
  "regex",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_sim"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "limbo_sqlite_test_ext"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "cc",
 ]
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "py-turso"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anyhow",
  "pyo3",
@@ -5502,7 +5502,7 @@ checksum = "d372029cb5195f9ab4e4b9aef550787dce78b124fcaee8d82519925defcd6f0d"
 
 [[package]]
 name = "sql_gen"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "proptest",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "sql_gen_prop"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "proptest",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "sql_generation"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anarchist-readable-name-generator-lib",
  "anyhow",
@@ -6488,7 +6488,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turso"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6513,7 +6513,7 @@ dependencies = [
 
 [[package]]
 name = "turso-dbhash"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "clap",
  "hex",
@@ -6524,14 +6524,14 @@ dependencies = [
 
 [[package]]
 name = "turso-dotnet"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "turso_core",
 ]
 
 [[package]]
 name = "turso-java"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "jni",
  "thiserror 2.0.16",
@@ -6540,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "turso_cli"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "aegis",
  "aes",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "chrono",
  "getrandom 0.4.2",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "turso_ext_tests"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -6681,7 +6681,7 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6690,7 +6690,7 @@ dependencies = [
 
 [[package]]
 name = "turso_node"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "chrono",
  "napi",
@@ -6704,7 +6704,7 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "bitflags 2.9.4",
  "codspeed-criterion-compat",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -6737,7 +6737,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit_macros"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6746,7 +6746,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sqlite3"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "env_logger",
  "libc",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "turso_stress"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "antithesis_sdk",
  "clap",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_engine"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6807,7 +6807,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_js"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "genawaiter",
  "napi",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_sdk_kit"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -6839,7 +6839,7 @@ dependencies = [
 
 [[package]]
 name = "turso_whopper"
-version = "0.6.0"
+version = "0.6.1-pre.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,24 +87,24 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1-pre.1"
 authors = ["the Turso authors"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/tursodatabase/turso"
 
 [workspace.dependencies]
-turso = { path = "bindings/rust", version = "0.6.0" }
-turso_node = { path = "bindings/javascript", version = "0.6.0" }
-turso_sdk_kit = { path = "sdk-kit", version = "0.6.0" }
-turso_sdk_kit_macros = { path = "sdk-kit-macros", version = "0.6.0" }
-turso_sync_sdk_kit = { path = "sync/sdk-kit", version = "0.6.0" }
-limbo_completion = { path = "extensions/completion", version = "0.6.0" }
-turso_core = { path = "core", version = "0.6.0" }
-turso_sync_engine = { path = "sync/engine", version = "0.6.0" }
-turso_ext = { path = "extensions/core", version = "0.6.0" }
-turso_macros = { path = "macros", version = "0.6.0" }
-turso_parser = { path = "parser", version = "0.6.0" }
+turso = { path = "bindings/rust", version = "0.6.1-pre.1" }
+turso_node = { path = "bindings/javascript", version = "0.6.1-pre.1" }
+turso_sdk_kit = { path = "sdk-kit", version = "0.6.1-pre.1" }
+turso_sdk_kit_macros = { path = "sdk-kit-macros", version = "0.6.1-pre.1" }
+turso_sync_sdk_kit = { path = "sync/sdk-kit", version = "0.6.1-pre.1" }
+limbo_completion = { path = "extensions/completion", version = "0.6.1-pre.1" }
+turso_core = { path = "core", version = "0.6.1-pre.1" }
+turso_sync_engine = { path = "sync/engine", version = "0.6.1-pre.1" }
+turso_ext = { path = "extensions/core", version = "0.6.1-pre.1" }
+turso_macros = { path = "macros", version = "0.6.1-pre.1" }
+turso_parser = { path = "parser", version = "0.6.1-pre.1" }
 sql_generation = { path = "sql_generation" }
 turso-dbhash = { path = "tools/dbhash" }
 strum = { version = "0.26", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,24 +87,24 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.6.1-pre.1"
+version = "0.6.1"
 authors = ["the Turso authors"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/tursodatabase/turso"
 
 [workspace.dependencies]
-turso = { path = "bindings/rust", version = "0.6.1-pre.1" }
-turso_node = { path = "bindings/javascript", version = "0.6.1-pre.1" }
-turso_sdk_kit = { path = "sdk-kit", version = "0.6.1-pre.1" }
-turso_sdk_kit_macros = { path = "sdk-kit-macros", version = "0.6.1-pre.1" }
-turso_sync_sdk_kit = { path = "sync/sdk-kit", version = "0.6.1-pre.1" }
-limbo_completion = { path = "extensions/completion", version = "0.6.1-pre.1" }
-turso_core = { path = "core", version = "0.6.1-pre.1" }
-turso_sync_engine = { path = "sync/engine", version = "0.6.1-pre.1" }
-turso_ext = { path = "extensions/core", version = "0.6.1-pre.1" }
-turso_macros = { path = "macros", version = "0.6.1-pre.1" }
-turso_parser = { path = "parser", version = "0.6.1-pre.1" }
+turso = { path = "bindings/rust", version = "0.6.1" }
+turso_node = { path = "bindings/javascript", version = "0.6.1" }
+turso_sdk_kit = { path = "sdk-kit", version = "0.6.1" }
+turso_sdk_kit_macros = { path = "sdk-kit-macros", version = "0.6.1" }
+turso_sync_sdk_kit = { path = "sync/sdk-kit", version = "0.6.1" }
+limbo_completion = { path = "extensions/completion", version = "0.6.1" }
+turso_core = { path = "core", version = "0.6.1" }
+turso_sync_engine = { path = "sync/engine", version = "0.6.1" }
+turso_ext = { path = "extensions/core", version = "0.6.1" }
+turso_macros = { path = "macros", version = "0.6.1" }
+turso_parser = { path = "parser", version = "0.6.1" }
 sql_generation = { path = "sql_generation" }
 turso-dbhash = { path = "tools/dbhash" }
 strum = { version = "0.26", features = ["derive"] }

--- a/bindings/java/gradle.properties
+++ b/bindings/java/gradle.properties
@@ -1,5 +1,5 @@
 projectGroup=tech.turso
-projectVersion=0.6.1-pre.1
+projectVersion=0.6.1
 projectArtifactId=turso
 
 # POM metadata

--- a/bindings/java/gradle.properties
+++ b/bindings/java/gradle.properties
@@ -1,5 +1,5 @@
 projectGroup=tech.turso
-projectVersion=0.6.0
+projectVersion=0.6.1-pre.1
 projectArtifactId=turso
 
 # POM metadata

--- a/bindings/javascript/package-lock.json
+++ b/bindings/javascript/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "javascript",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "workspaces": [
         "packages/common",
         "packages/wasm-common",
@@ -2742,7 +2742,7 @@
     },
     "packages/common": {
       "name": "@tursodatabase/database-common",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.2",
@@ -2751,10 +2751,10 @@
     },
     "packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.1-pre.1"
+        "@tursodatabase/database-common": "^0.6.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -2768,11 +2768,11 @@
     },
     "packages/wasm": {
       "name": "@tursodatabase/database-wasm",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.1-pre.1",
-        "@tursodatabase/database-wasm-common": "^0.6.1-pre.1"
+        "@tursodatabase/database-common": "^0.6.1",
+        "@tursodatabase/database-wasm-common": "^0.6.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -2785,7 +2785,7 @@
     },
     "packages/wasm-common": {
       "name": "@tursodatabase/database-wasm-common",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@emnapi/core": "1.8.1",
@@ -2829,10 +2829,10 @@
     },
     "sync/packages/common": {
       "name": "@tursodatabase/sync-common",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.1-pre.1",
+        "@tursodatabase/database-common": "^0.6.1",
         "@tursodatabase/serverless": "^0.2.2"
       },
       "devDependencies": {
@@ -2842,11 +2842,11 @@
     },
     "sync/packages/native": {
       "name": "@tursodatabase/sync",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.1-pre.1",
-        "@tursodatabase/sync-common": "^0.6.1-pre.1"
+        "@tursodatabase/database-common": "^0.6.1",
+        "@tursodatabase/sync-common": "^0.6.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -2857,12 +2857,12 @@
     },
     "sync/packages/wasm": {
       "name": "@tursodatabase/sync-wasm",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.1-pre.1",
-        "@tursodatabase/database-wasm-common": "^0.6.1-pre.1",
-        "@tursodatabase/sync-common": "^0.6.1-pre.1"
+        "@tursodatabase/database-common": "^0.6.1",
+        "@tursodatabase/database-wasm-common": "^0.6.1",
+        "@tursodatabase/sync-common": "^0.6.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",

--- a/bindings/javascript/package-lock.json
+++ b/bindings/javascript/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "javascript",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "workspaces": [
         "packages/common",
         "packages/wasm-common",
@@ -2742,7 +2742,7 @@
     },
     "packages/common": {
       "name": "@tursodatabase/database-common",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.2",
@@ -2751,10 +2751,10 @@
     },
     "packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0"
+        "@tursodatabase/database-common": "^0.6.1-pre.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -2768,11 +2768,11 @@
     },
     "packages/wasm": {
       "name": "@tursodatabase/database-wasm",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0",
-        "@tursodatabase/database-wasm-common": "^0.6.0"
+        "@tursodatabase/database-common": "^0.6.1-pre.1",
+        "@tursodatabase/database-wasm-common": "^0.6.1-pre.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -2785,7 +2785,7 @@
     },
     "packages/wasm-common": {
       "name": "@tursodatabase/database-wasm-common",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "dependencies": {
         "@emnapi/core": "1.8.1",
@@ -2829,10 +2829,10 @@
     },
     "sync/packages/common": {
       "name": "@tursodatabase/sync-common",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0",
+        "@tursodatabase/database-common": "^0.6.1-pre.1",
         "@tursodatabase/serverless": "^0.2.2"
       },
       "devDependencies": {
@@ -2842,11 +2842,11 @@
     },
     "sync/packages/native": {
       "name": "@tursodatabase/sync",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0",
-        "@tursodatabase/sync-common": "^0.6.0"
+        "@tursodatabase/database-common": "^0.6.1-pre.1",
+        "@tursodatabase/sync-common": "^0.6.1-pre.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -2857,12 +2857,12 @@
     },
     "sync/packages/wasm": {
       "name": "@tursodatabase/sync-wasm",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0",
-        "@tursodatabase/database-wasm-common": "^0.6.0",
-        "@tursodatabase/sync-common": "^0.6.0"
+        "@tursodatabase/database-common": "^0.6.1-pre.1",
+        "@tursodatabase/database-wasm-common": "^0.6.1-pre.1",
+        "@tursodatabase/sync-common": "^0.6.1-pre.1"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",

--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -22,5 +22,5 @@
     "@emnapi/wasi-threads": "1.1.0",
     "@napi-rs/cli": "3.1.5"
   },
-  "version": "0.6.0"
+  "version": "0.6.1-pre.1"
 }

--- a/bindings/javascript/package.json
+++ b/bindings/javascript/package.json
@@ -22,5 +22,5 @@
     "@emnapi/wasi-threads": "1.1.0",
     "@napi-rs/cli": "3.1.5"
   },
-  "version": "0.6.1-pre.1"
+  "version": "0.6.1"
 }

--- a/bindings/javascript/packages/common/package.json
+++ b/bindings/javascript/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database-common",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"

--- a/bindings/javascript/packages/common/package.json
+++ b/bindings/javascript/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database-common",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"

--- a/bindings/javascript/packages/native/package.json
+++ b/bindings/javascript/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.0"
+    "@tursodatabase/database-common": "^0.6.1-pre.1"
   },
   "imports": {
     "#index": "./index.js"

--- a/bindings/javascript/packages/native/package.json
+++ b/bindings/javascript/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.1-pre.1"
+    "@tursodatabase/database-common": "^0.6.1"
   },
   "imports": {
     "#index": "./index.js"

--- a/bindings/javascript/packages/wasm-common/package.json
+++ b/bindings/javascript/packages/wasm-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database-wasm-common",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"

--- a/bindings/javascript/packages/wasm-common/package.json
+++ b/bindings/javascript/packages/wasm-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database-wasm-common",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"

--- a/bindings/javascript/packages/wasm/package.json
+++ b/bindings/javascript/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database-wasm",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -51,7 +51,7 @@
     ]
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.0",
-    "@tursodatabase/database-wasm-common": "^0.6.0"
+    "@tursodatabase/database-common": "^0.6.1-pre.1",
+    "@tursodatabase/database-wasm-common": "^0.6.1-pre.1"
   }
 }

--- a/bindings/javascript/packages/wasm/package.json
+++ b/bindings/javascript/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/database-wasm",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -51,7 +51,7 @@
     ]
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.1-pre.1",
-    "@tursodatabase/database-wasm-common": "^0.6.1-pre.1"
+    "@tursodatabase/database-common": "^0.6.1",
+    "@tursodatabase/database-wasm-common": "^0.6.1"
   }
 }

--- a/bindings/javascript/sync/packages/common/package.json
+++ b/bindings/javascript/sync/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync-common",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -24,7 +24,7 @@
     "test": "echo 'no tests'"
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.0",
+    "@tursodatabase/database-common": "^0.6.1-pre.1",
     "@tursodatabase/serverless": "^0.2.2"
   }
 }

--- a/bindings/javascript/sync/packages/common/package.json
+++ b/bindings/javascript/sync/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync-common",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -24,7 +24,7 @@
     "test": "echo 'no tests'"
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.1-pre.1",
+    "@tursodatabase/database-common": "^0.6.1",
     "@tursodatabase/serverless": "^0.2.2"
   }
 }

--- a/bindings/javascript/sync/packages/native/package.json
+++ b/bindings/javascript/sync/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -45,8 +45,8 @@
     ]
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.1-pre.1",
-    "@tursodatabase/sync-common": "^0.6.1-pre.1"
+    "@tursodatabase/database-common": "^0.6.1",
+    "@tursodatabase/sync-common": "^0.6.1"
   },
   "imports": {
     "#index": "./index.js"

--- a/bindings/javascript/sync/packages/native/package.json
+++ b/bindings/javascript/sync/packages/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -45,8 +45,8 @@
     ]
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.0",
-    "@tursodatabase/sync-common": "^0.6.0"
+    "@tursodatabase/database-common": "^0.6.1-pre.1",
+    "@tursodatabase/sync-common": "^0.6.1-pre.1"
   },
   "imports": {
     "#index": "./index.js"

--- a/bindings/javascript/sync/packages/wasm/package.json
+++ b/bindings/javascript/sync/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync-wasm",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -54,8 +54,8 @@
     "#index": "./index.js"
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.1-pre.1",
-    "@tursodatabase/database-wasm-common": "^0.6.1-pre.1",
-    "@tursodatabase/sync-common": "^0.6.1-pre.1"
+    "@tursodatabase/database-common": "^0.6.1",
+    "@tursodatabase/database-wasm-common": "^0.6.1",
+    "@tursodatabase/sync-common": "^0.6.1"
   }
 }

--- a/bindings/javascript/sync/packages/wasm/package.json
+++ b/bindings/javascript/sync/packages/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync-wasm",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/tursodatabase/turso"
@@ -54,8 +54,8 @@
     "#index": "./index.js"
   },
   "dependencies": {
-    "@tursodatabase/database-common": "^0.6.0",
-    "@tursodatabase/database-wasm-common": "^0.6.0",
-    "@tursodatabase/sync-common": "^0.6.0"
+    "@tursodatabase/database-common": "^0.6.1-pre.1",
+    "@tursodatabase/database-wasm-common": "^0.6.1-pre.1",
+    "@tursodatabase/sync-common": "^0.6.1-pre.1"
   }
 }

--- a/bindings/javascript/yarn.lock
+++ b/bindings/javascript/yarn.lock
@@ -1972,7 +1972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tursodatabase/database-common@npm:^0.6.1-pre.1, @tursodatabase/database-common@workspace:packages/common":
+"@tursodatabase/database-common@npm:^0.6.1, @tursodatabase/database-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@tursodatabase/database-common@workspace:packages/common"
   dependencies:
@@ -1981,7 +1981,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tursodatabase/database-wasm-common@npm:^0.6.1-pre.1, @tursodatabase/database-wasm-common@workspace:packages/wasm-common":
+"@tursodatabase/database-wasm-common@npm:^0.6.1, @tursodatabase/database-wasm-common@workspace:packages/wasm-common":
   version: 0.0.0-use.local
   resolution: "@tursodatabase/database-wasm-common@workspace:packages/wasm-common"
   dependencies:
@@ -1997,8 +1997,8 @@ __metadata:
   resolution: "@tursodatabase/database-wasm@workspace:packages/wasm"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
-    "@tursodatabase/database-wasm-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/database-common": "npm:^0.6.1"
+    "@tursodatabase/database-wasm-common": "npm:^0.6.1"
     "@vitest/browser": "npm:^3.2.4"
     playwright: "npm:^1.55.0"
     typescript: "npm:^5.9.2"
@@ -2012,7 +2012,7 @@ __metadata:
   resolution: "@tursodatabase/database@workspace:packages/native"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/database-common": "npm:^0.6.1"
     "@types/node": "npm:^24.3.1"
     better-sqlite3: "npm:^12.2.0"
     drizzle-kit: "npm:^0.31.4"
@@ -2029,11 +2029,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tursodatabase/sync-common@npm:^0.6.1-pre.1, @tursodatabase/sync-common@workspace:sync/packages/common":
+"@tursodatabase/sync-common@npm:^0.6.1, @tursodatabase/sync-common@workspace:sync/packages/common":
   version: 0.0.0-use.local
   resolution: "@tursodatabase/sync-common@workspace:sync/packages/common"
   dependencies:
-    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/database-common": "npm:^0.6.1"
     "@tursodatabase/serverless": "npm:^0.2.2"
     "@types/node": "npm:^24.12.2"
     typescript: "npm:^5.9.2"
@@ -2045,9 +2045,9 @@ __metadata:
   resolution: "@tursodatabase/sync-wasm@workspace:sync/packages/wasm"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
-    "@tursodatabase/database-wasm-common": "npm:^0.6.1-pre.1"
-    "@tursodatabase/sync-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/database-common": "npm:^0.6.1"
+    "@tursodatabase/database-wasm-common": "npm:^0.6.1"
+    "@tursodatabase/sync-common": "npm:^0.6.1"
     "@vitest/browser": "npm:^3.2.4"
     playwright: "npm:^1.57.0"
     typescript: "npm:^5.9.2"
@@ -2061,8 +2061,8 @@ __metadata:
   resolution: "@tursodatabase/sync@workspace:sync/packages/native"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
-    "@tursodatabase/sync-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/database-common": "npm:^0.6.1"
+    "@tursodatabase/sync-common": "npm:^0.6.1"
     "@types/node": "npm:^24.12.2"
     typescript: "npm:^5.9.2"
     vitest: "npm:^3.2.4"

--- a/bindings/javascript/yarn.lock
+++ b/bindings/javascript/yarn.lock
@@ -1772,177 +1772,177 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.3"
+"@rollup/rollup-android-arm-eabi@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.4"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-android-arm64@npm:4.60.3"
+"@rollup/rollup-android-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.4"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.3"
+"@rollup/rollup-darwin-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-darwin-x64@npm:4.60.3"
+"@rollup/rollup-darwin-x64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.3"
+"@rollup/rollup-freebsd-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.4"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.3"
+"@rollup/rollup-freebsd-x64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.4"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.3"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.4"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.3"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.4"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.3"
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.3"
+"@rollup/rollup-linux-arm64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loong64-gnu@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.3"
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.4"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loong64-musl@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.3"
+"@rollup/rollup-linux-loong64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.4"
   conditions: os=linux & cpu=loong64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-ppc64-gnu@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.3"
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.4"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-ppc64-musl@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.3"
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.4"
   conditions: os=linux & cpu=ppc64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.3"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.4"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-musl@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.3"
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.4"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.3"
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.4"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.3"
+"@rollup/rollup-linux-x64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.3"
+"@rollup/rollup-linux-x64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-openbsd-x64@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.3"
+"@rollup/rollup-openbsd-x64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.4"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-openharmony-arm64@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.3"
+"@rollup/rollup-openharmony-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.4"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.3"
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.3"
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.4"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-gnu@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.3"
+"@rollup/rollup-win32-x64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.60.3":
-  version: 4.60.3
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.3"
+"@rollup/rollup-win32-x64-msvc@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1972,7 +1972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tursodatabase/database-common@npm:^0.6.0, @tursodatabase/database-common@workspace:packages/common":
+"@tursodatabase/database-common@npm:^0.6.1-pre.1, @tursodatabase/database-common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@tursodatabase/database-common@workspace:packages/common"
   dependencies:
@@ -1981,7 +1981,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tursodatabase/database-wasm-common@npm:^0.6.0, @tursodatabase/database-wasm-common@workspace:packages/wasm-common":
+"@tursodatabase/database-wasm-common@npm:^0.6.1-pre.1, @tursodatabase/database-wasm-common@workspace:packages/wasm-common":
   version: 0.0.0-use.local
   resolution: "@tursodatabase/database-wasm-common@workspace:packages/wasm-common"
   dependencies:
@@ -1997,8 +1997,8 @@ __metadata:
   resolution: "@tursodatabase/database-wasm@workspace:packages/wasm"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.0"
-    "@tursodatabase/database-wasm-common": "npm:^0.6.0"
+    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/database-wasm-common": "npm:^0.6.1-pre.1"
     "@vitest/browser": "npm:^3.2.4"
     playwright: "npm:^1.55.0"
     typescript: "npm:^5.9.2"
@@ -2012,7 +2012,7 @@ __metadata:
   resolution: "@tursodatabase/database@workspace:packages/native"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.0"
+    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
     "@types/node": "npm:^24.3.1"
     better-sqlite3: "npm:^12.2.0"
     drizzle-kit: "npm:^0.31.4"
@@ -2029,11 +2029,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tursodatabase/sync-common@npm:^0.6.0, @tursodatabase/sync-common@workspace:sync/packages/common":
+"@tursodatabase/sync-common@npm:^0.6.1-pre.1, @tursodatabase/sync-common@workspace:sync/packages/common":
   version: 0.0.0-use.local
   resolution: "@tursodatabase/sync-common@workspace:sync/packages/common"
   dependencies:
-    "@tursodatabase/database-common": "npm:^0.6.0"
+    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
     "@tursodatabase/serverless": "npm:^0.2.2"
     "@types/node": "npm:^24.12.2"
     typescript: "npm:^5.9.2"
@@ -2045,9 +2045,9 @@ __metadata:
   resolution: "@tursodatabase/sync-wasm@workspace:sync/packages/wasm"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.0"
-    "@tursodatabase/database-wasm-common": "npm:^0.6.0"
-    "@tursodatabase/sync-common": "npm:^0.6.0"
+    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/database-wasm-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/sync-common": "npm:^0.6.1-pre.1"
     "@vitest/browser": "npm:^3.2.4"
     playwright: "npm:^1.57.0"
     typescript: "npm:^5.9.2"
@@ -2061,8 +2061,8 @@ __metadata:
   resolution: "@tursodatabase/sync@workspace:sync/packages/native"
   dependencies:
     "@napi-rs/cli": "npm:^3.1.5"
-    "@tursodatabase/database-common": "npm:^0.6.0"
-    "@tursodatabase/sync-common": "npm:^0.6.0"
+    "@tursodatabase/database-common": "npm:^0.6.1-pre.1"
+    "@tursodatabase/sync-common": "npm:^0.6.1-pre.1"
     "@types/node": "npm:^24.12.2"
     typescript: "npm:^5.9.2"
     vitest: "npm:^3.2.4"
@@ -3312,7 +3312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
+"nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
   bin:
@@ -3455,13 +3455,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.5.6":
-  version: 8.5.14
-  resolution: "postcss@npm:8.5.14"
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.12"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
+  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
   languageName: node
   linkType: hard
 
@@ -3555,34 +3555,34 @@ __metadata:
   linkType: hard
 
 "rollup@npm:^4.43.0":
-  version: 4.60.3
-  resolution: "rollup@npm:4.60.3"
+  version: 4.60.4
+  resolution: "rollup@npm:4.60.4"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.60.3"
-    "@rollup/rollup-android-arm64": "npm:4.60.3"
-    "@rollup/rollup-darwin-arm64": "npm:4.60.3"
-    "@rollup/rollup-darwin-x64": "npm:4.60.3"
-    "@rollup/rollup-freebsd-arm64": "npm:4.60.3"
-    "@rollup/rollup-freebsd-x64": "npm:4.60.3"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.3"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.3"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.3"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.60.3"
-    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.3"
-    "@rollup/rollup-linux-loong64-musl": "npm:4.60.3"
-    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.3"
-    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.3"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.3"
-    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.3"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.3"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.60.3"
-    "@rollup/rollup-linux-x64-musl": "npm:4.60.3"
-    "@rollup/rollup-openbsd-x64": "npm:4.60.3"
-    "@rollup/rollup-openharmony-arm64": "npm:4.60.3"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.3"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.3"
-    "@rollup/rollup-win32-x64-gnu": "npm:4.60.3"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.60.3"
+    "@rollup/rollup-android-arm-eabi": "npm:4.60.4"
+    "@rollup/rollup-android-arm64": "npm:4.60.4"
+    "@rollup/rollup-darwin-arm64": "npm:4.60.4"
+    "@rollup/rollup-darwin-x64": "npm:4.60.4"
+    "@rollup/rollup-freebsd-arm64": "npm:4.60.4"
+    "@rollup/rollup-freebsd-x64": "npm:4.60.4"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.4"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.4"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-x64-musl": "npm:4.60.4"
+    "@rollup/rollup-openbsd-x64": "npm:4.60.4"
+    "@rollup/rollup-openharmony-arm64": "npm:4.60.4"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.4"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.4"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.60.4"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.60.4"
     "@types/estree": "npm:1.0.8"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
@@ -3640,7 +3640,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10c0/72c9c768f3fabeaeff228b6364e6600c169d6c231a4324c47c34880fd8961aebacd974cf905ecc2db75e56c6491bdd676409a06aecf589791bf419cd41d06e76
+  checksum: 10c0/2734511579da220408eefb877b51281767d790652cee25da8fcd4936c947e3db14882b5edb1d0d5d5bf60f2a71a58ae7d5f7f46c11e3fdf33182538953886243
   languageName: node
   linkType: hard
 
@@ -3665,11 +3665,11 @@ __metadata:
   linkType: hard
 
 "semver@npm:^7.3.5, semver@npm:^7.7.1":
-  version: 7.8.0
-  resolution: "semver@npm:7.8.0"
+  version: 7.8.1
+  resolution: "semver@npm:7.8.1"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/8f096ca9b80ffd47b308d03f9ce8c873e27e2983f36023c559cdc92c51e8433fc23ebbfe57ec9623fc155636a6961ee989501099841ae4bb1babc8d2b3f048cd
+  checksum: 10c0/92d6871d6347e1f99d0ba396a70f2545ccf2a032cda3d378fa0699edf7506b5c6d266aed55c8b88e72bd91a30d2351e4f39db479375374430fcdc4b58f4e3c1a
   languageName: node
   linkType: hard
 
@@ -3897,8 +3897,8 @@ __metadata:
   linkType: hard
 
 "tsx@npm:^4.21.0":
-  version: 4.22.0
-  resolution: "tsx@npm:4.22.0"
+  version: 4.22.3
+  resolution: "tsx@npm:4.22.3"
   dependencies:
     esbuild: "npm:~0.28.0"
     fsevents: "npm:~2.3.3"
@@ -3907,7 +3907,7 @@ __metadata:
       optional: true
   bin:
     tsx: dist/cli.mjs
-  checksum: 10c0/cc7474ac13eebf6bb4d87ce21bdd79213261a37a6e247a74d7920b3e0ce7b704b42e7642e7978e2f3de5762981b3b74ed0ae14cf60934107aa0b1390f25e46ba
+  checksum: 10c0/09a5a7d354ff75e5af6285217d709ec80a46c2ee19e0d9b5c5d00eab81047c3ea6b2a5498a2c5255f3960d6e7acd1a1eee34b9433dc56fb32907ca3b38271f41
   languageName: node
   linkType: hard
 

--- a/bindings/react-native/package-lock.json
+++ b/bindings/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tursodatabase/sync-react-native",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tursodatabase/sync-react-native",
-      "version": "0.6.1-pre.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0"

--- a/bindings/react-native/package-lock.json
+++ b/bindings/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tursodatabase/sync-react-native",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tursodatabase/sync-react-native",
-      "version": "0.6.0",
+      "version": "0.6.1-pre.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0"

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync-react-native",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "description": "React Native bindings for TursoDB",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/bindings/react-native/package.json
+++ b/bindings/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/sync-react-native",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "description": "React Native bindings for TursoDB",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1329,17 +1329,54 @@ impl Connection {
         }
         let current_schema = self.schema.read().clone();
         let schema = self.db.schema.lock();
-        if matches!(self.get_tx_state(), TransactionState::None)
-            && self.get_mv_tx().is_none()
-            && self.next_attached_mv_tx().is_none()
-            // In MVCC, checkpoint root publication can replace Database::schema
-            // without changing SQLite's schema cookie. If this connection
-            // still holds an older Schema snapshot, prepared statements must be
-            // invalidated and recompiled against the current roots.
+        // MVCC checkpoint can publish physical btree roots into the shared
+        // schema without changing SQLite's schema cookie. If this connection
+        // still has the older schema snapshot, prepared statements must be
+        // invalidated and recompiled with the published roots.
+        if self.has_no_open_transaction_state()
             && (current_schema.schema_version != schema.schema_version
-                || (self.mvcc_enabled() && !Arc::ptr_eq(&current_schema, &schema)))
+                || self
+                    .has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema))
         {
             *self.schema.write() = schema.clone();
+            self.bump_prepare_context_generation();
+        }
+    }
+
+    fn has_no_open_transaction_state(&self) -> bool {
+        matches!(self.get_tx_state(), TransactionState::None)
+            && self.get_mv_tx().is_none()
+            && self.next_attached_mv_tx().is_none()
+    }
+
+    fn has_mvcc_schema_snapshot_changed_with_same_version(
+        &self,
+        current_schema: &Arc<Schema>,
+        schema: &Arc<Schema>,
+    ) -> bool {
+        self.mvcc_enabled()
+            && current_schema.schema_version == schema.schema_version
+            && !Arc::ptr_eq(current_schema, schema)
+    }
+
+    pub(crate) fn mvcc_schema_requires_reprepare_before_tx(&self) -> bool {
+        if !self.has_no_open_transaction_state() {
+            return false;
+        }
+        let current_schema = self.schema.read().clone();
+        let schema = self.db.schema.lock();
+        self.has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema)
+    }
+
+    pub(crate) fn refresh_schema_from_shared_for_reprepare(&self) {
+        let current_schema = self.schema.read().clone();
+        let schema = self.db.schema.lock().clone();
+        if current_schema.schema_version < schema.schema_version
+            || (self.has_no_open_transaction_state()
+                && self
+                    .has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema))
+        {
+            *self.schema.write() = schema;
             self.bump_prepare_context_generation();
         }
     }

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -2490,11 +2490,16 @@ impl Drop for FtsCursor {
         // If the transaction has already committed (auto-commit), flushing to BTree
         // would create dirty pages outside of any transaction, causing the
         // "dirty pages must be empty for read txn" panic on the next read.
-        turso_assert!(
-            conn.is_in_write_tx(),
-            "FTS Drop: transaction already committed, cannot flush",
-            { "pending_docs_count": self.pending_docs_count }
-        );
+        // Gracefully bail instead of panicking — the documents were already committed
+        // as part of the transaction; only the Tantivy index flush is skipped, and
+        // the index will be rebuilt on the next write.
+        if !conn.is_in_write_tx() {
+            tracing::warn!(
+                pending_docs_count = self.pending_docs_count,
+                "FTS Drop: transaction already committed, skipping flush"
+            );
+            return;
+        }
 
         // Commit any pending writes to Tantivy
         if let Some(ref mut writer) = self.writer {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -942,6 +942,11 @@ pub enum CommitState<Clock: LogicalClock> {
     WaitForDependencies {
         end_ts: u64,
     },
+    /// Build the committed log record incrementally, yielding every
+    /// `MVCC_COMMIT_BATCH_SIZE` rowids so that very large write sets
+    /// (e.g. CREATE INDEX on a multi-million row table) don't monopolize
+    /// the executor.
+    BuildLogRecord(BuildLogRecordCtx),
     BeginCommitLogicalLog {
         end_ts: u64,
         log_record: LogRecord,
@@ -960,7 +965,45 @@ pub enum CommitState<Clock: LogicalClock> {
     CommitEnd {
         end_ts: u64,
     },
+    /// Publish committed timestamps into the live MVCC chains in chunks
+    /// of `MVCC_COMMIT_BATCH_SIZE` rowids, yielding between chunks. The
+    /// transaction is already in the Committed state at this point, so
+    /// readers consult `txs[tx_id]` to resolve any TxID references that
+    /// haven't been rewritten yet.
+    RewriteLiveVersions(RewriteLiveVersionsCtx),
+    /// Final post-rewrite cleanup: drain commit dependents, release the
+    /// commit lock, update the global header, finish the tx, and start
+    /// auto-checkpoint if needed.
+    FinalizeCommit {
+        end_ts: u64,
+    },
 }
+
+/// Iteration state for the chunked `BuildLogRecord` step.
+#[derive(Debug)]
+pub struct BuildLogRecordCtx {
+    pub end_ts: u64,
+    pub log_record: LogRecord,
+    /// Index into `CommitStateMachine::write_set` for the current pass.
+    pub cursor: usize,
+    /// True while emitting schema rows (sqlite_schema), false during the
+    /// data-row pass. Schema rows are emitted first so log replay sees
+    /// CREATE TABLE before related INSERTs.
+    pub schema_process: bool,
+}
+
+/// Iteration state for the chunked `RewriteLiveVersions` step.
+#[derive(Debug)]
+pub struct RewriteLiveVersionsCtx {
+    pub end_ts: u64,
+    /// Index into `CommitStateMachine::write_set`.
+    pub cursor: usize,
+}
+
+/// How many rowids `BuildLogRecord` / `RewriteLiveVersions` process before
+/// yielding to the executor. Picked to amortize state-machine overhead
+/// while keeping a CREATE INDEX on a 2M-row table responsive.
+const MVCC_COMMIT_BATCH_SIZE: usize = 1024;
 
 #[derive(Debug)]
 pub enum WriteRowState {
@@ -993,6 +1036,10 @@ impl CommitCoordinator {
 pub(crate) enum CommitYieldPoint {
     CommitValidation,
     WaitForDependencies,
+    /// Fires once on the first entry into `step_build_log_record` (cursor=0,
+    /// schema_process=true), before any chunk processing. Pairs with
+    /// `LogRecordPrepared` to bracket the BuildLogRecord chunked yields.
+    BuildLogRecordStart,
     LogRecordPrepared,
     BeforeCommittedTimestampWatermarkUpdate,
     BeforeFinishCommittedTx,
@@ -1438,25 +1485,45 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         Ok(())
     }
 
-    /// Build the committed image for the logical log without mutating the
-    /// live MVCC version chains, which must stay TxID-backed until CommitEnd.
-    fn build_committed_log_record(
+    /// Run one chunked step of `BuildLogRecord`. Processes up to
+    /// `MVCC_COMMIT_BATCH_SIZE` rowids per call, then yields. Schema rows
+    /// (table_id == SQLITE_SCHEMA_MVCC_TABLE_ID) are emitted before data rows
+    /// in two passes so that log replay sees CREATE TABLE before INSERTs.
+    fn step_build_log_record(
         &mut self,
         mvcc_store: &Arc<MvStore<Clock>>,
-        tx: &Transaction,
-        end_ts: u64,
-    ) -> LogRecord {
-        let mut log_record = LogRecord::new(end_ts);
-        if tx.header_dirty.load(Ordering::Acquire) {
-            // Persist the transaction-local header snapshot in the same logical-log frame.
-            log_record.header = Some(*tx.header.read());
+    ) -> Result<TransitionResult<()>> {
+        // First entry into BuildLogRecord (no chunk processed yet): a yield-
+        // point to bracket the chunked yields so tests can count them exactly.
+        // Must run before the `&mut self.state` re-bind below — the macro
+        // calls `self.yield_context()` which needs `&self`.
+        let is_first_entry = matches!(
+            self.state,
+            CommitState::BuildLogRecord(BuildLogRecordCtx {
+                cursor: 0,
+                schema_process: true,
+                ..
+            })
+        );
+        if is_first_entry {
+            inject_transition_yield!(self, CommitYieldPoint::BuildLogRecordStart);
         }
 
-        // Process schema rows (sqlite_schema) before data rows so that during log
-        // replay the table_id_to_rootpage map is populated before data row inserts
-        // reference it. `tx.write_set` is sorted by table_id descending (most
-        // negative first), which would otherwise place data table rows
-        // (e.g. table_id=-3) before schema rows (table_id=-1).
+        let tx_id = self.tx_id;
+        let tx_entry = mvcc_store.txs.get(&tx_id);
+        let tx = tx_entry
+            .as_ref()
+            .map(|entry| entry.value())
+            .ok_or_else(|| {
+                LimboError::NoSuchTransactionID(format!(
+                    "tx id {tx_id} not found in step_build_logical_record"
+                ))
+            })?;
+        let write_set_len = tx.write_set.lock().entries.len();
+        let CommitState::BuildLogRecord(ctx) = &mut self.state else {
+            unreachable!("step_build_log_record requires BuildLogRecord state")
+        };
+        let end_ts = ctx.end_ts;
 
         // Remap a table_id to its canonical form for the log. After checkpoint,
         // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
@@ -1481,11 +1548,11 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         let our_committed_image = |row_version: &RowVersion| -> Option<RowVersion> {
             let our_begin = matches!(
                 row_version.begin,
-                Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
             );
             let our_end = matches!(
                 row_version.end,
-                Some(TxTimestampOrID::TxID(vid)) if vid == self.tx_id
+                Some(TxTimestampOrID::TxID(vid)) if vid == tx_id
             );
             if !our_begin && !our_end {
                 // row_version belongs to another tx
@@ -1530,58 +1597,127 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             }
         };
 
-        {
-            let ws = tx.write_set.lock();
-            // First pass: schema rows only (ordering matters for recovery)
-            for (id, row_versions) in ws.iter() {
-                if id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    collect_versions(row_versions, &mut log_record);
-                }
+        // Process schema rows (sqlite_schema) before data rows so that during log
+        // replay the table_id_to_rootpage map is populated before data row inserts
+        // reference it. `tx.write_set` is sorted by table_id descending (most
+        // negative first), which would otherwise place data table rows
+        // (e.g. table_id=-3) before schema rows (table_id=-1).
+        let mut iterations = 0;
+
+        let write_set = tx.write_set.lock();
+        while ctx.cursor < write_set_len && iterations < MVCC_COMMIT_BATCH_SIZE {
+            let (id, row_versions) = &write_set.entries[ctx.cursor];
+            let is_schema = id.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID;
+            // schema_process=true: schema rows only, false: data rows only.
+            let process = if ctx.schema_process {
+                is_schema
+            } else {
+                !is_schema
+            };
+            if process {
+                collect_versions(row_versions, &mut ctx.log_record);
             }
-            // Second pass: all non-schema rows
-            for (id, row_versions) in ws.iter() {
-                if id.table_id != SQLITE_SCHEMA_MVCC_TABLE_ID {
-                    collect_versions(row_versions, &mut log_record);
-                }
-            }
+            ctx.cursor += 1;
+            iterations += 1;
         }
-        log_record
+
+        if ctx.cursor < write_set_len {
+            // More work remains in the current pass: yield and resume.
+            return Ok(TransitionResult::Io(IOCompletions::Single(
+                Completion::new_yield(),
+            )));
+        }
+
+        if ctx.schema_process {
+            // Schema pass done; start the data pass from the top.
+            ctx.schema_process = false;
+            ctx.cursor = 0;
+            return Ok(TransitionResult::Continue);
+        }
+
+        // Both passes complete. Move the assembled log record out and
+        // transition to BeginCommitLogicalLog (or directly to CommitEnd
+        // if there is nothing to log).
+        let log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
+        tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
+
+        if log_record.row_versions.is_empty() && log_record.header.is_none() {
+            // Nothing to log. We still need to release the commit lock here
+            // if this is an exclusive tx, mirroring the pre-chunk path
+            // through WaitForDependencies.
+            if mvcc_store.is_exclusive_tx(&self.tx_id) {
+                if let Some(tx_entry) = mvcc_store.txs.get(&self.tx_id) {
+                    mvcc_store.unlock_commit_lock_if_held(tx_entry.value());
+                }
+            }
+            self.state = CommitState::CommitEnd { end_ts };
+        } else {
+            self.state = CommitState::BeginCommitLogicalLog { end_ts, log_record };
+        }
+        inject_transition_yield!(self, CommitYieldPoint::LogRecordPrepared);
+        Ok(TransitionResult::Continue)
     }
 
-    /// Publish committed timestamps into the live MVCC chains after the
-    /// transaction has been finalized as Committed(end_ts).
-    /// This must run as postprocessing step i.e. the txn is written to log and is durable
-    fn rewrite_live_versions_to_timestamps(&self, mvcc_store: &Arc<MvStore<Clock>>, end_ts: u64) {
-        let tx_entry = mvcc_store.txs.get(&self.tx_id);
-        let tx = tx_entry.as_ref().map(|entry| entry.value());
-        turso_assert!(
-            matches!(tx.map(|t| t.state.load()), Some(TransactionState::Committed(ts)) if ts == end_ts),
-            "rewrite_live_versions_to_timestamps requires a committed transaction state"
-        );
-        let Some(tx) = tx else { return };
-
-        let ws = tx.write_set.lock();
-        for (_id, row_versions) in ws.iter() {
+    /// Run one chunked step of `RewriteLiveVersions`. Processes up to
+    /// `MVCC_COMMIT_BATCH_SIZE` rowids per call, then yields. The transaction
+    /// is already in the Committed state at this point; un-rewritten TxID
+    /// references resolve via `txs[tx_id]` for visibility/conflict checks.
+    fn step_rewrite_live_versions(
+        &mut self,
+        mvcc_store: &Arc<MvStore<Clock>>,
+    ) -> Result<TransitionResult<()>> {
+        let tx_id = self.tx_id;
+        let tx_entry = mvcc_store.txs.get(&tx_id);
+        let tx = tx_entry
+            .as_ref()
+            .map(|entry| entry.value())
+            .ok_or_else(|| {
+                LimboError::NoSuchTransactionID(format!(
+                    "tx id {tx_id} not found in step_build_logical_record"
+                ))
+            })?;
+        let write_set = tx.write_set.lock();
+        let write_set_len = write_set.entries.len();
+        let CommitState::RewriteLiveVersions(ctx) = &mut self.state else {
+            unreachable!("step_rewrite_live_versions requires RewriteLiveVersions state")
+        };
+        let end_ts = ctx.end_ts;
+        if ctx.cursor == 0 {
+            let tx_state = mvcc_store
+                .txs
+                .get(&tx_id)
+                .map(|entry| entry.value().state.load());
+            turso_assert!(
+                matches!(tx_state, Some(TransactionState::Committed(ts)) if ts == end_ts),
+                "RewriteLiveVersions requires a committed transaction state"
+            );
+        }
+        let mut iterations = 0;
+        while ctx.cursor < write_set_len && iterations < MVCC_COMMIT_BATCH_SIZE {
+            let (_id, row_versions) = &write_set.entries[ctx.cursor];
             let mut row_versions = row_versions.write();
             for row_version in row_versions.iter_mut() {
-                if let Some(TxTimestampOrID::TxID(id)) = row_version.begin {
-                    if id == self.tx_id {
-                        // Publish the committed begin timestamp into the live
-                        // version chain only after CommitEnd has decided the
-                        // transaction's fate.
+                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.begin {
+                    if rv_id == tx_id {
                         row_version.begin = Some(TxTimestampOrID::Timestamp(end_ts));
                     }
                 }
-                if let Some(TxTimestampOrID::TxID(id)) = row_version.end {
-                    if id == self.tx_id {
-                        // Publish the committed end timestamp into the live
-                        // version chain only after CommitEnd has decided the
-                        // transaction's fate.
+                if let Some(TxTimestampOrID::TxID(rv_id)) = row_version.end {
+                    if rv_id == tx_id {
                         row_version.end = Some(TxTimestampOrID::Timestamp(end_ts));
                     }
                 }
             }
+            ctx.cursor += 1;
+            iterations += 1;
         }
+        if ctx.cursor < write_set_len {
+            return Ok(TransitionResult::Io(IOCompletions::Single(
+                Completion::new_yield(),
+            )));
+        }
+        self.state = CommitState::FinalizeCommit { end_ts };
+        Ok(TransitionResult::Continue)
     }
 }
 
@@ -1858,25 +1994,29 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     return Ok(TransitionResult::Done(()));
                 }
 
-                // All dependencies resolved. Build the committed image for the
-                // logical log, but keep live row versions on TxID references
-                // until CommitEnd so rollback of an abandoned commit can still
-                // match them.
-                let log_record = self.build_committed_log_record(mvcc_store, tx, end_ts);
-                tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
-
-                if log_record.row_versions.is_empty() && log_record.header.is_none() {
-                    if mvcc_store.is_exclusive_tx(&self.tx_id) {
-                        mvcc_store.unlock_commit_lock_if_held(tx);
-                    }
-                    // Nothing to do, just end commit.
-                    self.state = CommitState::CommitEnd { end_ts };
-                } else {
-                    self.state = CommitState::BeginCommitLogicalLog { end_ts, log_record };
+                // All dependencies resolved. Initialize the log record (just
+                // the header snapshot, if any) and hand off to BuildLogRecord
+                // which fills in row_versions in `MVCC_COMMIT_BATCH_SIZE`-sized
+                // chunks, yielding between chunks. Live row versions stay on
+                // TxID references until CommitEnd so rollback of an abandoned
+                // commit can still match them.
+                let mut log_record = LogRecord::new(end_ts);
+                if tx.header_dirty.load(Ordering::Acquire) {
+                    log_record.header = Some(*tx.header.read());
                 }
-                inject_transition_yield!(self, CommitYieldPoint::LogRecordPrepared);
+                self.state = CommitState::BuildLogRecord(BuildLogRecordCtx {
+                    end_ts,
+                    log_record,
+                    cursor: 0,
+                    schema_process: true,
+                });
                 return Ok(TransitionResult::Continue);
             }
+            // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Pulled out
+            // to a helper because the arm body needs `&mut self` to mutate
+            // the cursor / pass / log_record inside the variant, which
+            // conflicts with the outer `&self.state` match borrow.
+            CommitState::BuildLogRecord(_) => self.step_build_log_record(mvcc_store),
             CommitState::BeginCommitLogicalLog { end_ts, log_record } => {
                 if !mvcc_store.is_exclusive_tx(&self.tx_id) {
                     // logical log needs to be serialized.
@@ -1949,7 +2089,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 // Order of operations matters here:
                 // 1. Advance logical log writer offset (makes the written bytes "owned")
                 // 2. Mark transaction Committed
-                // 3. Rewrite live row versions from TxID to Timestamp
+                // 3. Rewrite live row versions from TxID to Timestamp (chunked
+                //    in `RewriteLiveVersions` so 2M-row write sets don't stall)
                 // 4. Notify dependents
                 // 5. Release commit lock (allows next committer)
                 // 6. Update cached global header
@@ -1985,7 +2126,24 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     .state
                     .store(TransactionState::Committed(*end_ts));
 
-                self.rewrite_live_versions_to_timestamps(mvcc_store, *end_ts);
+                // Hand off to the chunked rewriter. Between chunks readers
+                // resolve any unwritten TxID refs via `txs[tx_id]` which now
+                // reports Committed(end_ts).
+                self.state = CommitState::RewriteLiveVersions(RewriteLiveVersionsCtx {
+                    end_ts: *end_ts,
+                    cursor: 0,
+                });
+                Ok(TransitionResult::Continue)
+            }
+            // Chunked: yields every MVCC_COMMIT_BATCH_SIZE rowids. Same
+            // helper-dispatch reason as BuildLogRecord above.
+            CommitState::RewriteLiveVersions(_) => self.step_rewrite_live_versions(mvcc_store),
+            CommitState::FinalizeCommit { end_ts } => {
+                let tx = mvcc_store
+                    .txs
+                    .get(&self.tx_id)
+                    .ok_or_else(|| LimboError::NoSuchTransactionID(self.tx_id.to_string()))?;
+                let tx_unlocked = tx.value();
 
                 // Hekaton Section 3.3: "The transaction then processes all outgoing
                 // commit dependencies listed in its CommitDepSet. If it committed, it
@@ -5858,6 +6016,7 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
                 .debug_struct("WaitForDependencies")
                 .field("end_ts", end_ts)
                 .finish(),
+            Self::BuildLogRecord(ctx) => f.debug_tuple("BuildLogRecord").field(ctx).finish(),
             Self::BeginCommitLogicalLog { end_ts, log_record } => f
                 .debug_struct("BeginCommitLogicalLog")
                 .field("end_ts", end_ts)
@@ -5875,6 +6034,13 @@ impl<Clock: LogicalClock> Debug for CommitState<Clock> {
             Self::CommitEnd { end_ts } => {
                 f.debug_struct("CommitEnd").field("end_ts", end_ts).finish()
             }
+            Self::RewriteLiveVersions(ctx) => {
+                f.debug_tuple("RewriteLiveVersions").field(ctx).finish()
+            }
+            Self::FinalizeCommit { end_ts } => f
+                .debug_struct("FinalizeCommit")
+                .field("end_ts", end_ts)
+                .finish(),
         }
     }
 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1759,15 +1759,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     }
                 }
 
-                if mvcc_store
-                    .last_committed_schema_change_ts
-                    .load(Ordering::Acquire)
-                    > tx.begin_ts
-                {
-                    // Schema changes made after the transaction began always cause a [SchemaConflict] error and the tx must abort.
-                    return Err(LimboError::SchemaConflict);
-                }
-
                 // Atomically generate end_ts and publish Preparing(end_ts) while the
                 // clock lock is held. This closes the TOCTOU window
                 // Consider the example:
@@ -1780,13 +1771,82 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 //
                 // hence we want to guard the timestamp generation by a mutex, only allow next
                 // ts to generate when the previous one is used / discarded
+
+                let write_set_is_empty = tx.write_set.lock().is_empty();
+                let header_write = tx.header_dirty.load(Ordering::Acquire);
+                // Read only is not only exclusive to empty write set, we could be writing the
+                // database header here.
+                let read_only = write_set_is_empty && !header_write;
+
+                let mut schema_conflict = false;
+                let mut exclusive_conflict = false;
+
                 let end_ts = mvcc_store.get_commit_timestamp(|ts| {
                     turso_assert!(
                         ts > tx.begin_ts,
                         "end_ts must be strictly greater than begin_ts"
                     );
-                    tx.state.store(TransactionState::Preparing(ts));
+
+                    // First we check if there is exclusive conflict, if there is then we won't
+                    // commit txn.
+                    if !mvcc_store.is_exclusive_tx(&self.tx_id) && mvcc_store.has_exclusive_tx() {
+                        // A non-CONCURRENT transaction is holding the exclusive lock, we must abort.
+                        turso_assert_reachable!("commit aborted due to exclusive tx conflict");
+                        exclusive_conflict = true;
+                    }
+                    // Now check if we saw schema change which would require reprepare. Let's note
+                    // that we check this right after exlusive tx because we update this before we release
+                    // exclusive lock.
+                    let schema_updated = mvcc_store
+                        .last_committed_schema_change_ts
+                        .load(Ordering::Acquire)
+                        > tx.begin_ts;
+                    // last_committed_schema_ts is not enough, we need to check schema cookie
+                    // is the same because e.g:
+                    // T1 CREATE INDEX
+                    // T1 Yield somewhere in middle of commit
+                    // T1 end_ts = x
+                    // T2 BEGIN CONCURRENT; INSERT (same table); COMMIT
+                    // T2 begin_ts = x+1
+                    // T2 begin_ts > end_ts
+                    //
+                    // Therefore even if exclusive tx (T1) finishes right in time
+                    // we will see schema was not updated because we see an younger timestamp and
+                    // ours is older!
+                    //
+                    let our_cookie = tx.header.read().schema_cookie.get();
+                    let global_cookie = {
+                        let h = mvcc_store.global_header.read();
+                        let h = h.as_ref();
+                        turso_assert!(h.is_some(), "global_header should be initialized");
+                        h.unwrap().schema_cookie.get()
+                    };
+
+                    let header_dirty = tx.header_dirty.load(Ordering::Acquire);
+                    turso_assert!(!header_dirty || mvcc_store.is_exclusive_tx(&tx.tx_id), "header_dirty=true implies that tx is exclusive");
+                    if our_cookie != global_cookie && !header_dirty {
+                        tracing::debug!("cookie mismatch in CommitState::Initial tx({our_cookie}) != global(!{global_cookie})");
+                        schema_conflict = true;
+                    }
+
+                    if schema_updated {
+                        tracing::debug!("schema ts is older than our ts");
+                        // Schema changes made after the transaction began always cause a [SchemaConflict] error and the tx must abort.
+                        schema_conflict = true;
+                    }
+
+                    let can_commit_tx = !(exclusive_conflict || schema_conflict);
+                    if can_commit_tx || read_only {
+                        tx.state.store(TransactionState::Preparing(ts));
+                    }
                 });
+                // We allow reads from happening. Exlusive means there is a single writer.
+                if exclusive_conflict && !read_only {
+                    return Err(LimboError::WriteWriteConflict);
+                }
+                if schema_conflict && !read_only {
+                    return Err(LimboError::SchemaConflict);
+                }
                 tracing::trace!("prepare_tx(tx_id={}, end_ts={})", self.tx_id, end_ts);
                 /* In order to implement serializability, we need the following steps:
                 **
@@ -1871,9 +1931,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                  ** 2. Validate if there are no phantoms by walking the scans from scan_set
                  */
                 tracing::trace!("commit_tx(tx_id={})", self.tx_id);
-                let write_set_is_empty = tx.write_set.lock().is_empty();
                 // Header-only writes must not take this fast path; they need durable log records.
-                if write_set_is_empty && !tx.header_dirty.load(Ordering::Acquire) {
+                if read_only {
                     turso_assert!(
                         tx.commit_dep_set.lock().is_empty(),
                         "MVCC read only transaction should not have commit dependencies on other txns"
@@ -1913,11 +1972,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 Ok(TransitionResult::Continue)
             }
             CommitState::Commit { end_ts } => {
-                if !mvcc_store.is_exclusive_tx(&self.tx_id) && mvcc_store.has_exclusive_tx() {
-                    // A non-CONCURRENT transaction is holding the exclusive lock, we must abort.
-                    turso_assert_reachable!("commit aborted due to exclusive tx conflict");
-                    return Err(LimboError::WriteWriteConflict);
-                }
                 // Check for rowid conflicts before committing (pure optimistic, first-committer-wins)
                 // Ref: Hekaton paper Section 3.2 - validation uses end_ts comparison
                 let tx = mvcc_store

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -966,6 +966,9 @@ pub enum CommitState<Clock: LogicalClock> {
 pub enum WriteRowState {
     Initial,
     Seek,
+    /// After seek returns TryAdvance for an index key stored in an interior node,
+    /// advance the cursor to that interior cell so insert overwrites it.
+    Advance,
     Insert,
     /// Move to the next record in order to leave the cursor in the next position, this is used for inserting multiple rows for optimizations.
     Next,
@@ -2127,12 +2130,37 @@ impl StateTransition for WriteRowStateMachine {
                     .write()
                     .seek(seek_key, SeekOp::GE { eq_only: true })?
                 {
-                    IOResult::Done(_) => {}
+                    IOResult::Done(seek_result) => {
+                        if self.row.is_index_row() && matches!(seek_result, SeekResult::TryAdvance)
+                        {
+                            self.state = WriteRowState::Advance;
+                            return Ok(TransitionResult::Continue);
+                        }
+                    }
                     IOResult::IO(io) => {
                         return Ok(TransitionResult::Io(io));
                     }
                 }
                 turso_assert_eq!(self.cursor.write().valid_state, CursorValidState::Valid);
+                self.state = WriteRowState::Insert;
+                Ok(TransitionResult::Continue)
+            }
+            WriteRowState::Advance => {
+                match self
+                    .cursor
+                    .write()
+                    .next()
+                    .map_err(|e: LimboError| LimboError::InternalError(e.to_string()))?
+                {
+                    IOResult::Done(_) => {}
+                    IOResult::IO(io) => {
+                        return Ok(TransitionResult::Io(io));
+                    }
+                }
+                turso_assert!(
+                    self.cursor.read().has_record(),
+                    "MVCC checkpoint index insert did not land on the matched interior record"
+                );
                 self.state = WriteRowState::Insert;
                 Ok(TransitionResult::Continue)
             }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -992,6 +992,7 @@ pub(crate) enum CommitYieldPoint {
     WaitForDependencies,
     LogRecordPrepared,
     BeforeCommittedTimestampWatermarkUpdate,
+    BeforeFinishCommittedTx,
     /// Boundary right after `remove_tx` runs but before the connection cache
     /// is cleared by the caller at vdbe/mod.rs. Used for failure injection
     /// to reproduce divergence between `mv_store.txs` and `connection.mv_tx_id`.
@@ -1033,6 +1034,7 @@ pub struct CommitStateMachine<Clock: LogicalClock> {
     yield_instance_id: u64,
     did_commit_schema_change: bool,
     tx_id: TxID,
+    mvcc_store: Arc<MvStore<Clock>>,
     connection: Arc<Connection>,
     /// Database index this commit is for (`MAIN_DB_ID` or an attached-db id).
     /// Threaded through so that `finish_committed_tx` can clear the matching
@@ -1054,6 +1056,12 @@ impl<Clock: LogicalClock> Debug for CommitStateMachine<Clock> {
             .field("state", &self.state)
             .field("is_finalized", &self.is_finalized)
             .finish()
+    }
+}
+
+impl<Clock: LogicalClock> Drop for CommitStateMachine<Clock> {
+    fn drop(&mut self) {
+        self.cleanup_unfinished_commit();
     }
 }
 
@@ -1093,55 +1101,11 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         }
     }
 
-    /// Release `pager_commit_lock` / `exclusive_tx` and roll back the in-flight
-    /// MVCC tx when the commit state machine has been abandoned mid-flight —
-    /// either because the wrapping Statement was dropped during an IO yield
-    /// (issues #6757 / #6755) or because a fallible helper like `log_tx`
-    /// returned an error and the VDBE abort handler's no-rollback list would
-    /// otherwise skip rollback (issue #6753).
-    ///
-    /// Gates `rollback_tx` on `is_tx_rollbackable` rather than bare `contains_key`:
-    /// `rollback_tx` asserts the tx state is `Active | Preparing(_)`, so we
-    /// must skip it if the tx already reached `Committed` in `CommitEnd` but
-    /// has not yet been removed from `txs`. The else-arm covers the narrow
-    /// window after `release_exclusive_tx` but before `finish_committed_tx`.
-    ///
-    /// For main-DB cleanups, also end the pager read tx and reset
-    /// `transaction_state` — matching what `Connection::rollback_current_txn_state`
-    /// would do. Without this, the next `op_transaction` either skips
-    /// `begin_read_tx` (stale `Write` state) or panics in `wal.begin_read_tx`
-    /// (pre-existing read lock not released).
-    ///
-    /// Returns true when cleanup actually ran, false if the state machine was
-    /// already finalized.
-    pub(crate) fn cleanup_abandoned_commit(&mut self, mv_store: &MvStore<Clock>) -> bool {
-        if self.is_finalized {
-            return false;
-        }
-        self.is_finalized = true;
-        if mv_store.is_tx_rollbackable(self.tx_id) {
-            mv_store.rollback_tx(self.tx_id, self.pager.clone(), &self.connection, self.db_id);
-        } else if mv_store.is_exclusive_tx(&self.tx_id) {
-            mv_store.release_exclusive_tx(&self.tx_id);
-            self.commit_coordinator.pager_commit_lock.unlock();
-            let tx = mv_store.txs.get(&self.tx_id).unwrap_or_else(|| {
-                panic!("tx id {} not found in cleanup_abandoned_commit", self.tx_id)
-            });
-            if tx.value().pager_commit_lock_held.load(Ordering::Acquire) {
-                self.commit_coordinator.pager_commit_lock.unlock();
-            }
-        }
-        if self.db_id == crate::MAIN_DB_ID {
-            self.pager.end_read_tx();
-            self.connection
-                .set_tx_state(crate::connection::TransactionState::None);
-        }
-        true
-    }
-
+    #[allow(clippy::too_many_arguments)]
     fn new(
         state: CommitState<Clock>,
         tx_id: TxID,
+        mvcc_store: Arc<MvStore<Clock>>,
         connection: Arc<Connection>,
         db_id: usize,
         commit_coordinator: Arc<CommitCoordinator>,
@@ -1167,6 +1131,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             yield_instance_id: connection.next_yield_instance_id(),
             did_commit_schema_change: schema_did_change_from_tx,
             tx_id,
+            mvcc_store,
             connection,
             db_id,
             commit_coordinator,
@@ -1176,6 +1141,50 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
             sync_mode,
             _phantom: PhantomData,
         }
+    }
+
+    fn cleanup_unfinished_commit(&mut self) {
+        if !self.is_finalized {
+            self.cleanup_mvcc_checkpoint_state();
+            if !matches!(self.state, CommitState::Checkpoint { .. }) {
+                self.mvcc_store.cleanup_dropped_commit(
+                    self.tx_id,
+                    self.connection.as_ref(),
+                    self.db_id,
+                );
+            }
+            self.end_read_tx_for_db();
+            if self.db_id == crate::MAIN_DB_ID {
+                self.connection
+                    .set_tx_state(crate::connection::TransactionState::None);
+            }
+        }
+
+        let tx_id = self.tx_id;
+        let db_id = self.db_id;
+        turso_assert!(
+            self.mvcc_store.txs.get(&tx_id).is_none(),
+            "MVCC tx should be removed from txs after a successful commit",
+            { "tx_id": tx_id }
+        );
+        turso_assert!(
+            !self.mvcc_store.is_exclusive_tx(&tx_id),
+            "MVCC tx should not still hold the exclusive slot after a successful commit",
+            { "tx_id": tx_id }
+        );
+        turso_assert!(
+            self.connection.get_mv_tx_id_for_db(db_id) != Some(tx_id),
+            "Connection should not still reference an MVCC tx after a successful commit",
+            { "tx_id": tx_id, "db_id": db_id }
+        );
+    }
+
+    fn end_read_tx_for_db(&self) {
+        if let Ok(pager) = self.connection.get_pager_from_database_index(&self.db_id) {
+            pager.end_read_tx();
+            return;
+        }
+        self.pager.end_read_tx();
     }
 
     /// Validates commit-time write-write conflicts for one table row key.
@@ -1868,13 +1877,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
             CommitState::BeginCommitLogicalLog { end_ts, log_record } => {
                 if !mvcc_store.is_exclusive_tx(&self.tx_id) {
                     // logical log needs to be serialized.
-                    //
-                    // Look up the tx BEFORE acquiring `pager_commit_lock` so
-                    // an `?` on a vanished tx cannot strand the lock. With
-                    // the previous order (acquire → fallible txs.get → set
-                    // flag) any Err between acquire and flag-set would leave
-                    // the lock held with no per-tx flag to signal release
-                    // (#6905).
                     let tx = mvcc_store
                         .txs
                         .get(&self.tx_id)
@@ -1918,7 +1920,6 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 }
             }
             CommitState::EndCommitLogicalLog { end_ts } => {
-                let connection = self.connection.clone();
                 let tx = mvcc_store
                     .txs
                     .get(&self.tx_id)
@@ -1933,8 +1934,8 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         .map(|header| header.schema_cookie.get())
                         != Some(tx_header.schema_cookie.get());
                 if schema_did_change {
-                    let schema = connection.schema.read().clone();
-                    connection.db.update_schema_if_newer(schema);
+                    let schema = self.connection.schema.read().clone();
+                    self.connection.db.update_schema_if_newer(schema);
                 }
                 self.header.write().replace(tx_header);
                 tracing::trace!("end_commit_logical_log(tx_id={})", self.tx_id);
@@ -2036,6 +2037,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 if mvcc_store.is_exclusive_tx(&self.tx_id) {
                     mvcc_store.release_exclusive_tx(&self.tx_id);
                 }
+                inject_transition_yield!(self, CommitYieldPoint::BeforeFinishCommittedTx);
                 mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id);
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                 if mvcc_store.storage.should_checkpoint() {
@@ -3775,7 +3777,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     ///
     /// * `tx_id` - The ID of the transaction to commit.
     pub fn commit_tx(
-        &self,
+        self: &Arc<Self>,
         tx_id: TxID,
         connection: &Arc<Connection>,
         db_id: usize,
@@ -3783,6 +3785,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let state = Box::new(CommitStateMachine::new(
             CommitState::Initial,
             tx_id,
+            self.clone(),
             connection.clone(),
             db_id,
             self.commit_coordinator.clone(),
@@ -3813,12 +3816,18 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// * `tx_id` - The ID of the transaction to abort.
     /// * `db` - The database index this transaction belongs to.
     pub fn rollback_tx(&self, tx_id: TxID, _pager: Arc<Pager>, connection: &Connection, db: usize) {
+        self.rollback_tx_inner(tx_id, Some(connection), db);
+    }
+
+    fn rollback_tx_inner(&self, tx_id: TxID, connection: Option<&Connection>, db: usize) {
         let tx_unlocked = self
             .txs
             .get(&tx_id)
             .expect("transaction should exist in txs map");
         let tx = tx_unlocked.value();
-        connection.set_mv_tx_for_db(db, None);
+        if let Some(connection) = connection {
+            connection.set_mv_tx_for_db(db, None);
+        }
         turso_assert!(matches!(
             tx.state.load(),
             TransactionState::Active | TransactionState::Preparing(_)
@@ -3856,9 +3865,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             }
         }
 
-        if connection.schema.read().schema_version > connection.db.schema.lock().schema_version {
-            // Connection made schema changes during tx and rolled back -> revert connection-local schema.
-            *connection.schema.write() = connection.db.clone_schema();
+        if let Some(connection) = connection {
+            if connection.schema.read().schema_version > connection.db.schema.lock().schema_version
+            {
+                // Connection made schema changes during tx and rolled back -> revert connection-local schema.
+                *connection.schema.write() = connection.db.clone_schema();
+            }
         }
 
         let tx = tx_unlocked.value();
@@ -3871,6 +3883,32 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // read lock), so no future txs.get() for this tx_id can come from a
         // speculative read path.
         self.remove_tx(tx_id);
+    }
+
+    fn cleanup_dropped_commit(&self, tx_id: TxID, connection: &Connection, db_id: usize) {
+        let tx_state = self.txs.get(&tx_id).map(|tx| tx.value().state.load());
+        match tx_state {
+            Some(TransactionState::Active | TransactionState::Preparing(_)) => {
+                self.rollback_tx_inner(tx_id, Some(connection), db_id);
+            }
+            Some(TransactionState::Committed(_)) => {
+                if let Some(tx) = self.txs.get(&tx_id) {
+                    self.unlock_commit_lock_if_held(tx.value());
+                }
+                if self.is_exclusive_tx(&tx_id) {
+                    self.release_exclusive_tx(&tx_id);
+                }
+                self.finish_committed_tx(tx_id, connection, db_id);
+            }
+            Some(TransactionState::Aborted | TransactionState::Terminated) | None => {
+                if connection.get_mv_tx_id_for_db(db_id) == Some(tx_id) {
+                    connection.set_mv_tx_for_db(db_id, None);
+                }
+                if self.is_exclusive_tx(&tx_id) {
+                    self.release_exclusive_tx(&tx_id);
+                }
+            }
+        }
     }
 
     fn unlock_commit_lock_if_held(&self, tx: &Transaction) {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5436,7 +5436,18 @@ impl RowidAllocator {
     /// Initialize from btree max. Called once per table, under lock.
     pub fn initialize(&self, rowid: Option<i64>) {
         tracing::trace!("initialize({rowid:?})");
-        self.max_rowid.store(rowid.unwrap_or(0), Ordering::SeqCst);
+        let _ = self
+            .max_rowid
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |cur| {
+                let next = match rowid {
+                    // max_rowid starts at 0, but a B-tree whose largest rowid is
+                    // negative still needs to seed automatic allocation from that value.
+                    Some(rowid) if cur == 0 => rowid,
+                    Some(rowid) => cur.max(rowid),
+                    None => cur,
+                };
+                (next != cur).then_some(next)
+            });
         self.initialized.store(true, Ordering::SeqCst);
     }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -19,6 +19,7 @@ use crate::storage::sqlite3_ondisk::{
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sync::Mutex;
 use crate::sync::RwLock;
+use crate::vdbe::execute::TransactionYieldPoint;
 use crate::{
     Buffer, Completion, DatabaseOpts, EncryptionKey, LimboError, OpenFlags, StatementStatusCounter,
 };
@@ -2442,6 +2443,148 @@ fn test_integrity_check_after_checkpoint_io_yield_then_post_durable_failure_uses
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0][0].as_int().unwrap(), 1);
     assert_eq!(&rows[0][1].to_string(), "a");
+}
+
+/// Steps:
+/// 1. Create an MVCC database with a table and unique index whose roots are still logical MVCC roots.
+/// 2. Prepare `PRAGMA integrity_check` on a second connection.
+/// 3. Start stepping it, then yield immediately before `OP_Transaction` opens the read transaction.
+/// 4. On the writer connection, insert a row and run `wal_checkpoint(TRUNCATE)` so checkpoint publishes physical roots.
+/// 5. Resume the stale statement; it must force one reprepare and then report `ok`.
+#[test]
+fn test_running_integrity_check_reprepares_after_checkpoint_root_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+
+    let stale_conn = db.connect();
+    let injector = FixedYieldInjector::new([TransactionYieldPoint::BeforeStart.point()]);
+    stale_conn.set_yield_injector(Some(injector.clone()));
+    let mut stale_integrity_check = stale_conn.prepare("PRAGMA integrity_check").unwrap();
+    assert!(
+        matches!(stale_integrity_check.step().unwrap(), crate::StepResult::IO)
+            && injector.is_empty(),
+        "integrity_check should yield before opening its read transaction"
+    );
+
+    writer.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    stale_conn.set_yield_injector(None);
+
+    // The statement has already passed its public step-time schema refresh, but
+    // its transaction has not opened yet. Checkpoint root publication does not
+    // change SQLite's schema cookie, so OP_Transaction must still force a
+    // reprepare before stale bytecode can use the new header with old roots.
+    let rows = stale_integrity_check.run_collect_rows().unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        1
+    );
+}
+
+/// Steps:
+/// 1. Create an MVCC database with a table and unique index whose roots are still logical MVCC roots.
+/// 2. Open a deferred transaction on a second connection without starting its MVCC read transaction yet.
+/// 3. Prepare `PRAGMA integrity_check` inside that deferred transaction.
+/// 4. Start stepping it, then yield immediately before `OP_Transaction` opens the read transaction.
+/// 5. On the writer connection, insert a row and run `wal_checkpoint(TRUNCATE)` so checkpoint publishes physical roots.
+/// 6. Resume the deferred statement; it must force one reprepare, report `ok`, and leave the transaction committable.
+#[test]
+fn test_deferred_begin_integrity_check_reprepares_after_checkpoint_root_publish() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+
+    let stale_conn = db.connect();
+    stale_conn.execute("BEGIN").unwrap();
+
+    let injector = FixedYieldInjector::new([TransactionYieldPoint::BeforeStart.point()]);
+    stale_conn.set_yield_injector(Some(injector.clone()));
+    let mut stale_integrity_check = stale_conn.prepare("PRAGMA integrity_check").unwrap();
+    assert!(
+        matches!(stale_integrity_check.step().unwrap(), crate::StepResult::IO)
+            && injector.is_empty(),
+        "integrity_check should yield before opening its read transaction"
+    );
+
+    writer.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    stale_conn.set_yield_injector(None);
+
+    let rows = stale_integrity_check.run_collect_rows().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        1
+    );
+
+    stale_conn.execute("COMMIT").unwrap();
+}
+
+/// Steps:
+/// 1. Create an MVCC database with a table and unique index whose roots are still logical MVCC roots.
+/// 2. Prepare `PRAGMA integrity_check` on a second connection and record that it has not reprepared yet.
+/// 3. Record `PRAGMA schema_version` before the checkpoint.
+/// 4. Start stepping the stale statement, then yield immediately before `OP_Transaction` opens the read transaction.
+/// 5. On the writer connection, insert a row and run `wal_checkpoint(TRUNCATE)` so checkpoint publishes physical roots.
+/// 6. Assert the checkpoint did not bump SQLite's schema cookie.
+/// 7. Resume the stale statement; it must force one reprepare and then report `ok`.
+#[test]
+fn test_running_integrity_check_reprepares_without_schema_cookie_bump() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+
+    let stale_conn = db.connect();
+    let injector = FixedYieldInjector::new([TransactionYieldPoint::BeforeStart.point()]);
+    stale_conn.set_yield_injector(Some(injector.clone()));
+    let mut stale_integrity_check = stale_conn.prepare("PRAGMA integrity_check").unwrap();
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        0
+    );
+
+    let schema_version_before = get_rows(&writer, "PRAGMA schema_version")[0][0]
+        .as_int()
+        .unwrap();
+    assert!(
+        matches!(stale_integrity_check.step().unwrap(), crate::StepResult::IO)
+            && injector.is_empty(),
+        "integrity_check should yield before opening its read transaction"
+    );
+
+    writer.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let schema_version_after = get_rows(&writer, "PRAGMA schema_version")[0][0]
+        .as_int()
+        .unwrap();
+    assert_eq!(
+        schema_version_after, schema_version_before,
+        "checkpoint root publication must not change SQLite's schema cookie"
+    );
+
+    stale_conn.set_yield_injector(None);
+    let rows = stale_integrity_check.run_collect_rows().unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+    assert_eq!(
+        stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
+        1
+    );
 }
 
 /// What this test checks: Auto-checkpoint post-commit failure does not invalidate committed transaction visibility on restart.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5,6 +5,7 @@ use crate::io::PlatformIO;
 use crate::mvcc::clock::MvccClock;
 use crate::mvcc::cursor::{CursorYieldPoint, MvccCursorType};
 use crate::mvcc::database::checkpoint_state_machine::CheckpointYieldPoint;
+use crate::mvcc::database::CommitYieldPoint;
 use crate::mvcc::persistent_storage::logical_log::{
     ENCRYPTED_PAYLOAD_CHUNK_SIZE, FRAME_MAGIC, LOG_HDR_SIZE,
 };
@@ -11352,4 +11353,69 @@ fn test_dropped_commit_corrupts_subsequent_insert() {
     }
 
     conn.execute("INSERT INTO t VALUES (2, 'second')").unwrap();
+}
+
+// https://github.com/tursodatabase/turso/issues/6755
+#[test]
+fn abandoned_exclusive_commit_should_not_block_subsequent_concurrent_writer() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn_a = db.connect();
+    let conn_b = db.connect();
+
+    conn_a
+        .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    conn_a.execute("BEGIN IMMEDIATE").unwrap();
+    conn_a.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    conn_a.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::LogRecordPrepared.point(),
+    ])));
+
+    match conn_a.prepare("COMMIT").unwrap().step().unwrap() {
+        StepResult::IO => {} // tx will immediately hit injected yield point
+        other => panic!("tx should yield, got: {other:?}"),
+    }
+
+    assert!(
+        matches!(conn_a.prepare("COMMIT").unwrap().step().err().unwrap(),
+            LimboError::TxError(msg) if msg == "cannot commit - no transaction is active")
+    );
+
+    conn_b.execute("BEGIN CONCURRENT").unwrap();
+    conn_b.execute("INSERT INTO t VALUES (2, 'b')").unwrap();
+    match conn_b.prepare("COMMIT").unwrap().step() {
+        Ok(StepResult::IO) => {}
+        Err(err) => panic!("conn_b COMMIT must not error; got: {err:?}"),
+        _ => {}
+    }
+}
+
+// https://github.com/tursodatabase/turso/issues/6751
+#[test]
+fn abandoned_commit_in_committed_state_should_not_block_subsequent_checkpoint() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn_a = db.connect();
+    let conn_b = db.connect();
+
+    conn_a
+        .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    conn_a.execute("BEGIN IMMEDIATE").unwrap();
+    conn_a.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    conn_a.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::BeforeFinishCommittedTx.point(),
+    ])));
+
+    match conn_a.prepare("COMMIT").unwrap().step().unwrap() {
+        StepResult::IO => {}
+        other => panic!("tx should yield, got: {other:?}"),
+    }
+
+    let _ = conn_a.prepare("COMMIT").unwrap().step();
+
+    conn_b.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8381,6 +8381,117 @@ fn test_abandoned_commit_rolls_back_insert_with_injected_yield() {
     observer.close().unwrap();
 }
 
+/// `step_build_log_record` chunks the commit's write_set into batches of
+/// `MVCC_COMMIT_BATCH_SIZE` rowids and yields between batches so that a
+/// large commit (e.g. CREATE INDEX over millions of rows) can't monopolize
+/// the executor.
+///
+/// We bracket the chunked yields with two injected yield points:
+/// `BuildLogRecordStart` (fires once on first entry into BuildLogRecord) and
+/// `LogRecordPrepared` (fires once after both passes complete). The IOs
+/// observed strictly between these two are the chunked yields, so the count
+/// is exact.
+///
+/// With `n_rows = 3 * BATCH_SIZE`, both passes (schema-row + data-row) walk
+/// the full write_set, each yielding twice and then transitioning without a
+/// final yield. Expected: 4 chunked yields between Start and Prepared.
+#[test]
+fn test_build_log_record_yields_for_large_write_set() {
+    use super::MVCC_COMMIT_BATCH_SIZE;
+
+    /// Yields once at each of the bracketing points and toggles the
+    /// corresponding flag so the test can detect when the bracket opens
+    /// and closes.
+    #[derive(Debug)]
+    struct BracketingYieldInjector {
+        start: YieldPoint,
+        end: YieldPoint,
+        started: Arc<AtomicBool>,
+        finished: Arc<AtomicBool>,
+    }
+    impl YieldInjector for BracketingYieldInjector {
+        fn should_yield(&self, _instance_id: u64, _selection_key: u64, point: YieldPoint) -> bool {
+            if point == self.start && !self.started.load(Ordering::SeqCst) {
+                self.started.store(true, Ordering::SeqCst);
+                return true;
+            }
+            if point == self.end && !self.finished.load(Ordering::SeqCst) {
+                self.finished.store(true, Ordering::SeqCst);
+                return true;
+            }
+            false
+        }
+    }
+
+    let db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new());
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    let n_rows = 3 * MVCC_COMMIT_BATCH_SIZE;
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    for i in 1..=n_rows {
+        conn.execute(format!("INSERT INTO t VALUES ({i}, 'val')"))
+            .unwrap();
+    }
+
+    let started = Arc::new(AtomicBool::new(false));
+    let finished = Arc::new(AtomicBool::new(false));
+    conn.set_yield_injector(Some(Arc::new(BracketingYieldInjector {
+        start: CommitYieldPoint::BuildLogRecordStart.point(),
+        end: CommitYieldPoint::LogRecordPrepared.point(),
+        started: started.clone(),
+        finished: finished.clone(),
+    })));
+
+    let mut stmt = conn.prepare("COMMIT").unwrap();
+    let mut chunked_io_yields = 0;
+    let mut saw_start = false;
+    loop {
+        match stmt.step().unwrap() {
+            crate::StepResult::IO => {
+                if !saw_start {
+                    // Wait for the BuildLogRecordStart yield to open the bracket.
+                    // IOs before this came from earlier states (Initial → Commit
+                    // → WaitForDependencies); they don't count.
+                    if started.load(Ordering::SeqCst) {
+                        saw_start = true;
+                    }
+                    continue;
+                }
+                if finished.load(Ordering::SeqCst) {
+                    // The IO we just popped is the LogRecordPrepared injection
+                    // closing the bracket. Don't count it.
+                    break;
+                }
+                // Strictly between Start and Prepared: a chunked yield from
+                // `Completion::new_yield()` in step_build_log_record's loop.
+                chunked_io_yields += 1;
+            }
+            crate::StepResult::Done => break,
+            other => panic!("unexpected step result: {other:?}"),
+        }
+    }
+
+    assert!(
+        saw_start,
+        "BuildLogRecordStart yield never fired — BuildLogRecord state never reached"
+    );
+    assert!(
+        finished.load(Ordering::SeqCst),
+        "LogRecordPrepared yield never fired — BuildLogRecord did not complete"
+    );
+    // n_rows = 3 * BATCH_SIZE → 2 yields per pass × 2 passes = 4 chunked yields.
+    assert_eq!(
+        chunked_io_yields, 4,
+        "with {n_rows} rows, expected exactly 4 chunked IO yields between \
+         BuildLogRecordStart and LogRecordPrepared, got {chunked_io_yields}"
+    );
+
+    drop(stmt);
+    conn.close().unwrap();
+}
+
 /// Regression guard for the `mv_store.txs` ↔ `connection.mv_tx_id` divergence
 /// originally observed in production as `Transaction <id> not found while
 /// releasing savepoint` (panic) and `NoSuchTransactionID(<id>)` (read-path

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6226,6 +6226,178 @@ fn test_mvcc_integrity_check() {
     ensure_integrity();
 }
 
+#[test]
+fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
+    fn run_pager_until_done<T>(
+        mut action: impl FnMut() -> Result<IOResult<T>>,
+        pager: &Pager,
+    ) -> Result<T> {
+        loop {
+            match action()? {
+                IOResult::Done(value) => return Ok(value),
+                IOResult::IO(io) => io.wait(pager.io.as_ref())?,
+            }
+        }
+    }
+
+    let db = MvccTestDb::new();
+    let pager = db.conn.pager.load().clone();
+    let index = crate::schema::Index {
+        name: "testindex".to_string(),
+        table_name: "test".to_string(),
+        root_page: 0,
+        columns: vec![crate::schema::IndexColumn {
+            name: "id".to_string(),
+            order: turso_parser::ast::SortOrder::Asc,
+            pos_in_table: 0,
+            collation: None,
+            default: None,
+            expr: None,
+        }],
+        unique: true,
+        ephemeral: false,
+        has_rowid: true,
+        where_clause: None,
+        index_method: None,
+        on_conflict: None,
+    };
+
+    pager.begin_read_tx().unwrap();
+    run_pager_until_done(
+        || pager.begin_write_tx(crate::storage::wal::WalAutoActions::all_enabled()),
+        pager.as_ref(),
+    )
+    .unwrap();
+    let root_page = pager
+        .io
+        .block(|| pager.btree_create(&crate::storage::pager::CreateBTreeFlags::new_index()))
+        .unwrap() as i64;
+    let cursor = Arc::new(RwLock::new(BTreeCursor::new_index(
+        pager.clone(),
+        root_page,
+        &index,
+        index.columns.len(),
+    )));
+
+    for key in 1..=600 {
+        let record = ImmutableRecord::from_values(&[Value::from_i64(key), Value::from_i64(key)], 2);
+        let seek_result = run_pager_until_done(
+            || {
+                cursor.write().seek(
+                    crate::types::SeekKey::IndexKey(&record),
+                    crate::types::SeekOp::GE { eq_only: true },
+                )
+            },
+            pager.as_ref(),
+        )
+        .unwrap();
+        if matches!(seek_result, SeekResult::TryAdvance) {
+            run_pager_until_done(|| cursor.write().next(), pager.as_ref()).unwrap();
+        }
+        run_pager_until_done(
+            || cursor.write().insert(&BTreeKey::new_index_key(&record)),
+            pager.as_ref(),
+        )
+        .unwrap();
+    }
+    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
+
+    pager.begin_read_tx().unwrap();
+    let mut interior_key = None;
+    for key in 1..=600 {
+        let record = ImmutableRecord::from_values(&[Value::from_i64(key), Value::from_i64(key)], 2);
+        let seek_result = run_pager_until_done(
+            || {
+                cursor.write().seek(
+                    crate::types::SeekKey::IndexKey(&record),
+                    crate::types::SeekOp::GE { eq_only: true },
+                )
+            },
+            pager.as_ref(),
+        )
+        .unwrap();
+        if matches!(seek_result, SeekResult::TryAdvance) {
+            interior_key = Some(key);
+            break;
+        }
+    }
+    let interior_key = interior_key.expect("test setup should create an index interior key");
+    let count_before = run_pager_until_done(|| cursor.write().count(), pager.as_ref()).unwrap();
+
+    run_pager_until_done(
+        || pager.begin_write_tx(crate::storage::wal::WalAutoActions::all_enabled()),
+        pager.as_ref(),
+    )
+    .unwrap();
+    let index_info = Arc::new(IndexInfo::new_from_index(&index));
+    let record = ImmutableRecord::from_values(
+        &[Value::from_i64(interior_key), Value::from_i64(interior_key)],
+        2,
+    );
+    let row_key = SortableIndexKey::new_from_record(record, index_info);
+    let row = Row::new_index_row(
+        RowID::new(MVTableId::new(-42), RowKey::Record(row_key)),
+        index.columns.len(),
+    );
+    let mut write_row_sm = db
+        .mvcc_store
+        .write_row_to_pager(&row, cursor.clone(), true)
+        .unwrap();
+    loop {
+        match write_row_sm.step(&()).unwrap() {
+            IOResult::Done(()) => break,
+            IOResult::IO(io) => io.wait(pager.io.as_ref()).unwrap(),
+        }
+    }
+    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
+
+    pager.begin_read_tx().unwrap();
+    let count_after = run_pager_until_done(|| cursor.write().count(), pager.as_ref()).unwrap();
+    assert_eq!(
+        count_after, count_before,
+        "checkpoint index writer should overwrite an existing interior key, not insert a duplicate"
+    );
+}
+
+#[test]
+fn test_sql_checkpoint_reinsert_existing_interior_index_key_keeps_sqlite_integrity() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    let db_path = db.path.as_ref().unwrap().clone();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute("CREATE TABLE t(payload BLOB, id INTEGER UNIQUE)")
+        .unwrap();
+
+    for id in 1..=600 {
+        conn.execute(format!(
+            "INSERT INTO t(rowid, payload, id) VALUES ({id}, x'70796c6f6164', {id})"
+        ))
+        .unwrap();
+    }
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    for id in 1..=600 {
+        conn.execute(format!("DELETE FROM t WHERE id = {id}"))
+            .unwrap();
+        conn.execute(format!(
+            "INSERT INTO t(rowid, payload, id) VALUES ({id}, x'7265696e73657274', {id})"
+        ))
+        .unwrap();
+    }
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+
+    conn.close().unwrap();
+    force_close_for_artifact_tamper(&mut db);
+
+    let sqlite = rusqlite::Connection::open(db_path).unwrap();
+    let integrity: String = sqlite
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(integrity, "ok");
+}
+
 /// Test that integrity_check passes after DROP TABLE but before checkpoint.
 /// Issue #4975: After checkpointing a table and then dropping it, integrity_check
 /// would fail because the dropped table's btree pages still exist but aren't

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8821,6 +8821,60 @@ fn test_close_persists_drop_table() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+#[test]
+fn test_abandoned_drop() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let io = Arc::new(MemoryIO::new());
+    let path = ":memory:";
+    let db = Database::open_file(io.clone(), path).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, row_number INTEGER, ts INTEGER)")
+        .unwrap();
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS t_index \
+         ON t (row_number) WHERE ts IS NULL",
+    )
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    assert!(conn.get_auto_commit());
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        CursorYieldPoint::NextStart.point()
+    ])));
+    conn.execute("BEGIN").unwrap();
+    let mut drop_stmt = conn.prepare("DROP TABLE t").unwrap();
+    match drop_stmt.step().unwrap() {
+        crate::StepResult::IO => {}
+        other => panic!("expected injected IO yield mid-DROP TABLE; got {other:?}"),
+    }
+    conn.set_yield_injector(None);
+
+    drop_stmt.reset().unwrap();
+    drop(drop_stmt);
+
+    conn.execute("COMMIT").unwrap();
+
+    drop(conn);
+    drop(db);
+
+    let db = Database::open_file(io, path).expect(
+        "reopen should not fail; abandoned DROP must not have committed its partial Delete",
+    );
+    let conn = db.connect().unwrap();
+    let after = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 't' ORDER BY rowid",
+    );
+    assert!(
+        after.len() == 2,
+        "schema must not be half-dropped; got rows: {after:?}",
+    );
+}
+
 /// Reproducer: DROP INDEX ghost pages after restart without explicit checkpoint.
 /// Session 1: create table + index + insert + checkpoint. Session 2: drop index. Session 3: reopen.
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6545,6 +6545,70 @@ fn test_integrity_check_after_drop_index_before_checkpoint() {
     assert_eq!(&rows[0][0].to_string(), "ok");
 }
 
+#[test]
+fn test_interrupted_drop_table_rolls_back_schema_table_and_indexes() {
+    let io = Arc::new(MemoryIO::new());
+    let path = ":memory:interrupted-drop-table-schema-rollback";
+    let db = Database::open_file(io.clone(), path).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+
+    conn.execute("CREATE TABLE repro_target(c0 INTEGER, c1 REAL)")
+        .unwrap();
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_repro_target_c0 \
+         ON repro_target (c0) WHERE c1 IS NULL",
+    )
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let target_schema_rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'repro_target' ORDER BY rowid",
+    );
+    assert_eq!(target_schema_rows.len(), 2);
+    assert_eq!(target_schema_rows[0][0].to_string(), "table");
+    assert_eq!(target_schema_rows[0][1].to_string(), "repro_target");
+    assert_eq!(target_schema_rows[1][0].to_string(), "index");
+    assert_eq!(target_schema_rows[1][1].to_string(), "idx_repro_target_c0");
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        CursorYieldPoint::NextStart.point()
+    ])));
+
+    let mut drop_stmt = conn.prepare("DROP TABLE repro_target").unwrap();
+    match drop_stmt.step().unwrap() {
+        crate::StepResult::IO => {}
+        other => panic!("expected injected IO yield while dropping repro_target; got {other:?}"),
+    }
+    conn.set_yield_injector(None);
+
+    let rows = get_rows(&conn, "SELECT 1");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].to_string(), "1");
+
+    drop(drop_stmt);
+    drop(conn);
+    drop(db);
+
+    // Reopening used to fail here because the same-connection SELECT could
+    // commit the interrupted DROP TABLE's partial sqlite_schema delete.
+    let db = Database::open_file(io, path).unwrap();
+    let conn = db.connect().unwrap();
+    let target_schema_rows = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'repro_target' ORDER BY rowid",
+    );
+    assert_eq!(target_schema_rows.len(), 2);
+    assert_eq!(target_schema_rows[0][0].to_string(), "table");
+    assert_eq!(target_schema_rows[0][1].to_string(), "repro_target");
+    assert_eq!(target_schema_rows[1][0].to_string(), "index");
+    assert_eq!(target_schema_rows[1][1].to_string(), "idx_repro_target_c0");
+}
+
 /// What this test checks: Rollback/savepoint behavior restores exactly the intended state when statements or transactions fail.
 /// Why this matters: Partial rollback mistakes leave data in impossible intermediate states.
 #[test]

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -11591,3 +11591,138 @@ fn abandoned_commit_in_committed_state_should_not_block_subsequent_checkpoint() 
 
     conn_b.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }
+
+/// A concurrent explicit rowid insert must raise the allocator watermark before
+/// another transaction performs auto-rowid allocation. Otherwise later auto
+/// inserts can overwrite the explicit row and leave secondary indexes stale.
+#[test]
+fn test_concurrent_explicit_rowid_high_watermark_not_clobbered() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn0 = db.connect();
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn0
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    conn1
+        .execute("INSERT INTO t(id, v) VALUES (1000, 'A-explicit')")
+        .unwrap();
+
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+    conn2.execute("INSERT INTO t(v) VALUES ('B-auto')").unwrap();
+    conn2.execute("COMMIT").unwrap();
+    conn1.execute("COMMIT").unwrap();
+
+    let rows = get_rows(&conn0, "SELECT rowid, v FROM t ORDER BY rowid");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), 1000);
+    assert_eq!(rows[0][1].to_string(), "A-explicit");
+    assert_eq!(rows[1][0].as_int().unwrap(), 1001);
+    assert_eq!(rows[1][1].to_string(), "B-auto");
+}
+
+#[test]
+fn test_concurrent_explicit_rowid_auto_rowid_does_not_walk_back_into_collision() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn0 = db.connect();
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn0
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    conn1
+        .execute("INSERT INTO t(id, v) VALUES (5, 'A')")
+        .unwrap();
+
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+    for i in 0..5 {
+        conn2
+            .execute(format!("INSERT INTO t(v) VALUES ('B{i}')"))
+            .unwrap();
+    }
+    conn2.execute("COMMIT").unwrap();
+    conn1
+        .execute("COMMIT")
+        .expect("explicit rowid transaction should not conflict with auto rowids");
+
+    let rows = get_rows(&conn0, "SELECT rowid, v FROM t ORDER BY rowid");
+    assert_eq!(rows.len(), 6);
+    assert_eq!(rows[0][0].as_int().unwrap(), 5);
+    assert_eq!(rows[0][1].to_string(), "A");
+    for i in 0..5 {
+        assert_eq!(rows[i + 1][0].as_int().unwrap(), 6 + i as i64);
+        assert_eq!(rows[i + 1][1].to_string(), format!("B{i}"));
+    }
+}
+
+#[test]
+fn test_concurrent_explicit_rowid_preserves_auto_rowid_watermark() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn1 = db.connect();
+    let conn2 = db.connect();
+
+    conn1
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, k INTEGER)")
+        .unwrap();
+    conn1.execute("CREATE INDEX t_k ON t(k)").unwrap();
+
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    conn1
+        .execute("INSERT INTO t(id, v, k) VALUES (5, 'A', 999)")
+        .unwrap();
+
+    conn2.execute("BEGIN CONCURRENT").unwrap();
+    conn2
+        .execute("INSERT INTO t(v, k) VALUES ('B', 100)")
+        .unwrap();
+    conn2.execute("COMMIT").unwrap();
+    conn1.execute("COMMIT").unwrap();
+
+    for (v, k) in [("p2", 200), ("p3", 300), ("p4", 400), ("p5", 500)] {
+        conn1
+            .execute(format!("INSERT INTO t(v, k) VALUES ('{v}', {k})"))
+            .unwrap();
+    }
+
+    let integrity = get_rows(&conn1, "PRAGMA integrity_check");
+    assert_eq!(integrity.len(), 1);
+    assert_eq!(
+        integrity[0][0].to_string(),
+        "ok",
+        "integrity_check should not report stale secondary index entries"
+    );
+
+    let indexed = get_rows(
+        &conn1,
+        "SELECT rowid, v, k FROM t INDEXED BY t_k WHERE k = 999",
+    );
+    assert_eq!(indexed.len(), 1);
+    assert_eq!(indexed[0][0].as_int().unwrap(), 5);
+    assert_eq!(indexed[0][1].to_string(), "A");
+    assert_eq!(indexed[0][2].as_int().unwrap(), 999);
+}
+
+#[test]
+fn test_auto_rowid_after_negative_explicit_rowid_uses_next_negative() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t(id, v) VALUES(-5, 'manual')")
+        .unwrap();
+    conn.execute("INSERT INTO t(v) VALUES('auto')").unwrap();
+
+    let rows = get_rows(&conn, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0].as_int().unwrap(), -5);
+    assert_eq!(rows[0][1].to_string(), "manual");
+    assert_eq!(rows[1][0].as_int().unwrap(), -4);
+    assert_eq!(rows[1][1].to_string(), "auto");
+}

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5507,6 +5507,83 @@ fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     rows
 }
 
+/// Any ddl specially CREATE INDEX must cause SchemaUpdated errors on ongoing INSERTS because
+/// we shouldn't commit an insert without inserting rows to this new index that is being created.
+/// Here we test that case by injecting in the middle of CREATE INDEX's commit and then doing a
+/// regular concurrent insert that will not take into account new index.
+#[test]
+fn test_insert_in_middle_commit_of_create_index_returns_err() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let setup = db.connect();
+        setup
+            .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, c INTEGER)")
+            .unwrap();
+        setup.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+        setup.close().unwrap();
+    }
+
+    let conn_a = db.connect();
+    let conn_b = db.connect();
+
+    // T1 (conn_a): CREATE INDEX, yielding at `LogRecordPrepared` — the
+    // point in the commit pipeline where `end_ts` has been assigned and the
+    // log record is built, but the global header and
+    // `last_committed_schema_change_ts` haven't been published yet.
+    conn_a.set_yield_injector(Some(FixedYieldInjector::new([
+        CommitYieldPoint::LogRecordPrepared.point(),
+    ])));
+    let mut create_idx = conn_a.prepare("CREATE INDEX i ON t(c)").unwrap();
+    let mut yielded = false;
+    for _ in 0..200 {
+        match create_idx.step().unwrap() {
+            StepResult::IO => {
+                yielded = true;
+                break;
+            }
+            StepResult::Done => break,
+            _ => {}
+        }
+    }
+    assert!(
+        yielded,
+        "CREATE INDEX should yield at CommitYieldPoint::LogRecordPrepared"
+    );
+
+    // T2 (conn_b): start a new tx now — its begin_ts will be > T1's end_ts,
+    // but the global schema view still doesn't know about the new index `i`.
+    // The INSERT compiles its bytecode against the stale schema and emits
+    // IdxInsert ops only for the indexes the stale schema knows about.
+    conn_b.execute("BEGIN CONCURRENT").unwrap();
+    conn_b.execute("INSERT INTO t VALUES (2, 20)").unwrap();
+
+    // T1 finishes finalizing the CREATE INDEX. After this point, the global
+    // header carries the new schema_cookie and `last_committed_schema_change_ts`
+    // is bumped to T1's `end_ts`.
+    create_idx.run_ignore_rows().unwrap();
+    drop(create_idx);
+
+    // T2 commits. The schema-conflict check at `CommitState::Initial` compares
+    // `last_committed_schema_change_ts (= T1.end_ts) > tx_b.begin_ts (> T1.end_ts)`
+    // which is FALSE — so no conflict is raised and T2 commits cleanly, even
+    // though its writes never touched the new index.
+
+    let commit_result = conn_b.execute("COMMIT");
+
+    assert!(
+        matches!(
+            commit_result,
+            Err(LimboError::SchemaConflict | LimboError::SchemaUpdated)
+        ),
+        "BUG: tx_b's COMMIT returned {commit_result:?} but should have been \
+         aborted with SchemaConflict/SchemaUpdated. tx_b began with a stale \
+         schema (missing index `i`), so its INSERT silently skipped writing \
+         to that index. Allowing the commit leaves `i` permanently short the \
+         row tx_b wrote."
+    );
+}
+
 /// What this test checks: MVCC transaction visibility and conflict handling follow the intended isolation behavior.
 /// Why this matters: Concurrency bugs are correctness bugs: they create anomalies users can observe as wrong query results.
 #[test]

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -561,14 +561,11 @@ impl Statement {
             }
         }
 
-        // if current connection is within a transaction which changed schema - we must use its schema version instead of DB schema version
-        // see test_prepared_stmt_reprepare_ddl_change_txn (plus test_sync_pull_after_local_ddl_and_remote_writes)
-        {
-            let mut conn_schema = conn.schema.write();
-            if conn_schema.schema_version < conn.db.schema.lock().schema_version {
-                *conn_schema = conn.db.clone_schema();
-            }
-        }
+        // Refresh from shared schema only when shared is newer; this preserves a
+        // connection-local schema that is ahead of shared. An MVCC checkpoint can
+        // publish new btree roots without bumping the schema cookie, so
+        // same-version reprepare still refreshes it.
+        conn.refresh_schema_from_shared_for_reprepare();
         let new_program = {
             let mut parser = Parser::new(self.program.sql.as_bytes());
             let cmd = parser.next_cmd()?;

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -25,6 +25,7 @@ use super::{
 use crate::instrument;
 use crate::schema::{
     BTreeTable, CheckConstraint, Column, ColumnLayout, GeneratedType, IndexColumn, Schema, Table,
+    EXPR_INDEX_SENTINEL,
 };
 use crate::translate::plan::ColumnMask;
 use crate::vdbe::{
@@ -1803,6 +1804,16 @@ pub(crate) fn emit_index_column_value_old_image(
             )?;
             Ok(())
         })?;
+        // For virtual generated column references, apply the column's 
+        // declared affinity to the computed expression result.
+        if idx_col.pos_in_table != EXPR_INDEX_SENTINEL {
+            if let Some(table) = program.btree_table_from_cursor(table_cursor_id) {
+                let column = &table.columns()[idx_col.pos_in_table];
+                if column.is_virtual_generated() {
+                    program.emit_column_affinity(dest_reg, column.affinity());
+                }
+            }
+        }
     } else if let Some(generated_column) = generated_column(program, table_cursor_id, idx_col) {
         emit_table_column(
             program,

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1927,7 +1927,7 @@ fn emit_update_insns<'a>(
             .columns
             .iter()
             .map(|ic| {
-                if ic.expr.is_some() {
+                if ic.pos_in_table == EXPR_INDEX_SENTINEL {
                     Affinity::Blob.aff_mask()
                 } else {
                     target_table.table.columns()[ic.pos_in_table]

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -361,6 +361,7 @@ pub fn translate_create_index(
                 resolver,
                 &mut table_references,
                 table_cursor_id,
+                &tbl,
                 col,
                 start_reg + i,
             )?;
@@ -464,6 +465,7 @@ pub fn translate_create_index(
                 resolver,
                 &mut table_references,
                 table_cursor_id,
+                &tbl,
                 col,
                 start_reg + i,
             )?;
@@ -853,6 +855,7 @@ fn emit_index_column_value_from_cursor(
     resolver: &Resolver,
     table_references: &mut TableReferences,
     table_cursor_id: usize,
+    table: &BTreeTable,
     idx_col: &IndexColumn,
     dest_reg: usize,
 ) -> crate::Result<()> {
@@ -877,6 +880,14 @@ fn emit_index_column_value_from_cursor(
             translate_expr(program, Some(table_references), &expr, dest_reg, resolver)?;
             Ok(())
         })?;
+        // For virtual generated column references, apply the column's 
+        // declared affinity to the computed expression result.
+        if idx_col.pos_in_table != EXPR_INDEX_SENTINEL {
+            let column = &table.columns()[idx_col.pos_in_table];
+            if column.is_virtual_generated() {
+                program.emit_column_affinity(dest_reg, column.affinity());
+            }
+        }
     } else {
         program.emit_column_or_rowid(table_cursor_id, idx_col.pos_in_table, dest_reg);
     }

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -5,7 +5,7 @@ use crate::{
     error::{SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_UNIQUE},
     schema::{
         self, BTreeTable, ColDef, Column, Index, IndexColumn, ResolvedFkRef, Table,
-        SQLITE_SEQUENCE_TABLE_NAME,
+        EXPR_INDEX_SENTINEL, SQLITE_SEQUENCE_TABLE_NAME,
     },
     sync::Arc,
     translate::{
@@ -3480,6 +3480,14 @@ fn emit_index_column_value_for_insert(
             table,
             dest_reg,
         )?;
+        // For virtual generated column references, apply the column's 
+        // declared affinity to the computed expression result.
+        if idx_col.pos_in_table != EXPR_INDEX_SENTINEL {
+            let column = &table.columns()[idx_col.pos_in_table];
+            if column.is_virtual_generated() {
+                program.emit_column_affinity(dest_reg, column.affinity());
+            }
+        }
     } else {
         let Some(cm) = insertion.get_col_mapping_by_name(&idx_col.name) else {
             return Err(LimboError::PlanningError(

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -1,7 +1,8 @@
 use crate::translate::expr::emit_table_column;
+use crate::vdbe::affinity::Affinity;
 use crate::vdbe::builder::SelfTableContext;
 use crate::{
-    schema::{GeneratedType, Index, Schema, Table},
+    schema::{GeneratedType, Index, Schema, Table, EXPR_INDEX_SENTINEL},
     translate::{
         emitter::Resolver,
         expr::{
@@ -24,7 +25,9 @@ pub const MAX_INTEGRITY_CHECK_ERRORS: usize = 100;
 
 enum BoundIndexColumn {
     Column(usize),
-    Expr(Box<ast::Expr>),
+    /// The affiniy is `Some` when the index column refers to a virtual generated column
+    /// (the affinity is the column's declared type).
+    Expr(Box<ast::Expr>, Option<Affinity>),
 }
 
 struct BoundIntegrityIndex {
@@ -267,11 +270,16 @@ fn translate_integrity_check_impl(
                 let mut unique_nullable = Vec::with_capacity(index.columns.len());
                 for col in &index.columns {
                     if let Some(expr) = col.expr.as_deref() {
-                        columns.push(BoundIndexColumn::Expr(Box::new(bind_expr_for_table(
-                            expr,
-                            &mut table_references,
-                            resolver,
-                        )?)));
+                        let affinity = if col.pos_in_table != EXPR_INDEX_SENTINEL {
+                            Some(btree_table.columns()[col.pos_in_table].affinity())
+                        } else {
+                            // expression indexes don't apply affinity from the basae table
+                            None
+                        };
+                        columns.push(BoundIndexColumn::Expr(
+                            Box::new(bind_expr_for_table(expr, &mut table_references, resolver)?),
+                            affinity,
+                        ));
                         unique_nullable.push(true);
                     } else {
                         columns.push(BoundIndexColumn::Column(col.pos_in_table));
@@ -310,7 +318,10 @@ fn translate_integrity_check_impl(
                     GeneratedType::Virtual { expr, .. } => {
                         let bound =
                             bind_expr_for_table(expr, &mut table_references, resolver).ok()?;
-                        Some((BoundIndexColumn::Expr(Box::new(bound)), name))
+                        Some((
+                            BoundIndexColumn::Expr(Box::new(bound), Some(col.affinity())),
+                            name,
+                        ))
                     }
                     GeneratedType::NotGenerated => Some((BoundIndexColumn::Column(idx), name)),
                 }
@@ -340,7 +351,7 @@ fn translate_integrity_check_impl(
                 BoundIndexColumn::Column(idx) => {
                     program.emit_column_or_rowid(table_cursor_id, *idx, col_value_reg);
                 }
-                BoundIndexColumn::Expr(expr) => {
+                BoundIndexColumn::Expr(expr, _affinity) => {
                     let self_table_context = table_references.joined_tables().first().map(|jt| {
                         SelfTableContext::ForSelect {
                             table_ref_id: jt.internal_id,
@@ -452,7 +463,7 @@ fn translate_integrity_check_impl(
                             resolver,
                         )?;
                     }
-                    BoundIndexColumn::Expr(expr) => {
+                    BoundIndexColumn::Expr(expr, affinity) => {
                         let self_table_context =
                             table_references.joined_tables().first().map(|jt| {
                                 SelfTableContext::ForSelect {
@@ -475,7 +486,10 @@ fn translate_integrity_check_impl(
                                 )?;
                                 Ok(())
                             },
-                        )?
+                        )?;
+                        if let Some(aff) = affinity {
+                            program.emit_column_affinity(target, *aff);
+                        }
                     }
                 }
             }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3784,6 +3784,9 @@ pub fn op_transaction_inner(
                         .n_active_writes
                         .fetch_add(1, Ordering::SeqCst);
                     state.is_active_write = true;
+                    if state.has_stmt_transaction {
+                        state.auto_txn_cleanup = TxnCleanup::RollbackSavepoint;
+                    }
                 }
                 state.pc += 1;
                 state.active_op_state.clear();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2870,6 +2870,7 @@ pub fn halt(
 ) -> Result<InsnFunctionStepResult> {
     let mv_store = program.connection.mv_store();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
+    let owns_auto_txn = state.owns_auto_txn();
 
     // Check if we're resuming from a FAIL commit I/O wait.
     // If pending_fail_error is set, we were in the middle of committing partial changes
@@ -2945,7 +2946,7 @@ pub fn halt(
         // For FAIL mode with autocommit, commit partial changes before returning error.
         // This matches SQLite behavior where FAIL keeps changes made before the error.
         // Note: ON CONFLICT FAIL does NOT apply to FK violations, so we check for those first.
-        if program.resolve_type == ResolveType::Fail && auto_commit {
+        if program.resolve_type == ResolveType::Fail && owns_auto_txn {
             // Check for immediate FK violations - FK errors don't respect ON CONFLICT
             if program.connection.foreign_keys_enabled()
                 && state.get_fk_immediate_violations_during_stmt() > 0
@@ -2976,7 +2977,11 @@ pub fn halt(
         return Err(error);
     }
 
-    tracing::trace!("halt(auto_commit={})", auto_commit);
+    tracing::trace!(
+        "halt(auto_commit={}, owns_auto_txn={})",
+        auto_commit,
+        owns_auto_txn
+    );
 
     // Check for immediate foreign key violations.
     // Any immediate violation causes the statement subtransaction to roll back.
@@ -2995,7 +3000,7 @@ pub fn halt(
     if auto_commit {
         // In autocommit mode, a statement that leaves deferred violations must fail here,
         // and it also ends the transaction.
-        if program.connection.foreign_keys_enabled() {
+        if owns_auto_txn && program.connection.foreign_keys_enabled() {
             let deferred_violations = program
                 .connection
                 .fk_deferred_violations
@@ -3017,19 +3022,34 @@ pub fn halt(
             }
         }
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
-        vtab_commit_all(&program.connection)?;
-        index_method_pre_commit_all(state, pager)?;
-        let result = program
-            .commit_txn(pager.clone(), state, mv_store.as_ref(), false)
-            .map(Into::into);
-        // Apply deferred CDC state and reset CDC txn ID after successful commit
-        if matches!(result, Ok(InsnFunctionStepResult::Done)) {
+        if owns_auto_txn {
+            vtab_commit_all(&program.connection)?;
+            index_method_pre_commit_all(state, pager)?;
+            let result = program
+                .commit_txn(pager.clone(), state, mv_store.as_ref(), false)
+                .map(Into::into);
+            // Apply deferred CDC state and reset CDC txn ID after successful commit
+            if matches!(result, Ok(InsnFunctionStepResult::Done)) {
+                if let Some(cdc_info) = state.pending_cdc_info.take() {
+                    program.connection.set_capture_data_changes_info(cdc_info);
+                }
+                program.connection.set_cdc_transaction_id(-1);
+            }
+            result
+        } else {
+            // Another root statement may own the implicit autocommit
+            // transaction. This statement can finish, but must not commit or
+            // roll back connection-level state it did not start.
             if let Some(cdc_info) = state.pending_cdc_info.take() {
                 program.connection.set_capture_data_changes_info(cdc_info);
             }
-            program.connection.set_cdc_transaction_id(-1);
+            if program.change_cnt_on {
+                program
+                    .connection
+                    .set_changes(state.n_change.load(Ordering::SeqCst));
+            }
+            Ok(InsnFunctionStepResult::Done)
         }
-        result
     } else {
         // Even if deferred violations are present, the statement subtransaction completes successfully when
         // it is part of an interactive transaction.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3181,6 +3181,23 @@ pub enum OpTransactionState {
     BeginStatement,
 }
 
+#[cfg(any(test, injected_yields))]
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TransactionYieldPoint {
+    BeforeStart,
+}
+
+#[cfg(any(test, injected_yields))]
+impl crate::mvcc::yield_hooks::YieldPointMarker for TransactionYieldPoint {
+    const POINT_COUNT: u8 = 1;
+
+    fn ordinal(self) -> u8 {
+        match self {
+            TransactionYieldPoint::BeforeStart => 0,
+        }
+    }
+}
+
 pub fn op_transaction(
     program: &Program,
     state: &mut ProgramState,
@@ -3390,6 +3407,31 @@ pub fn op_transaction_inner(
                     return Err(LimboError::ReadOnly);
                 }
 
+                // Fast path: if checkpoint root publication already replaced the
+                // shared schema, force reprepare before opening any transaction state.
+                if *db == crate::MAIN_DB_ID
+                    && mv_store.is_some()
+                    && conn.mvcc_schema_requires_reprepare_before_tx()
+                {
+                    tracing::debug!(
+                        "MVCC shared schema changed without a schema-cookie change; force reprepare"
+                    );
+                    return Err(LimboError::SchemaUpdated);
+                }
+                #[cfg(any(test, injected_yields))]
+                {
+                    if let Some(IOResult::IO(io)) =
+                        crate::mvcc::yield_hooks::maybe_inject_io_yield::<(), _>(
+                            conn.yield_injector().as_ref(),
+                            0,
+                            *db as u64,
+                            TransactionYieldPoint::BeforeStart,
+                        )
+                    {
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                }
+
                 // 1. We try to upgrade current version
                 let current_state = conn.get_tx_state();
                 let is_secondary_db = *db != crate::MAIN_DB_ID;
@@ -3538,6 +3580,19 @@ pub fn op_transaction_inner(
                         if !has_existing_mv_tx {
                             match begin_mvcc_tx(mv_store, &pager, tx_mode, None) {
                                 Ok(tx_id) => {
+                                    // Check again in case checkpoint published roots after the
+                                    // previous check and before this transaction was protected.
+                                    if conn.mvcc_schema_requires_reprepare_before_tx() {
+                                        tracing::debug!(
+                                            "MVCC shared schema changed while starting transaction; force reprepare"
+                                        );
+                                        mv_store.rollback_tx(tx_id, pager.clone(), &conn, *db);
+                                        if started_read_tx {
+                                            pager.end_read_tx();
+                                            state.auto_txn_cleanup = TxnCleanup::None;
+                                        }
+                                        return Err(LimboError::SchemaUpdated);
+                                    }
                                     program
                                         .connection
                                         .set_mv_tx_for_db(*db, Some((tx_id, *tx_mode)));

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -205,45 +205,28 @@ impl CommitState {
         }
     }
 
-    /// Release `pager_commit_lock` + `exclusive_tx` and roll back the MVCC tx
-    /// for an abandoned commit state machine (Statement dropped mid-IO yield,
-    /// `log_tx` returned Busy, etc.). No-op for finalized SMs and non-MVCC
-    /// commit states.
     fn cleanup_abandoned_mvcc_commit(&mut self, connection: &Connection) {
         match self {
-            CommitState::CommittingMvcc { state_machine } => {
-                if let Some(mv_store) = connection.mv_store().as_ref() {
-                    if state_machine.inner_mut().cleanup_abandoned_commit(mv_store) {
-                        connection.rollback_attached_mvcc_txs(true);
-                        connection.rollback_attached_wal_txns();
-                    }
-                }
-            }
             CommitState::CommittingAttachedMvcc {
                 state_machine,
-                db_id,
-                mv_store,
+                db_id: attached_db_id,
                 ..
-            } => {
-                if state_machine.inner_mut().cleanup_abandoned_commit(mv_store) {
-                    connection
-                        .get_pager_from_database_index(&*db_id)
-                        .expect("attached MVCC transaction should always have a pager")
-                        .end_read_tx();
-                    if connection
-                        .database_schemas()
-                        .write()
-                        .remove(db_id)
-                        .is_some()
-                    {
-                        connection.bump_prepare_context_generation();
-                    }
-                    connection.rollback_attached_mvcc_txs(true);
-                    connection.rollback_attached_wal_txns();
+            } if !state_machine.is_finalized() => {
+                if connection
+                    .database_schemas()
+                    .write()
+                    .remove(attached_db_id)
+                    .is_some()
+                {
+                    connection.bump_prepare_context_generation();
                 }
             }
-            CommitState::Ready | CommitState::Committing | CommitState::CommittingAttached => {}
-        }
+            CommitState::CommittingMvcc { state_machine } if !state_machine.is_finalized() => {}
+            _ => return, // no-op for already-finalized state machines and non-MVCC commit states
+        };
+
+        connection.rollback_attached_mvcc_txs(true);
+        connection.rollback_attached_wal_txns();
     }
 }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -356,6 +356,10 @@ pub struct Row {
 pub enum TxnCleanup {
     None,
     RollbackTxn,
+    /// begin_statement was called and statement is participating in an interactive transaction.
+    /// If statement is abandoned and/or dropped without an apparent error, we should rollback statement
+    /// to previous savepoint.
+    RollbackSavepoint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2394,11 +2398,31 @@ impl Program {
                         "RaiseIgnore should be caught by op_program, not reach abort"
                     );
                 }
-                _ => {
-                    if state.auto_txn_cleanup != TxnCleanup::None || err.is_some() {
+                _ => match state.auto_txn_cleanup {
+                    TxnCleanup::RollbackTxn => {
                         self.rollback_current_txn(pager);
                     }
-                }
+                    TxnCleanup::RollbackSavepoint => {
+                        if err.is_none() && !pager.is_checkpointing() {
+                            if let Err(end_stmt_err) = state.end_statement(
+                                &self.connection,
+                                pager,
+                                EndStatement::RollbackSavepoint,
+                            ) {
+                                capture_abort_error(
+                                    &mut abort_error,
+                                    end_stmt_err,
+                                    "Failed to rollback statement savepoint during abort",
+                                );
+                            }
+                        }
+                    }
+                    TxnCleanup::None => {
+                        if err.is_some() {
+                            self.rollback_current_txn(pager);
+                        }
+                    }
+                },
             }
         }
         if state.uses_subjournal {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -884,6 +884,14 @@ impl ProgramState {
         self.subprogram_stmt_cache.clear();
     }
 
+    /// Whether this statement owns the implicit autocommit transaction it is
+    /// about to finish, including re-entry while its commit is in progress.
+    #[inline]
+    pub(crate) fn owns_auto_txn(&self) -> bool {
+        self.auto_txn_cleanup == TxnCleanup::RollbackTxn
+            || !matches!(self.commit_state, CommitState::Ready)
+    }
+
     #[inline]
     pub fn record_rows_read(&mut self, count: u64) {
         self.metrics.rows_read = self.metrics.rows_read.saturating_add(count);
@@ -2253,6 +2261,7 @@ impl Program {
         }
         // Errors from nested statements are handled by the parent statement.
         if !self.connection.is_nested_stmt() && !self.is_trigger_subprogram() {
+            let owns_auto_txn = state.owns_auto_txn();
             if err.is_some() && !pager.is_checkpointing() {
                 // For ON CONFLICT FAIL, do NOT rollback the statement savepoint —
                 // changes made before the error should persist.
@@ -2293,7 +2302,7 @@ impl Program {
                 // FK errors always behave like ABORT: rollback statement,
                 // rollback transaction in autocommit mode.
                 Some(LimboError::ForeignKeyConstraint(_)) => {
-                    if self.connection.get_auto_commit() {
+                    if owns_auto_txn {
                         self.rollback_current_txn(pager);
                     }
                     self.connection.set_changes_without_total(0);
@@ -2329,7 +2338,7 @@ impl Program {
                                     "Failed to release statement savepoint during abort",
                                 );
                             }
-                            if self.connection.get_auto_commit() {
+                            if owns_auto_txn {
                                 // Autocommit FAIL: commit partial changes.
                                 // This matches halt()'s FAIL+autocommit path.
                                 let mv_store = self.connection.mv_store();
@@ -2378,7 +2387,7 @@ impl Program {
                             }
                         }
                         _ => {
-                            if self.connection.get_auto_commit() {
+                            if owns_auto_txn {
                                 self.rollback_current_txn(pager);
                             }
                         }
@@ -2403,7 +2412,9 @@ impl Program {
                         self.rollback_current_txn(pager);
                     }
                     TxnCleanup::RollbackSavepoint => {
-                        if err.is_none() && !pager.is_checkpointing() {
+                        if owns_auto_txn {
+                            self.rollback_current_txn(pager);
+                        } else if err.is_none() && !pager.is_checkpointing() {
                             if let Err(end_stmt_err) = state.end_statement(
                                 &self.connection,
                                 pager,
@@ -2418,7 +2429,7 @@ impl Program {
                         }
                     }
                     TxnCleanup::None => {
-                        if err.is_some() {
+                        if owns_auto_txn || (!self.connection.get_auto_commit() && err.is_some()) {
                             self.rollback_current_txn(pager);
                         }
                     }

--- a/packages/turso-cli/npm/darwin-arm64/package.json
+++ b/packages/turso-cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-darwin-arm64",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "description": "Turso CLI binary for macOS ARM64",
   "os": [
     "darwin"

--- a/packages/turso-cli/npm/darwin-arm64/package.json
+++ b/packages/turso-cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-darwin-arm64",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "description": "Turso CLI binary for macOS ARM64",
   "os": [
     "darwin"

--- a/packages/turso-cli/npm/darwin-x64/package.json
+++ b/packages/turso-cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-darwin-x64",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "description": "Turso CLI binary for macOS x64",
   "os": [
     "darwin"

--- a/packages/turso-cli/npm/darwin-x64/package.json
+++ b/packages/turso-cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-darwin-x64",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "description": "Turso CLI binary for macOS x64",
   "os": [
     "darwin"

--- a/packages/turso-cli/npm/linux-arm64-gnu/package.json
+++ b/packages/turso-cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-linux-arm64-gnu",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "description": "Turso CLI binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/packages/turso-cli/npm/linux-arm64-gnu/package.json
+++ b/packages/turso-cli/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-linux-arm64-gnu",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "description": "Turso CLI binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/packages/turso-cli/npm/linux-x64-gnu/package.json
+++ b/packages/turso-cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-linux-x64-gnu",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "description": "Turso CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/turso-cli/npm/linux-x64-gnu/package.json
+++ b/packages/turso-cli/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-linux-x64-gnu",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "description": "Turso CLI binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/turso-cli/npm/win32-x64-msvc/package.json
+++ b/packages/turso-cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-win32-x64-msvc",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "description": "Turso CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/turso-cli/npm/win32-x64-msvc/package.json
+++ b/packages/turso-cli/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tursodatabase/cli-win32-x64-msvc",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "description": "Turso CLI binary for Windows x64",
   "os": [
     "win32"

--- a/packages/turso-cli/package.json
+++ b/packages/turso-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turso",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.1",
   "description": "Turso CLI - SQLite for production",
   "license": "MIT",
   "repository": {
@@ -14,10 +14,10 @@
     "src/index.js"
   ],
   "optionalDependencies": {
-    "@tursodatabase/cli-darwin-arm64": "0.6.0",
-    "@tursodatabase/cli-darwin-x64": "0.6.0",
-    "@tursodatabase/cli-linux-arm64-gnu": "0.6.0",
-    "@tursodatabase/cli-linux-x64-gnu": "0.6.0",
-    "@tursodatabase/cli-win32-x64-msvc": "0.6.0"
+    "@tursodatabase/cli-darwin-arm64": "0.6.1-pre.1",
+    "@tursodatabase/cli-darwin-x64": "0.6.1-pre.1",
+    "@tursodatabase/cli-linux-arm64-gnu": "0.6.1-pre.1",
+    "@tursodatabase/cli-linux-x64-gnu": "0.6.1-pre.1",
+    "@tursodatabase/cli-win32-x64-msvc": "0.6.1-pre.1"
   }
 }

--- a/packages/turso-cli/package.json
+++ b/packages/turso-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turso",
-  "version": "0.6.1-pre.1",
+  "version": "0.6.1",
   "description": "Turso CLI - SQLite for production",
   "license": "MIT",
   "repository": {
@@ -14,10 +14,10 @@
     "src/index.js"
   ],
   "optionalDependencies": {
-    "@tursodatabase/cli-darwin-arm64": "0.6.1-pre.1",
-    "@tursodatabase/cli-darwin-x64": "0.6.1-pre.1",
-    "@tursodatabase/cli-linux-arm64-gnu": "0.6.1-pre.1",
-    "@tursodatabase/cli-linux-x64-gnu": "0.6.1-pre.1",
-    "@tursodatabase/cli-win32-x64-msvc": "0.6.1-pre.1"
+    "@tursodatabase/cli-darwin-arm64": "0.6.1",
+    "@tursodatabase/cli-darwin-x64": "0.6.1",
+    "@tursodatabase/cli-linux-arm64-gnu": "0.6.1",
+    "@tursodatabase/cli-linux-x64-gnu": "0.6.1",
+    "@tursodatabase/cli-win32-x64-msvc": "0.6.1"
   }
 }

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4908,3 +4908,51 @@ test update-expression-index-references-virtual-gencol {
     1|aaaaaa
     ok
 }
+
+@cross-check-integrity
+test gencol-virtual-affinity-applied-to-index {
+    CREATE TABLE t (a INTEGER, b INTEGER, v REAL AS (a + b));
+    INSERT INTO t (a, b) VALUES (5000000000000001, 5000000000000002);
+    INSERT INTO t (a, b) VALUES (1, 2);
+    CREATE INDEX idx_v ON t (v);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+@cross-check-integrity
+test gencol-virtual-real-affinity-applied-to-index {
+    CREATE TABLE t (a INTEGER, b INTEGER, v REAL AS (a + b));
+    INSERT INTO t (a, b) VALUES (5000000000000001, 5000000000000002);
+    INSERT INTO t (a, b) VALUES (1, 2);
+    CREATE INDEX idx_v ON t (v);
+    PRAGMA integrity_check;
+}
+expect {
+    ok
+}
+
+@cross-check-integrity
+test gencol-update-old-image-real-affinity-applied-to-index {
+    CREATE TABLE t (
+        a INTEGER,
+        b INTEGER,
+        c BLOB,
+        v1 INTEGER AS (a + b),
+        v2 REAL AS (-a - v1)
+    );
+    CREATE INDEX i ON t (c, v1, v2);
+    INSERT INTO t (a, b, c) VALUES (-2929861166669336, -5586410532100113, X'0102');
+    UPDATE t SET c = X'0303';
+    SELECT a, b, quote(c), v1, v2 FROM t INDEXED BY i;
+    PRAGMA integrity_check;
+}
+expect {
+    -2929861166669336|-5586410532100113|X'0303'|-8516271698769449|1.14461328654388e+16
+    ok
+}
+expect @js {
+    -2929861166669336|-5586410532100113|X'0303'|-8516271698769449|11446132865438784
+    ok
+}

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -5,6 +5,7 @@ pub mod grammar_generator;
 pub mod helpers;
 pub mod join;
 pub mod journal_mode;
+pub mod mvcc_rowid_allocator;
 pub mod orderby_collation;
 pub mod raise;
 pub mod rowid_alias;

--- a/tests/fuzz/mvcc_rowid_allocator.rs
+++ b/tests/fuzz/mvcc_rowid_allocator.rs
@@ -1,0 +1,623 @@
+#[cfg(test)]
+mod mvcc_rowid_allocator_fuzz_tests {
+    use crate::helpers;
+    use core_tester::common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase};
+    use rand::Rng;
+    use rand_chacha::ChaCha8Rng;
+    use rusqlite::{params, types::Value};
+    use std::sync::Arc;
+
+    #[derive(Clone, Copy, Debug)]
+    enum CommitOrder {
+        ExplicitFirst,
+        AutoFirst,
+    }
+
+    struct IndexedTable {
+        name: String,
+        idx_k: String,
+        idx_u: String,
+        idx_v_after: String,
+        idx_ku_after: String,
+        after_indexes_created: bool,
+        next_unique: i64,
+        history: Vec<String>,
+    }
+
+    impl IndexedTable {
+        fn new(name: String) -> Self {
+            Self {
+                idx_k: format!("{name}_k"),
+                idx_u: format!("{name}_u"),
+                idx_v_after: format!("{name}_v_after"),
+                idx_ku_after: format!("{name}_ku_after"),
+                name,
+                after_indexes_created: false,
+                next_unique: 1,
+                history: Vec::new(),
+            }
+        }
+
+        fn next_unique(&mut self) -> i64 {
+            let value = self.next_unique;
+            self.next_unique += 1;
+            value
+        }
+    }
+
+    fn sql_text(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "''"))
+    }
+
+    fn integer_value(value: &Value) -> i64 {
+        let Value::Integer(value) = value else {
+            panic!("expected integer value, got {value:?}");
+        };
+        *value
+    }
+
+    fn interesting_rowid(rng: &mut ChaCha8Rng) -> i64 {
+        const VALUES: &[i64] = &[-250, -100, -17, -5, -1, 0, 1, 2, 5, 17, 100, 250];
+        if rng.random_bool(0.75) {
+            VALUES[rng.random_range(0..VALUES.len())]
+        } else {
+            rng.random_range(-500..=500)
+        }
+    }
+
+    fn positive_explicit_rowid(rng: &mut ChaCha8Rng) -> i64 {
+        const VALUES: &[i64] = &[2, 3, 5, 8, 13, 21];
+        if rng.random_bool(0.8) {
+            VALUES[rng.random_range(0..VALUES.len())]
+        } else {
+            rng.random_range(2..=24)
+        }
+    }
+
+    fn create_base_schema(conn: &Arc<turso_core::Connection>, table: &IndexedTable) {
+        conn.execute(format!(
+            "CREATE TABLE {}(id INTEGER PRIMARY KEY, v TEXT NOT NULL, k INTEGER NOT NULL, u INTEGER NOT NULL)",
+            table.name
+        ))
+        .unwrap();
+        conn.execute(format!("CREATE INDEX {} ON {}(k)", table.idx_k, table.name))
+            .unwrap();
+        conn.execute(format!(
+            "CREATE UNIQUE INDEX {} ON {}(u)",
+            table.idx_u, table.name
+        ))
+        .unwrap();
+    }
+
+    fn create_after_indexes(
+        conn: &Arc<turso_core::Connection>,
+        table: &mut IndexedTable,
+        seed: u64,
+        iter: usize,
+        step: usize,
+    ) {
+        if table.after_indexes_created {
+            return;
+        }
+        conn.execute(format!(
+            "CREATE INDEX {} ON {}(v)",
+            table.idx_v_after, table.name
+        ))
+        .unwrap_or_else(|err| {
+            panic!(
+                "failed creating normal index after rows: {err:?}\nseed: {seed}\niter: {iter}\nstep: {step}\nhistory:\n{}",
+                helpers::history_tail(&table.history, 40)
+            )
+        });
+        conn.execute(format!(
+            "CREATE UNIQUE INDEX {} ON {}(k, u)",
+            table.idx_ku_after, table.name
+        ))
+        .unwrap_or_else(|err| {
+            panic!(
+                "failed creating unique index after rows: {err:?}\nseed: {seed}\niter: {iter}\nstep: {step}\nhistory:\n{}",
+                helpers::history_tail(&table.history, 40)
+            )
+        });
+        table.after_indexes_created = true;
+    }
+
+    fn current_values(conn: &Arc<turso_core::Connection>, table: &str, column: &str) -> Vec<i64> {
+        limbo_exec_rows(
+            conn,
+            &format!("SELECT {column} FROM {table} ORDER BY {column}"),
+        )
+        .into_iter()
+        .map(|row| integer_value(&row[0]))
+        .collect()
+    }
+
+    fn current_rowids(conn: &Arc<turso_core::Connection>, table: &str) -> Vec<i64> {
+        current_values(conn, table, "id")
+    }
+
+    fn random_existing_rowid(
+        conn: &Arc<turso_core::Connection>,
+        table: &str,
+        rng: &mut ChaCha8Rng,
+    ) -> Option<i64> {
+        let rowids = current_rowids(conn, table);
+        (!rowids.is_empty()).then(|| rowids[rng.random_range(0..rowids.len())])
+    }
+
+    fn random_fresh_rowid(
+        conn: &Arc<turso_core::Connection>,
+        table: &str,
+        rng: &mut ChaCha8Rng,
+    ) -> i64 {
+        let existing = current_rowids(conn, table);
+        for _ in 0..16 {
+            let rowid = interesting_rowid(rng);
+            if !existing.contains(&rowid) {
+                return rowid;
+            }
+        }
+        existing.iter().copied().max().unwrap_or(0) + 1
+    }
+
+    fn execute_limbo(
+        conn: &Arc<turso_core::Connection>,
+        table: &mut IndexedTable,
+        stmt: String,
+        seed: u64,
+        iter: usize,
+        step: usize,
+    ) {
+        conn.execute(&stmt).unwrap_or_else(|err| {
+            panic!(
+                "statement failed: {err:?}\nseed: {seed}\niter: {iter}\nstep: {step}\nstmt: {stmt}\nhistory:\n{}",
+                helpers::history_tail(&table.history, 40)
+            )
+        });
+        table.history.push(stmt);
+    }
+
+    fn verify_mvcc_invariants(
+        conn: &Arc<turso_core::Connection>,
+        table: &IndexedTable,
+        seed: u64,
+        iter: usize,
+        step: usize,
+    ) {
+        let integrity = limbo_exec_rows(conn, "PRAGMA integrity_check");
+        assert_eq!(
+            integrity,
+            vec![vec![Value::Text("ok".to_string())]],
+            "integrity_check failed\nseed: {seed}\niter: {iter}\nstep: {step}\ntable: {}\nhistory:\n{}",
+            table.name,
+            helpers::history_tail(&table.history, 40)
+        );
+
+        let duplicate_rowids = limbo_exec_rows(
+            conn,
+            &format!(
+                "SELECT id, COUNT(*) FROM {} GROUP BY id HAVING COUNT(*) > 1",
+                table.name
+            ),
+        );
+        assert!(
+            duplicate_rowids.is_empty(),
+            "duplicate visible rowids\nseed: {seed}\niter: {iter}\nstep: {step}\ntable: {}\nduplicates: {duplicate_rowids:?}\nhistory:\n{}",
+            table.name,
+            helpers::history_tail(&table.history, 40)
+        );
+
+        let Some(sample) = limbo_exec_rows(
+            conn,
+            &format!("SELECT id, v, k, u FROM {} ORDER BY id LIMIT 1", table.name),
+        )
+        .into_iter()
+        .next() else {
+            return;
+        };
+        let v = match &sample[1] {
+            Value::Text(value) => value.clone(),
+            other => panic!("expected text value in sample row, got {other:?}"),
+        };
+        let k = integer_value(&sample[2]);
+        let u = integer_value(&sample[3]);
+
+        assert_index_matches_table(
+            conn,
+            table,
+            &table.idx_k,
+            &format!("k = {k}"),
+            seed,
+            iter,
+            step,
+        );
+        assert_index_matches_table(
+            conn,
+            table,
+            &table.idx_u,
+            &format!("u = {u}"),
+            seed,
+            iter,
+            step,
+        );
+        if table.after_indexes_created {
+            assert_index_matches_table(
+                conn,
+                table,
+                &table.idx_v_after,
+                &format!("v = {}", sql_text(&v)),
+                seed,
+                iter,
+                step,
+            );
+            assert_index_matches_table(
+                conn,
+                table,
+                &table.idx_ku_after,
+                &format!("k = {k} AND u = {u}"),
+                seed,
+                iter,
+                step,
+            );
+        }
+    }
+
+    fn assert_index_matches_table(
+        conn: &Arc<turso_core::Connection>,
+        table: &IndexedTable,
+        index: &str,
+        predicate: &str,
+        seed: u64,
+        iter: usize,
+        step: usize,
+    ) {
+        let indexed_query = format!(
+            "SELECT id, v, k, u FROM {} INDEXED BY {index} WHERE {predicate} ORDER BY id",
+            table.name
+        );
+        let table_query = format!(
+            "SELECT id, v, k, u FROM {} NOT INDEXED WHERE {predicate} ORDER BY id",
+            table.name
+        );
+        let indexed = limbo_exec_rows(conn, &indexed_query);
+        let table_rows = limbo_exec_rows(conn, &table_query);
+        assert_eq!(
+            indexed,
+            table_rows,
+            "indexed lookup disagrees with table lookup\nseed: {seed}\niter: {iter}\nstep: {step}\nindexed_query: {indexed_query}\ntable_query: {table_query}\nhistory:\n{}",
+            helpers::history_tail(&table.history, 40)
+        );
+    }
+
+    fn insert_auto_stmt(table: &mut IndexedTable, rng: &mut ChaCha8Rng) -> String {
+        let u = table.next_unique();
+        format!(
+            "INSERT INTO {}(v, k, u) VALUES({}, {}, {u})",
+            table.name,
+            sql_text(&format!("v{u}")),
+            rng.random_range(-8..=8)
+        )
+    }
+
+    fn insert_explicit_stmt(
+        conn: &Arc<turso_core::Connection>,
+        table: &mut IndexedTable,
+        rng: &mut ChaCha8Rng,
+    ) -> String {
+        let rowid = random_fresh_rowid(conn, &table.name, rng);
+        let u = table.next_unique();
+        format!(
+            "INSERT INTO {}(id, v, k, u) VALUES({rowid}, {}, {}, {u})",
+            table.name,
+            sql_text(&format!("v{u}")),
+            rng.random_range(-8..=8)
+        )
+    }
+
+    fn delete_stmt(
+        conn: &Arc<turso_core::Connection>,
+        table: &IndexedTable,
+        rng: &mut ChaCha8Rng,
+    ) -> Option<String> {
+        let target = random_existing_rowid(conn, &table.name, rng)?;
+        if rng.random_bool(0.7) {
+            Some(format!("DELETE FROM {} WHERE id = {target}", table.name))
+        } else {
+            Some(format!(
+                "DELETE FROM {} WHERE k = {}",
+                table.name,
+                rng.random_range(-8..=8)
+            ))
+        }
+    }
+
+    fn update_rowid_stmt(
+        conn: &Arc<turso_core::Connection>,
+        table: &mut IndexedTable,
+        rng: &mut ChaCha8Rng,
+    ) -> Option<String> {
+        let target = random_existing_rowid(conn, &table.name, rng)?;
+        let new_rowid = random_fresh_rowid(conn, &table.name, rng);
+        let u = table.next_unique();
+        Some(format!(
+            "UPDATE {} SET id = {new_rowid}, v = {}, k = {}, u = {u} WHERE id = {target}",
+            table.name,
+            sql_text(&format!("v{u}")),
+            rng.random_range(-8..=8)
+        ))
+    }
+
+    fn insert_or_replace_stmt(
+        conn: &Arc<turso_core::Connection>,
+        table: &mut IndexedTable,
+        rng: &mut ChaCha8Rng,
+    ) -> String {
+        let existing_rowid = random_existing_rowid(conn, &table.name, rng);
+        let existing_u = current_values(conn, &table.name, "u");
+        let u = table.next_unique();
+        let v = sql_text(&format!("v{u}"));
+        let k = rng.random_range(-8..=8);
+
+        match rng.random_range(0..4) {
+            0 => format!(
+                "INSERT OR REPLACE INTO {}(v, k, u) VALUES({v}, {k}, {u})",
+                table.name
+            ),
+            1 if existing_rowid.is_some() => {
+                let rowid = existing_rowid.unwrap();
+                format!(
+                    "INSERT OR REPLACE INTO {}(id, v, k, u) VALUES({rowid}, {v}, {k}, {u})",
+                    table.name
+                )
+            }
+            2 if !existing_u.is_empty() => {
+                let conflicting_u = existing_u[rng.random_range(0..existing_u.len())];
+                format!(
+                    "INSERT OR REPLACE INTO {}(v, k, u) VALUES({v}, {k}, {conflicting_u})",
+                    table.name
+                )
+            }
+            _ => {
+                let rowid = random_fresh_rowid(conn, &table.name, rng);
+                format!(
+                    "INSERT OR REPLACE INTO {}(id, v, k, u) VALUES({rowid}, {v}, {k}, {u})",
+                    table.name
+                )
+            }
+        }
+    }
+
+    fn run_negative_rowid_sqlite_parity_case(
+        limbo_conn: &Arc<turso_core::Connection>,
+        sqlite_conn: &rusqlite::Connection,
+        name: &str,
+        explicit_rowid: i64,
+        seed: u64,
+        iter: usize,
+    ) {
+        let create_table = format!("CREATE TABLE {name}(id INTEGER PRIMARY KEY, v TEXT)");
+        let create_index = format!("CREATE UNIQUE INDEX {name}_v ON {name}(v)");
+        limbo_conn.execute(&create_table).unwrap();
+        sqlite_conn.execute(&create_table, params![]).unwrap();
+        limbo_conn.execute(&create_index).unwrap();
+        sqlite_conn.execute(&create_index, params![]).unwrap();
+
+        let explicit_insert =
+            format!("INSERT INTO {name}(id, v) VALUES({explicit_rowid}, 'manual')");
+        let auto_insert = format!("INSERT INTO {name}(v) VALUES('auto')");
+        limbo_conn.execute(&explicit_insert).unwrap();
+        sqlite_conn.execute(&explicit_insert, params![]).unwrap();
+        limbo_conn
+            .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        limbo_conn.execute(&auto_insert).unwrap();
+        sqlite_conn.execute(&auto_insert, params![]).unwrap();
+
+        let query = format!("SELECT id, v FROM {name} ORDER BY id");
+        let limbo_rows = limbo_exec_rows(limbo_conn, &query);
+        let sqlite_rows = sqlite_exec_rows(sqlite_conn, &query);
+        assert_eq!(
+            limbo_rows, sqlite_rows,
+            "negative rowid allocation mismatch\nseed: {seed}\niter: {iter}\nexplicit_rowid: {explicit_rowid}\nquery: {query}",
+        );
+    }
+
+    fn run_concurrent_mini_scenario(
+        db: &TempDatabase,
+        name: String,
+        rng: &mut ChaCha8Rng,
+        seed: u64,
+        iter: usize,
+        step: usize,
+    ) {
+        let mut table = IndexedTable::new(name);
+        let setup = db.connect_limbo();
+        create_base_schema(&setup, &table);
+
+        let explicit_rowid = positive_explicit_rowid(rng);
+        let explicit_k = 100_000_i64 + iter as i64 * 100 + step as i64;
+        let commit_order = if rng.random_bool(0.5) {
+            CommitOrder::ExplicitFirst
+        } else {
+            CommitOrder::AutoFirst
+        };
+
+        let conn1 = db.connect_limbo();
+        let conn2 = db.connect_limbo();
+
+        conn1.execute("BEGIN CONCURRENT").unwrap();
+        conn1
+            .execute(format!(
+                "INSERT INTO {}(id, v, k, u) VALUES({explicit_rowid}, 'explicit', {explicit_k}, 1)",
+                table.name
+            ))
+            .unwrap();
+
+        conn2.execute("BEGIN CONCURRENT").unwrap();
+        conn2
+            .execute(format!(
+                "INSERT INTO {}(v, k, u) VALUES('auto_tx', -1, 2)",
+                table.name
+            ))
+            .unwrap();
+
+        match commit_order {
+            CommitOrder::ExplicitFirst => {
+                conn1.execute("COMMIT").unwrap();
+                conn2.execute("COMMIT").unwrap();
+            }
+            CommitOrder::AutoFirst => {
+                conn2.execute("COMMIT").unwrap();
+                conn1.execute("COMMIT").unwrap();
+            }
+        }
+
+        setup.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        create_after_indexes(&setup, &mut table, seed, iter, step);
+
+        for n in 0..explicit_rowid {
+            setup
+                .execute(format!(
+                    "INSERT INTO {}(v, k, u) VALUES('post_{n}', {}, {})",
+                    table.name,
+                    10_000 + n,
+                    100 + n
+                ))
+                .unwrap();
+        }
+
+        verify_mvcc_invariants(&setup, &table, seed, iter, step);
+
+        let table_query = format!(
+            "SELECT id, v, k, u FROM {} WHERE id = {explicit_rowid}",
+            table.name
+        );
+        let indexed_query = format!(
+            "SELECT id, v, k, u FROM {} INDEXED BY {} WHERE k = {explicit_k}",
+            table.name, table.idx_k
+        );
+        let table_rows = limbo_exec_rows(&setup, &table_query);
+        let indexed_rows = limbo_exec_rows(&setup, &indexed_query);
+        assert_eq!(
+            table_rows,
+            vec![vec![
+                Value::Integer(explicit_rowid),
+                Value::Text("explicit".to_string()),
+                Value::Integer(explicit_k),
+                Value::Integer(1),
+            ]],
+            "explicit row was overwritten\nseed: {seed}\niter: {iter}\nstep: {step}\ncommit_order: {commit_order:?}\nquery: {table_query}",
+        );
+        assert_eq!(
+            indexed_rows, table_rows,
+            "explicit row index lookup disagrees\nseed: {seed}\niter: {iter}\nstep: {step}\ncommit_order: {commit_order:?}\nquery: {indexed_query}",
+        );
+    }
+
+    #[test]
+    pub fn mvcc_rowid_allocator_fuzz() {
+        let (mut rng, seed) = helpers::init_fuzz_test("mvcc_rowid_allocator_fuzz");
+        let iterations = helpers::fuzz_iterations(10);
+        let steps = std::env::var("FUZZ_ROWID_STEPS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(28);
+
+        for iter in 0..iterations {
+            helpers::log_progress("mvcc_rowid_allocator_fuzz", iter, iterations, 10);
+
+            let db = TempDatabase::builder().with_mvcc(true).build();
+            let limbo_conn = db.connect_limbo();
+            let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+
+            run_negative_rowid_sqlite_parity_case(
+                &limbo_conn,
+                &sqlite_conn,
+                &format!("rowid_sqlite_parity_{iter}"),
+                -positive_explicit_rowid(&mut rng),
+                seed,
+                iter,
+            );
+
+            let mut table = IndexedTable::new(format!("rowid_fuzz_{iter}"));
+            create_base_schema(&limbo_conn, &table);
+
+            for step in 0..steps {
+                let stmt = match step {
+                    0 => Some(insert_explicit_stmt(&limbo_conn, &mut table, &mut rng)),
+                    1 => {
+                        limbo_conn
+                            .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                            .unwrap();
+                        None
+                    }
+                    2 => Some(insert_auto_stmt(&mut table, &mut rng)),
+                    3 => Some(insert_or_replace_stmt(&limbo_conn, &mut table, &mut rng)),
+                    4 => update_rowid_stmt(&limbo_conn, &mut table, &mut rng),
+                    5 => delete_stmt(&limbo_conn, &table, &mut rng),
+                    6 => {
+                        run_concurrent_mini_scenario(
+                            &db,
+                            format!("rowid_concurrent_{iter}_{step}"),
+                            &mut rng,
+                            seed,
+                            iter,
+                            step,
+                        );
+                        None
+                    }
+                    7 => {
+                        create_after_indexes(&limbo_conn, &mut table, seed, iter, step);
+                        None
+                    }
+                    _ => match rng.random_range(0..100) {
+                        0..=24 => Some(insert_auto_stmt(&mut table, &mut rng)),
+                        25..=44 => Some(insert_explicit_stmt(&limbo_conn, &mut table, &mut rng)),
+                        45..=57 => delete_stmt(&limbo_conn, &table, &mut rng),
+                        58..=72 => update_rowid_stmt(&limbo_conn, &mut table, &mut rng),
+                        73..=84 => Some(insert_or_replace_stmt(&limbo_conn, &mut table, &mut rng)),
+                        85..=89 => {
+                            limbo_conn
+                                .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                                .unwrap();
+                            None
+                        }
+                        90..=94 => {
+                            create_after_indexes(&limbo_conn, &mut table, seed, iter, step);
+                            None
+                        }
+                        95..=99 => {
+                            run_concurrent_mini_scenario(
+                                &db,
+                                format!("rowid_concurrent_{iter}_{step}"),
+                                &mut rng,
+                                seed,
+                                iter,
+                                step,
+                            );
+                            None
+                        }
+                        _ => unreachable!(),
+                    },
+                };
+
+                if let Some(stmt) = stmt {
+                    execute_limbo(&limbo_conn, &mut table, stmt, seed, iter, step);
+                }
+
+                if step % 7 == 6 {
+                    limbo_conn
+                        .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                        .unwrap();
+                }
+                verify_mvcc_invariants(&limbo_conn, &table, seed, iter, step);
+            }
+
+            create_after_indexes(&limbo_conn, &mut table, seed, iter, steps);
+            limbo_conn
+                .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                .unwrap();
+            verify_mvcc_invariants(&limbo_conn, &table, seed, iter, steps);
+        }
+    }
+}

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1642,7 +1642,7 @@ pub fn test_empty_wal_truncate_checkpoint() {
 }
 
 #[test]
-pub fn test_mvcc_stale_snapshot_after_schema_updated() {
+pub fn test_mvcc_reader_stale_snapshot_after_schema_updated_returns_ok() {
     let _ = env_logger::try_init();
     let db_path = tempfile::NamedTempFile::new().unwrap();
     let (_file, db_path) = db_path.keep().unwrap();
@@ -1659,8 +1659,58 @@ pub fn test_mvcc_stale_snapshot_after_schema_updated() {
         .unwrap();
     // conn1: Start a CONCURRENT transaction
     conn1.execute("BEGIN CONCURRENT").unwrap();
-    // Do something to establish the MVCC snapshot
+    // Do something to establish the MVCC snapshot, we do not write anything so that tx
+    // is read only which would not trigger SchemaUpdated
     conn1.execute("SELECT * FROM t").unwrap();
+    // conn2: Modify schema while conn1's CONCURRENT transaction is active
+    conn2.execute("CREATE TABLE t2 (x)").unwrap();
+    // conn1: Try to COMMIT - should fail with SchemaConflict
+    let commit_result = conn1.execute("COMMIT");
+    assert!(matches!(commit_result, Ok(())));
+
+    // conn2: Insert a row and commit (this happens AFTER conn1's original snapshot)
+    conn2
+        .execute("INSERT INTO t VALUES ('test_key', 'test_value')")
+        .unwrap();
+
+    // conn1: Start a new CONCURRENT transaction
+    // BUG: This should get a fresh MVCC snapshot, but it reuses the old one
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+
+    // conn1: SELECT should see the row inserted by conn2
+    // BUG: Due to stale snapshot, this returns empty result
+    let rows: Vec<(String, String)> = conn1.exec_rows("SELECT * FROM t WHERE key = 'test_key'");
+
+    assert_eq!(
+        rows,
+        vec![("test_key".to_string(), "test_value".to_string())]
+    );
+
+    conn1.execute("COMMIT").unwrap();
+}
+
+#[test]
+pub fn test_mvcc_writer_stale_snapshot_after_schema_updated() {
+    let _ = env_logger::try_init();
+    let db_path = tempfile::NamedTempFile::new().unwrap();
+    let (_file, db_path) = db_path.keep().unwrap();
+    tracing::info!("path: {:?}", db_path);
+    let tmp_db = TempDatabase::builder()
+        .with_db_path(&db_path)
+        .with_mvcc(true)
+        .build();
+    let conn1 = tmp_db.connect_limbo();
+    let conn2 = tmp_db.connect_limbo();
+    // Setup: create initial table
+    conn1
+        .execute("CREATE TABLE t (key TEXT PRIMARY KEY, value TEXT)")
+        .unwrap();
+    // conn1: Start a CONCURRENT transaction
+    conn1.execute("BEGIN CONCURRENT").unwrap();
+    // Insert something so that we trigger schema updated
+    conn1
+        .execute("INSERT INTO t VALUES ('foo', 'var')")
+        .unwrap();
     // conn2: Modify schema while conn1's CONCURRENT transaction is active
     conn2.execute("CREATE TABLE t2 (x)").unwrap();
     // conn1: Try to COMMIT - should fail with SchemaConflict

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -1,5 +1,9 @@
+use std::sync::Arc;
+
 use crate::common::{limbo_exec_rows, TempDatabase};
+use crate::queued_io::QueuedIo;
 use turso_core::vdbe::StepResult;
+use turso_core::{Database, LimboError};
 
 /// Helper: step a statement through IO until it returns Row or Done.
 fn step_blocking(stmt: &mut turso_core::Statement) -> turso_core::Result<StepResult> {
@@ -92,6 +96,42 @@ fn returning_delete_drop_after_partial_read_commits(tmp_db: TempDatabase) -> any
     Ok(())
 }
 
+#[turso_macros::test]
+fn unrelated_runtime_error_does_not_rollback_open_returning_statement(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE pending (id INTEGER PRIMARY KEY, v TEXT)")?;
+    conn.execute("CREATE TABLE overflow (x INTEGER)")?;
+    conn.execute("INSERT INTO overflow VALUES (9223372036854775807), (1)")?;
+
+    {
+        let mut owner =
+            conn.prepare("INSERT INTO pending VALUES (1, 'a'), (2, 'b') RETURNING id")?;
+        let result = step_blocking(&mut owner)?;
+        assert!(
+            matches!(result, StepResult::Row),
+            "expected Row, got {result:?}"
+        );
+
+        let err = conn
+            .execute("SELECT sum(x) FROM overflow")
+            .expect_err("sum overflow should fail");
+        assert!(matches!(err, LimboError::IntegerOverflow), "{err:?}");
+    }
+
+    let rows = limbo_exec_rows(&conn, "SELECT id FROM pending ORDER BY id");
+    let ids: Vec<i64> = rows
+        .iter()
+        .map(|row| match &row[0] {
+            rusqlite::types::Value::Integer(i) => *i,
+            other => panic!("expected integer, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(ids, vec![1, 2]);
+    Ok(())
+}
+
 /// Plain INSERT (no RETURNING): runs to completion via step(), then drop.
 /// This is the normal case — Halt commits the transaction.
 #[turso_macros::test(init_sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);")]
@@ -113,6 +153,33 @@ fn plain_insert_step_to_done_commits(tmp_db: TempDatabase) -> anyhow::Result<()>
         other => panic!("expected integer, got {other:?}"),
     };
     assert_eq!(count, 2);
+    Ok(())
+}
+
+#[test]
+fn dropping_explicit_commit_waiting_on_io_rolls_back_transaction() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file(io, "queued-explicit-commit-drop.db")?;
+    let conn = db.connect()?;
+
+    conn.execute("CREATE TABLE t(x INTEGER)")?;
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (1)")?;
+
+    {
+        let mut commit = conn.prepare("COMMIT")?;
+        assert!(matches!(commit.step()?, StepResult::IO));
+    }
+
+    conn.execute("INSERT INTO t VALUES (2)")?;
+
+    let mut stmt = conn.prepare("SELECT x FROM t ORDER BY x")?;
+    let mut values = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        values.push(row.get::<i64>(0)?);
+        Ok(())
+    })?;
+    assert_eq!(values, vec![2]);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

When a SQL trigger INSERTs into a Tantivy FTS-indexed table, the transaction commits successfully but the FTS cursor's `Drop` impl then tries to flush pending documents. The `turso_assert!` at `core/index_method/fts.rs:2493` panics because the transaction is already committed, causing `SIGABRT` that kills the process.

## Fix

Replace the `turso_assert!` with a `tracing::warn` + early return. The documents were already committed as part of the transaction; the Tantivy index flush is safely skipped and the index will be rebuilt on the next write.

## Reproduction

1. Create a table with a Tantivy FTS index
2. Create a trigger that INSERTs into the FTS-indexed table on INSERT to another table
3. INSERT into the trigger source table
4. Process crashes with `SIGABRT`: `FTS Drop: transaction already committed, cannot flush | pending_docs_count=1`

Fixes #7259