### PR TITLE
core: commit autocommit write after open read rows

### DIFF
--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -458,6 +458,40 @@ async fn test_statement_query_resets_before_execution() {
 }
 
 #[tokio::test]
+async fn test_autocommit_write_persists_with_stepped_open_rows() {
+    async fn count_rows(conn: &turso::Connection) -> i64 {
+        let mut rows = conn.query("SELECT COUNT(*) FROM t", ()).await.unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    }
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_file = temp_dir.path().join("open-rows-write-loss.db");
+    let db_file = db_file.to_str().unwrap();
+    let db = Builder::new_local(db_file).build().await.unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute(
+        "CREATE TABLE t (k TEXT NOT NULL PRIMARY KEY, v INTEGER)",
+        (),
+    )
+    .await
+    .unwrap();
+
+    for key in ["a", "b", "c"] {
+        let mut rows = conn.query("SELECT COUNT(*) FROM t", ()).await.unwrap();
+        let _first: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+
+        conn.execute("INSERT INTO t (k, v) VALUES (?1, 1)", turso::params![key])
+            .await
+            .unwrap();
+
+        assert_eq!(rows.column_count(), 1);
+    }
+
+    assert_eq!(count_rows(&conn).await, 3);
+}
+
+#[tokio::test]
 async fn test_encryption() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_file = temp_dir.path().join("test-encrypted.db");

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3787,6 +3787,16 @@ pub fn op_transaction_inner(
 
                 // 3. Transaction state should be updated before checking for Schema cookie so that the tx is ended properly on error
                 if updated {
+                    if conn.get_auto_commit()
+                        && write
+                        && matches!(current_state, TransactionState::Read)
+                        && matches!(new_transaction_state, TransactionState::Write { .. })
+                    {
+                        // A stepped SELECT can own the implicit read transaction. If this
+                        // statement upgrades that read to a write, it is responsible for
+                        // finishing the autocommit write so successful DML cannot be dropped.
+                        state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                    }
                     conn.set_tx_state(new_transaction_state);
                 }
                 if is_secondary_db


### PR DESCRIPTION
Fixes #7260.

## Summary
- mark an autocommit statement as the implicit transaction owner when it upgrades an existing read transaction to a write transaction
- add a Rust binding regression test for stepped-but-open `Rows` across same-connection inserts

## Why
A stepped `SELECT` can own the implicit read transaction. If a later same-connection `INSERT` upgrades that transaction to a write, the write statement must finish the implicit transaction when it halts; otherwise it returns `Ok` while its changes are rolled back when the earlier rows are dropped.

## Testing
- `cargo test -p turso test_autocommit_write_persists_with_stepped_open_rows -- --nocapture`
- `cargo test -p core_tester --test integration_tests unrelated_runtime_error_does_not_rollback_open_returning_statement -- --nocapture`
- `cargo test -p turso --test integration_tests`
- `cargo fmt --check`