### PR TITLE
migrate `wal.rs` and dependent callers to use Vec fallible allocations

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1638,7 +1638,7 @@ impl Connection {
                 self.clone(),
                 true,
                 self.get_sync_mode(),
-            );
+            )?;
             loop {
                 match ckpt_sm.step(&()) {
                     Ok(TransitionResult::Continue) => {}

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2394,7 +2394,7 @@ impl Connection {
         shared_wal.page_size() != 0 || shared_wal.last_checksum_and_max_frame().1 != 0
     }
 
-    fn install_database_wal_on_pager(db: &Arc<Database>, pager: &mut Arc<Pager>) {
+    fn install_database_wal_on_pager(db: &Arc<Database>, pager: &mut Arc<Pager>) -> Result<()> {
         let shared_wal = db.shared_wal.clone();
         let last_checksum_and_max_frame = shared_wal.read().last_checksum_and_max_frame();
         let wal = Arc::new(crate::storage::wal::WalFile::new(
@@ -2402,11 +2402,12 @@ impl Connection {
             shared_wal,
             last_checksum_and_max_frame,
             db.buffer_pool.clone(),
-        ));
+        )?);
 
         let pager = Arc::get_mut(pager)
             .expect("fresh attached pager must not be shared before bootstrap or publication");
         pager.set_wal(wal);
+        Ok(())
     }
 
     fn set_mvcc_journal_mode_fresh_db(pager: &Pager) -> Result<()> {
@@ -2627,7 +2628,7 @@ impl Connection {
         // write and MVCC bootstrap agree on the target mode.
         if self.mvcc_enabled() && !db.mvcc_enabled() {
             Self::set_mvcc_journal_mode_fresh_db(&pager)?;
-            Self::install_database_wal_on_pager(&db, &mut pager);
+            Self::install_database_wal_on_pager(&db, &mut pager)?;
             let enc_ctx = pager.io_ctx.read().encryption_context().cloned();
             let mv_store = journal_mode::open_mv_store(
                 db.io.clone(),

--- a/core/json/cache.rs
+++ b/core/json/cache.rs
@@ -178,7 +178,6 @@ impl JsonCacheCell {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
 
     // Helper function to create test Value and Jsonb from JSON string
     fn create_test_pair(json_str: &str) -> (Value, Jsonb) {

--- a/core/json/error.rs
+++ b/core/json/error.rs
@@ -15,6 +15,13 @@ pub enum Error {
         /// The location of the error, if applicable.
         location: Option<usize>,
     },
+    Alloc,
+}
+
+impl From<crate::alloc::TryReserveError> for Error {
+    fn from(_: crate::alloc::TryReserveError) -> Self {
+        Self::Alloc
+    }
 }
 
 impl From<std::io::Error> for Error {
@@ -39,6 +46,7 @@ impl Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Message { ref msg, .. } => write!(formatter, "{msg}"),
+            Self::Alloc => write!(formatter, "out of memory"),
         }
     }
 }
@@ -49,6 +57,7 @@ impl From<Error> for crate::LimboError {
     fn from(err: Error) -> Self {
         match err {
             Error::Message { msg, .. } => crate::LimboError::ParseError(msg),
+            Error::Alloc => crate::LimboError::OutOfMemory,
         }
     }
 }

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -1,3 +1,5 @@
+use crate::alloc::vec;
+use crate::alloc::*;
 use crate::json::error::{Error as PError, Result as PResult};
 use crate::json::Conv;
 use crate::{bail_parse_error, LimboError, Result};
@@ -458,7 +460,7 @@ impl PathOperation for DeleteOperation {
             let nul = JsonbHeader::make_null().into_bytes();
             let nul_bytes = nul.as_bytes();
             json.data.clear();
-            json.data.extend_from_slice(nul_bytes);
+            json.append_from_data_unsafe(nul_bytes)?;
         }
 
         Ok(())
@@ -633,11 +635,11 @@ pub struct SearchOperation {
 }
 
 impl SearchOperation {
-    pub fn new(capacity: usize) -> Self {
-        Self {
+    pub fn new(capacity: usize) -> Result<Self> {
+        Ok(Self {
             mode: PathOperationMode::ReplaceExisting,
-            value: Jsonb::new(capacity, None),
-        }
+            value: Jsonb::new(capacity, None)?,
+        })
     }
 
     pub fn result(self) -> Jsonb {
@@ -661,8 +663,7 @@ impl PathOperation for SearchOperation {
         };
         let (JsonbHeader(_, size), header_size) = json.read_header(idx)?;
         self.value
-            .data
-            .extend_from_slice(&json.data[idx..idx + header_size + size]);
+            .append_from_data_unsafe(&json.data[idx..idx + header_size + size])?;
 
         Ok(())
     }
@@ -904,43 +905,50 @@ pub struct ObjectIteratorState {
 }
 
 impl Jsonb {
-    pub fn new(capacity: usize, data: Option<&[u8]>) -> Self {
+    pub fn empty() -> Self {
+        Self { data: Vec::new() }
+    }
+
+    pub fn new(capacity: usize, data: Option<&[u8]>) -> Result<Self> {
         if let Some(data) = data {
-            return Self {
-                data: data.to_vec(),
-            };
+            return Ok(Self {
+                data: data.to_vec(), // TODO: later have to_vec fallible
+            });
         }
-        Self {
-            data: Vec::with_capacity(capacity),
-        }
+        Ok(Self {
+            data: Vec::try_with_capacity_ext(capacity)?,
+        })
     }
 
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
-    pub fn make_empty_array(size: usize) -> Self {
+    pub fn make_empty_array(size: usize) -> Result<Self> {
         let mut jsonb = Self {
-            data: Vec::with_capacity(size),
+            data: Vec::try_with_capacity_ext(size)?,
         };
         jsonb
             .write_element_header(0, ElementType::ARRAY, 0, false)
             .expect("writing header to new vector should not fail");
-        jsonb
+        Ok(jsonb)
     }
 
-    pub fn make_empty_obj(size: usize) -> Self {
+    pub fn make_empty_obj(size: usize) -> Result<Self> {
         let mut jsonb = Self {
-            data: Vec::with_capacity(size),
+            data: Vec::try_with_capacity_ext(size)?,
         };
         jsonb
             .write_element_header(0, ElementType::OBJECT, 0, false)
             .expect("writing header to new vector should not fail");
-        jsonb
+        Ok(jsonb)
     }
 
-    pub fn append_to_array_unsafe(&mut self, data: &[u8]) {
-        self.data.extend_from_slice(data);
+    pub fn append_from_data_unsafe(
+        &mut self,
+        data: &[u8],
+    ) -> std::result::Result<(), crate::alloc::TryReserveError> {
+        self.data.try_extend(data.iter().copied())
     }
 
     pub fn append_jsonb_to_end(&mut self, mut data: Vec<u8>) {
@@ -1788,7 +1796,7 @@ impl Jsonb {
                         // Write header and content
                         if len <= 11 {
                             self.data
-                                .push((ElementType::TEXT as u8) | ((len as u8) << 4));
+                                .try_push((ElementType::TEXT as u8) | ((len as u8) << 4))?;
                         } else {
                             self.write_element_header(header_pos, ElementType::TEXT, len, false)
                                 .map_err(|_| PError::Message {
@@ -1797,7 +1805,7 @@ impl Jsonb {
                                 })?;
                         }
 
-                        self.data.extend_from_slice(&input[pos..end_pos]);
+                        self.append_from_data_unsafe(&input[pos..end_pos])?;
                         return Ok(end_pos + 1); // Skip past closing quote
                     }
                     break;
@@ -1827,7 +1835,7 @@ impl Jsonb {
 
         // Special case for unquoted JSON5 keys (identifiers)
         if !quoted {
-            self.data.push(quote);
+            self.data.try_push(quote)?;
             len += 1;
 
             if pos < input.len() && input[pos] == b':' {
@@ -1867,33 +1875,33 @@ impl Jsonb {
 
                 match esc {
                     b'b' => {
-                        self.data.extend_from_slice(b"\\b");
+                        self.append_from_data_unsafe(b"\\b")?;
                         len += 2;
                         element_type = ElementType::TEXTJ;
                     }
                     b'f' => {
-                        self.data.extend_from_slice(b"\\f");
+                        self.append_from_data_unsafe(b"\\f")?;
                         len += 2;
                         element_type = ElementType::TEXTJ;
                     }
                     b'n' => {
-                        self.data.extend_from_slice(b"\\n");
+                        self.append_from_data_unsafe(b"\\n")?;
                         len += 2;
                         element_type = ElementType::TEXTJ;
                     }
                     b'r' => {
-                        self.data.extend_from_slice(b"\\r");
+                        self.append_from_data_unsafe(b"\\r")?;
                         len += 2;
                         element_type = ElementType::TEXTJ;
                     }
                     b't' => {
-                        self.data.extend_from_slice(b"\\t");
+                        self.append_from_data_unsafe(b"\\t")?;
                         len += 2;
                         element_type = ElementType::TEXTJ;
                     }
                     b'\\' | b'"' | b'/' => {
-                        self.data.push(b'\\');
-                        self.data.push(esc);
+                        self.data.try_push(b'\\')?;
+                        self.data.try_push(esc)?;
                         len += 2;
                         element_type = ElementType::TEXTJ;
                     }
@@ -1920,29 +1928,29 @@ impl Jsonb {
                             escape_buffer[2 + i] = h;
                         }
 
-                        self.data.extend_from_slice(&escape_buffer[0..6]);
+                        self.append_from_data_unsafe(&escape_buffer[0..6])?;
                         len += 6;
                         pos += 4;
                         element_type = ElementType::TEXTJ;
                     }
                     // JSON5 extensions
                     b'\n' => {
-                        self.data.extend_from_slice(b"\\\n");
+                        self.append_from_data_unsafe(b"\\\n")?;
                         len += 2;
                         element_type = ElementType::TEXT5;
                     }
                     b'\'' => {
-                        self.data.extend_from_slice(b"\\\'");
+                        self.append_from_data_unsafe(b"\\\'")?;
                         len += 2;
                         element_type = ElementType::TEXT5;
                     }
                     b'0' => {
-                        self.data.extend_from_slice(b"\\0");
+                        self.append_from_data_unsafe(b"\\0")?;
                         len += 2;
                         element_type = ElementType::TEXT5;
                     }
                     b'v' => {
-                        self.data.extend_from_slice(b"\\v");
+                        self.append_from_data_unsafe(b"\\v")?;
                         len += 2;
                         element_type = ElementType::TEXT5;
                     }
@@ -1969,7 +1977,7 @@ impl Jsonb {
                             escape_buffer[2 + i] = h;
                         }
 
-                        self.data.extend_from_slice(&escape_buffer[0..4]);
+                        self.append_from_data_unsafe(&escape_buffer[0..4])?;
                         len += 4;
                         pos += 2;
                         element_type = ElementType::TEXT5;
@@ -1989,11 +1997,11 @@ impl Jsonb {
             } else if c <= 0x1F {
                 // Control character
                 element_type = ElementType::TEXT5;
-                self.data.push(c);
+                self.data.try_push(c)?;
                 len += 1;
             } else {
                 // Normal character
-                self.data.push(c);
+                self.data.try_push(c)?;
                 len += 1;
             }
         }
@@ -2028,7 +2036,7 @@ impl Jsonb {
                 is_json5 = true;
                 pos += 1;
             } else {
-                self.data.push(input[pos]);
+                self.data.try_push(input[pos])?;
                 pos += 1;
                 len += 1;
             }
@@ -2042,20 +2050,20 @@ impl Jsonb {
 
         // Check for hex (JSON5)
         if pos < input.len() && input[pos] == b'0' && pos + 1 < input.len() {
-            self.data.push(input[pos]);
+            self.data.try_push(input[pos])?;
             pos += 1;
             len += 1;
             has_digit = true;
 
             if pos < input.len() && (input[pos] == b'x' || input[pos] == b'X') {
                 // Hexadecimal number
-                self.data.push(input[pos]);
+                self.data.try_push(input[pos])?;
                 pos += 1;
                 len += 1;
 
                 let mut has_digit = false;
                 while pos < input.len() && is_hex_digit(input[pos]) {
-                    self.data.push(input[pos]);
+                    self.data.try_push(input[pos])?;
                     pos += 1;
                     len += 1;
                     has_digit = true;
@@ -2109,7 +2117,7 @@ impl Jsonb {
             pos += infinity.len();
 
             // Write Infinity as 9.0e+999
-            self.data.extend_from_slice(b"9.0e+999");
+            self.append_from_data_unsafe(b"9.0e+999")?;
             self.write_element_header(
                 num_start,
                 ElementType::FLOAT5,
@@ -2128,14 +2136,14 @@ impl Jsonb {
         while pos < input.len() {
             match input[pos] {
                 b'0'..=b'9' => {
-                    self.data.push(input[pos]);
+                    self.data.try_push(input[pos])?;
                     pos += 1;
                     len += 1;
                     has_digit = true;
                 }
                 b'.' => {
                     is_float = true;
-                    self.data.push(input[pos]);
+                    self.data.try_push(input[pos])?;
                     pos += 1;
                     len += 1;
 
@@ -2146,13 +2154,13 @@ impl Jsonb {
                 }
                 b'e' | b'E' => {
                     is_float = true;
-                    self.data.push(input[pos]);
+                    self.data.try_push(input[pos])?;
                     pos += 1;
                     len += 1;
 
                     // Optional sign after exponent
                     if pos < input.len() && (input[pos] == b'+' || input[pos] == b'-') {
-                        self.data.push(input[pos]);
+                        self.data.try_push(input[pos])?;
                         pos += 1;
                         len += 1;
                     }
@@ -2211,7 +2219,7 @@ impl Jsonb {
         }
 
         pos += true_lit.len();
-        self.data.push(ElementType::TRUE as u8);
+        self.data.try_push(ElementType::TRUE as u8)?;
 
         Ok(pos)
     }
@@ -2228,7 +2236,7 @@ impl Jsonb {
         }
 
         pos += false_lit.len();
-        self.data.push(ElementType::FALSE as u8);
+        self.data.try_push(ElementType::FALSE as u8)?;
 
         Ok(pos)
     }
@@ -2250,7 +2258,7 @@ impl Jsonb {
             && input[pos + 3] == b'l'
         {
             pos += 4;
-            self.data.push(ElementType::NULL as u8);
+            self.data.try_push(ElementType::NULL as u8)?;
             return Ok(pos);
         }
 
@@ -2261,7 +2269,7 @@ impl Jsonb {
             && (input[pos + 2] == b'n' || input[pos + 2] == b'N')
         {
             pos += 3;
-            self.data.push(ElementType::NULL as u8);
+            self.data.try_push(ElementType::NULL as u8)?;
             return Ok(pos);
         }
 
@@ -2281,7 +2289,7 @@ impl Jsonb {
         if payload_size <= 11 && !size_might_change {
             let header_byte = (element_type as u8) | ((payload_size as u8) << 4);
             if cursor == self.len() {
-                self.data.push(header_byte);
+                self.data.try_push(header_byte)?;
             } else {
                 self.data[cursor] = header_byte;
             }
@@ -2293,7 +2301,7 @@ impl Jsonb {
         let header_len = header_bytes.len();
 
         if cursor == self.len() {
-            self.data.extend_from_slice(header_bytes);
+            self.append_from_data_unsafe(header_bytes)?;
             return Ok(header_len);
         }
 
@@ -2326,8 +2334,10 @@ impl Jsonb {
         Ok(new_len)
     }
 
-    fn from_str(input: &str) -> PResult<Self> {
-        let mut result = Self::new(input.len(), None);
+    pub fn from_str(input: &str) -> PResult<Self> {
+        let mut result = Self {
+            data: Vec::try_with_capacity_ext(input.len())?,
+        };
         let input = input.as_bytes();
 
         if input.is_empty() {
@@ -2368,7 +2378,7 @@ impl Jsonb {
         }
     }
 
-    pub fn from_raw_data(data: &[u8]) -> Self {
+    pub fn from_raw_data(data: &[u8]) -> Result<Self> {
         Self::new(data.len(), Some(data))
     }
 
@@ -2407,7 +2417,7 @@ impl Jsonb {
     ) -> Result<Vec<JsonTraversalResult>> {
         let mut path_iter = path.elements.iter().peekable();
         let mut pos = 0;
-        let mut stack: Vec<JsonTraversalResult> = Vec::with_capacity(path.elements.len());
+        let mut stack: Vec<JsonTraversalResult> = Vec::try_with_capacity_ext(path.elements.len())?;
 
         while let Some(current) = path_iter.next() {
             let next_is_array = matches!(path_iter.peek(), Some(PathElement::ArrayLocator(_)))
@@ -2448,7 +2458,7 @@ impl Jsonb {
                 None => result.field_value_index,
             };
 
-            stack.push(result);
+            stack.try_push(result)?;
         }
 
         Ok(stack)
@@ -2985,7 +2995,7 @@ impl Jsonb {
 
         if patch_header.0 != ElementType::OBJECT {
             self.data.clear();
-            self.data.extend_from_slice(&patch.data);
+            self.append_from_data_unsafe(&patch.data)?;
             return Ok(());
         }
 
@@ -3034,13 +3044,13 @@ impl Jsonb {
                     Cow::Borrowed(key_text)
                 };
 
-                key_values.push((
+                key_values.try_push((
                     key_text,
                     value_header.0,
                     value_cursor,
                     value_header_size,
                     value_header.1,
-                ));
+                ))?;
 
                 patch_key_cursor = value_cursor + value_header_size + value_header.1;
             }
@@ -3049,7 +3059,9 @@ impl Jsonb {
                 // Create a path to this key
                 let mut key_path = path.clone();
 
-                key_path.elements.push(PathElement::Key(key_text, false));
+                key_path
+                    .elements
+                    .try_push(PathElement::Key(key_text, false))?;
 
                 match value_type {
                     ElementType::NULL => {
@@ -3078,7 +3090,7 @@ impl Jsonb {
                             if target_header.0 == ElementType::OBJECT {
                                 work_stack.push_back((key_path, value_cursor));
                             } else {
-                                let patch_obj = Jsonb::new(value_data.len(), Some(value_data));
+                                let patch_obj = Jsonb::new(value_data.len(), Some(value_data))?;
                                 let mut op = ReplaceOperation::new(patch_obj);
                                 result.operate_on_path(&key_path, &mut op)?;
                                 let _ = result.operate_on_path(&key_path, &mut op);
@@ -3089,7 +3101,7 @@ impl Jsonb {
                             let empty_obj = Jsonb::new(
                                 1,
                                 Some(JsonbHeader::make_obj().into_bytes().as_bytes()),
-                            );
+                            )?;
                             let mut op = SetOperation::new(empty_obj);
                             let _ = result.operate_on_path(&key_path, &mut op);
 
@@ -3099,7 +3111,7 @@ impl Jsonb {
                     _ => {
                         let value_data = &patch.data
                             [value_cursor..value_cursor + value_header_size + value_size];
-                        let patch_value = Jsonb::new(value_data.len(), Some(value_data));
+                        let patch_value = Jsonb::new(value_data.len(), Some(value_data))?;
 
                         let mut op = SetOperation::new(patch_value);
 
@@ -3127,27 +3139,31 @@ impl Jsonb {
     pub fn array_iterator_next(
         &self,
         st: &ArrayIteratorState,
-    ) -> Option<((usize, Jsonb), ArrayIteratorState)> {
+    ) -> Result<Option<((usize, Jsonb), ArrayIteratorState)>> {
         if st.cursor >= st.end {
-            return None;
+            return Ok(None);
         }
 
-        let (JsonbHeader(_, payload_len), header_len) = self.read_header(st.cursor).ok()?;
+        let Ok((JsonbHeader(_, payload_len), header_len)) = self.read_header(st.cursor) else {
+            return Ok(None);
+        };
         let start = st.cursor;
-        let stop = start.checked_add(header_len + payload_len)?;
+        let Some(stop) = start.checked_add(header_len + payload_len) else {
+            return Ok(None);
+        };
 
         if stop > st.end || stop > self.data.len() {
-            return None;
+            return Ok(None);
         }
 
-        let elem = Jsonb::new(stop - start, Some(&self.data[start..stop]));
+        let elem = Jsonb::new(stop - start, Some(&self.data[start..stop]))?;
         let next = ArrayIteratorState {
             cursor: stop,
             end: st.end,
             index: st.index + 1,
         };
 
-        Some(((st.index, elem), next))
+        Ok(Some(((st.index, elem), next)))
     }
 
     pub fn object_iterator(&self) -> Result<ObjectIteratorState> {
@@ -3162,42 +3178,51 @@ impl Jsonb {
         }
     }
 
+    #[expect(clippy::type_complexity)]
     pub fn object_iterator_next(
         &self,
         st: &ObjectIteratorState,
-    ) -> Option<((usize, Jsonb, Jsonb), ObjectIteratorState)> {
+    ) -> Result<Option<((usize, Jsonb, Jsonb), ObjectIteratorState)>> {
         if st.cursor >= st.end {
-            return None;
+            return Ok(None);
         }
 
         // key
-        let (JsonbHeader(key_ty, key_len), key_hdr_len) = self.read_header(st.cursor).ok()?;
+        let Ok((JsonbHeader(key_ty, key_len), key_hdr_len)) = self.read_header(st.cursor) else {
+            return Ok(None);
+        };
         if !key_ty.is_valid_key() {
-            return None;
+            return Ok(None);
         }
         let key_start = st.cursor;
-        let key_stop = key_start.checked_add(key_hdr_len + key_len)?;
+        let Some(key_stop) = key_start.checked_add(key_hdr_len + key_len) else {
+            return Ok(None);
+        };
         if key_stop > st.end || key_stop > self.data.len() {
-            return None;
+            return Ok(None);
         }
 
         // value
-        let (JsonbHeader(_, val_len), val_hdr_len) = self.read_header(key_stop).ok()?;
+        let Ok((JsonbHeader(_, val_len), val_hdr_len)) = self.read_header(key_stop) else {
+            return Ok(None);
+        };
         let val_start = key_stop;
-        let val_stop = val_start.checked_add(val_hdr_len + val_len)?;
+        let Some(val_stop) = val_start.checked_add(val_hdr_len + val_len) else {
+            return Ok(None);
+        };
         if val_stop > st.end || val_stop > self.data.len() {
-            return None;
+            return Ok(None);
         }
 
-        let key = Jsonb::new(key_stop - key_start, Some(&self.data[key_start..key_stop]));
-        let value = Jsonb::new(val_stop - val_start, Some(&self.data[val_start..val_stop]));
+        let key = Jsonb::new(key_stop - key_start, Some(&self.data[key_start..key_stop]))?;
+        let value = Jsonb::new(val_stop - val_start, Some(&self.data[val_start..val_stop]))?;
         let next = ObjectIteratorState {
             cursor: val_stop,
             end: st.end,
             index: st.index + 1,
         };
 
-        Some(((st.index, key, value), next))
+        Ok(Some(((st.index, key, value), next)))
     }
 
     /// If the iterator points at a container value, return an iterator for that container.
@@ -3484,11 +3509,12 @@ fn is_json_ok(ch: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc::vec;
 
     #[test]
     fn test_null_serialization() {
         // Create JSONB with null value
-        let mut jsonb = Jsonb::new(10, None);
+        let mut jsonb = Jsonb::new(10, None).unwrap();
         jsonb.data.push(ElementType::NULL as u8);
 
         // Test serialization
@@ -3503,12 +3529,12 @@ mod tests {
     #[test]
     fn test_boolean_serialization() {
         // True
-        let mut jsonb_true = Jsonb::new(10, None);
+        let mut jsonb_true = Jsonb::new(10, None).unwrap();
         jsonb_true.data.push(ElementType::TRUE as u8);
         assert_eq!(jsonb_true.to_string().unwrap(), "true");
 
         // False
-        let mut jsonb_false = Jsonb::new(10, None);
+        let mut jsonb_false = Jsonb::new(10, None).unwrap();
         jsonb_false.data.push(ElementType::FALSE as u8);
         assert_eq!(jsonb_false.to_string().unwrap(), "false");
 
@@ -3575,7 +3601,7 @@ mod tests {
             93,  // ']'
         ];
 
-        let jsonb = Jsonb::from_raw_data(&data);
+        let jsonb = Jsonb::from_raw_data(&data).unwrap();
         // This should not panic - the fix uses byte-level checks that handle
         // non-ASCII safely. The malformed data is rejected as invalid INT5,
         // matching SQLite's "malformed JSON" behavior.
@@ -3590,7 +3616,7 @@ mod tests {
         assert!(valid.to_string().is_ok());
 
         // Malformed JSONB with invalid element type should error
-        let malformed = Jsonb::from_raw_data(&[0xFF]);
+        let malformed = Jsonb::from_raw_data(&[0xFF]).unwrap();
         let err = malformed.to_string().unwrap_err();
         assert!(err.to_string().contains("Invalid element type"));
 
@@ -3598,14 +3624,16 @@ mod tests {
         let bad_int5 = Jsonb::from_raw_data(&[
             0x34, // INT5 header, 3 bytes payload
             b'a', b'b', b'c', // not a valid number
-        ]);
+        ])
+        .unwrap();
         let err = bad_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
 
         // Empty INT5 payload should error
         let empty_int5 = Jsonb::from_raw_data(&[
             0x04, // INT5 header, 0 bytes payload
-        ]);
+        ])
+        .unwrap();
         let err = empty_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
 
@@ -3613,14 +3641,16 @@ mod tests {
         let sign_only_int5 = Jsonb::from_raw_data(&[
             0x14, // INT5 header, 1 byte payload
             b'+',
-        ]);
+        ])
+        .unwrap();
         let err = sign_only_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
 
         let minus_only_int5 = Jsonb::from_raw_data(&[
             0x14, // INT5 header, 1 byte payload
             b'-',
-        ]);
+        ])
+        .unwrap();
         let err = minus_only_int5.to_string().unwrap_err();
         assert!(err.to_string().contains("malformed JSON"));
     }
@@ -4027,7 +4057,7 @@ world""#,
         let binary_data = parsed.data;
 
         // Create a new Jsonb from the binary data
-        let from_binary = Jsonb::new(0, Some(&binary_data));
+        let from_binary = Jsonb::new(0, Some(&binary_data)).unwrap();
         assert_eq!(from_binary.to_string().unwrap(), original);
     }
 
@@ -4058,7 +4088,7 @@ world""#,
         let mut invalid = jsonb.data;
         if !invalid.is_empty() {
             invalid[0] = 0xFF; // Invalid element type
-            let jsonb = Jsonb::new(0, Some(&invalid));
+            let jsonb = Jsonb::new(0, Some(&invalid)).unwrap();
             assert!(jsonb.element_type().is_err());
         }
     }
@@ -4101,7 +4131,7 @@ world""#,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // u64::MAX as payload size
             b'a', b'b', b'c', // some actual data (doesn't matter, cursor+len will overflow)
         ];
-        let jsonb = Jsonb::new(0, Some(&malformed_text));
+        let jsonb = Jsonb::new(0, Some(&malformed_text)).unwrap();
         let result = jsonb.to_string();
         assert!(result.is_err());
         assert!(
@@ -4116,7 +4146,7 @@ world""#,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // u64::MAX as payload size
             0x01, // NULL element inside (doesn't matter, cursor+len will overflow)
         ];
-        let jsonb = Jsonb::new(0, Some(&malformed_array));
+        let jsonb = Jsonb::new(0, Some(&malformed_array)).unwrap();
         let result = jsonb.to_string();
         assert!(result.is_err());
         assert!(
@@ -4131,7 +4161,7 @@ world""#,
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // u64::MAX as payload size
             0x17, b'k', // TEXT key "k" (doesn't matter, cursor+len will overflow)
         ];
-        let jsonb = Jsonb::new(0, Some(&malformed_object));
+        let jsonb = Jsonb::new(0, Some(&malformed_object)).unwrap();
         let result = jsonb.to_string();
         assert!(result.is_err());
         assert!(
@@ -4144,6 +4174,7 @@ world""#,
 #[cfg(test)]
 mod path_operations_tests {
     use super::*;
+    use crate::alloc::vec;
     use crate::json::path::{JsonPath, PathElement};
     use std::borrow::Cow;
 
@@ -4381,7 +4412,7 @@ mod path_operations_tests {
         let mut jsonb = Jsonb::from_str(json_str).unwrap();
 
         // Create a search operation
-        let mut operation = SearchOperation::new(100);
+        let mut operation = SearchOperation::new(100).unwrap();
 
         // Create a path to the "person" property
         let path = create_path(vec![

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -84,7 +84,7 @@ pub fn convert_dbtype_to_raw_jsonb(data: &Value) -> crate::Result<Vec<u8>> {
 }
 
 pub fn json_from_raw_bytes_agg(data: &[u8], raw: bool) -> crate::Result<Value> {
-    let mut json = Jsonb::from_raw_data(data);
+    let mut json = Jsonb::from_raw_data(data)?;
     let el_type = json.element_type()?;
     json.finalize_unsafe(el_type)?;
     if raw {
@@ -107,23 +107,32 @@ fn parse_as_json_text(slice: &[u8], mode: Conv) -> crate::Result<Jsonb> {
     Jsonb::from_str_with_mode(str, mode).map_err(Into::into)
 }
 
-fn is_jsonb_blob(slice: &[u8]) -> bool {
+fn is_jsonb_blob(slice: &[u8]) -> crate::Result<bool> {
     let Ok((header, header_offset)) = JsonbHeader::from_slice(0, slice) else {
-        return false;
+        return Ok(false);
     };
     let payload_size = header.payload_size();
     let Some(total_expected) = header_offset.checked_add(payload_size) else {
-        return false;
+        return Ok(false);
     };
     if total_expected != slice.len() {
-        return false;
+        return Ok(false);
     }
 
-    let jsonb = Jsonb::from_raw_data(slice);
-    if header.is_scalar() || payload_size <= JSONB_AMBIGUOUS_PAYLOAD_MAX {
-        jsonb.is_valid()
-    } else {
-        jsonb.element_type().is_ok()
+    let jsonb = Jsonb::from_raw_data(slice)?;
+    Ok(
+        if header.is_scalar() || payload_size <= JSONB_AMBIGUOUS_PAYLOAD_MAX {
+            jsonb.is_valid()
+        } else {
+            jsonb.element_type().is_ok()
+        },
+    )
+}
+
+fn malformed_json_or_alloc(err: JsonError) -> LimboError {
+    match err {
+        JsonError::Message { .. } => LimboError::ParseError("malformed JSON".to_string()),
+        JsonError::Alloc => LimboError::OutOfMemory,
     }
 }
 
@@ -141,7 +150,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                 str.push('"');
                 Jsonb::from_str(&str)
             };
-            res.map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+            res.map_err(malformed_json_or_alloc)
         }
         ValueRef::Blob(blob) => {
             let bytes = blob;
@@ -167,7 +176,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                         if total_expected != slice.len() {
                             parse_as_json_text(slice, strict)?
                         } else {
-                            let jsonb = Jsonb::from_raw_data(slice);
+                            let jsonb = Jsonb::from_raw_data(slice)?;
                             let is_valid_json = if payload_size <= 7 {
                                 jsonb.is_valid()
                             } else {
@@ -188,7 +197,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
         }
         ValueRef::Null => Ok(Jsonb::from_raw_data(
             JsonbHeader::make_null().into_bytes().as_bytes(),
-        )),
+        )?),
         ValueRef::Numeric(Numeric::Float(float)) => {
             let float: f64 = float.into();
             // Handle infinity for JSON compatibility with SQLite (#4196)
@@ -198,8 +207,7 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                 } else {
                     "9.0e+999"
                 };
-                Jsonb::from_str(json_str)
-                    .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+                Jsonb::from_str(json_str).map_err(malformed_json_or_alloc)
             } else {
                 let mut buff = ryu::Buffer::new();
                 let s_ryu = buff.format(float);
@@ -223,12 +231,12 @@ pub fn convert_ref_dbtype_to_jsonb(val: ValueRef<'_>, strict: Conv) -> crate::Re
                     inner.push_str(exponent);
                 }
 
-                Jsonb::from_str(&s)
-                    .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))
+                Jsonb::from_str(&s).map_err(malformed_json_or_alloc)
             }
         }
-        ValueRef::Numeric(Numeric::Integer(int)) => Jsonb::from_str(&int.to_string())
-            .map_err(|_| LimboError::ParseError("malformed JSON".to_string())),
+        ValueRef::Numeric(Numeric::Integer(int)) => {
+            Jsonb::from_str(&int.to_string()).map_err(malformed_json_or_alloc)
+        }
     }
 }
 
@@ -245,7 +253,7 @@ where
     I: IntoIterator<IntoIter = E, Item = V>,
 {
     let values = values.into_iter();
-    let mut json = Jsonb::make_empty_array(values.len());
+    let mut json = Jsonb::make_empty_array(values.len())?;
 
     for value in values {
         let value = value.as_value_ref();
@@ -267,7 +275,7 @@ where
     I: IntoIterator<IntoIter = E, Item = V>,
 {
     let values = values.into_iter();
-    let mut json = Jsonb::make_empty_array(values.len());
+    let mut json = Jsonb::make_empty_array(values.len())?;
 
     for value in values {
         let value = value.as_value_ref();
@@ -302,7 +310,7 @@ pub fn json_array_length(
     let path = json_path_from_db_value(path.expect("We already checked none"), true)?;
 
     if let Some(path) = path {
-        let mut op = SearchOperation::new(json.len() / 2);
+        let mut op = SearchOperation::new(json.len() / 2)?;
         let _ = json.operate_on_path(&path, &mut op);
         if let Ok(len) = op.result().array_len() {
             return Ok(Value::from_i64(len as i64));
@@ -415,7 +423,7 @@ pub fn json_arrow_extract(
     if let Some(path) = json_path_from_db_value(&path, false)? {
         let make_jsonb_fn = curry_convert_dbtype_to_jsonb(Conv::Strict);
         let mut json = json_cache.get_or_insert_with(value, make_jsonb_fn)?;
-        let mut op = SearchOperation::new(json.len());
+        let mut op = SearchOperation::new(json.len())?;
         let res = json.operate_on_path(&path, &mut op);
         let extracted = op.result();
         if res.is_ok() {
@@ -442,7 +450,7 @@ pub fn json_arrow_shift_extract(
     if let Some(path) = json_path_from_db_value(&path, false)? {
         let make_jsonb_fn = curry_convert_dbtype_to_jsonb(Conv::Strict);
         let mut json = json_cache.get_or_insert_with(value, make_jsonb_fn)?;
-        let mut op = SearchOperation::new(json.len());
+        let mut op = SearchOperation::new(json.len())?;
         let res = json.operate_on_path(&path, &mut op);
         let extracted = op.result();
         let element_type = match extracted.element_type() {
@@ -527,7 +535,7 @@ where
     V: AsValueRef,
     E: ExactSizeIterator<Item = V>,
 {
-    let null = Jsonb::from_raw_data(JsonbHeader::make_null().into_bytes().as_bytes());
+    let null = Jsonb::from_raw_data(JsonbHeader::make_null().into_bytes().as_bytes())?;
     if paths.len() == 1 {
         let first_path = paths.next().ok_or_else(|| {
             crate::LimboError::InternalError("paths should have one element".to_string())
@@ -535,7 +543,7 @@ where
         if let Some(path) = json_path_from_db_value(&first_path, true)? {
             let mut json = value;
 
-            let mut op = SearchOperation::new(json.len());
+            let mut op = SearchOperation::new(json.len())?;
             let res = json.operate_on_path(&path, &mut op);
             let extracted = op.result();
             let element_type = match extracted.element_type() {
@@ -553,19 +561,19 @@ where
     }
 
     let mut json = value;
-    let mut result = Jsonb::make_empty_array(json.len());
+    let mut result = Jsonb::make_empty_array(json.len())?;
 
     // TODO: make an op to avoid creating new json for every path element
     for path in paths {
         let path = json_path_from_db_value(&path, true);
         if let Some(path) = path? {
-            let mut op = SearchOperation::new(json.len());
+            let mut op = SearchOperation::new(json.len())?;
             let res = json.operate_on_path(&path, &mut op);
             let extracted = op.result();
             if res.is_ok() {
-                result.append_to_array_unsafe(&extracted.data());
+                result.append_from_data_unsafe(&extracted.data())?;
             } else {
-                result.append_to_array_unsafe(JsonbHeader::make_null().into_bytes().as_bytes());
+                result.append_from_data_unsafe(JsonbHeader::make_null().into_bytes().as_bytes())?;
             }
         } else {
             return Ok((null, ElementType::NULL));
@@ -727,7 +735,7 @@ fn json_path_from_db_value<'a>(
 
 pub fn json_error_position(json: impl AsValueRef) -> crate::Result<Value> {
     match json.as_value_ref() {
-        ValueRef::Text(t) => match Jsonb::from_str(t.as_str()) {
+        ValueRef::Text(t) => match <Jsonb as FromStr>::from_str(t.as_str()) {
             Ok(_) => Ok(Value::from_i64(0)),
             Err(JsonError::Message { location, .. }) => {
                 if let Some(loc) = location {
@@ -739,6 +747,7 @@ pub fn json_error_position(json: impl AsValueRef) -> crate::Result<Value> {
                     ))
                 }
             }
+            Err(JsonError::Alloc) => Err(LimboError::OutOfMemory),
         },
         ValueRef::Blob(_) => {
             bail_parse_error!("Unsupported")
@@ -761,7 +770,7 @@ where
     if values.len() % 2 != 0 {
         bail_constraint_error!("json_object() requires an even number of arguments")
     }
-    let mut json = Jsonb::make_empty_obj(values.len() * 50);
+    let mut json = Jsonb::make_empty_obj(values.len() * 50)?;
 
     // TODO: when `array_chunks` is stabilized we can chunk by 2 here
     while values.len() > 1 {
@@ -801,7 +810,7 @@ where
     if values.len() % 2 != 0 {
         bail_constraint_error!("json_object() requires an even number of arguments")
     }
-    let mut json = Jsonb::make_empty_obj(values.len() * 50);
+    let mut json = Jsonb::make_empty_obj(values.len() * 50)?;
 
     // TODO: when `array_chunks` is stabilized we can chunk by 2 here
     while values.len() > 1 {
@@ -833,27 +842,35 @@ where
 
 /// Tries to convert the value to jsonb. Returns Value::from_i64(1) if the conversion
 /// succeeded, and Value::from_i64(0) if it didn't.
-pub fn is_json_valid(json_value: impl AsValueRef) -> Value {
+pub fn is_json_valid(json_value: impl AsValueRef) -> crate::Result<Value> {
     let json_value = json_value.as_value_ref();
     match json_value {
-        ValueRef::Null => Value::Null,
+        ValueRef::Null => Ok(Value::Null),
         ValueRef::Blob(blob) => {
             let index = blob
                 .iter()
                 .position(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
                 .unwrap_or(blob.len());
             let slice = &blob[index..];
-            if is_jsonb_blob(slice) {
-                Value::from_i64(0)
+            if is_jsonb_blob(slice)? {
+                Ok(Value::from_i64(0))
             } else {
-                parse_as_json_text(slice, Conv::Strict)
-                    .map(|_| Value::from_i64(1))
-                    .unwrap_or_else(|_| Value::from_i64(0))
+                match parse_as_json_text(slice, Conv::Strict) {
+                    Ok(_) => Ok(Value::from_i64(1)),
+                    Err(LimboError::ParseError(_)) => Ok(Value::from_i64(0)),
+                    Err(err) => Err(err),
+                }
             }
         }
-        _ => convert_dbtype_to_jsonb(json_value, Conv::Strict)
-            .map(|_| Value::from_i64(1))
-            .unwrap_or_else(|_| Value::from_i64(0)),
+        _ => {
+            let is_valid = convert_dbtype_to_jsonb(json_value, Conv::Strict)
+                .map(|_| true)
+                .or_else(|err| match err {
+                    LimboError::ParseError(_) => Ok(false),
+                    err => Err(err),
+                })?;
+            Ok(Value::from_i64(is_valid as i64))
+        }
     }
 }
 
@@ -1870,6 +1887,6 @@ mod tests {
     fn test_is_jsonb_blob_rejects_scalar_like_overlap_header() {
         let overlapping_scalar = b"|1234567";
         assert_eq!(overlapping_scalar.len(), JSONB_AMBIGUOUS_PAYLOAD_MAX + 1);
-        assert!(!is_jsonb_blob(overlapping_scalar));
+        assert!(!is_jsonb_blob(overlapping_scalar).unwrap());
     }
 }

--- a/core/json/ops.rs
+++ b/core/json/ops.rs
@@ -43,7 +43,7 @@ pub fn json_patch(
         target = patch;
     } else {
         if target.element_type()? != super::jsonb::ElementType::OBJECT {
-            target = super::jsonb::Jsonb::make_empty_obj(0);
+            target = super::jsonb::Jsonb::make_empty_obj(0)?;
         }
         target.patch(&patch)?;
     }
@@ -75,7 +75,7 @@ pub fn jsonb_patch(
         target = patch;
     } else {
         if target.element_type()? != super::jsonb::ElementType::OBJECT {
-            target = super::jsonb::Jsonb::make_empty_obj(0);
+            target = super::jsonb::Jsonb::make_empty_obj(0)?;
         }
         target.patch(&patch)?;
     }

--- a/core/json/path.rs
+++ b/core/json/path.rs
@@ -1,3 +1,4 @@
+use crate::alloc::*;
 use crate::bail_parse_error;
 use std::borrow::Cow;
 
@@ -72,7 +73,7 @@ pub fn json_path(path: &str) -> crate::Result<JsonPath<'_>> {
     let mut index_state = ArrayIndexState::Start;
     let mut key_start = 0;
     let mut index_buffer: i128 = 0;
-    let mut path_components = Vec::with_capacity(estimate_path_capacity(path));
+    let mut path_components = Vec::try_with_capacity_ext(estimate_path_capacity(path))?;
     let mut path_iter = path.char_indices();
 
     while let Some(ch) = path_iter.next() {
@@ -140,7 +141,7 @@ fn handle_start(
 ) -> crate::Result<()> {
     match ch {
         (_, '$') => {
-            path_components.push(PathElement::Root());
+            path_components.try_push(PathElement::Root())?;
             *parser_state = PPState::AfterRoot;
             Ok(())
         }
@@ -195,7 +196,7 @@ fn handle_in_key<'a>(
                 } else {
                     *key_start = idx + ch.1.len_utf8();
                 }
-                path_components.push(PathElement::Key(Cow::Borrowed(key), false));
+                path_components.try_push(PathElement::Key(Cow::Borrowed(key), false))?;
             } else {
                 bail_parse_error!("Bad json path: {}", path)
             }
@@ -226,7 +227,7 @@ fn handle_quoted_key<'a>(
             '"' => {
                 if key_content_start <= idx {
                     let key = &path[key_content_start..idx];
-                    path_components.push(PathElement::Key(Cow::Borrowed(key), true));
+                    path_components.try_push(PathElement::Key(Cow::Borrowed(key), true))?;
                     *parser_state = PPState::ExpectDotOrBracket;
                     return Ok(());
                 }
@@ -268,7 +269,7 @@ fn handle_array_index<'a>(
         }
         (ArrayIndexState::AfterHash, ']') => {
             *parser_state = PPState::ExpectDotOrBracket;
-            path_components.push(PathElement::ArrayLocator(None));
+            path_components.try_push(PathElement::ArrayLocator(None))?;
         }
         (ArrayIndexState::CollectingNumbers, '0'..='9') => {
             let (new_num, is_max) = collect_num(
@@ -286,7 +287,7 @@ fn handle_array_index<'a>(
         (ArrayIndexState::IsMax, '0'..='9') => (),
         (ArrayIndexState::CollectingNumbers | ArrayIndexState::IsMax, ']') => {
             *parser_state = PPState::ExpectDotOrBracket;
-            path_components.push(PathElement::ArrayLocator(Some(*index_buffer as i32)));
+            path_components.try_push(PathElement::ArrayLocator(Some(*index_buffer as i32)))?;
         }
         (_, _) => bail_parse_error!("Bad json path: {}", path),
     }
@@ -335,7 +336,7 @@ fn handle_bracket_quoted_key<'a>(
     match path_iter.next() {
         Some((_, ']')) => {
             let key = &path[key_content_start..key_end];
-            path_components.push(PathElement::BracketQuotedKey(Cow::Borrowed(key)));
+            path_components.try_push(PathElement::BracketQuotedKey(Cow::Borrowed(key)))?;
             *parser_state = PPState::ExpectDotOrBracket;
             Ok(())
         }
@@ -404,7 +405,7 @@ fn finalize_path<'a>(
                 {
                     bail_parse_error!("Bad json path: {}", path)
                 }
-                path_components.push(PathElement::Key(Cow::Borrowed(key), false));
+                path_components.try_push(PathElement::Key(Cow::Borrowed(key), false))?;
             } else {
                 bail_parse_error!("Bad json path: {}", path)
             }
@@ -417,6 +418,7 @@ fn finalize_path<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc::vec;
 
     #[test]
     fn test_json_path_root() {

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -1,3 +1,4 @@
+use crate::alloc::*;
 use crate::sync::{Arc, RwLock};
 use std::iter::successors;
 use std::result::Result;
@@ -75,7 +76,7 @@ impl InternalVirtualTable for JsonVirtualTable {
     ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor + 'static>>> {
         Ok(Arc::new(RwLock::new(JsonEachCursor::empty(
             self.traversal_mode.clone(),
-        ))))
+        )?)))
     }
 
     fn best_index(
@@ -83,13 +84,14 @@ impl InternalVirtualTable for JsonVirtualTable {
         constraints: &[turso_ext::ConstraintInfo],
         _order_by: &[turso_ext::OrderByInfo],
     ) -> Result<turso_ext::IndexInfo, ResultCode> {
-        let mut usages = vec![
+        let mut usages = try_vec![
             ConstraintUsage {
                 argv_index: None,
                 omit: false
             };
             constraints.len()
-        ];
+        ]
+        .map_err(|_| ResultCode::OoM)?;
 
         let mut json_idx: Option<usize> = None;
         let mut path_idx: Option<usize> = None;
@@ -203,22 +205,22 @@ struct TraversalState {
 }
 
 impl JsonEachCursor {
-    fn empty(traversal_mode: JsonTraversalMode) -> Self {
-        Self {
+    fn empty(traversal_mode: JsonTraversalMode) -> Result<Self, LimboError> {
+        Ok(Self {
             rowid: 0,
-            json: Jsonb::new(0, None),
+            json: Jsonb::empty(),
             traversal_states: Vec::new(),
-            path_to_current_value: InPlaceJsonPath::new_root(),
-            columns: Columns::default(),
+            path_to_current_value: InPlaceJsonPath::new_root()?,
+            columns: Columns::empty(),
             traversal_mode,
-        }
+        })
     }
 
     fn push_state(
         &mut self,
         iterator_state: IteratorState,
         innermost_container_cursor: InPlaceJsonPathCursor,
-    ) {
+    ) -> Result<(), TryReserveError> {
         let parent_id = self
             .traversal_states
             .last()
@@ -230,12 +232,13 @@ impl JsonEachCursor {
             _ => parent_id,
         };
 
-        self.traversal_states.push(TraversalState {
+        self.traversal_states.try_push(TraversalState {
             iterator_state,
             parent_id,
             innermost_container_id: innermost_container,
             innermost_container_cursor,
-        });
+        })?;
+        Ok(())
     }
 
     fn peek_state(&self) -> Option<&TraversalState> {
@@ -294,7 +297,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
 
         self.json = root_json;
         self.path_to_current_value =
-            InPlaceJsonPath::from_json_path(path.to_owned(), json_path(path)?);
+            InPlaceJsonPath::from_json_path(path.to_owned(), json_path(path)?)?;
         let iterator_state = json_iterator_from(&self.json)?;
         let innermost_container_path = if matches!(self.traversal_mode, JsonTraversalMode::Tree)
             && matches!(iterator_state, IteratorState::Primitive(_))
@@ -303,7 +306,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
         } else {
             self.path_to_current_value.cursor()
         };
-        self.push_state(iterator_state, innermost_container_path);
+        self.push_state(iterator_state, innermost_container_path)?;
 
         let key = self.path_to_current_value.key().to_owned();
         match self.traversal_mode {
@@ -348,7 +351,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
         };
         match traversal_state.iterator_state {
             IteratorState::Array(state) => {
-                let Some(((idx, value), new_state)) = self.json.array_iterator_next(&state) else {
+                let Some(((idx, value), new_state)) = self.json.array_iterator_next(&state)? else {
                     self.path_to_current_value.pop();
                     return self.next();
                 };
@@ -362,11 +365,11 @@ impl InternalVirtualTableCursor for JsonEachCursor {
                 self.push_state(
                     IteratorState::Array(new_state),
                     self.path_to_current_value.cursor(),
-                );
+                )?;
                 let recurses = recursing_iterator.is_some();
-                self.path_to_current_value.push_array_index(&idx);
+                self.path_to_current_value.push_array_index(&idx)?;
                 if let Some(it) = recursing_iterator {
-                    self.push_state(it, self.path_to_current_value.cursor());
+                    self.push_state(it, self.path_to_current_value.cursor())?;
                 }
 
                 let key = self.path_to_current_value.key().to_owned();
@@ -385,7 +388,8 @@ impl InternalVirtualTableCursor for JsonEachCursor {
                 }
             }
             IteratorState::Object(state) => {
-                let Some(((_idx, key, value), new_state)) = self.json.object_iterator_next(&state)
+                let Some(((_idx, key, value), new_state)) =
+                    self.json.object_iterator_next(&state)?
                 else {
                     self.path_to_current_value.pop();
                     return self.next();
@@ -394,17 +398,19 @@ impl InternalVirtualTableCursor for JsonEachCursor {
                 self.push_state(
                     IteratorState::Object(new_state),
                     self.path_to_current_value.cursor(),
-                );
+                )?;
                 self.path_to_current_value
                     .push_object_key(&key.to_string()?)?;
-                let recursing = matches!(self.traversal_mode, JsonTraversalMode::Tree)
-                    && self
+                let mut recursing = false;
+                if matches!(self.traversal_mode, JsonTraversalMode::Tree) {
+                    if let Some(it) = self
                         .json
                         .container_property_iterator(&IteratorState::Object(state))
-                        .is_some_and(|it| {
-                            self.push_state(it, self.path_to_current_value.cursor());
-                            true
-                        });
+                    {
+                        self.push_state(it, self.path_to_current_value.cursor())?;
+                        recursing = true;
+                    }
+                }
 
                 self.columns = Columns::new(
                     self.path_to_current_value.key().to_owned(),
@@ -493,7 +499,7 @@ fn navigate_to_path(jsonb: &mut Jsonb, path: &Value) -> Result<Option<Jsonb>, Li
     let json_path = json_path_from_db_value(path, true)?.ok_or_else(|| {
         LimboError::InvalidArgument(format!("path '{path}' is not a valid json path"))
     })?;
-    let mut search_operation = SearchOperation::new(jsonb.len() / 2);
+    let mut search_operation = SearchOperation::new(jsonb.len() / 2)?;
     if jsonb
         .operate_on_path(&json_path, &mut search_operation)
         .is_err()
@@ -543,19 +549,17 @@ mod columns {
         innermost_container_path: String,
     }
 
-    impl Default for Columns {
-        fn default() -> Columns {
+    impl Columns {
+        pub(super) fn empty() -> Columns {
             Self {
                 key: Key::empty(),
-                value: Jsonb::new(0, None),
+                value: Jsonb::empty(),
                 fullkey: "".to_owned(),
                 parent_id: None,
                 innermost_container_path: "".to_owned(),
             }
         }
-    }
 
-    impl Columns {
         pub(super) fn new(
             key: Key,
             value: Jsonb,
@@ -684,12 +688,12 @@ struct InPlaceJsonPath {
 type InPlaceJsonPathCursor = usize;
 
 impl InPlaceJsonPath {
-    fn new_root() -> Self {
-        Self {
+    fn new_root() -> Result<Self, TryReserveError> {
+        Ok(Self {
             string: "$".to_owned(),
-            element_lengths: vec![1],
+            element_lengths: try_vec![1]?,
             last_element: Key::None,
-        }
+        })
     }
 
     fn pop(&mut self) {
@@ -700,9 +704,10 @@ impl InPlaceJsonPath {
         }
     }
 
-    fn push_array_index(&mut self, idx: &usize) {
+    fn push_array_index(&mut self, idx: &usize) -> Result<(), TryReserveError> {
         self.last_element = Key::Integer(*idx as i64);
-        self.push(format!("[{idx}]"));
+        self.push(format!("[{idx}]"))?;
+        Ok(())
     }
 
     fn push_object_key(&mut self, key: &str) -> crate::Result<()> {
@@ -723,13 +728,16 @@ impl InPlaceJsonPath {
             inner
         };
         self.last_element = Key::String(inner.to_owned());
-        self.push(format!(".{unquoted_if_necessary}"));
+        self.push(format!(".{unquoted_if_necessary}"))?;
         Ok(())
     }
 
-    fn push(&mut self, element: String) {
+    fn push(&mut self, element: String) -> Result<(), std::collections::TryReserveError> {
+        self.element_lengths.try_reserve(1)?;
+        self.string.try_reserve(element.len())?;
         self.element_lengths.push(element.len());
         self.string.push_str(&element);
+        Ok(())
     }
 
     fn cursor(&self) -> InPlaceJsonPathCursor {
@@ -740,11 +748,11 @@ impl InPlaceJsonPath {
         &self.string[0..cursor]
     }
 
-    fn from_json_path(path: String, json_path: JsonPath<'_>) -> Self {
+    fn from_json_path(path: String, json_path: JsonPath<'_>) -> crate::Result<Self> {
         let (json_path, last_element) = if json_path.elements.is_empty() {
             (
                 JsonPath {
-                    elements: vec![PathElement::Root()],
+                    elements: try_vec![PathElement::Root()]?,
                 },
                 Key::None,
             )
@@ -766,13 +774,13 @@ impl InPlaceJsonPath {
             .elements
             .iter()
             .map(Self::element_length)
-            .collect();
+            .try_collect()?;
 
-        Self {
+        Ok(Self {
             string: path,
             element_lengths,
             last_element,
-        }
+        })
     }
 
     fn element_length(element: &PathElement) -> usize {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2478,7 +2478,7 @@ impl Database {
                 authority,
                 last_checksum_and_max_frame,
                 buffer_pool,
-            )));
+            )?));
         }
 
         Ok(Arc::new(WalFile::new(
@@ -2486,7 +2486,7 @@ impl Database {
             self.shared_wal.clone(),
             last_checksum_and_max_frame,
             buffer_pool,
-        )))
+        )?))
     }
 
     fn init_pager(

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -439,7 +439,9 @@ fn database_open_reuses_trusted_tshm_snapshot_without_disk_scan_when_no_backfill
         snapshot_before.nbackfills, 0,
         "this coverage only applies when no positive backfill proof is required"
     );
-    let frames_before = authority.iter_latest_frames(0, snapshot_before.max_frame);
+    let frames_before = authority
+        .iter_latest_frames(0, snapshot_before.max_frame)
+        .unwrap();
     assert!(
         !frames_before.is_empty(),
         "trusted-tail reopen coverage requires a populated durable frame index"
@@ -469,7 +471,9 @@ fn database_open_reuses_trusted_tshm_snapshot_without_disk_scan_when_no_backfill
         "trusted reopen must preserve the authoritative WAL snapshot"
     );
     assert_eq!(
-        reopened_authority.iter_latest_frames(0, snapshot_before.max_frame),
+        reopened_authority
+            .iter_latest_frames(0, snapshot_before.max_frame)
+            .unwrap(),
         frames_before,
         "trusted reopen must preserve durable frame-index content"
     );
@@ -1577,7 +1581,9 @@ fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
         snapshot_before.max_frame > snapshot_before.nbackfills,
         "disk-scan reopen coverage requires live WAL frames beyond the backfill point"
     );
-    let frames_before = authority.iter_latest_frames(0, snapshot_before.max_frame);
+    let frames_before = authority
+        .iter_latest_frames(0, snapshot_before.max_frame)
+        .unwrap();
     assert!(
         !frames_before.is_empty(),
         "setup should publish durable frame-index entries before reopen repair"
@@ -1609,7 +1615,9 @@ fn database_open_reopen_with_live_child_reader_does_not_clobber_authority() {
     let reopened_authority = reopened.shared_wal_coordination().unwrap().unwrap();
     assert_eq!(reopened_authority.snapshot(), snapshot_before);
     assert_eq!(
-        reopened_authority.iter_latest_frames(0, snapshot_before.max_frame),
+        reopened_authority
+            .iter_latest_frames(0, snapshot_before.max_frame)
+            .unwrap(),
         frames_before,
         "reopen repair must preserve durable frame-index content while the child reader is still alive"
     );
@@ -1664,6 +1672,7 @@ fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
     assert!(
         !authority
             .iter_latest_frames(0, snapshot.max_frame)
+            .unwrap()
             .is_empty(),
         "overflow reopen coverage requires a populated durable frame index before it is discarded"
     );
@@ -1674,6 +1683,7 @@ fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
     assert!(
         authority
             .iter_latest_frames(0, snapshot.max_frame)
+            .unwrap()
             .is_empty(),
         "test setup should clear durable frame-index entries before reopen"
     );
@@ -1706,6 +1716,7 @@ fn database_open_rebuilds_from_disk_scan_when_shared_frame_index_overflowed() {
     assert!(
         !reopened_authority
             .iter_latest_frames(0, snapshot.max_frame)
+            .unwrap()
             .is_empty(),
         "disk-scan reopen should repopulate the durable frame index from the WAL"
     );

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1,3 +1,4 @@
+use crate::alloc::*;
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
     DeleteRowStateMachine, MVTableId, MvStore, Row, RowID, RowKey, RowVersion, SortableIndexKey,
@@ -312,7 +313,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         connection: Arc<Connection>,
         update_transaction_state: bool,
         sync_mode: SyncMode,
-    ) -> Self {
+    ) -> Result<Self> {
         let checkpoint_lock = mvstore.blocking_checkpoint_lock.clone();
         // Prevent stale per-connection schema during checkpoint by using the shared DB schema.
         // Unlike in WAL mode we actually write stuff from mv store to pager in checkpoint
@@ -329,7 +330,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     index.clone(),
                 )
             })
-            .collect();
+            .try_collect()?;
         let mvcc_meta_table = schema.get_btree_table(MVCC_META_TABLE_NAME).map(|table| {
             turso_assert!(
                 table.root_page != 0,
@@ -345,7 +346,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         let durable_txid_max_old = NonZeroU64::new(durable_tx_max);
         #[cfg(any(test, injected_yields))]
         let yield_instance_id = connection.next_yield_instance_id();
-        Self {
+        Ok(Self {
             state: CheckpointState::AcquireLock,
             lock_states: LockStates {
                 blocking_checkpoint_lock_held: false,
@@ -379,7 +380,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
             collect_table_cursor: None,
             collect_index_tableid_cursor: None,
             collect_index_key_cursor: None,
-        }
+        })
     }
 
     #[cfg(test)]
@@ -1897,7 +1898,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
             CheckpointState::Finalize => {
                 tracing::debug!("Releasing blocking checkpoint lock");
-                self.mvstore.drop_unused_row_versions();
+                self.mvstore.drop_unused_row_versions()?;
                 self.checkpoint_lock.unlock();
                 self.finalize(&())?;
                 Ok(TransitionResult::Done(
@@ -1943,6 +1944,7 @@ impl<Clock: LogicalClock> StateTransition for CheckpointStateMachine<Clock> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc::vec;
     use crate::mvcc::database::tests::MvccTestDbNoConn;
     use crate::mvcc::database::SortableIndexKey;
     use crate::translate::collate::CollationSeq;
@@ -2117,7 +2119,8 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
-        );
+        )
+        .unwrap();
         checkpoint.durable_txid_max_old = std::num::NonZeroU64::new(10);
         checkpoint.durable_txid_max_new = 10;
 
@@ -2175,7 +2178,8 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
-        );
+        )
+        .unwrap();
 
         // More than one chunk worth of committed rows so collection must preempt.
         let table_id = MVTableId::from(-2);
@@ -2213,7 +2217,8 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
-        );
+        )
+        .unwrap();
 
         let index_id = MVTableId::from(-7);
         let row_count = COLLECT_PREEMPTION_THRESHOLD + 10;

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2249,7 +2249,8 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
-        );
+        )
+        .unwrap();
         checkpoint.lock_states.blocking_checkpoint_lock_held = true;
         checkpoint.durable_txid_max_new = 5;
 
@@ -2295,7 +2296,8 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
-        );
+        )
+        .unwrap();
         checkpoint.lock_states.blocking_checkpoint_lock_held = true;
         checkpoint.durable_txid_max_new = 5;
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1,3 +1,4 @@
+use crate::alloc::*;
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
 #[cfg(any(test, injected_yields))]
@@ -383,8 +384,8 @@ pub struct LogRecord {
 }
 
 impl LogRecord {
-    pub(crate) fn new(tx_timestamp: TxID) -> Self {
-        Self {
+    pub(crate) fn new(tx_timestamp: TxID) -> Result<Self> {
+        Ok(Self {
             tx_timestamp,
             // Pre-reserve the framing prefix at the front of buf:
             //   [LOG_HDR slot (56B) | TX_HEADER slot (24B) | <ops here>]
@@ -392,14 +393,14 @@ impl LogRecord {
             // a log file; otherwise it stays zero and the flush path wraps
             // the buf with `Buffer::new_with_start(..., LOG_HDR_SIZE)` so
             // those 56 bytes never reach disk.
-            buf: vec![0u8; crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE],
+            buf: try_vec![0u8; crate::mvcc::persistent_storage::logical_log::LOG_RECORD_PREFIX_SIZE]?,
             op_count: 0,
             has_header: false,
             #[cfg(feature = "conn_raw_api")]
             portable_changes: Vec::new(),
             #[cfg(feature = "conn_raw_api")]
             portable_changes_enabled: false,
-        }
+        })
     }
 
     /// True iff no ops (row versions or header) have been appended.
@@ -424,7 +425,7 @@ impl LogRecord {
         row_versions: &[RowVersion],
         header: Option<DatabaseHeader>,
     ) -> Self {
-        let mut record = Self::new(tx_timestamp);
+        let mut record = Self::new(tx_timestamp).unwrap();
         for rv in row_versions {
             record.push_row_version_for_test(rv);
         }
@@ -870,7 +871,7 @@ impl Transaction {
 
     /// Release a named savepoint. If this savepoint starts a transaction, returns
     /// [SavepointResult::Commit] to indicate the transaction should be committed.
-    fn release_named_savepoint(&self, name: &str) -> SavepointResult {
+    fn release_named_savepoint(&self, name: &str) -> Result<SavepointResult> {
         let mut savepoints = self.savepoint_stack.write();
         let Some(target_idx) = savepoints.iter().rposition(|savepoint| {
             matches!(
@@ -881,7 +882,7 @@ impl Transaction {
                 } if savepoint_name == name
             )
         }) else {
-            return SavepointResult::NotFound;
+            return Ok(SavepointResult::NotFound);
         };
 
         let commits_transaction = if matches!(
@@ -899,24 +900,24 @@ impl Transaction {
         if matches!(commits_transaction, SavepointResult::Commit) {
             // Defer mutation until transaction commit succeeds. If commit fails
             // (e.g. deferred FK violation), savepoints must remain intact.
-            return commits_transaction;
+            return Ok(commits_transaction);
         }
 
-        let drained: Vec<Savepoint> = savepoints.drain(target_idx..).collect();
+        let drained: Vec<Savepoint> = savepoints.drain(target_idx..).try_collect()?;
         if let Some(parent) = savepoints.last_mut() {
             for savepoint in drained {
                 parent.merge_from(savepoint);
             }
         }
-        commits_transaction
+        Ok(commits_transaction)
     }
 
     /// Find the named savepoint to rollback to and pop all savepoints above it. Returns the rolled
     /// back savepoints and net change in deferred FK violations for undoing changes to transaction
     /// state.
-    fn rollback_to_named_savepoint(&self, name: &str) -> Option<SavepointRollbackResult> {
+    fn rollback_to_named_savepoint(&self, name: &str) -> Result<Option<SavepointRollbackResult>> {
         let mut savepoints = self.savepoint_stack.write();
-        let target_idx = savepoints.iter().rposition(|savepoint| {
+        let Some(target_idx) = savepoints.iter().rposition(|savepoint| {
             matches!(
                 savepoint.kind,
                 SavepointKind::Named {
@@ -924,7 +925,9 @@ impl Transaction {
                     ..
                 } if savepoint_name == name
             )
-        })?;
+        }) else {
+            return Ok(None);
+        };
 
         let target_name = match &savepoints[target_idx].kind {
             SavepointKind::Named { name, .. } => name.clone(),
@@ -941,7 +944,7 @@ impl Transaction {
         let header = savepoints[target_idx].header;
         let header_dirty = savepoints[target_idx].header_dirty;
 
-        let drained: Vec<Savepoint> = savepoints.drain(target_idx..).collect();
+        let drained: Vec<Savepoint> = savepoints.drain(target_idx..).try_collect()?;
         savepoints.push(Savepoint::named(
             target_name,
             starts_transaction,
@@ -949,10 +952,10 @@ impl Transaction {
             header,
             header_dirty,
         ));
-        Some(SavepointRollbackResult {
+        Ok(Some(SavepointRollbackResult {
             rolledback_savepoints: drained,
             deferred_fk_violations,
-        })
+        }))
     }
 
     /// Record a version that was created during the current savepoint.
@@ -2136,7 +2139,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         // Move the assembled log record out and transition to
         // BeginCommitLogicalLog (or directly to CommitEnd if there is nothing
         // to log).
-        let mut log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts));
+        let mut log_record = std::mem::replace(&mut ctx.log_record, LogRecord::new(end_ts)?);
         self.populate_portable_changes(mvcc_store, &mut log_record)?;
         tracing::trace!("prepared_log_record(tx_id={})", self.tx_id);
 
@@ -2802,7 +2805,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                 };
                 self.state = CommitState::BuildLogRecord(BuildLogRecordCtx {
                     end_ts,
-                    log_record: LogRecord::new(end_ts),
+                    log_record: LogRecord::new(end_ts)?,
                     cursor: 0,
                     schema_process: true,
                     pending_header,
@@ -3050,7 +3053,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         self.connection.clone(),
                         false,
                         self.connection.get_sync_mode(),
-                    ));
+                    )?);
                     let state_machine = Mutex::new(state_machine);
                     self.state = CommitState::Checkpoint { state_machine };
                     return Ok(TransitionResult::Continue);
@@ -3422,8 +3425,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// Captures table-valued functions (e.g. generate_series) from the schema before
     /// reparse_schema() drops them. Built-in TVFs are registered programmatically and
     /// don't survive schema re-parsing from sqlite_schema; we save and re-inject them.
-    fn capture_table_valued_functions(schema: &Schema) -> Vec<Arc<crate::vtab::VirtualTable>> {
-        schema
+    fn capture_table_valued_functions(
+        schema: &Schema,
+    ) -> Result<Vec<Arc<crate::vtab::VirtualTable>>> {
+        Ok(schema
             .tables
             .values()
             .filter_map(|table| match table.as_ref() {
@@ -3434,7 +3439,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 }
                 _ => None,
             })
-            .collect()
+            .try_collect()?)
     }
 
     fn rehydrate_table_valued_functions(
@@ -3465,10 +3470,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     pub fn new(
         clock: Clock,
         storage: Arc<dyn crate::mvcc::persistent_storage::DurableStorage>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             rows: SkipMap::new(),
-            table_id_to_rootpage: SkipMap::from_iter(vec![(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1))]), // table id 1 / root page 1 is always sqlite_schema.
+            // TODO: this will require allocations in the future so preemptively set this function as Result<Self>
+            table_id_to_rootpage: SkipMap::from_iter([(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1))]), // table id 1 / root page 1 is always sqlite_schema.
             index_rows: SkipMap::new(),
             txs: SkipMap::new(),
             finalized_tx_states: SkipMap::new(),
@@ -3486,7 +3492,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
-        }
+        })
     }
 
     /// Get the table ID from the root page.
@@ -3568,13 +3574,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// The caller must hold the MVCC vacuum gate and pass both the committed
     /// page-1 header and the schema parsed from the post-VACUUM physical
     /// database image.
-    pub(crate) fn reset_after_vacuum(&self, header: DatabaseHeader, schema: &Schema) {
+    pub(crate) fn reset_after_vacuum(&self, header: DatabaseHeader, schema: &Schema) -> Result<()> {
         turso_assert!(
             self.txs.is_empty(),
             "MVCC VACUUM reset requires no active transactions"
         );
         // see the test `test_mvcc_plain_vacuum_active_write_tx_returns_busy`
-        self.drop_unused_row_versions();
+        self.drop_unused_row_versions()?;
         let has_table_versions = self
             .rows
             .iter()
@@ -3616,13 +3622,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     .flatten()
                     .map(|index| index.root_page),
             )
-            .collect::<Vec<_>>();
-        for &root_page in &root_pages {
-            turso_assert!(
-                root_page > 0,
-                "post-VACUUM B-tree root page must be positive"
-            );
-        }
+            .inspect(|&root_page| {
+                turso_assert!(
+                    root_page > 0,
+                    "post-VACUUM B-tree root page must be positive"
+                );
+            });
         self.table_id_to_rootpage.clear();
         self.table_id_to_last_rowid.write().clear();
         self.insert_table_id_to_rootpage(SQLITE_SCHEMA_MVCC_TABLE_ID, Some(1));
@@ -3631,6 +3636,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             self.insert_table_id_to_rootpage(table_id, Some(root_page as u64));
         }
         self.global_header.write().replace(header);
+        Ok(())
     }
 
     /// Creates the `__turso_internal_mvcc_meta` table and seeds it with
@@ -3693,7 +3699,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// 6. Make sure schema changes reflected from deserialized logical log are captured in the schema
     pub fn bootstrap(&self, bootstrap_conn: Arc<Connection>) -> Result<()> {
         let preserved_table_valued_functions =
-            Self::capture_table_valued_functions(&bootstrap_conn.schema.read());
+            Self::capture_table_valued_functions(&bootstrap_conn.schema.read())?;
         self.maybe_complete_interrupted_checkpoint(&bootstrap_conn)?;
         bootstrap_conn.reparse_schema()?;
         self.rehydrate_connection_table_valued_functions(
@@ -4244,7 +4250,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     pub fn scan_row_ids(&self) -> Result<Vec<RowID>> {
         tracing::trace!("scan_row_ids");
         let keys = self.rows.iter().map(|entry| entry.key().clone());
-        Ok(keys.collect())
+        Ok(keys.try_collect()?)
     }
 
     pub fn get_row_id_range(
@@ -5037,7 +5043,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             .txs
             .get(&tx_id)
             .unwrap_or_else(|| panic!("Transaction {tx_id} not found while releasing savepoint"));
-        Ok(tx.value().release_named_savepoint(name))
+        tx.value().release_named_savepoint(name)
     }
 
     /// Rolls back a savepoint within a transaction.
@@ -5073,7 +5079,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let Some(SavepointRollbackResult {
             rolledback_savepoints,
             deferred_fk_violations,
-        }) = tx.value().rollback_to_named_savepoint(name)
+        }) = tx.value().rollback_to_named_savepoint(name)?
         else {
             return Ok(None);
         };
@@ -5392,14 +5398,14 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// Uses the low-water mark (LWM) to determine reclaimability in O(1) per version.
     /// Covers both table rows (`self.rows`) and index rows (`self.index_rows`).
     /// Returns the number of removed versions.
-    pub fn drop_unused_row_versions(&self) -> usize {
+    pub fn drop_unused_row_versions(&self) -> Result<usize> {
         let lwm = self.compute_lwm();
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
         let mut referenced_tx_ids = HashSet::default();
 
         let dropped = self.gc_table_row_versions(lwm, ckpt_max, &mut referenced_tx_ids)
             + self.gc_index_row_versions(lwm, ckpt_max, &mut referenced_tx_ids);
-        let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids);
+        let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids)?;
 
         tracing::trace!(
             "drop_unused_row_versions() -> dropped {dropped}, pruned_finalized={pruned_finalized}, txs: {}, finalized_tx_states: {}, rows: {}",
@@ -5407,7 +5413,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             self.finalized_tx_states.len(),
             self.rows.len()
         );
-        dropped
+        Ok(dropped)
     }
 
     fn gc_table_row_versions(
@@ -5463,9 +5469,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
-    fn prune_finalized_tx_states(&self, referenced_tx_ids: &HashSet<TxID>) -> usize {
+    fn prune_finalized_tx_states(&self, referenced_tx_ids: &HashSet<TxID>) -> Result<usize> {
         if self.finalized_tx_states.is_empty() {
-            return 0;
+            return Ok(0);
         }
 
         let to_remove: Vec<TxID> = self
@@ -5475,13 +5481,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 let tx_id = *entry.key();
                 (!referenced_tx_ids.contains(&tx_id)).then_some(tx_id)
             })
-            .collect();
+            .try_collect()?;
 
         for tx_id in &to_remove {
             self.finalized_tx_states.remove(tx_id);
         }
 
-        to_remove.len()
+        Ok(to_remove.len())
     }
 
     /// Apply GC rules to a single version chain. Returns number of versions removed.
@@ -5955,7 +5961,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let enc_ctx = self.storage.encryption_ctx();
         let mut reader = StreamingLogicalLogReader::new(file.clone(), enc_ctx);
         let preserved_table_valued_functions =
-            Self::capture_table_valued_functions(&connection.schema.read());
+            Self::capture_table_valued_functions(&connection.schema.read())?;
 
         let header = match reader.try_read_header(&pager.io)? {
             HeaderReadResult::Valid(header) => Some(header),
@@ -6032,7 +6038,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             let syms = connection.syms.read();
             let mv_store = connection.db.get_mv_store().clone();
 
-            let mut sorted_rowids: Vec<i64> = schema_rows.keys().copied().collect();
+            let mut sorted_rowids: Vec<i64> = schema_rows.keys().copied().try_collect()?;
             sorted_rowids.sort_unstable();
             for rowid in &sorted_rowids {
                 let record = &schema_rows[rowid];

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -903,12 +903,17 @@ impl Transaction {
             return Ok(commits_transaction);
         }
 
-        let drained: Vec<Savepoint> = savepoints.drain(target_idx..).try_collect()?;
-        if let Some(parent) = savepoints.last_mut() {
-            for savepoint in drained {
-                parent.merge_from(savepoint);
+        // Instead of using drain and collecting into a Vector, we can split the vec in 2 and then mem::take and then later
+        // just truncate the savepoints Vec
+        if let Some((rest, drained)) = savepoints.split_at_mut_checked(target_idx) {
+            if let Some(parent) = rest.last_mut() {
+                for savepoint in drained {
+                    parent.merge_from(std::mem::take(savepoint));
+                }
             }
-        }
+            savepoints.truncate(target_idx);
+        };
+
         Ok(commits_transaction)
     }
 
@@ -945,6 +950,7 @@ impl Transaction {
         let header_dirty = savepoints[target_idx].header_dirty;
 
         let drained: Vec<Savepoint> = savepoints.drain(target_idx..).try_collect()?;
+        // Should be safe to use this method as we just drained the Savepoints vec so it should have capacity
         savepoints.push(Savepoint::named(
             target_name,
             starts_transaction,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -2175,7 +2175,7 @@ impl<Clock: LogicalClock> CommitStateMachine<Clock> {
         {
             let _ = mvcc_store;
             let _ = log_record;
-            return Ok(());
+            Ok(())
         }
 
         #[cfg(feature = "conn_raw_api")]
@@ -2845,7 +2845,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     &mut self.state,
                     CommitState::UpgradeLogicalLogHeader {
                         end_ts,
-                        log_record: LogRecord::new(end_ts),
+                        log_record: LogRecord::new(end_ts)?,
                     },
                 ) {
                     CommitState::BeginCommitLogicalLog { log_record, .. } => log_record,
@@ -2865,7 +2865,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                     &mut self.state,
                     CommitState::WriteLogicalLog {
                         end_ts,
-                        log_record: LogRecord::new(end_ts),
+                        log_record: LogRecord::new(end_ts)?,
                     },
                 ) {
                     CommitState::UpgradeLogicalLogHeader { log_record, .. } => log_record,
@@ -5811,7 +5811,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn logical_log_header_crc_valid(&self, pager: &Arc<Pager>) -> Result<bool> {
         let file = self.get_logical_log_file();
         // Header is never encrypted; no need to pass EncryptionContext here.
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None)?;
         match reader.try_read_header(&pager.io)? {
             HeaderReadResult::Valid(_) => Ok(true),
             HeaderReadResult::NoLog | HeaderReadResult::Invalid => Ok(false),
@@ -5838,7 +5838,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let wal_max_frame = wal.get_max_frame_in_wal();
         let file = self.get_logical_log_file();
         // This method only reads the header (never encrypted); no need to pass EncryptionContext.
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None)?;
         let header_result = reader.try_read_header(&pager.io)?;
 
         let is_readonly = connection.db.is_readonly();
@@ -5965,7 +5965,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let pager = connection.pager.load().clone();
         let file = self.get_logical_log_file();
         let enc_ctx = self.storage.encryption_ctx();
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), enc_ctx);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), enc_ctx)?;
         let preserved_table_valued_functions =
             Self::capture_table_valued_functions(&connection.schema.read())?;
 
@@ -6036,7 +6036,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             fresh.generated_columns_enabled =
                 connection.db.experimental_generated_columns_enabled();
             fresh.schema_version = cookie;
-            let mut from_sql_indexes = Vec::with_capacity(10);
+            let mut from_sql_indexes = Vec::try_with_capacity_ext(10)?;
             let mut automatic_indices: HashMap<String, Vec<(String, i64)>> = HashMap::default();
             let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
             let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -11351,7 +11351,7 @@ fn collect_mvcc_portable_change_bytes(conn: &Arc<Connection>) -> Vec<u8> {
         .expect("test database must be in MVCC mode")
         .clone();
     let io = conn.get_pager().io.clone();
-    let mut reader = StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), None);
+    let mut reader = StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), None).unwrap();
     reader.read_header(&io).unwrap();
 
     let mut portable_changes = Vec::new();
@@ -11373,7 +11373,8 @@ fn collect_mvcc_portable_change_bytes_with_encryption(
         .clone();
     let io = conn.get_pager().io.clone();
     let mut reader =
-        StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), Some(encryption_ctx));
+        StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), Some(encryption_ctx))
+            .unwrap();
     reader.read_header(&io).unwrap();
 
     let mut portable_changes = Vec::new();
@@ -11391,7 +11392,7 @@ fn collect_mvcc_recovery_ops(conn: &Arc<Connection>) -> Vec<ParsedOp> {
         .expect("test database must be in MVCC mode")
         .clone();
     let io = conn.get_pager().io.clone();
-    let mut reader = StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), None);
+    let mut reader = StreamingLogicalLogReader::new(mv_store.get_logical_log_file(), None).unwrap();
     reader.read_header(&io).unwrap();
 
     let mut ops = Vec::new();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1,4 +1,5 @@
 use rustc_hash::FxHashSet as HashSet;
+use std::vec;
 
 use super::*;
 use crate::io::PlatformIO;
@@ -290,7 +291,9 @@ fn mvcc_reset_after_vacuum_installs_header_and_rootpages() {
         .insert_table_id_to_rootpage(MVTableId::from(-999_i64), Some(999));
 
     db.mvcc_store.try_begin_vacuum_gate().unwrap();
-    db.mvcc_store.reset_after_vacuum(header, schema.as_ref());
+    db.mvcc_store
+        .reset_after_vacuum(header, schema.as_ref())
+        .unwrap();
     db.mvcc_store.release_vacuum_gate();
 
     assert_eq!(
@@ -386,7 +389,8 @@ fn mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets() {
 
     db.mvcc_store.try_begin_vacuum_gate().unwrap();
     db.mvcc_store
-        .reset_after_vacuum(DatabaseHeader::default(), schema.as_ref());
+        .reset_after_vacuum(DatabaseHeader::default(), schema.as_ref())
+        .unwrap();
     db.mvcc_store.release_vacuum_gate();
 
     for row_id in checkpointed_row_ids {
@@ -616,7 +620,8 @@ fn advance_checkpoint_until_wal_has_commit_frame(
         conn.clone(),
         true,
         conn.get_sync_mode(),
-    );
+    )
+    .unwrap();
 
     for _ in 0..10_000 {
         if pager
@@ -1618,7 +1623,8 @@ fn test_checkpoint_truncates_wal_last() {
         conn.clone(),
         true,
         conn.get_sync_mode(),
-    );
+    )
+    .unwrap();
 
     let mut saw_truncate_log_state_with_wal = false;
     let mut finished = false;
@@ -2348,7 +2354,8 @@ fn test_meta_checkpoint_case_10_metadata_upsert_is_atomic_with_pager_commit() {
             conn.clone(),
             true,
             conn.get_sync_mode(),
-        );
+        )
+        .unwrap();
 
         for _ in 0..50_000 {
             if checkpoint_sm.state_for_test() == CheckpointState::CheckpointWal {
@@ -2720,7 +2727,8 @@ fn test_meta_checkpoint_case_11_auto_checkpoint_failure_after_commit_remains_rec
         conn.clone(),
         true,
         conn.get_sync_mode(),
-    );
+    )
+    .unwrap();
     let mut reached_truncate = false;
     for _ in 0..50_000 {
         if checkpoint_sm.state_for_test() == CheckpointState::TruncateLogicalLog {
@@ -2749,7 +2757,8 @@ fn test_meta_checkpoint_case_11_auto_checkpoint_failure_after_commit_remains_rec
     );
 
     let sync_mode = conn.get_sync_mode();
-    let checkpoint_sm2 = CheckpointStateMachine::new(pager, mvcc_store, conn, true, sync_mode);
+    let checkpoint_sm2 =
+        CheckpointStateMachine::new(pager, mvcc_store, conn, true, sync_mode).unwrap();
     let (old_boundary, _) = checkpoint_sm2.checkpoint_bounds_for_test();
     assert!(
         old_boundary.unwrap_or_default() >= ts1,
@@ -2817,7 +2826,8 @@ fn test_checkpoint_resamples_boundary_before_starting() {
         delayed_conn.clone(),
         true,
         delayed_conn.get_sync_mode(),
-    );
+    )
+    .unwrap();
     let (old_boundary, _) = delayed_checkpoint.checkpoint_bounds_for_test();
     assert_eq!(old_boundary, Some(first_boundary));
 
@@ -2829,7 +2839,8 @@ fn test_checkpoint_resamples_boundary_before_starting() {
         interrupted_conn.clone(),
         true,
         interrupted_conn.get_sync_mode(),
-    );
+    )
+    .unwrap();
     let mut reached_wal_checkpoint = false;
     for _ in 0..50_000 {
         if interrupted_checkpoint.state_for_test() == CheckpointState::CheckpointWal {
@@ -3473,7 +3484,7 @@ fn test_commit() {
         .unwrap();
     commit_tx(db.mvcc_store.clone(), &db.conn, tx2).unwrap();
     assert_eq!(tx1_updated_row, row);
-    db.mvcc_store.drop_unused_row_versions();
+    db.mvcc_store.drop_unused_row_versions().unwrap();
 }
 
 /// What this test checks: Rollback/savepoint behavior restores exactly the intended state when statements or transactions fail.
@@ -4544,7 +4555,7 @@ fn test_read_only_commit_does_not_cache_finalized_state() {
         .unwrap();
 
     // Establish a clean baseline after schema/setup writes.
-    mvcc_store.drop_unused_row_versions();
+    mvcc_store.drop_unused_row_versions().unwrap();
     let baseline = mvcc_store.finalized_tx_states.len();
 
     conn.execute("BEGIN CONCURRENT").unwrap();
@@ -4567,7 +4578,7 @@ fn test_drop_unused_row_versions_prunes_unreferenced_finalized_tx_states() {
         .unwrap();
 
     // Establish a clean baseline after schema/setup writes.
-    mvcc_store.drop_unused_row_versions();
+    mvcc_store.drop_unused_row_versions().unwrap();
     let baseline = mvcc_store.finalized_tx_states.len();
 
     conn.execute("INSERT INTO t VALUES (1, 1)").unwrap();
@@ -4577,7 +4588,7 @@ fn test_drop_unused_row_versions_prunes_unreferenced_finalized_tx_states() {
         "write commit should add at least one finalized tx cache entry"
     );
 
-    mvcc_store.drop_unused_row_versions();
+    mvcc_store.drop_unused_row_versions().unwrap();
 
     assert_eq!(
         mvcc_store.finalized_tx_states.len(),
@@ -7472,7 +7483,7 @@ fn test_gc_integration_insert_commit_gc() {
 
     // No active transactions → LWM = u64::MAX.
     // ckpt_max = 0 (no checkpoint yet), so rule 3 won't fire (b > ckpt_max).
-    let dropped = db.mvcc_store.drop_unused_row_versions();
+    let dropped = db.mvcc_store.drop_unused_row_versions().unwrap();
     assert_eq!(dropped, 0);
     assert!(!db.mvcc_store.rows.is_empty());
 }
@@ -7514,7 +7525,7 @@ fn test_gc_integration_rollback_creates_aborted_garbage() {
 
     // GC should clean up the version. The SkipMap entry stays (lazy removal
     // in background GC avoids TOCTOU), but the version vec should be empty.
-    let dropped = db.mvcc_store.drop_unused_row_versions();
+    let dropped = db.mvcc_store.drop_unused_row_versions().unwrap();
     assert_eq!(dropped, 1);
     let entry = db
         .mvcc_store
@@ -7567,7 +7578,7 @@ fn test_gc_active_reader_pins_lwm() {
 
     // GC should NOT remove the superseded version (its end_ts > lwm).
     let row_id = RowID::new(table_id, RowKey::Int(1));
-    let dropped = db.mvcc_store.drop_unused_row_versions();
+    let dropped = db.mvcc_store.drop_unused_row_versions().unwrap();
     assert_eq!(
         dropped, 0,
         "GC should not remove versions visible to active reader"
@@ -7592,7 +7603,7 @@ fn test_gc_active_reader_pins_lwm() {
     assert_eq!(db.mvcc_store.compute_lwm(), u64::MAX);
 
     // GC should now remove the superseded version.
-    let dropped = db.mvcc_store.drop_unused_row_versions();
+    let dropped = db.mvcc_store.drop_unused_row_versions().unwrap();
     assert_eq!(
         dropped, 1,
         "superseded version should be reclaimed after reader closes"

--- a/core/mvcc/mod.rs
+++ b/core/mvcc/mod.rs
@@ -241,7 +241,7 @@ mod tests {
                         tracing::debug!("{prefix}: {i}");
                     }
                     if i % 10000 == 0 {
-                        let dropped = mvcc_store.drop_unused_row_versions();
+                        let dropped = mvcc_store.drop_unused_row_versions().unwrap();
                         tracing::debug!("garbage collected {dropped} versions");
                     }
                     let tx = loop {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -231,6 +231,7 @@
 //! Frame-level atomicity only: torn tails are discarded; partially written frames are not salvaged.
 #![allow(dead_code)]
 
+use crate::alloc::TursoTryWithCapacityExt;
 use crate::io::FileSyncType;
 use crate::sync::Arc;
 use crate::sync::RwLock;
@@ -1445,7 +1446,7 @@ pub(crate) fn parse_ops_from_plaintext(
             plaintext.len()
         )));
     }
-    let mut ops = Vec::with_capacity((op_count as usize).min(1024));
+    let mut ops = Vec::try_with_capacity_ext((op_count as usize).min(1024))?;
     let mut cursor = 0usize;
     for _ in 0..op_count {
         match try_parse_one_op_from_buf(&plaintext[cursor..], commit_ts)? {
@@ -1705,17 +1706,20 @@ impl StreamingLogicalLogReader {
         file: Arc<dyn File>,
         encryption_ctx: Option<EncryptionContext>,
         encrypted_payload_chunk_size: usize,
-    ) -> Self {
+    ) -> Result<Self> {
         let file_size = file.size().expect("failed to get file size") as usize;
         let decrypt_scratch = encryption_ctx
             .as_ref()
-            .map(|enc_ctx| Vec::with_capacity(encrypted_payload_chunk_size + enc_ctx.tag_size()))
+            .map(|enc_ctx| {
+                Vec::try_with_capacity_ext(encrypted_payload_chunk_size + enc_ctx.tag_size())
+            })
+            .transpose()?
             .unwrap_or_default();
-        Self {
+        Ok(Self {
             file,
             offset: 0,
             header: None,
-            buffer: Arc::new(RwLock::new(Vec::with_capacity(4096))),
+            buffer: Arc::new(RwLock::new(Vec::try_with_capacity_ext(4096)?)),
             buffer_offset: 0,
             file_size,
             state: StreamingState::NeedTransactionStart,
@@ -1726,10 +1730,10 @@ impl StreamingLogicalLogReader {
             #[cfg(test)]
             pending_ops: std::collections::VecDeque::new(),
             decrypt_scratch,
-        }
+        })
     }
 
-    pub fn new(file: Arc<dyn File>, encryption_ctx: Option<EncryptionContext>) -> Self {
+    pub fn new(file: Arc<dyn File>, encryption_ctx: Option<EncryptionContext>) -> Result<Self> {
         Self::new_internal(file, encryption_ctx, ENCRYPTED_PAYLOAD_CHUNK_SIZE)
     }
 
@@ -1738,7 +1742,7 @@ impl StreamingLogicalLogReader {
         file: Arc<dyn File>,
         encryption_ctx: Option<EncryptionContext>,
         encrypted_payload_chunk_size: usize,
-    ) -> Self {
+    ) -> Result<Self> {
         Self::new_internal(file, encryption_ctx, encrypted_payload_chunk_size)
     }
 
@@ -2200,10 +2204,10 @@ impl StreamingLogicalLogReader {
         // it is possible that op might split between two chunks (or even multiple), in that case
         // we need to keep the previous payload, then decrypt the next chunk. Only when we have the
         // full payload, we parse it.
-        let mut carry = Vec::with_capacity(self.encrypted_payload_chunk_size);
+        let mut carry = Vec::try_with_capacity_ext(self.encrypted_payload_chunk_size)?;
         // we allocate some space to keep a vector of parsed ops, we set the 1024 as upper bound
         // size and extend the vector as required.
-        let mut parsed_ops = Vec::with_capacity((op_count as usize).min(1024));
+        let mut parsed_ops = Vec::try_with_capacity_ext((op_count as usize).min(1024))?;
         let chunk_count =
             encrypted_payload_chunk_count(payload_size, self.encrypted_payload_chunk_size);
 
@@ -2358,7 +2362,7 @@ impl StreamingLogicalLogReader {
         commit_ts: u64,
         mut running_crc: u32,
     ) -> Result<PayloadParseResult> {
-        let mut parsed_ops = Vec::with_capacity((op_count as usize).min(1024));
+        let mut parsed_ops = Vec::try_with_capacity_ext((op_count as usize).min(1024))?;
         let mut payload_bytes_read: u64 = 0;
 
         for _ in 0..op_count {
@@ -3287,7 +3291,7 @@ impl StreamingLogicalLogReader {
 
     fn read_exact_at(&self, io: &Arc<dyn crate::IO>, pos: u64, len: usize) -> Result<Vec<u8>> {
         let header_buf = Arc::new(Buffer::new_temporary(len));
-        let out = Arc::new(RwLock::new(Vec::with_capacity(len)));
+        let out = Arc::new(RwLock::new(Vec::try_with_capacity_ext(len)?));
         let out_clone = out.clone();
         let completion: Box<ReadComplete> = Box::new(move |res| {
             let out = out_clone.clone();
@@ -3593,7 +3597,7 @@ mod tests {
     }
 
     fn read_table_ops(file: Arc<dyn crate::File>, io: &Arc<dyn crate::IO>) -> Vec<ExpectedTableOp> {
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         reader.read_header(io).unwrap();
         let mut ops = Vec::new();
         while let Some(frame) = reader.next_frame(io).unwrap() {
@@ -3665,7 +3669,7 @@ mod tests {
         let file = io
             .open_file("logical_log_varint_decode_tmp", OpenFlags::Create, false)
             .unwrap();
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         reader.buffer.write().extend_from_slice(bytes);
         reader.consume_varint_bytes(&io)
     }
@@ -4118,7 +4122,7 @@ mod tests {
                 .unwrap();
             io.wait_for_completion(c).unwrap();
 
-            let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+            let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
             reader.read_header(&io).unwrap();
             let mut seen = 0;
             loop {
@@ -4207,7 +4211,7 @@ mod tests {
 
         append_single_table_op_tx(&mut log, &io, table_id, 7, 11, false, false, "min");
 
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         reader.read_header(&io).unwrap();
         let frame = reader.next_frame(&io).unwrap().expect("expected one frame");
         assert_eq!(frame.len(), 1);
@@ -4312,7 +4316,7 @@ mod tests {
         io.wait_for_completion(c).unwrap();
 
         // Flip one byte in the op data (varint payload_len).
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         // After read_header, reader.offset = LOG_HDR_SIZE.
         // Skip frame header (TX_HEADER_SIZE) + fixed op prefix (tag+flags+table_id = 6 bytes).
@@ -4323,7 +4327,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let res = reader.next_frame(&io);
         assert!(res.unwrap().is_none());
@@ -4395,7 +4399,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let res = reader.next_frame(&io);
         assert!(res.unwrap().is_none());
@@ -4421,7 +4425,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let res = reader.next_frame(&io);
         assert!(res.unwrap().is_none());
@@ -4443,7 +4447,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let res = reader.next_frame(&io);
         assert!(res.unwrap().is_none());
@@ -4464,7 +4468,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let res = reader.next_frame(&io);
         assert!(res.unwrap().is_none());
@@ -4535,7 +4539,7 @@ mod tests {
         let c = file.pwrite(0, bad, Completion::new_write(|_| {})).unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         let res = reader.read_header(&io);
         assert!(res.is_err());
     }
@@ -4558,7 +4562,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         let res = reader.read_header(&io);
         assert!(res.is_err());
     }
@@ -4595,7 +4599,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         let res = reader.read_header(&io);
         assert!(res.is_err());
 
@@ -4615,7 +4619,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         let result = reader.try_read_header(&io).unwrap();
         assert!(
             matches!(result, HeaderReadResult::Invalid),
@@ -4657,7 +4661,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         let res = reader.read_header(&io);
         assert!(res.is_err());
     }
@@ -4680,7 +4684,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let res = reader.next_frame(&io);
         assert!(res.unwrap().is_none());
@@ -4704,7 +4708,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let res = reader.next_frame(&io);
         assert!(res.unwrap().is_none());
@@ -4737,7 +4741,7 @@ mod tests {
         let c = log.log_tx(header_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
 
         // The reader skips the empty frame and returns the UpdateHeader from frame 2.
@@ -4803,7 +4807,7 @@ mod tests {
                     .unwrap();
                 io.wait_for_completion(c).unwrap();
 
-                let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+                let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
                 reader.read_header(&io).unwrap();
                 let res = reader.next_frame(&io);
                 match res {
@@ -5078,7 +5082,7 @@ mod tests {
             "payload_size at bytes [4..12] must be non-zero for a non-empty op"
         );
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let frame = reader.next_frame(&io).unwrap().expect("expected one frame");
         assert_eq!(frame.len(), 1);
@@ -5119,7 +5123,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         reader.read_header(&io).unwrap();
         let header = reader.header().unwrap();
         assert_eq!(header.version, LOG_VERSION_V2);
@@ -5177,7 +5181,7 @@ mod tests {
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         let result = reader.try_read_header(&io).unwrap();
         assert!(matches!(result, HeaderReadResult::Invalid));
     }
@@ -5211,7 +5215,7 @@ mod tests {
         append_single_table_op_tx(&mut log, &io, (-2).into(), 2, 20, false, false, "b");
 
         // Reader should see only the new frame (old data was truncated)
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         assert!(matches!(
             reader.try_read_header(&io).unwrap(),
             HeaderReadResult::Valid(_)
@@ -5254,7 +5258,7 @@ mod tests {
         append_single_table_op_tx(&mut log, &io, (-2).into(), 3, 30, false, false, "ccc");
 
         // Without corruption, all 3 frames should read back
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
+        let mut reader = StreamingLogicalLogReader::new(file.clone(), None).unwrap();
         assert!(matches!(
             reader.try_read_header(&io).unwrap(),
             HeaderReadResult::Valid(_)
@@ -5278,7 +5282,7 @@ mod tests {
 
         // Now frame 1 should fail CRC, and frames 2+3 should NOT be returned
         // (chained CRC means the reader stops at the first invalid frame)
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         assert!(matches!(
             reader.try_read_header(&io).unwrap(),
             HeaderReadResult::Valid(_)
@@ -5353,7 +5357,7 @@ mod tests {
         io.wait_for_completion(c).unwrap();
 
         // Read log A — should get 1 valid frame (A's own), then reject the spliced frame
-        let mut reader = StreamingLogicalLogReader::new(file_a, None);
+        let mut reader = StreamingLogicalLogReader::new(file_a, None).unwrap();
         assert!(matches!(
             reader.try_read_header(&io).unwrap(),
             HeaderReadResult::Valid(_)
@@ -5544,7 +5548,7 @@ mod tests {
         if file_size == 0 {
             return Vec::new();
         }
-        let reader = StreamingLogicalLogReader::new(file, None);
+        let reader = StreamingLogicalLogReader::new(file, None).unwrap();
         reader.read_exact_at(io, 0, file_size).unwrap()
     }
 
@@ -5667,7 +5671,7 @@ mod tests {
         io: &Arc<dyn crate::IO>,
         enc_ctx: &crate::storage::encryption::EncryptionContext,
     ) -> Vec<ParsedOp> {
-        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
+        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone())).unwrap();
         reader.read_header(io).unwrap();
         let ops = match reader.parse_next_transaction(io).unwrap() {
             ParseResult::Frame(frame) => frame.ops,
@@ -5690,7 +5694,8 @@ mod tests {
             file,
             Some(enc_ctx.clone()),
             encrypted_payload_chunk_size,
-        );
+        )
+        .unwrap();
         reader.read_header(io).unwrap();
         let ops = match reader.parse_next_transaction(io).unwrap() {
             ParseResult::Frame(frame) => frame.ops,
@@ -5713,7 +5718,8 @@ mod tests {
             file,
             Some(enc_ctx.clone()),
             encrypted_payload_chunk_size,
-        );
+        )
+        .map_err(|e| format!("failed to create fuzz log reader: {e}"))?;
         reader
             .read_header(io)
             .map_err(|e| format!("failed to read fuzz log header: {e}"))?;
@@ -6059,7 +6065,7 @@ mod tests {
         io: &Arc<dyn crate::IO>,
         enc_ctx: crate::storage::encryption::EncryptionContext,
     ) {
-        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
+        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx)).unwrap();
         reader.read_header(io).unwrap();
         match reader.parse_next_transaction(io).unwrap() {
             ParseResult::InvalidFrame => {}
@@ -6134,7 +6140,7 @@ mod tests {
         );
 
         // ── Roundtrip read ──
-        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
+        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx)).unwrap();
         reader.read_header(&io).unwrap();
 
         let ops = match reader.parse_next_transaction(&io).unwrap() {
@@ -6445,7 +6451,7 @@ mod tests {
         let c = log.log_tx(sync_tx).unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         reader.read_header(&io).unwrap();
         assert_eq!(reader.header().unwrap().version, LOG_VERSION);
         let first = reader.next_portable_change_frame(&io).unwrap().unwrap();
@@ -6535,7 +6541,7 @@ mod tests {
         io.wait_for_completion(file.pwrite(0, buffer, c).unwrap())
             .unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file, None);
+        let mut reader = StreamingLogicalLogReader::new(file, None).unwrap();
         reader.read_header(&io).unwrap();
         assert_eq!(reader.last_valid_offset(), LOG_HDR_SIZE);
         assert!(reader.next_portable_change_frame(&io).unwrap().is_none());
@@ -6682,7 +6688,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
+        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx)).unwrap();
         reader.read_header(&io).unwrap();
         match reader.parse_next_transaction(&io).unwrap() {
             ParseResult::InvalidFrame => {}
@@ -6950,7 +6956,7 @@ mod tests {
             append_encrypted_tx(&mut log, &io, tx);
         }
 
-        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
+        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx)).unwrap();
         reader.read_header(&io).unwrap();
 
         for i in 0..5u64 {
@@ -6996,7 +7002,8 @@ mod tests {
             );
             append_encrypted_tx(&mut log, &io, tx);
 
-            let mut reader = StreamingLogicalLogReader::new(file, Some(wrong_key_enc_ctx()));
+            let mut reader =
+                StreamingLogicalLogReader::new(file, Some(wrong_key_enc_ctx())).unwrap();
             reader.read_header(&io).unwrap();
 
             match reader.parse_next_transaction(&io).unwrap() {
@@ -7029,7 +7036,7 @@ mod tests {
             io.wait_for_completion(file.pwrite(corrupt_offset, byte_buf, c).unwrap())
                 .unwrap();
 
-            let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
+            let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone())).unwrap();
             reader.read_header(&io).unwrap();
 
             match reader.parse_next_transaction(&io).unwrap() {
@@ -7060,7 +7067,7 @@ mod tests {
             io.wait_for_completion(file.pwrite(corrupt_offset, byte_buf, c).unwrap())
                 .unwrap();
 
-            let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
+            let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx)).unwrap();
             reader.read_header(&io).unwrap();
 
             match reader.parse_next_transaction(&io).unwrap() {
@@ -7100,7 +7107,7 @@ mod tests {
         io.wait_for_completion(file.truncate(truncate_at, c).unwrap())
             .unwrap();
 
-        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
+        let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx)).unwrap();
         reader.read_header(&io).unwrap();
 
         // First frame should parse fine.
@@ -7232,7 +7239,8 @@ mod tests {
                 .unwrap();
             overwrite_file_bytes(file.clone(), &io, &bytes);
             if allow_eof {
-                let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
+                let mut reader =
+                    StreamingLogicalLogReader::new(file, Some(enc_ctx.clone())).unwrap();
                 reader.read_header(&io).unwrap();
                 match reader.parse_next_transaction(&io).unwrap() {
                     ParseResult::InvalidFrame | ParseResult::Eof => {}
@@ -7315,7 +7323,7 @@ mod tests {
                 .unwrap();
             overwrite_file_bytes(file.clone(), &io, &base_bytes[..cut]);
 
-            let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
+            let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone())).unwrap();
             reader.read_header(&io).unwrap();
             match reader.parse_next_transaction(&io).unwrap() {
                 ParseResult::Frame(frame) => {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3557,7 +3557,7 @@ mod tests {
         let file = io.open_file(file_name, OpenFlags::Create, false).unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(commit_ts);
+        let mut tx = crate::mvcc::database::LogRecord::new(commit_ts).unwrap();
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
@@ -4086,7 +4086,7 @@ mod tests {
         let op_size = 6 + payload_len_len + payload_len;
         let frame_size = TX_HEADER_SIZE + op_size + TX_TRAILER_SIZE;
 
-        let mut tx1 = crate::mvcc::database::LogRecord::new(10);
+        let mut tx1 = crate::mvcc::database::LogRecord::new(10).unwrap();
         tx1.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
             begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(10)),
@@ -4097,7 +4097,7 @@ mod tests {
         let c = log.log_tx(tx1).unwrap();
         io.wait_for_completion(c).unwrap();
 
-        let mut tx2 = crate::mvcc::database::LogRecord::new(20);
+        let mut tx2 = crate::mvcc::database::LogRecord::new(20).unwrap();
         tx2.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 2,
             begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(20)),
@@ -4298,7 +4298,7 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(123);
+        let mut tx = crate::mvcc::database::LogRecord::new(123).unwrap();
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,
@@ -4771,7 +4771,7 @@ mod tests {
             .open_file("bitflip.db-log", crate::OpenFlags::Create, false)
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
-        let mut tx = crate::mvcc::database::LogRecord::new(300);
+        let mut tx = crate::mvcc::database::LogRecord::new(300).unwrap();
         tx.push_row_version_for_test(&crate::mvcc::database::RowVersion {
             id: 1,
             begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(300)),
@@ -4840,7 +4840,7 @@ mod tests {
 
         let mut expected = Vec::new();
         for tx_i in 0..128u64 {
-            let mut tx = crate::mvcc::database::LogRecord::new(1_000 + tx_i);
+            let mut tx = crate::mvcc::database::LogRecord::new(1_000 + tx_i).unwrap();
             let op_count = (rng.next_u64() % 4) as usize;
             for _ in 0..op_count {
                 let rowid = (rng.next_u64() % 64) as i64 + 1;
@@ -4894,7 +4894,7 @@ mod tests {
         // correctly when a single frame spans chunk boundaries.
         let large_commit_ts = 1_000 + 128u64;
         let large_text: String = "x".repeat(200);
-        let mut large_tx = crate::mvcc::database::LogRecord::new(large_commit_ts);
+        let mut large_tx = crate::mvcc::database::LogRecord::new(large_commit_ts).unwrap();
         for rowid in 1..=30i64 {
             let row = generate_simple_string_row((-3).into(), rowid, &large_text);
             expected.push(ExpectedTableOp::Upsert {
@@ -5044,7 +5044,7 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(55);
+        let mut tx = crate::mvcc::database::LogRecord::new(55).unwrap();
         let mut row = generate_simple_string_row((-2).into(), 1, "foo");
         row.id.table_id = (-2).into();
         let version = crate::mvcc::database::RowVersion {
@@ -5101,7 +5101,7 @@ mod tests {
             .unwrap();
         let mut log = LogicalLog::new(file.clone(), io.clone(), None);
 
-        let mut tx = crate::mvcc::database::LogRecord::new(10);
+        let mut tx = crate::mvcc::database::LogRecord::new(10).unwrap();
         let row = generate_simple_string_row((-2).into(), 1, "foo");
         let version = crate::mvcc::database::RowVersion {
             id: 1,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10289,12 +10289,15 @@ mod tests {
         let wal_file = io.open_file("test.wal", OpenFlags::Create, false).unwrap();
         let wal_shared = WalFileShared::new_shared(wal_file).unwrap();
         let last_checksum_and_max_frame = wal_shared.read().last_checksum_and_max_frame();
-        let wal: Arc<dyn Wal> = Arc::new(WalFile::new(
-            io.clone(),
-            wal_shared,
-            last_checksum_and_max_frame,
-            buffer_pool.clone(),
-        ));
+        let wal: Arc<dyn Wal> = Arc::new(
+            WalFile::new(
+                io.clone(),
+                wal_shared,
+                last_checksum_and_max_frame,
+                buffer_pool.clone(),
+            )
+            .unwrap(),
+        );
 
         // For new empty databases, init_page_1 must be Some(page) so allocate_page1() can be called
         let init_page_1 = Arc::new(ArcSwapOption::new(Some(default_page1(None))));

--- a/core/storage/journal_mode.rs
+++ b/core/storage/journal_mode.rs
@@ -98,5 +98,5 @@ pub fn open_mv_store(
             ))
         };
 
-    Ok(Arc::new(MvStore::new(mvcc::MvccClock::new(), storage)))
+    Ok(Arc::new(MvStore::new(mvcc::MvccClock::new(), storage)?))
 }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4217,7 +4217,7 @@ impl Pager {
                 CommitState::WalCommitDone => {
                     // all I/O complete, NOW it's safe to advance WAL state
                     let mut commit_info = self.commit_info.write();
-                    wal.commit_prepared_frames(&commit_info.prepared_frames);
+                    wal.commit_prepared_frames(&commit_info.prepared_frames)?;
                     wal.finalize_committed_pages(&commit_info.prepared_frames);
                     wal.finish_append_frames_commit()?;
                     self.dirty_pages.write().clear();
@@ -5854,12 +5854,15 @@ mod ptrmap_tests {
         )
         .unwrap();
         let last_checksum_and_max_frame = wal_shared.read().last_checksum_and_max_frame();
-        let wal: Arc<dyn Wal> = Arc::new(WalFile::new(
-            io.clone(),
-            wal_shared,
-            last_checksum_and_max_frame,
-            buffer_pool.clone(),
-        ));
+        let wal: Arc<dyn Wal> = Arc::new(
+            WalFile::new(
+                io.clone(),
+                wal_shared,
+                last_checksum_and_max_frame,
+                buffer_pool.clone(),
+            )
+            .unwrap(),
+        );
 
         // For new empty databases, init_page_1 must be Some(page) so allocate_page1() can be called
         let init_page_1 = Arc::new(ArcSwapOption::new(Some(default_page1(None))));
@@ -6124,7 +6127,7 @@ mod ptrmap_tests {
             target_idx,
             PendingRead {
                 page: synthetic_page.clone(),
-                disk_read: Some(stub_disk_read.clone()),
+                disk_read: Some(stub_disk_read),
             },
         );
 

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -24,6 +24,7 @@
 //! dead, it must leave that slot in place.
 
 use crate::{
+    alloc::{vec, *},
     io::{Completion, File, FileSyncType, OpenFlags, SharedWalLockKind, SharedWalMappedRegion, IO},
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
@@ -2452,14 +2453,18 @@ impl MappedSharedWalCoordination {
     /// Used by checkpoint to determine which pages need to be copied from the
     /// WAL to the DB file. For each page, only the highest-numbered frame is
     /// returned (that frame contains the most recent version of the page).
-    pub(crate) fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)> {
+    pub(crate) fn iter_latest_frames(
+        &self,
+        min_frame: u64,
+        max_frame: u64,
+    ) -> Result<Vec<(u64, u64)>, TryReserveError> {
         let header = self.header();
         let len = header
             .frame_index_len
             .load(Ordering::Acquire)
             .min(header.frame_index_capacity);
         if len == 0 {
-            return Vec::new();
+            return Ok(Vec::new());
         }
         let required_blocks = len.div_ceil(FRAME_INDEX_BLOCK_CAPACITY);
         self.ensure_mapped_frame_index_blocks(required_blocks)
@@ -2467,7 +2472,7 @@ impl MappedSharedWalCoordination {
         let mappings = self.frame_index_blocks.read();
         let visible_slots = Self::visible_frame_index_slots(&mappings, len, max_frame);
         if visible_slots == 0 {
-            return Vec::new();
+            return Ok(Vec::new());
         }
         let mut seen_pages = std::collections::BTreeSet::new();
         let mut entries = Vec::new();
@@ -2486,12 +2491,12 @@ impl MappedSharedWalCoordination {
                 let slot = block_start_slot + local_index;
                 let frame_id = Self::frame_index_entry(&mappings, slot).frame_id;
                 if (min_frame..=max_frame).contains(&frame_id) {
-                    entries.push((page_id, frame_id));
+                    entries.try_push((page_id, frame_id))?;
                 }
             }
         }
         entries.sort_unstable_by_key(|&(page_id, _)| page_id);
-        entries
+        Ok(entries)
     }
 
     fn base_mapped_len(reader_slot_count: u32) -> usize {
@@ -2931,6 +2936,7 @@ impl MappedSharedWalCoordination {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::alloc::vec;
     #[cfg(not(all(target_os = "windows", feature = "experimental_win_iocp")))]
     use crate::io::PlatformIO;
     use crate::io::IO;
@@ -3886,12 +3892,18 @@ mod tests {
 
         assert_eq!(mapped.find_frame(7, 0, 5, None), Some(5));
         assert_eq!(mapped.find_frame(7, 0, 5, Some(4)), Some(2));
-        assert_eq!(mapped.iter_latest_frames(0, 5), vec![(7, 5), (9, 4)]);
+        assert_eq!(
+            mapped.iter_latest_frames(0, 5).unwrap(),
+            vec![(7, 5), (9, 4)]
+        );
 
         mapped.rollback_frames(4);
 
         assert_eq!(mapped.find_frame(7, 0, 5, None), Some(2));
-        assert_eq!(mapped.iter_latest_frames(0, 5), vec![(7, 2), (9, 4)]);
+        assert_eq!(
+            mapped.iter_latest_frames(0, 5).unwrap(),
+            vec![(7, 2), (9, 4)]
+        );
     }
 
     #[test]
@@ -3961,7 +3973,7 @@ mod tests {
         mapped.record_frame(13, boundary + 2);
 
         assert_eq!(
-            mapped.iter_latest_frames(0, boundary + 2),
+            mapped.iter_latest_frames(0, boundary + 2).unwrap(),
             vec![
                 (7, boundary),
                 (9, boundary + 1),
@@ -4071,7 +4083,7 @@ mod tests {
         assert_eq!(mapped.find_frame(colliding[2], 0, 10, None), Some(8));
         assert_eq!(mapped.find_frame(colliding[1], 0, 10, Some(9)), Some(4));
         assert_eq!(
-            mapped.iter_latest_frames(0, 10),
+            mapped.iter_latest_frames(0, 10).unwrap(),
             vec![(colliding[0], 6), (colliding[1], 10), (colliding[2], 8),]
         );
     }
@@ -4093,7 +4105,7 @@ mod tests {
         assert_eq!(mapped.find_frame(colliding[1], 0, 2, None), None);
         assert_eq!(mapped.find_frame(colliding[2], 0, 2, None), Some(2));
         assert_eq!(
-            mapped.iter_latest_frames(0, 2),
+            mapped.iter_latest_frames(0, 2).unwrap(),
             vec![(colliding[0], 1), (colliding[2], 2)]
         );
     }
@@ -4131,7 +4143,7 @@ mod tests {
         assert_eq!(mapped.find_frame(9, 5, 20, None), None);
         assert_eq!(mapped.find_frame(11, 0, 21, Some(7)), None);
         assert_eq!(
-            mapped.iter_latest_frames(0, 13),
+            mapped.iter_latest_frames(0, 13).unwrap(),
             vec![(7, 13), (9, 4), (11, 8)]
         );
     }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
+use crate::alloc::*;
 use crate::io::FileSyncType;
 use crate::sync::Mutex;
 use crate::sync::OnceLock;
@@ -501,7 +502,11 @@ trait WalCoordination: Debug + Send + Sync {
     ) -> Option<u64>;
 
     /// Enumerate the latest visible frame per page in the requested frame range.
-    fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)>;
+    fn iter_latest_frames(
+        &self,
+        min_frame: u64,
+        max_frame: u64,
+    ) -> Result<Vec<(u64, u64)>, TryReserveError>;
 
     /// Read the current checkpoint epoch used to tag cached WAL pages.
     fn checkpoint_epoch(&self) -> u32;
@@ -574,7 +579,7 @@ trait WalCoordination: Debug + Send + Sync {
     fn mark_initialized(&self);
 
     /// Record a newly appended frame in the backend's page-to-frame lookup state.
-    fn cache_frame(&self, page_id: u64, frame_id: u64);
+    fn cache_frame(&self, page_id: u64, frame_id: u64) -> Result<(), TryReserveError>;
 
     /// Drop any cached frame mappings newer than `max_frame`.
     fn rollback_cache(&self, max_frame: u64);
@@ -689,7 +694,7 @@ pub trait Wal: Debug + Send + Sync {
 
     /// For each prepared frame, update in-memory WAL index and rolling checksum
     /// and advance max_frame to make committed frames visible to readers.
-    fn commit_prepared_frames(&self, prepared: &[PreparedFrames]);
+    fn commit_prepared_frames(&self, prepared: &[PreparedFrames]) -> Result<()>;
 
     /// Mark in-memory pages clean and set WAL tags after durable commit.
     fn finalize_committed_pages(&self, prepared: &[PreparedFrames]);
@@ -906,10 +911,14 @@ impl WalCoordination for InProcessWalCoordination {
         })
     }
 
-    fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)> {
+    fn iter_latest_frames(
+        &self,
+        min_frame: u64,
+        max_frame: u64,
+    ) -> Result<Vec<(u64, u64)>, TryReserveError> {
         let shared = self.shared.read();
         let frame_cache = shared.runtime.frame_cache.lock();
-        let mut list = Vec::with_capacity(frame_cache.len());
+        let mut list = Vec::try_with_capacity_ext(frame_cache.len())?;
         for (&page_id, frames) in frame_cache.iter() {
             if let Some(&frame_id) = frames
                 .iter()
@@ -919,7 +928,7 @@ impl WalCoordination for InProcessWalCoordination {
             }
         }
         list.sort_unstable_by_key(|&(page_id, _)| page_id);
-        list
+        Ok(list)
     }
 
     fn checkpoint_epoch(&self) -> u32 {
@@ -1231,17 +1240,18 @@ impl WalCoordination for InProcessWalCoordination {
             .store(true, Ordering::Release);
     }
 
-    fn cache_frame(&self, page_id: u64, frame_id: u64) {
+    fn cache_frame(&self, page_id: u64, frame_id: u64) -> Result<(), TryReserveError> {
         let shared = self.shared.read();
         let mut frame_cache = shared.runtime.frame_cache.lock();
         match frame_cache.get_mut(&page_id) {
             Some(frames) => {
-                frames.push(frame_id);
+                frames.try_push(frame_id)?;
             }
             None => {
-                frame_cache.insert(page_id, vec![frame_id]);
+                frame_cache.insert(page_id, try_vec![frame_id]?);
             }
         }
+        Ok(())
     }
 
     fn rollback_cache(&self, max_frame: u64) {
@@ -1346,7 +1356,7 @@ impl ShmWalCoordination {
     fn new(
         shared: Arc<RwLock<WalFileShared>>,
         authority: Arc<MappedSharedWalCoordination>,
-    ) -> Self {
+    ) -> Result<Self, TryReserveError> {
         let fallback = InProcessWalCoordination::new(shared.clone());
         let coordination = Self {
             shared,
@@ -1355,8 +1365,8 @@ impl ShmWalCoordination {
             authority,
             active_reader: Mutex::new(None),
         };
-        coordination.seed_or_sync_authority();
-        coordination
+        coordination.seed_or_sync_authority()?;
+        Ok(coordination)
     }
 
     fn authority_is_uninitialized(snapshot: SharedWalCoordinationHeader) -> bool {
@@ -1430,14 +1440,14 @@ impl ShmWalCoordination {
         shared.runtime.overflow_fallback_coverage.lock().clear();
     }
 
-    fn sync_authority_frames_from_local(&self) {
+    fn sync_authority_frames_from_local(&self) -> Result<(), TryReserveError> {
         let entries = {
             let shared = self.shared.read();
             let frame_cache = shared.runtime.frame_cache.lock();
             let mut entries = Vec::new();
             for (&page_id, frames) in frame_cache.iter() {
                 for &frame_id in frames {
-                    entries.push((frame_id, page_id));
+                    entries.try_push((frame_id, page_id))?;
                 }
             }
             entries
@@ -1447,12 +1457,13 @@ impl ShmWalCoordination {
         for (frame_id, page_id) in entries {
             self.authority.record_frame(page_id, frame_id);
         }
+        Ok(())
     }
 
     fn repair_or_reseed_authority_from_local_disk_scan(
         &self,
         mut authority_snapshot: SharedWalCoordinationHeader,
-    ) {
+    ) -> Result<(), TryReserveError> {
         self.authority.repair_transient_state_for_exclusive_open();
         if authority_snapshot.nbackfills != 0 {
             // A local WAL scan can rebuild the visible WAL tail, but it cannot
@@ -1465,16 +1476,16 @@ impl ShmWalCoordination {
         let local_snapshot = self.local_authority_snapshot();
         if Self::local_scan_predates_zero_frame_authority(authority_snapshot, local_snapshot) {
             self.sync_local_to_zero_frame_authority(authority_snapshot);
-            return;
+            return Ok(());
         }
         if Self::local_scan_cannot_disprove_zero_frame_authority(authority_snapshot, local_snapshot)
         {
             self.sync_local_from_authority(authority_snapshot);
-            return;
+            return Ok(());
         }
         if Self::local_scan_cannot_disprove_positive_authority(authority_snapshot, local_snapshot) {
             self.sync_local_from_authority(authority_snapshot);
-            return;
+            return Ok(());
         }
         if Self::authority_matches_local_wal_scan(authority_snapshot, local_snapshot) {
             self.sync_local_from_authority(authority_snapshot);
@@ -1486,13 +1497,14 @@ impl ShmWalCoordination {
             // mappings directly and rebuild if they diverge.
             if self.authority.frame_index_overflowed()
                 || (self.authority.open_mode() == SharedWalCoordinationOpenMode::Exclusive
-                    && !self.authority_frame_index_matches_local_wal_scan(local_snapshot.max_frame))
+                    && !self
+                        .authority_frame_index_matches_local_wal_scan(local_snapshot.max_frame)?)
             {
                 self.authority
                     .discard_durable_frame_index_for_exclusive_rebuild();
-                self.sync_authority_frames_from_local();
+                self.sync_authority_frames_from_local()?;
             }
-            return;
+            return Ok(());
         }
         // The authority and disk scan are from the same generation (matching
         // checkpoint_seq/salts) but disagree on max_frame or checksums. This
@@ -1512,15 +1524,15 @@ impl ShmWalCoordination {
             {
                 self.authority
                     .discard_durable_frame_index_for_exclusive_rebuild();
-                self.sync_authority_frames_from_local();
+                self.sync_authority_frames_from_local()?;
             }
-            return;
+            return Ok(());
         }
 
         self.authority
             .discard_durable_frame_index_for_exclusive_rebuild();
         self.sync_authority_from_local();
-        self.sync_authority_frames_from_local();
+        self.sync_authority_frames_from_local()
     }
 
     fn local_scan_cannot_disprove_zero_frame_authority(
@@ -1597,9 +1609,12 @@ impl ShmWalCoordination {
             && authority_snapshot.checksum_2 == local_snapshot.checksum_2
     }
 
-    fn authority_frame_index_matches_local_wal_scan(&self, max_frame: u64) -> bool {
-        self.authority.iter_latest_frames(0, max_frame)
-            == self.fallback.iter_latest_frames(0, max_frame)
+    fn authority_frame_index_matches_local_wal_scan(
+        &self,
+        max_frame: u64,
+    ) -> Result<bool, TryReserveError> {
+        Ok(self.authority.iter_latest_frames(0, max_frame)?
+            == self.fallback.iter_latest_frames(0, max_frame)?)
     }
 
     fn local_zero_frame_generation_is_initialized(
@@ -1650,7 +1665,7 @@ impl ShmWalCoordination {
     ///    snapshot as our local state. If our local view also came from a
     ///    disk scan and the authority's frame index is empty, backfill it
     ///    from our local frame cache.
-    fn seed_or_sync_authority(&self) {
+    fn seed_or_sync_authority(&self) -> Result<(), TryReserveError> {
         let snapshot = self.authority.snapshot();
         let local_wal_view_loaded_from_disk = self
             .shared
@@ -1660,11 +1675,11 @@ impl ShmWalCoordination {
             .load(Ordering::Acquire);
         if Self::authority_is_uninitialized(snapshot) {
             self.sync_authority_from_local();
-            self.sync_authority_frames_from_local();
+            self.sync_authority_frames_from_local()?;
         } else if local_wal_view_loaded_from_disk
             && !self.authority.writer_or_checkpoint_lock_active()
         {
-            self.repair_or_reseed_authority_from_local_disk_scan(snapshot);
+            self.repair_or_reseed_authority_from_local_disk_scan(snapshot)?;
         } else {
             let needs_zero_frame_header_rewrite = snapshot.max_frame == 0 && {
                 let shared = self.shared.read();
@@ -1683,11 +1698,12 @@ impl ShmWalCoordination {
             }
             if local_wal_view_loaded_from_disk
                 && !self.authority.writer_or_checkpoint_lock_active()
-                && self.authority.iter_latest_frames(0, u64::MAX).is_empty()
+                && self.authority.iter_latest_frames(0, u64::MAX)?.is_empty()
             {
-                self.sync_authority_frames_from_local();
+                self.sync_authority_frames_from_local()?;
             }
         }
+        Ok(())
     }
 
     fn restart_snapshot_from_authority(
@@ -1873,7 +1889,11 @@ impl WalCoordination for ShmWalCoordination {
             .find_frame(page_id, min_frame, max_frame, frame_watermark)
     }
 
-    fn iter_latest_frames(&self, min_frame: u64, max_frame: u64) -> Vec<(u64, u64)> {
+    fn iter_latest_frames(
+        &self,
+        min_frame: u64,
+        max_frame: u64,
+    ) -> Result<Vec<(u64, u64)>, TryReserveError> {
         // Same trade-off as find_frame(): if the reserved shared index space is
         // exhausted, keep correctness by consulting the local scanned cache.
         if self.authority.frame_index_overflowed() {
@@ -2231,9 +2251,10 @@ impl WalCoordination for ShmWalCoordination {
         self.fallback.mark_initialized();
     }
 
-    fn cache_frame(&self, page_id: u64, frame_id: u64) {
-        self.fallback.cache_frame(page_id, frame_id);
+    fn cache_frame(&self, page_id: u64, frame_id: u64) -> Result<(), TryReserveError> {
+        self.fallback.cache_frame(page_id, frame_id)?;
         self.authority.record_frame(page_id, frame_id);
+        Ok(())
     }
 
     fn rollback_cache(&self, max_frame: u64) {
@@ -3404,7 +3425,7 @@ impl Wal for WalFile {
 
         // Lock each target page and pre-allocate its destination buffer so the
         // completion callback only parses headers, decrypts/verifies, and copies.
-        let mut slots: Vec<(PageRef, Arc<Buffer>)> = Vec::with_capacity(count);
+        let mut slots: Vec<(PageRef, Arc<Buffer>)> = Vec::try_with_capacity_ext(count)?;
         for page in pages.iter() {
             #[cfg(debug_assertions)]
             {
@@ -3423,6 +3444,7 @@ impl Wal for WalFile {
                 );
             }
             page.set_locked();
+            // Preallocated to not need try_push
             slots.push((page.clone(), Arc::new(buffer_pool.get_page())));
         }
 
@@ -3694,7 +3716,7 @@ impl Wal for WalFile {
         let c = Completion::new_write(|_| {});
         let c = file.pwrite(offset, frame_bytes, c)?;
         self.io.wait_for_completion(c)?;
-        self.complete_append_frame(page_id, frame_id, checksums);
+        self.complete_append_frame(page_id, frame_id, checksums)?;
         if db_size > 0 {
             self.finish_append_frames_commit()?;
         } else {
@@ -3934,14 +3956,14 @@ impl Wal for WalFile {
     fn changed_pages_after(&self, frame_watermark: u64) -> Result<Vec<u32>> {
         let frame_count = self.get_max_frame();
         let page_size = self.page_size();
-        let mut frame = vec![0u8; page_size as usize + WAL_FRAME_HEADER_SIZE];
+        let mut frame = try_vec![0u8; page_size as usize + WAL_FRAME_HEADER_SIZE]?;
         let mut seen = FxHashSet::default();
         turso_assert!(
             frame_count >= frame_watermark,
             "frame_count must be not less than frame_watermark",
             { "frame_count": frame_count, "frame_watermark": frame_watermark }
         );
-        let mut pages = Vec::with_capacity((frame_count - frame_watermark) as usize);
+        let mut pages = Vec::try_with_capacity_ext((frame_count - frame_watermark) as usize)?;
         for frame_no in frame_watermark + 1..=frame_count {
             let c = self.read_frame_raw(frame_no, &mut frame)?;
             self.io.wait_for_completion(c)?;
@@ -4112,8 +4134,8 @@ impl Wal for WalFile {
 
         let first_frame_id = next_frame_id;
 
-        let mut bufs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
-        let mut metadata = Vec::with_capacity(pages.len());
+        let mut bufs: Vec<Arc<Buffer>> = Vec::try_with_capacity_ext(pages.len())?;
+        let mut metadata = Vec::try_with_capacity_ext(pages.len())?;
 
         for (idx, page) in pages.iter().enumerate() {
             let page_id = page.get().id;
@@ -4149,6 +4171,7 @@ impl Wal for WalFile {
                 frame_db_size,
                 &data,
             );
+            // preallocated enough to not need try_push
             bufs.push(frame_buf);
             metadata.push((page.clone(), next_frame_id, checksum));
             rolling_checksum = checksum;
@@ -4167,11 +4190,11 @@ impl Wal for WalFile {
 
     /// For each prepared frame, update in-memory WAL index and rolling checksum.
     /// and advance max_frame to make frames visible to readers.
-    fn commit_prepared_frames(&self, batches: &[PreparedFrames]) {
+    fn commit_prepared_frames(&self, batches: &[PreparedFrames]) -> Result<()> {
         for batch in batches {
             for (page, frame_id, checksum) in &batch.metadata {
                 // Update WAL index mapping page -> frame
-                self.complete_append_frame(page.get().id as u64, *frame_id, *checksum);
+                self.complete_append_frame(page.get().id as u64, *frame_id, *checksum)?;
             }
             // Update rolling checksum
             *self.last_checksum.write() = batch.final_checksum;
@@ -4179,6 +4202,7 @@ impl Wal for WalFile {
             self.max_frame
                 .store(batch.final_max_frame, Ordering::Release);
         }
+        Ok(())
     }
 
     /// Mark pages clean and set WAL tags after durable commit.
@@ -4222,9 +4246,9 @@ impl Wal for WalFile {
         );
 
         // Prepare write buffers and bookkeeping
-        let mut iovecs: Vec<Arc<Buffer>> = Vec::with_capacity(pages.len());
+        let mut iovecs: Vec<Arc<Buffer>> = Vec::try_with_capacity_ext(pages.len())?;
         let mut page_frame_and_checksum: Vec<(PageRef, u64, (u32, u32))> =
-            Vec::with_capacity(pages.len());
+            Vec::try_with_capacity_ext(pages.len())?;
 
         // Rolling checksum input to each frame build
         let mut rolling_checksum: (u32, u32) = *self.last_checksum.read();
@@ -4300,7 +4324,7 @@ impl Wal for WalFile {
         self.io.drain_completions(std::slice::from_ref(&c))?;
 
         for (page, fid, csum) in &page_frame_and_checksum {
-            self.complete_append_frame(page.get().id as u64, *fid, *csum);
+            self.complete_append_frame(page.get().id as u64, *fid, *csum)?;
         }
 
         Ok(c)
@@ -4337,9 +4361,9 @@ impl WalFile {
         authority: Arc<MappedSharedWalCoordination>,
         _last_checksum_and_max_frame: ((u32, u32), u64),
         buffer_pool: Arc<BufferPool>,
-    ) -> Self {
+    ) -> Result<Self, TryReserveError> {
         let coordination: Arc<dyn WalCoordination> =
-            Arc::new(ShmWalCoordination::new(shared, authority));
+            Arc::new(ShmWalCoordination::new(shared, authority)?);
         let snapshot = coordination.load_snapshot();
         Self::new_with_coordination(
             io,
@@ -4354,7 +4378,7 @@ impl WalFile {
         shared: Arc<RwLock<WalFileShared>>,
         (last_checksum, max_frame): ((u32, u32), u64),
         buffer_pool: Arc<BufferPool>,
-    ) -> Self {
+    ) -> Result<Self, TryReserveError> {
         let coordination: Arc<dyn WalCoordination> =
             Arc::new(InProcessWalCoordination::new(shared));
         Self::new_with_coordination(io, coordination, (last_checksum, max_frame), buffer_pool)
@@ -4366,9 +4390,9 @@ impl WalFile {
         coordination: Arc<dyn WalCoordination>,
         (last_checksum, max_frame): ((u32, u32), u64),
         buffer_pool: Arc<BufferPool>,
-    ) -> Self {
+    ) -> Result<Self, TryReserveError> {
         let now = io.current_time_monotonic();
-        Self {
+        Ok(Self {
             io,
             coordination,
             // default to max frame in WAL, so that when we read schema we can read from WAL too if it's there.
@@ -4382,7 +4406,7 @@ impl WalFile {
                 max_frame: 0,
                 current_page: 0,
                 pages_to_checkpoint: Vec::new(),
-                inflight_reads: Vec::with_capacity(MAX_INFLIGHT_READS),
+                inflight_reads: Vec::try_with_capacity_ext(MAX_INFLIGHT_READS)?,
             }),
             checkpoint_threshold: 1000,
             buffer_pool,
@@ -4397,7 +4421,7 @@ impl WalFile {
             checkpoint_guard: RwLock::new(None),
             io_ctx: RwLock::new(IOContext::default()),
             has_unpublished_frames: AtomicBool::new(false),
-        }
+        })
     }
 
     #[cfg(test)]
@@ -4439,10 +4463,16 @@ impl WalFile {
         tracing::debug!("increment checkpoint epoch: prev={}", prev);
     }
 
-    fn complete_append_frame(&self, page_id: u64, frame_id: u64, checksums: (u32, u32)) {
+    fn complete_append_frame(
+        &self,
+        page_id: u64,
+        frame_id: u64,
+        checksums: (u32, u32),
+    ) -> Result<()> {
+        self.coordination.cache_frame(page_id, frame_id)?;
         *self.last_checksum.write() = checksums;
         self.max_frame.store(frame_id, Ordering::Release);
-        self.coordination.cache_frame(page_id, frame_id);
+        Ok(())
     }
 
     /// Reset connection-private WAL state.
@@ -4539,7 +4569,7 @@ impl WalFile {
                     );
                     let mut to_checkpoint = self
                         .coordination
-                        .iter_latest_frames(oc_min_frame, oc_max_frame);
+                        .iter_latest_frames(oc_min_frame, oc_max_frame)?;
                     // sort by frame_id for read locality
                     to_checkpoint.sort_unstable_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
                     {
@@ -4583,7 +4613,7 @@ impl WalFile {
                             .inflight_reads
                             .iter()
                             .map(|r| r.completion.clone())
-                            .collect();
+                            .try_collect()?;
                         pager.io.cancel(&to_cancel)?;
                         pager.io.drain_completions(&to_cancel)?;
                         return Err(LimboError::CompletionError(e));
@@ -4607,8 +4637,7 @@ impl WalFile {
                             // exact contents as one read from the WAL.
                             #[cfg(debug_assertions)]
                             {
-                                let mut raw =
-                                    vec![0u8; self.page_size() as usize + WAL_FRAME_HEADER_SIZE];
+                                let mut raw = try_vec![0u8; self.page_size() as usize + WAL_FRAME_HEADER_SIZE]?;
                                 self.io.wait_for_completion(
                                     self.read_frame_raw(target_frame, &mut raw)?,
                                 )?;
@@ -4771,7 +4800,7 @@ impl WalFile {
     /// because we might overwrite content the reader is reading from the database file.
     ///
     /// A checkpoint must never overwrite a page in the main DB file if some
-    /// active reader might still need to read that page from the WAL.  
+    /// active reader might still need to read that page from the WAL.
     /// Concretely: the checkpoint may only copy frames `<= aReadMark[k]` for
     /// every in-use reader slot `k > 0`.
     ///
@@ -5314,7 +5343,7 @@ impl WalFileShared {
         }
         if snapshot.max_frame > snapshot.nbackfills
             && authority
-                .iter_latest_frames(0, snapshot.max_frame)
+                .iter_latest_frames(0, snapshot.max_frame)?
                 .is_empty()
         {
             tracing::debug!(
@@ -5882,7 +5911,8 @@ pub mod test {
         let shared = WalFileShared::new_noop();
         let coordination: Arc<dyn WalCoordination> =
             Arc::new(InProcessWalCoordination::new(shared.clone()));
-        let wal = WalFile::new_with_coordination(io, coordination, ((0, 0), 0), buffer_pool);
+        let wal =
+            WalFile::new_with_coordination(io, coordination, ((0, 0), 0), buffer_pool).unwrap();
         (shared, wal)
     }
 
@@ -5890,7 +5920,7 @@ pub mod test {
         let io = shared_wal_test_io();
         let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
         let snapshot = shared.read().last_checksum_and_max_frame();
-        WalFile::new(io, shared, snapshot, buffer_pool)
+        WalFile::new(io, shared, snapshot, buffer_pool).unwrap()
     }
 
     fn make_initialized_memory_wal(page_size: u32) -> (Arc<dyn IO>, Arc<BufferPool>, WalFile) {
@@ -5903,7 +5933,7 @@ pub mod test {
             .open_file("direct-batch-read.db-wal", OpenFlags::Create, false)
             .unwrap();
         let shared = WalFileShared::new_shared(file).unwrap();
-        let wal = WalFile::new(io.clone(), shared, ((0, 0), 0), buffer_pool.clone());
+        let wal = WalFile::new(io.clone(), shared, ((0, 0), 0), buffer_pool.clone()).unwrap();
         let page_size = PageSize::new(page_size).unwrap();
 
         if let Some(c) = wal.prepare_wal_start(page_size).unwrap() {
@@ -5946,7 +5976,7 @@ pub mod test {
             )
             .unwrap();
         io.wait_for_completion(c).unwrap();
-        wal.commit_prepared_frames(&[prepared]);
+        wal.commit_prepared_frames(&[prepared]).unwrap();
         wal.finish_append_frames_commit().unwrap();
         expected
     }
@@ -6172,7 +6202,7 @@ pub mod test {
         let io = shared_wal_test_io();
         let authority =
             Arc::new(MappedSharedWalCoordination::create_or_open(&io, path, 64).unwrap());
-        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone()).unwrap();
         (authority, coordination)
     }
 
@@ -6312,7 +6342,8 @@ pub mod test {
                 snapshot.max_frame,
             ),
             buffer_pool.clone(),
-        );
+        )
+        .unwrap();
 
         let page = Arc::new(crate::storage::pager::Page::new(7));
         let issued_epoch = wal.coordination.checkpoint_epoch();
@@ -6449,7 +6480,10 @@ pub mod test {
         assert_eq!(coordination.checkpoint_epoch(), 5);
         assert_eq!(coordination.find_frame(1, 4, 9, None), Some(8));
         assert_eq!(coordination.find_frame(2, 4, 9, Some(5)), Some(2));
-        assert_eq!(coordination.iter_latest_frames(4, 9), vec![(1, 8), (2, 6)]);
+        assert_eq!(
+            coordination.iter_latest_frames(4, 9).unwrap(),
+            vec![(1, 8), (2, 6)]
+        );
 
         coordination.publish_commit(WalCommitState {
             max_frame: 12,
@@ -6523,17 +6557,23 @@ pub mod test {
         let (shared, _wal) = make_test_wal();
         let coordination = make_test_coordination(&shared);
 
-        coordination.cache_frame(7, 2);
-        coordination.cache_frame(7, 5);
-        coordination.cache_frame(9, 4);
+        coordination.cache_frame(7, 2).unwrap();
+        coordination.cache_frame(7, 5).unwrap();
+        coordination.cache_frame(9, 4).unwrap();
 
         assert_eq!(coordination.find_frame(7, 0, 5, None), Some(5));
-        assert_eq!(coordination.iter_latest_frames(0, 5), vec![(7, 5), (9, 4)]);
+        assert_eq!(
+            coordination.iter_latest_frames(0, 5).unwrap(),
+            vec![(7, 5), (9, 4)]
+        );
 
         coordination.rollback_cache(4);
 
         assert_eq!(coordination.find_frame(7, 0, 5, None), Some(2));
-        assert_eq!(coordination.iter_latest_frames(0, 5), vec![(7, 2), (9, 4)]);
+        assert_eq!(
+            coordination.iter_latest_frames(0, 5).unwrap(),
+            vec![(7, 2), (9, 4)]
+        );
         assert_eq!(
             shared.read().runtime.frame_cache.lock().get(&7),
             Some(&vec![2])
@@ -6555,9 +6595,9 @@ pub mod test {
             },
         );
 
-        coordination.cache_frame(7, 10);
-        coordination.cache_frame(9, 20);
-        coordination.cache_frame(11, 30);
+        coordination.cache_frame(7, 10).unwrap();
+        coordination.cache_frame(9, 20).unwrap();
+        coordination.cache_frame(11, 30).unwrap();
         wal.max_frame.store(30, Ordering::Release);
 
         wal.rollback(Some(RollbackTo {
@@ -6644,9 +6684,9 @@ pub mod test {
 
         let (_authority_a, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
         let (authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
-        coordination_a.cache_frame(7, 2);
-        coordination_a.cache_frame(9, 4);
-        coordination_a.cache_frame(7, 5);
+        coordination_a.cache_frame(7, 2).unwrap();
+        coordination_a.cache_frame(9, 4).unwrap();
+        coordination_a.cache_frame(7, 5).unwrap();
 
         assert_eq!(coordination_b.load_snapshot(), snapshot);
         assert_eq!(coordination_b.wal_header().page_size, 4096);
@@ -6654,7 +6694,7 @@ pub mod test {
         assert_eq!(coordination_b.wal_header().salt_2, 23);
         assert_eq!(coordination_b.find_frame(7, 0, 5, None), Some(5));
         assert_eq!(
-            coordination_b.iter_latest_frames(0, 5),
+            coordination_b.iter_latest_frames(0, 5).unwrap(),
             vec![(7, 5), (9, 4)]
         );
         assert_eq!(coordination_a.checkpoint_epoch(), 0);
@@ -6692,7 +6732,7 @@ pub mod test {
         coordination_b.rollback_cache(4);
         assert_eq!(coordination_a.find_frame(7, 0, 5, None), Some(2));
         assert_eq!(
-            coordination_a.iter_latest_frames(0, 5),
+            coordination_a.iter_latest_frames(0, 5).unwrap(),
             vec![(7, 2), (9, 4)]
         );
         assert!(shm_path.exists());
@@ -6731,7 +6771,7 @@ pub mod test {
             Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
         let mut readers = Vec::new();
         for _ in 0..128 {
-            let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+            let coordination = ShmWalCoordination::new(shared.clone(), authority.clone()).unwrap();
             let read_guard = coordination
                 .try_begin_read_tx(snapshot)
                 .expect("same-snapshot readers should share a published reader barrier");
@@ -6786,9 +6826,9 @@ pub mod test {
 
         let authority =
             Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
-        let reader_a1 = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let reader_a1 = ShmWalCoordination::new(shared.clone(), authority.clone()).unwrap();
         let guard_a1 = reader_a1.try_begin_read_tx(snapshot_a).unwrap();
-        let reader_a2 = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let reader_a2 = ShmWalCoordination::new(shared.clone(), authority.clone()).unwrap();
         let guard_a2 = reader_a2.try_begin_read_tx(snapshot_a).unwrap();
         assert_eq!(
             authority.min_active_reader_frame(),
@@ -6809,9 +6849,9 @@ pub mod test {
             transaction_count: snapshot_b.transaction_count,
         });
 
-        let reader_b1 = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let reader_b1 = ShmWalCoordination::new(shared.clone(), authority.clone()).unwrap();
         let guard_b1 = reader_b1.try_begin_read_tx(snapshot_b).unwrap();
-        let reader_b2 = ShmWalCoordination::new(shared, authority.clone());
+        let reader_b2 = ShmWalCoordination::new(shared, authority.clone()).unwrap();
         let guard_b2 = reader_b2.try_begin_read_tx(snapshot_b).unwrap();
 
         assert_eq!(
@@ -6881,11 +6921,13 @@ pub mod test {
         let (_authority_a, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
         let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
 
-        coordination_a.cache_frame(7, 2);
+        coordination_a.cache_frame(7, 2).unwrap();
         for frame_id in 3..=OLD_FIXED_LIMIT + 1 {
-            coordination_a.cache_frame(100 + (frame_id % 31), frame_id);
+            coordination_a
+                .cache_frame(100 + (frame_id % 31), frame_id)
+                .unwrap();
         }
-        coordination_a.cache_frame(7, OLD_FIXED_LIMIT + 2);
+        coordination_a.cache_frame(7, OLD_FIXED_LIMIT + 2).unwrap();
 
         assert_eq!(
             coordination_b.find_frame(7, 0, OLD_FIXED_LIMIT + 2, None),
@@ -6897,6 +6939,7 @@ pub mod test {
         );
         assert!(coordination_b
             .iter_latest_frames(0, OLD_FIXED_LIMIT + 2)
+            .unwrap()
             .contains(&(7, OLD_FIXED_LIMIT + 2)));
     }
 
@@ -6937,8 +6980,8 @@ pub mod test {
 
         let (_authority_a, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
         let (_authority_b, coordination_b) = make_test_shm_coordination(&shared_b, &shm_path);
-        coordination_a.cache_frame(7, 2);
-        coordination_a.cache_frame(9, 4);
+        coordination_a.cache_frame(7, 2).unwrap();
+        coordination_a.cache_frame(9, 4).unwrap();
 
         {
             let mut shared = shared_b.write();
@@ -6995,7 +7038,10 @@ pub mod test {
         assert_ne!(header.salt_2, 23);
         assert_eq!(header.checksum_1, snapshot.last_checksum.0);
         assert_eq!(header.checksum_2, snapshot.last_checksum.1);
-        assert_eq!(coordination_a.iter_latest_frames(0, u64::MAX), Vec::new());
+        assert_eq!(
+            coordination_a.iter_latest_frames(0, u64::MAX).unwrap(),
+            Vec::new()
+        );
         assert_eq!(coordination_a.checkpoint_epoch(), 5);
 
         let shared = shared_b.read();
@@ -7043,8 +7089,8 @@ pub mod test {
             }
 
             let (authority, coordination) = make_test_shm_coordination(&shared, &shm_path);
-            coordination.cache_frame(7, 2);
-            coordination.cache_frame(7, 5);
+            coordination.cache_frame(7, 2).unwrap();
+            coordination.cache_frame(7, 5).unwrap();
             assert_eq!(
                 authority.open_mode(),
                 SharedWalCoordinationOpenMode::Exclusive
@@ -7075,7 +7121,9 @@ pub mod test {
             }
         );
         assert_eq!(
-            reopened_coordination.iter_latest_frames(0, u64::MAX),
+            reopened_coordination
+                .iter_latest_frames(0, u64::MAX)
+                .unwrap(),
             vec![(7, 5)]
         );
         assert_eq!(reopened_authority.min_active_reader_frame(), None);
@@ -7167,7 +7215,8 @@ pub mod test {
             reopened_authority.clone(),
             ((0, 0), 0),
             buffer_pool,
-        );
+        )
+        .unwrap();
 
         wal.begin_read_tx().unwrap();
         reopened_authority.mark_frame_index_overflowed_for_tests();
@@ -7274,7 +7323,8 @@ pub mod test {
         let buffer_pool = BufferPool::begin_init(&io, BufferPool::TEST_ARENA_SIZE);
         buffer_pool.finalize_with_page_size(4096).unwrap();
         let wal =
-            WalFile::new_with_shared_coordination(io, shared, authority, ((0, 0), 0), buffer_pool);
+            WalFile::new_with_shared_coordination(io, shared, authority, ((0, 0), 0), buffer_pool)
+                .unwrap();
 
         assert_eq!(wal.get_max_frame(), 1);
         assert_eq!(wal.get_last_checksum(), (31, 37));
@@ -7356,12 +7406,15 @@ pub mod test {
             .loaded_from_disk_scan
             .load(Ordering::Acquire));
         assert!(
-            authority.iter_latest_frames(0, u64::MAX).is_empty(),
+            authority.iter_latest_frames(0, u64::MAX).unwrap().is_empty(),
             "open_shared_from_authority_if_exists should not republish authority before coordination reconciliation"
         );
 
-        let exclusive_coordination = ShmWalCoordination::new(exclusive, authority.clone());
-        assert_eq!(authority.iter_latest_frames(0, u64::MAX), vec![(7, 1)]);
+        let exclusive_coordination = ShmWalCoordination::new(exclusive, authority.clone()).unwrap();
+        assert_eq!(
+            authority.iter_latest_frames(0, u64::MAX).unwrap(),
+            vec![(7, 1)]
+        );
         assert_eq!(exclusive_coordination.find_frame(7, 0, 1, None), Some(1));
 
         drop(exclusive_coordination);
@@ -7387,7 +7440,8 @@ pub mod test {
             .metadata
             .loaded_from_disk_scan
             .load(Ordering::Acquire));
-        let reopened_coordination = ShmWalCoordination::new(reopened_shared, reopened_authority);
+        let reopened_coordination =
+            ShmWalCoordination::new(reopened_shared, reopened_authority).unwrap();
         assert_eq!(reopened_coordination.find_frame(7, 0, 1, None), Some(1));
     }
 
@@ -7432,7 +7486,7 @@ pub mod test {
             .loaded_from_disk_scan
             .load(Ordering::Acquire));
 
-        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone()).unwrap();
         let reopened = coordination.load_snapshot();
         assert_eq!(reopened.max_frame, 0);
         assert_eq!(reopened.nbackfills, 0);
@@ -7839,8 +7893,8 @@ pub mod test {
             header.checksum_2 = authoritative.last_checksum.1;
         }
         let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
-        coordination_a.cache_frame(7, 2);
-        coordination_a.cache_frame(7, 5);
+        coordination_a.cache_frame(7, 2).unwrap();
+        coordination_a.cache_frame(7, 5).unwrap();
         assert!(authority.try_acquire_writer(authority.owner_record()));
 
         let file_b = io
@@ -7916,8 +7970,8 @@ pub mod test {
             header.checksum_2 = authoritative.last_checksum.1;
         }
         let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
-        coordination_a.cache_frame(7, 2);
-        coordination_a.cache_frame(9, 5);
+        coordination_a.cache_frame(7, 2).unwrap();
+        coordination_a.cache_frame(9, 5).unwrap();
 
         let file_b = io
             .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
@@ -7955,7 +8009,9 @@ pub mod test {
         assert_eq!(authority.find_frame(7, 0, 5, None), Some(2));
         assert_eq!(authority.find_frame(9, 0, 5, None), Some(5));
         assert_eq!(
-            authority.iter_latest_frames(0, authoritative.max_frame),
+            authority
+                .iter_latest_frames(0, authoritative.max_frame)
+                .unwrap(),
             vec![(7, 2), (9, 5)]
         );
     }
@@ -7995,8 +8051,8 @@ pub mod test {
         }
         {
             let (_authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
-            coordination_a.cache_frame(7, 2);
-            coordination_a.cache_frame(9, 4);
+            coordination_a.cache_frame(7, 2).unwrap();
+            coordination_a.cache_frame(9, 4).unwrap();
         }
 
         let file_b = io
@@ -8038,7 +8094,9 @@ pub mod test {
             "matching snapshot metadata must not preserve a stale shared frame index across restart recovery"
         );
         assert_eq!(
-            authority.iter_latest_frames(0, authoritative.max_frame),
+            authority
+                .iter_latest_frames(0, authoritative.max_frame)
+                .unwrap(),
             vec![(7, 2), (9, 5)]
         );
     }
@@ -8081,7 +8139,7 @@ pub mod test {
                 .store(true, Ordering::Release);
         }
 
-        let coordination = ShmWalCoordination::new(shared, authority.clone());
+        let coordination = ShmWalCoordination::new(shared, authority.clone()).unwrap();
         let snapshot = authority.snapshot();
         assert_eq!(snapshot, authoritative);
         let header = coordination.wal_header();
@@ -8125,8 +8183,8 @@ pub mod test {
             header.checksum_2 = authoritative.last_checksum.1;
         }
         let (authority, coordination_a) = make_test_shm_coordination(&shared_a, &shm_path);
-        coordination_a.cache_frame(7, 2);
-        coordination_a.cache_frame(9, 5);
+        coordination_a.cache_frame(7, 2).unwrap();
+        coordination_a.cache_frame(9, 5).unwrap();
 
         let file_b = io
             .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
@@ -8212,7 +8270,7 @@ pub mod test {
             shared.runtime.epoch.store(1, Ordering::Release);
         }
 
-        let coordination = ShmWalCoordination::new(shared.clone(), authority);
+        let coordination = ShmWalCoordination::new(shared.clone(), authority).unwrap();
         assert!(
             !coordination.wal_is_initialized(),
             "a stale local initialized bit must not suppress the first header rewrite after RESTART/TRUNCATE"
@@ -8257,7 +8315,7 @@ pub mod test {
             .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
             .unwrap();
         let shared = WalFileShared::new_shared(file).unwrap();
-        let coordination = ShmWalCoordination::new(shared, authority.clone());
+        let coordination = ShmWalCoordination::new(shared, authority.clone()).unwrap();
 
         let prepared = coordination
             .prepare_wal_header(io.as_ref(), PageSize::new(4096).unwrap())
@@ -8336,7 +8394,7 @@ pub mod test {
             .open_file(wal_path.to_str().unwrap(), crate::OpenFlags::Create, false)
             .unwrap();
         let shared_b = WalFileShared::new_shared(file_b).unwrap();
-        let coordination_b = ShmWalCoordination::new(shared_b.clone(), authority.clone());
+        let coordination_b = ShmWalCoordination::new(shared_b.clone(), authority.clone()).unwrap();
         // Simulate a long-lived process whose process-wide shared WAL metadata
         // fell behind the authority after another process checkpointed and
         // restarted the WAL back to frame 0.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6706,7 +6706,7 @@ pub fn op_agg_final(
                 #[cfg(feature = "json")]
                 AggFunc::JsonbGroupArray => {
                     state.registers[dest_reg]
-                        .set_blob(json::jsonb::Jsonb::make_empty_array(1).data())?;
+                        .set_blob(json::jsonb::Jsonb::make_empty_array(1)?.data())?;
                 }
                 #[cfg(feature = "json")]
                 AggFunc::JsonGroupObject => {
@@ -6715,7 +6715,7 @@ pub fn op_agg_final(
                 #[cfg(feature = "json")]
                 AggFunc::JsonbGroupObject => {
                     state.registers[dest_reg]
-                        .set_blob(json::jsonb::Jsonb::make_empty_obj(1).data())?;
+                        .set_blob(json::jsonb::Jsonb::make_empty_obj(1)?.data())?;
                 }
                 AggFunc::External(ext_func) => {
                     let value = match ext_func.as_ref() {
@@ -7300,7 +7300,7 @@ pub fn op_function(
             }
             JsonFunc::JsonValid => {
                 let json_value = &state.registers[*start_reg];
-                state.registers[*dest].set_value(is_json_valid(json_value.get_value()));
+                state.registers[*dest].set_value(is_json_valid(json_value.get_value())?);
             }
             JsonFunc::JsonPatch => {
                 assert_eq!(arg_count, 2);
@@ -7888,7 +7888,8 @@ pub fn op_function(
                         }
                     };
 
-                    let mut json = json::jsonb::Jsonb::make_empty_array(table.columns().len() * 10);
+                    let mut json =
+                        json::jsonb::Jsonb::make_empty_array(table.columns().len() * 10)?;
                     for column in table.columns() {
                         use crate::types::TextRef;
 
@@ -7919,8 +7920,6 @@ pub fn op_function(
                 #[cfg(feature = "json")]
                 'outer: {
                     use crate::types::ValueIterator;
-                    use std::str::FromStr;
-
                     let columns_str = state.registers[*start_reg].get_value();
                     let bin_record = state.registers[*start_reg + 1].get_value();
                     let Value::Text(columns_str) = columns_str else {
@@ -7945,9 +7944,9 @@ pub fn op_function(
 
                     let mut payload_iterator = ValueIterator::new(bin_record.as_slice())?;
 
-                    let mut json = json::jsonb::Jsonb::make_empty_obj(columns_len);
+                    let mut json = json::jsonb::Jsonb::make_empty_obj(columns_len)?;
                     for i in 0..columns_len {
-                        let mut op = json::jsonb::SearchOperation::new(0);
+                        let mut op = json::jsonb::SearchOperation::new(0)?;
                         let path = json::path::JsonPath {
                             elements: vec![
                                 json::path::PathElement::Root(),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -605,7 +605,7 @@ pub fn op_checkpoint(
             program.connection.clone(),
             true,
             program.connection.get_sync_mode(),
-        );
+        )?;
         let CheckpointResult {
             wal_max_frame,
             wal_total_backfilled,
@@ -15063,7 +15063,7 @@ fn op_journal_mode_inner(
                                 program.connection.clone(),
                                 true,
                                 program.connection.get_sync_mode(),
-                            ))));
+                            )?)));
                     }
 
                     let ckpt_sm = state

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1535,7 +1535,11 @@ fn install_mvcc_state_after_vacuum_commit(
     header: DatabaseHeader,
     schema: Arc<Schema>,
 ) {
-    mv_store.reset_after_vacuum(header, schema.as_ref());
+    // TODO: currently memory allocation makes this fallible. If Skiplist supported `retain` we could probably remove
+    // the allocation
+    mv_store
+        .reset_after_vacuum(header, schema.as_ref())
+        .expect("post-commit MVCC VACUUM metadata install must not fail: physical replacement image is already durable");
     replace_shared_schema_after_vacuum(source_db, schema);
 }
 

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2061,7 +2061,7 @@ fn vacuum_in_place_step(
                 let prepared = prev_prepared
                     .as_ref()
                     .expect("VACUUM WriteWalBatch phase requires prepared frames");
-                wal.commit_prepared_frames(std::slice::from_ref(prepared.as_ref()));
+                wal.commit_prepared_frames(std::slice::from_ref(prepared.as_ref()))?;
 
                 // More pages to copy?
                 if *next_page <= *total_pages {


### PR DESCRIPTION
## Description
Depends on https://github.com/tursodatabase/turso/pull/7301

Again just migrating functions and call sites to return alloc errors

## Motivation and context
Fallible Allocations

## Description of AI Usage
Propagating errors
