### PR TITLE
Rework Dockerfiles to use a `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,25 @@
-*target
+# Build caches and local-only artifacts.
+**/target
+**/node_modules
+**/build
+**/dist
+bindings/javascript/packages/*/bundle
+bindings/javascript/packages/*/*.wasm
+bindings/javascript/packages/*/*.node
+bindings/java/libs
+
+# Local fuzzer / test artifacts that share dirs with tracked fixtures.
+/whopper-*
+testing/testing_clone.db
+testing/system/test_copy.db
+testing/sqltests/database/integrity_*.db
+
+# VCS
 .git
+
+# Project-specific excludes
 turso-test-runner
 assets
 perf/clickbench
 perf/tpc-h
-testing/sqlright/build
+fuzz/corpus

--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -10,37 +10,8 @@ WORKDIR /app
 #
 
 FROM chef AS planner
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./bindings/dotnet ./bindings/dotnet/
-COPY ./bindings/java ./bindings/java/
-COPY ./bindings/javascript ./bindings/javascript/
-COPY ./bindings/python ./bindings/python/
-COPY ./bindings/rust ./bindings/rust/
-COPY ./cli ./cli/
-COPY ./core ./core/
-COPY ./extensions ./extensions/
-COPY ./macros ./macros/
-COPY ./parser ./parser/
-COPY ./perf/encryption ./perf/encryption
-COPY ./perf/throughput/rusqlite ./perf/throughput/rusqlite/
-COPY ./perf/throughput/turso ./perf/throughput/turso/
-COPY ./perf/memory ./perf/memory/
-COPY ./testing/simulator ./testing/simulator/
-COPY ./sql_generation ./sql_generation
-COPY ./sqlite3 ./sqlite3/
-COPY ./testing/stress ./testing/stress/
-COPY ./sync ./sync/
-COPY ./testing/sqlite_test_ext ./testing/sqlite_test_ext/
-COPY ./testing/unreliable-libc ./testing/unreliable-libc/
-COPY ./tests ./tests/
-COPY ./testing/sqltests ./testing/sqltests/
-COPY ./testing/concurrent-simulator ./testing/concurrent-simulator/
-COPY ./testing/differential-oracle ./testing/differential-oracle/
-COPY ./sdk-kit ./sdk-kit/
-COPY ./sdk-kit-macros ./sdk-kit-macros/
-COPY ./tools ./tools/
-RUN cargo chef prepare --bin turso_stress --recipe-path recipe.json
+RUN --mount=type=bind,source=.,target=/app,ro \
+    cargo chef prepare --bin turso_stress --recipe-path /tmp/recipe.json
 
 #
 # Build the project.
@@ -56,37 +27,9 @@ RUN pip install --break-system-packages maturin
 # Antithesis instrumentation library
 ADD https://antithesis.com/assets/instrumentation/libvoidstar.so /opt/antithesis/libvoidstar.so
 
-COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /tmp/recipe.json recipe.json
 RUN cargo chef cook --bin turso_stress --release --recipe-path recipe.json
-COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
-COPY --from=planner /app/bindings/dotnet ./bindings/dotnet/
-COPY --from=planner /app/bindings/java ./bindings/java/
-COPY --from=planner /app/bindings/javascript ./bindings/javascript/
-COPY --from=planner /app/bindings/python ./bindings/python/
-COPY --from=planner /app/bindings/rust ./bindings/rust/
-COPY --from=planner /app/cli ./cli/
-COPY --from=planner /app/core ./core/
-COPY --from=planner /app/extensions ./extensions/
-COPY --from=planner /app/macros ./macros/
-COPY --from=planner /app/parser ./parser/
-COPY --from=planner /app/perf/encryption ./perf/encryption
-COPY --from=planner /app/perf/throughput/rusqlite ./perf/throughput/rusqlite/
-COPY --from=planner /app/perf/throughput/turso ./perf/throughput/turso/
-COPY --from=planner /app/perf/memory ./perf/memory/
-COPY --from=planner /app/testing/simulator ./testing/simulator/
-COPY --from=planner /app/sql_generation ./sql_generation
-COPY --from=planner /app/sqlite3 ./sqlite3/
-COPY --from=planner /app/testing/stress ./testing/stress/
-COPY --from=planner /app/sync ./sync/
-COPY --from=planner /app/testing/sqlite_test_ext ./testing/sqlite_test_ext/
-COPY --from=planner /app/testing/unreliable-libc ./testing/unreliable-libc/
-COPY --from=planner /app/tests ./tests/
-COPY --from=planner /app/testing/sqltests ./testing/sqltests/
-COPY --from=planner /app/testing/concurrent-simulator ./testing/concurrent-simulator/
-COPY --from=planner /app/testing/differential-oracle ./testing/differential-oracle
-COPY --from=planner /app/sdk-kit ./sdk-kit/
-COPY --from=planner /app/sdk-kit-macros ./sdk-kit-macros/
-COPY --from=planner /app/tools ./tools/
+COPY . .
 
 # Remove cdylib and staticlib from this line: `crate-type = ["lib", "cdylib", "staticlib"]`
 # This is because somehow we lose llvm sanitizer coverage if the crate is not just a lib.

--- a/testing/simulator/simulator-docker-runner/Dockerfile.simulator
+++ b/testing/simulator/simulator-docker-runner/Dockerfile.simulator
@@ -10,32 +10,8 @@ WORKDIR /app
 #
 
 FROM chef AS planner
-# cargo-chef requires all this crap to be present in the workspace
-COPY Cargo.toml Cargo.lock ./
-COPY core ./core/
-COPY testing/simulator ./testing/simulator/
-COPY bindings ./bindings/
-COPY extensions ./extensions/
-COPY macros ./macros/
-COPY sync ./sync
-COPY parser ./parser/
-COPY perf/encryption ./perf/encryption
-COPY perf/throughput/rusqlite ./perf/throughput/rusqlite
-COPY perf/throughput/turso ./perf/throughput/turso
-COPY perf/memory ./perf/memory/
-COPY cli ./cli/
-COPY sqlite3 ./sqlite3/
-COPY testing/stress ./testing/stress/
-COPY tests ./tests/
-COPY testing/sqlite_test_ext ./testing/sqlite_test_ext
-COPY sql_generation ./sql_generation/
-COPY testing/concurrent-simulator ./testing/concurrent-simulator
-COPY testing/differential-oracle ./testing/differential-oracle/
-COPY ./testing/sqltests ./testing/sqltests/
-COPY sdk-kit ./sdk-kit/
-COPY sdk-kit-macros ./sdk-kit-macros/
-COPY tools ./tools/
-RUN cargo chef prepare --bin limbo_sim --recipe-path recipe.json
+RUN --mount=type=bind,source=.,target=/app \
+    cargo chef prepare --bin limbo_sim --recipe-path /tmp/recipe.json
 
 #
 # Build the project.
@@ -43,22 +19,9 @@ RUN cargo chef prepare --bin limbo_sim --recipe-path recipe.json
 
 FROM chef AS builder 
 
-COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /tmp/recipe.json recipe.json
 RUN cargo chef cook --bin limbo_sim --release --recipe-path recipe.json
-COPY --from=planner /app/core ./core/
-COPY --from=planner /app/extensions ./extensions/
-COPY --from=planner /app/macros ./macros/
-COPY --from=planner /app/parser ./parser/
-COPY --from=planner /app/perf/encryption ./perf/encryption
-COPY --from=planner /app/perf/throughput/rusqlite ./perf/throughput/rusqlite
-COPY --from=planner /app/perf/throughput/turso ./perf/throughput/turso
-COPY --from=planner /app/perf/memory ./perf/memory/
-COPY --from=planner /app/testing/simulator ./testing/simulator/
-COPY --from=planner /app/sql_generation ./sql_generation/
-COPY --from=planner /app/testing/differential-oracle ./testing/differential-oracle/
-COPY --from=planner /app/testing/sqltests ./testing/sqltests/
-COPY --from=planner /app/tools ./tools/
-COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
+COPY . .
 
 RUN cargo build --bin limbo_sim --release
 

--- a/testing/sqlancer/sqlancer-runner/Dockerfile.sqlancer
+++ b/testing/sqlancer/sqlancer-runner/Dockerfile.sqlancer
@@ -18,65 +18,19 @@ WORKDIR /app
 
 # Prepare recipe for caching
 FROM chef AS planner
-COPY Cargo.toml Cargo.lock ./
-COPY core ./core/
-COPY bindings ./bindings/
-COPY extensions ./extensions/
-COPY macros ./macros/
-COPY sync ./sync
-COPY parser ./parser/
-COPY cli ./cli/
-COPY sqlite3 ./sqlite3/
-COPY testing/stress ./testing/stress/
-COPY tests ./tests/
-COPY testing/sqlite_test_ext ./testing/sqlite_test_ext
-COPY testing/simulator ./testing/simulator/
-COPY sql_generation ./sql_generation/
-COPY testing/concurrent-simulator ./testing/concurrent-simulator
-COPY testing/differential-oracle ./testing/differential-oracle/
-COPY perf/encryption ./perf/encryption
-COPY perf/throughput/rusqlite ./perf/throughput/rusqlite
-COPY perf/throughput/turso ./perf/throughput/turso
-COPY perf/memory ./perf/memory/
-COPY testing/sqltests ./testing/sqltests/
-COPY sdk-kit ./sdk-kit/
-COPY sdk-kit-macros ./sdk-kit-macros/
-COPY tools ./tools/
-RUN cargo chef prepare --recipe-path recipe.json
+RUN --mount=type=bind,source=.,target=/app \
+    cargo chef prepare --recipe-path /tmp/recipe.json
 
 #
 # Stage 2: Build native library and JAR
 #
 FROM chef AS builder
 
-COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /tmp/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 # Copy full source
-COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
-COPY --from=planner /app/core ./core/
-COPY --from=planner /app/bindings ./bindings/
-COPY --from=planner /app/extensions ./extensions/
-COPY --from=planner /app/macros ./macros/
-COPY --from=planner /app/sync ./sync
-COPY --from=planner /app/parser ./parser/
-COPY --from=planner /app/cli ./cli/
-COPY --from=planner /app/sqlite3 ./sqlite3/
-COPY --from=planner /app/testing/stress ./testing/stress/
-COPY --from=planner /app/tests ./tests/
-COPY --from=planner /app/testing/sqlite_test_ext ./testing/sqlite_test_ext
-COPY --from=planner /app/testing/simulator ./testing/simulator/
-COPY --from=planner /app/sql_generation ./sql_generation/
-COPY --from=planner /app/testing/concurrent-simulator ./testing/concurrent-simulator
-COPY --from=planner /app/testing/differential-oracle ./testing/differential-oracle/
-COPY --from=planner /app/perf/encryption ./perf/encryption
-COPY --from=planner /app/perf/throughput/rusqlite ./perf/throughput/rusqlite
-COPY --from=planner /app/perf/throughput/turso ./perf/throughput/turso
-COPY --from=planner /app/perf/memory ./perf/memory/
-COPY --from=planner /app/testing/sqltests ./testing/sqltests/
-COPY --from=planner /app/sdk-kit ./sdk-kit/
-COPY --from=planner /app/sdk-kit-macros ./sdk-kit-macros/
-COPY --from=planner /app/tools ./tools/
+COPY . .
 
 
 # Build native library for Linux x86_64


### PR DESCRIPTION
## Description

We had an issue where the Antithesis build was failing because we forgot to update it when adding a new crate. This is because the build uses `cargo chef` and it needs to walk the whole workspace. Previously, we added crates one by one, but this was brittle.

So I changed the dockerfiles to copy the whole source tree, and I added entries to the `.dockerignore` to ignore the files/directories that could be problematic.

That way, we'll never have a broken build because we forgot to modify the dockerfiles again.

Result: https://github.com/tursodatabase/turso/actions/runs/26573458483

<img width="303" height="206" alt="image" src="https://github.com/user-attachments/assets/c275e83d-6525-4ca7-aeb0-2858de96f224" />


## Description of AI Usage

Claude Code