### PR TITLE
add yielding IO back-end for turso-stress to test async re-entrancy

### DIFF
--- a/Dockerfile.antithesis
+++ b/Dockerfile.antithesis
@@ -78,6 +78,7 @@ WORKDIR /app
 COPY ./testing/antithesis/bank-test/*.py /opt/antithesis/test/v1/bank-test/
 COPY ./testing/antithesis/stress-composer/*.py /opt/antithesis/test/v1/stress-composer/
 COPY ./testing/antithesis/stress /opt/antithesis/test/v1/stress
+COPY ./testing/antithesis/stress-memory_yield /opt/antithesis/test/v1/stress-memory_yield
 COPY ./testing/antithesis/stress-io_uring /opt/antithesis/test/v1/stress-io_uring
 COPY ./testing/antithesis/stress-mvcc /opt/antithesis/test/v1/stress-mvcc
 COPY ./testing/antithesis/stress-io_uring-mvcc /opt/antithesis/test/v1/stress-io_uring-mvcc

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -19,6 +19,8 @@ pure-rust-crypto = ["turso_sdk_kit/pure-rust-crypto", "turso_sync_sdk_kit/pure-r
 fts = ["turso_sdk_kit/fts"]
 stacker = ["turso_core/stacker"]
 test_helper = ["turso_core/test_helper"]
+# Test-only: exposes the `memory_yield` VFS for stress/simulator harnesses.
+io_memory_yield = ["turso_core/io_memory_yield"]
 sync = [
     "dep:hyper",
     "dep:tokio",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,9 +29,7 @@ time = []
 fuzz = []
 omit_autovacuum = []
 simulator = ["fuzz", "serde", "io_memory_yield"]
-# Enables the in-memory `memory_yield` VFS, which defers every I/O completion
-# to force the engine through its cooperative-yield path on every op. Test-only:
-# exposed to testing/stress and the simulator, never to regular library users.
+# Test only: exposed to testing/stress and the simulator, never to regular library users.
 io_memory_yield = []
 serde = ["dep:serde"]
 series = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,11 @@ experimental_win_iocp = []
 time = []
 fuzz = []
 omit_autovacuum = []
-simulator = ["fuzz", "serde"]
+simulator = ["fuzz", "serde", "io_memory_yield"]
+# Enables the in-memory `memory_yield` VFS, which defers every I/O completion
+# to force the engine through its cooperative-yield path on every op. Test-only:
+# exposed to testing/stress and the simulator, never to regular library users.
+io_memory_yield = []
 serde = ["dep:serde"]
 series = []
 encryption = []

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -220,6 +220,8 @@ impl Database {
 
         let io: Arc<dyn IO> = match vfs {
             "memory" => Arc::new(MemoryIO::new()),
+            #[cfg(feature = "io_memory_yield")]
+            "memory_yield" => Arc::new(crate::MemoryYieldIO::new()),
             "syscall" => Arc::new(SyscallIO::new()?),
             #[cfg(all(target_os = "linux", feature = "io_uring", not(miri)))]
             "io_uring" => Arc::new(UringIO::new()?),

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -16,8 +16,8 @@ pub struct MemoryIO {
 }
 
 // TODO: page size flag
-const PAGE_SIZE: usize = 4096;
-type MemPage = Box<[u8; PAGE_SIZE]>;
+pub(super) const PAGE_SIZE: usize = 4096;
+pub(super) type MemPage = Box<[u8; PAGE_SIZE]>;
 
 impl MemoryIO {
     #[allow(clippy::arc_with_non_send_sync)]
@@ -60,8 +60,7 @@ impl IO for MemoryIO {
                 path.to_string(),
                 Arc::new(MemoryFile {
                     path: path.to_string(),
-                    pages: BTreeMap::new().into(),
-                    size: 0.into(),
+                    store: MemStore::new(),
                 }),
             );
         }
@@ -87,201 +86,29 @@ impl IO for MemoryIO {
     }
 }
 
-pub struct MemoryFile {
-    path: String,
+/// In-memory page-backed storage shared by the synchronous [`MemoryIO`] and
+/// the yield-forcing [`super::MemoryYieldIO`] backends. Holds the raw
+/// data-movement logic so both backends stay byte-for-byte compatible; the
+/// only difference between the two is *when* the I/O completion is signalled.
+pub(super) struct MemStore {
     pages: UnsafeCell<BTreeMap<usize, MemPage>>,
     size: Cell<u64>,
 }
 
-unsafe impl Sync for MemoryFile {}
-crate::assert::assert_sync!(MemoryFile);
+// SAFETY: callers serialize dependent operations (a dependent read is only
+// issued after the prior write's completion was observed), matching the
+// invariant the real async backends rely on. This is the same contract
+// `MemoryFile` has always upheld.
+unsafe impl Sync for MemStore {}
 
-impl File for MemoryFile {
-    fn lock_file(&self, _exclusive: bool) -> Result<()> {
-        Ok(())
-    }
-    fn unlock_file(&self) -> Result<()> {
-        Ok(())
-    }
-
-    fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
-        tracing::debug!("pread(path={}): pos={}", self.path, pos);
-        let r = c.as_read();
-        let buf_len = r.buf().len() as u64;
-        if buf_len == 0 {
-            c.complete(0);
-            return Ok(c);
+impl MemStore {
+    pub(super) fn new() -> Self {
+        Self {
+            pages: BTreeMap::new().into(),
+            size: 0.into(),
         }
-
-        let file_size = self.size.get();
-        if pos >= file_size {
-            c.complete(0);
-            return Ok(c);
-        }
-
-        let read_len = buf_len.min(file_size - pos);
-        {
-            let read_buf = r.buf();
-            let mut offset = pos as usize;
-            let mut remaining = read_len as usize;
-            let mut buf_offset = 0;
-
-            while remaining > 0 {
-                let page_no = offset / PAGE_SIZE;
-                let page_offset = offset % PAGE_SIZE;
-                let bytes_to_read = remaining.min(PAGE_SIZE - page_offset);
-                if let Some(page) = self.get_page(page_no) {
-                    read_buf.as_mut_slice()[buf_offset..buf_offset + bytes_to_read]
-                        .copy_from_slice(&page[page_offset..page_offset + bytes_to_read]);
-                } else {
-                    read_buf.as_mut_slice()[buf_offset..buf_offset + bytes_to_read].fill(0);
-                }
-
-                offset += bytes_to_read;
-                buf_offset += bytes_to_read;
-                remaining -= bytes_to_read;
-            }
-        }
-        c.complete(read_len as i32);
-        Ok(c)
     }
 
-    fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
-        tracing::debug!(
-            "pwrite(path={}): pos={}, size={}",
-            self.path,
-            pos,
-            buffer.len()
-        );
-        let buf_len = buffer.len();
-        if buf_len == 0 {
-            c.complete(0);
-            return Ok(c);
-        }
-
-        let mut offset = pos as usize;
-        let mut remaining = buf_len;
-        let mut buf_offset = 0;
-        let data = &buffer.as_slice();
-
-        while remaining > 0 {
-            let page_no = offset / PAGE_SIZE;
-            let page_offset = offset % PAGE_SIZE;
-            let bytes_to_write = remaining.min(PAGE_SIZE - page_offset);
-
-            {
-                let page = self.get_or_allocate_page(page_no as u64);
-                page[page_offset..page_offset + bytes_to_write]
-                    .copy_from_slice(&data[buf_offset..buf_offset + bytes_to_write]);
-            }
-
-            offset += bytes_to_write;
-            buf_offset += bytes_to_write;
-            remaining -= bytes_to_write;
-        }
-
-        self.size
-            .set(core::cmp::max(pos + buf_len as u64, self.size.get()));
-
-        c.complete(buf_len as i32);
-        Ok(c)
-    }
-
-    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
-        tracing::debug!("sync(path={})", self.path);
-        // no-op
-        c.complete(0);
-        Ok(c)
-    }
-
-    fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
-        tracing::debug!("truncate(path={}): len={}", self.path, len);
-        if len < self.size.get() {
-            // Truncate pages
-            unsafe {
-                let pages = &mut *self.pages.get();
-                pages.retain(|&k, _| k * PAGE_SIZE < len as usize);
-            }
-        }
-        self.size.set(len);
-        c.complete(0);
-        Ok(c)
-    }
-
-    fn pwritev(&self, pos: u64, buffers: Vec<Arc<Buffer>>, c: Completion) -> Result<Completion> {
-        tracing::debug!(
-            "pwritev(path={}): pos={}, buffers={:?}",
-            self.path,
-            pos,
-            buffers.iter().map(|x| x.len()).collect::<Vec<_>>()
-        );
-        let mut offset = pos as usize;
-        let mut total_written = 0;
-
-        for buffer in buffers {
-            let buf_len = buffer.len();
-            if buf_len == 0 {
-                continue;
-            }
-
-            let mut remaining = buf_len;
-            let mut buf_offset = 0;
-            let data = &buffer.as_slice();
-
-            while remaining > 0 {
-                let page_no = offset / PAGE_SIZE;
-                let page_offset = offset % PAGE_SIZE;
-                let bytes_to_write = remaining.min(PAGE_SIZE - page_offset);
-
-                {
-                    let page = self.get_or_allocate_page(page_no as u64);
-                    page[page_offset..page_offset + bytes_to_write]
-                        .copy_from_slice(&data[buf_offset..buf_offset + bytes_to_write]);
-                }
-
-                offset += bytes_to_write;
-                buf_offset += bytes_to_write;
-                remaining -= bytes_to_write;
-            }
-            total_written += buf_len;
-        }
-        c.complete(total_written as i32);
-        self.size
-            .set(core::cmp::max(pos + total_written as u64, self.size.get()));
-        Ok(c)
-    }
-
-    fn size(&self) -> Result<u64> {
-        tracing::debug!("size(path={}): {}", self.path, self.size.get());
-        Ok(self.size.get())
-    }
-
-    fn has_hole(&self, pos: usize, len: usize) -> Result<bool> {
-        let start_page = pos / PAGE_SIZE;
-        let end_page = ((pos + len.max(1)) - 1) / PAGE_SIZE;
-        for page_no in start_page..=end_page {
-            if self.get_page(page_no).is_some() {
-                return Ok(false);
-            }
-        }
-        Ok(true)
-    }
-
-    fn punch_hole(&self, pos: usize, len: usize) -> Result<()> {
-        turso_assert!(
-            pos % PAGE_SIZE == 0 && len % PAGE_SIZE == 0,
-            "hole must be page aligned"
-        );
-        let start_page = pos / PAGE_SIZE;
-        let end_page = ((pos + len.max(1)) - 1) / PAGE_SIZE;
-        for page_no in start_page..=end_page {
-            unsafe { (*self.pages.get()).remove(&page_no) };
-        }
-        Ok(())
-    }
-}
-
-impl MemoryFile {
     #[allow(clippy::mut_from_ref)]
     fn get_or_allocate_page(&self, page_no: u64) -> &mut MemPage {
         unsafe {
@@ -294,5 +121,187 @@ impl MemoryFile {
 
     fn get_page(&self, page_no: usize) -> Option<&MemPage> {
         unsafe { (*self.pages.get()).get(&page_no) }
+    }
+
+    pub(super) fn size(&self) -> u64 {
+        self.size.get()
+    }
+
+    /// Read `pos..` into `buf`, zero-filling holes. Returns bytes read.
+    pub(super) fn read_into(&self, pos: u64, buf: &Buffer) -> i32 {
+        let buf_len = buf.len() as u64;
+        if buf_len == 0 {
+            return 0;
+        }
+        let file_size = self.size.get();
+        if pos >= file_size {
+            return 0;
+        }
+        let read_len = buf_len.min(file_size - pos);
+        let dst = buf.as_mut_slice();
+        let mut offset = pos as usize;
+        let mut remaining = read_len as usize;
+        let mut buf_offset = 0;
+        while remaining > 0 {
+            let page_no = offset / PAGE_SIZE;
+            let page_offset = offset % PAGE_SIZE;
+            let bytes_to_read = remaining.min(PAGE_SIZE - page_offset);
+            if let Some(page) = self.get_page(page_no) {
+                dst[buf_offset..buf_offset + bytes_to_read]
+                    .copy_from_slice(&page[page_offset..page_offset + bytes_to_read]);
+            } else {
+                dst[buf_offset..buf_offset + bytes_to_read].fill(0);
+            }
+            offset += bytes_to_read;
+            buf_offset += bytes_to_read;
+            remaining -= bytes_to_read;
+        }
+        read_len as i32
+    }
+
+    /// Write `data` at `pos`, allocating pages as needed. Returns bytes written
+    /// and grows the recorded file size if the write extends past it.
+    pub(super) fn write_at(&self, pos: u64, data: &[u8]) -> usize {
+        let buf_len = data.len();
+        if buf_len == 0 {
+            return 0;
+        }
+        let mut offset = pos as usize;
+        let mut remaining = buf_len;
+        let mut buf_offset = 0;
+        while remaining > 0 {
+            let page_no = offset / PAGE_SIZE;
+            let page_offset = offset % PAGE_SIZE;
+            let bytes_to_write = remaining.min(PAGE_SIZE - page_offset);
+            let page = self.get_or_allocate_page(page_no as u64);
+            page[page_offset..page_offset + bytes_to_write]
+                .copy_from_slice(&data[buf_offset..buf_offset + bytes_to_write]);
+            offset += bytes_to_write;
+            buf_offset += bytes_to_write;
+            remaining -= bytes_to_write;
+        }
+        self.size
+            .set(core::cmp::max(pos + buf_len as u64, self.size.get()));
+        buf_len
+    }
+
+    /// Vectored write of `buffers` starting at `pos`. Returns total bytes written.
+    pub(super) fn writev(&self, pos: u64, buffers: &[Arc<Buffer>]) -> i32 {
+        let mut offset = pos;
+        let mut total_written = 0usize;
+        for buffer in buffers {
+            let written = self.write_at(offset, buffer.as_slice());
+            offset += written as u64;
+            total_written += written;
+        }
+        total_written as i32
+    }
+
+    pub(super) fn truncate(&self, len: u64) {
+        if len < self.size.get() {
+            unsafe {
+                let pages = &mut *self.pages.get();
+                pages.retain(|&k, _| k * PAGE_SIZE < len as usize);
+            }
+        }
+        self.size.set(len);
+    }
+
+    pub(super) fn has_hole(&self, pos: usize, len: usize) -> bool {
+        let start_page = pos / PAGE_SIZE;
+        let end_page = ((pos + len.max(1)) - 1) / PAGE_SIZE;
+        for page_no in start_page..=end_page {
+            if self.get_page(page_no).is_some() {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub(super) fn punch_hole(&self, pos: usize, len: usize) {
+        turso_assert!(
+            pos % PAGE_SIZE == 0 && len % PAGE_SIZE == 0,
+            "hole must be page aligned"
+        );
+        let start_page = pos / PAGE_SIZE;
+        let end_page = ((pos + len.max(1)) - 1) / PAGE_SIZE;
+        for page_no in start_page..=end_page {
+            unsafe { (*self.pages.get()).remove(&page_no) };
+        }
+    }
+}
+
+pub struct MemoryFile {
+    path: String,
+    store: MemStore,
+}
+
+crate::assert::assert_sync!(MemoryFile);
+
+impl File for MemoryFile {
+    fn lock_file(&self, _exclusive: bool) -> Result<()> {
+        Ok(())
+    }
+    fn unlock_file(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+        tracing::debug!("pread(path={}): pos={}", self.path, pos);
+        let n = self.store.read_into(pos, c.as_read().buf());
+        c.complete(n);
+        Ok(c)
+    }
+
+    fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+        tracing::debug!(
+            "pwrite(path={}): pos={}, size={}",
+            self.path,
+            pos,
+            buffer.len()
+        );
+        let n = self.store.write_at(pos, buffer.as_slice());
+        c.complete(n as i32);
+        Ok(c)
+    }
+
+    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
+        tracing::debug!("sync(path={})", self.path);
+        // no-op
+        c.complete(0);
+        Ok(c)
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+        tracing::debug!("truncate(path={}): len={}", self.path, len);
+        self.store.truncate(len);
+        c.complete(0);
+        Ok(c)
+    }
+
+    fn pwritev(&self, pos: u64, buffers: Vec<Arc<Buffer>>, c: Completion) -> Result<Completion> {
+        tracing::debug!(
+            "pwritev(path={}): pos={}, buffers={:?}",
+            self.path,
+            pos,
+            buffers.iter().map(|x| x.len()).collect::<Vec<_>>()
+        );
+        let n = self.store.writev(pos, &buffers);
+        c.complete(n);
+        Ok(c)
+    }
+
+    fn size(&self) -> Result<u64> {
+        tracing::debug!("size(path={}): {}", self.path, self.store.size());
+        Ok(self.store.size())
+    }
+
+    fn has_hole(&self, pos: usize, len: usize) -> Result<bool> {
+        Ok(self.store.has_hole(pos, len))
+    }
+
+    fn punch_hole(&self, pos: usize, len: usize) -> Result<()> {
+        self.store.punch_hole(pos, len);
+        Ok(())
     }
 }

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -87,9 +87,7 @@ impl IO for MemoryIO {
 }
 
 /// In-memory page-backed storage shared by the synchronous [`MemoryIO`] and
-/// the yield-forcing [`super::MemoryYieldIO`] backends. Holds the raw
-/// data-movement logic so both backends stay byte-for-byte compatible; the
-/// only difference between the two is *when* the I/O completion is signalled.
+/// the yield-forcing [`super::MemoryYieldIO`] backends used for testing.
 pub(super) struct MemStore {
     pages: UnsafeCell<BTreeMap<usize, MemPage>>,
     size: Cell<u64>,

--- a/core/io/memory_yield.rs
+++ b/core/io/memory_yield.rs
@@ -14,23 +14,11 @@ use tracing::debug;
 /// [`IO::step`] call, forcing the engine through its cooperative-yield path on
 /// *every* `pread` / `pwrite` / `pwritev` / `sync` / `truncate`.
 ///
-/// [`MemoryIO`](super::MemoryIO) signals completions synchronously, so
-/// `Completion::finished()` is already true when the operation returns. The
-/// VDBE step loop (`vdbe/mod.rs`) treats an already-finished completion as a
-/// fast path and continues without yielding, which means yield points in the
-/// engine are never exercised by purely in-memory tests.
-///
 /// This backend performs the identical byte-level data movement as
 /// `MemoryIO` (it shares [`MemStore`]) but enqueues the completion instead of
 /// signalling it. The completion only becomes `finished()` when `step()` runs,
 /// so the engine must return `StepResult::IO`, yield, and re-enter — exercising
-/// the resume path behind each yield point. This makes it the right backend for
-/// `testing/stress` (which runs under Antithesis) to shake out re-entrancy bugs
-/// once blocking I/O is removed from `core`.
-///
-/// Data movement happens at submit time (matching `MemoryIO` semantics exactly),
-/// so dependent operations observe the same ordering they would with the
-/// synchronous backend; only completion *signalling* is deferred.
+/// the resume path behind each yield point.
 pub struct MemoryYieldIO {
     files: Arc<Mutex<HashMap<String, Arc<MemoryYieldFile>>>>,
     /// Completions submitted but not yet signalled, drained FIFO by `step()`.

--- a/core/io/memory_yield.rs
+++ b/core/io/memory_yield.rs
@@ -1,0 +1,338 @@
+use super::memory::MemStore;
+use super::{Buffer, Clock, Completion, File, OpenFlags, IO};
+use crate::io::clock::{DefaultClock, MonotonicInstant, WallClockInstant};
+use crate::io::FileSyncType;
+use crate::sync::Mutex;
+use crate::Result;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+use tracing::debug;
+
+/// A memory-backed [`IO`] backend that defers every completion until the next
+/// [`IO::step`] call, forcing the engine through its cooperative-yield path on
+/// *every* `pread` / `pwrite` / `pwritev` / `sync` / `truncate`.
+///
+/// [`MemoryIO`](super::MemoryIO) signals completions synchronously, so
+/// `Completion::finished()` is already true when the operation returns. The
+/// VDBE step loop (`vdbe/mod.rs`) treats an already-finished completion as a
+/// fast path and continues without yielding, which means yield points in the
+/// engine are never exercised by purely in-memory tests.
+///
+/// This backend performs the identical byte-level data movement as
+/// `MemoryIO` (it shares [`MemStore`]) but enqueues the completion instead of
+/// signalling it. The completion only becomes `finished()` when `step()` runs,
+/// so the engine must return `StepResult::IO`, yield, and re-enter — exercising
+/// the resume path behind each yield point. This makes it the right backend for
+/// `testing/stress` (which runs under Antithesis) to shake out re-entrancy bugs
+/// once blocking I/O is removed from `core`.
+///
+/// Data movement happens at submit time (matching `MemoryIO` semantics exactly),
+/// so dependent operations observe the same ordering they would with the
+/// synchronous backend; only completion *signalling* is deferred.
+pub struct MemoryYieldIO {
+    files: Arc<Mutex<HashMap<String, Arc<MemoryYieldFile>>>>,
+    /// Completions submitted but not yet signalled, drained FIFO by `step()`.
+    pending: Arc<Mutex<VecDeque<Deferred>>>,
+}
+
+/// A completion awaiting `step()`, together with the byte count it should
+/// report. All completion kinds (read/write/sync/truncate) report a single
+/// `i32`, so this is all the state we need to defer.
+struct Deferred {
+    completion: Completion,
+    result: i32,
+}
+
+impl MemoryYieldIO {
+    #[allow(clippy::arc_with_non_send_sync)]
+    pub fn new() -> Self {
+        debug!("Using IO backend 'memory_yield'");
+        Self {
+            files: Arc::new(Mutex::new(HashMap::default())),
+            pending: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+}
+
+impl Default for MemoryYieldIO {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for MemoryYieldIO {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        DefaultClock.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        DefaultClock.current_time_wall_clock()
+    }
+}
+
+impl IO for MemoryYieldIO {
+    fn open_file(&self, path: &str, flags: OpenFlags, _direct: bool) -> Result<Arc<dyn File>> {
+        let mut files = self.files.lock();
+        if !files.contains_key(path) && !flags.contains(OpenFlags::Create) {
+            return Err(crate::error::CompletionError::IOError(
+                std::io::ErrorKind::NotFound,
+                "open",
+            )
+            .into());
+        }
+        if !files.contains_key(path) {
+            files.insert(
+                path.to_string(),
+                Arc::new(MemoryYieldFile {
+                    path: path.to_string(),
+                    store: MemStore::new(),
+                    pending: self.pending.clone(),
+                }),
+            );
+        }
+        Ok(files
+            .get(path)
+            .ok_or_else(|| {
+                crate::LimboError::InternalError("file should exist after insert".to_string())
+            })?
+            .clone())
+    }
+
+    fn remove_file(&self, path: &str) -> Result<()> {
+        let mut files = self.files.lock();
+        files.remove(path);
+        Ok(())
+    }
+
+    fn file_id(&self, path: &str) -> Result<super::FileId> {
+        Ok(super::FileId::from_path_hash(path))
+    }
+
+    fn supports_shared_wal_coordination(&self) -> bool {
+        false
+    }
+
+    /// Signal every completion that was deferred since the last `step()`.
+    ///
+    /// We snapshot the queue and release the lock before signalling so that a
+    /// completion callback is free to submit follow-up I/O (which lands in the
+    /// queue for the *next* step) without deadlocking or being drained within
+    /// this same call. Each deferred completion required at least one `step()`
+    /// to finish, which means at least one yield occurred per submitted op.
+    fn step(&self) -> Result<()> {
+        let drained: VecDeque<Deferred> = {
+            let mut pending = self.pending.lock();
+            std::mem::take(&mut *pending)
+        };
+        for Deferred { completion, result } in drained {
+            completion.complete(result);
+        }
+        Ok(())
+    }
+}
+
+pub struct MemoryYieldFile {
+    path: String,
+    store: MemStore,
+    pending: Arc<Mutex<VecDeque<Deferred>>>,
+}
+
+crate::assert::assert_sync!(MemoryYieldFile);
+
+impl MemoryYieldFile {
+    /// Defer `c` so it is signalled on the next `IO::step`, leaving it
+    /// `finished() == false` for now and forcing the caller to yield.
+    fn defer(&self, c: &Completion, result: i32) {
+        self.pending.lock().push_back(Deferred {
+            completion: c.clone(),
+            result,
+        });
+    }
+}
+
+impl File for MemoryYieldFile {
+    fn lock_file(&self, _exclusive: bool) -> Result<()> {
+        Ok(())
+    }
+    fn unlock_file(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+        tracing::debug!("pread(path={}): pos={} [deferred]", self.path, pos);
+        let n = self.store.read_into(pos, c.as_read().buf());
+        self.defer(&c, n);
+        Ok(c)
+    }
+
+    fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion> {
+        tracing::debug!(
+            "pwrite(path={}): pos={}, size={} [deferred]",
+            self.path,
+            pos,
+            buffer.len()
+        );
+        let n = self.store.write_at(pos, buffer.as_slice());
+        self.defer(&c, n as i32);
+        Ok(c)
+    }
+
+    fn sync(&self, c: Completion, _sync_type: FileSyncType) -> Result<Completion> {
+        tracing::debug!("sync(path={}) [deferred]", self.path);
+        self.defer(&c, 0);
+        Ok(c)
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+        tracing::debug!("truncate(path={}): len={} [deferred]", self.path, len);
+        self.store.truncate(len);
+        self.defer(&c, 0);
+        Ok(c)
+    }
+
+    fn pwritev(&self, pos: u64, buffers: Vec<Arc<Buffer>>, c: Completion) -> Result<Completion> {
+        tracing::debug!(
+            "pwritev(path={}): pos={}, buffers={:?} [deferred]",
+            self.path,
+            pos,
+            buffers.iter().map(|x| x.len()).collect::<Vec<_>>()
+        );
+        let n = self.store.writev(pos, &buffers);
+        self.defer(&c, n);
+        Ok(c)
+    }
+
+    fn size(&self) -> Result<u64> {
+        tracing::debug!("size(path={}): {}", self.path, self.store.size());
+        Ok(self.store.size())
+    }
+
+    fn has_hole(&self, pos: usize, len: usize) -> Result<bool> {
+        Ok(self.store.has_hole(pos, len))
+    }
+
+    fn punch_hole(&self, pos: usize, len: usize) -> Result<()> {
+        self.store.punch_hole(pos, len);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vdbe::StepResult;
+    use crate::{Database, OpenFlags};
+
+    /// Every op must come back unfinished and only complete once `step()` runs.
+    #[test]
+    fn completions_are_deferred_until_step() {
+        let io = MemoryYieldIO::new();
+        let file = io.open_file("t", OpenFlags::Create, false).unwrap();
+
+        let buf = Arc::new(Buffer::new(vec![0xAB; 64]));
+        let wc = file.pwrite(0, buf, Completion::new_write(|_| {})).unwrap();
+        assert!(
+            !wc.finished(),
+            "pwrite completion must not finish before step()"
+        );
+        io.step().unwrap();
+        assert!(wc.finished() && wc.succeeded());
+
+        let sc = file
+            .sync(Completion::new_sync(|_| {}), FileSyncType::Fsync)
+            .unwrap();
+        assert!(
+            !sc.finished(),
+            "sync completion must not finish before step()"
+        );
+        io.step().unwrap();
+        assert!(sc.succeeded());
+
+        let tc = file.truncate(16, Completion::new_trunc(|_| {})).unwrap();
+        assert!(
+            !tc.finished(),
+            "truncate completion must not finish before step()"
+        );
+        io.step().unwrap();
+        assert!(tc.succeeded());
+        assert_eq!(file.size().unwrap(), 16);
+    }
+
+    /// Data written before a `step()` is visible to a later read, exactly as
+    /// with the synchronous `MemoryIO` — only the signalling is deferred.
+    #[test]
+    fn read_returns_written_bytes_after_step() {
+        let io = MemoryYieldIO::new();
+        let file = io.open_file("t", OpenFlags::Create, false).unwrap();
+
+        let wbuf = Arc::new(Buffer::new(vec![0x42; 100]));
+        let wc = file.pwrite(0, wbuf, Completion::new_write(|_| {})).unwrap();
+        io.step().unwrap();
+        assert!(wc.succeeded());
+
+        let rbuf = Arc::new(Buffer::new_temporary(100));
+        let rc = file
+            .pread(0, Completion::new_read(rbuf.clone(), |_| None))
+            .unwrap();
+        assert!(
+            !rc.finished(),
+            "pread completion must not finish before step()"
+        );
+        io.step().unwrap();
+        assert!(rc.succeeded());
+        assert!(rbuf.as_slice().iter().all(|&b| b == 0x42));
+    }
+
+    /// Driving real SQL through the engine on this backend must force at least
+    /// one `StepResult::IO` (i.e. a genuine yield + re-entry), which the
+    /// synchronous `MemoryIO` fast-paths away, while still producing correct
+    /// results.
+    #[test]
+    fn engine_yields_and_round_trips() {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let io: Arc<dyn IO> = Arc::new(MemoryYieldIO::new());
+        let db = Database::open_file(io.clone(), "memory_yield_test.db").unwrap();
+        let conn = db.connect().unwrap();
+
+        // Step statements manually so we can observe the cooperative-yield path.
+        // Returns (rows, number of StepResult::IO yields).
+        let run = |sql: &str| -> (Vec<crate::Value>, usize) {
+            let mut stmt = conn.prepare(sql).unwrap();
+            let mut io_yields = 0usize;
+            let mut rows = Vec::new();
+            loop {
+                match stmt.step().unwrap() {
+                    StepResult::IO => {
+                        io_yields += 1;
+                        io.step().unwrap();
+                    }
+                    StepResult::Row => {
+                        let v = stmt.row().unwrap().get_values().next().unwrap().clone();
+                        rows.push(v);
+                    }
+                    StepResult::Done => break,
+                    other => panic!("unexpected step result: {other:?}"),
+                }
+            }
+            (rows, io_yields)
+        };
+
+        // A write transaction must flush pages, so it is guaranteed to defer at
+        // least one completion and surface a StepResult::IO. The synchronous
+        // MemoryIO would fast-path right past this.
+        let (_, create_yields) = run("CREATE TABLE t(x)");
+        assert!(
+            create_yields > 0,
+            "memory_yield backend must force at least one StepResult::IO on a write"
+        );
+        run("INSERT INTO t VALUES (1), (2), (3)");
+
+        // And the round trip still produces correct results.
+        let (rows, _) = run("SELECT x FROM t ORDER BY x");
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0], crate::Value::from_i64(1));
+        assert_eq!(rows[2], crate::Value::from_i64(3));
+    }
+}

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -51,9 +51,13 @@ cfg_block! {
 }
 
 mod memory;
+#[cfg(feature = "io_memory_yield")]
+mod memory_yield;
 #[cfg(feature = "fs")]
 mod vfs;
 pub use memory::MemoryIO;
+#[cfg(feature = "io_memory_yield")]
+pub use memory_yield::MemoryYieldIO;
 pub mod clock;
 mod common;
 mod completions;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -129,6 +129,8 @@ pub use connection::{resolve_ext_path, Connection, Row, StepResult, SymbolTable}
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
 pub use error::{io_error, CompletionError, LimboError};
 pub use function::ContextCollationFunction;
+#[cfg(feature = "io_memory_yield")]
+pub use io::MemoryYieldIO;
 #[cfg(all(feature = "fs", target_family = "unix", not(miri)))]
 pub use io::UnixIO;
 #[cfg(all(feature = "fs", target_os = "linux", feature = "io_uring", not(miri)))]
@@ -2587,6 +2589,8 @@ impl Database {
             Some(vfs) => vfs,
             None => match vfs.as_ref() {
                 "memory" => Arc::new(MemoryIO::new()),
+                #[cfg(feature = "io_memory_yield")]
+                "memory_yield" => Arc::new(MemoryYieldIO::new()),
                 "syscall" => Arc::new(SyscallIO::new()?),
                 #[cfg(all(target_os = "linux", feature = "io_uring", not(miri)))]
                 "io_uring" => Arc::new(UringIO::new()?),

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -6124,7 +6124,7 @@ mod ptrmap_tests {
             target_idx,
             PendingRead {
                 page: synthetic_page.clone(),
-                disk_read: Some(stub_disk_read.clone()),
+                disk_read: Some(stub_disk_read),
             },
         );
 

--- a/testing/antithesis/stress-memory_yield/singleton_driver_stress.sh
+++ b/testing/antithesis/stress-memory_yield/singleton_driver_stress.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --vfs memory_yield

--- a/testing/antithesis/stress/singleton_driver_stress.sh
+++ b/testing/antithesis/stress/singleton_driver_stress.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-/bin/turso_stress --nr-threads 2 --nr-iterations 10000
+/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --vfs memory_yield

--- a/testing/antithesis/stress/singleton_driver_stress.sh
+++ b/testing/antithesis/stress/singleton_driver_stress.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-/bin/turso_stress --nr-threads 2 --nr-iterations 10000 --vfs memory_yield
+/bin/turso_stress --nr-threads 2 --nr-iterations 10000

--- a/testing/stress/Cargo.toml
+++ b/testing/stress/Cargo.toml
@@ -32,7 +32,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
-turso = { workspace = true }
+turso = { workspace = true, features = ["io_memory_yield"] }
 turso_macros = { workspace = true }
 rusqlite = { workspace = true }
 

--- a/testing/stress/opts.rs
+++ b/testing/stress/opts.rs
@@ -50,7 +50,7 @@ pub struct Opts {
     /// Select VFS
     #[clap(
         long,
-        help = "Select VFS. options are io_uring (if feature enabled), win_iocp (if feature enabled), memory, and syscall"
+        help = "Select VFS. options are io_uring (if feature enabled), win_iocp (if feature enabled), memory, memory_yield (defers every IO completion to force yield points), and syscall"
     )]
     pub vfs: Option<String>,
 


### PR DESCRIPTION
Introduces a new IO back-end which otherwise acts like MemoryIO, but yields on each call to force functions to be safely re-entrant. Will be used for turso-stress in Antithesis
