### PR TITLE
fix: Invalid `changes()` Count When CDC Is Enabled

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1841,18 +1841,12 @@ impl Connection {
         self.last_insert_rowid.store(rowid, Ordering::SeqCst);
     }
 
-    /// Sets the value of `changes()`, but without altering `total_changes()`.
-    pub(crate) fn set_changes_without_total(&self, num_changes: i64) {
-        self.changes.store(num_changes, Ordering::SeqCst);
-    }
-
     pub(crate) fn add_total_changes(&self, num_changes: i64) {
         self.total_changes.fetch_add(num_changes, Ordering::SeqCst);
     }
 
     pub fn set_changes(&self, num_changes: i64) {
-        self.set_changes_without_total(num_changes);
-        self.add_total_changes(num_changes);
+        self.changes.store(num_changes, Ordering::SeqCst);
     }
 
     pub fn changes(&self) -> i64 {

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -188,6 +188,12 @@ impl Statement {
             .load(crate::sync::atomic::Ordering::SeqCst)
     }
 
+    pub fn n_total_change(&self) -> i64 {
+        self.state
+            .n_total_change
+            .load(crate::sync::atomic::Ordering::SeqCst)
+    }
+
     pub fn set_mv_tx(&mut self, mv_tx: Option<(u64, TransactionMode)>) {
         self.program.connection.set_mv_tx(mv_tx);
     }
@@ -993,7 +999,6 @@ impl Statement {
             self.release_active_root_if_counted();
         }
         self.state.reset(max_registers, max_cursors);
-        self.state.n_change.store(0, Ordering::SeqCst);
         self.busy = false;
         self.busy_handler_state = None;
         self.query_timeout_override = None;

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1345,7 +1345,9 @@ fn emit_cdc_insns_v1(
         cursor: cdc_cursor_id,
         key_reg: rowid_reg,
         record_reg,
-        flag: InsertFlags::new().skip_last_rowid(),
+        flag: InsertFlags::new()
+            .skip_last_rowid()
+            .skip_statement_change_count(),
         table_name: "".to_string(),
     });
     Ok(())
@@ -1484,7 +1486,9 @@ fn emit_cdc_insns_v2(
         cursor: cdc_cursor_id,
         key_reg: rowid_reg,
         record_reg,
-        flag: InsertFlags::new().skip_last_rowid(),
+        flag: InsertFlags::new()
+            .skip_last_rowid()
+            .skip_statement_change_count(),
         table_name: "".to_string(),
     });
     Ok(())
@@ -1570,7 +1574,9 @@ pub fn emit_cdc_commit_insns(
         cursor: cdc_cursor_id,
         key_reg: rowid_reg,
         record_reg,
-        flag: InsertFlags::new().skip_last_rowid(),
+        flag: InsertFlags::new()
+            .skip_last_rowid()
+            .skip_statement_change_count(),
         table_name: "".to_string(),
     });
     Ok(())

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3095,6 +3095,9 @@ pub fn halt(
                 program
                     .connection
                     .set_changes(state.n_change.load(Ordering::SeqCst));
+                program
+                    .connection
+                    .add_total_changes(state.n_total_change.load(Ordering::SeqCst));
             }
             Ok(InsnFunctionStepResult::Done)
         }
@@ -3110,6 +3113,9 @@ pub fn halt(
             program
                 .connection
                 .set_changes(state.n_change.load(Ordering::SeqCst));
+            program
+                .connection
+                .add_total_changes(state.n_total_change.load(Ordering::SeqCst));
         }
         Ok(InsnFunctionStepResult::Done)
     }
@@ -4445,7 +4451,7 @@ fn finish_subprogram(
     saved_last_insert_rowid: Option<i64>,
     saved_changes_value: Option<i64>,
 ) {
-    let pending_changes = statement.n_change();
+    let pending_changes = statement.n_total_change();
     if pending_changes != 0 {
         program.connection.add_total_changes(pending_changes);
     }
@@ -4464,7 +4470,7 @@ fn finish_subprogram(
 
     // Restore `changes()`, but not `total_changes()`
     if let Some(changes) = saved_changes_value {
-        program.connection.set_changes_without_total(changes);
+        program.connection.set_changes(changes);
     }
 }
 
@@ -4479,7 +4485,9 @@ pub fn op_reset_count(
     }
 
     let nchange = state.n_change.swap(0, Ordering::SeqCst);
+    let ntotal_change = state.n_total_change.swap(0, Ordering::SeqCst);
     program.connection.set_changes(nchange);
+    program.connection.add_total_changes(ntotal_change);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -9517,14 +9525,16 @@ pub fn op_insert(
                         if !flag.has(InsertFlags::SKIP_LAST_ROWID) {
                             program.connection.update_last_rowid(rowid);
                         }
-                        state
-                            .n_change
-                            .fetch_add(1, crate::sync::atomic::Ordering::SeqCst);
+                        if flag.has(InsertFlags::SKIP_STATEMENT_CHANGE_COUNT) {
+                            state.record_total_change();
+                        } else {
+                            state.record_statement_change();
+                        }
                     }
+                } else if flag.has(InsertFlags::SKIP_STATEMENT_CHANGE_COUNT) {
+                    state.record_total_change();
                 } else {
-                    state
-                        .n_change
-                        .fetch_add(1, crate::sync::atomic::Ordering::SeqCst);
+                    state.record_statement_change();
                 }
                 let schema = program.connection.schema.read();
                 let dependent_views = schema.get_dependent_materialized_views(table_name);
@@ -9736,9 +9746,7 @@ pub fn op_delete(
     if !is_part_of_update {
         // DELETEs do not count towards the total changes if they are part of an UPDATE statement,
         // i.e. the DELETE and subsequent INSERT of a row are the same "change".
-        state
-            .n_change
-            .fetch_add(1, crate::sync::atomic::Ordering::SeqCst);
+        state.record_statement_change();
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -179,6 +179,7 @@ impl InsertFlags {
     pub const REQUIRE_SEEK: u8 = 0x02; // Flag indicating that a seek is required to insert the row
     pub const EPHEMERAL_TABLE_INSERT: u8 = 0x04; // Flag indicating that this is an insert into an ephemeral table
     pub const SKIP_LAST_ROWID: u8 = 0x08; // Flag indicating that last_insert_rowid() must not be updated
+    pub const SKIP_STATEMENT_CHANGE_COUNT: u8 = 0x10; // Flag indicating that changes() must not count this insert
 
     pub fn new() -> Self {
         InsertFlags(0)
@@ -205,6 +206,11 @@ impl InsertFlags {
 
     pub fn skip_last_rowid(mut self) -> Self {
         self.0 |= InsertFlags::SKIP_LAST_ROWID;
+        self
+    }
+
+    pub fn skip_statement_change_count(mut self) -> Self {
+        self.0 |= InsertFlags::SKIP_STATEMENT_CHANGE_COUNT;
         self
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -701,6 +701,7 @@ pub struct ProgramState {
     /// Whether begin_statement was called (savepoint + FK bookkeeping active).
     has_stmt_transaction: bool,
     pub n_change: AtomicI64,
+    pub n_total_change: AtomicI64,
 }
 
 impl std::fmt::Debug for Program {
@@ -760,6 +761,7 @@ impl ProgramState {
             has_stmt_transaction: false,
             attached_savepoint_pagers: Vec::new(),
             n_change: AtomicI64::new(0),
+            n_total_change: AtomicI64::new(0),
             explain_state: RwLock::new(ExplainState::default()),
             pending_fail_error: None,
             pending_cdc_info: None,
@@ -884,10 +886,20 @@ impl ProgramState {
         self.distinct_key_values.clear();
         self.attached_savepoint_pagers.clear();
         self.n_change.store(0, Ordering::SeqCst);
+        self.n_total_change.store(0, Ordering::SeqCst);
         *self.explain_state.write() = ExplainState::default();
         self.pending_fail_error = None;
         self.pending_cdc_info = None;
         self.subprogram_stmt_cache.clear();
+    }
+
+    pub(crate) fn record_statement_change(&self) {
+        self.n_change.fetch_add(1, Ordering::SeqCst);
+        self.n_total_change.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn record_total_change(&self) {
+        self.n_total_change.fetch_add(1, Ordering::SeqCst);
     }
 
     /// Whether this statement owns the implicit autocommit transaction it is
@@ -1873,6 +1885,8 @@ impl Program {
             if self.change_cnt_on {
                 self.connection
                     .set_changes(program_state.n_change.load(Ordering::SeqCst));
+                self.connection
+                    .add_total_changes(program_state.n_total_change.load(Ordering::SeqCst));
             }
             let transaction_finished = self.connection.auto_commit.load(Ordering::SeqCst)
                 && self.connection.get_tx_state() == TransactionState::None;
@@ -2367,7 +2381,7 @@ impl Program {
                     // commit. Roll it back even if this statement opened a
                     // statement savepoint, as DDL does.
                     self.rollback_current_txn(pager);
-                    self.connection.set_changes_without_total(0);
+                    self.connection.set_changes(0);
                 }
                 // Foreign key constraint errors: ON CONFLICT does NOT apply to FK violations.
                 // FK errors always behave like ABORT: rollback statement,
@@ -2376,7 +2390,7 @@ impl Program {
                     if owns_auto_txn {
                         self.rollback_current_txn(pager);
                     }
-                    self.connection.set_changes_without_total(0);
+                    self.connection.set_changes(0);
                 }
                 // Constraint and RAISE errors: behavior depends on the effective resolve type.
                 // For normal constraints, the resolve type comes from the statement (ON CONFLICT).
@@ -2467,7 +2481,7 @@ impl Program {
                         ResolveType::Fail => state.n_change.load(Ordering::SeqCst),
                         _ => 0,
                     };
-                    self.connection.set_changes_without_total(last_change);
+                    self.connection.set_changes(last_change);
                 }
                 Some(LimboError::RaiseIgnore) => {
                     tracing::error!(

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -68,6 +68,38 @@ fn v2_row(
 }
 
 #[turso_macros::test]
+fn test_cdc_internal_inserts_change_counters(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
+        .unwrap();
+    conn.execute("PRAGMA capture_data_changes_conn('full')")
+        .unwrap();
+
+    let total_changes_before_insert = conn.total_changes();
+    conn.execute("INSERT INTO t VALUES (42, 'hello')").unwrap();
+
+    assert_eq!(
+        (
+            conn.changes(),
+            conn.total_changes() - total_changes_before_insert
+        ),
+        (1, 3)
+    );
+
+    let total_changes_before_insert = conn.total_changes();
+    conn.execute("INSERT INTO t VALUES (43, 'world'), (44, 'again')")
+        .unwrap();
+
+    assert_eq!(
+        (
+            conn.changes(),
+            conn.total_changes() - total_changes_before_insert
+        ),
+        (2, 5)
+    );
+}
+
+#[turso_macros::test]
 fn test_cdc_simple_id(db: TempDatabase) {
     let conn = db.connect_limbo();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")


### PR DESCRIPTION
closes #7329

## Description

Keep CDC internal inserts out of user-visible `changes()` while preserving their contribution to `total_changes()`.

CDC writes internal rows into `turso_cdc` for captured data changes and v2 commit records. Those internal inserts are physical changes and should still contribute to `total_changes()`, but they should not increase the statement-level `changes()` value reported for the user's SQL statement.

This separates the VDBE statement change counter from the per-statement total-change counter, and marks CDC insert bytecode with a new `SKIP_STATEMENT_CHANGE_COUNT` flag.

## Motivation and context

With CDC enabled, a single user insert currently reports `changes() = 3` because Turso counts:

1. the user row insert
2. the CDC data row insert
3. the CDC v2 commit marker insert

For SQLite-compatible statement semantics, `changes()` should report only the rows directly changed by the user statement. At the same time, `total_changes()` should remain cumulative and include the internal CDC writes.

After this change, CDC-enabled inserts report:

```text
single-row insert: changes() = 1, total_changes() delta = 3
multi-row insert:  changes() = 2, total_changes() delta = 5
```

## Testing

Before the fix, the new regression test failed as expected:

```text
test functions::test_cdc::test_cdc_internal_inserts_change_counters ... FAILED

assertion `left == right` failed
  left: (3, 3)
 right: (1, 3)
```

After the fix:

```text
cargo test -p core_tester --test integration_tests test_cdc_internal_inserts_change_counters
```

```text
test functions::test_cdc::test_cdc_internal_inserts_change_counters ... ok
```

Additional validation:

```text
make -C testing/sqltests run-one FILE=tests/changes.sqltest
make -C testing/sqltests run-one FILE=tests/total-changes.sqltest
cargo test -p core_tester --test integration_tests functions::test_cdc::
```

All passed.

## Description of AI Usage

AI was used in a supporting role.