### PR TITLE
Window functions plumbing 1: add stubs for builtins, refactor row_number() to use VDBE aggregate machinery

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -478,6 +478,27 @@ pub enum WindowFunc {
 }
 
 impl WindowFunc {
+    /// SQL name of this window function. Matches the strings used by
+    /// `Display` so EXPLAIN output and error messages agree.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::RowNumber => "row_number",
+            Self::Rank => "rank",
+            Self::DenseRank => "dense_rank",
+            Self::PercentRank => "percent_rank",
+            Self::CumeDist => "cume_dist",
+            Self::Ntile => "ntile",
+            Self::Lag => "lag",
+            Self::Lead => "lead",
+            Self::FirstValue => "first_value",
+            Self::LastValue => "last_value",
+            Self::NthValue => "nth_value",
+            Self::External(_) => unreachable!(
+                "WindowFunc::External is not constructible: ExtFunc has no Window variant"
+            ),
+        }
+    }
+
     pub fn arities(&self) -> &'static [i32] {
         match self {
             Self::RowNumber | Self::Rank | Self::DenseRank | Self::PercentRank | Self::CumeDist => {
@@ -546,21 +567,39 @@ impl Deterministic for WindowFunc {
 
 impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Function reference used by AggStep / AggValue / AggFinal opcodes.
+/// Aggregates used in window context and pure window functions share the same
+/// step/value dispatch path; this enum carries which side of that split a
+/// particular call belongs to.
+#[derive(Debug, Clone)]
+pub enum AccumulatorFunc {
+    Agg(AggFunc),
+    Window(WindowFunc),
+}
+
+impl AccumulatorFunc {
+    /// Extract the inner `AggFunc` when this kind is known to be an
+    /// aggregate. `unreachable!`s on `Window(...)` — the only opcodes
+    /// that carry an `AccumulatorFunc` are the AggStep / AggValue /
+    /// AggFinal trio, and the call sites that emit those wrap aggregates
+    /// only. A `Window` value reaching here is a planner bug.
+    pub fn expect_agg(&self) -> &AggFunc {
         match self {
-            Self::RowNumber => write!(f, "row_number"),
-            Self::Rank => write!(f, "rank"),
-            Self::DenseRank => write!(f, "dense_rank"),
-            Self::PercentRank => write!(f, "percent_rank"),
-            Self::CumeDist => write!(f, "cume_dist"),
-            Self::Ntile => write!(f, "ntile"),
-            Self::Lag => write!(f, "lag"),
-            Self::Lead => write!(f, "lead"),
-            Self::FirstValue => write!(f, "first_value"),
-            Self::LastValue => write!(f, "last_value"),
-            Self::NthValue => write!(f, "nth_value"),
-            Self::External(_) => unreachable!(
-                "WindowFunc::External is not constructible: ExtFunc has no Window variant"
-            ),
+            Self::Agg(f) => f,
+            Self::Window(f) => {
+                unreachable!("window function {f} reached an aggregate-only dispatch path")
+            }
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Agg(f) => f.as_str(),
+            Self::Window(f) => f.as_str(),
         }
     }
 }

--- a/core/function.rs
+++ b/core/function.rs
@@ -460,22 +460,87 @@ pub enum AggFunc {
     External(Arc<ExtFunc>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter)]
+#[derive(Debug, Clone, strum::EnumIter)]
 pub enum WindowFunc {
     RowNumber,
+    Rank,
+    DenseRank,
+    PercentRank,
+    CumeDist,
+    Ntile,
+    Lag,
+    Lead,
+    FirstValue,
+    LastValue,
+    NthValue,
+    #[strum(disabled)]
+    External(Arc<ExtFunc>),
 }
 
 impl WindowFunc {
     pub fn arities(&self) -> &'static [i32] {
         match self {
-            Self::RowNumber => &[0],
+            Self::RowNumber | Self::Rank | Self::DenseRank | Self::PercentRank | Self::CumeDist => {
+                &[0]
+            }
+            Self::Ntile | Self::FirstValue | Self::LastValue => &[1],
+            Self::NthValue => &[2],
+            Self::Lag | Self::Lead => &[1, 2, 3],
+            Self::External(_) => unreachable!(
+                "WindowFunc::External is not constructible: ExtFunc has no Window variant"
+            ),
+        }
+    }
+
+    /// Whether name resolution + runtime dispatch are wired up. Stub variants
+    /// must not be advertised via `pragma_function_list`, or introspection
+    /// drifts ahead of the resolver and users get "no such function" when
+    /// they try to call them.
+    pub fn is_implemented(&self) -> bool {
+        matches!(self, Self::RowNumber)
+    }
+}
+
+impl PartialEq for WindowFunc {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::RowNumber, Self::RowNumber)
+            | (Self::Rank, Self::Rank)
+            | (Self::DenseRank, Self::DenseRank)
+            | (Self::PercentRank, Self::PercentRank)
+            | (Self::CumeDist, Self::CumeDist)
+            | (Self::Ntile, Self::Ntile)
+            | (Self::Lag, Self::Lag)
+            | (Self::Lead, Self::Lead)
+            | (Self::FirstValue, Self::FirstValue)
+            | (Self::LastValue, Self::LastValue)
+            | (Self::NthValue, Self::NthValue) => true,
+            (Self::External(a), Self::External(b)) => Arc::ptr_eq(a, b),
+            _ => false,
         }
     }
 }
 
+impl Eq for WindowFunc {}
+
 impl Deterministic for WindowFunc {
     fn is_deterministic(&self) -> bool {
-        true
+        match self {
+            Self::RowNumber
+            | Self::Rank
+            | Self::DenseRank
+            | Self::PercentRank
+            | Self::CumeDist
+            | Self::Ntile
+            | Self::Lag
+            | Self::Lead
+            | Self::FirstValue
+            | Self::LastValue
+            | Self::NthValue => true,
+            Self::External(_) => unreachable!(
+                "WindowFunc::External is not constructible: ExtFunc has no Window variant"
+            ),
+        }
     }
 }
 
@@ -483,6 +548,19 @@ impl std::fmt::Display for WindowFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::RowNumber => write!(f, "row_number"),
+            Self::Rank => write!(f, "rank"),
+            Self::DenseRank => write!(f, "dense_rank"),
+            Self::PercentRank => write!(f, "percent_rank"),
+            Self::CumeDist => write!(f, "cume_dist"),
+            Self::Ntile => write!(f, "ntile"),
+            Self::Lag => write!(f, "lag"),
+            Self::Lead => write!(f, "lead"),
+            Self::FirstValue => write!(f, "first_value"),
+            Self::LastValue => write!(f, "last_value"),
+            Self::NthValue => write!(f, "nth_value"),
+            Self::External(_) => unreachable!(
+                "WindowFunc::External is not constructible: ExtFunc has no Window variant"
+            ),
         }
     }
 }
@@ -1721,8 +1799,11 @@ impl Func {
             push(f.to_string(), "w", f.arities(), f.is_deterministic());
         }
 
-        // Window functions.
+        // Window functions (skip stub variants until they're wired up).
         for f in WindowFunc::iter() {
+            if !f.is_implemented() {
+                continue;
+            }
             push(f.to_string(), "w", f.arities(), f.is_deterministic());
         }
 

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -1,7 +1,7 @@
 use turso_parser::ast;
 
 use crate::{
-    function::AggFunc,
+    function::{AccumulatorFunc, AggFunc},
     schema::Table,
     sync::Arc,
     translate::collate::CollationSeq,
@@ -36,7 +36,7 @@ pub fn emit_ungrouped_aggregation<'a>(
         let agg_result_reg = agg_start_reg + i;
         program.emit_insn(Insn::AggFinal {
             register: agg_result_reg,
-            func: agg.func.clone(),
+            func: AccumulatorFunc::Agg(agg.func.clone()),
         });
     }
     // we now have the agg results in (agg_start_reg..agg_start_reg + aggregates.len() - 1)
@@ -364,7 +364,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::Avg,
+                func: AccumulatorFunc::Agg(AggFunc::Avg),
                 comparator: None,
             });
             target_register
@@ -377,7 +377,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::Count0,
+                func: AccumulatorFunc::Agg(AggFunc::Count0),
                 comparator: None,
             });
             target_register
@@ -392,7 +392,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::Count,
+                func: AccumulatorFunc::Agg(AggFunc::Count),
                 comparator: None,
             });
             target_register
@@ -417,7 +417,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: delimiter_reg,
-                func: AggFunc::GroupConcat,
+                func: AccumulatorFunc::Agg(AggFunc::GroupConcat),
                 comparator: None,
             });
 
@@ -437,7 +437,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::Max,
+                func: AccumulatorFunc::Agg(AggFunc::Max),
                 comparator,
             });
             target_register
@@ -456,7 +456,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::Min,
+                func: AccumulatorFunc::Agg(AggFunc::Min),
                 comparator,
             });
             target_register
@@ -474,7 +474,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: value_reg,
-                func: AggFunc::JsonGroupObject,
+                func: AccumulatorFunc::Agg(AggFunc::JsonGroupObject),
                 comparator: None,
             });
             target_register
@@ -490,7 +490,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::JsonGroupArray,
+                func: AccumulatorFunc::Agg(AggFunc::JsonGroupArray),
                 comparator: None,
             });
             target_register
@@ -508,7 +508,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: delimiter_reg,
-                func: AggFunc::StringAgg,
+                func: AccumulatorFunc::Agg(AggFunc::StringAgg),
                 comparator: None,
             });
 
@@ -524,7 +524,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::Sum,
+                func: AccumulatorFunc::Agg(AggFunc::Sum),
                 comparator: None,
             });
             target_register
@@ -539,7 +539,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::Total,
+                func: AccumulatorFunc::Agg(AggFunc::Total),
                 comparator: None,
             });
             target_register
@@ -555,7 +555,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::ArrayAgg,
+                func: AccumulatorFunc::Agg(AggFunc::ArrayAgg),
                 comparator: None,
             });
             target_register
@@ -573,7 +573,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: value_reg,
                 delimiter: 0,
-                func: AggFunc::Mode,
+                func: AccumulatorFunc::Agg(AggFunc::Mode),
                 comparator: None,
             });
             target_register
@@ -595,7 +595,7 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: value_reg,
                 delimiter: fraction_reg,
-                func: func.clone(),
+                func: AccumulatorFunc::Agg(func.clone()),
                 comparator: None,
             });
             target_register
@@ -630,11 +630,11 @@ pub fn translate_aggregation_step(
                 acc_reg: target_register,
                 col: expr_reg,
                 delimiter: 0,
-                func: AggFunc::External(if registered_argc < 0 {
+                func: AccumulatorFunc::Agg(AggFunc::External(if registered_argc < 0 {
                     Arc::new(func.with_aggregate_arg_count(num_args))
                 } else {
                     func.clone()
-                }),
+                })),
                 comparator: None,
             });
             target_register

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -6,6 +6,7 @@ use super::{
     plan::{Distinctness, GroupBy, SelectPlan, SubqueryEvalPhase, SubqueryOrigin},
     result_row::emit_select_result,
 };
+use crate::function::AccumulatorFunc;
 use crate::translate::{
     aggregation::{translate_aggregation_step, AggArgumentSource},
     order_by::{custom_type_comparator, EmitOrderBy},
@@ -1014,7 +1015,7 @@ pub fn group_by_emit_row_phase<'a>(
         let agg_result_reg = agg_start_reg + i;
         program.emit_insn(Insn::AggFinal {
             register: agg_result_reg,
-            func: agg.func.clone(),
+            func: AccumulatorFunc::Agg(agg.func.clone()),
         });
         t_ctx.resolver.cache_expr_reg(
             std::borrow::Cow::Owned(agg.original_expr.clone()),

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -266,7 +266,7 @@ fn emit_loop_source<'a>(
                     acc_reg: start_reg,
                     col: expr_reg,
                     delimiter: 0,
-                    func: min_max.func.clone(),
+                    func: crate::function::AccumulatorFunc::Agg(min_max.func.clone()),
                     comparator,
                 });
                 program.emit_insn(Insn::Goto {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1,6 +1,6 @@
 use crate::{
     alloc::{self, TursoIteratorExt},
-    function::{AggFunc, WindowFunc},
+    function::{AccumulatorFunc, AggFunc},
     schema::{
         BTreeTable, ColDef, Column, FromClauseSubquery, Index, Schema, Table, Type, ROWID_SENTINEL,
     },
@@ -3090,12 +3090,6 @@ impl Window {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum WindowFunctionKind {
-    Agg(AggFunc),
-    Window(WindowFunc),
-}
-
 /// One window function call belonging to a `Window`.
 ///
 /// Window queries are planned by wrapping the original FROM/WHERE in a
@@ -3108,7 +3102,7 @@ pub enum WindowFunctionKind {
 pub struct WindowFunction {
     /// The resolved function. Aggregate window functions and specialized window
     /// functions such as ROW_NUMBER() are supported.
-    pub func: WindowFunctionKind,
+    pub func: AccumulatorFunc,
     /// The expression from which the function was resolved. Used as the lookup
     /// key when matching SQL occurrences back to this entry during rewriting.
     pub original_expr: Expr,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -27,11 +27,11 @@ use crate::{
     Result,
 };
 use crate::{
-    function::{AggFunc, ExtFunc},
+    function::{AccumulatorFunc, AggFunc, ExtFunc},
     translate::expr::bind_and_rewrite_expr,
 };
 use crate::{
-    translate::plan::{Window, WindowFunction, WindowFunctionKind},
+    translate::plan::{Window, WindowFunction},
     vdbe::builder::ProgramBuilder,
 };
 use smallvec::SmallVec;
@@ -263,7 +263,7 @@ pub fn resolve_window_and_aggregate_functions(
                                 windows.as_deref_mut(),
                                 resolver,
                                 expr,
-                                WindowFunctionKind::Agg(f),
+                                AccumulatorFunc::Agg(f),
                                 over_clause,
                                 filter_over.filter_clause.as_deref(),
                                 distinctness,
@@ -287,7 +287,7 @@ pub fn resolve_window_and_aggregate_functions(
                                 windows.as_deref_mut(),
                                 resolver,
                                 expr,
-                                WindowFunctionKind::Window(f),
+                                AccumulatorFunc::Window(f),
                                 over_clause,
                                 filter_over.filter_clause.as_deref(),
                                 distinctness,
@@ -309,7 +309,7 @@ pub fn resolve_window_and_aggregate_functions(
                                         windows.as_deref_mut(),
                                         resolver,
                                         expr,
-                                        WindowFunctionKind::Agg(func),
+                                        AccumulatorFunc::Agg(func),
                                         over_clause,
                                         filter_over.filter_clause.as_deref(),
                                         distinctness,
@@ -347,7 +347,7 @@ pub fn resolve_window_and_aggregate_functions(
                                 windows.as_deref_mut(),
                                 resolver,
                                 expr,
-                                WindowFunctionKind::Agg(f),
+                                AccumulatorFunc::Agg(f),
                                 over_clause,
                                 filter_over.filter_clause.as_deref(),
                                 Distinctness::NonDistinct,
@@ -371,7 +371,7 @@ pub fn resolve_window_and_aggregate_functions(
                                 windows.as_deref_mut(),
                                 resolver,
                                 expr,
-                                WindowFunctionKind::Window(f),
+                                AccumulatorFunc::Window(f),
                                 over_clause,
                                 filter_over.filter_clause.as_deref(),
                                 Distinctness::NonDistinct,
@@ -408,7 +408,7 @@ pub fn resolve_window_and_aggregate_functions(
                                         windows.as_deref_mut(),
                                         resolver,
                                         expr,
-                                        WindowFunctionKind::Agg(func),
+                                        AccumulatorFunc::Agg(func),
                                         over_clause,
                                         filter_over.filter_clause.as_deref(),
                                         Distinctness::NonDistinct,
@@ -445,7 +445,7 @@ fn link_with_window(
     windows: Option<&mut Vec<Window>>,
     resolver: &Resolver,
     expr: &Expr,
-    func: WindowFunctionKind,
+    func: AccumulatorFunc,
     over_clause: &Over,
     filter_clause: Option<&Expr>,
     distinctness: Distinctness,
@@ -456,7 +456,7 @@ fn link_with_window(
     // FILTER decides which input rows contribute to a running aggregate, so
     // it is only meaningful for aggregating window functions. Non-aggregate
     // ones (`row_number`/`lag`/`lead`) have nothing to filter.
-    if matches!(func, WindowFunctionKind::Window(_)) && filter_clause.is_some() {
+    if matches!(func, AccumulatorFunc::Window(_)) && filter_clause.is_some() {
         crate::bail_parse_error!("FILTER clause may only be used with aggregate window functions");
     }
     expr_vector_size(expr)?;
@@ -481,8 +481,8 @@ fn link_with_window(
         });
     } else {
         let func_name = match &func {
-            WindowFunctionKind::Agg(f) => f.as_str().to_string(),
-            WindowFunctionKind::Window(f) => f.to_string(),
+            AccumulatorFunc::Agg(f) => f.as_str().to_string(),
+            AccumulatorFunc::Window(f) => f.to_string(),
         };
         crate::bail_parse_error!("misuse of window function: {}()", func_name);
     }

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1,4 +1,4 @@
-use crate::function::{AccumulatorFunc, WindowFunc};
+use crate::function::AccumulatorFunc;
 use crate::schema::{BTreeCharacteristics, BTreeTable, Table};
 use crate::sync::Arc;
 use crate::translate::aggregation::{translate_aggregation_step, AggArgumentSource};
@@ -894,11 +894,6 @@ fn emit_reset_state_if_new_partition(
         dest: registers.acc_start,
         dest_end: Some(registers.acc_start + window.functions.len() - 1),
     });
-    for (i, func) in window.functions.iter().enumerate() {
-        if matches!(func.func, AccumulatorFunc::Window(WindowFunc::RowNumber)) {
-            program.emit_int(0, registers.acc_result_start + i);
-        }
-    }
 
     program.preassign_label_to_next_insn(label_skip_reset_state);
 }
@@ -1160,6 +1155,9 @@ fn emit_return_buffered_rows(
         ..
     } = t_ctx.meta_window.as_ref().expect("missing window metadata");
 
+    // Aggregate window functions: capture the running accumulator value once
+    // per flush. Every buffered row in the just-finished peer group sees the
+    // same value (RANGE UNBOUNDED PRECEDING TO CURRENT ROW semantics).
     for (i, func) in window.functions.iter().enumerate() {
         if let AccumulatorFunc::Agg(agg_func) = &func.func {
             program.emit_insn(Insn::AggValue {
@@ -1172,15 +1170,6 @@ fn emit_return_buffered_rows(
 
     let label_skip_returning_row = program.allocate_label();
     let label_loop_start = program.allocate_label();
-    let reg_one = window
-        .functions
-        .iter()
-        .any(|func| matches!(func.func, AccumulatorFunc::Window(WindowFunc::RowNumber)))
-        .then(|| {
-            let reg = program.alloc_register();
-            program.emit_int(1, reg);
-            reg
-        });
     program.preassign_label_to_next_insn(label_loop_start);
 
     // Propagate subquery result column values to the outer query (if any) or directly to
@@ -1190,14 +1179,26 @@ fn emit_return_buffered_rows(
         let reg_result = registers.result_columns_start + i;
         program.emit_column_or_rowid(cursors.buffer_read, *col_idx, reg_result);
     }
+    // Pure window functions (e.g. row_number) advance their accumulator and
+    // read it out once per buffered row as the buffer is replayed. Aggregate
+    // window functions instead advance their accumulator once per source row
+    // (in emit_aggregation_step) and only their final value is read out per
+    // emitted row (the AggValue loop earlier in this function).
     for (i, func) in window.functions.iter().enumerate() {
-        if let AccumulatorFunc::Window(WindowFunc::RowNumber) = &func.func {
-            let reg_one = reg_one.expect("row_number must allocate reg_one");
-            let reg_row_number = registers.acc_result_start + i;
-            program.emit_insn(Insn::Add {
-                lhs: reg_row_number,
-                rhs: reg_one,
-                dest: reg_row_number,
+        if let AccumulatorFunc::Window(win_func) = &func.func {
+            let acc_reg = registers.acc_start + i;
+            let dest_reg = registers.acc_result_start + i;
+            program.emit_insn(Insn::AggStep {
+                acc_reg,
+                col: 0,
+                delimiter: 0,
+                func: AccumulatorFunc::Window(win_func.clone()),
+                comparator: None,
+            });
+            program.emit_insn(Insn::AggValue {
+                acc_reg,
+                dest_reg,
+                func: AccumulatorFunc::Window(win_func.clone()),
             });
         }
     }

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -1,4 +1,4 @@
-use crate::function::WindowFunc;
+use crate::function::{AccumulatorFunc, WindowFunc};
 use crate::schema::{BTreeCharacteristics, BTreeTable, Table};
 use crate::sync::Arc;
 use crate::translate::aggregation::{translate_aggregation_step, AggArgumentSource};
@@ -11,7 +11,7 @@ use crate::translate::expr::{
 use crate::translate::order_by::EmitOrderBy;
 use crate::translate::plan::{
     Aggregate, Distinctness, JoinOrderMember, JoinedTable, QueryDestination, ResultSetColumn,
-    RewrittenWindowCall, SelectPlan, TableReferences, Window, WindowFunction, WindowFunctionKind,
+    RewrittenWindowCall, SelectPlan, TableReferences, Window, WindowFunction,
 };
 use crate::translate::planner::resolve_window_and_aggregate_functions;
 use crate::translate::result_row::emit_select_result;
@@ -895,7 +895,7 @@ fn emit_reset_state_if_new_partition(
         dest_end: Some(registers.acc_start + window.functions.len() - 1),
     });
     for (i, func) in window.functions.iter().enumerate() {
-        if matches!(func.func, WindowFunctionKind::Window(WindowFunc::RowNumber)) {
+        if matches!(func.func, AccumulatorFunc::Window(WindowFunc::RowNumber)) {
             program.emit_int(0, registers.acc_result_start + i);
         }
     }
@@ -1027,7 +1027,7 @@ fn emit_aggregation_step(
     registers: &WindowRegisters,
 ) -> crate::Result<()> {
     for (i, func) in window.functions.iter().enumerate() {
-        let WindowFunctionKind::Agg(agg_func) = &func.func else {
+        let AccumulatorFunc::Agg(agg_func) = &func.func else {
             continue;
         };
         // The aggregation step is performed incrementally as each row from the subquery is
@@ -1161,11 +1161,11 @@ fn emit_return_buffered_rows(
     } = t_ctx.meta_window.as_ref().expect("missing window metadata");
 
     for (i, func) in window.functions.iter().enumerate() {
-        if let WindowFunctionKind::Agg(agg_func) = &func.func {
+        if let AccumulatorFunc::Agg(agg_func) = &func.func {
             program.emit_insn(Insn::AggValue {
                 acc_reg: registers.acc_start + i,
                 dest_reg: registers.acc_result_start + i,
-                func: agg_func.clone(),
+                func: AccumulatorFunc::Agg(agg_func.clone()),
             });
         }
     }
@@ -1175,7 +1175,7 @@ fn emit_return_buffered_rows(
     let reg_one = window
         .functions
         .iter()
-        .any(|func| matches!(func.func, WindowFunctionKind::Window(WindowFunc::RowNumber)))
+        .any(|func| matches!(func.func, AccumulatorFunc::Window(WindowFunc::RowNumber)))
         .then(|| {
             let reg = program.alloc_register();
             program.emit_int(1, reg);
@@ -1191,7 +1191,7 @@ fn emit_return_buffered_rows(
         program.emit_column_or_rowid(cursors.buffer_read, *col_idx, reg_result);
     }
     for (i, func) in window.functions.iter().enumerate() {
-        if let WindowFunctionKind::Window(WindowFunc::RowNumber) = &func.func {
+        if let AccumulatorFunc::Window(WindowFunc::RowNumber) = &func.func {
             let reg_one = reg_one.expect("row_number must allocate reg_one");
             let reg_row_number = registers.acc_result_start + i;
             program.emit_insn(Insn::Add {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6401,6 +6401,7 @@ pub fn op_agg_step(
         },
         insn
     );
+    let func = func.expect_agg();
 
     // Initialize aggregate state if not already done
     if let Register::Value(Value::Null) = state.registers[*acc_reg] {
@@ -6592,6 +6593,7 @@ pub fn op_agg_final(
         } => (*acc_reg, *dest_reg, func),
         _ => unreachable!("unexpected Insn {:?}", insn),
     };
+    let func = func.expect_agg();
 
     match &state.registers[acc_reg] {
         Register::Aggregate(agg) => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1,5 +1,5 @@
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
-use crate::function::AlterTableFunc;
+use crate::function::{AccumulatorFunc, AlterTableFunc, WindowFunc};
 use crate::io::TempFile;
 use crate::mvcc::cursor::{MvccCursorType, NextRowidResult};
 use crate::mvcc::database::CheckpointStateMachine;
@@ -6385,6 +6385,63 @@ fn ordered_set_percentile_disc(values: &[Value], fraction: f64, collation: Colla
     sorted[index.min(n - 1)].clone()
 }
 
+fn op_window_step(
+    state: &mut ProgramState,
+    acc_reg: usize,
+    func: &WindowFunc,
+) -> Result<InsnFunctionStepResult> {
+    match func {
+        WindowFunc::RowNumber => {
+            if let Register::Value(Value::Null) = state.registers[acc_reg] {
+                state.registers[acc_reg] =
+                    Register::Aggregate(AggContext::Builtin(vec![Value::from_i64(0)]));
+            }
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                unreachable!("row_number accumulator must be a Builtin payload");
+            };
+            let Value::Numeric(Numeric::Integer(counter)) = &mut payload[0] else {
+                unreachable!("row_number counter must be Integer");
+            };
+            *counter += 1;
+        }
+        other => {
+            return Err(LimboError::InternalError(format!(
+                "window function {other} reached runtime dispatch but has no handler"
+            )))
+        }
+    }
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
+/// Per-row value read for pure window functions.
+fn op_window_value(
+    state: &mut ProgramState,
+    acc_reg: usize,
+    dest_reg: usize,
+    func: &WindowFunc,
+) -> Result<InsnFunctionStepResult> {
+    let value = match func {
+        WindowFunc::RowNumber => match &state.registers[acc_reg] {
+            Register::Aggregate(AggContext::Builtin(payload)) => payload[0].clone(),
+            other => {
+                return Err(LimboError::InternalError(format!(
+                    "row_number accumulator in unexpected register state: {other:?}"
+                )))
+            }
+        },
+        other => {
+            return Err(LimboError::InternalError(format!(
+                "window function {other} reached runtime dispatch but has no handler"
+            )))
+        }
+    };
+    state.registers[dest_reg].set_value(value);
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
 pub fn op_agg_step(
     program: &Program,
     state: &mut ProgramState,
@@ -6401,6 +6458,10 @@ pub fn op_agg_step(
         },
         insn
     );
+
+    if let AccumulatorFunc::Window(win_func) = func {
+        return op_window_step(state, *acc_reg, win_func);
+    }
     let func = func.expect_agg();
 
     // Initialize aggregate state if not already done
@@ -6593,6 +6654,10 @@ pub fn op_agg_final(
         } => (*acc_reg, *dest_reg, func),
         _ => unreachable!("unexpected Insn {:?}", insn),
     };
+
+    if let AccumulatorFunc::Window(win_func) = func {
+        return op_window_value(state, acc_reg, dest_reg, win_func);
+    }
     let func = func.expect_agg();
 
     match &state.registers[acc_reg] {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -7,7 +7,8 @@ pub fn to_u16(v: usize) -> u16 {
     v.try_into().expect("value exceeds u16::MAX")
 }
 
-use super::{execute, AggFunc, BranchOffset, CursorID, FuncCtx, InsnFunction, PageIdx};
+use super::{execute, BranchOffset, CursorID, FuncCtx, InsnFunction, PageIdx};
+use crate::function::AccumulatorFunc;
 use crate::{
     schema::{BTreeTable, CheckConstraint, Column, ForeignKey, Index},
     storage::{pager::CreateBTreeFlags, wal::CheckpointMode},
@@ -1033,14 +1034,14 @@ pub enum Insn {
         acc_reg: usize,
         col: usize,
         delimiter: usize,
-        func: AggFunc,
+        func: AccumulatorFunc,
         /// Optional custom type comparator for MIN/MAX aggregates.
         comparator: Option<SortComparatorType>,
     },
 
     AggFinal {
         register: usize,
-        func: AggFunc,
+        func: AccumulatorFunc,
     },
 
     /// Similar to AggFinal, but instead of writing the result back into the
@@ -1049,7 +1050,7 @@ pub enum Insn {
     AggValue {
         acc_reg: usize,
         dest_reg: usize,
-        func: AggFunc,
+        func: AccumulatorFunc,
     },
 
     /// Open a sorter.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -38,7 +38,7 @@ pub mod value;
 pub use crate::translate::collate::CollationSeq;
 use crate::{
     error::LimboError,
-    function::{AggFunc, FuncCtx},
+    function::FuncCtx,
     mvcc::{database::CommitStateMachine, MvccClock},
     numeric::Numeric,
     return_if_io,

--- a/testing/sqltests/tests/pragma/default.sqltest
+++ b/testing/sqltests/tests/pragma/default.sqltest
@@ -277,6 +277,25 @@ expect {
     avg|w|1
 }
 
+test pragma-function-list-window-row-number {
+    SELECT name, type, narg FROM pragma_function_list WHERE name = 'row_number';
+}
+expect {
+    row_number|w|0
+}
+
+@skip-if sqlite "sqlite implements these window functions; we don't yet, so they must not be advertised in pragma_function_list"
+test pragma-function-list-omits-unimplemented-window-functions {
+    SELECT COUNT(*) FROM pragma_function_list
+    WHERE name IN (
+        'rank','dense_rank','percent_rank','cume_dist','ntile',
+        'lag','lead','first_value','last_value','nth_value'
+    );
+}
+expect {
+    0
+}
+
 @skip-if sqlite "sqlite will default to 'delete'"
 @skip-if mvcc "will return mvcc as journal mode"
 test test-pragma-journal-mode-unsupported {

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
@@ -38,10 +38,10 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                   p1   p2   p3  p4                     p5  comment
-   0          Init              0  261    0                          0  Start at 261
-   1          InitCoroutine     1  209    2                          0
-   2          InitCoroutine     2  149    3                          0
-   3          InitCoroutine     3   92    4                          0
+   0          Init              0  259    0                          0  Start at 259
+   1          InitCoroutine     1  208    2                          0
+   2          InitCoroutine     2  148    3                          0
+   3          InitCoroutine     3   91    4                          0
    4          InitCoroutine     4   32    5                          0
    5          SorterOpen        0    2    0  k(2,B,-B)               0  cursor=0
    6          OpenRead          1    2    0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
@@ -76,148 +76,148 @@ addr  opcode                   p1   p2   p3  p4                     p5  comment
   35          Null              0   35    0                          0  r[35]=NULL
   36          Null              0   36    0                          0  r[36]=NULL
   37          InitCoroutine     4    0    5                          0
-  38            Yield           4   57    0                          0
+  38            Yield           4   56    0                          0
   39            Copy            6   39    0                          0  r[39]=r[6]
   40            Compare         5   36    1  k(1, Binary)            0  r[5..5]==r[36..36]; compare partition keys to detect new partition
   41            Jump           42   45   42                          0
-  42            Gosub          37   58    0                          0  ; detected new partition
+  42            Gosub          37   57    0                          0  ; detected new partition
   43            Null            0   35    0                          0  r[35]=NULL
   44            Copy            5   36    0                          0  r[36]=r[5]
-  45            NotNull        35   49    0                          0  r[35]!=NULL -> goto 49
+  45            NotNull        35   48    0                          0  r[35]!=NULL -> goto 48
   46            Copy           39   38    0                          0  r[38]=r[39]; initialize previous peer register for new partition
   47            Null            0   27   27                          0  r[27..27]=NULL; reset accumulator registers
-  48            Integer         0   28    0                          0  r[28]=0
-  49            Compare        38   39    1  k(1, Binary)            0  r[38..38]==r[39..39]; compare ORDER BY columns to detect peer
-  50            Jump           51   53   51                          0
-  51            Gosub          37   58    0                          0  ; detected non-peer row
-  52            Copy           39   38    0                          0  r[38]=r[39]
-  53            MakeRecord      5    6   40                          0  r[40]=mkrec(r[5..10])
-  54            NewRowid        6   35    0                          0  r[35]=rowid
-  55            Insert          6   40   35  buffer_table_window_3   0  intkey=r[35] data=r[40]
-  56          Goto              0   38    0                          0
-  57          Null              0   37    0                          0  r[37]=NULL; return remaining buffered rows
-  58          Rewind            5   77    0                          0  Rewind  ephemeral(buffer_table_window_3)
-  59          Integer           1   41    0                          0  r[41]=1
-  60            Column          5    2   29                          0  r[29]=ephemeral(buffer_table_window_3).department
-  61            Column          5    0   30                          0  r[30]=ephemeral(buffer_table_window_3).region
-  62            Column          5    3   31                          0  r[31]=ephemeral(buffer_table_window_3).salary
-  63            Column          5    4   32                          0  r[32]=ephemeral(buffer_table_window_3).emp_id
-  64            Column          5    5   33                          0  r[33]=ephemeral(buffer_table_window_3).name
-  65            Column          5    1   34                          0  r[34]=ephemeral(buffer_table_window_3).amount
-  66            Add            28   41   28                          0  r[28]=r[28]+r[41]
-  67            Copy           29   42    0                          0  r[42]=r[29]
-  68            Copy           30   43    0                          0  r[43]=r[30]
-  69            Copy           31   44    0                          0  r[44]=r[31]
-  70            Copy           32   45    0                          0  r[45]=r[32]
-  71            Copy           33   46    0                          0  r[46]=r[33]
-  72            Copy           34   47    0                          0  r[47]=r[34]
-  73            Copy           28   48    0                          0  r[48]=r[28]
-  74            MakeRecord     42    7   26                          0  r[26]=mkrec(r[42..48])
-  75            SorterInsert    4   26    0  0                       0  key=r[26]
-  76          Next              5   60    0                          0
-  77          ResetSorter       5    0    0                          0  cursor=5
-  78        Return             37    0    1                          0
-  79        OpenPseudo          7   26    7                          0  7 columns in r[26]
-  80        SorterSort          4   91    0                          0
-  81          SorterData        4   26    7                          0  r[26]=data
-  82          Column            7    0   19                          0  r[19]=pseudo.column 0
-  83          Column            7    1   20                          0  r[20]=pseudo.column 1
-  84          Column            7    2   21                          0  r[21]=pseudo.column 2
-  85          Column            7    3   22                          0  r[22]=pseudo.column 3
-  86          Column            7    4   23                          0  r[23]=pseudo.column 4
-  87          Column            7    5   24                          0  r[24]=pseudo.column 5
-  88          Column            7    6   25                          0  r[25]=pseudo.column 6
-  89          Yield             3    0    0                          0
-  90        SorterNext          4   81    0                          0
-  91        EndCoroutine        3    0    0                          0
-  92        SorterOpen          8    1    0  k(1,B)                  0  cursor=8
-  93        OpenEphemeral       9    1    0                          0  cursor=9 is_table=true
-  94        OpenDup            10    9    0                          0  new_cursor=10, original_cursor=9
+  48            Compare        38   39    1  k(1, Binary)            0  r[38..38]==r[39..39]; compare ORDER BY columns to detect peer
+  49            Jump           50   52   50                          0
+  50            Gosub          37   57    0                          0  ; detected non-peer row
+  51            Copy           39   38    0                          0  r[38]=r[39]
+  52            MakeRecord      5    6   40                          0  r[40]=mkrec(r[5..10])
+  53            NewRowid        6   35    0                          0  r[35]=rowid
+  54            Insert          6   40   35  buffer_table_window_3   0  intkey=r[35] data=r[40]
+  55          Goto              0   38    0                          0
+  56          Null              0   37    0                          0  r[37]=NULL; return remaining buffered rows
+  57          Rewind            5   76    0                          0  Rewind  ephemeral(buffer_table_window_3)
+  58            Column          5    2   29                          0  r[29]=ephemeral(buffer_table_window_3).department
+  59            Column          5    0   30                          0  r[30]=ephemeral(buffer_table_window_3).region
+  60            Column          5    3   31                          0  r[31]=ephemeral(buffer_table_window_3).salary
+  61            Column          5    4   32                          0  r[32]=ephemeral(buffer_table_window_3).emp_id
+  62            Column          5    5   33                          0  r[33]=ephemeral(buffer_table_window_3).name
+  63            Column          5    1   34                          0  r[34]=ephemeral(buffer_table_window_3).amount
+  64            AggStep         0    0   27  row_number              0  accum=r[27] step(r[0])
+  65            AggValue        0   27   28  row_number              0  accum=r[27] dest=r[28]
+  66            Copy           29   41    0                          0  r[41]=r[29]
+  67            Copy           30   42    0                          0  r[42]=r[30]
+  68            Copy           31   43    0                          0  r[43]=r[31]
+  69            Copy           32   44    0                          0  r[44]=r[32]
+  70            Copy           33   45    0                          0  r[45]=r[33]
+  71            Copy           34   46    0                          0  r[46]=r[34]
+  72            Copy           28   47    0                          0  r[47]=r[28]
+  73            MakeRecord     41    7   26                          0  r[26]=mkrec(r[41..47])
+  74            SorterInsert    4   26    0  0                       0  key=r[26]
+  75          Next              5   58    0                          0
+  76          ResetSorter       5    0    0                          0  cursor=5
+  77        Return             37    0    1                          0
+  78        OpenPseudo          7   26    7                          0  7 columns in r[26]
+  79        SorterSort          4   90    0                          0
+  80          SorterData        4   26    7                          0  r[26]=data
+  81          Column            7    0   19                          0  r[19]=pseudo.column 0
+  82          Column            7    1   20                          0  r[20]=pseudo.column 1
+  83          Column            7    2   21                          0  r[21]=pseudo.column 2
+  84          Column            7    3   22                          0  r[22]=pseudo.column 3
+  85          Column            7    4   23                          0  r[23]=pseudo.column 4
+  86          Column            7    5   24                          0  r[24]=pseudo.column 5
+  87          Column            7    6   25                          0  r[25]=pseudo.column 6
+  88          Yield             3    0    0                          0
+  89        SorterNext          4   80    0                          0
+  90        EndCoroutine        3    0    0                          0
+  91        SorterOpen          8    1    0  k(1,B)                  0  cursor=8
+  92        OpenEphemeral       9    1    0                          0  cursor=9 is_table=true
+  93        OpenDup            10    9    0                          0  new_cursor=10, original_cursor=9
+  94        Null                0   66    0                          0  r[66]=NULL
   95        Null                0   67    0                          0  r[67]=NULL
-  96        Null                0   68    0                          0  r[68]=NULL
-  97        InitCoroutine       3    0    4                          0
-  98          Yield             3  112    0                          0
-  99          Compare          19   68    1  k(1, Binary)            0  r[19..19]==r[68..68]; compare partition keys to detect new partition
- 100          Jump            101  104  101                          0
- 101          Gosub            69  113    0                          0  ; detected new partition
- 102          Null              0   67    0                          0  r[67]=NULL
- 103          Copy             19   68    0                          0  r[68]=r[19]
- 104          NotNull          67  106    0                          0  r[67]!=NULL -> goto 106
- 105          Null              0   58   58                          0  r[58..58]=NULL; reset accumulator registers
- 106          MakeRecord       19    7   70                          0  r[70]=mkrec(r[19..25])
- 107          NewRowid         10   67    0                          0  r[67]=rowid
- 108          Insert           10   70   67  buffer_table_window_2   0  intkey=r[67] data=r[70]
- 109          Copy             24   71    0                          0  r[71]=r[24]
- 110          AggStep           0   71   58  sum                     0  accum=r[58] step(r[71])
- 111        Goto                0   98    0                          0
- 112        Null                0   69    0                          0  r[69]=NULL; return remaining buffered rows
- 113        Rewind              9  133    0                          0  Rewind  ephemeral(buffer_table_window_2)
- 114        AggValue            0   58   59  sum                     0  accum=r[58] dest=r[59]
- 115          Column            9    1   60                          0  r[60]=ephemeral(buffer_table_window_2).region
- 116          Column            9    0   61                          0  r[61]=ephemeral(buffer_table_window_2).department
- 117          Column            9    2   62                          0  r[62]=ephemeral(buffer_table_window_2).salary
- 118          Column            9    3   63                          0  r[63]=ephemeral(buffer_table_window_2).emp_id
- 119          Column            9    4   64                          0  r[64]=ephemeral(buffer_table_window_2).name
- 120          Column            9    5   65                          0  r[65]=ephemeral(buffer_table_window_2).amount
- 121          Column            9    6   66                          0  r[66]=ephemeral(buffer_table_window_2).column 6
+  96        InitCoroutine       3    0    4                          0
+  97          Yield             3  111    0                          0
+  98          Compare          19   67    1  k(1, Binary)            0  r[19..19]==r[67..67]; compare partition keys to detect new partition
+  99          Jump            100  103  100                          0
+ 100          Gosub            68  112    0                          0  ; detected new partition
+ 101          Null              0   66    0                          0  r[66]=NULL
+ 102          Copy             19   67    0                          0  r[67]=r[19]
+ 103          NotNull          66  105    0                          0  r[66]!=NULL -> goto 105
+ 104          Null              0   57   57                          0  r[57..57]=NULL; reset accumulator registers
+ 105          MakeRecord       19    7   69                          0  r[69]=mkrec(r[19..25])
+ 106          NewRowid         10   66    0                          0  r[66]=rowid
+ 107          Insert           10   69   66  buffer_table_window_2   0  intkey=r[66] data=r[69]
+ 108          Copy             24   70    0                          0  r[70]=r[24]
+ 109          AggStep           0   70   57  sum                     0  accum=r[57] step(r[70])
+ 110        Goto                0   97    0                          0
+ 111        Null                0   68    0                          0  r[68]=NULL; return remaining buffered rows
+ 112        Rewind              9  132    0                          0  Rewind  ephemeral(buffer_table_window_2)
+ 113        AggValue            0   57   58  sum                     0  accum=r[57] dest=r[58]
+ 114          Column            9    1   59                          0  r[59]=ephemeral(buffer_table_window_2).region
+ 115          Column            9    0   60                          0  r[60]=ephemeral(buffer_table_window_2).department
+ 116          Column            9    2   61                          0  r[61]=ephemeral(buffer_table_window_2).salary
+ 117          Column            9    3   62                          0  r[62]=ephemeral(buffer_table_window_2).emp_id
+ 118          Column            9    4   63                          0  r[63]=ephemeral(buffer_table_window_2).name
+ 119          Column            9    5   64                          0  r[64]=ephemeral(buffer_table_window_2).amount
+ 120          Column            9    6   65                          0  r[65]=ephemeral(buffer_table_window_2).column 6
+ 121          Copy             59   71    0                          0  r[71]=r[59]
  122          Copy             60   72    0                          0  r[72]=r[60]
  123          Copy             61   73    0                          0  r[73]=r[61]
  124          Copy             62   74    0                          0  r[74]=r[62]
  125          Copy             63   75    0                          0  r[75]=r[63]
  126          Copy             64   76    0                          0  r[76]=r[64]
  127          Copy             65   77    0                          0  r[77]=r[65]
- 128          Copy             66   78    0                          0  r[78]=r[66]
- 129          Copy             59   79    0                          0  r[79]=r[59]
- 130          MakeRecord       72    8   57                          0  r[57]=mkrec(r[72..79])
- 131          SorterInsert      8   57    0  0                       0  key=r[57]
- 132        Next                9  115    0                          0
- 133        ResetSorter         9    0    0                          0  cursor=9
- 134      Return               69    0    1                          0
- 135      OpenPseudo           11   57    8                          0  8 columns in r[57]
- 136      SorterSort            8  148    0                          0
- 137        SorterData          8   57   11                          0  r[57]=data
- 138        Column             11    0   49                          0  r[49]=pseudo.column 0
- 139        Column             11    1   50                          0  r[50]=pseudo.column 1
- 140        Column             11    2   51                          0  r[51]=pseudo.column 2
- 141        Column             11    3   52                          0  r[52]=pseudo.column 3
- 142        Column             11    4   53                          0  r[53]=pseudo.column 4
- 143        Column             11    5   54                          0  r[54]=pseudo.column 5
- 144        Column             11    6   55                          0  r[55]=pseudo.column 6
- 145        Column             11    7   56                          0  r[56]=pseudo.column 7
- 146        Yield               2    0    0                          0
- 147      SorterNext            8  137    0                          0
- 148      EndCoroutine          2    0    0                          0
- 149      SorterOpen           12    2    0  k(2,B,-B)               0  cursor=12
- 150      OpenEphemeral        13    1    0                          0  cursor=13 is_table=true
- 151      OpenDup              14   13    0                          0  new_cursor=14, original_cursor=13
+ 128          Copy             58   78    0                          0  r[78]=r[58]
+ 129          MakeRecord       71    8   56                          0  r[56]=mkrec(r[71..78])
+ 130          SorterInsert      8   56    0  0                       0  key=r[56]
+ 131        Next                9  114    0                          0
+ 132        ResetSorter         9    0    0                          0  cursor=9
+ 133      Return               68    0    1                          0
+ 134      OpenPseudo           11   56    8                          0  8 columns in r[56]
+ 135      SorterSort            8  147    0                          0
+ 136        SorterData          8   56   11                          0  r[56]=data
+ 137        Column             11    0   48                          0  r[48]=pseudo.column 0
+ 138        Column             11    1   49                          0  r[49]=pseudo.column 1
+ 139        Column             11    2   50                          0  r[50]=pseudo.column 2
+ 140        Column             11    3   51                          0  r[51]=pseudo.column 3
+ 141        Column             11    4   52                          0  r[52]=pseudo.column 4
+ 142        Column             11    5   53                          0  r[53]=pseudo.column 5
+ 143        Column             11    6   54                          0  r[54]=pseudo.column 6
+ 144        Column             11    7   55                          0  r[55]=pseudo.column 7
+ 145        Yield               2    0    0                          0
+ 146      SorterNext            8  136    0                          0
+ 147      EndCoroutine          2    0    0                          0
+ 148      SorterOpen           12    2    0  k(2,B,-B)               0  cursor=12
+ 149      OpenEphemeral        13    1    0                          0  cursor=13 is_table=true
+ 150      OpenDup              14   13    0                          0  new_cursor=14, original_cursor=13
+ 151      Null                  0   99    0                          0  r[99]=NULL
  152      Null                  0  100    0                          0  r[100]=NULL
- 153      Null                  0  101    0                          0  r[101]=NULL
- 154      InitCoroutine         2    0    3                          0
- 155        Yield               2  169    0                          0
- 156        Compare            49  101    1  k(1, Binary)            0  r[49..49]==r[101..101]; compare partition keys to detect new partition
- 157        Jump              158  161  158                          0
- 158        Gosub             102  170    0                          0  ; detected new partition
- 159        Null                0  100    0                          0  r[100]=NULL
- 160        Copy               49  101    0                          0  r[101]=r[49]
- 161        NotNull           100  163    0                          0  r[100]!=NULL -> goto 163
- 162        Null                0   90   90                          0  r[90..90]=NULL; reset accumulator registers
- 163        MakeRecord         49    8  103                          0  r[103]=mkrec(r[49..56])
- 164        NewRowid           14  100    0                          0  r[100]=rowid
- 165        Insert             14  103  100  buffer_table_window_1   0  intkey=r[100] data=r[103]
- 166        Copy               51  104    0                          0  r[104]=r[51]
- 167        AggStep             0  104   90  avg                     0  accum=r[90] step(r[104])
- 168      Goto                  0  155    0                          0
- 169      Null                  0  102    0                          0  r[102]=NULL; return remaining buffered rows
- 170      Rewind               13  192    0                          0  Rewind  ephemeral(buffer_table_window_1)
- 171      AggValue              0   90   91  avg                     0  accum=r[90] dest=r[91]
- 172        Column             13    1   92                          0  r[92]=ephemeral(buffer_table_window_1).department
- 173        Column             13    2   93                          0  r[93]=ephemeral(buffer_table_window_1).salary
- 174        Column             13    3   94                          0  r[94]=ephemeral(buffer_table_window_1).emp_id
- 175        Column             13    4   95                          0  r[95]=ephemeral(buffer_table_window_1).name
- 176        Column             13    5   96                          0  r[96]=ephemeral(buffer_table_window_1).amount
- 177        Column             13    0   97                          0  r[97]=ephemeral(buffer_table_window_1).region
- 178        Column             13    6   98                          0  r[98]=ephemeral(buffer_table_window_1).column 6
- 179        Column             13    7   99                          0  r[99]=ephemeral(buffer_table_window_1).column 7
+ 153      InitCoroutine         2    0    3                          0
+ 154        Yield               2  168    0                          0
+ 155        Compare            48  100    1  k(1, Binary)            0  r[48..48]==r[100..100]; compare partition keys to detect new partition
+ 156        Jump              157  160  157                          0
+ 157        Gosub             101  169    0                          0  ; detected new partition
+ 158        Null                0   99    0                          0  r[99]=NULL
+ 159        Copy               48  100    0                          0  r[100]=r[48]
+ 160        NotNull            99  162    0                          0  r[99]!=NULL -> goto 162
+ 161        Null                0   89   89                          0  r[89..89]=NULL; reset accumulator registers
+ 162        MakeRecord         48    8  102                          0  r[102]=mkrec(r[48..55])
+ 163        NewRowid           14   99    0                          0  r[99]=rowid
+ 164        Insert             14  102   99  buffer_table_window_1   0  intkey=r[99] data=r[102]
+ 165        Copy               50  103    0                          0  r[103]=r[50]
+ 166        AggStep             0  103   89  avg                     0  accum=r[89] step(r[103])
+ 167      Goto                  0  154    0                          0
+ 168      Null                  0  101    0                          0  r[101]=NULL; return remaining buffered rows
+ 169      Rewind               13  191    0                          0  Rewind  ephemeral(buffer_table_window_1)
+ 170      AggValue              0   89   90  avg                     0  accum=r[89] dest=r[90]
+ 171        Column             13    1   91                          0  r[91]=ephemeral(buffer_table_window_1).department
+ 172        Column             13    2   92                          0  r[92]=ephemeral(buffer_table_window_1).salary
+ 173        Column             13    3   93                          0  r[93]=ephemeral(buffer_table_window_1).emp_id
+ 174        Column             13    4   94                          0  r[94]=ephemeral(buffer_table_window_1).name
+ 175        Column             13    5   95                          0  r[95]=ephemeral(buffer_table_window_1).amount
+ 176        Column             13    0   96                          0  r[96]=ephemeral(buffer_table_window_1).region
+ 177        Column             13    6   97                          0  r[97]=ephemeral(buffer_table_window_1).column 6
+ 178        Column             13    7   98                          0  r[98]=ephemeral(buffer_table_window_1).column 7
+ 179        Copy               91  104    0                          0  r[104]=r[91]
  180        Copy               92  105    0                          0  r[105]=r[92]
  181        Copy               93  106    0                          0  r[106]=r[93]
  182        Copy               94  107    0                          0  r[107]=r[94]
@@ -225,79 +225,77 @@ addr  opcode                   p1   p2   p3  p4                     p5  comment
  184        Copy               96  109    0                          0  r[109]=r[96]
  185        Copy               97  110    0                          0  r[110]=r[97]
  186        Copy               98  111    0                          0  r[111]=r[98]
- 187        Copy               99  112    0                          0  r[112]=r[99]
- 188        Copy               91  113    0                          0  r[113]=r[91]
- 189        MakeRecord        105    9   89                          0  r[89]=mkrec(r[105..113])
- 190        SorterInsert       12   89    0  0                       0  key=r[89]
- 191      Next                 13  172    0                          0
- 192      ResetSorter          13    0    0                          0  cursor=13
- 193    Return                102    0    1                          0
- 194    OpenPseudo             15   89    9                          0  9 columns in r[89]
- 195    SorterSort             12  208    0                          0
- 196      SorterData           12   89   15                          0  r[89]=data
- 197      Column               15    0   80                          0  r[80]=pseudo.column 0
- 198      Column               15    1   81                          0  r[81]=pseudo.column 1
- 199      Column               15    2   82                          0  r[82]=pseudo.column 2
- 200      Column               15    3   83                          0  r[83]=pseudo.column 3
- 201      Column               15    4   84                          0  r[84]=pseudo.column 4
- 202      Column               15    5   85                          0  r[85]=pseudo.column 5
- 203      Column               15    6   86                          0  r[86]=pseudo.column 6
- 204      Column               15    7   87                          0  r[87]=pseudo.column 7
- 205      Column               15    8   88                          0  r[88]=pseudo.column 8
- 206      Yield                 1    0    0                          0
- 207    SorterNext             12  196    0                          0
- 208    EndCoroutine            1    0    0                          0
- 209    OpenEphemeral          16    1    0                          0  cursor=16 is_table=true
- 210    OpenDup                17   16    0                          0  new_cursor=17, original_cursor=16
+ 187        Copy               90  112    0                          0  r[112]=r[90]
+ 188        MakeRecord        104    9   88                          0  r[88]=mkrec(r[104..112])
+ 189        SorterInsert       12   88    0  0                       0  key=r[88]
+ 190      Next                 13  171    0                          0
+ 191      ResetSorter          13    0    0                          0  cursor=13
+ 192    Return                101    0    1                          0
+ 193    OpenPseudo             15   88    9                          0  9 columns in r[88]
+ 194    SorterSort             12  207    0                          0
+ 195      SorterData           12   88   15                          0  r[88]=data
+ 196      Column               15    0   79                          0  r[79]=pseudo.column 0
+ 197      Column               15    1   80                          0  r[80]=pseudo.column 1
+ 198      Column               15    2   81                          0  r[81]=pseudo.column 2
+ 199      Column               15    3   82                          0  r[82]=pseudo.column 3
+ 200      Column               15    4   83                          0  r[83]=pseudo.column 4
+ 201      Column               15    5   84                          0  r[84]=pseudo.column 5
+ 202      Column               15    6   85                          0  r[85]=pseudo.column 6
+ 203      Column               15    7   86                          0  r[86]=pseudo.column 7
+ 204      Column               15    8   87                          0  r[87]=pseudo.column 8
+ 205      Yield                 1    0    0                          0
+ 206    SorterNext             12  195    0                          0
+ 207    EndCoroutine            1    0    0                          0
+ 208    OpenEphemeral          16    1    0                          0  cursor=16 is_table=true
+ 209    OpenDup                17   16    0                          0  new_cursor=17, original_cursor=16
+ 210    Null                    0  134    0                          0  r[134]=NULL
  211    Null                    0  135    0                          0  r[135]=NULL
- 212    Null                    0  136    0                          0  r[136]=NULL
- 213    InitCoroutine           1    0    2                          0
- 214      Yield                 1  233    0                          0
- 215      Copy                 81  139    0                          0  r[139]=r[81]
- 216      Compare              80  136    1  k(1, Binary)            0  r[80..80]==r[136..136]; compare partition keys to detect new partition
- 217      Jump                218  221  218                          0
- 218      Gosub               137  234    0                          0  ; detected new partition
- 219      Null                  0  135    0                          0  r[135]=NULL
- 220      Copy                 80  136    0                          0  r[136]=r[80]
- 221      NotNull             135  225    0                          0  r[135]!=NULL -> goto 225
- 222      Copy                139  138    0                          0  r[138]=r[139]; initialize previous peer register for new partition
- 223      Null                  0  124  124                          0  r[124..124]=NULL; reset accumulator registers
- 224      Integer               0  125    0                          0  r[125]=0
- 225      Compare             138  139    1  k(1, Binary)            0  r[138..138]==r[139..139]; compare ORDER BY columns to detect peer
- 226      Jump                227  229  227                          0
- 227      Gosub               137  234    0                          0  ; detected non-peer row
- 228      Copy                139  138    0                          0  r[138]=r[139]
- 229      MakeRecord           80    9  140                          0  r[140]=mkrec(r[80..88])
- 230      NewRowid             17  135    0                          0  r[135]=rowid
- 231      Insert               17  140  135  buffer_table_window_0   0  intkey=r[135] data=r[140]
- 232    Goto                    0  214    0                          0
- 233    Null                    0  137    0                          0  r[137]=NULL; return remaining buffered rows
- 234    Rewind                 16  258    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 235    Integer                 1  141    0                          0  r[141]=1
- 236      Column               16    2  126                          0  r[126]=ephemeral(buffer_table_window_0).emp_id
- 237      Column               16    3  127                          0  r[127]=ephemeral(buffer_table_window_0).name
- 238      Column               16    0  128                          0  r[128]=ephemeral(buffer_table_window_0).department
- 239      Column               16    1  129                          0  r[129]=ephemeral(buffer_table_window_0).salary
- 240      Column               16    4  130                          0  r[130]=ephemeral(buffer_table_window_0).amount
- 241      Column               16    5  131                          0  r[131]=ephemeral(buffer_table_window_0).region
- 242      Column               16    6  132                          0  r[132]=ephemeral(buffer_table_window_0).column 6
- 243      Column               16    7  133                          0  r[133]=ephemeral(buffer_table_window_0).column 7
- 244      Column               16    8  134                          0  r[134]=ephemeral(buffer_table_window_0).column 8
- 245      Add                 125  141  125                          0  r[125]=r[125]+r[141]
- 246      Copy                126  114    0                          0  r[114]=r[126]
- 247      Copy                127  115    0                          0  r[115]=r[127]
- 248      Copy                128  116    0                          0  r[116]=r[128]
- 249      Copy                129  117    0                          0  r[117]=r[129]
- 250      Copy                130  118    0                          0  r[118]=r[130]
- 251      Copy                131  119    0                          0  r[119]=r[131]
- 252      Copy                125  120    0                          0  r[120]=r[125]
- 253      Copy                132  121    0                          0  r[121]=r[132]
- 254      Copy                133  122    0                          0  r[122]=r[133]
- 255      Copy                134  123    0                          0  r[123]=r[134]
- 256      ResultRow           114   10    0                          0  output=r[114..123]
- 257    Next                   16  236    0                          0
- 258    ResetSorter            16    0    0                          0  cursor=16
- 259  Return                  137    0    1                          0
- 260  Halt                      0    0    0                          0
- 261  Transaction               0    1    7                          0  iDb=0 tx_mode=Read
- 262  Goto                      0    1    0                          0
+ 212    InitCoroutine           1    0    2                          0
+ 213      Yield                 1  231    0                          0
+ 214      Copy                 80  138    0                          0  r[138]=r[80]
+ 215      Compare              79  135    1  k(1, Binary)            0  r[79..79]==r[135..135]; compare partition keys to detect new partition
+ 216      Jump                217  220  217                          0
+ 217      Gosub               136  232    0                          0  ; detected new partition
+ 218      Null                  0  134    0                          0  r[134]=NULL
+ 219      Copy                 79  135    0                          0  r[135]=r[79]
+ 220      NotNull             134  223    0                          0  r[134]!=NULL -> goto 223
+ 221      Copy                138  137    0                          0  r[137]=r[138]; initialize previous peer register for new partition
+ 222      Null                  0  123  123                          0  r[123..123]=NULL; reset accumulator registers
+ 223      Compare             137  138    1  k(1, Binary)            0  r[137..137]==r[138..138]; compare ORDER BY columns to detect peer
+ 224      Jump                225  227  225                          0
+ 225      Gosub               136  232    0                          0  ; detected non-peer row
+ 226      Copy                138  137    0                          0  r[137]=r[138]
+ 227      MakeRecord           79    9  139                          0  r[139]=mkrec(r[79..87])
+ 228      NewRowid             17  134    0                          0  r[134]=rowid
+ 229      Insert               17  139  134  buffer_table_window_0   0  intkey=r[134] data=r[139]
+ 230    Goto                    0  213    0                          0
+ 231    Null                    0  136    0                          0  r[136]=NULL; return remaining buffered rows
+ 232    Rewind                 16  256    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 233      Column               16    2  125                          0  r[125]=ephemeral(buffer_table_window_0).emp_id
+ 234      Column               16    3  126                          0  r[126]=ephemeral(buffer_table_window_0).name
+ 235      Column               16    0  127                          0  r[127]=ephemeral(buffer_table_window_0).department
+ 236      Column               16    1  128                          0  r[128]=ephemeral(buffer_table_window_0).salary
+ 237      Column               16    4  129                          0  r[129]=ephemeral(buffer_table_window_0).amount
+ 238      Column               16    5  130                          0  r[130]=ephemeral(buffer_table_window_0).region
+ 239      Column               16    6  131                          0  r[131]=ephemeral(buffer_table_window_0).column 6
+ 240      Column               16    7  132                          0  r[132]=ephemeral(buffer_table_window_0).column 7
+ 241      Column               16    8  133                          0  r[133]=ephemeral(buffer_table_window_0).column 8
+ 242      AggStep               0    0  123  row_number              0  accum=r[123] step(r[0])
+ 243      AggValue              0  123  124  row_number              0  accum=r[123] dest=r[124]
+ 244      Copy                125  113    0                          0  r[113]=r[125]
+ 245      Copy                126  114    0                          0  r[114]=r[126]
+ 246      Copy                127  115    0                          0  r[115]=r[127]
+ 247      Copy                128  116    0                          0  r[116]=r[128]
+ 248      Copy                129  117    0                          0  r[117]=r[129]
+ 249      Copy                130  118    0                          0  r[118]=r[130]
+ 250      Copy                124  119    0                          0  r[119]=r[124]
+ 251      Copy                131  120    0                          0  r[120]=r[131]
+ 252      Copy                132  121    0                          0  r[121]=r[132]
+ 253      Copy                133  122    0                          0  r[122]=r[133]
+ 254      ResultRow           113   10    0                          0  output=r[113..122]
+ 255    Next                   16  233    0                          0
+ 256    ResetSorter            16    0    0                          0  cursor=16
+ 257  Return                  136    0    1                          0
+ 258  Halt                      0    0    0                          0
+ 259  Transaction               0    1    7                          0  iDb=0 tx_mode=Read
+ 260  Goto                      0    1    0                          0

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
@@ -22,7 +22,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode            p1  p2  p3  p4                     p5  comment
-   0    Init             0  49   0                          0  Start at 49
+   0    Init             0  48   0                          0  Start at 48
    1    InitCoroutine    1  13   2                          0
    2    OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
    3    OpenRead         1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
@@ -39,37 +39,36 @@ addr  opcode            p1  p2  p3  p4                     p5  comment
   14    OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
   15    Null             0  17   0                          0  r[17]=NULL
   16    InitCoroutine    1   0   2                          0
-  17      Yield          1  31   0                          0
+  17      Yield          1  30   0                          0
   18      Copy           2  20   0                          0  r[20]=r[2]
-  19      NotNull       17  23   0                          0  r[17]!=NULL -> goto 23
+  19      NotNull       17  22   0                          0  r[17]!=NULL -> goto 22
   20      Copy          20  19   0                          0  r[19]=r[20]; initialize previous peer register for new partition
   21      Null           0  11  11                          0  r[11..11]=NULL; reset accumulator registers
-  22      Integer        0  12   0                          0  r[12]=0
-  23      Compare       19  20   1  k(1, Binary)            0  r[19..19]==r[20..20]; compare ORDER BY columns to detect peer
-  24      Jump          25  27  25                          0
-  25      Gosub         18  32   0                          0  ; detected non-peer row
-  26      Copy          20  19   0                          0  r[19]=r[20]
-  27      MakeRecord     2   4  21                          0  r[21]=mkrec(r[2..5])
-  28      NewRowid       3  17   0                          0  r[17]=rowid
-  29      Insert         3  21  17  buffer_table_window_0   0  intkey=r[17] data=r[21]
-  30    Goto             0  17   0                          0
-  31    Null             0  18   0                          0  r[18]=NULL; return remaining buffered rows
-  32    Rewind           2  46   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  33    Integer          1  22   0                          0  r[22]=1
-  34      Column         2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
-  35      Column         2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
-  36      Column         2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
-  37      Column         2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
-  38      Add           12  22  12                          0  r[12]=r[12]+r[22]
-  39      Copy          13   6   0                          0  r[6]=r[13]
-  40      Copy          14   7   0                          0  r[7]=r[14]
-  41      Copy          15   8   0                          0  r[8]=r[15]
-  42      Copy          16   9   0                          0  r[9]=r[16]
-  43      Copy          12  10   0                          0  r[10]=r[12]
-  44      ResultRow      6   5   0                          0  output=r[6..10]
-  45    Next             2  34   0                          0
-  46    ResetSorter      2   0   0                          0  cursor=2
-  47  Return            18   0   1                          0
-  48  Halt               0   0   0                          0
-  49  Transaction        0   1   7                          0  iDb=0 tx_mode=Read
-  50  Goto               0   1   0                          0
+  22      Compare       19  20   1  k(1, Binary)            0  r[19..19]==r[20..20]; compare ORDER BY columns to detect peer
+  23      Jump          24  26  24                          0
+  24      Gosub         18  31   0                          0  ; detected non-peer row
+  25      Copy          20  19   0                          0  r[19]=r[20]
+  26      MakeRecord     2   4  21                          0  r[21]=mkrec(r[2..5])
+  27      NewRowid       3  17   0                          0  r[17]=rowid
+  28      Insert         3  21  17  buffer_table_window_0   0  intkey=r[17] data=r[21]
+  29    Goto             0  17   0                          0
+  30    Null             0  18   0                          0  r[18]=NULL; return remaining buffered rows
+  31    Rewind           2  45   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  32      Column         2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
+  33      Column         2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
+  34      Column         2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
+  35      Column         2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
+  36      AggStep        0   0  11  row_number              0  accum=r[11] step(r[0])
+  37      AggValue       0  11  12  row_number              0  accum=r[11] dest=r[12]
+  38      Copy          13   6   0                          0  r[6]=r[13]
+  39      Copy          14   7   0                          0  r[7]=r[14]
+  40      Copy          15   8   0                          0  r[8]=r[15]
+  41      Copy          16   9   0                          0  r[9]=r[16]
+  42      Copy          12  10   0                          0  r[10]=r[12]
+  43      ResultRow      6   5   0                          0  output=r[6..10]
+  44    Next             2  32   0                          0
+  45    ResetSorter      2   0   0                          0  cursor=2
+  46  Return            18   0   1                          0
+  47  Halt               0   0   0                          0
+  48  Transaction        0   1   7                          0  iDb=0 tx_mode=Read
+  49  Goto               0   1   0                          0

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
@@ -24,7 +24,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode            p1  p2  p3  p4                     p5  comment
-   0    Init             0  63   0                          0  Start at 63
+   0    Init             0  62   0                          0  Start at 62
    1    InitCoroutine    1  24   2                          0
    2    SorterOpen       0   2   0  k(2,B,-B)               0  cursor=0
    3    OpenRead         1   3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
@@ -52,40 +52,39 @@ addr  opcode            p1  p2  p3  p4                     p5  comment
   25    OpenDup          4   3   0                          0  new_cursor=4, original_cursor=3
   26    Null             0  26   0                          0  r[26]=NULL
   27    InitCoroutine    1   0   2                          0
-  28      Yield          1  43   0                          0
+  28      Yield          1  42   0                          0
   29      Copy           2  30   0                          0  r[30]=r[2]
   30      Copy           3  31   0                          0  r[31]=r[3]
-  31      NotNull       26  35   0                          0  r[26]!=NULL -> goto 35
+  31      NotNull       26  34   0                          0  r[26]!=NULL -> goto 34
   32      Copy          30  28   1                          0  r[28]=r[30]; initialize previous peer register for new partition
   33      Null           0  19  19                          0  r[19..19]=NULL; reset accumulator registers
-  34      Integer        0  20   0                          0  r[20]=0
-  35      Compare       28  30   2  k(2, Binary, Binary)    0  r[28..29]==r[30..31]; compare ORDER BY columns to detect peer
-  36      Jump          37  39  37                          0
-  37      Gosub         27  44   0                          0  ; detected non-peer row
-  38      Copy          30  28   1                          0  r[28]=r[30]
-  39      MakeRecord     2   5  32                          0  r[32]=mkrec(r[2..6])
-  40      NewRowid       4  26   0                          0  r[26]=rowid
-  41      Insert         4  32  26  buffer_table_window_0   0  intkey=r[26] data=r[32]
-  42    Goto             0  28   0                          0
-  43    Null             0  27   0                          0  r[27]=NULL; return remaining buffered rows
-  44    Rewind           3  60   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  45    Integer          1  33   0                          0  r[33]=1
-  46      Column         3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
-  47      Column         3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
-  48      Column         3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
-  49      Column         3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
-  50      Column         3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
-  51      Add           20  33  20                          0  r[20]=r[20]+r[33]
-  52      Copy          21  13   0                          0  r[13]=r[21]
-  53      Copy          22  14   0                          0  r[14]=r[22]
-  54      Copy          23  15   0                          0  r[15]=r[23]
-  55      Copy          24  16   0                          0  r[16]=r[24]
-  56      Copy          25  17   0                          0  r[17]=r[25]
-  57      Copy          20  18   0                          0  r[18]=r[20]
-  58      ResultRow     13   6   0                          0  output=r[13..18]
-  59    Next             3  46   0                          0
-  60    ResetSorter      3   0   0                          0  cursor=3
-  61  Return            27   0   1                          0
-  62  Halt               0   0   0                          0
-  63  Transaction        0   1   7                          0  iDb=0 tx_mode=Read
-  64  Goto               0   1   0                          0
+  34      Compare       28  30   2  k(2, Binary, Binary)    0  r[28..29]==r[30..31]; compare ORDER BY columns to detect peer
+  35      Jump          36  38  36                          0
+  36      Gosub         27  43   0                          0  ; detected non-peer row
+  37      Copy          30  28   1                          0  r[28]=r[30]
+  38      MakeRecord     2   5  32                          0  r[32]=mkrec(r[2..6])
+  39      NewRowid       4  26   0                          0  r[26]=rowid
+  40      Insert         4  32  26  buffer_table_window_0   0  intkey=r[26] data=r[32]
+  41    Goto             0  28   0                          0
+  42    Null             0  27   0                          0  r[27]=NULL; return remaining buffered rows
+  43    Rewind           3  59   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  44      Column         3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
+  45      Column         3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
+  46      Column         3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
+  47      Column         3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
+  48      Column         3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
+  49      AggStep        0   0  19  row_number              0  accum=r[19] step(r[0])
+  50      AggValue       0  19  20  row_number              0  accum=r[19] dest=r[20]
+  51      Copy          21  13   0                          0  r[13]=r[21]
+  52      Copy          22  14   0                          0  r[14]=r[22]
+  53      Copy          23  15   0                          0  r[15]=r[23]
+  54      Copy          24  16   0                          0  r[16]=r[24]
+  55      Copy          25  17   0                          0  r[17]=r[25]
+  56      Copy          20  18   0                          0  r[18]=r[20]
+  57      ResultRow     13   6   0                          0  output=r[13..18]
+  58    Next             3  44   0                          0
+  59    ResetSorter      3   0   0                          0  cursor=3
+  60  Return            27   0   1                          0
+  61  Halt               0   0   0                          0
+  62  Transaction        0   1   7                          0  iDb=0 tx_mode=Read
+  63  Goto               0   1   0                          0

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
@@ -23,7 +23,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4                     p5  comment
-   0            Init             0  85   0                          0  Start at 85
+   0            Init             0  84   0                          0  Start at 84
    1            InitCoroutine    1  51   2                          0
    2            SorterOpen       0   1   0  k(1,-B)                 0  cursor=0
    3            Null             0  11  12                          0  r[11..12]=NULL
@@ -78,36 +78,35 @@ addr  opcode                    p1  p2  p3  p4                     p5  comment
   52    OpenDup                  5   4   0                          0  new_cursor=5, original_cursor=4
   53    Null                     0  30   0                          0  r[30]=NULL
   54    InitCoroutine            1   0   2                          0
-  55      Yield                  1  69   0                          0
+  55      Yield                  1  68   0                          0
   56      Copy                   2  33   0                          0  r[33]=r[2]
-  57      NotNull               30  61   0                          0  r[30]!=NULL -> goto 61
+  57      NotNull               30  60   0                          0  r[30]!=NULL -> goto 60
   58      Copy                  33  32   0                          0  r[32]=r[33]; initialize previous peer register for new partition
   59      Null                   0  25  25                          0  r[25..25]=NULL; reset accumulator registers
-  60      Integer                0  26   0                          0  r[26]=0
-  61      Compare               32  33   1  k(1, Binary)            0  r[32..32]==r[33..33]; compare ORDER BY columns to detect peer
-  62      Jump                  63  65  63                          0
-  63      Gosub                 31  70   0                          0  ; detected non-peer row
-  64      Copy                  33  32   0                          0  r[32]=r[33]
-  65      MakeRecord             2   3  34                          0  r[34]=mkrec(r[2..4])
-  66      NewRowid               5  30   0                          0  r[30]=rowid
-  67      Insert                 5  34  30  buffer_table_window_0   0  intkey=r[30] data=r[34]
-  68    Goto                     0  55   0                          0
-  69    Null                     0  31   0                          0  r[31]=NULL; return remaining buffered rows
-  70    Rewind                   4  82   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  71    Integer                  1  35   0                          0  r[35]=1
-  72      Column                 4   1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
-  73      Column                 4   2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
-  74      Column                 4   0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
-  75      Add                   26  35  26                          0  r[26]=r[26]+r[35]
-  76      Copy                  27  21   0                          0  r[21]=r[27]
-  77      Copy                  28  22   0                          0  r[22]=r[28]
-  78      Copy                  29  23   0                          0  r[23]=r[29]
-  79      Copy                  26  24   0                          0  r[24]=r[26]
-  80      ResultRow             21   4   0                          0  output=r[21..24]
-  81    Next                     4  72   0                          0
-  82    ResetSorter              4   0   0                          0  cursor=4
-  83  Return                    31   0   1                          0
-  84  Halt                       0   0   0                          0
-  85  Transaction                0   1   7                          0  iDb=0 tx_mode=Read
-  86  Integer                    1  17   0                          0  r[17]=1
-  87  Goto                       0   1   0                          0
+  60      Compare               32  33   1  k(1, Binary)            0  r[32..32]==r[33..33]; compare ORDER BY columns to detect peer
+  61      Jump                  62  64  62                          0
+  62      Gosub                 31  69   0                          0  ; detected non-peer row
+  63      Copy                  33  32   0                          0  r[32]=r[33]
+  64      MakeRecord             2   3  34                          0  r[34]=mkrec(r[2..4])
+  65      NewRowid               5  30   0                          0  r[30]=rowid
+  66      Insert                 5  34  30  buffer_table_window_0   0  intkey=r[30] data=r[34]
+  67    Goto                     0  55   0                          0
+  68    Null                     0  31   0                          0  r[31]=NULL; return remaining buffered rows
+  69    Rewind                   4  81   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  70      Column                 4   1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
+  71      Column                 4   2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
+  72      Column                 4   0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
+  73      AggStep                0   0  25  row_number              0  accum=r[25] step(r[0])
+  74      AggValue               0  25  26  row_number              0  accum=r[25] dest=r[26]
+  75      Copy                  27  21   0                          0  r[21]=r[27]
+  76      Copy                  28  22   0                          0  r[22]=r[28]
+  77      Copy                  29  23   0                          0  r[23]=r[29]
+  78      Copy                  26  24   0                          0  r[24]=r[26]
+  79      ResultRow             21   4   0                          0  output=r[21..24]
+  80    Next                     4  70   0                          0
+  81    ResetSorter              4   0   0                          0  cursor=4
+  82  Return                    31   0   1                          0
+  83  Halt                       0   0   0                          0
+  84  Transaction                0   1   7                          0  iDb=0 tx_mode=Read
+  85  Integer                    1  17   0                          0  r[17]=1
+  86  Goto                       0   1   0                          0

--- a/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/testing/sqltests/tests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -35,7 +35,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode              p1   p2  p3  p4                     p5  comment
-   0      Init             0  118   0                          0  Start at 118
+   0      Init             0  117   0                          0  Start at 117
    1      InitCoroutine    1   77   2                          0
    2      InitCoroutine    2   51   3                          0
    3      InitCoroutine    3   15   4                          0
@@ -116,42 +116,41 @@ addr  opcode              p1   p2  p3  p4                     p5  comment
   78    OpenDup            7    6   0                          0  new_cursor=7, original_cursor=6
   79    Null               0   53   0                          0  r[53]=NULL
   80    InitCoroutine      1    0   2                          0
-  81      Yield            1   95   0                          0
+  81      Yield            1   94   0                          0
   82      Copy            24   56   0                          0  r[56]=r[24]
-  83      NotNull         53   87   0                          0  r[53]!=NULL -> goto 87
+  83      NotNull         53   86   0                          0  r[53]!=NULL -> goto 86
   84      Copy            56   55   0                          0  r[55]=r[56]; initialize previous peer register for new partition
   85      Null             0   46  46                          0  r[46..46]=NULL; reset accumulator registers
-  86      Integer          0   47   0                          0  r[47]=0
-  87      Compare         55   56   1  k(1, Binary)            0  r[55..55]==r[56..56]; compare ORDER BY columns to detect peer
-  88      Jump            89   91  89                          0
-  89      Gosub           54   96   0                          0  ; detected non-peer row
-  90      Copy            56   55   0                          0  r[55]=r[56]
-  91      MakeRecord      24    6  57                          0  r[57]=mkrec(r[24..29])
-  92      NewRowid         7   53   0                          0  r[53]=rowid
-  93      Insert           7   57  53  buffer_table_window_0   0  intkey=r[53] data=r[57]
-  94    Goto               0   81   0                          0
-  95    Null               0   54   0                          0  r[54]=NULL; return remaining buffered rows
-  96    Rewind             6  115   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  97    Integer            1   58   0                          0  r[58]=1
-  98      Column           6    1  48                          0  r[48]=ephemeral(buffer_table_window_0).emp_id
-  99      Column           6    2  49                          0  r[49]=ephemeral(buffer_table_window_0).name
- 100      Column           6    3  50                          0  r[50]=ephemeral(buffer_table_window_0).department
- 101      Column           6    4  51                          0  r[51]=ephemeral(buffer_table_window_0).salary
- 102      Column           6    5  52                          0  r[52]=ephemeral(buffer_table_window_0).dept_avg
- 103      Add             47   58  47                          0  r[47]=r[47]+r[58]
- 104      Copy            48   39   0                          0  r[39]=r[48]
- 105      Copy            49   40   0                          0  r[40]=r[49]
- 106      Copy            50   41   0                          0  r[41]=r[50]
- 107      Copy            51   42   0                          0  r[42]=r[51]
- 108      Copy            52   43   0                          0  r[43]=r[52]
- 109      Copy            51   59   0                          0  r[59]=r[51]
- 110      Copy            52   60   0                          0  r[60]=r[52]
- 111      Subtract        59   60  44                          0  r[44]=r[59]-r[60]
- 112      Copy            47   45   0                          0  r[45]=r[47]
- 113      ResultRow       39    7   0                          0  output=r[39..45]
- 114    Next               6   98   0                          0
- 115    ResetSorter        6    0   0                          0  cursor=6
- 116  Return              54    0   1                          0
- 117  Halt                 0    0   0                          0
- 118  Transaction          0    1   7                          0  iDb=0 tx_mode=Read
- 119  Goto                 0    1   0                          0
+  86      Compare         55   56   1  k(1, Binary)            0  r[55..55]==r[56..56]; compare ORDER BY columns to detect peer
+  87      Jump            88   90  88                          0
+  88      Gosub           54   95   0                          0  ; detected non-peer row
+  89      Copy            56   55   0                          0  r[55]=r[56]
+  90      MakeRecord      24    6  57                          0  r[57]=mkrec(r[24..29])
+  91      NewRowid         7   53   0                          0  r[53]=rowid
+  92      Insert           7   57  53  buffer_table_window_0   0  intkey=r[53] data=r[57]
+  93    Goto               0   81   0                          0
+  94    Null               0   54   0                          0  r[54]=NULL; return remaining buffered rows
+  95    Rewind             6  114   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  96      Column           6    1  48                          0  r[48]=ephemeral(buffer_table_window_0).emp_id
+  97      Column           6    2  49                          0  r[49]=ephemeral(buffer_table_window_0).name
+  98      Column           6    3  50                          0  r[50]=ephemeral(buffer_table_window_0).department
+  99      Column           6    4  51                          0  r[51]=ephemeral(buffer_table_window_0).salary
+ 100      Column           6    5  52                          0  r[52]=ephemeral(buffer_table_window_0).dept_avg
+ 101      AggStep          0    0  46  row_number              0  accum=r[46] step(r[0])
+ 102      AggValue         0   46  47  row_number              0  accum=r[46] dest=r[47]
+ 103      Copy            48   39   0                          0  r[39]=r[48]
+ 104      Copy            49   40   0                          0  r[40]=r[49]
+ 105      Copy            50   41   0                          0  r[41]=r[50]
+ 106      Copy            51   42   0                          0  r[42]=r[51]
+ 107      Copy            52   43   0                          0  r[43]=r[52]
+ 108      Copy            51   58   0                          0  r[58]=r[51]
+ 109      Copy            52   59   0                          0  r[59]=r[52]
+ 110      Subtract        58   59  44                          0  r[44]=r[58]-r[59]
+ 111      Copy            47   45   0                          0  r[45]=r[47]
+ 112      ResultRow       39    7   0                          0  output=r[39..45]
+ 113    Next               6   96   0                          0
+ 114    ResetSorter        6    0   0                          0  cursor=6
+ 115  Return              54    0   1                          0
+ 116  Halt                 0    0   0                          0
+ 117  Transaction          0    1   7                          0  iDb=0 tx_mode=Read
+ 118  Goto                 0    1   0                          0


### PR DESCRIPTION
1. Introduce stubs for all builtin window functions

2. rename `WindowFunctionKind` to `AccumulatorFunc`, because both window functions and aggregate functions will use the same `op_agg_step` mechanism

3. remove specialcased `row_number()` handling and route it through `op_agg_step`, which is what other window functions will use as well