### PR TITLE
Fix encrypted fresh DB page-size retargeting

### DIFF
--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -1,6 +1,7 @@
 use crate::io::FileSyncType;
 use crate::storage::checksum::ChecksumContext;
 use crate::storage::encryption::EncryptionContext;
+use crate::storage::sqlite3_ondisk::PageSize;
 use crate::sync::Arc;
 use crate::{io::Completion, Buffer, CompletionError, LimboError, Result};
 use crate::{
@@ -39,6 +40,22 @@ impl IOContext {
 
     pub fn set_encryption(&mut self, encryption_ctx: EncryptionContext) {
         self.encryption_or_checksum = EncryptionOrChecksum::Encryption(encryption_ctx);
+    }
+
+    /// Retarget the installed encryption context's expected page size to match a
+    /// pre-initialization layout change (e.g. `PRAGMA page_size`, fresh encrypted
+    /// `ATTACH`, in-place `VACUUM` temp DB). This is layout repair, not normal
+    /// configuration: it must only be called while the pager is uninitialized,
+    /// and never to change cipher or key. Returns true when a context was
+    /// present and updated; false when no encryption context is installed.
+    pub(crate) fn retarget_encryption_page_size(&mut self, page_size: PageSize) -> bool {
+        match &mut self.encryption_or_checksum {
+            EncryptionOrChecksum::Encryption(ctx) => {
+                ctx.set_page_size(page_size);
+                true
+            }
+            _ => false,
+        }
     }
 
     pub fn encryption_or_checksum(&self) -> &EncryptionOrChecksum {

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -42,13 +42,11 @@ impl IOContext {
         self.encryption_or_checksum = EncryptionOrChecksum::Encryption(encryption_ctx);
     }
 
-    /// Retarget the installed encryption context's expected page size to match a
-    /// pre-initialization layout change (e.g. `PRAGMA page_size`, fresh encrypted
-    /// `ATTACH`, in-place `VACUUM` temp DB). This is layout repair, not normal
-    /// configuration: it must only be called while the pager is uninitialized,
-    /// and never to change cipher or key. Returns true when a context was
-    /// present and updated; false when no encryption context is installed.
-    pub(crate) fn retarget_encryption_page_size(&mut self, page_size: PageSize) -> bool {
+    /// Set the page size stored in the encryption context, if one is installed.
+    ///
+    /// Returns true when the context was updated. The cipher mode and key are
+    /// unchanged.
+    pub(crate) fn reset_page_size_in_encryption_ctx(&mut self, page_size: PageSize) -> bool {
         match &mut self.encryption_or_checksum {
             EncryptionOrChecksum::Encryption(ctx) => {
                 ctx.set_page_size(page_size);

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -42,17 +42,9 @@ impl IOContext {
         self.encryption_or_checksum = EncryptionOrChecksum::Encryption(encryption_ctx);
     }
 
-    /// Set the page size stored in the encryption context, if one is installed.
-    ///
-    /// Returns true when the context was updated. The cipher mode and key are
-    /// unchanged.
-    pub(crate) fn reset_page_size_in_encryption_ctx(&mut self, page_size: PageSize) -> bool {
-        match &mut self.encryption_or_checksum {
-            EncryptionOrChecksum::Encryption(ctx) => {
-                ctx.set_page_size(page_size);
-                true
-            }
-            _ => false,
+    pub(crate) fn reset_page_size_in_encryption_ctx(&mut self, page_size: PageSize) {
+        if let EncryptionOrChecksum::Encryption(ctx) = &mut self.encryption_or_checksum {
+            ctx.set_page_size(page_size);
         }
     }
 

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -1,4 +1,5 @@
 #![allow(unused_variables, dead_code)]
+use crate::storage::sqlite3_ondisk::PageSize;
 use crate::turso_assert;
 use crate::{LimboError, Result};
 use aegis::aegis128l::Aegis128L;
@@ -550,6 +551,14 @@ impl EncryptionContext {
 
     pub fn cipher_mode(&self) -> CipherMode {
         self.cipher_mode
+    }
+
+    /// Update the page size this context expects. The cipher and key material are
+    /// page-size independent; page size only governs buffer length assertions and
+    /// reserved-tail slicing, so it can be retargeted in place when the pager's
+    /// initial page size changes before the database is initialized.
+    pub(crate) fn set_page_size(&mut self, page_size: PageSize) {
+        self.page_size = page_size.get() as usize;
     }
 
     /// Returns the number of reserved bytes required at the end of each page for encryption metadata.

--- a/core/storage/encryption.rs
+++ b/core/storage/encryption.rs
@@ -553,10 +553,9 @@ impl EncryptionContext {
         self.cipher_mode
     }
 
-    /// Update the page size this context expects. The cipher and key material are
-    /// page-size independent; page size only governs buffer length assertions and
-    /// reserved-tail slicing, so it can be retargeted in place when the pager's
-    /// initial page size changes before the database is initialized.
+    /// Set the database page size used when encrypting and decrypting pages.
+    ///
+    /// This does not change the selected cipher or key material.
     pub(crate) fn set_page_size(&mut self, page_size: PageSize) {
         self.page_size = page_size.get() as usize;
     }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2773,8 +2773,8 @@ impl Pager {
     ///
     /// This is a no-op when encryption is not configured.
     fn reset_page_size_in_encryption_ctx(&self, size: PageSize) {
-        let updated = self.io_ctx.write().reset_page_size_in_encryption_ctx(size);
-        if !updated {
+        self.io_ctx.write().reset_page_size_in_encryption_ctx(size);
+        if !self.is_encryption_ctx_set() {
             return;
         }
         if let Some(wal) = self.wal.as_ref() {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2761,6 +2761,25 @@ impl Pager {
         // Clear dirty pages since this is pre-initialization setup, not a real write transaction.
         // Rebuilding init_page_1 must not leak any stale 4 KiB page-1 image into the first write.
         self.dirty_pages.write().clear();
+
+        // Invariant: this is the sole pre-initialization page-size retargeting
+        // hook for the fresh DB / fresh ATTACH / in-place VACUUM temp DB paths.
+        // Any encryption context installed before this point (PRAGMA
+        // cipher/hexkey, URI-supplied cipher/hexkey, fresh-attach `_init`) was
+        // built against the prior page size and would panic on the first
+        // encrypted write with a stale buffer-length assertion. Retarget it in
+        // place and propagate to the WAL IOContext when one is installed.
+        let retargeted = {
+            let mut io_ctx = self.io_ctx.write();
+            io_ctx.retarget_encryption_page_size(size)
+        };
+        if !retargeted {
+            return Ok(());
+        }
+        let Some(wal) = self.wal.as_ref() else {
+            return Ok(());
+        };
+        wal.set_io_context(self.io_ctx.read().clone());
         Ok(())
     }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2762,25 +2762,24 @@ impl Pager {
         // Rebuilding init_page_1 must not leak any stale 4 KiB page-1 image into the first write.
         self.dirty_pages.write().clear();
 
-        // Invariant: this is the sole pre-initialization page-size retargeting
-        // hook for the fresh DB / fresh ATTACH / in-place VACUUM temp DB paths.
-        // Any encryption context installed before this point (PRAGMA
-        // cipher/hexkey, URI-supplied cipher/hexkey, fresh-attach `_init`) was
-        // built against the prior page size and would panic on the first
-        // encrypted write with a stale buffer-length assertion. Retarget it in
-        // place and propagate to the WAL IOContext when one is installed.
-        let retargeted = {
-            let mut io_ctx = self.io_ctx.write();
-            io_ctx.retarget_encryption_page_size(size)
-        };
-        if !retargeted {
-            return Ok(());
-        }
-        let Some(wal) = self.wal.as_ref() else {
-            return Ok(());
-        };
-        wal.set_io_context(self.io_ctx.read().clone());
+        // Encryption can be configured before a fresh database chooses its page
+        // size, so keep the IO context aligned with the pager before the first
+        // page write.
+        self.reset_page_size_in_encryption_ctx(size);
         Ok(())
+    }
+
+    /// Update the encryption page size in the pager IO context and its WAL copy.
+    ///
+    /// This is a no-op when encryption is not configured.
+    fn reset_page_size_in_encryption_ctx(&self, size: PageSize) {
+        let updated = self.io_ctx.write().reset_page_size_in_encryption_ctx(size);
+        if !updated {
+            return;
+        }
+        if let Some(wal) = self.wal.as_ref() {
+            wal.set_io_context(self.io_ctx.read().clone());
+        }
     }
 
     /// Set the initial journal version in page 1 before the database is initialized.

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -1351,3 +1351,184 @@ fn test_non_4k_page_size_encryption_enable_mvcc_after_encryption(
     .try_for_each(|query| run_query(&tmp_db, &conn, query))?;
     do_flush(&conn, &tmp_db)
 }
+
+// Regression coverage for https://github.com/tursodatabase/turso/issues/7375.
+// PRAGMA cipher/hexkey before PRAGMA page_size used to leave EncryptionContext
+// pinned to the default 4096-byte page size; the first write then panicked.
+
+const ISSUE_7375_KEY_256: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+const ISSUE_7375_KEY_128: &str = "000102030405060708090a0b0c0d0e0f";
+
+fn assert_encrypted_page_size_after_key_and_cipher(
+    page_size: i64,
+    cipher: &str,
+    hexkey: &str,
+) -> anyhow::Result<()> {
+    let tmp_db = TempDatabaseBuilder::new()
+        .with_opts(DatabaseOpts::new().with_encryption(true))
+        .build();
+
+    let conn = tmp_db.connect_limbo();
+    conn.execute(format!("PRAGMA cipher = '{cipher}'"))?;
+    conn.execute(format!("PRAGMA hexkey = '{hexkey}'"))?;
+    conn.execute(format!("PRAGMA page_size = {page_size}"))?;
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b BLOB)")?;
+    conn.execute("INSERT INTO t VALUES(1, randomblob(300))")?;
+
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows[0].0, 1, "row count mismatch for page_size={page_size}");
+    let ps: Vec<(i64,)> = conn.exec_rows("PRAGMA page_size");
+    assert_eq!(ps[0].0, page_size, "page_size readback mismatch");
+
+    do_flush(&conn, &tmp_db)?;
+
+    let uri = format!(
+        "file:{}?cipher={cipher}&hexkey={hexkey}",
+        tmp_db.path.to_str().unwrap()
+    );
+    let (_io, reopened) =
+        turso_core::Connection::from_uri(&uri, DatabaseOpts::new().with_encryption(true))?;
+    let rows: Vec<(i64,)> = reopened.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(
+        rows[0].0, 1,
+        "row count after reopen mismatch for page_size={page_size}"
+    );
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_encrypted_page_size_after_key_and_cipher(_tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    for page_size in [512, 4096, 65536] {
+        assert_encrypted_page_size_after_key_and_cipher(
+            page_size,
+            "aegis256x4",
+            ISSUE_7375_KEY_256,
+        )?;
+    }
+    // Different key size / metadata path.
+    assert_encrypted_page_size_after_key_and_cipher(512, "aes128gcm", ISSUE_7375_KEY_128)?;
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_uri_encryption_then_page_size(_tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let tmp_db = TempDatabaseBuilder::new()
+        .with_opts(DatabaseOpts::new().with_encryption(true))
+        .build();
+
+    let uri = format!(
+        "file:{}?cipher=aegis256x4&hexkey={ISSUE_7375_KEY_256}",
+        tmp_db.path.to_str().unwrap()
+    );
+
+    {
+        let (io, conn) =
+            turso_core::Connection::from_uri(&uri, DatabaseOpts::new().with_encryption(true))?;
+        conn.execute("PRAGMA page_size = 512")?;
+        conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b BLOB)")?;
+        conn.execute("INSERT INTO t VALUES(1, randomblob(300))")?;
+
+        let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+        assert_eq!(rows[0].0, 1);
+        let ps: Vec<(i64,)> = conn.exec_rows("PRAGMA page_size");
+        assert_eq!(ps[0].0, 512);
+
+        for c in conn.cacheflush()? {
+            io.wait_for_completion(c)?;
+        }
+    }
+
+    let (_io, reopened) =
+        turso_core::Connection::from_uri(&uri, DatabaseOpts::new().with_encryption(true))?;
+    let rows: Vec<(i64,)> = reopened.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows[0].0, 1);
+    let ps: Vec<(i64,)> = reopened.exec_rows("PRAGMA page_size");
+    assert_eq!(ps[0].0, 512);
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_fresh_attach_encrypted_non_4k_page_size(_tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let aux_dir = tempfile::tempdir()?;
+    let aux_path = aux_dir.path().join("aux.db");
+    let aux_uri = format!(
+        "file:{}?cipher=aegis256x4&hexkey={ISSUE_7375_KEY_256}",
+        aux_path.to_str().unwrap()
+    );
+
+    {
+        let main_db = TempDatabaseBuilder::new()
+            .with_opts(DatabaseOpts::new().with_encryption(true).with_attach(true))
+            .build();
+        let conn = main_db.connect_limbo();
+        conn.execute("PRAGMA page_size = 512")?;
+        conn.execute(format!("ATTACH '{aux_uri}' AS aux"))?;
+        conn.execute("CREATE TABLE aux.t(a INTEGER PRIMARY KEY, b BLOB)")?;
+        conn.execute("INSERT INTO aux.t VALUES(1, randomblob(300))")?;
+
+        let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM aux.t");
+        assert_eq!(rows[0].0, 1);
+        // Layout inheritance: the attached pager must adopt the main
+        // connection's page size, not the fresh-DB 4096 default.
+        let aux_ps: Vec<(i64,)> = conn.exec_rows("PRAGMA aux.page_size");
+        assert_eq!(aux_ps[0].0, 512);
+
+        // Force aux WAL onto its main file so the standalone reopen sees the row.
+        conn.execute("PRAGMA aux.wal_checkpoint(TRUNCATE)")?;
+        do_flush(&conn, &main_db)?;
+    }
+
+    let (_io, aux_conn) =
+        turso_core::Connection::from_uri(&aux_uri, DatabaseOpts::new().with_encryption(true))?;
+    let rows: Vec<(i64,)> = aux_conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows[0].0, 1);
+    let ps: Vec<(i64,)> = aux_conn.exec_rows("PRAGMA page_size");
+    assert_eq!(ps[0].0, 512);
+
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_inplace_vacuum_non_4k_encryption(_tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let tmp_db = TempDatabaseBuilder::new()
+        .with_opts(DatabaseOpts::new().with_encryption(true))
+        .build();
+
+    let conn = tmp_db.connect_limbo();
+    // Safe creation order so setup itself does not trigger the issue path.
+    conn.execute("PRAGMA page_size = 512")?;
+    conn.execute("PRAGMA cipher = 'aegis256x4'")?;
+    conn.execute(format!("PRAGMA hexkey = '{ISSUE_7375_KEY_256}'"))?;
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload BLOB)")?;
+    for i in 0..100i64 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, randomblob(300))"))?;
+    }
+    conn.execute("DELETE FROM t WHERE id % 3 = 0")?;
+
+    conn.execute("VACUUM")?;
+
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows[0].0, 66);
+    let ps: Vec<(i64,)> = conn.exec_rows("PRAGMA page_size");
+    assert_eq!(ps[0].0, 512);
+
+    do_flush(&conn, &tmp_db)?;
+
+    let uri = format!(
+        "file:{}?cipher=aegis256x4&hexkey={ISSUE_7375_KEY_256}",
+        tmp_db.path.to_str().unwrap()
+    );
+    let (_io, reopened) =
+        turso_core::Connection::from_uri(&uri, DatabaseOpts::new().with_encryption(true))?;
+    let rows: Vec<(i64,)> = reopened.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows[0].0, 66);
+
+    Ok(())
+}

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -1353,11 +1353,6 @@ fn test_non_4k_page_size_encryption_enable_mvcc_after_encryption(
 }
 
 // Regression coverage for https://github.com/tursodatabase/turso/issues/7375.
-// PRAGMA cipher/hexkey before PRAGMA page_size used to leave EncryptionContext
-// pinned to the default 4096-byte page size; the first write then panicked.
-
-const ISSUE_7375_KEY_256: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
-const ISSUE_7375_KEY_128: &str = "000102030405060708090a0b0c0d0e0f";
 
 fn assert_encrypted_page_size_after_key_and_cipher(
     page_size: i64,
@@ -1401,14 +1396,11 @@ fn assert_encrypted_page_size_after_key_and_cipher(
 fn test_encrypted_page_size_after_key_and_cipher(_tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();
     for page_size in [512, 4096, 65536] {
-        assert_encrypted_page_size_after_key_and_cipher(
-            page_size,
-            "aegis256x4",
-            ISSUE_7375_KEY_256,
-        )?;
+        assert_encrypted_page_size_after_key_and_cipher(page_size, CIPHER_A, KEY_A)?;
     }
-    // Different key size / metadata path.
-    assert_encrypted_page_size_after_key_and_cipher(512, "aes128gcm", ISSUE_7375_KEY_128)?;
+    // Exercise a cipher that uses a 16-byte key and different metadata size.
+    let aes128_key = &KEY_A[..32];
+    assert_encrypted_page_size_after_key_and_cipher(512, "aes128gcm", aes128_key)?;
     Ok(())
 }
 
@@ -1420,7 +1412,7 @@ fn test_uri_encryption_then_page_size(_tmp_db: TempDatabase) -> anyhow::Result<(
         .build();
 
     let uri = format!(
-        "file:{}?cipher=aegis256x4&hexkey={ISSUE_7375_KEY_256}",
+        "file:{}?cipher={CIPHER_A}&hexkey={KEY_A}",
         tmp_db.path.to_str().unwrap()
     );
 
@@ -1457,7 +1449,7 @@ fn test_fresh_attach_encrypted_non_4k_page_size(_tmp_db: TempDatabase) -> anyhow
     let aux_dir = tempfile::tempdir()?;
     let aux_path = aux_dir.path().join("aux.db");
     let aux_uri = format!(
-        "file:{}?cipher=aegis256x4&hexkey={ISSUE_7375_KEY_256}",
+        "file:{}?cipher={CIPHER_A}&hexkey={KEY_A}",
         aux_path.to_str().unwrap()
     );
 
@@ -1473,8 +1465,7 @@ fn test_fresh_attach_encrypted_non_4k_page_size(_tmp_db: TempDatabase) -> anyhow
 
         let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM aux.t");
         assert_eq!(rows[0].0, 1);
-        // Layout inheritance: the attached pager must adopt the main
-        // connection's page size, not the fresh-DB 4096 default.
+        // Attached pager must inherit main's page size, not the 4096 default.
         let aux_ps: Vec<(i64,)> = conn.exec_rows("PRAGMA aux.page_size");
         assert_eq!(aux_ps[0].0, 512);
 
@@ -1501,10 +1492,11 @@ fn test_inplace_vacuum_non_4k_encryption(_tmp_db: TempDatabase) -> anyhow::Resul
         .build();
 
     let conn = tmp_db.connect_limbo();
-    // Safe creation order so setup itself does not trigger the issue path.
+    // This test covers VACUUM, so create the source DB without using the issue
+    // #7375 PRAGMA order.
     conn.execute("PRAGMA page_size = 512")?;
-    conn.execute("PRAGMA cipher = 'aegis256x4'")?;
-    conn.execute(format!("PRAGMA hexkey = '{ISSUE_7375_KEY_256}'"))?;
+    conn.execute(format!("PRAGMA cipher = '{CIPHER_A}'"))?;
+    conn.execute(format!("PRAGMA hexkey = '{KEY_A}'"))?;
 
     conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, payload BLOB)")?;
     for i in 0..100i64 {
@@ -1522,7 +1514,7 @@ fn test_inplace_vacuum_non_4k_encryption(_tmp_db: TempDatabase) -> anyhow::Resul
     do_flush(&conn, &tmp_db)?;
 
     let uri = format!(
-        "file:{}?cipher=aegis256x4&hexkey={ISSUE_7375_KEY_256}",
+        "file:{}?cipher={CIPHER_A}&hexkey={KEY_A}",
         tmp_db.path.to_str().unwrap()
     );
     let (_io, reopened) =


### PR DESCRIPTION
## Description

This PR fixes encrypted database creation when the encryption context is initialised before the final database page size is selected.

Previously, `Pager::set_encryption_context` captured the current pager page size into `EncryptionContext`. For a fresh database, that value can still be the default `4096`. If `PRAGMA page_size` later changes the initial page size, the pager page size becomes e.g. `512`, but the encryption context still asserts/slices using `4096`, causing encrypted writes to panic.

This PR retargets the encryption context page-size field from `Pager::set_initial_page_size`, so all fresh-database page-size setup paths keep pager layout state and encryption layout state aligned.

### Why this fix

The fix is intentionally placed at the pager boundary where the invariant changes:

```rust
Pager::set_initial_page_size(...)
```

That covers all known reproducing surfaces:

- `PRAGMA cipher; PRAGMA hexkey; PRAGMA page_size=...`
- encrypted fresh `ATTACH`
- in-place `VACUUM` on encrypted non-4K databases

The encryption key and cipher mode are not rebuilt. Only the cached page-size value inside `EncryptionContext` is updated, because the page size is used for page slicing/assertions and is independent of key derivation.

No page-cache clear is needed here because `set_initial_page_size` already requires the pager to be uninitialised.

### Alternatives considered

**1) Fix only `Connection::reset_page_size`**

This was the smallest initial option, but it only covers the SQL PRAGMA path. It misses callers that set the initial page size directly on the pager, including fresh encrypted `ATTACH` and VACUUM-related pager setup.

That would fix the issue reproducer while leaving the same stale-context invariant reachable through other code paths.

**2) Rebuild the full encryption context**

Another option was to rebuild/reapply the full encryption context whenever the page size changes. That has a larger blast radius because it touches key/cipher setup semantics and risks introducing subtle differences in encryption initialisation order.

The bug does not require key material or cipher state to change. The stale field is only the page-size cache, so a narrow retarget is safer.

**3) Remove `page_size` from `EncryptionContext`**

Longer term, `EncryptionContext` could avoid storing page size and instead accept it from the caller at each encrypt/decrypt operation. That would make the invariant harder to violate by construction.

I did not choose that here because it would require changing the encryption API surface and all call sites that rely on the current context shape. That is a broader refactor with more regression risk than needed for this bug fix.

### Tests

Added regression coverage for:

- encryption context created before `PRAGMA page_size`
- URI encryption setup followed by `PRAGMA page_size`
- fresh encrypted `ATTACH` with inherited non-4K page size
- in-place `VACUUM` on encrypted non-4K database

Also verified nearby encryption, ATTACH, and VACUUM integration tests.

## Motivation and context

Issue: https://github.com/tursodatabase/turso/issues/7375

## Description of AI Usage

Same as previous contributions, used Codex for code & path discovery.