### PR TITLE
core/storage: port SQLite's saveAllCursors to a pager-level registry

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -11876,6 +11876,278 @@ mod tests {
         insert_into_cell(contents, &payload, cell_idx as usize, pager.usable_space()).unwrap();
     }
 
+    /// Direct red-first coverage for the pager-level cursor registry and
+    /// saveAllCursors port introduced in #7341 (register_with_pager,
+    /// has_peers toggling, drive_pending_peer_save inside insert/delete,
+    /// clear_btree's auto-invalidation of peers).
+    ///
+    /// Pairs with the SQL-surface red-first cases in
+    /// testing/sqltests/tests/save-all-cursors.sqltest (window function
+    /// over triple self-joined source) and the pre-existing
+    /// testing/sqltests/tests/window-selfjoin-reset-sorter.sqltest.
+    /// Those exercise the same machinery end-to-end; the cases here
+    /// pin individual primitives (peer registration, save vs.
+    /// invalidate, restore semantics) so a regression bisects faster.
+    mod save_all_cursors {
+        use super::*;
+        use crate::storage::btree::SavePositionResult;
+        use test_log::test;
+
+        /// Boxed cursor pinned to its heap location for the duration of the
+        /// test — register_cursor stores raw pointers, so the cursor must
+        /// not be moved after registration.
+        fn make_registered_cursor(
+            pager: &Arc<Pager>,
+            root_page: i64,
+            num_columns: usize,
+        ) -> Box<BTreeCursor> {
+            let cursor = Box::new(BTreeCursor::new_table(
+                pager.clone(),
+                root_page,
+                num_columns,
+            ));
+            (*cursor).register_with_pager();
+            cursor
+        }
+
+        #[test]
+        fn registry_toggles_has_peers_flag() {
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let cursor_a = make_registered_cursor(&pager, root_page, 1);
+            assert!(
+                !cursor_a
+                    .has_peers
+                    .load(crate::sync::atomic::Ordering::Relaxed),
+                "single registered cursor must have has_peers=false"
+            );
+
+            let cursor_b = make_registered_cursor(&pager, root_page, 1);
+            assert!(
+                cursor_a
+                    .has_peers
+                    .load(crate::sync::atomic::Ordering::Relaxed),
+                "registering a peer must set has_peers on the original"
+            );
+            assert!(
+                cursor_b
+                    .has_peers
+                    .load(crate::sync::atomic::Ordering::Relaxed),
+                "the newly registered cursor must also see has_peers=true"
+            );
+
+            drop(cursor_b);
+            assert!(
+                !cursor_a
+                    .has_peers
+                    .load(crate::sync::atomic::Ordering::Relaxed),
+                "dropping the peer must clear has_peers on the survivor"
+            );
+        }
+
+        #[test]
+        fn registry_buckets_per_root_page() {
+            // Cursors on different root pages must not see each other as
+            // peers; saveAllCursors is per-root (SQLite btree.c:806).
+            let (pager, root_a, _db, _conn) = empty_btree();
+            let page_b = run_until_done(|| pager.allocate_page(), &pager).unwrap();
+            btree_init_page(&page_b, PageType::TableLeaf, 0, pager.usable_space());
+            let root_b = page_b.get().id as i64;
+
+            let cursor_a = make_registered_cursor(&pager, root_a, 1);
+            let cursor_b = make_registered_cursor(&pager, root_b, 1);
+            assert!(
+                !cursor_a
+                    .has_peers
+                    .load(crate::sync::atomic::Ordering::Relaxed)
+                    && !cursor_b
+                        .has_peers
+                        .load(crate::sync::atomic::Ordering::Relaxed),
+                "cursors on different roots must not be peers"
+            );
+        }
+
+        #[test]
+        fn try_save_position_table_returns_saved() {
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut cursor = BTreeCursor::new_table(pager.clone(), root_page, 1);
+            for rowid in 1..=5 {
+                insert_record(&mut cursor, &pager, rowid, Value::from_i64(rowid)).unwrap();
+            }
+            run_until_done(
+                || cursor.seek(SeekKey::TableRowId(3), SeekOp::GE { eq_only: true }),
+                pager.deref(),
+            )
+            .unwrap();
+            assert!(cursor.has_record());
+
+            let outcome = run_until_done(
+                || cursor.try_save_position_for_external_balance(),
+                pager.deref(),
+            )
+            .unwrap();
+            assert_eq!(outcome, SavePositionResult::Saved);
+            assert_eq!(cursor.valid_state, CursorValidState::RequireSeek);
+            assert!(cursor.context.is_some());
+        }
+
+        #[test]
+        fn try_save_position_unpositioned_returns_saved_noop() {
+            // valid_state=Valid + has_record=false ⇒ nothing to save and
+            // nothing to invalidate (stack already in a re-navigable state).
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut cursor = BTreeCursor::new_table(pager.clone(), root_page, 1);
+            let outcome = run_until_done(
+                || cursor.try_save_position_for_external_balance(),
+                pager.deref(),
+            )
+            .unwrap();
+            assert_eq!(outcome, SavePositionResult::Saved);
+            assert!(cursor.context.is_none());
+        }
+
+        #[test]
+        fn clear_btree_auto_invalidates_peer() {
+            // Without saveAllCursors, ResetSorter used to invalidate dup
+            // cursors via pointer-equality from op_reset_sorter. Now
+            // clear_btree itself does it via the pager registry.
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut writer = make_registered_cursor(&pager, root_page, 1);
+            let mut peer = make_registered_cursor(&pager, root_page, 1);
+
+            for rowid in 1..=10 {
+                insert_record(&mut writer, &pager, rowid, Value::from_i64(rowid)).unwrap();
+            }
+            run_until_done(
+                || peer.seek(SeekKey::TableRowId(5), SeekOp::GE { eq_only: true }),
+                pager.deref(),
+            )
+            .unwrap();
+            assert!(peer.has_record());
+            assert!(peer.stack.current_page >= 0);
+
+            run_until_done(|| writer.clear_btree(), &pager).unwrap();
+
+            assert!(
+                !peer.has_record(),
+                "peer must observe has_record=false after a peer's clear_btree"
+            );
+            assert_eq!(
+                peer.stack.current_page, -1,
+                "peer's page stack must be reset to the sentinel"
+            );
+        }
+
+        #[test]
+        fn delete_preserves_peer_logical_position() {
+            // Cursor1 deletes rowid=3 while cursor2 sits on rowid=5. Without
+            // the saveAllCursors port, cursor2's cached cell_idx points to
+            // the cell that shifted left into rowid=5's slot (now rowid=6),
+            // and rowid() silently returns 6. With the port, cursor2's
+            // position is saved on entry to delete and restored on next
+            // access — rowid() returns 5.
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut writer = make_registered_cursor(&pager, root_page, 1);
+            let mut peer = make_registered_cursor(&pager, root_page, 1);
+
+            for rowid in 1..=10 {
+                insert_record(&mut writer, &pager, rowid, Value::from_i64(rowid)).unwrap();
+            }
+            run_until_done(
+                || peer.seek(SeekKey::TableRowId(5), SeekOp::GE { eq_only: true }),
+                pager.deref(),
+            )
+            .unwrap();
+            assert_eq!(
+                run_until_done(|| peer.rowid(), pager.deref()).unwrap(),
+                Some(5)
+            );
+
+            run_until_done(
+                || writer.seek(SeekKey::TableRowId(3), SeekOp::GE { eq_only: true }),
+                pager.deref(),
+            )
+            .unwrap();
+            run_until_done(|| writer.delete(), pager.deref()).unwrap();
+
+            assert_eq!(
+                run_until_done(|| peer.rowid(), pager.deref()).unwrap(),
+                Some(5),
+                "peer must still observe its logical rowid after a peer delete"
+            );
+        }
+
+        #[test]
+        fn delete_of_peers_own_row_lands_on_next_greater() {
+            // SQLite's CURSOR_SKIPNEXT (btree.c:915): when restore_context's
+            // re-seek lands on NotFound, the cursor sets skip_advance so the
+            // next() returns the cell the seek landed on instead of stepping
+            // past it. Forward iteration continues correctly after a peer
+            // deletes the row we were sitting on.
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut writer = make_registered_cursor(&pager, root_page, 1);
+            let mut peer = make_registered_cursor(&pager, root_page, 1);
+
+            for rowid in 1..=10 {
+                insert_record(&mut writer, &pager, rowid, Value::from_i64(rowid)).unwrap();
+            }
+            run_until_done(
+                || peer.seek(SeekKey::TableRowId(5), SeekOp::GE { eq_only: true }),
+                pager.deref(),
+            )
+            .unwrap();
+
+            run_until_done(
+                || writer.seek(SeekKey::TableRowId(5), SeekOp::GE { eq_only: true }),
+                pager.deref(),
+            )
+            .unwrap();
+            run_until_done(|| writer.delete(), pager.deref()).unwrap();
+
+            // First access after a peer wipe-out triggers restore_context's
+            // NotFound branch and sets skip_advance.
+            run_until_done(|| peer.next(), pager.deref()).unwrap();
+            assert_eq!(
+                run_until_done(|| peer.rowid(), pager.deref()).unwrap(),
+                Some(6),
+                "next() after peer deletion of our row must land on the next-greater rowid"
+            );
+        }
+
+        #[test]
+        fn insert_preserves_peer_logical_position() {
+            // Cursor2 sits on rowid=5; cursor1 inserts rowid=2 (causes
+            // cells to shift right on the shared page). Without saveAllCursors,
+            // cursor2's cell_idx now points to rowid=4. With the port, the
+            // saved rowid=5 is restored on next access.
+            let (pager, root_page, _db, _conn) = empty_btree();
+            let mut writer = make_registered_cursor(&pager, root_page, 1);
+            let mut peer = make_registered_cursor(&pager, root_page, 1);
+
+            // Insert odd rowids so even slots are open for the peer-disrupting
+            // insert below.
+            for rowid in [1i64, 3, 5, 7, 9] {
+                insert_record(&mut writer, &pager, rowid, Value::from_i64(rowid)).unwrap();
+            }
+            run_until_done(
+                || peer.seek(SeekKey::TableRowId(5), SeekOp::GE { eq_only: true }),
+                pager.deref(),
+            )
+            .unwrap();
+            assert_eq!(
+                run_until_done(|| peer.rowid(), pager.deref()).unwrap(),
+                Some(5)
+            );
+
+            insert_record(&mut writer, &pager, 2, Value::from_i64(2)).unwrap();
+
+            assert_eq!(
+                run_until_done(|| peer.rowid(), pager.deref()).unwrap(),
+                Some(5),
+                "peer must observe its saved rowid after a left-of-it peer insert"
+            );
+        }
+    }
+
     /// Strict property tests for page-level btree mutations.
     ///
     /// These tests model expected cell bytes and check that every mutation

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -658,6 +658,18 @@ pub trait CursorTrait: Any + Send + Sync {
     /// share a btree (e.g. OpenDup cursors) when the btree structure is
     /// modified by another cursor (e.g. clear_btree via ResetSorter).
     fn invalidate_btree_cache(&mut self) {}
+    /// Opt into the pager's cursor_registry. Default no-op so non-BTreeCursor
+    /// impls (MvccLazyCursor) stay out. Opt-in impls must unregister in Drop.
+    fn register_with_pager(&self) {}
+    /// Mirror of SQLite's BTCF_Multiple flag; toggled by Pager when a bucket
+    /// crosses the 1↔2 threshold.
+    fn set_has_peers_for_external_writes(&self, _has_peers: bool) {}
+    /// Save position so the cursor can re-seek after a peer write. Returns
+    /// `false` when the position can't be represented (MVCC cursors, stale
+    /// page stack); the caller falls back to invalidate_btree_cache.
+    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<bool>> {
+        Ok(IOResult::Done(false))
+    }
     // --- end: BTreeCursor specific functions ----
 }
 
@@ -734,6 +746,21 @@ pub struct BTreeCursor {
     /// short-circuits to retry the read+descend rather than re-running those
     /// mutations and corrupting the cursor's cell-index state.
     iteration_pending_descent: Option<IterationPendingDescent>,
+    /// (peers, idx) snapshot for the saveAllCursors pass driven from
+    /// insert/delete. Carries iteration progress across IO re-entry
+    /// (index records can yield via the overflow chain walk).
+    pending_peer_save: Option<(
+        smallvec::SmallVec<[crate::storage::pager::RegisteredCursor; 4]>,
+        usize,
+    )>,
+    /// Mirrors SQLite's BTCF_Multiple. Toggled by Pager::register_cursor /
+    /// unregister_cursor when the bucket crosses the 1↔2 threshold; lets
+    /// drive_pending_peer_save skip the registry mutex in the common case.
+    has_peers: std::sync::atomic::AtomicBool,
+    /// True if this cursor went through Cursor::new_btree (and thus pushed
+    /// itself into the registry). Direct BTreeCursor::new callers (tests,
+    /// internal utilities) bypass that path; their Drop skips unregister.
+    did_register: std::sync::atomic::AtomicBool,
 }
 
 /// Records the in-flight descent for `iteration_pending_descent`. The direction
@@ -810,6 +837,9 @@ impl BTreeCursor {
             skip_advance: false,
             reusable_cell_payload: Vec::new(),
             iteration_pending_descent: None,
+            pending_peer_save: None,
+            has_peers: std::sync::atomic::AtomicBool::new(false),
+            did_register: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -5258,16 +5288,67 @@ impl BTreeCursor {
         matches!(self.state, CursorState::Write(_))
     }
 
+    /// saveAllCursors pass for this cursor's insert/delete entry. Iteration
+    /// state lives in `pending_peer_save` so we can resume across IO yields
+    /// from per-peer overflow-chain reads.
+    fn drive_pending_peer_save(&mut self) -> Result<IOResult<()>> {
+        if self.pending_peer_save.is_none() && matches!(self.state, CursorState::None) {
+            // BTCF_Multiple fast path (sqlite3 btree.c:9348).
+            if !self.has_peers.load(std::sync::atomic::Ordering::Relaxed) {
+                return Ok(IOResult::Done(()));
+            }
+            let dyn_ref: &dyn CursorTrait = self;
+            let peers = self.pager.snapshot_peers_for_root(dyn_ref);
+            if peers.is_empty() {
+                return Ok(IOResult::Done(()));
+            }
+            self.pending_peer_save = Some((peers, 0));
+        }
+        let Some((peers, idx)) = self.pending_peer_save.as_mut() else {
+            return Ok(IOResult::Done(()));
+        };
+        while *idx < peers.len() {
+            let peer = peers[*idx];
+            // SAFETY: see RegisteredCursor's invariant.
+            let saved =
+                unsafe { return_if_io!(peer.as_mut().try_save_position_for_external_balance()) };
+            if !saved {
+                // SAFETY: see RegisteredCursor's invariant.
+                unsafe { peer.as_mut().invalidate_btree_cache() };
+            }
+            *idx += 1;
+        }
+        self.pending_peer_save = None;
+        Ok(IOResult::Done(()))
+    }
+
     // Save cursor context, to be restored later
     pub fn save_context(&mut self, cursor_context: CursorContext) {
         self.valid_state = CursorValidState::RequireSeek;
         self.context = Some(cursor_context);
     }
 
-    /// If context is defined, restore it and set it None on success
+    /// Drop any pending saved seek-context; used by callers that re-navigate
+    /// from the root and don't want restore_context to clobber them.
+    #[inline]
+    fn clear_saved_seek(&mut self) {
+        self.context = None;
+        self.valid_state = CursorValidState::Valid;
+    }
+
+    #[inline]
+    fn needs_restore(&self) -> bool {
+        self.context.is_some() && !matches!(self.valid_state, CursorValidState::Valid)
+    }
+
+    /// If context is defined, restore it and set it None on success. Parallels
+    /// SQLite's btreeRestoreCursorPosition (btree.c:896). NotFound stays at
+    /// Valid with has_record=false rather than transitioning to Invalid: a
+    /// peer-deleted cursor is still recoverable via Rewind/Seek, whereas our
+    /// Invalid is reserved for cursors that can never be repositioned.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn restore_context(&mut self) -> Result<IOResult<()>> {
-        if self.context.is_none() || matches!(self.valid_state, CursorValidState::Valid) {
+        if !self.needs_restore() {
             return Ok(IOResult::Done(()));
         }
         if let CursorValidState::RequireAdvance(direction) = self.valid_state {
@@ -5288,14 +5369,30 @@ impl BTreeCursor {
         let res = self.seek(seek_key, ctx.seek_op)?;
         match res {
             IOResult::Done(res) => {
-                if let SeekResult::TryAdvance = res {
-                    self.valid_state =
-                        CursorValidState::RequireAdvance(ctx.seek_op.iteration_direction());
-                    self.context = Some(ctx);
-                    io_yield_one!(Completion::new_yield());
+                match res {
+                    SeekResult::Found => {
+                        self.valid_state = CursorValidState::Valid;
+                        Ok(IOResult::Done(()))
+                    }
+                    SeekResult::TryAdvance => {
+                        self.valid_state =
+                            CursorValidState::RequireAdvance(ctx.seek_op.iteration_direction());
+                        self.context = Some(ctx);
+                        io_yield_one!(Completion::new_yield());
+                    }
+                    SeekResult::NotFound => {
+                        // Saved row is gone (deleted by us, or by a peer).
+                        // The seek positioned the stack at the next-greater
+                        // cell, which is the correct iteration target for
+                        // forward iteration after the deletion. Signal that
+                        // via skip_advance so the next next() returns the
+                        // landed cell instead of advancing past it — mirrors
+                        // SQLite's CURSOR_SKIPNEXT (btree.c:915).
+                        self.skip_advance = true;
+                        self.valid_state = CursorValidState::Valid;
+                        Ok(IOResult::Done(()))
+                    }
                 }
-                self.valid_state = CursorValidState::Valid;
-                Ok(IOResult::Done(()))
             }
             IOResult::IO(io) => {
                 self.context = Some(ctx);
@@ -5318,34 +5415,46 @@ impl BTreeCursor {
     }
 }
 
+impl Drop for BTreeCursor {
+    fn drop(&mut self) {
+        if !self.did_register.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+        let dyn_ref: &dyn CursorTrait = self;
+        self.pager.unregister_cursor(dyn_ref);
+    }
+}
+
 impl CursorTrait for BTreeCursor {
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn next(&mut self) -> Result<IOResult<()>> {
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
         }
-        if self.skip_advance {
-            // See DeleteState::RestoreContextAfterBalancing
-            self.skip_advance = false;
-            let mem_page = self.stack.top_ref();
-            let contents = mem_page.get_contents();
-            let cell_idx = self.stack.current_cell_index();
-            let cell_count = contents.cell_count();
-            let has_record = cell_idx >= 0 && cell_idx < cell_count as i32;
-            if has_record {
-                self.set_has_record(has_record);
-                // If we are positioned at a record, we stop here without advancing.
-                self.read_overflow_state = None;
-                return Ok(IOResult::Done(()));
-            }
-            // But: if we aren't currently positioned at a record (for example, we are at the end of a page),
-            // we need to advance despite the skip_advance flag
-            // because the intent is to find the next record immediately after the one we just deleted.
-        }
         loop {
             match self.advance_state {
                 AdvanceState::Start => {
                     return_if_io!(self.restore_context());
+                    // Set by DeleteState::RestoreContextAfterBalancing and by
+                    // restore_context on NotFound: the cursor is already at
+                    // the right iteration target, so return it without
+                    // advancing. If the landed cell has no record (past
+                    // EOF), fall through to Advance.
+                    if self.skip_advance {
+                        self.skip_advance = false;
+                        if self.stack.current_page >= 0 {
+                            let mem_page = self.stack.top_ref();
+                            let contents = mem_page.get_contents();
+                            let cell_idx = self.stack.current_cell_index();
+                            let cell_count = contents.cell_count();
+                            let has_record = cell_idx >= 0 && cell_idx < cell_count as i32;
+                            if has_record {
+                                self.set_has_record(true);
+                                self.read_overflow_state = None;
+                                return Ok(IOResult::Done(()));
+                            }
+                        }
+                    }
                     self.advance_state = AdvanceState::Advance;
                 }
                 AdvanceState::Advance => {
@@ -5361,6 +5470,10 @@ impl CursorTrait for BTreeCursor {
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn last(&mut self) -> Result<IOResult<()>> {
         self.set_null_flag(false);
+        if self.valid_state == CursorValidState::Invalid {
+            return Ok(IOResult::Done(()));
+        }
+        self.clear_saved_seek();
         let always_seek = false;
         let cursor_has_record = return_if_io!(self.move_to_rightmost(always_seek));
         self.set_has_record(cursor_has_record);
@@ -5389,6 +5502,9 @@ impl CursorTrait for BTreeCursor {
 
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
     fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+        if self.needs_restore() {
+            return_if_io!(self.restore_context());
+        }
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
@@ -5451,6 +5567,11 @@ impl CursorTrait for BTreeCursor {
 
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
     fn record(&mut self) -> Result<IOResult<Option<&ImmutableRecord>>> {
+        // Mirrors sqlite3BtreeRestoreCursorPosition called at btree read
+        // entry points (btree.c:5315, etc).
+        if self.needs_restore() {
+            return_if_io!(self.restore_context());
+        }
         if !self.has_record() {
             return Ok(IOResult::Done(None));
         }
@@ -5505,6 +5626,8 @@ impl CursorTrait for BTreeCursor {
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
         tracing::debug!(valid_state = ?self.valid_state, cursor_state = ?self.state, is_write_in_progress = self.is_write_in_progress());
+        // saveAllCursors at the head of sqlite3BtreeInsert (btree.c:9348).
+        return_if_io!(self.drive_pending_peer_save());
         return_if_io!(self.insert_into_page(key));
         self.invalidate_count_cache();
         if key.maybe_rowid().is_some() {
@@ -5528,6 +5651,8 @@ impl CursorTrait for BTreeCursor {
     /// 10. Finish -> Delete operation is done. Return CursorResult(Ok())
     fn delete(&mut self) -> Result<IOResult<()>> {
         if let CursorState::None = &self.state {
+            // saveAllCursors at the head of sqlite3BtreeDelete (btree.c:9841).
+            return_if_io!(self.drive_pending_peer_save());
             self.invalidate_count_cache();
             self.state = CursorState::Delete(DeleteState::Start);
         }
@@ -5917,7 +6042,16 @@ impl CursorTrait for BTreeCursor {
     /// this method only clears the tree’s contents. The root page remains
     /// allocated and is reset to an empty leaf page.
     fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>> {
-        self.invalidate_count_cache();
+        // First entry only — destroy_btree_contents yields IO and resumes
+        // through this method, so guard with the same state==None gate it
+        // uses for its own state machine. Every page in this btree is about
+        // to be freed; peers must drop their page stacks rather than save
+        // positions that wouldn't outlive the clear (cf. sqlite3BtreeClearTable,
+        // btree.c:10194).
+        if matches!(self.state, CursorState::None) {
+            self.pager.invalidate_peer_cursors(self);
+            self.invalidate_count_cache();
+        }
         self.destroy_btree_contents(true)
     }
 
@@ -5929,6 +6063,10 @@ impl CursorTrait for BTreeCursor {
     /// For cases where the B-Tree should remain allocated but emptied, see [`btree_clear`].
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
     fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>> {
+        // See clear_btree for the state==None gate rationale.
+        if matches!(self.state, CursorState::None) {
+            self.pager.invalidate_peer_cursors(self);
+        }
         self.destroy_btree_contents(false)
     }
 
@@ -5940,10 +6078,15 @@ impl CursorTrait for BTreeCursor {
         let mut mem_page;
         let mut contents;
 
+        if self.valid_state == CursorValidState::Invalid {
+            return Ok(IOResult::Done(0));
+        }
+
         'outer: loop {
             let state = self.count_state;
             match state {
                 CountState::Start => {
+                    self.clear_saved_seek();
                     let c = return_if_io!(self.move_to_root_nonblock());
                     self.count_state = CountState::Loop;
                     if let Some(c) = c {
@@ -6095,6 +6238,7 @@ impl CursorTrait for BTreeCursor {
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
         }
+        self.clear_saved_seek();
         self.skip_advance = false;
         loop {
             match self.rewind_state {
@@ -6140,9 +6284,99 @@ impl CursorTrait for BTreeCursor {
         self.skip_advance
     }
 
+    /// Drop the page stack and auxiliary caches so the cursor will re-navigate
+    /// from the root on its next access. Used when saving the position via
+    /// try_save_position_for_external_balance isn't applicable (the peer
+    /// btree was cleared/destroyed, or the position can't be expressed).
+    /// valid_state stays Valid — only rewind/seek-style entry points are safe
+    /// next; next/prev land on `current_page == -1` and return Done(false).
     fn invalidate_btree_cache(&mut self) {
+        for slot in self.stack.stack.iter_mut() {
+            *slot = None;
+        }
+        self.stack.current_page = -1;
+        self.has_record = false;
         self.move_to_right_state.1 = None;
         self.invalidate_count_cache();
+    }
+
+    fn register_with_pager(&self) {
+        // Store before the push so a panic inside register_cursor still
+        // triggers an (idempotent) unregister via Drop.
+        self.did_register
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.pager.register_cursor(self);
+    }
+
+    fn set_has_peers_for_external_writes(&self, has_peers: bool) {
+        self.has_peers
+            .store(has_peers, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Mirrors SQLite's saveCursorPosition (btree.c:756). Saves rowid for
+    /// table btrees, the cell record for index btrees; index records can
+    /// yield IO via the overflow chain walk (`record()`). Returns `false`
+    /// when the page stack is in a sentinel/dirty state we can't save from
+    /// — has_record can lag the stack across an in-flight Insert/Delete —
+    /// in which case the caller falls back to invalidate_btree_cache.
+    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<bool>> {
+        if self.valid_state != CursorValidState::Valid || !self.has_record() {
+            return Ok(IOResult::Done(true));
+        }
+        // A peer mid-Insert/Delete may not yet have reached its own
+        // save_context-at-balance point, so we can't claim it's saved. Fall
+        // back to invalidation; the peer will re-navigate on next use.
+        if !matches!(self.state, CursorState::None) {
+            return Ok(IOResult::Done(false));
+        }
+        if self.stack.current_page < 0
+            || (self.stack.current_page as usize) >= self.stack.stack.len()
+            || self.stack.stack[self.stack.current_page as usize].is_none()
+        {
+            return Ok(IOResult::Done(false));
+        }
+        let cell_idx = self.stack.current_cell_index();
+        if cell_idx < 0 {
+            return Ok(IOResult::Done(false));
+        }
+        let (is_table, cell_count) = {
+            let page = self.stack.top_ref();
+            let contents = page.get_contents();
+            (contents.page_type()?.is_table(), contents.cell_count())
+        };
+        if (cell_idx as usize) >= cell_count {
+            return Ok(IOResult::Done(false));
+        }
+        if is_table {
+            let page = self.stack.top_ref();
+            let contents = page.get_contents();
+            debug_assert!(
+                matches!(contents.page_type(), Ok(PageType::TableLeaf)),
+                "save_position: table cursor with has_record=true must be on a leaf"
+            );
+            let rowid = contents.cell_table_leaf_read_rowid(cell_idx as usize)?;
+            self.save_context(CursorContext {
+                key: CursorContextKey::TableRowId(rowid),
+                seek_op: SeekOp::GE { eq_only: true },
+            });
+            return Ok(IOResult::Done(true));
+        }
+        // Index btree: yield IO for overflow chains. Allocate to the actual
+        // payload size so wide-key indexes don't keep a page-sized buffer
+        // per saved cursor.
+        let cloned = {
+            let record = return_if_io!(self.record());
+            let record = record.expect("has_record=true but record() returned None");
+            let payload = record.get_payload();
+            let mut owned = ImmutableRecord::new(payload.len())?;
+            owned.start_serialization(payload)?;
+            owned
+        };
+        self.save_context(CursorContext {
+            key: CursorContextKey::IndexKeyRowId(cloned),
+            seek_op: SeekOp::GE { eq_only: true },
+        });
+        Ok(IOResult::Done(true))
     }
 
     #[inline]
@@ -6161,9 +6395,13 @@ impl CursorTrait for BTreeCursor {
     }
 
     fn seek_end(&mut self) -> Result<IOResult<()>> {
+        if self.valid_state == CursorValidState::Invalid {
+            return Ok(IOResult::Done(()));
+        }
         loop {
             match self.seek_end_state {
                 SeekEndState::Start => {
+                    self.clear_saved_seek();
                     let c = return_if_io!(self.move_to_root_nonblock());
                     self.seek_end_state = SeekEndState::ProcessPage;
                     if let Some(c) = c {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -601,6 +601,20 @@ pub enum CursorSeekState {
     },
 }
 
+/// Outcome of [`CursorTrait::try_save_position_for_external_balance`]. Mirrors
+/// the two paths SQLite's saveCursorPosition takes (btree.c:756) — succeed and
+/// have the caller skip invalidation, or fall through to clearing the cached
+/// page stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SavePositionResult {
+    /// Position captured via [`CursorTrait::save_context`]; cursor will re-seek
+    /// on next use. Caller does not need to invalidate.
+    Saved,
+    /// Position cannot be represented (MVCC cursor, mid-operation page stack,
+    /// stale record state). Caller must fall back to `invalidate_btree_cache`.
+    MustInvalidate,
+}
+
 pub trait CursorTrait: Any + Send + Sync {
     /// Move cursor to last entry.
     fn last(&mut self) -> Result<IOResult<()>>;
@@ -665,10 +679,11 @@ pub trait CursorTrait: Any + Send + Sync {
     /// crosses the 1↔2 threshold.
     fn set_has_peers_for_external_writes(&self, _has_peers: bool) {}
     /// Save position so the cursor can re-seek after a peer write. Returns
-    /// `false` when the position can't be represented (MVCC cursors, stale
-    /// page stack); the caller falls back to invalidate_btree_cache.
-    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<bool>> {
-        Ok(IOResult::Done(false))
+    /// [`SavePositionResult::MustInvalidate`] when the position can't be
+    /// represented (MVCC cursors, stale page stack); the caller falls back to
+    /// invalidate_btree_cache.
+    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<SavePositionResult>> {
+        Ok(IOResult::Done(SavePositionResult::MustInvalidate))
     }
     // --- end: BTreeCursor specific functions ----
 }
@@ -5310,9 +5325,9 @@ impl BTreeCursor {
         while *idx < peers.len() {
             let peer = peers[*idx];
             // SAFETY: see RegisteredCursor's invariant.
-            let saved =
+            let outcome =
                 unsafe { return_if_io!(peer.as_mut().try_save_position_for_external_balance()) };
-            if !saved {
+            if outcome == SavePositionResult::MustInvalidate {
                 // SAFETY: see RegisteredCursor's invariant.
                 unsafe { peer.as_mut().invalidate_btree_cache() };
             }
@@ -6318,29 +6333,33 @@ impl CursorTrait for BTreeCursor {
 
     /// Mirrors SQLite's saveCursorPosition (btree.c:756). Saves rowid for
     /// table btrees, the cell record for index btrees; index records can
-    /// yield IO via the overflow chain walk (`record()`). Returns `false`
-    /// when the page stack is in a sentinel/dirty state we can't save from
-    /// — has_record can lag the stack across an in-flight Insert/Delete —
-    /// in which case the caller falls back to invalidate_btree_cache.
-    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<bool>> {
+    /// yield IO via the overflow chain walk (`record()`). Returns
+    /// [`SavePositionResult::MustInvalidate`] when the page stack is in a
+    /// sentinel/dirty state we can't save from — has_record can lag the stack
+    /// across an in-flight Insert/Delete — in which case the caller falls back
+    /// to invalidate_btree_cache.
+    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<SavePositionResult>> {
         if self.valid_state != CursorValidState::Valid || !self.has_record() {
-            return Ok(IOResult::Done(true));
+            // Nothing to save: cursor has no live position. No invalidation
+            // needed either — the stack is already in a state where the next
+            // entry point will re-navigate from the root.
+            return Ok(IOResult::Done(SavePositionResult::Saved));
         }
         // A peer mid-Insert/Delete may not yet have reached its own
         // save_context-at-balance point, so we can't claim it's saved. Fall
         // back to invalidation; the peer will re-navigate on next use.
         if !matches!(self.state, CursorState::None) {
-            return Ok(IOResult::Done(false));
+            return Ok(IOResult::Done(SavePositionResult::MustInvalidate));
         }
         if self.stack.current_page < 0
             || (self.stack.current_page as usize) >= self.stack.stack.len()
             || self.stack.stack[self.stack.current_page as usize].is_none()
         {
-            return Ok(IOResult::Done(false));
+            return Ok(IOResult::Done(SavePositionResult::MustInvalidate));
         }
         let cell_idx = self.stack.current_cell_index();
         if cell_idx < 0 {
-            return Ok(IOResult::Done(false));
+            return Ok(IOResult::Done(SavePositionResult::MustInvalidate));
         }
         let (is_table, cell_count) = {
             let page = self.stack.top_ref();
@@ -6348,7 +6367,7 @@ impl CursorTrait for BTreeCursor {
             (contents.page_type()?.is_table(), contents.cell_count())
         };
         if (cell_idx as usize) >= cell_count {
-            return Ok(IOResult::Done(false));
+            return Ok(IOResult::Done(SavePositionResult::MustInvalidate));
         }
         if is_table {
             let page = self.stack.top_ref();
@@ -6362,7 +6381,7 @@ impl CursorTrait for BTreeCursor {
                 key: CursorContextKey::TableRowId(rowid),
                 seek_op: SeekOp::GE { eq_only: true },
             });
-            return Ok(IOResult::Done(true));
+            return Ok(IOResult::Done(SavePositionResult::Saved));
         }
         // Index btree: yield IO for overflow chains. Allocate to the actual
         // payload size so wide-key indexes don't keep a page-sized buffer
@@ -6379,7 +6398,7 @@ impl CursorTrait for BTreeCursor {
             key: CursorContextKey::IndexKeyRowId(cloned),
             seek_op: SeekOp::GE { eq_only: true },
         });
-        Ok(IOResult::Done(true))
+        Ok(IOResult::Done(SavePositionResult::Saved))
     }
 
     #[inline]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -756,11 +756,11 @@ pub struct BTreeCursor {
     /// Mirrors SQLite's BTCF_Multiple. Toggled by Pager::register_cursor /
     /// unregister_cursor when the bucket crosses the 1↔2 threshold; lets
     /// drive_pending_peer_save skip the registry mutex in the common case.
-    has_peers: std::sync::atomic::AtomicBool,
+    has_peers: crate::sync::atomic::AtomicBool,
     /// True if this cursor went through Cursor::new_btree (and thus pushed
     /// itself into the registry). Direct BTreeCursor::new callers (tests,
     /// internal utilities) bypass that path; their Drop skips unregister.
-    did_register: std::sync::atomic::AtomicBool,
+    did_register: crate::sync::atomic::AtomicBool,
 }
 
 /// Records the in-flight descent for `iteration_pending_descent`. The direction
@@ -838,8 +838,8 @@ impl BTreeCursor {
             reusable_cell_payload: Vec::new(),
             iteration_pending_descent: None,
             pending_peer_save: None,
-            has_peers: std::sync::atomic::AtomicBool::new(false),
-            did_register: std::sync::atomic::AtomicBool::new(false),
+            has_peers: crate::sync::atomic::AtomicBool::new(false),
+            did_register: crate::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -5294,7 +5294,7 @@ impl BTreeCursor {
     fn drive_pending_peer_save(&mut self) -> Result<IOResult<()>> {
         if self.pending_peer_save.is_none() && matches!(self.state, CursorState::None) {
             // BTCF_Multiple fast path (sqlite3 btree.c:9348).
-            if !self.has_peers.load(std::sync::atomic::Ordering::Relaxed) {
+            if !self.has_peers.load(crate::sync::atomic::Ordering::Relaxed) {
                 return Ok(IOResult::Done(()));
             }
             let dyn_ref: &dyn CursorTrait = self;
@@ -5417,7 +5417,10 @@ impl BTreeCursor {
 
 impl Drop for BTreeCursor {
     fn drop(&mut self) {
-        if !self.did_register.load(std::sync::atomic::Ordering::Relaxed) {
+        if !self
+            .did_register
+            .load(crate::sync::atomic::Ordering::Relaxed)
+        {
             return;
         }
         let dyn_ref: &dyn CursorTrait = self;
@@ -6304,13 +6307,13 @@ impl CursorTrait for BTreeCursor {
         // Store before the push so a panic inside register_cursor still
         // triggers an (idempotent) unregister via Drop.
         self.did_register
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+            .store(true, crate::sync::atomic::Ordering::Relaxed);
         self.pager.register_cursor(self);
     }
 
     fn set_has_peers_for_external_writes(&self, has_peers: bool) {
         self.has_peers
-            .store(has_peers, std::sync::atomic::Ordering::Relaxed);
+            .store(has_peers, crate::sync::atomic::Ordering::Relaxed);
     }
 
     /// Mirrors SQLite's saveCursorPosition (btree.c:756). Saves rowid for

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1383,7 +1383,50 @@ pub struct Pager {
     /// Only stored on Apple platforms; on others, always returns Fsync.
     #[cfg(target_vendor = "apple")]
     sync_type: AtomicFileSyncType,
+    /// Live BTreeCursors on this pager, bucketed by btree root page.
+    /// Counterpart of SQLite's BtShared.pCursor list; bucketing per root
+    /// supplies the BTCF_Multiple fast path (btree.c:9348).
+    pub(crate) cursor_registry: Mutex<rustc_hash::FxHashMap<i64, Vec<RegisteredCursor>>>,
 }
+
+/// Raw fat pointer to a registered cursor.
+///
+/// # Safety
+/// Dereferencing requires that no other reference to the referent cursor
+/// is live at the same time. The registry Mutex serializes registry
+/// mutation but not access to the cursors themselves; that exclusion comes
+/// from the execution model — a Connection runs one statement at a time,
+/// and a statement's cursors are touched only by its executor thread.
+///
+/// Identity compares the data half of the pointer only: codegen may emit
+/// multiple vtable pointers for the same trait/type pair across
+/// translation units, so vtable comparison can spuriously fail.
+#[derive(Clone, Copy)]
+pub(crate) struct RegisteredCursor(std::ptr::NonNull<dyn crate::storage::btree::CursorTrait>);
+
+impl RegisteredCursor {
+    pub(crate) fn for_cursor(cursor: &dyn crate::storage::btree::CursorTrait) -> Self {
+        Self(std::ptr::NonNull::from(cursor))
+    }
+
+    /// # Safety
+    /// See the type-level doc.
+    #[allow(clippy::mut_from_ref)]
+    pub(crate) unsafe fn as_mut(&self) -> &mut dyn crate::storage::btree::CursorTrait {
+        unsafe { self.0.as_ptr().as_mut().unwrap() }
+    }
+}
+
+impl PartialEq for RegisteredCursor {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_ptr() as *const () == other.0.as_ptr() as *const ()
+    }
+}
+
+impl Eq for RegisteredCursor {}
+
+unsafe impl Send for RegisteredCursor {}
+unsafe impl Sync for RegisteredCursor {}
 
 assert_send_sync!(Pager);
 
@@ -1623,7 +1666,93 @@ impl Pager {
             init_page_1,
             #[cfg(target_vendor = "apple")]
             sync_type: AtomicFileSyncType::new(FileSyncType::Fsync),
+            cursor_registry: Mutex::new(rustc_hash::FxHashMap::default()),
         })
+    }
+
+    /// Add a cursor to the registry. Called from Cursor::new_btree once the
+    /// cursor lives in its final heap location; BTreeCursor::drop unregisters.
+    pub(crate) fn register_cursor(&self, cursor: &dyn crate::storage::btree::CursorTrait) {
+        let root = cursor.root_page();
+        let mut registry = self.cursor_registry.lock();
+        let bucket = registry.entry(root).or_default();
+        bucket.push(RegisteredCursor::for_cursor(cursor));
+        // Set BTCF_Multiple on every cursor in the bucket. Idempotent for
+        // existing peers; we don't bother branching on the 1→2 transition.
+        if bucket.len() >= 2 {
+            for &peer in bucket.iter() {
+                // SAFETY: see RegisteredCursor's invariant.
+                unsafe { peer.as_mut().set_has_peers_for_external_writes(true) };
+            }
+        }
+    }
+
+    pub(crate) fn unregister_cursor(&self, cursor: &dyn crate::storage::btree::CursorTrait) {
+        let target = RegisteredCursor::for_cursor(cursor);
+        let root = cursor.root_page();
+        let mut registry = self.cursor_registry.lock();
+        if let Some(bucket) = registry.get_mut(&root) {
+            if let Some(idx) = bucket.iter().position(|c| *c == target) {
+                bucket.swap_remove(idx);
+            }
+            // 2→1: clear BTCF_Multiple on the survivor.
+            if bucket.len() == 1 {
+                let surviving = bucket[0];
+                // SAFETY: see RegisteredCursor's invariant.
+                unsafe { surviving.as_mut().set_has_peers_for_external_writes(false) };
+            }
+            if bucket.is_empty() {
+                registry.remove(&root);
+            }
+        }
+    }
+
+    /// Snapshot all peers of `except` on the same btree root. Snapshotting
+    /// under the lock lets the caller iterate (and yield IO) without
+    /// blocking concurrent cursor open/close on the registry.
+    pub(crate) fn snapshot_peers_for_root(
+        &self,
+        except: &dyn crate::storage::btree::CursorTrait,
+    ) -> smallvec::SmallVec<[RegisteredCursor; 4]> {
+        let except_handle = RegisteredCursor::for_cursor(except);
+        let except_root = except.root_page();
+        let registry = self.cursor_registry.lock();
+        let Some(bucket) = registry.get(&except_root) else {
+            return smallvec::SmallVec::new();
+        };
+        if bucket.len() <= 1 {
+            return smallvec::SmallVec::new();
+        }
+        bucket
+            .iter()
+            .copied()
+            .filter(|c| *c != except_handle)
+            .collect()
+    }
+
+    /// Invalidate every cursor's page stack. Called from rollback — pinned
+    /// pages may now hold pre-rollback bytes (cf. saveAllCursors in
+    /// sqlite3BtreeRollback, btree.c:4485).
+    pub(crate) fn invalidate_all_cursors(&self) {
+        let snapshot: smallvec::SmallVec<[RegisteredCursor; 8]> = {
+            let registry = self.cursor_registry.lock();
+            registry.values().flat_map(|b| b.iter().copied()).collect()
+        };
+        for peer in snapshot {
+            // SAFETY: see RegisteredCursor's invariant.
+            unsafe { peer.as_mut().invalidate_btree_cache() };
+        }
+    }
+
+    /// Invalidate the page stacks of every peer on `except`'s btree. Used
+    /// by clear_btree / btree_destroy where every page is freed; saving
+    /// positions would just stash keys that no longer exist.
+    pub(crate) fn invalidate_peer_cursors(&self, except: &dyn crate::storage::btree::CursorTrait) {
+        let peers = self.snapshot_peers_for_root(except);
+        for peer in peers {
+            // SAFETY: see RegisteredCursor's invariant.
+            unsafe { peer.as_mut().invalidate_btree_cache() };
+        }
     }
 
     /// Get the sync type setting.
@@ -2130,6 +2259,9 @@ impl Pager {
                     ))
                 })?;
         }
+
+        // saveAllCursors at sqlite3BtreeSavepoint (btree.c:4580).
+        self.invalidate_all_cursors();
 
         Ok(())
     }
@@ -2977,6 +3109,8 @@ impl Pager {
             // Clear dirty pages and page cache before releasing the write lock
             self.clear_page_cache(true);
             self.dirty_pages.write().clear();
+            // saveAllCursors at sqlite3BtreeRollback (btree.c:4485).
+            self.invalidate_all_cursors();
             self.reset_internal_states();
             self.set_schema_cookie(None);
             wal.rollback(None);
@@ -5273,6 +5407,8 @@ impl Pager {
             // since we only need to clear the dirty pages that were modified by the write transaction.
             self.clear_page_cache(clear_dirty);
             self.dirty_pages.write().clear();
+            // saveAllCursors at sqlite3BtreeRollback (btree.c:4485).
+            self.invalidate_all_cursors();
         } else {
             turso_assert!(
                 self.dirty_pages.read().is_empty(),

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2336,53 +2336,26 @@ pub fn translate_expr(
                         let is_btree_index = index_cursor_id.is_some_and(|cid| {
                             program.get_cursor_type(cid).is_some_and(|ct| ct.is_index())
                         });
-                        // FIXME(https://github.com/tursodatabase/turso/issues/4801):
-                        // This is a defensive workaround for cursor desynchronization.
-                        //
-                        // When `use_covering_index` is false, both table AND index cursors
-                        // are open and positioned at the same row. If we read some columns
-                        // from the index cursor and others from the table cursor, we rely
-                        // on both cursors staying synchronized.
-                        //
-                        // The problem: AFTER triggers can INSERT into the same table,
-                        // which modifies the index btree. This repositions or invalidates
-                        // the parent program's index cursor, while the table cursor remains
-                        // at the correct position. Result: we read a mix of data from
-                        // different rows - corruption.
-                        //
-                        // Why does the table cursor not have this problem? Because it's
-                        // explicitly re-sought by rowid (via NotExists instruction) before
-                        // each use. The rowid is stored in a register and used as a stable
-                        // key. The index cursor, by contrast, just trusts its internal
-                        // position (page + cell index) without re-seeking.
-                        //
-                        // Why not check if the table has triggers and allow the optimization
-                        // when there are none? Several reasons:
-                        // 1. ProgramBuilder.trigger indicates if THIS program is a trigger
-                        //    subprogram, not whether the table has triggers.
-                        // 2. In translate_expr(), we lack context about which table is being
-                        //    modified or whether we're even in an UPDATE/INSERT/DELETE.
-                        // 3. Triggers can be recursive (trigger on T inserts into U, whose
-                        //    trigger inserts back into T).
-                        //
-                        // The proper fix is to implement SQLite's `saveAllCursors()` approach:
-                        // before ANY btree write, find all cursors pointing to that btree
-                        // (by root_page) and save their positions. When those cursors are
-                        // next accessed, they re-seek to their saved position. This could
-                        // be done lazily with a generation number per btree - cursors check
-                        // if the generation changed and re-seek if needed. This would
-                        // require a global cursor registry and significant refactoring.
-                        //
-                        // For now, we only read from the index cursor when `use_covering_index`
-                        // is true, meaning only the index cursor exists (no table cursor to
-                        // get out of sync with). This foregoes the optimization of reading
-                        // individual columns from a non-covering index.
+                        // For non-outer-scope reads: an index can supply a
+                        // column's value only when the index actually
+                        // stores it. Presence in the index's column list
+                        // (`column_table_pos_to_index_pos`) is necessary
+                        // but not sufficient for VIRTUAL generated
+                        // columns — the index has a slot but the value
+                        // is only materialized when the index is
+                        // covering. For stored columns the slot implies
+                        // the value, so any in-index hit is fine.
                         let read_from_index = if is_from_outer_query_scope {
                             is_btree_index
-                        } else if is_btree_index && use_covering_index {
-                            index.as_ref().is_some_and(|idx| {
+                        } else if is_btree_index {
+                            let column_is_in_index = index.as_ref().is_some_and(|idx| {
                                 idx.column_table_pos_to_index_pos(*column).is_some()
-                            })
+                            });
+                            let column_is_virtual = matches!(
+                                table.get_column_at(*column).map(|c| c.generated_type()),
+                                Some(GeneratedType::Virtual { .. })
+                            );
+                            column_is_in_index && (!column_is_virtual || use_covering_index)
                         } else {
                             false
                         };

--- a/core/types.rs
+++ b/core/types.rs
@@ -2860,6 +2860,8 @@ impl Debug for Cursor {
 
 impl Cursor {
     pub fn new_btree(cursor: Box<dyn CursorTrait>) -> Self {
+        // Matches sqlite3BtreeCursor adding to BtShared.pCursor (btree.c:4699).
+        cursor.register_with_pager();
         Self::BTree(cursor)
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11115,27 +11115,6 @@ pub fn op_reset_sorter(
         CursorType::BTreeTable(_) => {
             let cursor = cursor.as_btree_mut();
             return_if_io!(cursor.clear_btree());
-            // FIXME: cuurently we don't have a good way to identify cursors that are
-            // iterating in the same underlying BTree
-
-            // After clearing the btree, invalidate cached navigation state on all
-            // other cursors that share the same underlying btree (e.g. OpenDup cursors).
-            // Without this, dup cursors may use stale cached rightmost-page info and
-            // attempt to insert into freed pages, causing corruption.
-            let cleared_pager = {
-                let cursor = state.get_cursor(*cursor_id);
-                cursor.as_btree_mut().get_pager()
-            };
-            for (i, other_cursor_opt) in state.cursors.iter_mut().enumerate() {
-                if i == *cursor_id {
-                    continue;
-                }
-                if let Some(Cursor::BTree(ref mut btree_cursor)) = other_cursor_opt {
-                    if Arc::ptr_eq(&btree_cursor.get_pager(), &cleared_pager) {
-                        btree_cursor.invalidate_btree_cache();
-                    }
-                }
-            }
         }
         CursorType::Sorter => {
             return Err(LimboError::InternalError(

--- a/testing/sqltests/tests/save-all-cursors.sqltest
+++ b/testing/sqltests/tests/save-all-cursors.sqltest
@@ -1,0 +1,109 @@
+@database :memory:
+
+# Regression tests for the saveAllCursors port (#7341).
+#
+# These cases all use the pattern from window-selfjoin-reset-sorter.sqltest:
+# a window function over a self-joined source produces enough rows to
+# overflow an ephemeral btree (forcing splits) and the window's
+# ResetSorter then clears that btree while OpenDup peer cursors are
+# still live. Without saveAllCursors-driven peer invalidation in
+# clear_btree, the dup cursor navigates to a freed page on the next
+# round of inserts and the subsequent balance trips on
+# "parent page is a leaf page, expected interior page".
+#
+# All cases below were verified red-first by neutralising
+# drive_pending_peer_save and invalidate_peer_cursors in the
+# btree.rs runtime — they then fail with the corruption error above.
+
+# -----------------------------------------------------------------------------
+# Multi-partition variant of window-selfjoin-reset-sorter. Three distinct
+# partitions over a wider integer key surface more ResetSorter calls
+# between partitions than the two-partition base case.
+# -----------------------------------------------------------------------------
+setup multi_partition {
+    CREATE TABLE w(p TEXT, v INT);
+    INSERT INTO w SELECT 'p' || (value % 3), value FROM generate_series(1, 60);
+}
+
+@setup multi_partition
+test save-all-cursors-window-triple-selfjoin-multi-partition {
+    SELECT a.p
+    FROM w AS a JOIN w AS b USING (p) JOIN w AS d USING (p)
+    ORDER BY a.p, sum(1e18) OVER (ORDER BY a.p)
+    LIMIT 6;
+}
+expect {
+    p0
+    p0
+    p0
+    p0
+    p0
+    p0
+}
+
+# -----------------------------------------------------------------------------
+# DELETE driven by a scalar subquery that contains the same
+# window-over-triple-selfjoin pattern. Exercises the peer-invalidate
+# path while the outer statement is in the write entry of a delete.
+# -----------------------------------------------------------------------------
+@setup multi_partition
+@cross-check-integrity
+test save-all-cursors-window-triple-selfjoin-delete-scalar-subquery {
+    DELETE FROM w WHERE v = (
+        SELECT a.v
+        FROM w AS a JOIN w AS b USING (p) JOIN w AS d USING (p)
+        ORDER BY a.v, sum(1e18) OVER (ORDER BY a.p)
+        LIMIT 1
+    );
+    SELECT count(*) FROM w;
+}
+expect {
+    59
+}
+
+# -----------------------------------------------------------------------------
+# UPDATE driven by an IN subquery that contains the bad pattern.
+# -----------------------------------------------------------------------------
+@setup multi_partition
+@cross-check-integrity
+test save-all-cursors-window-triple-selfjoin-update-in-subquery {
+    UPDATE w SET v = -v WHERE v IN (
+        SELECT a.v
+        FROM w AS a JOIN w AS b USING (p) JOIN w AS d USING (p)
+        ORDER BY a.v, sum(1e18) OVER (ORDER BY a.p)
+        LIMIT 3
+    );
+    SELECT count(*) FROM w WHERE v < 0;
+}
+expect {
+    1
+}
+
+# -----------------------------------------------------------------------------
+# Same window-over-self-join pattern but the source is a materialized
+# CTE referenced three times. The OpenDup cursors here come from the
+# CTE references rather than directly from the table, so the peer set
+# the registry tracks is on the ephemeral CTE btree.
+# -----------------------------------------------------------------------------
+setup cte_source {
+    CREATE TABLE v0(c1 TEXT);
+    INSERT INTO v0(c1) VALUES
+        ('a'),('a'),('a'),('a'),('a'),('a'),('a'),
+        ('b'),('b'),('b'),('b'),('b'),('b');
+}
+
+@setup cte_source
+test save-all-cursors-window-triple-selfjoin-via-cte {
+    WITH cte AS MATERIALIZED (SELECT c1 FROM v0)
+    SELECT a.c1
+    FROM cte AS a JOIN cte AS b USING (c1) JOIN cte AS d USING (c1)
+    ORDER BY a.c1, sum(1e18) OVER (ORDER BY a.c1)
+    LIMIT 5;
+}
+expect {
+    a
+    a
+    a
+    a
+    a
+}

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__count-distinct.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__count-distinct.snap
@@ -39,7 +39,7 @@ addr  opcode                          p1  p2  p3  p4                  p5  commen
    9          OpenRead                 2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
   10          Rewind                   2  29   0                       0  Rewind index idx_sales_category
   11            DeferredSeek           2   1   0                       0
-  12            Column                 1   1  13                       0  r[13]=sales.category
+  12            Column                 2   0  13                       0  r[13]=idx_sales_category.category
   13            Column                 1   6  14                       0  r[14]=sales.salesperson_id
   14            Column                 1   2  15                       0  r[15]=sales.region
   15            Compare                8  13   1  k(1, Binary)         0  r[8..8]==r[13..13]
@@ -53,7 +53,7 @@ addr  opcode                          p1  p2  p3  p4                  p5  commen
   23            HashDistinct  1073741825  15   1  jmp=25               0
   24            AggStep                0  15  11  count                0  accum=r[11] step(r[15])
   25            If                     6  27   0                       0  if r[6] goto 27; don't emit group columns if continuing existing group
-  26            Column                 1   1   9                       0  r[9]=sales.category
+  26            Column                 2   0   9                       0  r[9]=idx_sales_category.category
   27            Integer                1   6   0                       0  r[6]=1; indicate data in accumulator
   28          Next                     2  11   0                       0
   29          Gosub                    5  33   0                       0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
@@ -37,7 +37,7 @@ addr  opcode                     p1  p2  p3  p4                  p5  comment
    7          OpenRead            2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
    8          Rewind              2  25   0                       0  Rewind index idx_sales_category
    9            DeferredSeek      2   1   0                       0
-  10            Column            1   1  13                       0  r[13]=sales.category
+  10            Column            2   0  13                       0  r[13]=idx_sales_category.category
   11            Column            1   4  14                       0  r[14]=sales.amount
   12            Column            1   4  15                       0  r[15]=sales.amount
   13            Compare           8  13   1  k(1, Binary)         0  r[8..8]==r[13..13]
@@ -49,7 +49,7 @@ addr  opcode                     p1  p2  p3  p4                  p5  comment
   19            AggStep           0  14  10  sum                  0  accum=r[10] step(r[14])
   20            AggStep           0  15  11  avg                  0  accum=r[11] step(r[15])
   21            If                6  23   0                       0  if r[6] goto 23; don't emit group columns if continuing existing group
-  22            Column            1   1   9                       0  r[9]=sales.category
+  22            Column            2   0   9                       0  r[9]=idx_sales_category.category
   23            Integer           1   6   0                       0  r[6]=1; indicate data in accumulator
   24          Next                2   9   0                       0
   25          Gosub               5  29   0                       0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
@@ -33,7 +33,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
    6          OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
    7          Rewind           1  26   0                       0  Rewind index idx_sales_category
    8            DeferredSeek   1   0   0                       0
-   9            Column         0   1  12                       0  r[12]=sales.category
+   9            Column         1   0  12                       0  r[12]=idx_sales_category.category
   10            Column         0   4  13                       0  r[13]=sales.amount
   11            Column         0   4  14                       0  r[14]=sales.amount
   12            Compare        7  12   1  k(1, Binary)         0  r[7..7]==r[12..12]
@@ -47,7 +47,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   20            CollSeq        0   0   0  Binary               0  collation=Binary
   21            AggStep        0  14  10  max                  0  accum=r[10] step(r[14])
   22            If             5  24   0                       0  if r[5] goto 24; don't emit group columns if continuing existing group
-  23            Column         0   1   8                       0  r[8]=sales.category
+  23            Column         1   0   8                       0  r[8]=idx_sales_category.category
   24            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
   25          Next             1   8   0                       0
   26          Gosub            4  30   0                       0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__multi-column-group-by.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__multi-column-group-by.snap
@@ -36,8 +36,8 @@ addr  opcode                  p1  p2  p3  p4                    p5  comment
    6          OpenRead         1   5   0  k(3,B,B)               0  index=idx_sales_category_region, root=5, iDb=0
    7          Rewind           1  25   0                         0  Rewind index idx_sales_category_region
    8            DeferredSeek   1   0   0                         0
-   9            Column         0   1  15                         0  r[15]=sales.category
-  10            Column         0   2  16                         0  r[16]=sales.region
+   9            Column         1   0  15                         0  r[15]=idx_sales_category_region.category
+  10            Column         1   1  16                         0  r[16]=idx_sales_category_region.region
   11            Column         0   4  17                         0  r[17]=sales.amount
   12            Compare        8  15   2  k(2, Binary, Binary)   0  r[8..9]==r[15..16]
   13            Jump          14  18  14                         0  ; start new group if comparison is not equal
@@ -48,8 +48,8 @@ addr  opcode                  p1  p2  p3  p4                    p5  comment
   18            AggStep        0  17  12  sum                    0  accum=r[12] step(r[17])
   19            AggStep        0  19  13  count                  0  accum=r[13] step(r[19])
   20            If             6  23   0                         0  if r[6] goto 23; don't emit group columns if continuing existing group
-  21            Column         0   1  10                         0  r[10]=sales.category
-  22            Column         0   2  11                         0  r[11]=sales.region
+  21            Column         1   0  10                         0  r[10]=idx_sales_category_region.category
+  22            Column         1   1  11                         0  r[11]=idx_sales_category_region.region
   23            Integer        1   6   0                         0  r[6]=1; indicate data in accumulator
   24          Next             1   8   0                         0
   25          Gosub            5  29   0                         0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__multiple-aggregates.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__multiple-aggregates.snap
@@ -38,7 +38,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
    7          OpenRead         2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
    8          Rewind           2  30   0                       0  Rewind index idx_sales_category
    9            DeferredSeek   2   1   0                       0
-  10            Column         1   1  19                       0  r[19]=sales.category
+  10            Column         2   0  19                       0  r[19]=idx_sales_category.category
   11            Column         1   4  20                       0  r[20]=sales.amount
   12            Column         1   4  21                       0  r[21]=sales.amount
   13            Column         1   5  22                       0  r[22]=sales.quantity
@@ -55,7 +55,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   24            AggStep        0  22  16  sum                  0  accum=r[16] step(r[22])
   25            AggStep        0  23  17  avg                  0  accum=r[17] step(r[23])
   26            If             9  28   0                       0  if r[9] goto 28; don't emit group columns if continuing existing group
-  27            Column         1   1  12                       0  r[12]=sales.category
+  27            Column         2   0  12                       0  r[12]=idx_sales_category.category
   28            Integer        1   9   0                       0  r[9]=1; indicate data in accumulator
   29          Next             2   9   0                       0
   30          Gosub            8  34   0                       0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
@@ -39,7 +39,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
    7          OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
    8          Rewind           1  23   0                       0  Rewind index idx_sales_category
    9            DeferredSeek   1   0   0                       0
-  10            Column         0   1  11                       0  r[11]=sales.category
+  10            Column         1   0  11                       0  r[11]=idx_sales_category.category
   11            Column         0   4  12                       0  r[12]=sales.amount
   12            Compare        7  11   1  k(1, Binary)         0  r[7..7]==r[11..11]
   13            Jump          14  18  14                       0  ; start new group if comparison is not equal
@@ -49,7 +49,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   17            Gosub         13  34   0                       0  ; goto clear accumulator subroutine
   18            AggStep        0  12   9  sum                  0  accum=r[9] step(r[12])
   19            If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
-  20            Column         0   1   8                       0  r[8]=sales.category
+  20            Column         1   0   8                       0  r[8]=idx_sales_category.category
   21            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
   22          Next             1   9   0                       0
   23          Gosub            4  27   0                       0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-group-by-single-column.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__simple-group-by-single-column.snap
@@ -34,7 +34,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
    7          OpenRead         2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
    8          Rewind           2  23   0                       0  Rewind index idx_sales_category
    9            DeferredSeek   2   1   0                       0
-  10            Column         1   1  11                       0  r[11]=sales.category
+  10            Column         2   0  11                       0  r[11]=idx_sales_category.category
   11            Column         1   4  12                       0  r[12]=sales.amount
   12            Compare        7  11   1  k(1, Binary)         0  r[7..7]==r[11..11]
   13            Jump          14  18  14                       0  ; start new group if comparison is not equal
@@ -44,7 +44,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   17            Gosub         13  35   0                       0  ; goto clear accumulator subroutine
   18            AggStep        0  12   9  sum                  0  accum=r[9] step(r[12])
   19            If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
-  20            Column         1   1   8                       0  r[8]=sales.category
+  20            Column         2   0   8                       0  r[8]=idx_sales_category.category
   21            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
   22          Next             2   9   0                       0
   23          Gosub            4  27   0                       0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__query-composite-range-after-analyze.snap
+++ b/testing/sqltests/tests/snapshot_tests/analyze/snapshots/analyze__query-composite-range-after-analyze.snap
@@ -27,7 +27,7 @@ addr  opcode           p1  p2  p3  p4              p5  comment
    7    IdxGE           1  15   4                   0  key=[4..5]
    8    DeferredSeek    1   0   0                   0
    9    IdxRowId        1   1   0                   0  r[1]=cursor 1 for index idx_orders_customer_date.rowid
-  10    Column          0   2   2                   0  r[2]=orders.order_date
+  10    Column          1   1   2                   0  r[2]=idx_orders_customer_date.order_date
   11    Column          0   4   3                   0  r[3]=orders.total_amount
   12    RealAffinity    3   0   0                   0
   13    ResultRow       1   3   0                   0  output=r[1..3]

--- a/testing/sqltests/tests/snapshot_tests/setops/snapshots/setops__union-all-filtered.snap
+++ b/testing/sqltests/tests/snapshot_tests/setops/snapshots/setops__union-all-filtered.snap
@@ -30,7 +30,7 @@ addr  opcode          p1  p2  p3  p4              p5  comment
    5    IdxGT          1  11   3                   0  key=[3..3]
    6    DeferredSeek   1   0   0                   0
    7    Column         0   1   1                   0  r[1]=current_employees.name
-   8    Column         0   2   2                   0  r[2]=current_employees.department
+   8    Column         1   0   2                   0  r[2]=idx_current_dept.department
    9    ResultRow      1   2   0                   0  output=r[1..2]
   10  Next             1   5   0                   0
   11  OpenRead         2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
@@ -40,7 +40,7 @@ addr  opcode          p1  p2  p3  p4              p5  comment
   15    IdxGT          3  21   6                   0  key=[6..6]
   16    DeferredSeek   3   2   0                   0
   17    Column         2   1   4                   0  r[4]=former_employees.name
-  18    Column         2   2   5                   0  r[5]=former_employees.department
+  18    Column         3   0   5                   0  r[5]=idx_former_dept.department
   19    ResultRow      4   2   0                   0  output=r[4..5]
   20  Next             3  15   0                   0
   21  Halt             0   0   0                   0

--- a/testing/sqltests/tests/snapshot_tests/sorting/snapshots/sorting__large-offset-small-limit.snap
+++ b/testing/sqltests/tests/snapshot_tests/sorting/snapshots/sorting__large-offset-small-limit.snap
@@ -31,7 +31,7 @@ addr  opcode            p1  p2  p3  p4                p5  comment
   10    IfPos            5  17   1                     0  r[5]>0 -> r[5]-=1, goto 17
   11    IdxRowId         1   1   0                     0  r[1]=cursor 1 for index idx_products_price.rowid
   12    Column           0   1   2                     0  r[2]=products.name
-  13    Column           0   2   3                     0  r[3]=products.price
+  13    Column           1   0   3                     0  r[3]=idx_products_price.price
   14    RealAffinity     3   0   0                     0
   15    ResultRow        1   3   0                     0  output=r[1..3]
   16    DecrJumpZero     4  18   0                     0  if (--r[4]==0) goto 18

--- a/testing/sqltests/tests/snapshot_tests/sorting/snapshots/sorting__order-by-limit-one.snap
+++ b/testing/sqltests/tests/snapshot_tests/sorting/snapshots/sorting__order-by-limit-one.snap
@@ -27,7 +27,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    6    DeferredSeek   1   0   0                     0
    7    IdxRowId       1   1   0                     0  r[1]=cursor 1 for index idx_products_price.rowid
    8    Column         0   1   2                     0  r[2]=products.name
-   9    Column         0   2   3                     0  r[3]=products.price
+   9    Column         1   0   3                     0  r[3]=idx_products_price.price
   10    RealAffinity   3   0   0                     0
   11    ResultRow      1   3   0                     0  output=r[1..3]
   12    DecrJumpZero   4  14   0                     0  if (--r[4]==0) goto 14

--- a/testing/sqltests/tests/snapshot_tests/sorting/snapshots/sorting__order-by-with-where.snap
+++ b/testing/sqltests/tests/snapshot_tests/sorting/snapshots/sorting__order-by-with-where.snap
@@ -27,7 +27,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    6    DeferredSeek   1   0   0                     0
    7    IdxRowId       1   1   0                     0  r[1]=cursor 1 for index idx_products_category_price.rowid
    8    Column         0   1   2                     0  r[2]=products.name
-   9    Column         0   2   3                     0  r[3]=products.price
+   9    Column         1   1   3                     0  r[3]=idx_products_category_price.price
   10    RealAffinity   3   0   0                     0
   11    ResultRow      1   3   0                     0  output=r[1..3]
   12  Next             1   5   0                     0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -45,7 +45,7 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
   10                    OpenRead         1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   11                    Rewind           1   27    0                   0  Rewind index idx_products_category
   12                      DeferredSeek   1    0    0                   0
-  13                      Column         0    2   13                   0  r[13]=products.category_id
+  13                      Column         1    0   13                   0  r[13]=idx_products_category.category_id
   14                      Column         0    3   14                   0  r[14]=products.price
   15                      RealAffinity  14    0    0                   0
   16                      Compare        9   13    1  k(1, Binary)     0  r[9..9]==r[13..13]
@@ -56,7 +56,7 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
   21                      Gosub         15   38    0                   0  ; goto clear accumulator subroutine
   22                      AggStep        0   14   11  avg              0  accum=r[11] step(r[14])
   23                      If             7   25    0                   0  if r[7] goto 25; don't emit group columns if continuing existing group
-  24                      Column         0    2   10                   0  r[10]=products.category_id
+  24                      Column         1    0   10                   0  r[10]=idx_products_category.category_id
   25                      Integer        1    7    0                   0  r[7]=1; indicate data in accumulator
   26                    Next             1   12    0                   0
   27                    Gosub            6   31    0                   0  ; emit row for final group
@@ -96,7 +96,7 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
   61          OpenRead                   4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   62          Rewind                     4   78    0                   0  Rewind index idx_products_category
   63            DeferredSeek             4    3    0                   0
-  64            Column                   3    2   31                   0  r[31]=products.category_id
+  64            Column                   4    0   31                   0  r[31]=idx_products_category.category_id
   65            Column                   3    3   32                   0  r[32]=products.price
   66            RealAffinity            32    0    0                   0
   67            Compare                 27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
@@ -107,7 +107,7 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
   72            Gosub                   33   91    0                   0  ; goto clear accumulator subroutine
   73            AggStep                  0   32   29  avg              0  accum=r[29] step(r[32])
   74            If                      25   76    0                   0  if r[25] goto 76; don't emit group columns if continuing existing group
-  75            Column                   3    2   28                   0  r[28]=products.category_id
+  75            Column                   4    0   28                   0  r[28]=idx_products_category.category_id
   76            Integer                  1   25    0                   0  r[25]=1; indicate data in accumulator
   77          Next                       4   63    0                   0
   78          Gosub                     24   82    0                   0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
@@ -50,7 +50,7 @@ addr  opcode                                       p1   p2   p3  p4            p
   10                              OpenRead          1    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
   11                              Rewind            1   27    0                 0  Rewind index idx_orders_customer
   12                                DeferredSeek    1    0    0                 0
-  13                                Column          0    1   14                 0  r[14]=orders.customer_id
+  13                                Column          1    0   14                 0  r[14]=idx_orders_customer.customer_id
   14                                Column          0    3   15                 0  r[15]=orders.total_amount
   15                                RealAffinity   15    0    0                 0
   16                                Compare        10   14    1  k(1, Binary)   0  r[10..10]==r[14..14]
@@ -61,7 +61,7 @@ addr  opcode                                       p1   p2   p3  p4            p
   21                                Gosub          16   38    0                 0  ; goto clear accumulator subroutine
   22                                AggStep         0   15   12  sum            0  accum=r[12] step(r[15])
   23                                If              8   25    0                 0  if r[8] goto 25; don't emit group columns if continuing existing group
-  24                                Column          0    1   11                 0  r[11]=orders.customer_id
+  24                                Column          1    0   11                 0  r[11]=idx_orders_customer.customer_id
   25                                Integer         1    8    0                 0  r[8]=1; indicate data in accumulator
   26                              Next              1   12    0                 0
   27                              Gosub             7   31    0                 0  ; emit row for final group
@@ -103,7 +103,7 @@ addr  opcode                                       p1   p2   p3  p4            p
   63                    OpenRead                    3    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
   64                    Rewind                      3   80    0                 0  Rewind index idx_orders_customer
   65                      DeferredSeek              3    2    0                 0
-  66                      Column                    2    1   32                 0  r[32]=orders.customer_id
+  66                      Column                    3    0   32                 0  r[32]=idx_orders_customer.customer_id
   67                      Column                    2    3   33                 0  r[33]=orders.total_amount
   68                      RealAffinity             33    0    0                 0
   69                      Compare                  28   32    1  k(1, Binary)   0  r[28..28]==r[32..32]
@@ -114,7 +114,7 @@ addr  opcode                                       p1   p2   p3  p4            p
   74                      Gosub                    34   91    0                 0  ; goto clear accumulator subroutine
   75                      AggStep                   0   33   30  sum            0  accum=r[30] step(r[33])
   76                      If                       26   78    0                 0  if r[26] goto 78; don't emit group columns if continuing existing group
-  77                      Column                    2    1   29                 0  r[29]=orders.customer_id
+  77                      Column                    3    0   29                 0  r[29]=idx_orders_customer.customer_id
   78                      Integer                   1   26    0                 0  r[26]=1; indicate data in accumulator
   79                    Next                        3   65    0                 0
   80                    Gosub                      25   84    0                 0  ; emit row for final group
@@ -153,7 +153,7 @@ addr  opcode                                       p1   p2   p3  p4            p
  113          OpenRead                              6    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
  114          Rewind                                6  130    0                 0  Rewind index idx_orders_customer
  115            DeferredSeek                        6    5    0                 0
- 116            Column                              5    1   50                 0  r[50]=orders.customer_id
+ 116            Column                              6    0   50                 0  r[50]=idx_orders_customer.customer_id
  117            Column                              5    3   51                 0  r[51]=orders.total_amount
  118            RealAffinity                       51    0    0                 0
  119            Compare                            46   50    1  k(1, Binary)   0  r[46..46]==r[50..50]
@@ -164,7 +164,7 @@ addr  opcode                                       p1   p2   p3  p4            p
  124            Gosub                              52  143    0                 0  ; goto clear accumulator subroutine
  125            AggStep                             0   51   48  sum            0  accum=r[48] step(r[51])
  126            If                                 44  128    0                 0  if r[44] goto 128; don't emit group columns if continuing existing group
- 127            Column                              5    1   47                 0  r[47]=orders.customer_id
+ 127            Column                              6    0   47                 0  r[47]=idx_orders_customer.customer_id
  128            Integer                             1   44    0                 0  r[44]=1; indicate data in accumulator
  129          Next                                  6  115    0                 0
  130          Gosub                                43  134    0                 0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
@@ -62,7 +62,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
    9          OpenRead           1  11   0  k(2,B)           0  index=idx_order_items_product, root=11, iDb=0
   10          Rewind             1  30   0                   0  Rewind index idx_order_items_product
   11            DeferredSeek     1   0   0                   0
-  12            Column           0   2  15                   0  r[15]=order_items.product_id
+  12            Column           1   0  15                   0  r[15]=idx_order_items_product.product_id
   13            Column           0   3  16                   0  r[16]=order_items.quantity
   14            Column           0   3  19                   0  r[19]=order_items.quantity
   15            Column           0   4  20                   0  r[20]=order_items.unit_price
@@ -77,7 +77,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   24            AggStep          0  16  12  sum              0  accum=r[12] step(r[16])
   25            AggStep          0  17  13  sum              0  accum=r[13] step(r[17])
   26            If               8  28   0                   0  if r[8] goto 28; don't emit group columns if continuing existing group
-  27            Column           0   2  11                   0  r[11]=order_items.product_id
+  27            Column           1   0  11                   0  r[11]=idx_order_items_product.product_id
   28            Integer          1   8   0                   0  r[8]=1; indicate data in accumulator
   29          Next               1  11   0                   0
   30          Gosub              7  34   0                   0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
@@ -39,7 +39,7 @@ addr  opcode                   p1  p2  p3  p4            p5  comment
    7          OpenRead          1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    8          Rewind            1  25   0                 0  Rewind index idx_orders_customer
    9            DeferredSeek    1   0   0                 0
-  10            Column          0   1  13                 0  r[13]=orders.customer_id
+  10            Column          1   0  13                 0  r[13]=idx_orders_customer.customer_id
   11            Column          0   3  14                 0  r[14]=orders.total_amount
   12            RealAffinity   14   0   0                 0
   13            Compare         8  13   1  k(1, Binary)   0  r[8..8]==r[13..13]
@@ -51,7 +51,7 @@ addr  opcode                   p1  p2  p3  p4            p5  comment
   19            AggStep         0  16  10  count          0  accum=r[10] step(r[16])
   20            AggStep         0  14  11  sum            0  accum=r[11] step(r[14])
   21            If              6  23   0                 0  if r[6] goto 23; don't emit group columns if continuing existing group
-  22            Column          0   1   9                 0  r[9]=orders.customer_id
+  22            Column          1   0   9                 0  r[9]=idx_orders_customer.customer_id
   23            Integer         1   6   0                 0  r[6]=1; indicate data in accumulator
   24          Next              1   9   0                 0
   25          Gosub             5  29   0                 0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
@@ -42,7 +42,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
    8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
   10            DeferredSeek     2   1   0                 0
-  11            Column           1   1  13                 0  r[13]=orders.customer_id
+  11            Column           2   0  13                 0  r[13]=idx_orders_customer.customer_id
   12            Column           1   3  14                 0  r[14]=orders.total_amount
   13            RealAffinity    14   0   0                 0
   14            Compare          9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
@@ -53,7 +53,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   19            Gosub           15  36   0                 0  ; goto clear accumulator subroutine
   20            AggStep          0  14  11  sum            0  accum=r[11] step(r[14])
   21            If               7  23   0                 0  if r[7] goto 23; don't emit group columns if continuing existing group
-  22            Column           1   1  10                 0  r[10]=orders.customer_id
+  22            Column           2   0  10                 0  r[10]=idx_orders_customer.customer_id
   23            Integer          1   7   0                 0  r[7]=1; indicate data in accumulator
   24          Next               2  10   0                 0
   25          Gosub              6  29   0                 0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -33,7 +33,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
    6            OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
    7            Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
    8              DeferredSeek   1   0   0                 0
-   9              Column         0   0  11                 0  r[11]=grouped_values.grp
+   9              Column         1   0  11                 0  r[11]=idx_grouped_values_grp.grp
   10              Column         0   1  12                 0  r[12]=grouped_values.val
   11              Compare        7  11   1  k(1, Binary)   0  r[7..7]==r[11..11]
   12              Jump          13  17  13                 0  ; start new group if comparison is not equal
@@ -43,7 +43,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   16              Gosub         13  56   0                 0  ; goto clear accumulator subroutine
   17              AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
   18              If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
-  19              Column         0   0   8                 0  r[8]=grouped_values.grp
+  19              Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
   20              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
   21            Next             1   8   0                 0
   22            Gosub            4  26   0                 0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -35,7 +35,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
    7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
    8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
    9              DeferredSeek   2   1   0                   0
-  10              Column         1   0  12                   0  r[12]=grouped_values.grp
+  10              Column         2   0  12                   0  r[12]=idx_grouped_values_grp.grp
   11              Column         1   1  13                   0  r[13]=grouped_values.val
   12              Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
   13              Jump          14  18  14                   0  ; start new group if comparison is not equal
@@ -45,7 +45,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   17              Gosub         14  58   0                   0  ; goto clear accumulator subroutine
   18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
   19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
-  20              Column         1   0   9                   0  r[9]=grouped_values.grp
+  20              Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
   21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
   22            Next             2   9   0                   0
   23            Gosub            5  27   0                   0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
@@ -36,7 +36,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
    8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
    9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
   10            DeferredSeek     2   1   0                 0
-  11            Column           1   1   9                 0  r[9]=orders.customer_id
+  11            Column           2   0   9                 0  r[9]=idx_orders_customer.customer_id
   12            Column           1   3  10                 0  r[10]=orders.total_amount
   13            RealAffinity    10   0   0                 0
   14            Compare          5   9   1  k(1, Binary)   0  r[5..5]==r[9..9]
@@ -47,7 +47,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   19            Gosub           11  39   0                 0  ; goto clear accumulator subroutine
   20            AggStep          0  10   7  sum            0  accum=r[7] step(r[10])
   21            If               3  23   0                 0  if r[3] goto 23; don't emit group columns if continuing existing group
-  22            Column           1   1   6                 0  r[6]=orders.customer_id
+  22            Column           2   0   6                 0  r[6]=idx_orders_customer.customer_id
   23            Integer          1   3   0                 0  r[3]=1; indicate data in accumulator
   24          Next               2  10   0                 0
   25          Gosub              2  29   0                 0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
@@ -60,13 +60,13 @@ addr  opcode                    p1  p2  p3  p4                  p5  comment
    9            OpenRead         4   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
   10            Rewind           2  33   0                       0  Rewind index sqlite_autoindex_partsupp_1
   11              DeferredSeek   2   1   0                       0
-  12              Column         1   1  15                       0  r[15]=partsupp.PS_SUPPKEY
+  12              Column         2   1  15                       0  r[15]=sqlite_autoindex_partsupp_1.ps_suppkey
   13              SeekRowid      3  15  32                       0  if (r[15]!=cursor 3 for table supplier.rowid) goto 32
   14              Column         3   3  16                       0  r[16]=supplier.S_NATIONKEY
   15              SeekRowid      4  16  32                       0  if (r[16]!=cursor 4 for table nation.rowid) goto 32
   16              Column         4   1  18                       0  r[18]=nation.N_NAME
   17              Ne            18  19  32  Binary               0  if r[18]!=r[19] goto 32
-  18              Column         1   0  12                       0  r[12]=partsupp.PS_PARTKEY
+  18              Column         2   0  12                       0  r[12]=sqlite_autoindex_partsupp_1.ps_partkey
   19              Column         1   3  20                       0  r[20]=partsupp.PS_SUPPLYCOST
   20              Column         1   2  21                       0  r[21]=partsupp.PS_AVAILQTY
   21              Multiply      20  21  13                       0  r[13]=r[20]*r[21]
@@ -78,7 +78,7 @@ addr  opcode                    p1  p2  p3  p4                  p5  comment
   27              Gosub         14  76   0                       0  ; goto clear accumulator subroutine
   28              AggStep        0  13  10  sum                  0  accum=r[10] step(r[13])
   29              If             6  31   0                       0  if r[6] goto 31; don't emit group columns if continuing existing group
-  30              Column         1   0   9                       0  r[9]=partsupp.PS_PARTKEY
+  30              Column         2   0   9                       0  r[9]=sqlite_autoindex_partsupp_1.ps_partkey
   31              Integer        1   6   0                       0  r[6]=1; indicate data in accumulator
   32            Next             2  11   0                       0
   33            Gosub            5  37   0                       0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -34,7 +34,7 @@ addr  opcode              p1   p2  p3  p4                     p5  comment
    4      OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    5      Rewind           1   13   0                          0  Rewind index idx_employees_department
    6        DeferredSeek   1    0   0                          0
-   7        Column         0    2   3                          0  r[3]=employees.department
+   7        Column         1    0   3                          0  r[3]=idx_employees_department.department
    8        IdxRowId       1    4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
    9        Column         0    1   5                          0  r[5]=employees.name
   10        Column         0    3   6                          0  r[6]=employees.salary

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
@@ -31,7 +31,7 @@ addr  opcode              p1  p2  p3  p4                     p5  comment
    4      OpenRead         1   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    5      Rewind           1  13   0                          0  Rewind index idx_employees_department
    6        DeferredSeek   1   0   0                          0
-   7        Column         0   2   3                          0  r[3]=employees.department
+   7        Column         1   0   3                          0  r[3]=idx_employees_department.department
    8        IdxRowId       1   4   0                          0  r[4]=cursor 1 for index idx_employees_department.rowid
    9        Column         0   1   5                          0  r[5]=employees.name
   10        Column         0   3   6                          0  r[6]=employees.salary

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
@@ -28,7 +28,7 @@ addr  opcode            p1  p2  p3  p4                     p5  comment
    3    OpenRead         1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
    4    Last             1  12   0                          0
    5      DeferredSeek   1   0   0                          0
-   6      Column         0   3   2                          0  r[2]=employees.salary
+   6      Column         1   0   2                          0  r[2]=idx_employees_salary.salary
    7      IdxRowId       1   3   0                          0  r[3]=cursor 1 for index idx_employees_salary.rowid
    8      Column         0   1   4                          0  r[4]=employees.name
    9      Column         0   2   5                          0  r[5]=employees.department

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
@@ -34,7 +34,7 @@ addr  opcode                    p1  p2  p3  p4                     p5  comment
    8            OpenRead         2   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    9            Rewind           2  25   0                          0  Rewind index idx_employees_department
   10              DeferredSeek   2   1   0                          0
-  11              Column         1   2  14                          0  r[14]=employees.department
+  11              Column         2   0  14                          0  r[14]=idx_employees_department.department
   12              Column         1   3  15                          0  r[15]=employees.salary
   13              Compare        9  14   1  k(1, Binary)            0  r[9..9]==r[14..14]
   14              Jump          15  19  15                          0  ; start new group if comparison is not equal
@@ -45,7 +45,7 @@ addr  opcode                    p1  p2  p3  p4                     p5  comment
   19              AggStep        0  15  11  sum                     0  accum=r[11] step(r[15])
   20              AggStep        0  17  12  count                   0  accum=r[12] step(r[17])
   21              If             7  23   0                          0  if r[7] goto 23; don't emit group columns if continuing existing group
-  22              Column         1   2  10                          0  r[10]=employees.department
+  22              Column         2   0  10                          0  r[10]=idx_employees_department.department
   23              Integer        1   7   0                          0  r[7]=1; indicate data in accumulator
   24            Next             2  10   0                          0
   25            Gosub            6  29   0                          0  ; emit row for final group

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -43,7 +43,7 @@ addr  opcode              p1   p2  p3  p4                     p5  comment
    5      OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
    6      Rewind           1   14   0                          0  Rewind index idx_employees_department
    7        DeferredSeek   1    0   0                          0
-   8        Column         0    2   4                          0  r[4]=employees.department
+   8        Column         1    0   4                          0  r[4]=idx_employees_department.department
    9        IdxRowId       1    5   0                          0  r[5]=cursor 1 for index idx_employees_department.rowid
   10        Column         0    1   6                          0  r[6]=employees.name
   11        Column         0    3   7                          0  r[7]=employees.salary


### PR DESCRIPTION
## Beef

We allow multiple BTreeCursors against the same ephemeral B-tree via OpenDup (used heavily by upcoming window functions and HASH joins), and triggers can also have cursors targeting the same btree as a parent statement. When one cursor's Insert/Delete/Clear/Destroy rebalances the tree, peer cursors on the same root_page hold page-stack references that become stale. This manifested as "unexpected page_type" panics and silent row drops when implementing window functions that require peer cursors on the same btree.

SQLite handles this by walking BtShared.pCursor on every write entry point and calling saveCursorPosition on each peer (btree.c:saveAllCursors, :saveCursorPosition, :btreeRestoreCursorPosition). Lower-level reads restore via sqlite3BtreeRestoreCursorPosition before touching the page.

## Current workarounds on main

We currently have no standard way of knowing whether there are multiple cursors targeting the same btree and what those cursors are.

1. In `translate_expr: Expr::Column`, we are explicitly disallowing non-covering index column reads because we don't have the mechanism to save peer cursors before invalidating their positions -- this workaround is specifically for triggers that may insert to the parent table and cause a rebalance. See the deleted comment there which explicitly calls out that we need `saveAllCursors` ported from SQLite.

2. In `op_reset_sorter` we are pretty much doing a sorter-specific cursor invalidation using pointer equality comparison between cursors stored in the VDBE - this site also calls out that we don't have a centralized mechanism for identifying cursors using the same btree

## Impl

This change ports that mechanism and removes our existing workarounds, which only paper over a subset of issues and don't work for upcoming window functions.

## Tests

No new tests here because they would rely on window functions that don't exist yet. Removing the current workarounds and nothing failing in CI should be sufficient evidence that the change works

Snapshot test noise is from removing the hack in `translate_expr` which leads to greater utilization of indexes for column reads