### PR TITLE
do not rollback attached pagers on reprepare if the conn is inside transaction

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -556,12 +556,15 @@ impl Statement {
             .filter(|&id| id != crate::MAIN_DB_ID)
             .try_collect()?;
         for db_id in &attached_db_ids {
-            // Discard any connection-local schema changes for this non-main DB
-            // (temp or attached) so the re-translate reads the committed schema.
-            conn.database_schemas().write().remove(&db_id);
-            if db_id == crate::TEMP_DB_ID && conn.temp.database.read().is_none() {
+            // Reprepare must not roll back an explicit transaction. SQLite allows
+            // reprepare inside a transaction, and uncommitted writes in temp or
+            // attached databases remain visible after the statement is retried.
+            if db_id == crate::TEMP_DB_ID || !conn.get_auto_commit() {
                 continue;
             }
+            // Discard any connection-local schema changes for this attached DB
+            // so the re-translate reads the committed schema.
+            conn.database_schemas().write().remove(&db_id);
             let pager = conn.get_pager_from_database_index(&db_id)?;
             if pager.holds_read_lock() {
                 pager.rollback_attached();

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use crate::common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase};
 use crate::queued_io::QueuedIo;
+use rusqlite::StatementStatus;
 use turso_core::vdbe::StepResult;
+use turso_core::StatementStatusCounter;
 use turso_core::{Database, LimboError};
 
 /// Helper: step a statement through IO until it returns Row or Done.
@@ -82,6 +84,53 @@ fn query_rows_with_reset(
     Ok(rows)
 }
 
+fn collect_limbo_prepared_rows(
+    stmt: &mut turso_core::Statement,
+) -> anyhow::Result<Vec<Vec<rusqlite::types::Value>>> {
+    let mut rows = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        let row = row
+            .get_values()
+            .map(|value| match value {
+                turso_core::Value::Null => rusqlite::types::Value::Null,
+                turso_core::Value::Numeric(turso_core::Numeric::Integer(value)) => {
+                    rusqlite::types::Value::Integer(*value)
+                }
+                turso_core::Value::Numeric(turso_core::Numeric::Float(value)) => {
+                    rusqlite::types::Value::Real(f64::from(*value))
+                }
+                turso_core::Value::Text(value) => {
+                    rusqlite::types::Value::Text(value.as_str().to_string())
+                }
+                turso_core::Value::Blob(value) => rusqlite::types::Value::Blob(value.to_vec()),
+            })
+            .collect();
+        rows.push(row);
+        Ok(())
+    })?;
+    Ok(rows)
+}
+
+fn collect_sqlite_prepared_rows(
+    stmt: &mut rusqlite::Statement<'_>,
+) -> rusqlite::Result<Vec<Vec<rusqlite::types::Value>>> {
+    let mut rows = stmt.query([])?;
+    let mut results = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut result = Vec::new();
+        for i in 0.. {
+            let column: rusqlite::types::Value = match row.get(i) {
+                Ok(column) => column,
+                Err(rusqlite::Error::InvalidColumnIndex(_)) => break,
+                Err(err) => return Err(err),
+            };
+            result.push(column);
+        }
+        results.push(result);
+    }
+    Ok(results)
+}
+
 fn assert_temp_table_transaction_matches_rusqlite(
     tmp_db: TempDatabase,
     hook: ResetHook,
@@ -125,6 +174,66 @@ fn busy_handler_change_after_prepare_does_not_reprepare_temp_transaction(
     tmp_db: TempDatabase,
 ) -> anyhow::Result<()> {
     assert_temp_table_transaction_matches_rusqlite(tmp_db, ResetHook::BusyHandlerAfterPrepare)
+}
+
+#[turso_macros::test]
+fn attached_transaction_survives_reprepare_after_schema_change(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let turso = tmp_db.connect_limbo();
+    let turso_aux_path = tmp_db.path.with_file_name("attached-reprepare-aux.db");
+    turso.execute(format!("ATTACH '{}' AS aux", turso_aux_path.display()))?;
+
+    let sqlite_dir = tempfile::TempDir::new()?;
+    let sqlite_main_path = sqlite_dir.path().join("main.db");
+    let sqlite_aux_path = sqlite_dir.path().join("aux.db");
+    let sqlite = rusqlite::Connection::open(sqlite_main_path)?;
+    sqlite.execute(
+        &format!("ATTACH '{}' AS aux", sqlite_aux_path.display()),
+        [],
+    )?;
+
+    for sql in [
+        "CREATE TABLE aux.reprepare_probe(id INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+        "BEGIN",
+        "INSERT INTO aux.reprepare_probe VALUES (1, 'x')",
+    ] {
+        turso.execute(sql)?;
+        sqlite.execute(sql, [])?;
+    }
+
+    let query = "SELECT id, value FROM aux.reprepare_probe ORDER BY id";
+    let mut turso_stmt = turso.prepare(query)?;
+    let mut sqlite_stmt = sqlite.prepare(query)?;
+
+    let schema_change = "CREATE TABLE aux.reprepare_probe_schema_change(marker INTEGER)";
+    turso.execute(schema_change)?;
+    sqlite.execute(schema_change, [])?;
+
+    let turso_rows = collect_limbo_prepared_rows(&mut turso_stmt)?;
+    let sqlite_rows = collect_sqlite_prepared_rows(&mut sqlite_stmt)?;
+
+    assert!(
+        turso_stmt.stmt_status(StatementStatusCounter::Reprepare) > 0,
+        "expected Turso statement to reprepare after attached schema change"
+    );
+    assert!(
+        sqlite_stmt.get_status(StatementStatus::RePrepare) > 0,
+        "expected SQLite statement to reprepare after attached schema change"
+    );
+    assert_eq!(turso_rows, sqlite_rows);
+
+    turso_stmt.reset()?;
+    drop(sqlite_stmt);
+
+    turso.execute("COMMIT")?;
+    sqlite.execute("COMMIT", [])?;
+    let turso_rows = limbo_exec_rows(&turso, query);
+    let sqlite_rows = sqlite_exec_rows(&sqlite, query);
+    dbg!(&turso_rows, &sqlite_rows);
+    assert_eq!(turso_rows, sqlite_rows);
+
+    Ok(())
 }
 
 /// INSERT ... RETURNING: read one row then drop the statement.

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::common::{limbo_exec_rows, TempDatabase};
+use crate::common::{limbo_exec_rows, sqlite_exec_rows, TempDatabase};
 use crate::queued_io::QueuedIo;
 use turso_core::vdbe::StepResult;
 use turso_core::{Database, LimboError};
@@ -13,6 +13,118 @@ fn step_blocking(stmt: &mut turso_core::Statement) -> turso_core::Result<StepRes
             other => return Ok(other),
         }
     }
+}
+
+#[derive(Clone, Copy)]
+enum ResetHook {
+    None,
+    BusyHandlerAfterPrepare,
+}
+
+fn set_busy_handler_if_needed(conn: &Arc<turso_core::Connection>, hook: ResetHook) {
+    if matches!(hook, ResetHook::BusyHandlerAfterPrepare) {
+        conn.set_busy_handler(Some(Box::new(|_| 0)));
+    }
+}
+
+fn clear_busy_handler_if_needed(conn: &Arc<turso_core::Connection>, hook: ResetHook) {
+    if matches!(hook, ResetHook::BusyHandlerAfterPrepare) {
+        conn.set_busy_handler(None);
+    }
+}
+
+fn exec_with_reset(
+    conn: &Arc<turso_core::Connection>,
+    sql: &str,
+    hook: ResetHook,
+) -> anyhow::Result<()> {
+    let mut stmt = conn.prepare(sql)?;
+    set_busy_handler_if_needed(conn, hook);
+    let result = stmt.run_ignore_rows();
+    clear_busy_handler_if_needed(conn, hook);
+    result?;
+    stmt.reset()?;
+    Ok(())
+}
+
+fn query_rows_with_reset(
+    conn: &Arc<turso_core::Connection>,
+    sql: &str,
+    hook: ResetHook,
+) -> anyhow::Result<Vec<Vec<rusqlite::types::Value>>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = Vec::new();
+
+    set_busy_handler_if_needed(conn, hook);
+    let result = stmt.run_with_row_callback(|row| {
+        let row = row
+            .get_values()
+            .map(|value| match value {
+                turso_core::Value::Null => rusqlite::types::Value::Null,
+                turso_core::Value::Numeric(turso_core::Numeric::Integer(value)) => {
+                    rusqlite::types::Value::Integer(*value)
+                }
+                turso_core::Value::Numeric(turso_core::Numeric::Float(value)) => {
+                    rusqlite::types::Value::Real(f64::from(*value))
+                }
+                turso_core::Value::Text(value) => {
+                    rusqlite::types::Value::Text(value.as_str().to_string())
+                }
+                turso_core::Value::Blob(value) => rusqlite::types::Value::Blob(value.to_vec()),
+            })
+            .collect();
+        rows.push(row);
+        Ok(())
+    });
+    clear_busy_handler_if_needed(conn, hook);
+    result?;
+    stmt.reset()?;
+    Ok(rows)
+}
+
+fn assert_temp_table_transaction_matches_rusqlite(
+    tmp_db: TempDatabase,
+    hook: ResetHook,
+) -> anyhow::Result<()> {
+    let turso = tmp_db.connect_limbo();
+    let sqlite = rusqlite::Connection::open_in_memory()?;
+
+    for sql in [
+        "CREATE TEMP TABLE temp_reset_probe(id INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+        "BEGIN",
+        "INSERT INTO temp_reset_probe VALUES (1, 'x')",
+    ] {
+        exec_with_reset(&turso, sql, hook)?;
+        sqlite.execute_batch(sql)?;
+    }
+
+    let query = "SELECT id, value FROM temp_reset_probe ORDER BY id";
+    assert_eq!(
+        query_rows_with_reset(&turso, query, hook)?,
+        sqlite_exec_rows(&sqlite, query)
+    );
+
+    exec_with_reset(&turso, "COMMIT", hook)?;
+    sqlite.execute_batch("COMMIT")?;
+
+    assert_eq!(
+        query_rows_with_reset(&turso, query, hook)?,
+        sqlite_exec_rows(&sqlite, query)
+    );
+
+    Ok(())
+}
+
+#[turso_macros::test(mvcc)]
+fn temp_table_transaction_survives_statement_reset(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    assert_temp_table_transaction_matches_rusqlite(tmp_db, ResetHook::None)
+}
+
+#[turso_macros::test]
+fn busy_handler_change_after_prepare_does_not_reprepare_temp_transaction(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    assert_temp_table_transaction_matches_rusqlite(tmp_db, ResetHook::BusyHandlerAfterPrepare)
 }
 
 /// INSERT ... RETURNING: read one row then drop the statement.


### PR DESCRIPTION
## Description
The problem here is that you could have the statement error with database changed after creating the temp table inside a transaction, or creating it outside of the transaction but then trying to insert into into it, but not seeing the inserted row.

```
1. CREATE TEMP TABLE inside BEGIN, followed by INSERT/SELECT, returns "Database schema changed".
2. CREATE TEMP TABLE outside BEGIN works, but INSERT into that temp table inside BEGIN returns success while the row is not visible inside the transaction or after COMMIT.
```

This is my attempt to fix this after comparing the behaviour with sqlite. Essentially we should not rollback the attached pagers if we are in explicit transaction, and seems like we should not rollback at all for temp tables (maybe I'm wrong on this appreciate some rebuttal).
## Motivation and context
Fix temp tables with reprepare


## Description of AI Usage
AI found the potential issue.
