### PR TITLE
core/mvcc: prevent stale tx from acquiring `exclusive_tx` after concurrent commit

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -80,6 +80,9 @@ pub mod tests;
 /// Sentinel value for `MvStore::exclusive_tx` indicating no exclusive transaction is active.
 const NO_EXCLUSIVE_TX: u64 = 0;
 
+#[cfg(not(any(test, injected_yields)))]
+struct YieldContext;
+
 /// A table ID for MVCC.
 /// MVCC table IDs are always negative. Their corresponding rootpage entry in sqlite_schema
 /// is the same negative value if the table has not been checkpointed yet. Otherwise, the root page
@@ -1271,6 +1274,22 @@ pub(crate) enum CommitYieldPoint {
     /// is cleared by the caller at vdbe/mod.rs. Used for failure injection
     /// to reproduce divergence between `mv_store.txs` and `connection.mv_tx_id`.
     AfterRemoveTx,
+}
+
+#[cfg(any(test, injected_yields))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumCount)]
+#[repr(u8)]
+pub(crate) enum ExclusiveTxYieldPoint {
+    AfterTimestampCheckBeforeCas,
+}
+
+#[cfg(any(test, injected_yields))]
+impl YieldPointMarker for ExclusiveTxYieldPoint {
+    const POINT_COUNT: u8 = Self::COUNT as u8;
+
+    fn ordinal(self) -> u8 {
+        self as u8
+    }
 }
 
 #[cfg(any(test, injected_yields))]
@@ -4525,7 +4544,10 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         pager: Arc<Pager>,
         maybe_existing_tx_id: Option<TxID>,
+        connection: &Connection,
     ) -> Result<TxID> {
+        #[cfg(not(any(test, injected_yields)))]
+        let _ = connection;
         // Existing transactions already hold one blocking-checkpoint read guard
         // from begin_tx(). When upgrading read->write, do not acquire another one.
         let acquires_checkpoint_guard = maybe_existing_tx_id.is_none();
@@ -4548,10 +4570,21 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         } else {
             self.get_begin_timestamp()
         };
+        #[cfg(any(test, injected_yields))]
+        let exclusive_yield_context = YieldContext::new(
+            connection.yield_injector(),
+            None,
+            connection.next_yield_instance_id(),
+            tx_id,
+        );
+        #[cfg(any(test, injected_yields))]
+        let exclusive_yield_context = Some(&exclusive_yield_context);
+        #[cfg(not(any(test, injected_yields)))]
+        let exclusive_yield_context: Option<&YieldContext> = None;
 
         let already_exclusive = self.is_exclusive_tx(&tx_id);
         if !already_exclusive {
-            self.acquire_exclusive_tx(&tx_id)
+            self.acquire_exclusive_tx(&tx_id, exclusive_yield_context)
                 .inspect_err(|_| unlock_checkpoint_guard())?;
         }
 
@@ -5214,7 +5247,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     }
 
     /// Acquires the exclusive transaction lock to the given transaction ID.
-    fn acquire_exclusive_tx(&self, tx_id: &TxID) -> Result<()> {
+    fn acquire_exclusive_tx(
+        &self,
+        tx_id: &TxID,
+        yield_context: Option<&YieldContext>,
+    ) -> Result<()> {
+        #[cfg(not(any(test, injected_yields)))]
+        let _ = yield_context;
         if self.exclusive_tx.load(Ordering::Acquire) == *tx_id {
             // Re-entrant upgrade attempt for the same transaction.
             return Ok(());
@@ -5228,6 +5267,21 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 // Another transaction committed after this transaction's begin timestamp, do not allow exclusive lock.
                 // This mimics regular (non-CONCURRENT) sqlite transaction behavior.
                 return Err(LimboError::Busy);
+            }
+        }
+        #[cfg(any(test, injected_yields))]
+        if let Some(yield_context) = yield_context {
+            if yield_context.injector.as_ref().is_some_and(|injector| {
+                injector.should_yield(
+                    yield_context.instance_id,
+                    yield_context.selection_key,
+                    ExclusiveTxYieldPoint::AfterTimestampCheckBeforeCas.point(),
+                )
+            }) {
+                tracing::debug!(
+                    tx_id,
+                    "injected exclusive acquisition interleaving before CAS"
+                );
             }
         }
         match self.exclusive_tx.compare_exchange(

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5258,9 +5258,16 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             // Re-entrant upgrade attempt for the same transaction.
             return Ok(());
         }
+        // if some other transaction is in preparing state, then we cannot let this tx to
+        // continue, as the preparing txn will eventually commit
         if self.has_preparing_tx_other_than(*tx_id) {
             return Err(LimboError::Busy);
         }
+        // after we acquired begin_ts, we will check if some other txn committed in the meantime.
+        // If so, no point in letting this txn to progress as it's begin_ts is less than
+        // other txn's commit ts.
+        // do note that this is an optimistic / early check. We need to check this again after this
+        // txn gets exclusive txn status. check below after the CAS
         if let Some(tx) = self.txs.get(tx_id) {
             let tx = tx.value();
             if tx.begin_ts < self.last_committed_tx_ts.load(Ordering::Acquire) {
@@ -5294,6 +5301,30 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 if self.has_preparing_tx_other_than(*tx_id) {
                     self.release_exclusive_tx(tx_id);
                     return Err(LimboError::Busy);
+                }
+                // we will check again, if some other txn committed in the meantime.
+                // we did this check previously too, but we will have to do this again.
+                // consider this timeline of events:
+                //
+                // t0 - no txn is preparing, and last_committed_ts is smaller than begin_ts
+                //      we proceed to do CAS
+                // t1 - we are yet to do CAS, but another txn comes in, goes into
+                //      preparing state, and commits with commit_ts greater than our begin_ts
+                // t3 - we proceed with CAS and get exclusive txn status
+                //
+                // at this point, we have got exclusive txn but last_committed_tx_ts is greater than
+                // our begin_ts, violating the isolation guarantee.
+                //
+                // we want to prevent this. so we acquire the exclusive txn and then check again.
+                // we can also be sure that once we get the exclusive txn status, no other txn can sneak in and commit,
+                // because to commit, we make sure that there is no other exclusive txn. Check
+                // `CommitState::Initial`.
+                if let Some(tx) = self.txs.get(tx_id) {
+                    let tx = tx.value();
+                    if tx.begin_ts < self.last_committed_tx_ts.load(Ordering::Acquire) {
+                        self.release_exclusive_tx(tx_id);
+                        return Err(LimboError::Busy);
+                    }
                 }
                 Ok(())
             }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -5,7 +5,7 @@ use crate::io::PlatformIO;
 use crate::mvcc::clock::MvccClock;
 use crate::mvcc::cursor::{CursorYieldPoint, MvccCursorType};
 use crate::mvcc::database::checkpoint_state_machine::CheckpointYieldPoint;
-use crate::mvcc::database::CommitYieldPoint;
+use crate::mvcc::database::{CommitYieldPoint, ExclusiveTxYieldPoint};
 #[cfg(feature = "conn_raw_api")]
 use crate::mvcc::persistent_storage::logical_log::{ParsedOp, StreamingLogicalLogReader};
 use crate::mvcc::persistent_storage::logical_log::{
@@ -71,6 +71,51 @@ impl FixedYieldInjector {
 impl YieldInjector for FixedYieldInjector {
     fn should_yield(&self, _instance_id: u64, _selection_key: u64, point: YieldPoint) -> bool {
         self.remaining.lock().remove(&point)
+    }
+}
+
+struct CommitWriterOnExclusiveAcquireInjector {
+    point: YieldPoint,
+    selection_key: u64,
+    writer: Arc<Connection>,
+    fired: AtomicBool,
+}
+
+impl CommitWriterOnExclusiveAcquireInjector {
+    fn new(point: YieldPoint, selection_key: u64, writer: Arc<Connection>) -> Arc<Self> {
+        Arc::new(Self {
+            point,
+            selection_key,
+            writer,
+            fired: AtomicBool::new(false),
+        })
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.load(Ordering::Acquire)
+    }
+}
+
+impl std::fmt::Debug for CommitWriterOnExclusiveAcquireInjector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommitWriterOnExclusiveAcquireInjector")
+            .field("point", &self.point)
+            .field("selection_key", &self.selection_key)
+            .field("fired", &self.fired())
+            .finish_non_exhaustive()
+    }
+}
+
+impl YieldInjector for CommitWriterOnExclusiveAcquireInjector {
+    fn should_yield(&self, _instance_id: u64, selection_key: u64, point: YieldPoint) -> bool {
+        if point != self.point
+            || selection_key != self.selection_key
+            || self.fired.swap(true, Ordering::AcqRel)
+        {
+            return false;
+        }
+        self.writer.execute("COMMIT").unwrap();
+        true
     }
 }
 
@@ -147,7 +192,7 @@ fn mvcc_active_write_tx_blocks_vacuum_gate() {
     let pager = db.conn.pager.load().clone();
     let tx_id = db
         .mvcc_store
-        .begin_exclusive_tx(pager.clone(), None)
+        .begin_exclusive_tx(pager.clone(), None, &db.conn)
         .unwrap();
 
     assert!(matches!(
@@ -173,7 +218,7 @@ fn mvcc_vacuum_gate_blocks_new_read_and_write_tx() {
         Err(LimboError::Busy)
     ));
     assert!(matches!(
-        db.mvcc_store.begin_exclusive_tx(pager, None),
+        db.mvcc_store.begin_exclusive_tx(pager, None, &db.conn),
         Err(LimboError::Busy)
     ));
 
@@ -5384,7 +5429,7 @@ fn test_commit_dep_readonly_does_not_cause_spurious_busy() {
     // Now try to acquire exclusive lock for the tx that started before the
     // read-only dependent committed. Should succeed because the read-only tx
     // did not advance last_committed_tx_ts.
-    let acquire_result = mvcc_store.acquire_exclusive_tx(&exclusive_tx_id);
+    let acquire_result = mvcc_store.acquire_exclusive_tx(&exclusive_tx_id, None);
     assert!(
         acquire_result.is_ok(),
         "acquire_exclusive_tx should not return Busy after a read-only dependent committed: {acquire_result:?}",
@@ -14292,4 +14337,74 @@ fn test_global_header_regression_would_lose_committed_user_version() {
         42,
         "older out-of-order FinalizeCommit regressed committed PRAGMA user_version"
     );
+}
+
+#[test]
+fn test_create_index_exclusive_acquire_rechecks_timestamp_after_cas() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER)")
+        .unwrap();
+    setup.execute("INSERT INTO t VALUES (1, 100)").unwrap();
+    setup.close().unwrap();
+
+    let writer = db.connect();
+    writer.execute("BEGIN CONCURRENT").unwrap();
+    writer.execute("INSERT INTO t VALUES (2, 200)").unwrap();
+
+    let ddl = db.connect();
+    ddl.execute("BEGIN DEFERRED").unwrap();
+    let mut read = ddl.prepare("SELECT COUNT(*) FROM t").unwrap();
+    read.run_ignore_rows().unwrap();
+    drop(read);
+
+    let mvcc_store = db.get_mvcc_store();
+    let ddl_tx_id = ddl
+        .get_mv_tx_id()
+        .expect("DDL connection should have an active MVCC transaction");
+    let ddl_begin_ts = mvcc_store
+        .txs
+        .get(&ddl_tx_id)
+        .expect("DDL transaction should be tracked")
+        .value()
+        .begin_ts;
+    assert!(
+        ddl_begin_ts >= mvcc_store.last_committed_tx_ts.load(Ordering::Acquire),
+        "pre-CAS timestamp check should pass before the injected writer commit"
+    );
+
+    let injector = CommitWriterOnExclusiveAcquireInjector::new(
+        ExclusiveTxYieldPoint::AfterTimestampCheckBeforeCas.point(),
+        ddl_tx_id,
+        writer,
+    );
+    ddl.set_yield_injector(Some(injector.clone()));
+
+    let result = ddl.execute("CREATE INDEX idx_v ON t(v)");
+    assert!(
+        injector.fired(),
+        "writer should commit in the exclusive-acquire CAS window"
+    );
+    assert!(
+        matches!(result, Err(crate::LimboError::Busy)),
+        "stale DDL transaction should release exclusive and return Busy after post-CAS recheck: {result:?}"
+    );
+    assert!(
+        !mvcc_store.is_exclusive_tx(&ddl_tx_id),
+        "failed stale DDL should not keep the exclusive slot"
+    );
+    ddl.set_yield_injector(None);
+    if ddl.get_mv_tx_id().is_some() {
+        ddl.execute("ROLLBACK").unwrap();
+    }
+
+    let observer = db.connect();
+    observer.execute("CREATE INDEX idx_v ON t(v)").unwrap();
+    observer.execute("DELETE FROM t WHERE id = 2").unwrap();
+
+    let integrity = get_rows(&observer, "PRAGMA integrity_check");
+    assert_eq!(integrity.len(), 1);
+    assert_eq!(integrity[0][0].to_string(), "ok");
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3274,12 +3274,15 @@ fn begin_mvcc_tx(
     pager: &Arc<Pager>,
     mode: &TransactionMode,
     existing_tx_id: Option<u64>,
+    connection: &Connection,
 ) -> Result<u64> {
     match mode {
         TransactionMode::None | TransactionMode::Read | TransactionMode::Concurrent => {
             mv_store.begin_tx(pager.clone())
         }
-        TransactionMode::Write => mv_store.begin_exclusive_tx(pager.clone(), existing_tx_id),
+        TransactionMode::Write => {
+            mv_store.begin_exclusive_tx(pager.clone(), existing_tx_id, connection)
+        }
     }
 }
 
@@ -3563,7 +3566,7 @@ pub fn op_transaction_inner(
                             // applies to all databases uniformly.
                             let effective_mode =
                                 conn.get_mv_tx().map(|(_, mode)| mode).unwrap_or(*tx_mode);
-                            match begin_mvcc_tx(mv_store, &pager, &effective_mode, None) {
+                            match begin_mvcc_tx(mv_store, &pager, &effective_mode, None, &conn) {
                                 Ok(tx_id) => {
                                     conn.set_mv_tx_for_db(*db, Some((tx_id, effective_mode)));
                                     started_secondary_tx = true;
@@ -3582,7 +3585,7 @@ pub fn op_transaction_inner(
                                 && matches!(tx_mode, TransactionMode::Write)
                             {
                                 if let Err(err) =
-                                    begin_mvcc_tx(mv_store, &pager, tx_mode, Some(tx_id))
+                                    begin_mvcc_tx(mv_store, &pager, tx_mode, Some(tx_id), &conn)
                                 {
                                     pager.end_read_tx();
                                     return Err(err);
@@ -3628,7 +3631,7 @@ pub fn op_transaction_inner(
                         }
 
                         if !has_existing_mv_tx {
-                            match begin_mvcc_tx(mv_store, &pager, tx_mode, None) {
+                            match begin_mvcc_tx(mv_store, &pager, tx_mode, None, &conn) {
                                 Ok(tx_id) => {
                                     // Check again in case checkpoint published roots after the
                                     // previous check and before this transaction was protected.
@@ -3671,9 +3674,13 @@ pub fn op_transaction_inner(
                             if matches!(new_transaction_state, TransactionState::Write { .. })
                                 && matches!(actual_tx_mode, TransactionMode::Write)
                             {
-                                if let Err(err) =
-                                    begin_mvcc_tx(mv_store, &pager, &actual_tx_mode, Some(tx_id))
-                                {
+                                if let Err(err) = begin_mvcc_tx(
+                                    mv_store,
+                                    &pager,
+                                    &actual_tx_mode,
+                                    Some(tx_id),
+                                    &conn,
+                                ) {
                                     if started_read_tx {
                                         pager.end_read_tx();
                                         conn.set_tx_state(TransactionState::None);


### PR DESCRIPTION
## Motivation and context

This is a TOCTOU race in `acquire_exclusive_tx`. The function checks that no other transaction is preparing and that the caller’s `begin_ts` is not older than `last_committed_tx_ts`, then attempts the `exclusive_tx` CAS. A concurrent writer can commit after those checks but before the CAS. By the time the CAS succeeds, the writer is no longer Preparing, so the second `has_preparing_tx_other_than` does not catch it, and without a second timestamp check the stale transaction can proceed as the exclusive writer.

Consider this example:

```
Timeline:

  W = normal writer
  E = exclusive/DDL tx

  t0: E has an existing snapshot with begin_ts = 10
  t1: W is Active and has not started commit

  t2: E runs acquire_exclusive_tx
  t3: E checks has_preparing_tx_other_than == false
  t4: E checks last_committed_tx_ts <= E.begin_ts

  t5: W commits before E executes the exclusive_tx CAS
  t6: W briefly enters Preparing(ts), then Committed(ts)
  t7: W advances last_committed_tx_ts past E.begin_ts
  t8: W is removed from txs, so it is no longer Preparing

  t9: E wins exclusive_tx CAS
  t10: E checks has_preparing_tx_other_than == false
```

  Without the post-CAS `last_committed_tx_ts` recheck, E now holds `exclusive_tx`
  from a stale snapshot. For CREATE INDEX, E can build the index without rows
  committed by W, causing data corruption / loss.

This patch comes with a regression test:

```rust
cargo test -p turso_core test_create_index_exclusive_acquire_rechecks_timestamp_after_cas -- --nocapture
  
running 1 test

thread 'mvcc::database::tests::test_create_index_exclusive_acquire_rechecks_timestamp_after_cas' panicked at core/mvcc/database/tests.rs:14390:5:
stale DDL transaction should release exclusive and return Busy after post-CAS recheck: Ok(())

failures:
    mvcc::database::tests::test_create_index_exclusive_acquire_rechecks_timestamp_after_cas
```

This bug was found by @glommer with his fren Claude, eventually getting him [banned from Claude](https://x.com/glcst/status/2061522948192715196). RIP.
