### PR TITLE
core/translate: SQLite-compatible affinity check for index seeks

### DIFF
--- a/core/translate/main_loop/seek.rs
+++ b/core/translate/main_loop/seek.rs
@@ -1,36 +1,16 @@
 use super::*;
 
-fn index_seek_affinities(
-    idx: &Index,
-    tables: &TableReferences,
-    seek_def: &SeekDef,
-    seek_key: &SeekKey,
-) -> String {
-    let table = tables
-        .joined_tables()
-        .iter()
-        .find(|jt| jt.table.get_name() == idx.table_name)
-        .expect("index source table not found in table references");
-
-    idx.columns
-        .iter()
-        .zip(seek_def.iter(seek_key))
-        .map(|(ic, key_component)| {
-            let col_aff = if let Some(ref expr) = ic.expr {
-                crate::translate::expr::get_expr_affinity(expr, Some(tables), None)
-            } else {
-                table
-                    .table
-                    .get_column_at(ic.pos_in_table)
-                    .expect("index column position out of bounds")
-                    .affinity()
-            };
-            match key_component {
-                SeekKeyComponent::Expr(expr) if col_aff.expr_needs_no_affinity_change(expr) => {
-                    affinity::SQLITE_AFF_NONE
-                }
-                _ => col_aff.aff_mask(),
+fn index_seek_affinities(seek_def: &SeekDef, seek_key: &SeekKey) -> String {
+    // Apply the constraint's resolved comparison affinity to the seek key,
+    // not the indexed column's affinity.
+    seek_def
+        .iter(seek_key)
+        .zip(seek_def.iter_affinity(seek_key))
+        .map(|(key_component, aff)| match key_component {
+            SeekKeyComponent::Expr(expr) if aff.expr_needs_no_affinity_change(expr) => {
+                affinity::SQLITE_AFF_NONE
             }
+            _ => aff.aff_mask(),
         })
         .collect()
 }
@@ -222,8 +202,7 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                 0,
                 &self.t_ctx.resolver,
             )?;
-            let affinities =
-                index_seek_affinities(idx, self.tables, self.seek_def, &self.seek_def.start);
+            let affinities = index_seek_affinities(self.seek_def, &self.seek_def.start);
             if affinities.chars().any(|c| c != affinity::SQLITE_AFF_NONE) {
                 self.program.emit_insn(Insn::Affinity {
                     start_reg: self.start_reg,
@@ -342,8 +321,7 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                         self.seek_def.prefix.len(),
                         &self.t_ctx.resolver,
                     )?;
-                    let affinities =
-                        index_seek_affinities(idx, self.tables, self.seek_def, &self.seek_def.end);
+                    let affinities = index_seek_affinities(self.seek_def, &self.seek_def.end);
                     if affinities.chars().any(|c| c != affinity::SQLITE_AFF_NONE) {
                         self.program.emit_insn(Insn::Affinity {
                             start_reg: self.start_reg,

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -577,6 +577,10 @@ pub(super) fn choose_best_in_seek_candidate(
                 if table_collation != index_collation {
                     continue;
                 }
+                let idx_aff = constrained_column.affinity_with_strict(rhs_table.table.is_strict());
+                if !constraint.satisfies_index_affinity(idx_aff) {
+                    continue;
+                }
             }
 
             let rows_per_seek = if (index_info.unique && index_info.column_count == 1)
@@ -1402,18 +1406,16 @@ fn find_best_access_method_for_subquery(
         .iter()
         .enumerate()
         .filter(|(_, c)| {
-            c.usable
-                && c.table_col_pos.is_some()
-                && matches!(
-                    c.operator.as_ast_operator(),
-                    Some(
-                        ast::Operator::Equals
-                            | ast::Operator::Greater
-                            | ast::Operator::GreaterEquals
-                            | ast::Operator::Less
-                            | ast::Operator::LessEquals
-                    )
+            matches!(
+                c.operator.as_ast_operator(),
+                Some(
+                    ast::Operator::Equals
+                        | ast::Operator::Greater
+                        | ast::Operator::GreaterEquals
+                        | ast::Operator::Less
+                        | ast::Operator::LessEquals
                 )
+            ) && c.can_drive_index_seek(&subquery.columns, false)
         })
         .collect();
 

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -3,7 +3,10 @@ use crate::{
     schema::{Column, Index, Schema},
     translate::{
         collate::get_collseq_from_expr,
-        expr::{as_binary_components, comparison_affinity, walk_expr_mut, WalkControl},
+        expr::{
+            as_binary_components, comparison_affinity, get_expr_affinity, unwrap_parens,
+            walk_expr_mut, WalkControl,
+        },
         expression_index::normalize_expr_for_index_matching,
         plan::{JoinOrderMember, JoinedTable, NonFromClauseSubquery, TableReferences, WhereTerm},
         planner::{break_predicate_at_and_boundaries, table_mask_from_expr, TableMask, ROWID_STRS},
@@ -70,6 +73,18 @@ pub struct Constraint {
     /// Whether this constraint references the implicit rowid (tables without an INTEGER PRIMARY KEY alias).
     /// When true and `table_col_pos` is None, this constraint targets the rowid pseudo-column.
     pub is_rowid: bool,
+    /// The constraint's resolved comparison affinity, as defined by SQLite's
+    /// `comparisonAffinity` in `expr.c`. Cached at construction time so the
+    /// `sqlite3IndexAffinityOk` check can run without re-resolving the
+    /// WhereTerm at every index-selection callsite.
+    ///
+    /// `None` for forms whose comparison affinity has no single resolved value:
+    /// FTS MATCH and virtual-table push-downs (operators outside SQLite's
+    /// comparison set), and row-value IN (`(a,b) IN (...)`, which SQLite
+    /// handles per-LHS-column via `sqlite3VectorFieldSubexpr` — Turso does
+    /// not yet plumb per-column affinity into the index-selection path, so
+    /// such constraints fall through to scans).
+    pub comparison_affinity: Option<Affinity>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -118,8 +133,7 @@ impl Constraint {
             panic!("Expected a valid binary expression");
         };
         let mut affinity = Affinity::Blob;
-        if op.as_ast_operator().is_some_and(|op| op.is_comparison()) && self.table_col_pos.is_some()
-        {
+        if op.as_ast_operator().is_some_and(|op| op.is_comparison()) {
             affinity = comparison_affinity(lhs, rhs, referenced_tables, None);
         }
 
@@ -159,6 +173,35 @@ impl Constraint {
         } else {
             rhs
         }
+    }
+
+    /// Returns true when an index column with affinity `idx_aff` can satisfy
+    /// this constraint per SQLite's `sqlite3IndexAffinityOk`. Constraints
+    /// whose form has no SQLite-defined comparison affinity (FTS MATCH,
+    /// virtual-table push-downs, row-value IN) carry `None` and bypass the
+    /// check — those paths handle types themselves.
+    pub fn satisfies_index_affinity(&self, idx_aff: Affinity) -> bool {
+        match self.comparison_affinity {
+            Some(comparison_aff) => idx_aff.index_affinity_ok(comparison_aff),
+            None => true,
+        }
+    }
+
+    /// Whether this constraint can drive an index seek on its target column.
+    /// Composes the `usable`/`table_col_pos` gates with the affinity check
+    /// against the column at `table_col_pos` in `columns` (set `is_strict`
+    /// only for STRICT tables; subqueries pass `false`).
+    pub fn can_drive_index_seek(&self, columns: &[Column], is_strict: bool) -> bool {
+        if !self.usable {
+            return false;
+        }
+        let Some(pos) = self.table_col_pos else {
+            return false;
+        };
+        let col = columns.get(pos).unwrap_or_else(|| {
+            unreachable!("constraint table_col_pos {pos} out of bounds for {columns:?}")
+        });
+        self.satisfies_index_affinity(col.affinity_with_strict(is_strict))
     }
 }
 
@@ -449,6 +492,13 @@ pub fn constraints_from_where_clause(
 
             // Try to extract as binary expression first
             if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {
+                // Resolve the comparison affinity once per term per SQLite's
+                // `comparisonAffinity` (see `Constraint::comparison_affinity`)
+                // and propagate it to every constraint derived from this term.
+                let cmp_aff = operator
+                    .as_ast_operator()
+                    .filter(|op| op.is_comparison())
+                    .map(|_| comparison_affinity(lhs, rhs, Some(table_references), None));
                 // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
                 match lhs {
                     ast::Expr::Column { table, column, .. } => {
@@ -472,6 +522,7 @@ pub fn constraints_from_where_clause(
                                 ),
                                 usable: true,
                                 is_rowid: false,
+                                comparison_affinity: cmp_aff,
                             });
                         }
                     }
@@ -500,6 +551,7 @@ pub fn constraints_from_where_clause(
                                 ),
                                 usable: true,
                                 is_rowid: true,
+                                comparison_affinity: cmp_aff,
                             });
                         }
                     }
@@ -537,6 +589,7 @@ pub fn constraints_from_where_clause(
                             selectivity,
                             usable: true,
                             is_rowid: false,
+                            comparison_affinity: cmp_aff,
                         });
                     }
                     _ => {}
@@ -563,6 +616,7 @@ pub fn constraints_from_where_clause(
                                 ),
                                 usable: true,
                                 is_rowid: false,
+                                comparison_affinity: cmp_aff,
                             });
                         }
                     }
@@ -591,6 +645,7 @@ pub fn constraints_from_where_clause(
                                 ),
                                 usable: true,
                                 is_rowid: true,
+                                comparison_affinity: cmp_aff,
                             });
                         }
                     }
@@ -628,6 +683,7 @@ pub fn constraints_from_where_clause(
                             selectivity,
                             usable: true,
                             is_rowid: false,
+                            comparison_affinity: cmp_aff,
                         });
                     }
                     _ => {}
@@ -658,6 +714,9 @@ pub fn constraints_from_where_clause(
                     .unwrap_or(params.rows_per_table_fallback as u64)
                     as f64;
                 let selectivity = estimate_in_selectivity(estimated_values, row_count, *not);
+                // SQLite's `comparisonAffinity` for IN-list (`x IN (lit, ...)`)
+                // is the LHS column's affinity; the RHS literals are not folded.
+                let cmp_aff = Some(get_expr_affinity(lhs, Some(table_references), None));
 
                 match lhs.as_ref() {
                     ast::Expr::Column { table, column, .. }
@@ -677,6 +736,7 @@ pub fn constraints_from_where_clause(
                             selectivity,
                             usable: false, // IN uses a separate seek path, not the range-seek model
                             is_rowid,
+                            comparison_affinity: cmp_aff,
                         });
                     }
                     ast::Expr::RowId { table, .. } if *table == table_reference.internal_id => {
@@ -693,6 +753,7 @@ pub fn constraints_from_where_clause(
                             selectivity,
                             usable: false,
                             is_rowid: true,
+                            comparison_affinity: cmp_aff,
                         });
                     }
                     _ => {}
@@ -704,7 +765,7 @@ pub fn constraints_from_where_clause(
                 subquery_id,
                 lhs: Some(lhs_expr),
                 not_in,
-                query_type: ast::SubqueryType::In { .. },
+                query_type: ast::SubqueryType::In { affinity_str, .. },
             } = &term.expr
             {
                 // Find the subquery to check if it's correlated
@@ -723,6 +784,19 @@ pub fn constraints_from_where_clause(
                         .unwrap_or(params.rows_per_table_fallback as u64)
                         as f64;
                     let selectivity = estimate_in_selectivity(estimated_values, row_count, *not_in);
+                    // SQLite's `comparisonAffinity` for IN-subquery combines the
+                    // LHS column affinity with each result column via
+                    // `sqlite3CompareAffinity` — that result is already cached on
+                    // `SubqueryType::In::affinity_str`. For a single-LHS-column
+                    // IN it is the first character; row-value IN has no single
+                    // resolved affinity and is left as `None`.
+                    let is_row_value = matches!(
+                        unwrap_parens(lhs_expr.as_ref()).ok(),
+                        Some(ast::Expr::Parenthesized(exprs)) if exprs.len() != 1
+                    );
+                    let cmp_aff = (!is_row_value)
+                        .then(|| affinity_str.chars().next().map(Affinity::from_char))
+                        .flatten();
 
                     match lhs_expr.as_ref() {
                         ast::Expr::Column { table, column, .. }
@@ -742,6 +816,7 @@ pub fn constraints_from_where_clause(
                                 selectivity,
                                 usable: false, // IN uses a separate seek path (consider_in_list_seek)
                                 is_rowid,
+                                comparison_affinity: cmp_aff,
                             });
                         }
                         ast::Expr::RowId { table, .. } if *table == table_reference.internal_id => {
@@ -758,6 +833,7 @@ pub fn constraints_from_where_clause(
                                 selectivity,
                                 usable: false,
                                 is_rowid: true,
+                                comparison_affinity: cmp_aff,
                             });
                         }
                         _ => {}
@@ -860,6 +936,11 @@ pub fn constraints_from_where_clause(
                             .is_some()
                             && constraint.operator != ast::Operator::Equals.into()
                         {
+                            continue;
+                        }
+                        let idx_col_aff = constrained_column
+                            .affinity_with_strict(table_reference.table.is_strict());
+                        if !constraint.satisfies_index_affinity(idx_col_aff) {
                             continue;
                         }
                     }
@@ -1731,6 +1812,7 @@ pub(crate) fn analyze_binary_term_for_index(
         selectivity,
         usable: true,
         is_rowid,
+        comparison_affinity: Some(affinity),
     };
 
     Some(AnalyzedTerm {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2235,14 +2235,17 @@ fn optimize_table_access(
                             });
                         continue;
                     };
-                    // Ephemeral indexes mirror rowid/column lookups. If the constraint targets an
-                    // expression (table_col_pos == None) we cannot derive a seek key that matches
-                    // the row layout, so fall back to a scan in that situation.
+                    // Ephemeral indexes mirror rowid/column lookups; expression-index
+                    // constraints (table_col_pos == None) fall back to a scan.
+                    let table_columns = table_references.joined_tables()[table_idx].table.columns();
+                    let is_strict = table_references.joined_tables()[table_idx]
+                        .table
+                        .is_strict();
                     let usable: Vec<(usize, &Constraint)> = table_constraints
                         .constraints
                         .iter()
                         .enumerate()
-                        .filter(|(_, c)| c.usable && c.table_col_pos.is_some())
+                        .filter(|(_, c)| c.can_drive_index_seek(table_columns, is_strict))
                         .collect();
                     // Find this table's position in best_join_order (which excludes build tables)
                     let join_order_pos = best_join_order

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -280,6 +280,31 @@ impl Affinity {
         }
     }
 
+    /// Can an index column with `self` affinity drive a seek for a
+    /// comparison whose resolved affinity is `comparison_aff`?
+    ///
+    /// Port of SQLite's `sqlite3IndexAffinityOk` (src/expr.c).
+    /// The basic idea is: an index can be used if probing it would
+    /// produce the same result as a scan + WHERE filter.
+    ///
+    /// - `Blob`: e.g. `x IS NULL`. No coercion either way. Any index OK.
+    /// - `Text`: e.g. `WHERE txt = 5` (txt TEXT). WHERE coerces `5` to
+    ///   `'5'`. Only a TEXT index's keys are stored as text, so it can
+    ///   match `'5'` directly.
+    /// - `Numeric`: e.g. `WHERE l.txt = r.flag` (l.txt TEXT, r.flag
+    ///   INTEGER). WHERE NUMERIC-coerces both sides: `'6'` → 6, 6 = 6,
+    ///   match. A TEXT-index seek would probe stored text `'6'` with
+    ///   integer 6, but the b-tree comparator orders every integer
+    ///   below every text (INTEGER < TEXT) and finds nothing — opposite
+    ///   answer from the scan. Only a numeric-affinity index is safe.
+    pub fn index_affinity_ok(self, comparison_aff: Affinity) -> bool {
+        match comparison_aff {
+            Affinity::Blob => true,
+            Affinity::Text => matches!(self, Affinity::Text),
+            Affinity::Numeric | Affinity::Integer | Affinity::Real => self.is_numeric(),
+        }
+    }
+
     /// Return TRUE if the given expression is a constant which would be
     /// unchanged by OP_Affinity with the affinity given in the second
     /// argument.

--- a/testing/sqltests/tests/index_seek_comparison_affinity.sqltest
+++ b/testing/sqltests/tests/index_seek_comparison_affinity.sqltest
@@ -1,0 +1,132 @@
+@database :memory:
+
+# Regression tests for #7373: when a JOIN ON predicate is satisfied by an
+# index seek, Turso was applying the *indexed column's* affinity to the
+# seek key. For a TEXT-affinity index probed by an INTEGER-affinity column,
+# that converted the integer to TEXT ("0") instead of leaving the integer
+# alone — and the BTREE comparator then ranked '' below '0' lexicographically
+# instead of using SQLite's type ordering (INTEGER < TEXT) which puts the
+# integer below every text value. The seek therefore reported false matches.
+#
+# The correct affinity for the seek key is the comparison affinity already
+# computed by the planner, not the column affinity: applied to an INTEGER
+# column it is a no-op, so the comparator sees the original integer value
+# and ranks it correctly against the stored TEXT keys.
+
+setup issue-7373-schema {
+    CREATE TABLE l(txt TEXT);
+    CREATE TABLE r(flag INTEGER);
+    INSERT INTO l VALUES ('');
+    INSERT INTO r VALUES (0);
+}
+
+@setup issue-7373-schema
+test issue-7373-derived-join-on-text-le-int {
+    SELECT 'inner', L.txt, R.flag
+    FROM (SELECT txt FROM l) AS L
+    JOIN r AS R ON L.txt <= R.flag
+    UNION ALL
+    SELECT 'cross', L.txt, R.flag
+    FROM (SELECT txt FROM l) AS L
+    CROSS JOIN r AS R
+    WHERE L.txt <= R.flag
+    ORDER BY 1, 2, 3;
+}
+expect {
+}
+
+# Same shape without a derived subquery — exercises the regular b-tree index
+# path on a TEXT column being probed by an INTEGER column.
+setup issue-7373-direct-index-schema {
+    CREATE TABLE l(txt TEXT);
+    CREATE INDEX l_txt ON l(txt);
+    CREATE TABLE r(flag INTEGER);
+    INSERT INTO l VALUES ('');
+    INSERT INTO r VALUES (0);
+}
+
+@setup issue-7373-direct-index-schema
+test issue-7373-direct-index-text-le-int {
+    SELECT l.txt, r.flag FROM l JOIN r ON l.txt <= r.flag;
+}
+expect {
+}
+
+@setup issue-7373-direct-index-schema
+test issue-7373-direct-index-text-eq-int {
+    SELECT l.txt, r.flag FROM l JOIN r ON l.txt = r.flag;
+}
+expect {
+}
+
+# Affinity application should still work when the seek key is a literal —
+# SQLite *does* apply TEXT affinity to literals against a TEXT index, which
+# is how `txt = 0` returns the row with txt='0'. The comparison affinity
+# computed for text-vs-literal is TEXT, so this path is preserved.
+setup issue-7373-literal-affinity-schema {
+    CREATE TABLE l(txt TEXT);
+    CREATE INDEX l_txt ON l(txt);
+    INSERT INTO l VALUES ('0'), ('a');
+}
+
+@setup issue-7373-literal-affinity-schema
+test issue-7373-literal-affinity-preserved {
+    SELECT txt FROM l WHERE txt = 0;
+}
+expect {
+0
+}
+
+# #7374: a RIGHT JOIN whose left side is a derived TEXT subquery and whose
+# right side is a derived numeric subquery used to drop the match because the
+# ephemeral index on the TEXT side coerced the integer probe to TEXT and the
+# resulting `>=` against the empty/text values diverged from a row-by-row
+# evaluation. Rejecting the TEXT index for a numeric comparison (and applying
+# the comparison affinity at seek time) brings Turso back in line with SQLite.
+setup issue-7374-schema {
+    CREATE TABLE l(id INTEGER PRIMARY KEY, txt TEXT);
+    CREATE TABLE r(id INTEGER PRIMARY KEY, flag BOOLEAN);
+    INSERT INTO l VALUES (1, '6');
+    INSERT INTO r VALUES (10, 0);
+}
+
+@setup issue-7374-schema
+test issue-7374-right-join-mixed-affinity {
+    SELECT l.id, l.txt, typeof(l.txt), r.id, r.flag, typeof(r.flag)
+    FROM (SELECT id, txt FROM l WHERE txt IS NOT NULL) AS l
+    RIGHT JOIN (SELECT DISTINCT id, flag FROM r) AS r
+    ON l.txt >= r.flag;
+}
+expect {
+1|6|text|10|0|integer
+}
+
+# An IN-list / IN-subquery against an affinity-incompatible index is the same
+# class of bug as the issues referenced above: the index seek bypasses the comparison affinity SQLite would
+# apply at WHERE time and silently returns wrong rows. Here
+# `l.txt IN (SELECT flag FROM r)` resolves to comparison affinity NUMERIC
+# (TEXT col vs INTEGER col), so the TEXT index `l_txt` must be rejected; the
+# row-by-row WHERE evaluation NUMERIC-coerces '0' to 0 and matches r.flag=0.
+setup in-list-text-idx-numeric-source-schema {
+    CREATE TABLE l(txt TEXT);
+    CREATE INDEX l_txt ON l(txt);
+    CREATE TABLE r(flag INTEGER);
+    INSERT INTO l VALUES (''), ('0');
+    INSERT INTO r VALUES (0), (1);
+}
+
+@setup in-list-text-idx-numeric-source-schema
+test in-subquery-text-idx-numeric-source {
+    SELECT l.txt FROM l WHERE l.txt IN (SELECT flag FROM r);
+}
+expect {
+0
+}
+
+@setup in-list-text-idx-numeric-source-schema
+test in-literal-list-text-idx-numeric-source {
+    SELECT l.txt FROM l WHERE l.txt IN (0, 1) ORDER BY l.txt;
+}
+expect {
+0
+}

--- a/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
+++ b/testing/sqltests/tests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
@@ -58,7 +58,7 @@ addr  opcode               p1  p2  p3  p4      p5  comment
   27      Next              2  23   0           0
   28      Copy              2  18   0           0  r[18]=r[2]
   29      IsNull           18  42   0           0  if (r[18]==NULL) goto 42
-  30      Affinity         18   1   0           0  r[18..19] = E
+  30      Affinity         18   1   0           0  r[18..19] = C
   31      SeekLT            3  42  18           0  key=[18..18]
   32        Null            0  18   0           0  r[18]=NULL
   33        IdxLE           3  42  18           0  key=[18..18]

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
@@ -35,7 +35,7 @@ addr  opcode              p1  p2  p3  p4              p5  comment
    9      OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   10      Column           0   2   9                   0  r[9]=products.category_id
   11      IsNull           9  20   0                   0  if (r[9]==NULL) goto 20
-  12      Affinity         9   1   0                   0  r[9..10] = D
+  12      Affinity         9   1   0                   0  r[9..10] = C
   13      SeekGE           2  20   9                   0  key=[9..9]
   14        IdxGT          2  20   9                   0  key=[9..9]
   15        DeferredSeek   2   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -133,7 +133,7 @@ addr  opcode                            p1   p2   p3  p4              p5  commen
   98    Column                           2    1   21                   0  r[21]=ephemeral().avg_price
   99    Copy                            20   39    0                   0  r[39]=r[20]
  100    IsNull                          39  116    0                   0  if (r[39]==NULL) goto 116
- 101    Affinity                        39    1    0                   0  r[39..40] = D
+ 101    Affinity                        39    1    0                   0  r[39..40] = C
  102    SeekGE                           6  116   39                   0  key=[39..39]
  103      IdxGT                          6  116   39                   0  key=[39..39]
  104      DeferredSeek                   6    5    0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -99,7 +99,7 @@ addr  opcode              p1  p2  p3  p4            p5  comment
   52    Yield              1  67   0                 0
   53    Copy              11  30   0                 0  r[30]=r[11]
   54    IsNull            30  66   0                 0  if (r[30]==NULL) goto 66
-  55    Affinity          30   1   0                 0  r[30..31] = D
+  55    Affinity          30   1   0                 0  r[30..31] = C
   56    SeekGE             3  66  30                 0  key=[30..30]
   57      IdxGT            3  66  30                 0  key=[30..30]
   58      Column           3   1  14                 0  r[14]=ephemeral(ephemeral_subquery_t8).id

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
@@ -31,9 +31,9 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                      p1  p2  p3  p4              p5  comment
-   0            Init               0  77   0                   0  Start at 77
+   0            Init               0  76   0                   0  Start at 76
    1            OpenRead           0   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   2            Rewind             0  76   0                   0  Rewind table employees
+   2            Rewind             0  75   0                   0  Rewind table employees
    3              BeginSubrtn      5   0   0                   0  r[5]=NULL
    4              Null             0   1   0                   0  r[1]=NULL
    5              OpenEphemeral    1   0   0                   0  cursor=1 is_table=false
@@ -84,29 +84,28 @@ addr  opcode                      p1  p2  p3  p4              p5  comment
   50        Integer                0  11   0                   0  r[11]=0
   51      Return                  19   0   0                   0
   52      Integer                  1  27   0                   0  r[27]=1; LIMIT counter
-  53      IfNot                   27  65   0                   0  if !r[27] goto 65
+  53      IfNot                   27  64   0                   0  if !r[27] goto 64
   54      Column                   0   3  28                   0  r[28]=employees.department
-  55      IsNull                  28  65   0                   0  if (r[28]==NULL) goto 65
-  56      Affinity                28   1   0                   0  r[28..29] = B
-  57      SeekGE                   1  65  28                   0  key=[28..28]
-  58        IdxGT                  1  65  28                   0  key=[28..28]
-  59        Column                 1   0   6                   0  r[6]=ephemeral(ephemeral_subquery_t6).department
-  60        Column                 1   1   7                   0  r[7]=ephemeral(ephemeral_subquery_t6).avg_salary
-  61        Column                 1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
-  62        Copy                  26   1   0                   0  r[1]=r[26]
-  63        DecrJumpZero          27  65   0                   0  if (--r[27]==0) goto 65
-  64      Next                     1  58   0                   0
-  65    Return                     5   0   1                   0
-  66    Column                     0   4  30                   0  r[30]=employees.salary
-  67    RealAffinity              30   0   0                   0
-  68    Copy                       1  31   0                   0  r[31]=r[1]
-  69    Le                        30  31  75  Binary           0  if r[30]<=r[31] goto 75
-  70    Column                     0   1   2                   0  r[2]=employees.name
-  71    Column                     0   3   3                   0  r[3]=employees.department
-  72    Column                     0   4   4                   0  r[4]=employees.salary
-  73    RealAffinity               4   0   0                   0
-  74    ResultRow                  2   3   0                   0  output=r[2..4]
-  75  Next                         0   3   0                   0
-  76  Halt                         0   0   0                   0
-  77  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
-  78  Goto                         0   1   0                   0
+  55      IsNull                  28  64   0                   0  if (r[28]==NULL) goto 64
+  56      SeekGE                   1  64  28                   0  key=[28..28]
+  57        IdxGT                  1  64  28                   0  key=[28..28]
+  58        Column                 1   0   6                   0  r[6]=ephemeral(ephemeral_subquery_t6).department
+  59        Column                 1   1   7                   0  r[7]=ephemeral(ephemeral_subquery_t6).avg_salary
+  60        Column                 1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
+  61        Copy                  26   1   0                   0  r[1]=r[26]
+  62        DecrJumpZero          27  64   0                   0  if (--r[27]==0) goto 64
+  63      Next                     1  57   0                   0
+  64    Return                     5   0   1                   0
+  65    Column                     0   4  30                   0  r[30]=employees.salary
+  66    RealAffinity              30   0   0                   0
+  67    Copy                       1  31   0                   0  r[31]=r[1]
+  68    Le                        30  31  74  Binary           0  if r[30]<=r[31] goto 74
+  69    Column                     0   1   2                   0  r[2]=employees.name
+  70    Column                     0   3   3                   0  r[3]=employees.department
+  71    Column                     0   4   4                   0  r[4]=employees.salary
+  72    RealAffinity               4   0   0                   0
+  73    ResultRow                  2   3   0                   0  output=r[2..4]
+  74  Next                         0   3   0                   0
+  75  Halt                         0   0   0                   0
+  76  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
+  77  Goto                         0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -24,11 +24,11 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment
-   0            Init             0  60   0                 0  Start at 60
+   0            Init             0  59   0                 0  Start at 59
    1            Null             0   9   0                 0  r[9]=NULL
    2            Integer          0   6   0                 0  r[6]=0; clear group by abort flag
    3            Null             0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
-   4            Gosub           13  56   0                 0  ; go to clear accumulator subroutine
+   4            Gosub           13  55   0                 0  ; go to clear accumulator subroutine
    5            OpenRead         0   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
    6            OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
    7            Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
@@ -39,15 +39,15 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   12              Jump          13  17  13                 0  ; start new group if comparison is not equal
   13              Gosub          4  26   0                 0  ; check if ended group had data, and output if so
   14              Move          11   7   1                 0  r[7..7]=r[11..11]
-  15              IfPos          6  59   0                 0  r[6]>0 -> r[6]-=0, goto 59; check abort flag
-  16              Gosub         13  56   0                 0  ; goto clear accumulator subroutine
+  15              IfPos          6  58   0                 0  r[6]>0 -> r[6]-=0, goto 58; check abort flag
+  16              Gosub         13  55   0                 0  ; goto clear accumulator subroutine
   17              AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
   18              If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
   19              Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
   20              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
   21            Next             1   8   0                 0
   22            Gosub            4  26   0                 0  ; emit row for final group
-  23            Goto             0  59   0                 0  ; group by finished
+  23            Goto             0  58   0                 0  ; group by finished
   24            Integer          1   6   0                 0  r[6]=1
   25          Return             4   0   0                 0
   26          IfPos              5  28   0                 0  r[5]>0 -> r[5]-=0, goto 28; output group by row subroutine start
@@ -57,32 +57,31 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   30        Null                 0   1   0                 0  r[1]=NULL
   31        Null                 0  16   0                 0  r[16]=NULL
   32        Integer              1  17   0                 0  r[17]=1; LIMIT counter
-  33        IfNot               17  46   0                 0  if !r[17] goto 46
+  33        IfNot               17  45   0                 0  if !r[17] goto 45
   34        OpenRead             2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
   35        OpenRead             3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
   36        Copy                 8  18   0                 0  r[18]=r[8]
-  37        IsNull              18  46   0                 0  if (r[18]==NULL) goto 46
-  38        Affinity            18   1   0                 0  r[18..19] = B
-  39        SeekGE               3  46  18                 0  key=[18..18]
-  40          IdxGT              3  46  18                 0  key=[18..18]
-  41          DeferredSeek       3   2   0                 0
-  42          Column             2   1  19                 0  r[19]=grouped_values.val
-  43          CollSeq            0   0   0  Binary         0  collation=Binary
-  44          AggStep            0  19  16  max            0  accum=r[16] step(r[19])
-  45        Next                 3  40   0                 0
-  46        AggFinal             0  16   0  max            0  accum=r[16]
-  47        Copy                16  15   0                 0  r[15]=r[16]
-  48        Copy                15   1   0                 0  r[1]=r[15]
-  49      Return                14   0   1                 0
-  50      Copy                   1  20   0                 0  r[20]=r[1]
-  51      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
-  52      Copy                   8   2   0                 0  r[2]=r[8]
-  53      Copy                   9   3   0                 0  r[3]=r[9]
-  54      ResultRow              2   2   0                 0  output=r[2..3]
-  55    Return                   4   0   0                 0
-  56    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
-  57    Integer                  0   5   0                 0  r[5]=0
-  58  Return                    13   0   0                 0
-  59  Halt                       0   0   0                 0
-  60  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
-  61  Goto                       0   1   0                 0
+  37        IsNull              18  45   0                 0  if (r[18]==NULL) goto 45
+  38        SeekGE               3  45  18                 0  key=[18..18]
+  39          IdxGT              3  45  18                 0  key=[18..18]
+  40          DeferredSeek       3   2   0                 0
+  41          Column             2   1  19                 0  r[19]=grouped_values.val
+  42          CollSeq            0   0   0  Binary         0  collation=Binary
+  43          AggStep            0  19  16  max            0  accum=r[16] step(r[19])
+  44        Next                 3  39   0                 0
+  45        AggFinal             0  16   0  max            0  accum=r[16]
+  46        Copy                16  15   0                 0  r[15]=r[16]
+  47        Copy                15   1   0                 0  r[1]=r[15]
+  48      Return                14   0   1                 0
+  49      Copy                   1  20   0                 0  r[20]=r[1]
+  50      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
+  51      Copy                   8   2   0                 0  r[2]=r[8]
+  52      Copy                   9   3   0                 0  r[3]=r[9]
+  53      ResultRow              2   2   0                 0  output=r[2..3]
+  54    Return                   4   0   0                 0
+  55    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
+  56    Integer                  0   5   0                 0  r[5]=0
+  57  Return                    13   0   0                 0
+  58  Halt                       0   0   0                 0
+  59  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
+  60  Goto                       0   1   0                 0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -25,12 +25,12 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  69   0                   0  Start at 69
+   0            Init             0  68   0                   0  Start at 68
    1            SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
    2            Null             0  10   0                   0  r[10]=NULL
    3            Integer          0   7   0                   0  r[7]=0; clear group by abort flag
    4            Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  58   0                   0  ; go to clear accumulator subroutine
+   5            Gosub           14  57   0                   0  ; go to clear accumulator subroutine
    6            OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
    7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
    8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
@@ -41,15 +41,15 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   13              Jump          14  18  14                   0  ; start new group if comparison is not equal
   14              Gosub          5  27   0                   0  ; check if ended group had data, and output if so
   15              Move          12   8   1                   0  r[8..8]=r[12..12]
-  16              IfPos          7  61   0                   0  r[7]>0 -> r[7]-=0, goto 61; check abort flag
-  17              Gosub         14  58   0                   0  ; goto clear accumulator subroutine
+  16              IfPos          7  60   0                   0  r[7]>0 -> r[7]-=0, goto 60; check abort flag
+  17              Gosub         14  57   0                   0  ; goto clear accumulator subroutine
   18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
   19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
   20              Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
   21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
   22            Next             2   9   0                   0
   23            Gosub            5  27   0                   0  ; emit row for final group
-  24            Goto             0  61   0                   0  ; group by finished
+  24            Goto             0  60   0                   0  ; group by finished
   25            Integer          1   7   0                   0  r[7]=1
   26          Return             5   0   0                   0
   27          IfPos              6  29   0                   0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
@@ -59,40 +59,39 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   31        Null                 0   1   0                   0  r[1]=NULL
   32        Null                 0  17   0                   0  r[17]=NULL
   33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
-  34        IfNot               18  47   0                   0  if !r[18] goto 47
+  34        IfNot               18  46   0                   0  if !r[18] goto 46
   35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
   36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
   37        Copy                 9  19   0                   0  r[19]=r[9]
-  38        IsNull              19  47   0                   0  if (r[19]==NULL) goto 47
-  39        Affinity            19   1   0                   0  r[19..20] = B
-  40        SeekGE               4  47  19                   0  key=[19..19]
-  41          IdxGT              4  47  19                   0  key=[19..19]
-  42          DeferredSeek       4   3   0                   0
-  43          Column             3   1  20                   0  r[20]=grouped_values.val
-  44          CollSeq            0   0   0  Binary           0  collation=Binary
-  45          AggStep            0  20  17  max              0  accum=r[17] step(r[20])
-  46        Next                 4  41   0                   0
-  47        AggFinal             0  17   0  max              0  accum=r[17]
-  48        Copy                17  16   0                   0  r[16]=r[17]
-  49        Copy                16   1   0                   0  r[1]=r[16]
-  50      Return                15   0   1                   0
-  51      Copy                   1  21   0                   0  r[21]=r[1]
-  52      Sequence               0  22   0                   0
-  53      Copy                   9  23   0                   0  r[23]=r[9]
-  54      Copy                  10  24   0                   0  r[24]=r[10]
-  55      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
-  56      SorterInsert           0   4   0  0                0  key=r[4]
-  57    Return                   5   0   0                   0
-  58    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  59    Integer                  0   6   0                   0  r[6]=0
-  60  Return                    14   0   0                   0
-  61  OpenPseudo                 5   4   4                   0  4 columns in r[4]
-  62  SorterSort                 0  68   0                   0
-  63    SorterData               0   4   5                   0  r[4]=data
-  64    Column                   5   2   2                   0  r[2]=pseudo.column 2
-  65    Column                   5   3   3                   0  r[3]=pseudo.column 3
-  66    ResultRow                2   2   0                   0  output=r[2..3]
-  67  SorterNext                 0  63   0                   0
-  68  Halt                       0   0   0                   0
-  69  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
-  70  Goto                       0   1   0                   0
+  38        IsNull              19  46   0                   0  if (r[19]==NULL) goto 46
+  39        SeekGE               4  46  19                   0  key=[19..19]
+  40          IdxGT              4  46  19                   0  key=[19..19]
+  41          DeferredSeek       4   3   0                   0
+  42          Column             3   1  20                   0  r[20]=grouped_values.val
+  43          CollSeq            0   0   0  Binary           0  collation=Binary
+  44          AggStep            0  20  17  max              0  accum=r[17] step(r[20])
+  45        Next                 4  40   0                   0
+  46        AggFinal             0  17   0  max              0  accum=r[17]
+  47        Copy                17  16   0                   0  r[16]=r[17]
+  48        Copy                16   1   0                   0  r[1]=r[16]
+  49      Return                15   0   1                   0
+  50      Copy                   1  21   0                   0  r[21]=r[1]
+  51      Sequence               0  22   0                   0
+  52      Copy                   9  23   0                   0  r[23]=r[9]
+  53      Copy                  10  24   0                   0  r[24]=r[10]
+  54      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
+  55      SorterInsert           0   4   0  0                0  key=r[4]
+  56    Return                   5   0   0                   0
+  57    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
+  58    Integer                  0   6   0                   0  r[6]=0
+  59  Return                    14   0   0                   0
+  60  OpenPseudo                 5   4   4                   0  4 columns in r[4]
+  61  SorterSort                 0  67   0                   0
+  62    SorterData               0   4   5                   0  r[4]=data
+  63    Column                   5   2   2                   0  r[2]=pseudo.column 2
+  64    Column                   5   3   3                   0  r[3]=pseudo.column 3
+  65    ResultRow                2   2   0                   0  output=r[2..3]
+  66  SorterNext                 0  62   0                   0
+  67  Halt                       0   0   0                   0
+  68  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
+  69  Goto                       0   1   0                   0


### PR DESCRIPTION
Fixes #7373, #7374, and a related IN-list/IN-subquery affinity bypass surfaced during review.

## Bug

Index seeks applied the indexed column's affinity to the seek key. SQLite applies the comparison's resolved affinity (`sqlite3CompareAffinity`). The two diverge for cross-type comparisons:

```
  -- l.txt TEXT, r.flag INTEGER, the empty string '' stored in l.
  SELECT l.txt, r.flag FROM l JOIN r ON l.txt <= r.flag;
  ```

Comparison affinity here is NUMERIC. The TEXT index forced TEXT onto the integer probe ('0') and the b-tree comparator then ranked '' below '0' lexicographically rather than SQLite's type ordering (INTEGER < TEXT) that puts every integer below every text. False match.

The same shape broke `WHERE x IN (SELECT y ...)` with TEXT x / INTEGER y: the IN ephemeral stored integers, the TEXT index never coerced them, and the b-tree sorted every integer below every text key — zero rows.

## Fix

- Port SQLite's `sqlite3IndexAffinityOk` (`Affinity::index_affinity_ok`)
- cache the resolved comparison affinity on each `Constraint` at construction,
- consult it at every index-selection site (regular b-tree, auto-index, ephemeral-subquery, IN-seek) so incompatible indexes are rejected up front. At emission, `index_seek_affinities` now reads the cached comparison affinity instead of the column's.

Snapshot churn: 7 files. All are affinity-character shifts (D→C for cross-type numeric comparisons) or removal of redundant TEXT-on-TEXT Affinity opcodes that SQLite never emits either.

Fixes #7373.
Fixes #7374.