### PR TITLE
core/mvcc: reuse record

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -421,31 +421,61 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
-        let current_pos = &self.current_pos;
-        tracing::trace!("current_row({:?})", current_pos);
-        match current_pos {
+        tracing::trace!("current_row({:?})", self.current_pos);
+        match &self.current_pos {
+            CursorPosition::Loaded { in_btree: true, .. } => self.btree_cursor.record(),
             CursorPosition::Loaded {
-                row_id: _,
-                in_btree,
-                ..
+                in_btree: false, ..
             } => {
-                if *in_btree {
-                    self.btree_cursor.record()
-                } else {
-                    let Some(row) = self.read_mvcc_current_row()? else {
-                        return Ok(IOResult::Done(None));
-                    };
-                    {
-                        let record = self.get_immutable_record_or_create()?;
-                        record.invalidate();
-                        record.start_serialization(row.payload())?;
-                    }
+                // Lightweight handle clone (refcount bump) so we can drop the
+                // borrow of `current_pos` and mutably borrow the reusable record.
+                let versions = match &self.current_pos {
+                    CursorPosition::Loaded { versions, .. } => versions.clone(),
+                    _ => unreachable!("matched Loaded above"),
+                };
 
-                    let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
-                        LimboError::InternalError("immutable record not initialized".to_string())
-                    })?;
-                    Ok(IOResult::Done(Some(record_ref)))
+                let found = if let Some(versions) = &versions {
+                    // Fast path: serialize the visible version straight into our
+                    // reusable record — like the btree cursor does with a cell —
+                    // instead of cloning a `Row` first.
+                    if self.reusable_immutable_record.is_none() {
+                        self.reusable_immutable_record = Some(ImmutableRecord::new(1024)?);
+                    }
+                    let record = self.reusable_immutable_record.as_mut().unwrap();
+                    self.db
+                        .read_visible_into_record(self.tx_id, versions, record)?
+                } else {
+                    // Cold fallback (seek-positioned, no cached chain): point
+                    // lookup, then serialize.
+                    let row_id = match &self.current_pos {
+                        CursorPosition::Loaded { row_id, .. } => row_id.clone(),
+                        _ => unreachable!("matched Loaded above"),
+                    };
+                    let maybe_index_id = match &self.mv_cursor_type {
+                        MvccCursorType::Index(_) => Some(self.table_id),
+                        MvccCursorType::Table => None,
+                    };
+                    match self
+                        .db
+                        .read_from_table_or_index(self.tx_id, &row_id, maybe_index_id)?
+                    {
+                        Some(row) => {
+                            let record = self.get_immutable_record_or_create()?;
+                            record.invalidate();
+                            record.start_serialization(row.payload())?;
+                            true
+                        }
+                        None => false,
+                    }
+                };
+
+                if !found {
+                    return Ok(IOResult::Done(None));
                 }
+                let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
+                    LimboError::InternalError("immutable record not initialized".to_string())
+                })?;
+                Ok(IOResult::Done(Some(record_ref)))
             }
             CursorPosition::BeforeFirst => {
                 // Before first is not a valid position, so we return none.

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -34,6 +34,11 @@ enum CursorPosition {
         row_id: RowID,
         /// Indicates whether the rowid is pointing BTreeCursor or MVCC index.
         in_btree: bool,
+        /// Resolved MVCC version chain for this row, captured from the range
+        /// iterator so `read_mvcc_current_row` can skip a second `self.rows.get`.
+        /// `Some` only for MVCC table rows reached via the scan path; `None`
+        /// (btree rows, index rows, seek/insert positions) falls back to a lookup.
+        versions: Option<RowVersions>,
     },
     /// We have reached the end of the table.
     End,
@@ -190,8 +195,9 @@ struct DualCursorPeek {
 }
 
 impl DualCursorPeek {
-    /// Returns the next row key and whether the row is from the BTree.
-    fn get_next(&self, dir: IterationDirection) -> Option<(RowKey, bool)> {
+    /// Returns the next row key, whether the row is from the BTree, and (for
+    /// MVCC winners) the resolved version chain captured during iteration.
+    fn get_next(&self, dir: IterationDirection) -> Option<(RowKey, bool, Option<RowVersions>)> {
         tracing::trace!(
             "get_next: mvcc_key: {:?}, btree_key: {:?}",
             self.mvcc_peek.get_row_key(),
@@ -202,19 +208,21 @@ impl DualCursorPeek {
                 if dir == IterationDirection::Forwards {
                     // In forwards iteration we want the smaller of the two keys
                     if mvcc_key <= btree_key {
-                        Some((mvcc_key.clone(), false))
+                        Some((mvcc_key.clone(), false, self.mvcc_peek.get_versions()))
                     } else {
-                        Some((btree_key.clone(), true))
+                        Some((btree_key.clone(), true, None))
                     }
                 // In backwards iteration we want the larger of the two keys
                 } else if mvcc_key >= btree_key {
-                    Some((mvcc_key.clone(), false))
+                    Some((mvcc_key.clone(), false, self.mvcc_peek.get_versions()))
                 } else {
-                    Some((btree_key.clone(), true))
+                    Some((btree_key.clone(), true, None))
                 }
             }
-            (Some(mvcc_key), None) => Some((mvcc_key.clone(), false)),
-            (None, Some(btree_key)) => Some((btree_key.clone(), true)),
+            (Some(mvcc_key), None) => {
+                Some((mvcc_key.clone(), false, self.mvcc_peek.get_versions()))
+            }
+            (None, Some(btree_key)) => Some((btree_key.clone(), true, None)),
             (None, None) => None,
         }
     }
@@ -226,12 +234,13 @@ impl DualCursorPeek {
         dir: IterationDirection,
     ) -> CursorPosition {
         match self.get_next(dir) {
-            Some((row_key, in_btree)) => CursorPosition::Loaded {
+            Some((row_key, in_btree, versions)) => CursorPosition::Loaded {
                 row_id: RowID {
                     table_id,
                     row_id: row_key,
                 },
                 in_btree,
+                versions,
             },
             None => match dir {
                 IterationDirection::Forwards => CursorPosition::End,
@@ -261,14 +270,26 @@ impl DualCursorPeek {
 enum CursorPeek {
     #[default]
     Uninitialized,
-    Row(RowKey),
+    Row {
+        key: RowKey,
+        /// Resolved MVCC version chain, set when this peek came from the MVCC
+        /// table iterator. `None` for btree peeks and index peeks.
+        versions: Option<RowVersions>,
+    },
     Exhausted,
 }
 
 impl CursorPeek {
     pub fn get_row_key(&self) -> Option<&RowKey> {
         match self {
-            CursorPeek::Row(k) => Some(k),
+            CursorPeek::Row { key, .. } => Some(key),
+            _ => None,
+        }
+    }
+
+    pub fn get_versions(&self) -> Option<RowVersions> {
+        match self {
+            CursorPeek::Row { versions, .. } => versions.clone(),
             _ => None,
         }
     }
@@ -406,6 +427,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             CursorPosition::Loaded {
                 row_id: _,
                 in_btree,
+                ..
             } => {
                 if *in_btree {
                     self.btree_cursor.record()
@@ -434,10 +456,19 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
     }
 
     pub fn read_mvcc_current_row(&self) -> Result<Option<Row>> {
-        let row_id = match &self.current_pos {
-            CursorPosition::Loaded { row_id, in_btree } if !in_btree => row_id,
+        let (row_id, versions) = match &self.current_pos {
+            CursorPosition::Loaded {
+                row_id,
+                in_btree,
+                versions,
+            } if !in_btree => (row_id, versions),
             _ => panic!("invalid position to read current mvcc row"),
         };
+        // Scan path: the range iterator already resolved this row's version
+        // chain, so read it directly instead of a second skiplist lookup.
+        if let Some(versions) = versions {
+            return self.db.read_visible_from_versions(self.tx_id, versions);
+        }
         let maybe_index_id = match &self.mv_cursor_type {
             MvccCursorType::Index(_) => Some(self.table_id),
             MvccCursorType::Table => None,
@@ -528,19 +559,28 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
 
     /// Advance MVCC iterator and return next visible row key in the direction that the iterator was initialized in.
     fn advance_mvcc_iterator(&mut self) {
-        let next = match &self.mv_cursor_type {
-            MvccCursorType::Table => self.db.advance_cursor_and_get_row_id_for_table(
+        let new_peek_state = match &self.mv_cursor_type {
+            MvccCursorType::Table => match self.db.advance_cursor_and_get_row_id_for_table(
                 self.table_id,
                 &mut self.table_iterator,
                 self.tx_id,
-            ),
-            MvccCursorType::Index(_) => self
+            ) {
+                Some((row_id, versions)) => CursorPeek::Row {
+                    key: row_id.row_id,
+                    versions: Some(versions),
+                },
+                None => CursorPeek::Exhausted,
+            },
+            MvccCursorType::Index(_) => match self
                 .db
-                .advance_cursor_and_get_row_id_for_index(&mut self.index_iterator, self.tx_id),
-        };
-        let new_peek_state = match next {
-            Some(k) => CursorPeek::Row(k.row_id),
-            None => CursorPeek::Exhausted,
+                .advance_cursor_and_get_row_id_for_index(&mut self.index_iterator, self.tx_id)
+            {
+                Some(row_id) => CursorPeek::Row {
+                    key: row_id.row_id,
+                    versions: None,
+                },
+                None => CursorPeek::Exhausted,
+            },
         };
         self.dual_peek.mvcc_peek = new_peek_state;
     }
@@ -578,7 +618,10 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                     let key = self.get_btree_current_key()?;
                     match key {
                         Some(k) if self.query_btree_version_is_valid(&k) => {
-                            self.dual_peek.btree_peek = CursorPeek::Row(k);
+                            self.dual_peek.btree_peek = CursorPeek::Row {
+                                key: k,
+                                versions: None,
+                            };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
                         }
@@ -609,7 +652,10 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                     let key = self.get_btree_current_key()?;
                     if let Some(key) = key {
                         if self.query_btree_version_is_valid(&key) {
-                            self.dual_peek.btree_peek = CursorPeek::Row(key);
+                            self.dual_peek.btree_peek = CursorPeek::Row {
+                                key,
+                                versions: None,
+                            };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
                         }
@@ -660,7 +706,10 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                     let key = self.get_btree_current_key()?;
                     match key {
                         Some(k) if self.query_btree_version_is_valid(&k) => {
-                            self.dual_peek.btree_peek = CursorPeek::Row(k);
+                            self.dual_peek.btree_peek = CursorPeek::Row {
+                                key: k,
+                                versions: None,
+                            };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
                         }
@@ -691,7 +740,10 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                     let key = self.get_btree_current_key()?;
                     match key {
                         Some(k) if self.query_btree_version_is_valid(&k) => {
-                            self.dual_peek.btree_peek = CursorPeek::Row(k);
+                            self.dual_peek.btree_peek = CursorPeek::Row {
+                                key: k,
+                                versions: None,
+                            };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
                         }
@@ -827,7 +879,10 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                     let key = self.get_btree_current_key()?;
                     match key {
                         Some(k) if self.query_btree_version_is_valid(&k) => {
-                            self.dual_peek.btree_peek = CursorPeek::Row(k);
+                            self.dual_peek.btree_peek = CursorPeek::Row {
+                                key: k,
+                                versions: None,
+                            };
                             return Ok(IOResult::Done(()));
                         }
                         Some(_) => {
@@ -926,7 +981,10 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             ) {
                 Some(k) => {
                     tracing::trace!("last: mvcc_key: {:?}", k);
-                    self.dual_peek.mvcc_peek = CursorPeek::Row(k);
+                    self.dual_peek.mvcc_peek = CursorPeek::Row {
+                        key: k,
+                        versions: None,
+                    };
                 }
                 None => {
                     self.dual_peek.mvcc_peek = CursorPeek::Exhausted;
@@ -938,7 +996,10 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 &mut self.index_iterator,
             ) {
                 Some(k) => {
-                    self.dual_peek.mvcc_peek = CursorPeek::Row(k);
+                    self.dual_peek.mvcc_peek = CursorPeek::Row {
+                        key: k,
+                        versions: None,
+                    };
                 }
                 None => {
                     self.dual_peek.mvcc_peek = CursorPeek::Exhausted;
@@ -1129,6 +1190,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             CursorPosition::Loaded {
                 row_id,
                 in_btree: _,
+                ..
             } => match &row_id.row_id {
                 RowKey::Int(id) => Some(*id),
                 RowKey::Record(sortable_key) => {
@@ -1260,7 +1322,10 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                             // Set MVCC peek
                             {
                                 self.dual_peek.mvcc_peek = match &mvcc_rowid {
-                                    Some(rid) => CursorPeek::Row(rid.row_id.clone()),
+                                    Some(rid) => CursorPeek::Row {
+                                        key: rid.row_id.clone(),
+                                        versions: None,
+                                    },
                                     None => CursorPeek::Exhausted,
                                 };
                             }
@@ -1293,7 +1358,10 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                             // Set MVCC peek
                             {
                                 self.dual_peek.mvcc_peek = match &mvcc_rowid {
-                                    Some(rid) => CursorPeek::Row(rid.row_id.clone()),
+                                    Some(rid) => CursorPeek::Row {
+                                        key: rid.row_id.clone(),
+                                        versions: None,
+                                    },
                                     None => CursorPeek::Exhausted,
                                 };
                             }
@@ -1321,13 +1389,14 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                     // Clear seek state
                     self.state = None;
 
-                    if let Some((winner_key, in_btree)) = winner {
+                    if let Some((winner_key, in_btree, winner_versions)) = winner {
                         self.current_pos = CursorPosition::Loaded {
                             row_id: RowID {
                                 table_id: self.table_id,
                                 row_id: winner_key.clone(),
                             },
                             in_btree,
+                            versions: winner_versions,
                         };
 
                         if op.eq_only() {
@@ -1422,6 +1491,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             CursorPosition::Loaded {
                 row_id: current_row_id,
                 in_btree,
+                ..
             } => *in_btree && *current_row_id == row.id,
             _ => false,
         };
@@ -1429,6 +1499,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
         self.current_pos = CursorPosition::Loaded {
             row_id: row.id.clone(),
             in_btree: was_btree_resident,
+            versions: None,
         };
         let maybe_index_id = match &self.mv_cursor_type {
             MvccCursorType::Index(_) => Some(self.table_id),
@@ -1466,7 +1537,9 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
 
     fn delete(&mut self) -> Result<IOResult<()>> {
         let (rowid, in_btree) = match self.get_current_pos() {
-            CursorPosition::Loaded { row_id, in_btree } => (row_id, in_btree),
+            CursorPosition::Loaded {
+                row_id, in_btree, ..
+            } => (row_id, in_btree),
             _ => panic!("Cannot delete: no current row"),
         };
         if in_btree {
@@ -1569,13 +1642,17 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
 
             // If found in MVCC, update dual_peek and return true
             if mvcc_exists {
-                self.dual_peek.mvcc_peek = CursorPeek::Row(RowKey::Int(*int_key));
+                self.dual_peek.mvcc_peek = CursorPeek::Row {
+                    key: RowKey::Int(*int_key),
+                    versions: None,
+                };
                 self.current_pos = CursorPosition::Loaded {
                     row_id: RowID {
                         table_id: self.table_id,
                         row_id: RowKey::Int(*int_key),
                     },
                     in_btree: false,
+                    versions: None,
                 };
                 self.state = None;
                 return Ok(IOResult::Done(true));
@@ -1625,13 +1702,17 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
 
             if is_valid {
                 // B-tree row is visible (not shadowed), update dual_peek
-                self.dual_peek.btree_peek = CursorPeek::Row(row_key.clone());
+                self.dual_peek.btree_peek = CursorPeek::Row {
+                    key: row_key.clone(),
+                    versions: None,
+                };
                 self.current_pos = CursorPosition::Loaded {
                     row_id: RowID {
                         table_id: self.table_id,
                         row_id: row_key,
                     },
                     in_btree: true,
+                    versions: None,
                 };
                 self.state = None;
                 Ok(IOResult::Done(true))
@@ -1674,6 +1755,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                     if let CursorPosition::Loaded {
                         row_id: _,
                         in_btree: _,
+                        ..
                     } = self.get_current_pos()
                     {
                         self.count_state

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3725,6 +3725,32 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
+    /// Like the table branch of [`read_from_table_or_index`], but reads from an
+    /// already-resolved version chain instead of looking the row up in
+    /// `self.rows`. Used on the scan path where the cursor's range iterator
+    /// already located the `Arc`, so the second skiplist traversal is avoided.
+    pub(crate) fn read_visible_from_versions(
+        &self,
+        tx_id: TxID,
+        versions: &RowVersions,
+    ) -> Result<Option<Row>> {
+        let tx = self
+            .txs
+            .get(&tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        let tx = tx.value();
+        turso_assert_eq!(tx.state, TransactionState::Active);
+        let versions = versions.read();
+        if let Some(rv) = versions
+            .iter()
+            .rev()
+            .find(|rv| rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
+        {
+            return Ok(Some(rv.row.clone()));
+        }
+        Ok(None)
+    }
+
     /// Gets all row ids in the database.
     pub fn scan_row_ids(&self) -> Result<Vec<RowID>> {
         tracing::trace!("scan_row_ids");
@@ -3767,7 +3793,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         table_id: MVTableId,
         mv_store_iterator: &mut Option<MvccIterator<'static, RowID>>,
         tx_id: TxID,
-    ) -> Option<RowID> {
+    ) -> Option<(RowID, RowVersions)> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
             "mv_store_iterator must be initialized when calling get_row_id_for_table_in_direction",
         );
@@ -3874,13 +3900,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         tx: &Transaction,
         row: &Entry<'_, RowID, Arc<RwLock<Vec<RowVersion>>>>,
-    ) -> Option<RowID> {
+    ) -> Option<(RowID, RowVersions)> {
         row.value()
             .read()
             .iter()
             .rev()
             .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
-            .map(|_| row.key().clone())
+            .map(|_| (row.key().clone(), row.value().clone()))
     }
 
     fn find_last_visible_index_version(
@@ -3919,7 +3945,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         tx: &Transaction,
         mut rows: I,
         table_id: MVTableId,
-    ) -> Option<RowID>
+    ) -> Option<(RowID, RowVersions)>
     where
         I: Iterator<Item = Entry<'a, RowID, Arc<RwLock<Vec<RowVersion>>>>>,
     {
@@ -3978,6 +4004,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let tx = tx.value();
 
         self.find_next_visible_table_row(tx, mv_store_iterator, table_id)
+            .map(|(row_id, _versions)| row_id)
     }
 
     pub fn seek_index(

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3751,6 +3751,36 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         Ok(None)
     }
 
+    /// Like [`read_visible_from_versions`] but serializes the visible row's
+    /// payload directly into `record` instead of cloning a `Row`. Mirrors the
+    /// btree cursor, which serializes a cell straight into its reusable record.
+    /// Returns true if a visible version was found. The version-chain read lock
+    /// is held only for the serialization copy.
+    pub(crate) fn read_visible_into_record(
+        &self,
+        tx_id: TxID,
+        versions: &RowVersions,
+        record: &mut ImmutableRecord,
+    ) -> Result<bool> {
+        let tx = self
+            .txs
+            .get(&tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        let tx = tx.value();
+        turso_assert_eq!(tx.state, TransactionState::Active);
+        let versions = versions.read();
+        if let Some(rv) = versions
+            .iter()
+            .rev()
+            .find(|rv| rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
+        {
+            record.invalidate();
+            record.start_serialization(rv.row.payload())?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     /// Gets all row ids in the database.
     pub fn scan_row_ids(&self) -> Result<Vec<RowID>> {
         tracing::trace!("scan_row_ids");


### PR DESCRIPTION

## Description
this is heavily vibe coded because I'm going out right now, but I'll leave it here for later


looks like it improves a bunch
```bash
query_batch/sqlite/10   time:   [919.62 ns 922.55 ns 925.54 ns]
                        thrpt:  [10.804 Melem/s 10.840 Melem/s 10.874 Melem/s]
                 change:
                        time:   [+1.7260% +2.1659% +2.5747%] (p = 0.00 < 0.05)
                        thrpt:  [-2.5101% -2.1200% -1.6967%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
query_batch/turso/10    time:   [4.2019 µs 4.2150 µs 4.2298 µs]
                        thrpt:  [2.3642 Melem/s 2.3725 Melem/s 2.3799 Melem/s]
                 change:
                        time:   [-0.7727% -0.3237% +0.1244%] (p = 0.16 > 0.05)
                        thrpt:  [-0.1242% +0.3247% +0.7787%]
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
query_batch/sqlite/100  time:   [7.0129 µs 7.0348 µs 7.0581 µs]
                        thrpt:  [14.168 Melem/s 14.215 Melem/s 14.259 Melem/s]
                 change:
                        time:   [-5.7171% -4.4875% -3.3527%] (p = 0.00 < 0.05)
                        thrpt:  [+3.4690% +4.6984% +6.0637%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
query_batch/turso/100   time:   [31.279 µs 31.365 µs 31.453 µs]
                        thrpt:  [3.1794 Melem/s 3.1883 Melem/s 3.1970 Melem/s]
                 change:
                        time:   [-12.057% -11.067% -10.110%] (p = 0.00 < 0.05)
                        thrpt:  [+11.247% +12.444% +13.710%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
query_batch/sqlite/1000 time:   [66.696 µs 66.904 µs 67.099 µs]
                        thrpt:  [14.903 Melem/s 14.947 Melem/s 14.993 Melem/s]
                 change:
                        time:   [-8.7528% -7.7073% -6.7557%] (p = 0.00 < 0.05)
                        thrpt:  [+7.2451% +8.3510% +9.5925%]
                        Performance has improved.
query_batch/turso/1000  time:   [299.63 µs 300.70 µs 301.78 µs]
                        thrpt:  [3.3137 Melem/s 3.3256 Melem/s 3.3374 Melem/s]
                 change:
                        time:   [-18.810% -16.867% -14.853%] (p = 0.00 < 0.05)
                        thrpt:  [+17.444% +20.289% +23.168%]
                        Performance has improved.

```