### PR TITLE
Fix ROUND() to use round-half-away-from-zero

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -789,11 +789,9 @@ impl Value {
         let precision = if precision < 1.0 { 0.0 } else { precision };
         let precision = precision.clamp(0.0, 30.0) as usize;
 
-        if precision == 0 {
-            return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
-        }
-
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
+        let multiplier = 10i64.pow(precision as u32) as f64;
+        let rounded = (f * multiplier + if f < 0.0 { -0.5 } else { 0.5 }).trunc() / multiplier;
+        let f: f64 = crate::numeric::str_to_f64(format!("{rounded:.precision$}"))
             .expect("formatted float should always parse successfully")
             .into();
 
@@ -2730,6 +2728,26 @@ mod tests {
         let input_val = Value::from_f64(100.123);
         let expected_val = Value::Null;
         assert_eq!(input_val.exec_round(Some(&Value::Null)), expected_val);
+
+        let input_val = Value::from_f64(2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(-2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.35);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.4);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.35);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(-2.4);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #5748

`ROUND(x, d)` was using Rust's default banker's rounding (round-half-to-even) instead of round-half-away-from-zero when the digit at the rounding boundary is exactly 5.

**Before:**
```sql
SELECT ROUND(2.25, 1);  -- returned 2.2 (wrong)
```

**After:**
```sql
SELECT ROUND(2.25, 1);  -- returns 2.3 (matches SQLite)
```

## Changes

- Unified the `precision == 0` and `precision > 0` code paths in `exec_round` to both use round-half-away-from-zero
- Added regression tests for `ROUND(±2.25, 1)` and `ROUND(±2.35, 1)`

## Testing

- Unit tests pass: `cargo test -p turso_core test_exec_round`
- Clippy clean: `cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings`