### PR TITLE
core/mvcc: avoid SeekingToLast with MVCC in newrowid

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -573,6 +573,9 @@ fn bench_execute_select_count(criterion: &mut Criterion) {
 fn bench_insert_rows(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+    // When set, disable auto-checkpoint in all three engines so per-iter time
+    // reflects pure insert cost without amortized checkpoint stalls.
+    let disable_checkpoint = std::env::var("DISABLE_CHECKPOINT_BENCHMARK").is_ok();
 
     let mut group = criterion.benchmark_group("Insert rows in batches");
 
@@ -585,6 +588,9 @@ fn bench_insert_rows(criterion: &mut Criterion) {
         let io = Arc::new(PlatformIO::new().unwrap());
         let db = Database::open_file(io.clone(), db_path.to_str().unwrap()).unwrap();
         let limbo_conn = db.connect().unwrap();
+        if disable_checkpoint {
+            limbo_conn.wal_auto_actions_disable();
+        }
 
         let mut stmt = limbo_conn
             .query("CREATE TABLE test (id INTEGER, value TEXT)")
@@ -638,6 +644,74 @@ fn bench_insert_rows(criterion: &mut Criterion) {
             });
         });
 
+        // Same workload under MVCC. Separate db so the WAL/MVCC files don't collide.
+        let mvcc_temp_dir = tempfile::tempdir().unwrap();
+        let mvcc_db_path = mvcc_temp_dir.path().join("bench.db");
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let mvcc_io = Arc::new(PlatformIO::new().unwrap());
+        let mvcc_db =
+            Database::open_file(mvcc_io.clone(), mvcc_db_path.to_str().unwrap()).unwrap();
+        let mvcc_conn = mvcc_db.connect().unwrap();
+        mvcc_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        if disable_checkpoint {
+            mvcc_conn
+                .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+                .unwrap();
+            mvcc_conn.wal_auto_actions_disable();
+        }
+
+        let mut stmt = mvcc_conn
+            .query("CREATE TABLE test (id INTEGER, value TEXT)")
+            .unwrap()
+            .unwrap();
+        loop {
+            match stmt.step().unwrap() {
+                turso_core::StepResult::IO => {
+                    mvcc_db.io.step().unwrap();
+                }
+                turso_core::StepResult::Done => {
+                    break;
+                }
+                turso_core::StepResult::Row => {
+                    unreachable!();
+                }
+                turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                    unreachable!();
+                }
+            }
+        }
+
+        group.bench_function(format!("limbo_mvcc_insert_{batch_size}_rows"), |b| {
+            let mut values = String::from("INSERT INTO test VALUES ");
+            for i in 0..batch_size {
+                if i > 0 {
+                    values.push(',');
+                }
+                values.push_str(&format!("({}, '{}')", i, format_args!("value_{i}")));
+            }
+            let mut stmt = mvcc_conn.prepare(&values).unwrap();
+            b.iter(|| {
+                loop {
+                    match stmt.step().unwrap() {
+                        turso_core::StepResult::IO => {
+                            mvcc_db.io.step().unwrap();
+                        }
+                        turso_core::StepResult::Done => {
+                            break;
+                        }
+                        turso_core::StepResult::Row => {
+                            unreachable!();
+                        }
+                        turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                            unreachable!();
+                        }
+                    }
+                }
+                stmt.reset().unwrap();
+            });
+        });
+
         if enable_rusqlite {
             let temp_dir = tempfile::tempdir().unwrap();
             let db_path = temp_dir.path().join("bench.db");
@@ -651,6 +725,11 @@ fn bench_insert_rows(criterion: &mut Criterion) {
             sqlite_conn
                 .pragma_update(None, "locking_mode", "EXCLUSIVE")
                 .unwrap();
+            if disable_checkpoint {
+                sqlite_conn
+                    .pragma_update(None, "wal_autocheckpoint", 0)
+                    .unwrap();
+            }
             let journal_mode = sqlite_conn
                 .pragma_query_value(None, "journal_mode", |row| row.get::<_, String>(0))
                 .unwrap();

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -650,8 +650,7 @@ fn bench_insert_rows(criterion: &mut Criterion) {
 
         #[allow(clippy::arc_with_non_send_sync)]
         let mvcc_io = Arc::new(PlatformIO::new().unwrap());
-        let mvcc_db =
-            Database::open_file(mvcc_io.clone(), mvcc_db_path.to_str().unwrap()).unwrap();
+        let mvcc_db = Database::open_file(mvcc_io.clone(), mvcc_db_path.to_str().unwrap()).unwrap();
         let mvcc_conn = mvcc_db.connect().unwrap();
         mvcc_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         if disable_checkpoint {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4052,7 +4052,11 @@ pub fn op_auto_commit(
         };
     }
 
-    turso_debug_assert!(matches!(tx_op, TxOp::Commit | TxOp::Rollback), "tx_op should be commit or rollback by now", {"tx_op": tx_op});
+    turso_debug_assert!(
+        matches!(tx_op, TxOp::Commit | TxOp::Rollback),
+        "tx_op should be commit or rollback by now",
+        { "tx_op": tx_op }
+    );
 
     // For explicit COMMIT, flush any pending index method writes first
     if matches!(tx_op, TxOp::Commit) {
@@ -10106,10 +10110,9 @@ fn new_rowid_inner(
                                     state.registers[*prev_largest_reg]
                                         .set_int(prev_rowid.unwrap_or(0));
                                 }
-                                *state.active_op_state.new_rowid() =
-                                    OpNewRowidState::SeekingToLast {
-                                        mvcc_already_initialized: true,
-                                    };
+                                state.active_op_state.clear();
+                                state.pc += 1;
+                                return Ok(InsnFunctionStepResult::Step);
                             }
                             NextRowidResult::FindRandom => {
                                 mvcc_cursor.end_new_rowid();


### PR DESCRIPTION

## Description
`DISABLE_CHECKPOINT_BENCHMARK=1 cargo bench -p turso_core --bench benchmark -- "Insert rows in batches/limbo_mvcc_insert"`

Benchmark with inserts and disabled checkpoint to skip noise of checkpoints

```bash
Insert rows in batches/limbo_mvcc_insert_1_rows
                        time:   [29.609 µs 31.747 µs 34.261 µs]
                        change: [-37.593% -24.221% -9.7907%] (p = 0.00 < 0.05)
Insert rows in batches/limbo_mvcc_insert_10_rows
                        time:   [32.219 µs 32.770 µs 33.365 µs]
Insert rows in batches/limbo_mvcc_insert_100_rows
                        time:   [89.904 µs 92.224 µs 94.827 µs]
                        change: [-31.246% -29.313% -27.326%] (p = 0.00 < 0.05)
```

## Description of AI Usage

used ai to setup the benchmark with mvcc
