### PR TITLE
core/translate: Fix affinity of compound subquery result columns

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -289,7 +289,7 @@ fn emit_delete_sqlite_sequence_entry(
     });
 }
 
-fn literal_default_value(literal: &ast::Literal) -> Result<Value> {
+pub(crate) fn literal_default_value(literal: &ast::Literal) -> Result<Value> {
     match literal {
         ast::Literal::Numeric(val) => parse_numeric_literal(val),
         ast::Literal::String(s) => Ok(Value::from_text(crate::translate::expr::sanitize_string(s))),

--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::{translate::alter::literal_default_value, types::ValueType};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ExprAffinityInfo {
@@ -97,6 +98,63 @@ pub fn get_expr_affinity(
     resolver: Option<&Resolver>,
 ) -> Affinity {
     get_expr_affinity_info(expr, referenced_tables, resolver).affinity
+}
+
+/// Mirrors SQLite's `sqlite3ExprDataType()` (expr.c): a bitmask of the storage
+/// classes an expression could yield. Used to combine column affinities across
+/// the arms of a compound (UNION/INTERSECT/EXCEPT) subquery.
+///
+///   0x01 = numeric, 0x02 = text, 0x04 = blob; 0x00 = always NULL.
+pub(crate) fn expr_data_type(expr: &ast::Expr, referenced_tables: Option<&TableReferences>) -> u8 {
+    match expr {
+        ast::Expr::Collate(inner, _) | ast::Expr::Unary(ast::UnaryOperator::Positive, inner) => {
+            expr_data_type(inner, referenced_tables)
+        }
+        ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+            expr_data_type(exprs.first().unwrap(), referenced_tables)
+        }
+        // A literal's storage class is its data type; reuse the literal->Value
+        // inference rather than re-deriving the class from the AST here.
+        ast::Expr::Literal(lit) => match literal_default_value(lit).map(|v| v.value_type()) {
+            Ok(ValueType::Null) => 0x00,
+            Ok(ValueType::Text) => 0x02,
+            Ok(ValueType::Blob) => 0x04,
+            // Integer/Float (and the fallback for keyword literals) are numeric.
+            _ => 0x01,
+        },
+        ast::Expr::Binary(_, ast::Operator::Concat, _) => 0x06,
+        ast::Expr::FunctionCall { .. }
+        | ast::Expr::FunctionCallStar { .. }
+        | ast::Expr::Variable(_) => 0x07,
+        ast::Expr::Column { .. }
+        | ast::Expr::RowId { .. }
+        | ast::Expr::Cast { .. }
+        | ast::Expr::Subquery(_) => {
+            let aff = get_expr_affinity(expr, referenced_tables, None);
+            if aff.is_numeric() {
+                0x05
+            } else if matches!(aff, Affinity::Text) {
+                0x06
+            } else {
+                0x07
+            }
+        }
+        ast::Expr::Case {
+            when_then_pairs,
+            else_expr,
+            ..
+        } => {
+            let mut res = 0;
+            for (_, then) in when_then_pairs {
+                res |= expr_data_type(then, referenced_tables);
+            }
+            if let Some(else_expr) = else_expr {
+                res |= expr_data_type(else_expr, referenced_tables);
+            }
+            res
+        }
+        _ => 0x01,
+    }
 }
 
 pub fn comparison_affinity(

--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -1,5 +1,48 @@
 use super::*;
 use crate::{translate::alter::literal_default_value, types::ValueType};
+use bitflags::bitflags;
+
+bitflags! {
+    /// Storage class flags that represent the possible storage classes an expression can yield.
+    /// Used to combine column affinities across UNION/INTERSECT/EXCEPT arms.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct StorageClassMask: u8 {
+        const NUMERIC = 0x01;
+        const TEXT = 0x02;
+        const BLOB = 0x04;
+    }
+}
+
+impl StorageClassMask {
+    pub const fn from_numeric() -> Self {
+        Self::NUMERIC
+    }
+
+    pub const fn from_text() -> Self {
+        Self::TEXT
+    }
+
+    pub const fn from_blob() -> Self {
+        Self::BLOB
+    }
+
+    pub const fn from_null() -> Self {
+        Self::empty()
+    }
+
+    pub fn has_numeric(&self) -> bool {
+        self.contains(Self::NUMERIC)
+    }
+
+    pub fn has_text(&self) -> bool {
+        self.contains(Self::TEXT)
+    }
+
+    #[allow(dead_code)]
+    pub fn has_blob(&self) -> bool {
+        self.contains(Self::BLOB)
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ExprAffinityInfo {
@@ -103,9 +146,10 @@ pub fn get_expr_affinity(
 /// Mirrors SQLite's `sqlite3ExprDataType()` (expr.c): a bitmask of the storage
 /// classes an expression could yield. Used to combine column affinities across
 /// the arms of a compound (UNION/INTERSECT/EXCEPT) subquery.
-///
-///   0x01 = numeric, 0x02 = text, 0x04 = blob; 0x00 = always NULL.
-pub(crate) fn expr_data_type(expr: &ast::Expr, referenced_tables: Option<&TableReferences>) -> u8 {
+pub(crate) fn expr_data_type(
+    expr: &ast::Expr,
+    referenced_tables: Option<&TableReferences>,
+) -> StorageClassMask {
     match expr {
         ast::Expr::Collate(inner, _) | ast::Expr::Unary(ast::UnaryOperator::Positive, inner) => {
             expr_data_type(inner, referenced_tables)
@@ -116,27 +160,29 @@ pub(crate) fn expr_data_type(expr: &ast::Expr, referenced_tables: Option<&TableR
         // A literal's storage class is its data type; reuse the literal->Value
         // inference rather than re-deriving the class from the AST here.
         ast::Expr::Literal(lit) => match literal_default_value(lit).map(|v| v.value_type()) {
-            Ok(ValueType::Null) => 0x00,
-            Ok(ValueType::Text) => 0x02,
-            Ok(ValueType::Blob) => 0x04,
+            Ok(ValueType::Null) => StorageClassMask::from_null(),
+            Ok(ValueType::Text) => StorageClassMask::from_text(),
+            Ok(ValueType::Blob) => StorageClassMask::from_blob(),
             // Integer/Float (and the fallback for keyword literals) are numeric.
-            _ => 0x01,
+            _ => StorageClassMask::from_numeric(),
         },
-        ast::Expr::Binary(_, ast::Operator::Concat, _) => 0x06,
+        ast::Expr::Binary(_, ast::Operator::Concat, _) => {
+            StorageClassMask::TEXT | StorageClassMask::BLOB
+        }
         ast::Expr::FunctionCall { .. }
         | ast::Expr::FunctionCallStar { .. }
-        | ast::Expr::Variable(_) => 0x07,
+        | ast::Expr::Variable(_) => StorageClassMask::all(),
         ast::Expr::Column { .. }
         | ast::Expr::RowId { .. }
         | ast::Expr::Cast { .. }
         | ast::Expr::Subquery(_) => {
             let aff = get_expr_affinity(expr, referenced_tables, None);
             if aff.is_numeric() {
-                0x05
+                StorageClassMask::NUMERIC | StorageClassMask::BLOB
             } else if matches!(aff, Affinity::Text) {
-                0x06
+                StorageClassMask::TEXT | StorageClassMask::BLOB
             } else {
-                0x07
+                StorageClassMask::all()
             }
         }
         ast::Expr::Case {
@@ -144,7 +190,7 @@ pub(crate) fn expr_data_type(expr: &ast::Expr, referenced_tables: Option<&TableR
             else_expr,
             ..
         } => {
-            let mut res = 0;
+            let mut res = StorageClassMask::from_null();
             for (_, then) in when_then_pairs {
                 res |= expr_data_type(then, referenced_tables);
             }
@@ -153,7 +199,7 @@ pub(crate) fn expr_data_type(expr: &ast::Expr, referenced_tables: Option<&TableR
             }
             res
         }
-        _ => 0x01,
+        _ => StorageClassMask::from_numeric(),
     }
 }
 

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -79,7 +79,9 @@ use vectors::*;
 #[allow(unused_imports)]
 use walk::*;
 
-pub(crate) use affinity::{compare_affinity, get_expr_affinity_info, ExprAffinityInfo};
+pub(crate) use affinity::{
+    compare_affinity, expr_data_type, get_expr_affinity_info, ExprAffinityInfo,
+};
 pub use affinity::{comparison_affinity, get_expr_affinity};
 pub(crate) use arrays::{
     emit_array_decode, emit_custom_type_decode_columns, emit_custom_type_encode_columns,

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -80,7 +80,7 @@ use vectors::*;
 use walk::*;
 
 pub(crate) use affinity::{
-    compare_affinity, expr_data_type, get_expr_affinity_info, ExprAffinityInfo,
+    compare_affinity, expr_data_type, get_expr_affinity_info, ExprAffinityInfo, StorageClassMask,
 };
 pub use affinity::{comparison_affinity, get_expr_affinity};
 pub(crate) use arrays::{

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -7,7 +7,7 @@ use crate::{
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         emitter::UpdateRowSource,
-        expr::{as_binary_components, get_expr_affinity},
+        expr::{as_binary_components, expr_data_type, get_expr_affinity},
         expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
         optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
         planner::determine_where_to_eval_term,
@@ -34,6 +34,17 @@ use turso_parser::ast::TableInternalId;
 
 use super::emitter::OperationMode;
 
+/// Maps an affinity to the Type and type name used for a subquery result column.
+fn type_from_affinity(affinity: Affinity) -> (Type, &'static str) {
+    match affinity {
+        Affinity::Integer => (Type::Integer, "INTEGER"),
+        Affinity::Real => (Type::Real, "REAL"),
+        Affinity::Text => (Type::Text, "TEXT"),
+        Affinity::Numeric => (Type::Numeric, "NUMERIC"),
+        Affinity::Blob => (Type::Blob, "BLOB"),
+    }
+}
+
 /// Infer the Type and type name from an expression's affinity.
 ///
 /// Used for subquery result columns. SQLite derives column affinity from:
@@ -47,13 +58,56 @@ fn infer_type_from_expr(
     expr: &ast::Expr,
     tables: Option<&TableReferences>,
 ) -> (Type, &'static str) {
-    let affinity = get_expr_affinity(expr, tables, None);
+    type_from_affinity(get_expr_affinity(expr, tables, None))
+}
+
+/// Computes the affinity of column `i` of a compound (UNION/INTERSECT/EXCEPT)
+/// subquery, matching SQLite's `sqlite3SubqueryColumnTypes` (select.c).
+///
+/// Scanning the arms left-to-right, the affinity is the first arm's affinity,
+/// skipping leading arms that have no affinity (adopting the next arm's). If
+/// every arm has no affinity the result is BLOB (none). Otherwise the column
+/// keeps that affinity unless a later arm yields a conflicting datatype class
+/// (TEXT affinity + a numeric arm, or numeric affinity + a text arm), in which
+/// case it is downgraded to BLOB (none) so the column is compared by storage
+/// class.
+fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affinity {
+    if arms.is_empty() {
+        return Affinity::Blob;
+    }
+    let col_affinity = |arm: &SelectPlan| {
+        arm.result_columns
+            .get(i)
+            .map(|rc| get_expr_affinity(&rc.expr, Some(&arm.table_references), None))
+            .unwrap_or(Affinity::Blob)
+    };
+    let col_data_type = |arm: &SelectPlan| {
+        arm.result_columns
+            .get(i)
+            .map(|rc| expr_data_type(&rc.expr, Some(&arm.table_references)))
+            .unwrap_or(0)
+    };
+
+    let mut affinity = col_affinity(arms[0]);
+    let mut data_types = 0u8;
+    let mut idx = 0;
+    // Skip leading arms with no affinity, adopting the next arm's affinity.
+    while matches!(affinity, Affinity::Blob) && idx + 1 < arms.len() {
+        data_types |= col_data_type(arms[idx]);
+        idx += 1;
+        affinity = col_affinity(arms[idx]);
+    }
+    if matches!(affinity, Affinity::Blob) {
+        return Affinity::Blob;
+    }
+    // `affinity` is TEXT or numeric here; accumulate the remaining arms' classes.
+    for &arm in &arms[idx + 1..] {
+        data_types |= col_data_type(arm);
+    }
     match affinity {
-        Affinity::Integer => (Type::Integer, "INTEGER"),
-        Affinity::Real => (Type::Real, "REAL"),
-        Affinity::Text => (Type::Text, "TEXT"),
-        Affinity::Numeric => (Type::Numeric, "NUMERIC"),
-        Affinity::Blob => (Type::Blob, "BLOB"),
+        Affinity::Text if data_types & 0x01 != 0 => Affinity::Blob,
+        a if a.is_numeric() && data_types & 0x02 != 0 => Affinity::Blob,
+        a => a,
     }
 }
 
@@ -2324,6 +2378,19 @@ impl JoinedTable {
         // actually referenced. Callers that represent actual CTE references should
         // validate the count before calling this method.
 
+        // For a compound select, a column's affinity is combined across every arm
+        // (not just the leftmost one), so collect the arms to fold over.
+        let compound_arms: Option<Vec<&SelectPlan>> = match &plan {
+            Plan::CompoundSelect {
+                left, right_most, ..
+            } => {
+                let mut arms: Vec<&SelectPlan> = left.iter().map(|(p, _)| p).collect();
+                arms.push(right_most);
+                Some(arms)
+            }
+            _ => None,
+        };
+
         let mut columns = result_columns
             .iter()
             .enumerate()
@@ -2332,7 +2399,10 @@ impl JoinedTable {
                 let col_name = explicit_columns
                     .and_then(|cols| cols.get(i).cloned())
                     .or_else(|| rc.name(table_references).map(String::from));
-                let (col_type, type_name) = infer_type_from_expr(&rc.expr, Some(table_references));
+                let (col_type, type_name) = match &compound_arms {
+                    Some(arms) => type_from_affinity(compound_column_affinity(arms, i)),
+                    None => infer_type_from_expr(&rc.expr, Some(table_references)),
+                };
                 Column::new(
                     col_name,
                     type_name.to_string(),

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -7,7 +7,7 @@ use crate::{
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         emitter::UpdateRowSource,
-        expr::{as_binary_components, expr_data_type, get_expr_affinity},
+        expr::{as_binary_components, expr_data_type, get_expr_affinity, StorageClassMask},
         expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
         optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
         planner::determine_where_to_eval_term,
@@ -34,18 +34,7 @@ use turso_parser::ast::TableInternalId;
 
 use super::emitter::OperationMode;
 
-/// Maps an affinity to the Type and type name used for a subquery result column.
-fn type_from_affinity(affinity: Affinity) -> (Type, &'static str) {
-    match affinity {
-        Affinity::Integer => (Type::Integer, "INTEGER"),
-        Affinity::Real => (Type::Real, "REAL"),
-        Affinity::Text => (Type::Text, "TEXT"),
-        Affinity::Numeric => (Type::Numeric, "NUMERIC"),
-        Affinity::Blob => (Type::Blob, "BLOB"),
-    }
-}
-
-/// Infer the Type and type name from an expression's affinity.
+/// Infer the Type from an expression's affinity.
 ///
 /// Used for subquery result columns. SQLite derives column affinity from:
 /// - Column references: the declared column type
@@ -54,11 +43,9 @@ fn type_from_affinity(affinity: Affinity) -> (Type, &'static str) {
 /// - Literals: BLOB affinity (no affinity)
 ///
 /// The affinity determines comparison behavior in IN expressions, etc.
-fn infer_type_from_expr(
-    expr: &ast::Expr,
-    tables: Option<&TableReferences>,
-) -> (Type, &'static str) {
-    type_from_affinity(get_expr_affinity(expr, tables, None))
+fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> Type {
+    let affinity = get_expr_affinity(expr, tables, None);
+    affinity.to_type()
 }
 
 /// Computes the affinity of column `i` of a compound (UNION/INTERSECT/EXCEPT)
@@ -85,11 +72,11 @@ fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affinity {
         arm.result_columns
             .get(i)
             .map(|rc| expr_data_type(&rc.expr, Some(&arm.table_references)))
-            .unwrap_or(0)
+            .unwrap_or(StorageClassMask::from_null())
     };
 
     let mut affinity = col_affinity(arms[0]);
-    let mut data_types = 0u8;
+    let mut data_types = StorageClassMask::from_null();
     let mut idx = 0;
     // Skip leading arms with no affinity, adopting the next arm's affinity.
     while matches!(affinity, Affinity::Blob) && idx + 1 < arms.len() {
@@ -105,8 +92,8 @@ fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affinity {
         data_types |= col_data_type(arm);
     }
     match affinity {
-        Affinity::Text if data_types & 0x01 != 0 => Affinity::Blob,
-        a if a.is_numeric() && data_types & 0x02 != 0 => Affinity::Blob,
+        Affinity::Text if data_types.has_numeric() => Affinity::Blob,
+        a if a.is_numeric() && data_types.has_text() => Affinity::Blob,
         a => a,
     }
 }
@@ -2289,11 +2276,11 @@ impl JoinedTable {
             .result_columns
             .iter()
             .map(|rc| {
-                let (col_type, type_name) =
-                    infer_type_from_expr(&rc.expr, Some(&plan.table_references));
+                let col_type = infer_type_from_expr(&rc.expr, Some(&plan.table_references));
+                let type_name = col_type.to_string();
                 Column::new(
                     rc.name(&plan.table_references).map(String::from),
-                    type_name.to_string(),
+                    type_name,
                     None,
                     None,
                     col_type,
@@ -2399,13 +2386,14 @@ impl JoinedTable {
                 let col_name = explicit_columns
                     .and_then(|cols| cols.get(i).cloned())
                     .or_else(|| rc.name(table_references).map(String::from));
-                let (col_type, type_name) = match &compound_arms {
-                    Some(arms) => type_from_affinity(compound_column_affinity(arms, i)),
+                let col_type = match &compound_arms {
+                    Some(arms) => compound_column_affinity(arms, i).to_type(),
                     None => infer_type_from_expr(&rc.expr, Some(table_references)),
                 };
+                let type_name = col_type.to_string();
                 Column::new(
                     col_name,
-                    type_name.to_string(),
+                    type_name,
                     None,
                     None,
                     col_type,

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -125,6 +125,18 @@ impl Affinity {
         Self::from_char(code as char)
     }
 
+    /// Convert affinity to the corresponding Type enum
+    pub fn to_type(&self) -> crate::schema::Type {
+        use crate::schema::Type;
+        match self {
+            Affinity::Blob => Type::Blob,
+            Affinity::Text => Type::Text,
+            Affinity::Numeric => Type::Numeric,
+            Affinity::Integer => Type::Integer,
+            Affinity::Real => Type::Real,
+        }
+    }
+
     pub fn is_numeric(&self) -> bool {
         matches!(self, Affinity::Integer | Affinity::Real | Affinity::Numeric)
     }

--- a/testing/sqltests/tests/affinity.sqltest
+++ b/testing/sqltests/tests/affinity.sqltest
@@ -571,3 +571,100 @@ expect @js {
     2251799813685247|integer
     2251799813685248|real
 }
+
+# Regression tests for https://github.com/tursodatabase/turso/issues/4927
+# A compound (UNION/UNION ALL) subquery column's affinity must be combined
+# across all arms, not taken from the leftmost arm alone. Scanning left to
+# right, the affinity is the first arm that has one (leading no-affinity arms
+# are skipped); it is then downgraded to no affinity if a later arm has a
+# conflicting type class (text vs numeric), so the column compares by storage
+# class. This matches SQLite's sqlite3SubqueryColumnTypes.
+#
+# These select typeof(x) instead of x so the output never contains a float
+# literal (which the JavaScript driver mishandles); the second column is the
+# integer comparison result.
+
+@cross-check-integrity
+test affinity-compound-subquery-text-numeric-no-affinity {
+    SELECT typeof(x), x = 2 FROM (SELECT CAST(2 AS TEXT) AS x UNION ALL SELECT 2.0);
+}
+expect {
+    text|0
+    real|1
+}
+
+@cross-check-integrity
+test affinity-compound-subquery-order-independent {
+    SELECT typeof(x), x = 2 FROM (SELECT 2.0 AS x UNION ALL SELECT CAST(2 AS TEXT));
+}
+expect {
+    real|1
+    text|0
+}
+
+@cross-check-integrity
+test affinity-compound-subquery-all-text {
+    SELECT typeof(x), x = 2 FROM (SELECT CAST(2 AS TEXT) AS x UNION ALL SELECT CAST(3 AS TEXT));
+}
+expect {
+    text|1
+    text|0
+}
+
+@cross-check-integrity
+test affinity-compound-subquery-all-numeric {
+    SELECT typeof(x), x = 2 FROM (SELECT 2 AS x UNION ALL SELECT 2.0);
+}
+expect {
+    integer|1
+    real|1
+}
+
+@cross-check-integrity
+test affinity-compound-subquery-numeric-col-plus-numeric-literal {
+    CREATE TABLE ti (a INTEGER);
+    INSERT INTO ti VALUES (5);
+    SELECT typeof(x), x = '5' FROM (SELECT a AS x FROM ti UNION ALL SELECT 5.0);
+}
+expect {
+    integer|1
+    real|1
+}
+
+# Leading no-affinity arm (float literal) is skipped; the INTEGER column's
+# affinity is adopted, so x compares numerically.
+@cross-check-integrity
+test affinity-compound-subquery-numeric-literal-first-then-col {
+    CREATE TABLE ti (a INTEGER);
+    INSERT INTO ti VALUES (5);
+    SELECT typeof(x), x = '5' FROM (SELECT 5.0 AS x UNION ALL SELECT a FROM ti);
+}
+expect {
+    real|1
+    integer|1
+}
+
+@cross-check-integrity
+test affinity-compound-subquery-text-col-plus-numeric-literal {
+    CREATE TABLE tt (a TEXT);
+    INSERT INTO tt VALUES ('5');
+    SELECT typeof(x), x = 5 FROM (SELECT a AS x FROM tt UNION ALL SELECT 5);
+}
+expect {
+    text|0
+    integer|1
+}
+
+@cross-check-integrity
+test affinity-compound-subquery-three-arms-mixed {
+    SELECT typeof(x), x = '5' FROM (
+        SELECT CAST(5 AS INT) AS x
+        UNION ALL SELECT CAST(5 AS INTEGER)
+        UNION ALL SELECT CAST(5 AS TEXT)
+    );
+}
+expect {
+    integer|0
+    integer|0
+    text|1
+}


### PR DESCRIPTION
A compound (UNION/UNION ALL/INTERSECT/EXCEPT) subquery's result-column affinity was derived from the leftmost arm alone. SQLite combines affinity across every arm: the column keeps the leftmost arm's affinity, but is downgraded to no affinity when a later arm has a conflicting type class (TEXT affinity + a numeric arm, or numeric affinity + a text arm), in which case the column is compared by storage class.

This made e.g.

  SELECT x, x = 2 FROM (SELECT CAST(2 AS TEXT) AS x UNION ALL SELECT 2.0);

apply TEXT affinity (from the leftmost CAST), coercing both operands to text and inverting the comparison results versus SQLite.

compound_column_affinity now folds SQLite's sqlite3SubqueryColumnTypes rule across all arms, reusing get_expr_affinity for the leftmost arm and a new expr_data_type helper (a port of SQLite's sqlite3ExprDataType) to classify the remaining arms. expr_data_type reuses get_expr_affinity for columns/casts/subqueries and literal_default_value().value_type() for the literal storage class.

Adds cross-checked sqltest regression coverage in affinity.sqltest.

Fixes #4927

