### PR TITLE
extensions: add macro for context-scalar functions

### DIFF
--- a/extensions/core/src/functions.rs
+++ b/extensions/core/src/functions.rs
@@ -60,3 +60,21 @@ pub trait AggFunc {
     fn step(state: &mut Self::State, args: &[Value]);
     fn finalize(state: Self::State) -> Result<Value, Self::Error>;
 }
+
+/// A scalar function that carries opaque, per-registration state.
+///
+/// `State` is constructed once per registration via [`ScalarFunc::init`], shared
+/// by reference across every invocation, and dropped when the function is
+/// unregistered or the owning connection is dropped. Because a single registration
+/// is shared across connections and may be invoked concurrently, `State` must be
+/// `Send + Sync`.
+///
+/// Stateless functions should use the `#[scalar]` attribute macro instead.
+pub trait ScalarFunc {
+    type State: Send + Sync;
+    const NAME: &'static str;
+    const ALIAS: Option<&'static str> = None;
+
+    fn init() -> Self::State;
+    fn call(state: &Self::State, args: &[Value]) -> Value;
+}

--- a/extensions/core/src/lib.rs
+++ b/extensions/core/src/lib.rs
@@ -4,14 +4,16 @@ mod types;
 mod vfs_modules;
 mod vtabs;
 pub use functions::{
-    AggCtx, AggFunc, ContextDestructor, FinalizeFunction, InitAggFunction, ScalarFunction,
-    StepFunction, ValueDestructor,
+    AggCtx, AggFunc, ContextDestructor, FinalizeFunction, InitAggFunction, ScalarFunc,
+    ScalarFunction, StepFunction, ValueDestructor,
 };
 use functions::{RegisterAggFn, RegisterScalarFn, UnregisterFunctionFn};
 use std::os::raw::c_void;
 #[cfg(feature = "vfs")]
 pub use turso_macros::VfsDerive;
-pub use turso_macros::{register_extension, scalar, AggregateDerive, VTabModuleDerive};
+pub use turso_macros::{
+    register_extension, scalar, AggregateDerive, ScalarDerive, VTabModuleDerive,
+};
 pub use types::{ResultCode, StepResult, Value, ValueType};
 #[cfg(feature = "vfs")]
 pub use vfs_modules::{

--- a/extensions/tests/src/lib.rs
+++ b/extensions/tests/src/lib.rs
@@ -9,15 +9,15 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use turso_ext::{
     register_extension, scalar, Connection, ConstraintInfo, ConstraintOp, ConstraintUsage,
-    ExtResult, IndexInfo, OrderByInfo, ResultCode, StepResult, VTabCursor, VTabKind, VTabModule,
-    VTabModuleDerive, VTable, Value,
+    ExtResult, IndexInfo, OrderByInfo, ResultCode, ScalarDerive, ScalarFunc, StepResult,
+    VTabCursor, VTabKind, VTabModule, VTabModuleDerive, VTable, Value,
 };
 #[cfg(not(target_family = "wasm"))]
 use turso_ext::{BufferRef, Callback, VfsDerive, VfsExtension, VfsFile};
 
 register_extension! {
     vtabs: { KVStoreVTabModule, TableStatsVtabModule },
-    scalars: { test_scalar },
+    scalars: { test_scalar, CtxScalar },
     vfs: { TestFS },
 }
 
@@ -340,6 +340,25 @@ pub struct TestFS {
 #[scalar(name = "test_scalar")]
 fn test_scalar(_args: turso_ext::Value) -> turso_ext::Value {
     turso_ext::Value::from_integer(42)
+}
+
+// Exercises the context-aware scalar path: per-registration state (a multiplier)
+// built once via `init` and shared by reference across every call.
+#[derive(ScalarDerive)]
+struct CtxScalar;
+
+impl ScalarFunc for CtxScalar {
+    type State = i64;
+    const NAME: &'static str = "test_ctx_scalar";
+
+    fn init() -> Self::State {
+        100
+    }
+
+    fn call(state: &Self::State, args: &[Value]) -> Value {
+        let sum: i64 = args.iter().filter_map(Value::to_integer).sum();
+        Value::from_integer(sum + *state)
+    }
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/macros/src/ext/mod.rs
+++ b/macros/src/ext/mod.rs
@@ -11,7 +11,7 @@ mod vfs_derive;
 mod vtab_derive;
 pub use agg_derive::derive_agg_func;
 pub use match_ignore_ascii_case::match_ignore_ascci_case;
-pub use scalars::scalar;
+pub use scalars::{derive_scalar, scalar};
 pub use vfs_derive::derive_vfs_module;
 pub use vtab_derive::derive_vtab_module;
 

--- a/macros/src/ext/scalars.rs
+++ b/macros/src/ext/scalars.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Ident, ItemFn};
+use syn::{parse_macro_input, DeriveInput, Ident, ItemFn};
 
 use super::ScalarInfo;
 
@@ -89,6 +89,120 @@ pub fn scalar(attr: TokenStream, input: TokenStream) -> TokenStream {
                 unsafe { std::slice::from_raw_parts(argv, argc as usize) }
             };
             #fn_body
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Derive registration glue for a stateful scalar function (a struct that
+/// implements `turso_ext::ScalarFunc`).
+///
+/// Generates C-ABI `call`/`drop` shims plus a free `register_<Struct>` entry
+/// point so the struct can be listed directly in the `scalars: { .. }` section
+/// of `register_extension!`, alongside `#[scalar]` functions.
+///
+/// The `ScalarFunc::State` is boxed once per registration and handed back to the
+/// engine as the opaque `context` pointer; the generated drop shim is registered
+/// as the context destructor so the engine frees the state exactly once when the
+/// function is unregistered or the owning connection is dropped.
+pub fn derive_scalar(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let struct_name = &ast.ident;
+
+    let call_fn_name = format_ident!("{}_call", struct_name);
+    let drop_fn_name = format_ident!("{}_drop", struct_name);
+    let register_fn_name = format_ident!("register_{}", struct_name);
+
+    let expanded = quote! {
+        #[no_mangle]
+        pub unsafe extern "C" fn #call_fn_name(
+            context: usize,
+            argc: i32,
+            argv: *const ::turso_ext::Value,
+            _context_destructor: Option<::turso_ext::ContextDestructor>,
+            _value_destructor: Option<::turso_ext::ValueDestructor>,
+        ) -> ::turso_ext::Value {
+            let state = unsafe {
+                &*(context as *const <#struct_name as ::turso_ext::ScalarFunc>::State)
+            };
+            let args = if argv.is_null() || argc <= 0 {
+                &[]
+            } else {
+                unsafe { std::slice::from_raw_parts(argv, argc as usize) }
+            };
+            <#struct_name as ::turso_ext::ScalarFunc>::call(state, args)
+        }
+
+        #[no_mangle]
+        pub unsafe extern "C" fn #drop_fn_name(context: usize) {
+            if context != 0 {
+                drop(unsafe {
+                    ::std::boxed::Box::from_raw(
+                        context as *mut <#struct_name as ::turso_ext::ScalarFunc>::State,
+                    )
+                });
+            }
+        }
+
+        #[no_mangle]
+        pub unsafe extern "C" fn #register_fn_name(
+            api: *const ::turso_ext::ExtensionApi
+        ) -> ::turso_ext::ResultCode {
+            if api.is_null() {
+                return ::turso_ext::ResultCode::Error;
+            }
+            let api = unsafe { &*api };
+
+            let Ok(c_name) = ::std::ffi::CString::new(
+                <#struct_name as ::turso_ext::ScalarFunc>::NAME
+            ) else {
+                return ::turso_ext::ResultCode::Error;
+            };
+            let context = ::std::boxed::Box::into_raw(::std::boxed::Box::new(
+                <#struct_name as ::turso_ext::ScalarFunc>::init(),
+            )) as usize;
+            let rc = (api.register_scalar_function)(
+                api.ctx,
+                c_name.as_ptr(),
+                -1,
+                false,
+                context,
+                #call_fn_name,
+                Some(#drop_fn_name),
+                None,
+            );
+            if !rc.is_ok() {
+                unsafe { #drop_fn_name(context) };
+                return rc;
+            }
+
+            if let Some(alias) = <#struct_name as ::turso_ext::ScalarFunc>::ALIAS {
+                let Ok(alias_c_name) = ::std::ffi::CString::new(alias) else {
+                    return ::turso_ext::ResultCode::Error;
+                };
+                // Each registration owns an independent state box so the drop
+                // shim frees each exactly once.
+                let alias_context = ::std::boxed::Box::into_raw(::std::boxed::Box::new(
+                    <#struct_name as ::turso_ext::ScalarFunc>::init(),
+                )) as usize;
+                let alias_rc = (api.register_scalar_function)(
+                    api.ctx,
+                    alias_c_name.as_ptr(),
+                    -1,
+                    false,
+                    alias_context,
+                    #call_fn_name,
+                    Some(#drop_fn_name),
+                    None,
+                );
+                if !alias_rc.is_ok() {
+                    unsafe { #drop_fn_name(alias_context) };
+                    return alias_rc;
+                }
+            }
+
+            ::turso_ext::ResultCode::OK
         }
     };
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -320,6 +320,35 @@ pub fn scalar(attr: TokenStream, input: TokenStream) -> TokenStream {
     ext::scalar(attr, input)
 }
 
+/// Derive a context-aware scalar function for your extension by deriving
+/// `ScalarDerive` on a struct that implements the `ScalarFunc` trait.
+///
+/// The associated `State` is built once per registration via `init`, shared by
+/// reference across every call, and dropped when the function is unregistered or
+/// the owning connection is dropped. The derived `register_<Struct>` entry point
+/// can be listed directly in the `scalars: { .. }` section of `register_extension!`.
+/// ```ignore
+/// use turso_ext::{register_extension, ScalarDerive, ScalarFunc, Value};
+///
+/// #[derive(ScalarDerive)]
+/// struct Multiply;
+///
+/// impl ScalarFunc for Multiply {
+///     type State = i64;
+///     const NAME: &'static str = "ctx_multiply";
+///     fn init() -> Self::State {
+///         3
+///     }
+///     fn call(state: &Self::State, args: &[Value]) -> Value {
+///         Value::from_integer(args[0].to_integer().unwrap_or_default() * *state)
+///     }
+/// }
+/// ```
+#[proc_macro_derive(ScalarDerive)]
+pub fn derive_scalar(input: TokenStream) -> TokenStream {
+    ext::derive_scalar(input)
+}
+
 /// Define an aggregate function for your extension by deriving
 /// AggregateDerive on a struct that implements the AggFunc trait.
 /// ```ignore

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -427,6 +427,14 @@ def _test_kv(exec_name, ext_path):
         lambda res: "no such module: kv_store" in res,
     )
     turso.execute_dot(f".load {ext_path}")
+    # test_ctx_scalar is only registered by the turso test extension, not the
+    # sqlite3-compat one.
+    if exec_name is None:
+        turso.run_test_fn(
+            "SELECT test_ctx_scalar(40, 2);",
+            lambda res: "142" == res,
+            "can call ScalarDerive context-aware extension function",
+        )
     turso.execute_dot(
         "create virtual table t using kv_store;",
     )

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -11,9 +11,76 @@ use std::{
 };
 use turso_core::{Connection, LimboError, StepResult};
 use turso_ext::{
-    AggCtx, ContextDestructor, FinalizeFunction, InitAggFunction, ResultCode, ScalarFunction,
-    StepFunction, Value as ExtValue, ValueDestructor, ValueType as ExtValueType,
+    AggCtx, ContextDestructor, FinalizeFunction, InitAggFunction, ResultCode, ScalarDerive,
+    ScalarFunc, ScalarFunction, StepFunction, Value as ExtValue, ValueDestructor,
+    ValueType as ExtValueType,
 };
+
+static CTX_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+static CTX_DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct MultiplierState {
+    multiplier: i64,
+}
+
+impl Drop for MultiplierState {
+    fn drop(&mut self) {
+        CTX_DROP_COUNT.fetch_add(1, AtomicOrdering::SeqCst);
+    }
+}
+
+#[derive(ScalarDerive)]
+struct CtxMultiply;
+
+impl ScalarFunc for CtxMultiply {
+    type State = MultiplierState;
+    const NAME: &'static str = "ctx_multiply";
+
+    fn init() -> Self::State {
+        MultiplierState { multiplier: 3 }
+    }
+
+    fn call(state: &Self::State, args: &[ExtValue]) -> ExtValue {
+        CTX_CALL_COUNT.fetch_add(1, AtomicOrdering::SeqCst);
+        let n = args
+            .first()
+            .and_then(ExtValue::to_integer)
+            .unwrap_or_default();
+        ExtValue::from_integer(n * state.multiplier)
+    }
+}
+
+#[turso_macros::test]
+fn scalar_derive_state_is_shared_across_calls_and_dropped_once(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    CTX_CALL_COUNT.store(0, AtomicOrdering::SeqCst);
+    CTX_DROP_COUNT.store(0, AtomicOrdering::SeqCst);
+
+    let conn = tmp_db.connect_limbo();
+
+    // Register via the derive-generated entry point against this connection.
+    let api = unsafe { conn._build_turso_ext() };
+    let rc = unsafe { register_CtxMultiply(&api as *const _) };
+    unsafe { conn._free_extension_ctx(api) };
+    assert_eq!(rc, ResultCode::OK);
+
+    // State (multiplier = 3) is applied, and shared across multiple calls.
+    let first: Vec<(i64,)> = conn.exec_rows("SELECT ctx_multiply(5)");
+    assert_eq!(first, vec![(15,)]);
+    let second: Vec<(i64,)> = conn.exec_rows("SELECT ctx_multiply(10)");
+    assert_eq!(second, vec![(30,)]);
+    assert_eq!(CTX_CALL_COUNT.load(AtomicOrdering::SeqCst), 2);
+
+    // No destructor has fired while the registration is still live.
+    assert_eq!(CTX_DROP_COUNT.load(AtomicOrdering::SeqCst), 0);
+
+    // Dropping the connection drops its symbol table, which runs the state
+    // destructor exactly once.
+    drop(conn);
+    assert_eq!(CTX_DROP_COUNT.load(AtomicOrdering::SeqCst), 1);
+    Ok(())
+}
 
 #[turso_macros::test]
 fn sql_extension_loading_is_disabled_by_default(tmp_db: TempDatabase) -> anyhow::Result<()> {


### PR DESCRIPTION
As part of #7205, scalar functions with context and custom destructors were added, but without the fancy macros we use in the other extensions to improve ergonomics and hide all our unsafe/FFI code from end-users.

This PR adds a new trait/macro for extensions to register those custom functions for stateful/context scalar functions  