### PR TITLE
core/numeric: Coerce text exceeding i64::MAX to Float, not saturated int

### DIFF
--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -74,15 +74,10 @@ impl Numeric {
                     | Some(StrToF64::FractionalPrefix(_))
                     | Some(StrToF64::DecimalPrefix(_)) => None,
                     Some(StrToF64::Fractional(value)) => Some(Self::Float(value)),
-                    Some(StrToF64::Decimal(real)) => {
-                        let integer = str_to_i64(s).unwrap_or(0);
-
-                        Some(if real == integer as f64 {
-                            Self::Integer(integer)
-                        } else {
-                            Self::Float(real)
-                        })
-                    }
+                    Some(StrToF64::Decimal(real)) => Some(match str_to_i64_checked(s) {
+                        Ok(integer) => Self::Integer(integer),
+                        Err(_) => Self::Float(real),
+                    }),
                 }
             }
         }
@@ -198,12 +193,9 @@ impl<T: AsRef<str>> From<T> for Numeric {
                 Self::Float(value)
             }
             Some(StrToF64::Decimal(real) | StrToF64::DecimalPrefix(real)) => {
-                let integer = str_to_i64(text).unwrap_or(0);
-
-                if real == integer as f64 {
-                    Self::Integer(integer)
-                } else {
-                    Self::Float(real)
+                match str_to_i64_checked(text) {
+                    Ok(integer) => Self::Integer(integer),
+                    Err(_) => Self::Float(real),
                 }
             }
         }
@@ -534,6 +526,22 @@ impl std::ops::MulAssign for DoubleDouble {
 }
 
 pub fn str_to_i64(input: impl AsRef<str>) -> Option<i64> {
+    Some(match str_to_i64_checked(input) {
+        Ok(v) => v,
+        Err(IntOverflow::Positive) => i64::MAX,
+        Err(IntOverflow::Negative) => i64::MIN,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum IntOverflow {
+    Positive,
+    Negative,
+}
+
+/// Like [`str_to_i64`] but distinguishes overflow from a successful parse.
+/// Returns `Err(_)` when the leading numeric prefix does not fit in i64.
+pub fn str_to_i64_checked(input: impl AsRef<str>) -> Result<i64, IntOverflow> {
     let input = input
         .as_ref()
         .trim_matches(|ch: char| ch.is_ascii_whitespace() || ch == VERTICAL_TAB);
@@ -542,18 +550,21 @@ pub fn str_to_i64(input: impl AsRef<str>) -> Option<i64> {
 
     iter.next_if(|(_, ch)| matches!(ch, '+' | '-'));
     let Some((end, _)) = iter.take_while(|(_, ch)| ch.is_ascii_digit()).last() else {
-        return Some(0);
+        return Ok(0);
     };
 
-    input[0..=end].parse::<i64>().map_or_else(
-        |err| match err.kind() {
-            std::num::IntErrorKind::PosOverflow => Some(i64::MAX),
-            std::num::IntErrorKind::NegOverflow => Some(i64::MIN),
-            std::num::IntErrorKind::Empty => unreachable!(),
-            _ => Some(0),
-        },
-        Some,
-    )
+    input[0..=end]
+        .parse::<i64>()
+        .map_err(|err| match err.kind() {
+            std::num::IntErrorKind::PosOverflow => IntOverflow::Positive,
+            std::num::IntErrorKind::NegOverflow => IntOverflow::Negative,
+            // Empty/InvalidDigit are ruled out: the early `return Ok(0)` above
+            // fires when there are no digits, and the slice spans only an
+            // optional sign followed by ASCII digits. Zero is produced only by
+            // `NonZeroI*::from_str`, not by `i64::from_str`. `IntErrorKind` is
+            // `#[non_exhaustive]`, hence the catch-all.
+            _ => unreachable!("unexpected IntErrorKind from i64::from_str: {err:?}"),
+        })
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/testing/sqltests/tests/numeric-text-overflow.sqltest
+++ b/testing/sqltests/tests/numeric-text-overflow.sqltest
@@ -1,0 +1,65 @@
+@database :memory:
+
+# Text whose magnitude exceeds i64::MAX must coerce to REAL when used as a
+# number, matching SQLite's CAST/affinity semantics. Regression for
+# https://github.com/tursodatabase/turso/issues/7382 — the simulator's shadow
+# model parsed such literals as Integer(i64::MAX), which propagated to the
+# math/arithmetic codepaths that route Text through Numeric::from_value_strict.
+
+test ceil-text-overflow-i64 {
+    SELECT ceil('9223372036854776000'), typeof(ceil('9223372036854776000'));
+}
+expect {
+    9.22337203685478e+18|real
+}
+expect @js {
+    9223372036854776000|real
+}
+
+test floor-text-overflow-i64 {
+    SELECT floor('9223372036854776000'), typeof(floor('9223372036854776000'));
+}
+expect {
+    9.22337203685478e+18|real
+}
+expect @js {
+    9223372036854776000|real
+}
+
+test trunc-text-overflow-i64 {
+    SELECT trunc('9223372036854776000'), typeof(trunc('9223372036854776000'));
+}
+expect {
+    9.22337203685478e+18|real
+}
+expect @js {
+    9223372036854776000|real
+}
+
+test add-text-overflow-i64 {
+    SELECT '9223372036854776000' + 0, typeof('9223372036854776000' + 0);
+}
+expect {
+    9.22337203685478e+18|real
+}
+expect @js {
+    9223372036854776000|real
+}
+
+test mul-text-overflow-i64 {
+    SELECT '9223372036854776000' * 1, typeof('9223372036854776000' * 1);
+}
+expect {
+    9.22337203685478e+18|real
+}
+expect @js {
+    9223372036854776000|real
+}
+
+# Boundary: i64::MAX itself fits exactly in i64 and must stay INTEGER.
+test ceil-text-i64-max-stays-integer {
+    SELECT ceil('9223372036854775807'), typeof(ceil('9223372036854775807'));
+}
+expect {
+    9223372036854775807|integer
+}


### PR DESCRIPTION
`Numeric::from<&str>` and `Numeric::from_value_strict` chose between Integer and Float by asking whether the parsed real round-tripped through i64:

    let integer = str_to_i64(text).unwrap_or(0);
    if real == integer as f64 { Self::Integer(integer) } else { Self::Float(real) }

Two problems with that check:

- `str_to_i64` quietly saturates on overflow — PosOverflow becomes `Some(i64::MAX)`, which looks the same as a real parse of "9223372036854775807". So `integer` always looks like a clean result.
- `i64::MAX as f64` rounds up to 2^63 (f64 can't represent 2^63 - 1), and any decimal text whose value also rounds to 2^63 in f64 passes `real == integer as f64`. That covers "9223372036854776000" and every neighbor in the ~1024-wide gap around 2^63.

What that meant in practice:

- Text strictly larger than i64::MAX was getting coerced to `Integer(i64::MAX)` instead of REAL.
- SQLite and tursodb's own literal parser `parse_numeric_literal` treat such text as REAL.
- So `ceil('9223372036854776000')`, `'9223372036854776000' + 0`, and similar arithmetic returned `9223372036854775807 / integer` in tursodb where SQLite returned `9.2233720368547758e+18 / real`.
- The same wrong type flowed through the simulator's shadow model, which is how this surfaced — the WHERE-clause path saw `Float(2^63) = Integer(i64::MAX)` as false and predicted the wrong row count.

The fix:

- Add `str_to_i64_checked`, which returns `Result<i64, OverflowDirection>` and lets callers tell saturation apart from a real parse.
- The saturating `str_to_i64` becomes a thin wrapper that maps the two overflow arms to `i64::MAX` / `i64::MIN`.
- Both `Numeric::from` paths now use the checked variant: `Err(_)` means the input did not fit in i64, so emit `Float(real)`.
- The match's catch-all is now `unreachable!()` — `IntErrorKind`'s remaining variants (Empty, InvalidDigit, Zero) cannot show up here because the slice fed to `parse` is preprocessed to an optional sign followed by ASCII digits.

Regression test in `testing/sqltests/tests/numeric-text-overflow.sqltest`:

- Covers `ceil`/`floor`/`trunc`/`+`/`*` on text exceeding i64::MAX.
- Includes a boundary case at exactly i64::MAX which must stay INTEGER.
- The JS backend prints the same REAL value as `9223372036854776000` rather than scientific notation, so a parallel `expect @js` block is included.

Fixes #7382