### PR TITLE
core/mvcc: skip seeking on contigous writes to pager

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -790,6 +790,33 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         write_set_index < self.write_set.len()
     }
 
+    fn next_requires_seek_after_insert(&self, current_idx: usize) -> bool {
+        let Some(curr) = self.write_set.get(current_idx) else {
+            return true;
+        };
+        let Some(next) = self.write_set.get(current_idx + 1) else {
+            return true;
+        };
+        // Table not the same, then seek
+        if curr.0.row.id.table_id != next.0.row.id.table_id {
+            return true;
+        }
+        // If we have special write then seek
+        if curr.1.is_some() || next.1.is_some() {
+            return true;
+        }
+        let (RowKey::Int(prev_id), RowKey::Int(next_id)) =
+            (&curr.0.row.id.row_id, &next.0.row.id.row_id)
+        else {
+            return true;
+        };
+        // if next id is strictly prev_id + 1 then we don't need to seek
+        if next_id.checked_sub(*prev_id) != Some(1) {
+            return true;
+        }
+        false
+    }
+
     /// Fsync the logical log file
     fn fsync_logical_log(&self) -> Result<Completion> {
         self.mvstore.storage.sync(self.pager.get_sync_type())
@@ -1455,9 +1482,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 match write_row_state_machine.step(&())? {
                     IOResult::IO(io) => Ok(TransitionResult::Io(io)),
                     IOResult::Done(_) => {
+                        let requires_seek = self.next_requires_seek_after_insert(write_set_index);
                         self.state = CheckpointState::WriteRow {
                             write_set_index: write_set_index + 1,
-                            requires_seek: true,
+                            requires_seek,
                         };
                         Ok(TransitionResult::Continue)
                     }


### PR DESCRIPTION
## Description

We were seeking for every insert to pager, I don't know when we reverted this but seems wasteful. (waiting to see if codspeed sees any improvement)

```
Concurrent writes/limbo_mvcc_concurrent_writes
                        time:   [13.974 ms 14.213 ms 14.514 ms]
                        change: [-11.232% -7.9410% -4.8149%] (p = 0.00 < 0.05)
```