### PR TITLE
core/translate: support FILTER in window clauses

### DIFF
--- a/bindings/javascript/Cargo.toml
+++ b/bindings/javascript/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { workspace = true, default-features = false, features = ["clock"] }
 
 [features]
 browser = []
+test_helper = ["turso_core/test_helper"]
 tracing_release = ["turso_core/tracing_release"]
 [build-dependencies]
 napi-build = "2.3.1"

--- a/bindings/javascript/packages/native/index.d.ts
+++ b/bindings/javascript/packages/native/index.d.ts
@@ -137,7 +137,7 @@ export declare class Statement {
    */
   safeIntegers(toggle?: boolean | undefined | null): void
   /** Get column information for the statement */
-  columns(): Promise<any>
+  columns(): Promise<TableColumn[]>
   /** Finalizes the statement. */
   finalize(): void
 }
@@ -179,4 +179,12 @@ export interface EncryptionOpts {
 
 export interface QueryOptions {
   queryTimeout?: number
+}
+
+export interface TableColumn {
+  name: string
+  type?: string | null
+  column?: undefined
+  table?: undefined
+  database?: undefined
 }

--- a/bindings/javascript/packages/native/index.js
+++ b/bindings/javascript/packages/native/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-android-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-android-arm-eabi')
         const bindingPackageVersion = require('@tursodatabase/database-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -117,8 +117,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-x64-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -133,8 +133,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-ia32-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -149,8 +149,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-win32-arm64-msvc')
         const bindingPackageVersion = require('@tursodatabase/database-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -168,8 +168,8 @@ function requireNative() {
     try {
       const binding = require('@tursodatabase/database-darwin-universal')
       const bindingPackageVersion = require('@tursodatabase/database-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -184,8 +184,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-darwin-x64')
         const bindingPackageVersion = require('@tursodatabase/database-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -200,8 +200,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-darwin-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -220,8 +220,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-freebsd-x64')
         const bindingPackageVersion = require('@tursodatabase/database-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -236,8 +236,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-freebsd-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -257,8 +257,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-x64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -273,8 +273,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-x64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -307,8 +307,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm-musleabihf')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -341,8 +341,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@tursodatabase/database-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-riscv64-musl')
           const bindingPackageVersion = require('@tursodatabase/database-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -375,8 +375,8 @@ function requireNative() {
         try {
           const binding = require('@tursodatabase/database-linux-riscv64-gnu')
           const bindingPackageVersion = require('@tursodatabase/database-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -392,8 +392,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-linux-ppc64-gnu')
         const bindingPackageVersion = require('@tursodatabase/database-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -408,8 +408,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-linux-s390x-gnu')
         const bindingPackageVersion = require('@tursodatabase/database-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -428,8 +428,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-arm64')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-x64')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@tursodatabase/database-openharmony-arm')
         const bindingPackageVersion = require('@tursodatabase/database-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.6.0-pre.18' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.6.0-pre.18 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.7.0-pre.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.7.0-pre.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/javascript/packages/native/package.json
+++ b/bindings/javascript/packages/native/package.json
@@ -30,10 +30,12 @@
   },
   "scripts": {
     "napi-build": "napi build --platform --profile release-official --esm --manifest-path ../../Cargo.toml --output-dir .",
+    "napi-build:test-helper": "napi build --platform --profile release-official --esm --manifest-path ../../Cargo.toml --output-dir . --features test_helper",
     "napi-dirs": "napi create-npm-dirs",
     "napi-artifacts": "napi artifacts --output-dir .",
     "tsc-build": "npm exec tsc",
     "build": "npm run napi-build && npm run tsc-build",
+    "build:test-helper": "npm run napi-build:test-helper && npm run tsc-build",
     "test": "vitest --run",
     "prepublishOnly": "npm run napi-dirs && npm run napi-artifacts && napi prepublish -t npm"
   },

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -18,6 +18,7 @@ mimalloc = ["dep:mimalloc"]
 pure-rust-crypto = ["turso_sdk_kit/pure-rust-crypto", "turso_sync_sdk_kit/pure-rust-crypto"]
 fts = ["turso_sdk_kit/fts"]
 stacker = ["turso_core/stacker"]
+test_helper = ["turso_core/test_helper"]
 sync = [
     "dep:hyper",
     "dep:tokio",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -73,6 +73,7 @@ mimalloc = ["dep:mimalloc"]
 fts = ["turso_core/fts"]
 mvcc_repl = []
 stacker = ["turso_core/stacker"]
+test_helper = ["turso_core/test_helper"]
 
 [build-dependencies]
 syntect = { git = "https://github.com/trishume/syntect.git", rev = "64644ffe064457265cbcee12a0c1baf9485ba6ee", default-features = false, features = ["default-fancy"] }

--- a/core/function.rs
+++ b/core/function.rs
@@ -652,6 +652,11 @@ pub enum ScalarFunc {
     TestUintDiv,
     TestUintLt,
     TestUintEq,
+    /// Test-only: returns a monotonically increasing 64-bit integer on every
+    /// evaluation. Used to verify that the planner does not deduplicate
+    /// equivalent SQL calls that contain nondeterministic functions.
+    #[cfg(feature = "test_helper")]
+    TestNondetCounter,
     StringReverse,
     // Built-in type support functions
     BooleanToInt,
@@ -769,6 +774,8 @@ impl Deterministic for ScalarFunc {
             | ScalarFunc::TestUintLt
             | ScalarFunc::TestUintEq
             | ScalarFunc::StringReverse => true,
+            #[cfg(feature = "test_helper")]
+            ScalarFunc::TestNondetCounter => false,
             ScalarFunc::BooleanToInt
             | ScalarFunc::IntToBoolean
             | ScalarFunc::ValidateIpAddr
@@ -904,6 +911,8 @@ impl Display for ScalarFunc {
             Self::TestUintDiv => "test_uint_div",
             Self::TestUintLt => "test_uint_lt",
             Self::TestUintEq => "test_uint_eq",
+            #[cfg(feature = "test_helper")]
+            Self::TestNondetCounter => "test_nondet_counter",
             Self::StringReverse => "string_reverse",
             Self::BooleanToInt => "boolean_to_int",
             Self::IntToBoolean => "int_to_boolean",
@@ -975,6 +984,8 @@ impl ScalarFunc {
             | Self::TursoVersion
             | Self::SqliteSourceId
             | Self::TotalChanges => &[0],
+            #[cfg(feature = "test_helper")]
+            Self::TestNondetCounter => &[0],
             // 1-arg
             Self::Abs
             | Self::Hex
@@ -1301,7 +1312,7 @@ impl Func {
         }
         match self {
             Self::Scalar(scalar_func) => {
-                matches!(
+                let basic = matches!(
                     scalar_func,
                     ScalarFunc::Changes
                         | ScalarFunc::Random
@@ -1310,7 +1321,10 @@ impl Func {
                         | ScalarFunc::TursoVersion
                         | ScalarFunc::SqliteSourceId
                         | ScalarFunc::LastInsertRowid
-                )
+                );
+                #[cfg(feature = "test_helper")]
+                let basic = basic || matches!(scalar_func, ScalarFunc::TestNondetCounter);
+                basic
             }
             Self::Math(math_func) => {
                 matches!(math_func.arity(), MathFuncArity::Nullary)
@@ -1608,6 +1622,8 @@ impl Func {
             "test_uint_div" => Ok(Some(Self::Scalar(ScalarFunc::TestUintDiv))),
             "test_uint_lt" => Ok(Some(Self::Scalar(ScalarFunc::TestUintLt))),
             "test_uint_eq" => Ok(Some(Self::Scalar(ScalarFunc::TestUintEq))),
+            #[cfg(feature = "test_helper")]
+            "test_nondet_counter" => Ok(Some(Self::Scalar(ScalarFunc::TestNondetCounter))),
             "string_reverse" => Ok(Some(Self::Scalar(ScalarFunc::StringReverse))),
             // Built-in type support functions
             "boolean_to_int" => Ok(Some(Self::Scalar(ScalarFunc::BooleanToInt))),

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -108,6 +108,6 @@ pub use utils::{
 };
 pub use vectors::expr_vector_size;
 pub use walk::{
-    expr_references_any_subquery, expr_references_subquery_id, walk_expr, walk_expr_mut,
-    WalkControl,
+    expr_contains_nondeterministic_scalar_function, expr_references_any_subquery,
+    expr_references_subquery_id, walk_expr, walk_expr_mut, WalkControl,
 };

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -1288,6 +1288,23 @@ pub fn translate_expr(
                             });
                             Ok(target_register)
                         }
+                        #[cfg(feature = "test_helper")]
+                        ScalarFunc::TestNondetCounter => {
+                            if !args.is_empty() {
+                                crate::bail_parse_error!(
+                                    "{} function with arguments",
+                                    srf.to_string()
+                                );
+                            }
+                            let regs = program.alloc_register();
+                            program.emit_insn(Insn::Function {
+                                constant_mask: 0,
+                                start_reg: regs,
+                                dest: target_register,
+                                func: func_ctx,
+                            });
+                            Ok(target_register)
+                        }
                         ScalarFunc::Date | ScalarFunc::DateTime | ScalarFunc::JulianDay => {
                             let start_reg = program.alloc_registers(args.len().max(1));
                             for (i, arg) in args.iter().enumerate() {

--- a/core/translate/expr/walk.rs
+++ b/core/translate/expr/walk.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::function::{Deterministic, ExtFunc};
 
 pub enum WalkControl {
     Continue,     // Visit children
@@ -207,6 +208,78 @@ pub fn expr_references_any_subquery(expr: &ast::Expr) -> bool {
         Ok(WalkControl::Continue)
     });
     found
+}
+
+/// Returns true if this expression calls a scalar function whose result can
+/// change between calls.
+///
+/// This is used when deciding whether two repeated window expressions can use
+/// one `WindowFunction` entry. For example, two copies of `sum(x) OVER w` can
+/// use one entry. Two copies of
+/// `sum(x) FILTER (WHERE random() % 2 = 0) OVER w` cannot share the filter
+/// value, because SQLite runs `random()` separately at each place it appears.
+///
+/// FIXME: `walk_expr` does not descend into `Expr::Subquery`, `Expr::Exists`,
+/// or the `Select` side of `Expr::InSelect`. A nondeterministic call buried
+/// inside such a subquery in a FILTER predicate will not be detected, and the
+/// two FILTERs would be incorrectly deduped. Lift the walker's subquery TODO
+/// before relying on this for correctness in those cases.
+pub fn expr_contains_nondeterministic_scalar_function(
+    expr: &ast::Expr,
+    resolver: &Resolver<'_>,
+) -> Result<bool> {
+    fn is_nondeterministic_scalar_like_function(func: &Func) -> bool {
+        match func {
+            // Aggregate and window function calls themselves are not flagged
+            // at any nesting depth — their outputs are deterministic given the
+            // same input rows. The walker still descends into their args,
+            // FILTER, and OVER subexprs, so nondet scalars buried inside
+            // (e.g. `sum(random())`) are still caught. Note also that
+            // `AggFunc::is_deterministic` returns `false`, so the catch-all
+            // below would otherwise flag every aggregate call.
+            Func::Agg(_) | Func::Window(_) => false,
+
+            // User-defined scalar functions can do anything, so treat them
+            // like `random()`. User-defined aggregates are treated like
+            // built-in aggregates: two copies of `myagg(x) OVER w` should
+            // share one window entry when `x` and the FILTER/OVER clauses are
+            // stable.
+            Func::External(external) if matches!(external.func, ExtFunc::Aggregate { .. }) => false,
+
+            _ => !func.is_deterministic(),
+        }
+    }
+
+    let mut found = false;
+    walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
+        if found {
+            return Ok(WalkControl::SkipChildren);
+        }
+
+        let func = match e {
+            ast::Expr::FunctionCall { name, args, .. } => {
+                resolver.resolve_function(name.as_str(), args.len())?
+            }
+            ast::Expr::FunctionCallStar { name, .. } => {
+                resolver.resolve_function(name.as_str(), 0)?
+            }
+            _ => None,
+        };
+
+        // If the name is unknown here, leave the error to the normal resolver.
+        // This helper only answers "may repeated copies share work?"
+        if func
+            .as_ref()
+            .is_some_and(is_nondeterministic_scalar_like_function)
+        {
+            found = true;
+            return Ok(WalkControl::SkipChildren);
+        }
+
+        Ok(WalkControl::Continue)
+    })?;
+
+    Ok(found)
 }
 
 /// Walks a mutable expression, applying a function to each sub-expression.

--- a/core/translate/expr/walk.rs
+++ b/core/translate/expr/walk.rs
@@ -219,11 +219,6 @@ pub fn expr_references_any_subquery(expr: &ast::Expr) -> bool {
 /// `sum(x) FILTER (WHERE random() % 2 = 0) OVER w` cannot share the filter
 /// value, because SQLite runs `random()` separately at each place it appears.
 ///
-/// FIXME: `walk_expr` does not descend into `Expr::Subquery`, `Expr::Exists`,
-/// or the `Select` side of `Expr::InSelect`. A nondeterministic call buried
-/// inside such a subquery in a FILTER predicate will not be detected, and the
-/// two FILTERs would be incorrectly deduped. Lift the walker's subquery TODO
-/// before relying on this for correctness in those cases.
 pub fn expr_contains_nondeterministic_scalar_function(
     expr: &ast::Expr,
     resolver: &Resolver<'_>,
@@ -251,7 +246,7 @@ pub fn expr_contains_nondeterministic_scalar_function(
     }
 
     let mut found = false;
-    walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
+    crate::util::walk_expr_with_subqueries(expr, &mut |e| -> Result<WalkControl> {
         if found {
             return Ok(WalkControl::SkipChildren);
         }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3033,44 +3033,33 @@ pub enum WindowFunctionKind {
     Window(WindowFunc),
 }
 
+/// One window function call belonging to a `Window`.
+///
+/// Window queries are planned by wrapping the original FROM/WHERE in a
+/// subquery, pushing each window function's arguments and FILTER predicate
+/// into that subquery as new output columns, and rewriting the call to read
+/// those columns instead of the original tables. See `plan_windows` in
+/// `translate/window.rs` for the full rewrite, including worked examples.
+/// "Source subquery" below refers to that wrapper subquery.
 #[derive(Debug, Clone)]
 pub struct WindowFunction {
     /// The resolved function. Aggregate window functions and specialized window
     /// functions such as ROW_NUMBER() are supported.
     pub func: WindowFunctionKind,
-    /// Rewritten FILTER predicate, evaluated before `AggStep` to decide
-    /// whether the current input row contributes.
-    ///
-    /// Kept separate from `rewritten_expr`. Window planning emits an input
-    /// subquery that pre-computes each argument and FILTER predicate as one of
-    /// its result columns (`col0`, `col1`, ... below refer to those subquery
-    /// output columns). Given two calls in the same SELECT,
-    ///     sum(val) FILTER (WHERE flag = 1) OVER w,
-    ///     sum(val) FILTER (WHERE flag = 0) OVER w,
-    /// the input subquery computes `val` once as `col0`, `flag = 1` as `col1`,
-    /// and `flag = 0` as `col2`. Then:
-    ///
-    /// - `rewritten_expr` is `sum(col0) FILTER (WHERE col1) OVER w` for the
-    ///   first call and `sum(col0) FILTER (WHERE col2) OVER w` for the second.
-    ///   The FILTER clause is rewritten but still attached, so the two calls
-    ///   compare as distinct when later code looks up the result register by
-    ///   expression equality. Without that, both calls would share one entry
-    ///   and produce the same value.
-    /// - `filter_expr` is `col1` / `col2` on its own — the bare `Column`
-    ///   reference AggStep evaluates per input row to decide whether to step.
-    ///
-    /// Merging them would either lose the per-call distinction in
-    /// `rewritten_expr` or force AggStep to dig the predicate back out of the
-    /// function call. Storing the predicate separately avoids both.
+    /// The FILTER predicate, rewritten to reference the source subquery's
+    /// output columns. AggStep evaluates this once per input row and skips
+    /// the step when it is false. Stored as its own field so AggStep doesn't
+    /// have to pattern-match it back out of `rewritten_expr`'s `filter_over`
+    /// tail on every row.
     pub filter_expr: Option<Expr>,
     /// The expression from which the function was resolved. Used as the lookup
-    /// key when locating this function during window-to-subquery rewriting.
+    /// key when matching SQL occurrences back to this entry during rewriting.
     pub original_expr: Expr,
-    /// The rewritten form of `original_expr`, with arguments and the OVER clause
-    /// remapped to reference the window's input subquery. Set the first time
-    /// `rewrite_terminal_expr` matches this function. Subsequent occurrences of
-    /// the same `original_expr` reuse this cached rewrite so they end up pointing
-    /// at the same registers as the first occurrence.
+    /// `original_expr` with its arguments, FILTER predicate, and OVER clause
+    /// rewritten to reference the source subquery. Set the first time
+    /// `rewrite_terminal_expr` matches this function; later occurrences of
+    /// the same call reuse this cached rewrite so they resolve to the same
+    /// result register.
     pub rewritten_expr: Option<Expr>,
 }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3038,6 +3038,31 @@ pub struct WindowFunction {
     /// The resolved function. Aggregate window functions and specialized window
     /// functions such as ROW_NUMBER() are supported.
     pub func: WindowFunctionKind,
+    /// Rewritten FILTER predicate, evaluated before `AggStep` to decide
+    /// whether the current input row contributes.
+    ///
+    /// Kept separate from `rewritten_expr`. Window planning emits an input
+    /// subquery that pre-computes each argument and FILTER predicate as one of
+    /// its result columns (`col0`, `col1`, ... below refer to those subquery
+    /// output columns). Given two calls in the same SELECT,
+    ///     sum(val) FILTER (WHERE flag = 1) OVER w,
+    ///     sum(val) FILTER (WHERE flag = 0) OVER w,
+    /// the input subquery computes `val` once as `col0`, `flag = 1` as `col1`,
+    /// and `flag = 0` as `col2`. Then:
+    ///
+    /// - `rewritten_expr` is `sum(col0) FILTER (WHERE col1) OVER w` for the
+    ///   first call and `sum(col0) FILTER (WHERE col2) OVER w` for the second.
+    ///   The FILTER clause is rewritten but still attached, so the two calls
+    ///   compare as distinct when later code looks up the result register by
+    ///   expression equality. Without that, both calls would share one entry
+    ///   and produce the same value.
+    /// - `filter_expr` is `col1` / `col2` on its own — the bare `Column`
+    ///   reference AggStep evaluates per input row to decide whether to step.
+    ///
+    /// Merging them would either lose the per-call distinction in
+    /// `rewritten_expr` or force AggStep to dig the predicate back out of the
+    /// function call. Storing the predicate separately avoids both.
+    pub filter_expr: Option<Expr>,
     /// The expression from which the function was resolved. Used as the lookup
     /// key when locating this function during window-to-subquery rewriting.
     pub original_expr: Expr,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3046,21 +3046,39 @@ pub struct WindowFunction {
     /// The resolved function. Aggregate window functions and specialized window
     /// functions such as ROW_NUMBER() are supported.
     pub func: WindowFunctionKind,
-    /// The FILTER predicate, rewritten to reference the source subquery's
-    /// output columns. AggStep evaluates this once per input row and skips
-    /// the step when it is false. Stored as its own field so AggStep doesn't
-    /// have to pattern-match it back out of `rewritten_expr`'s `filter_over`
-    /// tail on every row.
-    pub filter_expr: Option<Expr>,
     /// The expression from which the function was resolved. Used as the lookup
     /// key when matching SQL occurrences back to this entry during rewriting.
     pub original_expr: Expr,
-    /// `original_expr` with its arguments, FILTER predicate, and OVER clause
-    /// rewritten to reference the source subquery. Set the first time
-    /// `rewrite_terminal_expr` matches this function; later occurrences of
-    /// the same call reuse this cached rewrite so they resolve to the same
-    /// result register.
-    pub rewritten_expr: Option<Expr>,
+    /// Populated the first time `rewrite_terminal_expr` matches this function.
+    /// Later occurrences of the same call reuse this cached rewrite so they
+    /// resolve to the same result register.
+    pub rewritten: Option<RewrittenWindowCall>,
+}
+
+/// The rewritten form of a window function call, populated once `WindowFunction`
+/// has been mapped onto its source subquery.
+#[derive(Debug, Clone)]
+pub struct RewrittenWindowCall {
+    /// `WindowFunction::original_expr` with its arguments, FILTER predicate, and
+    /// OVER clause rewritten to reference the source subquery.
+    pub expr: Expr,
+    /// The FILTER predicate, rewritten to reference the source subquery's
+    /// output columns. AggStep evaluates this once per input row and skips
+    /// the step when it is false. A copy of the predicate already inside
+    /// `expr.filter_over`, lifted to a bare `Expr` so AggStep doesn't have to
+    /// pattern-match it back out on every row.
+    pub filter_expr: Option<Expr>,
+}
+
+impl WindowFunction {
+    /// The expression that downstream lookups should match against: the
+    /// rewritten form once available, otherwise the original.
+    pub fn current_expr(&self) -> &Expr {
+        self.rewritten
+            .as_ref()
+            .map(|r| &r.expr)
+            .unwrap_or(&self.original_expr)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -443,9 +443,8 @@ fn link_with_window(
         }
         window.functions.push(WindowFunction {
             func,
-            filter_expr: None,
             original_expr: expr.clone(),
-            rewritten_expr: None,
+            rewritten: None,
         });
     } else {
         let func_name = match &func {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -13,7 +13,10 @@ use super::{
 use crate::translate::plan::BitSet;
 use crate::translate::{
     emitter::Resolver,
-    expr::{expr_vector_size, unwrap_parens, BindingBehavior, WalkControl},
+    expr::{
+        expr_contains_nondeterministic_scalar_function, expr_vector_size, unwrap_parens,
+        BindingBehavior, WalkControl,
+    },
     plan::{NonFromClauseSubquery, SubqueryState},
 };
 use crate::{
@@ -225,9 +228,11 @@ pub fn resolve_window_and_aggregate_functions(
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
+                                resolver,
                                 expr,
                                 WindowFunctionKind::Agg(f),
                                 over_clause,
+                                filter_over.filter_clause.as_deref(),
                                 distinctness,
                             )?;
                         } else {
@@ -247,9 +252,11 @@ pub fn resolve_window_and_aggregate_functions(
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
+                                resolver,
                                 expr,
                                 WindowFunctionKind::Window(f),
                                 over_clause,
+                                filter_over.filter_clause.as_deref(),
                                 distinctness,
                             )?;
                         } else {
@@ -267,9 +274,11 @@ pub fn resolve_window_and_aggregate_functions(
                                 if let Some(over_clause) = filter_over.over_clause.as_ref() {
                                     link_with_window(
                                         windows.as_deref_mut(),
+                                        resolver,
                                         expr,
                                         WindowFunctionKind::Agg(func),
                                         over_clause,
+                                        filter_over.filter_clause.as_deref(),
                                         distinctness,
                                     )?;
                                 } else {
@@ -303,9 +312,11 @@ pub fn resolve_window_and_aggregate_functions(
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
+                                resolver,
                                 expr,
                                 WindowFunctionKind::Agg(f),
                                 over_clause,
+                                filter_over.filter_clause.as_deref(),
                                 Distinctness::NonDistinct,
                             )?;
                         } else {
@@ -325,9 +336,11 @@ pub fn resolve_window_and_aggregate_functions(
                         if let Some(over_clause) = filter_over.over_clause.as_ref() {
                             link_with_window(
                                 windows.as_deref_mut(),
+                                resolver,
                                 expr,
                                 WindowFunctionKind::Window(f),
                                 over_clause,
+                                filter_over.filter_clause.as_deref(),
                                 Distinctness::NonDistinct,
                             )?;
                         } else {
@@ -360,9 +373,11 @@ pub fn resolve_window_and_aggregate_functions(
                                 if let Some(over_clause) = filter_over.over_clause.as_ref() {
                                     link_with_window(
                                         windows.as_deref_mut(),
+                                        resolver,
                                         expr,
                                         WindowFunctionKind::Agg(func),
                                         over_clause,
+                                        filter_over.filter_clause.as_deref(),
                                         Distinctness::NonDistinct,
                                     )?;
                                 } else {
@@ -395,30 +410,40 @@ pub fn resolve_window_and_aggregate_functions(
 
 fn link_with_window(
     windows: Option<&mut Vec<Window>>,
+    resolver: &Resolver,
     expr: &Expr,
     func: WindowFunctionKind,
     over_clause: &Over,
+    filter_clause: Option<&Expr>,
     distinctness: Distinctness,
 ) -> Result<()> {
     if distinctness.is_distinct() {
         crate::bail_parse_error!("DISTINCT is not supported for window functions");
     }
+    // FILTER decides which input rows contribute to a running aggregate, so
+    // it is only meaningful for aggregating window functions. Non-aggregate
+    // ones (`row_number`/`lag`/`lead`) have nothing to filter.
+    if matches!(func, WindowFunctionKind::Window(_)) && filter_clause.is_some() {
+        crate::bail_parse_error!("FILTER clause may only be used with aggregate window functions");
+    }
     expr_vector_size(expr)?;
     if let Some(windows) = windows {
         let window = resolve_window(windows, over_clause)?;
-        // Dedup: if an equivalent window function expression is already linked to
-        // this window, skip adding it again. Multiple occurrences of the same
-        // window function should share a single entry so the rewrite + emit code
-        // can rely on each entry being rewritten exactly once.
-        if window
-            .functions
-            .iter()
-            .any(|f| exprs_are_equivalent(&f.original_expr, expr))
+        // Two equivalent window expressions can share one `WindowFunction`
+        // entry unless they contain nondeterministic calls like `random()`,
+        // which SQLite evaluates separately at each SQL occurrence.
+        let deduplicate = !expr_contains_nondeterministic_scalar_function(expr, resolver)?;
+        if deduplicate
+            && window
+                .functions
+                .iter()
+                .any(|f| exprs_are_equivalent(&f.original_expr, expr))
         {
             return Ok(());
         }
         window.functions.push(WindowFunction {
             func,
+            filter_expr: None,
             original_expr: expr.clone(),
             rewritten_expr: None,
         });

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -11,7 +11,7 @@ use crate::translate::expr::{
 use crate::translate::order_by::EmitOrderBy;
 use crate::translate::plan::{
     Aggregate, Distinctness, JoinOrderMember, JoinedTable, QueryDestination, ResultSetColumn,
-    SelectPlan, TableReferences, Window, WindowFunction, WindowFunctionKind,
+    RewrittenWindowCall, SelectPlan, TableReferences, Window, WindowFunction, WindowFunctionKind,
 };
 use crate::translate::planner::resolve_window_and_aggregate_functions;
 use crate::translate::result_row::emit_select_result;
@@ -319,20 +319,20 @@ fn rewrite_terminal_expr(
                     {
                         // Window function tied to the current window: rewrite its
                         // children to reference the subquery, not the call itself.
-                        if let Some(rewritten) = &window_function.rewritten_expr {
-                            *expr = rewritten.clone();
+                        if let Some(rewritten) = &window_function.rewritten {
+                            *expr = rewritten.expr.clone();
                         } else {
                             let window_name = current_window
                                 .name
                                 .clone()
                                 .expect("current_window must always have a name here");
-                            rewrite_expr_referencing_current_window(
-                                aggregates,
-                                window_name,
-                                ctx,
-                                expr,
-                                window_function,
-                            )?;
+                            window_function.rewritten =
+                                Some(rewrite_expr_referencing_current_window(
+                                    aggregates,
+                                    window_name,
+                                    ctx,
+                                    expr,
+                                )?);
                         }
                         return Ok(WalkControl::SkipChildren);
                     } else {
@@ -371,7 +371,7 @@ fn find_window_function_entry<'a>(
         if !exprs_are_equivalent(&f.original_expr, expr) {
             continue;
         }
-        if f.rewritten_expr.is_none() {
+        if f.rewritten.is_none() {
             chosen = Some(i);
             break;
         }
@@ -401,15 +401,14 @@ fn push_into_source_subquery(
 
 /// Rewrite a window function call `expr` so its arguments and FILTER predicate
 /// reference output columns of the source subquery (the one being built in
-/// `ctx`), then record the rewritten form and the rewritten filter predicate
-/// on `window_function` for later emission.
+/// `ctx`). Returns the rewritten form, ready to be stored on the matching
+/// `WindowFunction`.
 fn rewrite_expr_referencing_current_window(
     aggregates: &mut Vec<Aggregate>,
     window_name: String,
     ctx: &mut WindowSubqueryContext,
     expr: &mut Expr,
-    window_function: &mut WindowFunction,
-) -> crate::Result<()> {
+) -> crate::Result<RewrittenWindowCall> {
     let filter_over = match expr {
         Expr::FunctionCall {
             args,
@@ -433,10 +432,12 @@ fn rewrite_expr_referencing_current_window(
     if let Some(filter_expr) = filter_over.filter_clause.as_deref_mut() {
         push_into_source_subquery(filter_expr, aggregates, ctx)?;
     }
-    window_function.filter_expr = filter_over.filter_clause.as_deref().cloned();
+    let filter_expr = filter_over.filter_clause.as_deref().cloned();
     filter_over.over_clause = Some(Over::Name(Name::exact(window_name)));
-    window_function.rewritten_expr = Some(expr.clone());
-    Ok(())
+    Ok(RewrittenWindowCall {
+        expr: expr.clone(),
+        filter_expr,
+    })
 }
 
 /// Rewrites an expression into a reference to a subquery column. If an
@@ -619,9 +620,8 @@ impl EmitWindow {
             // Cache by the rewritten form (when available) so lookups against the
             // result-column / ORDER-BY expressions — which were rewritten to
             // reference this window's subquery — find the cached register.
-            let cache_expr = func.rewritten_expr.as_ref().unwrap_or(&func.original_expr);
             t_ctx.resolver.cache_expr_reg(
-                std::borrow::Cow::Borrowed(cache_expr),
+                std::borrow::Cow::Borrowed(func.current_expr()),
                 reg_acc_result_start + i,
                 false,
                 None,
@@ -1034,8 +1034,7 @@ fn emit_aggregation_step(
         // values directly by evaluating the expressions that reference the subquery result columns.
         // Use the rewritten form when available so the args reference the subquery
         // rather than the (no-longer-visible) original tables.
-        let func_expr = func.rewritten_expr.as_ref().unwrap_or(&func.original_expr);
-        let args = match func_expr {
+        let args = match func.current_expr() {
             Expr::FunctionCall { args, .. } => args.iter().map(|a| (**a).clone()).collect(),
             Expr::FunctionCallStar { .. } => vec![],
             _ => unreachable!(
@@ -1046,7 +1045,9 @@ fn emit_aggregation_step(
         let reg_acc_start = registers.acc_start + i;
         // FILTER controls whether the current input row contributes to the
         // running aggregate; it does not suppress the output row itself.
-        let filter_skip_label = if let Some(filter_expr) = &func.filter_expr {
+        let filter_skip_label = if let Some(filter_expr) =
+            func.rewritten.as_ref().and_then(|r| r.filter_expr.as_ref())
+        {
             let label = program.allocate_label();
             let filter_reg = program.alloc_register();
             translate_expr(

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -359,10 +359,8 @@ fn rewrite_terminal_expr(
     )
 }
 
-/// Find the `WindowFunction` entry that this SQL occurrence corresponds to.
-/// Returns an entry that has not been rewritten yet when one exists, so
-/// repeated occurrences of a nondeterministic call each pick a distinct entry;
-/// otherwise returns any equivalent entry (the deduplicated case).
+/// Find the `WindowFunction` entry that this expression corresponds to.
+/// Returns an entry that has not been rewritten yet when one exists.
 fn find_window_function_entry<'a>(
     functions: &'a mut [WindowFunction],
     expr: &Expr,
@@ -382,11 +380,11 @@ fn find_window_function_entry<'a>(
     functions.get_mut(chosen.or(fallback)?)
 }
 
-/// Push `expr` into the input subquery as a result column and replace `*expr`
-/// in place with a reference to that column. Reuses an existing equivalent
-/// column when `expr` is deterministic; nondeterministic calls (e.g.
-/// `random()`) get a fresh column on every occurrence.
-fn push_into_input_subquery(
+/// Add `expr` as an output column of the source subquery (the one being built
+/// in `ctx`) and replace `*expr` with a reference to that column. Reuses an
+/// existing equivalent column when `expr` is deterministic; nondeterministic
+/// calls (e.g. `random()`) get a fresh column on every occurrence.
+fn push_into_source_subquery(
     expr: &mut Expr,
     aggregates: &mut Vec<Aggregate>,
     ctx: &mut WindowSubqueryContext,
@@ -402,8 +400,9 @@ fn push_into_input_subquery(
 }
 
 /// Rewrite a window function call `expr` so its arguments and FILTER predicate
-/// reference the input subquery, then record the rewritten form and the
-/// rewritten filter predicate on `window_function` for later emission.
+/// reference output columns of the source subquery (the one being built in
+/// `ctx`), then record the rewritten form and the rewritten filter predicate
+/// on `window_function` for later emission.
 fn rewrite_expr_referencing_current_window(
     aggregates: &mut Vec<Aggregate>,
     window_name: String,
@@ -419,7 +418,7 @@ fn rewrite_expr_referencing_current_window(
             ..
         } => {
             for arg in args.iter_mut() {
-                push_into_input_subquery(arg, aggregates, ctx)?;
+                push_into_source_subquery(arg, aggregates, ctx)?;
             }
             turso_assert!(
                 order_by.is_empty(),
@@ -432,7 +431,7 @@ fn rewrite_expr_referencing_current_window(
     };
 
     if let Some(filter_expr) = filter_over.filter_clause.as_deref_mut() {
-        push_into_input_subquery(filter_expr, aggregates, ctx)?;
+        push_into_source_subquery(filter_expr, aggregates, ctx)?;
     }
     window_function.filter_expr = filter_over.filter_clause.as_deref().cloned();
     filter_over.over_clause = Some(Over::Name(Name::exact(window_name)));

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -4,11 +4,14 @@ use crate::sync::Arc;
 use crate::translate::aggregation::{translate_aggregation_step, AggArgumentSource};
 use crate::translate::collate::{get_collseq_from_expr, CollationSeq};
 use crate::translate::emitter::{Resolver, TranslateCtx};
-use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
+use crate::translate::expr::{
+    expr_contains_nondeterministic_scalar_function, translate_expr, walk_expr, walk_expr_mut,
+    WalkControl,
+};
 use crate::translate::order_by::EmitOrderBy;
 use crate::translate::plan::{
     Aggregate, Distinctness, JoinOrderMember, JoinedTable, QueryDestination, ResultSetColumn,
-    SelectPlan, TableReferences, Window, WindowFunctionKind,
+    SelectPlan, TableReferences, Window, WindowFunction, WindowFunctionKind,
 };
 use crate::translate::planner::resolve_window_and_aggregate_functions;
 use crate::translate::result_row::emit_select_result;
@@ -25,7 +28,7 @@ use crate::Result;
 use crate::{turso_assert, turso_assert_eq};
 use std::mem;
 use turso_parser::ast::Name;
-use turso_parser::ast::{Expr, FunctionTail, Literal, Over, SortOrder, TableInternalId};
+use turso_parser::ast::{Expr, Literal, Over, SortOrder, TableInternalId};
 
 const SUBQUERY_DATABASE_ID: usize = 0;
 
@@ -311,41 +314,30 @@ fn rewrite_terminal_expr(
                         {
                             rewrite_expr_as_subquery_column(expr, ctx, true);
                         }
-                    } else if let Some(window_function) = current_window
-                        .functions
-                        .iter_mut()
-                        .find(|f| exprs_are_equivalent(&f.original_expr, expr))
+                    } else if let Some(window_function) =
+                        find_window_function_entry(&mut current_window.functions, expr)
                     {
-                        // If the expression is a window function tied to the current window,
-                        // do not push it to the subquery. Instead, rewrite it so its child
-                        // expressions reference the subquery where needed.
-                        //
-                        // The same window function expression may appear in multiple places
-                        // (e.g. both in result columns and in ORDER BY, or twice in result
-                        // columns). The first occurrence performs the rewrite and caches the
-                        // result in `rewritten_expr`; subsequent occurrences just clone the
-                        // cached form so every reference points at the same window output.
+                        // Window function tied to the current window: rewrite its
+                        // children to reference the subquery, not the call itself.
                         if let Some(rewritten) = &window_function.rewritten_expr {
                             *expr = rewritten.clone();
                         } else {
+                            let window_name = current_window
+                                .name
+                                .clone()
+                                .expect("current_window must always have a name here");
                             rewrite_expr_referencing_current_window(
                                 aggregates,
-                                current_window
-                                    .name
-                                    .clone()
-                                    .expect("current_window must always have a name here"),
+                                window_name,
                                 ctx,
                                 expr,
+                                window_function,
                             )?;
-                            window_function.rewritten_expr = Some(expr.clone());
                         }
-
-                        // At this point, the expression and all its children now reference the subquery,
-                        // so further traversal is unnecessary.
                         return Ok(WalkControl::SkipChildren);
                     } else {
-                        // This is a window function referencing a different window (not the current one).
-                        // Push the entire expression to the subquery; it will be rewritten later.
+                        // Window function referencing a different window. Push the
+                        // whole expression to the subquery; it will be rewritten later.
                         rewrite_expr_as_subquery_column(expr, ctx, false);
                     }
                 }
@@ -367,93 +359,132 @@ fn rewrite_terminal_expr(
     )
 }
 
+/// Find the `WindowFunction` entry that this SQL occurrence corresponds to.
+/// Returns an entry that has not been rewritten yet when one exists, so
+/// repeated occurrences of a nondeterministic call each pick a distinct entry;
+/// otherwise returns any equivalent entry (the deduplicated case).
+fn find_window_function_entry<'a>(
+    functions: &'a mut [WindowFunction],
+    expr: &Expr,
+) -> Option<&'a mut WindowFunction> {
+    let mut fallback = None;
+    let mut chosen = None;
+    for (i, f) in functions.iter().enumerate() {
+        if !exprs_are_equivalent(&f.original_expr, expr) {
+            continue;
+        }
+        if f.rewritten_expr.is_none() {
+            chosen = Some(i);
+            break;
+        }
+        fallback.get_or_insert(i);
+    }
+    functions.get_mut(chosen.or(fallback)?)
+}
+
+/// Push `expr` into the input subquery as a result column and replace `*expr`
+/// in place with a reference to that column. Reuses an existing equivalent
+/// column when `expr` is deterministic; nondeterministic calls (e.g.
+/// `random()`) get a fresh column on every occurrence.
+fn push_into_input_subquery(
+    expr: &mut Expr,
+    aggregates: &mut Vec<Aggregate>,
+    ctx: &mut WindowSubqueryContext,
+) -> crate::Result<()> {
+    let contains_aggregates =
+        resolve_window_and_aggregate_functions(expr, ctx.resolver, aggregates, None)?;
+    if expr_contains_nondeterministic_scalar_function(expr, ctx.resolver)? {
+        push_new_subquery_column(expr, ctx, contains_aggregates);
+    } else {
+        rewrite_expr_as_subquery_column(expr, ctx, contains_aggregates);
+    }
+    Ok(())
+}
+
+/// Rewrite a window function call `expr` so its arguments and FILTER predicate
+/// reference the input subquery, then record the rewritten form and the
+/// rewritten filter predicate on `window_function` for later emission.
 fn rewrite_expr_referencing_current_window(
     aggregates: &mut Vec<Aggregate>,
     window_name: String,
     ctx: &mut WindowSubqueryContext,
     expr: &mut Expr,
+    window_function: &mut WindowFunction,
 ) -> crate::Result<()> {
-    fn normalize_over_clause(filter_over: &mut FunctionTail, window_name: &str) {
-        // FILTER clause is not supported yet. Proper checks elsewhere return appropriate
-        // error messages, and this ensures that nothing slips through unnoticed.
-        turso_assert!(
-            filter_over.filter_clause.is_none(),
-            "FILTER in window functions is not supported"
-        );
-
-        // Replace inline OVER clause with a reference to the named window.
-        // The window name may be user-provided or planner-generated.
-        *filter_over = FunctionTail {
-            filter_clause: None,
-            over_clause: Some(Over::Name(Name::exact(window_name.to_string()))),
-        };
-    }
-
-    match expr {
+    let filter_over = match expr {
         Expr::FunctionCall {
-            name: _,
-            distinctness: _,
             args,
             order_by,
             filter_over,
+            ..
         } => {
             for arg in args.iter_mut() {
-                let contains_aggregates =
-                    resolve_window_and_aggregate_functions(arg, ctx.resolver, aggregates, None)?;
-                rewrite_expr_as_subquery_column(arg, ctx, contains_aggregates);
+                push_into_input_subquery(arg, aggregates, ctx)?;
             }
             turso_assert!(
                 order_by.is_empty(),
                 "ORDER BY in window functions is not supported"
             );
-            normalize_over_clause(filter_over, &window_name);
+            filter_over
         }
-        Expr::FunctionCallStar {
-            filter_over,
-            name: _,
-        } => {
-            normalize_over_clause(filter_over, &window_name);
-        }
+        Expr::FunctionCallStar { filter_over, .. } => filter_over,
         _ => unreachable!("only functions can reference windows"),
+    };
+
+    if let Some(filter_expr) = filter_over.filter_clause.as_deref_mut() {
+        push_into_input_subquery(filter_expr, aggregates, ctx)?;
     }
+    window_function.filter_expr = filter_over.filter_clause.as_deref().cloned();
+    filter_over.over_clause = Some(Over::Name(Name::exact(window_name)));
+    window_function.rewritten_expr = Some(expr.clone());
     Ok(())
 }
 
-/// Rewrites an expression into a reference to a subquery column.
-/// If the expression was already pushed down, reuses the existing column index.
-/// Otherwise, adds it as a new column in the subquery's result set.
+/// Rewrites an expression into a reference to a subquery column. If an
+/// equivalent expression was already pushed down, reuses its column index.
 fn rewrite_expr_as_subquery_column(
     expr: &mut Expr,
     ctx: &mut WindowSubqueryContext,
     contains_aggregates: bool,
 ) {
-    let (column_idx, existing) = match ctx
+    if let Some(pos) = ctx
         .subquery_result_columns
         .iter()
         .position(|col| exprs_are_equivalent(&col.expr, expr))
     {
-        Some(pos) => (pos, true),
-        None => (ctx.subquery_result_columns.len(), false),
-    };
+        *expr = Expr::Column {
+            database: Some(SUBQUERY_DATABASE_ID),
+            table: *ctx.subquery_id,
+            column: pos,
+            is_rowid_alias: false,
+        };
+    } else {
+        push_new_subquery_column(expr, ctx, contains_aggregates);
+    }
+}
 
+/// Pushes `expr` as a fresh subquery column even if an equivalent column
+/// already exists. Use this for expressions containing nondeterministic calls
+/// like `random()`, which SQLite evaluates separately at each SQL occurrence.
+fn push_new_subquery_column(
+    expr: &mut Expr,
+    ctx: &mut WindowSubqueryContext,
+    contains_aggregates: bool,
+) {
+    let column_idx = ctx.subquery_result_columns.len();
     let subquery_ref = Expr::Column {
         database: Some(SUBQUERY_DATABASE_ID),
         table: *ctx.subquery_id,
         column: column_idx,
         is_rowid_alias: false,
     };
-
-    if existing {
-        *expr = subquery_ref;
-    } else {
-        let subquery_expr = mem::replace(expr, subquery_ref);
-        ctx.subquery_result_columns.push(ResultSetColumn {
-            expr: subquery_expr,
-            alias: None,
-            implicit_column_name: None,
-            contains_aggregates,
-        });
-    }
+    let subquery_expr = mem::replace(expr, subquery_ref);
+    ctx.subquery_result_columns.push(ResultSetColumn {
+        expr: subquery_expr,
+        alias: None,
+        implicit_column_name: None,
+        contains_aggregates,
+    });
 }
 
 #[derive(Debug)]
@@ -1014,6 +1045,28 @@ fn emit_aggregation_step(
         };
 
         let reg_acc_start = registers.acc_start + i;
+        // FILTER controls whether the current input row contributes to the
+        // running aggregate; it does not suppress the output row itself.
+        let filter_skip_label = if let Some(filter_expr) = &func.filter_expr {
+            let label = program.allocate_label();
+            let filter_reg = program.alloc_register();
+            translate_expr(
+                program,
+                Some(&plan.table_references),
+                filter_expr,
+                filter_reg,
+                resolver,
+            )?;
+            program.emit_insn(Insn::IfNot {
+                reg: filter_reg,
+                target_pc: label,
+                jump_if_null: true,
+            });
+            Some(label)
+        } else {
+            None
+        };
+
         translate_aggregation_step(
             program,
             &plan.table_references,
@@ -1021,6 +1074,9 @@ fn emit_aggregation_step(
             reg_acc_start,
             resolver,
         )?;
+        if let Some(label) = filter_skip_label {
+            program.preassign_label_to_next_insn(label);
+        }
     }
 
     Ok(())

--- a/core/util.rs
+++ b/core/util.rs
@@ -350,6 +350,8 @@ pub fn check_literal_equivalency(lhs: &Literal, rhs: &Literal) -> bool {
         (Literal::Blob(b1), Literal::Blob(b2)) => b1 == b2,
         (Literal::Keyword(k1), Literal::Keyword(k2)) => check_ident_equivalency(k1, k2),
         (Literal::Null, Literal::Null) => true,
+        (Literal::True, Literal::True) => true,
+        (Literal::False, Literal::False) => true,
         (Literal::CurrentDate, Literal::CurrentDate) => true,
         (Literal::CurrentTime, Literal::CurrentTime) => true,
         (Literal::CurrentTimestamp, Literal::CurrentTimestamp) => true,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7399,6 +7399,17 @@ pub fn op_function(
             ScalarFunc::Random => {
                 state.registers[*dest].set_int(pager.io.generate_random_number());
             }
+            #[cfg(feature = "test_helper")]
+            ScalarFunc::TestNondetCounter => {
+                // Test-only: process-global atomic counter that increments on
+                // every evaluation. Used in sqltests to verify that the
+                // planner does not deduplicate equivalent SQL calls that
+                // contain nondeterministic functions.
+                static TEST_NONDET_COUNTER: std::sync::atomic::AtomicI64 =
+                    std::sync::atomic::AtomicI64::new(0);
+                let value = TEST_NONDET_COUNTER.fetch_add(1, Ordering::Relaxed);
+                state.registers[*dest].set_int(value);
+            }
             ScalarFunc::Trim => {
                 let reg_value = &state.registers[*start_reg];
                 let pattern_value = if func.arg_count == 2 {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6425,7 +6425,9 @@ pub fn op_agg_final(
             state.registers[dest_reg].set_value(value);
         }
         Register::Value(Value::Null) => {
-            // When the set is empty, return appropriate default
+            // No row was stepped: write the empty-set default explicitly.
+            // For window aggregates `dest_reg` differs from `acc_reg` and may
+            // still hold an earlier partition's result.
             match func {
                 AggFunc::Total => {
                     state.registers[dest_reg]
@@ -6479,7 +6481,9 @@ pub fn op_agg_final(
                     };
                     state.registers[dest_reg].set_value(value);
                 }
-                _ => {}
+                _ => {
+                    state.registers[dest_reg].set_value(Value::Null);
+                }
             }
         }
         other => {

--- a/testing/sqltests/Cargo.toml
+++ b/testing/sqltests/Cargo.toml
@@ -53,8 +53,10 @@ fake = { version = "4.4", features = ["derive", "rand_core"] }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 
-# Turso Rust bindings
-turso = { workspace = true }
+# Turso Rust bindings.
+# `test_helper` exposes test-only SQL functions (e.g. test_nondet_counter)
+# that the sqltests use to observe planner behavior.
+turso = { workspace = true, features = ["test_helper"] }
 
 # Turso SQL parser (for splitting multi-statement SQL)
 turso_parser = { workspace = true }

--- a/testing/sqltests/Makefile
+++ b/testing/sqltests/Makefile
@@ -26,7 +26,7 @@ build: build-tursodb build-runner
 
 # Build tursodb CLI
 build-tursodb:
-	cd $(ROOT_DIR) && cargo build $(CARGO_PROFILE) --package turso_cli
+	cd $(ROOT_DIR) && cargo build $(CARGO_PROFILE) --package turso_cli --features test_helper
 
 # Build the test runner
 build-runner:
@@ -72,7 +72,7 @@ run-rust: build-runner
 # Build JavaScript bindings (requires Node.js and yarn)
 JS_DIR := $(ROOT_DIR)/bindings/javascript
 build-js-bindings:
-	cd $(JS_DIR) && yarn install && yarn workspace @tursodatabase/database-common build && yarn workspace @tursodatabase/database build
+	cd $(JS_DIR) && yarn install && yarn workspace @tursodatabase/database-common build && yarn workspace @tursodatabase/database build:test-helper
 
 # Run tests with JavaScript backend (Node.js + @tursodatabase/database)
 run-js: build-runner build-js-bindings

--- a/testing/sqltests/tests/window/filter-over.sqltest
+++ b/testing/sqltests/tests/window/filter-over.sqltest
@@ -355,6 +355,46 @@ expect {
 }
 
 @setup filter_over_base
+@cross-check-integrity
+test filter-over-repeated-deterministic-correlated-subquery-filter {
+    WITH markers(id) AS (VALUES (1),(3),(5))
+    SELECT DISTINCT
+           sum(val) FILTER (
+               WHERE EXISTS (SELECT 1 FROM markers m WHERE m.id = filter_over_items.id)
+           ) OVER () AS a,
+           sum(val) FILTER (
+               WHERE EXISTS (SELECT 1 FROM markers m WHERE m.id = filter_over_items.id)
+           ) OVER () AS b,
+           count(*) FILTER (
+               WHERE id IN (SELECT m.id FROM markers m)
+           ) OVER () AS marker_count
+    FROM filter_over_items;
+}
+expect {
+    25|25|3
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-multiple-window-layers-with-filters {
+    SELECT id,
+           sum(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp ORDER BY id),
+           sum(val) FILTER (WHERE y IS NOT NULL) OVER (ORDER BY id DESC),
+           count(*) FILTER (WHERE kind='x') OVER (PARTITION BY kind ORDER BY id)
+    FROM filter_over_items
+    ORDER BY id;
+}
+expect {
+    1|10|55|1
+    2|10|45|0
+    3|10|45|2
+    4||45|3
+    5|15|40|0
+    6|15|25|4
+    7|||0
+}
+
+@setup filter_over_base
 test filter-over-distinct-argument-rejected {
     SELECT count(DISTINCT val) FILTER (WHERE flag) OVER (PARTITION BY grp)
     FROM filter_over_items;
@@ -379,6 +419,15 @@ test filter-over-non-aggregate-window-rejected {
 }
 expect error {
     FILTER clause may only be used with aggregate window functions
+}
+
+@setup filter_over_base
+test filter-over-scalar-function-rejected {
+    SELECT abs(val) FILTER (WHERE flag=1) OVER ()
+    FROM filter_over_items;
+}
+expect error {
+    may not be used as a window function
 }
 
 @setup filter_over_base
@@ -466,6 +515,84 @@ test filter-over-mixed-deterministic-and-nondeterministic-dedup {
 }
 expect {
     25|25|7
+}
+
+@setup filter_over_base
+@backend cli
+@skip-if sqlite "uses turso-only test_nondet_counter() to observe nondet dedup behavior"
+test filter-over-nondeterministic-subquery-filter-dedup {
+    -- The nondeterministic call is inside the FILTER subquery. Repeated
+    -- SQL occurrences must get independent filter columns; otherwise both
+    -- sums read the same predicate stream and the difference collapses to 0.
+    WITH diffs(ord, scenario, abs_diff) AS (
+        SELECT DISTINCT
+               1,
+               'exists',
+               abs(
+                   coalesce(sum(val) FILTER (
+                       WHERE EXISTS (
+                           SELECT 1
+                           WHERE filter_over_items.id > 0
+                             AND (test_nondet_counter() % 2) = 0
+                       )
+                   ) OVER (), 0)
+                   -
+                   coalesce(sum(val) FILTER (
+                       WHERE EXISTS (
+                           SELECT 1
+                           WHERE filter_over_items.id > 0
+                             AND (test_nondet_counter() % 2) = 0
+                       )
+                   ) OVER (), 0)
+               )
+        FROM filter_over_items
+        UNION ALL
+        SELECT DISTINCT
+               2,
+               'in-select',
+               abs(
+                   coalesce(sum(val) FILTER (
+                       WHERE id IN (
+                           SELECT filter_over_items.id
+                           WHERE (test_nondet_counter() % 2) = 0
+                       )
+                   ) OVER (), 0)
+                   -
+                   coalesce(sum(val) FILTER (
+                       WHERE id IN (
+                           SELECT filter_over_items.id
+                           WHERE (test_nondet_counter() % 2) = 0
+                       )
+                   ) OVER (), 0)
+               )
+        FROM filter_over_items
+        UNION ALL
+        SELECT DISTINCT
+               3,
+               'scalar-subquery',
+               abs(
+                   coalesce(sum(val) FILTER (
+                       WHERE (
+                           SELECT (test_nondet_counter() % 2) = 0
+                           WHERE filter_over_items.id > 0
+                       )
+                   ) OVER (), 0)
+                   -
+                   coalesce(sum(val) FILTER (
+                       WHERE (
+                           SELECT (test_nondet_counter() % 2) = 0
+                           WHERE filter_over_items.id > 0
+                       )
+                   ) OVER (), 0)
+               )
+        FROM filter_over_items
+    )
+    SELECT scenario, abs_diff FROM diffs ORDER BY ord;
+}
+expect {
+    exists|75
+    in-select|75
+    scalar-subquery|75
 }
 
 @setup filter_over_base

--- a/testing/sqltests/tests/window/filter-over.sqltest
+++ b/testing/sqltests/tests/window/filter-over.sqltest
@@ -382,26 +382,29 @@ expect error {
 }
 
 @setup filter_over_base
-@cross-check-integrity
-test filter-over-repeated-nondeterministic-filter {
-    -- `random()*0 = 0` is always true but contains a nondeterministic call,
-    -- which must disable FILTER-clause dedup. Both result columns should still
-    -- evaluate to the same `flag=1` count; the test asserts the query plans
-    -- and executes correctly with two distinct subquery columns for the
-    -- otherwise-identical FILTER predicates.
-    SELECT id,
-           count(*) FILTER (WHERE flag=1 AND random()*0 = 0) OVER (PARTITION BY grp),
-           count(*) FILTER (WHERE flag=1 AND random()*0 = 0) OVER (PARTITION BY grp)
-    FROM filter_over_items ORDER BY id;
+@skip-if sqlite "uses turso-only test_nondet_counter() to observe nondet dedup behavior"
+test filter-over-repeated-nondeterministic-call {
+    -- Two window calls with identical nondeterministic arguments. The planner
+    -- must NOT dedup them: each call needs its own source-subquery column, so
+    -- the two aggregates accumulate independent counter streams.
+    --
+    -- Per source row, the source subquery evaluates the two argument columns
+    -- in order, so successive counter calls alternate between them. Each
+    -- column sees counter values that differ from the other column's by exactly
+    -- one per row — over 7 rows, abs(sum_a - sum_b) = 7. If the two calls were
+    -- wrongly deduped, both aggregates would read the same per-row counter
+    -- value and abs_diff would be 0.
+    --
+    -- The same `push_into_source_subquery` codepath handles dedup-skip for
+    -- both function arguments and FILTER predicates, so a single args-based
+    -- test exercises it.
+    SELECT DISTINCT
+           abs((sum(test_nondet_counter()) OVER ()) -
+               (sum(test_nondet_counter()) OVER ())) AS abs_diff
+    FROM filter_over_items;
 }
 expect {
-    1|2|2
-    2|2|2
-    3|2|2
-    4|1|1
-    5|1|1
-    6|1|1
-    7|0|0
+    7
 }
 
 @setup filter_over_base
@@ -439,27 +442,30 @@ expect @js {
 }
 
 @setup filter_over_base
-@cross-check-integrity
+@skip-if sqlite "uses turso-only test_nondet_counter() to observe walker pairing"
 test filter-over-mixed-deterministic-and-nondeterministic-dedup {
-    -- Exercises the planner's mixed-dedup pairing: three identical
-    -- deterministic FILTER calls collapse to one `WindowFunction` entry; the
-    -- nondeterministic copy gets its own entry. The walker must pair each SQL
-    -- occurrence with the correct entry.
-    SELECT id,
+    -- Two identical deterministic calls (a, b) collapse to one WindowFunction
+    -- entry. Two identical nondeterministic calls must each get their own
+    -- entry; the walker picks a fresh entry per SQL occurrence so the two
+    -- accumulators see independent counter streams.
+    --
+    -- Per source row, the source subquery evaluates one column for {a,b} (the
+    -- shared deterministic argument `val`) and two separate columns for the
+    -- two nondet occurrences (one fresh column per occurrence). Within the
+    -- same row, the first nondet call precedes the second, so one column sums
+    -- counter values at row offsets 0,2,4,... and the other at 1,3,5,... —
+    -- giving a difference of exactly one counter increment per row, i.e. 7.
+    -- If the walker wrongly paired both nondet occurrences with the same
+    -- entry, the two sums would be equal and the difference would be 0.
+    SELECT DISTINCT
            sum(val) FILTER (WHERE flag=1) OVER () AS a,
            sum(val) FILTER (WHERE flag=1) OVER () AS b,
-           sum(val) FILTER (WHERE flag=1) OVER () AS c,
-           count(*) FILTER (WHERE flag=1 AND random()*0=0) OVER () AS d
-    FROM filter_over_items ORDER BY id;
+           abs((sum(test_nondet_counter()) OVER ()) -
+               (sum(test_nondet_counter()) OVER ())) AS nondet_pair_diff
+    FROM filter_over_items;
 }
 expect {
-    1|25|25|25|3
-    2|25|25|25|3
-    3|25|25|25|3
-    4|25|25|25|3
-    5|25|25|25|3
-    6|25|25|25|3
-    7|25|25|25|3
+    25|25|7
 }
 
 @setup filter_over_base

--- a/testing/sqltests/tests/window/filter-over.sqltest
+++ b/testing/sqltests/tests/window/filter-over.sqltest
@@ -1,0 +1,521 @@
+@database :memory:
+
+setup filter_over_base {
+    CREATE TABLE filter_over_items(
+        id INTEGER PRIMARY KEY,
+        grp TEXT COLLATE NOCASE,
+        kind TEXT,
+        val INTEGER,
+        y INTEGER,
+        flag INTEGER,
+        txt TEXT COLLATE NOCASE
+    );
+    INSERT INTO filter_over_items VALUES
+        (1,'a','x',10,100,1,'alpha'),
+        (2,'a','y',20,NULL,0,'Beta'),
+        (3,'a','x',NULL,300,1,'ALPHA'),
+        (4,'b','x',5,50,NULL,'delta'),
+        (5,'b','y',15,150,1,'epsilon'),
+        (6,'B','x',25,250,0,'Gamma'),
+        (7,'c','y',NULL,NULL,NULL,'eta');
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-full-window-aggregate-matrix {
+    SELECT id,
+           sum(val) FILTER (WHERE flag) OVER (),
+           count(*) FILTER (WHERE flag) OVER (),
+           count(val) FILTER (WHERE flag) OVER (),
+           avg(val) FILTER (WHERE flag) OVER (),
+           min(val) FILTER (WHERE flag) OVER (),
+           max(val) FILTER (WHERE flag) OVER (),
+           count(*) FILTER (WHERE y IS NULL) OVER ()
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|25|3|2|12.5|10|15|2
+    2|25|3|2|12.5|10|15|2
+    3|25|3|2|12.5|10|15|2
+    4|25|3|2|12.5|10|15|2
+    5|25|3|2|12.5|10|15|2
+    6|25|3|2|12.5|10|15|2
+    7|25|3|2|12.5|10|15|2
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-empty-filter-results {
+    SELECT id,
+           count(*) FILTER (WHERE 0) OVER (),
+           count(val) FILTER (WHERE NULL) OVER (),
+           sum(val) FILTER (WHERE 0) OVER (),
+           avg(val) FILTER (WHERE 0) OVER (),
+           min(val) FILTER (WHERE 0) OVER (),
+           max(val) FILTER (WHERE 0) OVER ()
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|0|0||||
+    2|0|0||||
+    3|0|0||||
+    4|0|0||||
+    5|0|0||||
+    6|0|0||||
+    7|0|0||||
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-partition-and-running-default-frame {
+    SELECT id, grp,
+           sum(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp ORDER BY id),
+           count(*) FILTER (WHERE y IS NOT NULL) OVER (PARTITION BY grp),
+           count(*) FILTER (WHERE y IS NULL) OVER (PARTITION BY grp ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|a|10|2|0
+    2|a|10|2|1
+    3|a|10|2|1
+    4|b||3|0
+    5|b|15|3|0
+    6|B|15|3|0
+    7|c||0|1
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-same-row-columns-and-case {
+    SELECT id, grp,
+           count(*) FILTER (WHERE val > y / 10) OVER w,
+           sum(val) FILTER (
+               WHERE CASE
+                   WHEN kind = 'x' THEN y IS NOT NULL
+                   WHEN kind = 'y' THEN flag = 1
+                   ELSE flag
+               END
+           ) OVER w
+    FROM filter_over_items
+    WINDOW w AS (PARTITION BY grp ORDER BY id)
+    ORDER BY id;
+}
+expect {
+    1|a|0|10
+    2|a|0|10
+    3|a|0|10
+    4|b|0|5
+    5|b|0|20
+    6|B|0|45
+    7|c|0|
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-group-concat-collation-order {
+    SELECT id, grp,
+           group_concat(txt, '.') FILTER (WHERE kind = 'x') OVER (
+               PARTITION BY grp ORDER BY txt COLLATE NOCASE, id
+           )
+    FROM filter_over_items
+    WHERE grp = 'b'
+    ORDER BY txt COLLATE NOCASE, id;
+}
+expect {
+    4|b|delta
+    5|b|delta
+    6|B|delta.Gamma
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-identical-window-different-filters {
+    SELECT id,
+           sum(val) FILTER (WHERE flag=1) OVER win,
+           sum(val) FILTER (WHERE flag=0) OVER win,
+           count(*) FILTER (WHERE kind='x') OVER win
+    FROM filter_over_items
+    WINDOW win AS (PARTITION BY grp ORDER BY id)
+    ORDER BY id;
+}
+expect {
+    1|10||1
+    2|10|20|1
+    3|10|20|2
+    4|||1
+    5|15||1
+    6|15|25|2
+    7|||0
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-cte {
+    WITH base AS (SELECT id, grp, val, flag FROM filter_over_items)
+    SELECT id, sum(val) FILTER (WHERE flag) OVER (PARTITION BY grp ORDER BY id)
+    FROM base ORDER BY id;
+}
+expect {
+    1|10
+    2|10
+    3|10
+    4|
+    5|15
+    6|15
+    7|
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-subquery-outer-where-alias {
+    SELECT id, filtered_sum FROM (
+        SELECT id, sum(val) FILTER (WHERE flag=1) OVER (ORDER BY id) AS filtered_sum
+        FROM filter_over_items
+    ) WHERE filtered_sum >= 25 ORDER BY id;
+}
+expect {
+    5|25
+    6|25
+    7|25
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-order-by-expression {
+    SELECT id FROM filter_over_items
+    ORDER BY sum(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp) DESC, id;
+}
+expect {
+    4
+    5
+    6
+    1
+    2
+    3
+    7
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-grouped-result {
+    SELECT grp, count(*) AS n,
+           sum(count(*)) FILTER (WHERE grp='a') OVER ()
+    FROM filter_over_items GROUP BY grp ORDER BY grp;
+}
+expect {
+    a|3|3
+    b|3|3
+    c|1|3
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-filter-expression-subquery {
+    SELECT id,
+           sum(val) FILTER (
+               WHERE EXISTS (SELECT 1 WHERE filter_over_items.flag=1)
+           ) OVER (ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|10
+    2|10
+    3|10
+    4|10
+    5|25
+    6|25
+    7|25
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-between-and-null-predicates {
+    SELECT id,
+           max(val) FILTER (WHERE y BETWEEN 100 AND 250) OVER (PARTITION BY grp ORDER BY id),
+           min(val) FILTER (WHERE y IS NULL OR flag IS NULL) OVER (PARTITION BY grp ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|10|
+    2|10|20
+    3|10|20
+    4||5
+    5|15|5
+    6|25|5
+    7||
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-count-star-is-true-false {
+    SELECT id,
+           count(*) FILTER (WHERE flag IS TRUE) OVER (ORDER BY id),
+           count(*) FILTER (WHERE flag IS FALSE) OVER (ORDER BY id),
+           count(*) FILTER (WHERE flag IS NOT TRUE) OVER (ORDER BY id),
+           count(*) FILTER (WHERE flag IS NOT FALSE) OVER (ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|1|0|0|1
+    2|1|1|1|1
+    3|2|1|1|2
+    4|2|1|2|3
+    5|3|1|2|4
+    6|3|2|3|4
+    7|3|2|4|5
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-empty-prefix-defaults {
+    SELECT id,
+           count(*) FILTER (WHERE id >= 5) OVER (ORDER BY id),
+           total(val) FILTER (WHERE id >= 5) OVER (ORDER BY id),
+           group_concat(val) FILTER (WHERE id >= 5) OVER (ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|0|0.0|
+    2|0|0.0|
+    3|0|0.0|
+    4|0|0.0|
+    5|1|15.0|15
+    6|2|40.0|15,25
+    7|3|40.0|15,25
+}
+expect @js {
+    1|0|0|
+    2|0|0|
+    3|0|0|
+    4|0|0|
+    5|1|15|15
+    6|2|40|15,25
+    7|3|40|15,25
+}
+
+setup filter_over_peers {
+    CREATE TABLE filter_over_peers(id INTEGER, grp TEXT, ord INTEGER, x INTEGER, flag INTEGER);
+    INSERT INTO filter_over_peers VALUES
+        (1,'a',1,10,1),
+        (2,'a',2,20,0),
+        (3,'a',2,30,1),
+        (4,'a',3,40,0),
+        (5,'b',1,5,0),
+        (6,'b',1,6,1);
+}
+
+@setup filter_over_peers
+@cross-check-integrity
+test filter-over-peer-group-default-range {
+    SELECT id,
+           sum(x) FILTER (WHERE flag) OVER (PARTITION BY grp ORDER BY ord),
+           count(*) FILTER (WHERE flag) OVER (PARTITION BY grp ORDER BY ord)
+    FROM filter_over_peers ORDER BY id;
+}
+expect {
+    1|10|1
+    2|40|2
+    3|40|2
+    4|40|2
+    5|6|1
+    6|6|1
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-repeated-expression-cache {
+    SELECT id,
+           coalesce(sum(val) FILTER (WHERE flag) OVER w, -1),
+           sum(val) FILTER (WHERE flag) OVER w
+    FROM filter_over_items
+    WINDOW w AS (ORDER BY id)
+    ORDER BY 2 DESC, id;
+}
+expect {
+    5|25|25
+    6|25|25
+    7|25|25
+    1|10|10
+    2|10|10
+    3|10|10
+    4|10|10
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-grouped-filter-aggregate-predicate {
+    SELECT grp, sum(val),
+           sum(sum(val)) FILTER (WHERE count(*) > 1) OVER (ORDER BY grp)
+    FROM filter_over_items GROUP BY grp ORDER BY grp;
+}
+expect {
+    a|30|30
+    b|45|75
+    c||75
+}
+
+@setup filter_over_base
+test filter-over-distinct-argument-rejected {
+    SELECT count(DISTINCT val) FILTER (WHERE flag) OVER (PARTITION BY grp)
+    FROM filter_over_items;
+}
+expect error {
+    DISTINCT is not supported for window functions
+}
+
+@setup filter_over_base
+test filter-over-nested-window-in-filter-rejected {
+    SELECT sum(val) FILTER (WHERE row_number() OVER (ORDER BY id) = 1) OVER ()
+    FROM filter_over_items;
+}
+expect error {
+    misuse of window function
+}
+
+@setup filter_over_base
+test filter-over-non-aggregate-window-rejected {
+    SELECT row_number() FILTER (WHERE flag=1) OVER (ORDER BY id)
+    FROM filter_over_items;
+}
+expect error {
+    FILTER clause may only be used with aggregate window functions
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-repeated-nondeterministic-filter {
+    -- `random()*0 = 0` is always true but contains a nondeterministic call,
+    -- which must disable FILTER-clause dedup. Both result columns should still
+    -- evaluate to the same `flag=1` count; the test asserts the query plans
+    -- and executes correctly with two distinct subquery columns for the
+    -- otherwise-identical FILTER predicates.
+    SELECT id,
+           count(*) FILTER (WHERE flag=1 AND random()*0 = 0) OVER (PARTITION BY grp),
+           count(*) FILTER (WHERE flag=1 AND random()*0 = 0) OVER (PARTITION BY grp)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|2|2
+    2|2|2
+    3|2|2
+    4|1|1
+    5|1|1
+    6|1|1
+    7|0|0
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-empty-filtered-partition {
+    -- Regression test for the `Insn::AggValue` NULL-init fix. Partition 'c'
+    -- (row 7) has flag=NULL so no row passes the FILTER. Without the fix the
+    -- destination register would still hold the previous partition's value
+    -- (15) instead of NULL.
+    SELECT id, grp,
+           sum(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp ORDER BY id),
+           avg(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp ORDER BY id),
+           min(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp ORDER BY id),
+           max(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|a|10|10.0|10|10
+    2|a|10|10.0|10|10
+    3|a|10|10.0|10|10
+    4|b||||
+    5|b|15|15.0|15|15
+    6|B|15|15.0|15|15
+    7|c||||
+}
+# JS Number drops the .0 suffix on integer-valued floats
+expect @js {
+    1|a|10|10|10|10
+    2|a|10|10|10|10
+    3|a|10|10|10|10
+    4|b||||
+    5|b|15|15|15|15
+    6|B|15|15|15|15
+    7|c||||
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-mixed-deterministic-and-nondeterministic-dedup {
+    -- Exercises the planner's mixed-dedup pairing: three identical
+    -- deterministic FILTER calls collapse to one `WindowFunction` entry; the
+    -- nondeterministic copy gets its own entry. The walker must pair each SQL
+    -- occurrence with the correct entry.
+    SELECT id,
+           sum(val) FILTER (WHERE flag=1) OVER () AS a,
+           sum(val) FILTER (WHERE flag=1) OVER () AS b,
+           sum(val) FILTER (WHERE flag=1) OVER () AS c,
+           count(*) FILTER (WHERE flag=1 AND random()*0=0) OVER () AS d
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|25|25|25|3
+    2|25|25|25|3
+    3|25|25|25|3
+    4|25|25|25|3
+    5|25|25|25|3
+    6|25|25|25|3
+    7|25|25|25|3
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-multi-key-partition {
+    SELECT id, grp, kind,
+           sum(val) FILTER (WHERE flag=1) OVER (PARTITION BY grp, kind ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|a|x|10
+    2|a|y|
+    3|a|x|10
+    4|b|x|
+    5|b|y|15
+    6|B|x|
+    7|c|y|
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-non-boolean-truthy-predicates {
+    -- Any nonzero numeric (including negative and fractional) is truthy;
+    -- 0, 0.0, and NULL all skip the row.
+    SELECT DISTINCT
+           sum(val) FILTER (WHERE 2) OVER () AS pos_int,
+           sum(val) FILTER (WHERE -1) OVER () AS neg_int,
+           sum(val) FILTER (WHERE 0.5) OVER () AS frac,
+           sum(val) FILTER (WHERE -0.0) OVER () AS neg_zero,
+           sum(val) FILTER (WHERE NULL) OVER () AS null_pred
+    FROM filter_over_items;
+}
+expect {
+    75|75|75||
+}
+
+@setup filter_over_base
+@cross-check-integrity
+test filter-over-correlated-subquery-in-filter {
+    -- The FILTER predicate contains a correlated EXISTS subquery that
+    -- references the outer row via `filter_over_items.id`. After the planner
+    -- rewrites FILTER into an input-subquery column, the correlation must
+    -- still resolve to the right input row at AggStep time.
+    WITH markers(id) AS (VALUES (1),(3),(5))
+    SELECT id, grp,
+           sum(val) FILTER (
+               WHERE EXISTS (SELECT 1 FROM markers m WHERE m.id = filter_over_items.id)
+           ) OVER (PARTITION BY grp ORDER BY id)
+    FROM filter_over_items ORDER BY id;
+}
+expect {
+    1|a|10
+    2|a|10
+    3|a|10
+    4|b|
+    5|b|15
+    6|B|15
+    7|c|
+}


### PR DESCRIPTION
We used to panic here, so instead of making the simple change to turn that into a parse error like "Unsupported xyz", let's just add support.

Closes #7342