### PR TITLE
core/storage: Only mark WAL initialized after a successful header sync

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4004,8 +4004,14 @@ impl Wal for WalFile {
         let file = self.coordination.wal_file()?;
         let coordination = self.coordination.clone();
         let c = file.sync(
-            Completion::new_sync(move |_| {
-                coordination.mark_initialized();
+            Completion::new_sync(move |res| {
+                // Only mark the WAL header durable once its sync has actually
+                // succeeded. A failed sync must leave the WAL uninitialized so
+                // the header is re-issued before the next append, keeping the
+                // in-memory initialized state consistent with what is on disk.
+                if res.is_ok() {
+                    coordination.mark_initialized();
+                }
             }),
             sync_type,
         )?;


### PR DESCRIPTION
prepare_wal_finish's sync completion callback ignored its result and
called mark_initialized() unconditionally. Because the completion
machinery runs the sync callback on failure as well as success, a failed
header fsync still flipped the in-memory initialized flag to true. After
that, prepare_wal_start short-circuits and prepare_wal_header returns
None, so the header is never re-issued before the next append, leaving
the in-memory state claiming durability the on-disk header never reached.

Guard the mark_initialized() call on res.is_ok() so a failed sync leaves
the WAL uninitialized and the header is rewritten on the next append.

Found by Aristo.
