### PR TITLE
Add managed aggregate callback support

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2920,7 +2920,7 @@ impl Connection {
             .map(|f| {
                 let is_agg = f.func.is_aggregate();
                 let argc = match &f.func {
-                    function::ExtFunc::Aggregate { argc, .. } => *argc as i32,
+                    function::ExtFunc::Aggregate { argc, .. } => *argc,
                     function::ExtFunc::Scalar { argc, .. } => *argc,
                 };
                 (

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -170,18 +170,22 @@ pub(crate) unsafe extern "C" fn register_aggregate_function(
     ctx: *mut c_void,
     name: *const c_char,
     args: i32,
+    context: usize,
     init_func: InitAggFunction,
     step_func: StepFunction,
     finalize_func: FinalizeFunction,
+    context_destructor: Option<ContextDestructor>,
+    aggregate_destructor: Option<ContextDestructor>,
+    value_destructor: Option<ValueDestructor>,
 ) -> ResultCode {
+    if ctx.is_null() || name.is_null() || args < -1 {
+        return ResultCode::InvalidArgs;
+    }
     let c_str = unsafe { CStr::from_ptr(name) };
     let name_str = match c_str.to_str() {
-        Ok(s) => s.to_string(),
+        Ok(s) => crate::util::normalize_ident(s),
         Err(_) => return ResultCode::InvalidArgs,
     };
-    if ctx.is_null() {
-        return ResultCode::Error;
-    }
     let ext_ctx = unsafe { &mut *(ctx as *mut ExtensionCtx) };
     unsafe {
         (*ext_ctx.syms).functions.insert(
@@ -189,7 +193,11 @@ pub(crate) unsafe extern "C" fn register_aggregate_function(
             Arc::new(ExternalFunc::new_aggregate(
                 name_str,
                 args,
+                context,
                 (init_func, step_func, finalize_func),
+                context_destructor,
+                aggregate_destructor,
+                value_destructor,
             )),
         );
         if !ext_ctx.prepare_context_generation.is_null() {

--- a/core/function.rs
+++ b/core/function.rs
@@ -38,15 +38,19 @@ pub enum ExtFunc {
         value_destructor: Option<ValueDestructor>,
     },
     Aggregate {
-        argc: usize,
+        context: usize,
+        argc: i32,
         init: InitAggFunction,
         step: StepFunction,
         finalize: FinalizeFunction,
+        context_destructor: Option<ContextDestructor>,
+        aggregate_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ValueDestructor>,
     },
 }
 
 impl ExtFunc {
-    pub fn agg_args(&self) -> Result<usize, ()> {
+    pub fn agg_args(&self) -> Result<i32, ()> {
         if let ExtFunc::Aggregate { argc, .. } = self {
             return Ok(*argc);
         }
@@ -56,12 +60,36 @@ impl ExtFunc {
     pub fn matches_arg_count(&self, arg_count: usize) -> bool {
         match self {
             Self::Scalar { argc, .. } => *argc < 0 || *argc as usize == arg_count,
-            Self::Aggregate { .. } => true,
+            Self::Aggregate { argc, .. } => *argc < 0 || *argc as usize == arg_count,
         }
     }
 
     pub fn is_aggregate(&self) -> bool {
         matches!(self, Self::Aggregate { .. })
+    }
+
+    pub fn with_aggregate_arg_count(&self, arg_count: usize) -> Self {
+        match self {
+            Self::Aggregate {
+                context,
+                init,
+                step,
+                finalize,
+                aggregate_destructor,
+                value_destructor,
+                ..
+            } => Self::Aggregate {
+                context: *context,
+                argc: arg_count as i32,
+                init: *init,
+                step: *step,
+                finalize: *finalize,
+                context_destructor: None,
+                aggregate_destructor: *aggregate_destructor,
+                value_destructor: *value_destructor,
+            },
+            _ => self.clone(),
+        }
     }
 }
 
@@ -91,15 +119,23 @@ impl ExternalFunc {
     pub fn new_aggregate(
         name: String,
         argc: i32,
+        context: usize,
         func: (InitAggFunction, StepFunction, FinalizeFunction),
+        context_destructor: Option<ContextDestructor>,
+        aggregate_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ValueDestructor>,
     ) -> Self {
         Self {
             name,
             func: ExtFunc::Aggregate {
-                argc: argc as usize,
+                context,
+                argc,
                 init: func.0,
                 step: func.1,
                 finalize: func.2,
+                context_destructor,
+                aggregate_destructor,
+                value_destructor,
             },
         }
     }
@@ -107,13 +143,18 @@ impl ExternalFunc {
 
 impl Drop for ExternalFunc {
     fn drop(&mut self) {
-        if let ExtFunc::Scalar {
-            context,
-            context_destructor: Some(context_destructor),
-            ..
-        } = self.func
-        {
-            unsafe { context_destructor(context) };
+        match self.func {
+            ExtFunc::Scalar {
+                context,
+                context_destructor: Some(context_destructor),
+                ..
+            }
+            | ExtFunc::Aggregate {
+                context,
+                context_destructor: Some(context_destructor),
+                ..
+            } => unsafe { context_destructor(context) },
+            _ => {}
         }
     }
 }
@@ -433,7 +474,10 @@ impl AggFunc {
             Self::JsonGroupArray | Self::JsonbGroupArray => 1,
             #[cfg(feature = "json")]
             Self::JsonGroupObject | Self::JsonbGroupObject => 2,
-            Self::External(func) => func.agg_args().unwrap_or(0),
+            Self::External(func) => func
+                .agg_args()
+                .map(|argc| argc.max(0) as usize)
+                .unwrap_or(0),
         }
     }
 

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -3,6 +3,7 @@ use turso_parser::ast;
 use crate::{
     function::AggFunc,
     schema::Table,
+    sync::Arc,
     translate::collate::CollationSeq,
     vdbe::{
         builder::ProgramBuilder,
@@ -556,17 +557,22 @@ pub fn translate_aggregation_step(
             target_register
         }
         AggFunc::External(ref func) => {
-            let argc = func.agg_args().map_err(|_| {
+            let registered_argc = func.agg_args().map_err(|_| {
                 LimboError::ExtensionError(
                     "External aggregate function called with wrong number of arguments".to_string(),
                 )
             })?;
-            if argc != num_args {
+            if registered_argc >= 0 && registered_argc as usize != num_args {
                 crate::bail_parse_error!(
                     "External aggregate function called with wrong number of arguments"
                 );
             }
-            let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
+            let argc = num_args;
+            let expr_reg = if argc == 0 {
+                0
+            } else {
+                agg_arg_source.translate(program, referenced_tables, resolver, 0)?
+            };
             for i in 0..argc {
                 if i != 0 {
                     let _ = agg_arg_source.translate(program, referenced_tables, resolver, i)?;
@@ -580,7 +586,11 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::External(func.clone()),
+                func: AggFunc::External(if registered_argc < 0 {
+                    Arc::new(func.with_aggregate_arg_count(num_args))
+                } else {
+                    func.clone()
+                }),
                 comparator: None,
             });
             target_register

--- a/core/types.rs
+++ b/core/types.rs
@@ -1,7 +1,7 @@
 use crate::turso_debug_assert;
 use branches::{mark_unlikely, unlikely};
 use either::Either;
-use turso_ext::{AggCtx, FinalizeFunction, StepFunction};
+use turso_ext::{AggCtx, ContextDestructor, FinalizeFunction, StepFunction, ValueDestructor};
 use turso_parser::ast::SortOrder;
 
 use crate::alloc::vec;
@@ -494,10 +494,13 @@ impl Value {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExternalAggState {
+    pub context: usize,
     pub state: *mut AggCtx,
     pub argc: usize,
     pub step_fn: StepFunction,
     pub finalize_fn: FinalizeFunction,
+    pub aggregate_destructor: Option<ContextDestructor>,
+    pub value_destructor: Option<ValueDestructor>,
 }
 
 /// Please use Display trait for all limbo output so we have single origin of truth
@@ -728,8 +731,18 @@ pub enum AggContext {
 impl AggContext {
     pub fn compute_external(&self) -> Result<Value> {
         if let Self::External(ext_state) = self {
-            let final_value = unsafe { (ext_state.finalize_fn)(ext_state.state) };
-            Value::from_ffi(final_value)
+            let mut final_value =
+                unsafe { (ext_state.finalize_fn)(ext_state.context, ext_state.state) };
+            let value = Value::from_ffi_ref(&final_value);
+            if let Some(value_destructor) = ext_state.value_destructor {
+                unsafe { value_destructor(&mut final_value) };
+            } else {
+                unsafe { final_value.__free_internal_type() };
+            }
+            if let Some(aggregate_destructor) = ext_state.aggregate_destructor {
+                unsafe { aggregate_destructor(ext_state.state as usize) };
+            }
+            value
         } else {
             panic!("AggContext::compute_external() expected External, found {self:?}");
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -73,7 +73,6 @@ use crate::{
         SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_TRIGGER,
         SQLITE_ERROR,
     },
-    ext::ExtValue,
     function::{AggFunc, ExtFunc, MathFunc, MathFuncArity, ScalarFunc, VectorFunc},
     functions::{
         datetime::{
@@ -6210,15 +6209,22 @@ pub fn op_agg_step(
         state.registers[*acc_reg] = match func {
             AggFunc::External(ext_func) => match ext_func.as_ref() {
                 ExtFunc::Aggregate {
+                    context,
                     init,
                     step,
                     finalize,
                     argc,
+                    aggregate_destructor,
+                    value_destructor,
+                    ..
                 } => Register::Aggregate(AggContext::External(ExternalAggState {
-                    state: unsafe { (init)() },
-                    argc: *argc,
+                    context: *context,
+                    state: unsafe { (init)(*context) },
+                    argc: (*argc).max(0) as usize,
                     step_fn: *step,
                     finalize_fn: *finalize,
+                    aggregate_destructor: *aggregate_destructor,
+                    value_destructor: *value_destructor,
                 })),
                 _ => unreachable!("scalar function called in aggregate context"),
             },
@@ -6238,28 +6244,50 @@ pub fn op_agg_step(
     match func {
         AggFunc::External(_) => {
             // External aggregates use FFI and need special handling
-            let (step_fn, state_ptr, argc) = {
+            let (context, step_fn, state_ptr, argc, aggregate_destructor, value_destructor) = {
                 let Register::Aggregate(agg) = &state.registers[*acc_reg] else {
                     unreachable!();
                 };
                 let AggContext::External(agg_state) = agg else {
                     unreachable!();
                 };
-                (agg_state.step_fn, agg_state.state, agg_state.argc)
+                (
+                    agg_state.context,
+                    agg_state.step_fn,
+                    agg_state.state,
+                    agg_state.argc,
+                    agg_state.aggregate_destructor,
+                    agg_state.value_destructor,
+                )
             };
-            if argc == 0 {
-                unsafe { step_fn(state_ptr, 0, std::ptr::null()) };
-            } else {
+            let mut ext_values = Vec::with_capacity(argc);
+            if argc != 0 {
                 let register_slice = &state.registers[*col..*col + argc];
-                let mut ext_values: Vec<ExtValue> = Vec::with_capacity(argc);
                 for ov in register_slice.iter() {
                     ext_values.push(ov.get_value().to_ffi());
                 }
-                let argv_ptr = ext_values.as_ptr();
-                unsafe { step_fn(state_ptr, argc as i32, argv_ptr) };
-                for ext_value in ext_values {
-                    unsafe { ext_value.__free_internal_type() };
+            }
+            let argv_ptr = if ext_values.is_empty() {
+                std::ptr::null()
+            } else {
+                ext_values.as_ptr()
+            };
+            let mut result = unsafe { step_fn(context, state_ptr, argc as i32, argv_ptr) };
+            let value = Value::from_ffi_ref(&result);
+            if let Some(value_destructor) = value_destructor {
+                unsafe { value_destructor(&mut result) };
+            } else {
+                unsafe { result.__free_internal_type() };
+            }
+            for ext_value in ext_values {
+                unsafe { ext_value.__free_internal_type() };
+            }
+            if let Err(err) = value {
+                if let Some(aggregate_destructor) = aggregate_destructor {
+                    unsafe { aggregate_destructor(state_ptr as usize) };
                 }
+                state.registers[*acc_reg].set_value(Value::Null);
+                return Err(err);
             }
         }
         _ => {
@@ -6368,6 +6396,33 @@ pub fn op_agg_final(
                 AggFunc::JsonbGroupObject => {
                     state.registers[dest_reg]
                         .set_blob(json::jsonb::Jsonb::make_empty_obj(1).data())?;
+                }
+                AggFunc::External(ext_func) => {
+                    let value = match ext_func.as_ref() {
+                        ExtFunc::Aggregate {
+                            context,
+                            init,
+                            finalize,
+                            aggregate_destructor,
+                            value_destructor,
+                            ..
+                        } => {
+                            let aggregate_context = unsafe { init(*context) };
+                            let mut result = unsafe { finalize(*context, aggregate_context) };
+                            let value = Value::from_ffi_ref(&result);
+                            if let Some(value_destructor) = value_destructor {
+                                unsafe { value_destructor(&mut result) };
+                            } else {
+                                unsafe { result.__free_internal_type() };
+                            }
+                            if let Some(aggregate_destructor) = aggregate_destructor {
+                                unsafe { aggregate_destructor(aggregate_context as usize) };
+                            }
+                            value?
+                        }
+                        _ => unreachable!("scalar function called in aggregate context"),
+                    };
+                    state.registers[dest_reg].set_value(value);
                 }
                 _ => {}
             }

--- a/extensions/core/src/functions.rs
+++ b/extensions/core/src/functions.rs
@@ -32,14 +32,19 @@ pub type RegisterAggFn = unsafe extern "C" fn(
     ctx: *mut c_void,
     name: *const c_char,
     args: i32,
+    context: usize,
     init: InitAggFunction,
     step: StepFunction,
     finalize: FinalizeFunction,
+    context_destructor: Option<ContextDestructor>,
+    aggregate_destructor: Option<ContextDestructor>,
+    value_destructor: Option<ValueDestructor>,
 ) -> ResultCode;
 
-pub type InitAggFunction = unsafe extern "C" fn() -> *mut AggCtx;
-pub type StepFunction = unsafe extern "C" fn(ctx: *mut AggCtx, argc: i32, argv: *const Value);
-pub type FinalizeFunction = unsafe extern "C" fn(ctx: *mut AggCtx) -> Value;
+pub type InitAggFunction = unsafe extern "C" fn(context: usize) -> *mut AggCtx;
+pub type StepFunction =
+    unsafe extern "C" fn(context: usize, ctx: *mut AggCtx, argc: i32, argv: *const Value) -> Value;
+pub type FinalizeFunction = unsafe extern "C" fn(context: usize, ctx: *mut AggCtx) -> Value;
 
 #[repr(C)]
 pub struct AggCtx {

--- a/macros/src/ext/agg_derive.rs
+++ b/macros/src/ext/agg_derive.rs
@@ -15,7 +15,7 @@ pub fn derive_agg_func(input: TokenStream) -> TokenStream {
     let expanded = quote! {
         impl #struct_name {
             #[no_mangle]
-            pub extern "C" fn #init_fn_name() -> *mut ::turso_ext::AggCtx {
+            pub extern "C" fn #init_fn_name(_context: usize) -> *mut ::turso_ext::AggCtx {
                 let state = ::std::boxed::Box::new(<#struct_name as ::turso_ext::AggFunc>::State::default());
                 let ctx = ::std::boxed::Box::new(::turso_ext::AggCtx {
                     state: ::std::boxed::Box::into_raw(state) as *mut ::std::os::raw::c_void,
@@ -25,24 +25,31 @@ pub fn derive_agg_func(input: TokenStream) -> TokenStream {
 
             #[no_mangle]
             pub extern "C" fn #step_fn_name(
+                _context: usize,
                 ctx: *mut ::turso_ext::AggCtx,
                 argc: i32,
                 argv: *const ::turso_ext::Value,
-            ) {
+            ) -> ::turso_ext::Value {
                 unsafe {
                     let ctx = &mut *ctx;
                     let state = &mut *(ctx.state as *mut <#struct_name as ::turso_ext::AggFunc>::State);
-                    let args = ::std::slice::from_raw_parts(argv, argc as usize);
+                    let args = if argc <= 0 || argv.is_null() {
+                        &[]
+                    } else {
+                        ::std::slice::from_raw_parts(argv, argc as usize)
+                    };
                     <#struct_name as ::turso_ext::AggFunc>::step(state, args);
                 }
+                ::turso_ext::Value::null()
             }
 
             #[no_mangle]
             pub extern "C" fn #finalize_fn_name(
+                _context: usize,
                 ctx: *mut ::turso_ext::AggCtx
             ) -> ::turso_ext::Value {
                 unsafe {
-                    let ctx = &mut *ctx;
+                    let ctx = ::std::boxed::Box::from_raw(ctx);
                     let state = ::std::boxed::Box::from_raw(ctx.state as *mut <#struct_name as ::turso_ext::AggFunc>::State);
                     match <#struct_name as ::turso_ext::AggFunc>::finalize(*state) {
                         Ok(val) => val,
@@ -72,12 +79,16 @@ pub fn derive_agg_func(input: TokenStream) -> TokenStream {
                     api.ctx,
                     c_name.as_ptr(),
                     #struct_name::ARGS,
+                    0,
                     #struct_name::#init_fn_name
                         as ::turso_ext::InitAggFunction,
                     #struct_name::#step_fn_name
                         as ::turso_ext::StepFunction,
                     #struct_name::#finalize_fn_name
                         as ::turso_ext::FinalizeFunction,
+                    None,
+                    None,
+                    None,
                 )
             }
         }

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -3,6 +3,7 @@ use rusqlite::types::Value as SqliteValue;
 use serial_test::serial;
 use std::{
     ffi::CString,
+    os::raw::c_void,
     sync::{
         atomic::{AtomicUsize, Ordering as AtomicOrdering},
         Arc,
@@ -10,8 +11,8 @@ use std::{
 };
 use turso_core::{Connection, LimboError, StepResult};
 use turso_ext::{
-    ContextDestructor, ResultCode, ScalarFunction, Value as ExtValue, ValueDestructor,
-    ValueType as ExtValueType,
+    AggCtx, ContextDestructor, FinalizeFunction, InitAggFunction, ResultCode, ScalarFunction,
+    StepFunction, Value as ExtValue, ValueDestructor, ValueType as ExtValueType,
 };
 
 #[turso_macros::test]
@@ -75,15 +76,29 @@ fn direct_connection_extension_loading_bypasses_sql_flag(
 }
 
 static SCALAR_VALUE_DROPS: AtomicUsize = AtomicUsize::new(0);
+static AGG_VALUE_DROPS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Default)]
 struct CallbackCounters {
     calls: AtomicUsize,
     context_drops: AtomicUsize,
+    aggregate_inits: AtomicUsize,
+    aggregate_steps: AtomicUsize,
+    aggregate_finals: AtomicUsize,
+    aggregate_drops: AtomicUsize,
 }
 
 struct ScalarContext {
     multiplier: i64,
+    counters: Arc<CallbackCounters>,
+}
+
+struct AggregateContext {
+    counters: Arc<CallbackCounters>,
+}
+
+struct SumState {
+    sum: i64,
     counters: Arc<CallbackCounters>,
 }
 
@@ -265,6 +280,162 @@ fn unregister_extension_function(conn: &Connection, name: &str) -> anyhow::Resul
     Ok(())
 }
 
+unsafe extern "C" fn managed_sum_init(context: usize) -> *mut AggCtx {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_inits
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    let state = Box::into_raw(Box::new(SumState {
+        sum: 0,
+        counters: ctx.counters.clone(),
+    }));
+    Box::into_raw(Box::new(AggCtx {
+        state: state as *mut c_void,
+    }))
+}
+
+unsafe fn sum_state<'a>(aggregate_context: *mut AggCtx) -> &'a mut SumState {
+    let aggregate_context = unsafe { &mut *aggregate_context };
+    unsafe { &mut *(aggregate_context.state as *mut SumState) }
+}
+
+unsafe extern "C" fn managed_sum_step(
+    context: usize,
+    aggregate_context: *mut AggCtx,
+    argc: i32,
+    argv: *const ExtValue,
+) -> ExtValue {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_steps
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    let state = unsafe { sum_state(aggregate_context) };
+    if argc > 0 && !argv.is_null() {
+        let args = unsafe { std::slice::from_raw_parts(argv, argc as usize) };
+        state.sum += args
+            .first()
+            .and_then(ExtValue::to_integer)
+            .unwrap_or_default();
+    }
+    ExtValue::null()
+}
+
+unsafe extern "C" fn managed_variadic_sum_step(
+    context: usize,
+    aggregate_context: *mut AggCtx,
+    argc: i32,
+    argv: *const ExtValue,
+) -> ExtValue {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_steps
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    let state = unsafe { sum_state(aggregate_context) };
+    state.sum += argc as i64;
+    if argc > 0 && !argv.is_null() {
+        let args = unsafe { std::slice::from_raw_parts(argv, argc as usize) };
+        state.sum += args.iter().filter_map(ExtValue::to_integer).sum::<i64>();
+    }
+    ExtValue::null()
+}
+
+unsafe extern "C" fn managed_step_fail(
+    context: usize,
+    _aggregate_context: *mut AggCtx,
+    _argc: i32,
+    _argv: *const ExtValue,
+) -> ExtValue {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_steps
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    ExtValue::error_with_message("aggregate step failure".to_string())
+}
+
+unsafe extern "C" fn managed_sum_final(context: usize, aggregate_context: *mut AggCtx) -> ExtValue {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_finals
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    let state = unsafe { sum_state(aggregate_context) };
+    ExtValue::from_integer(state.sum)
+}
+
+unsafe extern "C" fn managed_final_fail(
+    context: usize,
+    _aggregate_context: *mut AggCtx,
+) -> ExtValue {
+    let ctx = unsafe { &*(context as *const AggregateContext) };
+    ctx.counters
+        .aggregate_finals
+        .fetch_add(1, AtomicOrdering::SeqCst);
+    ExtValue::error_with_message("aggregate final failure".to_string())
+}
+
+unsafe extern "C" fn drop_aggregate_context(context: usize) {
+    let context = unsafe { Box::from_raw(context as *mut AggregateContext) };
+    context
+        .counters
+        .context_drops
+        .fetch_add(1, AtomicOrdering::SeqCst);
+}
+
+unsafe extern "C" fn drop_sum_state(aggregate_context: usize) {
+    let aggregate_context = unsafe { Box::from_raw(aggregate_context as *mut AggCtx) };
+    let state = unsafe { Box::from_raw(aggregate_context.state as *mut SumState) };
+    state
+        .counters
+        .aggregate_drops
+        .fetch_add(1, AtomicOrdering::SeqCst);
+}
+
+unsafe extern "C" fn count_aggregate_value_drop(result: *mut ExtValue) {
+    if !result.is_null() {
+        unsafe { std::ptr::read(result).__free_internal_type() };
+    }
+    AGG_VALUE_DROPS.fetch_add(1, AtomicOrdering::SeqCst);
+}
+
+fn boxed_aggregate_context(counters: Arc<CallbackCounters>) -> usize {
+    Box::into_raw(Box::new(AggregateContext { counters })) as usize
+}
+
+#[allow(clippy::too_many_arguments)]
+fn register_context_aggregate(
+    conn: &Connection,
+    name: &str,
+    argc: i32,
+    context: usize,
+    init: InitAggFunction,
+    step: StepFunction,
+    finalize: FinalizeFunction,
+    context_destructor: Option<ContextDestructor>,
+    aggregate_destructor: Option<ContextDestructor>,
+    value_destructor: Option<ValueDestructor>,
+) -> anyhow::Result<()> {
+    let name = CString::new(name)?;
+    let api = unsafe { conn._build_turso_ext() };
+    let result = unsafe {
+        (api.register_aggregate_function)(
+            api.ctx,
+            name.as_ptr(),
+            argc,
+            context,
+            init,
+            step,
+            finalize,
+            context_destructor,
+            aggregate_destructor,
+            value_destructor,
+        )
+    };
+    unsafe { conn._free_extension_ctx(api) };
+    if result != ResultCode::OK {
+        anyhow::bail!("managed aggregate registration failed: {result}");
+    }
+    Ok(())
+}
+
 #[turso_macros::test]
 #[serial]
 fn managed_scalar_callbacks_cover_fixed_args_metadata_and_invalidation(
@@ -408,5 +579,169 @@ fn managed_scalar_variadic_callbacks_receive_callsite_arguments(
     unregister_extension_function(&conn, "managed_variadic_score")?;
     assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 1);
     assert_eq!(counters.calls.load(AtomicOrdering::SeqCst), 2);
+    Ok(())
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_aggregate_callbacks_cover_grouping_distinct_filter_and_empty_sets(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    AGG_VALUE_DROPS.store(0, AtomicOrdering::SeqCst);
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+
+    register_context_aggregate(
+        &conn,
+        "managed_sum",
+        1,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_sum_step,
+        managed_sum_final,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        Some(count_aggregate_value_drop),
+    )?;
+
+    let function_list: Vec<(String, i64, String, String, i64, i64)> =
+        conn.exec_rows("PRAGMA function_list");
+    let managed_sum_metadata = function_list
+        .iter()
+        .find(|(name, _, _, _, _, _)| name == "managed_sum")
+        .expect("managed_sum should be listed");
+    assert_eq!(managed_sum_metadata.2, "a");
+    assert_eq!(managed_sum_metadata.4, 1);
+    assert_eq!(managed_sum_metadata.5 & 0x800, 0);
+
+    conn.execute("CREATE TABLE items(category TEXT, value INTEGER)")?;
+    conn.execute("INSERT INTO items VALUES ('a', 1), ('a', 2), ('a', 2), ('b', 4), ('b', NULL)")?;
+
+    let grouped: Vec<(String, i64)> = conn.exec_rows(
+        "SELECT category, managed_sum(value) FROM items GROUP BY category ORDER BY category",
+    );
+    assert_eq!(grouped, vec![("a".to_string(), 5), ("b".to_string(), 4)]);
+
+    let filtered_distinct: Vec<(i64,)> =
+        conn.exec_rows("SELECT managed_sum(DISTINCT value) FILTER (WHERE value < 3) FROM items");
+    assert_eq!(filtered_distinct, vec![(3,)]);
+
+    let empty: Vec<(i64,)> = conn.exec_rows("SELECT managed_sum(value) FROM items WHERE 0");
+    assert_eq!(empty, vec![(0,)]);
+
+    unregister_extension_function(&conn, "managed_sum")?;
+    let err = conn
+        .prepare("SELECT managed_sum(value) FROM items")
+        .unwrap_err();
+    assert!(err.to_string().contains("no such function"));
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 1);
+    assert!(counters.aggregate_inits.load(AtomicOrdering::SeqCst) >= 4);
+    assert_eq!(
+        counters.aggregate_inits.load(AtomicOrdering::SeqCst),
+        counters.aggregate_finals.load(AtomicOrdering::SeqCst)
+    );
+    assert_eq!(
+        counters.aggregate_inits.load(AtomicOrdering::SeqCst),
+        counters.aggregate_drops.load(AtomicOrdering::SeqCst)
+    );
+    let aggregate_value_drops = AGG_VALUE_DROPS.load(AtomicOrdering::SeqCst);
+    assert!(aggregate_value_drops >= counters.aggregate_finals.load(AtomicOrdering::SeqCst));
+    assert!(aggregate_value_drops > counters.aggregate_finals.load(AtomicOrdering::SeqCst));
+    Ok(())
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_aggregate_variadic_callbacks_receive_callsite_arg_count(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+
+    register_context_aggregate(
+        &conn,
+        "managed_variadic_sum",
+        -1,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_variadic_sum_step,
+        managed_sum_final,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        None,
+    )?;
+    conn.execute("CREATE TABLE variadic_items(first INTEGER, second INTEGER)")?;
+    conn.execute("INSERT INTO variadic_items VALUES (1, 2), (3, 4)")?;
+
+    let sum: Vec<(i64,)> =
+        conn.exec_rows("SELECT managed_variadic_sum(first, second) FROM variadic_items");
+    assert_eq!(sum, vec![(14,)]);
+
+    let empty: Vec<(i64,)> =
+        conn.exec_rows("SELECT managed_variadic_sum(first) FROM variadic_items WHERE 0");
+    assert_eq!(empty, vec![(0,)]);
+
+    unregister_extension_function(&conn, "managed_variadic_sum")?;
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 1);
+    assert_eq!(
+        counters.aggregate_inits.load(AtomicOrdering::SeqCst),
+        counters.aggregate_drops.load(AtomicOrdering::SeqCst)
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+#[serial]
+fn managed_aggregate_errors_leave_connection_usable(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let counters = Arc::new(CallbackCounters::default());
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE aggregate_errors(value INTEGER)")?;
+    conn.execute("INSERT INTO aggregate_errors VALUES (1)")?;
+
+    register_context_aggregate(
+        &conn,
+        "managed_step_fail",
+        1,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_step_fail,
+        managed_sum_final,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        None,
+    )?;
+    let err = conn
+        .execute("SELECT managed_step_fail(value) FROM aggregate_errors")
+        .unwrap_err();
+    assert!(err.to_string().contains("aggregate step failure"));
+    let usable: Vec<(i64,)> = conn.exec_rows("SELECT 1");
+    assert_eq!(usable, vec![(1,)]);
+    unregister_extension_function(&conn, "managed_step_fail")?;
+
+    register_context_aggregate(
+        &conn,
+        "managed_final_fail",
+        1,
+        boxed_aggregate_context(counters.clone()),
+        managed_sum_init,
+        managed_sum_step,
+        managed_final_fail,
+        Some(drop_aggregate_context),
+        Some(drop_sum_state),
+        None,
+    )?;
+    let err = conn
+        .execute("SELECT managed_final_fail(value) FROM aggregate_errors")
+        .unwrap_err();
+    assert!(err.to_string().contains("aggregate final failure"));
+    let usable: Vec<(i64,)> = conn.exec_rows("SELECT 1");
+    assert_eq!(usable, vec![(1,)]);
+    unregister_extension_function(&conn, "managed_final_fail")?;
+
+    assert_eq!(counters.context_drops.load(AtomicOrdering::SeqCst), 2);
+    assert_eq!(
+        counters.aggregate_inits.load(AtomicOrdering::SeqCst),
+        counters.aggregate_drops.load(AtomicOrdering::SeqCst)
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Split from the advanced .NET/core support work. Adds managed aggregate callback support on top of the merged managed scalar callback foundation.

## Scope

- Register and discover managed aggregate callbacks through core extension APIs
- Carry aggregate context, destructor, and value cleanup through runtime execution
- Support fixed and variadic aggregate call-site arity
- Handle grouped, ungrouped, zero-row, and callback-error aggregate execution paths
- Add focused Rust integration coverage for managed aggregate callbacks

Out of scope: SDK-kit/.NET exposure, custom collations, extension loading, workflows, simulator changes, and unrelated hunks.

## Validation

- Focused managed_aggregate tests passed
- Full external_apis filter passed
- cargo fmt --check
- git diff --check
- cargo check -q -p core_tester --features pure-rust-crypto --test integration_tests
- Targeted clippy for the integration test target