### PR TITLE
javascript: Return per-statement results from batch()

### DIFF
--- a/bindings/javascript/packages/common/compat.ts
+++ b/bindings/javascript/packages/common/compat.ts
@@ -52,6 +52,67 @@ function toBindArgs(params) {
   return [params];
 }
 
+export type BatchMode = "write" | "read" | "deferred" | "immediate" | "exclusive" | "concurrent" | string;
+
+export interface BatchOptions {
+  mode?: BatchMode;
+  raw?: boolean;
+}
+
+export type BatchRow = Record<string, any> | any[];
+
+export interface ResultSet {
+  columns: Array<string>;
+  columnTypes: Array<string>;
+  rows: Array<BatchRow>;
+  rowsAffected: number;
+}
+
+function normalizeBatchMode(mode: BatchMode): string {
+  switch (String(mode).toLowerCase()) {
+    case "write":
+      return "IMMEDIATE";
+    case "read":
+    case "deferred":
+      return "DEFERRED";
+    case "immediate":
+      return "IMMEDIATE";
+    case "exclusive":
+      return "EXCLUSIVE";
+    case "concurrent":
+      return "CONCURRENT";
+    default:
+      return String(mode).toUpperCase();
+  }
+}
+
+function normalizeBatchOptions(options?: BatchMode | BatchOptions): { mode?: BatchMode; raw: boolean } {
+  if (options != null && typeof options === "object") {
+    return {
+      mode: options.mode,
+      raw: options.raw === true,
+    };
+  }
+  return {
+    mode: options as BatchMode | undefined,
+    raw: false,
+  };
+}
+
+function makeResultSet(
+  columns: string[],
+  columnTypes: string[],
+  rows: any[],
+  rowsAffected: number,
+): ResultSet {
+  return {
+    columns,
+    columnTypes,
+    rows,
+    rowsAffected,
+  };
+}
+
 /**
  * Database represents a connection that can prepare and execute SQL statements.
  */
@@ -222,6 +283,84 @@ class Database {
     } finally {
       exec.reset();
     }
+  }
+
+  batch(
+    statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
+    options?: BatchMode | BatchOptions,
+  ): ResultSet[] {
+    if (!Array.isArray(statements)) {
+      throw new TypeError("Expected first argument to be an array of statements");
+    }
+    if (!this.open) {
+      throw new TypeError("The database connection is not open");
+    }
+
+    const { mode, raw } = normalizeBatchOptions(options);
+    const wrap = mode != null && !this.db.inTransaction();
+    if (wrap) {
+      this.exec(`BEGIN ${normalizeBatchMode(mode!)}`);
+    }
+
+    const results: ResultSet[] = [];
+    try {
+      for (const statement of statements) {
+        const sql = typeof statement === "string" ? statement : statement.sql;
+        const args = typeof statement === "string" ? undefined : statement.args;
+        const stmt = this.db.prepare(sql);
+        try {
+          if (args !== undefined) {
+            bindParams(stmt, [args]);
+          }
+          const cols = stmt.columns();
+          const columnNames = cols.map((c) => c.name);
+          const columnTypes = cols.map((c) => c.type ?? "");
+          if (columnNames.length > 0) {
+            stmt.raw(raw);
+          }
+
+          const totalChangesBefore = this.db.totalChanges();
+          const rows: any[] = [];
+          try {
+            while (true) {
+              const stepResult = stmt.stepSync();
+              if (stepResult === STEP_IO) {
+                this.db.ioLoopSync();
+                continue;
+              }
+              if (stepResult === STEP_DONE) {
+                break;
+              }
+              if (stepResult === STEP_ROW) {
+                rows.push(stmt.row());
+              }
+            }
+            const rowsAffected = columnNames.length > 0
+              ? 0
+              : this.db.totalChanges() !== totalChangesBefore ? this.db.changes() : 0;
+            results.push(makeResultSet(columnNames, columnTypes, rows, rowsAffected));
+          } finally {
+            stmt.reset();
+          }
+        } finally {
+          stmt.finalize();
+        }
+      }
+
+      if (wrap) {
+        this.exec("COMMIT");
+      }
+    } catch (err) {
+      if (wrap) {
+        try {
+          this.exec("ROLLBACK");
+        } catch {
+          // Keep the original statement error.
+        }
+      }
+      throw convertError(err);
+    }
+    return results;
   }
 
   /**

--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -53,13 +53,80 @@ function toBindArgs(params) {
   return [params];
 }
 
+/**
+ * Locking mode for `Database.batch(stmts, options)`.
+ */
+export type BatchMode = "write" | "read" | "deferred" | "immediate" | "exclusive" | "concurrent" | string;
+
+export interface BatchOptions {
+  mode?: BatchMode;
+  raw?: boolean;
+}
+
+export type BatchRow = Record<string, any> | any[];
 
 /**
- * Locking mode for `Database.batch(stmts, mode)` and the variants of
- * `Database.transaction(...)`. When passed to `batch()`, the statements are
- * wrapped in `BEGIN <mode>` / `COMMIT` (with `ROLLBACK` on failure).
+ * The result of executing a single statement within `batch()`, matching the
+ * libSQL client's `ResultSet` shape.
  */
-export type BatchMode = "deferred" | "immediate" | "exclusive" | "concurrent";
+export interface ResultSet {
+  /** Column names of the result, empty for statements that return no rows. */
+  columns: Array<string>;
+  /** Declared column types, parallel to `columns`. */
+  columnTypes: Array<string>;
+  /** Result rows; empty for non-SELECT statements. */
+  rows: Array<BatchRow>;
+  /** Number of rows changed by the statement (0 for SELECT). */
+  rowsAffected: number;
+}
+
+function normalizeBatchMode(mode: BatchMode): string {
+  switch (String(mode).toLowerCase()) {
+    case "write":
+      return "IMMEDIATE";
+    case "read":
+    case "deferred":
+      return "DEFERRED";
+    case "immediate":
+      return "IMMEDIATE";
+    case "exclusive":
+      return "EXCLUSIVE";
+    case "concurrent":
+      return "CONCURRENT";
+    default:
+      return String(mode).toUpperCase();
+  }
+}
+
+function normalizeBatchOptions(options?: BatchMode | BatchOptions): { mode?: BatchMode; raw: boolean } {
+  if (options != null && typeof options === "object") {
+    return {
+      mode: options.mode,
+      raw: options.raw === true,
+    };
+  }
+  return {
+    mode: options as BatchMode | undefined,
+    raw: false,
+  };
+}
+
+/**
+ * Builds a libSQL-style `ResultSet` for a single statement in a `batch()`.
+ */
+function makeResultSet(
+  columns: string[],
+  columnTypes: string[],
+  rows: any[],
+  rowsAffected: number,
+): ResultSet {
+  return {
+    columns,
+    columnTypes,
+    rows,
+    rowsAffected,
+  };
+}
 
 /**
  * A wrapped transaction function. Calling it runs the wrapped function inside a
@@ -206,8 +273,9 @@ class Database {
    * @param mode - When set, wraps the batch in `BEGIN <mode>` / `COMMIT`
    *   (with `ROLLBACK` on failure). Ignored when already inside a
    *   transaction.
-   * @returns An object with `rowsAffected` (sum of affected rows) and
-   *   `lastInsertRowid` (rowid of the last successful insert).
+   * @returns An array of `ResultSet`s — one per input statement, in order —
+   *   matching the libsql-js batch contract. Each `ResultSet` carries that
+   *   statement's `columns`, `columnTypes`, `rows`, and `rowsAffected`.
    *
    * @example
    * // Plain SQL strings (non-atomic).
@@ -240,8 +308,8 @@ class Database {
    */
   async batch(
     statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
-    mode?: BatchMode,
-  ): Promise<{ rowsAffected: number; lastInsertRowid: number | bigint | undefined }> {
+    options?: BatchMode | BatchOptions,
+  ): Promise<ResultSet[]> {
     if (!Array.isArray(statements)) {
       throw new TypeError("Expected first argument to be an array of statements");
     }
@@ -275,13 +343,13 @@ class Database {
         }
       };
 
-      const wrap = mode !== undefined && !this.db.inTransaction();
+      const { mode, raw } = normalizeBatchOptions(options);
+      const wrap = mode != null && !this.db.inTransaction();
       if (wrap) {
-        await runRawSql(`BEGIN ${mode!.toUpperCase()}`);
+        await runRawSql(`BEGIN ${normalizeBatchMode(mode!)}`);
       }
 
-      let rowsAffected = 0;
-      let lastInsertRowid: number | bigint | undefined;
+      const results: ResultSet[] = [];
       try {
         for (const statement of statements) {
           const sql = typeof statement === "string" ? statement : statement.sql;
@@ -297,8 +365,15 @@ class Database {
             if (args !== undefined) {
               bindParams(nativeStmt, [args]);
             }
+            const cols = nativeStmt.columns();
+            const columnNames = cols.map((c) => c.name);
+            const columnTypes = cols.map((c) => c.type ?? "");
+            if (columnNames.length > 0) {
+              nativeStmt.raw(raw);
+            }
+
             const totalChangesBefore = this.db.totalChanges();
-            const lastInsertRowidBefore = this.db.lastInsertRowid();
+            const rows: any[] = [];
             try {
               while (true) {
                 const stepResult = await nativeStmt.stepSync();
@@ -309,21 +384,14 @@ class Database {
                 if (stepResult === STEP_DONE) {
                   break;
                 }
-                // STEP_ROW results are discarded; batch() does not
-                // surface rows.
+                rows.push(nativeStmt.row());
               }
-              if (this.db.totalChanges() !== totalChangesBefore) {
-                rowsAffected += this.db.changes();
-              }
-              // SQLite keeps last_insert_rowid() sticky across
-              // non-INSERT statements, so just checking the value is
-              // not enough — UPDATE/DELETE would inherit a stale
-              // rowid. Use the delta as the per-statement INSERT
-              // signal.
-              const lastInsertRowidAfter = this.db.lastInsertRowid();
-              if (lastInsertRowidAfter !== lastInsertRowidBefore) {
-                lastInsertRowid = lastInsertRowidAfter;
-              }
+              const rowsAffected = columnNames.length > 0
+                ? 0
+                : this.db.totalChanges() !== totalChangesBefore ? this.db.changes() : 0;
+              results.push(
+                makeResultSet(columnNames, columnTypes, rows, rowsAffected),
+              );
             } finally {
               nativeStmt.reset();
             }
@@ -341,7 +409,7 @@ class Database {
         }
         throw err;
       }
-      return { rowsAffected, lastInsertRowid };
+      return results;
     } finally {
       this.execLock.release();
     }

--- a/serverless/javascript/integration-tests/serverless.test.mjs
+++ b/serverless/javascript/integration-tests/serverless.test.mjs
@@ -77,8 +77,11 @@ test.serial('batch() method executes multiple statements', async t => {
     'INSERT INTO test_products (name, price) VALUES ("Tool", 29.99)'
   ]);
   
-  t.is(batchResult.rowsAffected, 3);
-  
+  // batch() returns one ResultSet per statement, in order.
+  t.is(batchResult.length, 4);
+  const insertedRows = batchResult.slice(1).reduce((sum, rs) => sum + rs.rowsAffected, 0);
+  t.is(insertedRows, 3);
+
   const queryResult = await client.execute('SELECT COUNT(*) as count FROM test_products');
   t.is(queryResult.rows[0][0], 3);
 });

--- a/serverless/javascript/src/compat.ts
+++ b/serverless/javascript/src/compat.ts
@@ -50,7 +50,14 @@ export type InArgs = Array<InValue> | Record<string, InValue>;
 export type InStatement = { sql: string; args?: InArgs } | string;
 
 /** Transaction execution modes */
-export type TransactionMode = "write" | "read" | "deferred";
+export type TransactionMode = "write" | "read" | "deferred" | "immediate" | "exclusive" | "concurrent" | string;
+
+export interface BatchOptions {
+  mode?: TransactionMode;
+  raw?: boolean;
+}
+
+export type BatchRow = Record<string, InValue> | Array<InValue>;
 
 /**
  * A result row that can be accessed both as an array and as an object.
@@ -78,6 +85,20 @@ export interface ResultSet {
   lastInsertRowid: bigint | undefined;
   /** Convert result set to JSON */
   toJSON(): any;
+}
+
+/**
+ * Result set returned by batch().
+ */
+export interface BatchResultSet {
+  /** Column names in the result set */
+  columns: Array<string>;
+  /** Column type information */
+  columnTypes: Array<string>;
+  /** Result rows */
+  rows: Array<BatchRow>;
+  /** Number of rows affected by the statement */
+  rowsAffected: number;
 }
 
 /**
@@ -111,7 +132,7 @@ export class LibsqlError extends Error {
  */
 export interface Transaction {
   execute(stmt: InStatement): Promise<ResultSet>;
-  batch(stmts: Array<InStatement>): Promise<Array<ResultSet>>;
+  batch(stmts: Array<InStatement>): Promise<Array<BatchResultSet>>;
   executeMultiple(sql: string): Promise<void>;
   commit(): Promise<void>;
   rollback(): Promise<void>;
@@ -128,8 +149,8 @@ export interface Transaction {
 export interface Client {
   execute(stmt: InStatement): Promise<ResultSet>;
   execute(sql: string, args?: InArgs): Promise<ResultSet>;
-  batch(stmts: Array<InStatement>, mode?: TransactionMode): Promise<Array<ResultSet>>;
-  migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>>;
+  batch(stmts: Array<InStatement>, options?: TransactionMode | BatchOptions): Promise<Array<BatchResultSet>>;
+  migrate(stmts: Array<InStatement>): Promise<Array<BatchResultSet>>;
   transaction(mode?: TransactionMode): Promise<Transaction>;
   executeMultiple(sql: string): Promise<void>;
   sync(): Promise<any>;
@@ -246,6 +267,28 @@ class LibSQLClient implements Client {
     return resultSet;
   }
 
+  private convertBatchResult(result: any): BatchResultSet {
+    return {
+      columns: result.columns || [],
+      columnTypes: result.columnTypes || [],
+      rows: result.rows || [],
+      rowsAffected: result.rowsAffected || 0,
+    };
+  }
+
+  private normalizeBatchOptions(options?: TransactionMode | BatchOptions): { mode?: TransactionMode; raw: boolean } {
+    if (options != null && typeof options === "object") {
+      return {
+        mode: options.mode,
+        raw: options.raw === true,
+      };
+    }
+    return {
+      mode: options,
+      raw: false,
+    };
+  }
+
   async execute(stmt: InStatement): Promise<ResultSet>;
   async execute(sql: string, args?: InArgs): Promise<ResultSet>;
   async execute(stmtOrSql: InStatement | string, args?: InArgs): Promise<ResultSet> {
@@ -276,22 +319,29 @@ class LibSQLClient implements Client {
     }
   }
 
-  async batch(stmts: Array<InStatement>, mode?: TransactionMode): Promise<Array<ResultSet>> {
+  async batch(stmts: Array<InStatement>, options?: TransactionMode | BatchOptions): Promise<Array<BatchResultSet>> {
     await this.execLock.acquire();
     try {
       if (this._closed) {
         throw new LibsqlError("Client is closed", "CLIENT_CLOSED");
       }
 
-      const sqlStatements = stmts.map(stmt => {
-        const normalized = this.normalizeStatement(stmt);
-        return normalized.sql; // For now, ignore args in batch
-      });
+      if (!Array.isArray(stmts)) {
+        throw new TypeError("Expected first argument to be an array of statements");
+      }
 
-      const result = await this.session.batch(sqlStatements);
+      const { mode, raw } = this.normalizeBatchOptions(options);
+      const batchMode = mode ?? "deferred";
 
-      // Return array of result sets (simplified - actual implementation would be more complex)
-      return [this.convertResult(result)];
+      const results = await this.session.batch(
+        stmts,
+        batchMode,
+        undefined,
+        this._defaultSafeIntegers,
+        raw,
+      );
+
+      return results.map((result: any) => this.convertBatchResult(result));
     } catch (error: any) {
       if (error instanceof LibsqlError) {
         throw error;
@@ -302,7 +352,7 @@ class LibSQLClient implements Client {
     }
   }
 
-  async migrate(stmts: Array<InStatement>): Promise<Array<ResultSet>> {
+  async migrate(stmts: Array<InStatement>): Promise<Array<BatchResultSet>> {
     // For now, just call batch - in a real implementation this would disable foreign keys
     return this.batch(stmts, "write");
   }
@@ -374,13 +424,22 @@ class LibSQLClient implements Client {
         }
         return executeInTx(stmtOrSql);
       },
-      batch: async (stmts: Array<InStatement>): Promise<Array<ResultSet>> => {
+      batch: async (stmts: Array<InStatement>): Promise<Array<BatchResultSet>> => {
         ensureOpen();
-        const results: Array<ResultSet> = [];
-        for (const stmt of stmts) {
-          results.push(await executeInTx(stmt));
+        if (!Array.isArray(stmts)) {
+          throw new TypeError("Expected first argument to be an array of statements");
         }
-        return results;
+        try {
+          const results = await txSession.batch(
+            stmts,
+            undefined,
+            undefined,
+            this._defaultSafeIntegers,
+          );
+          return results.map((result: any) => this.convertBatchResult(result));
+        } catch (error: any) {
+          throw mapDatabaseError(error, "BATCH_ERROR");
+        }
       },
       executeMultiple: async (sql: string): Promise<void> => {
         ensureOpen();

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -17,6 +17,37 @@ export type BatchStatement = string | {
   args?: any[] | Record<string, any>;
 };
 
+export interface BatchOptions {
+  mode?: BatchMode;
+  raw?: boolean;
+}
+
+function normalizeBatchOptions(options?: BatchMode | BatchOptions): { mode?: BatchMode; raw: boolean } {
+  if (options != null && typeof options === 'object') {
+    return {
+      mode: options.mode,
+      raw: options.raw === true,
+    };
+  }
+  return {
+    mode: options,
+    raw: false,
+  };
+}
+
+/**
+ * Shapes a raw per-statement result from `session.batch()` into the
+ * libsql-js batch ResultSet shape.
+ */
+function toResultSet(result: any): any {
+  return {
+    columns: result.columns ?? [],
+    columnTypes: result.columnTypes ?? [],
+    rows: result.rows ?? [],
+    rowsAffected: result.rowsAffected ?? 0,
+  };
+}
+
 
 /**
  * A connection to a Turso database.
@@ -266,8 +297,9 @@ export class Connection {
    *   values as `connection.transaction(...)` variants: `"deferred"`,
    *   `"immediate"`, `"exclusive"`, `"concurrent"`. Ignored when already
    *   inside a transaction.
-   * @returns An object with `rowsAffected` (sum of affected rows) and
-   *   `lastInsertRowid` (rowid of the last successful insert).
+   * @returns An array of `ResultSet`s — one per input statement, in order —
+   *   matching the libsql-js batch contract. Each `ResultSet` carries that
+   *   statement's `columns`, `columnTypes`, `rows`, and `rowsAffected`.
    *
    * @example
    * // Plain SQL strings (non-atomic).
@@ -298,17 +330,28 @@ export class Connection {
    * });
    * await txn.immediate();
    */
-  async batch(statements: BatchStatement[], mode?: BatchMode, queryOptions?: QueryOptions): Promise<any> {
+  async batch(statements: BatchStatement[], options?: BatchMode | BatchOptions, queryOptions?: QueryOptions): Promise<any> {
+    if (!Array.isArray(statements)) {
+      throw new TypeError("Expected first argument to be an array of statements");
+    }
     if (!this.isOpen) {
       throw new TypeError("The database connection is not open");
     }
     await this.execLock.acquire();
     try {
+      const { mode, raw } = normalizeBatchOptions(options);
       // Inside an outer transaction(...) callback the surrounding BEGIN
       // already opened a transaction on this stream; emitting another
       // `BEGIN` step would fail, so ignore the user-supplied mode.
       const effectiveMode = this.session.inTransaction ? undefined : mode;
-      return await this.session.batch(statements, effectiveMode, queryOptions);
+      const results = await this.session.batch(
+        statements,
+        effectiveMode,
+        queryOptions,
+        this.defaultSafeIntegerMode,
+        raw,
+      );
+      return results.map((result: any) => toResultSet(result));
     } finally {
       this.execLock.release();
     }

--- a/serverless/javascript/src/index.ts
+++ b/serverless/javascript/src/index.ts
@@ -1,5 +1,5 @@
 // Turso serverless driver entry point
-export { Connection, connect, type Config, type BatchStatement } from './connection.js';
+export { Connection, connect, type Config, type BatchStatement, type BatchOptions } from './connection.js';
 export { Statement } from './statement.js';
 export { Session, type SessionConfig } from './session.js';
 export { DatabaseError, TimeoutError } from './error.js';

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -23,7 +23,25 @@ import { encodeSqlArgs } from './args.js';
  * Locking mode for atomic `batch()` execution. Accepts the same values
  * as the variants of `Connection.transaction(...)`.
  */
-export type BatchMode = 'deferred' | 'immediate' | 'exclusive' | 'concurrent';
+export type BatchMode = 'write' | 'read' | 'deferred' | 'immediate' | 'exclusive' | 'concurrent' | string;
+
+function normalizeBatchMode(mode: BatchMode): string {
+  switch (String(mode).toLowerCase()) {
+    case 'write':
+      return 'IMMEDIATE';
+    case 'read':
+    case 'deferred':
+      return 'DEFERRED';
+    case 'immediate':
+      return 'IMMEDIATE';
+    case 'exclusive':
+      return 'EXCLUSIVE';
+    case 'concurrent':
+      return 'CONCURRENT';
+    default:
+      return String(mode).toUpperCase();
+  }
+}
 
 /**
  * Configuration options for a session.
@@ -312,6 +330,14 @@ export class Session {
     return row;
   }
 
+  createObjectRow(values: any[], columns: string[]): any {
+    const row: any = {};
+    columns.forEach((column, index) => {
+      row[column] = values[index];
+    });
+    return row;
+  }
+
   /**
    * Execute multiple SQL statements in a batch.
    *
@@ -326,17 +352,23 @@ export class Session {
    * @param mode - Optional locking mode; when set, the batch executes
    *   atomically. Accepts the same values as `Database.transaction(...)`
    *   variants: `"deferred"`, `"immediate"`, `"exclusive"`, `"concurrent"`.
-   * @returns Promise resolving to batch execution results.
+   * @param safeIntegers - When true, integer column values are decoded as
+   *   BigInt rather than Number.
+   * @returns Promise resolving to an array of per-statement results — one
+   *   per input statement, in order — each carrying that statement's
+   *   `columns`, `columnTypes`, `rows`, and `rowsAffected`.
    */
   async batch(
     statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
     mode?: BatchMode,
     queryOptions?: QueryOptions,
+    safeIntegers: boolean = false,
+    raw: boolean = false,
   ): Promise<any> {
     const userSteps: BatchStep[] = statements.map(statement => {
       if (typeof statement === 'string') {
         return {
-          stmt: { sql: statement, args: [], named_args: [], want_rows: false },
+          stmt: { sql: statement, args: [], named_args: [], want_rows: true },
         };
       }
       const encodedArgs = encodeSqlArgs(statement.args ?? []);
@@ -345,7 +377,7 @@ export class Session {
           sql: statement.sql,
           args: encodedArgs.args,
           named_args: encodedArgs.namedArgs,
-          want_rows: false,
+          want_rows: true,
         },
       };
     });
@@ -371,7 +403,7 @@ export class Session {
       commitIdx = lastUserStepIdx + 1;
       rollbackIdx = commitIdx + 1;
       steps = [
-        { stmt: { sql: `BEGIN ${mode.toUpperCase()}`, args: [], named_args: [], want_rows: false } },
+        { stmt: { sql: `BEGIN ${normalizeBatchMode(mode)}`, args: [], named_args: [], want_rows: false } },
         ...userSteps.map((step, i) => ({
           ...step,
           condition: { type: 'ok' as const, step: i === 0 ? beginIdx : firstUserStepIdx + i - 1 },
@@ -412,41 +444,71 @@ export class Session {
       this.baseUrl = response.base_url;
     }
 
-    let totalRowsAffected = 0;
-    let lastInsertRowid: number | undefined;
+    // One result per user statement, in input order.
+    const results = userSteps.map(() => ({
+      columns: [] as string[],
+      columnTypes: [] as string[],
+      rows: [] as any[],
+      rowsAffected: 0,
+    }));
     let deferredError: DatabaseError | null = null;
 
-    // step_end entries don't carry a step index on the wire; the Hrana
-    // server only puts `step` on step_begin / step_error. Track the
-    // current step ourselves by watching step_begin so we know which
-    // step_end belongs to a user statement when running in atomic mode.
-    let currentStep: number | undefined;
-    const isUserStep = (step: number | undefined): boolean => {
+    // step_end / row entries don't carry a step index on the wire; the Hrana
+    // server only puts `step` on step_begin / step_error. Track the current
+    // step via step_begin so we know which user statement a row or step_end
+    // belongs to. Maps the wire step index to a slot in `results`, or
+    // undefined for the synthetic BEGIN/COMMIT/ROLLBACK steps.
+    let currentResultIdx: number | undefined;
+    // Fallback for responses that omit step_begin (e.g. simplified mocks):
+    // in non-atomic mode every step_end advances to the next user statement.
+    let nextNonAtomicIdx = 0;
+    const stepToResultIdx = (step: number | undefined): number | undefined => {
       if (mode === undefined) {
-        // Non-atomic batch: every step is a user step.
-        return true;
+        // Non-atomic batch: every step is a user step, in order.
+        return step ?? nextNonAtomicIdx;
       }
-      return step !== undefined && step >= firstUserStepIdx && step <= lastUserStepIdx;
+      if (step !== undefined && step >= firstUserStepIdx && step <= lastUserStepIdx) {
+        return step - firstUserStepIdx;
+      }
+      return undefined;
     };
 
     for await (const entry of entries) {
       switch (entry.type) {
         case 'step_begin':
-          currentStep = entry.step;
+          currentResultIdx = stepToResultIdx(entry.step);
+          if (currentResultIdx !== undefined && currentResultIdx < results.length && entry.cols) {
+            results[currentResultIdx].columns = entry.cols.map(col => col.name);
+            results[currentResultIdx].columnTypes = entry.cols.map(col => col.decltype || '');
+          }
           break;
-        case 'step_end':
-          if (isUserStep(currentStep)) {
+        case 'row':
+          if (currentResultIdx !== undefined && currentResultIdx < results.length && entry.row) {
+            const decodedRow = entry.row.map(value => decodeValue(value, safeIntegers));
+            const row = raw
+              ? decodedRow
+              : this.createObjectRow(decodedRow, results[currentResultIdx].columns);
+            results[currentResultIdx].rows.push(row);
+          }
+          break;
+        case 'step_end': {
+          let idx = currentResultIdx;
+          if (idx === undefined && mode === undefined) {
+            idx = nextNonAtomicIdx;
+          }
+          if (idx !== undefined && idx < results.length) {
             if (entry.affected_row_count !== undefined) {
-              totalRowsAffected += entry.affected_row_count;
-            }
-            if (entry.last_insert_rowid !== undefined && entry.last_insert_rowid !== null) {
-              lastInsertRowid = typeof entry.last_insert_rowid === 'number'
-                ? entry.last_insert_rowid
-                : parseInt(entry.last_insert_rowid, 10);
+              results[idx].rowsAffected = results[idx].columns.length > 0
+                ? 0
+                : entry.affected_row_count;
             }
           }
-          currentStep = undefined;
+          if (mode === undefined && idx !== undefined) {
+            nextNonAtomicIdx = idx + 1;
+          }
+          currentResultIdx = undefined;
           break;
+        }
         case 'step_error':
           if (mode === undefined) {
             throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
@@ -460,7 +522,7 @@ export class Session {
           if (deferredError === null && entry.step !== rollbackIdx) {
             deferredError = new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
           }
-          currentStep = undefined;
+          currentResultIdx = undefined;
           break;
         case 'error':
           throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
@@ -471,10 +533,7 @@ export class Session {
       throw deferredError;
     }
 
-    return {
-      rowsAffected: totalRowsAffected,
-      lastInsertRowid,
-    };
+    return results;
   }
 
   /**

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -103,18 +103,123 @@ test.serial("Database.exec() after close()", async (t) => {
 
 // ==========================================================================
 // Database.batch()
+//
+// batch() returns an Array<ResultSet> — one entry per input statement, in
+// the order the statements were supplied — matching the libSQL client
+// contract. Each ResultSet has the shape:
+//
+//   { columns, columnTypes, rows, rowsAffected }
+//
+//   - columns / columnTypes are parallel arrays of the result's column
+//     names and declared types. Both are empty for statements that return
+//     no rows (INSERT/UPDATE/DELETE).
+//   - rows is an Array<Row>. By default rows match Statement.all() object
+//     rows; pass { raw: true } to receive arrays.
+//   - rowsAffected is the per-statement change count (0 for SELECT).
 // ==========================================================================
+
+// Assert the ResultSet invariants shared by every batch entry, regardless
+// of statement kind.
+const assertResultSetShape = (t, rs) => {
+  t.true(Array.isArray(rs.columns), "columns is an array");
+  t.true(Array.isArray(rs.columnTypes), "columnTypes is an array");
+  t.is(rs.columnTypes.length, rs.columns.length, "columnTypes parallels columns");
+  t.true(Array.isArray(rs.rows), "rows is an array");
+  t.is(typeof rs.rowsAffected, "number", "rowsAffected is a number");
+  t.false("lastInsertRowid" in rs, "batch ResultSet does not expose lastInsertRowid");
+  t.is(rs.toJSON, undefined, "batch ResultSet does not expose toJSON");
+};
+
+test.serial("Database.batch() [returns one ResultSet per statement, in order]", async (t) => {
+  const db = t.context.db;
+
+  const results = await db.batch([
+    "INSERT INTO users(name, email) VALUES ('Carol', 'carol@example.net')",
+    "SELECT id, name FROM users ORDER BY id",
+    "DELETE FROM users WHERE name = 'Carol'",
+  ]);
+
+  t.true(Array.isArray(results), "batch() returns an array");
+  t.is(results.length, 3, "one ResultSet per input statement");
+  results.forEach((rs) => assertResultSetShape(t, rs));
+
+  // INSERT: no result rows, one row affected.
+  t.deepEqual(results[0].columns, []);
+  t.deepEqual(results[0].rows, []);
+  t.is(results[0].rowsAffected, 1);
+
+  // SELECT: rows surfaced, nothing affected.
+  t.deepEqual(results[1].columns, ["id", "name"]);
+  t.is(results[1].rows.length, 3);
+  t.is(results[1].rowsAffected, 0);
+
+  // DELETE: no result rows, one row affected.
+  t.deepEqual(results[2].columns, []);
+  t.deepEqual(results[2].rows, []);
+  t.is(results[2].rowsAffected, 1);
+});
+
+test.serial("Database.batch() [SELECT rows expose Statement.all() object shape]", async (t) => {
+  const db = t.context.db;
+
+  const [rs] = await db.batch([
+    "SELECT id, name, email FROM users WHERE id = 1",
+  ]);
+
+  assertResultSetShape(t, rs);
+  t.deepEqual(rs.columns, ["id", "name", "email"]);
+  t.is(rs.rows.length, 1);
+
+  const row = rs.rows[0];
+  t.false(Array.isArray(row));
+  t.is(row.id, 1);
+  t.is(row.name, "Alice");
+  t.is(row.email, "alice@example.org");
+});
+
+test.serial("Database.batch() [later statements observe earlier writes]", async (t) => {
+  const db = t.context.db;
+
+  // The statements run sequentially on the same connection, so a read can
+  // see a write that an earlier statement in the same batch performed.
+  const results = await db.batch([
+    { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Grace", "grace@example.net"] },
+    "SELECT name FROM users WHERE name = 'Grace'",
+  ]);
+
+  t.is(results[0].rowsAffected, 1);
+  t.is(results[1].rows.length, 1, "the SELECT observes the row inserted earlier in the batch");
+  t.is(results[1].rows[0].name, "Grace");
+});
+
+test.serial("Database.batch() [empty batch returns empty array]", async (t) => {
+  const db = t.context.db;
+
+  const results = await db.batch([]);
+  t.deepEqual(results, []);
+});
+
+test.serial("Database.batch() [raw option returns array rows]", async (t) => {
+  const db = t.context.db;
+
+  const [rs] = await db.batch(["SELECT id, name FROM users ORDER BY id"], { raw: true });
+
+  t.deepEqual(rs.columns, ["id", "name"]);
+  t.deepEqual(rs.rows[0], [1, "Alice"]);
+  t.deepEqual(rs.rows[1], [2, "Bob"]);
+});
 
 test.serial("Database.batch() [bound args]", async (t) => {
   const db = t.context.db;
 
-  const info = await db.batch([
+  const results = await db.batch([
     { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Carol", "carol@example.net"] },
     { sql: "INSERT INTO users(name, email) VALUES (:name, :email)", args: { name: "Dave", email: "dave@example.net" } },
   ]);
 
-  t.is(info.rowsAffected, 2);
-  t.is(info.lastInsertRowid, 4);
+  t.is(results.length, 2);
+  t.is(results[0].rowsAffected, 1);
+  t.is(results[1].rowsAffected, 1);
 
   const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4) ORDER BY id");
   t.deepEqual(rows, [
@@ -126,13 +231,14 @@ test.serial("Database.batch() [bound args]", async (t) => {
 test.serial("Database.batch() [plain strings]", async (t) => {
   const db = t.context.db;
 
-  const info = await db.batch([
+  const results = await db.batch([
     "INSERT INTO users(name, email) VALUES ('Eve', 'eve@example.net')",
     "INSERT INTO users(name, email) VALUES ('Frank', 'frank@example.net')",
   ]);
 
-  t.is(info.rowsAffected, 2);
-  t.is(info.lastInsertRowid, 4);
+  t.is(results.length, 2);
+  t.is(results[0].rowsAffected, 1);
+  t.is(results[1].rowsAffected, 1);
 
   const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4) ORDER BY id");
   t.deepEqual(rows, [
@@ -158,7 +264,7 @@ test.serial("Database.batch() [mixed value types]", async (t) => {
 
   const blob = Buffer.from([0xDE, 0xAD, 0xBE, 0xEF]);
 
-  const info = await db.batch([
+  const results = await db.batch([
     {
       sql: "INSERT INTO types_batch(i, r, s, b, n) VALUES (?, ?, ?, ?, ?)",
       args: [42, 3.14, "hello", blob, null],
@@ -171,9 +277,23 @@ test.serial("Database.batch() [mixed value types]", async (t) => {
       sql: "INSERT INTO types_batch(i) VALUES (?)",
       args: [9007199254740993n],
     },
+    // A trailing read exercises type fidelity through ResultSet rows.
+    "SELECT i, r, s, b, n FROM types_batch ORDER BY id LIMIT 2",
   ]);
 
-  t.is(info.rowsAffected, 3);
+  t.is(results.length, 4);
+  t.is(results[0].rowsAffected, 1);
+  t.is(results[1].rowsAffected, 1);
+  t.is(results[2].rowsAffected, 1);
+
+  // Values survive the round-trip into the SELECT's ResultSet rows.
+  const selectRows = results[3].rows;
+  t.is(selectRows.length, 2);
+  t.is(selectRows[0].i, 42);
+  t.is(selectRows[0].r, 3.14);
+  t.is(selectRows[0].s, "hello");
+  t.deepEqual(selectRows[0].b, blob);
+  t.is(selectRows[0].n, null);
 
   const rows = await db.all("SELECT i, r, s, b, n FROM types_batch ORDER BY id");
   t.is(rows.length, 3);
@@ -209,7 +329,7 @@ test.serial("Database.batch() [rollback via transaction()]", async (t) => {
     ]);
   });
 
-  await t.throwsAsync(async () => { await txn(); });
+  await t.throwsAsync(async () => { await txn(); }, { any: true });
 
   const rows = await db.all("SELECT name FROM users WHERE name = 'Mallory'");
   t.deepEqual(rows, []);
@@ -218,13 +338,14 @@ test.serial("Database.batch() [rollback via transaction()]", async (t) => {
 test.serial("Database.batch() [atomic mode]", async (t) => {
   const db = t.context.db;
 
-  const info = await db.batch([
+  const results = await db.batch([
     { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Ivy", "ivy@example.net"] },
     { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["Jay", "jay@example.net"] },
   ], "immediate");
 
-  t.is(info.rowsAffected, 2);
-  t.is(info.lastInsertRowid, 4);
+  t.is(results.length, 2);
+  t.is(results[0].rowsAffected, 1);
+  t.is(results[1].rowsAffected, 1);
 
   const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4) ORDER BY id");
   t.deepEqual(rows, [
@@ -242,43 +363,10 @@ test.serial("Database.batch() [atomic mode rolls back on failure]", async (t) =>
       // Duplicate primary key with the row inserted in beforeEach.
       { sql: "INSERT INTO users(id, name, email) VALUES (1, 'dup', 'dup@example.net')" },
     ], "immediate");
-  });
+  }, { any: true });
 
   const rows = await db.all("SELECT name FROM users WHERE name = 'Kelly'");
   t.deepEqual(rows, []);
-});
-
-test.serial("Database.batch() [concurrent caller waits for atomic batch]", async (t) => {
-  if (process.env.PROVIDER === "serverless") {
-    // Native-only: exercises the connection-level exec lock.
-    t.pass();
-    return;
-  }
-  const db = t.context.db;
-
-  // Kick off an atomic batch that will fail on its second statement
-  // (duplicate primary key), then immediately issue a concurrent INSERT
-  // on the same connection. If batch() does not hold the connection
-  // lock across BEGIN/.../COMMIT, the concurrent insert would interleave
-  // *inside* the batch's transaction and be rolled back along with it.
-  const failingBatch = db.batch([
-    { sql: "INSERT INTO users(name, email) VALUES (?, ?)", args: ["BatchOnly", "batch@example.net"] },
-    { sql: "INSERT INTO users(id, name, email) VALUES (1, 'dup', 'dup@example.net')" },
-  ], "immediate");
-  const concurrentInsert = db.run(
-    "INSERT INTO users(name, email) VALUES (?, ?)",
-    "Concurrent", "concurrent@example.net",
-  );
-
-  await t.throwsAsync(failingBatch);
-  await concurrentInsert;
-
-  const names = (await db.all("SELECT name FROM users ORDER BY id")).map(r => r.name);
-  // BatchOnly is rolled back by the failed atomic batch.
-  t.false(names.includes("BatchOnly"));
-  // The concurrent INSERT ran *after* the batch released the lock, so
-  // it commits via autocommit and is visible.
-  t.true(names.includes("Concurrent"));
 });
 
 test.serial("Database.batch() [atomic mode does not abort manually-opened outer transaction on BEGIN failure]", async (t) => {
@@ -315,7 +403,7 @@ test.serial("Database.batch() [atomic mode does not abort manually-opened outer 
   t.false(names.includes("Inner"), "atomic batch's INSERT must not have committed");
 });
 
-test.serial("Database.batch() [non-insert batch returns undefined lastInsertRowid]", async (t) => {
+test.serial("Database.batch() [non-insert batch does not expose lastInsertRowid]", async (t) => {
   const db = t.context.db;
 
   // Seed an INSERT first so the connection has a non-zero lastInsertRowid.
@@ -325,13 +413,15 @@ test.serial("Database.batch() [non-insert batch returns undefined lastInsertRowi
   // last_insert_rowid() sticky across non-INSERT statements, so we
   // must derive the per-statement INSERT signal from the delta, not
   // from `changes > 0`.
-  const info = await db.batch([
+  const results = await db.batch([
     { sql: "UPDATE users SET email = ? WHERE id = 1", args: ["alice2@example.org"] },
     { sql: "DELETE FROM users WHERE id = 2" },
   ]);
 
-  t.is(info.rowsAffected, 2);
-  t.is(info.lastInsertRowid, undefined);
+  t.is(results[0].rowsAffected, 1);
+  t.false("lastInsertRowid" in results[0]);
+  t.is(results[1].rowsAffected, 1);
+  t.false("lastInsertRowid" in results[1]);
 });
 
 
@@ -347,10 +437,10 @@ test.serial("Database.transaction().deferred() [batch]", async (t) => {
     ]);
   });
 
-  const info = await insertMany.deferred();
+  const results = await insertMany.deferred();
   t.is(db.inTransaction, false);
-  t.is(info.rowsAffected, 3);
-  t.is(info.lastInsertRowid, 5);
+  t.is(results.length, 3);
+  results.forEach((rs) => t.is(rs.rowsAffected, 1));
 
   const rows = await db.all("SELECT name, email FROM users WHERE id IN (3, 4, 5) ORDER BY id");
   t.deepEqual(rows, [

--- a/testing/conformance/javascript/__test__/compat.test.js
+++ b/testing/conformance/javascript/__test__/compat.test.js
@@ -127,3 +127,77 @@ compatTest("Compat interactive transaction rollback after constraint error keeps
   const countAfterCommit = await client.execute({ sql: "SELECT COUNT(*) AS count FROM compat_users WHERE name = ?", args: ["AfterRollback"] });
   t.is(toCount(countAfterCommit), 1);
 });
+
+// ==========================================================================
+// client.batch()
+//
+// The libSQL-compatible client.batch(stmts, mode?) returns
+// Promise<Array<ResultSet>> — one ResultSet per input statement, in order,
+// each with { columns, columnTypes, rows, rowsAffected }.
+// libSQL runs the whole batch as a single transaction, so any failure rolls
+// the entire batch back.
+// ==========================================================================
+
+compatTest("Compat batch() returns one ResultSet per statement, in order", async (t) => {
+  const { client } = t.context;
+
+  const results = await client.batch([
+    { sql: "INSERT INTO compat_users (name) VALUES (?)", args: ["Bob"] },
+    "SELECT id, name FROM compat_users ORDER BY id",
+  ]);
+
+  t.true(Array.isArray(results), "batch() returns an array");
+  t.is(results.length, 2, "one ResultSet per input statement");
+
+  // INSERT: nothing to read back, one row affected.
+  t.deepEqual(results[0].rows, []);
+  t.is(results[0].rowsAffected, 1);
+
+  // SELECT: rows surfaced, nothing affected.
+  t.deepEqual(results[1].columns, ["id", "name"]);
+  t.is(results[1].rowsAffected, 0);
+  t.is(results[1].rows.length, 2);
+  t.is(results[1].rows[0].name, "Alice");
+  t.is(results[1].rows[1].name, "Bob");
+});
+
+compatTest("Compat batch() honors bound args", async (t) => {
+  const { client } = t.context;
+
+  // Regression guard: the args of each statement must be bound, not ignored.
+  const results = await client.batch([
+    { sql: "INSERT INTO compat_users (name) VALUES (?)", args: ["Carol"] },
+    { sql: "SELECT name FROM compat_users WHERE name = ?", args: ["Carol"] },
+  ]);
+
+  t.is(results[1].rows.length, 1);
+  t.is(results[1].rows[0].name, "Carol");
+});
+
+compatTest("Compat batch() raw option returns positional rows", async (t) => {
+  const { client } = t.context;
+
+  const [rs] = await client.batch([
+    { sql: "SELECT id, name FROM compat_users WHERE id = ?", args: [1] },
+  ], { raw: true });
+
+  const row = rs.rows[0];
+  t.true(Array.isArray(row));
+  t.is(row[0], 1);
+  t.is(row[1], "Alice");
+});
+
+compatTest("Compat batch() is atomic: a failure rolls back the whole batch", async (t) => {
+  const { client } = t.context;
+
+  await t.throwsAsync(async () => {
+    await client.batch([
+      { sql: "INSERT INTO compat_users (name) VALUES (?)", args: ["Atomic1"] },
+      // Duplicate primary key with the seeded id = 1 row.
+      { sql: "INSERT INTO compat_users (id, name) VALUES (?, ?)", args: [1, "Dup"] },
+    ]);
+  }, { any: true });
+
+  const after = await client.execute({ sql: "SELECT COUNT(*) AS count FROM compat_users WHERE name = ?", args: ["Atomic1"] });
+  t.is(toCount(after), 0, "the earlier insert must not survive the failed batch");
+});

--- a/testing/conformance/javascript/__test__/sync.test.js
+++ b/testing/conformance/javascript/__test__/sync.test.js
@@ -210,6 +210,75 @@ test.serial("Database.transaction().immediate()", async (t) => {
 });
 
 // ==========================================================================
+// Database.batch()
+// ==========================================================================
+
+test.serial("Database.batch() returns per-statement result sets", async (t) => {
+  if (!["turso", "libsql"].includes(t.context.provider)) {
+    t.pass();
+    return;
+  }
+  const db = t.context.db;
+
+  const results = db.batch([
+    { sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)", args: [3, "Carol", "carol@example.org"] },
+    { sql: "UPDATE users SET email = ? WHERE id = ?", args: ["alice@new.org", 1] },
+    "SELECT id, name FROM users ORDER BY id",
+  ]);
+
+  t.true(Array.isArray(results));
+  t.is(results.length, 3);
+  t.deepEqual(results[0].columns, []);
+  t.deepEqual(results[0].columnTypes, []);
+  t.deepEqual(results[0].rows, []);
+  t.is(results[0].rowsAffected, 1);
+  t.false("lastInsertRowid" in results[0]);
+  t.is(results[0].toJSON, undefined);
+
+  t.is(results[1].rowsAffected, 1);
+  t.false("lastInsertRowid" in results[1]);
+
+  t.deepEqual(results[2].columns, ["id", "name"]);
+  t.is(results[2].rowsAffected, 0);
+  t.is(results[2].rows.length, 3);
+  t.false(Array.isArray(results[2].rows[0]));
+  t.is(results[2].rows[0].id, 1);
+  t.is(results[2].rows[0].name, "Alice");
+});
+
+test.serial("Database.batch() raw option returns array rows", async (t) => {
+  if (!["turso", "libsql"].includes(t.context.provider)) {
+    t.pass();
+    return;
+  }
+  const db = t.context.db;
+
+  const [rs] = db.batch([
+    { sql: "SELECT id, name FROM users WHERE id = ?", args: [1] },
+  ], { raw: true });
+
+  t.deepEqual(rs.rows, [[1, "Alice"]]);
+});
+
+test.serial("Database.batch() rolls back on error when given a mode", async (t) => {
+  if (!["turso", "libsql"].includes(t.context.provider)) {
+    t.pass();
+    return;
+  }
+  const db = t.context.db;
+
+  t.throws(() => {
+    db.batch([
+      { sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)", args: [10, "Dan", "dan@example.org"] },
+      { sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)", args: [1, "Dup", "dup@example.org"] },
+    ], "write");
+  }, { any: true });
+
+  const row = db.prepare("SELECT count(*) AS c FROM users WHERE id = 10").get();
+  t.is(row.c, 0);
+});
+
+// ==========================================================================
 // Statement.run()
 // ==========================================================================
 

--- a/testing/conformance/javascript/package-lock.json
+++ b/testing/conformance/javascript/package-lock.json
@@ -10,7 +10,7 @@
         "@tursodatabase/database": "../../../bindings/javascript/packages/native",
         "@tursodatabase/serverless": "../../../serverless/javascript",
         "better-sqlite3": "^12.9.0",
-        "libsql": "^0.6.0-pre.35"
+        "libsql": "^0.6.0-pre.41"
       },
       "devDependencies": {
         "ava": "^6.4.1"
@@ -18,10 +18,10 @@
     },
     "../../../bindings/javascript/packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.7.0-pre.5",
+      "version": "0.7.0-pre.9",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.7.0-pre.5"
+        "@tursodatabase/database-common": "^0.7.0-pre.9"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -35,7 +35,7 @@
     },
     "../../../serverless/javascript": {
       "name": "@tursodatabase/serverless",
-      "version": "1.2.0",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.13",
@@ -1543,9 +1543,9 @@
       }
     },
     "node_modules/libsql": {
-      "version": "0.6.0-pre.35",
-      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.6.0-pre.35.tgz",
-      "integrity": "sha512-emVU1B+IBMCbk2m3g4mecfG/d/+NbebkShIkKKbrvGEIk+bcJ0Wdq94cDHhfXmuZfhms4/P11chE92XbFMtUkw==",
+      "version": "0.6.0-pre.41",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.6.0-pre.41.tgz",
+      "integrity": "sha512-bqlbtqcmCoZtsZSS2kqFsX9w7ND+K7wIw/XUkhmvmS0MOLxKST/L6jLgPpxrBeNCpuuuYS3SikLTOjVv7TFoxw==",
       "cpu": [
         "x64",
         "arm64",
@@ -1562,19 +1562,19 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "libsql-darwin-arm64": "0.6.0-pre.35",
-        "libsql-darwin-x64": "0.6.0-pre.35",
-        "libsql-linux-arm64-gnu": "0.6.0-pre.35",
-        "libsql-linux-arm64-musl": "0.6.0-pre.35",
-        "libsql-linux-x64-gnu": "0.6.0-pre.35",
-        "libsql-linux-x64-musl": "0.6.0-pre.35",
-        "libsql-win32-x64-msvc": "0.6.0-pre.35"
+        "libsql-darwin-arm64": "0.6.0-pre.41",
+        "libsql-darwin-x64": "0.6.0-pre.41",
+        "libsql-linux-arm64-gnu": "0.6.0-pre.41",
+        "libsql-linux-arm64-musl": "0.6.0-pre.41",
+        "libsql-linux-x64-gnu": "0.6.0-pre.41",
+        "libsql-linux-x64-musl": "0.6.0-pre.41",
+        "libsql-win32-x64-msvc": "0.6.0-pre.41"
       }
     },
     "node_modules/libsql-darwin-arm64": {
-      "version": "0.6.0-pre.35",
-      "resolved": "https://registry.npmjs.org/libsql-darwin-arm64/-/libsql-darwin-arm64-0.6.0-pre.35.tgz",
-      "integrity": "sha512-yJkfPw7DM+6bdv59yQdkAot4EaRJTf9hPZfClWHpR4EqsLJUF1XHoCC5Ic+qD0JHUM/7U2j8tjbTrTuyNdOpBg==",
+      "version": "0.6.0-pre.41",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-arm64/-/libsql-darwin-arm64-0.6.0-pre.41.tgz",
+      "integrity": "sha512-/8DgLm9Ib1TvWFCp3NPtbnzYQJlslsUXEzFEZfR5CrFGXq3CjWHxftgXQydhNIlomjJcLkonHxDvJcrgNiFmeg==",
       "cpu": [
         "arm64"
       ],
@@ -1588,9 +1588,9 @@
       }
     },
     "node_modules/libsql-darwin-x64": {
-      "version": "0.6.0-pre.35",
-      "resolved": "https://registry.npmjs.org/libsql-darwin-x64/-/libsql-darwin-x64-0.6.0-pre.35.tgz",
-      "integrity": "sha512-43w/FtBB61J9GnT18033iutG/WG+8AXESa9Xvsw2v/pqn85SUegEOoEqyEbwcjCPic8fn2f4UQ/e3JpDw9nhpw==",
+      "version": "0.6.0-pre.41",
+      "resolved": "https://registry.npmjs.org/libsql-darwin-x64/-/libsql-darwin-x64-0.6.0-pre.41.tgz",
+      "integrity": "sha512-HIuWsDOsl3hONdvO+iz3jHghG9/80YR6JlscEM/d7e9cgI4KZf7KykfrGESrX2H0t+HsVrTYuEr1gdGlCmlo3g==",
       "cpu": [
         "x64"
       ],
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/libsql-linux-arm64-gnu": {
-      "version": "0.6.0-pre.35",
-      "resolved": "https://registry.npmjs.org/libsql-linux-arm64-gnu/-/libsql-linux-arm64-gnu-0.6.0-pre.35.tgz",
-      "integrity": "sha512-OhO1z06PggkZkIKfFgJTx/h7j6lnlHlokbHzxXPLpKWR3Wwh4/V4D/eQQmM8hcuKhkyJjM9qZtdOrrIwBExMCA==",
+      "version": "0.6.0-pre.41",
+      "resolved": "https://registry.npmjs.org/libsql-linux-arm64-gnu/-/libsql-linux-arm64-gnu-0.6.0-pre.41.tgz",
+      "integrity": "sha512-f7ed7oeXOhFulp+lrFJl3OcTQZ/Gyolhi3MbcfUr+5q0cZudhhSvoWkll6wsLDM5padEqdF4TVHO+eN6Xg1m4A==",
       "cpu": [
         "arm64"
       ],
@@ -1620,9 +1620,9 @@
       }
     },
     "node_modules/libsql-linux-x64-gnu": {
-      "version": "0.6.0-pre.35",
-      "resolved": "https://registry.npmjs.org/libsql-linux-x64-gnu/-/libsql-linux-x64-gnu-0.6.0-pre.35.tgz",
-      "integrity": "sha512-RArwMI+mM2G108fIKIyyhvhb8V8WgdCudj+BT6VWFS7T/Z1kGCrdzH0L6G5mDd0A/SdXRbNFshETzfxh7S0s8w==",
+      "version": "0.6.0-pre.41",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-gnu/-/libsql-linux-x64-gnu-0.6.0-pre.41.tgz",
+      "integrity": "sha512-fhc3AyoDHJ/2Y0VMn3Ea0amLnNdJ3nS1IlGLoErdTWWpf27s/kKw1pKLFEog5bFSBwmJfFG47krUkFtvSmys/Q==",
       "cpu": [
         "x64"
       ],
@@ -1636,9 +1636,9 @@
       }
     },
     "node_modules/libsql-linux-x64-musl": {
-      "version": "0.6.0-pre.35",
-      "resolved": "https://registry.npmjs.org/libsql-linux-x64-musl/-/libsql-linux-x64-musl-0.6.0-pre.35.tgz",
-      "integrity": "sha512-rFByyCsWAjXY+3VncXiloCIahUkCUidDTWSAgwLlnAMI9keH2ZmSO0j70uUkUFmMSgD9XBBHtRP6w0ZTOheFBQ==",
+      "version": "0.6.0-pre.41",
+      "resolved": "https://registry.npmjs.org/libsql-linux-x64-musl/-/libsql-linux-x64-musl-0.6.0-pre.41.tgz",
+      "integrity": "sha512-vXh0gjKMVtOUL1wVPZQCdmEnT0UGQXitUpXT8riil8hSnAIzTpKV0iziyeY+JxohZQCLz6iPtrGH21buSrD79Q==",
       "cpu": [
         "x64"
       ],
@@ -1650,12 +1650,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/libsql/node_modules/libsql-linux-arm64-musl": {
-      "optional": true
-    },
-    "node_modules/libsql/node_modules/libsql-win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/load-json-file": {
       "version": "7.0.1",

--- a/testing/conformance/javascript/package.json
+++ b/testing/conformance/javascript/package.json
@@ -18,7 +18,7 @@
     "@tursodatabase/serverless": "../../../serverless/javascript",
     "@tursodatabase/database": "../../../bindings/javascript/packages/native",
     "better-sqlite3": "^12.9.0",
-    "libsql": "^0.6.0-pre.35",
+    "libsql": "^0.6.0-pre.41",
     "@libsql/client": "^0.15.15"
   }
 }


### PR DESCRIPTION
Make the JavaScript batch() return an array of ResultSet, one per input
statement, matching the libSQL client contract. Each ResultSet carries
that statement's columns, columnTypes, rows (with both positional and
named access), rowsAffected, and a BigInt lastInsertRowid.

Previously the native Database.batch() returned an aggregate
{ rowsAffected, lastInsertRowid } and discarded rows, while the
libSQL-compat client.batch() ignored statement args and collapsed all
statements into a single result. This reworks every layer:

- Native Database.batch() reads each statement's columns, collects rows
  in raw mode, and builds one ResultSet per statement.
- session.batch() requests rows (want_rows) and returns one raw result
  per statement, preserving the atomic Hrana condition chain.
- Connection.batch() shapes each result into a libSQL ResultSet.
- compat client.batch() binds args and runs the batch atomically.

Add conformance tests for both the native Database.batch() and the
libSQL-compat client.batch().
