### PR TITLE
Begin to remove all blocking IO from core

### DIFF
--- a/core/dbpage.rs
+++ b/core/dbpage.rs
@@ -186,7 +186,8 @@ impl InternalVirtualTableCursor for DbPageCursor {
                     }
                 }
 
-                let (page_ref, completion) = self.pager.read_page(self.pgno)?;
+                let (page_ref, completion) =
+                    self.pager.io.block(|| self.pager.read_page(self.pgno))?;
                 if let Some(c) = completion {
                     self.pager.io.wait_for_completion(c)?;
                 }
@@ -319,7 +320,7 @@ pub(crate) fn update_dbpage(pager: &Arc<Pager>, args: &[Value]) -> Result<Option
         )));
     }
 
-    let (page_ref, completion) = pager.read_page(target_pgno)?;
+    let (page_ref, completion) = pager.io.block(|| pager.read_page(target_pgno))?;
     if let Some(c) = completion {
         pager.io.wait_for_completion(c)?;
     }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -165,6 +165,7 @@ pub use turso_macros::{
     turso_assert_sometimes_less_than, turso_assert_sometimes_less_than_or_equal,
     turso_assert_unreachable, turso_debug_assert, turso_soft_unreachable,
 };
+use types::IOCompletions;
 pub use types::{IOResult, Value, ValueRef};
 pub use util::IOExt;
 pub use vdbe::{
@@ -388,10 +389,86 @@ fn new_header_read_completion(buf: Arc<Buffer>) -> Completion {
 pub enum OpenDbAsyncPhase {
     #[default]
     Init,
+    /// Drives `Database::header_validation` (header validation + WAL recovery)
+    /// as a sub state machine so WAL recovery on open does not block.
+    ValidatingHeader,
     ReadingHeader,
     LoadingSchema,
     BootstrapMvStore,
     Done,
+}
+
+/// Sub state machine for [`Database::header_validation`], driven from
+/// [`OpenDbAsyncPhase::ValidatingHeader`]. Keeps WAL recovery on open
+/// non-blocking by yielding through its IO instead of `io.block`.
+/// Non-blocking read of the 512-byte database file header. Used by
+/// [`Database::init_pager`] to recover page size + reserved bytes without
+/// blocking on open.
+#[derive(Default)]
+enum DbHeaderReadState {
+    #[default]
+    Start,
+    Reading {
+        buf: Arc<Buffer>,
+        completion: Completion,
+    },
+}
+
+/// Sub state machine for [`Database::_init`], driven from
+/// [`HeaderValidationState::Start`]. Builds the `Pager` (reading page-size /
+/// reserved bytes from the DB header), begins a read transaction, then reads
+/// page 1 to determine the autovacuum mode — all without blocking.
+#[derive(Default)]
+enum InitState {
+    #[default]
+    Start,
+    /// Driving `init_pager` (its only IO is the DB-header read).
+    InitPager(DbHeaderReadState),
+    /// Pager built and read-tx open; reading page 1 for the autovacuum mode.
+    ReadPage1 { pager: Box<Pager> },
+}
+
+/// Sub state machine for [`Database::header_validation`], driven from
+/// [`OpenDbAsyncPhase::ValidatingHeader`]. Keeps WAL recovery on open
+/// non-blocking by yielding through its IO instead of `io.block`.
+enum HeaderValidationState {
+    Start {
+        init: InitState,
+    },
+    /// Pager created; (re-entrant) header reads + validation. Holds the owned
+    /// `Pager` because `set_wal` needs `&mut Pager`; it is `Arc`-wrapped only
+    /// once validation completes. `is_readonly`/`log_exists` are captured in
+    /// `Start` (before the autovacuum check may force ReadOnly) so re-entry
+    /// observes the original values.
+    Validate {
+        pager: Box<Pager>,
+        is_readonly: bool,
+        log_exists: bool,
+    },
+    /// A modified header (e.g. Legacy→WAL conversion) must be written to disk
+    /// before the WAL is attached. `completion` is the in-flight write.
+    WriteHeader {
+        pager: Box<Pager>,
+        page: PageRef,
+        open_mv_store: bool,
+        completion: Option<Completion>,
+    },
+    /// Open/recover the shared WAL. On non-host builds `driver` drives the
+    /// `OpenSharedWal` recovery scan; on host builds the WAL is produced
+    /// synchronously (native, where `io.step` pumps).
+    OpenWal {
+        pager: Box<Pager>,
+        open_mv_store: bool,
+        driver: Option<storage::wal::OpenSharedWal>,
+    },
+}
+
+impl Default for HeaderValidationState {
+    fn default() -> Self {
+        Self::Start {
+            init: InitState::default(),
+        }
+    }
 }
 
 /// State machine for async database opening
@@ -406,6 +483,11 @@ pub struct OpenDbAsyncState {
     schema_guard: Option<sync::ArcMutexGuard<Arc<Schema>>>,
     /// Registry key for insertion (computed once at start)
     registry_key: Option<DatabaseKey>,
+    /// The database being built, held across the ValidatingHeader phase yields
+    /// before it is wrapped in an `Arc`.
+    building_db: Option<Database>,
+    /// Sub state machine for `header_validation`, driven in ValidatingHeader.
+    header_validation_state: HeaderValidationState,
 }
 
 impl Default for OpenDbAsyncState {
@@ -425,6 +507,8 @@ impl OpenDbAsyncState {
             make_from_btree_state: schema::MakeFromBtreeState::new(),
             schema_guard: None,
             registry_key: None,
+            building_db: None,
+            header_validation_state: HeaderValidationState::default(),
         }
     }
 }
@@ -1187,7 +1271,30 @@ impl Database {
                     )?;
                     db.durable_storage.clone_from(&durable_storage);
 
-                    let pager = db.header_validation(encryption_key.as_ref())?;
+                    // Header validation + WAL recovery runs as a sub state
+                    // machine in the ValidatingHeader phase so it can yield
+                    // through IO instead of blocking. Stash the owned db and
+                    // the parsed key for that phase.
+                    state.building_db = Some(db);
+                    state.encryption_key = encryption_key;
+                    state.header_validation_state = HeaderValidationState::default();
+                    state.phase = OpenDbAsyncPhase::ValidatingHeader;
+                }
+
+                OpenDbAsyncPhase::ValidatingHeader => {
+                    let db = state
+                        .building_db
+                        .as_mut()
+                        .expect("building_db must be set in Init phase");
+                    let mut hv_state = std::mem::take(&mut state.header_validation_state);
+                    let result = db.header_validation(&mut hv_state, state.encryption_key.as_ref());
+                    state.header_validation_state = hv_state;
+                    let pager = return_if_io!(result);
+
+                    let mut db = state
+                        .building_db
+                        .take()
+                        .expect("building_db must be set in Init phase");
 
                     #[cfg(debug_assertions)]
                     {
@@ -1199,12 +1306,14 @@ impl Database {
                             "Either WAL or MVStore must be enabled"
                         );
                     }
+                    let _ = &mut db;
 
                     // Wrap db in Arc before connecting
                     let db = Arc::new(db);
 
                     // Check: https://github.com/tursodatabase/turso/pull/1761#discussion_r2154013123
-                    let conn = db._connect(false, Some(pager.clone()), encryption_key.clone())?;
+                    let conn =
+                        db._connect(false, Some(pager.clone()), state.encryption_key.clone())?;
 
                     // Acquire schema lock and hold it through ReadingHeader and LoadingSchema phases
                     // to ensure schema_version and make_from_btree are atomic
@@ -1213,7 +1322,6 @@ impl Database {
                     state.db = Some(db);
                     state.pager = Some(pager);
                     state.conn = Some(conn);
-                    state.encryption_key = encryption_key;
                     state.schema_guard = Some(guard);
 
                     state.phase = OpenDbAsyncPhase::ReadingHeader;
@@ -1355,294 +1463,430 @@ impl Database {
 
     /// Necessary Pager initialization, so that we are prepared to read from Page 1.
     /// For encrypted databases, the encryption key must be provided to properly decrypt page 1.
+    /// Blocking shim over [`Database::_init_nonblock`], retained for the
+    /// synchronous callers (connection setup paths). The open state machine
+    /// uses `_init_nonblock` directly so a fresh open never blocks here.
     pub(crate) fn _init(&self, encryption_key: Option<&EncryptionKey>) -> Result<Pager> {
-        let pager = self.init_pager(None)?;
-        pager.enable_encryption(self.opts.enable_encryption);
+        let mut st = InitState::default();
+        self.io
+            .block(|| self._init_nonblock(&mut st, encryption_key))
+    }
 
-        // Set up encryption context BEFORE reading the header page.
-        // For encrypted databases, page 1 has:
-        // - Bytes 0-15: Turso magic header (replaces SQLite magic)
-        // - Bytes 16-100: Unencrypted header metadata
-        // - Bytes 100+: Encrypted content
-        // The encryption context is needed to properly decrypt page 1 when reopening.
-        if let Some(key) = encryption_key {
-            let cipher_mode = self.encryption_cipher_mode.get();
-            pager.set_encryption_context(cipher_mode, key)?;
-        }
-
-        // Start a read transaction before reading page 1 to prevent a concurrent
-        // checkpoint from truncating the WAL underneath bootstrap. Under heavy
-        // same-process connection churn, the shared WAL bootstrap path can
-        // briefly contend on short-lived in-process locks, so treat Busy here as
-        // a transient and retry rather than failing `connect()`.
-        let mut read_tx_attempts = 0u32;
+    /// Necessary Pager initialization, so that we are prepared to read from
+    /// Page 1. For encrypted databases, the encryption key must be provided to
+    /// properly decrypt page 1. Non-blocking: drives `init_pager` (DB-header
+    /// read) and the page-1 autovacuum read through their IO.
+    pub(crate) fn _init_nonblock(
+        &self,
+        st: &mut InitState,
+        encryption_key: Option<&EncryptionKey>,
+    ) -> Result<IOResult<Pager>> {
         loop {
-            match pager.begin_read_tx() {
-                Ok(()) => break,
-                Err(LimboError::Busy) => {
-                    read_tx_attempts += 1;
-                    if read_tx_attempts > 1 {
-                        return Err(LimboError::Busy);
-                    }
-                    pager.io.yield_now();
+            match st {
+                InitState::Start => {
+                    *st = InitState::InitPager(DbHeaderReadState::default());
                 }
-                Err(err) => return Err(err),
+                InitState::InitPager(hdr_st) => {
+                    let pager = return_if_io!(self.init_pager(None, hdr_st));
+                    pager.enable_encryption(self.opts.enable_encryption);
+
+                    // Set up encryption context BEFORE reading the header page.
+                    // For encrypted databases, page 1 has:
+                    // - Bytes 0-15: Turso magic header (replaces SQLite magic)
+                    // - Bytes 16-100: Unencrypted header metadata
+                    // - Bytes 100+: Encrypted content
+                    // The encryption context is needed to properly decrypt page 1 when reopening.
+                    if let Some(key) = encryption_key {
+                        let cipher_mode = self.encryption_cipher_mode.get();
+                        pager.set_encryption_context(cipher_mode, key)?;
+                    }
+
+                    // Start a read transaction before reading page 1 to prevent a concurrent
+                    // checkpoint from truncating the WAL underneath bootstrap. Under heavy
+                    // same-process connection churn, the shared WAL bootstrap path can
+                    // briefly contend on short-lived in-process locks, so treat Busy here as
+                    // a transient and retry rather than failing `connect()`.
+                    let mut read_tx_attempts = 0u32;
+                    loop {
+                        match pager.begin_read_tx() {
+                            Ok(()) => break,
+                            Err(LimboError::Busy) => {
+                                read_tx_attempts += 1;
+                                if read_tx_attempts > 1 {
+                                    return Err(LimboError::Busy);
+                                }
+                                pager.io.yield_now();
+                            }
+                            Err(err) => return Err(err),
+                        }
+                    }
+
+                    *st = InitState::ReadPage1 {
+                        pager: Box::new(pager),
+                    };
+                }
+                InitState::ReadPage1 { pager } => {
+                    // Read page 1 within the read transaction to determine the
+                    // autovacuum mode. The read tx stays open across an IO
+                    // yield here (re-entry resumes the read); we only end it
+                    // once the read completes or errors.
+                    let mode = match HeaderRef::from_pager(pager) {
+                        Ok(IOResult::Done(header_ref)) => {
+                            let header = header_ref.borrow();
+                            if header.vacuum_mode_largest_root_page.get() > 0 {
+                                if header.incremental_vacuum_enabled.get() > 0 {
+                                    AutoVacuumMode::Incremental
+                                } else {
+                                    AutoVacuumMode::Full
+                                }
+                            } else {
+                                AutoVacuumMode::None
+                            }
+                        }
+                        Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
+                        Err(err) => {
+                            pager.end_read_tx();
+                            return Err(err);
+                        }
+                    };
+
+                    pager.end_read_tx();
+                    pager.set_auto_vacuum_mode(mode);
+
+                    let InitState::ReadPage1 { pager } = std::mem::take(st) else {
+                        unreachable!("state is ReadPage1");
+                    };
+                    return Ok(IOResult::Done(*pager));
+                }
             }
         }
-
-        // Read header within the read transaction, ensuring cleanup on error
-        let result = (|| -> Result<AutoVacuumMode> {
-            let header_ref = pager.io.block(|| HeaderRef::from_pager(&pager))?;
-            let header = header_ref.borrow();
-
-            let mode = if header.vacuum_mode_largest_root_page.get() > 0 {
-                if header.incremental_vacuum_enabled.get() > 0 {
-                    AutoVacuumMode::Incremental
-                } else {
-                    AutoVacuumMode::Full
-                }
-            } else {
-                AutoVacuumMode::None
-            };
-
-            Ok(mode)
-        })();
-
-        // Always end read transaction, even on error
-        pager.end_read_tx();
-
-        let mode = result?;
-
-        pager.set_auto_vacuum_mode(mode);
-
-        Ok(pager)
     }
 
     /// Checks the Version numbers in the DatabaseHeader, and changes it according to the required options
     ///
-    /// Will also open MVStore and WAL if needed
-    fn header_validation(&mut self, encryption_key: Option<&EncryptionKey>) -> Result<Arc<Pager>> {
-        let log_exists = journal_mode::logical_log_exists(std::path::Path::new(&self.path));
-        let is_readonly = self.open_flags.contains(OpenFlags::ReadOnly);
-
-        let mut pager = self._init(encryption_key)?;
-        turso_assert!(pager.wal.is_none(), "Pager should have no WAL yet");
-
-        let is_autovacuumed_db = self.io.block(|| {
-            pager.with_header(|header| {
-                header.vacuum_mode_largest_root_page.get() > 0
-                    || header.incremental_vacuum_enabled.get() > 0
-            })
-        })?;
-
-        if is_autovacuumed_db && !self.opts.enable_autovacuum {
-            tracing::warn!(
-                "Database has autovacuum enabled but --experimental-autovacuum flag is not set. Opening in readonly mode."
-            );
-            self.open_flags |= OpenFlags::ReadOnly;
-        }
-
-        let header: HeaderRefMut = self.io.block(|| HeaderRefMut::from_pager(&pager))?;
-        let header_mut = header.borrow_mut();
-
-        if !header_mut.text_encoding.is_utf8() {
-            return Err(LimboError::UnsupportedEncoding(
-                header_mut.text_encoding.to_string(),
-            ));
-        }
-
-        let (read_version, write_version) = { (header_mut.read_version, header_mut.write_version) };
-
-        if encryption_key.is_none() && header_mut.magic != SQLITE_HEADER {
-            tracing::error!(
-                "invalid value of database header magic bytes: {:?}",
-                header_mut.magic
-            );
-            return Err(LimboError::NotADB);
-        }
-        // when we open fresh db with encryption params - header will be SQLite at this point
-        if encryption_key.is_some()
-            && (header_mut.magic != SQLITE_HEADER
-                && !header_mut.magic.starts_with(TURSO_HEADER_PREFIX))
-        {
-            tracing::error!(
-                "invalid value of database header magic bytes: {:?}",
-                header_mut.magic
-            );
-            return Err(LimboError::NotADB);
-        }
-
-        // TODO: right now we don't support READ ONLY and no READ or WRITE in the Version header
-        // https://www.sqlite.org/fileformat.html#file_format_version_numbers
-        if read_version != write_version {
-            return Err(LimboError::Corrupt(format!(
-                "Read version `{read_version:?}` is not equal to Write version `{write_version:?} in database header`"
-            )));
-        }
-
-        let (read_version, _write_version) = (
-            read_version
-                .to_version()
-                .map_err(|val| LimboError::Corrupt(format!("Invalid read_version: {val}")))?,
-            write_version
-                .to_version()
-                .map_err(|val| LimboError::Corrupt(format!("Invalid write_version: {val}")))?,
-        );
-
-        // Validate fixed header fields per SQLite spec
-        if header_mut.max_embed_frac != 64 {
-            return Err(LimboError::Corrupt(format!(
-                "Invalid max_embed_frac: expected 64, got {}",
-                header_mut.max_embed_frac
-            )));
-        }
-        if header_mut.min_embed_frac != 32 {
-            return Err(LimboError::Corrupt(format!(
-                "Invalid min_embed_frac: expected 32, got {}",
-                header_mut.min_embed_frac
-            )));
-        }
-        if header_mut.leaf_frac != 32 {
-            return Err(LimboError::Corrupt(format!(
-                "Invalid leaf_frac: expected 32, got {}",
-                header_mut.leaf_frac
-            )));
-        }
-        let schema_format = header_mut.schema_format.get();
-        // If the database is completely empty, if it has no schema, then the schema format number can be zero.
-        if !(0..=4).contains(&schema_format) {
-            return Err(LimboError::Corrupt(format!(
-                "Invalid schema_format: expected 1-4, got {schema_format}"
-            )));
-        }
-        if !matches!(
-            header_mut.text_encoding,
-            TextEncoding::Unset
-                | TextEncoding::Utf8
-                | TextEncoding::Utf16Le
-                | TextEncoding::Utf16Be
-        ) {
-            return Err(LimboError::Corrupt(format!(
-                "Invalid text_encoding: {}",
-                header_mut.text_encoding
-            )));
-        }
-        if !matches!(
-            header_mut.text_encoding,
-            TextEncoding::Unset | TextEncoding::Utf8
-        ) {
-            return Err(LimboError::Corrupt(format!(
-                "Only utf8 text_encoding is supported by tursodb: got={}",
-                header_mut.text_encoding
-            )));
-        }
-
-        // Determine if we should open in MVCC mode based on the database header version
-        // MVCC is controlled only by the database header (set via PRAGMA journal_mode)
-        let open_mv_store = matches!(read_version, Version::Mvcc);
-
-        // Now check the Header Version to see which mode the DB file really is on
-        // Track if header was modified so we can write it to disk
-        let header_modified = match read_version {
-            Version::Legacy => {
-                if is_readonly {
-                    tracing::warn!(
-                        "Database {} is opened in readonly mode, cannot convert Legacy mode to WAL. Running in Legacy mode.",
-                        self.path
-                    );
-                    false
-                } else {
-                    // Convert Legacy to WAL mode
-                    header_mut.read_version = RawVersion::from(Version::Wal);
-                    header_mut.write_version = RawVersion::from(Version::Wal);
-                    true
+    /// Will also open MVStore and WAL if needed.
+    ///
+    /// Driven as a sub state machine (see [`HeaderValidationState`]) from the
+    /// `ValidatingHeader` open phase so that WAL recovery on open yields
+    /// through its IO instead of blocking — this is what lets a fresh open
+    /// make progress on runtimes (e.g. WASM) that cannot pump `io.step`
+    /// synchronously.
+    fn header_validation(
+        &mut self,
+        st: &mut HeaderValidationState,
+        encryption_key: Option<&EncryptionKey>,
+    ) -> Result<IOResult<Arc<Pager>>> {
+        loop {
+            match st {
+                HeaderValidationState::Start { init } => {
+                    // `_init` does not modify `open_flags` (the autovacuum
+                    // override happens later in `Validate`), so capturing
+                    // `is_readonly` across the `_init` yields is stable.
+                    let pager = return_if_io!(self._init_nonblock(init, encryption_key));
+                    let log_exists =
+                        journal_mode::logical_log_exists(std::path::Path::new(&self.path));
+                    let is_readonly = self.open_flags.contains(OpenFlags::ReadOnly);
+                    turso_assert!(pager.wal.is_none(), "Pager should have no WAL yet");
+                    *st = HeaderValidationState::Validate {
+                        pager: Box::new(pager),
+                        is_readonly,
+                        log_exists,
+                    };
                 }
-            }
-            Version::Wal => false,
-            Version::Mvcc => false,
-        };
+                HeaderValidationState::Validate {
+                    pager,
+                    is_readonly,
+                    log_exists,
+                } => {
+                    let is_readonly = *is_readonly;
+                    let log_exists = *log_exists;
 
-        // In WAL mode, a logical log is always unexpected.
-        // In MVCC mode, WAL and logical-log coexistence can happen across interrupted checkpoint
-        // recovery and is reconciled in MvStore::bootstrap().
-        if !open_mv_store && log_exists {
-            return Err(LimboError::Corrupt(format!(
-                "MVCC logical log file exists for database {}, but database header indicates WAL mode. The database may be corrupted.",
-                self.path
-            )));
-        }
-
-        // If header was modified, write it directly to disk before we clear the cache
-        // This must happen before WAL is attached since we need to write directly to the DB file
-        if header_modified {
-            let completion =
-                storage::sqlite3_ondisk::begin_write_btree_page(&pager, header.page())?;
-            self.io.wait_for_completion(completion)?;
-        }
-
-        drop(header);
-
-        let flags = self.open_flags;
-
-        // Always Open shared wal and set it in the Database and Pager.
-        // MVCC currently requires a WAL open to function
-        #[cfg(host_shared_wal)]
-        let shared_authority = self.open_shared_wal_coordination_for_open()?;
-        #[cfg(not(host_shared_wal))]
-        let shared_authority: Option<()> = None;
-
-        let shared_wal = {
-            #[cfg(host_shared_wal)]
-            {
-                if let Some(authority) = shared_authority.as_ref() {
-                    // The no-scan open path only works if the shared frame index
-                    // is complete. If the reserved shared index space was fully
-                    // exhausted, rebuild local WAL state from the file instead.
-                    if !authority.frame_index_overflowed() {
-                        WalFileShared::open_shared_from_authority_if_exists(
-                            &self.io,
-                            &self.wal_path,
-                            flags,
-                            authority,
-                            &self.db_file,
-                        )?
-                    } else {
-                        WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+                    // Re-entrant reads: both `with_header` and `from_pager`
+                    // resume via their own state machines, and the autovacuum
+                    // flag update is idempotent.
+                    let is_autovacuumed_db = return_if_io!(pager.with_header(|header| {
+                        header.vacuum_mode_largest_root_page.get() > 0
+                            || header.incremental_vacuum_enabled.get() > 0
+                    }));
+                    if is_autovacuumed_db && !self.opts.enable_autovacuum {
+                        tracing::warn!(
+                            "Database has autovacuum enabled but --experimental-autovacuum flag is not set. Opening in readonly mode."
+                        );
+                        self.open_flags |= OpenFlags::ReadOnly;
                     }
-                } else {
-                    WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
+
+                    let header: HeaderRefMut = return_if_io!(HeaderRefMut::from_pager(pager));
+                    let header_mut = header.borrow_mut();
+
+                    if !header_mut.text_encoding.is_utf8() {
+                        return Err(LimboError::UnsupportedEncoding(
+                            header_mut.text_encoding.to_string(),
+                        ));
+                    }
+
+                    let (read_version, write_version) =
+                        { (header_mut.read_version, header_mut.write_version) };
+
+                    if encryption_key.is_none() && header_mut.magic != SQLITE_HEADER {
+                        tracing::error!(
+                            "invalid value of database header magic bytes: {:?}",
+                            header_mut.magic
+                        );
+                        return Err(LimboError::NotADB);
+                    }
+                    // when we open fresh db with encryption params - header will be SQLite at this point
+                    if encryption_key.is_some()
+                        && (header_mut.magic != SQLITE_HEADER
+                            && !header_mut.magic.starts_with(TURSO_HEADER_PREFIX))
+                    {
+                        tracing::error!(
+                            "invalid value of database header magic bytes: {:?}",
+                            header_mut.magic
+                        );
+                        return Err(LimboError::NotADB);
+                    }
+
+                    // TODO: right now we don't support READ ONLY and no READ or WRITE in the Version header
+                    // https://www.sqlite.org/fileformat.html#file_format_version_numbers
+                    if read_version != write_version {
+                        return Err(LimboError::Corrupt(format!(
+                            "Read version `{read_version:?}` is not equal to Write version `{write_version:?} in database header`"
+                        )));
+                    }
+
+                    let (read_version, _write_version) = (
+                        read_version.to_version().map_err(|val| {
+                            LimboError::Corrupt(format!("Invalid read_version: {val}"))
+                        })?,
+                        write_version.to_version().map_err(|val| {
+                            LimboError::Corrupt(format!("Invalid write_version: {val}"))
+                        })?,
+                    );
+
+                    // Validate fixed header fields per SQLite spec
+                    if header_mut.max_embed_frac != 64 {
+                        return Err(LimboError::Corrupt(format!(
+                            "Invalid max_embed_frac: expected 64, got {}",
+                            header_mut.max_embed_frac
+                        )));
+                    }
+                    if header_mut.min_embed_frac != 32 {
+                        return Err(LimboError::Corrupt(format!(
+                            "Invalid min_embed_frac: expected 32, got {}",
+                            header_mut.min_embed_frac
+                        )));
+                    }
+                    if header_mut.leaf_frac != 32 {
+                        return Err(LimboError::Corrupt(format!(
+                            "Invalid leaf_frac: expected 32, got {}",
+                            header_mut.leaf_frac
+                        )));
+                    }
+                    let schema_format = header_mut.schema_format.get();
+                    // If the database is completely empty, if it has no schema, then the schema format number can be zero.
+                    if !(0..=4).contains(&schema_format) {
+                        return Err(LimboError::Corrupt(format!(
+                            "Invalid schema_format: expected 1-4, got {schema_format}"
+                        )));
+                    }
+                    if !matches!(
+                        header_mut.text_encoding,
+                        TextEncoding::Unset
+                            | TextEncoding::Utf8
+                            | TextEncoding::Utf16Le
+                            | TextEncoding::Utf16Be
+                    ) {
+                        return Err(LimboError::Corrupt(format!(
+                            "Invalid text_encoding: {}",
+                            header_mut.text_encoding
+                        )));
+                    }
+                    if !matches!(
+                        header_mut.text_encoding,
+                        TextEncoding::Unset | TextEncoding::Utf8
+                    ) {
+                        return Err(LimboError::Corrupt(format!(
+                            "Only utf8 text_encoding is supported by tursodb: got={}",
+                            header_mut.text_encoding
+                        )));
+                    }
+
+                    // Determine if we should open in MVCC mode based on the database header version
+                    // MVCC is controlled only by the database header (set via PRAGMA journal_mode)
+                    let open_mv_store = matches!(read_version, Version::Mvcc);
+
+                    // Now check the Header Version to see which mode the DB file really is on
+                    // Track if header was modified so we can write it to disk
+                    let header_modified = match read_version {
+                        Version::Legacy => {
+                            if is_readonly {
+                                tracing::warn!(
+                                    "Database {} is opened in readonly mode, cannot convert Legacy mode to WAL. Running in Legacy mode.",
+                                    self.path
+                                );
+                                false
+                            } else {
+                                // Convert Legacy to WAL mode
+                                header_mut.read_version = RawVersion::from(Version::Wal);
+                                header_mut.write_version = RawVersion::from(Version::Wal);
+                                true
+                            }
+                        }
+                        Version::Wal => false,
+                        Version::Mvcc => false,
+                    };
+
+                    // In WAL mode, a logical log is always unexpected.
+                    // In MVCC mode, WAL and logical-log coexistence can happen across interrupted checkpoint
+                    // recovery and is reconciled in MvStore::bootstrap().
+                    if !open_mv_store && log_exists {
+                        return Err(LimboError::Corrupt(format!(
+                            "MVCC logical log file exists for database {}, but database header indicates WAL mode. The database may be corrupted.",
+                            self.path
+                        )));
+                    }
+
+                    let page = header.page().clone();
+                    // `header` (a cheap Arc<Page> wrapper, no lock) is dropped
+                    // here; the page ref carries the (possibly modified) header
+                    // buffer forward.
+                    drop(header);
+
+                    // Move the owned pager out of the state to build the next.
+                    let HeaderValidationState::Validate { pager, .. } = std::mem::take(st) else {
+                        unreachable!("state is Validate");
+                    };
+                    *st = if header_modified {
+                        HeaderValidationState::WriteHeader {
+                            pager,
+                            page,
+                            open_mv_store,
+                            completion: None,
+                        }
+                    } else {
+                        HeaderValidationState::OpenWal {
+                            pager,
+                            open_mv_store,
+                            driver: None,
+                        }
+                    };
+                }
+                HeaderValidationState::WriteHeader {
+                    pager,
+                    page,
+                    open_mv_store,
+                    completion,
+                } => {
+                    // If header was modified, write it directly to disk before we attach the
+                    // WAL / clear the cache (must hit the DB file, not the WAL).
+                    let c = match completion.take() {
+                        Some(c) => c,
+                        None => storage::sqlite3_ondisk::begin_write_btree_page(pager, page)?,
+                    };
+                    if !c.succeeded() {
+                        *completion = Some(c.clone());
+                        io_yield_one!(c);
+                    }
+                    let open_mv_store = *open_mv_store;
+                    let HeaderValidationState::WriteHeader { pager, .. } = std::mem::take(st)
+                    else {
+                        unreachable!("state is WriteHeader");
+                    };
+                    *st = HeaderValidationState::OpenWal {
+                        pager,
+                        open_mv_store,
+                        driver: None,
+                    };
+                }
+                HeaderValidationState::OpenWal {
+                    open_mv_store,
+                    driver,
+                    ..
+                } => {
+                    // Always open shared WAL and set it in the Database and Pager.
+                    // MVCC currently requires a WAL open to function.
+                    let shared_wal = {
+                        #[cfg(not(host_shared_wal))]
+                        {
+                            if driver.is_none() {
+                                *driver = Some(WalFileShared::open_shared_if_exists_begin(
+                                    &self.io,
+                                    &self.wal_path,
+                                    self.open_flags,
+                                )?);
+                            }
+                            return_if_io!(driver.as_mut().expect("driver initialized above").poll())
+                        }
+                        #[cfg(host_shared_wal)]
+                        {
+                            // Native-only coordination path: `io.step` pumps
+                            // synchronously here, so the blocking shims are
+                            // fine. (Driver field is unused on host.)
+                            let _ = &driver;
+                            let flags = self.open_flags;
+                            let shared_authority = self.open_shared_wal_coordination_for_open()?;
+                            if let Some(authority) = shared_authority.as_ref() {
+                                if !authority.frame_index_overflowed() {
+                                    WalFileShared::open_shared_from_authority_if_exists(
+                                        &self.io,
+                                        &self.wal_path,
+                                        flags,
+                                        authority,
+                                        &self.db_file,
+                                    )?
+                                } else {
+                                    WalFileShared::open_shared_if_exists(
+                                        &self.io,
+                                        &self.wal_path,
+                                        flags,
+                                    )?
+                                }
+                            } else {
+                                WalFileShared::open_shared_if_exists(
+                                    &self.io,
+                                    &self.wal_path,
+                                    flags,
+                                )?
+                            }
+                        }
+                    };
+
+                    let open_mv_store = *open_mv_store;
+                    let HeaderValidationState::OpenWal { mut pager, .. } = std::mem::take(st)
+                    else {
+                        unreachable!("state is OpenWal");
+                    };
+
+                    self.shared_wal = shared_wal;
+                    let last_checksum_and_max_frame =
+                        self.shared_wal.read().last_checksum_and_max_frame();
+                    let wal =
+                        self.build_wal(last_checksum_and_max_frame, pager.buffer_pool.clone())?;
+                    pager.set_wal(wal);
+
+                    // Clear page cache after attaching WAL since pages may have been cached
+                    // from disk reads before WAL was attached. The WAL may contain newer
+                    // versions of these pages (e.g., page 1 with updated schema_cookie).
+                    pager.clear_page_cache(true);
+                    pager.set_schema_cookie(None);
+
+                    if open_mv_store {
+                        let canonical_path = self.get_database_canonical_path();
+                        let enc_ctx = pager.io_ctx.read().encryption_context().cloned();
+                        let mv_store = journal_mode::open_mv_store(
+                            self.io.clone(),
+                            &canonical_path,
+                            self.open_flags,
+                            self.durable_storage.clone(),
+                            enc_ctx,
+                        )?;
+                        self.mv_store.store(Some(mv_store));
+                    }
+
+                    return Ok(IOResult::Done(Arc::new(*pager)));
                 }
             }
-            #[cfg(not(host_shared_wal))]
-            {
-                WalFileShared::open_shared_if_exists(&self.io, &self.wal_path, flags)?
-            }
-        };
-        self.shared_wal = shared_wal;
-        let last_checksum_and_max_frame = self.shared_wal.read().last_checksum_and_max_frame();
-        let wal = self.build_wal(last_checksum_and_max_frame, pager.buffer_pool.clone())?;
-        pager.set_wal(wal);
-
-        // Clear page cache after attaching WAL since pages may have been cached
-        // from disk reads before WAL was attached. The WAL may contain newer
-        // versions of these pages (e.g., page 1 with updated schema_cookie).
-        pager.clear_page_cache(true);
-        pager.set_schema_cookie(None);
-
-        if open_mv_store {
-            let canonical_path = self.get_database_canonical_path();
-            let enc_ctx = pager.io_ctx.read().encryption_context().cloned();
-            let mv_store = journal_mode::open_mv_store(
-                self.io.clone(),
-                &canonical_path,
-                self.open_flags,
-                self.durable_storage.clone(),
-                enc_ctx,
-            )?;
-            self.mv_store.store(Some(mv_store));
         }
-
-        Ok(Arc::new(pager))
     }
 
     pub fn get_database_canonical_path(&self) -> String {
@@ -1771,44 +2015,37 @@ impl Database {
 
     /// If we do not have a physical WAL file, but we know the database file is initialized on disk,
     /// we need to read the page_size from the database header.
-    fn read_page_size_from_db_header(&self) -> Result<PageSize> {
-        turso_assert!(
-            self.initialized(),
-            "read_reserved_space_bytes_from_db_header called on uninitialized database"
-        );
-        turso_assert!(
-            PageSize::MIN % 512 == 0,
-            "header read must be a multiple of 512 for O_DIRECT"
-        );
-        let buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
-        let c = new_header_read_completion(buf.clone());
-        let c = self.db_file.read_header(c)?;
-        self.io.wait_for_completion(c)?;
-        let page_size = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
-        let page_size = PageSize::new_from_header_u16(page_size)?;
-        Ok(page_size)
+    /// Non-blocking read of the 512-byte database file header (page 1's
+    /// header region). Yields the read completion via the supplied state until
+    /// it finishes, then returns the filled buffer.
+    fn read_db_header_buf(&self, st: &mut DbHeaderReadState) -> Result<IOResult<Arc<Buffer>>> {
+        loop {
+            match st {
+                DbHeaderReadState::Start => {
+                    turso_assert!(
+                        PageSize::MIN % 512 == 0,
+                        "header read must be a multiple of 512 for O_DIRECT"
+                    );
+                    let buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
+                    let c = new_header_read_completion(buf.clone());
+                    let c = self.db_file.read_header(c)?;
+                    *st = DbHeaderReadState::Reading { buf, completion: c };
+                }
+                DbHeaderReadState::Reading { buf, completion } => {
+                    if !completion.succeeded() {
+                        let c = completion.clone();
+                        io_yield_one!(c);
+                    }
+                    return Ok(IOResult::Done(buf.clone()));
+                }
+            }
+        }
     }
 
-    fn read_reserved_space_bytes_from_db_header(&self) -> Result<u8> {
-        turso_assert!(
-            self.initialized(),
-            "read_reserved_space_bytes_from_db_header called on uninitialized database"
-        );
-        turso_assert!(
-            PageSize::MIN % 512 == 0,
-            "header read must be a multiple of 512 for O_DIRECT"
-        );
-        let buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
-        let c = new_header_read_completion(buf.clone());
-        let c = self.db_file.read_header(c)?;
-        self.io.wait_for_completion(c)?;
-        let reserved_bytes = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
-        Ok(reserved_bytes)
-    }
-
-    /// Read the page size in order of preference:
+    /// Determine the actual page size, in order of preference:
     /// 1. From the WAL header if it exists and is initialized
-    /// 2. From the database header if the database is initialized
+    /// 2. From `header_page_size` (read from the DB header by the caller) if
+    ///    the database is initialized
     ///
     /// Otherwise, fall back to, in order of preference:
     /// 1. From the requested page size if it is provided
@@ -1817,6 +2054,7 @@ impl Database {
         &self,
         shared_wal: &WalFileShared,
         requested_page_size: Option<usize>,
+        header_page_size: Option<PageSize>,
     ) -> Result<PageSize> {
         if shared_wal.metadata.enabled.load(Ordering::SeqCst) {
             let size_in_wal = shared_wal.page_size();
@@ -1827,8 +2065,8 @@ impl Database {
                 return Ok(page_size);
             }
         }
-        if self.initialized() {
-            Ok(self.read_page_size_from_db_header()?)
+        if let Some(page_size) = header_page_size {
+            Ok(page_size)
         } else {
             let Some(size) = requested_page_size else {
                 return Ok(PageSize::default());
@@ -1837,16 +2075,6 @@ impl Database {
                 bail_corrupt_error!("invalid requested page size: {size}");
             };
             Ok(page_size)
-        }
-    }
-
-    /// if the database is initialized i.e. it exists on disk, return the reserved space bytes from
-    /// the header or None
-    fn maybe_get_reserved_space_bytes(&self) -> Result<Option<u8>> {
-        if self.initialized() {
-            Ok(Some(self.read_reserved_space_bytes_from_db_header()?))
-        } else {
-            Ok(None)
         }
     }
 
@@ -2252,9 +2480,27 @@ impl Database {
         )))
     }
 
-    fn init_pager(&self, requested_page_size: Option<usize>) -> Result<Pager> {
+    fn init_pager(
+        &self,
+        requested_page_size: Option<usize>,
+        hdr_st: &mut DbHeaderReadState,
+    ) -> Result<IOResult<Pager>> {
         let cipher = self.encryption_cipher_mode.get();
-        let reserved_bytes = self.maybe_get_reserved_space_bytes()?.or_else(|| {
+
+        // For an existing (initialized) database, read the 512-byte header
+        // once (non-blocking) and recover both the reserved-space byte and the
+        // on-disk page size from it.
+        let (header_reserved_bytes, header_page_size) = if self.initialized() {
+            let buf = return_if_io!(self.read_db_header_buf(hdr_st));
+            let reserved = u8::from_be_bytes(buf.as_slice()[20..21].try_into().unwrap());
+            let ps_raw = u16::from_be_bytes(buf.as_slice()[16..18].try_into().unwrap());
+            let page_size = PageSize::new_from_header_u16(ps_raw)?;
+            (Some(reserved), Some(page_size))
+        } else {
+            (None, None)
+        };
+
+        let reserved_bytes = header_reserved_bytes.or_else(|| {
             if !matches!(cipher, CipherMode::None) {
                 // For encryption, use the cipher's metadata size
                 Some(cipher.metadata_size() as u8)
@@ -2271,7 +2517,8 @@ impl Database {
         // Check if WAL is enabled
         let shared_wal = self.shared_wal.read();
 
-        let page_size = self.determine_actual_page_size(&shared_wal, requested_page_size)?;
+        let page_size =
+            self.determine_actual_page_size(&shared_wal, requested_page_size, header_page_size)?;
 
         let buffer_pool = self.buffer_pool.clone();
         if self.initialized() {
@@ -2304,7 +2551,7 @@ impl Database {
             pager.reset_checksum_context();
         }
 
-        Ok(pager)
+        Ok(IOResult::Done(pager))
     }
 
     #[cfg(feature = "fs")]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -887,19 +887,14 @@ impl BTreeCursor {
             let state = self.is_empty_table_state.clone();
             match state {
                 EmptyTableState::Start => {
-                    // On `IO(spill_c)` we have not produced a page yet — leave
-                    // the state at `Start` so re-entry restarts here and the
-                    // pager's pending-read tracking returns the same PageRef.
-                    match self.pager.read_page(self.root_page)? {
-                        IOResult::Done((page, c)) => {
-                            self.is_empty_table_state = EmptyTableState::ReadPage { page };
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    // On spill `return_if_io!` propagates `IO` up unchanged —
+                    // we have not produced a page yet, the state stays at
+                    // `Start`, and re-entry resumes here with the pager's
+                    // pending-read tracking returning the same PageRef.
+                    let (page, c) = return_if_io!(self.pager.read_page(self.root_page));
+                    self.is_empty_table_state = EmptyTableState::ReadPage { page };
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
                 }
                 EmptyTableState::ReadPage { page } => {
@@ -925,19 +920,13 @@ impl BTreeCursor {
                 if let Some(IterationPendingDescent::Backwards(target)) =
                     self.iteration_pending_descent
                 {
-                    match self.pager.read_page(target)? {
-                        IOResult::Done((mem_page, c)) => {
-                            self.iteration_pending_descent = None;
-                            self.descend_backwards(mem_page);
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                            continue;
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    let (mem_page, c) = return_if_io!(self.pager.read_page(target));
+                    self.iteration_pending_descent = None;
+                    self.descend_backwards(mem_page);
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
+                    continue;
                 }
                 let (old_top_idx, page_type, is_index, is_leaf, cell_count) = {
                     let page = self.stack.top_ref();
@@ -964,19 +953,13 @@ impl BTreeCursor {
                         // descend; the loop's outer match on `cell_idx ==
                         // i32::MAX` would not re-fire if `set_cell_index`
                         // had moved us past it.
-                        match self.read_page(rightmost_pointer as i64)? {
-                            IOResult::Done((page, c)) => {
-                                self.stack.set_cell_index(past_rightmost_pointer);
-                                self.descend_backwards(page);
-                                if let Some(c) = c {
-                                    io_yield_one!(c);
-                                }
-                                continue;
-                            }
-                            IOResult::IO(IOCompletions::Single(spill_c)) => {
-                                io_yield_one!(spill_c);
-                            }
+                        let (page, c) = return_if_io!(self.read_page(rightmost_pointer as i64));
+                        self.stack.set_cell_index(past_rightmost_pointer);
+                        self.descend_backwards(page);
+                        if let Some(c) = c {
+                            io_yield_one!(c);
                         }
+                        continue;
                     }
                 }
 
@@ -1092,23 +1075,17 @@ impl BTreeCursor {
                 // would leave `read_overflow_state` half-initialized on a
                 // page that doesn't exist yet, and re-entry would skip the
                 // `is_none()` branch entirely.
-                match self.read_page(start_next_page as i64)? {
-                    IOResult::Done((page, c)) => {
-                        self.read_overflow_state.replace(ReadPayloadOverflow {
-                            payload: payload.to_vec(),
-                            next_page: start_next_page,
-                            remaining_to_read,
-                            page,
-                        });
-                        if let Some(c) = c {
-                            io_yield_one!(c);
-                        }
-                        continue;
-                    }
-                    IOResult::IO(IOCompletions::Single(spill_c)) => {
-                        io_yield_one!(spill_c);
-                    }
+                let (page, c) = return_if_io!(self.read_page(start_next_page as i64));
+                self.read_overflow_state.replace(ReadPayloadOverflow {
+                    payload: payload.to_vec(),
+                    next_page: start_next_page,
+                    remaining_to_read,
+                    page,
+                });
+                if let Some(c) = c {
+                    io_yield_one!(c);
                 }
+                continue;
             }
             // Compute `next` / `to_read` and fetch the next chain page (if
             // any) BEFORE applying the loop body's non-idempotent mutations,
@@ -1132,12 +1109,7 @@ impl BTreeCursor {
                 )
             };
             let new_page_and_c = if need_next_page {
-                match self.read_page(next as i64)? {
-                    IOResult::Done(v) => Some(v),
-                    IOResult::IO(IOCompletions::Single(spill_c)) => {
-                        io_yield_one!(spill_c);
-                    }
-                }
+                Some(return_if_io!(self.read_page(next as i64)))
             } else {
                 None
             };
@@ -1225,19 +1197,13 @@ impl BTreeCursor {
                 if let Some(IterationPendingDescent::Forwards(target)) =
                     self.iteration_pending_descent
                 {
-                    match self.pager.read_page(target)? {
-                        IOResult::Done((mem_page, c)) => {
-                            self.iteration_pending_descent = None;
-                            self.descend(mem_page);
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                            continue;
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    let (mem_page, c) = return_if_io!(self.pager.read_page(target));
+                    self.iteration_pending_descent = None;
+                    self.descend(mem_page);
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
+                    continue;
                 }
                 let mem_page = self.stack.top_ref();
                 let contents = mem_page.get_contents();
@@ -1436,16 +1402,10 @@ impl BTreeCursor {
         self.seek_state = CursorSeekState::Start;
         self.going_upwards = false;
         tracing::trace!(root_page = self.root_page);
-        match self.read_page(self.root_page)? {
-            IOResult::Done((mem_page, c)) => {
-                self.stack.clear();
-                self.stack.push(mem_page);
-                Ok(IOResult::Done(c))
-            }
-            IOResult::IO(IOCompletions::Single(spill_c)) => {
-                io_yield_one!(spill_c);
-            }
-        }
+        let (mem_page, c) = return_if_io!(self.read_page(self.root_page));
+        self.stack.clear();
+        self.stack.push(mem_page);
+        Ok(IOResult::Done(c))
     }
 
     /// Move the cursor to the rightmost record in the btree.
@@ -1496,17 +1456,12 @@ impl BTreeCursor {
                             // re-reads the same parent contents and retries the
                             // descent — the disk-read for this child is memoized
                             // in `pending_reads`, so no duplicate IO is issued.
-                            match self.read_page(right_most_pointer as i64)? {
-                                IOResult::Done((mem_page, c)) => {
-                                    self.stack.set_cell_index(contents.cell_count() as i32 + 1);
-                                    self.stack.push(mem_page);
-                                    if let Some(c) = c {
-                                        io_yield_one!(c);
-                                    }
-                                }
-                                IOResult::IO(IOCompletions::Single(spill_c)) => {
-                                    io_yield_one!(spill_c);
-                                }
+                            let (mem_page, c) =
+                                return_if_io!(self.read_page(right_most_pointer as i64));
+                            self.stack.set_cell_index(contents.cell_count() as i32 + 1);
+                            self.stack.push(mem_page);
+                            if let Some(c) = c {
+                                io_yield_one!(c);
                             }
                         }
                         None => {
@@ -4856,17 +4811,10 @@ impl BTreeCursor {
                         }
                         // No mutations precede this read in the Start branch,
                         // so a spill yield safely re-enters here.
-                        match self.read_page(next_page as i64)? {
-                            IOResult::Done((page, c)) => {
-                                self.overflow_state =
-                                    OverflowState::ProcessPage { next_page: page };
-                                if let Some(c) = c {
-                                    io_yield_one!(c);
-                                }
-                            }
-                            IOResult::IO(IOCompletions::Single(spill_c)) => {
-                                io_yield_one!(spill_c);
-                            }
+                        let (page, c) = return_if_io!(self.read_page(next_page as i64));
+                        self.overflow_state = OverflowState::ProcessPage { next_page: page };
+                        if let Some(c) = c {
+                            io_yield_one!(c);
                         }
                     } else {
                         self.overflow_state = OverflowState::Done;
@@ -4906,17 +4854,13 @@ impl BTreeCursor {
                         self.overflow_state = OverflowState::Done;
                     }
                 }
-                OverflowState::ReadNext { next } => match self.pager.read_page(next as i64)? {
-                    IOResult::Done((page, c)) => {
-                        self.overflow_state = OverflowState::ProcessPage { next_page: page };
-                        if let Some(c) = c {
-                            io_yield_one!(c);
-                        }
+                OverflowState::ReadNext { next } => {
+                    let (page, c) = return_if_io!(self.pager.read_page(next as i64));
+                    self.overflow_state = OverflowState::ProcessPage { next_page: page };
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
-                    IOResult::IO(IOCompletions::Single(spill_c)) => {
-                        io_yield_one!(spill_c);
-                    }
-                },
+                }
                 OverflowState::Done => {
                     self.overflow_state = OverflowState::Start;
                     return Ok(IOResult::Done(()));
@@ -5151,22 +5095,18 @@ impl BTreeCursor {
                         _ => panic!("unexpected cell type"),
                     }
                 }
-                DestroyState::PendingDescent { target } => match self.pager.read_page(target)? {
-                    IOResult::Done((child_page, c)) => {
-                        self.stack.push(child_page);
-                        let destroy_info = self
-                            .state
-                            .mut_destroy_info()
-                            .expect("unable to get a mut reference to destroy state in cursor");
-                        destroy_info.state = DestroyState::LoadPage;
-                        if let Some(c) = c {
-                            io_yield_one!(c);
-                        }
+                DestroyState::PendingDescent { target } => {
+                    let (child_page, c) = return_if_io!(self.pager.read_page(target));
+                    self.stack.push(child_page);
+                    let destroy_info = self
+                        .state
+                        .mut_destroy_info()
+                        .expect("unable to get a mut reference to destroy state in cursor");
+                    destroy_info.state = DestroyState::LoadPage;
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
-                    IOResult::IO(IOCompletions::Single(spill_c)) => {
-                        io_yield_one!(spill_c);
-                    }
-                },
+                }
                 DestroyState::FreePage => {
                     let page = self.stack.top();
                     let page_id = page.get().id;
@@ -6119,18 +6059,12 @@ impl CursorTrait for BTreeCursor {
                     // Resume after a spill yield from `CountState::Loop` mid-
                     // descent. The loop-top mutations are already applied for
                     // this step; finish the descent and return to `Loop`.
-                    match self.pager.read_page(target)? {
-                        IOResult::Done((child, c)) => {
-                            self.stack.advance();
-                            self.stack.push(child);
-                            self.count_state = CountState::Loop;
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    let (child, c) = return_if_io!(self.pager.read_page(target));
+                    self.stack.advance();
+                    self.stack.push(child);
+                    self.count_state = CountState::Loop;
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
                 }
                 CountState::Finish => {
@@ -6248,17 +6182,12 @@ impl CursorTrait for BTreeCursor {
 
                     match contents.rightmost_pointer()? {
                         Some(right_most_pointer) => {
-                            match self.read_page(right_most_pointer as i64)? {
-                                IOResult::Done((child, c)) => {
-                                    self.stack.set_cell_index(contents.cell_count() as i32 + 1); // invalid on interior
-                                    self.stack.push(child);
-                                    if let Some(c) = c {
-                                        io_yield_one!(c);
-                                    }
-                                }
-                                IOResult::IO(IOCompletions::Single(spill_c)) => {
-                                    io_yield_one!(spill_c);
-                                }
+                            let (child, c) =
+                                return_if_io!(self.read_page(right_most_pointer as i64));
+                            self.stack.set_cell_index(contents.cell_count() as i32 + 1); // invalid on interior
+                            self.stack.push(child);
+                            if let Some(c) = c {
+                                io_yield_one!(c);
                             }
                         }
                         None => unreachable!("interior page must have rightmost pointer"),
@@ -6554,18 +6483,12 @@ pub fn integrity_check(
                 // On `IO(spill_c)` we leave `state.page = None` so re-entry
                 // re-takes this None branch and resumes via the pager's
                 // `pending_reads` memoization.
-                match pager.read_page(page_idx)? {
-                    IOResult::Done((page, c)) => {
-                        state.page = Some(page);
-                        if let Some(c) = c {
-                            io_yield_one!(c);
-                        }
-                        state.page.take().expect("page should be present")
-                    }
-                    IOResult::IO(IOCompletions::Single(spill_c)) => {
-                        io_yield_one!(spill_c);
-                    }
+                let (page, c) = return_if_io!(pager.read_page(page_idx));
+                state.page = Some(page);
+                if let Some(c) = c {
+                    io_yield_one!(c);
                 }
+                state.page.take().expect("page should be present")
             }
         };
         turso_assert!(page.is_loaded(), "page should be loaded");

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -964,7 +964,7 @@ impl BTreeCursor {
                         // descend; the loop's outer match on `cell_idx ==
                         // i32::MAX` would not re-fire if `set_cell_index`
                         // had moved us past it.
-                        match self.read_page_nonblock(rightmost_pointer as i64)? {
+                        match self.read_page(rightmost_pointer as i64)? {
                             IOResult::Done((page, c)) => {
                                 self.stack.set_cell_index(past_rightmost_pointer);
                                 self.descend_backwards(page);
@@ -1092,7 +1092,7 @@ impl BTreeCursor {
                 // would leave `read_overflow_state` half-initialized on a
                 // page that doesn't exist yet, and re-entry would skip the
                 // `is_none()` branch entirely.
-                match self.read_page_nonblock(start_next_page as i64)? {
+                match self.read_page(start_next_page as i64)? {
                     IOResult::Done((page, c)) => {
                         self.read_overflow_state.replace(ReadPayloadOverflow {
                             payload: payload.to_vec(),
@@ -1133,7 +1133,7 @@ impl BTreeCursor {
                 // Same invariant as the `is_none()` branch above: the spill
                 // yield must leave `read_overflow_state.page` pointing at the
                 // *previous* page so re-entry recomputes `next` from it.
-                match self.read_page_nonblock(next as i64)? {
+                match self.read_page(next as i64)? {
                     IOResult::Done((new_page, c)) => {
                         let ReadPayloadOverflow {
                             next_page, page, ..
@@ -1419,7 +1419,7 @@ impl BTreeCursor {
         self.seek_state = CursorSeekState::Start;
         self.going_upwards = false;
         tracing::trace!(root_page = self.root_page);
-        match self.read_page_nonblock(self.root_page)? {
+        match self.read_page(self.root_page)? {
             IOResult::Done((mem_page, c)) => {
                 self.stack.clear();
                 self.stack.push(mem_page);
@@ -1479,7 +1479,7 @@ impl BTreeCursor {
                             // re-reads the same parent contents and retries the
                             // descent — the disk-read for this child is memoized
                             // in `pending_reads`, so no duplicate IO is issued.
-                            match self.read_page_nonblock(right_most_pointer as i64)? {
+                            match self.read_page(right_most_pointer as i64)? {
                                 IOResult::Done((mem_page, c)) => {
                                     self.stack.set_cell_index(contents.cell_count() as i32 + 1);
                                     self.stack.push(mem_page);
@@ -1587,7 +1587,7 @@ impl BTreeCursor {
                 // `InteriorPageBinarySearch` (the caller persists `state` to
                 // it after we return), so re-entry retries this same step
                 // with no double-push and no cell-index drift.
-                match self.read_page_nonblock(left_child_page as i64)? {
+                match self.read_page(left_child_page as i64)? {
                     IOResult::Done((mem_page, c)) => {
                         self.stack.set_cell_index(nearest_matching_cell as i32);
                         self.stack.push(mem_page);
@@ -1612,28 +1612,24 @@ impl BTreeCursor {
                 .unwrap()
                 .rightmost_pointer()?
             {
-                Some(right_most_pointer) => {
-                    match self.read_page_nonblock(right_most_pointer as i64)? {
-                        IOResult::Done((mem_page, c)) => {
-                            self.stack.set_cell_index(cell_count as i32 + 1);
-                            self.stack.push(mem_page);
-                            self.seek_state = CursorSeekState::MovingBetweenPages {
-                                eq_seen: state.eq_seen,
-                            };
-                            if let Some(c) = c {
-                                return Ok(ControlFlow::Break(IOResult::IO(
-                                    IOCompletions::Single(c),
-                                )));
-                            }
-                            return Ok(ControlFlow::Continue(()));
+                Some(right_most_pointer) => match self.read_page(right_most_pointer as i64)? {
+                    IOResult::Done((mem_page, c)) => {
+                        self.stack.set_cell_index(cell_count as i32 + 1);
+                        self.stack.push(mem_page);
+                        self.seek_state = CursorSeekState::MovingBetweenPages {
+                            eq_seen: state.eq_seen,
+                        };
+                        if let Some(c) = c {
+                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(c))));
                         }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(
-                                spill_c,
-                            ))));
-                        }
+                        return Ok(ControlFlow::Continue(()));
                     }
-                }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(
+                            spill_c,
+                        ))));
+                    }
+                },
                 None => {
                     unreachable!("we shall not go back up! The only way is down the slope");
                 }
@@ -1846,7 +1842,7 @@ impl BTreeCursor {
                         // On `IO(spill_c)` keep seek_state at the binary
                         // search so re-entry retries this same step. None
                         // of the cursor mutations have happened yet.
-                        match self.read_page_nonblock(right_most_pointer as i64)? {
+                        match self.read_page(right_most_pointer as i64)? {
                             IOResult::Done((mem_page, c)) => {
                                 self.stack.set_cell_index(cell_count as i32 + 1);
                                 self.stack.push(mem_page);
@@ -1904,7 +1900,7 @@ impl BTreeCursor {
                 );
             }
 
-            match self.read_page_nonblock(*left_child_page as i64)? {
+            match self.read_page(*left_child_page as i64)? {
                 IOResult::Done((mem_page, c)) => {
                     self.stack.set_cell_index(leftmost_matching_cell as i32);
                     if iter_dir == IterationDirection::Backwards {
@@ -4843,7 +4839,7 @@ impl BTreeCursor {
                         }
                         // No mutations precede this read in the Start branch,
                         // so a spill yield safely re-enters here.
-                        match self.read_page_nonblock(next_page as i64)? {
+                        match self.read_page(next_page as i64)? {
                             IOResult::Done((page, c)) => {
                                 self.overflow_state =
                                     OverflowState::ProcessPage { next_page: page };
@@ -5355,12 +5351,7 @@ impl BTreeCursor {
         self.pager.io.block(|| self.pager.read_page(page_idx))
     }
 
-    /// Non-blocking variant of [`BTreeCursor::read_page`]. See
-    /// [`Pager::read_page_nonblock`] for the IO/Done contract.
-    pub fn read_page_nonblock(
-        &self,
-        page_idx: i64,
-    ) -> Result<IOResult<(PageRef, Option<Completion>)>> {
+    pub fn read_page(&self, page_idx: i64) -> Result<IOResult<(PageRef, Option<Completion>)>> {
         self.pager.read_page(page_idx)
     }
 
@@ -6237,7 +6228,7 @@ impl CursorTrait for BTreeCursor {
 
                     match contents.rightmost_pointer()? {
                         Some(right_most_pointer) => {
-                            match self.read_page_nonblock(right_most_pointer as i64)? {
+                            match self.read_page(right_most_pointer as i64)? {
                                 IOResult::Done((child, c)) => {
                                     self.stack.set_cell_index(contents.cell_count() as i32 + 1); // invalid on interior
                                     self.stack.push(child);
@@ -6887,8 +6878,8 @@ pub fn integrity_check(
         if first_freeblock > 0 {
             let mut pc = first_freeblock;
             while pc > 0 {
-                let next = contents.read_u16_no_offset(pc as usize) as usize;
-                let size = contents.read_u16_no_offset(pc as usize + 2) as usize;
+                let next = contents.read_u16_no_offset(pc) as usize;
+                let size = contents.read_u16_no_offset(pc + 2) as usize;
                 // check it doesn't go out of range
                 if pc > usable_space - 4 {
                     errors.push(IntegrityCheckError::FreeBlockOutOfRange {
@@ -9026,7 +9017,10 @@ mod tests {
         }
         let first_page_type = child_pages.first_mut().map(|p| {
             if !p.is_loaded() {
-                let (new_page, _c) = pager.io.block(|| pager.read_page(p.get().id as i64))?;
+                let (new_page, _c) = pager
+                    .io
+                    .block(|| pager.read_page(p.get().id as i64))
+                    .unwrap();
                 *p = new_page;
             }
             while p.is_locked() {
@@ -9037,8 +9031,10 @@ mod tests {
         if let Some(child_type) = first_page_type {
             for page in child_pages.iter_mut().skip(1) {
                 if !page.is_loaded() {
-                    let (new_page, _c) =
-                        pager.io.block(|| pager.read_page(page.get().id as i64))?;
+                    let (new_page, _c) = pager
+                        .io
+                        .block(|| pager.read_page(page.get().id as i64))
+                        .unwrap();
                     *page = new_page;
                 }
                 while page.is_locked() {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -150,7 +150,19 @@ enum DestroyState {
     Start,
     LoadPage,
     ProcessPage,
-    ClearOverflowPages { cell: BTreeCell },
+    ClearOverflowPages {
+        cell: BTreeCell,
+    },
+    /// Transitional state used after a spill yield from one of the descent
+    /// reads inside `ProcessPage` or after `ClearOverflowPages` returned
+    /// `Done`. We've committed to descending into `target` (its parent's
+    /// cell_idx has already been advanced or `clear_overflow_pages` has
+    /// already cleared the overflow chain for the divider cell), so on
+    /// re-entry we just retry the read + push + transition to `LoadPage`
+    /// without re-running those prior steps.
+    PendingDescent {
+        target: i64,
+    },
     FreePage,
 }
 
@@ -290,6 +302,15 @@ struct BalanceState {
     /// Reusable Vec for CellArray cell_payloads to avoid per-balance allocation.
     /// Cleared before each use; grows as needed and retains capacity across operations.
     reusable_cell_payloads: Vec<&'static mut [u8]>,
+    /// Disk-read completions accumulated during the sibling-load loop in
+    /// `NonRootPickSiblings`. We persist them in `BalanceState` (rather than
+    /// in a local `CompletionGroup`) so that when the loop yields for spill
+    /// IO and is re-entered, completions from earlier iterations are not
+    /// lost — they would otherwise leak: the IO is still in flight, but we
+    /// would no longer have a handle to wait on them before reading page
+    /// contents in `NonRootDoBalancing`. Cleared when the loop completes
+    /// and transitions to `NonRootDoBalancing`.
+    pending_sibling_load_completions: Vec<Completion>,
 }
 
 /// State machine of a write operation.
@@ -465,7 +486,18 @@ impl Debug for CursorState {
 #[derive(Debug, Clone)]
 enum OverflowState {
     Start,
-    ProcessPage { next_page: PageRef },
+    ProcessPage {
+        next_page: PageRef,
+    },
+    /// Transitional state used to make `OverflowState::ProcessPage`
+    /// re-entry-safe across spill yields. Once `free_page` has returned
+    /// `Done` for the current page, we move to this state so that a
+    /// subsequent spill yield on the read of the next page does NOT cause
+    /// `free_page` to be invoked a second time on a page that is already in
+    /// the freelist.
+    ReadNext {
+        next: u32,
+    },
     Done,
 }
 
@@ -695,6 +727,21 @@ pub struct BTreeCursor {
     /// Reusable buffer for cell payloads during insert/update operations.
     /// This avoids allocating a new Vec for each write operation.
     reusable_cell_payload: Vec<u8>,
+    /// If `Some(page_idx)`, a previous call to [`BTreeCursor::get_next_record`]
+    /// or [`BTreeCursor::get_prev_record`] yielded mid-descent into `page_idx`
+    /// for spill IO, AFTER the loop-top `stack.advance()` / `stack.retreat()`
+    /// mutations had already been applied. On re-entry, the traversal loop
+    /// short-circuits to retry the read+descend rather than re-running those
+    /// mutations and corrupting the cursor's cell-index state.
+    iteration_pending_descent: Option<IterationPendingDescent>,
+}
+
+/// Records the in-flight descent for `iteration_pending_descent`. The direction
+/// determines which `descend*` helper to apply once the page is read.
+#[derive(Clone, Copy)]
+enum IterationPendingDescent {
+    Forwards(i64),
+    Backwards(i64),
 }
 
 crate::assert::assert_send!(BTreeCursor);
@@ -762,6 +809,7 @@ impl BTreeCursor {
             move_to_state: MoveToState::Start,
             skip_advance: false,
             reusable_cell_payload: Vec::new(),
+            iteration_pending_descent: None,
         }
     }
 
@@ -839,10 +887,19 @@ impl BTreeCursor {
             let state = self.is_empty_table_state.clone();
             match state {
                 EmptyTableState::Start => {
-                    let (page, c) = self.pager.read_page(self.root_page)?;
-                    self.is_empty_table_state = EmptyTableState::ReadPage { page };
-                    if let Some(c) = c {
-                        io_yield_one!(c);
+                    // On `IO(spill_c)` we have not produced a page yet — leave
+                    // the state at `Start` so re-entry restarts here and the
+                    // pager's pending-read tracking returns the same PageRef.
+                    match self.pager.read_page(self.root_page)? {
+                        IOResult::Done((page, c)) => {
+                            self.is_empty_table_state = EmptyTableState::ReadPage { page };
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
                     }
                 }
                 EmptyTableState::ReadPage { page } => {
@@ -860,6 +917,28 @@ impl BTreeCursor {
     pub fn get_prev_record(&mut self) -> Result<IOResult<()>> {
         let mut inner = || {
             loop {
+                // Resume hook: if a previous backwards-iteration call yielded
+                // for spill IO mid-descent, the loop-top mutations
+                // (cell_idx set, `stack.retreat()` for IndexInterior) have
+                // already been applied. Retry the read+descend without
+                // re-running them.
+                if let Some(IterationPendingDescent::Backwards(target)) =
+                    self.iteration_pending_descent
+                {
+                    match self.pager.read_page(target)? {
+                        IOResult::Done((mem_page, c)) => {
+                            self.iteration_pending_descent = None;
+                            self.descend_backwards(mem_page);
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                            continue;
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
+                    }
+                }
                 let (old_top_idx, page_type, is_index, is_leaf, cell_count) = {
                     let page = self.stack.top_ref();
                     let contents = page.get_contents();
@@ -881,13 +960,23 @@ impl BTreeCursor {
                         self.stack.top_ref().get_contents().rightmost_pointer()?;
                     if let Some(rightmost_pointer) = rightmost_pointer {
                         let past_rightmost_pointer = cell_count as i32 + 1;
-                        self.stack.set_cell_index(past_rightmost_pointer);
-                        let (page, c) = self.read_page(rightmost_pointer as i64)?;
-                        self.descend_backwards(page);
-                        if let Some(c) = c {
-                            io_yield_one!(c);
+                        // On `IO(spill_c)` we must NOT mutate `cell_idx` or
+                        // descend; the loop's outer match on `cell_idx ==
+                        // i32::MAX` would not re-fire if `set_cell_index`
+                        // had moved us past it.
+                        match self.read_page_nonblock(rightmost_pointer as i64)? {
+                            IOResult::Done((page, c)) => {
+                                self.stack.set_cell_index(past_rightmost_pointer);
+                                self.descend_backwards(page);
+                                if let Some(c) = c {
+                                    io_yield_one!(c);
+                                }
+                                continue;
+                            }
+                            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                io_yield_one!(spill_c);
+                            }
                         }
-                        continue;
                     }
                 }
 
@@ -952,10 +1041,23 @@ impl BTreeCursor {
                     self.stack.retreat();
                 }
 
-                let (mem_page, c) = self.read_page(left_child_page as i64)?;
-                self.descend_backwards(mem_page);
-                if let Some(c) = c {
-                    io_yield_one!(c);
+                // The loop-top mutations (cell_idx set above, optional
+                // `stack.retreat()` for IndexInterior) have already been
+                // applied for this step. Route a spill yield through
+                // `iteration_pending_descent` so the resume hook at the top
+                // of the loop replays only the read+descend on re-entry.
+                match self.pager.read_page(left_child_page as i64)? {
+                    IOResult::Done((mem_page, c)) => {
+                        self.descend_backwards(mem_page);
+                        if let Some(c) = c {
+                            io_yield_one!(c);
+                        }
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        self.iteration_pending_descent =
+                            Some(IterationPendingDescent::Backwards(left_child_page as i64));
+                        io_yield_one!(spill_c);
+                    }
                 }
             }
         };
@@ -985,17 +1087,28 @@ impl BTreeCursor {
                                 "payload size is smaller than local payload bytes".to_string(),
                             )
                         })? as usize;
-                let (page, c) = self.read_page(start_next_page as i64)?;
-                self.read_overflow_state.replace(ReadPayloadOverflow {
-                    payload: payload.to_vec(),
-                    next_page: start_next_page,
-                    remaining_to_read,
-                    page,
-                });
-                if let Some(c) = c {
-                    io_yield_one!(c);
+                // We must not populate `read_overflow_state` before the page
+                // is actually produced — otherwise an `IO(spill_c)` yield
+                // would leave `read_overflow_state` half-initialized on a
+                // page that doesn't exist yet, and re-entry would skip the
+                // `is_none()` branch entirely.
+                match self.read_page_nonblock(start_next_page as i64)? {
+                    IOResult::Done((page, c)) => {
+                        self.read_overflow_state.replace(ReadPayloadOverflow {
+                            payload: payload.to_vec(),
+                            next_page: start_next_page,
+                            remaining_to_read,
+                            page,
+                        });
+                        if let Some(c) = c {
+                            io_yield_one!(c);
+                        }
+                        continue;
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        io_yield_one!(spill_c);
+                    }
                 }
-                continue;
             }
             let ReadPayloadOverflow {
                 payload,
@@ -1017,16 +1130,25 @@ impl BTreeCursor {
             *remaining_to_read -= to_read;
 
             if *remaining_to_read != 0 && next != 0 {
-                let (new_page, c) = self.read_page(next as i64)?;
-                let ReadPayloadOverflow {
-                    next_page, page, ..
-                } = self.read_overflow_state.as_mut().unwrap();
-                *page = new_page;
-                *next_page = next;
-                if let Some(c) = c {
-                    io_yield_one!(c);
+                // Same invariant as the `is_none()` branch above: the spill
+                // yield must leave `read_overflow_state.page` pointing at the
+                // *previous* page so re-entry recomputes `next` from it.
+                match self.read_page_nonblock(next as i64)? {
+                    IOResult::Done((new_page, c)) => {
+                        let ReadPayloadOverflow {
+                            next_page, page, ..
+                        } = self.read_overflow_state.as_mut().unwrap();
+                        *page = new_page;
+                        *next_page = next;
+                        if let Some(c) = c {
+                            io_yield_one!(c);
+                        }
+                        continue;
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        io_yield_one!(spill_c);
+                    }
                 }
-                continue;
             }
             if *remaining_to_read != 0 || next != 0 {
                 let chain_page = *next_page;
@@ -1077,6 +1199,29 @@ impl BTreeCursor {
                 return Ok(IOResult::Done(false));
             }
             loop {
+                // Resume hook: if a previous call yielded for spill IO mid-
+                // descent, the loop-top mutations (stack.advance) have
+                // already been applied. Retry the read+descend without
+                // re-running them. If the spill is still pending the pager's
+                // `pending_reads` memoization will return IO again; otherwise
+                // it returns Done immediately and we descend.
+                if let Some(IterationPendingDescent::Forwards(target)) =
+                    self.iteration_pending_descent
+                {
+                    match self.pager.read_page(target)? {
+                        IOResult::Done((mem_page, c)) => {
+                            self.iteration_pending_descent = None;
+                            self.descend(mem_page);
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                            continue;
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
+                    }
+                }
                 let mem_page = self.stack.top_ref();
                 let contents = mem_page.get_contents();
                 let cell_idx = self.stack.current_cell_index();
@@ -1124,12 +1269,27 @@ impl BTreeCursor {
                         (Some(right_most_pointer), false) => {
                             // do rightmost
                             self.stack.advance();
-                            let (mem_page, c) = self.read_page(right_most_pointer as i64)?;
-                            self.descend(mem_page);
-                            if let Some(c) = c {
-                                io_yield_one!(c);
+                            // Spill yield from here would re-enter the loop
+                            // top with cell_idx already advanced twice; we
+                            // record the descent target in
+                            // `iteration_pending_descent` so the resume hook
+                            // above skips the loop-top advances on re-entry.
+                            match self.pager.read_page(right_most_pointer as i64)? {
+                                IOResult::Done((mem_page, c)) => {
+                                    self.descend(mem_page);
+                                    if let Some(c) = c {
+                                        io_yield_one!(c);
+                                    }
+                                    continue;
+                                }
+                                IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                    self.iteration_pending_descent =
+                                        Some(IterationPendingDescent::Forwards(
+                                            right_most_pointer as i64,
+                                        ));
+                                    io_yield_one!(spill_c);
+                                }
                             }
-                            continue;
                         }
                         _ => {
                             if self.ancestor_pages_have_more_children() {
@@ -1161,10 +1321,22 @@ impl BTreeCursor {
                 }
 
                 let left_child_page = contents.cell_interior_read_left_child_page(cell_idx)?;
-                let (mem_page, c) = self.read_page(left_child_page as i64)?;
-                self.descend(mem_page);
-                if let Some(c) = c {
-                    io_yield_one!(c);
+                // Same re-entry handling as the rightmost branch above —
+                // the loop-top `stack.advance()` has already fired for this
+                // step, so we route a spill yield through
+                // `iteration_pending_descent`.
+                match self.pager.read_page(left_child_page as i64)? {
+                    IOResult::Done((mem_page, c)) => {
+                        self.descend(mem_page);
+                        if let Some(c) = c {
+                            io_yield_one!(c);
+                        }
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        self.iteration_pending_descent =
+                            Some(IterationPendingDescent::Forwards(left_child_page as i64));
+                        io_yield_one!(spill_c);
+                    }
                 }
             }
         };
@@ -1223,15 +1395,40 @@ impl BTreeCursor {
     }
 
     /// Move the cursor to the root page of the btree.
+    ///
+    /// Blocking shim retained for tests and any caller that doesn't have an
+    /// outer state machine yet. Production state machines should prefer
+    /// [`BTreeCursor::move_to_root_nonblock`] so they can yield through spill
+    /// IO instead of blocking inside the pager.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn move_to_root(&mut self) -> Result<Option<Completion>> {
+        let io = self.pager.io.clone();
+        io.block(|| self.move_to_root_nonblock())
+    }
+
+    /// Non-blocking variant of [`BTreeCursor::move_to_root`].
+    ///
+    /// Re-entrancy: `seek_state`, `going_upwards`, `stack.clear()` and
+    /// `stack.push(root)` are all idempotent across re-entry — clearing an
+    /// already-cleared stack and pushing the same root yields the same state.
+    /// The disk-read completion (if any) is returned as the `Done` payload for
+    /// the caller to yield itself, matching the contract of the legacy
+    /// `move_to_root`.
+    #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
+    fn move_to_root_nonblock(&mut self) -> Result<IOResult<Option<Completion>>> {
         self.seek_state = CursorSeekState::Start;
         self.going_upwards = false;
         tracing::trace!(root_page = self.root_page);
-        let (mem_page, c) = self.read_page(self.root_page)?;
-        self.stack.clear();
-        self.stack.push(mem_page);
-        Ok(c)
+        match self.read_page_nonblock(self.root_page)? {
+            IOResult::Done((mem_page, c)) => {
+                self.stack.clear();
+                self.stack.push(mem_page);
+                Ok(IOResult::Done(c))
+            }
+            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                io_yield_one!(spill_c);
+            }
+        }
     }
 
     /// Move the cursor to the rightmost record in the btree.
@@ -1257,7 +1454,7 @@ impl BTreeCursor {
                         }
                     }
                     let rightmost_page_id = *rightmost_page_id;
-                    let c = self.move_to_root()?;
+                    let c = return_if_io!(self.move_to_root_nonblock());
                     self.move_to_right_state = (MoveToRightState::ProcessPage, rightmost_page_id);
                     if let Some(c) = c {
                         io_yield_one!(c);
@@ -1278,11 +1475,21 @@ impl BTreeCursor {
 
                     match contents.rightmost_pointer()? {
                         Some(right_most_pointer) => {
-                            self.stack.set_cell_index(contents.cell_count() as i32 + 1);
-                            let (mem_page, c) = self.read_page(right_most_pointer as i64)?;
-                            self.stack.push(mem_page);
-                            if let Some(c) = c {
-                                io_yield_one!(c);
+                            // On `IO(spill_c)` the stack is unchanged, so re-entry
+                            // re-reads the same parent contents and retries the
+                            // descent — the disk-read for this child is memoized
+                            // in `pending_reads`, so no duplicate IO is issued.
+                            match self.read_page_nonblock(right_most_pointer as i64)? {
+                                IOResult::Done((mem_page, c)) => {
+                                    self.stack.set_cell_index(contents.cell_count() as i32 + 1);
+                                    self.stack.push(mem_page);
+                                    if let Some(c) = c {
+                                        io_yield_one!(c);
+                                    }
+                                }
+                                IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                    io_yield_one!(spill_c);
+                                }
                             }
                         }
                         None => {
@@ -1376,18 +1583,29 @@ impl BTreeCursor {
                     .get_page_contents_at_level(old_top_idx)
                     .unwrap()
                     .cell_interior_read_left_child_page(nearest_matching_cell)?;
-                self.stack.set_cell_index(nearest_matching_cell as i32);
-                let (mem_page, c) = self.read_page(left_child_page as i64)?;
-                self.stack.push(mem_page);
-                self.seek_state = CursorSeekState::MovingBetweenPages {
-                    eq_seen: state.eq_seen,
-                };
-                if let Some(c) = c {
-                    return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(c))));
+                // On `IO(spill_c)` we keep `seek_state` at
+                // `InteriorPageBinarySearch` (the caller persists `state` to
+                // it after we return), so re-entry retries this same step
+                // with no double-push and no cell-index drift.
+                match self.read_page_nonblock(left_child_page as i64)? {
+                    IOResult::Done((mem_page, c)) => {
+                        self.stack.set_cell_index(nearest_matching_cell as i32);
+                        self.stack.push(mem_page);
+                        self.seek_state = CursorSeekState::MovingBetweenPages {
+                            eq_seen: state.eq_seen,
+                        };
+                        if let Some(c) = c {
+                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(c))));
+                        }
+                        return Ok(ControlFlow::Continue(()));
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(
+                            spill_c,
+                        ))));
+                    }
                 }
-                return Ok(ControlFlow::Continue(()));
             }
-            self.stack.set_cell_index(cell_count as i32 + 1);
             match self
                 .stack
                 .get_page_contents_at_level(old_top_idx)
@@ -1395,15 +1613,26 @@ impl BTreeCursor {
                 .rightmost_pointer()?
             {
                 Some(right_most_pointer) => {
-                    let (mem_page, c) = self.read_page(right_most_pointer as i64)?;
-                    self.stack.push(mem_page);
-                    self.seek_state = CursorSeekState::MovingBetweenPages {
-                        eq_seen: state.eq_seen,
-                    };
-                    if let Some(c) = c {
-                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(c))));
+                    match self.read_page_nonblock(right_most_pointer as i64)? {
+                        IOResult::Done((mem_page, c)) => {
+                            self.stack.set_cell_index(cell_count as i32 + 1);
+                            self.stack.push(mem_page);
+                            self.seek_state = CursorSeekState::MovingBetweenPages {
+                                eq_seen: state.eq_seen,
+                            };
+                            if let Some(c) = c {
+                                return Ok(ControlFlow::Break(IOResult::IO(
+                                    IOCompletions::Single(c),
+                                )));
+                            }
+                            return Ok(ControlFlow::Continue(()));
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(
+                                spill_c,
+                            ))));
+                        }
                     }
-                    return Ok(ControlFlow::Continue(()));
                 }
                 None => {
                     unreachable!("we shall not go back up! The only way is down the slope");
@@ -1488,7 +1717,7 @@ impl BTreeCursor {
         }
 
         if matches!(self.seek_state, CursorSeekState::Start) {
-            if let Some(c) = self.move_to_root()? {
+            if let Some(c) = return_if_io!(self.move_to_root_nonblock()) {
                 return Ok(IOResult::IO(IOCompletions::Single(c)));
             }
         }
@@ -1607,7 +1836,6 @@ impl BTreeCursor {
         let max = state.max_cell_idx;
         if min > max {
             let Some(leftmost_matching_cell) = state.nearest_matching_cell else {
-                self.stack.set_cell_index(cell_count as i32 + 1);
                 match self
                     .stack
                     .get_page_contents_at_level(old_top_idx)
@@ -1615,15 +1843,29 @@ impl BTreeCursor {
                     .rightmost_pointer()?
                 {
                     Some(right_most_pointer) => {
-                        let (mem_page, c) = self.read_page(right_most_pointer as i64)?;
-                        self.stack.push(mem_page);
-                        self.seek_state = CursorSeekState::MovingBetweenPages {
-                            eq_seen: state.eq_seen,
-                        };
-                        if let Some(c) = c {
-                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(c))));
+                        // On `IO(spill_c)` keep seek_state at the binary
+                        // search so re-entry retries this same step. None
+                        // of the cursor mutations have happened yet.
+                        match self.read_page_nonblock(right_most_pointer as i64)? {
+                            IOResult::Done((mem_page, c)) => {
+                                self.stack.set_cell_index(cell_count as i32 + 1);
+                                self.stack.push(mem_page);
+                                self.seek_state = CursorSeekState::MovingBetweenPages {
+                                    eq_seen: state.eq_seen,
+                                };
+                                if let Some(c) = c {
+                                    return Ok(ControlFlow::Break(IOResult::IO(
+                                        IOCompletions::Single(c),
+                                    )));
+                                }
+                                return Ok(ControlFlow::Continue(()));
+                            }
+                            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                return Ok(ControlFlow::Break(IOResult::IO(
+                                    IOCompletions::Single(spill_c),
+                                )));
+                            }
                         }
-                        return Ok(ControlFlow::Continue(()));
                     }
                     None => {
                         unreachable!("we shall not go back up! The only way is down the slope");
@@ -1635,16 +1877,17 @@ impl BTreeCursor {
                 .get_page_contents_at_level(old_top_idx)
                 .unwrap()
                 .cell_get(leftmost_matching_cell, self.usable_space())?;
-            self.stack.set_cell_index(leftmost_matching_cell as i32);
-            // we don't advance in case of forward iteration and index tree internal nodes because we will visit this node going up.
-            // in backwards iteration, we must retreat because otherwise we would unnecessarily visit this node again.
-            // Example:
-            // this parent: key 666, and we found the target key in the left child.
-            // left child has: key 663, key 664, key 665
-            // we need to move to the previous parent (with e.g. key 662) when iterating backwards so that we don't end up back here again.
-            if iter_dir == IterationDirection::Backwards {
-                self.stack.retreat();
-            }
+            // We don't advance in case of forward iteration and index tree
+            // internal nodes because we will visit this node going up.
+            // In backwards iteration, we must retreat because otherwise we
+            // would unnecessarily visit this node again. Example:
+            //   parent:     key 666 (target found in left child)
+            //   left child: key 663, key 664, key 665
+            // we need to move to the previous parent (e.g. key 662) when
+            // iterating backwards so that we don't end up back here again.
+            //
+            // On `IO(spill_c)` we MUST NOT mutate `cell_idx` (set or
+            // retreat) — see the Done branch.
             let BTreeCell::IndexInteriorCell(IndexInteriorCell {
                 left_child_page, ..
             }) = &matching_cell
@@ -1661,13 +1904,25 @@ impl BTreeCursor {
                 );
             }
 
-            let (mem_page, c) = self.read_page(*left_child_page as i64)?;
-            self.stack.push(mem_page);
-            self.seek_state = CursorSeekState::MovingBetweenPages {
-                eq_seen: state.eq_seen,
-            };
-            if let Some(c) = c {
-                return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(c))));
+            match self.read_page_nonblock(*left_child_page as i64)? {
+                IOResult::Done((mem_page, c)) => {
+                    self.stack.set_cell_index(leftmost_matching_cell as i32);
+                    if iter_dir == IterationDirection::Backwards {
+                        self.stack.retreat();
+                    }
+                    self.stack.push(mem_page);
+                    self.seek_state = CursorSeekState::MovingBetweenPages {
+                        eq_seen: state.eq_seen,
+                    };
+                    if let Some(c) = c {
+                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(c))));
+                    }
+                }
+                IOResult::IO(IOCompletions::Single(spill_c)) => {
+                    return Ok(ControlFlow::Break(IOResult::IO(IOCompletions::Single(
+                        spill_c,
+                    ))));
+                }
             }
             return Ok(ControlFlow::Continue(()));
         }
@@ -1991,7 +2246,7 @@ impl BTreeCursor {
                 | CursorSeekState::InteriorPageBinarySearch { .. }
         ) {
             if matches!(self.seek_state, CursorSeekState::Start) {
-                if let Some(c) = self.move_to_root()? {
+                if let Some(c) = return_if_io!(self.move_to_root_nonblock()) {
                     return Ok(IOResult::IO(IOCompletions::Single(c)));
                 }
             }
@@ -2240,12 +2495,14 @@ impl BTreeCursor {
         loop {
             match self.move_to_state {
                 MoveToState::Start => {
-                    self.move_to_state = MoveToState::MoveToPage;
                     if matches!(self.seek_state, CursorSeekState::Start) {
-                        let c = self.move_to_root()?;
+                        let c = return_if_io!(self.move_to_root_nonblock());
+                        self.move_to_state = MoveToState::MoveToPage;
                         if let Some(c) = c {
                             io_yield_one!(c);
                         }
+                    } else {
+                        self.move_to_state = MoveToState::MoveToPage;
                     }
                 }
                 MoveToState::MoveToPage => {
@@ -2695,6 +2952,7 @@ impl BTreeCursor {
                 balance_info,
                 reusable_divider_buffers,
                 reusable_cell_payloads,
+                pending_sibling_load_completions,
             } = &mut self.balance_state;
             tracing::debug!(?sub_state);
 
@@ -2845,21 +3103,40 @@ impl BTreeCursor {
                     let mut pgno: u32 =
                         unsafe { right_pointer.cast::<u32>().read_unaligned().swap_bytes() };
                     let current_sibling = sibling_pointer;
-                    let mut group = CompletionGroup::new(|_| {});
                     for i in (0..=current_sibling).rev() {
-                        match btree_read_page(&self.pager, pgno as i64) {
+                        match self.pager.read_page(pgno as i64) {
                             Err(e) => {
                                 mark_unlikely();
                                 tracing::error!("error reading page {}: {}", pgno, e);
-                                group.cancel();
-                                self.pager.io.drain_completions(group.completions())?;
+                                // Drain any in-flight reads we accumulated
+                                // across previous iterations / yields so the
+                                // IO scheduler can finalize them before we
+                                // bail out.
+                                self.pager
+                                    .io
+                                    .drain_completions(pending_sibling_load_completions)?;
+                                pending_sibling_load_completions.clear();
                                 return Err(e);
                             }
-                            Ok((page, c)) => {
+                            Ok(IOResult::Done((page, c))) => {
                                 pages_to_balance[i].replace(PinGuard::new(page));
                                 if let Some(c) = c {
-                                    group.add(&c);
+                                    // Accumulate in `BalanceState` rather
+                                    // than a local group: a spill yield
+                                    // later in this loop drops local state
+                                    // but the persistent vec survives.
+                                    pending_sibling_load_completions.push(c);
                                 }
+                            }
+                            Ok(IOResult::IO(IOCompletions::Single(spill_c))) => {
+                                // Spill yield. The loop is fully re-entrant:
+                                // on re-entry we re-execute from the top of
+                                // `NonRootPickSiblings`, the pager's
+                                // `pending_reads` returns the same PageRef
+                                // for the in-flight sibling, and cache hits
+                                // for previously-loaded siblings yield
+                                // `c=None` so we don't double-add them.
+                                io_yield_one!(spill_c);
                             }
                         }
                         if i == 0 {
@@ -2929,6 +3206,14 @@ impl BTreeCursor {
                         reusable_divider_cell: Vec::new(),
                     });
                     *sub_state = BalanceSubState::NonRootDoBalancing;
+                    // Build the wait-group from the accumulated completions
+                    // collected across (possibly multiple) calls. Drain so
+                    // a subsequent balance operation starts fresh.
+                    let mut group = CompletionGroup::new(|_| {});
+                    let completions = std::mem::take(pending_sibling_load_completions);
+                    for c in &completions {
+                        group.add(c);
+                    }
                     let completion = group.build();
                     if !completion.finished() {
                         io_yield_one!(completion);
@@ -4556,10 +4841,19 @@ impl BTreeCursor {
                             self.overflow_state = OverflowState::Start;
                             return Err(LimboError::Corrupt("Invalid overflow page number".into()));
                         }
-                        let (page, c) = self.read_page(next_page as i64)?;
-                        self.overflow_state = OverflowState::ProcessPage { next_page: page };
-                        if let Some(c) = c {
-                            io_yield_one!(c);
+                        // No mutations precede this read in the Start branch,
+                        // so a spill yield safely re-enters here.
+                        match self.read_page_nonblock(next_page as i64)? {
+                            IOResult::Done((page, c)) => {
+                                self.overflow_state =
+                                    OverflowState::ProcessPage { next_page: page };
+                                if let Some(c) = c {
+                                    io_yield_one!(c);
+                                }
+                            }
+                            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                io_yield_one!(spill_c);
+                            }
                         }
                     } else {
                         self.overflow_state = OverflowState::Done;
@@ -4574,6 +4868,11 @@ impl BTreeCursor {
 
                     return_if_io!(self.pager.free_page(Some(page), next_page_id));
 
+                    // free_page returned `Done` — commit `next` to state
+                    // BEFORE the next read so that a spill yield from the
+                    // read does not cause re-entry into `ProcessPage` with
+                    // the now-freed page, which would re-invoke `free_page`
+                    // and corrupt the freelist.
                     if next != 0 {
                         if unlikely(
                             next < 2
@@ -4589,15 +4888,22 @@ impl BTreeCursor {
                             self.overflow_state = OverflowState::Start;
                             return Err(LimboError::Corrupt("Invalid overflow page number".into()));
                         }
-                        let (page, c) = self.read_page(next as i64)?;
-                        self.overflow_state = OverflowState::ProcessPage { next_page: page };
-                        if let Some(c) = c {
-                            io_yield_one!(c);
-                        }
+                        self.overflow_state = OverflowState::ReadNext { next };
                     } else {
                         self.overflow_state = OverflowState::Done;
                     }
                 }
+                OverflowState::ReadNext { next } => match self.pager.read_page(next as i64)? {
+                    IOResult::Done((page, c)) => {
+                        self.overflow_state = OverflowState::ProcessPage { next_page: page };
+                        if let Some(c) = c {
+                            io_yield_one!(c);
+                        }
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        io_yield_one!(spill_c);
+                    }
+                },
                 OverflowState::Done => {
                     self.overflow_state = OverflowState::Start;
                     return Ok(IOResult::Done(()));
@@ -4625,7 +4931,7 @@ impl BTreeCursor {
     /// The destruction order would be: [4',4,5,2,6,7,3,1]
     fn destroy_btree_contents(&mut self, keep_root: bool) -> Result<IOResult<Option<usize>>> {
         if let CursorState::None = &self.state {
-            let c = self.move_to_root()?;
+            let c = return_if_io!(self.move_to_root_nonblock());
             self.state = CursorState::Destroy(DestroyInfo {
                 state: DestroyState::Start,
             });
@@ -4680,14 +4986,33 @@ impl BTreeCursor {
                             //  Non-leaf page which has processed all children but not it's potential right child
                             (false, n) if n == contents.cell_count() as i32 => {
                                 if let Some(rightmost) = contents.rightmost_pointer()? {
-                                    let (rightmost_page, c) = self.read_page(rightmost as i64)?;
-                                    self.stack.push(rightmost_page);
-                                    let destroy_info = self.state.mut_destroy_info().expect(
-                                        "unable to get a mut reference to destroy state in cursor",
-                                    );
-                                    destroy_info.state = DestroyState::LoadPage;
-                                    if let Some(c) = c {
-                                        io_yield_one!(c);
+                                    // Spill yield here would re-enter
+                                    // `ProcessPage` and re-fire the loop-top
+                                    // `stack.advance()`. Route through
+                                    // `PendingDescent` so re-entry resumes
+                                    // there.
+                                    match self.pager.read_page(rightmost as i64)? {
+                                        IOResult::Done((rightmost_page, c)) => {
+                                            self.stack.push(rightmost_page);
+                                            let destroy_info =
+                                                self.state.mut_destroy_info().expect(
+                                                    "unable to get a mut reference to destroy state in cursor",
+                                                );
+                                            destroy_info.state = DestroyState::LoadPage;
+                                            if let Some(c) = c {
+                                                io_yield_one!(c);
+                                            }
+                                        }
+                                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                            let destroy_info =
+                                                self.state.mut_destroy_info().expect(
+                                                    "unable to get a mut reference to destroy state in cursor",
+                                                );
+                                            destroy_info.state = DestroyState::PendingDescent {
+                                                target: rightmost as i64,
+                                            };
+                                            io_yield_one!(spill_c);
+                                        }
                                     }
                                 } else {
                                     let destroy_info = self.state.mut_destroy_info().expect(
@@ -4740,14 +5065,30 @@ impl BTreeCursor {
                                     BTreeCell::IndexInteriorCell(cell) => cell.left_child_page,
                                     _ => panic!("expected interior cell"),
                                 };
-                                let (child_page, c) = self.read_page(child_page_id as i64)?;
-                                self.stack.push(child_page);
-                                let destroy_info = self.state.mut_destroy_info().expect(
-                                    "unable to get a mut reference to destroy state in cursor",
-                                );
-                                destroy_info.state = DestroyState::LoadPage;
-                                if let Some(c) = c {
-                                    io_yield_one!(c);
+                                // Spill yield routed through `PendingDescent`
+                                // — see the rightmost branch comment above.
+                                match self.pager.read_page(child_page_id as i64)? {
+                                    IOResult::Done((child_page, c)) => {
+                                        self.stack.push(child_page);
+                                        let destroy_info =
+                                            self.state.mut_destroy_info().expect(
+                                                "unable to get a mut reference to destroy state in cursor",
+                                            );
+                                        destroy_info.state = DestroyState::LoadPage;
+                                        if let Some(c) = c {
+                                            io_yield_one!(c);
+                                        }
+                                    }
+                                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                        let destroy_info =
+                                            self.state.mut_destroy_info().expect(
+                                                "unable to get a mut reference to destroy state in cursor",
+                                            );
+                                        destroy_info.state = DestroyState::PendingDescent {
+                                            target: child_page_id as i64,
+                                        };
+                                        io_yield_one!(spill_c);
+                                    }
                                 }
                             }
                         },
@@ -4758,16 +5099,32 @@ impl BTreeCursor {
                     match cell {
                         //  For an index interior cell, clear the left child page now that overflow pages have been cleared
                         BTreeCell::IndexInteriorCell(index_int_cell) => {
-                            let (child_page, c) =
-                                self.read_page(index_int_cell.left_child_page as i64)?;
-                            self.stack.push(child_page);
-                            let destroy_info = self
-                                .state
-                                .mut_destroy_info()
-                                .expect("unable to get a mut reference to destroy state in cursor");
-                            destroy_info.state = DestroyState::LoadPage;
-                            if let Some(c) = c {
-                                io_yield_one!(c);
+                            // `clear_overflow_pages` has returned `Done` and
+                            // reset its internal state to `Start`. Re-entry
+                            // into `ClearOverflowPages` would re-run it
+                            // against the same (already-cleared) cell, so
+                            // route a spill yield from the read through
+                            // `PendingDescent` to skip back into the descent
+                            // path.
+                            let target = index_int_cell.left_child_page as i64;
+                            match self.pager.read_page(target)? {
+                                IOResult::Done((child_page, c)) => {
+                                    self.stack.push(child_page);
+                                    let destroy_info = self.state.mut_destroy_info().expect(
+                                        "unable to get a mut reference to destroy state in cursor",
+                                    );
+                                    destroy_info.state = DestroyState::LoadPage;
+                                    if let Some(c) = c {
+                                        io_yield_one!(c);
+                                    }
+                                }
+                                IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                    let destroy_info = self.state.mut_destroy_info().expect(
+                                        "unable to get a mut reference to destroy state in cursor",
+                                    );
+                                    destroy_info.state = DestroyState::PendingDescent { target };
+                                    io_yield_one!(spill_c);
+                                }
                             }
                         }
                         //  For any leaf cell, advance the index now that overflow pages have been cleared
@@ -4781,6 +5138,22 @@ impl BTreeCursor {
                         _ => panic!("unexpected cell type"),
                     }
                 }
+                DestroyState::PendingDescent { target } => match self.pager.read_page(target)? {
+                    IOResult::Done((child_page, c)) => {
+                        self.stack.push(child_page);
+                        let destroy_info = self
+                            .state
+                            .mut_destroy_info()
+                            .expect("unable to get a mut reference to destroy state in cursor");
+                        destroy_info.state = DestroyState::LoadPage;
+                        if let Some(c) = c {
+                            io_yield_one!(c);
+                        }
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        io_yield_one!(spill_c);
+                    }
+                },
                 DestroyState::FreePage => {
                     let page = self.stack.top();
                     let page_id = page.get().id;
@@ -4978,8 +5351,17 @@ impl BTreeCursor {
         }
     }
 
-    pub fn read_page(&self, page_idx: i64) -> Result<(PageRef, Option<Completion>)> {
-        btree_read_page(&self.pager, page_idx)
+    pub fn read_page_blocking(&self, page_idx: i64) -> Result<(PageRef, Option<Completion>)> {
+        self.pager.io.block(|| self.pager.read_page(page_idx))
+    }
+
+    /// Non-blocking variant of [`BTreeCursor::read_page`]. See
+    /// [`Pager::read_page_nonblock`] for the IO/Done contract.
+    pub fn read_page_nonblock(
+        &self,
+        page_idx: i64,
+    ) -> Result<IOResult<(PageRef, Option<Completion>)>> {
+        self.pager.read_page(page_idx)
     }
 
     pub fn allocate_page(&self, page_type: PageType, offset: usize) -> Result<IOResult<PageRef>> {
@@ -5614,7 +5996,7 @@ impl CursorTrait for BTreeCursor {
             let state = self.count_state;
             match state {
                 CountState::Start => {
-                    let c = self.move_to_root()?;
+                    let c = return_if_io!(self.move_to_root_nonblock());
                     self.count_state = CountState::Loop;
                     if let Some(c) = c {
                         io_yield_one!(c);
@@ -5640,7 +6022,7 @@ impl CursorTrait for BTreeCursor {
                         loop {
                             if !self.stack.has_parent() {
                                 // All pages of the b-tree have been visited. Return successfully
-                                let c = self.move_to_root()?;
+                                let c = return_if_io!(self.move_to_root_nonblock());
                                 self.count_state = CountState::Finish;
                                 if let Some(c) = c {
                                     io_yield_one!(c);
@@ -5672,11 +6054,25 @@ impl CursorTrait for BTreeCursor {
                         // Move to right child
                         // should be safe as contents is not a leaf page
                         let right_most_pointer = contents.rightmost_pointer()?.unwrap();
-                        self.stack.advance();
-                        let (child, c) = self.read_page(right_most_pointer as i64)?;
-                        self.stack.push(child);
-                        if let Some(c) = c {
-                            io_yield_one!(c);
+                        // Spill yield here would re-enter `CountState::Loop`,
+                        // which re-runs `stack.advance()` and the leaf-count
+                        // increment. Transition to `CountState::Descend` so
+                        // re-entry skips those mutations and only retries the
+                        // read + (second) advance + push.
+                        match self.pager.read_page(right_most_pointer as i64)? {
+                            IOResult::Done((child, c)) => {
+                                self.stack.advance();
+                                self.stack.push(child);
+                                if let Some(c) = c {
+                                    io_yield_one!(c);
+                                }
+                            }
+                            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                self.count_state = CountState::Descend {
+                                    target: right_most_pointer as i64,
+                                };
+                                io_yield_one!(spill_c);
+                            }
                         }
                     } else {
                         // Move to child left page
@@ -5691,14 +6087,43 @@ impl CursorTrait for BTreeCursor {
                                 left_child_page,
                                 ..
                             }) => {
-                                self.stack.advance();
-                                let (child, c) = self.read_page(left_child_page as i64)?;
-                                self.stack.push(child);
-                                if let Some(c) = c {
-                                    io_yield_one!(c);
+                                // Same re-entry handling as the rightmost
+                                // branch above.
+                                match self.pager.read_page(left_child_page as i64)? {
+                                    IOResult::Done((child, c)) => {
+                                        self.stack.advance();
+                                        self.stack.push(child);
+                                        if let Some(c) = c {
+                                            io_yield_one!(c);
+                                        }
+                                    }
+                                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                        self.count_state = CountState::Descend {
+                                            target: left_child_page as i64,
+                                        };
+                                        io_yield_one!(spill_c);
+                                    }
                                 }
                             }
                             _ => unreachable!(),
+                        }
+                    }
+                }
+                CountState::Descend { target } => {
+                    // Resume after a spill yield from `CountState::Loop` mid-
+                    // descent. The loop-top mutations are already applied for
+                    // this step; finish the descent and return to `Loop`.
+                    match self.pager.read_page(target)? {
+                        IOResult::Done((child, c)) => {
+                            self.stack.advance();
+                            self.stack.push(child);
+                            self.count_state = CountState::Loop;
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
                         }
                     }
                 }
@@ -5729,8 +6154,8 @@ impl CursorTrait for BTreeCursor {
         loop {
             match self.rewind_state {
                 RewindState::Start => {
+                    let c = return_if_io!(self.move_to_root_nonblock());
                     self.rewind_state = RewindState::NextRecord;
-                    let c = self.move_to_root()?;
                     if let Some(c) = c {
                         io_yield_one!(c);
                     }
@@ -5794,7 +6219,7 @@ impl CursorTrait for BTreeCursor {
         loop {
             match self.seek_end_state {
                 SeekEndState::Start => {
-                    let c = self.move_to_root()?;
+                    let c = return_if_io!(self.move_to_root_nonblock());
                     self.seek_end_state = SeekEndState::ProcessPage;
                     if let Some(c) = c {
                         io_yield_one!(c);
@@ -5812,11 +6237,17 @@ impl CursorTrait for BTreeCursor {
 
                     match contents.rightmost_pointer()? {
                         Some(right_most_pointer) => {
-                            self.stack.set_cell_index(contents.cell_count() as i32 + 1); // invalid on interior
-                            let (child, c) = self.read_page(right_most_pointer as i64)?;
-                            self.stack.push(child);
-                            if let Some(c) = c {
-                                io_yield_one!(c);
+                            match self.read_page_nonblock(right_most_pointer as i64)? {
+                                IOResult::Done((child, c)) => {
+                                    self.stack.set_cell_index(contents.cell_count() as i32 + 1); // invalid on interior
+                                    self.stack.push(child);
+                                    if let Some(c) = c {
+                                        io_yield_one!(c);
+                                    }
+                                }
+                                IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                    io_yield_one!(spill_c);
+                                }
                             }
                         }
                         None => unreachable!("interior page must have rightmost pointer"),
@@ -6109,12 +6540,21 @@ pub fn integrity_check(
         let page = match state.page.take() {
             Some(page) => page,
             None => {
-                let (page, c) = btree_read_page(pager, page_idx)?;
-                state.page = Some(page);
-                if let Some(c) = c {
-                    io_yield_one!(c);
+                // On `IO(spill_c)` we leave `state.page = None` so re-entry
+                // re-takes this None branch and resumes via the pager's
+                // `pending_reads` memoization.
+                match pager.read_page(page_idx)? {
+                    IOResult::Done((page, c)) => {
+                        state.page = Some(page);
+                        if let Some(c) = c {
+                            io_yield_one!(c);
+                        }
+                        state.page.take().expect("page should be present")
+                    }
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        io_yield_one!(spill_c);
+                    }
                 }
-                state.page.take().expect("page should be present")
             }
         };
         turso_assert!(page.is_loaded(), "page should be loaded");
@@ -6471,10 +6911,6 @@ pub fn integrity_check(
             contents.num_frag_free_bytes() as usize,
         );
     }
-}
-
-pub fn btree_read_page(pager: &Arc<Pager>, page_idx: i64) -> Result<(PageRef, Option<Completion>)> {
-    pager.read_page(page_idx)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8512,7 +8948,7 @@ mod tests {
     fn validate_btree(pager: Arc<Pager>, page_idx: i64) -> (usize, bool) {
         let num_columns = 5;
         let cursor = BTreeCursor::new_table(pager.clone(), page_idx, num_columns);
-        let (page, _c) = cursor.read_page(page_idx).unwrap();
+        let (page, _c) = cursor.read_page_blocking(page_idx).unwrap();
         while page.is_locked() {
             pager.io.step().unwrap();
         }
@@ -8532,7 +8968,8 @@ mod tests {
                 BTreeCell::TableInteriorCell(TableInteriorCell {
                     left_child_page, ..
                 }) => {
-                    let (child_page, _c) = cursor.read_page(left_child_page as i64).unwrap();
+                    let (child_page, _c) =
+                        cursor.read_page_blocking(left_child_page as i64).unwrap();
                     while child_page.is_locked() {
                         pager.io.step().unwrap();
                     }
@@ -8589,7 +9026,7 @@ mod tests {
         }
         let first_page_type = child_pages.first_mut().map(|p| {
             if !p.is_loaded() {
-                let (new_page, _c) = pager.read_page(p.get().id as i64).unwrap();
+                let (new_page, _c) = pager.io.block(|| pager.read_page(p.get().id as i64))?;
                 *p = new_page;
             }
             while p.is_locked() {
@@ -8600,7 +9037,8 @@ mod tests {
         if let Some(child_type) = first_page_type {
             for page in child_pages.iter_mut().skip(1) {
                 if !page.is_loaded() {
-                    let (new_page, _c) = pager.read_page(page.get().id as i64).unwrap();
+                    let (new_page, _c) =
+                        pager.io.block(|| pager.read_page(page.get().id as i64))?;
                     *page = new_page;
                 }
                 while page.is_locked() {
@@ -8623,7 +9061,7 @@ mod tests {
         let num_columns = 5;
 
         let cursor = BTreeCursor::new_table(pager.clone(), page_idx, num_columns);
-        let (page, _c) = cursor.read_page(page_idx).unwrap();
+        let (page, _c) = cursor.read_page_blocking(page_idx).unwrap();
         while page.is_locked() {
             pager.io.step().unwrap();
         }
@@ -9726,7 +10164,7 @@ mod tests {
                     .write_page(current_page, buf.clone(), &IOContext::default(), c)?;
             pager.io.step()?;
 
-            let (page, _c) = cursor.read_page(current_page as i64)?;
+            let (page, _c) = cursor.read_page_blocking(current_page as i64)?;
             while page.is_locked() {
                 cursor.pager.io.step()?;
             }
@@ -9786,7 +10224,7 @@ mod tests {
         let trunk_page_id = freelist_trunk_page;
         if trunk_page_id > 0 {
             // Verify trunk page structure
-            let (trunk_page, _c) = cursor.read_page(trunk_page_id as i64)?;
+            let (trunk_page, _c) = cursor.read_page_blocking(trunk_page_id as i64)?;
             let contents = trunk_page.get_contents();
             // Read number of leaf pages in trunk
             let n_leaf = contents.read_u32_no_offset(4);
@@ -9809,7 +10247,7 @@ mod tests {
         let pager = setup_test_env(3);
         let mut cursor = BTreeCursor::new_table(pager.clone(), 1, 5);
 
-        let (overflow_page, c) = cursor.read_page(2)?;
+        let (overflow_page, c) = cursor.read_page_blocking(2)?;
         if let Some(c) = c {
             pager.io.wait_for_completion(c)?;
         }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1110,45 +1110,62 @@ impl BTreeCursor {
                     }
                 }
             }
+            // Compute `next` / `to_read` and fetch the next chain page (if
+            // any) BEFORE applying the loop body's non-idempotent mutations,
+            // so that a spill yield from `read_page(next)` leaves
+            // `read_overflow_state` untouched and is safe to re-enter.
+            let (next, to_read, need_next_page) = {
+                let state = self.read_overflow_state.as_ref().unwrap();
+                turso_assert!(state.page.is_loaded(), "page should be loaded");
+                tracing::debug!(
+                    next_page = state.next_page,
+                    remaining_to_read = state.remaining_to_read,
+                    "reading overflow page"
+                );
+                // The first four bytes of each overflow page are a big-endian integer which is the page number of the next page in the chain, or zero for the final page in the chain.
+                let next = state.page.get_contents().read_u32_no_offset(0);
+                let to_read = state.remaining_to_read.min(self.pager.usable_space() - 4);
+                (
+                    next,
+                    to_read,
+                    state.remaining_to_read > to_read && next != 0,
+                )
+            };
+            let new_page_and_c = if need_next_page {
+                match self.read_page(next as i64)? {
+                    IOResult::Done(v) => Some(v),
+                    IOResult::IO(IOCompletions::Single(spill_c)) => {
+                        io_yield_one!(spill_c);
+                    }
+                }
+            } else {
+                None
+            };
+
             let ReadPayloadOverflow {
                 payload,
                 remaining_to_read,
                 next_page,
                 page,
-                ..
             } = self.read_overflow_state.as_mut().unwrap();
-
-            turso_assert!(page.is_loaded(), "page should be loaded");
-            tracing::debug!(next_page, remaining_to_read, "reading overflow page");
-            let contents = page.get_contents();
-            // The first four bytes of each overflow page are a big-endian integer which is the page number of the next page in the chain, or zero for the final page in the chain.
-            let next = contents.read_u32_no_offset(0);
-            let buf = contents.as_ptr();
-            let usable_space = self.pager.usable_space();
-            let to_read = (*remaining_to_read).min(usable_space - 4);
+            let buf = page.get_contents().as_ptr();
             payload.extend_from_slice(&buf[4..4 + to_read]);
             *remaining_to_read -= to_read;
 
-            if *remaining_to_read != 0 && next != 0 {
-                // Same invariant as the `is_none()` branch above: the spill
-                // yield must leave `read_overflow_state.page` pointing at the
-                // *previous* page so re-entry recomputes `next` from it.
-                match self.read_page(next as i64)? {
-                    IOResult::Done((new_page, c)) => {
-                        let ReadPayloadOverflow {
-                            next_page, page, ..
-                        } = self.read_overflow_state.as_mut().unwrap();
-                        *page = new_page;
-                        *next_page = next;
-                        if let Some(c) = c {
-                            io_yield_one!(c);
-                        }
-                        continue;
-                    }
-                    IOResult::IO(IOCompletions::Single(spill_c)) => {
-                        io_yield_one!(spill_c);
-                    }
+            if let Some((new_page, c)) = new_page_and_c {
+                *page = new_page;
+                *next_page = next;
+                // Re-entrancy: the four mutations above (payload extend,
+                // remaining decrement, page swap, next_page swap) together
+                // advance the state to "current page consumed, positioned on
+                // new_page". Yielding on `c` here is safe because re-entry
+                // resumes one iteration forward — the loop top reads from
+                // the new page, not the old one — so none of these mutations
+                // re-fire against the page they were applied to.
+                if let Some(c) = c {
+                    io_yield_one!(c);
                 }
+                continue;
             }
             if *remaining_to_read != 0 || next != 0 {
                 let chain_page = *next_page;
@@ -6012,12 +6029,10 @@ impl CursorTrait for BTreeCursor {
                     if contents.is_leaf() || cell_idx > contents.cell_count() {
                         loop {
                             if !self.stack.has_parent() {
-                                // All pages of the b-tree have been visited. Return successfully
-                                let c = return_if_io!(self.move_to_root_nonblock());
+                                // All pages of the b-tree have been visited. Return successfully.
+                                // Move the `move_to_root_nonblock` call into `Finish` so a spill
+                                // yield from it can't re-enter `Loop`'s `count += cell_count()`.
                                 self.count_state = CountState::Finish;
-                                if let Some(c) = c {
-                                    io_yield_one!(c);
-                                }
                                 continue 'outer;
                             }
 
@@ -6119,6 +6134,11 @@ impl CursorTrait for BTreeCursor {
                     }
                 }
                 CountState::Finish => {
+                    // Idempotent: a spill yield re-enters this same arm.
+                    let c = return_if_io!(self.move_to_root_nonblock());
+                    if let Some(c) = c {
+                        io_yield_one!(c);
+                    }
                     return Ok(IOResult::Done(self.count));
                 }
             }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10269,6 +10269,76 @@ mod tests {
         Ok(())
     }
 
+    /// Forces a spill yield from `read_page(next-chain-page)` during
+    /// `process_overflow_read`'s loop and verifies the resulting record
+    /// holds the chain's bytes in order with no duplicates and no truncation.
+    #[test]
+    fn process_overflow_read_survives_spill_yield_from_next_chain_read() {
+        let pager = setup_test_env(5);
+        let mut cursor = BTreeCursor::new_table(pager.clone(), 1, 5);
+        let usable = cursor.usable_space();
+        let data_per_page = usable - 4;
+
+        // Re-purpose pages 4 and 5 as a 2-page overflow chain: 4 -> 5 -> end.
+        let load_and_fill = |id: i64, next: u32, fill: u8| {
+            let (page, c) = cursor.read_page_blocking(id).unwrap();
+            if let Some(c) = c {
+                pager.io.wait_for_completion(c).unwrap();
+            }
+            while page.is_locked() {
+                pager.io.step().unwrap();
+            }
+            let buf = page.get_contents().as_ptr();
+            buf[0..4].copy_from_slice(&next.to_be_bytes());
+            buf[4..usable].fill(fill);
+        };
+        load_and_fill(4, 5, b'A');
+        load_and_fill(5, 0, b'B');
+
+        // Arm `read_page(5)` to yield IO once
+        pager.arm_spill_yield_on_read(5, 0);
+
+        let payload_size = (2 * data_per_page) as u64;
+        let cursor_pager = cursor.pager.clone();
+        run_until_done(
+            || cursor.process_overflow_read(b"", 4, payload_size),
+            &cursor_pager,
+        )
+        .unwrap();
+
+        let rec_slot = cursor.get_immutable_record_or_create().unwrap();
+        let bytes = rec_slot.as_ref().unwrap().get_payload();
+        assert_eq!(bytes.len(), 2 * data_per_page);
+        assert!(bytes[..data_per_page].iter().all(|&b| b == b'A'));
+        assert!(bytes[data_per_page..].iter().all(|&b| b == b'B'));
+    }
+
+    /// Forces a real spill yield from the finalization `move_to_root_nonblock`
+    /// at the end of `count`'s traversal and verifies the returned tally
+    /// equals the true cell count.
+    #[test]
+    fn count_survives_spill_yield_at_finalization() {
+        let (pager, root_page, _db, _conn) = empty_btree();
+        let n: u16 = 7;
+
+        // `count()` only reads cell_count from the header; no real cells needed.
+        let (root, _c) = pager.io.block(|| pager.read_page(root_page)).unwrap();
+        while root.is_locked() {
+            pager.io.step().unwrap();
+        }
+        root.get_contents().write_cell_count(n);
+
+        let mut cursor = BTreeCursor::new_table(pager.clone(), root_page, 5);
+
+        // `count` calls `move_to_root_nonblock` -> `read_page(root)` twice:
+        // once in `Start` to push the root, and once at finalization. Skip
+        // the first; yield on the second.
+        pager.arm_spill_yield_on_read(root_page, 1);
+
+        let final_count = run_until_done(|| cursor.count(), &pager).unwrap();
+        assert_eq!(final_count, n as usize);
+    }
+
     #[test]
     pub fn test_clear_overflow_pages_no_overflow() -> Result<()> {
         let pager = setup_test_env(5);

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1450,6 +1450,19 @@ enum SpillState {
     #[default]
     /// No spill operation in progress
     Idle,
+    /// Lazily initializing the WAL header before the first spill write.
+    /// Waiting for the header write (and possible truncate) to complete.
+    /// The pinned pages destined for spilling are carried across the yield.
+    PreparingWalStart {
+        pages: Vec<PinGuard>,
+        completion: Completion,
+    },
+    /// WAL header written; waiting for the fsync that marks the WAL
+    /// initialized before we append spill frames.
+    PreparingWalFinish {
+        pages: Vec<PinGuard>,
+        completion: Completion,
+    },
     /// WAL spill in progress, waiting for write completions
     WritingToWal {
         /// Pinned pages being spilled
@@ -3456,154 +3469,204 @@ impl Pager {
     /// For ephemeral tables: writes pages directly to the temp database file.
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn try_spill_dirty_pages(&self) -> Result<IOResult<bool>> {
-        let state = self.spill_state.read().clone();
-        match state {
-            SpillState::Idle => {
-                // Check if spilling is needed
-                let spill_result = {
-                    let cache = self.page_cache.read();
-                    cache.check_spill(IOV_MAX)
-                };
-                match spill_result {
-                    SpillResult::NotNeeded | SpillResult::Disabled => {
-                        return Ok(IOResult::Done(false));
-                    }
-                    SpillResult::CacheFull => {
-                        tracing::debug!("try_spill_dirty_pages: cache full, no spillable pages");
-                        return Ok(IOResult::Done(false));
-                    }
-                    SpillResult::PagesToSpill(pages) => {
-                        if pages.is_empty() {
+        loop {
+            let state = self.spill_state.read().clone();
+            match state {
+                SpillState::Idle => {
+                    // Check if spilling is needed
+                    let spill_result = {
+                        let cache = self.page_cache.read();
+                        cache.check_spill(IOV_MAX)
+                    };
+                    match spill_result {
+                        SpillResult::NotNeeded | SpillResult::Disabled => {
                             return Ok(IOResult::Done(false));
                         }
-                        let page_count = pages.len();
-                        tracing::debug!("try_spill_dirty_pages: spilling {} pages", page_count);
-                        if let Some(wal) = self.wal.as_ref() {
-                            let page_sz = self.get_page_size().unwrap_or_default();
-
-                            // Ensure WAL is initialized. Most of the time this is a no-op.
-                            let prepare = wal.prepare_wal_start(page_sz)?;
-                            if let Some(c) = prepare {
-                                self.io.wait_for_completion(c)?;
-                                let c = wal.prepare_wal_finish(self.get_sync_type())?;
-                                self.io.wait_for_completion(c)?;
+                        SpillResult::CacheFull => {
+                            tracing::debug!(
+                                "try_spill_dirty_pages: cache full, no spillable pages"
+                            );
+                            return Ok(IOResult::Done(false));
+                        }
+                        SpillResult::PagesToSpill(pages) => {
+                            if pages.is_empty() {
+                                return Ok(IOResult::Done(false));
                             }
+                            let page_count = pages.len();
+                            tracing::debug!("try_spill_dirty_pages: spilling {} pages", page_count);
+                            if let Some(wal) = self.wal.as_ref() {
+                                let page_sz = self.get_page_size().unwrap_or_default();
 
-                            let wal_pages: Vec<PageRef> = pages
-                                .iter()
-                                .map(|p| -> Result<PageRef> {
-                                    self.subjournal_page_if_required(p)?;
-                                    // Set write_pending on all pages before WAL write so callback can
-                                    // detect mid-write modifications.
-                                    p.set_write_pending();
-                                    Ok(p.to_page())
-                                })
-                                .collect::<Result<Vec<_>>>()?;
-                            let c = wal.append_frames_vectored(wal_pages, page_sz)?;
-
-                            if c.succeeded() {
-                                // Synchronous completion, WAL tags already set by callback.
-                                {
-                                    let mut cache = self.page_cache.write();
-                                    for page in &pages {
-                                        if page.has_wal_tag() {
-                                            let key = PageCacheKey::new(page.get().id);
-                                            cache.notify_page_spilled(key);
-                                            page.set_spilled();
-                                        }
+                                // Ensure WAL is initialized. Most of the time this
+                                // is a no-op (returns None). When it does require
+                                // IO we transition through `PreparingWalStart` /
+                                // `PreparingWalFinish` and yield rather than block,
+                                // carrying the pinned `pages` across each yield.
+                                match wal.prepare_wal_start(page_sz)? {
+                                    Some(c) => {
+                                        *self.spill_state.write() = SpillState::PreparingWalStart {
+                                            pages,
+                                            completion: c,
+                                        };
+                                        // Loop to handle the new state (which will
+                                        // yield if the completion isn't finished).
+                                        continue;
+                                    }
+                                    None => {
+                                        // WAL already initialized — append directly.
+                                        return self.spill_append_frames_to_wal(pages);
                                     }
                                 }
-                                *self.spill_state.write() = SpillState::Idle;
-                                return Ok(IOResult::Done(true));
+                            } else {
+                                let mut group = CompletionGroup::new(|_| {});
+                                // Ephemeral table case: write directly to temp file
+                                for page in &pages {
+                                    page.set_write_pending();
+                                }
+                                let completions = self.spill_pages_to_disk(&pages)?;
+                                if completions.is_empty() {
+                                    self.finish_ephemeral_spill(&pages);
+                                    return Ok(IOResult::Done(true));
+                                }
+                                for completion in &completions {
+                                    group.add(completion);
+                                }
+                                *self.spill_state.write() = SpillState::WritingToDisk {
+                                    pages,
+                                    completions: completions.clone(),
+                                };
+                                io_yield_one!(group.build());
                             }
-                            *self.spill_state.write() = SpillState::WritingToWal {
-                                pages,
-                                completions: vec![c.clone()],
-                            };
-                            io_yield_one!(c);
-                        } else {
-                            let mut group = CompletionGroup::new(|_| {});
-                            // Ephemeral table case: write directly to temp file
-                            for page in &pages {
-                                page.set_write_pending();
-                            }
-                            let completions = self.spill_pages_to_disk(&pages)?;
-                            if completions.is_empty() {
-                                self.finish_ephemeral_spill(&pages);
-                                return Ok(IOResult::Done(true));
-                            }
-                            for completion in &completions {
-                                group.add(completion);
-                            }
-                            *self.spill_state.write() = SpillState::WritingToDisk {
-                                pages,
-                                completions: completions.clone(),
-                            };
-                            io_yield_one!(group.build());
                         }
                     }
                 }
-            }
-            SpillState::WritingToWal { pages, completions } => {
-                for c in &completions {
-                    if !c.succeeded() {
-                        io_yield_one!(c.clone());
+                SpillState::PreparingWalStart { pages, completion } => {
+                    if !completion.succeeded() {
+                        io_yield_one!(completion);
                     }
+                    // Header (and any truncate) durable — issue the fsync that
+                    // marks the WAL initialized.
+                    let wal = self.wal.as_ref().expect("PreparingWalStart requires a WAL");
+                    let finish_c = wal.prepare_wal_finish(self.get_sync_type())?;
+                    *self.spill_state.write() = SpillState::PreparingWalFinish {
+                        pages,
+                        completion: finish_c,
+                    };
+                    continue;
                 }
-                // All I/O complete, pages are now in WAL.
-                // Mark spilled pages so they can be evicted while dirty.
-                // Only do so if page wasn't modified since write started (each page has valid wal_tag).
-                let mut spilled_count = 0;
-                {
-                    let mut cache = self.page_cache.write();
-                    for page in &pages {
-                        if page.has_wal_tag() {
-                            let key = PageCacheKey::new(page.get().id);
-                            cache.notify_page_spilled(key);
-                            page.set_spilled();
-                            spilled_count += 1;
-                        } else {
-                            // Page was modified during write, it will need to be re-spilled
-                            tracing::debug!(
-                                "try_spill_dirty_pages: page {} modified during write, not marking as spilled",
-                                page.get().id
-                            );
-                        }
+                SpillState::PreparingWalFinish { pages, completion } => {
+                    if !completion.succeeded() {
+                        io_yield_one!(completion);
                     }
+                    // WAL is now initialized; append the spill frames.
+                    return self.spill_append_frames_to_wal(pages);
                 }
-                if spilled_count == 0 && !pages.is_empty() {
-                    tracing::warn!(
-                        "try_spill_dirty_pages: no pages marked as spilled out of {}, all were modified during write",
-                        pages.len()
-                    );
-                }
-                *self.spill_state.write() = SpillState::Idle;
-                trace!(
-                    "try_spill_dirty_pages: successfully spilled {} / {} pages to WAL",
-                    spilled_count,
-                    pages.len(),
-                );
-                return Ok(IOResult::Done(true));
-            }
-            SpillState::WritingToDisk { pages, completions } => {
-                let all_done = completions.iter().all(|c| c.succeeded());
-                if !all_done {
+                SpillState::WritingToWal { pages, completions } => {
                     for c in &completions {
                         if !c.succeeded() {
                             io_yield_one!(c.clone());
                         }
                     }
+                    // All I/O complete, pages are now in WAL.
+                    // Mark spilled pages so they can be evicted while dirty.
+                    // Only do so if page wasn't modified since write started (each page has valid wal_tag).
+                    let mut spilled_count = 0;
+                    {
+                        let mut cache = self.page_cache.write();
+                        for page in &pages {
+                            if page.has_wal_tag() {
+                                let key = PageCacheKey::new(page.get().id);
+                                cache.notify_page_spilled(key);
+                                page.set_spilled();
+                                spilled_count += 1;
+                            } else {
+                                // Page was modified during write, it will need to be re-spilled
+                                tracing::debug!(
+                                "try_spill_dirty_pages: page {} modified during write, not marking as spilled",
+                                page.get().id
+                            );
+                            }
+                        }
+                    }
+                    if spilled_count == 0 && !pages.is_empty() {
+                        tracing::warn!(
+                        "try_spill_dirty_pages: no pages marked as spilled out of {}, all were modified during write",
+                        pages.len()
+                    );
+                    }
+                    *self.spill_state.write() = SpillState::Idle;
+                    trace!(
+                        "try_spill_dirty_pages: successfully spilled {} / {} pages to WAL",
+                        spilled_count,
+                        pages.len(),
+                    );
+                    return Ok(IOResult::Done(true));
                 }
-                // All I/O complete, finish ephemeral spill
-                self.finish_ephemeral_spill(&pages);
-                *self.spill_state.write() = SpillState::Idle;
-                trace!(
-                    "try_spill_dirty_pages: successfully spilled {} pages to disk",
-                    pages.len()
-                );
-                return Ok(IOResult::Done(true));
+                SpillState::WritingToDisk { pages, completions } => {
+                    let all_done = completions.iter().all(|c| c.succeeded());
+                    if !all_done {
+                        for c in &completions {
+                            if !c.succeeded() {
+                                io_yield_one!(c.clone());
+                            }
+                        }
+                    }
+                    // All I/O complete, finish ephemeral spill
+                    self.finish_ephemeral_spill(&pages);
+                    *self.spill_state.write() = SpillState::Idle;
+                    trace!(
+                        "try_spill_dirty_pages: successfully spilled {} pages to disk",
+                        pages.len()
+                    );
+                    return Ok(IOResult::Done(true));
+                }
             }
         }
+    }
+
+    /// Append the prepared spill `pages` as WAL frames. Returns
+    /// `Done(true)` if the write completed synchronously, otherwise
+    /// transitions to `SpillState::WritingToWal` and yields the write
+    /// completion. The WAL must already be initialized (callers route
+    /// through `PreparingWal*` first).
+    fn spill_append_frames_to_wal(&self, pages: Vec<PinGuard>) -> Result<IOResult<bool>> {
+        let wal = self
+            .wal
+            .as_ref()
+            .expect("spill_append_frames_to_wal requires a WAL");
+        let page_sz = self.get_page_size().unwrap_or_default();
+        let wal_pages: Vec<PageRef> = pages
+            .iter()
+            .map(|p| -> Result<PageRef> {
+                self.subjournal_page_if_required(p)?;
+                // Set write_pending on all pages before WAL write so callback can
+                // detect mid-write modifications.
+                p.set_write_pending();
+                Ok(p.to_page())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let c = wal.append_frames_vectored(wal_pages, page_sz)?;
+
+        if c.succeeded() {
+            // Synchronous completion, WAL tags already set by callback.
+            {
+                let mut cache = self.page_cache.write();
+                for page in &pages {
+                    if page.has_wal_tag() {
+                        let key = PageCacheKey::new(page.get().id);
+                        cache.notify_page_spilled(key);
+                        page.set_spilled();
+                    }
+                }
+            }
+            *self.spill_state.write() = SpillState::Idle;
+            return Ok(IOResult::Done(true));
+        }
+        *self.spill_state.write() = SpillState::WritingToWal {
+            pages,
+            completions: vec![c.clone()],
+        };
+        io_yield_one!(c);
     }
 
     /// Wait for any in-flight spill writes to finish.
@@ -5756,7 +5819,7 @@ mod ptrmap_tests {
         //  Ensure the pointer map page ref is created and loadable via the pager
         let ptrmap_page_ref = pager
             .io
-            .block(|| pager.read_page(expected_ptrmap_pg_no as i64))?;
+            .block(|| pager.read_page(expected_ptrmap_pg_no as i64));
         assert!(ptrmap_page_ref.is_ok());
 
         //  Ensure that the database header size is correctly reflected

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1338,6 +1338,8 @@ pub struct Pager {
     /// `read_page_nonblock(idx)` reuses the stored `(page, disk_read)` pair
     /// instead of issuing a duplicate disk read.
     pending_reads: RwLock<HashMap<i64, PendingRead>>,
+    #[cfg(test)]
+    spill_yield: SpillYieldHook,
     /// Dirty pages as a bitmap, naturally sorted by page number.
     dirty_pages: Arc<RwLock<RoaringBitmap>>,
     subjournal: RwLock<Option<Subjournal>>,
@@ -1395,6 +1397,50 @@ struct PendingRead {
     /// `None` if the page was satisfied from WAL/cache shortcut and no
     /// disk read completion needs to be surfaced to the caller.
     disk_read: Option<Completion>,
+}
+
+/// Test-only deterministic spill-yield injector for `Pager::read_page`. When
+/// armed, the next matching call (after `skip` ignored matches) returns
+/// `IO(yield)` once, then disarms itself.
+#[cfg(test)]
+struct SpillYieldHook {
+    /// `-1` = disarmed; otherwise the `page_idx` to fire on.
+    target: std::sync::atomic::AtomicI64,
+    /// Number of matching calls to ignore before firing.
+    skip: std::sync::atomic::AtomicUsize,
+}
+
+#[cfg(test)]
+impl SpillYieldHook {
+    const fn new() -> Self {
+        Self {
+            target: std::sync::atomic::AtomicI64::new(-1),
+            skip: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    fn arm(&self, page_id: i64, skip: usize) {
+        use std::sync::atomic::Ordering::Relaxed;
+        self.skip.store(skip, Relaxed);
+        self.target.store(page_id, Relaxed);
+    }
+
+    /// Returns true exactly once per arming, when the (`skip + 1`)th call for
+    /// the armed page id arrives. Internal load-then-store is fine because
+    /// tests using this hook are single-threaded.
+    fn should_yield_for(&self, page_idx: i64) -> bool {
+        use std::sync::atomic::Ordering::Relaxed;
+        if self.target.load(Relaxed) != page_idx {
+            return false;
+        }
+        if self.skip.load(Relaxed) == 0 {
+            self.target.store(-1, Relaxed);
+            true
+        } else {
+            self.skip.fetch_sub(1, Relaxed);
+            false
+        }
+    }
 }
 
 #[cfg(not(feature = "omit_autovacuum"))]
@@ -1537,6 +1583,8 @@ impl Pager {
             page_cache: Arc::new(RwLock::new(page_cache)),
             io,
             pending_reads: RwLock::new(HashMap::new()),
+            #[cfg(test)]
+            spill_yield: SpillYieldHook::new(),
             dirty_pages: Arc::new(RwLock::new(RoaringBitmap::new())),
             subjournal: RwLock::new(None),
             savepoints: Arc::new(RwLock::new(Vec::new())),
@@ -3020,6 +3068,10 @@ impl Pager {
     pub fn read_page(&self, page_idx: i64) -> Result<IOResult<(PageRef, Option<Completion>)>> {
         turso_assert_greater_than_or_equal!(page_idx, 0, "pages in pager should be positive, negative might indicate unallocated pages from mvcc or any other nasty bug");
         tracing::debug!("read_page_nonblock(page_idx = {})", page_idx);
+        #[cfg(test)]
+        if self.spill_yield.should_yield_for(page_idx) {
+            io_yield_one!(crate::Completion::new_yield());
+        }
         let pending = self.pending_reads.read().get(&page_idx).cloned();
         let (page, c_disk) = if let Some(pending) = pending {
             // Re-entry: previous call yielded on spill before completing
@@ -3115,6 +3167,13 @@ impl Pager {
             IOResult::Done(false) => Err(LimboError::Busy),
             IOResult::IO(c) => Ok(IOResult::IO(c)),
         }
+    }
+
+    /// Test-only: arm `read_page` to return `IO(yield)` once for `page_id`
+    /// after `skip` matching calls have passed through.
+    #[cfg(test)]
+    pub(crate) fn arm_spill_yield_on_read(&self, page_id: i64, skip: usize) {
+        self.spill_yield.arm(page_id, skip);
     }
 
     // Get a page from the cache, if it exists.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1671,22 +1671,16 @@ impl Pager {
                         return Ok(IOResult::Done(page1));
                     }
 
-                    // On `IO(spill_c)` we keep the state at `Start` so
+                    // On spill `return_if_io!` propagates IO up unchanged so
                     // re-entry resumes here via the pager's `pending_reads`
                     // memoization (no duplicate disk read).
-                    match self.read_page(DatabaseHeader::PAGE_ID as i64)? {
-                        IOResult::Done((page, c)) => {
-                            *self.header_ref_state.write() = HeaderRefState::CreateHeader {
-                                page,
-                                completion: c.clone(),
-                            };
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    let (page, c) = return_if_io!(self.read_page(DatabaseHeader::PAGE_ID as i64));
+                    *self.header_ref_state.write() = HeaderRefState::CreateHeader {
+                        page,
+                        completion: c.clone(),
+                    };
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
                 }
                 HeaderRefState::CreateHeader { page, completion } => {
@@ -2260,22 +2254,15 @@ impl Pager {
                         ptrmap_pg_no
                     );
 
-                    // On `IO(spill_c)` keep `ptrmap_get_state` at `Start` so
-                    // re-entry resumes via the pager's pending-read tracking.
-                    match self.read_page(ptrmap_pg_no as i64)? {
-                        IOResult::Done((ptrmap_page, c)) => {
-                            self.vacuum_state.write().ptrmap_get_state =
-                                PtrMapGetState::Deserialize {
-                                    ptrmap_page,
-                                    offset_in_ptrmap_page,
-                                };
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    // `return_if_io!` keeps `ptrmap_get_state` at `Start` on
+                    // spill so re-entry resumes via pending-read tracking.
+                    let (ptrmap_page, c) = return_if_io!(self.read_page(ptrmap_pg_no as i64));
+                    self.vacuum_state.write().ptrmap_get_state = PtrMapGetState::Deserialize {
+                        ptrmap_page,
+                        offset_in_ptrmap_page,
+                    };
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
                 }
                 PtrMapGetState::Deserialize {
@@ -2369,22 +2356,15 @@ impl Pager {
                         offset_in_ptrmap_page
                     );
 
-                    // On `IO(spill_c)` keep `ptrmap_put_state` at `Start` so
-                    // re-entry resumes via the pager's pending-read tracking.
-                    match self.read_page(ptrmap_pg_no as i64)? {
-                        IOResult::Done((ptrmap_page, c)) => {
-                            self.vacuum_state.write().ptrmap_put_state =
-                                PtrMapPutState::Deserialize {
-                                    ptrmap_page,
-                                    offset_in_ptrmap_page,
-                                };
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    // `return_if_io!` keeps `ptrmap_put_state` at `Start` on
+                    // spill so re-entry resumes via pending-read tracking.
+                    let (ptrmap_page, c) = return_if_io!(self.read_page(ptrmap_pg_no as i64));
+                    self.vacuum_state.write().ptrmap_put_state = PtrMapPutState::Deserialize {
+                        ptrmap_page,
+                        offset_in_ptrmap_page,
+                    };
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
                 }
                 PtrMapPutState::Deserialize {
@@ -4800,12 +4780,7 @@ impl Pager {
                             }
                             (page, None)
                         }
-                        None => match self.read_page(page_id as i64)? {
-                            IOResult::Done(v) => v,
-                            IOResult::IO(IOCompletions::Single(spill_c)) => {
-                                io_yield_one!(spill_c);
-                            }
-                        },
+                        None => return_if_io!(self.read_page(page_id as i64)),
                     };
                     header.freelist_pages = (header.freelist_pages.get() + 1).into();
 
@@ -4833,12 +4808,7 @@ impl Pager {
                     // `pending_reads` returns the same `trunk_page`, and the
                     // writes are byte-identical (we haven't written yet so
                     // `number_of_leaf_pages` is unchanged).
-                    let (trunk_page, c) = match self.read_page(trunk_page_id as i64)? {
-                        IOResult::Done(v) => v,
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
-                    };
+                    let (trunk_page, c) = return_if_io!(self.read_page(trunk_page_id as i64));
                     if let Some(c) = c {
                         if !c.succeeded() {
                             io_yield_one!(c);
@@ -5059,17 +5029,12 @@ impl Pager {
                     // Spill yield routes back through `Start`; the ptrmap
                     // allocation above is idempotent and `trunk_page.pin()`
                     // happens only after `Done`, so no double-pin.
-                    match self.read_page(first_freelist_trunk_page_id as i64)? {
-                        IOResult::Done((trunk_page, c)) => {
-                            trunk_page.pin();
-                            *state = AllocatePageState::SearchAvailableFreeListLeaf { trunk_page };
-                            if let Some(c) = c {
-                                io_yield_one!(c);
-                            }
-                        }
-                        IOResult::IO(IOCompletions::Single(spill_c)) => {
-                            io_yield_one!(spill_c);
-                        }
+                    let (trunk_page, c) =
+                        return_if_io!(self.read_page(first_freelist_trunk_page_id as i64));
+                    trunk_page.pin();
+                    *state = AllocatePageState::SearchAvailableFreeListLeaf { trunk_page };
+                    if let Some(c) = c {
+                        io_yield_one!(c);
                     }
                 }
                 AllocatePageState::SearchAvailableFreeListLeaf { trunk_page } => {
@@ -5092,32 +5057,27 @@ impl Pager {
                             page_contents.read_u32_no_offset(FREELIST_TRUNK_OFFSET_FIRST_LEAF_PTR);
                         // Pin + state-advance happen only on `Done` so a
                         // spill yield doesn't double-pin the leaf page.
-                        match self.read_page(next_leaf_page_id as i64)? {
-                            IOResult::Done((leaf_page, c)) => {
-                                turso_assert!(
-                                    number_of_freelist_leaves > 0,
-                                    "Freelist trunk page has no leaves",
-                                    { "page_id": trunk_page.get().id }
-                                );
+                        let (leaf_page, c) =
+                            return_if_io!(self.read_page(next_leaf_page_id as i64));
+                        turso_assert!(
+                            number_of_freelist_leaves > 0,
+                            "Freelist trunk page has no leaves",
+                            { "page_id": trunk_page.get().id }
+                        );
 
-                                // Pin leaf_page to prevent eviction while stored in state machine
-                                // trunk_page is already pinned from previous state
-                                leaf_page.pin();
+                        // Pin leaf_page to prevent eviction while stored in state machine
+                        // trunk_page is already pinned from previous state
+                        leaf_page.pin();
 
-                                *state = AllocatePageState::ReuseFreelistLeaf {
-                                    trunk_page: trunk_page.clone(),
-                                    leaf_page,
-                                    number_of_freelist_leaves,
-                                };
-                                if let Some(c) = c {
-                                    io_yield_one!(c);
-                                }
-                                continue;
-                            }
-                            IOResult::IO(IOCompletions::Single(spill_c)) => {
-                                io_yield_one!(spill_c);
-                            }
+                        *state = AllocatePageState::ReuseFreelistLeaf {
+                            trunk_page: trunk_page.clone(),
+                            leaf_page,
+                            number_of_freelist_leaves,
+                        };
+                        if let Some(c) = c {
+                            io_yield_one!(c);
                         }
+                        continue;
                     }
 
                     // No freelist leaves on this trunk page.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -36,6 +36,7 @@ use crate::{
 use arc_swap::ArcSwapOption;
 use roaring::RoaringBitmap;
 use std::cell::UnsafeCell;
+use std::collections::HashMap;
 use tracing::{instrument, trace, Level};
 
 use super::btree::offset::{
@@ -1331,6 +1332,12 @@ pub struct Pager {
     pub buffer_pool: Arc<BufferPool>,
     /// I/O interface for input/output operations.
     pub io: Arc<dyn crate::io::IO>,
+    /// Reads that have begun (disk IO issued, page allocated) but whose
+    /// `cache_insert` has not yet succeeded because the cache was full and we
+    /// yielded waiting for a spill to complete. The next call to
+    /// `read_page_nonblock(idx)` reuses the stored `(page, disk_read)` pair
+    /// instead of issuing a duplicate disk read.
+    pending_reads: RwLock<HashMap<i64, PendingRead>>,
     /// Dirty pages as a bitmap, naturally sorted by page number.
     dirty_pages: Arc<RwLock<RoaringBitmap>>,
     subjournal: RwLock<Option<Subjournal>>,
@@ -1377,6 +1384,18 @@ pub struct Pager {
 }
 
 assert_send_sync!(Pager);
+
+/// State for a `read_page_nonblock` call that has issued its disk read but has
+/// not yet been able to insert the page into the cache (cache full, spill in
+/// flight). Stored in `Pager::pending_reads` so the next re-entry can resume
+/// without issuing a duplicate disk read.
+#[derive(Clone)]
+struct PendingRead {
+    page: PageRef,
+    /// `None` if the page was satisfied from WAL/cache shortcut and no
+    /// disk read completion needs to be surfaced to the caller.
+    disk_read: Option<Completion>,
+}
 
 #[cfg(not(feature = "omit_autovacuum"))]
 pub struct VacuumState {
@@ -1504,6 +1523,7 @@ impl Pager {
             wal,
             page_cache: Arc::new(RwLock::new(page_cache)),
             io,
+            pending_reads: RwLock::new(HashMap::new()),
             dirty_pages: Arc::new(RwLock::new(RoaringBitmap::new())),
             subjournal: RwLock::new(None),
             savepoints: Arc::new(RwLock::new(Vec::new())),
@@ -1590,13 +1610,22 @@ impl Pager {
                         return Ok(IOResult::Done(page1));
                     }
 
-                    let (page, c) = self.read_page(DatabaseHeader::PAGE_ID as i64)?;
-                    *self.header_ref_state.write() = HeaderRefState::CreateHeader {
-                        page,
-                        completion: c.clone(),
-                    };
-                    if let Some(c) = c {
-                        io_yield_one!(c);
+                    // On `IO(spill_c)` we keep the state at `Start` so
+                    // re-entry resumes here via the pager's `pending_reads`
+                    // memoization (no duplicate disk read).
+                    match self.read_page(DatabaseHeader::PAGE_ID as i64)? {
+                        IOResult::Done((page, c)) => {
+                            *self.header_ref_state.write() = HeaderRefState::CreateHeader {
+                                page,
+                                completion: c.clone(),
+                            };
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
                     }
                 }
                 HeaderRefState::CreateHeader { page, completion } => {
@@ -2170,13 +2199,22 @@ impl Pager {
                         ptrmap_pg_no
                     );
 
-                    let (ptrmap_page, c) = self.read_page(ptrmap_pg_no as i64)?;
-                    self.vacuum_state.write().ptrmap_get_state = PtrMapGetState::Deserialize {
-                        ptrmap_page,
-                        offset_in_ptrmap_page,
-                    };
-                    if let Some(c) = c {
-                        io_yield_one!(c);
+                    // On `IO(spill_c)` keep `ptrmap_get_state` at `Start` so
+                    // re-entry resumes via the pager's pending-read tracking.
+                    match self.read_page(ptrmap_pg_no as i64)? {
+                        IOResult::Done((ptrmap_page, c)) => {
+                            self.vacuum_state.write().ptrmap_get_state =
+                                PtrMapGetState::Deserialize {
+                                    ptrmap_page,
+                                    offset_in_ptrmap_page,
+                                };
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
                     }
                 }
                 PtrMapGetState::Deserialize {
@@ -2270,13 +2308,22 @@ impl Pager {
                         offset_in_ptrmap_page
                     );
 
-                    let (ptrmap_page, c) = self.read_page(ptrmap_pg_no as i64)?;
-                    self.vacuum_state.write().ptrmap_put_state = PtrMapPutState::Deserialize {
-                        ptrmap_page,
-                        offset_in_ptrmap_page,
-                    };
-                    if let Some(c) = c {
-                        io_yield_one!(c);
+                    // On `IO(spill_c)` keep `ptrmap_put_state` at `Start` so
+                    // re-entry resumes via the pager's pending-read tracking.
+                    match self.read_page(ptrmap_pg_no as i64)? {
+                        IOResult::Done((ptrmap_page, c)) => {
+                            self.vacuum_state.write().ptrmap_put_state =
+                                PtrMapPutState::Deserialize {
+                                    ptrmap_page,
+                                    offset_in_ptrmap_page,
+                                };
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
                     }
                 }
                 PtrMapPutState::Deserialize {
@@ -2941,43 +2988,68 @@ impl Pager {
         Ok((page, c))
     }
 
-    /// Reads a page from the database.
+    /// Issue a non-blocking page read, inserting into the page cache, may spill to disk.
+    ///
+    /// * `Done((page, None))`: page was already in cache, no IO needed.
+    /// * `Done((page, Some(c_disk)))`: page was not in cache; it has been
+    ///   inserted into the cache and a disk-read is in flight against it.
+    ///   The caller must yield on `c_disk` before reading `page` contents.
+    /// * `IO(c_spill)`: the page cache was full and a spill is in flight.
+    ///   Caller must yield on `c_spill` and then call `read_page_nonblock(idx)`
+    ///   again. The disk read for this page has already been issued and will
+    ///   be reused on re-entry via `pending_reads` (no duplicate IO).
+    ///
+    /// Re-entrancy contract: the caller may invoke this with the same
+    /// `page_idx` arbitrarily many times. Each `Some(page_idx)` mapping in
+    /// `pending_reads` corresponds to a single outstanding disk read; the
+    /// entry is removed exactly when this method returns `Done`.
     #[tracing::instrument(skip_all, level = Level::TRACE)]
-    pub fn read_page(&self, page_idx: i64) -> Result<(PageRef, Option<Completion>)> {
+    pub fn read_page(&self, page_idx: i64) -> Result<IOResult<(PageRef, Option<Completion>)>> {
         turso_assert_greater_than_or_equal!(page_idx, 0, "pages in pager should be positive, negative might indicate unallocated pages from mvcc or any other nasty bug");
-        tracing::debug!("read_page(page_idx = {})", page_idx);
-
-        // First check if page is in cache
-        {
-            let mut page_cache = self.page_cache.write();
-            let page_key = PageCacheKey::new(page_idx as usize);
-            if let Some(page) = page_cache.get(&page_key)? {
-                turso_assert!(
-                    page_idx as usize == page.get().id,
-                    "attempted to read page but got different page",
-                    { "expected_page": page_idx, "actual_page": page.get().id }
-                );
-                return Ok((page, None));
+        tracing::debug!("read_page_nonblock(page_idx = {})", page_idx);
+        let pending = self.pending_reads.read().get(&page_idx).cloned();
+        let (page, c_disk) = if let Some(pending) = pending {
+            // Re-entry: previous call yielded on spill before completing
+            // `cache_insert`. Reuse the same PageRef and in-flight disk read
+            // rather than issuing duplicate IO.
+            (pending.page, pending.disk_read)
+        } else {
+            // Fast path: cache hit.
+            {
+                let mut page_cache = self.page_cache.write();
+                let page_key = PageCacheKey::new(page_idx as usize);
+                if let Some(page) = page_cache.get(&page_key)? {
+                    turso_assert!(
+                        page_idx as usize == page.get().id,
+                        "attempted to read page but got different page",
+                        { "expected_page": page_idx, "actual_page": page.get().id }
+                    );
+                    return Ok(IOResult::Done((page, None)));
+                }
             }
-        }
 
-        tracing::debug!("read_page(page_idx = {page_idx}) = reading page from disk");
-        // Page not in cache, read from disk
-        let (page, c) = self.read_page_no_cache(page_idx, None, false)?;
-        loop {
-            match self.cache_insert(page_idx as usize, page.clone())? {
-                IOResult::Done(()) => {
-                    return Ok((page, Some(c)));
-                }
-                IOResult::IO(IOCompletions::Single(spill_c)) => {
-                    // NOTE: Because `cache_insert` can return completions as *multiple* different states, we cannot
-                    // simply create a new CompletionGroup and return it here without inserting the
-                    // page into the cache. In order to do this, we would need to make read_page
-                    // re-entrant so it continues to call cache_insert and have every caller
-                    // propogate the IOResult. For now, we will wait syncronously for spilling IO
-                    // on cache insertion on read_page.
-                    self.io.wait_for_completion(spill_c)?;
-                }
+            tracing::debug!("read_page_nonblock(page_idx = {page_idx}) = reading page from disk");
+            let (page, c) = self.read_page_no_cache(page_idx, None, false)?;
+            self.pending_reads.write().insert(
+                page_idx,
+                PendingRead {
+                    page: page.clone(),
+                    disk_read: Some(c.clone()),
+                },
+            );
+            (page, Some(c))
+        };
+
+        match self.cache_insert(page_idx as usize, page.clone())? {
+            IOResult::Done(()) => {
+                self.pending_reads.write().remove(&page_idx);
+                Ok(IOResult::Done((page, c_disk)))
+            }
+            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                // Leave the pending entry in place; the next call to
+                // `read_page_nonblock(page_idx)` will recover it and retry
+                // `cache_insert` without re-issuing the disk read.
+                io_yield_one!(spill_c);
             }
         }
     }
@@ -4582,6 +4654,16 @@ impl Pager {
                         )));
                     }
 
+                    // The non-blocking read fork here is safe: if the caller
+                    // passes `Some(page)`, no IO occurs and the mutations
+                    // below run synchronously. If the caller passes `None`
+                    // and `read_page_nonblock` yields for spill, we leave
+                    // `state` at `Start` so re-entry re-takes either branch
+                    // (the pager's `pending_reads` memoization returns the
+                    // same `PageRef` the next time). Crucially, the
+                    // non-idempotent mutations (`freelist_pages` increment,
+                    // `page.pin()`, state advance) all happen AFTER both
+                    // branches converge.
                     let (page, c) = match page.take() {
                         Some(page) => {
                             turso_assert_eq!(
@@ -4596,7 +4678,12 @@ impl Pager {
                             }
                             (page, None)
                         }
-                        None => self.read_page(page_id as i64)?,
+                        None => match self.read_page(page_id as i64)? {
+                            IOResult::Done(v) => v,
+                            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                io_yield_one!(spill_c);
+                            }
+                        },
                     };
                     header.freelist_pages = (header.freelist_pages.get() + 1).into();
 
@@ -4618,7 +4705,18 @@ impl Pager {
                 }
                 FreePageState::AddToTrunk { page } => {
                     let trunk_page_id = header.freelist_trunk_page.get();
-                    let (trunk_page, c) = self.read_page(trunk_page_id as i64)?;
+                    // Spill yield here keeps `state` at `AddToTrunk`. The
+                    // subsequent writes / `unpin()` only run after we have
+                    // a loaded `trunk_page`; on re-entry the pager's
+                    // `pending_reads` returns the same `trunk_page`, and the
+                    // writes are byte-identical (we haven't written yet so
+                    // `number_of_leaf_pages` is unchanged).
+                    let (trunk_page, c) = match self.read_page(trunk_page_id as i64)? {
+                        IOResult::Done(v) => v,
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
+                    };
                     if let Some(c) = c {
                         if !c.succeeded() {
                             io_yield_one!(c);
@@ -4808,11 +4906,24 @@ impl Pager {
                         {
                             // we will allocate a ptrmap page, so increment size
                             new_db_size += 1;
-                            let page = allocate_new_page(new_db_size as i64, &self.buffer_pool);
-                            self.add_dirty(&page)?;
-                            let page_key = PageCacheKey::new(page.get().id as usize);
-                            let mut cache = self.page_cache.write();
-                            cache.insert(page_key, page)?;
+                            // Make the ptrmap allocation idempotent across
+                            // spill-yield re-entries: only allocate + insert
+                            // if the cache doesn't already contain it. The
+                            // read-then-write pattern is safe because
+                            // `allocate_page` holds the only writer for
+                            // `database_size`/`freelist_trunk_page`; no
+                            // concurrent caller can race in between.
+                            let page_key = PageCacheKey::new(new_db_size as usize);
+                            let already_present = {
+                                let cache = self.page_cache.read();
+                                cache.contains_key(&page_key)
+                            };
+                            if !already_present {
+                                let page = allocate_new_page(new_db_size as i64, &self.buffer_pool);
+                                self.add_dirty(&page)?;
+                                let mut cache = self.page_cache.write();
+                                cache.insert(page_key, page)?;
+                            }
                         }
                     }
 
@@ -4823,12 +4934,20 @@ impl Pager {
                         };
                         continue;
                     }
-                    let (trunk_page, c) = self.read_page(first_freelist_trunk_page_id as i64)?;
-                    // Pin trunk_page to prevent eviction while stored in state machine
-                    trunk_page.pin();
-                    *state = AllocatePageState::SearchAvailableFreeListLeaf { trunk_page };
-                    if let Some(c) = c {
-                        io_yield_one!(c);
+                    // Spill yield routes back through `Start`; the ptrmap
+                    // allocation above is idempotent and `trunk_page.pin()`
+                    // happens only after `Done`, so no double-pin.
+                    match self.read_page(first_freelist_trunk_page_id as i64)? {
+                        IOResult::Done((trunk_page, c)) => {
+                            trunk_page.pin();
+                            *state = AllocatePageState::SearchAvailableFreeListLeaf { trunk_page };
+                            if let Some(c) = c {
+                                io_yield_one!(c);
+                            }
+                        }
+                        IOResult::IO(IOCompletions::Single(spill_c)) => {
+                            io_yield_one!(spill_c);
+                        }
                     }
                 }
                 AllocatePageState::SearchAvailableFreeListLeaf { trunk_page } => {
@@ -4849,27 +4968,34 @@ impl Pager {
                         let page_contents = trunk_page.get_contents();
                         let next_leaf_page_id =
                             page_contents.read_u32_no_offset(FREELIST_TRUNK_OFFSET_FIRST_LEAF_PTR);
-                        let (leaf_page, c) = self.read_page(next_leaf_page_id as i64)?;
+                        // Pin + state-advance happen only on `Done` so a
+                        // spill yield doesn't double-pin the leaf page.
+                        match self.read_page(next_leaf_page_id as i64)? {
+                            IOResult::Done((leaf_page, c)) => {
+                                turso_assert!(
+                                    number_of_freelist_leaves > 0,
+                                    "Freelist trunk page has no leaves",
+                                    { "page_id": trunk_page.get().id }
+                                );
 
-                        turso_assert!(
-                            number_of_freelist_leaves > 0,
-                            "Freelist trunk page has no leaves",
-                            { "page_id": trunk_page.get().id }
-                        );
+                                // Pin leaf_page to prevent eviction while stored in state machine
+                                // trunk_page is already pinned from previous state
+                                leaf_page.pin();
 
-                        // Pin leaf_page to prevent eviction while stored in state machine
-                        // trunk_page is already pinned from previous state
-                        leaf_page.pin();
-
-                        *state = AllocatePageState::ReuseFreelistLeaf {
-                            trunk_page: trunk_page.clone(),
-                            leaf_page,
-                            number_of_freelist_leaves,
-                        };
-                        if let Some(c) = c {
-                            io_yield_one!(c);
+                                *state = AllocatePageState::ReuseFreelistLeaf {
+                                    trunk_page: trunk_page.clone(),
+                                    leaf_page,
+                                    number_of_freelist_leaves,
+                                };
+                                if let Some(c) = c {
+                                    io_yield_one!(c);
+                                }
+                                continue;
+                            }
+                            IOResult::IO(IOCompletions::Single(spill_c)) => {
+                                io_yield_one!(spill_c);
+                            }
                         }
-                        continue;
                     }
 
                     // No freelist leaves on this trunk page.
@@ -5628,7 +5754,9 @@ mod ptrmap_tests {
         assert_eq!(expected_ptrmap_pg_no, FIRST_PTRMAP_PAGE_NO);
 
         //  Ensure the pointer map page ref is created and loadable via the pager
-        let ptrmap_page_ref = pager.read_page(expected_ptrmap_pg_no as i64);
+        let ptrmap_page_ref = pager
+            .io
+            .block(|| pager.read_page(expected_ptrmap_pg_no as i64))?;
         assert!(ptrmap_page_ref.is_ok());
 
         //  Ensure that the database header size is correctly reflected
@@ -5715,6 +5843,94 @@ mod ptrmap_tests {
         assert_eq!(
             get_ptrmap_offset_in_page(108, 105, page_size).unwrap(),
             2 * PTRMAP_ENTRY_SIZE
+        );
+    }
+
+    /// Cache-hit fast path: `read_page_nonblock` must return `Done` with no
+    /// disk-read completion and must not touch `pending_reads`.
+    #[test]
+    fn read_page_nonblock_cache_hit_returns_done() {
+        let pager = test_pager_setup(4096, 10);
+
+        // Page 1 is unconditionally loaded into cache by `allocate_page1`.
+        let res = pager.read_page(1).unwrap();
+        match res {
+            IOResult::Done((page, c)) => {
+                assert_eq!(page.get().id, 1);
+                assert!(
+                    c.is_none(),
+                    "cache hit must not return a disk-read completion"
+                );
+            }
+            IOResult::IO(_) => panic!("cache hit should not yield"),
+        }
+        assert!(
+            pager.pending_reads.read().is_empty(),
+            "pending_reads must stay empty on cache-hit path"
+        );
+    }
+
+    /// Re-entry contract: if `pending_reads` already has a `PendingRead` for
+    /// this page (as happens after a previous call yielded for spill), the
+    /// next call must reuse that `(page, disk_read)` instead of allocating a
+    /// new page and issuing a duplicate disk read.
+    ///
+    /// This test does NOT force a real spill yield — that requires an IO
+    /// backend that returns non-finished completions, which we don't have at
+    /// the core unit-test layer. We instead synthesize the post-yield state
+    /// directly and assert the function honors it.
+    #[test]
+    fn read_page_nonblock_reentry_reuses_pending_entry() {
+        let pager = test_pager_setup(4096, 10);
+
+        // Pick a page id well beyond the initialized DB so it is *not* in
+        // the cache. We never actually issue IO against it (we short-circuit
+        // via the pre-populated `pending_reads` entry), so the page id only
+        // needs to be unique within the cache.
+        let target_idx: i64 = 9999;
+        assert!(
+            pager.cache_get(target_idx as usize).unwrap().is_none(),
+            "test precondition: target page must not be in cache"
+        );
+
+        // Synthesize the state that would exist after a previous call had to
+        // yield on spill: a `PendingRead` entry whose `page` is the
+        // PageRef we already handed back to the caller, and whose
+        // `disk_read` is the in-flight disk-read completion.
+        let synthetic_page: PageRef = Arc::new(Page::new(target_idx));
+        // Mark loaded so cache eviction logic treats it as a normal page; the
+        // contents don't matter for this test.
+        synthetic_page.set_loaded();
+        let stub_disk_read = Completion::new_yield();
+        pager.pending_reads.write().insert(
+            target_idx,
+            PendingRead {
+                page: synthetic_page.clone(),
+                disk_read: Some(stub_disk_read.clone()),
+            },
+        );
+
+        let res = pager.read_page(target_idx).unwrap();
+        let (page, c) = match res {
+            IOResult::Done(v) => v,
+            IOResult::IO(_) => panic!(
+                "with pending entry present and cache space available, \
+                 read_page_nonblock should complete without yielding"
+            ),
+        };
+
+        assert!(
+            Arc::ptr_eq(&page, &synthetic_page),
+            "read_page_nonblock must reuse the PageRef from pending_reads, \
+             not allocate a new page (this is the no-duplicate-IO invariant)"
+        );
+        assert!(
+            c.is_some(),
+            "the disk-read completion from pending_reads should be returned"
+        );
+        assert!(
+            pager.pending_reads.read().get(&target_idx).is_none(),
+            "pending_reads entry must be cleared once read_page_nonblock returns Done"
         );
     }
 }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -43,7 +43,11 @@
 
 #![allow(clippy::arc_with_non_send_sync)]
 
-use crate::{turso_assert, turso_assert_eq, turso_assert_greater_than};
+use crate::{
+    io_yield_one, turso_assert, turso_assert_eq, turso_assert_greater_than,
+    types::{IOCompletions, IOResult},
+    util::IOExt as _,
+};
 use branches::{mark_unlikely, unlikely};
 use bytemuck::{Pod, Zeroable};
 use pack1::{I32BE, U16BE, U32BE};
@@ -1419,87 +1423,180 @@ pub fn write_varint_to_vec(value: u64, payload: &mut Vec<u8>) {
 
 /// Stream through frames in chunks, building frame_cache incrementally
 /// Track last valid commit frame for consistency
+/// Non-blocking driver for WAL recovery on open.
+///
+/// Created by [`BuildSharedWal::begin`] (which performs only synchronous
+/// setup and may complete immediately for an empty/headerless WAL), then
+/// driven via [`BuildSharedWal::poll`] until it returns `Done`. All recovery
+/// state lives in the [`StreamingWalReader`] (atomics + `RwLock<StreamingState>`)
+/// and is updated by the read completions' callbacks, so the only state this
+/// driver tracks is which phase/completion it's waiting on.
+pub struct BuildSharedWal {
+    reader: Option<Arc<StreamingWalReader>>,
+    wal_file_shared: Arc<RwLock<WalFileShared>>,
+    file_size: u64,
+    phase: BuildSharedWalPhase,
+}
+
+#[derive(Clone)]
+enum BuildSharedWalPhase {
+    /// Issue the WAL header read.
+    NeedHeaderRead,
+    /// Waiting on the header read completion.
+    AwaitHeader(Completion),
+    /// Decide whether to read the next chunk or finalize.
+    ChunkLoop,
+    /// Waiting on a chunk read that began at `offset`.
+    AwaitChunk { completion: Completion, offset: u64 },
+    /// Recovery complete.
+    Done,
+}
+
+impl BuildSharedWal {
+    /// Synchronous setup: read the file size, build the (initially unloaded)
+    /// `WalFileShared`, and decide the starting phase. For a WAL smaller than
+    /// the header it marks the shared state loaded and starts in `Done`.
+    pub fn begin(file: &Arc<dyn File>) -> Result<Self> {
+        let size = file.size()?;
+
+        let header = Arc::new(SpinLock::new(WalHeader::default()));
+        let read_locks = std::array::from_fn(|_| TursoRwLock::new());
+        for (i, l) in read_locks.iter().enumerate() {
+            l.write();
+            l.set_value_exclusive(if i < 2 { 0 } else { READMARK_NOT_USED });
+            l.unlock();
+        }
+
+        let wal_file_shared = Arc::new(RwLock::new(WalFileShared {
+            metadata: WalSharedMetadata {
+                enabled: AtomicBool::new(true),
+                wal_header: header.clone(),
+                min_frame: AtomicU64::new(0),
+                max_frame: AtomicU64::new(0),
+                nbackfills: AtomicU64::new(0),
+                transaction_count: AtomicU64::new(0),
+                last_checksum: (0, 0),
+                loaded: AtomicBool::new(false),
+                loaded_from_disk_scan: AtomicBool::new(true),
+                initialized: AtomicBool::new(false),
+            },
+            runtime: WalSharedRuntime {
+                frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
+                file: Some(file.clone()),
+                read_locks,
+                vacuum_lock: TursoRwLock::new(),
+                write_lock: TursoRwLock::new(),
+                checkpoint_lock: TursoRwLock::new(),
+                epoch: AtomicU32::new(0),
+                overflow_fallback_coverage: Arc::new(SpinLock::new(
+                    OverflowFallbackCoverage::default(),
+                )),
+            },
+        }));
+
+        if size < WAL_HEADER_SIZE as u64 {
+            wal_file_shared
+                .write()
+                .metadata
+                .loaded
+                .store(true, Ordering::SeqCst);
+            return Ok(Self {
+                reader: None,
+                wal_file_shared,
+                file_size: size,
+                phase: BuildSharedWalPhase::Done,
+            });
+        }
+
+        let reader = Arc::new(StreamingWalReader::new(
+            file.clone(),
+            wal_file_shared.clone(),
+            header,
+            size,
+        ));
+
+        Ok(Self {
+            reader: Some(reader),
+            wal_file_shared,
+            file_size: size,
+            phase: BuildSharedWalPhase::NeedHeaderRead,
+        })
+    }
+
+    /// Drive the recovery state machine. Yields the in-flight read completion
+    /// when it must wait; returns `Done(wal_file_shared)` once the full WAL
+    /// has been scanned (or recovery short-circuited).
+    pub fn poll(&mut self) -> Result<IOResult<Arc<RwLock<WalFileShared>>>> {
+        loop {
+            match self.phase.clone() {
+                BuildSharedWalPhase::NeedHeaderRead => {
+                    let reader = self
+                        .reader
+                        .clone()
+                        .expect("reader must exist outside the Done phase");
+                    let c = reader.read_header()?;
+                    self.phase = BuildSharedWalPhase::AwaitHeader(c);
+                }
+                BuildSharedWalPhase::AwaitHeader(c) => {
+                    if !c.succeeded() {
+                        io_yield_one!(c);
+                    }
+                    self.phase = BuildSharedWalPhase::ChunkLoop;
+                }
+                BuildSharedWalPhase::ChunkLoop => {
+                    let reader = self
+                        .reader
+                        .clone()
+                        .expect("reader must exist outside the Done phase");
+                    if reader.done.load(Ordering::Acquire) {
+                        self.phase = BuildSharedWalPhase::Done;
+                        continue;
+                    }
+                    let offset = reader.off_atomic.load(Ordering::Acquire);
+                    if offset >= self.file_size {
+                        reader.finalize_loading();
+                        self.phase = BuildSharedWalPhase::Done;
+                        continue;
+                    }
+                    let (_read_size, c) = reader.submit_one_chunk(offset)?;
+                    self.phase = BuildSharedWalPhase::AwaitChunk {
+                        completion: c,
+                        offset,
+                    };
+                }
+                BuildSharedWalPhase::AwaitChunk { completion, offset } => {
+                    if !completion.succeeded() {
+                        io_yield_one!(completion);
+                    }
+                    let reader = self
+                        .reader
+                        .clone()
+                        .expect("reader must exist outside the Done phase");
+                    let new_off = reader.off_atomic.load(Ordering::Acquire);
+                    if new_off <= offset {
+                        // No forward progress — treat as end of valid log.
+                        reader.finalize_loading();
+                        self.phase = BuildSharedWalPhase::Done;
+                    } else {
+                        self.phase = BuildSharedWalPhase::ChunkLoop;
+                    }
+                }
+                BuildSharedWalPhase::Done => {
+                    return Ok(IOResult::Done(self.wal_file_shared.clone()));
+                }
+            }
+        }
+    }
+}
+
+/// Blocking shim over [`BuildSharedWal`]. Retained for the unit test and any
+/// caller not yet lifted to drive the recovery state machine directly.
 pub fn build_shared_wal(
     file: &Arc<dyn File>,
     io: &Arc<dyn crate::IO>,
 ) -> Result<Arc<RwLock<WalFileShared>>> {
-    let size = file.size()?;
-
-    let header = Arc::new(SpinLock::new(WalHeader::default()));
-    let read_locks = std::array::from_fn(|_| TursoRwLock::new());
-    for (i, l) in read_locks.iter().enumerate() {
-        l.write();
-        l.set_value_exclusive(if i < 2 { 0 } else { READMARK_NOT_USED });
-        l.unlock();
-    }
-
-    let wal_file_shared = Arc::new(RwLock::new(WalFileShared {
-        metadata: WalSharedMetadata {
-            enabled: AtomicBool::new(true),
-            wal_header: header.clone(),
-            min_frame: AtomicU64::new(0),
-            max_frame: AtomicU64::new(0),
-            nbackfills: AtomicU64::new(0),
-            transaction_count: AtomicU64::new(0),
-            last_checksum: (0, 0),
-            loaded: AtomicBool::new(false),
-            loaded_from_disk_scan: AtomicBool::new(true),
-            initialized: AtomicBool::new(false),
-        },
-        runtime: WalSharedRuntime {
-            frame_cache: Arc::new(SpinLock::new(FxHashMap::default())),
-            file: Some(file.clone()),
-            read_locks,
-            vacuum_lock: TursoRwLock::new(),
-            write_lock: TursoRwLock::new(),
-            checkpoint_lock: TursoRwLock::new(),
-            epoch: AtomicU32::new(0),
-            overflow_fallback_coverage: Arc::new(
-                SpinLock::new(OverflowFallbackCoverage::default()),
-            ),
-        },
-    }));
-
-    if size < WAL_HEADER_SIZE as u64 {
-        wal_file_shared
-            .write()
-            .metadata
-            .loaded
-            .store(true, Ordering::SeqCst);
-        return Ok(wal_file_shared);
-    }
-
-    let reader = Arc::new(StreamingWalReader::new(
-        file.clone(),
-        wal_file_shared.clone(),
-        header,
-        size,
-    ));
-
-    let h = reader.clone().read_header()?;
-    io.wait_for_completion(h)?;
-
-    loop {
-        if reader.done.load(Ordering::Acquire) {
-            break;
-        }
-        let offset = reader.off_atomic.load(Ordering::Acquire);
-        if offset >= size {
-            reader.finalize_loading();
-            break;
-        }
-
-        let (_read_size, c) = reader.clone().submit_one_chunk(offset)?;
-        io.wait_for_completion(c)?;
-
-        let new_off = reader.off_atomic.load(Ordering::Acquire);
-        if new_off <= offset {
-            reader.finalize_loading();
-            break;
-        }
-    }
-
-    Ok(wal_file_shared)
+    let mut driver = BuildSharedWal::begin(file)?;
+    io.block(|| driver.poll())
 }
 
 pub(super) struct StreamingWalReader {

--- a/core/storage/state_machines.rs
+++ b/core/storage/state_machines.rs
@@ -34,6 +34,14 @@ pub enum AdvanceState {
 pub enum CountState {
     Start,
     Loop,
+    /// Resume state used after `CountState::Loop` yielded for spill IO
+    /// mid-descent. The loop-top `stack.advance()` and `self.count +=
+    /// cell_count()` mutations have already been applied for this step,
+    /// so on re-entry we retry only the read + (second-)advance + push,
+    /// then transition back to `Loop`.
+    Descend {
+        target: i64,
+    },
     Finish,
 }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -40,6 +40,7 @@ use crate::storage::sqlite3_ondisk::{
     write_pages_vectored, PageSize, WAL_FRAME_HEADER_SIZE, WAL_HEADER_SIZE,
 };
 use crate::types::{IOCompletions, IOResult};
+use crate::util::IOExt as _;
 use crate::{
     bail_corrupt_error, io_yield_one, Buffer, Completion, CompletionError, IOContext, LimboError,
     Result,
@@ -2688,6 +2689,23 @@ pub struct WalSharedRuntime {
     /// Tracks how far the process-local `frame_cache` is known to be complete
     /// for overflow fallback in the current WAL generation.
     pub overflow_fallback_coverage: Arc<SpinLock<OverflowFallbackCoverage>>,
+}
+
+/// Drivable result of [`WalFileShared::open_shared_if_exists_begin`]. Either an
+/// immediate no-op WAL (readonly, file absent) or an in-progress recovery scan
+/// to be pumped via [`OpenSharedWal::poll`] until it returns `Done`.
+pub enum OpenSharedWal {
+    Noop(Arc<RwLock<WalFileShared>>),
+    Build(sqlite3_ondisk::BuildSharedWal),
+}
+
+impl OpenSharedWal {
+    pub fn poll(&mut self) -> Result<IOResult<Arc<RwLock<WalFileShared>>>> {
+        match self {
+            OpenSharedWal::Noop(wal) => Ok(IOResult::Done(wal.clone())),
+            OpenSharedWal::Build(driver) => driver.poll(),
+        }
+    }
 }
 
 /// WalFileShared holds process-wide WAL metadata plus process-local coordination state.
@@ -5370,6 +5388,18 @@ impl WalFileShared {
         path: &str,
         flags: crate::OpenFlags,
     ) -> Result<Arc<RwLock<WalFileShared>>> {
+        let mut driver = Self::open_shared_if_exists_begin(io, path, flags)?;
+        io.block(|| driver.poll())
+    }
+
+    /// Non-blocking entry point for [`WalFileShared::open_shared_if_exists`].
+    /// Performs only the synchronous file open (and readonly/NotFound noop
+    /// handling); the WAL recovery scan is driven via [`OpenSharedWal::poll`].
+    pub fn open_shared_if_exists_begin(
+        io: &Arc<dyn IO>,
+        path: &str,
+        flags: crate::OpenFlags,
+    ) -> Result<OpenSharedWal> {
         let file = match io.open_file(path, flags, false) {
             Ok(file) => file,
             Err(LimboError::CompletionError(CompletionError::IOError(
@@ -5378,18 +5408,13 @@ impl WalFileShared {
             ))) if flags.contains(crate::OpenFlags::ReadOnly) => {
                 // In readonly mode, if the WAL file doesn't exist, we just return a noop WAL
                 // since there's nothing to read from.
-                return Ok(WalFileShared::new_noop());
+                return Ok(OpenSharedWal::Noop(WalFileShared::new_noop()));
             }
             Err(e) => return Err(e),
         };
-        let wal_file_shared = sqlite3_ondisk::build_shared_wal(&file, io)?;
-        turso_assert!(
-            wal_file_shared
-                .try_read()
-                .is_some_and(|wfs| wfs.metadata.loaded.load(Ordering::Acquire)),
-            "Unable to read WAL shared state"
-        );
-        Ok(wal_file_shared)
+        Ok(OpenSharedWal::Build(sqlite3_ondisk::BuildSharedWal::begin(
+            &file,
+        )?))
     }
 
     pub fn is_initialized(&self) -> Result<bool> {


### PR DESCRIPTION
This PR begins to remove any calls to `wait_for_completion` or `io.block` internally, as these are problematic for two reasons:

1. They can cause hanging on platforms like WASM who rely on IO being driven externally by the runtime
2. For external consumers who rely on using turso in a multi-tenant + async context

This PR begins the work necessary to remove both of those methods from the IO trait, as we should have all of our IO yield in place of blocking internally.

The largest segment of work done is in `Pager::read_page` which previously returned `Result<(PageRef, Option<Completion>)>`:
meaning that you got back a `locked` page and an  IO Completion to possibly wait on.. this was a pretty decent API because it allowed you to store the PageRef in some state machine, then yield on that IO Completion. The problem was for the cache-spilling path: we had to block on any spilling IO because that meant you could no longer get back that locked PageRef as part of the `read_page` API: now you had to deal with the fact you might yield before the page is even inserted into the cache.. so ALL call-sites in the BTree may now yield before any PageRef exists. This PR solves this problem very carefully by creating new state machines in the BTree and creating a PendingRead API in the pager which caches any pending page reads pending cache-spilling IO for re-entrancy. *Each new possible yield point is commented for it's re-entrant safety.*


**Will need to run this branch on antithesis before merging** but I have ran the simulator with io-uring backend and write-heavy-spill profile locally and everything seems to work fine so far