### PR TITLE
Fix between subquery double planning

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1350,81 +1350,84 @@ pub fn parse_where(
                 resolver,
                 BindingBehavior::TryCanonicalColumnsFirst,
             )?;
-            let _ = walk_expr_mut(&mut expr.expr, &mut |e: &mut Expr| -> Result<WalkControl> {
-                if let Expr::Between {
-                    lhs,
-                    not,
-                    start,
-                    end,
-                } = e
-                {
-                    let lhs_expr = std::mem::take(lhs.as_mut());
-                    let start_expr = std::mem::take(start.as_mut());
-                    let end_expr = std::mem::take(end.as_mut());
+        }
+    }
+    Ok(())
+}
 
-                    let (lower, upper, combine_op) = if *not {
-                        (
-                            Expr::Binary(
-                                Box::new(start_expr),
-                                ast::Operator::Greater,
-                                Box::new(lhs_expr.clone()),
-                            ),
-                            Expr::Binary(
-                                Box::new(lhs_expr),
-                                ast::Operator::Greater,
-                                Box::new(end_expr),
-                            ),
-                            ast::Operator::Or,
-                        )
-                    } else {
-                        (
-                            Expr::Binary(
-                                Box::new(start_expr),
-                                ast::Operator::LessEquals,
-                                Box::new(lhs_expr.clone()),
-                            ),
-                            Expr::Binary(
-                                Box::new(lhs_expr),
-                                ast::Operator::LessEquals,
-                                Box::new(end_expr),
-                            ),
-                            ast::Operator::And,
-                        )
-                    };
-                    *e = Expr::Binary(Box::new(lower), combine_op, Box::new(upper));
-                }
-                Ok(WalkControl::Continue)
-            });
-        }
-        // BETWEEN in WHERE is rewritten to binary terms here so each side can be
-        // considered independently by constraint extraction and range planning.
-        // Re-break any ANDs that were created so they become separate WhereTerms for
-        // constraint extraction.
-        let mut i = start_idx;
-        while i < out_where_clause.len() {
-            if matches!(
-                &out_where_clause[i].expr,
-                Expr::Binary(_, ast::Operator::And, _)
-            ) {
-                let term = out_where_clause.remove(i);
-                let mut new_terms: Vec<WhereTerm> = Vec::new();
-                break_predicate_at_and_boundaries(&term.expr, &mut new_terms);
-                // Preserve from_outer_join from the original term
-                for new_term in new_terms.iter_mut() {
-                    new_term.from_outer_join = term.from_outer_join;
-                }
-                let count = new_terms.len();
-                for (j, new_term) in new_terms.into_iter().enumerate() {
-                    out_where_clause.insert(i + j, new_term);
-                }
-                i += count;
-            } else {
-                i += 1;
+pub fn rewrite_between_in_where_clause(out_where_clause: &mut Vec<WhereTerm>) {
+    for expr in out_where_clause.iter_mut() {
+        let _ = walk_expr_mut(&mut expr.expr, &mut |e: &mut Expr| -> Result<WalkControl> {
+            if let Expr::Between {
+                lhs,
+                not,
+                start,
+                end,
+            } = e
+            {
+                let lhs_expr = std::mem::take(lhs.as_mut());
+                let start_expr = std::mem::take(start.as_mut());
+                let end_expr = std::mem::take(end.as_mut());
+
+                let (lower, upper, combine_op) = if *not {
+                    (
+                        Expr::Binary(
+                            Box::new(start_expr),
+                            ast::Operator::Greater,
+                            Box::new(lhs_expr.clone()),
+                        ),
+                        Expr::Binary(
+                            Box::new(lhs_expr),
+                            ast::Operator::Greater,
+                            Box::new(end_expr),
+                        ),
+                        ast::Operator::Or,
+                    )
+                } else {
+                    (
+                        Expr::Binary(
+                            Box::new(start_expr),
+                            ast::Operator::LessEquals,
+                            Box::new(lhs_expr.clone()),
+                        ),
+                        Expr::Binary(
+                            Box::new(lhs_expr),
+                            ast::Operator::LessEquals,
+                            Box::new(end_expr),
+                        ),
+                        ast::Operator::And,
+                    )
+                };
+                *e = Expr::Binary(Box::new(lower), combine_op, Box::new(upper));
             }
+            Ok(WalkControl::Continue)
+        });
+    }
+    // BETWEEN in WHERE is rewritten to binary terms here so each side can be
+    // considered independently by constraint extraction and range planning.
+    // Re-break any ANDs that were created so they become separate WhereTerms for
+    // constraint extraction.
+    let mut i = 0;
+    while i < out_where_clause.len() {
+        if matches!(
+            &out_where_clause[i].expr,
+            Expr::Binary(_, ast::Operator::And, _)
+        ) {
+            let term = out_where_clause.remove(i);
+            let mut new_terms: Vec<WhereTerm> = Vec::new();
+            break_predicate_at_and_boundaries(&term.expr, &mut new_terms);
+            // Preserve from_outer_join from the original term
+            for new_term in new_terms.iter_mut() {
+                new_term.from_outer_join = term.from_outer_join;
+            }
+            let count = new_terms.len();
+            for (j, new_term) in new_terms.into_iter().enumerate() {
+                out_where_clause.insert(i + j, new_term);
+            }
+            i += count;
+        } else {
+            i += 1;
         }
-        Ok(())
-    } else {
-        Ok(())
     }
 }
 

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -40,7 +40,7 @@ use super::{
     emitter::{Resolver, TranslateCtx},
     main_loop::LoopLabels,
     plan::{Aggregate, Operation, QueryDestination, Scan, Search, SelectPlan},
-    planner::{resolve_window_and_aggregate_functions, TableMask},
+    planner::{resolve_window_and_aggregate_functions, rewrite_between_in_where_clause, TableMask},
 };
 
 struct DirectMaterializedSubquery {
@@ -242,6 +242,7 @@ pub fn plan_subqueries_from_select_plan(
             SubqueryOrigin::SelectWhere,
             SubqueryPosition::Where.allow_correlated(),
         )?;
+        rewrite_between_in_where_clause(&mut plan.where_clause);
     }
 
     // GROUP BY
@@ -368,7 +369,7 @@ pub fn plan_subqueries_from_where_clause(
     program: &mut ProgramBuilder,
     non_from_clause_subqueries: &mut Vec<NonFromClauseSubquery>,
     table_references: &mut TableReferences,
-    where_clause: &mut [WhereTerm],
+    where_clause: &mut Vec<WhereTerm>,
     resolver: &Resolver,
     connection: &Arc<Connection>,
 ) -> Result<()> {
@@ -384,6 +385,7 @@ pub fn plan_subqueries_from_where_clause(
         SubqueryPosition::Where.allow_correlated(),
     )?;
 
+    rewrite_between_in_where_clause(where_clause);
     update_column_used_masks(table_references, non_from_clause_subqueries)?;
     Ok(())
 }

--- a/testing/sqltests/tests/not_between.sqltest
+++ b/testing/sqltests/tests/not_between.sqltest
@@ -82,3 +82,15 @@ test not-between-subquery-bound-orderby-offset {
 expect {
     0
 }
+
+@cross-check-integrity
+test between-scalar-subquery-lhs-issue-5152 {
+    CREATE TABLE t(id INTEGER PRIMARY KEY);
+    INSERT INTO t VALUES(1), (2), (3);
+    SELECT id FROM t WHERE (SELECT max(id) FROM t) BETWEEN 1 AND 3;
+}
+expect {
+    1
+    2
+    3
+}

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-delete.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-delete.snap
@@ -1,0 +1,66 @@
+---
+source: subqueries.sqltest
+expression: |-
+  DELETE FROM products
+      WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+info:
+  statement_type: DELETE
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4              p5  comment
+   0    Init           0  42   0                   0  Start at 42
+   1    OpenWrite      0   2   0                   0  root=2; iDb=0
+   2    OpenWrite      1   8   0                   0  root=8; iDb=0
+   3    Null           0   1   0                   0  r[1]=NULL
+   4    Once          21   0   0                   0  goto 21
+   5    BeginSubrtn    3   0   0                   0  r[3]=NULL
+   6    Null           0   2   0                   0  r[2]=NULL
+   7    Null           0   5   0                   0  r[5]=NULL
+   8    Integer        1   6   0                   0  r[6]=1; LIMIT counter
+   9    IfNot          6  17   0                   0  if !r[6] goto 17
+  10    OpenRead       2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  11    Last           2  17   0                   0
+  12      RowId        2   7   0                   0  r[7]=products.rowid
+  13      CollSeq      0   0   0  Binary           0  collation=Binary
+  14      AggStep      0   7   5  max              0  accum=r[5] step(r[7])
+  15      Goto         0  17   0                   0
+  16    Prev           2  12   0                   0
+  17    AggFinal       0   5   0  max              0  accum=r[5]
+  18    Copy           5   4   0                   0  r[4]=r[5]
+  19    Copy           4   2   0                   0  r[2]=r[4]
+  20  Return           3   0   1                   0
+  21  OpenRead         0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  22  Copy             2  11   0                   0  r[11]=r[2]
+  23  Gt              10  11  30                   0  if r[10]>r[11] goto 30
+  24  Copy             2  13   0                   0  r[13]=r[2]
+  25  Gt              13  14  30                   0  if r[13]>r[14] goto 30
+  26  Rewind           0  30   0                   0  Rewind table products
+  27    RowId          0   8   0                   0  r[8]=products.rowid
+  28    RowSetAdd      1   8   0                   0
+  29  Next             0  27   0                   0
+  30  Close            0   0   0                   0
+  31  OpenWrite        0   2   0                   0  root=2; iDb=0
+  32  OpenWrite        3   8   0                   0  root=8; iDb=0
+  33    RowSetRead     1  41  15                   0
+  34    NotExists      0  40  15                   0
+  35    NotExists      0  40  15                   0
+  36    Column         0   2  16                   0  r[16]=products.category_id
+  37    RowId          0  17   0                   0  r[17]=products.rowid
+  38    IdxDelete      1  16   2                   1
+  39    Delete         0   0   0  products         0
+  40  Goto             0  33   0                   0
+  41  Halt             0   0   0                   0
+  42  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
+  43  Integer          1  10   0                   0  r[10]=1
+  44  Integer        100  14   0                   0  r[14]=100
+  45  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-not.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-not.snap
@@ -1,0 +1,53 @@
+---
+source: subqueries.sqltest
+expression: |-
+  SELECT id
+      FROM products
+      WHERE (SELECT max(id) FROM products) NOT BETWEEN 10 AND 20;
+info:
+  statement_type: SELECT
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode         p1  p2  p3  p4              p5  comment
+   0    Init          0  28   0                   0  Start at 28
+   1    Once         18   0   0                   0  goto 18
+   2    BeginSubrtn   2   0   0                   0  r[2]=NULL
+   3    Null          0   1   0                   0  r[1]=NULL
+   4    Null          0   4   0                   0  r[4]=NULL
+   5    Integer       1   5   0                   0  r[5]=1; LIMIT counter
+   6    IfNot         5  14   0                   0  if !r[5] goto 14
+   7    OpenRead      0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   8    Last          0  14   0                   0
+   9      RowId       0   6   0                   0  r[6]=products.rowid
+  10      CollSeq     0   0   0  Binary           0  collation=Binary
+  11      AggStep     0   6   4  max              0  accum=r[4] step(r[6])
+  12      Goto        0  14   0                   0
+  13    Prev          0   9   0                   0
+  14    AggFinal      0   4   0  max              0  accum=r[4]
+  15    Copy          4   3   0                   0  r[3]=r[4]
+  16    Copy          3   1   0                   0  r[1]=r[3]
+  17  Return          2   0   1                   0
+  18  OpenRead        1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  19  Copy            1  10   0                   0  r[10]=r[1]
+  20  Gt              9  10  23                   0  if r[9]>r[10] goto 23
+  21  Copy            1  12   0                   0  r[12]=r[1]
+  22  Le             12  13  27                   0  if r[12]<=r[13] goto 27
+  23  Rewind          1  27   0                   0  Rewind table products
+  24    RowId         1   7   0                   0  r[7]=products.rowid
+  25    ResultRow     7   1   0                   0  output=r[7]
+  26  Next            1  24   0                   0
+  27  Halt            0   0   0                   0
+  28  Transaction     0   1  11                   0  iDb=0 tx_mode=Read
+  29  Integer        10   9   0                   0  r[9]=10
+  30  Integer        20  13   0                   0  r[13]=20
+  31  Goto            0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
@@ -18,46 +18,55 @@ QUERY PLAN
 `--SCAN products
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4              p5  comment
-   0    Init           0  37   0                   0  Start at 37
-   1    Once          18   0   0                   0  goto 18
-   2    BeginSubrtn    2   0   0                   0  r[2]=NULL
-   3    Null           0   1   0                   0  r[1]=NULL
-   4    Null           0   4   0                   0  r[4]=NULL
-   5    Integer        1   5   0                   0  r[5]=1; LIMIT counter
-   6    IfNot          5  14   0                   0  if !r[5] goto 14
-   7    OpenRead       0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   8    Last           0  14   0                   0
-   9      RowId        0   6   0                   0  r[6]=products.rowid
-  10      CollSeq      0   0   0  Binary           0  collation=Binary
-  11      AggStep      0   6   4  max              0  accum=r[4] step(r[6])
-  12      Goto         0  14   0                   0
-  13    Prev           0   9   0                   0
-  14    AggFinal       0   4   0  max              0  accum=r[4]
-  15    Copy           4   3   0                   0  r[3]=r[4]
-  16    Copy           3   1   0                   0  r[1]=r[3]
-  17  Return           2   0   1                   0
-  18  OpenWrite        1   2   0                   0  root=2; iDb=0
-  19  Copy             1   9   0                   0  r[9]=r[1]
-  20  Gt               8   9  36                   0  if r[8]>r[9] goto 36
-  21  Copy             1  11   0                   0  r[11]=r[1]
-  22  Gt              11  12  36                   0  if r[11]>r[12] goto 36
-  23  Rewind           1  36   0                   0  Rewind table products
-  24    RowId          1  13   0                   0  r[13]=products.rowid
-  25    IsNull        13  36   0                   0  if (r[13]==NULL) goto 36
-  26    Null           0  14   0                   0  r[14]=NULL
-  27    Column         1   1  15                   0  r[15]=products.name
-  28    Column         1   2  16                   0  r[16]=products.category_id
-  29    Column         1   3  17                   0  r[17]=products.price
-  30    Column         1   4  19  0                0  r[19]=products.stock
-  31    Add           19  20  18                   0  r[18]=r[19]+r[20]
-  32    Affinity      14   5   0                   0  r[14..19] = D, B, D, E, D
-  33    MakeRecord    14   5  21                   0  r[21]=mkrec(r[14..18])
-  34    Insert         1  21  13  products         8  intkey=r[13] data=r[21]
-  35  Next             1  24   0                   0
-  36  Halt             0   0   0                   0
-  37  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
-  38  Integer          1   8   0                   0  r[8]=1
-  39  Integer        100  12   0                   0  r[12]=100
-  40  Integer          1  20   0                   0  r[20]=1
-  41  Goto             0   1   0                   0
+addr  opcode            p1  p2  p3  p4                 p5  comment
+   0    Init             0  46   0                      0  Start at 46
+   1    OpenEphemeral    0   1   0                      0  cursor=0 is_table=true
+   2    Once            19   0   0                      0  goto 19
+   3    BeginSubrtn      2   0   0                      0  r[2]=NULL
+   4    Null             0   1   0                      0  r[1]=NULL
+   5    Null             0   4   0                      0  r[4]=NULL
+   6    Integer          1   5   0                      0  r[5]=1; LIMIT counter
+   7    IfNot            5  15   0                      0  if !r[5] goto 15
+   8    OpenRead         1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   9    Last             1  15   0                      0
+  10      RowId          1   6   0                      0  r[6]=products.rowid
+  11      CollSeq        0   0   0  Binary              0  collation=Binary
+  12      AggStep        0   6   4  max                 0  accum=r[4] step(r[6])
+  13      Goto           0  15   0                      0
+  14    Prev             1  10   0                      0
+  15    AggFinal         0   4   0  max                 0  accum=r[4]
+  16    Copy             4   3   0                      0  r[3]=r[4]
+  17    Copy             3   1   0                      0  r[1]=r[3]
+  18  Return             2   0   1                      0
+  19  OpenRead           2   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+  20  Copy               1  10   0                      0  r[10]=r[1]
+  21  Gt                 9  10  29                      0  if r[9]>r[10] goto 29
+  22  Copy               1  12   0                      0  r[12]=r[1]
+  23  Gt                12  13  29                      0  if r[12]>r[13] goto 29
+  24  Rewind             2  29   0                      0  Rewind table products
+  25    RowId            2   7   0                      0  r[7]=products.rowid
+  26    MakeRecord       7   1  14                      0  r[14]=mkrec(r[7..7]); for ephemeral_scratch
+  27    Insert           0  14   7  ephemeral_scratch   6  intkey=r[7] data=r[14]
+  28  Next               2  25   0                      0
+  29  OpenWrite          2   2   0                      0  root=2; iDb=0
+  30  Rewind             0  45   0                      0  Rewind table ephemeral(ephemeral_scratch)
+  31    RowId            0  15   0                      0  r[15]=ephemeral(ephemeral_scratch).rowid
+  32    NotExists        2  44  15                      0
+  33    Null             0  16   0                      0  r[16]=NULL
+  34    Column           2   1  17                      0  r[17]=products.name
+  35    Column           2   2  18                      0  r[18]=products.category_id
+  36    Column           2   3  19                      0  r[19]=products.price
+  37    Column           2   4  21  0                   0  r[21]=products.stock
+  38    Add             21  22  20                      0  r[20]=r[21]+r[22]
+  39    Affinity        16   5   0                      0  r[16..21] = D, B, D, E, D
+  40    MakeRecord      16   5  23                      0  r[23]=mkrec(r[16..20])
+  41    NotExists        2  44  15                      0
+  42    Delete           2   0   0  products            0
+  43    Insert           2  23  15  products           11  intkey=r[15] data=r[23]
+  44  Next               0  31   0                      0
+  45  Halt               0   0   0                      0
+  46  Transaction        0   2  11                      0  iDb=0 tx_mode=Write
+  47  Integer            1   9   0                      0  r[9]=1
+  48  Integer          100  13   0                      0  r[13]=100
+  49  Integer            1  22   0                      0  r[22]=1
+  50  Goto               0   1   0                      0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
@@ -1,0 +1,63 @@
+---
+source: subqueries.sqltest
+expression: |-
+  UPDATE products
+      SET stock = stock + 1
+      WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+info:
+  statement_type: UPDATE
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4              p5  comment
+   0    Init           0  37   0                   0  Start at 37
+   1    Once          18   0   0                   0  goto 18
+   2    BeginSubrtn    2   0   0                   0  r[2]=NULL
+   3    Null           0   1   0                   0  r[1]=NULL
+   4    Null           0   4   0                   0  r[4]=NULL
+   5    Integer        1   5   0                   0  r[5]=1; LIMIT counter
+   6    IfNot          5  14   0                   0  if !r[5] goto 14
+   7    OpenRead       0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   8    Last           0  14   0                   0
+   9      RowId        0   6   0                   0  r[6]=products.rowid
+  10      CollSeq      0   0   0  Binary           0  collation=Binary
+  11      AggStep      0   6   4  max              0  accum=r[4] step(r[6])
+  12      Goto         0  14   0                   0
+  13    Prev           0   9   0                   0
+  14    AggFinal       0   4   0  max              0  accum=r[4]
+  15    Copy           4   3   0                   0  r[3]=r[4]
+  16    Copy           3   1   0                   0  r[1]=r[3]
+  17  Return           2   0   1                   0
+  18  OpenWrite        1   2   0                   0  root=2; iDb=0
+  19  Copy             1   9   0                   0  r[9]=r[1]
+  20  Gt               8   9  36                   0  if r[8]>r[9] goto 36
+  21  Copy             1  11   0                   0  r[11]=r[1]
+  22  Gt              11  12  36                   0  if r[11]>r[12] goto 36
+  23  Rewind           1  36   0                   0  Rewind table products
+  24    RowId          1  13   0                   0  r[13]=products.rowid
+  25    IsNull        13  36   0                   0  if (r[13]==NULL) goto 36
+  26    Null           0  14   0                   0  r[14]=NULL
+  27    Column         1   1  15                   0  r[15]=products.name
+  28    Column         1   2  16                   0  r[16]=products.category_id
+  29    Column         1   3  17                   0  r[17]=products.price
+  30    Column         1   4  19  0                0  r[19]=products.stock
+  31    Add           19  20  18                   0  r[18]=r[19]+r[20]
+  32    Affinity      14   5   0                   0  r[14..19] = D, B, D, E, D
+  33    MakeRecord    14   5  21                   0  r[21]=mkrec(r[14..18])
+  34    Insert         1  21  13  products         8  intkey=r[13] data=r[21]
+  35  Next             1  24   0                   0
+  36  Halt             0   0   0                   0
+  37  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
+  38  Integer          1   8   0                   0  r[8]=1
+  39  Integer        100  12   0                   0  r[12]=100
+  40  Integer          1  20   0                   0  r[20]=1
+  41  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs.snap
@@ -1,0 +1,53 @@
+---
+source: subqueries.sqltest
+expression: |-
+  SELECT id
+      FROM products
+      WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+info:
+  statement_type: SELECT
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4              p5  comment
+   0    Init           0  28   0                   0  Start at 28
+   1    Once          18   0   0                   0  goto 18
+   2    BeginSubrtn    2   0   0                   0  r[2]=NULL
+   3    Null           0   1   0                   0  r[1]=NULL
+   4    Null           0   4   0                   0  r[4]=NULL
+   5    Integer        1   5   0                   0  r[5]=1; LIMIT counter
+   6    IfNot          5  14   0                   0  if !r[5] goto 14
+   7    OpenRead       0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   8    Last           0  14   0                   0
+   9      RowId        0   6   0                   0  r[6]=products.rowid
+  10      CollSeq      0   0   0  Binary           0  collation=Binary
+  11      AggStep      0   6   4  max              0  accum=r[4] step(r[6])
+  12      Goto         0  14   0                   0
+  13    Prev           0   9   0                   0
+  14    AggFinal       0   4   0  max              0  accum=r[4]
+  15    Copy           4   3   0                   0  r[3]=r[4]
+  16    Copy           3   1   0                   0  r[1]=r[3]
+  17  Return           2   0   1                   0
+  18  OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  19  Copy             1  10   0                   0  r[10]=r[1]
+  20  Gt               9  10  27                   0  if r[9]>r[10] goto 27
+  21  Copy             1  12   0                   0  r[12]=r[1]
+  22  Gt              12  13  27                   0  if r[12]>r[13] goto 27
+  23  Rewind           1  27   0                   0  Rewind table products
+  24    RowId          1   7   0                   0  r[7]=products.rowid
+  25    ResultRow      7   1   0                   0  output=r[7]
+  26  Next             1  24   0                   0
+  27  Halt             0   0   0                   0
+  28  Transaction      0   1  11                   0  iDb=0 tx_mode=Read
+  29  Integer          1   9   0                   0  r[9]=1
+  30  Integer        100  13   0                   0  r[13]=100
+  31  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/subqueries.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/subqueries.sqltest
@@ -86,6 +86,37 @@ snapshot scalar-subquery-simple-count {
     SELECT (SELECT count(*) FROM orders) AS order_count;
 }
 
+# Ensures BETWEEN expr is emitted once. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs {
+    SELECT id
+    FROM products
+    WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+}
+
+# Ensures BETWEEN expr is emitted once in UPDATE. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs-update {
+    UPDATE products
+    SET stock = stock + 1
+    WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+}
+
+# Ensures BETWEEN expr is emitted once in DELETE. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs-delete {
+    DELETE FROM products
+    WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+}
+
+# Ensures NOT BETWEEN expr is emitted once. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs-not {
+    SELECT id
+    FROM products
+    WHERE (SELECT max(id) FROM products) NOT BETWEEN 10 AND 20;
+}
+
 # =============================================================================
 # EXISTS SUBQUERIES
 # =============================================================================


### PR DESCRIPTION
## Description

BETWEEN gets rewritten into `>= low AND <= high` early in the planner, which duplicates the left-hand expression. When that expression is a subquery, the subquery planner sees two separate copies and plans each one independently. The expr cache can't help because it operates at codegen time, after the rewrite already happened.

This fix moves the BETWEEN rewrite to after the point where the AST is in a shape where the subquery has already been planned once. This allows the codegen to emit the subquery exactly once and have both arms of the rewritten AND read its result from the same register.

## Motivation and context

Closes #5152

## Description of AI Usage

Claude was used for codebase exploration and tracing the phase ordering between the BETWEEN rewrite and subquery planning. 