### PR TITLE
core/translate: case-insensitive NATURAL JOIN and USING column lookup

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1866,7 +1866,12 @@ fn parse_join(
                 .take(table_references.joined_tables().len() - 1)
             {
                 for left_col in left_table.columns().iter().filter(|col| !col.hidden()) {
-                    if left_col.name == right_col.name {
+                    if left_col
+                        .name
+                        .as_deref()
+                        .zip(right_col.name.as_deref())
+                        .is_some_and(|(l, r)| l.eq_ignore_ascii_case(r))
+                    {
                         distinct_names.push(ast::Name::exact(
                             left_col.name.clone().expect("column name is None"),
                         ));
@@ -1927,8 +1932,8 @@ fn parse_join(
                             .filter(|(_, col)| !natural || !col.hidden())
                             .find(|(_, col)| {
                                 col.name
-                                    .as_ref()
-                                    .is_some_and(|name| *name == name_normalized)
+                                    .as_deref()
+                                    .is_some_and(|name| name.eq_ignore_ascii_case(&name_normalized))
                             })
                             .map(|(idx, col)| {
                                 (left_table_offset, left_table.internal_id, idx, col)
@@ -1945,8 +1950,8 @@ fn parse_join(
                     }
                     let right_col = right_table.columns().iter().enumerate().find(|(_, col)| {
                         col.name
-                            .as_ref()
-                            .is_some_and(|name| *name == name_normalized)
+                            .as_deref()
+                            .is_some_and(|name| name.eq_ignore_ascii_case(&name_normalized))
                     });
                     if right_col.is_none() {
                         crate::bail_parse_error!(

--- a/testing/sqltests/tests/joins/using_clause_case_insensitive.sqltest
+++ b/testing/sqltests/tests/joins/using_clause_case_insensitive.sqltest
@@ -1,0 +1,67 @@
+@database :memory:
+
+# Regression test for #7371: NATURAL JOIN and USING() were rejecting
+# columns whose stored name was not all-lowercase (i.e. any column that
+# was originally quoted with mixed case, including names containing
+# punctuation that forced quoting). The USING-clause expansion in
+# planner.rs lowercased the join column name but then compared it
+# case-sensitively against `Column::name`, which preserves the original
+# casing for quoted identifiers. SQLite identifier comparisons are
+# case-insensitive.
+
+setup natural-join-quoted-hyphen-schema {
+    CREATE TABLE t("NUMERIC-ish" NUMERIC);
+    INSERT INTO t VALUES (1);
+}
+
+@setup natural-join-quoted-hyphen-schema
+test issue-7371-natural-join-quoted-hyphen {
+    SELECT *
+    FROM t AS a
+    NATURAL JOIN t AS b;
+}
+expect {
+1
+}
+
+setup natural-join-mixed-case-schema {
+    CREATE TABLE t("MyCol" INTEGER);
+    INSERT INTO t VALUES (7);
+}
+
+@setup natural-join-mixed-case-schema
+test issue-7371-natural-join-mixed-case {
+    SELECT *
+    FROM t AS a
+    NATURAL JOIN t AS b;
+}
+expect {
+7
+}
+
+setup using-mixed-case-schema {
+    CREATE TABLE t1("MyCol" INTEGER, x INTEGER);
+    CREATE TABLE t2("MyCol" INTEGER, y INTEGER);
+    INSERT INTO t1 VALUES (1, 10);
+    INSERT INTO t2 VALUES (1, 20);
+}
+
+@setup using-mixed-case-schema
+test issue-7371-using-quoted-mixed-case {
+    SELECT *
+    FROM t1 JOIN t2 USING("MyCol")
+    ORDER BY 1;
+}
+expect {
+1|10|20
+}
+
+@setup using-mixed-case-schema
+test issue-7371-using-bare-different-case {
+    SELECT *
+    FROM t1 JOIN t2 USING(mycol)
+    ORDER BY 1;
+}
+expect {
+1|10|20
+}


### PR DESCRIPTION
SQLite identifiers are case-insensitive, but the NATURAL JOIN common-column discovery and the USING-clause expansion in `parse_join` were comparing the join column name against `Column::name` with `==`. `Column::name` preserves the original casing for quoted identifiers (e.g. a column declared as `"MyCol"` is stored as `"MyCol"`, not `"mycol"`), so any column that wasn't already all-lowercase failed the lookup with "cannot join using column <name> - column not present in both tables". The issue title called out a hyphen because punctuation forces quoting, but the real trigger is the preserved case, not the hyphen.

Switch all three comparison sites — the NATURAL JOIN common-column scan and the left/right USING lookups — to `eq_ignore_ascii_case` so identifier matching is case-insensitive, matching SQLite.

Fixes #7371.