### PR TITLE
github: Use Blacksmith build-push action for simulator image build

### DIFF
--- a/.github/workflows/build-sim.yml
+++ b/.github/workflows/build-sim.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   deploy:
     runs-on: blacksmith
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,6 +41,11 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push limbo-sim docker image
-        run: |
-          docker build -f testing/simulator/simulator-docker-runner/Dockerfile.simulator -t ${{ env.ECR_URL }}/${{ env.ECR_IMAGE_NAME }} --build-arg GIT_HASH=${{ env.GIT_HASH }} .
-          docker push ${{ env.ECR_URL }}/${{ env.ECR_IMAGE_NAME }}
+        uses: useblacksmith/build-push-action@v1
+        with:
+          context: .
+          file: testing/simulator/simulator-docker-runner/Dockerfile.simulator
+          push: true
+          tags: ${{ env.ECR_URL }}/${{ env.ECR_IMAGE_NAME }}
+          build-args: |
+            GIT_HASH=${{ env.GIT_HASH }}


### PR DESCRIPTION
The simulator image build was hitting the 30-minute job timeout because
the raw docker build recompiled the entire Rust workspace from scratch
every run. Switch to useblacksmith/build-push-action, which mounts a
sticky-disk Docker layer cache on Blacksmith runners so the cargo-chef
dependency layer is reused across builds. Also bump the timeout to 60
minutes as a safety net.
