### PR TITLE
Pin cargo-c to 0.10.16 due to rust-toolchain.toml being pegged at 1.88

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ The purpose of these tests is to verify behavior matches with SQLite and Turso.
 
 1. [Cargo-c](https://github.com/lu-zero/cargo-c) is needed for building C-ABI compatible library. You can get it via:
 ```console
-cargo install cargo-c
+cargo install cargo-c --version 0.10.16 --locked
 ```
 2. [SQLite](https://www.sqlite.org/index.html) is needed for compatibility checking. You can install it using `brew` on macOS/Linux:
 ```console


### PR DESCRIPTION
## Description

Pinned the `cargo-c` install version to `0.10.16` due to `rust-toolchain.toml` pegging the channel at `1.88`.

## Motivation and context

I was setting up the turso repo and encountered the issue with installing `cargo-c`. `cargo-c` is now at `0.10.23` and requires `1.94` or newer, but the `rust-toolchain.toml` is pegged at `1.88`.  `cargo` recommended the fix, and I'm documenting it here.