### PR TITLE
testing: revive and fix the sqlite3-format differential test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,12 @@ uv-sync-test:
 	uv sync --all-extras --dev --package turso_test
 .PHONE: uv-sync
 
-test: build uv-sync-test test-compat test-sqlite3 test-shell test-memory test-write test-update test-constraint test-collate test-extensions test-runner test-runner-js test-runner-cli
+test: build uv-sync-test test-compat test-sqlite3 test-shell test-memory test-write test-update test-constraint test-collate test-extensions test-runner test-runner-js test-runner-cli test-format
 .PHONY: test
+
+test-format: build
+	cd testing/sqlite3-format && ./all
+.PHONY: test-format
 
 test-runner:
 	@make -C testing/sqltests run

--- a/testing/sqlite3-format/all
+++ b/testing/sqlite3-format/all
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+fail=0
+run_test() {
+  test="$1"
+  db="$test.db"
+  rm -f "$db"
+  if ! sqlite3 "$db" < "$test-create.sql"; then
+    echo "$test: SETUP FAILED"; fail=1; return
+  fi
+  if ./database-cmp "$db" "$(cat $test-check.sql)"; then
+    echo "$test: ok"
+  else
+    echo "$test: FAIL"; fail=1
+  fi
+}
+
+run_test "test-btree-depth"
+run_test "test-freelist"
+run_test "test-large-db"
+run_test "test-overflow-page"
+run_test "test-pagesize-512"
+run_test "test-pagesize-65536"
+run_test "test-types"
+
+exit "$fail"

--- a/testing/sqlite3-format/database-cmp
+++ b/testing/sqlite3-format/database-cmp
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <database_file> [sql_command]"
+    echo
+    echo "Examples:"
+    echo "  $0 database.db"
+    echo "  $0 database.db '.dump'"
+    echo "  $0 database.db 'SELECT * FROM t;'"
+    exit 1
+fi
+
+DATABASE="$1"
+SQL_COMMAND="${2:-.dump}"
+
+if [ ! -f "$DATABASE" ]; then
+    echo "error: Database file '$DATABASE' not found"
+    exit 1
+fi
+
+SQLITE3_BIN="sqlite3"
+TURSO_BIN="../../target/debug/tursodb"
+
+SQLITE_OUTPUT=$(mktemp)
+TURSO_OUTPUT=$(mktemp)
+
+SQLITE_ERR=$(mktemp)
+TURSO_ERR=$(mktemp)
+
+cleanup() {
+    rm -f "$SQLITE_OUTPUT" "$TURSO_OUTPUT" "$SQLITE_ERR" "$TURSO_ERR"
+}
+trap cleanup EXIT
+
+if "$SQLITE3_BIN" "$DATABASE" "$SQL_COMMAND" > "$SQLITE_OUTPUT" 2> "$SQLITE_ERR"; then
+    SQLITE_EXIT_CODE=0
+else
+    SQLITE_EXIT_CODE=$?
+    echo "SQLite failed with exit code: $SQLITE_EXIT_CODE"
+    cat "$SQLITE_ERR"
+fi
+
+STATUS=0
+
+if "$TURSO_BIN" -m list "$DATABASE" "$SQL_COMMAND" > "$TURSO_OUTPUT" 2> "$TURSO_ERR"; then
+    TURSO_EXIT_CODE=0
+else
+    TURSO_EXIT_CODE=$?
+    echo "Turso failed with exit code: $TURSO_EXIT_CODE"
+    cat "$TURSO_ERR"
+fi
+
+if [ "$SQLITE_EXIT_CODE" -ne "$TURSO_EXIT_CODE" ]; then
+    echo "Exit codes differ: SQLite=$SQLITE_EXIT_CODE, Turso=$TURSO_EXIT_CODE"
+    STATUS=1
+fi
+
+if ! diff -u "$SQLITE_OUTPUT" "$TURSO_OUTPUT" > /dev/null; then
+    echo "Outputs differ:"
+    echo
+    diff -u "$SQLITE_OUTPUT" "$TURSO_OUTPUT" | head -20
+    if [ $(diff -u "$SQLITE_OUTPUT" "$TURSO_OUTPUT" | wc -l) -gt 20 ]; then
+        echo "... (output truncated, showing first 20 lines of diff)"
+    fi
+    STATUS=1
+fi
+
+exit $STATUS

--- a/testing/sqlite3-format/test-btree-depth-check.sql
+++ b/testing/sqlite3-format/test-btree-depth-check.sql
@@ -1,0 +1,2 @@
+SELECT id, data, hex(padding) FROM btree_depth;
+SELECT COUNT(*) FROM btree_depth;

--- a/testing/sqlite3-format/test-btree-depth-create.sql
+++ b/testing/sqlite3-format/test-btree-depth-create.sql
@@ -1,0 +1,121 @@
+-- Test multi-level B-tree structures
+-- With default 4096-byte pages, we need many rows to force multiple B-tree levels
+-- Each leaf page can hold roughly 100-200 small records
+-- Interior pages can reference roughly 200-500 child pages
+
+CREATE TABLE btree_depth (
+    id INTEGER PRIMARY KEY,
+    data TEXT,
+    padding BLOB
+);
+
+-- Create an index to test index B-tree structure as well
+CREATE INDEX idx_data ON btree_depth(data);
+
+-- Insert enough rows to create at least a 3-level B-tree
+-- Using small records first to maximize entries per page
+-- This should create leaf pages -> interior pages -> root page structure
+
+-- Insert 10,000 rows with small data
+-- This should create roughly 50-100 leaf pages
+WITH RECURSIVE generate_series(value) AS (
+    SELECT 1
+    UNION ALL
+    SELECT value + 1 FROM generate_series WHERE value < 10000
+)
+INSERT INTO btree_depth (id, data, padding)
+SELECT 
+    value,
+    'Data_' || printf('%05d', value),
+    randomblob(50)
+FROM generate_series;
+
+-- Add some larger records to test mixed page usage
+INSERT INTO btree_depth (id, data, padding)
+SELECT 
+    10000 + value,
+    'Large_' || printf('%05d', value),
+    randomblob(500)
+FROM (
+    WITH RECURSIVE generate_series(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM generate_series WHERE value < 1000
+    )
+    SELECT value FROM generate_series
+);
+
+-- Create gaps by deleting some records (tests interior page updates)
+DELETE FROM btree_depth WHERE id % 100 = 0;
+
+-- Insert records in the gaps (tests B-tree rebalancing)
+INSERT INTO btree_depth (id, data, padding)
+SELECT 
+    value * 100,
+    'Gap_' || printf('%05d', value * 100),
+    randomblob(75)
+FROM (
+    WITH RECURSIVE generate_series(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM generate_series WHERE value < 100
+    )
+    SELECT value FROM generate_series
+);
+
+-- Add records with non-sequential IDs to test B-tree insertion algorithms
+INSERT INTO btree_depth VALUES (50000, 'Out_of_order_1', randomblob(100));
+INSERT INTO btree_depth VALUES (25000, 'Out_of_order_2', randomblob(100));
+INSERT INTO btree_depth VALUES (75000, 'Out_of_order_3', randomblob(100));
+INSERT INTO btree_depth VALUES (12500, 'Out_of_order_4', randomblob(100));
+INSERT INTO btree_depth VALUES (37500, 'Out_of_order_5', randomblob(100));
+
+-- Test very sparse IDs to stress interior pages
+INSERT INTO btree_depth VALUES (100000, 'Sparse_1', randomblob(50));
+INSERT INTO btree_depth VALUES (200000, 'Sparse_2', randomblob(50));
+INSERT INTO btree_depth VALUES (300000, 'Sparse_3', randomblob(50));
+INSERT INTO btree_depth VALUES (400000, 'Sparse_4', randomblob(50));
+INSERT INTO btree_depth VALUES (500000, 'Sparse_5', randomblob(50));
+
+-- Force index B-tree depth with duplicate data values
+INSERT INTO btree_depth (id, data, padding)
+SELECT 
+    600000 + value,
+    'Duplicate_' || printf('%03d', value % 100),  -- Only 100 unique values
+    randomblob(30)
+FROM (
+    WITH RECURSIVE generate_series(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM generate_series WHERE value < 5000
+    )
+    SELECT value FROM generate_series
+);
+
+-- Analyze to update sqlite_stat1 (tests internal statistics pages)
+ANALYZE;
+
+-- Create a second table with composite primary key for different B-tree structure
+CREATE TABLE btree_composite (
+    a INTEGER,
+    b INTEGER,
+    c TEXT,
+    data BLOB,
+    PRIMARY KEY (a, b)
+) WITHOUT ROWID;
+
+-- Insert data into composite key table
+INSERT INTO btree_composite (a, b, c, data)
+SELECT 
+    value / 100,
+    value % 100,
+    'Composite_' || value,
+    randomblob(40)
+FROM (
+    WITH RECURSIVE generate_series(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM generate_series WHERE value < 5000
+    )
+    SELECT value FROM generate_series
+);

--- a/testing/sqlite3-format/test-freelist-check.sql
+++ b/testing/sqlite3-format/test-freelist-check.sql
@@ -1,0 +1,2 @@
+SELECT id, hex(data) FROM t;
+SELECT COUNT(*) FROM t;

--- a/testing/sqlite3-format/test-freelist-create.sql
+++ b/testing/sqlite3-format/test-freelist-create.sql
@@ -1,0 +1,32 @@
+CREATE TABLE t (
+    id INTEGER PRIMARY KEY,
+    data BLOB
+);
+
+INSERT INTO t VALUES (1, randomblob(500));
+INSERT INTO t VALUES (2, randomblob(500));
+INSERT INTO t VALUES (3, randomblob(500));
+INSERT INTO t VALUES (4, randomblob(500));
+INSERT INTO t VALUES (5, randomblob(500));
+INSERT INTO t VALUES (6, randomblob(500));
+INSERT INTO t VALUES (7, randomblob(500));
+INSERT INTO t VALUES (8, randomblob(500));
+INSERT INTO t VALUES (9, randomblob(500));
+INSERT INTO t VALUES (10, randomblob(500));
+INSERT INTO t VALUES (11, randomblob(500));
+INSERT INTO t VALUES (12, randomblob(500));
+INSERT INTO t VALUES (13, randomblob(500));
+INSERT INTO t VALUES (14, randomblob(500));
+INSERT INTO t VALUES (15, randomblob(500));
+INSERT INTO t VALUES (16, randomblob(500));
+INSERT INTO t VALUES (17, randomblob(500));
+INSERT INTO t VALUES (18, randomblob(500));
+INSERT INTO t VALUES (19, randomblob(500));
+INSERT INTO t VALUES (20, randomblob(500));
+
+INSERT INTO t SELECT id + 20, randomblob(500) FROM t WHERE id <= 20;
+INSERT INTO t SELECT id + 40, randomblob(500) FROM t WHERE id <= 40;
+INSERT INTO t SELECT id + 80, randomblob(500) FROM t WHERE id <= 80;
+
+-- Delete even-numbered rows to create freelist pages
+DELETE FROM t WHERE (id % 2) = 0;

--- a/testing/sqlite3-format/test-large-db-check.sql
+++ b/testing/sqlite3-format/test-large-db-check.sql
@@ -1,0 +1,9 @@
+SELECT COUNT(*) as total_rows FROM large_db;
+
+SELECT id, text_data FROM large_db WHERE id > 9223372036854775800 ORDER BY id;
+
+SELECT page_count * 1024 as db_size_bytes FROM pragma_page_count();
+
+SELECT COUNT(*) FROM large_aux1;
+SELECT COUNT(*) FROM large_aux2;
+SELECT COUNT(*) FROM large_overflow;

--- a/testing/sqlite3-format/test-large-db-create.sql
+++ b/testing/sqlite3-format/test-large-db-create.sql
@@ -1,0 +1,124 @@
+-- Test large database features and page number handling
+-- SQLite uses 32-bit page numbers, max 2^32 pages
+-- With 4096-byte pages, max size is ~17TB
+-- With 512-byte pages, max size is ~2TB
+-- We'll create a smaller but representative test
+
+-- Use smaller page size to test page number handling with less data
+PRAGMA page_size = 1024;
+
+CREATE TABLE large_db (
+    id INTEGER PRIMARY KEY,
+    data BLOB,
+    text_data TEXT
+);
+
+-- Create a reasonable number of pages to test page number handling
+-- Insert 100,000 rows with data that spans multiple pages
+WITH RECURSIVE generate_series(value) AS (
+    SELECT 1
+    UNION ALL
+    SELECT value + 1 FROM generate_series WHERE value < 100000
+)
+INSERT INTO large_db (id, data, text_data)
+SELECT 
+    value,
+    randomblob(800),  -- Most of a 1024-byte page
+    'Row_' || printf('%06d', value)
+FROM generate_series;
+
+-- Create sparse entries with very high IDs to test large page numbers
+INSERT INTO large_db VALUES (1000000, randomblob(500), 'Sparse_1M');
+INSERT INTO large_db VALUES (2000000, randomblob(500), 'Sparse_2M');
+INSERT INTO large_db VALUES (3000000, randomblob(500), 'Sparse_3M');
+INSERT INTO large_db VALUES (4000000, randomblob(500), 'Sparse_4M');
+INSERT INTO large_db VALUES (5000000, randomblob(500), 'Sparse_5M');
+
+-- Test maximum integer primary key (approaching 2^63-1)
+INSERT INTO large_db VALUES (9223372036854775800, randomblob(100), 'Near_max_id_1');
+INSERT INTO large_db VALUES (9223372036854775801, randomblob(100), 'Near_max_id_2');
+INSERT INTO large_db VALUES (9223372036854775802, randomblob(100), 'Near_max_id_3');
+INSERT INTO large_db VALUES (9223372036854775803, randomblob(100), 'Near_max_id_4');
+INSERT INTO large_db VALUES (9223372036854775804, randomblob(100), 'Near_max_id_5');
+INSERT INTO large_db VALUES (9223372036854775805, randomblob(100), 'Near_max_id_6');
+INSERT INTO large_db VALUES (9223372036854775806, randomblob(100), 'Near_max_id_7');
+
+-- Create an index to increase page count
+CREATE INDEX idx_large_text ON large_db(text_data);
+
+-- Create additional tables to spread data across more pages
+CREATE TABLE large_aux1 (
+    id INTEGER PRIMARY KEY,
+    ref_id INTEGER REFERENCES large_db(id),
+    aux_data BLOB
+);
+
+CREATE TABLE large_aux2 (
+    id INTEGER PRIMARY KEY,
+    ref_id INTEGER REFERENCES large_db(id),
+    aux_data BLOB
+);
+
+-- Insert data into auxiliary tables
+INSERT INTO large_aux1 (id, ref_id, aux_data)
+SELECT 
+    value,
+    value,
+    randomblob(700)
+FROM (
+    WITH RECURSIVE generate_series(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM generate_series WHERE value < 10000
+    )
+    SELECT value FROM generate_series
+);
+
+INSERT INTO large_aux2 (id, ref_id, aux_data)
+SELECT 
+    value,
+    value * 10,
+    randomblob(700)
+FROM (
+    WITH RECURSIVE generate_series(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM generate_series WHERE value < 10000
+    )
+    SELECT value FROM generate_series
+);
+
+-- Create a table with overflow pages
+CREATE TABLE large_overflow (
+    id INTEGER PRIMARY KEY,
+    huge_data BLOB
+);
+
+-- Insert rows with large blobs that require overflow pages
+INSERT INTO large_overflow VALUES (1, randomblob(10000));
+INSERT INTO large_overflow VALUES (2, randomblob(20000));
+INSERT INTO large_overflow VALUES (3, randomblob(30000));
+INSERT INTO large_overflow VALUES (4, randomblob(40000));
+INSERT INTO large_overflow VALUES (5, randomblob(50000));
+
+-- Test page allocation near boundaries
+-- Delete some data to create freelist pages
+DELETE FROM large_db WHERE id % 1000 = 0 AND id <= 50000;
+
+-- Reinsert to test freelist reuse with large page numbers
+INSERT INTO large_db (id, data, text_data)
+SELECT 
+    value * 1000,
+    randomblob(600),
+    'Reinserted_' || value
+FROM (
+    WITH RECURSIVE generate_series(value) AS (
+        SELECT 1
+        UNION ALL
+        SELECT value + 1 FROM generate_series WHERE value < 50
+    )
+    SELECT value FROM generate_series
+);
+
+-- Update statistics
+ANALYZE;

--- a/testing/sqlite3-format/test-overflow-page-check.sql
+++ b/testing/sqlite3-format/test-overflow-page-check.sql
@@ -1,0 +1,1 @@
+SELECT id, small_data, hex(large_data) FROM overflow_test ORDER BY id;

--- a/testing/sqlite3-format/test-overflow-page-create.sql
+++ b/testing/sqlite3-format/test-overflow-page-create.sql
@@ -1,0 +1,67 @@
+CREATE TABLE overflow_test (
+    id INTEGER PRIMARY KEY,
+    small_data TEXT,
+    large_data BLOB
+);
+
+-- SQLite's default page size is 4096 bytes
+-- After headers and other overhead, approximately 3900 bytes available per page
+-- To force overflow pages, we need payloads larger than this
+
+-- Test 1: Just under the threshold (should fit in one page)
+INSERT INTO overflow_test VALUES (1, 'Small', randomblob(3000));
+
+-- Test 2: Just over threshold (requires 1 overflow page)
+INSERT INTO overflow_test VALUES (2, 'Medium', randomblob(4000));
+
+-- Test 3: Multiple overflow pages
+INSERT INTO overflow_test VALUES (3, 'Large', randomblob(10000));
+
+-- Test 4: Many overflow pages
+INSERT INTO overflow_test VALUES (4, 'Very Large', randomblob(50000));
+
+-- Test 5: Edge case - exactly at page boundary (approximately)
+INSERT INTO overflow_test VALUES (5, 'Boundary', randomblob(3900));
+
+-- Test 6: Multiple records with overflow to test freelist interaction
+INSERT INTO overflow_test VALUES (6, 'Test6', randomblob(5000));
+INSERT INTO overflow_test VALUES (7, 'Test7', randomblob(5000));
+INSERT INTO overflow_test VALUES (8, 'Test8', randomblob(5000));
+INSERT INTO overflow_test VALUES (9, 'Test9', randomblob(5000));
+INSERT INTO overflow_test VALUES (10, 'Test10', randomblob(5000));
+
+-- Test 7: Delete some records to create gaps in overflow chain
+DELETE FROM overflow_test WHERE id IN (7, 9);
+
+-- Test 8: Insert new records that might reuse overflow pages
+INSERT INTO overflow_test VALUES (11, 'Reuse1', randomblob(4500));
+INSERT INTO overflow_test VALUES (12, 'Reuse2', randomblob(4500));
+
+-- Test 9: Very large TEXT (not just BLOB)
+INSERT INTO overflow_test VALUES (13, 'Text overflow', 
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' ||
+    'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ' ||
+    substr(quote(randomblob(10000)), 4, 20000));
+
+-- Test 10: NULL in large_data column
+INSERT INTO overflow_test VALUES (14, 'NULL test', NULL);
+
+-- Test 11: Empty blob vs NULL
+INSERT INTO overflow_test VALUES (15, 'Empty blob', x'');
+
+-- Test 12: Maximum inline vs overflow threshold
+-- The first 'usable_size - 35' bytes are stored directly, rest in overflow
+-- Testing exact boundary conditions
+INSERT INTO overflow_test VALUES (16, 'Threshold-1', randomblob(3864));  
+INSERT INTO overflow_test VALUES (17, 'Threshold', randomblob(3865));
+INSERT INTO overflow_test VALUES (18, 'Threshold+1', randomblob(3866));
+
+-- Test 13: Largest practical blob (multiple overflow pages)
+INSERT INTO overflow_test VALUES (19, 'Huge', randomblob(100000));
+
+-- Test 14: Mix of small and large in same page
+INSERT INTO overflow_test VALUES (20, 'A', randomblob(100));
+INSERT INTO overflow_test VALUES (21, 'B', randomblob(10000));
+INSERT INTO overflow_test VALUES (22, 'C', randomblob(100));
+INSERT INTO overflow_test VALUES (23, 'D', randomblob(10000));
+INSERT INTO overflow_test VALUES (24, 'E', randomblob(100));

--- a/testing/sqlite3-format/test-pagesize-512-check.sql
+++ b/testing/sqlite3-format/test-pagesize-512-check.sql
@@ -1,0 +1,1 @@
+SELECT hex(x) FROM t;

--- a/testing/sqlite3-format/test-pagesize-512-create.sql
+++ b/testing/sqlite3-format/test-pagesize-512-create.sql
@@ -1,0 +1,3 @@
+PRAGMA page_size=512;
+CREATE TABLE t(x);
+INSERT INTO t VALUES (randomblob(5000));

--- a/testing/sqlite3-format/test-pagesize-65536-check.sql
+++ b/testing/sqlite3-format/test-pagesize-65536-check.sql
@@ -1,0 +1,1 @@
+SELECT hex(x) FROM t;

--- a/testing/sqlite3-format/test-pagesize-65536-create.sql
+++ b/testing/sqlite3-format/test-pagesize-65536-create.sql
@@ -1,0 +1,3 @@
+PRAGMA page_size=512;
+CREATE TABLE t(x);
+INSERT INTO t VALUES (randomblob(5000));

--- a/testing/sqlite3-format/test-pagesize-65536-create.sql
+++ b/testing/sqlite3-format/test-pagesize-65536-create.sql
@@ -1,3 +1,3 @@
-PRAGMA page_size=512;
+PRAGMA page_size=65536;
 CREATE TABLE t(x);
 INSERT INTO t VALUES (randomblob(5000));

--- a/testing/sqlite3-format/test-types-check.sql
+++ b/testing/sqlite3-format/test-types-check.sql
@@ -1,0 +1,1 @@
+SELECT i, r, t, hex(b) as b, n, CASE WHEN typeof(x) = 'blob' THEN hex(x) ELSE x END as x FROM types_test ORDER BY i;

--- a/testing/sqlite3-format/test-types-create.sql
+++ b/testing/sqlite3-format/test-types-create.sql
@@ -1,0 +1,80 @@
+CREATE TABLE types_test (
+    i INTEGER PRIMARY KEY,
+    r REAL,
+    t TEXT,
+    b BLOB,
+    n NUMERIC,
+    -- No affinity
+    x
+);
+
+-- Test INTEGER storage classes (1, 2, 3, 4, 6, 8 bytes)
+INSERT INTO types_test VALUES (0, 0.0, '0', x'00', 0, 0);
+INSERT INTO types_test VALUES (1, 1.0, '1', x'01', 1, 1);
+INSERT INTO types_test VALUES (127, 127.0, '127', x'7F', 127, 127);  -- max 1-byte
+INSERT INTO types_test VALUES (-128, -128.0, '-128', x'80', -128, -128);  -- min 1-byte
+INSERT INTO types_test VALUES (32767, 32767.0, '32767', x'7FFF', 32767, 32767);  -- max 2-byte
+INSERT INTO types_test VALUES (-32768, -32768.0, '-32768', x'8000', -32768, -32768);  -- min 2-byte
+INSERT INTO types_test VALUES (8388607, 8388607.0, '8388607', x'7FFFFF', 8388607, 8388607);  -- max 3-byte
+INSERT INTO types_test VALUES (-8388608, -8388608.0, '-8388608', x'800000', -8388608, -8388608);  -- min 3-byte
+INSERT INTO types_test VALUES (2147483647, 2147483647.0, '2147483647', x'7FFFFFFF', 2147483647, 2147483647);  -- max 4-byte
+INSERT INTO types_test VALUES (-2147483648, -2147483648.0, '-2147483648', x'80000000', -2147483648, -2147483648);  -- min 4-byte
+INSERT INTO types_test VALUES (140737488355327, 140737488355327.0, '140737488355327', x'7FFFFFFFFFFF', 140737488355327, 140737488355327);  -- max 6-byte
+INSERT INTO types_test VALUES (-140737488355328, -140737488355328.0, '-140737488355328', x'800000000000', -140737488355328, -140737488355328);  -- min 6-byte
+INSERT INTO types_test VALUES (9223372036854775807, 9223372036854775807.0, '9223372036854775807', x'7FFFFFFFFFFFFFFF', 9223372036854775807, 9223372036854775807);  -- max 8-byte
+INSERT INTO types_test VALUES (-9223372036854775808, -9223372036854775808.0, '-9223372036854775808', x'8000000000000000', -9223372036854775808, -9223372036854775808);  -- min 8-byte
+
+-- Test REAL values (some will be stored as integers due to affinity)
+INSERT INTO types_test VALUES (NULL, 3.14159, 'pi', x'40490FDB', 3.14159, 3.14159);
+INSERT INTO types_test VALUES (NULL, 2.71828, 'e', x'402DF854', 2.71828, 2.71828);
+INSERT INTO types_test VALUES (NULL, 0.1, '0.1', x'3FB999999999999A', 0.1, 0.1);
+INSERT INTO types_test VALUES (NULL, -0.0, '-0.0', x'8000000000000000', -0.0, -0.0);
+INSERT INTO types_test VALUES (NULL, 1.23e45, '1.23e45', NULL, 1.23e45, 1.23e45);
+INSERT INTO types_test VALUES (NULL, 1.7976931348623157e308, 'max double', NULL, 1.7976931348623157e308, 1.7976931348623157e308);
+INSERT INTO types_test VALUES (NULL, 2.2250738585072014e-308, 'min positive double', NULL, 2.2250738585072014e-308, 2.2250738585072014e-308);
+
+-- Test NULL values
+INSERT INTO types_test VALUES (NULL, NULL, NULL, NULL, NULL, NULL);
+
+-- Test TEXT with different lengths (serial types 13+)
+INSERT INTO types_test VALUES (NULL, NULL, '', NULL, '', '');  -- empty string
+INSERT INTO types_test VALUES (NULL, NULL, 'a', NULL, 'a', 'a');  -- 1 byte
+INSERT INTO types_test VALUES (NULL, NULL, 'Hello, World!', NULL, 'Hello', 'Hello');  -- 13 bytes
+INSERT INTO types_test VALUES (NULL, NULL, 'The quick brown fox jumps over the lazy dog', NULL, 42, 'Mixed');  -- 43 bytes
+
+-- Test BLOB data (serial types 12+)
+INSERT INTO types_test VALUES (NULL, NULL, 'blob', x'', NULL, x'');  -- empty blob
+INSERT INTO types_test VALUES (NULL, NULL, 'blob', x'DEADBEEF', NULL, x'DEADBEEF');
+INSERT INTO types_test VALUES (NULL, NULL, 'blob', randomblob(16), NULL, randomblob(16));
+INSERT INTO types_test VALUES (NULL, NULL, 'blob', randomblob(100), NULL, randomblob(100));
+INSERT INTO types_test VALUES (NULL, NULL, 'blob', randomblob(1000), NULL, randomblob(1000));
+
+-- Test UTF-8 text
+INSERT INTO types_test VALUES (NULL, NULL, 'Hello 世界', NULL, NULL, 'Unicode');
+INSERT INTO types_test VALUES (NULL, NULL, '🚀🌟🎉', NULL, NULL, 'Emoji');
+INSERT INTO types_test VALUES (NULL, NULL, 'Café', NULL, NULL, 'Accented');
+
+-- Test numeric strings stored as TEXT (NUMERIC affinity)
+INSERT INTO types_test VALUES (NULL, NULL, '123', NULL, '123', '123');  -- stored as integer in NUMERIC
+INSERT INTO types_test VALUES (NULL, NULL, '123.45', NULL, '123.45', '123.45');  -- stored as real in NUMERIC
+INSERT INTO types_test VALUES (NULL, NULL, '123abc', NULL, '123abc', '123abc');  -- stored as text in NUMERIC
+INSERT INTO types_test VALUES (NULL, NULL, '0x123', NULL, '0x123', '0x123');  -- stored as text
+
+-- Test special float values
+INSERT INTO types_test VALUES (NULL, 1.0/0.0, 'infinity', NULL, 1.0/0.0, 'inf');  -- infinity
+INSERT INTO types_test VALUES (NULL, -1.0/0.0, '-infinity', NULL, -1.0/0.0, '-inf');  -- -infinity
+-- Note: NaN cannot be directly inserted via SQL
+
+-- Test REAL stored as INTEGER optimization
+INSERT INTO types_test VALUES (NULL, 1.0, '1.0', NULL, 1.0, 1.0);  -- should store as integer
+INSERT INTO types_test VALUES (NULL, 2.0, '2.0', NULL, 2.0, 2.0);  -- should store as integer
+INSERT INTO types_test VALUES (NULL, 123.0, '123.0', NULL, 123.0, 123.0);  -- should store as integer
+
+-- Test very long strings (will create overflow pages if long enough)
+INSERT INTO types_test VALUES (NULL, NULL, substr(quote(randomblob(5000)),4,10000), randomblob(5000), NULL, NULL);
+
+-- Test edge cases for no affinity column (x)
+INSERT INTO types_test VALUES (NULL, NULL, NULL, NULL, NULL, 123);  -- integer
+INSERT INTO types_test VALUES (NULL, NULL, NULL, NULL, NULL, 123.45);  -- real
+INSERT INTO types_test VALUES (NULL, NULL, NULL, NULL, NULL, 'text');  -- text
+INSERT INTO types_test VALUES (NULL, NULL, NULL, NULL, NULL, x'424C4F42');  -- blob


### PR DESCRIPTION
Revives @penberg's #2963 the `testing/sqlite3-format/` differential suite that builds a database with real `sqlite3`, then runs the same query through `sqlite3` and `tursodb -m list` and asserts the output matches . #2963 went stale; this picks it up per #2576.

This PR fixes the two bugs that kept it from actually testing anything, and wires it into `make test`.

## Bugs fixed

1. **Silent pass.** `all`'s `run_test` printed `"$test: ok"` regardless of `database-cmp`'s exit code, and `all` always exited 0 (the last command was an `echo`, no `set -e`), so `make test-format` stayed green even on a real divergence. `all` now reports `ok`/`FAIL` per scenario, accumulates a failure flag, and `exit`s non-zero if any scenario diverges.

2. **stderr pollution in `database-cmp`.** It captured both engines with `2>&1`, so Turso's log lines caused a false divergence. stdout and stderr are now captured separately, only stdout is compared, and an exit-code mismatch is now a hard failure too.

## Test plan

- `make test-format` (or `cd testing/sqlite3-format && ./all`) → all 7 scenarios pass, exit 0.
- Injecting a real divergence (e.g. a UTF-16-encoded database, which Turso declines) → the suite prints `<scenario>: FAIL` and exits 1.

Closes #2576.