### PR TITLE
core/mvcc: cache Transaction in Cursor to avoid queries

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -74,6 +74,97 @@ fn setup_rusqlite(temp_dir: &TempDir, query: &str) -> rusqlite::Connection {
     sqlite_conn
 }
 
+/// Creates a temp database in MVCC journal mode with a `users` table seeded
+/// with `num_rows` rows, committed in a single transaction. Returns the
+/// database (for `io.step()`) and an open connection.
+fn setup_mvcc_db(
+    temp_dir: &TempDir,
+    num_rows: usize,
+) -> (Arc<Database>, Arc<turso_core::Connection>) {
+    let db_path = temp_dir.path().join("mvcc_bench.db");
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, db_path.to_str().unwrap()).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, first_name TEXT, last_name TEXT, age INTEGER, email TEXT)",
+    )
+    .unwrap();
+    conn.execute("BEGIN").unwrap();
+    for i in 0..num_rows {
+        conn.execute(format!(
+            "INSERT INTO users VALUES ({i}, 'first_{i}', 'last_{i}', {}, 'user{i}@example.com')",
+            i % 100
+        ))
+        .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+    (db, conn)
+}
+
+/// Drives a prepared statement to completion, discarding rows. Shared by the
+/// MVCC read benchmarks.
+fn drain_stmt(db: &Database, stmt: &mut turso_core::Statement) {
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row());
+            }
+            StepResult::IO => {
+                db.io.step().unwrap();
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => unreachable!(),
+        }
+    }
+    stmt.reset().unwrap();
+}
+
+/// Read-path benchmarks exercising the MVCC cursor: full table scan, bounded
+/// range scan, `count(*)`, and `LIMIT` scans.
+fn bench_mvcc_reads(criterion: &mut Criterion) {
+    const NUM_ROWS: usize = 10_000;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (db, conn) = setup_mvcc_db(&temp_dir, NUM_ROWS);
+
+    let mut group = criterion.benchmark_group("MVCC reads");
+
+    group.bench_function("limbo_mvcc_scan_all", |b| {
+        let mut stmt = conn
+            .prepare("SELECT id, first_name, age FROM users")
+            .unwrap();
+        b.iter(|| drain_stmt(&db, &mut stmt));
+    });
+
+    group.bench_function("limbo_mvcc_range_scan", |b| {
+        let mut stmt = conn
+            .prepare(format!(
+                "SELECT id, first_name, age FROM users WHERE id >= {} AND id < {}",
+                NUM_ROWS / 4,
+                NUM_ROWS / 2
+            ))
+            .unwrap();
+        b.iter(|| drain_stmt(&db, &mut stmt));
+    });
+
+    group.bench_function("limbo_mvcc_select_count", |b| {
+        let mut stmt = conn.prepare("SELECT count() FROM users").unwrap();
+        b.iter(|| drain_stmt(&db, &mut stmt));
+    });
+
+    for i in [1, 10, 100] {
+        group.bench_with_input(BenchmarkId::new("limbo_mvcc_select_rows", i), &i, |b, i| {
+            let mut stmt = conn
+                .prepare(format!("SELECT * FROM users LIMIT {}", *i))
+                .unwrap();
+            b.iter(|| drain_stmt(&db, &mut stmt));
+        });
+    }
+
+    group.finish();
+}
+
 fn bench_open(criterion: &mut Criterion) {
     // https://github.com/tursodatabase/turso/issues/174
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
@@ -1049,14 +1140,14 @@ fn bench_insert_randomblob(criterion: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
+    targets = bench_mvcc_reads, bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
 }
 
 #[cfg(feature = "codspeed")]
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
+    targets = bench_mvcc_reads, bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
 }
 
 criterion_main!(benches);

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -5,6 +5,7 @@ use crossbeam_skiplist::SkipMap;
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
     create_seek_range, MVTableId, MvStore, Row, RowID, RowKey, RowVersions, SortableIndexKey,
+    Transaction,
 };
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
@@ -352,6 +353,9 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static> {
     mv_cursor_type: MvccCursorType,
     table_id: MVTableId,
     tx_id: u64,
+    // Cache transaction struct to use instead of trying to get it from the txs map.
+    // Txs is a SkipList which can be heavy to query to the Transaction.
+    cached_tx: Arc<Transaction>,
     /// Reusable immutable record, used to allow better allocation strategy.
     reusable_immutable_record: Option<ImmutableRecord>,
     btree_cursor: Box<dyn CursorTrait>,
@@ -391,6 +395,11 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             "BTreeCursor expected for mvcc cursor"
         );
         let table_id = db.get_table_id_from_root_page(root_page_or_table_id);
+        // Resolve the cursor's transaction once; it stays in `txs` for the
+        // cursor's whole lifetime, so we never look it up again per row.
+        let cached_tx = db
+            .get_tx(tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
         #[cfg(not(any(test, injected_yields)))]
         let _ = connection;
         Ok(Self {
@@ -400,6 +409,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             #[cfg(any(test, injected_yields))]
             connection: connection.clone(),
             tx_id,
+            cached_tx,
             table_iterator: None,
             index_iterator: None,
             mv_cursor_type,
@@ -467,14 +477,14 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
         // Scan path: the range iterator already resolved this row's version
         // chain, so read it directly instead of a second skiplist lookup.
         if let Some(versions) = versions {
-            return self.db.read_visible_from_versions(self.tx_id, versions);
+            return self.db.read_visible_from_versions(self.tx(), versions);
         }
         let maybe_index_id = match &self.mv_cursor_type {
             MvccCursorType::Index(_) => Some(self.table_id),
             MvccCursorType::Table => None,
         };
         self.db
-            .read_from_table_or_index(self.tx_id, row_id, maybe_index_id)
+            .read_from_table_or_index(self.tx(), row_id, maybe_index_id)
     }
 
     pub fn close(self) -> Result<()> {
@@ -554,16 +564,26 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
 
     fn query_btree_version_is_valid(&self, key: &RowKey) -> bool {
         self.db
-            .query_btree_version_is_valid(self.table_id, key, self.tx_id)
+            .query_btree_version_is_valid(self.table_id, key, self.tx())
+    }
+
+    /// Lazily cache the reader's own transaction handle so the scan hot path
+    /// doesn't re-fetch the same `txs` entry (a skiplist `get` + epoch pin) for
+    /// every row.
+    /// The cursor's own transaction, resolved once at construction.
+    #[inline]
+    fn tx(&self) -> &Transaction {
+        self.cached_tx.as_ref()
     }
 
     /// Advance MVCC iterator and return next visible row key in the direction that the iterator was initialized in.
     fn advance_mvcc_iterator(&mut self) {
+        let tx = self.cached_tx.as_ref();
         let new_peek_state = match &self.mv_cursor_type {
             MvccCursorType::Table => match self.db.advance_cursor_and_get_row_id_for_table(
                 self.table_id,
                 &mut self.table_iterator,
-                self.tx_id,
+                tx,
             ) {
                 Some((row_id, versions)) => CursorPeek::Row {
                     key: row_id.row_id,
@@ -573,7 +593,7 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
             },
             MvccCursorType::Index(_) => match self
                 .db
-                .advance_cursor_and_get_row_id_for_index(&mut self.index_iterator, self.tx_id)
+                .advance_cursor_and_get_row_id_for_index(&mut self.index_iterator, tx)
             {
                 Some(row_id) => CursorPeek::Row {
                     key: row_id.row_id,
@@ -1273,7 +1293,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                     };
                     if self
                         .db
-                        .read_from_table_or_index(self.tx_id, row_id, maybe_index_id)?
+                        .read_from_table_or_index(self.tx(), row_id, maybe_index_id)?
                         .is_some()
                     {
                         // We need to clear the null flag for the table cursor before seeking,
@@ -1315,7 +1335,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                                 rowid.clone(),
                                 inclusive,
                                 direction,
-                                self.tx_id,
+                                self.cached_tx.as_ref(),
                                 &mut self.table_iterator,
                             );
 
@@ -1351,7 +1371,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                                 sortable_key.clone(),
                                 inclusive,
                                 direction,
-                                self.tx_id,
+                                self.cached_tx.as_ref(),
                                 &mut self.index_iterator,
                             );
 
@@ -1508,11 +1528,11 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
         // FIXME: set btree to somewhere close to this rowid?
         if self
             .db
-            .read_from_table_or_index(self.tx_id, &row.id, maybe_index_id)?
+            .read_from_table_or_index(self.tx(), &row.id, maybe_index_id)?
             .is_some()
         {
             self.db
-                .update_to_table_or_index(self.tx_id, row, maybe_index_id)
+                .update_to_table_or_index(self.tx(), row, maybe_index_id)
                 .inspect_err(|_| {
                     self.current_pos = CursorPosition::BeforeFirst;
                 })?;
@@ -1520,13 +1540,13 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
             // The row exists in B-tree but not in MvStore - mark it as B-tree resident
             // so that checkpoint knows to write deletes to the B-tree file.
             self.db
-                .insert_btree_resident_to_table_or_index(self.tx_id, row, maybe_index_id)
+                .insert_btree_resident_to_table_or_index(self.tx(), row, maybe_index_id)
                 .inspect_err(|_| {
                     self.current_pos = CursorPosition::BeforeFirst;
                 })?;
         } else {
             self.db
-                .insert_to_table_or_index(self.tx_id, row, maybe_index_id)
+                .insert_to_table_or_index(self.tx(), row, maybe_index_id)
                 .inspect_err(|_| {
                     self.current_pos = CursorPosition::BeforeFirst;
                 })?;
@@ -1564,7 +1584,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
         }
         let was_deleted =
             self.db
-                .delete_from_table_or_index(self.tx_id, rowid.clone(), maybe_index_id)?;
+                .delete_from_table_or_index(self.tx(), rowid.clone(), maybe_index_id)?;
         // If was_deleted is false, this can ONLY happen when we have a row that only exists
         // in the btree but not the mv store. In this case, we create a tombstone for the row
         // based on the btree row.
@@ -1592,7 +1612,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 MvccCursorType::Index(_) => Row::new_index_row(rowid.clone(), column_count),
             };
             self.db
-                .insert_tombstone_to_table_or_index(self.tx_id, rowid, row, maybe_index_id)?;
+                .insert_tombstone_to_table_or_index(self.tx(), rowid, row, maybe_index_id)?;
         }
         self.invalidate_record();
         Ok(IOResult::Done(()))
@@ -1623,7 +1643,7 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 },
                 inclusive,
                 IterationDirection::Forwards,
-                self.tx_id,
+                self.cached_tx.as_ref(),
                 &mut self.table_iterator,
             );
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2883,7 +2883,10 @@ pub struct MvStore<Clock: LogicalClock> {
     /// because operations like last() on an index are much easier when we don't have to take the
     /// table identifier into account.
     pub index_rows: SkipMap<MVTableId, SkipMap<Arc<SortableIndexKey>, RowVersions>>,
-    txs: SkipMap<TxID, Transaction>,
+    /// Transactions are stored behind `Arc` so cursors can cache a handle to the
+    /// reader's own transaction and reuse it across a scan without re-doing a
+    /// skiplist lookup (+ epoch pin) per row. See [`MvStore::get_tx`].
+    txs: SkipMap<TxID, Arc<Transaction>>,
     /// Final state for removed transactions. Readers may still race with stale TxID
     /// references in row versions after a transaction is removed from `txs`.
     finalized_tx_states: SkipMap<TxID, TransactionState>,
@@ -3328,22 +3331,20 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// * `row` - the row object containing the values to be inserted.
     ///
     pub fn insert(&self, tx_id: TxID, row: Row) -> Result<()> {
-        self.insert_to_table_or_index(tx_id, row, None)
+        let tx = self
+            .get_tx(tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        self.insert_to_table_or_index(&tx, row, None)
     }
 
     /// Same as insert() but can insert to a table or an index, indicated by the `maybe_index_id` argument.
     pub fn insert_to_table_or_index(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         row: Row,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<()> {
-        tracing::trace!("insert(tx_id={}, row.id={:?})", tx_id, row.id);
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-        let tx = tx.value();
+        tracing::trace!("insert(tx_id={}, row.id={:?})", tx.tx_id, row.id);
         turso_assert_eq!(tx.state, TransactionState::Active);
         let id = row.id.clone();
         match maybe_index_id {
@@ -3395,7 +3396,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// This is used in cases where the BTree contains that record, but it is logically deleted.
     pub fn insert_tombstone_to_table_or_index(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         id: RowID,
         row: Row,
         maybe_index_id: Option<MVTableId>,
@@ -3406,15 +3407,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             // Tombstones over B-tree-resident rows have no MVCC creator begin.
             // They invalidate B-tree visibility via end timestamp only.
             begin: None,
-            end: Some(TxTimestampOrID::TxID(tx_id)),
+            end: Some(TxTimestampOrID::TxID(tx.tx_id)),
             row: row.clone(),
             btree_resident: true,
         };
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-        let tx = tx.value();
         match maybe_index_id {
             Some(index_id) => {
                 let RowKey::Record(sortable_key) = row.id.row_id else {
@@ -3440,20 +3436,15 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// determine if subsequent deletes should be checkpointed to the B-tree file.
     pub fn insert_btree_resident_to_table_or_index(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         row: Row,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<()> {
         tracing::trace!(
             "insert_btree_resident(tx_id={}, row.id={:?})",
-            tx_id,
+            tx.tx_id,
             row.id
         );
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-        let tx = tx.value();
         turso_assert_eq!(tx.state, TransactionState::Active);
         let id = row.id.clone();
         match maybe_index_id {
@@ -3510,40 +3501,46 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     ///
     /// Returns `true` if the row was successfully updated, and `false` otherwise.
     pub fn update(&self, tx_id: TxID, row: Row) -> Result<bool> {
-        self.update_to_table_or_index(tx_id, row, None)
+        let tx = self
+            .get_tx(tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        self.update_to_table_or_index(&tx, row, None)
     }
 
     /// Same as update() but can update a table or an index, indicated by the `maybe_index_id` argument.
     pub fn update_to_table_or_index(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         row: Row,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<bool> {
-        tracing::trace!("update(tx_id={}, row.id={:?})", tx_id, row.id);
-        if !self.delete_from_table_or_index(tx_id, row.id.clone(), maybe_index_id)? {
+        tracing::trace!("update(tx_id={}, row.id={:?})", tx.tx_id, row.id);
+        if !self.delete_from_table_or_index(tx, row.id.clone(), maybe_index_id)? {
             return Ok(false);
         }
-        self.insert_to_table_or_index(tx_id, row, maybe_index_id)?;
+        self.insert_to_table_or_index(tx, row, maybe_index_id)?;
         Ok(true)
     }
 
     /// Inserts a row into a table in the database with new values, previously deleting
     /// any old data if it existed. Bails on a delete error, e.g. write-write conflict.
     pub fn upsert(&self, tx_id: TxID, row: Row) -> Result<()> {
-        self.upsert_to_table_or_index(tx_id, row, None)
+        let tx = self
+            .get_tx(tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        self.upsert_to_table_or_index(&tx, row, None)
     }
 
     /// Same as upsert() but can upsert to a table or an index, indicated by the `maybe_index_id` argument.
     pub fn upsert_to_table_or_index(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         row: Row,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<()> {
-        tracing::trace!("upsert(tx_id={}, row.id={:?})", tx_id, row.id);
-        self.delete_from_table_or_index(tx_id, row.id.clone(), maybe_index_id)?;
-        self.insert_to_table_or_index(tx_id, row, maybe_index_id)?;
+        tracing::trace!("upsert(tx_id={}, row.id={:?})", tx.tx_id, row.id);
+        self.delete_from_table_or_index(tx, row.id.clone(), maybe_index_id)?;
+        self.insert_to_table_or_index(tx, row, maybe_index_id)?;
         Ok(())
     }
 
@@ -3562,17 +3559,20 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// Returns `true` if the row was successfully deleted, and `false` otherwise.
     ///
     pub fn delete(&self, tx_id: TxID, id: RowID) -> Result<bool> {
-        self.delete_from_table_or_index(tx_id, id, None)
+        let tx = self
+            .get_tx(tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        self.delete_from_table_or_index(&tx, id, None)
     }
 
     /// Same as delete() but can delete from a table or an index, indicated by the `maybe_index_id` argument.
     pub fn delete_from_table_or_index(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         id: RowID,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<bool> {
-        tracing::trace!("delete(tx_id={}, id={:?})", tx_id, id);
+        tracing::trace!("delete(tx_id={}, id={:?})", tx.tx_id, id);
         match maybe_index_id {
             Some(index_id) => {
                 let rows = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
@@ -3585,11 +3585,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     let arc_key = row_versions_entry.key().clone();
                     let row_versions = row_versions_entry.value().clone();
                     for rv in row_versions.write().iter_mut().rev() {
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
                         // A transaction cannot delete a version that it cannot see,
                         // nor can it conflict with it.
@@ -3603,11 +3598,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
                         let version_id = rv.id;
                         rv.end = Some(TxTimestampOrID::TxID(tx.tx_id));
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
                         tx.insert_to_write_set(id, row_versions.clone());
                         tx.record_deleted_index_version((index_id, arc_key), version_id);
                         return Ok(true);
@@ -3621,11 +3611,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     let row_versions = row_versions_entry.value().clone();
                     let mut locked_row_versions = row_versions.write();
                     for rv in locked_row_versions.iter_mut().rev() {
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
                         turso_assert_eq!(tx.state, TransactionState::Active);
                         // A transaction cannot delete a version that it cannot see,
                         // nor can it conflict with it.
@@ -3641,11 +3626,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         rv.end = Some(TxTimestampOrID::TxID(tx.tx_id));
                         drop(locked_row_versions);
                         drop(row_versions_opt);
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
                         tx.insert_to_write_set(id.clone(), row_versions.clone());
                         tx.record_deleted_table_version(id.clone(), version_id);
                         return Ok(true);
@@ -3671,23 +3651,21 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// Returns `Some(row)` with the row data if the row with the given `id` exists,
     /// and `None` otherwise.
     pub fn read(&self, tx_id: TxID, id: &RowID) -> Result<Option<Row>> {
-        self.read_from_table_or_index(tx_id, id, None)
+        let tx = self
+            .get_tx(tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        self.read_from_table_or_index(&tx, id, None)
     }
 
     /// Same as read() but can read from a table or an index, indicated by the `maybe_index_id` argument.
     pub fn read_from_table_or_index(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         id: &RowID,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<Option<Row>> {
-        tracing::trace!("read(tx_id={}, id={:?})", tx_id, id);
+        tracing::trace!("read(tx_id={}, id={:?})", tx.tx_id, id);
 
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-        let tx = tx.value();
         turso_assert_eq!(tx.state, TransactionState::Active);
         match maybe_index_id {
             Some(index_id) => {
@@ -3731,14 +3709,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// already located the `Arc`, so the second skiplist traversal is avoided.
     pub(crate) fn read_visible_from_versions(
         &self,
-        tx_id: TxID,
+        tx: &Transaction,
         versions: &RowVersions,
     ) -> Result<Option<Row>> {
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-        let tx = tx.value();
         turso_assert_eq!(tx.state, TransactionState::Active);
         let versions = versions.read();
         if let Some(rv) = versions
@@ -3788,21 +3761,25 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         Ok(())
     }
 
+    /// Returns an owned handle to the given transaction, if present.
+    ///
+    /// Cursors use this to cache the reader's own transaction once and reuse it
+    /// across the whole scan, avoiding a per-row skiplist lookup (+ epoch pin)
+    /// to re-fetch the same entry on the read hot path.
+    pub(crate) fn get_tx(&self, tx_id: TxID) -> Option<Arc<Transaction>> {
+        self.txs.get(&tx_id).map(|entry| entry.value().clone())
+    }
+
     pub(crate) fn advance_cursor_and_get_row_id_for_table(
         &self,
         table_id: MVTableId,
         mv_store_iterator: &mut Option<MvccIterator<'static, RowID>>,
-        tx_id: TxID,
+        tx: &Transaction,
     ) -> Option<(RowID, RowVersions)> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
             "mv_store_iterator must be initialized when calling get_row_id_for_table_in_direction",
         );
 
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .expect("transaction should exist in txs map");
-        let tx = tx.value();
         loop {
             // We are moving forward, so if a row was deleted we just need to skip it. Therefore, we need
             // to loop either until we find a row that is not deleted or until we reach the end of the table.
@@ -3827,17 +3804,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     pub(crate) fn advance_cursor_and_get_row_id_for_index(
         &self,
         mv_store_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
-        tx_id: TxID,
+        tx: &Transaction,
     ) -> Option<RowID> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
             "mv_store_iterator must be initialized when calling get_row_id_for_index_in_direction",
         );
-
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .expect("transaction should exist in txs map");
-        let tx = tx.value();
 
         self.find_next_visible_index_row(tx, mv_store_iterator)
     }
@@ -3850,14 +3821,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         table_id: MVTableId,
         row_id: &RowKey,
-        tx_id: TxID,
+        tx: &Transaction,
     ) -> bool {
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .expect("transaction should exist in txs map");
-        let tx = tx.value();
-
         match row_id {
             RowKey::Int(_) => {
                 let row_id_full = RowID {
@@ -3965,7 +3930,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         start: RowID,
         inclusive: bool,
         direction: IterationDirection,
-        tx_id: TxID,
+        tx: &Transaction,
         table_iterator: &mut Option<MvccIterator<'static, RowID>>,
     ) -> Option<RowID> {
         let table_id = start.table_id;
@@ -3997,12 +3962,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             .as_mut()
             .expect("table_iterator was assigned above if it was None");
 
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .expect("transaction should exist in txs map");
-        let tx = tx.value();
-
         self.find_next_visible_table_row(tx, mv_store_iterator, table_id)
             .map(|(row_id, _versions)| row_id)
     }
@@ -4013,7 +3972,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         start: SortableIndexKey,
         inclusive: bool,
         direction: IterationDirection,
-        tx_id: TxID,
+        tx: &Transaction,
         index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>>>,
     ) -> Option<RowID> {
         let index_rows = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
@@ -4045,11 +4004,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             .as_mut()
             .expect("index_iterator was assigned above if it was None");
 
-        let tx = self
-            .txs
-            .get(&tx_id)
-            .expect("transaction should exist in txs map");
-        let tx = tx.value();
         self.find_next_visible_index_row(tx, mv_store_iterator)
     }
 
@@ -4162,7 +4116,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             begin_ts
         );
         tracing::debug!("begin_exclusive_tx: tx_id={} succeeded", tx_id);
-        self.txs.insert(tx_id, tx);
+        self.txs.insert(tx_id, Arc::new(tx));
         Ok(tx_id)
     }
 
@@ -4183,7 +4137,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let header = self.get_new_transaction_database_header(&pager);
         let tx = Transaction::new(tx_id, begin_ts, header);
         tracing::trace!("begin_tx(tx_id={}, begin_ts={})", tx_id, begin_ts);
-        self.txs.insert(tx_id, tx);
+        self.txs.insert(tx_id, Arc::new(tx));
 
         Ok(tx_id)
     }
@@ -6218,7 +6172,7 @@ pub fn create_seek_range<K: Ord>(
 /// Ref: https://www.cs.cmu.edu/~15721-f24/papers/Hekaton.pdf , page 301,
 /// 2.6. Updating a Version.
 fn is_write_write_conflict(
-    txs: &SkipMap<TxID, Transaction>,
+    txs: &SkipMap<TxID, Arc<Transaction>>,
     finalized_tx_states: &SkipMap<TxID, TransactionState>,
     tx: &Transaction,
     rv: &RowVersion,
@@ -6259,7 +6213,7 @@ impl RowVersion {
     fn is_visible_to(
         &self,
         tx: &Transaction,
-        txs: &SkipMap<TxID, Transaction>,
+        txs: &SkipMap<TxID, Arc<Transaction>>,
         finalized_tx_states: &SkipMap<TxID, TransactionState>,
     ) -> bool {
         is_begin_visible(txs, finalized_tx_states, tx, self)
@@ -6277,7 +6231,7 @@ impl RowVersion {
     fn is_btree_invalidating_version(
         &self,
         tx: &Transaction,
-        txs: &SkipMap<TxID, Transaction>,
+        txs: &SkipMap<TxID, Arc<Transaction>>,
         finalized_tx_states: &SkipMap<TxID, TransactionState>,
     ) -> bool {
         // If the version is fully visible, it invalidates the B-tree
@@ -6339,7 +6293,7 @@ impl RowVersion {
 /// The lock on `commit_dep_set` serializes with the drain in commit/abort
 /// resolution, preventing the race where we push an entry after the drain.
 fn register_commit_dependency(
-    txs: &SkipMap<TxID, Transaction>,
+    txs: &SkipMap<TxID, Arc<Transaction>>,
     dependent_tx: &Transaction,
     depended_on_tx_id: TxID,
 ) {
@@ -6397,7 +6351,7 @@ fn register_commit_dependency(
 }
 
 fn lookup_tx_state(
-    txs: &SkipMap<TxID, Transaction>,
+    txs: &SkipMap<TxID, Arc<Transaction>>,
     finalized_tx_states: &SkipMap<TxID, TransactionState>,
     tx_id: TxID,
 ) -> Option<TransactionState> {
@@ -6424,7 +6378,7 @@ fn lookup_finalized_tx_state(
 }
 
 fn is_begin_visible(
-    txs: &SkipMap<TxID, Transaction>,
+    txs: &SkipMap<TxID, Arc<Transaction>>,
     finalized_tx_states: &SkipMap<TxID, TransactionState>,
     tx: &Transaction,
     rv: &RowVersion,
@@ -6515,7 +6469,7 @@ fn is_begin_visible(
 }
 
 fn is_end_visible(
-    txs: &SkipMap<TxID, Transaction>,
+    txs: &SkipMap<TxID, Arc<Transaction>>,
     finalized_tx_states: &SkipMap<TxID, TransactionState>,
     current_tx: &Transaction,
     row_version: &RowVersion,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4267,9 +4267,9 @@ Terminated   | Irrelevant         | Reread V’s End field. TE has terminated so
 or not found |                    | the timestamp.
 */
 
-fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Transaction {
+fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Arc<Transaction> {
     let state = state.into();
-    Transaction {
+    Arc::new(Transaction {
         state,
         tx_id,
         begin_ts,
@@ -4281,14 +4281,14 @@ fn new_tx(tx_id: TxID, begin_ts: u64, state: TransactionState) -> Transaction {
         commit_dep_counter: AtomicU64::new(0),
         abort_now: AtomicBool::new(false),
         commit_dep_set: Mutex::new(HashSet::default()),
-    }
+    })
 }
 
 /// What this test checks: MVCC transaction visibility and conflict handling follow the intended isolation behavior.
 /// Why this matters: Concurrency bugs are correctness bugs: they create anomalies users can observe as wrong query results.
 #[test]
 fn test_snapshot_isolation_tx_visible1() {
-    let txs: SkipMap<TxID, Transaction> = SkipMap::from_iter([
+    let txs: SkipMap<TxID, Arc<Transaction>> = SkipMap::from_iter([
         (1, new_tx(1, 1, TransactionState::Committed(2))),
         (2, new_tx(2, 2, TransactionState::Committed(5))),
         (3, new_tx(3, 3, TransactionState::Aborted)),
@@ -4398,7 +4398,7 @@ fn test_snapshot_isolation_tx_visible1() {
 
 #[test]
 fn test_visibility_uses_finalized_state_for_removed_committed_tx() {
-    let txs: SkipMap<TxID, Transaction> = SkipMap::new();
+    let txs: SkipMap<TxID, Arc<Transaction>> = SkipMap::new();
     let finalized_tx_states: SkipMap<TxID, TransactionState> =
         SkipMap::from_iter([(42, TransactionState::Committed(5))]);
     let reader = new_tx(7, 10, TransactionState::Active);
@@ -4483,7 +4483,7 @@ fn test_drop_unused_row_versions_prunes_unreferenced_finalized_tx_states() {
 /// and adds to CommitDepSet.
 #[test]
 fn test_commit_dependency_speculative_read() {
-    let txs: SkipMap<TxID, Transaction> =
+    let txs: SkipMap<TxID, Arc<Transaction>> =
         SkipMap::from_iter([(1, new_tx(1, 1, TransactionState::Preparing(5)))]);
     let finalized_tx_states: SkipMap<TxID, TransactionState> = SkipMap::new();
 
@@ -4516,7 +4516,7 @@ fn test_commit_dependency_speculative_read() {
 /// and decrements their CommitDepCounter.
 #[test]
 fn test_commit_dependency_cascade_abort() {
-    let txs: SkipMap<TxID, Transaction> =
+    let txs: SkipMap<TxID, Arc<Transaction>> =
         SkipMap::from_iter([(1, new_tx(1, 1, TransactionState::Preparing(5)))]);
     let finalized_tx_states: SkipMap<TxID, TransactionState> = SkipMap::new();
 
@@ -4560,7 +4560,7 @@ fn test_commit_dependency_cascade_abort() {
 /// Test that registering a dependency on an already-committed tx is a no-op.
 #[test]
 fn test_commit_dependency_already_committed() {
-    let txs: SkipMap<TxID, Transaction> =
+    let txs: SkipMap<TxID, Arc<Transaction>> =
         SkipMap::from_iter([(1, new_tx(1, 1, TransactionState::Committed(5)))]);
 
     let reader = new_tx(2, 10, TransactionState::Active);
@@ -4574,7 +4574,7 @@ fn test_commit_dependency_already_committed() {
 /// Test that registering a dependency on an already-aborted tx sets AbortNow.
 #[test]
 fn test_commit_dependency_already_aborted() {
-    let txs: SkipMap<TxID, Transaction> =
+    let txs: SkipMap<TxID, Arc<Transaction>> =
         SkipMap::from_iter([(1, new_tx(1, 1, TransactionState::Aborted))]);
 
     let reader = new_tx(2, 10, TransactionState::Active);
@@ -4588,7 +4588,7 @@ fn test_commit_dependency_already_aborted() {
 /// Test speculative ignore in is_end_visible registers dependency.
 #[test]
 fn test_commit_dependency_speculative_ignore() {
-    let txs: SkipMap<TxID, Transaction> = SkipMap::from_iter([
+    let txs: SkipMap<TxID, Arc<Transaction>> = SkipMap::from_iter([
         (1, new_tx(1, 1, TransactionState::Committed(2))),
         (3, new_tx(3, 3, TransactionState::Preparing(5))),
     ]);
@@ -4620,7 +4620,7 @@ fn test_commit_dependency_speculative_ignore() {
 /// register one commit dependency (dedup).
 #[test]
 fn test_commit_dependency_multiple_reads_dedup() {
-    let txs: SkipMap<TxID, Transaction> =
+    let txs: SkipMap<TxID, Arc<Transaction>> =
         SkipMap::from_iter([(1, new_tx(1, 1, TransactionState::Preparing(5)))]);
     let finalized_tx_states: SkipMap<TxID, TransactionState> = SkipMap::new();
 
@@ -5060,7 +5060,7 @@ fn test_commit_dep_threaded_readonly_abort_cascades() {
 /// a concurrent drain could fetch_sub(1) on a zero counter, wrapping to MAX.
 #[test]
 fn test_commit_dependency_counter_no_underflow() {
-    let txs: SkipMap<TxID, Transaction> =
+    let txs: SkipMap<TxID, Arc<Transaction>> =
         SkipMap::from_iter([(1, new_tx(1, 1, TransactionState::Preparing(5)))]);
     let reader = new_tx(2, 10, TransactionState::Active);
 
@@ -5082,7 +5082,7 @@ fn test_commit_dependency_counter_no_underflow() {
 /// tx from txs, so register_commit_dependency saw None and assumed "committed."
 #[test]
 fn test_commit_dependency_terminated_tx_sets_abort() {
-    let txs: SkipMap<TxID, Transaction> =
+    let txs: SkipMap<TxID, Arc<Transaction>> =
         SkipMap::from_iter([(1, new_tx(1, 1, TransactionState::Terminated))]);
 
     let reader = new_tx(2, 10, TransactionState::Active);
@@ -5106,7 +5106,7 @@ fn test_commit_dependency_terminated_tx_sets_abort() {
 /// from the map (Issue #3 fix ensures this).
 #[test]
 fn test_commit_dependency_missing_tx_assumes_committed() {
-    let txs: SkipMap<TxID, Transaction> = SkipMap::new();
+    let txs: SkipMap<TxID, Arc<Transaction>> = SkipMap::new();
 
     let reader = new_tx(2, 10, TransactionState::Active);
     register_commit_dependency(&txs, &reader, 99);
@@ -10597,7 +10597,7 @@ fn test_speculative_delete_hides_committed_version() {
     // simulate the UPSERT code path that bypasses eager conflict detection).
     let row_v2 = generate_simple_string_row(table_id, 1, "v2");
     db.mvcc_store
-        .insert_btree_resident_to_table_or_index(tx2, row_v2, None)
+        .insert_btree_resident_to_table_or_index(&db.mvcc_store.get_tx(tx2).unwrap(), row_v2, None)
         .unwrap();
 
     // T2: commit → must fail with WriteWriteConflict.
@@ -10653,7 +10653,7 @@ fn test_committed_delete_tombstone_conflict() {
     // T2: insert_btree_resident for the same row.
     let row_v2 = generate_simple_string_row(table_id, 1, "v2");
     db.mvcc_store
-        .insert_btree_resident_to_table_or_index(tx2, row_v2, None)
+        .insert_btree_resident_to_table_or_index(&db.mvcc_store.get_tx(tx2).unwrap(), row_v2, None)
         .unwrap();
 
     // T2: commit → must detect conflict with Td.
@@ -10707,7 +10707,7 @@ fn test_committed_update_version_conflict() {
     // T2: insert_btree_resident for the same row.
     let row_v2 = generate_simple_string_row(table_id, 1, "v2");
     db.mvcc_store
-        .insert_btree_resident_to_table_or_index(tx2, row_v2, None)
+        .insert_btree_resident_to_table_or_index(&db.mvcc_store.get_tx(tx2).unwrap(), row_v2, None)
         .unwrap();
 
     // T2: commit → must detect conflict with Td.

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -2809,7 +2809,7 @@ mod tests {
             // Use read_from_table_or_index to read the index row
             // This verifies that index rows were properly serialized and deserialized from the logical log
             let index_row_opt = mvcc_store
-                .read_from_table_or_index(tx, &index_rowid, Some(index_id))
+                .read_from_table_or_index(&mvcc_store.get_tx(tx).unwrap(), &index_rowid, Some(index_id))
                 .unwrap_or_else(|e| {
                     panic!("Failed to read index row for ({}, {}): {:?}. Index ID: {:?}, root_page: {}",
                            data_value, row_id, e, index_id, index.root_page)


### PR DESCRIPTION
## Description
SkipList are norously slow to query anything. One clear winner for this
is caching the Transaction which is stored inside a tx map with a
SkipList.

## Results

```bash
MVCC reads/limbo_mvcc_scan_all
                        time:   [2.1713 ms 2.1738 ms 2.1764 ms]
                        change: [-9.9966% -9.7872% -9.5989%] (p = 0.00 < 0.05)
                        Performance has improved.
MVCC reads/limbo_mvcc_range_scan
                        time:   [632.28 µs 633.23 µs 634.29 µs]
                        change: [-11.228% -10.981% -10.742%] (p = 0.00 < 0.05)
                        Performance has improved.
MVCC reads/limbo_mvcc_select_count
                        time:   [704.01 µs 705.10 µs 706.41 µs]
                        change: [-13.197% -12.928% -12.682%] (p = 0.00 < 0.05)
                        Performance has improved.
MVCC reads/limbo_mvcc_select_rows/1
                        time:   [1.3019 µs 1.3042 µs 1.3064 µs]
                        change: [-3.5788% -3.3594% -3.0998%] (p = 0.00 < 0.05)
                        Performance has improved.
MVCC reads/limbo_mvcc_select_rows/10
                        time:   [4.4120 µs 4.4181 µs 4.4240 µs]
                        change: [-14.876% -14.649% -14.417%] (p = 0.00 < 0.05)
                        Performance has improved.
MVCC reads/limbo_mvcc_select_rows/100
                        time:   [33.260 µs 33.447 µs 33.708 µs]
                        change: [-18.248% -17.725% -17.027%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Description of AI Usage

Quite good PR for a clanker. Built the benchmark and with my direction I told him to reuse transaction that should be stored from the start of cursor since it should be used with a transaction anyways.
