### PR TITLE
Expose managed extension APIs through SDK-kit and .NET bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6899,6 +6899,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "turso_core",
+ "turso_ext",
  "turso_sdk_kit_macros",
 ]
 

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Aggregates.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Aggregates.cs
@@ -17,10 +17,15 @@ public partial class SqliteConnection
         if (step is null)
         {
             _aggregateFunctions.Remove(name);
+            if (_database is not null)
+                TursoBindings.UnregisterFunction(DatabaseHandle, name);
             return;
         }
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        var registration = new AggregateFunctionRegistration(name, argc, isDeterministic, seed, step, resultSelector);
+        _aggregateFunctions[name] = registration;
+        if (_database is not null)
+            _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
     }
 
     private void RegisterAggregateFunctions()
@@ -60,40 +65,40 @@ public partial class SqliteConnection
         return registration.CreateInvocationHandle();
     }
 
-    private static void StepAggregate(IntPtr context, IntPtr aggregateContext, int argc, IntPtr argv, IntPtr result)
+    private static TursoExtensionValue StepAggregate(IntPtr context, IntPtr aggregateContext, int argc, IntPtr argv)
     {
         try
         {
             var invocation = (AggregateInvocation?)GCHandle.FromIntPtr(aggregateContext).Target
                 ?? throw new ObjectDisposedException(nameof(AggregateInvocation));
             invocation.Step(ReadArguments(argc, argv));
-            WriteResult(result, null);
+            return CreateResult(null);
         }
         catch (SqliteException ex)
         {
-            WriteError(result, "__turso_sqlite_error__:" + ex.SqliteErrorCode.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + ex.Message);
+            return CreateError("__turso_sqlite_error__:" + ex.SqliteErrorCode.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + ex.Message);
         }
         catch (Exception ex)
         {
-            WriteError(result, ex.Message);
+            return CreateError(ex.Message);
         }
     }
 
-    private static void FinalizeAggregate(IntPtr context, IntPtr aggregateContext, IntPtr result)
+    private static TursoExtensionValue FinalizeAggregate(IntPtr context, IntPtr aggregateContext)
     {
         try
         {
             var invocation = (AggregateInvocation?)GCHandle.FromIntPtr(aggregateContext).Target
                 ?? throw new ObjectDisposedException(nameof(AggregateInvocation));
-            WriteResult(result, invocation.FinalizeResult());
+            return CreateResult(invocation.FinalizeResult());
         }
         catch (SqliteException ex)
         {
-            WriteError(result, "__turso_sqlite_error__:" + ex.SqliteErrorCode.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + ex.Message);
+            return CreateError("__turso_sqlite_error__:" + ex.SqliteErrorCode.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + ex.Message);
         }
         catch (Exception ex)
         {
-            WriteError(result, ex.Message);
+            return CreateError(ex.Message);
         }
     }
 

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Collations.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Collations.cs
@@ -15,10 +15,15 @@ public partial class SqliteConnection
         if (comparison is null)
         {
             _collations.Remove(name);
+            if (_database is not null)
+                TursoBindings.UnregisterCollation(DatabaseHandle, name);
             return;
         }
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        var registration = new CollationRegistration(name, comparison);
+        _collations[name] = registration;
+        if (_database is not null)
+            _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
     }
 
     private void RegisterCollations()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
@@ -19,10 +19,15 @@ public partial class SqliteConnection
         if (function is null)
         {
             _scalarFunctions.Remove(name);
+            if (_database is not null)
+                TursoBindings.UnregisterFunction(DatabaseHandle, name);
             return;
         }
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        var registration = new ScalarFunctionRegistration(name, argc, isDeterministic, function);
+        _scalarFunctions[name] = registration;
+        if (_database is not null)
+            _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
     }
 
     private void RegisterScalarFunctions()
@@ -82,22 +87,22 @@ public partial class SqliteConnection
         return (T)Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
     }
 
-    private static void InvokeScalarFunction(IntPtr context, int argc, IntPtr argv, IntPtr result)
+    private static TursoExtensionValue InvokeScalarFunction(IntPtr context, int argc, IntPtr argv, IntPtr contextDestructor, IntPtr valueDestructor)
     {
         try
         {
             var registration = (ScalarFunctionRegistration?)GCHandle.FromIntPtr(context).Target
                 ?? throw new ObjectDisposedException(nameof(ScalarFunctionRegistration));
             var args = ReadArguments(argc, argv);
-            WriteResult(result, registration.Invoke(args));
+            return CreateResult(registration.Invoke(args));
         }
         catch (SqliteException ex)
         {
-            WriteError(result, "__turso_sqlite_error__:" + ex.SqliteErrorCode.ToString(CultureInfo.InvariantCulture) + ":" + ex.Message);
+            return CreateError("__turso_sqlite_error__:" + ex.SqliteErrorCode.ToString(CultureInfo.InvariantCulture) + ":" + ex.Message);
         }
         catch (Exception ex)
         {
-            WriteError(result, ex.Message);
+            return CreateError(ex.Message);
         }
     }
 
@@ -110,13 +115,8 @@ public partial class SqliteConnection
         if (result == IntPtr.Zero)
             return;
 
-        var value = Marshal.PtrToStructure<ExtensionResultValue>(result);
-        if (value.ValueType is ExtensionValueType.Text or ExtensionValueType.Blob or ExtensionValueType.Error)
-        {
-            var data = value.Value.Bytes.Data;
-            if (data != IntPtr.Zero)
-                Marshal.FreeHGlobal(data);
-        }
+        var value = Marshal.PtrToStructure<TursoExtensionValue>(result);
+        FreeExtensionValue(value);
     }
 
     private static object?[] ReadArguments(int argc, IntPtr argv)
@@ -125,17 +125,17 @@ public partial class SqliteConnection
             return [];
 
         var args = new object?[argc];
-        var size = Marshal.SizeOf<ExtensionInputValue>();
+        var size = Marshal.SizeOf<TursoExtensionValue>();
         for (var i = 0; i < argc; i++)
         {
-            var value = Marshal.PtrToStructure<ExtensionInputValue>(IntPtr.Add(argv, i * size));
+            var value = Marshal.PtrToStructure<TursoExtensionValue>(IntPtr.Add(argv, i * size));
             args[i] = value.ValueType switch
             {
-                ExtensionValueType.Null => null,
-                ExtensionValueType.Integer => value.Value.IntValue,
-                ExtensionValueType.Real => value.Value.RealValue,
-                ExtensionValueType.Text => ReadText(value.Value.TextValue),
-                ExtensionValueType.Blob => ReadBlob(value.Value.BlobValue),
+                TursoExtensionValueType.Null => null,
+                TursoExtensionValueType.Integer => value.Value.IntValue,
+                TursoExtensionValueType.Float => value.Value.RealValue,
+                TursoExtensionValueType.Text => ReadText(value.Value.TextValue),
+                TursoExtensionValueType.Blob => ReadBlob(value.Value.BlobValue),
                 _ => null
             };
         }
@@ -171,60 +171,118 @@ public partial class SqliteConnection
         return bytes;
     }
 
-    private static void WriteResult(IntPtr result, object? value)
+    private static TursoExtensionValue CreateResult(object? value)
     {
         if (value is null or DBNull)
-        {
-            Marshal.StructureToPtr(ExtensionResultValue.Null(), result, false);
-            return;
-        }
+            return new TursoExtensionValue { ValueType = TursoExtensionValueType.Null };
 
-        switch (value)
+        return value switch
         {
-            case bool boolValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(boolValue ? 1 : 0), result, false);
+            bool boolValue => CreateInteger(boolValue ? 1 : 0),
+            byte byteValue => CreateInteger(byteValue),
+            sbyte sbyteValue => CreateInteger(sbyteValue),
+            short shortValue => CreateInteger(shortValue),
+            ushort ushortValue => CreateInteger(ushortValue),
+            int intValue => CreateInteger(intValue),
+            uint uintValue => CreateInteger(uintValue),
+            long longValue => CreateInteger(longValue),
+            float floatValue => CreateReal(floatValue),
+            double doubleValue => CreateReal(doubleValue),
+            decimal decimalValue => CreateReal((double)decimalValue),
+            byte[] bytes => CreateBlob(bytes),
+            _ => CreateText(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty),
+        };
+    }
+
+    private static TursoExtensionValue CreateInteger(long value)
+        => new() { ValueType = TursoExtensionValueType.Integer, Value = new TursoExtensionValueUnion { IntValue = value } };
+
+    private static TursoExtensionValue CreateReal(double value)
+        => new() { ValueType = TursoExtensionValueType.Float, Value = new TursoExtensionValueUnion { RealValue = value } };
+
+    private static TursoExtensionValue CreateText(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var text = new ExtensionTextValue { Subtype = 0, Text = AllocBytes(bytes), Length = checked((uint)bytes.Length) };
+        var ptr = Marshal.AllocHGlobal(Marshal.SizeOf<ExtensionTextValue>());
+        Marshal.StructureToPtr(text, ptr, false);
+        return new TursoExtensionValue { ValueType = TursoExtensionValueType.Text, Value = new TursoExtensionValueUnion { TextValue = ptr } };
+    }
+
+    private static TursoExtensionValue CreateBlob(byte[] bytes)
+    {
+        var blob = new ExtensionBlobValue { Data = AllocBytes(bytes), Length = (ulong)bytes.Length };
+        var ptr = Marshal.AllocHGlobal(Marshal.SizeOf<ExtensionBlobValue>());
+        Marshal.StructureToPtr(blob, ptr, false);
+        return new TursoExtensionValue { ValueType = TursoExtensionValueType.Blob, Value = new TursoExtensionValueUnion { BlobValue = ptr } };
+    }
+
+    private static TursoExtensionValue CreateError(string message)
+    {
+        var text = CreateText(message);
+        var error = new ExtensionErrorValue { Code = 14, Message = text.Value.TextValue };
+        var ptr = Marshal.AllocHGlobal(Marshal.SizeOf<ExtensionErrorValue>());
+        Marshal.StructureToPtr(error, ptr, false);
+        return new TursoExtensionValue { ValueType = TursoExtensionValueType.Error, Value = new TursoExtensionValueUnion { ErrorValue = ptr } };
+    }
+
+    private static IntPtr AllocBytes(byte[] bytes)
+    {
+        if (bytes.Length == 0)
+            return IntPtr.Zero;
+
+        var data = Marshal.AllocHGlobal(bytes.Length);
+        Marshal.Copy(bytes, 0, data, bytes.Length);
+        return data;
+    }
+
+    private static void FreeExtensionValue(TursoExtensionValue value)
+    {
+        switch (value.ValueType)
+        {
+            case TursoExtensionValueType.Text:
+                FreeText(value.Value.TextValue);
                 break;
-            case byte byteValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(byteValue), result, false);
+            case TursoExtensionValueType.Blob:
+                FreeBlob(value.Value.BlobValue);
                 break;
-            case sbyte sbyteValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(sbyteValue), result, false);
-                break;
-            case short shortValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(shortValue), result, false);
-                break;
-            case ushort ushortValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(ushortValue), result, false);
-                break;
-            case int intValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(intValue), result, false);
-                break;
-            case uint uintValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(uintValue), result, false);
-                break;
-            case long longValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Integer(longValue), result, false);
-                break;
-            case float floatValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Real(floatValue), result, false);
-                break;
-            case double doubleValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Real(doubleValue), result, false);
-                break;
-            case decimal decimalValue:
-                Marshal.StructureToPtr(ExtensionResultValue.Real((double)decimalValue), result, false);
-                break;
-            case byte[] bytes:
-                Marshal.StructureToPtr(ExtensionResultValue.Bytes(ExtensionValueType.Blob, bytes), result, false);
-                break;
-            default:
-                Marshal.StructureToPtr(ExtensionResultValue.Bytes(ExtensionValueType.Text, Encoding.UTF8.GetBytes(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty)), result, false);
+            case TursoExtensionValueType.Error:
+                FreeError(value.Value.ErrorValue);
                 break;
         }
     }
 
-    private static void WriteError(IntPtr result, string message)
-        => Marshal.StructureToPtr(ExtensionResultValue.Bytes(ExtensionValueType.Error, Encoding.UTF8.GetBytes(message)), result, false);
+    private static void FreeText(IntPtr ptr)
+    {
+        if (ptr == IntPtr.Zero)
+            return;
+
+        var text = Marshal.PtrToStructure<ExtensionTextValue>(ptr);
+        if (text.Text != IntPtr.Zero)
+            Marshal.FreeHGlobal(text.Text);
+        Marshal.FreeHGlobal(ptr);
+    }
+
+    private static void FreeBlob(IntPtr ptr)
+    {
+        if (ptr == IntPtr.Zero)
+            return;
+
+        var blob = Marshal.PtrToStructure<ExtensionBlobValue>(ptr);
+        if (blob.Data != IntPtr.Zero)
+            Marshal.FreeHGlobal(blob.Data);
+        Marshal.FreeHGlobal(ptr);
+    }
+
+    private static void FreeError(IntPtr ptr)
+    {
+        if (ptr == IntPtr.Zero)
+            return;
+
+        var error = Marshal.PtrToStructure<ExtensionErrorValue>(ptr);
+        FreeText(error.Message);
+        Marshal.FreeHGlobal(ptr);
+    }
 
     private sealed class ScalarFunctionRegistration(string name, int argc, bool isDeterministic, Func<object?[], object?> invoke)
     {
@@ -254,42 +312,6 @@ public partial class SqliteConnection
         }
     }
 
-    private enum ExtensionValueType
-    {
-        Null = 0,
-        Integer = 1,
-        Real = 2,
-        Text = 3,
-        Blob = 4,
-        Error = 5,
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    private struct ExtensionInputValue
-    {
-        [FieldOffset(0)]
-        public ExtensionValueType ValueType;
-
-        [FieldOffset(8)]
-        public ExtensionInputValueUnion Value;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    private struct ExtensionInputValueUnion
-    {
-        [FieldOffset(0)]
-        public long IntValue;
-
-        [FieldOffset(0)]
-        public double RealValue;
-
-        [FieldOffset(0)]
-        public IntPtr TextValue;
-
-        [FieldOffset(0)]
-        public IntPtr BlobValue;
-    }
-
     [StructLayout(LayoutKind.Sequential)]
     private struct ExtensionTextValue
     {
@@ -306,57 +328,9 @@ public partial class SqliteConnection
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct ExtensionBytes
+    private struct ExtensionErrorValue
     {
-        public IntPtr Data;
-        public nuint Length;
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    private struct ExtensionResultValue
-    {
-        [FieldOffset(0)]
-        public ExtensionValueType ValueType;
-
-        [FieldOffset(8)]
-        public ExtensionResultValueUnion Value;
-
-        public static ExtensionResultValue Null()
-            => new() { ValueType = ExtensionValueType.Null };
-
-        public static ExtensionResultValue Integer(long value)
-            => new() { ValueType = ExtensionValueType.Integer, Value = new ExtensionResultValueUnion { IntValue = value } };
-
-        public static ExtensionResultValue Real(double value)
-            => new() { ValueType = ExtensionValueType.Real, Value = new ExtensionResultValueUnion { RealValue = value } };
-
-        public static ExtensionResultValue Bytes(ExtensionValueType valueType, byte[] bytes)
-        {
-            var data = Marshal.AllocHGlobal(bytes.Length);
-            if (bytes.Length != 0)
-                Marshal.Copy(bytes, 0, data, bytes.Length);
-
-            return new ExtensionResultValue
-            {
-                ValueType = valueType,
-                Value = new ExtensionResultValueUnion
-                {
-                    Bytes = new ExtensionBytes { Data = data, Length = (nuint)bytes.Length }
-                }
-            };
-        }
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    private struct ExtensionResultValueUnion
-    {
-        [FieldOffset(0)]
-        public long IntValue;
-
-        [FieldOffset(0)]
-        public double RealValue;
-
-        [FieldOffset(0)]
-        public ExtensionBytes Bytes;
+        public int Code;
+        public IntPtr Message;
     }
 }

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
@@ -11,8 +11,6 @@ public partial class SqliteConnection : DbConnection
 {
     private const int SQLITE_ERROR = 1;
     private const int SQLITE_CANTOPEN = 14;
-    private const string AdvancedExtensionApisNotSupportedMessage =
-        "SQLite-compatible user-defined functions, aggregates, collations, and extension loading require Turso core managed extension support.";
     private static readonly object SharedMemoryLock = new();
     private static readonly Dictionary<string, int> SharedMemoryReferences = new(StringComparer.OrdinalIgnoreCase);
 
@@ -26,6 +24,8 @@ public partial class SqliteConnection : DbConnection
     private bool _recursiveTriggers;
     private bool _readUncommitted;
     private string? _sharedMemoryPath;
+    private bool _extensionsEnabled;
+    private readonly List<(string File, string? Proc)> _pendingExtensions = [];
 
     public SqliteConnection()
     {
@@ -103,10 +103,12 @@ public partial class SqliteConnection : DbConnection
             _dataSource = filename;
             _readOnly = readOnly;
             _sharedMemoryPath = sharedMemoryPath;
+            ApplyExtensionSettings();
             ApplyConnectionOptions();
             RegisterScalarFunctions();
             RegisterAggregateFunctions();
             RegisterCollations();
+            LoadPendingExtensions();
             OnStateChange(new StateChangeEventArgs(originalState, State));
         }
         catch (TursoException ex)
@@ -312,7 +314,9 @@ public partial class SqliteConnection : DbConnection
 
     public virtual void EnableExtensions(bool enable = true)
     {
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        _extensionsEnabled = enable;
+        if (_database is not null)
+            TursoBindings.EnableLoadExtension(DatabaseHandle, enable);
     }
 
     public virtual void LoadExtension(string file, string? proc = null)
@@ -321,7 +325,13 @@ public partial class SqliteConnection : DbConnection
         if (proc is not null)
             throw new NotSupportedException("Custom extension entry points are not yet supported by the Turso SQLite-compatible provider.");
 
-        throw new NotSupportedException(AdvancedExtensionApisNotSupportedMessage);
+        if (_database is null)
+        {
+            _pendingExtensions.Add((file, proc));
+            return;
+        }
+
+        LoadExtensionCore(file, proc);
     }
 
     public virtual void BackupDatabase(SqliteConnection destination)
@@ -432,6 +442,19 @@ public partial class SqliteConnection : DbConnection
             ExecuteNonQuery("PRAGMA foreign_keys = " + (_connectionOptions.ForeignKeys.Value ? "1" : "0") + ";");
         if (_connectionOptions.RecursiveTriggers)
             _recursiveTriggers = true;
+    }
+
+    private void ApplyExtensionSettings()
+    {
+        if (_extensionsEnabled)
+            TursoBindings.EnableLoadExtension(DatabaseHandle, true);
+    }
+
+    private void LoadPendingExtensions()
+    {
+        foreach (var (file, proc) in _pendingExtensions)
+            LoadExtensionCore(file, proc);
+        _pendingExtensions.Clear();
     }
 
     private void LoadExtensionCore(string file, string? proc)

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
@@ -7,9 +7,6 @@ namespace Turso.Raw.Public;
 
 public static class TursoBindings
 {
-    private const string AdvancedExtensionApisMessage =
-        "SQLite-compatible function, aggregate, collation, and extension-loading APIs require Turso core managed extension support.";
-
     public static TursoDatabaseHandle OpenDatabase(string path)
     {
         ArgumentNullException.ThrowIfNull(path);
@@ -58,7 +55,17 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(contextDestructor);
         ArgumentNullException.ThrowIfNull(valueDestructor);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.RegisterScalarFunction(
+            db,
+            name,
+            argc,
+            deterministic,
+            context,
+            callback,
+            contextDestructor,
+            valueDestructor,
+            out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void RegisterAggregateFunction(
@@ -82,8 +89,21 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(contextDestructor);
         ArgumentNullException.ThrowIfNull(aggregateDestructor);
         ArgumentNullException.ThrowIfNull(valueDestructor);
+        _ = deterministic;
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.RegisterAggregateFunction(
+            db,
+            name,
+            argc,
+            context,
+            init,
+            step,
+            finalize,
+            contextDestructor,
+            aggregateDestructor,
+            valueDestructor,
+            out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void UnregisterFunction(TursoDatabaseHandle db, string name)
@@ -91,7 +111,8 @@ public static class TursoBindings
         db.ThrowIfInvalid();
         ArgumentNullException.ThrowIfNull(name);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.UnregisterFunction(db, name, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void RegisterCollation(
@@ -106,7 +127,8 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(callback);
         ArgumentNullException.ThrowIfNull(contextDestructor);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.RegisterCollation(db, name, context, callback, contextDestructor, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void UnregisterCollation(TursoDatabaseHandle db, string name)
@@ -114,13 +136,15 @@ public static class TursoBindings
         db.ThrowIfInvalid();
         ArgumentNullException.ThrowIfNull(name);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.UnregisterCollation(db, name, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void EnableLoadExtension(TursoDatabaseHandle db, bool enabled)
     {
         db.ThrowIfInvalid();
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.EnableLoadExtension(db, enabled, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void LoadExtension(TursoDatabaseHandle db, string path)
@@ -128,7 +152,8 @@ public static class TursoBindings
         db.ThrowIfInvalid();
         ArgumentNullException.ThrowIfNull(path);
 
-        throw new NotSupportedException(AdvancedExtensionApisMessage);
+        var status = TursoInterop.LoadExtension(db, path, out var errorPtr);
+        ThrowIfError(status, errorPtr);
     }
 
     public static void BindParameter(TursoStatementHandle statement, int index, TursoValue parameter)

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoExtensionCallbacks.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoExtensionCallbacks.cs
@@ -3,16 +3,16 @@ using System.Runtime.InteropServices;
 namespace Turso.Raw.Public;
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public delegate void TursoScalarFunctionCallback(IntPtr context, int argc, IntPtr argv, IntPtr result);
+public delegate TursoExtensionValue TursoScalarFunctionCallback(IntPtr context, int argc, IntPtr argv, IntPtr contextDestructor, IntPtr valueDestructor);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public delegate IntPtr TursoAggregateInitCallback(IntPtr context);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public delegate void TursoAggregateStepCallback(IntPtr context, IntPtr aggregateContext, int argc, IntPtr argv, IntPtr result);
+public delegate TursoExtensionValue TursoAggregateStepCallback(IntPtr context, IntPtr aggregateContext, int argc, IntPtr argv);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-public delegate void TursoAggregateFinalCallback(IntPtr context, IntPtr aggregateContext, IntPtr result);
+public delegate TursoExtensionValue TursoAggregateFinalCallback(IntPtr context, IntPtr aggregateContext);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public delegate int TursoCollationCallback(IntPtr context, IntPtr leftPtr, UIntPtr leftLen, IntPtr rightPtr, UIntPtr rightLen);
@@ -22,3 +22,42 @@ public delegate void TursoContextDestructorCallback(IntPtr context);
 
 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 public delegate void TursoValueDestructorCallback(IntPtr result);
+
+public enum TursoExtensionValueType
+{
+    Null = 0,
+    Integer = 1,
+    Float = 2,
+    Text = 3,
+    Blob = 4,
+    Error = 5,
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public struct TursoExtensionValue
+{
+    [FieldOffset(0)]
+    public TursoExtensionValueType ValueType;
+
+    [FieldOffset(8)]
+    public TursoExtensionValueUnion Value;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public struct TursoExtensionValueUnion
+{
+    [FieldOffset(0)]
+    public long IntValue;
+
+    [FieldOffset(0)]
+    public double RealValue;
+
+    [FieldOffset(0)]
+    public IntPtr TextValue;
+
+    [FieldOffset(0)]
+    public IntPtr BlobValue;
+
+    [FieldOffset(0)]
+    public IntPtr ErrorValue;
+}

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Turso.Raw.Public;
 using Turso.Raw.Public.Handles;
 
 namespace Turso.Raw;
@@ -70,6 +71,65 @@ internal static class TursoInterop
 
     [DllImport(DllName, EntryPoint = "turso_connection_deinit", CallingConvention = CallingConvention.Cdecl)]
     public static extern void ConnectionDeinit(IntPtr connection);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_register_scalar_function", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode RegisterScalarFunction(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        int argc,
+        [MarshalAs(UnmanagedType.I1)] bool deterministic,
+        IntPtr context,
+        TursoScalarFunctionCallback callback,
+        TursoContextDestructorCallback contextDestructor,
+        TursoValueDestructorCallback valueDestructor,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_register_aggregate_function", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode RegisterAggregateFunction(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        int argc,
+        IntPtr context,
+        TursoAggregateInitCallback init,
+        TursoAggregateStepCallback step,
+        TursoAggregateFinalCallback finalize,
+        TursoContextDestructorCallback contextDestructor,
+        TursoContextDestructorCallback aggregateDestructor,
+        TursoValueDestructorCallback valueDestructor,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_unregister_function", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode UnregisterFunction(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_register_collation", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode RegisterCollation(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        IntPtr context,
+        TursoCollationCallback callback,
+        TursoContextDestructorCallback contextDestructor,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_unregister_collation", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode UnregisterCollation(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string name,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_enable_load_extension", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode EnableLoadExtension(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.I1)] bool enabled,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_connection_load_extension", CallingConvention = CallingConvention.Cdecl)]
+    public static extern TursoStatusCode LoadExtension(
+        TursoDatabaseHandle connection,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string path,
+        out IntPtr errorPtr);
 
     [DllImport(DllName, EntryPoint = "turso_connection_prepare_single", CallingConvention = CallingConvention.Cdecl)]
     public static extern TursoStatusCode ConnectionPrepareSingle(

--- a/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
@@ -385,24 +385,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    public void AdvancedApisRequireCoreManagedExtensionSupport()
-    {
-        using var connection = new SqliteConnection("Data Source=:memory:");
-
-        Assert.Throws<NotSupportedException>(() => connection.CreateFunction("test", () => 1L))!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.CreateAggregate<int>("test", value => value))!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.CreateCollation("test", StringComparer.Ordinal.Compare))!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.EnableExtensions())!
-            .Message.Should().Contain("core managed extension support");
-        Assert.Throws<NotSupportedException>(() => connection.LoadExtension("unknown"))!
-            .Message.Should().Contain("core managed extension support");
-    }
-
-    [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionWorksWhenRegisteredBeforeOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -413,7 +395,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionSupportsVariadicArgumentsAndBlobValues()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -425,7 +406,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionReportsNullForNonNullableParameters()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -439,7 +419,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionPropagatesSqliteExceptionCode()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -453,7 +432,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void ScalarFunctionCanBeRemoved()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -468,7 +446,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionWorksWhenRegisteredBeforeOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -485,7 +462,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionSupportsVariadicArgumentsAndNoRows()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -498,7 +474,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionPropagatesSqliteExceptionCode()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -514,7 +489,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionFinalizerErrorLeavesConnectionUsable()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -534,7 +508,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void AggregateFunctionCanBeRemoved()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -550,7 +523,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void CollationWorksWhenRegisteredBeforeOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -561,7 +533,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void CollationStateOverloadCanBeRemoved()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -576,27 +547,23 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
-    public void CustomCollationUnsupportedPathsDoNotFallBackToBinary()
+    public void CustomCollationCanBeUsedInExpressionsAndOrderingButNotSchema()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
         connection.Open();
         connection.CreateCollation("reverse_text", static (left, right) => -string.CompareOrdinal(left, right));
 
         connection.ExecuteScalar<long>("SELECT 'b' > 'a' COLLATE reverse_text;").Should().Be(0);
-
-        Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery("CREATE TABLE Collated(Value TEXT COLLATE reverse_text);"))!
-            .Message.Should().Contain("custom collations are not supported");
-
         connection.ExecuteNonQuery("CREATE TABLE Data(Value TEXT); INSERT INTO Data VALUES ('a'), ('b');");
-        Assert.Throws<SqliteException>(() => connection.ExecuteScalar<string>("SELECT Value FROM Data ORDER BY Value COLLATE reverse_text LIMIT 1;"))!
-            .Message.Should().Contain("custom collations are not supported");
+        connection.ExecuteScalar<string>("SELECT Value FROM Data ORDER BY Value COLLATE reverse_text LIMIT 1;")
+            .Should().Be("b");
+        Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery("CREATE TABLE Collated(Value TEXT COLLATE reverse_text);"))!
+            .Message.Should().Contain("custom collations are not supported in schema definitions");
         Assert.Throws<SqliteException>(() => connection.ExecuteNonQuery("CREATE INDEX Data_Value_Custom ON Data(Value COLLATE reverse_text);"))!
-            .Message.Should().Contain("custom collations are not supported");
+            .Message.Should().Contain("custom collations are not supported in indexes");
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void EnableExtensionsControlsSqlLoadExtension()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -627,7 +594,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void LoadExtensionUsesNativeLoaderEvenWhenSqlFunctionDisabled()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");
@@ -641,7 +607,6 @@ public class SqliteFacadeTests
     }
 
     [Test]
-    [Ignore("Requires Turso core managed extension support.")]
     public void LoadExtensionWhenClosedRunsOnNextOpen()
     {
         using var connection = new SqliteConnection("Data Source=:memory:");

--- a/sdk-kit/Cargo.toml
+++ b/sdk-kit/Cargo.toml
@@ -24,6 +24,7 @@ turso_core = { workspace = true, features = [
     "io_uring",
     "experimental_win_iocp",
 ] }
+turso_ext = { workspace = true }
 turso_sdk_kit_macros = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -45,6 +45,200 @@ pub enum turso_type_t {
     TURSO_TYPE_BLOB = 4,
     TURSO_TYPE_NULL = 5,
 }
+pub const turso_extension_value_type_t_TURSO_EXTENSION_VALUE_NULL: turso_extension_value_type_t = 0;
+pub const turso_extension_value_type_t_TURSO_EXTENSION_VALUE_INTEGER: turso_extension_value_type_t =
+    1;
+pub const turso_extension_value_type_t_TURSO_EXTENSION_VALUE_FLOAT: turso_extension_value_type_t =
+    2;
+pub const turso_extension_value_type_t_TURSO_EXTENSION_VALUE_TEXT: turso_extension_value_type_t = 3;
+pub const turso_extension_value_type_t_TURSO_EXTENSION_VALUE_BLOB: turso_extension_value_type_t = 4;
+pub const turso_extension_value_type_t_TURSO_EXTENSION_VALUE_ERROR: turso_extension_value_type_t =
+    5;
+pub type turso_extension_value_type_t = ::std::os::raw::c_uint;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_OK: turso_extension_result_code_t =
+    0;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_ERROR:
+    turso_extension_result_code_t = 1;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_INVALID_ARGS:
+    turso_extension_result_code_t = 2;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_UNKNOWN:
+    turso_extension_result_code_t = 3;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_OOM: turso_extension_result_code_t =
+    4;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_CORRUPT:
+    turso_extension_result_code_t = 5;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_NOT_FOUND:
+    turso_extension_result_code_t = 6;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_ALREADY_EXISTS:
+    turso_extension_result_code_t = 7;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_PERMISSION_DENIED:
+    turso_extension_result_code_t = 8;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_ABORTED:
+    turso_extension_result_code_t = 9;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_OUT_OF_RANGE:
+    turso_extension_result_code_t = 10;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_UNIMPLEMENTED:
+    turso_extension_result_code_t = 11;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_INTERNAL:
+    turso_extension_result_code_t = 12;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_UNAVAILABLE:
+    turso_extension_result_code_t = 13;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_CUSTOM_ERROR:
+    turso_extension_result_code_t = 14;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_EOF: turso_extension_result_code_t =
+    15;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_READ_ONLY:
+    turso_extension_result_code_t = 16;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_ROWID:
+    turso_extension_result_code_t = 17;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_ROW: turso_extension_result_code_t =
+    18;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_INTERRUPT:
+    turso_extension_result_code_t = 19;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_BUSY: turso_extension_result_code_t =
+    20;
+pub const turso_extension_result_code_t_TURSO_EXTENSION_RESULT_CONSTRAINT_VIOLATION:
+    turso_extension_result_code_t = 21;
+pub type turso_extension_result_code_t = ::std::os::raw::c_uint;
+pub const turso_extension_text_subtype_t_TURSO_EXTENSION_TEXT_TEXT: turso_extension_text_subtype_t =
+    0;
+pub const turso_extension_text_subtype_t_TURSO_EXTENSION_TEXT_JSON: turso_extension_text_subtype_t =
+    1;
+pub type turso_extension_text_subtype_t = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_extension_text_t {
+    pub subtype: turso_extension_text_subtype_t,
+    pub text: *const u8,
+    pub len: u32,
+}
+impl Default for turso_extension_text_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_extension_blob_t {
+    pub data: *const u8,
+    pub size: u64,
+}
+impl Default for turso_extension_blob_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_extension_error_t {
+    pub code: turso_extension_result_code_t,
+    pub message: *mut turso_extension_text_t,
+}
+impl Default for turso_extension_error_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union turso_extension_value_data_t {
+    pub int_value: i64,
+    pub float_value: f64,
+    pub text: *const turso_extension_text_t,
+    pub blob: *const turso_extension_blob_t,
+    pub error: *const turso_extension_error_t,
+}
+impl Default for turso_extension_value_data_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct turso_value_t {
+    pub value_type: turso_extension_value_type_t,
+    pub value: turso_extension_value_data_t,
+}
+impl Default for turso_value_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_agg_ctx_t {
+    pub state: *mut ::std::os::raw::c_void,
+}
+impl Default for turso_agg_ctx_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[doc = " Frees per-registration state supplied to scalar, aggregate, or collation callbacks."]
+pub type turso_context_destructor_t = ::std::option::Option<unsafe extern "C" fn(context: usize)>;
+#[doc = " Frees a value returned by a managed scalar or aggregate callback after Turso copies it."]
+pub type turso_value_destructor_t =
+    ::std::option::Option<unsafe extern "C" fn(result: *mut turso_value_t)>;
+#[doc = " Scalar callback. argv points to argc immutable turso_value_t entries valid only for the call."]
+pub type turso_scalar_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        context: usize,
+        argc: i32,
+        argv: *const turso_value_t,
+        context_destructor: turso_context_destructor_t,
+        value_destructor: turso_value_destructor_t,
+    ) -> turso_value_t,
+>;
+#[doc = " Aggregate initializer. Return value is passed unchanged to step/final/destructor callbacks."]
+pub type turso_aggregate_init_function_t =
+    ::std::option::Option<unsafe extern "C" fn(context: usize) -> *mut turso_agg_ctx_t>;
+#[doc = " Aggregate step callback. argv points to argc immutable turso_value_t entries valid only for the call."]
+pub type turso_aggregate_step_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        context: usize,
+        aggregate_context: *mut turso_agg_ctx_t,
+        argc: i32,
+        argv: *const turso_value_t,
+    ) -> turso_value_t,
+>;
+#[doc = " Aggregate final callback. The aggregate_context is the value returned by the initializer."]
+pub type turso_aggregate_final_function_t = ::std::option::Option<
+    unsafe extern "C" fn(context: usize, aggregate_context: *mut turso_agg_ctx_t) -> turso_value_t,
+>;
+#[doc = " Collation callback. Byte ranges are UTF-8 text valid only for the call. Return follows strcmp ordering."]
+pub type turso_collation_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        context: usize,
+        left_ptr: *const u8,
+        left_len: usize,
+        right_ptr: *const u8,
+        right_len: usize,
+    ) -> i32,
+>;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum turso_tracing_level_t {
@@ -180,6 +374,79 @@ unsafe extern "C" {
 unsafe extern "C" {
     #[doc = " Get last insert rowid for the connection or 0 if no inserts happened before"]
     pub fn turso_connection_last_insert_rowid(self_: *const turso_connection_t) -> i64;
+}
+unsafe extern "C" {
+    #[doc = " Register or replace a per-connection managed scalar function."]
+    pub fn turso_connection_register_scalar_function(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        callback: turso_scalar_function_t,
+        context_destructor: turso_context_destructor_t,
+        value_destructor: turso_value_destructor_t,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    #[doc = " Register or replace a per-connection managed aggregate function."]
+    pub fn turso_connection_register_aggregate_function(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        argc: i32,
+        context: usize,
+        init: turso_aggregate_init_function_t,
+        step: turso_aggregate_step_function_t,
+        finalize: turso_aggregate_final_function_t,
+        context_destructor: turso_context_destructor_t,
+        aggregate_destructor: turso_context_destructor_t,
+        value_destructor: turso_value_destructor_t,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    #[doc = " Unregister a per-connection managed scalar or aggregate function."]
+    pub fn turso_connection_unregister_function(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    #[doc = " Register or replace a per-connection managed collation."]
+    pub fn turso_connection_register_collation(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        context: usize,
+        callback: turso_collation_function_t,
+        context_destructor: turso_context_destructor_t,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    #[doc = " Unregister a per-connection managed collation."]
+    pub fn turso_connection_unregister_collation(
+        self_: *const turso_connection_t,
+        name: *const ::std::os::raw::c_char,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    #[doc = " Enable or disable SQL load_extension() for this connection."]
+    pub fn turso_connection_enable_load_extension(
+        self_: *const turso_connection_t,
+        enabled: bool,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
+}
+unsafe extern "C" {
+    #[doc = " Load an extension library on this connection using Turso's native extension loader."]
+    pub fn turso_connection_load_extension(
+        self_: *const turso_connection_t,
+        path: *const ::std::os::raw::c_char,
+        error_opt_out: *mut *const ::std::os::raw::c_char,
+    ) -> turso_status_code_t;
 }
 unsafe extern "C" {
     #[doc = " Prepare single statement in a connection"]

--- a/sdk-kit/src/capi.rs
+++ b/sdk-kit/src/capi.rs
@@ -21,6 +21,23 @@ pub mod c {
 
 pub static PKG_VERSION_C: &[u8] = concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes();
 
+type CScalarFunction = unsafe extern "C" fn(
+    usize,
+    i32,
+    *const c::turso_value_t,
+    c::turso_context_destructor_t,
+    c::turso_value_destructor_t,
+) -> c::turso_value_t;
+type CValueDestructor = unsafe extern "C" fn(*mut c::turso_value_t);
+type CInitAggFunction = unsafe extern "C" fn(usize) -> *mut c::turso_agg_ctx_t;
+type CStepFunction = unsafe extern "C" fn(
+    usize,
+    *mut c::turso_agg_ctx_t,
+    i32,
+    *const c::turso_value_t,
+) -> c::turso_value_t;
+type CFinalizeFunction = unsafe extern "C" fn(usize, *mut c::turso_agg_ctx_t) -> c::turso_value_t;
+
 #[no_mangle]
 #[signature(c)]
 pub extern "C" fn turso_version() -> *const std::ffi::c_char {
@@ -128,6 +145,234 @@ pub extern "C" fn turso_connection_last_insert_rowid(
     match unsafe { TursoConnection::ref_from_capi(connection) } {
         Ok(connection) => connection.last_insert_rowid(),
         Err(_) => 0,
+    }
+}
+
+/// # Safety
+/// All pointers must be valid according to `turso.h`; callback function pointers must use the declared C ABI.
+#[no_mangle]
+#[signature(c)]
+pub unsafe extern "C" fn turso_connection_register_scalar_function(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    argc: i32,
+    deterministic: bool,
+    context: usize,
+    callback: c::turso_scalar_function_t,
+    context_destructor: c::turso_context_destructor_t,
+    value_destructor: c::turso_value_destructor_t,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let callback = match callback {
+        Some(callback) => {
+            std::mem::transmute::<CScalarFunction, turso_ext::ScalarFunction>(callback)
+        }
+        None => {
+            return unsafe {
+                rsapi::TursoError::Misuse("expected scalar callback, got null pointer".to_string())
+                    .to_capi(error_opt_out)
+            };
+        }
+    };
+    let value_destructor = value_destructor.map(|destructor| {
+        std::mem::transmute::<CValueDestructor, turso_ext::ValueDestructor>(destructor)
+    });
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    match connection.register_external_scalar_function(
+        name.to_string(),
+        argc,
+        deterministic,
+        context,
+        callback,
+        context_destructor,
+        value_destructor,
+    ) {
+        Ok(()) => c::turso_status_code_t::TURSO_OK,
+        Err(err) => unsafe { err.to_capi(error_opt_out) },
+    }
+}
+
+/// # Safety
+/// All pointers must be valid according to `turso.h`; callback function pointers must use the declared C ABI.
+#[no_mangle]
+#[signature(c)]
+pub unsafe extern "C" fn turso_connection_register_aggregate_function(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    argc: i32,
+    context: usize,
+    init: c::turso_aggregate_init_function_t,
+    step: c::turso_aggregate_step_function_t,
+    finalize: c::turso_aggregate_final_function_t,
+    context_destructor: c::turso_context_destructor_t,
+    aggregate_destructor: c::turso_context_destructor_t,
+    value_destructor: c::turso_value_destructor_t,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let (init, step, finalize) = match (init, step, finalize) {
+        (Some(init), Some(step), Some(finalize)) => (
+            std::mem::transmute::<CInitAggFunction, turso_ext::InitAggFunction>(init),
+            std::mem::transmute::<CStepFunction, turso_ext::StepFunction>(step),
+            std::mem::transmute::<CFinalizeFunction, turso_ext::FinalizeFunction>(finalize),
+        ),
+        _ => {
+            return unsafe {
+                rsapi::TursoError::Misuse(
+                    "expected aggregate callbacks, got null pointer".to_string(),
+                )
+                .to_capi(error_opt_out)
+            };
+        }
+    };
+    let value_destructor = value_destructor.map(|destructor| {
+        std::mem::transmute::<CValueDestructor, turso_ext::ValueDestructor>(destructor)
+    });
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    match connection.register_external_aggregate_function(
+        name.to_string(),
+        argc,
+        context,
+        init,
+        step,
+        finalize,
+        context_destructor,
+        aggregate_destructor,
+        value_destructor,
+    ) {
+        Ok(()) => c::turso_status_code_t::TURSO_OK,
+        Err(err) => unsafe { err.to_capi(error_opt_out) },
+    }
+}
+
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_connection_unregister_function(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    match connection.unregister_external_function(name) {
+        Ok(()) => c::turso_status_code_t::TURSO_OK,
+        Err(err) => unsafe { err.to_capi(error_opt_out) },
+    }
+}
+
+/// # Safety
+/// All pointers must be valid according to `turso.h`; callback function pointers must use the declared C ABI.
+#[no_mangle]
+#[signature(c)]
+pub unsafe extern "C" fn turso_connection_register_collation(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    context: usize,
+    callback: c::turso_collation_function_t,
+    context_destructor: c::turso_context_destructor_t,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let callback = match callback {
+        Some(callback) => callback,
+        None => {
+            return unsafe {
+                rsapi::TursoError::Misuse(
+                    "expected collation callback, got null pointer".to_string(),
+                )
+                .to_capi(error_opt_out)
+            };
+        }
+    };
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.register_external_collation(name.to_string(), context, callback, context_destructor);
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_connection_unregister_collation(
+    connection: *const c::turso_connection_t,
+    name: *const std::ffi::c_char,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let name = match unsafe { str_from_c_str(name) } {
+        Ok(name) => name,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.unregister_external_collation(name);
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_connection_enable_load_extension(
+    connection: *const c::turso_connection_t,
+    enabled: bool,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    connection.set_load_extension_enabled(enabled);
+    c::turso_status_code_t::TURSO_OK
+}
+
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_connection_load_extension(
+    connection: *const c::turso_connection_t,
+    path: *const std::ffi::c_char,
+    error_opt_out: *mut *const std::ffi::c_char,
+) -> c::turso_status_code_t {
+    let path = match unsafe { str_from_c_str(path) } {
+        Ok(path) => path,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+    let connection = match unsafe { TursoConnection::ref_from_capi(connection) } {
+        Ok(connection) => connection,
+        Err(err) => return unsafe { err.to_capi(error_opt_out) },
+    };
+
+    match connection.load_extension(path) {
+        Ok(()) => c::turso_status_code_t::TURSO_OK,
+        Err(err) => unsafe { err.to_capi(error_opt_out) },
     }
 }
 

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    ffi::CString,
     fmt::Display,
     ops::Deref,
     sync::{
@@ -33,6 +34,10 @@ assert_send!(TursoDatabase, TursoConnection, TursoStatement);
 assert_sync!(TursoDatabase);
 
 pub use turso_core::types::FromValue;
+pub use turso_ext::{
+    AggCtx, ContextDestructor, FinalizeFunction, InitAggFunction, ResultCode, ScalarFunction,
+    StepFunction, Value as ExtensionValue, ValueDestructor,
+};
 pub type EncryptionOpts = turso_core::EncryptionOpts;
 pub type Value = turso_core::Value;
 pub type ValueRef<'a> = turso_core::types::ValueRef<'a>;
@@ -360,6 +365,14 @@ impl TursoStatusCode {
             TursoStatusCode::Row => capi::c::turso_status_code_t::TURSO_ROW,
             TursoStatusCode::Io => capi::c::turso_status_code_t::TURSO_IO,
         }
+    }
+}
+
+fn result_code_to_result(result: ResultCode, operation: &str) -> Result<(), TursoError> {
+    if result.is_ok() {
+        Ok(())
+    } else {
+        Err(TursoError::Error(format!("{operation} failed: {result}")))
     }
 }
 
@@ -827,6 +840,113 @@ impl TursoConnection {
     }
     pub fn last_insert_rowid(&self) -> i64 {
         self.connection.last_insert_rowid()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_external_scalar_function(
+        &self,
+        name: String,
+        argc: i32,
+        deterministic: bool,
+        context: usize,
+        callback: ScalarFunction,
+        context_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ValueDestructor>,
+    ) -> Result<(), TursoError> {
+        let name = CString::new(name).map_err(|err| {
+            TursoError::Misuse(format!(
+                "external scalar function name contains interior NUL: {err}"
+            ))
+        })?;
+        let api = unsafe { self.connection._build_turso_ext() };
+        let result = unsafe {
+            (api.register_scalar_function)(
+                api.ctx,
+                name.as_ptr(),
+                argc,
+                deterministic,
+                context,
+                callback,
+                context_destructor,
+                value_destructor,
+            )
+        };
+        unsafe { self.connection._free_extension_ctx(api) };
+        result_code_to_result(result, "register external scalar function")
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_external_aggregate_function(
+        &self,
+        name: String,
+        argc: i32,
+        context: usize,
+        init: InitAggFunction,
+        step: StepFunction,
+        finalize: FinalizeFunction,
+        context_destructor: Option<ContextDestructor>,
+        aggregate_destructor: Option<ContextDestructor>,
+        value_destructor: Option<ValueDestructor>,
+    ) -> Result<(), TursoError> {
+        let name = CString::new(name).map_err(|err| {
+            TursoError::Misuse(format!(
+                "external aggregate function name contains interior NUL: {err}"
+            ))
+        })?;
+        let api = unsafe { self.connection._build_turso_ext() };
+        let result = unsafe {
+            (api.register_aggregate_function)(
+                api.ctx,
+                name.as_ptr(),
+                argc,
+                context,
+                init,
+                step,
+                finalize,
+                context_destructor,
+                aggregate_destructor,
+                value_destructor,
+            )
+        };
+        unsafe { self.connection._free_extension_ctx(api) };
+        result_code_to_result(result, "register external aggregate function")
+    }
+
+    pub fn unregister_external_function(&self, name: &str) -> Result<(), TursoError> {
+        let name = CString::new(name).map_err(|err| {
+            TursoError::Misuse(format!(
+                "external function name contains interior NUL: {err}"
+            ))
+        })?;
+        let api = unsafe { self.connection._build_turso_ext() };
+        let result = unsafe { (api.unregister_function)(api.ctx, name.as_ptr()) };
+        unsafe { self.connection._free_extension_ctx(api) };
+        result_code_to_result(result, "unregister external function")
+    }
+
+    pub fn register_external_collation(
+        &self,
+        name: String,
+        context: usize,
+        callback: turso_core::ContextCollationFunction,
+        context_destructor: Option<ContextDestructor>,
+    ) {
+        self.connection
+            .register_external_collation(name, context, callback, context_destructor);
+    }
+
+    pub fn unregister_external_collation(&self, name: &str) {
+        self.connection.unregister_external_collation(name);
+    }
+
+    pub fn set_load_extension_enabled(&self, enabled: bool) {
+        self.connection.set_load_extension_enabled(enabled);
+    }
+
+    pub fn load_extension(&self, path: &str) -> Result<(), TursoError> {
+        turso_core::resolve_ext_path(path)
+            .and_then(|path| self.connection.load_extension(path))
+            .map_err(TursoError::from)
     }
 
     /// prepares single SQL statement

--- a/sdk-kit/turso.h
+++ b/sdk-kit/turso.h
@@ -46,6 +46,109 @@ typedef enum
     TURSO_TYPE_NULL = 5,
 } turso_type_t;
 
+
+typedef enum
+{
+    TURSO_EXTENSION_VALUE_NULL = 0,
+    TURSO_EXTENSION_VALUE_INTEGER = 1,
+    TURSO_EXTENSION_VALUE_FLOAT = 2,
+    TURSO_EXTENSION_VALUE_TEXT = 3,
+    TURSO_EXTENSION_VALUE_BLOB = 4,
+    TURSO_EXTENSION_VALUE_ERROR = 5,
+} turso_extension_value_type_t;
+
+typedef enum
+{
+    TURSO_EXTENSION_RESULT_OK = 0,
+    TURSO_EXTENSION_RESULT_ERROR = 1,
+    TURSO_EXTENSION_RESULT_INVALID_ARGS = 2,
+    TURSO_EXTENSION_RESULT_UNKNOWN = 3,
+    TURSO_EXTENSION_RESULT_OOM = 4,
+    TURSO_EXTENSION_RESULT_CORRUPT = 5,
+    TURSO_EXTENSION_RESULT_NOT_FOUND = 6,
+    TURSO_EXTENSION_RESULT_ALREADY_EXISTS = 7,
+    TURSO_EXTENSION_RESULT_PERMISSION_DENIED = 8,
+    TURSO_EXTENSION_RESULT_ABORTED = 9,
+    TURSO_EXTENSION_RESULT_OUT_OF_RANGE = 10,
+    TURSO_EXTENSION_RESULT_UNIMPLEMENTED = 11,
+    TURSO_EXTENSION_RESULT_INTERNAL = 12,
+    TURSO_EXTENSION_RESULT_UNAVAILABLE = 13,
+    TURSO_EXTENSION_RESULT_CUSTOM_ERROR = 14,
+    TURSO_EXTENSION_RESULT_EOF = 15,
+    TURSO_EXTENSION_RESULT_READ_ONLY = 16,
+    TURSO_EXTENSION_RESULT_ROWID = 17,
+    TURSO_EXTENSION_RESULT_ROW = 18,
+    TURSO_EXTENSION_RESULT_INTERRUPT = 19,
+    TURSO_EXTENSION_RESULT_BUSY = 20,
+    TURSO_EXTENSION_RESULT_CONSTRAINT_VIOLATION = 21,
+} turso_extension_result_code_t;
+
+typedef enum
+{
+    TURSO_EXTENSION_TEXT_TEXT = 0,
+    TURSO_EXTENSION_TEXT_JSON = 1,
+} turso_extension_text_subtype_t;
+
+typedef struct
+{
+    turso_extension_text_subtype_t subtype;
+    const uint8_t *text;
+    uint32_t len;
+} turso_extension_text_t;
+
+typedef struct
+{
+    const uint8_t *data;
+    uint64_t size;
+} turso_extension_blob_t;
+
+typedef struct
+{
+    turso_extension_result_code_t code;
+    turso_extension_text_t *message;
+} turso_extension_error_t;
+
+typedef union
+{
+    int64_t int_value;
+    double float_value;
+    const turso_extension_text_t *text;
+    const turso_extension_blob_t *blob;
+    const turso_extension_error_t *error;
+} turso_extension_value_data_t;
+
+typedef struct
+{
+    turso_extension_value_type_t value_type;
+    turso_extension_value_data_t value;
+} turso_value_t;
+
+typedef struct
+{
+    void *state;
+} turso_agg_ctx_t;
+
+/** Frees per-registration state supplied to scalar, aggregate, or collation callbacks. */
+typedef void (*turso_context_destructor_t)(uintptr_t context);
+
+/** Frees a value returned by a managed scalar or aggregate callback after Turso copies it. */
+typedef void (*turso_value_destructor_t)(turso_value_t *result);
+
+/** Scalar callback. argv points to argc immutable turso_value_t entries valid only for the call. */
+typedef turso_value_t (*turso_scalar_function_t)(uintptr_t context, int32_t argc, const turso_value_t *argv, turso_context_destructor_t context_destructor, turso_value_destructor_t value_destructor);
+
+/** Aggregate initializer. Return value is passed unchanged to step/final/destructor callbacks. */
+typedef turso_agg_ctx_t *(*turso_aggregate_init_function_t)(uintptr_t context);
+
+/** Aggregate step callback. argv points to argc immutable turso_value_t entries valid only for the call. */
+typedef turso_value_t (*turso_aggregate_step_function_t)(uintptr_t context, turso_agg_ctx_t *aggregate_context, int32_t argc, const turso_value_t *argv);
+
+/** Aggregate final callback. The aggregate_context is the value returned by the initializer. */
+typedef turso_value_t (*turso_aggregate_final_function_t)(uintptr_t context, turso_agg_ctx_t *aggregate_context);
+
+/** Collation callback. Byte ranges are UTF-8 text valid only for the call. Return follows strcmp ordering. */
+typedef int32_t (*turso_collation_function_t)(uintptr_t context, const uint8_t *left_ptr, size_t left_len, const uint8_t *right_ptr, size_t right_len);
+
 typedef enum
 {
     TURSO_TRACING_LEVEL_ERROR = 1,
@@ -164,6 +267,66 @@ bool turso_connection_get_autocommit(const turso_connection_t *self);
 
 /** Get last insert rowid for the connection or 0 if no inserts happened before */
 int64_t turso_connection_last_insert_rowid(const turso_connection_t *self);
+
+
+/** Register or replace a per-connection managed scalar function. */
+turso_status_code_t turso_connection_register_scalar_function(
+    const turso_connection_t *self,
+    const char *name,
+    int32_t argc,
+    bool deterministic,
+    uintptr_t context,
+    turso_scalar_function_t callback,
+    turso_context_destructor_t context_destructor,
+    turso_value_destructor_t value_destructor,
+    const char **error_opt_out);
+
+/** Register or replace a per-connection managed aggregate function. */
+turso_status_code_t turso_connection_register_aggregate_function(
+    const turso_connection_t *self,
+    const char *name,
+    int32_t argc,
+    uintptr_t context,
+    turso_aggregate_init_function_t init,
+    turso_aggregate_step_function_t step,
+    turso_aggregate_final_function_t finalize,
+    turso_context_destructor_t context_destructor,
+    turso_context_destructor_t aggregate_destructor,
+    turso_value_destructor_t value_destructor,
+    const char **error_opt_out);
+
+/** Unregister a per-connection managed scalar or aggregate function. */
+turso_status_code_t turso_connection_unregister_function(
+    const turso_connection_t *self,
+    const char *name,
+    const char **error_opt_out);
+
+/** Register or replace a per-connection managed collation. */
+turso_status_code_t turso_connection_register_collation(
+    const turso_connection_t *self,
+    const char *name,
+    uintptr_t context,
+    turso_collation_function_t callback,
+    turso_context_destructor_t context_destructor,
+    const char **error_opt_out);
+
+/** Unregister a per-connection managed collation. */
+turso_status_code_t turso_connection_unregister_collation(
+    const turso_connection_t *self,
+    const char *name,
+    const char **error_opt_out);
+
+/** Enable or disable SQL load_extension() for this connection. */
+turso_status_code_t turso_connection_enable_load_extension(
+    const turso_connection_t *self,
+    bool enabled,
+    const char **error_opt_out);
+
+/** Load an extension library on this connection using Turso's native extension loader. */
+turso_status_code_t turso_connection_load_extension(
+    const turso_connection_t *self,
+    const char *path,
+    const char **error_opt_out);
 
 /** Prepare single statement in a connection */
 turso_status_code_t


### PR DESCRIPTION
## Summary

This is the final SDK-kit/.NET exposure split from the managed API work in #7154. The core dependencies have already landed:

- Scalar callback foundation: #7205
- Extension loading: #7206
- Custom collations: #7207
- Managed aggregate callbacks: #7271

This PR exposes those merged core capabilities through SDK-kit and the .NET bindings.

## Changes

- Adds SDK-kit C/Rust API surface for managed scalar, aggregate, and collation callbacks plus extension loading controls
- Updates generated SDK-kit bindings and public header
- Wires .NET raw interop and facade methods for `CreateFunction`, `CreateAggregate`, `CreateCollation`, `EnableExtensions`, and `LoadExtension`
- Re-enables the previously skipped .NET advanced facade tests

## Notes

The earlier reference branch called direct `Connection::register_external_*` helpers. Those were removed when #7205 landed; this split intentionally routes scalar and aggregate registration through `Connection::_build_turso_ext()` and `ExtensionApi` function pointers, matching the merged core design. Collations and extension loading use the merged direct `Connection` methods.

## Explicitly out of scope

- New core implementation changes beyond consuming merged APIs
- Workflow or simulator changes
- Unrelated package/facade cleanup
- The superseded all-in-one branch #7154

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -q -p turso_sdk_kit --features pure-rust-crypto`
- `cargo clippy -q -p turso_sdk_kit --features pure-rust-crypto --all-targets -- --deny=warnings`
- `cargo build -q -p turso_sdk_kit --features pure-rust-crypto`
- `dotnet test bindings\\dotnet\\src\\Turso.Tests\\Turso.Tests.csproj` — 73 passed, 1 skipped