### PR TITLE
core/mvcc: remove unused read_set and add batch query read bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "query-batch-benchmark"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "rusqlite",
+ "tokio",
+ "turso",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "perf/throughput/rusqlite",
     "perf/encryption",
     "perf/memory",
+    "perf/query-batch",
     "tools/dbhash",
     "sdk-kit",
     "sdk-kit-macros",

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -594,8 +594,6 @@ pub struct Transaction {
     begin_ts: u64,
     /// The transaction write set. Only writer is the [Transaction]'s own connection.
     write_set: Mutex<WriteSet>,
-    /// The transaction read set.
-    read_set: Mutex<Vec<RowID>>,
     /// The transaction header.
     header: RwLock<DatabaseHeader>,
     /// True when the transaction mutated its local database header snapshot.
@@ -626,7 +624,6 @@ impl Transaction {
             tx_id,
             begin_ts,
             write_set: Mutex::new(WriteSet::new()),
-            read_set: Mutex::new(Vec::new()),
             header: RwLock::new(header),
             header_dirty: AtomicBool::new(false),
             savepoint_stack: RwLock::new(Vec::new()),
@@ -635,10 +632,6 @@ impl Transaction {
             abort_now: AtomicBool::new(false),
             commit_dep_set: Mutex::new(HashSet::default()),
         }
-    }
-
-    fn insert_to_read_set(&self, id: RowID) {
-        self.read_set.lock().push(id);
     }
 
     fn insert_to_write_set(&self, id: RowID, row_versions: RowVersions) {
@@ -887,14 +880,6 @@ impl std::fmt::Display for Transaction {
                 write!(f, ", ")?
             }
             write!(f, "{id:?}")?;
-        }
-
-        write!(f, "], read_set: [")?;
-        for (i, v) in self.read_set.lock().iter().enumerate() {
-            if i > 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{:?}", *v)?;
         }
 
         write!(f, "] }}")
@@ -3732,7 +3717,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         .rev()
                         .find(|rv| rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
                     {
-                        tx.insert_to_read_set(id.clone());
                         return Ok(Some(rv.row.clone()));
                     }
                 }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 use crate::{Connection, Pager, SyncMode};
 use crossbeam_skiplist::map::Entry;
-use crossbeam_skiplist::{SkipMap, SkipSet};
+use crossbeam_skiplist::SkipMap;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 use std::collections::BTreeSet;
@@ -595,7 +595,7 @@ pub struct Transaction {
     /// The transaction write set. Only writer is the [Transaction]'s own connection.
     write_set: Mutex<WriteSet>,
     /// The transaction read set.
-    read_set: SkipSet<RowID>,
+    read_set: Mutex<Vec<RowID>>,
     /// The transaction header.
     header: RwLock<DatabaseHeader>,
     /// True when the transaction mutated its local database header snapshot.
@@ -626,7 +626,7 @@ impl Transaction {
             tx_id,
             begin_ts,
             write_set: Mutex::new(WriteSet::new()),
-            read_set: SkipSet::new(),
+            read_set: Mutex::new(Vec::new()),
             header: RwLock::new(header),
             header_dirty: AtomicBool::new(false),
             savepoint_stack: RwLock::new(Vec::new()),
@@ -638,7 +638,7 @@ impl Transaction {
     }
 
     fn insert_to_read_set(&self, id: RowID) {
-        self.read_set.insert(id);
+        self.read_set.lock().push(id);
     }
 
     fn insert_to_write_set(&self, id: RowID, row_versions: RowVersions) {
@@ -890,11 +890,11 @@ impl std::fmt::Display for Transaction {
         }
 
         write!(f, "], read_set: [")?;
-        for (i, v) in self.read_set.iter().enumerate() {
+        for (i, v) in self.read_set.lock().iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "{:?}", *v.value())?;
+            write!(f, "{:?}", *v)?;
         }
 
         write!(f, "] }}")

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4274,7 +4274,7 @@ fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Transaction {
         tx_id,
         begin_ts,
         write_set: Mutex::new(WriteSet::new()),
-        read_set: SkipSet::new(),
+        read_set: Mutex::new(Vec::new()),
         header: RwLock::new(DatabaseHeader::default()),
         header_dirty: AtomicBool::new(false),
         savepoint_stack: RwLock::new(Vec::new()),
@@ -5849,9 +5849,13 @@ fn transaction_display() {
         write_set
     });
 
-    let read_set = SkipSet::new();
-    read_set.insert(RowID::new((-2).into(), RowKey::Int(17)));
-    read_set.insert(RowID::new((-2).into(), RowKey::Int(19)));
+    let read_set = Mutex::new(Vec::new());
+    read_set
+        .lock()
+        .push(RowID::new((-2).into(), RowKey::Int(17)));
+    read_set
+        .lock()
+        .push(RowID::new((-2).into(), RowKey::Int(19)));
 
     let tx = Transaction {
         state,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4274,7 +4274,6 @@ fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Transaction {
         tx_id,
         begin_ts,
         write_set: Mutex::new(WriteSet::new()),
-        read_set: Mutex::new(Vec::new()),
         header: RwLock::new(DatabaseHeader::default()),
         header_dirty: AtomicBool::new(false),
         savepoint_stack: RwLock::new(Vec::new()),
@@ -5849,20 +5848,11 @@ fn transaction_display() {
         write_set
     });
 
-    let read_set = Mutex::new(Vec::new());
-    read_set
-        .lock()
-        .push(RowID::new((-2).into(), RowKey::Int(17)));
-    read_set
-        .lock()
-        .push(RowID::new((-2).into(), RowKey::Int(19)));
-
     let tx = Transaction {
         state,
         tx_id,
         begin_ts,
         write_set,
-        read_set,
         header: RwLock::new(DatabaseHeader::default()),
         header_dirty: AtomicBool::new(false),
         savepoint_stack: RwLock::new(Vec::new()),
@@ -5872,7 +5862,7 @@ fn transaction_display() {
         commit_dep_set: Mutex::new(HashSet::default()),
     };
 
-    let expected = "{ state: Preparing(20250915), id: 42, begin_ts: 20250914, write_set: [RowID { table_id: MVTableId(-2), row_id: Int(11) }, RowID { table_id: MVTableId(-2), row_id: Int(13) }], read_set: [RowID { table_id: MVTableId(-2), row_id: Int(17) }, RowID { table_id: MVTableId(-2), row_id: Int(19) }] }";
+    let expected = "{ state: Preparing(20250915), id: 42, begin_ts: 20250914, write_set: [RowID { table_id: MVTableId(-2), row_id: Int(11) }, RowID { table_id: MVTableId(-2), row_id: Int(13) }] }";
     let output = format!("{tx}");
     assert_eq!(output, expected);
 }

--- a/perf/query-batch/Cargo.toml
+++ b/perf/query-batch/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "query-batch-benchmark"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+
+[dependencies]
+turso = { workspace = true }
+rusqlite = { workspace = true }
+tokio = { workspace = true, default-features = true, features = ["full"] }
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "query_batch"
+harness = false

--- a/perf/query-batch/benches/query_batch.rs
+++ b/perf/query-batch/benches/query_batch.rs
@@ -7,19 +7,6 @@
 //! SELECT id, name, value, is_active FROM test_table WHERE is_active = ?
 //! ```
 //!
-//! Both lanes use an equivalent mapper that materializes all four columns of
-//! every row into a `Record`. The structural difference under test:
-//!
-//! * SQLite (rusqlite) crosses into the query engine once and iterates rows in
-//!   a tight synchronous `sqlite3_step` loop.
-//! * Turso runs in MVCC mode and its `Rows::next()` is `async` (the engine
-//!   yields per row), so every row pays the runtime's poll/wake machinery even
-//!   when the next row is already available. MVCC mode is the dominant cost
-//!   here: it roughly quadruples the per-row time versus legacy mode.
-//!
-//! At small row counts the per-query fixed cost dominates and the two are
-//! comparable; as the row count grows the per-row `.await` overhead makes Turso
-//! progressively slower. Sweeping the row count makes the crossover visible.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use tokio::runtime::Runtime;

--- a/perf/query-batch/benches/query_batch.rs
+++ b/perf/query-batch/benches/query_batch.rs
@@ -1,0 +1,167 @@
+//! Reproduces a per-row latency gap between Turso and SQLite on small batch
+//! reads.
+//!
+//! The query returns every row of a table whose rows all share one flag value:
+//!
+//! ```sql
+//! SELECT id, name, value, is_active FROM test_table WHERE is_active = ?
+//! ```
+//!
+//! Both lanes use an equivalent mapper that materializes all four columns of
+//! every row into a `Record`. The structural difference under test:
+//!
+//! * SQLite (rusqlite) crosses into the query engine once and iterates rows in
+//!   a tight synchronous `sqlite3_step` loop.
+//! * Turso runs in MVCC mode and its `Rows::next()` is `async` (the engine
+//!   yields per row), so every row pays the runtime's poll/wake machinery even
+//!   when the next row is already available. MVCC mode is the dominant cost
+//!   here: it roughly quadruples the per-row time versus legacy mode.
+//!
+//! At small row counts the per-query fixed cost dominates and the two are
+//! comparable; as the row count grows the per-row `.await` overhead makes Turso
+//! progressively slower. Sweeping the row count makes the crossover visible.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use tokio::runtime::Runtime;
+
+const ROW_COUNTS: &[usize] = &[10, 100, 1000];
+
+const QUERY: &str = "SELECT id, name, value, is_active FROM test_table WHERE is_active = ?";
+
+/// One materialized result row. Both lanes produce the same shape so the mapper
+/// work is identical.
+#[derive(Debug, PartialEq)]
+struct Record {
+    id: i64,
+    name: String,
+    value: i64,
+    is_active: bool,
+}
+
+fn schema_sql() -> &'static str {
+    "CREATE TABLE test_table (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        value INTEGER NOT NULL,
+        is_active INTEGER NOT NULL
+    )"
+}
+
+fn build_sqlite(rows: usize) -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    conn.execute_batch(schema_sql()).unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    {
+        let mut stmt = tx
+            .prepare("INSERT INTO test_table (id, name, value, is_active) VALUES (?, ?, ?, 1)")
+            .unwrap();
+        for i in 0..rows {
+            stmt.execute(rusqlite::params![i as i64, format!("name_{i}"), i as i64])
+                .unwrap();
+        }
+    }
+    tx.commit().unwrap();
+    conn
+}
+
+async fn build_turso(rows: usize) -> (turso::Database, turso::Connection) {
+    let db = turso::Builder::new_local(":memory:").build().await.unwrap();
+    let conn = db.connect().unwrap();
+    conn.pragma_update("journal_mode", "'mvcc'").await.unwrap();
+    conn.execute(schema_sql(), ()).await.unwrap();
+    conn.execute("BEGIN", ()).await.unwrap();
+    let mut stmt = conn
+        .prepare("INSERT INTO test_table (id, name, value, is_active) VALUES (?, ?, ?, 1)")
+        .await
+        .unwrap();
+    for i in 0..rows {
+        stmt.execute((i as i64, format!("name_{i}"), i as i64))
+            .await
+            .unwrap();
+    }
+    conn.execute("COMMIT", ()).await.unwrap();
+    (db, conn)
+}
+
+/// SQLite lane: a single sync iteration over all rows, mapping each into a
+/// `Record`.
+fn query_sqlite(conn: &rusqlite::Connection) -> Vec<Record> {
+    let mut stmt = conn.prepare_cached(QUERY).unwrap();
+    let mapped = stmt
+        .query_map([1i64], |row| {
+            Ok(Record {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                value: row.get(2)?,
+                is_active: row.get::<_, i64>(3)? != 0,
+            })
+        })
+        .unwrap();
+    let mut out = Vec::new();
+    for r in mapped {
+        out.push(r.unwrap());
+    }
+    out
+}
+
+/// Turso lane: one `.await` per row, mapping each into a `Record`.
+async fn query_turso(conn: &turso::Connection) -> Vec<Record> {
+    let mut stmt = conn.prepare_cached(QUERY).await.unwrap();
+    let mut rows = stmt.query((1i64,)).await.unwrap();
+    let mut out = Vec::new();
+    while let Some(row) = rows.next().await.unwrap() {
+        out.push(Record {
+            id: int_value(&row, 0),
+            name: text_value(&row, 1),
+            value: int_value(&row, 2),
+            is_active: int_value(&row, 3) != 0,
+        });
+    }
+    out
+}
+
+fn int_value(row: &turso::Row, idx: usize) -> i64 {
+    match row.get_value(idx).unwrap() {
+        turso::Value::Integer(i) => i,
+        other => panic!("expected integer at column {idx}, got {other:?}"),
+    }
+}
+
+fn text_value(row: &turso::Row, idx: usize) -> String {
+    match row.get_value(idx).unwrap() {
+        turso::Value::Text(t) => t,
+        other => panic!("expected text at column {idx}, got {other:?}"),
+    }
+}
+
+fn bench(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("query_batch");
+
+    for &rows in ROW_COUNTS {
+        group.throughput(Throughput::Elements(rows as u64));
+
+        let sqlite_conn = build_sqlite(rows);
+        group.bench_with_input(BenchmarkId::new("sqlite", rows), &rows, |b, _| {
+            b.iter(|| {
+                let out = query_sqlite(&sqlite_conn);
+                assert_eq!(out.len(), rows);
+                out
+            });
+        });
+
+        let (_turso_db, turso_conn) = rt.block_on(build_turso(rows));
+        group.bench_with_input(BenchmarkId::new("turso", rows), &rows, |b, _| {
+            b.iter(|| {
+                let out = rt.block_on(query_turso(&turso_conn));
+                assert_eq!(out.len(), rows);
+                out
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);


### PR DESCRIPTION

## Description

We currently don't use read_set at all and we used skiplist to track
read set which is slower than a simple vector (we would not dedup now
here :))

## Results
with 100 rows batch we had a ~41.3 % improvement`
```bash
query_batch/sqlite/10   time:   [897.76 ns 902.69 ns 908.08 ns]
                        thrpt:  [11.012 Melem/s 11.078 Melem/s 11.139 Melem/s]
                 change:
                        time:   [-0.6343% -0.0325% +0.5632%] (p = 0.90 > 0.05)
query_batch/turso/10    time:   [5.5973 µs 5.6038 µs 5.6111 µs]
                        time:   [-29.539% -29.371% -29.201%] (p = 0.00 < 0.05)
query_batch/sqlite/100  time:   [6.9632 µs 7.0041 µs 7.0455 µs]
                        time:   [-0.9963% -0.3489% +0.2983%] (p = 0.32 > 0.05)
query_batch/turso/100   time:   [51.946 µs 52.321 µs 52.681 µs]
                        time:   [-35.707% -35.388% -35.082%] (p = 0.00 < 0.05)
query_batch/sqlite/1000 time:   [64.807 µs 65.140 µs 65.518 µs]
                        time:   [+2.6010% +3.1595% +3.7391%] (p = 0.00 < 0.05)
query_batch/turso/1000  time:   [528.56 µs 529.46 µs 530.35 µs]
                        time:   [-41.446% -41.301% -41.152%] (p = 0.00 < 0.05)
```
## Description of AI Usage

Claude was kind to create the benchmark from specification.