### PR TITLE
core/storage: Fix truncate checkpoint error handling

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4859,7 +4859,21 @@ impl Pager {
         mode: CheckpointMode,
         sync_mode: crate::SyncMode,
     ) -> Result<CheckpointResult> {
-        self.io.block(|| self.checkpoint(mode, sync_mode, true))
+        let result = self.io.block(|| self.checkpoint(mode, sync_mode, true));
+        if result.is_err() {
+            // When the checkpoint state machine errors mid-flight (e.g. a failed
+            // WAL ftruncate during a TRUNCATE checkpoint), `io.block` surfaces the
+            // completion error from `io.wait` *without* re-entering `checkpoint()`,
+            // so the state machine never reaches `Finalize` to release its guard.
+            // That guard holds the exclusive WRITER and read-mark-0 locks, so a
+            // leak would stall every subsequent reader into `Busy`. Reset the
+            // checkpoint state here, which drops the lingering `CheckpointResult`
+            // and releases those locks. The data is already durable in the synced
+            // DB file; any un-truncated WAL frames are stale and get cleaned up on
+            // the next write.
+            self.clear_checkpoint_state();
+        }
+        result
     }
 
     pub fn freepage_list(&self) -> u32 {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -71,6 +71,12 @@ pub struct CheckpointResult {
     pub wal_truncate_sent: bool,
     /// Whether WAL sync I/O has been submitted after truncation
     pub wal_sync_sent: bool,
+    /// I/O error captured by the WAL truncate completion, if any. Surfaced as a
+    /// checkpoint error rather than silently dropped, matching SQLite's TRUNCATE
+    /// checkpoint, which returns the result code of `sqlite3OsTruncate`.
+    wal_truncate_err: Arc<crate::sync::OnceLock<CompletionError>>,
+    /// I/O error captured by the post-truncation WAL sync completion, if any.
+    wal_sync_err: Arc<crate::sync::OnceLock<CompletionError>>,
 }
 
 impl Drop for CheckpointResult {
@@ -94,6 +100,8 @@ impl CheckpointResult {
             db_truncate_sent: false,
             wal_truncate_sent: false,
             wal_sync_sent: false,
+            wal_truncate_err: Arc::new(crate::sync::OnceLock::new()),
+            wal_sync_err: Arc::new(crate::sync::OnceLock::new()),
         }
     }
 
@@ -4862,28 +4870,41 @@ impl WalFile {
         let file = self.coordination.prepare_truncate()?;
 
         if !result.wal_truncate_sent {
-            let c = Completion::new_trunc({
-                move |res| {
-                    if let Err(err) = res {
-                        tracing::debug!("WAL truncate failed: {err}")
-                    } else {
-                        tracing::trace!("WAL file truncated to 0 B");
-                    }
+            let err = result.wal_truncate_err.clone();
+            let c = Completion::new_trunc(move |res| match res {
+                Ok(_) => tracing::trace!("WAL file truncated to 0 B"),
+                Err(e) => {
+                    tracing::debug!("WAL truncate failed: {e}");
+                    let _ = err.set(e);
                 }
             });
             let c = file.truncate(0, c)?;
             result.wal_truncate_sent = true;
-            // after truncation - there will be nothing in the WAL
+            // SQLite (walRestartHdr) makes the in-memory header authoritative for
+            // "zero valid frames" *before* the on-disk truncate, so the wal-index
+            // header never disagrees with what readers should see. We mirror that
+            // ordering; the truncate's outcome is surfaced as an error below
+            // rather than swallowed.
             result.wal_max_frame = 0;
             result.wal_total_backfilled = 0;
             io_yield_one!(c);
-        } else if !result.wal_sync_sent {
+        }
+        // The truncate completion has fired by the time we re-enter. Like
+        // SQLite's TRUNCATE checkpoint (which returns the rc of
+        // sqlite3OsTruncate), report a failed truncation as a checkpoint error
+        // instead of claiming a successfully emptied log.
+        if let Some(e) = result.wal_truncate_err.get().cloned() {
+            return Err(LimboError::CompletionError(e));
+        }
+
+        if !result.wal_sync_sent {
+            let err = result.wal_sync_err.clone();
             let c = file.sync(
-                Completion::new_sync(move |res| {
-                    if let Err(err) = res {
-                        tracing::debug!("WAL sync failed: {err}")
-                    } else {
-                        tracing::trace!("WAL file synced after truncation");
+                Completion::new_sync(move |res| match res {
+                    Ok(_) => tracing::trace!("WAL file synced after truncation"),
+                    Err(e) => {
+                        tracing::debug!("WAL sync failed: {e}");
+                        let _ = err.set(e);
                     }
                 }),
                 sync_type,
@@ -4891,6 +4912,10 @@ impl WalFile {
             result.wal_sync_sent = true;
             io_yield_one!(c);
         }
+        if let Some(e) = result.wal_sync_err.get().cloned() {
+            return Err(LimboError::CompletionError(e));
+        }
+
         Ok(IOResult::Done(()))
     }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3991,6 +3991,12 @@ impl Wal for WalFile {
             }
         };
         if !should_skip_truncate {
+            // The callback only logs; the truncate's I/O error is *not* swallowed.
+            // `trunc_c` is added to the returned CompletionGroup, whose first
+            // member error is surfaced to the caller (via `wait_for_completion`
+            // or the VDBE driver's `get_error` check), so a failed truncate
+            // propagates as a real error and the write is retried rather than
+            // proceeding with orphaned frames still on disk.
             let trunc_c = file.truncate(
                 WAL_HEADER_SIZE as u64,
                 Completion::new_trunc(|res| {

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -7,19 +7,23 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tracing::debug;
 use turso_core::{
-    Clock, Completion, File, IO, MonotonicInstant, OpenFlags, Result, WallClockInstant,
+    Clock, Completion, CompletionError, File, IO, MonotonicInstant, OpenFlags, Result,
+    WallClockInstant,
 };
 
 #[derive(Debug, Clone)]
 pub struct IOFaultConfig {
     /// Probability of a cosmic ray bit flip on write (0.0-1.0)
     pub cosmic_ray_probability: f64,
+    /// Probability that an `ftruncate()` call fails with an I/O error (0.0-1.0)
+    pub truncate_fault_probability: f64,
 }
 
 impl Default for IOFaultConfig {
     fn default() -> Self {
         Self {
             cosmic_ray_probability: 0.0,
+            truncate_fault_probability: 0.0,
         }
     }
 }
@@ -34,7 +38,7 @@ pub struct SimulatorIO {
     files: Mutex<Vec<(String, Arc<SimulatorFile>)>>,
     file_sizes: Arc<Mutex<HashMap<String, u64>>>,
     keep_files: bool,
-    rng: Mutex<ChaCha8Rng>,
+    rng: Arc<Mutex<ChaCha8Rng>>,
     fault_config: IOFaultConfig,
     /// Simulated time in microseconds, incremented on each step
     time: AtomicU64,
@@ -48,7 +52,7 @@ impl SimulatorIO {
             files: Mutex::new(Vec::new()),
             file_sizes: Arc::new(Mutex::new(HashMap::new())),
             keep_files,
-            rng: Mutex::new(rng),
+            rng: Arc::new(Mutex::new(rng)),
             fault_config,
             time: AtomicU64::new(0),
             pending: Arc::new(Mutex::new(Vec::new())),
@@ -143,6 +147,8 @@ impl IO for SimulatorIO {
             path,
             self.file_sizes.clone(),
             self.pending.clone(),
+            self.fault_config.truncate_fault_probability,
+            self.rng.clone(),
         ));
         let insert_key = canonical_key(path);
 
@@ -171,7 +177,10 @@ impl IO for SimulatorIO {
         // Complete any pending IO operations
         let mut pending = self.pending.lock().unwrap();
         for pc in pending.drain(..) {
-            pc.completion.complete(pc.result);
+            match pc.error {
+                Some(err) => pc.completion.error(err),
+                None => pc.completion.complete(pc.result),
+            }
         }
         drop(pending);
 
@@ -230,6 +239,9 @@ impl IO for SimulatorIO {
 struct PendingCompletion {
     completion: Completion,
     result: i32,
+    /// When set, the completion is finished with this I/O error instead of the
+    /// success `result`, used to inject faults (e.g. a failed `ftruncate`).
+    error: Option<CompletionError>,
 }
 type PendingQueue = Arc<Mutex<Vec<PendingCompletion>>>;
 
@@ -243,6 +255,10 @@ struct SimulatorFile {
     path: String,
     _file: StdFile,
     pending: PendingQueue,
+    /// Probability that an `ftruncate()` call fails with an injected I/O error.
+    truncate_fault_probability: f64,
+    /// Shared with `SimulatorIO` so fault decisions stay seeded/deterministic.
+    rng: Arc<Mutex<ChaCha8Rng>>,
 }
 
 impl SimulatorFile {
@@ -250,6 +266,8 @@ impl SimulatorFile {
         file_path: &str,
         file_sizes: Arc<Mutex<HashMap<String, u64>>>,
         pending: PendingQueue,
+        truncate_fault_probability: f64,
+        rng: Arc<Mutex<ChaCha8Rng>>,
     ) -> Self {
         let file = OpenOptions::new()
             .read(true)
@@ -281,6 +299,8 @@ impl SimulatorFile {
             path: file_path.to_string(),
             _file: file,
             pending,
+            truncate_fault_probability,
+            rng,
         }
     }
 }
@@ -309,6 +329,7 @@ impl File for SimulatorFile {
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
             result,
+            error: None,
         });
         Ok(c)
     }
@@ -340,6 +361,7 @@ impl File for SimulatorFile {
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
             result,
+            error: None,
         });
         Ok(c)
     }
@@ -383,6 +405,7 @@ impl File for SimulatorFile {
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
             result: total_written as i32,
+            error: None,
         });
         Ok(c)
     }
@@ -392,11 +415,32 @@ impl File for SimulatorFile {
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
             result: 0,
+            error: None,
         });
         Ok(c)
     }
 
     fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+        // Inject an `ftruncate()` fault with the configured probability. The
+        // completion is finished with an I/O error during `step()`, exercising
+        // the engine's TRUNCATE-checkpoint error handling.
+        let inject_fault = self.truncate_fault_probability > 0.0 && {
+            let mut rng = self.rng.lock().unwrap();
+            rng.random::<f64>() < self.truncate_fault_probability
+        };
+        if inject_fault {
+            debug!("injecting ftruncate() fault for file {}", self.path);
+            self.pending.lock().unwrap().push(PendingCompletion {
+                completion: c.clone(),
+                result: -1,
+                error: Some(CompletionError::IOError(
+                    std::io::ErrorKind::Other,
+                    "simulated ftruncate fault",
+                )),
+            });
+            return Ok(c);
+        }
+
         let mut size = self.size.lock().unwrap();
         *size = len as usize;
         let mut sizes = self.file_sizes.lock().unwrap();
@@ -404,6 +448,7 @@ impl File for SimulatorFile {
         self.pending.lock().unwrap().push(PendingCompletion {
             completion: c.clone(),
             result: 0,
+            error: None,
         });
         Ok(c)
     }

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -924,14 +924,19 @@ impl Whopper {
 
             if let Err(error) = op_result {
                 let in_tx = ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit();
-                // An injected ftruncate fault surfaces as a CompletionError from
-                // the WAL write/truncate path. Under active fault injection it is
-                // expected and recoverable, so roll back / clear txn instead of
-                // aborting the run; without injection it stays Fatal so real bugs
-                // are not masked.
+                // An injected ftruncate fault is expected under active fault
+                // injection: a failed WAL write/truncate surfaces as a
+                // CompletionError, and a failed checkpoint truncate surfaces as a
+                // CheckpointFailed (the write is durable, only the checkpoint
+                // maintenance op failed). Both are recoverable here, so roll back /
+                // clear txn instead of aborting the run; without injection they stay
+                // Respawn/Fatal so real bugs are not masked.
                 let action = if truncate_fault_injection
-                    && matches!(error, turso_core::LimboError::CompletionError(..))
-                {
+                    && matches!(
+                        error,
+                        turso_core::LimboError::CompletionError(..)
+                            | turso_core::LimboError::CheckpointFailed(..)
+                    ) {
                     if in_tx {
                         crate::error_handling::ErrorAction::Rollback
                     } else {

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -597,6 +597,11 @@ pub struct Whopper {
     disable_mvcc_auto_checkpoint: bool,
     /// If false, drop fiber connections without first closing them.
     close_connections_gracefully: bool,
+    /// True when `ftruncate()` fault injection is active. Injected I/O errors
+    /// are then expected, so they are treated as recoverable (the operation is
+    /// rolled back) rather than crashing the run. With injection off, an
+    /// `IoError` still aborts the run so genuine I/O bugs are not masked.
+    truncate_fault_injection: bool,
 }
 
 impl Whopper {
@@ -743,6 +748,7 @@ impl Whopper {
             chaotic_profiles: opts.chaotic_profiles,
             disable_mvcc_auto_checkpoint: opts.disable_mvcc_auto_checkpoint,
             close_connections_gracefully: opts.close_connections_gracefully,
+            truncate_fault_injection: opts.truncate_fault_probability > 0.0,
         };
 
         whopper.open_connections()?;
@@ -779,6 +785,7 @@ impl Whopper {
     fn perform_work(&mut self, fiber_idx: usize) -> anyhow::Result<()> {
         let exec_id = self.context.fibers[fiber_idx].execution_id;
         let txn_id = self.context.fibers[fiber_idx].txn_id;
+        let truncate_fault_injection = self.truncate_fault_injection;
         trace!(
             "perform_work: step={}, fiber_idx={}/{} exec_id={:?} txn_id={:?}",
             self.current_step,
@@ -917,7 +924,23 @@ impl Whopper {
 
             if let Err(error) = op_result {
                 let in_tx = ctx.fiber.state.is_in_tx() && !ctx.fiber.connection.get_auto_commit();
-                match crate::error_handling::classify_op_error(&error, in_tx) {
+                // An injected ftruncate fault surfaces as a CompletionError from
+                // the WAL write/truncate path. Under active fault injection it is
+                // expected and recoverable, so roll back / clear txn instead of
+                // aborting the run; without injection it stays Fatal so real bugs
+                // are not masked.
+                let action = if truncate_fault_injection
+                    && matches!(error, turso_core::LimboError::CompletionError(..))
+                {
+                    if in_tx {
+                        crate::error_handling::ErrorAction::Rollback
+                    } else {
+                        crate::error_handling::ErrorAction::ClearTxn
+                    }
+                } else {
+                    crate::error_handling::classify_op_error(&error, in_tx)
+                };
+                match action {
                     crate::error_handling::ErrorAction::Rollback => {
                         ctx.fiber.current_op = Some(Operation::Rollback);
                     }

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -253,6 +253,8 @@ pub struct WhopperOpts {
     pub max_drain_steps: usize,
     /// Probability of cosmic ray bit flip on each step (0.0-1.0).
     pub cosmic_ray_probability: f64,
+    /// Probability that an `ftruncate()` call fails with an injected I/O error (0.0-1.0).
+    pub truncate_fault_probability: f64,
     /// Keep mmap I/O files on disk after run.
     pub keep_files: bool,
     /// Enable MVCC (Multi-Version Concurrency Control).
@@ -313,6 +315,7 @@ impl Default for WhopperOpts {
             max_steps: 100_000,
             max_drain_steps: 1_000_000,
             cosmic_ray_probability: 0.0,
+            truncate_fault_probability: 0.0,
             keep_files: false,
             enable_mvcc: false,
             enable_encryption: false,
@@ -329,27 +332,31 @@ impl Default for WhopperOpts {
 }
 
 impl WhopperOpts {
-    /// Create options for "fast" mode: 100k steps, no cosmic rays.
+    /// Create options for "fast" mode: 100k steps, no cosmic rays, 1% ftruncate faults.
     pub fn fast() -> Self {
         Self {
             max_steps: 100_000,
+            truncate_fault_probability: 0.01,
             ..Default::default()
         }
     }
 
-    /// Create options for "chaos" mode: 10M steps, no cosmic rays.
+    /// Create options for "chaos" mode: 10M steps, no cosmic rays, 1% ftruncate faults.
     pub fn chaos() -> Self {
         Self {
             max_steps: 10_000_000,
+            truncate_fault_probability: 0.01,
             ..Default::default()
         }
     }
 
-    /// Create options for "ragnarök" mode: 1M steps, 0.01% cosmic ray probability.
+    /// Create options for "ragnarök" mode: 1M steps, 0.01% cosmic ray probability,
+    /// 1% ftruncate faults.
     pub fn ragnarok() -> Self {
         Self {
             max_steps: 1_000_000,
             cosmic_ray_probability: 0.0001,
+            truncate_fault_probability: 0.01,
             ..Default::default()
         }
     }
@@ -392,6 +399,11 @@ impl WhopperOpts {
 
     pub fn with_cosmic_ray_probability(mut self, probability: f64) -> Self {
         self.cosmic_ray_probability = probability;
+        self
+    }
+
+    pub fn with_truncate_fault_probability(mut self, probability: f64) -> Self {
+        self.truncate_fault_probability = probability;
         self
     }
 
@@ -602,6 +614,7 @@ impl Whopper {
 
         let fault_config = IOFaultConfig {
             cosmic_ray_probability: opts.cosmic_ray_probability,
+            truncate_fault_probability: opts.truncate_fault_probability,
         };
 
         let io = Arc::new(SimulatorIO::new(opts.keep_files, io_rng, fault_config));

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -249,6 +249,12 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
     if opts.cosmic_ray_probability > 0.0 {
         println!("cosmic ray probability = {}", opts.cosmic_ray_probability);
     }
+    if opts.truncate_fault_probability > 0.0 {
+        println!(
+            "truncate fault probability = {}",
+            opts.truncate_fault_probability
+        );
+    }
 
     let reopen_probability = args.reopen_probability.unwrap_or(opts.reopen_probability);
 

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -28,6 +28,7 @@ fn test_concurrent_commit_no_yield_spin() {
     let io_rng = ChaCha8Rng::seed_from_u64(42);
     let fault_config = IOFaultConfig {
         cosmic_ray_probability: 0.0,
+        truncate_fault_probability: 0.0,
     };
     let io = Arc::new(SimulatorIO::new(false, io_rng, fault_config));
 

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -789,6 +789,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         let schema_for_task = schema.clone();
         let busy_timeout = opts.busy_timeout;
         let tx_mode = opts.tx_mode;
+        let truncate_checkpoint_probability = opts.truncate_checkpoint_probability;
         let sql_log = sql_log.clone();
 
         let progress_bar = multi_progress.add(ProgressBar::new(nr_iterations as u64));
@@ -822,6 +823,87 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                     let db_guard = db.lock().await;
                     conn = db_guard.connect()?;
                     conn.busy_timeout(std::time::Duration::from_millis(busy_timeout))?;
+                }
+
+                // Occasionally issue a TRUNCATE checkpoint to exercise the WAL
+                // truncate + sync path (and its error propagation). This runs
+                // outside of any transaction, since checkpointing requires no
+                // active transaction on the connection.
+                if gen_bool(&mut rng, truncate_checkpoint_probability) {
+                    let checkpoint_sql = "PRAGMA wal_checkpoint(TRUNCATE)";
+                    // wal_checkpoint returns a (busy, log, checkpointed) row, so
+                    // use query() and drain it rather than execute().
+                    match conn.query(checkpoint_sql, ()).await {
+                        Ok(mut rows) => {
+                            // Drive the statement to completion by draining rows.
+                            loop {
+                                match rows.next().await {
+                                    Ok(Some(_)) => {}
+                                    Ok(None) => {
+                                        log_sql(&sql_log, thread, checkpoint_sql, "OK");
+                                        break;
+                                    }
+                                    Err(e) => {
+                                        log_sql(
+                                            &sql_log,
+                                            thread,
+                                            checkpoint_sql,
+                                            &format!("ERROR: {e}"),
+                                        );
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Err(turso::Error::Busy(e)) => {
+                            log_sql(
+                                &sql_log,
+                                thread,
+                                checkpoint_sql,
+                                &format!("ERROR(busy): {e}"),
+                            );
+                        }
+                        Err(turso::Error::BusySnapshot(e)) => {
+                            log_sql(
+                                &sql_log,
+                                thread,
+                                checkpoint_sql,
+                                &format!("ERROR(busy_snapshot): {e}"),
+                            );
+                        }
+                        Err(turso::Error::DatabaseFull(e)) => {
+                            log_sql(
+                                &sql_log,
+                                thread,
+                                checkpoint_sql,
+                                &format!("ERROR(database_full): {e}"),
+                            );
+                            eprintln!("thread#{thread} Database full during checkpoint: {e}");
+                        }
+                        Err(turso::Error::IoError(kind, op)) => {
+                            log_sql(
+                                &sql_log,
+                                thread,
+                                checkpoint_sql,
+                                &format!("ERROR(io): {op}: {kind:?}"),
+                            );
+                            eprintln!(
+                                "thread#{thread} I/O error during checkpoint ({op}: {kind:?}), continuing..."
+                            );
+                        }
+                        Err(turso::Error::Corrupt(e)) => {
+                            log_sql(
+                                &sql_log,
+                                thread,
+                                checkpoint_sql,
+                                &format!("ERROR(corrupt): {e}"),
+                            );
+                            turso_macros::turso_assert_unreachable!("corrupt error during checkpoint", { "thread": thread, "error": e });
+                        }
+                        Err(e) => {
+                            log_sql(&sql_log, thread, checkpoint_sql, &format!("ERROR: {e}"));
+                        }
+                    }
                 }
 
                 let tx = if rng.get_random() % 2 == 0 {

--- a/testing/stress/opts.rs
+++ b/testing/stress/opts.rs
@@ -78,6 +78,14 @@ pub struct Opts {
         help = "If true, this will run a modified minimal version of turso_stress that ensure the DB is deterministic (no sources of randomness that are not controlled by the seed)"
     )]
     pub check_uncontrolled_nondeterminism: bool,
+
+    /// Probability of issuing a TRUNCATE checkpoint per iteration
+    #[clap(
+        long,
+        help = "Probability (0.0-1.0) of running PRAGMA wal_checkpoint(TRUNCATE) per iteration",
+        default_value_t = 0.01
+    )]
+    pub truncate_checkpoint_probability: f64,
 }
 
 /// Returns a constrained value when running under miri or shuttle,

--- a/testing/unreliable-libc/file.c
+++ b/testing/unreliable-libc/file.c
@@ -161,6 +161,24 @@ int fsync(int fd)
 	return libc_fsync(fd);
 }
 
+static int (*libc_ftruncate) (int, off_t);
+
+int ftruncate(int fd, off_t length)
+{
+	if (libc_ftruncate == NULL) {
+		libc_ftruncate = dlsym(RTLD_NEXT, "ftruncate");
+	}
+	if (inject_fault(ENOSPC)) {
+		printf("%s: injecting fault NOSPC\n", __func__);
+		return -1;
+	}
+	if (inject_fault(EIO)) {
+		printf("%s: injecting fault EIO\n", __func__);
+		return -1;
+	}
+	return libc_ftruncate(fd, length);
+}
+
 __attribute__((constructor))
 static void init(void)
 {


### PR DESCRIPTION
Propagate ftruncate() and fsync() errors to callers on truncate checkpoint errors. As the issue was discovered by Aretta, add ftruncate() fault injection to `unreliable-libc` and `concurrent-simulator`. Also add truncate checkpoint support to `turso-stress`.