### PR TITLE
Remove blocking IO from mvcc bootstrap and recovery paths

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -19,9 +19,9 @@ use crate::{
     ast, function,
     io::{MemoryIO, IO},
     progress::{ProgressHandler, ProgressHandlerCallback},
-    refresh_analyze_stats, translate,
+    translate,
     translate::collate::CollationSeq,
-    util::{parse_schema_rows, IOExt},
+    util::IOExt,
     vdbe, AllViewsTxState, AtomicCipherMode, AtomicSyncMode, AtomicTempStore, BusyHandler,
     BusyHandlerCallback, CaptureDataChangesInfo, CheckpointMode, CheckpointResult, CipherMode, Cmd,
     Completion, ConnectionMetrics, Database, DatabaseCatalog, DatabaseOpts, Duration,
@@ -164,6 +164,121 @@ impl Drop for SchemaReparseGuard {
             .schema_reparse_in_progress
             .store(false, Ordering::SeqCst);
     }
+}
+
+/// Re-entrant state for [`Connection::reparse_schema`] /
+/// [`Connection::reparse_schema_with_cookie`]. `Start` is the fresh state
+/// (cookie not yet read / schema build not yet begun); `Building` carries the
+/// half-built schema, captured table-valued functions, the held reparse guard,
+/// and the current sub-phase across IO yields.
+#[derive(Default)]
+pub enum ReparseSchemaState {
+    #[default]
+    Start,
+    Building(Box<ReparseSchemaInner>),
+}
+
+pub struct ReparseSchemaInner {
+    /// Held for the whole reparse so a concurrent reparse on this connection
+    /// trips the recursion assert. Dropped when the schema is finalized.
+    _guard: SchemaReparseGuard,
+    fresh: Schema,
+    /// Built-in table-valued functions captured from the old schema; rehydrated
+    /// after the sqlite_schema scan since they don't survive re-parsing.
+    tvfs: Vec<Arc<crate::vtab::VirtualTable>>,
+    /// VACUUM-supplied sequence descriptors to graft onto the rebuilt schema
+    /// instead of re-reading each backing table. `None` for a normal reparse,
+    /// which recovers descriptors from disk in the `PopulateSequences` phase.
+    preserved_sequences: Option<rustc_hash::FxHashMap<String, Arc<crate::schema::Sequence>>>,
+    phase: ReparsePhase,
+}
+
+enum ReparsePhase {
+    /// Scanning `SELECT * FROM sqlite_schema` into `fresh`.
+    ParseSchema {
+        parse: Box<crate::util::ParseSchemaRowsState>,
+    },
+    /// Recovering sequence descriptors from each `__turso_internal_seq_*`
+    /// backing table via SQL (or grafting the VACUUM-preserved map). The
+    /// per-backing-table descriptor read yields IO, so the worklist and the
+    /// in-flight statement are carried across re-entry here.
+    PopulateSequences {
+        /// `(backing_table_name, seq_name)` worklist; `None` until lazily
+        /// computed. Left empty when preserved sequences are grafted.
+        pending: Option<Vec<(String, String)>>,
+        /// Index of the backing table currently being read.
+        idx: usize,
+        /// In-flight descriptor `SELECT`, created lazily per backing table.
+        stmt: Option<Box<Statement>>,
+        /// Descriptor row `(start, inc, min, max, cycle)` captured from `stmt`.
+        meta: Option<(i64, i64, i64, i64, bool)>,
+    },
+    /// Loading custom type definitions from the internal types table.
+    LoadTypes {
+        stmt: Box<Statement>,
+        type_rows: Vec<String>,
+    },
+    /// Best-effort ANALYZE-stats refresh before finalizing.
+    RefreshStats {
+        stats: crate::stats::RefreshAnalyzeStatsState,
+    },
+}
+
+/// Re-entrant driver state for
+/// [`Connection::load_sequence_descriptors_via_sql_nonblock`]. Walks every
+/// `__turso_internal_seq_*` backing table and registers its descriptor,
+/// carrying the worklist and the in-flight descriptor read across IO yields.
+#[derive(Default)]
+pub(crate) enum LoadSequenceDescriptorsState {
+    #[default]
+    Start,
+    Reading {
+        /// `(backing_table_name, seq_name)` worklist captured from the schema.
+        pending: Vec<(String, String)>,
+        /// Index of the backing table currently being read.
+        idx: usize,
+        /// In-flight descriptor `SELECT`, created lazily per backing table.
+        stmt: Option<Box<Statement>>,
+        /// Descriptor row `(start, inc, min, max, cycle)` captured from `stmt`.
+        meta: Option<(i64, i64, i64, i64, bool)>,
+    },
+}
+
+/// Re-entrant driver state for
+/// [`Connection::sync_autoincrement_backing_tables_from_sqlite_sequence_nonblock`].
+#[derive(Default)]
+pub(crate) enum SyncAutoincrementState {
+    #[default]
+    Start,
+    /// Reading all `(name, seq)` rows from `sqlite_sequence`.
+    ReadSeqRows {
+        stmt: Box<Statement>,
+        rows: Vec<(String, i64)>,
+    },
+    /// Per-table: read the backing `MAX(value)` then maybe upsert a watermark.
+    Process {
+        rows: Vec<(String, i64)>,
+        idx: usize,
+        sub: SyncRowStep,
+    },
+}
+
+/// Per-row sub-state of [`SyncAutoincrementState::Process`].
+#[derive(Default)]
+enum SyncRowStep {
+    /// Resolve `rows[idx]`'s backing table and start reading `MAX(value)`.
+    #[default]
+    Start,
+    /// Reading `MAX(value)` from the backing table.
+    ReadMax {
+        backing_table_name: String,
+        stmt: Box<Statement>,
+        current_max: Option<i64>,
+    },
+    /// Running the `INSERT OR REPLACE` watermark upsert.
+    Upsert {
+        stmt: Box<Statement>,
+    },
 }
 
 /// Database connection handle.
@@ -989,10 +1104,14 @@ impl Connection {
         Ok(())
     }
 
+    /// Blocking shim: drives [`Self::reparse_schema_nonblock`] to completion.
+    /// Retained for the many synchronous callers (statement reprepare, attach,
+    /// extension load, vacuum). The genuinely non-blocking callers (MVCC
+    /// bootstrap, the open-db state machine) drive `*_nonblock` directly.
     pub(crate) fn reparse_schema(self: &Arc<Connection>) -> Result<()> {
-        // read cookie before consuming statement program - otherwise we can end up reading cookie with closed transaction state
-        let cookie = self.read_current_schema_cookie()?;
-        self.reparse_schema_with_cookie(cookie)
+        let io = self.pager.load().io.clone();
+        let mut state = ReparseSchemaState::default();
+        io.block(|| self.reparse_schema_nonblock(&mut state))
     }
 
     /// VACUUM-only reparse that grafts a caller-supplied sequence-
@@ -1002,29 +1121,79 @@ impl Connection {
     /// page locations change — so the source connection's pre-VACUUM
     /// sequences map is still valid for the post-VACUUM image.
     ///
-    /// This variant exists because the standard `reparse_schema_with_cookie`
-    /// runs `populate_sequences_via_sql` (which drives a SELECT via
-    /// `prepare_internal + run_with_row_callback`) — the surrounding
-    /// statement-execution loop is fine in any normal caller, but
-    /// VACUUM's state machine cannot host a nested statement.
+    /// Blocking shim: VACUUM runs through the VDBE stepping layer (which
+    /// does not thread IO out), so it drives the non-blocking reparse to
+    /// completion here, seeding the `PopulateSequences` phase with the
+    /// preserved map so it grafts rather than re-reading each backing table.
     pub(crate) fn reparse_schema_with_cookie_keeping_sequences(
         self: &Arc<Connection>,
         cookie: u32,
         sequences: rustc_hash::FxHashMap<String, Arc<crate::schema::Sequence>>,
     ) -> Result<()> {
-        self.reparse_schema_inner(cookie, Some(sequences))
+        let io = self.pager.load().io.clone();
+        let mut state = ReparseSchemaState::default();
+        // `init_reparse_building` consumes the preserved map exactly once, on
+        // the first (Start) invocation; `io.block` re-invokes the closure on
+        // every IO completion, so `take()` yields `Some` only that first time.
+        let mut preserved = Some(sequences);
+        io.block(|| {
+            if matches!(state, ReparseSchemaState::Start) {
+                state = ReparseSchemaState::Building(Box::new(
+                    self.init_reparse_building(cookie, preserved.take())?,
+                ));
+            }
+            self.drive_reparse_building(&mut state)
+        })
     }
 
+    /// Non-blocking schema reparse. Reads the current schema cookie, then drives
+    /// the schema rebuild via the shared [`ReparseSchemaState`].
+    pub(crate) fn reparse_schema_nonblock(
+        self: &Arc<Connection>,
+        state: &mut ReparseSchemaState,
+    ) -> Result<crate::types::IOResult<()>> {
+        use crate::types::IOResult;
+        if matches!(state, ReparseSchemaState::Start) {
+            // read cookie before consuming statement program - otherwise we can
+            // end up reading cookie with closed transaction state
+            let cookie = crate::return_if_io!(self.read_current_schema_cookie_nonblock());
+            *state =
+                ReparseSchemaState::Building(Box::new(self.init_reparse_building(cookie, None)?));
+        }
+        self.drive_reparse_building(state)
+    }
+
+    /// Blocking shim for callers that already hold the cookie.
     pub(crate) fn reparse_schema_with_cookie(self: &Arc<Connection>, cookie: u32) -> Result<()> {
-        self.reparse_schema_inner(cookie, None)
+        let io = self.pager.load().io.clone();
+        let mut state = ReparseSchemaState::default();
+        io.block(|| self.reparse_schema_with_cookie_nonblock(cookie, &mut state))
     }
 
-    fn reparse_schema_inner(
+    /// Non-blocking reparse starting from a known cookie.
+    pub(crate) fn reparse_schema_with_cookie_nonblock(
+        self: &Arc<Connection>,
+        cookie: u32,
+        state: &mut ReparseSchemaState,
+    ) -> Result<crate::types::IOResult<()>> {
+        if matches!(state, ReparseSchemaState::Start) {
+            *state =
+                ReparseSchemaState::Building(Box::new(self.init_reparse_building(cookie, None)?));
+        }
+        self.drive_reparse_building(state)
+    }
+
+    /// Synchronous setup shared by the reparse entry points: install the cookie,
+    /// build a fresh schema, capture table-valued functions, install the empty
+    /// schema (the reprepare hack), and prepare the sqlite_schema scan.
+    /// `preserved_sequences` is `Some` only for VACUUM, which grafts the map in
+    /// the `PopulateSequences` phase instead of re-reading the backing tables.
+    fn init_reparse_building(
         self: &Arc<Connection>,
         cookie: u32,
         preserved_sequences: Option<rustc_hash::FxHashMap<String, Arc<crate::schema::Sequence>>>,
-    ) -> Result<()> {
-        let _reparse_guard = self.schema_reparse_guard();
+    ) -> Result<ReparseSchemaInner> {
+        let guard = self.schema_reparse_guard();
         self.pager.load().set_schema_cookie(Some(cookie));
         // create fresh schema as some objects can be deleted
         let mut fresh = Schema::with_options(self.experimental_custom_types_enabled())?;
@@ -1034,21 +1203,20 @@ impl Connection {
         // Capture built-in table-valued functions (e.g. generate_series, json_each)
         // before dropping the old schema. These are registered programmatically and
         // don't survive re-parsing from sqlite_schema alone.
-        let table_valued_functions = {
-            let schema = self.schema.read();
-            schema
-                .tables
-                .values()
-                .filter_map(|table| match table.as_ref() {
-                    crate::schema::Table::Virtual(vtab)
-                        if matches!(vtab.kind, turso_ext::VTabKind::TableValuedFunction) =>
-                    {
-                        Some(vtab.clone())
-                    }
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-        };
+        let tvfs: Vec<Arc<crate::vtab::VirtualTable>> = self
+            .schema
+            .read()
+            .tables
+            .values()
+            .filter_map(|table| match table.as_ref() {
+                crate::schema::Table::Virtual(vtab)
+                    if matches!(vtab.kind, turso_ext::VTabKind::TableValuedFunction) =>
+                {
+                    Some(vtab.clone())
+                }
+                _ => None,
+            })
+            .collect();
 
         // TODO: this is hack to avoid a cyclical problem with schema reprepare
         // The problem here is that we prepare a statement here, but when the statement tries
@@ -1067,89 +1235,197 @@ impl Connection {
         } else {
             self.get_mv_tx()
         };
-        // Resolver so attached-db qualifiers in temp triggers can be
-        // mapped to their actual index on this connection (Phase 1.4c).
-        let attached_resolver = |name: &str| -> Option<usize> {
-            self.attached_databases
-                .read()
-                .get_database_by_name(&crate::util::normalize_ident(name))
-                .map(|(idx, _)| idx)
-        };
-        // TODO: This function below is synchronous, make it async
-        parse_schema_rows(
-            stmt,
-            &mut fresh,
-            &self.syms.read(),
-            mv_tx,
-            &attached_resolver,
-        )?;
+        Ok(ReparseSchemaInner {
+            _guard: guard,
+            fresh,
+            tvfs,
+            preserved_sequences,
+            phase: ReparsePhase::ParseSchema {
+                parse: Box::new(crate::util::ParseSchemaRowsState::new(stmt, mv_tx)),
+            },
+        })
+    }
 
-        // Rehydrate built-in table-valued functions that were captured above.
-        for vtab in &table_valued_functions {
-            let normalized = crate::util::normalize_ident(&vtab.name);
-            fresh
-                .tables
-                .entry(normalized)
-                .or_insert_with(|| Arc::new(crate::schema::Table::Virtual(vtab.clone())));
-        }
+    /// Drive the schema-rebuild phases held in `state` (must be `Building`).
+    /// Yields IO; on completion installs the finished schema and resets `state`.
+    fn drive_reparse_building(
+        self: &Arc<Connection>,
+        state: &mut ReparseSchemaState,
+    ) -> Result<crate::types::IOResult<()>> {
+        use crate::types::IOResult;
+        loop {
+            let ReparseSchemaState::Building(inner) = state else {
+                unreachable!("drive_reparse_building requires Building state");
+            };
+            match &mut inner.phase {
+                ReparsePhase::ParseSchema { parse } => {
+                    // Resolver so attached-db qualifiers in temp triggers can be
+                    // mapped to their actual index on this connection.
+                    let attached_resolver = |name: &str| -> Option<usize> {
+                        self.attached_databases
+                            .read()
+                            .get_database_by_name(&crate::util::normalize_ident(name))
+                            .map(|(idx, _)| idx)
+                    };
+                    crate::return_if_io!(crate::util::parse_schema_rows(
+                        parse,
+                        &mut inner.fresh,
+                        &self.syms.read(),
+                        &attached_resolver,
+                    ));
 
-        // Sequence descriptors: either graft a caller-supplied map or
-        // walk every backing table via SQL and recover its descriptor.
-        // The caller-supplied path is used by VACUUM, which preserves
-        // every sequence's definition (only physical page locations
-        // change). The SQL path runs through the normal statement
-        // execution helpers, so it cannot regress the engine's
-        // async-IO contract — no `io.block` / `wait_for_completion`.
-        match preserved_sequences {
-            Some(sequences) => {
-                fresh.sequences = sequences;
-                self.with_schema_mut(|schema| {
-                    *schema = fresh.clone();
-                });
+                    // Rehydrate built-in table-valued functions captured at init.
+                    for vtab in &inner.tvfs {
+                        let normalized = crate::util::normalize_ident(&vtab.name);
+                        inner.fresh.tables.entry(normalized).or_insert_with(|| {
+                            Arc::new(crate::schema::Table::Virtual(vtab.clone()))
+                        });
+                    }
+
+                    // Next: recover sequence descriptors (or graft the VACUUM map).
+                    inner.phase = ReparsePhase::PopulateSequences {
+                        pending: None,
+                        idx: 0,
+                        stmt: None,
+                        meta: None,
+                    };
+                }
+                ReparsePhase::PopulateSequences {
+                    pending,
+                    idx,
+                    stmt,
+                    meta,
+                } => {
+                    // Lazy init: graft the VACUUM-preserved descriptor map, or
+                    // compute the worklist of backing tables to read from disk.
+                    // When there is real work, install `fresh` first so the
+                    // descriptor SELECTs can resolve the backing tables.
+                    if pending.is_none() {
+                        if let Some(sequences) = inner.preserved_sequences.take() {
+                            inner.fresh.sequences = sequences;
+                            *pending = Some(Vec::new());
+                        } else {
+                            let work = inner.fresh.sequence_backing_table_names();
+                            if !work.is_empty() {
+                                self.with_schema_mut(|schema| {
+                                    *schema = inner.fresh.clone();
+                                });
+                            }
+                            *pending = Some(work);
+                        }
+                    }
+
+                    // Read each remaining backing table's descriptor row. The
+                    // backing table is internal; a missing/unreadable descriptor
+                    // row is on-disk corruption (not "sequence missing"), so any
+                    // failure surfaces as `Corrupt` and fails the open rather than
+                    // silently dropping the sequence.
+                    loop {
+                        let entry = {
+                            let work = pending.as_ref().expect("pending initialized above");
+                            if *idx >= work.len() {
+                                break;
+                            }
+                            work[*idx].clone()
+                        };
+                        let (backing_table_name, seq_name) = entry;
+                        let normalized = crate::util::normalize_ident(&seq_name);
+                        if inner.fresh.sequences.contains_key(&normalized) {
+                            *idx += 1;
+                            *stmt = None;
+                            continue;
+                        }
+                        crate::return_if_io!(self.read_seq_descriptor_row_nonblock(
+                            &backing_table_name,
+                            &seq_name,
+                            stmt,
+                            meta,
+                        ));
+                        let seq = Self::sequence_from_descriptor_meta(
+                            &seq_name,
+                            &backing_table_name,
+                            *meta,
+                        )?;
+                        inner.fresh.sequences.insert(normalized, Arc::new(seq));
+                        *idx += 1;
+                        *stmt = None;
+                    }
+
+                    // Decide whether to load custom types next.
+                    if self.experimental_custom_types_enabled()
+                        && inner
+                            .fresh
+                            .tables
+                            .contains_key(crate::schema::TURSO_TYPES_TABLE_NAME)
+                    {
+                        // Temporarily install the schema so we can query against it.
+                        self.with_schema_mut(|schema| {
+                            *schema = inner.fresh.clone();
+                        });
+                        let stmt = self.prepare_internal(format!(
+                            "SELECT name, sql FROM {}",
+                            crate::schema::TURSO_TYPES_TABLE_NAME
+                        ))?;
+                        inner.phase = ReparsePhase::LoadTypes {
+                            stmt: Box::new(stmt),
+                            type_rows: Vec::new(),
+                        };
+                    } else {
+                        inner.phase = ReparsePhase::RefreshStats {
+                            stats: Default::default(),
+                        };
+                    }
+                }
+                ReparsePhase::LoadTypes { stmt, type_rows } => {
+                    // Type loading is best-effort: log and continue on error.
+                    let scan = (|| -> Result<IOResult<()>> {
+                        crate::return_if_io!(stmt.run_with_row_callback_nonblock(|row| {
+                            type_rows.push(row.get::<&str>(1)?.to_string());
+                            Ok(())
+                        }));
+                        Ok(IOResult::Done(()))
+                    })();
+                    match scan {
+                        Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
+                        Ok(IOResult::Done(())) => {
+                            let type_rows = std::mem::take(type_rows);
+                            if let Err(e) = inner.fresh.load_type_definitions(&type_rows) {
+                                tracing::warn!("Failed to load custom types: {}", e);
+                            }
+                            inner.phase = ReparsePhase::RefreshStats {
+                                stats: Default::default(),
+                            };
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to load custom types: {}", e);
+                            inner.phase = ReparsePhase::RefreshStats {
+                                stats: Default::default(),
+                            };
+                        }
+                    }
+                }
+                ReparsePhase::RefreshStats { stats } => {
+                    // Best-effort load stats if sqlite_stat1 is present.
+                    crate::return_if_io!(crate::stats::refresh_analyze_stats_nonblock(self, stats));
+
+                    // Finalize: install the rebuilt schema. Take ownership so the
+                    // guard drops and `state` is reusable.
+                    let ReparseSchemaState::Building(inner) = std::mem::take(state) else {
+                        unreachable!("state is Building");
+                    };
+                    let fresh = inner.fresh;
+                    tracing::debug!(
+                        "reparse_schema: schema_version={}, tables={:?}",
+                        fresh.schema_version,
+                        fresh.tables.keys()
+                    );
+                    self.with_schema_mut(|schema| {
+                        *schema = fresh;
+                    });
+                    return Ok(IOResult::Done(()));
+                }
             }
-            None => {
-                self.with_schema_mut(|schema| {
-                    *schema = fresh.clone();
-                });
-                self.populate_sequences_via_sql(&mut fresh)?;
-                self.with_schema_mut(|schema| schema.sequences.clone_from(&fresh.sequences));
-            }
         }
-
-        // Load custom types from __turso_internal_types if the table exists
-        // and custom types are enabled. Type loading errors are non-fatal: we log
-        // warnings and continue with whatever types loaded successfully.
-        if self.experimental_custom_types_enabled()
-            && fresh
-                .tables
-                .contains_key(crate::schema::TURSO_TYPES_TABLE_NAME)
-        {
-            // Temporarily install the schema so we can prepare a query against it
-            self.with_schema_mut(|schema| {
-                *schema = fresh.clone();
-            });
-            let load_result: Result<()> = (|| {
-                let type_sqls = self.query_stored_type_definitions()?;
-                fresh.load_type_definitions(&type_sqls)?;
-                Ok(())
-            })();
-            if let Err(e) = load_result {
-                tracing::warn!("Failed to load custom types: {}", e);
-            }
-        }
-
-        // Best-effort load stats if sqlite_stat1 is present and DB is initialized.
-        refresh_analyze_stats(self);
-
-        tracing::debug!(
-            "reparse_schema: schema_version={}, tables={:?}",
-            fresh.schema_version,
-            fresh.tables.keys()
-        );
-        self.with_schema_mut(|schema| {
-            *schema = fresh;
-        });
-        Result::Ok(())
     }
 
     pub(crate) fn read_current_schema_cookie(&self) -> Result<u32> {
@@ -1162,6 +1438,25 @@ impl Connection {
                 .io
                 .block(|| pager.with_header(|header| header.schema_cookie))
                 .map(|cookie| cookie.get())
+        }
+    }
+
+    /// Non-blocking variant of [`Self::read_current_schema_cookie`]. The MVCC
+    /// path reads an in-memory header (never yields); the pager path may yield
+    /// while reading page 1. Idempotent across re-entry.
+    pub(crate) fn read_current_schema_cookie_nonblock(
+        &self,
+    ) -> Result<crate::types::IOResult<u32>> {
+        use crate::types::IOResult;
+        if let Some(mv_store) = self.mv_store().as_ref() {
+            let tx_id = self.get_mv_tx_id();
+            let cookie =
+                mv_store.with_header(|header| header.schema_cookie.get(), tx_id.as_ref())?;
+            Ok(crate::types::IOResult::Done(cookie))
+        } else {
+            let pager = self.pager.load();
+            let cookie = crate::return_if_io!(pager.with_header(|header| header.schema_cookie));
+            Ok(crate::types::IOResult::Done(cookie.get()))
         }
     }
 
@@ -3078,69 +3373,136 @@ impl Connection {
     }
 
     /// Bootstrap-time sequence descriptor loader. Used by MVCC bootstrap
-    /// after log recovery and by ATTACH: walks `__turso_internal_seq_*`
-    /// tables and registers a pure descriptor for each into the active
-    /// schema. No atomic state is seeded — the runtime watermark is
-    /// always read from disk by nextval/setval.
-    pub(crate) fn load_sequence_descriptors_via_sql(self: &Arc<Connection>) -> Result<()> {
-        // Walk schema.tables in-memory rather than issuing a SELECT against
-        // sqlite_master — avoids the side-effects of running a fresh
-        // statement here, which can leave the connection's mv_tx in a
-        // non-exclusive state and cause the next DDL to trip the
-        // exclusive-tx guard in op_open_write.
-        let backing_tables = self.with_schema(MAIN_DB_ID, |s| s.sequence_backing_table_names());
-        for (backing_table_name, seq_name) in backing_tables {
-            let normalized = crate::util::normalize_ident(&seq_name);
-            let already_present =
-                self.with_schema(MAIN_DB_ID, |s| s.get_sequence(&normalized).is_some());
-            if already_present {
-                continue;
+    /// after log recovery: walks `__turso_internal_seq_*` tables and registers
+    /// a pure descriptor for each into the active schema. No atomic state is
+    /// seeded — the runtime watermark is always read from disk by
+    /// nextval/setval.
+    ///
+    /// Non-blocking: driven by the bootstrap state machine via `return_if_io!`,
+    /// so the per-backing-table descriptor read yields IO rather than pumping
+    /// `io.step()`. Re-entrant — the worklist and in-flight read live in
+    /// `state`.
+    pub(crate) fn load_sequence_descriptors_via_sql_nonblock(
+        self: &Arc<Connection>,
+        state: &mut LoadSequenceDescriptorsState,
+    ) -> Result<crate::types::IOResult<()>> {
+        use crate::types::IOResult;
+        loop {
+            match state {
+                LoadSequenceDescriptorsState::Start => {
+                    // Walk schema.tables in-memory rather than issuing a SELECT
+                    // against sqlite_master — avoids the side-effects of running
+                    // a fresh statement here, which can leave the connection's
+                    // mv_tx in a non-exclusive state and cause the next DDL to
+                    // trip the exclusive-tx guard in op_open_write.
+                    let pending =
+                        self.with_schema(MAIN_DB_ID, |s| s.sequence_backing_table_names());
+                    *state = LoadSequenceDescriptorsState::Reading {
+                        pending,
+                        idx: 0,
+                        stmt: None,
+                        meta: None,
+                    };
+                }
+                LoadSequenceDescriptorsState::Reading {
+                    pending,
+                    idx,
+                    stmt,
+                    meta,
+                } => loop {
+                    let entry = {
+                        if *idx >= pending.len() {
+                            return Ok(IOResult::Done(()));
+                        }
+                        pending[*idx].clone()
+                    };
+                    let (backing_table_name, seq_name) = entry;
+                    let normalized = crate::util::normalize_ident(&seq_name);
+                    let already_present =
+                        self.with_schema(MAIN_DB_ID, |s| s.get_sequence(&normalized).is_some());
+                    if already_present {
+                        *idx += 1;
+                        *stmt = None;
+                        continue;
+                    }
+                    crate::return_if_io!(self.read_seq_descriptor_row_nonblock(
+                        &backing_table_name,
+                        &seq_name,
+                        stmt,
+                        meta,
+                    ));
+                    let seq =
+                        Self::sequence_from_descriptor_meta(&seq_name, &backing_table_name, *meta)?;
+                    self.with_database_schema_mut(MAIN_DB_ID, |schema| {
+                        schema.sequences.insert(normalized.clone(), Arc::new(seq));
+                    });
+                    *idx += 1;
+                    *stmt = None;
+                },
             }
-            let seq = self.read_sequence_descriptor_via_sql(&backing_table_name, &seq_name)?;
-            self.with_database_schema_mut(MAIN_DB_ID, |schema| {
-                schema.sequences.insert(normalized.clone(), Arc::new(seq));
-            });
         }
-        Ok(())
     }
 
-    /// Read the descriptor (start/inc/min/max/cycle) of a single sequence
-    /// from its backing-table first row. The backing table is internal
-    /// (`__turso_internal_seq_*`); a missing or malformed descriptor row
-    /// is on-disk corruption, not "the sequence doesn't exist", so this
-    /// surfaces `LimboError::Corrupt` on any failure — silently dropping
-    /// the sequence would manifest as a misleading "sequence does not
-    /// exist" error on the next nextval that masks the real problem.
-    fn read_sequence_descriptor_via_sql(
+    /// Drive one backing-table descriptor read to completion (re-entrant).
+    /// Lazily prepares the `SELECT` into `*stmt`, then runs it non-blocking,
+    /// stashing the captured row in `*meta`. The backing table is internal
+    /// (`__turso_internal_seq_*`); a prepare/read failure is on-disk
+    /// corruption, not "the sequence doesn't exist", so it surfaces
+    /// `LimboError::Corrupt` — silently dropping the sequence would manifest
+    /// as a misleading "sequence does not exist" error on the next nextval
+    /// that masks the real problem.
+    fn read_seq_descriptor_row_nonblock(
         self: &Arc<Connection>,
         backing_table_name: &str,
         seq_name: &str,
-    ) -> Result<crate::schema::Sequence> {
-        let escaped = backing_table_name.replace('"', "\"\"");
-        let sql = format!("SELECT start, inc, min, max, cycle FROM \"{escaped}\" LIMIT 1");
-        let mut stmt = self.prepare_internal(sql).map_err(|err| {
-            LimboError::Corrupt(format!(
-                "internal sequence backing table \"{backing_table_name}\" for sequence \
-                 \"{seq_name}\": cannot prepare descriptor SELECT: {err}"
-            ))
-        })?;
-        let mut metadata: Option<(i64, i64, i64, i64, bool)> = None;
-        stmt.run_with_row_callback(|row| {
-            let start = row.get::<i64>(0)?;
-            let inc = row.get::<i64>(1)?;
-            let min = row.get::<i64>(2)?;
-            let max = row.get::<i64>(3)?;
-            let cycle = row.get::<i64>(4)? != 0;
-            metadata = Some((start, inc, min, max, cycle));
+        stmt: &mut Option<Box<Statement>>,
+        meta: &mut Option<(i64, i64, i64, i64, bool)>,
+    ) -> Result<crate::types::IOResult<()>> {
+        use crate::types::IOResult;
+        if stmt.is_none() {
+            let escaped = backing_table_name.replace('"', "\"\"");
+            let sql = format!("SELECT start, inc, min, max, cycle FROM \"{escaped}\" LIMIT 1");
+            let prepared = self.prepare_internal(sql).map_err(|err| {
+                LimboError::Corrupt(format!(
+                    "internal sequence backing table \"{backing_table_name}\" for sequence \
+                     \"{seq_name}\": cannot prepare descriptor SELECT: {err}"
+                ))
+            })?;
+            *stmt = Some(Box::new(prepared));
+            // Fresh statement → clear any descriptor captured for a prior backing
+            // table, so an empty backing table is detected as missing-row
+            // corruption rather than silently reusing the previous descriptor.
+            *meta = None;
+        }
+        let s = stmt.as_mut().expect("stmt set above");
+        match s.run_with_row_callback_nonblock(|row| {
+            *meta = Some((
+                row.get::<i64>(0)?,
+                row.get::<i64>(1)?,
+                row.get::<i64>(2)?,
+                row.get::<i64>(3)?,
+                row.get::<i64>(4)? != 0,
+            ));
             Ok(())
-        })
-        .map_err(|err| {
-            LimboError::Corrupt(format!(
+        }) {
+            Ok(IOResult::IO(io)) => Ok(IOResult::IO(io)),
+            Ok(IOResult::Done(())) => Ok(IOResult::Done(())),
+            Err(err) => Err(LimboError::Corrupt(format!(
                 "internal sequence backing table \"{backing_table_name}\" for sequence \
                  \"{seq_name}\": descriptor row read failed: {err}"
-            ))
-        })?;
-        let (start, inc, min, max, cycle) = metadata.ok_or_else(|| {
+            ))),
+        }
+    }
+
+    /// Build a `Sequence` from a descriptor row captured by
+    /// [`Self::read_seq_descriptor_row_nonblock`]. An absent/invalid descriptor
+    /// is on-disk corruption (see that method's doc).
+    fn sequence_from_descriptor_meta(
+        seq_name: &str,
+        backing_table_name: &str,
+        meta: Option<(i64, i64, i64, i64, bool)>,
+    ) -> Result<crate::schema::Sequence> {
+        let (start, inc, min, max, cycle) = meta.ok_or_else(|| {
             LimboError::Corrupt(format!(
                 "internal sequence backing table \"{backing_table_name}\" for sequence \
                  \"{seq_name}\" is empty; the descriptor metadata row must always be present"
@@ -3185,104 +3547,129 @@ impl Connection {
     /// the DB), and synthesising a backing table here would forge data
     /// the user did not author. Importing a foreign SQLite database is
     /// out of scope for this helper.
-    pub(crate) fn sync_autoincrement_backing_tables_from_sqlite_sequence(
+    ///
+    /// Non-blocking: driven by the bootstrap state machine via `return_if_io!`.
+    /// Each step is on the correctness path documented above — a silent failure
+    /// leaves MVCC AUTOINCREMENT able to re-emit a rowid already in use after a
+    /// WAL→MVCC mode switch, so errors propagate to fail the open rather than
+    /// continue into a state where the next INSERT NULL collides on disk.
+    pub(crate) fn sync_autoincrement_backing_tables_from_sqlite_sequence_nonblock(
         self: &Arc<Connection>,
-    ) -> Result<()> {
+        state: &mut SyncAutoincrementState,
+    ) -> Result<crate::types::IOResult<()>> {
         use crate::schema::{autoincrement_sequence_name, SQLITE_SEQUENCE_TABLE_NAME};
         use crate::translate::sequence::sequence_backing_table_name;
+        use crate::types::IOResult;
 
-        let has_seq_table = self.with_schema(MAIN_DB_ID, |s| {
-            s.get_btree_table(SQLITE_SEQUENCE_TABLE_NAME).is_some()
-        });
-        if !has_seq_table {
-            return Ok(());
-        }
-
-        // Each step here is on the correctness path documented above —
-        // a silent failure leaves MVCC AUTOINCREMENT able to re-emit a
-        // rowid already in use after a WAL→MVCC mode switch. Propagate
-        // the errors so the bootstrap caller can fail the open rather
-        // than continue into a state where the next INSERT NULL
-        // collides on disk.
-        let mut rows: Vec<(String, i64)> = Vec::new();
-        let mut stmt = self.prepare_internal(format!(
-            "SELECT name, seq FROM {SQLITE_SEQUENCE_TABLE_NAME}"
-        ))?;
-        stmt.run_with_row_callback(|row| {
-            let name = row.get::<&str>(0)?.to_string();
-            let seq = row.get::<i64>(1)?;
-            rows.push((name, seq));
-            Ok(())
-        })?;
-
-        for (table_name, watermark) in rows {
-            let backing_table_name =
-                sequence_backing_table_name(&autoincrement_sequence_name(&table_name));
-            let has_backing = self.with_schema(MAIN_DB_ID, |s| {
-                s.get_btree_table(&backing_table_name).is_some()
-            });
-            if !has_backing {
-                continue;
-            }
-            let escaped = backing_table_name.replace('"', "\"\"");
-            // Read current backing watermark; only insert if we'd actually
-            // be advancing it (avoids unnecessary writes on every boot).
-            let mut current_max: Option<i64> = None;
-            let mut read_stmt =
-                self.prepare_internal(format!("SELECT MAX(value) FROM \"{escaped}\""))?;
-            read_stmt.run_with_row_callback(|row| {
-                if let crate::Value::Numeric(crate::Numeric::Integer(v)) = row.get_value(0) {
-                    current_max = Some(*v);
+        loop {
+            match state {
+                SyncAutoincrementState::Start => {
+                    let has_seq_table = self.with_schema(MAIN_DB_ID, |s| {
+                        s.get_btree_table(SQLITE_SEQUENCE_TABLE_NAME).is_some()
+                    });
+                    if !has_seq_table {
+                        return Ok(IOResult::Done(()));
+                    }
+                    let stmt = self
+                        .prepare_internal(format!("SELECT name, seq FROM {SQLITE_SEQUENCE_TABLE_NAME}"))?;
+                    *state = SyncAutoincrementState::ReadSeqRows {
+                        stmt: Box::new(stmt),
+                        rows: Vec::new(),
+                    };
                 }
-                Ok(())
-            })?;
-            // Skip only when the backing table is already strictly ahead;
-            // an equal value is NOT enough because the initial row written
-            // by CREATE TABLE bytecode is (value=1, is_called=false), which
-            // would cause the next nextval to re-emit value=1 and collide
-            // with the rowid that was already inserted in WAL mode. We
-            // always upsert here with is_called=1 so the next nextval
-            // computes watermark+1 like sqlite_sequence semantics demand.
-            if matches!(current_max, Some(c) if c > watermark) {
-                continue;
+                SyncAutoincrementState::ReadSeqRows { stmt, rows } => {
+                    crate::return_if_io!(stmt.run_with_row_callback_nonblock(|row| {
+                        let name = row.get::<&str>(0)?.to_string();
+                        let seq = row.get::<i64>(1)?;
+                        rows.push((name, seq));
+                        Ok(())
+                    }));
+                    let rows = std::mem::take(rows);
+                    *state = SyncAutoincrementState::Process {
+                        rows,
+                        idx: 0,
+                        sub: SyncRowStep::Start,
+                    };
+                }
+                SyncAutoincrementState::Process { rows, idx, sub } => {
+                    if *idx >= rows.len() {
+                        return Ok(IOResult::Done(()));
+                    }
+                    match sub {
+                        SyncRowStep::Start => {
+                            let backing_table_name = sequence_backing_table_name(
+                                &autoincrement_sequence_name(&rows[*idx].0),
+                            );
+                            let has_backing = self.with_schema(MAIN_DB_ID, |s| {
+                                s.get_btree_table(&backing_table_name).is_some()
+                            });
+                            if !has_backing {
+                                *idx += 1;
+                                continue;
+                            }
+                            // Read current backing watermark; only upsert if we'd
+                            // actually advance it (avoids needless writes on boot).
+                            let escaped = backing_table_name.replace('"', "\"\"");
+                            let stmt = self
+                                .prepare_internal(format!("SELECT MAX(value) FROM \"{escaped}\""))?;
+                            *sub = SyncRowStep::ReadMax {
+                                backing_table_name,
+                                stmt: Box::new(stmt),
+                                current_max: None,
+                            };
+                        }
+                        SyncRowStep::ReadMax {
+                            backing_table_name,
+                            stmt,
+                            current_max,
+                        } => {
+                            crate::return_if_io!(stmt.run_with_row_callback_nonblock(|row| {
+                                if let crate::Value::Numeric(crate::Numeric::Integer(v)) =
+                                    row.get_value(0)
+                                {
+                                    *current_max = Some(*v);
+                                }
+                                Ok(())
+                            }));
+                            let watermark = rows[*idx].1;
+                            // Skip only when the backing table is already strictly
+                            // ahead; an equal value is NOT enough because the
+                            // initial row written by CREATE TABLE bytecode is
+                            // (value=1, is_called=false), which would cause the
+                            // next nextval to re-emit value=1 and collide with the
+                            // rowid already inserted in WAL mode. We always upsert
+                            // with is_called=1 so the next nextval computes
+                            // watermark+1 like sqlite_sequence semantics demand.
+                            if matches!(*current_max, Some(c) if c > watermark) {
+                                *idx += 1;
+                                *sub = SyncRowStep::Start;
+                                continue;
+                            }
+                            // Standard AUTOINCREMENT descriptor columns (start=1,
+                            // inc=1, min=1, max=i64::MAX, cycle=0) — mirror what
+                            // the translator emits when CREATE TABLE bytecode
+                            // creates the backing table for an AUTOINCREMENT column.
+                            let escaped = backing_table_name.replace('"', "\"\"");
+                            let insert_sql = format!(
+                                "INSERT OR REPLACE INTO \"{escaped}\"\
+                                 (value, is_called, start, inc, min, max, cycle) \
+                                 VALUES ({watermark}, 1, 1, 1, 1, {}, 0)",
+                                i64::MAX
+                            );
+                            let stmt = self.prepare_internal(insert_sql)?;
+                            *sub = SyncRowStep::Upsert {
+                                stmt: Box::new(stmt),
+                            };
+                        }
+                        SyncRowStep::Upsert { stmt } => {
+                            crate::return_if_io!(stmt.run_with_row_callback_nonblock(|_| Ok(())));
+                            *idx += 1;
+                            *sub = SyncRowStep::Start;
+                        }
+                    }
+                }
             }
-            // Standard AUTOINCREMENT descriptor columns (start=1, inc=1,
-            // min=1, max=i64::MAX, cycle=0) — these mirror what the
-            // translator emits when CREATE TABLE bytecode creates the
-            // backing table for an AUTOINCREMENT column.
-            let insert_sql = format!(
-                "INSERT OR REPLACE INTO \"{escaped}\"\
-                 (value, is_called, start, inc, min, max, cycle) \
-                 VALUES ({watermark}, 1, 1, 1, 1, {}, 0)",
-                i64::MAX
-            );
-            let mut insert_stmt = self.prepare_internal(insert_sql)?;
-            insert_stmt.run_with_row_callback(|_| Ok(()))?;
         }
-
-        Ok(())
-    }
-
-    /// SQL-based fallback for sequence-descriptor reconstruction. The
-    /// pager-backed `Schema::populate_sequences` only sees checkpointed
-    /// pages; under MVCC, backing tables created within still-uncommitted-
-    /// to-pager transactions live in the MVCC layer with negative root
-    /// page identifiers that the pager cannot read. This function walks
-    /// every `__turso_internal_seq_*` table in the schema and issues a
-    /// SELECT through the normal query path (which goes through MVCC),
-    /// reading one row to recover the immutable descriptor
-    /// (start/inc/min/max/cycle). The runtime watermark is never read
-    /// here — it's always fetched on demand by nextval.
-    fn populate_sequences_via_sql(self: &Arc<Connection>, fresh: &mut Schema) -> Result<()> {
-        for (backing_table_name, seq_name) in fresh.sequence_backing_table_names() {
-            let normalized = crate::util::normalize_ident(&seq_name);
-            if fresh.sequences.contains_key(&normalized) {
-                continue;
-            }
-            let seq = self.read_sequence_descriptor_via_sql(&backing_table_name, &seq_name)?;
-            fresh.sequences.insert(normalized, Arc::new(seq));
-        }
-        Ok(())
     }
 
     /// Create a `TempDir` honoring `TURSO_TMPDIR` and `SQLITE_TMPDIR`,

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -166,11 +166,12 @@ impl Drop for SchemaReparseGuard {
     }
 }
 
-/// Re-entrant state for [`Connection::reparse_schema`] /
-/// [`Connection::reparse_schema_with_cookie`]. `Start` is the fresh state
-/// (cookie not yet read / schema build not yet begun); `Building` carries the
-/// half-built schema, captured table-valued functions, the held reparse guard,
-/// and the current sub-phase across IO yields.
+/// Re-entrant state for [`Connection::reparse_schema_nonblock`] and the
+/// VACUUM-only [`Connection::reparse_schema_with_cookie_keeping_sequences`].
+/// `Start` is the fresh state (cookie not yet read / schema build not yet
+/// begun); `Building` carries the half-built schema, captured table-valued
+/// functions, the held reparse guard, and the current sub-phase across IO
+/// yields.
 #[derive(Default)]
 pub enum ReparseSchemaState {
     #[default]
@@ -229,7 +230,7 @@ enum ReparsePhase {
 /// `__turso_internal_seq_*` backing table and registers its descriptor,
 /// carrying the worklist and the in-flight descriptor read across IO yields.
 #[derive(Default)]
-pub(crate) enum LoadSequenceDescriptorsState {
+pub enum LoadSequenceDescriptorsState {
     #[default]
     Start,
     Reading {
@@ -247,7 +248,7 @@ pub(crate) enum LoadSequenceDescriptorsState {
 /// Re-entrant driver state for
 /// [`Connection::sync_autoincrement_backing_tables_from_sqlite_sequence_nonblock`].
 #[derive(Default)]
-pub(crate) enum SyncAutoincrementState {
+pub enum SyncAutoincrementState {
     #[default]
     Start,
     /// Reading all `(name, seq)` rows from `sqlite_sequence`.
@@ -265,7 +266,7 @@ pub(crate) enum SyncAutoincrementState {
 
 /// Per-row sub-state of [`SyncAutoincrementState::Process`].
 #[derive(Default)]
-enum SyncRowStep {
+pub enum SyncRowStep {
     /// Resolve `rows[idx]`'s backing table and start reading `MAX(value)`.
     #[default]
     Start,
@@ -276,9 +277,7 @@ enum SyncRowStep {
         current_max: Option<i64>,
     },
     /// Running the `INSERT OR REPLACE` watermark upsert.
-    Upsert {
-        stmt: Box<Statement>,
-    },
+    Upsert { stmt: Box<Statement> },
 }
 
 /// Database connection handle.
@@ -1157,26 +1156,6 @@ impl Connection {
             // read cookie before consuming statement program - otherwise we can
             // end up reading cookie with closed transaction state
             let cookie = crate::return_if_io!(self.read_current_schema_cookie_nonblock());
-            *state =
-                ReparseSchemaState::Building(Box::new(self.init_reparse_building(cookie, None)?));
-        }
-        self.drive_reparse_building(state)
-    }
-
-    /// Blocking shim for callers that already hold the cookie.
-    pub(crate) fn reparse_schema_with_cookie(self: &Arc<Connection>, cookie: u32) -> Result<()> {
-        let io = self.pager.load().io.clone();
-        let mut state = ReparseSchemaState::default();
-        io.block(|| self.reparse_schema_with_cookie_nonblock(cookie, &mut state))
-    }
-
-    /// Non-blocking reparse starting from a known cookie.
-    pub(crate) fn reparse_schema_with_cookie_nonblock(
-        self: &Arc<Connection>,
-        cookie: u32,
-        state: &mut ReparseSchemaState,
-    ) -> Result<crate::types::IOResult<()>> {
-        if matches!(state, ReparseSchemaState::Start) {
             *state =
                 ReparseSchemaState::Building(Box::new(self.init_reparse_building(cookie, None)?));
         }
@@ -3570,8 +3549,9 @@ impl Connection {
                     if !has_seq_table {
                         return Ok(IOResult::Done(()));
                     }
-                    let stmt = self
-                        .prepare_internal(format!("SELECT name, seq FROM {SQLITE_SEQUENCE_TABLE_NAME}"))?;
+                    let stmt = self.prepare_internal(format!(
+                        "SELECT name, seq FROM {SQLITE_SEQUENCE_TABLE_NAME}"
+                    ))?;
                     *state = SyncAutoincrementState::ReadSeqRows {
                         stmt: Box::new(stmt),
                         rows: Vec::new(),
@@ -3610,8 +3590,9 @@ impl Connection {
                             // Read current backing watermark; only upsert if we'd
                             // actually advance it (avoids needless writes on boot).
                             let escaped = backing_table_name.replace('"', "\"\"");
-                            let stmt = self
-                                .prepare_internal(format!("SELECT MAX(value) FROM \"{escaped}\""))?;
+                            let stmt = self.prepare_internal(format!(
+                                "SELECT MAX(value) FROM \"{escaped}\""
+                            ))?;
                             *sub = SyncRowStep::ReadMax {
                                 backing_table_name,
                                 stmt: Box::new(stmt),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -487,6 +487,12 @@ pub struct OpenDbAsyncState {
     building_db: Option<Database>,
     /// Sub state machine for `header_validation`, driven in ValidatingHeader.
     header_validation_state: HeaderValidationState,
+    /// The dedicated bootstrap connection used by `BootstrapMvStore`, held
+    /// across yields from `MvStore::bootstrap_nonblock`.
+    mvcc_bootstrap_conn: Option<Arc<Connection>>,
+    /// Sub state machine for `MvStore::bootstrap_nonblock`, driven in
+    /// `BootstrapMvStore`.
+    mvcc_bootstrap_state: mvcc::database::BootstrapState,
 }
 
 impl Default for OpenDbAsyncState {
@@ -508,6 +514,8 @@ impl OpenDbAsyncState {
             registry_key: None,
             building_db: None,
             header_validation_state: HeaderValidationState::default(),
+            mvcc_bootstrap_conn: None,
+            mvcc_bootstrap_state: mvcc::database::BootstrapState::default(),
         }
     }
 }
@@ -1444,9 +1452,22 @@ impl Database {
                         .expect("pager must be initialized in Init phase");
 
                     if let Some(mv_store) = db.get_mv_store().as_ref() {
-                        let mvcc_bootstrap_conn =
-                            db._connect(true, Some(pager.clone()), state.encryption_key.clone())?;
-                        mv_store.bootstrap(mvcc_bootstrap_conn)?;
+                        // Create the dedicated bootstrap connection once and
+                        // hold it across yields. Re-entry reuses the existing
+                        // connection and the persisted `BootstrapState`.
+                        if state.mvcc_bootstrap_conn.is_none() {
+                            state.mvcc_bootstrap_conn = Some(db._connect(
+                                true,
+                                Some(pager.clone()),
+                                state.encryption_key.clone(),
+                            )?);
+                        }
+                        let conn = state.mvcc_bootstrap_conn.as_ref().expect("created above");
+                        return_if_io!(
+                            mv_store.bootstrap_nonblock(conn, &mut state.mvcc_bootstrap_state)
+                        );
+                        // Done — drop the bootstrap connection.
+                        state.mvcc_bootstrap_conn = None;
                     }
 
                     state.phase = OpenDbAsyncPhase::Done;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -64,7 +64,7 @@ use super::persistent_storage::logical_log::{
     encode_delete_portable_extension, parse_ops_from_plaintext, LOG_RECORD_PREFIX_SIZE,
 };
 use super::persistent_storage::logical_log::{
-    HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader, StreamingResult,
+    HeaderReadResult, IndexOpKind, LogHeader, ParsedOp, StreamingLogicalLogReader, StreamingResult,
     LOG_HDR_SIZE,
 };
 #[cfg(feature = "conn_raw_api")]
@@ -3367,12 +3367,55 @@ pub struct RowidAllocator {
 /// Sub state machine for [`MvStore::bootstrap_nonblock`]. Carried by the
 /// open state machine (`OpenDbAsyncPhase::BootstrapMvStore`) across the
 /// metadata-bootstrap IO chain so opening an MVCC database does not block on
-/// the log-header truncate / write / fsync sequence.
+/// the log-header truncate / write / fsync sequence, the interrupted-checkpoint
+/// reconciliation, the schema reparse, or the metadata-table reads/writes.
 #[derive(Default)]
 pub enum BootstrapState {
     #[default]
     Start,
+    /// Pre-metadata: reconcile an interrupted checkpoint (non-blocking).
+    PreCheckpoint {
+        tvfs: Vec<Arc<crate::vtab::VirtualTable>>,
+        checkpoint_st: CompleteCheckpointState,
+    },
+    /// Pre-metadata: reparse the schema (non-blocking).
+    PreReparse {
+        tvfs: Vec<Arc<crate::vtab::VirtualTable>>,
+        reparse_st: crate::connection::ReparseSchemaState,
+    },
+    /// Reading the persistent tx-ts-max from the MVCC metadata table to decide
+    /// whether the metadata-bootstrap IO chain is needed.
+    BeginReadTxTs {
+        read_st: ReadPersistentTxTsMaxState,
+    },
     MetadataIo(MetadataIoInFlight),
+    /// Finish: create/seed the MVCC metadata table (non-blocking).
+    FinishInit {
+        init_st: InitMetadataTableState,
+    },
+    /// Finish: reconcile the interrupted checkpoint again after metadata writes.
+    FinishCheckpoint {
+        checkpoint_st: CompleteCheckpointState,
+    },
+    /// Replay the logical log into the MVCC store (non-blocking), then promote
+    /// the bootstrap connection to a regular MVCC connection.
+    Recover {
+        recover_st: RecoverLogicalLogState,
+    },
+    /// Recover sequence descriptors from each backing table (non-blocking).
+    /// The pre-replay reparse missed backing tables created by committed-but-
+    /// not-checkpointed CREATE SEQUENCE statements; this pass registers pure
+    /// descriptors via the MVCC-aware SQL path. The runtime watermark is never
+    /// read — every nextval queries disk on demand.
+    LoadSequences {
+        load_st: crate::connection::LoadSequenceDescriptorsState,
+    },
+    /// Compatibility sync for AUTOINCREMENT tables created in WAL mode (where
+    /// the watermark lives in sqlite_sequence) and then reopened in MVCC mode
+    /// (where the disk-only allocation path reads backing tables). Non-blocking.
+    SyncAutoincrement {
+        sync_st: crate::connection::SyncAutoincrementState,
+    },
     AwaitingGlobalHeader,
 }
 
@@ -3394,6 +3437,143 @@ pub enum MetadataIoStep {
     AfterUpdateHeader { sync_mode_off: bool },
     /// `storage.sync` just finished — metadata IO chain done.
     AfterSync,
+}
+
+/// Sub state machine for
+/// [`MvStore::maybe_complete_interrupted_checkpoint_nonblock`]. Tracks the
+/// sequence of IO yields needed to reconcile an interrupted MVCC checkpoint
+/// without blocking: read log header → optional early WAL truncate, or
+/// WAL→DB backfill + db_file.sync + log-header rewrite (with a single-shot
+/// CRC retry) + final WAL truncate.
+#[derive(Default)]
+pub enum CompleteCheckpointState {
+    #[default]
+    Start,
+    /// Reading the log header via the streaming reader.
+    ReadingHeader {
+        reader: Box<StreamingLogicalLogReader>,
+    },
+    /// `wal_max_frame == 0` branch: driving the early `wal.truncate_wal`.
+    /// `checkpoint_result` must persist across IO yields because
+    /// `truncate_wal`/`truncate_log` tracks its truncate/sync progress through
+    /// its `wal_truncate_sent` / `wal_sync_sent` flags; recreating it each
+    /// re-entry would re-issue the truncate forever.
+    DriveEarlyTruncate {
+        header_result: HeaderReadResult,
+        checkpoint_result: CheckpointResult,
+    },
+    /// Main path: driving `wal.checkpoint(Truncate)`.
+    DriveCheckpoint { header: LogHeader },
+    /// Awaiting the `db_file.sync` completion after a successful backfill.
+    AwaitDbFileSync {
+        completion: Completion,
+        checkpoint_result: CheckpointResult,
+    },
+    /// Retry loop: rewriting the log header + verifying CRC. `retried_crc`
+    /// allows a single retry on torn-tail mismatch before failing closed.
+    RetryHeader {
+        checkpoint_result: CheckpointResult,
+        retried_crc: bool,
+        phase: RetryHeaderPhase,
+    },
+    /// Driving the final `wal.truncate_wal`.
+    DriveFinalTruncate { checkpoint_result: CheckpointResult },
+}
+
+#[doc(hidden)]
+pub enum RetryHeaderPhase {
+    /// Need to issue `storage.update_header`.
+    NeedUpdateHeader,
+    /// Awaiting the `storage.update_header` write.
+    AwaitUpdateHeader(Completion),
+    /// Awaiting `storage.sync` (only when `sync_mode != Off`).
+    AwaitLogSync(Completion),
+    /// Reading the log header to verify the CRC.
+    AwaitCrcCheck {
+        reader: Box<StreamingLogicalLogReader>,
+    },
+}
+
+/// Sub state machine for [`MvStore::try_read_persistent_tx_ts_max_nonblock`].
+/// Holds the prepared metadata-read statement + accumulated value across IO
+/// yields while the SELECT runs cooperatively.
+#[derive(Default)]
+pub enum ReadPersistentTxTsMaxState {
+    #[default]
+    Start,
+    Running {
+        stmt: Box<crate::Statement>,
+        value: Option<i64>,
+    },
+}
+
+/// Sub state machine for [`MvStore::initialize_mvcc_metadata_table_nonblock`].
+/// Sequences the CREATE TABLE then INSERT statements, holding each prepared
+/// statement across IO yields.
+#[derive(Default)]
+pub enum InitMetadataTableState {
+    #[default]
+    Start,
+    CreateTable {
+        stmt: Box<crate::Statement>,
+    },
+    Insert {
+        stmt: Box<crate::Statement>,
+    },
+}
+
+/// Sub state machine for [`MvStore::maybe_recover_logical_log`]. The
+/// setup phases (header read, persistent-tx-ts read, schema-cookie read,
+/// sqlite_schema scan) each yield IO; the `Replay` phase carries the loop
+/// accumulators in [`RecoverCtx`] across per-frame `next_frame` yields.
+#[derive(Default)]
+pub enum RecoverLogicalLogState {
+    #[default]
+    Start,
+    ReadHeader {
+        reader: Box<StreamingLogicalLogReader>,
+        preserved_tvfs: Vec<Arc<crate::vtab::VirtualTable>>,
+    },
+    ReadTxTs {
+        reader: Box<StreamingLogicalLogReader>,
+        preserved_tvfs: Vec<Arc<crate::vtab::VirtualTable>>,
+        header_present: bool,
+        txts_st: ReadPersistentTxTsMaxState,
+    },
+    ReadCookie {
+        reader: Box<StreamingLogicalLogReader>,
+        preserved_tvfs: Vec<Arc<crate::vtab::VirtualTable>>,
+        persistent_tx_ts_max: u64,
+    },
+    QuerySchema {
+        reader: Box<StreamingLogicalLogReader>,
+        preserved_tvfs: Vec<Arc<crate::vtab::VirtualTable>>,
+        persistent_tx_ts_max: u64,
+        cookie: u32,
+        stmt: Option<Box<crate::Statement>>,
+        schema_rows: HashMap<i64, ImmutableRecord>,
+    },
+    Replay {
+        ctx: Box<RecoverCtx>,
+    },
+    Done,
+}
+
+/// Accumulated state of the logical-log replay loop, persisted across
+/// `next_frame` IO yields. See [`MvStore::maybe_recover_logical_log`].
+pub struct RecoverCtx {
+    reader: Box<StreamingLogicalLogReader>,
+    preserved_table_valued_functions: Vec<Arc<crate::vtab::VirtualTable>>,
+    /// Fallback schema cookie (pre-read) used by `recover_build_schema` only
+    /// when `global_header` is unset.
+    cookie: u32,
+    persistent_tx_ts_max: u64,
+    replay_cutoff_ts: u64,
+    max_commit_ts_seen: u64,
+    schema_rows: HashMap<i64, ImmutableRecord>,
+    dropped_root_pages: HashSet<i64>,
+    current_schema: Arc<Schema>,
+    index_infos: HashMap<(MVTableId, IndexOpKind), Arc<IndexInfo>>,
 }
 
 /// A multi-version concurrency control database.
@@ -3696,39 +3876,45 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// `persistent_tx_ts_max` (initialized to 0). This table stores the durable replay
     /// boundary: on recovery, only logical-log frames with `commit_ts > persistent_tx_ts_max`
     /// are replayed. Called once during first MVCC bootstrap.
-    fn initialize_mvcc_metadata_table(&self, connection: &Arc<Connection>) -> Result<()> {
-        connection.execute(format!(
-            "CREATE TABLE IF NOT EXISTS {MVCC_META_TABLE_NAME}(k TEXT, v INTEGER NOT NULL)"
-        ))?;
-        connection.execute(format!(
-            "INSERT OR IGNORE INTO {MVCC_META_TABLE_NAME}(rowid, k, v) VALUES (1, '{MVCC_META_KEY_PERSISTENT_TX_TS_MAX}', 0)"
-        ))?;
-        Ok(())
+    /// Creates and seeds the MVCC metadata table, driving the CREATE TABLE then
+    /// INSERT statements cooperatively via the supplied [`InitMetadataTableState`]
+    /// so bootstrap does not block on backends without a synchronous IO pump.
+    fn initialize_mvcc_metadata_table_nonblock(
+        &self,
+        connection: &Arc<Connection>,
+        st: &mut InitMetadataTableState,
+    ) -> Result<IOResult<()>> {
+        loop {
+            match st {
+                InitMetadataTableState::Start => {
+                    let stmt = connection.prepare(format!(
+                        "CREATE TABLE IF NOT EXISTS {MVCC_META_TABLE_NAME}(k TEXT, v INTEGER NOT NULL)"
+                    ))?;
+                    *st = InitMetadataTableState::CreateTable {
+                        stmt: Box::new(stmt),
+                    };
+                }
+                InitMetadataTableState::CreateTable { stmt } => {
+                    return_if_io!(stmt.run_ignore_rows_nonblock());
+                    let stmt = connection.prepare(format!(
+                        "INSERT OR IGNORE INTO {MVCC_META_TABLE_NAME}(rowid, k, v) VALUES (1, '{MVCC_META_KEY_PERSISTENT_TX_TS_MAX}', 0)"
+                    ))?;
+                    *st = InitMetadataTableState::Insert {
+                        stmt: Box::new(stmt),
+                    };
+                }
+                InitMetadataTableState::Insert { stmt } => {
+                    return_if_io!(stmt.run_ignore_rows_nonblock());
+                    *st = InitMetadataTableState::Start;
+                    return Ok(IOResult::Done(()));
+                }
+            }
+        }
     }
 
-    /// Read the persistent transaction timestamp maximum from the MVCC metadata table.
-    fn try_read_persistent_tx_ts_max(&self, connection: &Arc<Connection>) -> Result<Option<u64>> {
-        let query_result = connection.query(format!(
-            "SELECT v FROM {MVCC_META_TABLE_NAME}
-             WHERE k = '{MVCC_META_KEY_PERSISTENT_TX_TS_MAX}'"
-        ));
-        let maybe_stmt = match query_result {
-            Ok(stmt) => stmt,
-            Err(LimboError::ParseError(msg)) if msg.contains("no such table") => return Ok(None),
-            Err(err) => {
-                return Err(LimboError::Corrupt(format!(
-                    "Failed to read MVCC metadata table: {err}"
-                )));
-            }
-        };
-        let mut value: Option<i64> = None;
-        if let Some(mut stmt) = maybe_stmt {
-            stmt.run_with_row_callback(|row| {
-                value = Some(row.get::<i64>(0)?);
-                Ok(())
-            })?;
-        }
-
+    /// Shared validation/normalization for the persistent-tx-ts-max metadata
+    /// value used by both the blocking and non-blocking readers.
+    fn validate_persistent_tx_ts_max(value: Option<i64>) -> Result<Option<u64>> {
         let value = value.ok_or_else(|| {
             LimboError::Corrupt(format!(
                 "Missing MVCC metadata row for key {MVCC_META_KEY_PERSISTENT_TX_TS_MAX}"
@@ -3741,6 +3927,60 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             )));
         }
         Ok(Some(value as u64))
+    }
+
+    /// Non-blocking variant of [`Self::try_read_persistent_tx_ts_max`]: runs the
+    /// metadata SELECT cooperatively via the supplied
+    /// [`ReadPersistentTxTsMaxState`], yielding IO instead of pumping it. Returns
+    /// `None` if the metadata table does not exist yet.
+    fn try_read_persistent_tx_ts_max_nonblock(
+        &self,
+        connection: &Arc<Connection>,
+        st: &mut ReadPersistentTxTsMaxState,
+    ) -> Result<IOResult<Option<u64>>> {
+        loop {
+            match st {
+                ReadPersistentTxTsMaxState::Start => {
+                    let query_result = connection.query(format!(
+                        "SELECT v FROM {MVCC_META_TABLE_NAME}
+                         WHERE k = '{MVCC_META_KEY_PERSISTENT_TX_TS_MAX}'"
+                    ));
+                    let maybe_stmt = match query_result {
+                        Ok(stmt) => stmt,
+                        Err(LimboError::ParseError(msg)) if msg.contains("no such table") => {
+                            return Ok(IOResult::Done(None))
+                        }
+                        Err(err) => {
+                            return Err(LimboError::Corrupt(format!(
+                                "Failed to read MVCC metadata table: {err}"
+                            )))
+                        }
+                    };
+                    match maybe_stmt {
+                        Some(stmt) => {
+                            *st = ReadPersistentTxTsMaxState::Running {
+                                stmt: Box::new(stmt),
+                                value: None,
+                            };
+                        }
+                        // No statement to run — fall through to the missing-row
+                        // error path (matches the blocking variant).
+                        None => {
+                            return Self::validate_persistent_tx_ts_max(None).map(IOResult::Done)
+                        }
+                    }
+                }
+                ReadPersistentTxTsMaxState::Running { stmt, value } => {
+                    return_if_io!(stmt.run_with_row_callback_nonblock(|row| {
+                        *value = Some(row.get::<i64>(0)?);
+                        Ok(())
+                    }));
+                    let value = *value;
+                    *st = ReadPersistentTxTsMaxState::Start;
+                    return Self::validate_persistent_tx_ts_max(value).map(IOResult::Done);
+                }
+            }
+        }
     }
 
     /// Bootstrap the MV store from the SQLite schema table and logical log.
@@ -3771,15 +4011,60 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         loop {
             match st {
                 BootstrapState::Start => {
-                    self.bootstrap_pre_metadata(bootstrap_conn)?;
-                    if let Some(next) = self.bootstrap_begin_metadata_io(bootstrap_conn)? {
+                    // Capture built-in table-valued functions before the schema
+                    // reparse drops them (sync, no IO).
+                    let tvfs = Self::capture_table_valued_functions(&bootstrap_conn.schema.read());
+                    *st = BootstrapState::PreCheckpoint {
+                        tvfs,
+                        checkpoint_st: CompleteCheckpointState::default(),
+                    };
+                }
+                BootstrapState::PreCheckpoint {
+                    tvfs,
+                    checkpoint_st,
+                } => {
+                    return_if_io!(self.maybe_complete_interrupted_checkpoint_nonblock(
+                        bootstrap_conn,
+                        checkpoint_st
+                    ));
+                    let tvfs = std::mem::take(tvfs);
+                    *st = BootstrapState::PreReparse {
+                        tvfs,
+                        reparse_st: crate::connection::ReparseSchemaState::default(),
+                    };
+                }
+                BootstrapState::PreReparse { tvfs, reparse_st } => {
+                    return_if_io!(bootstrap_conn.reparse_schema_nonblock(reparse_st));
+                    self.rehydrate_connection_table_valued_functions(bootstrap_conn, tvfs);
+                    // pre_metadata done. Decide whether metadata bootstrap IO is needed.
+                    if !self.uses_durable_mvcc_metadata(bootstrap_conn) {
+                        self.bootstrap_map_root_pages(bootstrap_conn)?;
+                        *st = BootstrapState::Recover {
+                            recover_st: RecoverLogicalLogState::default(),
+                        };
+                    } else {
+                        *st = BootstrapState::BeginReadTxTs {
+                            read_st: ReadPersistentTxTsMaxState::default(),
+                        };
+                    }
+                }
+                BootstrapState::BeginReadTxTs { read_st } => {
+                    let persistent_tx_ts = return_if_io!(
+                        self.try_read_persistent_tx_ts_max_nonblock(bootstrap_conn, read_st)
+                    );
+                    if persistent_tx_ts.is_some() {
+                        // Metadata already durable — no bootstrap IO chain needed.
+                        self.bootstrap_map_root_pages(bootstrap_conn)?;
+                        *st = BootstrapState::Recover {
+                            recover_st: RecoverLogicalLogState::default(),
+                        };
+                    } else if let Some(next) = self.bootstrap_issue_metadata_io(bootstrap_conn)? {
                         *st = BootstrapState::MetadataIo(next);
                     } else {
-                        // No metadata IO needed (either non-durable mode, or
-                        // persistent_tx_ts already set). Run the post-metadata
-                        // sync work and transition.
-                        self.bootstrap_post_metadata_setup(bootstrap_conn)?;
-                        *st = BootstrapState::AwaitingGlobalHeader;
+                        self.bootstrap_map_root_pages(bootstrap_conn)?;
+                        *st = BootstrapState::Recover {
+                            recover_st: RecoverLogicalLogState::default(),
+                        };
                     }
                 }
                 BootstrapState::MetadataIo(phase) => {
@@ -3787,7 +4072,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let c = phase.completion.clone();
                         io_yield_one!(c);
                     }
-                    let pager = bootstrap_conn.pager.load().clone();
                     let sync_type = phase.sync_type;
                     match phase.next {
                         MetadataIoStep::AfterTruncate {
@@ -3804,9 +4088,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                 };
                                 // Loop to re-check succeeded immediately
                             } else {
-                                self.bootstrap_finish_metadata_io(bootstrap_conn)?;
-                                self.bootstrap_post_metadata_setup(bootstrap_conn)?;
-                                *st = BootstrapState::AwaitingGlobalHeader;
+                                *st = BootstrapState::FinishInit {
+                                    init_st: InitMetadataTableState::default(),
+                                };
                             }
                         }
                         MetadataIoStep::AfterUpdateHeader { sync_mode_off } => {
@@ -3818,18 +4102,68 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                                     next: MetadataIoStep::AfterSync,
                                 };
                             } else {
-                                self.bootstrap_finish_metadata_io(bootstrap_conn)?;
-                                self.bootstrap_post_metadata_setup(bootstrap_conn)?;
-                                *st = BootstrapState::AwaitingGlobalHeader;
+                                *st = BootstrapState::FinishInit {
+                                    init_st: InitMetadataTableState::default(),
+                                };
                             }
-                            let _ = pager; // silence unused on this arm
                         }
                         MetadataIoStep::AfterSync => {
-                            self.bootstrap_finish_metadata_io(bootstrap_conn)?;
-                            self.bootstrap_post_metadata_setup(bootstrap_conn)?;
-                            *st = BootstrapState::AwaitingGlobalHeader;
+                            *st = BootstrapState::FinishInit {
+                                init_st: InitMetadataTableState::default(),
+                            };
                         }
                     }
+                }
+                BootstrapState::FinishInit { init_st } => {
+                    return_if_io!(
+                        self.initialize_mvcc_metadata_table_nonblock(bootstrap_conn, init_st)
+                    );
+                    *st = BootstrapState::FinishCheckpoint {
+                        checkpoint_st: CompleteCheckpointState::default(),
+                    };
+                }
+                BootstrapState::FinishCheckpoint { checkpoint_st } => {
+                    return_if_io!(self.maybe_complete_interrupted_checkpoint_nonblock(
+                        bootstrap_conn,
+                        checkpoint_st
+                    ));
+                    self.bootstrap_map_root_pages(bootstrap_conn)?;
+                    *st = BootstrapState::Recover {
+                        recover_st: RecoverLogicalLogState::default(),
+                    };
+                }
+                BootstrapState::Recover { recover_st } => {
+                    // Recover the logical log while the bootstrap connection still
+                    // reads from the pager-backed schema, so recovery can merge
+                    // checkpointed sqlite_schema rows with non-checkpointed rows
+                    // from log replay.
+                    return_if_io!(self.maybe_recover_logical_log(bootstrap_conn, recover_st));
+                    // Recovery done; switch back to regular MVCC reads.
+                    bootstrap_conn.promote_to_regular_connection();
+                    *st = BootstrapState::LoadSequences {
+                        load_st: crate::connection::LoadSequenceDescriptorsState::default(),
+                    };
+                }
+                BootstrapState::LoadSequences { load_st } => {
+                    // After log replay, recover sequence descriptors from each
+                    // backing table (non-blocking). A read failure on an internal
+                    // backing table is on-disk corruption, surfaced as a hard
+                    // bootstrap failure rather than a misleading "sequence does
+                    // not exist" on the next nextval.
+                    return_if_io!(bootstrap_conn.load_sequence_descriptors_via_sql_nonblock(load_st));
+                    *st = BootstrapState::SyncAutoincrement {
+                        sync_st: crate::connection::SyncAutoincrementState::default(),
+                    };
+                }
+                BootstrapState::SyncAutoincrement { sync_st } => {
+                    // WAL→MVCC AUTOINCREMENT watermark compatibility sync (non-
+                    // blocking). A failure here cannot be downgraded: it would
+                    // leave the next AUTOINCREMENT INSERT able to re-emit a rowid
+                    // already on disk, so it propagates as a bootstrap failure.
+                    return_if_io!(bootstrap_conn
+                        .sync_autoincrement_backing_tables_from_sqlite_sequence_nonblock(sync_st));
+                    *bootstrap_conn.db.schema.lock() = bootstrap_conn.schema.read().clone();
+                    *st = BootstrapState::AwaitingGlobalHeader;
                 }
                 BootstrapState::AwaitingGlobalHeader => {
                     if self.global_header.read().is_none() {
@@ -3843,40 +4177,15 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
     }
 
-    /// Synchronous prelude to bootstrap: capture vtabs, run the first
-    /// checkpoint reconciliation, reparse schema, rehydrate vtabs.
-    fn bootstrap_pre_metadata(&self, bootstrap_conn: &Arc<Connection>) -> Result<()> {
-        let preserved_table_valued_functions =
-            Self::capture_table_valued_functions(&bootstrap_conn.schema.read());
-        self.maybe_complete_interrupted_checkpoint(bootstrap_conn)?;
-        bootstrap_conn.reparse_schema()?;
-        self.rehydrate_connection_table_valued_functions(
-            bootstrap_conn,
-            &preserved_table_valued_functions,
-        );
-        Ok(())
-    }
-
-    /// Decide whether the metadata-bootstrap IO chain is required and, if so,
-    /// issue its first completion. Returns `Some(MetadataIoInFlight)` carrying
-    /// the in-flight completion and the next step to take after it completes;
-    /// returns `None` if the chain is not required (either the database does
-    /// not use durable MVCC metadata, or the persistent tx-ts max is already
-    /// set, or the log is in a clean state).
-    fn bootstrap_begin_metadata_io(
+    /// Issue the first completion of the metadata-bootstrap IO chain, if one is
+    /// needed. Called from the bootstrap state machine only after it has already
+    /// confirmed durable MVCC metadata is in use and the persistent tx-ts max is
+    /// absent. Returns `Some(MetadataIoInFlight)` with the in-flight completion
+    /// and next step, or `None` if the log is already in a clean state.
+    fn bootstrap_issue_metadata_io(
         &self,
         bootstrap_conn: &Arc<Connection>,
     ) -> Result<Option<MetadataIoInFlight>> {
-        if !self.uses_durable_mvcc_metadata(bootstrap_conn) {
-            return Ok(None);
-        }
-        if self
-            .try_read_persistent_tx_ts_max(bootstrap_conn)?
-            .is_some()
-        {
-            return Ok(None);
-        }
-
         let log_size = self.get_logical_log_file().size()?;
         let pager = bootstrap_conn.pager.load().clone();
         if bootstrap_conn.db.is_readonly() {
@@ -3920,81 +4229,36 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         Ok(None)
     }
 
-    /// Once the metadata-bootstrap IO chain has finished, initialize the MVCC
-    /// metadata table and reconcile any interrupted checkpoint immediately so
-    /// that subsequent opens (including read-only opens) do not depend on WAL
-    /// replay of those metadata writes.
-    fn bootstrap_finish_metadata_io(&self, bootstrap_conn: &Arc<Connection>) -> Result<()> {
-        self.initialize_mvcc_metadata_table(bootstrap_conn)?;
-        self.maybe_complete_interrupted_checkpoint(bootstrap_conn)?;
-        Ok(())
-    }
-
-    /// Sync work between the metadata IO chain (or its skip) and the final
-    /// global-header read: build the schema mapping, recover the logical log,
-    /// and promote the bootstrap connection to a regular MVCC connection.
-    fn bootstrap_post_metadata_setup(&self, bootstrap_conn: &Arc<Connection>) -> Result<()> {
-        {
-            let schema = bootstrap_conn.schema.read();
-            let sqlite_schema_root_pages = {
-                schema
-                    .tables
-                    .values()
-                    .filter_map(|t| {
-                        if let Table::BTree(btree) = t.as_ref() {
-                            Some(btree.root_page)
-                        } else {
-                            None
-                        }
-                    })
-                    .chain(
-                        schema
-                            .indexes
-                            .values()
-                            .flatten()
-                            .map(|index| index.root_page),
-                    )
-            };
-            // Map all existing checkpointed root pages to table ids so that if root_page=R, table_id=-R
-            for root_page in sqlite_schema_root_pages {
-                turso_assert!(root_page > 0, "root_page={root_page} must be positive");
-                let root_page_as_table_id = MVTableId::from(-(root_page));
-                self.insert_table_id_to_rootpage(root_page_as_table_id, Some(root_page as u64));
-            }
+    /// Sync prelude to logical-log recovery: map all existing checkpointed
+    /// sqlite_schema root pages to MVCC table ids (root_page=R → table_id=-R).
+    /// Recovery itself (and the connection promotion) is driven separately by
+    /// the bootstrap state machine's `Recover` phase so it can yield IO.
+    fn bootstrap_map_root_pages(&self, bootstrap_conn: &Arc<Connection>) -> Result<()> {
+        let schema = bootstrap_conn.schema.read();
+        let sqlite_schema_root_pages = {
+            schema
+                .tables
+                .values()
+                .filter_map(|t| {
+                    if let Table::BTree(btree) = t.as_ref() {
+                        Some(btree.root_page)
+                    } else {
+                        None
+                    }
+                })
+                .chain(
+                    schema
+                        .indexes
+                        .values()
+                        .flatten()
+                        .map(|index| index.root_page),
+                )
+        };
+        for root_page in sqlite_schema_root_pages {
+            turso_assert!(root_page > 0, "root_page={root_page} must be positive");
+            let root_page_as_table_id = MVTableId::from(-(root_page));
+            self.insert_table_id_to_rootpage(root_page_as_table_id, Some(root_page as u64));
         }
-
-        // Recover logical log while bootstrap connection still reads from pager-backed schema.
-        // This lets recovery merge checkpointed sqlite_schema rows with non-checkpointed rows from log replay.
-        let _recovered = self.maybe_recover_logical_log(bootstrap_conn.clone())?;
-
-        // Recovery is done, switch back to regular MVCC reads.
-        bootstrap_conn.promote_to_regular_connection();
-
-        // After log replay, recover sequence descriptors from each backing
-        // table. The pre-replay reparse at the top of bootstrap missed
-        // backing tables created by committed-but-not-checkpointed CREATE
-        // SEQUENCE statements; this pass goes through the normal SQL path
-        // (MVCC-aware) to register pure descriptors. The runtime watermark
-        // is never read — every nextval queries disk on demand.
-        //
-        // `load_sequence_descriptors_via_sql` classifies any read failure
-        // on an internal backing table as `LimboError::Corrupt`; bootstrap
-        // must fail rather than swallow that — opening a database whose
-        // sequence backing table is unreadable would leave the engine
-        // reporting "sequence does not exist" on the next nextval, hiding
-        // real on-disk corruption.
-        bootstrap_conn.load_sequence_descriptors_via_sql()?;
-        // Compatibility sync for AUTOINCREMENT tables created in WAL mode
-        // (where the watermark lives in sqlite_sequence) and then reopened
-        // in MVCC mode (where the new disk-only allocation path reads
-        // backing tables). Without this, the next MVCC AUTOINCREMENT
-        // INSERT would regress to start_value and collide with existing
-        // rowids — so a failure here cannot be downgraded to a warning;
-        // the inner helper now propagates I/O / corruption errors and
-        // we surface them to the caller as a hard bootstrap failure.
-        bootstrap_conn.sync_autoincrement_backing_tables_from_sqlite_sequence()?;
-        *bootstrap_conn.db.schema.lock() = bootstrap_conn.schema.read().clone();
-
         Ok(())
     }
 
@@ -6027,319 +6291,440 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         Ok(None)
     }
 
-    fn logical_log_header_crc_valid(&self, pager: &Arc<Pager>) -> Result<bool> {
-        let file = self.get_logical_log_file();
-        // Header is never encrypted; no need to pass EncryptionContext here.
-        let mut reader = StreamingLogicalLogReader::new(file, None);
-        match reader.try_read_header(&pager.io)? {
-            HeaderReadResult::Valid(_) => Ok(true),
-            HeaderReadResult::NoLog | HeaderReadResult::Invalid => Ok(false),
-        }
-    }
-
-    /// Runs during bootstrap to reconcile WAL state left by a prior crash or incomplete
-    /// checkpoint. Classifies startup state by WAL frame count and logical-log header
-    /// validity, then either completes the interrupted checkpoint (backfill WAL → DB,
-    /// sync, truncate) or fails closed on corrupt/inconsistent artifacts.
+    /// Reconcile WAL state left by a prior crash or incomplete checkpoint.
+    /// Classifies startup state by WAL frame count and logical-log header
+    /// validity, then either completes the interrupted checkpoint
+    /// (backfill WAL → DB, sync, truncate) or fails closed on corrupt /
+    /// inconsistent artifacts. Non-blocking: all IO yields through the
+    /// supplied [`CompleteCheckpointState`].
     /// See RECOVERY_SEMANTICS.md "Startup Case Classification" for the full case table.
-    fn maybe_complete_interrupted_checkpoint(&self, connection: &Arc<Connection>) -> Result<()> {
+    pub(crate) fn maybe_complete_interrupted_checkpoint_nonblock(
+        &self,
+        connection: &Arc<Connection>,
+        st: &mut CompleteCheckpointState,
+    ) -> Result<IOResult<()>> {
         let pager = connection.pager.load().clone();
         let Some(wal) = &pager.wal else {
-            return Ok(());
+            return Ok(IOResult::Done(()));
         };
-        // The bootstrap connection may have acquired a WAL read lock during earlier
-        // bootstrap steps (e.g. schema parsing). Drop it so the TRUNCATE checkpoint
-        // below isn't blocked by our own read lock.
-        if wal.holds_read_lock() {
-            wal.end_read_tx();
-        }
-
-        let wal_max_frame = wal.get_max_frame_in_wal();
-        let file = self.get_logical_log_file();
-        // This method only reads the header (never encrypted); no need to pass EncryptionContext.
-        let mut reader = StreamingLogicalLogReader::new(file, None);
-        let header_result = reader.try_read_header(&pager.io)?;
-
-        let is_readonly = connection.db.is_readonly();
-        if wal_max_frame == 0 {
-            if !is_readonly {
-                let mut checkpoint_result = CheckpointResult::new(0, 0, 0);
-                pager
-                    .io
-                    .block(|| wal.truncate_wal(&mut checkpoint_result, pager.get_sync_type()))?;
-                if let HeaderReadResult::Valid(header) = &header_result {
+        loop {
+            match st {
+                CompleteCheckpointState::Start => {
+                    // The bootstrap connection may have acquired a WAL read lock during
+                    // earlier bootstrap steps (e.g. schema parsing). Drop it so the
+                    // TRUNCATE checkpoint below isn't blocked by our own read lock.
+                    // Idempotent across re-entry (holds_read_lock is checked first).
+                    if wal.holds_read_lock() {
+                        wal.end_read_tx();
+                    }
+                    let file = self.get_logical_log_file();
+                    // Header is never encrypted; no EncryptionContext needed.
+                    *st = CompleteCheckpointState::ReadingHeader {
+                        reader: Box::new(StreamingLogicalLogReader::new(file, None)),
+                    };
+                }
+                CompleteCheckpointState::ReadingHeader { reader } => {
+                    let header_result = return_if_io!(reader.try_read_header_nonblock());
+                    let wal_max_frame = wal.get_max_frame_in_wal();
+                    let is_readonly = connection.db.is_readonly();
+                    if wal_max_frame == 0 {
+                        if is_readonly {
+                            // Nothing to reconcile in read-only mode with no committed frames.
+                            *st = CompleteCheckpointState::Start;
+                            return Ok(IOResult::Done(()));
+                        }
+                        *st = CompleteCheckpointState::DriveEarlyTruncate {
+                            header_result,
+                            checkpoint_result: CheckpointResult::new(0, 0, 0),
+                        };
+                        continue;
+                    }
+                    if is_readonly {
+                        return Err(LimboError::Corrupt(
+                            "Cannot reconcile interrupted MVCC checkpoint in read-only mode"
+                                .to_string(),
+                        ));
+                    }
+                    let header = match header_result {
+                        HeaderReadResult::Valid(header) => header,
+                        HeaderReadResult::NoLog => {
+                            return Err(LimboError::Corrupt(
+                                "WAL has committed frames but logical log header is missing"
+                                    .to_string(),
+                            ))
+                        }
+                        HeaderReadResult::Invalid => {
+                            return Err(LimboError::Corrupt(
+                                "WAL has committed frames but logical log header is invalid"
+                                    .to_string(),
+                            ))
+                        }
+                    };
                     self.storage.set_header(header.clone());
+                    *st = CompleteCheckpointState::DriveCheckpoint { header };
                 }
-            }
-            return Ok(());
-        }
-
-        if is_readonly {
-            return Err(LimboError::Corrupt(
-                "Cannot reconcile interrupted MVCC checkpoint in read-only mode".to_string(),
-            ));
-        }
-
-        let header = match header_result {
-            HeaderReadResult::Valid(header) => header,
-            HeaderReadResult::NoLog => {
-                return Err(LimboError::Corrupt(
-                    "WAL has committed frames but logical log header is missing".to_string(),
-                ));
-            }
-            HeaderReadResult::Invalid => {
-                return Err(LimboError::Corrupt(
-                    "WAL has committed frames but logical log header is invalid".to_string(),
-                ));
-            }
-        };
-        self.storage.set_header(header);
-
-        self.storage.on_checkpoint_start()?;
-
-        // NOTE: this uses `CheckpointMode::Truncate` to drive WAL backfill only; we still
-        // truncate the WAL explicitly below to preserve WAL-last ordering in recovery.
-        let mut checkpoint_result = match pager.io.block(|| {
-            wal.checkpoint(
-                &pager,
-                CheckpointMode::Truncate {
-                    upper_bound_inclusive: None,
-                },
-            )
-        }) {
-            Ok(result) => result,
-            Err(err) => {
-                self.storage.on_checkpoint_end(Err(err.clone()))?;
-                return Err(err);
-            }
-        };
-
-        let recovery_result = (|| -> Result<()> {
-            if !checkpoint_result.everything_backfilled() {
-                return Err(LimboError::Corrupt(
-                    "Unable to fully backfill committed WAL frames during MVCC recovery"
-                        .to_string(),
-                ));
-            }
-
-            if connection.get_sync_mode() != SyncMode::Off
-                && checkpoint_result.wal_checkpoint_backfilled > 0
-            {
-                let c = pager
-                    .db_file
-                    .sync(Completion::new_sync(|_| {}), pager.get_sync_type())?;
-                pager.io.wait_for_completion(c)?;
-            }
-
-            // Write a fresh log header (distinct from the checkpoint state machine which no
-            // longer rewrites the header). This is bootstrap-only: we need a valid header on
-            // disk before truncating WAL. CRC verify + retry guards against torn header writes.
-            let mut retried_crc = false;
-            loop {
-                let c = self.storage.update_header()?;
-                pager.io.wait_for_completion(c)?;
-
-                if connection.get_sync_mode() != SyncMode::Off {
-                    let c = self.storage.sync(pager.get_sync_type())?;
-                    pager.io.wait_for_completion(c)?;
+                CompleteCheckpointState::DriveEarlyTruncate {
+                    header_result,
+                    checkpoint_result,
+                } => {
+                    return_if_io!(wal.truncate_wal(checkpoint_result, pager.get_sync_type()));
+                    if let HeaderReadResult::Valid(header) = header_result {
+                        self.storage.set_header(header.clone());
+                    }
+                    *st = CompleteCheckpointState::Start;
+                    return Ok(IOResult::Done(()));
                 }
-
-                if self.logical_log_header_crc_valid(&pager)? {
-                    break;
-                }
-
-                if retried_crc {
-                    return Err(LimboError::Corrupt(
-                        "Logical log header CRC mismatch after retry".to_string(),
+                CompleteCheckpointState::DriveCheckpoint { header: _header } => {
+                    // NOTE: uses `CheckpointMode::Truncate` to drive WAL backfill
+                    // only; we still truncate the WAL explicitly below to preserve
+                    // WAL-last ordering in recovery.
+                    let checkpoint_result = return_if_io!(wal.checkpoint(
+                        &pager,
+                        CheckpointMode::Truncate {
+                            upper_bound_inclusive: None,
+                        },
                     ));
+                    if !checkpoint_result.everything_backfilled() {
+                        return Err(LimboError::Corrupt(
+                            "Unable to fully backfill committed WAL frames during MVCC recovery"
+                                .to_string(),
+                        ));
+                    }
+                    let need_db_sync = connection.get_sync_mode() != SyncMode::Off
+                        && checkpoint_result.wal_checkpoint_backfilled > 0;
+                    if need_db_sync {
+                        let c = pager
+                            .db_file
+                            .sync(Completion::new_sync(|_| {}), pager.get_sync_type())?;
+                        *st = CompleteCheckpointState::AwaitDbFileSync {
+                            completion: c,
+                            checkpoint_result,
+                        };
+                    } else {
+                        *st = CompleteCheckpointState::RetryHeader {
+                            checkpoint_result,
+                            retried_crc: false,
+                            phase: RetryHeaderPhase::NeedUpdateHeader,
+                        };
+                    }
                 }
-                retried_crc = true;
-            }
-
-            pager
-                .io
-                .block(|| wal.truncate_wal(&mut checkpoint_result, pager.get_sync_type()))?;
-            Ok(())
-        })();
-
-        match recovery_result {
-            Ok(()) => {
-                self.storage.on_checkpoint_end(Ok(&checkpoint_result))?;
-                Ok(())
-            }
-            Err(err) => {
-                self.storage.on_checkpoint_end(Err(err.clone()))?;
-                Err(err)
+                CompleteCheckpointState::AwaitDbFileSync {
+                    completion,
+                    checkpoint_result,
+                } => {
+                    if !completion.succeeded() {
+                        let c = completion.clone();
+                        io_yield_one!(c);
+                    }
+                    let checkpoint_result =
+                        std::mem::replace(checkpoint_result, CheckpointResult::new(0, 0, 0));
+                    *st = CompleteCheckpointState::RetryHeader {
+                        checkpoint_result,
+                        retried_crc: false,
+                        phase: RetryHeaderPhase::NeedUpdateHeader,
+                    };
+                }
+                CompleteCheckpointState::RetryHeader {
+                    checkpoint_result,
+                    retried_crc,
+                    phase,
+                } => match phase {
+                    RetryHeaderPhase::NeedUpdateHeader => {
+                        let c = self.storage.update_header()?;
+                        *phase = RetryHeaderPhase::AwaitUpdateHeader(c);
+                    }
+                    RetryHeaderPhase::AwaitUpdateHeader(completion) => {
+                        if !completion.succeeded() {
+                            let c = completion.clone();
+                            io_yield_one!(c);
+                        }
+                        if connection.get_sync_mode() != SyncMode::Off {
+                            let c = self.storage.sync(pager.get_sync_type())?;
+                            *phase = RetryHeaderPhase::AwaitLogSync(c);
+                        } else {
+                            let file = self.get_logical_log_file();
+                            *phase = RetryHeaderPhase::AwaitCrcCheck {
+                                reader: Box::new(StreamingLogicalLogReader::new(file, None)),
+                            };
+                        }
+                    }
+                    RetryHeaderPhase::AwaitLogSync(completion) => {
+                        if !completion.succeeded() {
+                            let c = completion.clone();
+                            io_yield_one!(c);
+                        }
+                        let file = self.get_logical_log_file();
+                        *phase = RetryHeaderPhase::AwaitCrcCheck {
+                            reader: Box::new(StreamingLogicalLogReader::new(file, None)),
+                        };
+                    }
+                    RetryHeaderPhase::AwaitCrcCheck { reader } => {
+                        let header_result = return_if_io!(reader.try_read_header_nonblock());
+                        let crc_valid = matches!(header_result, HeaderReadResult::Valid(_));
+                        if crc_valid {
+                            let checkpoint_result = std::mem::replace(
+                                checkpoint_result,
+                                CheckpointResult::new(0, 0, 0),
+                            );
+                            *st = CompleteCheckpointState::DriveFinalTruncate { checkpoint_result };
+                        } else {
+                            if *retried_crc {
+                                return Err(LimboError::Corrupt(
+                                    "Logical log header CRC mismatch after retry".to_string(),
+                                ));
+                            }
+                            *retried_crc = true;
+                            *phase = RetryHeaderPhase::NeedUpdateHeader;
+                        }
+                    }
+                },
+                CompleteCheckpointState::DriveFinalTruncate { checkpoint_result } => {
+                    match wal.truncate_wal(checkpoint_result, pager.get_sync_type()) {
+                        Ok(IOResult::Done(())) => {
+                            self.storage.on_checkpoint_end(Ok(checkpoint_result))?;
+                        }
+                        Ok(IOResult::IO(c)) => {
+                            return Ok(IOResult::IO(c));
+                        }
+                        Err(err) => {
+                            self.storage.on_checkpoint_end(Err(err.clone()))?;
+                            return Err(err);
+                        }
+                    }
+                    *st = CompleteCheckpointState::Start;
+                    return Ok(IOResult::Done(()));
+                }
             }
         }
     }
 
     /// Replays committed logical-log frames into the in-memory MVCC store.
-    /// Only frames with `commit_ts > persistent_tx_ts_max` (the durable replay boundary
-    /// from the metadata table) are applied; earlier frames were already checkpointed.
-    /// On success, reseeds the MVCC clock to `max(persistent_tx_ts_max, max_replayed_commit_ts) + 1`
-    /// and sets the log writer offset to `last_valid_offset` so torn-tail bytes are overwritten.
-    /// Returns true if any frames were replayed, false otherwise.
-    pub fn maybe_recover_logical_log(&self, connection: Arc<Connection>) -> Result<bool> {
-        let pager = connection.pager.load().clone();
-        let file = self.get_logical_log_file();
-        let enc_ctx = self.storage.encryption_ctx();
-        let mut reader = StreamingLogicalLogReader::new(file.clone(), enc_ctx);
-        let preserved_table_valued_functions =
-            Self::capture_table_valued_functions(&connection.schema.read());
+    /// Only frames with `commit_ts > persistent_tx_ts_max` (the durable replay
+    /// boundary from the metadata table) are applied; earlier frames were
+    /// already checkpointed. On success, reseeds the MVCC clock and sets the log
+    /// writer offset so torn-tail bytes are overwritten. Returns true if any
+    /// frames were replayed.
+    pub fn maybe_recover_logical_log(
+        &self,
+        connection: &Arc<Connection>,
+        st: &mut RecoverLogicalLogState,
+    ) -> Result<IOResult<bool>> {
+        loop {
+            match st {
+                RecoverLogicalLogState::Start => {
+                    let file = self.get_logical_log_file();
+                    let enc_ctx = self.storage.encryption_ctx();
+                    let reader = Box::new(StreamingLogicalLogReader::new(file, enc_ctx));
+                    let preserved_tvfs =
+                        Self::capture_table_valued_functions(&connection.schema.read());
+                    *st = RecoverLogicalLogState::ReadHeader {
+                        reader,
+                        preserved_tvfs,
+                    };
+                }
+                RecoverLogicalLogState::ReadHeader { reader, .. } => {
+                    let header = match return_if_io!(reader.try_read_header_nonblock()) {
+                        HeaderReadResult::Valid(header) => Some(header),
+                        HeaderReadResult::NoLog => None,
+                        HeaderReadResult::Invalid => {
+                            return Err(LimboError::Corrupt(
+                                "Logical log header corrupt and no WAL recovery available"
+                                    .to_string(),
+                            ));
+                        }
+                    };
+                    if let Some(header) = &header {
+                        self.storage.set_header(header.clone());
+                    }
+                    let header_present = header.is_some();
+                    let RecoverLogicalLogState::ReadHeader {
+                        reader,
+                        preserved_tvfs,
+                    } = std::mem::take(st)
+                    else {
+                        unreachable!("state is ReadHeader");
+                    };
+                    *st = RecoverLogicalLogState::ReadTxTs {
+                        reader,
+                        preserved_tvfs,
+                        header_present,
+                        txts_st: ReadPersistentTxTsMaxState::default(),
+                    };
+                }
+                RecoverLogicalLogState::ReadTxTs {
+                    header_present,
+                    txts_st,
+                    ..
+                } => {
+                    let header_present = *header_present;
+                    let persistent_tx_ts_max = if self.uses_durable_mvcc_metadata(connection) {
+                        match return_if_io!(
+                            self.try_read_persistent_tx_ts_max_nonblock(connection, txts_st)
+                        ) {
+                            Some(ts) => ts,
+                            None if !header_present => 0,
+                            None => {
+                                return Err(LimboError::Corrupt(
+                                    "Missing MVCC metadata table".to_string(),
+                                ));
+                            }
+                        }
+                    } else {
+                        0
+                    };
+                    self.durable_txid_max
+                        .store(persistent_tx_ts_max, Ordering::SeqCst);
+                    self.clock.reset(persistent_tx_ts_max + 1);
 
-        let header = match reader.try_read_header(&pager.io)? {
-            HeaderReadResult::Valid(header) => Some(header),
-            HeaderReadResult::NoLog => None,
-            HeaderReadResult::Invalid => {
-                return Err(LimboError::Corrupt(
-                    "Logical log header corrupt and no WAL recovery available".to_string(),
-                ));
-            }
-        };
-
-        if let Some(header) = &header {
-            self.storage.set_header(header.clone());
-        }
-        let persistent_tx_ts_max = if self.uses_durable_mvcc_metadata(&connection) {
-            match self.try_read_persistent_tx_ts_max(&connection)? {
-                Some(ts) => ts,
-                None if header.is_none() => 0,
-                None => {
-                    return Err(LimboError::Corrupt(
-                        "Missing MVCC metadata table".to_string(),
-                    ));
+                    if !header_present || self.get_logical_log_file().size()? <= LOG_HDR_SIZE as u64
+                    {
+                        *st = RecoverLogicalLogState::Done;
+                        return Ok(IOResult::Done(false));
+                    }
+                    let RecoverLogicalLogState::ReadTxTs {
+                        reader,
+                        preserved_tvfs,
+                        ..
+                    } = std::mem::take(st)
+                    else {
+                        unreachable!("state is ReadTxTs");
+                    };
+                    *st = RecoverLogicalLogState::ReadCookie {
+                        reader,
+                        preserved_tvfs,
+                        persistent_tx_ts_max,
+                    };
+                }
+                RecoverLogicalLogState::ReadCookie { .. } => {
+                    let fallback_cookie = if self.global_header.read().is_some() {
+                        0
+                    } else {
+                        let pager = connection.pager.load().clone();
+                        return_if_io!(pager.with_header(|header| header.schema_cookie)).get()
+                    };
+                    let RecoverLogicalLogState::ReadCookie {
+                        reader,
+                        preserved_tvfs,
+                        persistent_tx_ts_max,
+                    } = std::mem::take(st)
+                    else {
+                        unreachable!("state is ReadCookie");
+                    };
+                    let stmt = connection
+                        .query(
+                            "SELECT rowid, type, name, tbl_name, rootpage, sql FROM sqlite_schema",
+                        )?
+                        .map(Box::new);
+                    *st = RecoverLogicalLogState::QuerySchema {
+                        reader,
+                        preserved_tvfs,
+                        persistent_tx_ts_max,
+                        cookie: fallback_cookie,
+                        stmt,
+                        schema_rows: HashMap::default(),
+                    };
+                }
+                RecoverLogicalLogState::QuerySchema {
+                    stmt, schema_rows, ..
+                } => {
+                    if let Some(stmt) = stmt {
+                        return_if_io!(stmt.run_with_row_callback_nonblock(|row| {
+                            let rowid = row.get::<i64>(0)?;
+                            let values = (1..=5)
+                                .map(|i| row.get_value(i).clone())
+                                .collect::<Vec<_>>();
+                            schema_rows.insert(
+                                rowid,
+                                ImmutableRecord::from_values(&values, values.len())?,
+                            );
+                            Ok(())
+                        }));
+                    }
+                    let RecoverLogicalLogState::QuerySchema {
+                        reader,
+                        preserved_tvfs,
+                        persistent_tx_ts_max,
+                        cookie,
+                        schema_rows,
+                        ..
+                    } = std::mem::take(st)
+                    else {
+                        unreachable!("state is QuerySchema");
+                    };
+                    let current_schema = connection.schema.read().clone();
+                    *st = RecoverLogicalLogState::Replay {
+                        ctx: Box::new(RecoverCtx {
+                            reader,
+                            preserved_table_valued_functions: preserved_tvfs,
+                            cookie,
+                            persistent_tx_ts_max,
+                            replay_cutoff_ts: persistent_tx_ts_max,
+                            max_commit_ts_seen: persistent_tx_ts_max,
+                            schema_rows,
+                            dropped_root_pages: HashSet::default(),
+                            current_schema,
+                            index_infos: HashMap::default(),
+                        }),
+                    };
+                }
+                RecoverLogicalLogState::Replay { ctx } => {
+                    loop {
+                        let Some(frame) = return_if_io!(ctx.reader.next_frame()) else {
+                            let recovered_offset = ctx.reader.last_valid_offset() as u64;
+                            let recovered_running_crc = ctx.reader.running_crc();
+                            self.storage.restore_logical_log_state_after_recovery(
+                                recovered_offset,
+                                recovered_running_crc,
+                            );
+                            break;
+                        };
+                        self.recover_process_frame(connection, ctx, frame)?;
+                    }
+                    let max_commit_ts_seen = ctx.max_commit_ts_seen;
+                    let persistent_tx_ts_max = ctx.persistent_tx_ts_max;
+                    let dropped_root_pages = std::mem::take(&mut ctx.dropped_root_pages);
+                    assert!(
+                        max_commit_ts_seen >= persistent_tx_ts_max,
+                        "replay clock would rewind below metadata boundary: max_commit_ts_seen={max_commit_ts_seen} persistent_tx_ts_max={persistent_tx_ts_max}"
+                    );
+                    connection.with_schema_mut(|schema| {
+                        schema.dropped_root_pages = dropped_root_pages;
+                    });
+                    if let Some(header) = self.global_header.read().as_ref() {
+                        connection.with_schema_mut(|schema| {
+                            schema.schema_version = header.schema_cookie.get();
+                        });
+                    }
+                    *connection.db.schema.lock() = connection.schema.read().clone();
+                    self.clock.reset(max_commit_ts_seen + 1);
+                    self.last_committed_tx_ts
+                        .store(max_commit_ts_seen, Ordering::SeqCst);
+                    *st = RecoverLogicalLogState::Done;
+                    return Ok(IOResult::Done(true));
+                }
+                RecoverLogicalLogState::Done => {
+                    return Ok(IOResult::Done(false));
                 }
             }
-        } else {
-            0
-        };
-        self.durable_txid_max
-            .store(persistent_tx_ts_max, Ordering::SeqCst);
-        self.clock.reset(persistent_tx_ts_max + 1);
-
-        if header.is_none() || file.size()? <= LOG_HDR_SIZE as u64 {
-            return Ok(false);
         }
+    }
 
-        let mut max_commit_ts_seen = persistent_tx_ts_max;
-        let replay_cutoff_ts = persistent_tx_ts_max;
-        let mut schema_rows: HashMap<i64, ImmutableRecord> = HashMap::default();
-        let mut dropped_root_pages: HashSet<i64> = HashSet::default();
-        if let Some(mut stmt) = connection
-            .query("SELECT rowid, type, name, tbl_name, rootpage, sql FROM sqlite_schema")?
-        {
-            stmt.run_with_row_callback(|row| {
-                let rowid = row.get::<i64>(0)?;
-                let values = (1..=5)
-                    .map(|i| row.get_value(i).clone())
-                    .collect::<Vec<_>>();
-                schema_rows.insert(rowid, ImmutableRecord::from_values(&values, values.len())?);
-                Ok(())
-            })?;
-        }
-        let build_schema = |schema_rows: &HashMap<i64, ImmutableRecord>| -> Result<Arc<Schema>> {
-            let pager = connection.pager.load().clone();
-            let cookie = self
-                .global_header
-                .read()
-                .as_ref()
-                .map(|header| header.schema_cookie.get())
-                .unwrap_or(
-                    pager
-                        .io
-                        .block(|| pager.with_header(|header| header.schema_cookie))?
-                        .get(),
-                );
-            let mut fresh = Schema::new();
-            fresh.generated_columns_enabled =
-                connection.db.experimental_generated_columns_enabled();
-            fresh.schema_version = cookie;
-            let mut from_sql_indexes = Vec::with_capacity(10);
-            let mut automatic_indices: HashMap<String, Vec<(String, i64)>> = HashMap::default();
-            let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
-            let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();
-            let mut materialized_view_info: HashMap<String, (String, i64)> = HashMap::default();
-            let syms = connection.syms.read();
-            let mv_store = connection.db.get_mv_store().clone();
-
-            let mut sorted_rowids: Vec<i64> = schema_rows.keys().copied().collect();
-            sorted_rowids.sort_unstable();
-            for rowid in &sorted_rowids {
-                let record = &schema_rows[rowid];
-                let ty = match record.get_value_opt(0) {
-                    Some(ValueRef::Text(v)) => v.as_str(),
-                    _ => {
-                        return Err(LimboError::Corrupt(
-                            "sqlite_schema type must be text".to_string(),
-                        ));
-                    }
-                };
-                let name = match record.get_value_opt(1) {
-                    Some(ValueRef::Text(v)) => v.as_str(),
-                    _ => {
-                        return Err(LimboError::Corrupt(
-                            "sqlite_schema name must be text".to_string(),
-                        ));
-                    }
-                };
-                let table_name = match record.get_value_opt(2) {
-                    Some(ValueRef::Text(v)) => v.as_str(),
-                    _ => {
-                        return Err(LimboError::Corrupt(
-                            "sqlite_schema tbl_name must be text".to_string(),
-                        ));
-                    }
-                };
-                let root_page = match record.get_value_opt(3) {
-                    Some(ValueRef::Numeric(Numeric::Integer(v))) => v,
-                    _ => {
-                        return Err(LimboError::Corrupt(
-                            "sqlite_schema root_page must be integer".to_string(),
-                        ));
-                    }
-                };
-                let sql = match record.get_value_opt(4) {
-                    Some(ValueRef::Text(v)) => Some(v.as_str()),
-                    _ => None,
-                };
-                let attached_resolver = |alias: &str| -> Option<usize> {
-                    connection
-                        .attached_databases()
-                        .read()
-                        .get_database_by_name(&crate::util::normalize_ident(alias))
-                        .map(|(idx, _)| idx)
-                };
-                fresh.handle_schema_row(
-                    ty,
-                    name,
-                    table_name,
-                    root_page,
-                    sql,
-                    &syms,
-                    &mut from_sql_indexes,
-                    &mut automatic_indices,
-                    &mut dbsp_state_roots,
-                    &mut dbsp_state_index_roots,
-                    &mut materialized_view_info,
-                    &attached_resolver,
-                )?;
-            }
-            fresh.populate_indices(
-                &syms,
-                from_sql_indexes,
-                automatic_indices,
-                mv_store.is_some(),
-            )?;
-            fresh.populate_materialized_views(
-                materialized_view_info,
-                dbsp_state_roots,
-                dbsp_state_index_roots,
-            )?;
-            Self::rehydrate_table_valued_functions(&mut fresh, &preserved_table_valued_functions);
-
-            Ok(Arc::new(fresh))
-        };
+    /// Replay a single committed logical-log transaction frame into the MVCC
+    /// store. Fully synchronous (the only recovery IO is reading the next frame,
+    /// driven by the caller); operates on accumulators borrowed from `ctx`.
+    fn recover_process_frame(
+        &self,
+        connection: &Arc<Connection>,
+        ctx: &mut RecoverCtx,
+        frame: Vec<ParsedOp>,
+    ) -> Result<()> {
+        let mut max_commit_ts_seen = ctx.max_commit_ts_seen;
+        let replay_cutoff_ts = ctx.replay_cutoff_ts;
+        let cookie = ctx.cookie;
+        let mut schema_rows = std::mem::take(&mut ctx.schema_rows);
+        let mut dropped_root_pages = std::mem::take(&mut ctx.dropped_root_pages);
+        let mut current_schema = ctx.current_schema.clone();
+        let mut index_infos = std::mem::take(&mut ctx.index_infos);
 
         let install_schema = |schema: Arc<Schema>| {
             *connection.schema.write() = schema.clone();
@@ -6379,28 +6764,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             | ParsedOp::DeleteIndex { commit_ts, .. }
             | ParsedOp::UpdateHeader { commit_ts, .. } => *commit_ts,
         };
-
-        let mut current_schema = connection.schema.read().clone();
-        let mut index_infos: HashMap<(MVTableId, IndexOpKind), Arc<IndexInfo>> = HashMap::default();
-
-        loop {
-            // Read one committed transaction at a time. This is important for
-            // schema recovery: a single transaction can contain both sqlite_schema
-            // changes and index-row changes, and the index-row log records do not
-            // carry CREATE INDEX SQL. They carry only the serialized index key
-            // bytes plus the index root page encoded as an MVCC table id. To turn
-            // those bytes back into an index row, recovery needs IndexInfo from a
-            // schema that is valid for this transaction frame.
-            let Some(frame) = reader.next_frame(&pager.io)? else {
-                let recovered_offset = reader.last_valid_offset() as u64;
-                let recovered_running_crc = reader.running_crc();
-                self.storage.restore_logical_log_state_after_recovery(
-                    recovered_offset,
-                    recovered_running_crc,
-                );
-                break;
-            };
-
+        'frame: {
             let frame_commit_ts = parsed_op_commit_ts(
                 frame
                     .first()
@@ -6408,7 +6772,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             );
             max_commit_ts_seen = max_commit_ts_seen.max(frame_commit_ts);
             if frame_commit_ts <= replay_cutoff_ts {
-                continue;
+                break 'frame;
             }
 
             // A single transaction frame can mix sqlite_schema changes with
@@ -6448,7 +6812,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 } else {
                     if frame_changes_schema && schema_after.is_none() {
                         // Now that all schema ops have been seen, build this frame's AFTER schema.
-                        schema_after = Some(build_schema(&schema_rows)?);
+                        schema_after = Some(self.recover_build_schema(
+                            connection,
+                            &schema_rows,
+                            cookie,
+                            &ctx.preserved_table_valued_functions,
+                        )?);
                     }
                     seen_data_op = true;
                 }
@@ -6510,7 +6879,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     index_infos.insert((index_id, op_kind), index_info.clone());
                     Ok(index_info)
                 };
-                let next_rec = reader.parsed_op_to_streaming(parsed_op, &mut get_index_info)?;
+                let next_rec = ctx
+                    .reader
+                    .parsed_op_to_streaming(parsed_op, &mut get_index_info)?;
 
                 tracing::trace!("next_rec {next_rec:?}");
 
@@ -6803,7 +7174,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         // Earlier, we build the schema when encountering the first non-schema op,
                         // so the AFTER schema can still be None if the frame only contained schema
                         // ops.
-                        build_schema(&schema_rows)?
+                        self.recover_build_schema(
+                            connection,
+                            &schema_rows,
+                            cookie,
+                            &ctx.preserved_table_valued_functions,
+                        )?
                     }
                 };
 
@@ -6819,26 +7195,117 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             }
         }
 
-        assert!(
-            max_commit_ts_seen >= persistent_tx_ts_max,
-            "replay clock would rewind below metadata boundary: max_commit_ts_seen={max_commit_ts_seen} persistent_tx_ts_max={persistent_tx_ts_max}"
-        );
-        connection.with_schema_mut(|schema| {
-            schema.dropped_root_pages = dropped_root_pages;
-        });
-        if let Some(header) = self.global_header.read().as_ref() {
-            // Replay may rebuild schema rows before seeing a later UpdateHeader op in the same
-            // logical-log tail. Normalize to the final recovered header cookie so VDBE schema
-            // cookie checks do not observe a stale in-memory schema version after restart.
-            connection.with_schema_mut(|schema| {
-                schema.schema_version = header.schema_cookie.get();
-            });
+        ctx.max_commit_ts_seen = max_commit_ts_seen;
+        ctx.schema_rows = schema_rows;
+        ctx.dropped_root_pages = dropped_root_pages;
+        ctx.current_schema = current_schema;
+        ctx.index_infos = index_infos;
+        Ok(())
+    }
+
+    /// Build a fresh `Schema` from the recovered `sqlite_schema` rows. Sync: the
+    /// schema cookie comes from `global_header` (in-memory) or `fallback_cookie`
+    /// (pre-read by the caller); no IO here.
+    fn recover_build_schema(
+        &self,
+        connection: &Arc<Connection>,
+        schema_rows: &HashMap<i64, ImmutableRecord>,
+        fallback_cookie: u32,
+        preserved_table_valued_functions: &[Arc<crate::vtab::VirtualTable>],
+    ) -> Result<Arc<Schema>> {
+        let cookie = self
+            .global_header
+            .read()
+            .as_ref()
+            .map(|header| header.schema_cookie.get())
+            .unwrap_or(fallback_cookie);
+        let mut fresh = Schema::new();
+        fresh.generated_columns_enabled = connection.db.experimental_generated_columns_enabled();
+        fresh.schema_version = cookie;
+        let mut from_sql_indexes = Vec::with_capacity(10);
+        let mut automatic_indices: HashMap<String, Vec<(String, i64)>> = HashMap::default();
+        let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
+        let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();
+        let mut materialized_view_info: HashMap<String, (String, i64)> = HashMap::default();
+        let syms = connection.syms.read();
+        let mv_store = connection.db.get_mv_store().clone();
+
+        let mut sorted_rowids: Vec<i64> = schema_rows.keys().copied().collect();
+        sorted_rowids.sort_unstable();
+        for rowid in &sorted_rowids {
+            let record = &schema_rows[rowid];
+            let ty = match record.get_value_opt(0) {
+                Some(ValueRef::Text(v)) => v.as_str(),
+                _ => {
+                    return Err(LimboError::Corrupt(
+                        "sqlite_schema type must be text".to_string(),
+                    ));
+                }
+            };
+            let name = match record.get_value_opt(1) {
+                Some(ValueRef::Text(v)) => v.as_str(),
+                _ => {
+                    return Err(LimboError::Corrupt(
+                        "sqlite_schema name must be text".to_string(),
+                    ));
+                }
+            };
+            let table_name = match record.get_value_opt(2) {
+                Some(ValueRef::Text(v)) => v.as_str(),
+                _ => {
+                    return Err(LimboError::Corrupt(
+                        "sqlite_schema tbl_name must be text".to_string(),
+                    ));
+                }
+            };
+            let root_page = match record.get_value_opt(3) {
+                Some(ValueRef::Numeric(Numeric::Integer(v))) => v,
+                _ => {
+                    return Err(LimboError::Corrupt(
+                        "sqlite_schema root_page must be integer".to_string(),
+                    ));
+                }
+            };
+            let sql = match record.get_value_opt(4) {
+                Some(ValueRef::Text(v)) => Some(v.as_str()),
+                _ => None,
+            };
+            let attached_resolver = |alias: &str| -> Option<usize> {
+                connection
+                    .attached_databases()
+                    .read()
+                    .get_database_by_name(&crate::util::normalize_ident(alias))
+                    .map(|(idx, _)| idx)
+            };
+            fresh.handle_schema_row(
+                ty,
+                name,
+                table_name,
+                root_page,
+                sql,
+                &syms,
+                &mut from_sql_indexes,
+                &mut automatic_indices,
+                &mut dbsp_state_roots,
+                &mut dbsp_state_index_roots,
+                &mut materialized_view_info,
+                &attached_resolver,
+            )?;
         }
-        *connection.db.schema.lock() = connection.schema.read().clone();
-        self.clock.reset(max_commit_ts_seen + 1);
-        self.last_committed_tx_ts
-            .store(max_commit_ts_seen, Ordering::SeqCst);
-        Ok(true)
+        fresh.populate_indices(
+            &syms,
+            from_sql_indexes,
+            automatic_indices,
+            mv_store.is_some(),
+        )?;
+        fresh.populate_materialized_views(
+            materialized_view_info,
+            dbsp_state_roots,
+            dbsp_state_index_roots,
+        )?;
+        Self::rehydrate_table_valued_functions(&mut fresh, preserved_table_valued_functions);
+
+        Ok(Arc::new(fresh))
     }
 
     pub fn set_checkpoint_threshold(&self, threshold: i64) {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -36,6 +36,7 @@ use crate::ValueRef;
 use crate::{
     contains_ignore_ascii_case, eq_ignore_ascii_case, match_ignore_ascii_case, Completion,
 };
+use crate::{io::FileSyncType, io_yield_one, return_if_io};
 use crate::{
     turso_assert, turso_assert_eq, turso_assert_less_than, turso_assert_reachable, Numeric,
 };
@@ -3363,6 +3364,38 @@ pub struct RowidAllocator {
     initialized: AtomicBool,
 }
 
+/// Sub state machine for [`MvStore::bootstrap_nonblock`]. Carried by the
+/// open state machine (`OpenDbAsyncPhase::BootstrapMvStore`) across the
+/// metadata-bootstrap IO chain so opening an MVCC database does not block on
+/// the log-header truncate / write / fsync sequence.
+#[derive(Default)]
+pub enum BootstrapState {
+    #[default]
+    Start,
+    MetadataIo(MetadataIoInFlight),
+    AwaitingGlobalHeader,
+}
+
+#[doc(hidden)]
+pub struct MetadataIoInFlight {
+    pub completion: Completion,
+    pub sync_type: FileSyncType,
+    pub next: MetadataIoStep,
+}
+
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub enum MetadataIoStep {
+    /// `log_file.truncate(0)` just finished. If the log was <= header size we
+    /// still need to write a fresh header (and maybe fsync). `log_size` is the
+    /// original on-disk size; `sync_mode_off` records whether sync is disabled.
+    AfterTruncate { log_size: u64, sync_mode_off: bool },
+    /// `storage.update_header` just finished. Maybe issue `storage.sync`.
+    AfterUpdateHeader { sync_mode_off: bool },
+    /// `storage.sync` just finished — metadata IO chain done.
+    AfterSync,
+}
+
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock> {
@@ -3717,58 +3750,190 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// 4. Promote the bootstrap connection to a regular connection so that it reads from the MV store again
     /// 5. Recover the logical log
     /// 6. Make sure schema changes reflected from deserialized logical log are captured in the schema
+    ///
+    /// Blocking shim retained for [`Connection::attach_database_inner`] and the
+    /// `op_journal_mode_inner` VDBE opcode — both of which are synchronous
+    /// public/VDBE entry points. The open state machine drives
+    /// [`MvStore::bootstrap_nonblock`] directly so a WAL/log header write
+    /// during open does not block.
     pub fn bootstrap(&self, bootstrap_conn: Arc<Connection>) -> Result<()> {
-        let preserved_table_valued_functions =
-            Self::capture_table_valued_functions(&bootstrap_conn.schema.read());
-        self.maybe_complete_interrupted_checkpoint(&bootstrap_conn)?;
-        bootstrap_conn.reparse_schema()?;
-        self.rehydrate_connection_table_valued_functions(
-            &bootstrap_conn,
-            &preserved_table_valued_functions,
-        );
+        let mut st = BootstrapState::default();
+        let io = bootstrap_conn.db.io.clone();
+        io.block(|| self.bootstrap_nonblock(&bootstrap_conn, &mut st))
+    }
 
-        if self.uses_durable_mvcc_metadata(&bootstrap_conn) {
-            match self.try_read_persistent_tx_ts_max(&bootstrap_conn)? {
-                Some(_) => {}
-                None => {
-                    let log_size = self.get_logical_log_file().size()?;
+    #[doc(hidden)]
+    pub fn bootstrap_nonblock(
+        &self,
+        bootstrap_conn: &Arc<Connection>,
+        st: &mut BootstrapState,
+    ) -> Result<IOResult<()>> {
+        loop {
+            match st {
+                BootstrapState::Start => {
+                    self.bootstrap_pre_metadata(bootstrap_conn)?;
+                    if let Some(next) = self.bootstrap_begin_metadata_io(bootstrap_conn)? {
+                        *st = BootstrapState::MetadataIo(next);
+                    } else {
+                        // No metadata IO needed (either non-durable mode, or
+                        // persistent_tx_ts already set). Run the post-metadata
+                        // sync work and transition.
+                        self.bootstrap_post_metadata_setup(bootstrap_conn)?;
+                        *st = BootstrapState::AwaitingGlobalHeader;
+                    }
+                }
+                BootstrapState::MetadataIo(phase) => {
+                    if !phase.completion.succeeded() {
+                        let c = phase.completion.clone();
+                        io_yield_one!(c);
+                    }
                     let pager = bootstrap_conn.pager.load().clone();
-                    if bootstrap_conn.db.is_readonly() {
-                        return Err(LimboError::Corrupt(
-                            "Missing MVCC metadata table in read-only mode".to_string(),
-                        ));
-                    }
-                    if log_size > LOG_HDR_SIZE as u64 {
-                        return Err(LimboError::Corrupt(
-                            "Missing MVCC metadata table while logical log state exists"
-                                .to_string(),
-                        ));
-                    }
-                    // First-time MVCC bootstrap: ensure a durable logical-log header exists
-                    // before any metadata-table writes can commit into WAL.
-                    // If a previous crash left a torn header tail (0 < size < LOG_HDR_SIZE),
-                    // clear it before rewriting the header.
-                    if log_size > 0 && log_size < LOG_HDR_SIZE as u64 {
-                        let log_file = self.get_logical_log_file();
-                        let c = log_file.truncate(0, Completion::new_trunc(|_| {}))?;
-                        bootstrap_conn.db.io.wait_for_completion(c)?;
-                    }
-                    if log_size <= LOG_HDR_SIZE as u64 {
-                        let c = self.storage.update_header()?;
-                        pager.io.wait_for_completion(c)?;
-                        if bootstrap_conn.get_sync_mode() != SyncMode::Off {
-                            let c = self.storage.sync(pager.get_sync_type())?;
-                            pager.io.wait_for_completion(c)?;
+                    let sync_type = phase.sync_type;
+                    match phase.next {
+                        MetadataIoStep::AfterTruncate {
+                            log_size,
+                            sync_mode_off,
+                        } => {
+                            // Truncate done. Maybe issue update_header next.
+                            if log_size <= LOG_HDR_SIZE as u64 {
+                                let c = self.storage.update_header()?;
+                                *phase = MetadataIoInFlight {
+                                    completion: c,
+                                    sync_type,
+                                    next: MetadataIoStep::AfterUpdateHeader { sync_mode_off },
+                                };
+                                // Loop to re-check succeeded immediately
+                            } else {
+                                self.bootstrap_finish_metadata_io(bootstrap_conn)?;
+                                self.bootstrap_post_metadata_setup(bootstrap_conn)?;
+                                *st = BootstrapState::AwaitingGlobalHeader;
+                            }
+                        }
+                        MetadataIoStep::AfterUpdateHeader { sync_mode_off } => {
+                            if !sync_mode_off {
+                                let c = self.storage.sync(sync_type)?;
+                                *phase = MetadataIoInFlight {
+                                    completion: c,
+                                    sync_type,
+                                    next: MetadataIoStep::AfterSync,
+                                };
+                            } else {
+                                self.bootstrap_finish_metadata_io(bootstrap_conn)?;
+                                self.bootstrap_post_metadata_setup(bootstrap_conn)?;
+                                *st = BootstrapState::AwaitingGlobalHeader;
+                            }
+                            let _ = pager; // silence unused on this arm
+                        }
+                        MetadataIoStep::AfterSync => {
+                            self.bootstrap_finish_metadata_io(bootstrap_conn)?;
+                            self.bootstrap_post_metadata_setup(bootstrap_conn)?;
+                            *st = BootstrapState::AwaitingGlobalHeader;
                         }
                     }
-                    self.initialize_mvcc_metadata_table(&bootstrap_conn)?;
-                    // Metadata bootstrap writes land in SQLite WAL first; reconcile immediately so
-                    // subsequent opens (including read-only opens) do not depend on WAL replay.
-                    self.maybe_complete_interrupted_checkpoint(&bootstrap_conn)?;
+                }
+                BootstrapState::AwaitingGlobalHeader => {
+                    if self.global_header.read().is_none() {
+                        let pager = bootstrap_conn.pager.load();
+                        let header = return_if_io!(pager.with_header(|header| *header));
+                        self.global_header.write().replace(header);
+                    }
+                    return Ok(IOResult::Done(()));
                 }
             }
         }
+    }
 
+    /// Synchronous prelude to bootstrap: capture vtabs, run the first
+    /// checkpoint reconciliation, reparse schema, rehydrate vtabs.
+    fn bootstrap_pre_metadata(&self, bootstrap_conn: &Arc<Connection>) -> Result<()> {
+        let preserved_table_valued_functions =
+            Self::capture_table_valued_functions(&bootstrap_conn.schema.read());
+        self.maybe_complete_interrupted_checkpoint(bootstrap_conn)?;
+        bootstrap_conn.reparse_schema()?;
+        self.rehydrate_connection_table_valued_functions(
+            bootstrap_conn,
+            &preserved_table_valued_functions,
+        );
+        Ok(())
+    }
+
+    /// Decide whether the metadata-bootstrap IO chain is required and, if so,
+    /// issue its first completion. Returns `Some(MetadataIoInFlight)` carrying
+    /// the in-flight completion and the next step to take after it completes;
+    /// returns `None` if the chain is not required (either the database does
+    /// not use durable MVCC metadata, or the persistent tx-ts max is already
+    /// set, or the log is in a clean state).
+    fn bootstrap_begin_metadata_io(
+        &self,
+        bootstrap_conn: &Arc<Connection>,
+    ) -> Result<Option<MetadataIoInFlight>> {
+        if !self.uses_durable_mvcc_metadata(bootstrap_conn) {
+            return Ok(None);
+        }
+        if self
+            .try_read_persistent_tx_ts_max(bootstrap_conn)?
+            .is_some()
+        {
+            return Ok(None);
+        }
+
+        let log_size = self.get_logical_log_file().size()?;
+        let pager = bootstrap_conn.pager.load().clone();
+        if bootstrap_conn.db.is_readonly() {
+            return Err(LimboError::Corrupt(
+                "Missing MVCC metadata table in read-only mode".to_string(),
+            ));
+        }
+        if log_size > LOG_HDR_SIZE as u64 {
+            return Err(LimboError::Corrupt(
+                "Missing MVCC metadata table while logical log state exists".to_string(),
+            ));
+        }
+        let sync_type = pager.get_sync_type();
+        let sync_mode_off = bootstrap_conn.get_sync_mode() == SyncMode::Off;
+
+        // First-time MVCC bootstrap: ensure a durable logical-log header exists
+        // before any metadata-table writes can commit into WAL. If a previous
+        // crash left a torn header tail (0 < size < LOG_HDR_SIZE), clear it
+        // before rewriting the header.
+        if log_size > 0 && log_size < LOG_HDR_SIZE as u64 {
+            let log_file = self.get_logical_log_file();
+            let completion = log_file.truncate(0, Completion::new_trunc(|_| {}))?;
+            return Ok(Some(MetadataIoInFlight {
+                completion,
+                sync_type,
+                next: MetadataIoStep::AfterTruncate {
+                    log_size,
+                    sync_mode_off,
+                },
+            }));
+        }
+        if log_size <= LOG_HDR_SIZE as u64 {
+            let completion = self.storage.update_header()?;
+            return Ok(Some(MetadataIoInFlight {
+                completion,
+                sync_type,
+                next: MetadataIoStep::AfterUpdateHeader { sync_mode_off },
+            }));
+        }
+        // Shouldn't reach here given the earlier error returns, but be safe.
+        Ok(None)
+    }
+
+    /// Once the metadata-bootstrap IO chain has finished, initialize the MVCC
+    /// metadata table and reconcile any interrupted checkpoint immediately so
+    /// that subsequent opens (including read-only opens) do not depend on WAL
+    /// replay of those metadata writes.
+    fn bootstrap_finish_metadata_io(&self, bootstrap_conn: &Arc<Connection>) -> Result<()> {
+        self.initialize_mvcc_metadata_table(bootstrap_conn)?;
+        self.maybe_complete_interrupted_checkpoint(bootstrap_conn)?;
+        Ok(())
+    }
+
+    /// Sync work between the metadata IO chain (or its skip) and the final
+    /// global-header read: build the schema mapping, recover the logical log,
+    /// and promote the bootstrap connection to a regular MVCC connection.
+    fn bootstrap_post_metadata_setup(&self, bootstrap_conn: &Arc<Connection>) -> Result<()> {
         {
             let schema = bootstrap_conn.schema.read();
             let sqlite_schema_root_pages = {
@@ -3800,9 +3965,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 
         // Recover logical log while bootstrap connection still reads from pager-backed schema.
         // This lets recovery merge checkpointed sqlite_schema rows with non-checkpointed rows from log replay.
-        // Return value indicates whether recovery replayed any frames; unused here because
-        // global_header initialization below is unconditional (guarded by is_none() instead).
-        // The return value is still used by tests to verify recovery behavior.
         let _recovered = self.maybe_recover_logical_log(bootstrap_conn.clone())?;
 
         // Recovery is done, switch back to regular MVCC reads.
@@ -3832,15 +3994,6 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // we surface them to the caller as a hard bootstrap failure.
         bootstrap_conn.sync_autoincrement_backing_tables_from_sqlite_sequence()?;
         *bootstrap_conn.db.schema.lock() = bootstrap_conn.schema.read().clone();
-
-        if self.global_header.read().is_none() {
-            let pager = bootstrap_conn.pager.load();
-            let header = pager
-                .io
-                .block(|| pager.with_header(|header| *header))
-                .expect("failed to read database header");
-            self.global_header.write().replace(header);
-        }
 
         Ok(())
     }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4150,7 +4150,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     // backing table is on-disk corruption, surfaced as a hard
                     // bootstrap failure rather than a misleading "sequence does
                     // not exist" on the next nextval.
-                    return_if_io!(bootstrap_conn.load_sequence_descriptors_via_sql_nonblock(load_st));
+                    return_if_io!(
+                        bootstrap_conn.load_sequence_descriptors_via_sql_nonblock(load_st)
+                    );
                     *st = BootstrapState::SyncAutoincrement {
                         sync_st: crate::connection::SyncAutoincrementState::default(),
                     };

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -6363,6 +6363,14 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         }
                     };
                     self.storage.set_header(header.clone());
+                    // Enter the checkpoint lifecycle before any WAL→DB backfill so
+                    // that `DurableStorage` implementations observing the
+                    // start/end pairing (e.g. the diskless server, which arms its
+                    // next-generation metadata here) see a checkpoint in progress
+                    // when `wal.checkpoint` writes pages into the DB file. Called
+                    // exactly once at this transition (never on `DriveCheckpoint`
+                    // re-entry) since `on_checkpoint_start` is not idempotent.
+                    self.storage.on_checkpoint_start()?;
                     *st = CompleteCheckpointState::DriveCheckpoint { header };
                 }
                 CompleteCheckpointState::DriveEarlyTruncate {
@@ -6387,17 +6395,28 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         },
                     ));
                     if !checkpoint_result.everything_backfilled() {
-                        return Err(LimboError::Corrupt(
+                        let err = LimboError::Corrupt(
                             "Unable to fully backfill committed WAL frames during MVCC recovery"
                                 .to_string(),
-                        ));
+                        );
+                        // Close out the lifecycle opened in `ReadingHeader` so the
+                        // start/end pairing stays balanced on this error path.
+                        self.storage.on_checkpoint_end(Err(err.clone()))?;
+                        return Err(err);
                     }
                     let need_db_sync = connection.get_sync_mode() != SyncMode::Off
                         && checkpoint_result.wal_checkpoint_backfilled > 0;
                     if need_db_sync {
-                        let c = pager
+                        let c = match pager
                             .db_file
-                            .sync(Completion::new_sync(|_| {}), pager.get_sync_type())?;
+                            .sync(Completion::new_sync(|_| {}), pager.get_sync_type())
+                        {
+                            Ok(c) => c,
+                            Err(err) => {
+                                self.storage.on_checkpoint_end(Err(err.clone()))?;
+                                return Err(err);
+                            }
+                        };
                         *st = CompleteCheckpointState::AwaitDbFileSync {
                             completion: c,
                             checkpoint_result,
@@ -6432,7 +6451,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     phase,
                 } => match phase {
                     RetryHeaderPhase::NeedUpdateHeader => {
-                        let c = self.storage.update_header()?;
+                        let c = match self.storage.update_header() {
+                            Ok(c) => c,
+                            Err(err) => {
+                                self.storage.on_checkpoint_end(Err(err.clone()))?;
+                                return Err(err);
+                            }
+                        };
                         *phase = RetryHeaderPhase::AwaitUpdateHeader(c);
                     }
                     RetryHeaderPhase::AwaitUpdateHeader(completion) => {
@@ -6441,7 +6466,13 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             io_yield_one!(c);
                         }
                         if connection.get_sync_mode() != SyncMode::Off {
-                            let c = self.storage.sync(pager.get_sync_type())?;
+                            let c = match self.storage.sync(pager.get_sync_type()) {
+                                Ok(c) => c,
+                                Err(err) => {
+                                    self.storage.on_checkpoint_end(Err(err.clone()))?;
+                                    return Err(err);
+                                }
+                            };
                             *phase = RetryHeaderPhase::AwaitLogSync(c);
                         } else {
                             let file = self.get_logical_log_file();
@@ -6471,9 +6502,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                             *st = CompleteCheckpointState::DriveFinalTruncate { checkpoint_result };
                         } else {
                             if *retried_crc {
-                                return Err(LimboError::Corrupt(
+                                let err = LimboError::Corrupt(
                                     "Logical log header CRC mismatch after retry".to_string(),
-                                ));
+                                );
+                                self.storage.on_checkpoint_end(Err(err.clone()))?;
+                                return Err(err);
                             }
                             *retried_crc = true;
                             *phase = RetryHeaderPhase::NeedUpdateHeader;

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1171,7 +1171,12 @@ fn test_recover_logical_log_short_file_ignored() {
     conn.db.io.wait_for_completion(c).unwrap();
     assert_eq!(file.size().unwrap(), 1);
 
-    let recovered = mvcc_store.maybe_recover_logical_log(conn).unwrap();
+    use crate::util::IOExt as _;
+    let io = conn.db.io.clone();
+    let mut st = RecoverLogicalLogState::default();
+    let recovered = io
+        .block(|| mvcc_store.maybe_recover_logical_log(&conn, &mut st))
+        .unwrap();
     assert!(!recovered);
 }
 
@@ -1219,7 +1224,9 @@ fn test_recovery_rejects_schema_op_after_data_op_in_frame() {
     let c = log.log_tx(tx).unwrap();
     io.wait_for_completion(c).unwrap();
 
-    let result = mvcc_store.maybe_recover_logical_log(conn);
+    use crate::util::IOExt as _;
+    let mut st = RecoverLogicalLogState::default();
+    let result = io.block(|| mvcc_store.maybe_recover_logical_log(&conn, &mut st));
     assert!(
         matches!(&result, Err(LimboError::Corrupt(msg)) if msg.contains("schema op after a data op")),
     );
@@ -11526,7 +11533,7 @@ fn collect_mvcc_recovery_ops(conn: &Arc<Connection>) -> Vec<ParsedOp> {
     reader.read_header(&io).unwrap();
 
     let mut ops = Vec::new();
-    while let Some(frame_ops) = reader.next_frame(&io).unwrap() {
+    while let Some(frame_ops) = reader.next_frame_blocking(&io).unwrap() {
         ops.extend(frame_ops);
     }
     ops

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -11493,7 +11493,7 @@ fn collect_mvcc_portable_change_bytes(conn: &Arc<Connection>) -> Vec<u8> {
     reader.read_header(&io).unwrap();
 
     let mut portable_changes = Vec::new();
-    while let Some(frame) = reader.next_portable_changes(&io).unwrap() {
+    while let Some(frame) = io.block(|| reader.next_portable_changes()).unwrap() {
         portable_changes.extend_from_slice(&frame.payload);
     }
     portable_changes
@@ -11515,7 +11515,7 @@ fn collect_mvcc_portable_change_bytes_with_encryption(
     reader.read_header(&io).unwrap();
 
     let mut portable_changes = Vec::new();
-    while let Some(frame) = reader.next_portable_changes(&io).unwrap() {
+    while let Some(frame) = io.block(|| reader.next_portable_changes()).unwrap() {
         portable_changes.extend_from_slice(&frame.payload);
     }
     portable_changes

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1663,6 +1663,99 @@ enum StreamingState {
     NeedTransactionStart,
 }
 
+/// Phase of the in-progress transaction frame parse. Each phase corresponds to a
+/// re-entrant unit: the header (atomic), an optional unencrypted extension block,
+/// the payload, and the trailer. See [`FrameInProgress`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum FramePhase {
+    Header,
+    ExtensionBlock,
+    Payload,
+    Trailer,
+}
+
+/// Progress carried across IO yields while parsing one transaction frame.
+///
+/// The reader yields mid-frame (any `try_consume_*` can need more data). Instead
+/// of re-parsing the whole frame from its start on every re-entry (the previous
+/// model), we checkpoint at unit boundaries: when a unit (header / extension
+/// block / one op / trailer) is fully consumed *and* its bytes are folded into
+/// `running_crc`, we record progress here and advance `frame_anchor` to the
+/// consume cursor. Re-entry then rewinds only to the latest checkpoint and
+/// re-parses just the in-flight unit, so the buffer compacts as units are
+/// consumed (memory bounded by the largest single op, not the whole frame) and
+/// no unit is parsed more than its own yields require.
+///
+/// `running_crc` is the chained CRC *up to and excluding* the in-flight unit; the
+/// in-flight unit folds onto a local copy that is committed back here only at its
+/// checkpoint. `frame_start` is captured once at frame open and is the value used
+/// for `last_valid_offset` when the frame turns out to be invalid — it must never
+/// be recomputed from the (mid-frame) consume cursor.
+struct FrameInProgress {
+    frame_start: usize,
+    phase: FramePhase,
+    // Header fields (filled once the Header phase completes):
+    payload_size: usize,
+    op_count: u32,
+    commit_ts: u64,
+    extension_size: usize,
+    extension_record_count: u32,
+    frame_flags: u32,
+    // Accumulators carried across op/unit yields:
+    running_crc: u32,
+    parsed_ops: Vec<ParsedOp>,
+    portable_changes: Vec<u8>,
+    payload_bytes_read: u64,
+    op_index: u32,
+}
+
+impl FrameInProgress {
+    fn new(frame_start: usize) -> Self {
+        Self {
+            frame_start,
+            phase: FramePhase::Header,
+            payload_size: 0,
+            op_count: 0,
+            commit_ts: 0,
+            extension_size: 0,
+            extension_record_count: 0,
+            frame_flags: 0,
+            running_crc: 0,
+            parsed_ops: Vec::new(),
+            portable_changes: Vec::new(),
+            payload_bytes_read: 0,
+            op_index: 0,
+        }
+    }
+}
+
+/// Parsed transaction-header fields returned by `parse_frame_header`.
+struct FrameHeader {
+    payload_size: usize,
+    op_count: u32,
+    commit_ts: u64,
+    extension_size: usize,
+    extension_record_count: u32,
+    frame_flags: u32,
+    /// Chained CRC seeded from `self.running_crc` and folded over the header bytes.
+    running_crc: u32,
+}
+
+/// Outcome of parsing the transaction header (a re-entrant atomic unit).
+enum HeaderParseOutcome {
+    Ok(FrameHeader),
+    Eof,
+    Invalid,
+}
+
+/// Outcome of parsing a payload phase. Corruption is signalled via
+/// `Err(LimboError::Corrupt(..))` and translated to `Invalid` by the caller,
+/// mirroring the previous control flow.
+enum PayloadOutcome {
+    Ok,
+    Eof,
+}
+
 /// Result of attempting to read and validate the logical log file header.
 #[derive(Debug, Clone)]
 pub enum HeaderReadResult {
@@ -1736,6 +1829,11 @@ pub struct StreamingLogicalLogReader {
     /// Set when a read has been issued but its completion has not yet been
     /// observed by the calling IOResult method. Cleared on completion.
     in_flight_read: Option<InFlightRead>,
+    /// Progress of the transaction frame currently being parsed by
+    /// `parse_next_transaction`, carried across IO yields. `None` between frames.
+    /// See [`FrameInProgress`]. (The portable-changes reader uses the
+    /// rewind-and-rebuild model and does not populate this.)
+    frame_in_progress: Option<FrameInProgress>,
 }
 
 impl StreamingLogicalLogReader {
@@ -1766,6 +1864,7 @@ impl StreamingLogicalLogReader {
             pending_ops: std::collections::VecDeque::new(),
             decrypt_scratch,
             in_flight_read: None,
+            frame_in_progress: None,
         }
     }
 
@@ -1854,6 +1953,7 @@ impl StreamingLogicalLogReader {
                 self.buffer.write().clear();
                 self.buffer_offset = 0;
                 self.frame_anchor = 0;
+                self.frame_in_progress = None;
                 self.last_valid_offset = hdr_len;
                 Ok(IOResult::Done(HeaderReadResult::Valid(header)))
             }
@@ -1871,6 +1971,7 @@ impl StreamingLogicalLogReader {
         self.buffer.write().clear();
         self.buffer_offset = 0;
         self.frame_anchor = 0;
+        self.frame_in_progress = None;
         self.last_valid_offset = LOG_HDR_SIZE;
     }
 
@@ -1892,13 +1993,19 @@ impl StreamingLogicalLogReader {
         loop {
             match self.state {
                 StreamingState::NeedTransactionStart => {
-                    // Rewind to the current frame anchor before the EOF check:
-                    // on a mid-frame re-entry `buffer_offset` is advanced, which
-                    // would undercount `remaining_bytes()` and stop recovery
-                    // early. `parse_next_transaction` rewinds again (idempotent).
-                    self.buffer_offset = self.frame_anchor;
-                    if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
-                        return Ok(IOResult::Done(None));
+                    // EOF fast-path, only meaningful when starting a fresh frame.
+                    // When a frame is in progress we must resume it regardless of
+                    // how few bytes remain from the latest checkpoint (e.g. only
+                    // the 8-byte trailer is left), so gate the guard on
+                    // `frame_in_progress.is_none()`. Rewind to the frame anchor
+                    // first so a mid-frame `buffer_offset` does not undercount
+                    // `remaining_bytes()`. `parse_next_transaction` rewinds again
+                    // (idempotent).
+                    if self.frame_in_progress.is_none() {
+                        self.buffer_offset = self.frame_anchor;
+                        if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
+                            return Ok(IOResult::Done(None));
+                        }
                     }
 
                     let ops = match return_if_io!(self.parse_next_transaction()) {
@@ -1968,20 +2075,16 @@ impl StreamingLogicalLogReader {
     /// Empty payloads are returned because internal-only commits still
     /// advance the logical-log offset even though clients have no operation to
     /// apply.
-    pub fn next_portable_change_frame(
-        &mut self,
-        io: &Arc<dyn crate::IO>,
-    ) -> Result<Option<PortableChangeFrame>> {
+    pub fn next_portable_change_frame(&mut self) -> Result<IOResult<Option<PortableChangeFrame>>> {
         self.file_size = self.file.size()? as usize;
-        let io = io.clone();
-        match io.block(|| self.parse_next_portable_changes_frame())? {
-            ParseResult::Frame(frame) => Ok(Some(PortableChangeFrame {
+        match return_if_io!(self.parse_next_portable_changes_frame()) {
+            ParseResult::Frame(frame) => Ok(IOResult::Done(Some(PortableChangeFrame {
                 end_offset: frame.end_offset as u64,
                 commit_ts: frame.commit_ts,
                 extension_record_count: frame.extension_record_count,
                 payload: frame.portable_changes,
-            })),
-            ParseResult::Eof | ParseResult::InvalidFrame => Ok(None),
+            }))),
+            ParseResult::Eof | ParseResult::InvalidFrame => Ok(IOResult::Done(None)),
         }
     }
 
@@ -1990,16 +2093,13 @@ impl StreamingLogicalLogReader {
     ///
     /// Empty payloads are valid: internal-only commits still need recovery
     /// log frames, but they do not produce client-visible logical operations.
-    pub fn next_portable_changes(
-        &mut self,
-        io: &Arc<dyn crate::IO>,
-    ) -> Result<Option<PortableChangeFrame>> {
+    pub fn next_portable_changes(&mut self) -> Result<IOResult<Option<PortableChangeFrame>>> {
         loop {
-            let Some(frame) = self.next_portable_change_frame(io)? else {
-                return Ok(None);
+            let Some(frame) = return_if_io!(self.next_portable_change_frame()) else {
+                return Ok(IOResult::Done(None));
             };
             if !frame.payload.is_empty() {
-                return Ok(Some(frame));
+                return Ok(IOResult::Done(Some(frame)));
             }
         }
     }
@@ -2419,21 +2519,56 @@ impl StreamingLogicalLogReader {
     }
 
     /// Parse an unencrypted payload via field-by-field streaming IO reads.
-    fn parse_streaming_payload(
-        &mut self,
-        op_count: u32,
-        payload_size: usize,
-        commit_ts: u64,
-        mut running_crc: u32,
-    ) -> Result<IOResult<PayloadParseResult>> {
-        let mut parsed_ops = Vec::with_capacity((op_count as usize).min(1024));
-        let mut payload_bytes_read: u64 = 0;
+    ///
+    /// Resumable: progress lives in `self.frame_in_progress` (op index, parsed
+    /// ops, chained CRC, payload byte count). Each fully consumed op is committed
+    /// there and the consume cursor is checkpointed (`advance_checkpoint`), so a
+    /// mid-op IO yield re-parses only the in-flight op on re-entry and the buffer
+    /// compacts as ops are consumed. Corruption is reported as
+    /// `Err(LimboError::Corrupt(..))`; the caller maps it to an invalid frame.
+    fn parse_streaming_payload(&mut self) -> Result<IOResult<PayloadOutcome>> {
+        loop {
+            let (op_index, op_count, commit_ts) = {
+                let fip = self
+                    .frame_in_progress
+                    .as_ref()
+                    .expect("frame in progress while parsing streaming payload");
+                (fip.op_index, fip.op_count, fip.commit_ts)
+            };
 
-        for _ in 0..op_count {
+            if op_index >= op_count {
+                let (payload_size, payload_bytes_read) = {
+                    let fip = self
+                        .frame_in_progress
+                        .as_ref()
+                        .expect("frame in progress while parsing streaming payload");
+                    (fip.payload_size, fip.payload_bytes_read)
+                };
+                if payload_size as u64 != payload_bytes_read {
+                    return Err(LimboError::Corrupt(format!(
+                        "payload_size ({payload_size}) != payload_bytes_read ({payload_bytes_read})"
+                    )));
+                }
+                return Ok(IOResult::Done(PayloadOutcome::Ok));
+            }
+
+            // Seed this op's accumulators from the last committed op; they fold
+            // this op's bytes and are written back only once it is fully parsed.
+            let mut running_crc = self
+                .frame_in_progress
+                .as_ref()
+                .expect("frame in progress while parsing streaming payload")
+                .running_crc;
+            let mut payload_bytes_read = self
+                .frame_in_progress
+                .as_ref()
+                .expect("frame in progress while parsing streaming payload")
+                .payload_bytes_read;
+
             // Op header (6 bytes): tag(1) | flags(1) | table_id(4, little-endian i32)
             let op_bytes = match return_if_io!(self.try_consume_fixed::<6>()) {
                 Some(bytes) => bytes,
-                None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
+                None => return Ok(IOResult::Done(PayloadOutcome::Eof)),
             };
             running_crc = crc32c::crc32c_append(running_crc, &op_bytes);
             let tag = op_bytes[0];
@@ -2467,7 +2602,7 @@ impl StreamingLogicalLogReader {
             let (payload_len, payload_len_bytes, payload_len_bytes_len) =
                 match return_if_io!(self.consume_varint_bytes()) {
                     Some((value, bytes, len)) => (value, bytes, len),
-                    None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
+                    None => return Ok(IOResult::Done(PayloadOutcome::Eof)),
                 };
             running_crc =
                 crc32c::crc32c_append(running_crc, &payload_len_bytes[..payload_len_bytes_len]);
@@ -2476,7 +2611,7 @@ impl StreamingLogicalLogReader {
 
             let payload = match return_if_io!(self.try_consume_bytes(payload_len)) {
                 Some(bytes) => bytes,
-                None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
+                None => return Ok(IOResult::Done(PayloadOutcome::Eof)),
             };
             running_crc = crc32c::crc32c_append(running_crc, &payload);
 
@@ -2484,7 +2619,7 @@ impl StreamingLogicalLogReader {
                 let (extension_len, extension_len_bytes, extension_len_bytes_len) =
                     match return_if_io!(self.consume_varint_bytes()) {
                         Some((value, bytes, len)) => (value, bytes, len),
-                        None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
+                        None => return Ok(IOResult::Done(PayloadOutcome::Eof)),
                     };
                 running_crc = crc32c::crc32c_append(
                     running_crc,
@@ -2495,7 +2630,7 @@ impl StreamingLogicalLogReader {
                 })?;
                 let extension = match return_if_io!(self.try_consume_bytes(extension_len)) {
                     Some(bytes) => bytes,
-                    None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
+                    None => return Ok(IOResult::Done(PayloadOutcome::Eof)),
                 };
                 running_crc = crc32c::crc32c_append(running_crc, &extension);
                 (extension, extension_len_bytes_len + extension_len)
@@ -2610,44 +2745,185 @@ impl StreamingLogicalLogReader {
                 }
             };
 
-            parsed_ops.push(parsed_op);
+            // Op fully parsed and folded: commit it and checkpoint the cursor so
+            // re-entry resumes at the next op and the buffer can compact this one.
+            {
+                let fip = self
+                    .frame_in_progress
+                    .as_mut()
+                    .expect("frame in progress while parsing streaming payload");
+                fip.parsed_ops.push(parsed_op);
+                fip.running_crc = running_crc;
+                fip.payload_bytes_read = payload_bytes_read;
+                fip.op_index += 1;
+            }
+            self.advance_checkpoint();
         }
-
-        if payload_size as u64 != payload_bytes_read {
-            return Err(LimboError::Corrupt(format!(
-                "payload_size ({payload_size}) != payload_bytes_read ({payload_bytes_read})"
-            )));
-        }
-
-        Ok(IOResult::Done(PayloadParseResult::Ok(
-            parsed_ops,
-            running_crc,
-        )))
     }
 
+    /// Parse the next transaction frame as a re-entrant phase machine.
+    ///
+    /// Progress is carried in `self.frame_in_progress` across IO yields. Each
+    /// phase (header, optional unencrypted extension block, payload, trailer) is
+    /// a re-entrant unit: once fully consumed and folded into the chained CRC it
+    /// checkpoints (`advance_checkpoint`), advancing `frame_anchor` to the
+    /// consume cursor so `read_more_data` can compact everything before it and a
+    /// later yield rewinds only to the latest checkpoint. Re-entry rewinds
+    /// `buffer_offset` to `frame_anchor` and re-runs just the in-flight unit from
+    /// local state. `frame_start` is captured once at frame open (never
+    /// recomputed) so an invalid frame reports the correct `last_valid_offset`.
     fn parse_next_transaction(&mut self) -> Result<IOResult<ParseResult>> {
-        // Rewind to the start of the current frame. This function consumes
-        // incrementally and can yield mid-frame; on re-entry it restarts from
-        // the top, so we must re-read from the frame boundary (not the
-        // partially-consumed position). `frame_anchor` bytes are kept buffered
-        // by `read_more_data` for exactly this. CRC is reseeded from
-        // `self.running_crc` and recomputed over the re-read bytes.
-        self.buffer_offset = self.frame_anchor;
-        if self.remaining_bytes() < self.tx_min_frame_size() {
-            return Ok(IOResult::Done(ParseResult::Eof));
+        loop {
+            if self.frame_in_progress.is_none() {
+                // Start a fresh frame at the current consume cursor.
+                self.buffer_offset = self.frame_anchor;
+                if self.remaining_bytes() < self.tx_min_frame_size() {
+                    return Ok(IOResult::Done(ParseResult::Eof));
+                }
+                let frame_start = self.offset.saturating_sub(self.bytes_can_read());
+                self.frame_in_progress = Some(FrameInProgress::new(frame_start));
+            } else {
+                // Resume the in-flight frame: rewind the consume cursor to the
+                // latest checkpoint and re-run the current phase from there.
+                self.buffer_offset = self.frame_anchor;
+            }
+
+            let phase = self
+                .frame_in_progress
+                .as_ref()
+                .expect("frame in progress")
+                .phase;
+            match phase {
+                FramePhase::Header => {
+                    let header = match return_if_io!(self.parse_frame_header()) {
+                        HeaderParseOutcome::Ok(header) => header,
+                        HeaderParseOutcome::Eof => return self.abort_frame_eof(),
+                        HeaderParseOutcome::Invalid => return self.invalidate_frame(),
+                    };
+                    // Unencrypted frames with an extension block consume it as a
+                    // separate phase; encrypted frames carry the extension inside
+                    // the encrypted plaintext (handled in the payload phase).
+                    let next_phase = if self.encryption_ctx.is_none() && header.extension_size > 0 {
+                        FramePhase::ExtensionBlock
+                    } else {
+                        FramePhase::Payload
+                    };
+                    {
+                        let fip = self.frame_in_progress.as_mut().expect("frame in progress");
+                        fip.payload_size = header.payload_size;
+                        fip.op_count = header.op_count;
+                        fip.commit_ts = header.commit_ts;
+                        fip.extension_size = header.extension_size;
+                        fip.extension_record_count = header.extension_record_count;
+                        fip.frame_flags = header.frame_flags;
+                        fip.running_crc = header.running_crc;
+                        fip.phase = next_phase;
+                    }
+                    self.advance_checkpoint();
+                }
+                FramePhase::ExtensionBlock => {
+                    let (extension_size, extension_record_count, running_crc) = {
+                        let fip = self.frame_in_progress.as_ref().expect("frame in progress");
+                        (
+                            fip.extension_size,
+                            fip.extension_record_count,
+                            fip.running_crc,
+                        )
+                    };
+                    let bytes = match return_if_io!(self.try_consume_bytes(extension_size)) {
+                        Some(bytes) => bytes,
+                        None => return self.abort_frame_eof(),
+                    };
+                    let running_crc = crc32c::crc32c_append(running_crc, &bytes);
+                    let portable_changes = match find_extension_payload(
+                        &bytes,
+                        extension_record_count,
+                        EXTENSION_TYPE_PORTABLE_CHANGES,
+                    ) {
+                        Ok(payload) => payload,
+                        Err(LimboError::Corrupt(msg)) => {
+                            tracing::warn!("corrupt extension block: {msg}");
+                            return self.invalidate_frame();
+                        }
+                        Err(e) => return Err(e),
+                    };
+                    {
+                        let fip = self.frame_in_progress.as_mut().expect("frame in progress");
+                        fip.portable_changes = portable_changes;
+                        fip.running_crc = running_crc;
+                        fip.phase = FramePhase::Payload;
+                    }
+                    self.advance_checkpoint();
+                }
+                FramePhase::Payload => match self.parse_payload_phase() {
+                    Ok(IOResult::Done(PayloadOutcome::Ok)) => {
+                        self.frame_in_progress
+                            .as_mut()
+                            .expect("frame in progress")
+                            .phase = FramePhase::Trailer;
+                        self.advance_checkpoint();
+                    }
+                    Ok(IOResult::Done(PayloadOutcome::Eof)) => return self.abort_frame_eof(),
+                    Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
+                    Err(LimboError::Corrupt(msg)) => {
+                        tracing::warn!("corrupt payload: {msg}");
+                        return self.invalidate_frame();
+                    }
+                    Err(e) => return Err(e),
+                },
+                FramePhase::Trailer => {
+                    // TX TRAILER layout (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
+                    let trailer_bytes =
+                        match return_if_io!(self.try_consume_fixed::<TX_TRAILER_SIZE>()) {
+                            Some(bytes) => bytes,
+                            None => return self.abort_frame_eof(),
+                        };
+                    let crc32c_expected = u32::from_le_bytes([
+                        trailer_bytes[0],
+                        trailer_bytes[1],
+                        trailer_bytes[2],
+                        trailer_bytes[3],
+                    ]);
+                    let end_magic = u32::from_le_bytes([
+                        trailer_bytes[4],
+                        trailer_bytes[5],
+                        trailer_bytes[6],
+                        trailer_bytes[7],
+                    ]);
+                    let running_crc = self
+                        .frame_in_progress
+                        .as_ref()
+                        .expect("frame in progress")
+                        .running_crc;
+                    if crc32c_expected != running_crc {
+                        return self.invalidate_frame();
+                    }
+                    if end_magic != END_MAGIC {
+                        return self.invalidate_frame();
+                    }
+                    return self.commit_frame();
+                }
+            }
         }
-        let frame_start = self.offset.saturating_sub(self.bytes_can_read());
+    }
 
-        let mut header_bytes = match return_if_io!(self.try_consume_bytes(TX_HEADER_SIZE)) {
-            Some(bytes) => bytes,
-            None => return Ok(IOResult::Done(ParseResult::Eof)),
-        };
-
+    /// Parse and validate the transaction header (a re-entrant atomic unit).
+    /// Reads from the current consume cursor and mutates only local state plus
+    /// the consume cursor, so it is safe to re-run from the frame anchor on
+    /// re-entry. The chained CRC is seeded from `self.running_crc` and folded
+    /// over the header bytes. Field/structural problems return `Invalid`; the
+    /// caller sets `last_valid_offset` from the captured `frame_start`.
+    fn parse_frame_header(&mut self) -> Result<IOResult<HeaderParseOutcome>> {
         // TX HEADER v2 layout (24 bytes):
         // FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
         //
         // TX HEADER v3 extension frames append:
         // extension_size(8) | extension_record_count(4) | frame_flags(4)
+        let mut header_bytes = match return_if_io!(self.try_consume_bytes(TX_HEADER_SIZE)) {
+            Some(bytes) => bytes,
+            None => return Ok(IOResult::Done(HeaderParseOutcome::Eof)),
+        };
+
         let frame_magic = u32::from_le_bytes([
             header_bytes[0],
             header_bytes[1],
@@ -2660,18 +2936,16 @@ impl StreamingLogicalLogReader {
             .is_some_and(|header| header.version == LOG_VERSION_V2);
         let has_extension_header = !is_v2 && frame_magic == EXT_FRAME_MAGIC;
         if frame_magic != FRAME_MAGIC && !has_extension_header {
-            self.last_valid_offset = frame_start;
-            return Ok(IOResult::Done(ParseResult::InvalidFrame));
+            return Ok(IOResult::Done(HeaderParseOutcome::Invalid));
         }
         if is_v2 && frame_magic != FRAME_MAGIC {
-            self.last_valid_offset = frame_start;
-            return Ok(IOResult::Done(ParseResult::InvalidFrame));
+            return Ok(IOResult::Done(HeaderParseOutcome::Invalid));
         }
         if has_extension_header {
             let Some(extension_header) =
                 return_if_io!(self.try_consume_bytes(TX_EXT_HEADER_SIZE - TX_HEADER_SIZE))
             else {
-                return Ok(IOResult::Done(ParseResult::Eof));
+                return Ok(IOResult::Done(HeaderParseOutcome::Eof));
             };
             header_bytes.extend_from_slice(&extension_header);
         }
@@ -2716,8 +2990,7 @@ impl StreamingLogicalLogReader {
                 Ok(v) => v,
                 Err(e) => {
                     tracing::warn!("extension_size overflows usize: {e}");
-                    self.last_valid_offset = frame_start;
-                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
+                    return Ok(IOResult::Done(HeaderParseOutcome::Invalid));
                 }
             };
             let extension_record_count = u32::from_le_bytes([
@@ -2733,16 +3006,13 @@ impl StreamingLogicalLogReader {
                 header_bytes[39],
             ]);
             if frame_flags & !TX_FRAME_FLAG_HAS_EXTENSION_BLOCK != 0 {
-                self.last_valid_offset = frame_start;
-                return Ok(IOResult::Done(ParseResult::InvalidFrame));
+                return Ok(IOResult::Done(HeaderParseOutcome::Invalid));
             }
             if extension_size == 0 && extension_record_count != 0 {
-                self.last_valid_offset = frame_start;
-                return Ok(IOResult::Done(ParseResult::InvalidFrame));
+                return Ok(IOResult::Done(HeaderParseOutcome::Invalid));
             }
             if extension_size > 0 && frame_flags & TX_FRAME_FLAG_HAS_EXTENSION_BLOCK == 0 {
-                self.last_valid_offset = frame_start;
-                return Ok(IOResult::Done(ParseResult::InvalidFrame));
+                return Ok(IOResult::Done(HeaderParseOutcome::Invalid));
             }
             (extension_size, extension_record_count, frame_flags)
         } else {
@@ -2753,23 +3023,50 @@ impl StreamingLogicalLogReader {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!("payload_size overflows usize: {e}");
-                self.last_valid_offset = frame_start;
-                return Ok(IOResult::Done(ParseResult::InvalidFrame));
+                return Ok(IOResult::Done(HeaderParseOutcome::Invalid));
             }
         };
 
-        // Chained CRC: seed from running_crc (derived from salt, or previous frame's CRC)
+        // Chained CRC: seed from running_crc (derived from salt, or previous frame's CRC).
         let running_crc = crc32c::crc32c_append(self.running_crc, &header_bytes);
 
-        // 2. Parse payload — branches for encrypted vs unencrypted.
-        //    Corrupt errors from payload parsing are treated as an invalid frame
-        //    (stop scanning, keep previously validated frames).
+        Ok(IOResult::Done(HeaderParseOutcome::Ok(FrameHeader {
+            payload_size,
+            op_count,
+            commit_ts,
+            extension_size,
+            extension_record_count,
+            frame_flags,
+            running_crc,
+        })))
+    }
+
+    /// Parse the payload phase, dispatching on encryption. The unencrypted path
+    /// is the resumable per-op machine (`parse_streaming_payload`) that
+    /// checkpoints into `frame_in_progress`; the encrypted paths are parsed
+    /// wholesale from the payload start (rewind-and-rebuild from `frame_anchor`)
+    /// and store their result into `frame_in_progress` once complete. Corruption
+    /// propagates as `Err(LimboError::Corrupt(..))` for the caller to map to an
+    /// invalid frame.
+    fn parse_payload_phase(&mut self) -> Result<IOResult<PayloadOutcome>> {
+        let (payload_size, op_count, commit_ts, extension_size, extension_record_count, header_crc) = {
+            let fip = self.frame_in_progress.as_ref().expect("frame in progress");
+            (
+                fip.payload_size,
+                fip.op_count,
+                fip.commit_ts,
+                fip.extension_size,
+                fip.extension_record_count,
+                fip.running_crc,
+            )
+        };
         let encrypted_extension_size = if self.encryption_ctx.is_some() {
             extension_size
         } else {
             0
         };
-        let (parsed_ops, portable_changes, running_crc) = if encrypted_extension_size > 0 {
+
+        if encrypted_extension_size > 0 {
             let plaintext_size = payload_size
                 .checked_add(encrypted_extension_size)
                 .ok_or_else(|| {
@@ -2779,130 +3076,102 @@ impl StreamingLogicalLogReader {
                 plaintext_size,
                 op_count,
                 commit_ts,
-                running_crc,
+                header_crc,
             )) else {
-                return Ok(IOResult::Done(ParseResult::Eof));
+                return Ok(IOResult::Done(PayloadOutcome::Eof));
             };
             let recovery_start = extension_size;
             let recovery_end = recovery_start
                 .checked_add(payload_size)
                 .ok_or_else(|| LimboError::Corrupt("recovery payload offset overflow".into()))?;
-            let portable_changes = match find_extension_payload(
+            let portable_changes = find_extension_payload(
                 &plaintext[..extension_size],
                 extension_record_count,
                 EXTENSION_TYPE_PORTABLE_CHANGES,
-            ) {
-                Ok(payload) => payload,
-                Err(LimboError::Corrupt(msg)) => {
-                    tracing::warn!("corrupt extension block: {msg}");
-                    self.last_valid_offset = frame_start;
-                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
-                }
-                Err(e) => return Err(e),
-            };
-            let parsed_ops = match parse_ops_from_plaintext(
+            )?;
+            let parsed_ops = parse_ops_from_plaintext(
                 &plaintext[recovery_start..recovery_end],
                 payload_size,
                 op_count,
                 commit_ts,
-            ) {
-                Ok(ops) => ops,
-                Err(LimboError::Corrupt(msg)) => {
-                    tracing::warn!("corrupt payload: {msg}");
-                    self.last_valid_offset = frame_start;
-                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
-                }
-                Err(e) => return Err(e),
-            };
-            (parsed_ops, portable_changes, running_crc)
-        } else {
-            let (portable_changes, running_crc) = if extension_size > 0 {
-                match return_if_io!(self.try_consume_bytes(extension_size)) {
-                    Some(bytes) => {
-                        let running_crc = crc32c::crc32c_append(running_crc, &bytes);
-                        let portable_changes = match find_extension_payload(
-                            &bytes,
-                            extension_record_count,
-                            EXTENSION_TYPE_PORTABLE_CHANGES,
-                        ) {
-                            Ok(payload) => payload,
-                            Err(LimboError::Corrupt(msg)) => {
-                                tracing::warn!("corrupt extension block: {msg}");
-                                self.last_valid_offset = frame_start;
-                                return Ok(IOResult::Done(ParseResult::InvalidFrame));
-                            }
-                            Err(e) => return Err(e),
-                        };
-                        (portable_changes, running_crc)
-                    }
-                    None => return Ok(IOResult::Done(ParseResult::Eof)),
-                }
-            } else {
-                (Vec::new(), running_crc)
-            };
-
-            let payload_result = if self.encryption_ctx.is_some() {
-                self.parse_encrypted_payload(op_count, payload_size, commit_ts, running_crc)
-            } else {
-                self.parse_streaming_payload(op_count, payload_size, commit_ts, running_crc)
-            };
-            let (parsed_ops, running_crc) = match payload_result {
-                Ok(IOResult::Done(PayloadParseResult::Ok(ops, crc))) => (ops, crc),
-                Ok(IOResult::Done(PayloadParseResult::Eof)) => {
-                    return Ok(IOResult::Done(ParseResult::Eof))
-                }
-                Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
-                Err(LimboError::Corrupt(msg)) => {
-                    tracing::warn!("corrupt payload: {msg}");
-                    self.last_valid_offset = frame_start;
-                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
-                }
-                Err(e) => return Err(e),
-            };
-            (parsed_ops, portable_changes, running_crc)
-        };
-
-        // 3. TX TRAILER layout (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
-        let trailer_bytes = match return_if_io!(self.try_consume_fixed::<TX_TRAILER_SIZE>()) {
-            Some(bytes) => bytes,
-            None => return Ok(IOResult::Done(ParseResult::Eof)),
-        };
-
-        let crc32c_expected = u32::from_le_bytes([
-            trailer_bytes[0],
-            trailer_bytes[1],
-            trailer_bytes[2],
-            trailer_bytes[3],
-        ]);
-        let end_magic = u32::from_le_bytes([
-            trailer_bytes[4],
-            trailer_bytes[5],
-            trailer_bytes[6],
-            trailer_bytes[7],
-        ]);
-
-        if crc32c_expected != running_crc {
-            self.last_valid_offset = frame_start;
-            return Ok(IOResult::Done(ParseResult::InvalidFrame));
-        }
-        if end_magic != END_MAGIC {
-            self.last_valid_offset = frame_start;
-            return Ok(IOResult::Done(ParseResult::InvalidFrame));
+            )?;
+            let fip = self.frame_in_progress.as_mut().expect("frame in progress");
+            fip.parsed_ops = parsed_ops;
+            fip.portable_changes = portable_changes;
+            fip.running_crc = running_crc;
+            return Ok(IOResult::Done(PayloadOutcome::Ok));
         }
 
+        if self.encryption_ctx.is_some() {
+            let (parsed_ops, running_crc) = match self.parse_encrypted_payload(
+                op_count,
+                payload_size,
+                commit_ts,
+                header_crc,
+            )? {
+                IOResult::Done(PayloadParseResult::Ok(ops, crc)) => (ops, crc),
+                IOResult::Done(PayloadParseResult::Eof) => {
+                    return Ok(IOResult::Done(PayloadOutcome::Eof))
+                }
+                IOResult::IO(io) => return Ok(IOResult::IO(io)),
+            };
+            let fip = self.frame_in_progress.as_mut().expect("frame in progress");
+            fip.parsed_ops = parsed_ops;
+            fip.running_crc = running_crc;
+            return Ok(IOResult::Done(PayloadOutcome::Ok));
+        }
+
+        // Unencrypted: resumable per-op machine that checkpoints into
+        // `frame_in_progress` (parsed ops + CRC + byte count) as it goes.
+        self.parse_streaming_payload()
+    }
+
+    /// Commit the consume cursor as the new rewind point. Called once a unit
+    /// (header / extension block / op / payload) is fully consumed and folded
+    /// into the in-progress chained CRC, so `read_more_data` may compact every
+    /// byte before it and re-entry resumes here rather than at the frame start.
+    fn advance_checkpoint(&mut self) {
+        self.frame_anchor = self.buffer_offset;
+    }
+
+    /// Torn tail: not enough bytes remain to finish the in-progress frame. Drop
+    /// it without advancing the chain — `last_valid_offset`/`running_crc` stay at
+    /// the last fully committed frame. EOF is terminal for a recovery pass
+    /// (`file_size` is fixed once recovery starts).
+    fn abort_frame_eof(&mut self) -> Result<IOResult<ParseResult>> {
+        self.frame_in_progress = None;
+        Ok(IOResult::Done(ParseResult::Eof))
+    }
+
+    /// The in-progress frame is structurally invalid (bad magic/flags/CRC/op).
+    /// Set `last_valid_offset` to the captured frame start so the writer
+    /// overwrites the torn frame on the next append, and drop the frame without
+    /// advancing the chain.
+    fn invalidate_frame(&mut self) -> Result<IOResult<ParseResult>> {
+        let frame_start = self
+            .frame_in_progress
+            .as_ref()
+            .expect("frame in progress")
+            .frame_start;
+        self.last_valid_offset = frame_start;
+        self.frame_in_progress = None;
+        Ok(IOResult::Done(ParseResult::InvalidFrame))
+    }
+
+    /// Commit a fully validated frame: advance `last_valid_offset` to the byte
+    /// past the trailer, carry this frame's CRC as the seed for the next frame,
+    /// and move the frame anchor past the trailer.
+    fn commit_frame(&mut self) -> Result<IOResult<ParseResult>> {
+        let fip = self.frame_in_progress.take().expect("frame in progress");
         self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
-        // Advance the chain: this frame's CRC becomes the seed for the next frame.
-        self.running_crc = running_crc;
-        // Commit the frame boundary: the next frame starts at the current
-        // consume cursor. Until now `frame_anchor` pointed at this frame's
-        // start so re-entry could rewind to it.
+        self.running_crc = fip.running_crc;
         self.frame_anchor = self.buffer_offset;
         Ok(IOResult::Done(ParseResult::Frame(ParsedFrame {
-            ops: parsed_ops,
-            portable_changes,
-            extension_record_count,
-            frame_flags,
-            commit_ts,
+            ops: fip.parsed_ops,
+            portable_changes: fip.portable_changes,
+            extension_record_count: fip.extension_record_count,
+            frame_flags: fip.frame_flags,
+            commit_ts: fip.commit_ts,
             end_offset: self.last_valid_offset,
         })))
     }
@@ -3457,19 +3726,31 @@ impl StreamingLogicalLogReader {
             let still_need = need.saturating_sub(bytes_available_in_buffer);
 
             if still_need == 0 {
-                // Compact only the bytes *before* the current frame's anchor.
-                // The in-progress frame (`frame_anchor..`) must stay buffered so
-                // that a mid-frame IO yield can be resumed by rewinding
-                // `buffer_offset` back to `frame_anchor` and re-parsing. Draining
-                // up to `buffer_offset` (the consume cursor) instead would discard
-                // frame-start bytes and corrupt the re-parse.
-                let drain_to = self.frame_anchor.min(self.buffer.read().len());
-                if drain_to > 0 {
-                    let _ = self.buffer.write().drain(0..drain_to);
-                    self.buffer_offset -= drain_to;
-                    self.frame_anchor -= drain_to;
-                }
+                // Data is already buffered — return without touching the buffer.
+                // Compaction happens only on the disk-read path below: draining
+                // here would memmove the buffer tail on every consume (i.e. once
+                // per frame for tiny frames), which is a large recovery
+                // regression with no benefit, since the buffer only grows when we
+                // actually read from disk.
                 return Ok(IOResult::Done(()));
+            }
+
+            // We must read from disk. Compact the consumed bytes *before* the
+            // latest checkpoint (`frame_anchor`) first, so the buffer doesn't
+            // grow without bound. `frame_anchor` advances at every parse
+            // checkpoint (each header / extension block / op), so for the
+            // streaming path this drains fully-consumed ops and bounds the buffer
+            // to roughly the in-flight unit rather than the whole frame. Bytes at
+            // `frame_anchor..` must stay buffered so a mid-unit IO yield can be
+            // resumed by rewinding `buffer_offset` back to `frame_anchor` and
+            // re-parsing that unit. Draining up to `buffer_offset` (the consume
+            // cursor) instead would discard the in-flight unit's bytes and
+            // corrupt its re-parse.
+            let drain_to = self.frame_anchor.min(self.buffer.read().len());
+            if drain_to > 0 {
+                let _ = self.buffer.write().drain(0..drain_to);
+                self.buffer_offset -= drain_to;
+                self.frame_anchor -= drain_to;
             }
 
             turso_assert!(
@@ -3477,6 +3758,10 @@ impl StreamingLogicalLogReader {
                 "file_size < offset",
                 { "file_size": self.file_size, "offset": self.offset }
             );
+            // Recompute after draining: `buffer.len()` shrank, and `pre_size`
+            // (captured below) must reflect the post-drain length so the
+            // completion's `bytes_read = buffer.len() - pre_size` is correct.
+            let buffer_size_before_read = self.buffer.read().len();
             let to_read = 4096.max(still_need).min(self.file_size - self.offset);
 
             if to_read == 0 {
@@ -3613,6 +3898,7 @@ pub(crate) enum IndexOpKind {
 
 #[cfg(test)]
 mod tests {
+    use crate::types::IOResult;
     use crate::util::IOExt as _;
     use std::collections::BTreeSet;
     use std::sync::Once;
@@ -3782,6 +4068,297 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.buffer.write().extend_from_slice(bytes);
         io.block(|| reader.consume_varint_bytes())
+    }
+
+    /// A test `File` that DEFERS every pread and SHORT-READS at most `max_read`
+    /// bytes per call, so the streaming reader actually yields mid-frame (and is
+    /// re-entered) and a single op spans many reads. Owns the full log bytes;
+    /// reads complete only via an explicit `step()`, letting the test drive the
+    /// reader's state machine one IO at a time and observe peak buffer usage.
+    /// `MemoryIO` completes preads synchronously and fully, so it cannot exercise
+    /// the mid-frame yield/resume paths — this can.
+    struct SlowReadFile {
+        data: Vec<u8>,
+        max_read: usize,
+        pending: std::sync::Mutex<std::collections::VecDeque<(u64, Completion)>>,
+    }
+
+    impl SlowReadFile {
+        fn new(data: Vec<u8>, max_read: usize) -> Self {
+            Self {
+                data,
+                max_read,
+                pending: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            }
+        }
+
+        /// Complete the oldest pending pread with a short read. Returns false if
+        /// nothing is pending (a stall — the reader expected more IO).
+        fn step(&self) -> bool {
+            let Some((pos, c)) = self.pending.lock().unwrap().pop_front() else {
+                return false;
+            };
+            let pos = pos as usize;
+            let read = c.as_read();
+            let cap = read.buf().len();
+            let avail = self.data.len().saturating_sub(pos);
+            let n = cap.min(self.max_read).min(avail);
+            if n > 0 {
+                read.buf().as_mut_slice()[..n].copy_from_slice(&self.data[pos..pos + n]);
+            }
+            c.complete(n as i32);
+            true
+        }
+    }
+
+    impl crate::File for SlowReadFile {
+        fn lock_file(&self, _exclusive: bool) -> crate::Result<()> {
+            Ok(())
+        }
+        fn unlock_file(&self) -> crate::Result<()> {
+            Ok(())
+        }
+        fn pread(&self, pos: u64, c: Completion) -> crate::Result<Completion> {
+            self.pending.lock().unwrap().push_back((pos, c.clone()));
+            Ok(c)
+        }
+        fn pwrite(
+            &self,
+            _pos: u64,
+            _buffer: Arc<Buffer>,
+            _c: Completion,
+        ) -> crate::Result<Completion> {
+            unimplemented!("SlowReadFile is read-only")
+        }
+        fn sync(
+            &self,
+            _c: Completion,
+            _sync_type: crate::io::FileSyncType,
+        ) -> crate::Result<Completion> {
+            unimplemented!("SlowReadFile is read-only")
+        }
+        fn size(&self) -> crate::Result<u64> {
+            Ok(self.data.len() as u64)
+        }
+        fn truncate(&self, _len: u64, _c: Completion) -> crate::Result<Completion> {
+            unimplemented!("SlowReadFile is read-only")
+        }
+    }
+
+    /// Read an entire (synchronous) file into a `Vec`.
+    fn read_file_to_vec(file: &Arc<dyn crate::File>) -> Vec<u8> {
+        let size = file.size().unwrap() as usize;
+        let out = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = out.clone();
+        let buf = Arc::new(Buffer::new_temporary(size));
+        let c = Completion::new_read(buf, move |res| {
+            if let Ok((b, n)) = res {
+                sink.lock()
+                    .unwrap()
+                    .extend_from_slice(&b.as_slice()[..n as usize]);
+            }
+            None
+        });
+        let _completion = file.pread(0, c).unwrap();
+        let bytes = out.lock().unwrap().clone();
+        assert_eq!(bytes.len(), size, "expected a synchronous full read");
+        bytes
+    }
+
+    fn table_row_version(
+        table_id: MVTableId,
+        rowid: i64,
+        commit_ts: u64,
+        data: &str,
+    ) -> crate::mvcc::database::RowVersion {
+        crate::mvcc::database::RowVersion {
+            id: commit_ts,
+            begin: Some(crate::mvcc::database::TxTimestampOrID::Timestamp(commit_ts)),
+            end: None,
+            row: generate_simple_string_row(table_id, rowid, data),
+            btree_resident: false,
+        }
+    }
+
+    /// Recover all ops through `SlowReadFile`, driving the reader one deferred IO
+    /// at a time. Returns the recovered ops and the peak `buffer` length observed
+    /// across the whole recovery.
+    fn recover_with_forced_yields(data: Vec<u8>, max_read: usize) -> (Vec<ParsedOp>, usize) {
+        recover_with_forced_yields_inner(data, max_read, None)
+    }
+
+    fn recover_with_forced_yields_inner(
+        data: Vec<u8>,
+        max_read: usize,
+        encryption: Option<(crate::storage::encryption::EncryptionContext, usize)>,
+    ) -> (Vec<ParsedOp>, usize) {
+        let slow = Arc::new(SlowReadFile::new(data, max_read));
+        let file: Arc<dyn crate::File> = slow.clone();
+        let mut reader = match encryption {
+            Some((ctx, chunk_size)) => {
+                StreamingLogicalLogReader::new_with_payload_chunk_size(file, Some(ctx), chunk_size)
+            }
+            None => StreamingLogicalLogReader::new(file, None),
+        };
+        let mut peak = 0usize;
+
+        // Header (read in one shot; max_read must exceed LOG_HDR_SIZE).
+        loop {
+            match reader.try_read_header_nonblock().unwrap() {
+                IOResult::Done(HeaderReadResult::Valid(_)) => break,
+                IOResult::Done(other) => panic!("unexpected header result: {other:?}"),
+                IOResult::IO(_) => assert!(slow.step(), "stalled reading header"),
+            }
+            peak = peak.max(reader.buffer.read().len());
+        }
+
+        // Frames.
+        let mut ops = Vec::new();
+        loop {
+            let result = reader.next_frame().unwrap();
+            peak = peak.max(reader.buffer.read().len());
+            match result {
+                IOResult::Done(Some(frame_ops)) => ops.extend(frame_ops),
+                IOResult::Done(None) => break,
+                IOResult::IO(_) => {
+                    assert!(slow.step(), "stalled reading frame");
+                    peak = peak.max(reader.buffer.read().len());
+                }
+            }
+        }
+        (ops, peak)
+    }
+
+    /// What this test checks: streaming recovery is correctly re-entrant when IO
+    /// yields at every read boundary, and the read buffer compacts per-op so a
+    /// large multi-op frame is not forced wholesale into memory.
+    /// Why this matters: recovery runs on a cooperative event loop, so a frame
+    /// must resume identically across yields; and a huge transaction must not
+    /// blow up memory during replay (the buffer is bounded to ~one op, not the
+    /// whole frame).
+    #[test]
+    fn test_logical_log_streaming_recovery_forced_yields_bounded_memory() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file("logical_log_forced_yields", OpenFlags::Create, false)
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+
+        let table_id: MVTableId = (-100).into();
+
+        // A small frame, then one large frame with many sizable ops, then a
+        // multi-op small frame. The large frame is what would dominate memory if
+        // the whole frame had to stay buffered for re-parse.
+        let big_payload = "x".repeat(3000);
+        let frames: Vec<Vec<crate::mvcc::database::RowVersion>> = vec![
+            vec![table_row_version(table_id, 1, 10, "first")],
+            (0..40)
+                .map(|i| table_row_version(table_id, 100 + i as i64, 20, &big_payload))
+                .collect(),
+            vec![
+                table_row_version(table_id, 2, 30, "a"),
+                table_row_version(table_id, 3, 30, "b"),
+            ],
+        ];
+        for (idx, rows) in frames.iter().enumerate() {
+            let commit_ts = (idx as u64 + 1) * 10;
+            let tx = crate::mvcc::database::LogRecord::for_test(commit_ts, rows, None);
+            let c = log.log_tx(tx).unwrap();
+            io.wait_for_completion(c).unwrap();
+        }
+
+        // Expected ops via the straightforward synchronous (full-read) path.
+        let mut expected_reader = StreamingLogicalLogReader::new(file.clone(), None);
+        expected_reader.read_header(&io).unwrap();
+        let mut expected = Vec::new();
+        while let Some(frame) = expected_reader.next_frame_blocking(&io).unwrap() {
+            expected.extend(frame);
+        }
+        assert_eq!(expected.len(), 1 + 40 + 2);
+
+        // Recover the same bytes with deferred, short (64-byte) reads so every
+        // `try_consume_*` yields and a single op spans dozens of reads.
+        let bytes = read_file_to_vec(&file);
+        let (recovered, peak) = recover_with_forced_yields(bytes, 64);
+
+        assert_eq!(
+            recovered, expected,
+            "forced-yield recovery must match the synchronous path exactly"
+        );
+
+        // The large frame is ~40 * ~3KB ≈ 120KB. With per-op checkpointing the
+        // buffer holds at most ~one op plus a read chunk; the whole-frame rewind
+        // model would keep the entire frame resident. Assert a bound far below
+        // the frame size.
+        assert!(
+            peak < 16 * 1024,
+            "peak buffer {peak} bytes should be bounded to ~one op, not the whole frame"
+        );
+    }
+
+    /// What this test checks: encrypted recovery is correctly re-entrant when IO
+    /// yields at every read boundary. The encrypted payload is parsed wholesale
+    /// (rewind-and-rebuild from the payload start), so this exercises that the
+    /// post-header checkpoint + payload-start resume decrypts identically across
+    /// yields. (Memory is intentionally not bounded for encrypted frames — the
+    /// plaintext is accumulated contiguously by design — so only correctness is
+    /// asserted here.)
+    /// Why this matters: the refactor changed the encrypted resume point from the
+    /// frame start to the payload start; this guards that change under yields,
+    /// which `MemoryIO`-based tests cannot reach.
+    #[test]
+    fn test_encrypted_log_recovery_forced_yields() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let enc_ctx = test_enc_ctx();
+        const TEST_CHUNK_SIZE: usize = 2 * 1024;
+
+        // Two transactions; the first has a multi-op payload large enough to span
+        // several encrypted chunks, the second is small.
+        let big = "z".repeat(2500);
+        let tx0 = crate::mvcc::database::LogRecord::for_test(
+            100,
+            &[
+                make_test_row_version((-2).into(), 1, &big, 100),
+                make_test_row_version((-2).into(), 2, &big, 100),
+                make_test_row_version((-2).into(), 3, "small", 100),
+            ],
+            None,
+        );
+        let tx1 = crate::mvcc::database::LogRecord::for_test(
+            200,
+            &[make_test_row_version((-2).into(), 4, "tail", 200)],
+            None,
+        );
+        let file = write_encrypted_txs_with_chunk_size_for_test(
+            &io,
+            "enc-forced-yields.db-log",
+            &enc_ctx,
+            TEST_CHUNK_SIZE,
+            vec![tx0, tx1],
+        );
+
+        let expected: Vec<ParsedOp> = parse_all_encrypted_tx_ops_with_chunk_size_for_test(
+            file.clone(),
+            &io,
+            &enc_ctx,
+            TEST_CHUNK_SIZE,
+        )
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .collect();
+        assert_eq!(expected.len(), 4);
+
+        let bytes = read_file_to_vec(&file);
+        let (recovered, _peak) =
+            recover_with_forced_yields_inner(bytes, 64, Some((enc_ctx.clone(), TEST_CHUNK_SIZE)));
+
+        assert_eq!(
+            recovered, expected,
+            "encrypted forced-yield recovery must match the synchronous path exactly"
+        );
     }
 
     /// What this test checks: A committed transaction written to the logical log is replayed correctly after restart.
@@ -6568,18 +7145,27 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.read_header(&io).unwrap();
         assert_eq!(reader.header().unwrap().version, LOG_VERSION);
-        let first = reader.next_portable_change_frame(&io).unwrap().unwrap();
+        let first = io
+            .block(|| reader.next_portable_change_frame())
+            .unwrap()
+            .unwrap();
         assert_eq!(first.commit_ts, 10);
         assert_eq!(first.extension_record_count, 0);
         assert!(first.payload.is_empty());
 
-        let second = reader.next_portable_change_frame(&io).unwrap().unwrap();
+        let second = io
+            .block(|| reader.next_portable_change_frame())
+            .unwrap()
+            .unwrap();
         assert_eq!(second.commit_ts, 20);
         assert_eq!(second.extension_record_count, 1);
         assert!(!second.payload.is_empty());
         assert_eq!(second.end_offset, reader.last_valid_offset() as u64);
 
-        assert!(reader.next_portable_change_frame(&io).unwrap().is_none());
+        assert!(io
+            .block(|| reader.next_portable_change_frame())
+            .unwrap()
+            .is_none());
     }
 
     #[cfg(feature = "conn_raw_api")]
@@ -6658,7 +7244,10 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.read_header(&io).unwrap();
         assert_eq!(reader.last_valid_offset(), LOG_HDR_SIZE);
-        assert!(reader.next_portable_change_frame(&io).unwrap().is_none());
+        assert!(io
+            .block(|| reader.next_portable_change_frame())
+            .unwrap()
+            .is_none());
         assert_eq!(reader.last_valid_offset(), LOG_HDR_SIZE);
     }
 

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1708,6 +1708,14 @@ pub struct StreamingLogicalLogReader {
     buffer: Arc<RwLock<Vec<u8>>>,
     /// Position to read from loaded buffer
     buffer_offset: usize,
+    /// Buffer index of the start of the transaction frame currently being
+    /// parsed. The reader yields mid-frame (any `try_consume_*` can need more
+    /// data), and `next_frame`/`parse_next_transaction` restart from the top on
+    /// re-entry — so on each parse entry we rewind `buffer_offset` to this
+    /// anchor and re-parse the whole frame, and the buffer is only compacted
+    /// (drained) up to this anchor, never mid-frame. Advanced to the new frame
+    /// boundary only once a frame is fully validated.
+    frame_anchor: usize,
     file_size: usize,
     state: StreamingState,
     /// Byte offset of the end of the last fully validated transaction frame. Used during
@@ -1747,6 +1755,7 @@ impl StreamingLogicalLogReader {
             header: None,
             buffer: Arc::new(RwLock::new(Vec::with_capacity(4096))),
             buffer_offset: 0,
+            frame_anchor: 0,
             file_size,
             state: StreamingState::NeedTransactionStart,
             last_valid_offset: 0,
@@ -1844,6 +1853,7 @@ impl StreamingLogicalLogReader {
                 self.offset = hdr_len;
                 self.buffer.write().clear();
                 self.buffer_offset = 0;
+                self.frame_anchor = 0;
                 self.last_valid_offset = hdr_len;
                 Ok(IOResult::Done(HeaderReadResult::Valid(header)))
             }
@@ -1860,6 +1870,7 @@ impl StreamingLogicalLogReader {
         self.offset = LOG_HDR_SIZE;
         self.buffer.write().clear();
         self.buffer_offset = 0;
+        self.frame_anchor = 0;
         self.last_valid_offset = LOG_HDR_SIZE;
     }
 
@@ -1881,6 +1892,11 @@ impl StreamingLogicalLogReader {
         loop {
             match self.state {
                 StreamingState::NeedTransactionStart => {
+                    // Rewind to the current frame anchor before the EOF check:
+                    // on a mid-frame re-entry `buffer_offset` is advanced, which
+                    // would undercount `remaining_bytes()` and stop recovery
+                    // early. `parse_next_transaction` rewinds again (idempotent).
+                    self.buffer_offset = self.frame_anchor;
                     if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
                         return Ok(IOResult::Done(None));
                     }
@@ -2610,6 +2626,13 @@ impl StreamingLogicalLogReader {
     }
 
     fn parse_next_transaction(&mut self) -> Result<IOResult<ParseResult>> {
+        // Rewind to the start of the current frame. This function consumes
+        // incrementally and can yield mid-frame; on re-entry it restarts from
+        // the top, so we must re-read from the frame boundary (not the
+        // partially-consumed position). `frame_anchor` bytes are kept buffered
+        // by `read_more_data` for exactly this. CRC is reseeded from
+        // `self.running_crc` and recomputed over the re-read bytes.
+        self.buffer_offset = self.frame_anchor;
         if self.remaining_bytes() < self.tx_min_frame_size() {
             return Ok(IOResult::Done(ParseResult::Eof));
         }
@@ -2870,6 +2893,10 @@ impl StreamingLogicalLogReader {
         self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
         // Advance the chain: this frame's CRC becomes the seed for the next frame.
         self.running_crc = running_crc;
+        // Commit the frame boundary: the next frame starts at the current
+        // consume cursor. Until now `frame_anchor` pointed at this frame's
+        // start so re-entry could rewind to it.
+        self.frame_anchor = self.buffer_offset;
         Ok(IOResult::Done(ParseResult::Frame(ParsedFrame {
             ops: parsed_ops,
             portable_changes,
@@ -2924,6 +2951,9 @@ impl StreamingLogicalLogReader {
     }
 
     fn parse_next_portable_changes_frame(&mut self) -> Result<IOResult<ParseResult>> {
+        // See `parse_next_transaction`: rewind to the frame anchor so a mid-frame
+        // IO yield resumes correctly on re-entry.
+        self.buffer_offset = self.frame_anchor;
         if self
             .header
             .as_ref()
@@ -3154,6 +3184,7 @@ impl StreamingLogicalLogReader {
 
         self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
         self.running_crc = running_crc;
+        self.frame_anchor = self.buffer_offset;
         Ok(IOResult::Done(ParseResult::Frame(ParsedFrame {
             ops: Vec::new(),
             portable_changes,
@@ -3394,12 +3425,6 @@ impl StreamingLogicalLogReader {
     /// and the method yields its completion until done. Re-entry picks up
     /// where it left off without re-issuing the read.
     pub fn read_more_data(&mut self, need: usize) -> Result<IOResult<()>> {
-        // Capture initial_buffer_offset only on the very first entry (no
-        // in-flight read yet). On a re-entry we want to preserve the
-        // post-loop buffer cleanup, but the cleanup is keyed off the
-        // current `self.buffer_offset` which has not changed across yields.
-        let initial_buffer_offset = self.buffer_offset;
-
         loop {
             // Resume hook: a pread that was issued by a previous call to
             // this method completed; observe its result and advance.
@@ -3432,15 +3457,18 @@ impl StreamingLogicalLogReader {
             let still_need = need.saturating_sub(bytes_available_in_buffer);
 
             if still_need == 0 {
-                // Cleanup consumed bytes. If everything was consumed, clear
-                // avoids memmove.
-                let mut buffer = self.buffer.write();
-                if initial_buffer_offset >= buffer.len() {
-                    buffer.clear();
-                } else if initial_buffer_offset > 0 {
-                    let _ = buffer.drain(0..initial_buffer_offset);
+                // Compact only the bytes *before* the current frame's anchor.
+                // The in-progress frame (`frame_anchor..`) must stay buffered so
+                // that a mid-frame IO yield can be resumed by rewinding
+                // `buffer_offset` back to `frame_anchor` and re-parsing. Draining
+                // up to `buffer_offset` (the consume cursor) instead would discard
+                // frame-start bytes and corrupt the re-parse.
+                let drain_to = self.frame_anchor.min(self.buffer.read().len());
+                if drain_to > 0 {
+                    let _ = self.buffer.write().drain(0..drain_to);
+                    self.buffer_offset -= drain_to;
+                    self.frame_anchor -= drain_to;
                 }
-                self.buffer_offset = 0;
                 return Ok(IOResult::Done(()));
             }
 

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -237,11 +237,14 @@ use crate::sync::RwLock;
 use crate::turso_assert;
 use crate::{
     io::{CompletionGroup, ReadComplete},
+    io_yield_one,
     mvcc::database::{LogRecord, MVTableId, Row, RowID, RowKey, RowVersion, SortableIndexKey},
+    return_if_io,
     storage::sqlite3_ondisk::{
         read_varint, read_varint_partial, varint_len, write_varint_to_vec, DatabaseHeader,
     },
-    types::IndexInfo,
+    types::{IOCompletions, IOResult, IndexInfo},
+    util::IOExt as _,
     Buffer, Completion, CompletionError, LimboError, Result,
 };
 
@@ -1671,6 +1674,27 @@ pub(crate) enum HeaderReadResult {
     Invalid,
 }
 
+/// In-flight read state for [`StreamingLogicalLogReader`]. Tracks a pread
+/// that has been issued but not yet completed, so the reader's IO-returning
+/// methods can yield through their completion and resume on re-entry without
+/// re-issuing the read.
+#[derive(Debug)]
+enum InFlightRead {
+    /// A `read_more_data` chunk read whose callback appends to `self.buffer`.
+    /// `pre_size` is the buffer length at the moment the read was issued, so
+    /// `bytes_read = buffer.len() - pre_size` once the completion finishes.
+    Chunk {
+        completion: Completion,
+        pre_size: usize,
+    },
+    /// A `read_exact_at` one-shot read whose callback appends to `out`.
+    Exact {
+        completion: Completion,
+        out: Arc<RwLock<Vec<u8>>>,
+        expected_len: usize,
+    },
+}
+
 pub struct StreamingLogicalLogReader {
     file: Arc<dyn File>,
     /// Offset to read from file
@@ -1698,6 +1722,9 @@ pub struct StreamingLogicalLogReader {
     // Reused scratch buffer for decrypted chunk plaintext. Kept on the reader so encrypted
     // recovery can reuse the allocation across chunks and transaction frames.
     decrypt_scratch: Vec<u8>,
+    /// Set when a read has been issued but its completion has not yet been
+    /// observed by the calling IOResult method. Cleared on completion.
+    in_flight_read: Option<InFlightRead>,
 }
 
 impl StreamingLogicalLogReader {
@@ -1726,6 +1753,7 @@ impl StreamingLogicalLogReader {
             #[cfg(test)]
             pending_ops: std::collections::VecDeque::new(),
             decrypt_scratch,
+            in_flight_read: None,
         }
     }
 
@@ -1783,17 +1811,27 @@ impl StreamingLogicalLogReader {
         }
     }
 
+    /// Blocking shim — retained for tests and the synchronous
+    /// `MvStore::bootstrap` callers that have not yet been lifted to
+    /// IOResult. The open state machine prefers
+    /// [`StreamingLogicalLogReader::try_read_header_nonblock`] so the
+    /// MVCC log-header read on open does not block.
     pub(crate) fn try_read_header(&mut self, io: &Arc<dyn crate::IO>) -> Result<HeaderReadResult> {
+        let io = io.clone();
+        io.block(|| self.try_read_header_nonblock())
+    }
+
+    pub(crate) fn try_read_header_nonblock(&mut self) -> Result<IOResult<HeaderReadResult>> {
         self.file_size = self.file.size()? as usize;
         if self.file_size < LOG_HDR_SIZE {
-            return Ok(HeaderReadResult::NoLog);
+            return Ok(IOResult::Done(HeaderReadResult::NoLog));
         }
 
-        let header_bytes = self.read_exact_at(io, 0, LOG_HDR_SIZE)?;
+        let header_bytes = return_if_io!(self.read_exact_at(0, LOG_HDR_SIZE));
         let hdr_len = u16::from_le_bytes([header_bytes[6], header_bytes[7]]) as usize;
         if hdr_len != LOG_HDR_SIZE {
             self.set_invalid_header_state();
-            return Ok(HeaderReadResult::Invalid);
+            return Ok(IOResult::Done(HeaderReadResult::Invalid));
         }
 
         match LogHeader::decode(&header_bytes) {
@@ -1804,11 +1842,11 @@ impl StreamingLogicalLogReader {
                 self.buffer.write().clear();
                 self.buffer_offset = 0;
                 self.last_valid_offset = hdr_len;
-                Ok(HeaderReadResult::Valid(header))
+                Ok(IOResult::Done(HeaderReadResult::Valid(header)))
             }
             Err(LimboError::Corrupt(_)) => {
                 self.set_invalid_header_state();
-                Ok(HeaderReadResult::Invalid)
+                Ok(IOResult::Done(HeaderReadResult::Invalid))
             }
             Err(err) => Err(err),
         }
@@ -1827,23 +1865,34 @@ impl StreamingLogicalLogReader {
     /// Recovery needs the whole frame so it can decide which schema snapshot should decode each
     /// index op. Empty parsed frames are skipped, so callers that receive Some(frame) can
     /// rely on `frame` being non-empty.
+    /// Blocking shim — retained for tests and synchronous callers. Production
+    /// recovery should drive
+    /// [`StreamingLogicalLogReader::next_frame_nonblock`] directly so that
+    /// log-replay reads yield instead of blocking.
     pub(crate) fn next_frame(&mut self, io: &Arc<dyn crate::IO>) -> Result<Option<Vec<ParsedOp>>> {
+        let io = io.clone();
+        io.block(|| self.next_frame_nonblock())
+    }
+
+    pub(crate) fn next_frame_nonblock(&mut self) -> Result<IOResult<Option<Vec<ParsedOp>>>> {
         loop {
             match self.state {
                 StreamingState::NeedTransactionStart => {
                     if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
-                        return Ok(None);
+                        return Ok(IOResult::Done(None));
                     }
 
-                    let ops = match self.parse_next_transaction(io)? {
+                    let ops = match return_if_io!(self.parse_next_transaction()) {
                         ParseResult::Frame(frame) => frame.ops,
-                        ParseResult::Eof | ParseResult::InvalidFrame => return Ok(None),
+                        ParseResult::Eof | ParseResult::InvalidFrame => {
+                            return Ok(IOResult::Done(None))
+                        }
                     };
 
                     if ops.is_empty() {
                         continue;
                     }
-                    return Ok(Some(ops));
+                    return Ok(IOResult::Done(Some(ops)));
                 }
             }
         }
@@ -1872,7 +1921,7 @@ impl StreamingLogicalLogReader {
                         return Ok(StreamingResult::Eof);
                     }
 
-                    let ops = match self.parse_next_transaction(io)? {
+                    let ops = match io.block(|| self.parse_next_transaction())? {
                         ParseResult::Frame(frame) => frame.ops,
                         ParseResult::Eof | ParseResult::InvalidFrame => {
                             return Ok(StreamingResult::Eof);
@@ -1905,7 +1954,8 @@ impl StreamingLogicalLogReader {
         io: &Arc<dyn crate::IO>,
     ) -> Result<Option<PortableChangeFrame>> {
         self.file_size = self.file.size()? as usize;
-        match self.parse_next_portable_changes_frame(io)? {
+        let io = io.clone();
+        match io.block(|| self.parse_next_portable_changes_frame())? {
             ParseResult::Frame(frame) => Ok(Some(PortableChangeFrame {
                 end_offset: frame.end_offset as u64,
                 commit_ts: frame.commit_ts,
@@ -1998,11 +2048,10 @@ impl StreamingLogicalLogReader {
     /// given the chunk index, read the chunk off the disk and decrypt it
     fn read_and_decrypt_encrypted_chunk(
         &mut self,
-        io: &Arc<dyn crate::IO>,
         payload_ctx: &EncryptedPayloadReadContext,
         chunk_index: usize,
         running_crc: u32,
-    ) -> Result<EncryptedChunkReadResult> {
+    ) -> Result<IOResult<EncryptedChunkReadResult>> {
         // first we gotta figure out, how many bytes to read off the disk, its either
         // `self.encrypted_payload_chunk_size` or the remainder in the last chunk
         let plaintext_len = encrypted_chunk_plaintext_len(
@@ -2029,9 +2078,9 @@ impl StreamingLogicalLogReader {
         );
 
         if self.remaining_bytes() < on_disk_size {
-            return Ok(EncryptedChunkReadResult::Eof);
+            return Ok(IOResult::Done(EncryptedChunkReadResult::Eof));
         }
-        self.read_more_data(io, on_disk_size)?;
+        return_if_io!(self.read_more_data(on_disk_size));
         let start = self.buffer_offset;
         let end = start + on_disk_size;
 
@@ -2063,9 +2112,9 @@ impl StreamingLogicalLogReader {
             )));
         }
 
-        Ok(EncryptedChunkReadResult::Ok {
+        Ok(IOResult::Done(EncryptedChunkReadResult::Ok {
             running_crc: next_crc,
-        })
+        }))
     }
 
     /// Extend the carried partial op with enough bytes from the current plaintext chunk to decode
@@ -2169,12 +2218,11 @@ impl StreamingLogicalLogReader {
     /// ciphertext(chunk_plain_len + tag_size) | nonce(nonce_size), one blob per chunk.
     fn parse_encrypted_payload(
         &mut self,
-        io: &Arc<dyn crate::IO>,
         op_count: u32,
         payload_size: usize,
         commit_ts: u64,
         running_crc: u32,
-    ) -> Result<PayloadParseResult> {
+    ) -> Result<IOResult<PayloadParseResult>> {
         let (nonce_size, tag_size) = {
             let enc = self
                 .encryption_ctx
@@ -2209,14 +2257,15 @@ impl StreamingLogicalLogReader {
 
         for chunk_index in 0..chunk_count {
             // lets decrypt the log file, chunk by chunk
-            running_crc = match self.read_and_decrypt_encrypted_chunk(
-                io,
+            running_crc = match return_if_io!(self.read_and_decrypt_encrypted_chunk(
                 &payload_ctx,
                 chunk_index,
                 running_crc,
-            )? {
+            )) {
                 EncryptedChunkReadResult::Ok { running_crc } => running_crc,
-                EncryptedChunkReadResult::Eof => return Ok(PayloadParseResult::Eof),
+                EncryptedChunkReadResult::Eof => {
+                    return Ok(IOResult::Done(PayloadParseResult::Eof))
+                }
             };
 
             let mut plaintext_start = 0usize;
@@ -2293,17 +2342,19 @@ impl StreamingLogicalLogReader {
             )));
         }
 
-        Ok(PayloadParseResult::Ok(parsed_ops, running_crc))
+        Ok(IOResult::Done(PayloadParseResult::Ok(
+            parsed_ops,
+            running_crc,
+        )))
     }
 
     fn read_encrypted_plaintext(
         &mut self,
-        io: &Arc<dyn crate::IO>,
         plaintext_size: usize,
         op_count: u32,
         commit_ts: u64,
         running_crc: u32,
-    ) -> Result<Option<(Vec<u8>, u32)>> {
+    ) -> Result<IOResult<Option<(Vec<u8>, u32)>>> {
         let (nonce_size, tag_size) = {
             let enc = self
                 .encryption_ctx
@@ -2329,14 +2380,13 @@ impl StreamingLogicalLogReader {
         let mut running_crc = running_crc;
         let mut plaintext = Vec::with_capacity(plaintext_size);
         for chunk_index in 0..chunk_count {
-            running_crc = match self.read_and_decrypt_encrypted_chunk(
-                io,
+            running_crc = match return_if_io!(self.read_and_decrypt_encrypted_chunk(
                 &payload_ctx,
                 chunk_index,
                 running_crc,
-            )? {
+            )) {
                 EncryptedChunkReadResult::Ok { running_crc } => running_crc,
-                EncryptedChunkReadResult::Eof => return Ok(None),
+                EncryptedChunkReadResult::Eof => return Ok(IOResult::Done(None)),
             };
             plaintext.extend_from_slice(&self.decrypt_scratch);
         }
@@ -2346,26 +2396,25 @@ impl StreamingLogicalLogReader {
                 plaintext.len()
             )));
         }
-        Ok(Some((plaintext, running_crc)))
+        Ok(IOResult::Done(Some((plaintext, running_crc))))
     }
 
     /// Parse an unencrypted payload via field-by-field streaming IO reads.
     fn parse_streaming_payload(
         &mut self,
-        io: &Arc<dyn crate::IO>,
         op_count: u32,
         payload_size: usize,
         commit_ts: u64,
         mut running_crc: u32,
-    ) -> Result<PayloadParseResult> {
+    ) -> Result<IOResult<PayloadParseResult>> {
         let mut parsed_ops = Vec::with_capacity((op_count as usize).min(1024));
         let mut payload_bytes_read: u64 = 0;
 
         for _ in 0..op_count {
             // Op header (6 bytes): tag(1) | flags(1) | table_id(4, little-endian i32)
-            let op_bytes = match self.try_consume_fixed::<6>(io)? {
+            let op_bytes = match return_if_io!(self.try_consume_fixed::<6>()) {
                 Some(bytes) => bytes,
-                None => return Ok(PayloadParseResult::Eof),
+                None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
             };
             running_crc = crc32c::crc32c_append(running_crc, &op_bytes);
             let tag = op_bytes[0];
@@ -2397,28 +2446,26 @@ impl StreamingLogicalLogReader {
             let has_portable_extension = (flags & OP_FLAG_PORTABLE_EXTENSION) != 0;
 
             let (payload_len, payload_len_bytes, payload_len_bytes_len) =
-                match self.consume_varint_bytes(io) {
-                    Ok(Some((value, bytes, len))) => (value, bytes, len),
-                    Ok(None) => return Ok(PayloadParseResult::Eof),
-                    Err(err) => return Err(err),
+                match return_if_io!(self.consume_varint_bytes()) {
+                    Some((value, bytes, len)) => (value, bytes, len),
+                    None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
                 };
             running_crc =
                 crc32c::crc32c_append(running_crc, &payload_len_bytes[..payload_len_bytes_len]);
             let payload_len = usize::try_from(payload_len)
                 .map_err(|e| LimboError::Corrupt(format!("payload_len overflows usize: {e}")))?;
 
-            let payload = match self.try_consume_bytes(io, payload_len)? {
+            let payload = match return_if_io!(self.try_consume_bytes(payload_len)) {
                 Some(bytes) => bytes,
-                None => return Ok(PayloadParseResult::Eof),
+                None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
             };
             running_crc = crc32c::crc32c_append(running_crc, &payload);
 
             let (portable_extension, extension_total_bytes) = if has_portable_extension {
                 let (extension_len, extension_len_bytes, extension_len_bytes_len) =
-                    match self.consume_varint_bytes(io) {
-                        Ok(Some((value, bytes, len))) => (value, bytes, len),
-                        Ok(None) => return Ok(PayloadParseResult::Eof),
-                        Err(err) => return Err(err),
+                    match return_if_io!(self.consume_varint_bytes()) {
+                        Some((value, bytes, len)) => (value, bytes, len),
+                        None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
                     };
                 running_crc = crc32c::crc32c_append(
                     running_crc,
@@ -2427,9 +2474,9 @@ impl StreamingLogicalLogReader {
                 let extension_len = usize::try_from(extension_len).map_err(|e| {
                     LimboError::Corrupt(format!("op extension length overflows usize: {e}"))
                 })?;
-                let extension = match self.try_consume_bytes(io, extension_len)? {
+                let extension = match return_if_io!(self.try_consume_bytes(extension_len)) {
                     Some(bytes) => bytes,
-                    None => return Ok(PayloadParseResult::Eof),
+                    None => return Ok(IOResult::Done(PayloadParseResult::Eof)),
                 };
                 running_crc = crc32c::crc32c_append(running_crc, &extension);
                 (extension, extension_len_bytes_len + extension_len)
@@ -2553,18 +2600,21 @@ impl StreamingLogicalLogReader {
             )));
         }
 
-        Ok(PayloadParseResult::Ok(parsed_ops, running_crc))
+        Ok(IOResult::Done(PayloadParseResult::Ok(
+            parsed_ops,
+            running_crc,
+        )))
     }
 
-    fn parse_next_transaction(&mut self, io: &Arc<dyn crate::IO>) -> Result<ParseResult> {
+    fn parse_next_transaction(&mut self) -> Result<IOResult<ParseResult>> {
         if self.remaining_bytes() < self.tx_min_frame_size() {
-            return Ok(ParseResult::Eof);
+            return Ok(IOResult::Done(ParseResult::Eof));
         }
         let frame_start = self.offset.saturating_sub(self.bytes_can_read());
 
-        let mut header_bytes = match self.try_consume_bytes(io, TX_HEADER_SIZE)? {
+        let mut header_bytes = match return_if_io!(self.try_consume_bytes(TX_HEADER_SIZE)) {
             Some(bytes) => bytes,
-            None => return Ok(ParseResult::Eof),
+            None => return Ok(IOResult::Done(ParseResult::Eof)),
         };
 
         // TX HEADER v2 layout (24 bytes):
@@ -2585,17 +2635,17 @@ impl StreamingLogicalLogReader {
         let has_extension_header = !is_v2 && frame_magic == EXT_FRAME_MAGIC;
         if frame_magic != FRAME_MAGIC && !has_extension_header {
             self.last_valid_offset = frame_start;
-            return Ok(ParseResult::InvalidFrame);
+            return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
         if is_v2 && frame_magic != FRAME_MAGIC {
             self.last_valid_offset = frame_start;
-            return Ok(ParseResult::InvalidFrame);
+            return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
         if has_extension_header {
             let Some(extension_header) =
-                self.try_consume_bytes(io, TX_EXT_HEADER_SIZE - TX_HEADER_SIZE)?
+                return_if_io!(self.try_consume_bytes(TX_EXT_HEADER_SIZE - TX_HEADER_SIZE))
             else {
-                return Ok(ParseResult::Eof);
+                return Ok(IOResult::Done(ParseResult::Eof));
             };
             header_bytes.extend_from_slice(&extension_header);
         }
@@ -2641,7 +2691,7 @@ impl StreamingLogicalLogReader {
                 Err(e) => {
                     tracing::warn!("extension_size overflows usize: {e}");
                     self.last_valid_offset = frame_start;
-                    return Ok(ParseResult::InvalidFrame);
+                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
                 }
             };
             let extension_record_count = u32::from_le_bytes([
@@ -2658,15 +2708,15 @@ impl StreamingLogicalLogReader {
             ]);
             if frame_flags & !TX_FRAME_FLAG_HAS_EXTENSION_BLOCK != 0 {
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             if extension_size == 0 && extension_record_count != 0 {
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             if extension_size > 0 && frame_flags & TX_FRAME_FLAG_HAS_EXTENSION_BLOCK == 0 {
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             (extension_size, extension_record_count, frame_flags)
         } else {
@@ -2678,7 +2728,7 @@ impl StreamingLogicalLogReader {
             Err(e) => {
                 tracing::warn!("payload_size overflows usize: {e}");
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
         };
 
@@ -2699,15 +2749,14 @@ impl StreamingLogicalLogReader {
                 .ok_or_else(|| {
                     LimboError::Corrupt("encrypted plaintext size overflows usize".into())
                 })?;
-            let Some((plaintext, running_crc)) = self.read_encrypted_plaintext(
-                io,
+            let Some((plaintext, running_crc)) = return_if_io!(self.read_encrypted_plaintext(
                 plaintext_size,
                 op_count,
                 commit_ts,
                 running_crc,
-            )?
+            ))
             else {
-                return Ok(ParseResult::Eof);
+                return Ok(IOResult::Done(ParseResult::Eof));
             };
             let recovery_start = extension_size;
             let recovery_end = recovery_start
@@ -2722,7 +2771,7 @@ impl StreamingLogicalLogReader {
                 Err(LimboError::Corrupt(msg)) => {
                     tracing::warn!("corrupt extension block: {msg}");
                     self.last_valid_offset = frame_start;
-                    return Ok(ParseResult::InvalidFrame);
+                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
                 }
                 Err(e) => return Err(e),
             };
@@ -2736,14 +2785,14 @@ impl StreamingLogicalLogReader {
                 Err(LimboError::Corrupt(msg)) => {
                     tracing::warn!("corrupt payload: {msg}");
                     self.last_valid_offset = frame_start;
-                    return Ok(ParseResult::InvalidFrame);
+                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
                 }
                 Err(e) => return Err(e),
             };
             (parsed_ops, portable_changes, running_crc)
         } else {
             let (portable_changes, running_crc) = if extension_size > 0 {
-                match self.try_consume_bytes(io, extension_size)? {
+                match return_if_io!(self.try_consume_bytes(extension_size)) {
                     Some(bytes) => {
                         let running_crc = crc32c::crc32c_append(running_crc, &bytes);
                         let portable_changes = match find_extension_payload(
@@ -2755,29 +2804,33 @@ impl StreamingLogicalLogReader {
                             Err(LimboError::Corrupt(msg)) => {
                                 tracing::warn!("corrupt extension block: {msg}");
                                 self.last_valid_offset = frame_start;
-                                return Ok(ParseResult::InvalidFrame);
+                                return Ok(IOResult::Done(ParseResult::InvalidFrame));
                             }
                             Err(e) => return Err(e),
                         };
                         (portable_changes, running_crc)
                     }
-                    None => return Ok(ParseResult::Eof),
+                    None => return Ok(IOResult::Done(ParseResult::Eof)),
                 }
             } else {
                 (Vec::new(), running_crc)
             };
 
-            let (parsed_ops, running_crc) = match if self.encryption_ctx.is_some() {
-                self.parse_encrypted_payload(io, op_count, payload_size, commit_ts, running_crc)
+            let payload_result = if self.encryption_ctx.is_some() {
+                self.parse_encrypted_payload(op_count, payload_size, commit_ts, running_crc)
             } else {
-                self.parse_streaming_payload(io, op_count, payload_size, commit_ts, running_crc)
-            } {
-                Ok(PayloadParseResult::Ok(ops, crc)) => (ops, crc),
-                Ok(PayloadParseResult::Eof) => return Ok(ParseResult::Eof),
+                self.parse_streaming_payload(op_count, payload_size, commit_ts, running_crc)
+            };
+            let (parsed_ops, running_crc) = match payload_result {
+                Ok(IOResult::Done(PayloadParseResult::Ok(ops, crc))) => (ops, crc),
+                Ok(IOResult::Done(PayloadParseResult::Eof)) => {
+                    return Ok(IOResult::Done(ParseResult::Eof))
+                }
+                Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
                 Err(LimboError::Corrupt(msg)) => {
                     tracing::warn!("corrupt payload: {msg}");
                     self.last_valid_offset = frame_start;
-                    return Ok(ParseResult::InvalidFrame);
+                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
                 }
                 Err(e) => return Err(e),
             };
@@ -2785,9 +2838,9 @@ impl StreamingLogicalLogReader {
         };
 
         // 3. TX TRAILER layout (8 bytes): crc32c(4, le u32) | END_MAGIC(4)
-        let trailer_bytes = match self.try_consume_fixed::<TX_TRAILER_SIZE>(io)? {
+        let trailer_bytes = match return_if_io!(self.try_consume_fixed::<TX_TRAILER_SIZE>()) {
             Some(bytes) => bytes,
-            None => return Ok(ParseResult::Eof),
+            None => return Ok(IOResult::Done(ParseResult::Eof)),
         };
 
         let crc32c_expected = u32::from_le_bytes([
@@ -2805,42 +2858,41 @@ impl StreamingLogicalLogReader {
 
         if crc32c_expected != running_crc {
             self.last_valid_offset = frame_start;
-            return Ok(ParseResult::InvalidFrame);
+            return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
         if end_magic != END_MAGIC {
             self.last_valid_offset = frame_start;
-            return Ok(ParseResult::InvalidFrame);
+            return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
 
         self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
         // Advance the chain: this frame's CRC becomes the seed for the next frame.
         self.running_crc = running_crc;
-        Ok(ParseResult::Frame(ParsedFrame {
+        Ok(IOResult::Done(ParseResult::Frame(ParsedFrame {
             ops: parsed_ops,
             portable_changes,
             extension_record_count,
             frame_flags,
             commit_ts,
             end_offset: self.last_valid_offset,
-        }))
+        })))
     }
 
     fn consume_and_crc_bytes(
         &mut self,
-        io: &Arc<dyn crate::IO>,
         mut amount: usize,
         mut running_crc: u32,
-    ) -> Result<Option<u32>> {
+    ) -> Result<IOResult<Option<u32>>> {
         const CHUNK_SIZE: usize = 64 * 1024;
         while amount > 0 {
             let chunk_len = amount.min(CHUNK_SIZE);
-            let Some(bytes) = self.try_consume_bytes(io, chunk_len)? else {
-                return Ok(None);
+            let Some(bytes) = return_if_io!(self.try_consume_bytes(chunk_len)) else {
+                return Ok(IOResult::Done(None));
             };
             running_crc = crc32c::crc32c_append(running_crc, &bytes);
             amount -= chunk_len;
         }
-        Ok(Some(running_crc))
+        Ok(IOResult::Done(Some(running_crc)))
     }
 
     fn encrypted_payload_on_disk_size(&self, payload_size: usize) -> Result<usize> {
@@ -2869,25 +2921,22 @@ impl StreamingLogicalLogReader {
         Ok(on_disk_size)
     }
 
-    fn parse_next_portable_changes_frame(
-        &mut self,
-        io: &Arc<dyn crate::IO>,
-    ) -> Result<ParseResult> {
+    fn parse_next_portable_changes_frame(&mut self) -> Result<IOResult<ParseResult>> {
         if self
             .header
             .as_ref()
             .is_some_and(|h| h.version == LOG_VERSION_V2)
         {
-            return Ok(ParseResult::Eof);
+            return Ok(IOResult::Done(ParseResult::Eof));
         }
         if self.remaining_bytes() < TX_MIN_FRAME_SIZE {
-            return Ok(ParseResult::Eof);
+            return Ok(IOResult::Done(ParseResult::Eof));
         }
         let frame_start = self.offset.saturating_sub(self.bytes_can_read());
 
-        let mut header_bytes = match self.try_consume_bytes(io, TX_HEADER_SIZE)? {
+        let mut header_bytes = match return_if_io!(self.try_consume_bytes(TX_HEADER_SIZE)) {
             Some(bytes) => bytes,
-            None => return Ok(ParseResult::Eof),
+            None => return Ok(IOResult::Done(ParseResult::Eof)),
         };
 
         let frame_magic = u32::from_le_bytes([
@@ -2899,13 +2948,13 @@ impl StreamingLogicalLogReader {
         let has_extension_header = frame_magic == EXT_FRAME_MAGIC;
         if frame_magic != FRAME_MAGIC && !has_extension_header {
             self.last_valid_offset = frame_start;
-            return Ok(ParseResult::InvalidFrame);
+            return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
         if has_extension_header {
             let Some(extension_header) =
-                self.try_consume_bytes(io, TX_EXT_HEADER_SIZE - TX_HEADER_SIZE)?
+                return_if_io!(self.try_consume_bytes(TX_EXT_HEADER_SIZE - TX_HEADER_SIZE))
             else {
-                return Ok(ParseResult::Eof);
+                return Ok(IOResult::Done(ParseResult::Eof));
             };
             header_bytes.extend_from_slice(&extension_header);
         }
@@ -2960,15 +3009,15 @@ impl StreamingLogicalLogReader {
             ]);
             if frame_flags & !TX_FRAME_FLAG_HAS_EXTENSION_BLOCK != 0 {
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             if extension_size_u64 == 0 && extension_record_count != 0 {
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             if extension_size_u64 > 0 && frame_flags & TX_FRAME_FLAG_HAS_EXTENSION_BLOCK == 0 {
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             (extension_size_u64, extension_record_count, frame_flags)
         } else {
@@ -2980,7 +3029,7 @@ impl StreamingLogicalLogReader {
             Err(e) => {
                 tracing::warn!("payload_size overflows usize: {e}");
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
         };
         let extension_size = match usize::try_from(extension_size_u64) {
@@ -2988,7 +3037,7 @@ impl StreamingLogicalLogReader {
             Err(e) => {
                 tracing::warn!("extension_size overflows usize: {e}");
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
         };
 
@@ -3011,7 +3060,7 @@ impl StreamingLogicalLogReader {
             Err(LimboError::Corrupt(msg)) => {
                 tracing::warn!("corrupt payload size: {msg}");
                 self.last_valid_offset = frame_start;
-                return Ok(ParseResult::InvalidFrame);
+                return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             Err(e) => return Err(e),
         };
@@ -3021,15 +3070,14 @@ impl StreamingLogicalLogReader {
                 .ok_or_else(|| {
                     LimboError::Corrupt("encrypted plaintext size overflows usize".into())
                 })?;
-            let Some((plaintext, running_crc)) = self.read_encrypted_plaintext(
-                io,
+            let Some((plaintext, running_crc)) = return_if_io!(self.read_encrypted_plaintext(
                 plaintext_size,
                 op_count,
                 commit_ts,
                 running_crc,
-            )?
+            ))
             else {
-                return Ok(ParseResult::Eof);
+                return Ok(IOResult::Done(ParseResult::Eof));
             };
             let portable_changes = match find_extension_payload(
                 &plaintext[..extension_size],
@@ -3040,14 +3088,14 @@ impl StreamingLogicalLogReader {
                 Err(LimboError::Corrupt(msg)) => {
                     tracing::warn!("corrupt extension block: {msg}");
                     self.last_valid_offset = frame_start;
-                    return Ok(ParseResult::InvalidFrame);
+                    return Ok(IOResult::Done(ParseResult::InvalidFrame));
                 }
                 Err(e) => return Err(e),
             };
             (portable_changes, running_crc)
         } else {
             let (portable_changes, running_crc) = if extension_size > 0 {
-                match self.try_consume_bytes(io, extension_size)? {
+                match return_if_io!(self.try_consume_bytes(extension_size)) {
                     Some(bytes) => {
                         let running_crc = crc32c::crc32c_append(running_crc, &bytes);
                         let portable_changes = match find_extension_payload(
@@ -3059,28 +3107,28 @@ impl StreamingLogicalLogReader {
                             Err(LimboError::Corrupt(msg)) => {
                                 tracing::warn!("corrupt extension block: {msg}");
                                 self.last_valid_offset = frame_start;
-                                return Ok(ParseResult::InvalidFrame);
+                                return Ok(IOResult::Done(ParseResult::InvalidFrame));
                             }
                             Err(e) => return Err(e),
                         };
                         (portable_changes, running_crc)
                     }
-                    None => return Ok(ParseResult::Eof),
+                    None => return Ok(IOResult::Done(ParseResult::Eof)),
                 }
             } else {
                 (Vec::new(), running_crc)
             };
             let Some(running_crc) =
-                self.consume_and_crc_bytes(io, payload_on_disk_size, running_crc)?
+                return_if_io!(self.consume_and_crc_bytes(payload_on_disk_size, running_crc))
             else {
-                return Ok(ParseResult::Eof);
+                return Ok(IOResult::Done(ParseResult::Eof));
             };
             (portable_changes, running_crc)
         };
 
-        let trailer_bytes = match self.try_consume_fixed::<TX_TRAILER_SIZE>(io)? {
+        let trailer_bytes = match return_if_io!(self.try_consume_fixed::<TX_TRAILER_SIZE>()) {
             Some(bytes) => bytes,
-            None => return Ok(ParseResult::Eof),
+            None => return Ok(IOResult::Done(ParseResult::Eof)),
         };
         let crc32c_expected = u32::from_le_bytes([
             trailer_bytes[0],
@@ -3096,23 +3144,23 @@ impl StreamingLogicalLogReader {
         ]);
         if crc32c_expected != running_crc {
             self.last_valid_offset = frame_start;
-            return Ok(ParseResult::InvalidFrame);
+            return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
         if end_magic != END_MAGIC {
             self.last_valid_offset = frame_start;
-            return Ok(ParseResult::InvalidFrame);
+            return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
 
         self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
         self.running_crc = running_crc;
-        Ok(ParseResult::Frame(ParsedFrame {
+        Ok(IOResult::Done(ParseResult::Frame(ParsedFrame {
             ops: Vec::new(),
             portable_changes,
             extension_record_count,
             frame_flags,
             commit_ts,
             end_offset: self.last_valid_offset,
-        }))
+        })))
     }
 
     pub(crate) fn parsed_op_to_streaming(
@@ -3205,48 +3253,41 @@ impl StreamingLogicalLogReader {
         bytes_in_buffer + bytes_in_file
     }
 
-    fn try_consume_bytes(
-        &mut self,
-        io: &Arc<dyn crate::IO>,
-        amount: usize,
-    ) -> Result<Option<Vec<u8>>> {
+    fn try_consume_bytes(&mut self, amount: usize) -> Result<IOResult<Option<Vec<u8>>>> {
         if self.remaining_bytes() < amount {
-            return Ok(None);
+            return Ok(IOResult::Done(None));
         }
-        self.read_more_data(io, amount)?;
+        return_if_io!(self.read_more_data(amount));
         let buffer = self.buffer.read();
         let start = self.buffer_offset;
         let end = start + amount;
         let bytes = buffer[start..end].to_vec();
         self.buffer_offset = end;
-        Ok(Some(bytes))
+        Ok(IOResult::Done(Some(bytes)))
     }
 
-    fn try_consume_fixed<const N: usize>(
-        &mut self,
-        io: &Arc<dyn crate::IO>,
-    ) -> Result<Option<[u8; N]>> {
+    fn try_consume_fixed<const N: usize>(&mut self) -> Result<IOResult<Option<[u8; N]>>> {
         if self.remaining_bytes() < N {
-            return Ok(None);
+            return Ok(IOResult::Done(None));
         }
-        self.read_more_data(io, N)?;
+        return_if_io!(self.read_more_data(N));
         let buffer = self.buffer.read();
         let start = self.buffer_offset;
         let end = start + N;
         let mut out = [0u8; N];
         out.copy_from_slice(&buffer[start..end]);
         self.buffer_offset = end;
-        Ok(Some(out))
+        Ok(IOResult::Done(Some(out)))
     }
 
-    fn try_consume_u8(&mut self, io: &Arc<dyn crate::IO>) -> Result<Option<u8>> {
+    fn try_consume_u8(&mut self) -> Result<IOResult<Option<u8>>> {
         if self.remaining_bytes() == 0 {
-            return Ok(None);
+            return Ok(IOResult::Done(None));
         }
-        self.read_more_data(io, 1)?;
+        return_if_io!(self.read_more_data(1));
         let r = self.buffer.read()[self.buffer_offset];
         self.buffer_offset += 1;
-        Ok(Some(r))
+        Ok(IOResult::Done(Some(r)))
     }
 
     /// Reads a SQLite-format varint one byte at a time from the streaming reader.
@@ -3255,26 +3296,24 @@ impl StreamingLogicalLogReader {
     /// Unlike `read_varint` from sqlite3_ondisk (which requires a contiguous buffer),
     /// this reads byte-by-byte via `try_consume_u8` to handle streaming I/O where
     /// the varint may span a buffer boundary. Returns `None` on EOF (short read).
-    fn consume_varint_bytes(
-        &mut self,
-        io: &Arc<dyn crate::IO>,
-    ) -> Result<Option<(u64, [u8; 9], usize)>> {
+    #[allow(clippy::type_complexity)]
+    fn consume_varint_bytes(&mut self) -> Result<IOResult<Option<(u64, [u8; 9], usize)>>> {
         let mut v: u64 = 0;
         let mut bytes = [0u8; 9];
         let mut len = 0usize;
         for _ in 0..8 {
-            let Some(c) = self.try_consume_u8(io)? else {
-                return Ok(None);
+            let Some(c) = return_if_io!(self.try_consume_u8()) else {
+                return Ok(IOResult::Done(None));
             };
             bytes[len] = c;
             len += 1;
             v = (v << 7) + (c & 0x7f) as u64;
             if (c & 0x80) == 0 {
-                return Ok(Some((v, bytes, len)));
+                return Ok(IOResult::Done(Some((v, bytes, len))));
             }
         }
-        let Some(c) = self.try_consume_u8(io)? else {
-            return Ok(None);
+        let Some(c) = return_if_io!(self.try_consume_u8()) else {
+            return Ok(IOResult::Done(None));
         };
         bytes[len] = c;
         len += 1;
@@ -3282,53 +3321,106 @@ impl StreamingLogicalLogReader {
             return Err(LimboError::Corrupt("Invalid varint".to_string()));
         }
         v = (v << 8) + c as u64;
-        Ok(Some((v, bytes, len)))
+        Ok(IOResult::Done(Some((v, bytes, len))))
     }
 
-    fn read_exact_at(&self, io: &Arc<dyn crate::IO>, pos: u64, len: usize) -> Result<Vec<u8>> {
-        let header_buf = Arc::new(Buffer::new_temporary(len));
-        let out = Arc::new(RwLock::new(Vec::with_capacity(len)));
-        let out_clone = out.clone();
-        let completion: Box<ReadComplete> = Box::new(move |res| {
-            let out = out_clone.clone();
-            let mut out = out.write();
-            let Ok((buf, bytes_read)) = res else {
-                tracing::error!("couldn't read logical log header err={:?}", res);
-                return None;
-            };
-            if bytes_read > 0 {
-                out.extend_from_slice(&buf.as_slice()[..bytes_read as usize]);
+    /// Non-blocking read of exactly `len` bytes at file offset `pos`.
+    ///
+    /// On entry: if an in-flight `Exact` read is already pending, resume it
+    /// (yield until done, then return its accumulated buffer). Otherwise
+    /// issue a fresh pread, stash it in `self.in_flight_read`, and either
+    /// yield the completion (when not synchronously done) or loop to take
+    /// the resume branch.
+    fn read_exact_at(&mut self, pos: u64, len: usize) -> Result<IOResult<Vec<u8>>> {
+        loop {
+            if let Some(InFlightRead::Exact { completion, .. }) = &self.in_flight_read {
+                if !completion.succeeded() {
+                    let c = completion.clone();
+                    io_yield_one!(c);
+                }
+                let Some(InFlightRead::Exact {
+                    out, expected_len, ..
+                }) = self.in_flight_read.take()
+                else {
+                    unreachable!("in_flight_read variant just matched Exact");
+                };
+                let result = out.read().clone();
+                if result.len() != expected_len {
+                    return Err(LimboError::Corrupt(format!(
+                        "Logical log short read: expected {expected_len}, got {}",
+                        result.len()
+                    )));
+                }
+                return Ok(IOResult::Done(result));
             }
-            None
-        });
-        let c = Completion::new_read(header_buf, completion);
-        let c = self.file.pread(pos, c)?;
-        io.wait_for_completion(c)?;
-        let out = out.read().clone();
-        if out.len() != len {
-            return Err(LimboError::Corrupt(format!(
-                "Logical log short read: expected {len}, got {}",
-                out.len()
-            )));
+
+            let header_buf = Arc::new(Buffer::new_temporary(len));
+            let out = Arc::new(RwLock::new(Vec::with_capacity(len)));
+            let out_clone = out.clone();
+            let completion: Box<ReadComplete> = Box::new(move |res| {
+                let out = out_clone.clone();
+                let mut out = out.write();
+                let Ok((buf, bytes_read)) = res else {
+                    tracing::error!("couldn't read logical log header err={:?}", res);
+                    return None;
+                };
+                if bytes_read > 0 {
+                    out.extend_from_slice(&buf.as_slice()[..bytes_read as usize]);
+                }
+                None
+            });
+            let c = Completion::new_read(header_buf, completion);
+            let c = self.file.pread(pos, c)?;
+            self.in_flight_read = Some(InFlightRead::Exact {
+                completion: c,
+                out,
+                expected_len: len,
+            });
+            // Loop to take the resume branch — handles both the synchronous-
+            // completion and not-finished cases uniformly.
         }
-        Ok(out)
     }
 
     fn get_buffer(&self) -> crate::sync::RwLockReadGuard<'_, Vec<u8>> {
         self.buffer.read()
     }
 
-    /// Read at least `need` bytes from the logical log, issuing multiple reads if necessary.
-    /// If at any point 0 bytes are read, that indicates corruption.
-    pub fn read_more_data(&mut self, io: &Arc<dyn crate::IO>, need: usize) -> Result<()> {
-        let bytes_can_read = self.bytes_can_read();
-        if bytes_can_read >= need {
-            return Ok(());
-        }
-
+    /// Read at least `need` bytes from the logical log, issuing multiple
+    /// reads if necessary. If at any point 0 bytes are read, that indicates
+    /// corruption.
+    ///
+    /// Non-blocking: a pread in flight is tracked in `self.in_flight_read`
+    /// and the method yields its completion until done. Re-entry picks up
+    /// where it left off without re-issuing the read.
+    pub fn read_more_data(&mut self, need: usize) -> Result<IOResult<()>> {
+        // Capture initial_buffer_offset only on the very first entry (no
+        // in-flight read yet). On a re-entry we want to preserve the
+        // post-loop buffer cleanup, but the cleanup is keyed off the
+        // current `self.buffer_offset` which has not changed across yields.
         let initial_buffer_offset = self.buffer_offset;
 
         loop {
+            // Resume hook: a pread that was issued by a previous call to
+            // this method completed; observe its result and advance.
+            if let Some(InFlightRead::Chunk { completion, .. }) = &self.in_flight_read {
+                if !completion.succeeded() {
+                    let c = completion.clone();
+                    io_yield_one!(c);
+                }
+                let Some(InFlightRead::Chunk { pre_size, .. }) = self.in_flight_read.take() else {
+                    unreachable!("in_flight_read variant just matched Chunk");
+                };
+                let buffer_size_after_read = self.buffer.read().len();
+                let bytes_read = buffer_size_after_read - pre_size;
+                if bytes_read == 0 {
+                    return Err(LimboError::Corrupt(format!(
+                        "Expected to read more bytes but read 0 bytes at offset {}",
+                        self.offset
+                    )));
+                }
+                self.offset += bytes_read;
+            }
+
             let buffer_size_before_read = self.buffer.read().len();
             turso_assert!(
                 buffer_size_before_read >= self.buffer_offset,
@@ -3339,7 +3431,16 @@ impl StreamingLogicalLogReader {
             let still_need = need.saturating_sub(bytes_available_in_buffer);
 
             if still_need == 0 {
-                break;
+                // Cleanup consumed bytes. If everything was consumed, clear
+                // avoids memmove.
+                let mut buffer = self.buffer.write();
+                if initial_buffer_offset >= buffer.len() {
+                    buffer.clear();
+                } else if initial_buffer_offset > 0 {
+                    let _ = buffer.drain(0..initial_buffer_offset);
+                }
+                self.buffer_offset = 0;
+                return Ok(IOResult::Done(()));
             }
 
             turso_assert!(
@@ -3372,30 +3473,13 @@ impl StreamingLogicalLogReader {
             });
             let c = Completion::new_read(header_buf, completion);
             let c = self.file.pread(self.offset as u64, c)?;
-            io.wait_for_completion(c)?;
-
-            let buffer_size_after_read = self.buffer.read().len();
-            let bytes_read = buffer_size_after_read - buffer_size_before_read;
-
-            if bytes_read == 0 {
-                return Err(LimboError::Corrupt(format!(
-                    "Expected to read {still_need} bytes more but read 0 bytes at offset {}",
-                    self.offset
-                )));
-            }
-
-            self.offset += bytes_read;
+            self.in_flight_read = Some(InFlightRead::Chunk {
+                completion: c,
+                pre_size: buffer_size_before_read,
+            });
+            // Loop to take the resume branch — covers both synchronous and
+            // asynchronous completion paths.
         }
-
-        // Cleanup consumed bytes. If everything was consumed, clear avoids memmove.
-        let mut buffer = self.buffer.write();
-        if initial_buffer_offset >= buffer.len() {
-            buffer.clear();
-        } else if initial_buffer_offset > 0 {
-            let _ = buffer.drain(0..initial_buffer_offset);
-        }
-        self.buffer_offset = 0;
-        Ok(())
     }
 
     fn bytes_can_read(&self) -> usize {
@@ -3500,6 +3584,7 @@ pub(crate) enum IndexOpKind {
 
 #[cfg(test)]
 mod tests {
+    use crate::util::IOExt as _;
     use std::collections::BTreeSet;
     use std::sync::Once;
 
@@ -3667,7 +3752,7 @@ mod tests {
             .unwrap();
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.buffer.write().extend_from_slice(bytes);
-        reader.consume_varint_bytes(&io)
+        io.block(|| reader.consume_varint_bytes())
     }
 
     /// What this test checks: A committed transaction written to the logical log is replayed correctly after restart.
@@ -5219,7 +5304,7 @@ mod tests {
         let header = reader.header().unwrap();
         assert_eq!(header.salt, salt_after);
 
-        match reader.parse_next_transaction(&io) {
+        match io.block(|| reader.parse_next_transaction()) {
             Ok(ParseResult::Frame(frame)) => {
                 let ops = frame.ops;
                 assert!(!ops.is_empty(), "expected at least one op");
@@ -5229,7 +5314,7 @@ mod tests {
             Err(e) => panic!("expected ops, got error: {e:?}"),
         }
         assert!(matches!(
-            reader.parse_next_transaction(&io),
+            io.block(|| reader.parse_next_transaction()),
             Ok(ParseResult::Eof)
         ));
     }
@@ -5260,7 +5345,7 @@ mod tests {
             HeaderReadResult::Valid(_)
         ));
         let mut count = 0;
-        while let Ok(ParseResult::Frame(_)) = reader.parse_next_transaction(&io) {
+        while let Ok(ParseResult::Frame(_)) = io.block(|| reader.parse_next_transaction()) {
             count += 1;
         }
         assert_eq!(count, 3);
@@ -5284,7 +5369,7 @@ mod tests {
             HeaderReadResult::Valid(_)
         ));
         // Frame 1 is corrupted — CRC mismatch on structurally complete frame
-        match reader.parse_next_transaction(&io) {
+        match io.block(|| reader.parse_next_transaction()) {
             Ok(ParseResult::InvalidFrame) => {}
             other => panic!("expected InvalidFrame after corrupted frame 1, got {other:?}"),
         }
@@ -5360,13 +5445,13 @@ mod tests {
         ));
 
         // Frame 1 from log A should validate fine
-        match reader.parse_next_transaction(&io) {
+        match io.block(|| reader.parse_next_transaction()) {
             Ok(ParseResult::Frame(frame)) => assert!(!frame.ops.is_empty()),
             other => panic!("expected log A's frame to parse, got {other:?}"),
         }
 
         // The spliced frame from log B should fail CRC validation
-        match reader.parse_next_transaction(&io) {
+        match io.block(|| reader.parse_next_transaction()) {
             Ok(ParseResult::InvalidFrame) => {}
             other => {
                 panic!("spliced frame from a different log should NOT validate, got {other:?}")
@@ -5544,8 +5629,8 @@ mod tests {
         if file_size == 0 {
             return Vec::new();
         }
-        let reader = StreamingLogicalLogReader::new(file, None);
-        reader.read_exact_at(io, 0, file_size).unwrap()
+        let mut reader = StreamingLogicalLogReader::new(file, None);
+        io.block(|| reader.read_exact_at(0, file_size)).unwrap()
     }
 
     fn overwrite_file_bytes(file: Arc<dyn crate::File>, io: &Arc<dyn crate::IO>, bytes: &[u8]) {
@@ -5669,12 +5754,12 @@ mod tests {
     ) -> Vec<ParsedOp> {
         let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
         reader.read_header(io).unwrap();
-        let ops = match reader.parse_next_transaction(io).unwrap() {
+        let ops = match io.block(|| reader.parse_next_transaction()).unwrap() {
             ParseResult::Frame(frame) => frame.ops,
             other => panic!("expected Ops, got {other:?}"),
         };
         assert!(matches!(
-            reader.parse_next_transaction(io).unwrap(),
+            io.block(|| reader.parse_next_transaction()).unwrap(),
             ParseResult::Eof
         ));
         ops
@@ -5692,12 +5777,12 @@ mod tests {
             encrypted_payload_chunk_size,
         );
         reader.read_header(io).unwrap();
-        let ops = match reader.parse_next_transaction(io).unwrap() {
+        let ops = match io.block(|| reader.parse_next_transaction()).unwrap() {
             ParseResult::Frame(frame) => frame.ops,
             other => panic!("expected Ops, got {other:?}"),
         };
         assert!(matches!(
-            reader.parse_next_transaction(io).unwrap(),
+            io.block(|| reader.parse_next_transaction()).unwrap(),
             ParseResult::Eof
         ));
         ops
@@ -5720,8 +5805,8 @@ mod tests {
         let mut frames = Vec::new();
         let mut tx_index = 0usize;
         loop {
-            match reader
-                .parse_next_transaction(io)
+            match io
+                .block(|| reader.parse_next_transaction())
                 .map_err(|e| format!("failed to parse fuzz frame {tx_index}: {e}"))?
             {
                 ParseResult::Frame(frame) => frames.push(frame.ops),
@@ -6061,7 +6146,7 @@ mod tests {
     ) {
         let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
         reader.read_header(io).unwrap();
-        match reader.parse_next_transaction(io).unwrap() {
+        match io.block(|| reader.parse_next_transaction()).unwrap() {
             ParseResult::InvalidFrame => {}
             other => panic!("expected InvalidFrame, got {other:?}"),
         }
@@ -6137,7 +6222,7 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
         reader.read_header(&io).unwrap();
 
-        let ops = match reader.parse_next_transaction(&io).unwrap() {
+        let ops = match io.block(|| reader.parse_next_transaction()).unwrap() {
             ParseResult::Frame(frame) => frame.ops,
             other => panic!("expected Ops, got {other:?}"),
         };
@@ -6146,7 +6231,7 @@ mod tests {
         assert_upsert_table_op(&ops[1], table_id, 2, &expected_world_record_bytes, 100);
 
         assert!(matches!(
-            reader.parse_next_transaction(&io).unwrap(),
+            io.block(|| reader.parse_next_transaction()).unwrap(),
             ParseResult::Eof
         ));
     }
@@ -6684,7 +6769,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
         reader.read_header(&io).unwrap();
-        match reader.parse_next_transaction(&io).unwrap() {
+        match io.block(|| reader.parse_next_transaction()).unwrap() {
             ParseResult::InvalidFrame => {}
             other => panic!("expected InvalidFrame after payload_size tamper, got {other:?}"),
         }
@@ -6954,7 +7039,7 @@ mod tests {
         reader.read_header(&io).unwrap();
 
         for i in 0..5u64 {
-            let ops = match reader.parse_next_transaction(&io).unwrap() {
+            let ops = match io.block(|| reader.parse_next_transaction()).unwrap() {
                 ParseResult::Frame(frame) => frame.ops,
                 other => panic!("frame {i}: expected Ops, got {other:?}"),
             };
@@ -6969,7 +7054,7 @@ mod tests {
         }
 
         assert!(matches!(
-            reader.parse_next_transaction(&io).unwrap(),
+            io.block(|| reader.parse_next_transaction()).unwrap(),
             ParseResult::Eof
         ));
     }
@@ -6999,7 +7084,7 @@ mod tests {
             let mut reader = StreamingLogicalLogReader::new(file, Some(wrong_key_enc_ctx()));
             reader.read_header(&io).unwrap();
 
-            match reader.parse_next_transaction(&io).unwrap() {
+            match io.block(|| reader.parse_next_transaction()).unwrap() {
                 ParseResult::InvalidFrame => {}
                 other => panic!("expected InvalidFrame with wrong key, got {other:?}"),
             }
@@ -7032,7 +7117,7 @@ mod tests {
             let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
             reader.read_header(&io).unwrap();
 
-            match reader.parse_next_transaction(&io).unwrap() {
+            match io.block(|| reader.parse_next_transaction()).unwrap() {
                 ParseResult::InvalidFrame => {}
                 other => panic!("expected InvalidFrame after TX header tamper, got {other:?}"),
             }
@@ -7071,7 +7156,7 @@ mod tests {
             let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx));
             reader.read_header(&io).unwrap();
 
-            match reader.parse_next_transaction(&io).unwrap() {
+            match io.block(|| reader.parse_next_transaction()).unwrap() {
                 ParseResult::InvalidFrame => {}
                 other => panic!("expected InvalidFrame after ciphertext tamper, got {other:?}"),
             }
@@ -7112,7 +7197,7 @@ mod tests {
         reader.read_header(&io).unwrap();
 
         // First frame should parse fine.
-        match reader.parse_next_transaction(&io).unwrap() {
+        match io.block(|| reader.parse_next_transaction()).unwrap() {
             ParseResult::Frame(frame) => {
                 let ops = frame.ops;
                 assert_eq!(ops.len(), 1);
@@ -7122,7 +7207,7 @@ mod tests {
         }
 
         // Second frame is torn — should be EOF.
-        match reader.parse_next_transaction(&io).unwrap() {
+        match io.block(|| reader.parse_next_transaction()).unwrap() {
             ParseResult::Eof => {}
             other => panic!("expected Eof for torn frame 2, got {other:?}"),
         }
@@ -7242,7 +7327,7 @@ mod tests {
             if allow_eof {
                 let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
                 reader.read_header(&io).unwrap();
-                match reader.parse_next_transaction(&io).unwrap() {
+                match io.block(|| reader.parse_next_transaction()).unwrap() {
                     ParseResult::InvalidFrame | ParseResult::Eof => {}
                     other => panic!("expected rejection for {label}, got {other:?}"),
                 }
@@ -7325,7 +7410,7 @@ mod tests {
 
             let mut reader = StreamingLogicalLogReader::new(file, Some(enc_ctx.clone()));
             reader.read_header(&io).unwrap();
-            match reader.parse_next_transaction(&io).unwrap() {
+            match io.block(|| reader.parse_next_transaction()).unwrap() {
                 ParseResult::Frame(frame) => {
                     let ops = frame.ops;
                     assert_eq!(ops.len(), 1);
@@ -7339,7 +7424,7 @@ mod tests {
                 }
                 other => panic!("expected prefix frame to survive, got {other:?}"),
             }
-            match reader.parse_next_transaction(&io).unwrap() {
+            match io.block(|| reader.parse_next_transaction()).unwrap() {
                 ParseResult::Eof => {}
                 other => panic!("expected Eof for torn multi-chunk frame, got {other:?}"),
             }

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1665,7 +1665,7 @@ enum StreamingState {
 
 /// Result of attempting to read and validate the logical log file header.
 #[derive(Debug, Clone)]
-pub(crate) enum HeaderReadResult {
+pub enum HeaderReadResult {
     /// Header is well-formed: magic, version, flags, reserved, and CRC all valid.
     Valid(LogHeader),
     /// File is smaller than `LOG_HDR_SIZE` — no log exists (first run or truncated to zero).
@@ -1694,6 +1694,9 @@ enum InFlightRead {
         expected_len: usize,
     },
 }
+
+/// Plaintext + crc32 result to appease clippy for type complexity
+type ReadEncryptedResult = Option<(Vec<u8>, u32)>;
 
 pub struct StreamingLogicalLogReader {
     file: Arc<dyn File>,
@@ -1860,21 +1863,21 @@ impl StreamingLogicalLogReader {
         self.last_valid_offset = LOG_HDR_SIZE;
     }
 
+    #[cfg(test)]
+    pub(crate) fn next_frame_blocking(
+        &mut self,
+        io: &Arc<dyn crate::IO>,
+    ) -> Result<Option<Vec<ParsedOp>>> {
+        let io = io.clone();
+        io.block(|| self.next_frame())
+    }
+
     /// Reads the next complete transaction frame.
     ///
     /// Recovery needs the whole frame so it can decide which schema snapshot should decode each
     /// index op. Empty parsed frames are skipped, so callers that receive Some(frame) can
     /// rely on `frame` being non-empty.
-    /// Blocking shim — retained for tests and synchronous callers. Production
-    /// recovery should drive
-    /// [`StreamingLogicalLogReader::next_frame_nonblock`] directly so that
-    /// log-replay reads yield instead of blocking.
-    pub(crate) fn next_frame(&mut self, io: &Arc<dyn crate::IO>) -> Result<Option<Vec<ParsedOp>>> {
-        let io = io.clone();
-        io.block(|| self.next_frame_nonblock())
-    }
-
-    pub(crate) fn next_frame_nonblock(&mut self) -> Result<IOResult<Option<Vec<ParsedOp>>>> {
+    pub(crate) fn next_frame(&mut self) -> Result<IOResult<Option<Vec<ParsedOp>>>> {
         loop {
             match self.state {
                 StreamingState::NeedTransactionStart => {
@@ -2354,7 +2357,7 @@ impl StreamingLogicalLogReader {
         op_count: u32,
         commit_ts: u64,
         running_crc: u32,
-    ) -> Result<IOResult<Option<(Vec<u8>, u32)>>> {
+    ) -> Result<IOResult<ReadEncryptedResult>> {
         let (nonce_size, tag_size) = {
             let enc = self
                 .encryption_ctx
@@ -2754,8 +2757,7 @@ impl StreamingLogicalLogReader {
                 op_count,
                 commit_ts,
                 running_crc,
-            ))
-            else {
+            )) else {
                 return Ok(IOResult::Done(ParseResult::Eof));
             };
             let recovery_start = extension_size;
@@ -3075,8 +3077,7 @@ impl StreamingLogicalLogReader {
                 op_count,
                 commit_ts,
                 running_crc,
-            ))
-            else {
+            )) else {
                 return Ok(IOResult::Done(ParseResult::Eof));
             };
             let portable_changes = match find_extension_payload(
@@ -3681,7 +3682,7 @@ mod tests {
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.read_header(io).unwrap();
         let mut ops = Vec::new();
-        while let Some(frame) = reader.next_frame(io).unwrap() {
+        while let Some(frame) = reader.next_frame_blocking(io).unwrap() {
             for op in frame {
                 match op {
                     ParsedOp::UpsertTable {
@@ -4207,7 +4208,7 @@ mod tests {
             reader.read_header(&io).unwrap();
             let mut seen = 0;
             loop {
-                match reader.next_frame(&io) {
+                match reader.next_frame_blocking(&io) {
                     Ok(Some(frame)) => {
                         for op in frame {
                             match op {
@@ -4294,7 +4295,10 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file, None);
         reader.read_header(&io).unwrap();
-        let frame = reader.next_frame(&io).unwrap().expect("expected one frame");
+        let frame = reader
+            .next_frame_blocking(&io)
+            .unwrap()
+            .expect("expected one frame");
         assert_eq!(frame.len(), 1);
         match &frame[0] {
             ParsedOp::UpsertTable { rowid, .. } => {
@@ -4410,7 +4414,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let res = reader.next_frame(&io);
+        let res = reader.next_frame_blocking(&io);
         assert!(res.unwrap().is_none());
     }
 
@@ -4482,7 +4486,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let res = reader.next_frame(&io);
+        let res = reader.next_frame_blocking(&io);
         assert!(res.unwrap().is_none());
     }
 
@@ -4508,7 +4512,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let res = reader.next_frame(&io);
+        let res = reader.next_frame_blocking(&io);
         assert!(res.unwrap().is_none());
     }
 
@@ -4530,7 +4534,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let res = reader.next_frame(&io);
+        let res = reader.next_frame_blocking(&io);
         assert!(res.unwrap().is_none());
     }
 
@@ -4551,7 +4555,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let res = reader.next_frame(&io);
+        let res = reader.next_frame_blocking(&io);
         assert!(res.unwrap().is_none());
     }
 
@@ -4767,7 +4771,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let res = reader.next_frame(&io);
+        let res = reader.next_frame_blocking(&io);
         assert!(res.unwrap().is_none());
     }
 
@@ -4791,7 +4795,7 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let res = reader.next_frame(&io);
+        let res = reader.next_frame_blocking(&io);
         assert!(res.unwrap().is_none());
     }
 
@@ -4827,7 +4831,7 @@ mod tests {
 
         // The reader skips the empty frame and returns the UpdateHeader from frame 2.
         let frame = reader
-            .next_frame(&io)
+            .next_frame_blocking(&io)
             .unwrap()
             .expect("expected UpdateHeader frame after empty tx");
         assert_eq!(frame.len(), 1);
@@ -4843,7 +4847,7 @@ mod tests {
         }
 
         // Nothing left after frame 2.
-        assert!(reader.next_frame(&io).unwrap().is_none());
+        assert!(reader.next_frame_blocking(&io).unwrap().is_none());
     }
 
     /// What this test checks: Every single-bit flip in a full frame is either detected or safely rejected.
@@ -4890,7 +4894,7 @@ mod tests {
 
                 let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
                 reader.read_header(&io).unwrap();
-                let res = reader.next_frame(&io);
+                let res = reader.next_frame_blocking(&io);
                 match res {
                     Err(_) | Ok(None) => {}
                     Ok(Some(frame)) => {
@@ -5165,7 +5169,10 @@ mod tests {
 
         let mut reader = StreamingLogicalLogReader::new(file.clone(), None);
         reader.read_header(&io).unwrap();
-        let frame = reader.next_frame(&io).unwrap().expect("expected one frame");
+        let frame = reader
+            .next_frame_blocking(&io)
+            .unwrap()
+            .expect("expected one frame");
         assert_eq!(frame.len(), 1);
         match &frame[0] {
             ParsedOp::UpsertTable { btree_resident, .. } => {

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -504,6 +504,65 @@ impl Statement {
         Ok(())
     }
 
+    /// Non-blocking counterpart of [`Self::run_ignore_rows`]: drives the
+    /// statement to completion, ignoring rows, but instead of pumping IO
+    /// synchronously it yields the pending completion to the caller. Re-invoke
+    /// after the yielded completion finishes; the program resumes at the same
+    /// pc. Rows are discarded.
+    ///
+    /// Used by engine-internal callers that must stay non-blocking (MVCC
+    /// bootstrap/recovery) so they don't call `io.step()` on backends that have
+    /// no synchronous IO pump (e.g. WASM).
+    pub fn run_ignore_rows_nonblock(&mut self) -> Result<crate::IOResult<()>> {
+        loop {
+            match self.step()? {
+                vdbe::StepResult::Done => return Ok(crate::IOResult::Done(())),
+                vdbe::StepResult::Row => continue,
+                vdbe::StepResult::IO => {
+                    let io = self.take_io_completions().unwrap_or_else(|| {
+                        crate::types::IOCompletions::Single(crate::io::Completion::new_yield())
+                    });
+                    return Ok(crate::IOResult::IO(io));
+                }
+                vdbe::StepResult::Interrupt => return Err(LimboError::Interrupt),
+                vdbe::StepResult::Busy => return Err(LimboError::Busy),
+            }
+        }
+    }
+
+    /// Non-blocking counterpart of [`Self::run_with_row_callback`]: drives the
+    /// statement to completion, invoking `func` once per emitted row, but
+    /// yields the pending completion to the caller instead of pumping IO
+    /// synchronously.
+    ///
+    /// Re-entrancy: on an IO yield the program is paused mid-opcode (never
+    /// between emitting a row and this loop observing it), so on re-invocation
+    /// stepping resumes without replaying the last row — every row's `func`
+    /// runs exactly once. Because the runner restarts from the top on each
+    /// re-entry, `func` must append to caller-owned state that persists across
+    /// yields (e.g. a field in the driving state machine), not to a local.
+    pub fn run_with_row_callback_nonblock(
+        &mut self,
+        mut func: impl FnMut(&Row) -> Result<()>,
+    ) -> Result<crate::IOResult<()>> {
+        loop {
+            match self.step()? {
+                vdbe::StepResult::Done => return Ok(crate::IOResult::Done(())),
+                vdbe::StepResult::Row => {
+                    func(self.row().expect("row should be present"))?;
+                }
+                vdbe::StepResult::IO => {
+                    let io = self.take_io_completions().unwrap_or_else(|| {
+                        crate::types::IOCompletions::Single(crate::io::Completion::new_yield())
+                    });
+                    return Ok(crate::IOResult::IO(io));
+                }
+                vdbe::StepResult::Interrupt => return Err(LimboError::Interrupt),
+                vdbe::StepResult::Busy => return Err(LimboError::Busy),
+            }
+        }
+    }
+
     /// Blocks execution, advances IO, and stops at any StepResult except IO
     /// You can optionally pass a handler to run after IO is advanced
     pub fn run_one_step_blocking(
@@ -1135,6 +1194,51 @@ mod tests {
 
         stmt.reset_metrics();
         assert_eq!(stmt.metrics().rows_written, 0);
+    }
+
+    #[test]
+    fn test_run_with_row_callback_nonblock_collects_all_rows() {
+        let conn = open_test_connection().unwrap();
+        conn.execute("CREATE TABLE t(x)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1), (2), (3), (4), (5)")
+            .unwrap();
+
+        let io = conn.db.io.clone();
+        let mut stmt = conn.prepare("SELECT x FROM t ORDER BY x").unwrap();
+
+        // Drive the non-blocking runner via the IOResult loop, exactly as a
+        // state-machine caller would: collect into an accumulator that persists
+        // across yields and wait on each yielded completion.
+        let mut collected: Vec<i64> = Vec::new();
+        loop {
+            let res = stmt
+                .run_with_row_callback_nonblock(|row| {
+                    collected.push(row.get::<i64>(0)?);
+                    Ok(())
+                })
+                .unwrap();
+            match res {
+                crate::IOResult::Done(()) => break,
+                crate::IOResult::IO(c) => c.wait(io.as_ref()).unwrap(),
+            }
+        }
+        assert_eq!(collected, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_run_ignore_rows_nonblock_completes() {
+        let conn = open_test_connection().unwrap();
+        conn.execute("CREATE TABLE t(x)").unwrap();
+
+        let io = conn.db.io.clone();
+        let mut stmt = conn.prepare("INSERT INTO t VALUES (1), (2)").unwrap();
+        loop {
+            match stmt.run_ignore_rows_nonblock().unwrap() {
+                crate::IOResult::Done(()) => break,
+                crate::IOResult::IO(c) => c.wait(io.as_ref()).unwrap(),
+            }
+        }
+        assert_eq!(stmt.metrics().rows_written, 2);
     }
 
     #[test]

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -3,6 +3,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::schema::Schema;
 use crate::translate::emitter::TransactionMode;
+use crate::types::IOResult;
 use crate::util::normalize_ident;
 use crate::{Connection, Result, Statement, TransactionState, Value};
 pub const STATS_TABLE: &str = "sqlite_stat1";
@@ -125,66 +126,156 @@ pub fn refresh_analyze_stats(conn: &Arc<Connection>) {
     }
 }
 
+/// Carries the in-progress `sqlite_stat1` scan across IO yields for
+/// [`refresh_analyze_stats_nonblock`].
+#[derive(Default)]
+pub enum RefreshAnalyzeStatsState {
+    #[default]
+    Start,
+    Running {
+        stmt: Box<Statement>,
+        schema_snapshot: Arc<Schema>,
+        stats: AnalyzeStats,
+    },
+}
+
+/// Non-blocking variant of [`refresh_analyze_stats`]: best-effort refresh of
+/// the connection's in-memory ANALYZE stats from `sqlite_stat1`, yielding IO
+/// via the supplied state instead of pumping it. Errors are swallowed (matches
+/// the blocking variant's best-effort contract).
+pub fn refresh_analyze_stats_nonblock(
+    conn: &Arc<Connection>,
+    st: &mut RefreshAnalyzeStatsState,
+) -> Result<IOResult<()>> {
+    loop {
+        match st {
+            RefreshAnalyzeStatsState::Start => {
+                if !conn.is_db_initialized() || conn.is_nested_stmt() {
+                    return Ok(IOResult::Done(()));
+                }
+                if matches!(conn.get_tx_state(), TransactionState::Write { .. }) {
+                    return Ok(IOResult::Done(()));
+                }
+                let schema_snapshot = { conn.schema.read().clone() };
+                if schema_snapshot.get_btree_table(STATS_TABLE).is_none() {
+                    return Ok(IOResult::Done(()));
+                }
+                let mv_tx = conn.get_mv_tx();
+                let mut stmt = conn.prepare(STATS_QUERY)?;
+                stmt.set_mv_tx(mv_tx);
+                *st = RefreshAnalyzeStatsState::Running {
+                    stmt: Box::new(stmt),
+                    schema_snapshot,
+                    stats: AnalyzeStats::default(),
+                };
+            }
+            RefreshAnalyzeStatsState::Running {
+                stmt,
+                schema_snapshot,
+                stats,
+            } => {
+                let scan = load_sqlite_stat1_rows_nonblock(stmt, schema_snapshot, stats);
+                match scan {
+                    Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
+                    Ok(IOResult::Done(())) => {
+                        let stats = std::mem::take(stats);
+                        conn.with_schema_mut(|schema| {
+                            schema.analyze_stats = stats;
+                        });
+                        *st = RefreshAnalyzeStatsState::Start;
+                        return Ok(IOResult::Done(()));
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to refresh analyze stats: {e}");
+                        *st = RefreshAnalyzeStatsState::Start;
+                        return Ok(IOResult::Done(()));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Non-blocking row scan shared by [`refresh_analyze_stats_nonblock`]. Steps the
+/// prepared `sqlite_stat1` statement, accumulating into `stats`.
+fn load_sqlite_stat1_rows_nonblock(
+    stmt: &mut Statement,
+    schema: &Schema,
+    stats: &mut AnalyzeStats,
+) -> Result<crate::types::IOResult<()>> {
+    crate::return_if_io!(
+        stmt.run_with_row_callback_nonblock(|row| { load_sqlite_stat1_row(row, schema, stats) })
+    );
+    Ok(crate::types::IOResult::Done(()))
+}
+
+/// Apply a single `sqlite_stat1` row to the accumulating [`AnalyzeStats`].
+/// Shared by the blocking and non-blocking scanners.
+fn load_sqlite_stat1_row(
+    row: &crate::vdbe::Row,
+    schema: &Schema,
+    stats: &mut AnalyzeStats,
+) -> Result<()> {
+    let table_name = row.get::<&str>(0)?;
+    let idx_value = row.get::<&Value>(1)?;
+    let stat_value = row.get::<&Value>(2)?;
+
+    let idx_name = match idx_value {
+        Value::Null => None,
+        Value::Text(s) => Some(s.as_str()),
+        _ => None,
+    };
+    let stat = match stat_value {
+        Value::Text(s) => s.as_str(),
+        _ => return Ok(()),
+    };
+
+    // Skip if table is not a regular B-tree.
+    if schema.get_btree_table(table_name).is_none() {
+        return Ok(());
+    }
+    let Some(numbers) = parse_stat_numbers(stat) else {
+        return Ok(());
+    };
+    if numbers.is_empty() {
+        return Ok(());
+    }
+    if idx_name.is_none() {
+        if let Some(total_rows) = numbers.first().copied() {
+            stats.table_stats_mut(table_name).row_count = Some(total_rows);
+        }
+        return Ok(());
+    }
+
+    // Index-level entry: only keep if the index exists on this table.
+    let idx_name = normalize_ident(idx_name.unwrap());
+    if schema.get_index(table_name, &idx_name).is_none() {
+        return Ok(());
+    }
+
+    let total_rows = numbers.first().copied();
+    {
+        let idx_stats = stats.table_stats_mut(table_name).index_stats_mut(&idx_name);
+        idx_stats.total_rows = total_rows;
+        idx_stats.avg_rows_per_distinct_prefix = numbers.iter().skip(1).copied().collect();
+    }
+
+    // If we didn't see a table-level row yet, seed row_count from index stats.
+    if let Some(total_rows) = total_rows {
+        let table_stats = stats.table_stats_mut(table_name);
+        if table_stats.row_count.is_none() {
+            table_stats.row_count = Some(total_rows);
+        }
+    }
+    Ok(())
+}
+
 fn load_sqlite_stat1_from_stmt(
     mut stmt: Statement,
     schema: &Schema,
     stats: &mut AnalyzeStats,
 ) -> Result<()> {
-    stmt.run_with_row_callback(|row| {
-        let table_name = row.get::<&str>(0)?;
-        let idx_value = row.get::<&Value>(1)?;
-        let stat_value = row.get::<&Value>(2)?;
-
-        let idx_name = match idx_value {
-            Value::Null => None,
-            Value::Text(s) => Some(s.as_str()),
-            _ => None,
-        };
-        let stat = match stat_value {
-            Value::Text(s) => s.as_str(),
-            _ => return Ok(()),
-        };
-
-        // Skip if table is not a regular B-tree.
-        if schema.get_btree_table(table_name).is_none() {
-            return Ok(());
-        }
-        let Some(numbers) = parse_stat_numbers(stat) else {
-            return Ok(());
-        };
-        if numbers.is_empty() {
-            return Ok(());
-        }
-        if idx_name.is_none() {
-            if let Some(total_rows) = numbers.first().copied() {
-                stats.table_stats_mut(table_name).row_count = Some(total_rows);
-            }
-            return Ok(());
-        }
-
-        // Index-level entry: only keep if the index exists on this table.
-        let idx_name = normalize_ident(idx_name.unwrap());
-        if schema.get_index(table_name, &idx_name).is_none() {
-            return Ok(());
-        }
-
-        let total_rows = numbers.first().copied();
-        {
-            let idx_stats = stats.table_stats_mut(table_name).index_stats_mut(&idx_name);
-            idx_stats.total_rows = total_rows;
-            idx_stats.avg_rows_per_distinct_prefix = numbers.iter().skip(1).copied().collect();
-        }
-
-        // If we didn't see a table-level row yet, seed row_count from index stats.
-        if let Some(total_rows) = total_rows {
-            let table_stats = stats.table_stats_mut(table_name);
-            if table_stats.row_count.is_none() {
-                table_stats.row_count = Some(total_rows);
-            }
-        }
-        Ok(())
-    })?;
-
+    stmt.run_with_row_callback(|row| load_sqlite_stat1_row(row, schema, stats))?;
     Ok(())
 }
 

--- a/core/util.rs
+++ b/core/util.rs
@@ -155,65 +155,111 @@ pub struct UnparsedFromSqlIndex {
     pub sql: String,
 }
 
+/// Carries the in-progress state of [`parse_schema_rows`] across IO yields:
+/// the schema-scan statement plus the accumulators that `handle_schema_row`
+/// fills row-by-row. Without this, a yield mid-scan would lose the partially
+/// accumulated indexes/materialized-view info and re-run the statement from
+/// scratch.
+#[derive(Default)]
+pub struct ParseSchemaRowsState {
+    inner: Option<ParseSchemaRowsInner>,
+}
+
+struct ParseSchemaRowsInner {
+    rows: Statement,
+    from_sql_indexes: Vec<UnparsedFromSqlIndex>,
+    automatic_indices: HashMap<String, Vec<(String, i64)>>,
+    dbsp_state_roots: HashMap<String, i64>,
+    dbsp_state_index_roots: HashMap<String, i64>,
+    materialized_view_info: HashMap<String, (String, i64)>,
+}
+
+impl ParseSchemaRowsState {
+    /// Initialize the scan state from a prepared `SELECT * FROM sqlite_schema`
+    /// statement (or equivalent) and the MVCC transaction it should read under.
+    pub fn new(mut rows: Statement, mv_tx: Option<(u64, TransactionMode)>) -> Self {
+        rows.set_mv_tx(mv_tx);
+        Self {
+            inner: Some(ParseSchemaRowsInner {
+                rows,
+                from_sql_indexes: Vec::with_capacity(10),
+                automatic_indices: HashMap::with_capacity_and_hasher(10, Default::default()),
+                dbsp_state_roots: HashMap::default(),
+                dbsp_state_index_roots: HashMap::default(),
+                materialized_view_info: HashMap::default(),
+            }),
+        }
+    }
+}
+
+/// Non-blocking schema-row parser: steps the schema-scan statement held in
+/// `state`, feeding each row to `handle_schema_row`, and yields IO instead of
+/// pumping it. Re-invoke after each yielded completion; accumulators persist in
+/// `state`. On completion, populates indices and materialized views.
 #[instrument(skip_all, level = Level::INFO)]
 pub fn parse_schema_rows(
-    mut rows: Statement,
+    state: &mut ParseSchemaRowsState,
     schema: &mut Schema,
     syms: &SymbolTable,
-    mv_tx: Option<(u64, TransactionMode)>,
     resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
-) -> Result<()> {
-    rows.set_mv_tx(mv_tx);
-    let mv_store = rows.mv_store().clone();
-    // TODO: if we IO, this unparsed indexes is lost. Will probably need some state between
-    // IO runs
-    let mut from_sql_indexes = Vec::with_capacity(10);
-    let mut automatic_indices = HashMap::with_capacity_and_hasher(10, Default::default());
+) -> Result<IOResult<()>> {
+    {
+        let inner = state
+            .inner
+            .as_mut()
+            .expect("ParseSchemaRowsState not initialized");
+        // Destructure so the statement (receiver) and the accumulators (captured
+        // by the closure) are borrowed as disjoint fields.
+        let ParseSchemaRowsInner {
+            rows,
+            from_sql_indexes,
+            automatic_indices,
+            dbsp_state_roots,
+            dbsp_state_index_roots,
+            materialized_view_info,
+        } = inner;
+        crate::return_if_io!(rows.run_with_row_callback_nonblock(|row| {
+            let ty = row.get::<&str>(0)?;
+            let name = row.get::<&str>(1)?;
+            let table_name = row.get::<&str>(2)?;
+            let root_page = row.get::<i64>(3)?;
+            let sql = row.get::<&str>(4).ok();
+            schema.handle_schema_row(
+                ty,
+                name,
+                table_name,
+                root_page,
+                sql,
+                syms,
+                from_sql_indexes,
+                automatic_indices,
+                dbsp_state_roots,
+                dbsp_state_index_roots,
+                materialized_view_info,
+                resolve_attached_db,
+            )
+        }));
+    }
 
-    // Store DBSP state table root pages: view_name -> dbsp_state_root_page
-    let mut dbsp_state_roots: HashMap<String, i64> = HashMap::default();
-    // Store DBSP state table index root pages: view_name -> dbsp_state_index_root_page
-    let mut dbsp_state_index_roots: HashMap<String, i64> = HashMap::default();
-    // Store materialized view info (SQL and root page) for later creation
-    let mut materialized_view_info: HashMap<String, (String, i64)> = HashMap::default();
-
-    // TODO: How do we ensure that the I/O we submitted to
-    // read the schema is actually complete?
-    rows.run_with_row_callback(|row| {
-        let ty = row.get::<&str>(0)?;
-        let name = row.get::<&str>(1)?;
-        let table_name = row.get::<&str>(2)?;
-        let root_page = row.get::<i64>(3)?;
-        let sql = row.get::<&str>(4).ok();
-        schema.handle_schema_row(
-            ty,
-            name,
-            table_name,
-            root_page,
-            sql,
-            syms,
-            &mut from_sql_indexes,
-            &mut automatic_indices,
-            &mut dbsp_state_roots,
-            &mut dbsp_state_index_roots,
-            &mut materialized_view_info,
-            resolve_attached_db,
-        )
-    })?;
-
+    // Scan complete: finalize. Take ownership of the accumulators.
+    let inner = state
+        .inner
+        .take()
+        .expect("ParseSchemaRowsState not initialized");
+    let has_mv_store = inner.rows.mv_store().is_some();
     schema.populate_indices(
         syms,
-        from_sql_indexes,
-        automatic_indices,
-        mv_store.is_some(),
+        inner.from_sql_indexes,
+        inner.automatic_indices,
+        has_mv_store,
     )?;
     schema.populate_materialized_views(
-        materialized_view_info,
-        dbsp_state_roots,
-        dbsp_state_index_roots,
+        inner.materialized_view_info,
+        inner.dbsp_state_roots,
+        inner.dbsp_state_index_roots,
     )?;
 
-    Ok(())
+    Ok(IOResult::Done(()))
 }
 
 fn cmp_numeric_strings(num_str: &str, other: &str) -> bool {


### PR DESCRIPTION
## Lift blocking IO part 2: schema reparse + MVCC bootstrap/recovery

Removes synchronous `io.block`/`wait_for_completion` from the MVCC open path so it no longer hangs on backends without a synchronous IO pump (e.g. WASM, where `io.step()` is a no-op). The whole bootstrap → checkpoint-reconcile → schema
reparse → metadata-table init → logical-log replay sequence now yields IO cooperatively via `IOResult` instead of blocking.

## Major changes

**Non-blocking statement runner**
- `Statement::run_ignore_rows_nonblock` / `run_with_row_callback_nonblock`:
  drive a statement to completion returning `IOResult`, surfacing the pending
  completion (via `take_io_completions`) instead of pumping `io.step()`. The
  VDBE interpreter already yields `StepResult::IO`; these just bridge it to the
  `IOResult` model. No interpreter changes.

**Schema reparse**
- `reparse_schema` / `reparse_schema_with_cookie` lifted to a `ReparseSchemaState`
  machine (read cookie → scan `sqlite_schema` → load custom types → refresh
  stats), carrying the half-built schema + captured table-valued functions +
  reparse guard across yields.
- `parse_schema_rows`, `refresh_analyze_stats`, and `read_current_schema_cookie`
  lifted to `IOResult` accordingly.

**MVCC bootstrap** 
- `bootstrap_nonblock` reworked into a linear state machine that drives, all
  non-blocking: interrupted-checkpoint reconciliation, schema reparse, the
  `persistent_tx_ts_max` read, metadata-table create/seed, and the metadata IO
  chain. Dead blocking shims removed.

**Logical-log recovery**
- `maybe_recover_logical_log` lifted to a `RecoverLogicalLogState` machine. Setup
  phases (header / tx-ts / cookie / `sqlite_schema` scan) yield IO; the replay
  loop carries its accumulators in `RecoverCtx` across per-frame `next_frame`
  yields. The per-frame replay body is unchanged in behavior. Driven from a new
  bootstrap `Recover` phase.

**Checkpoint hang fix** (`mvcc/database/checkpoint_state_machine.rs` path)
- `maybe_complete_interrupted_checkpoint`'s `DriveEarlyTruncate` was recreating
  its `CheckpointResult` on every re-entry, so `truncate_wal` (which tracks
  truncate/sync progress through that struct) never completed and spun under
  `io.block`. The result now persists in the state variant.
