### PR TITLE
cli: use shlex tokenization when parsing dot commands arguments

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -780,20 +780,20 @@ impl Limbo {
 
     pub fn handle_dot_command(&mut self, line: &str) {
         let first = line.split_whitespace().next();
+        let args = shlex::split(line).unwrap_or_else(|| {
+            line.split_whitespace()
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        });
+
         let parse = match first {
             Some("parameter") | Some("param") => {
-                let args = shlex::split(line).unwrap_or_else(|| {
-                    line.split_whitespace()
-                        .map(str::to_owned)
-                        .collect::<Vec<_>>()
-                });
                 if args.is_empty() {
                     return;
                 }
                 CommandParser::try_parse_from(args)
             }
             _ => {
-                let args = line.split_whitespace();
                 CommandParser::try_parse_from(args)
             }
         };

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -793,9 +793,7 @@ impl Limbo {
                 }
                 CommandParser::try_parse_from(args)
             }
-            _ => {
-                CommandParser::try_parse_from(args)
-            }
+            _ => CommandParser::try_parse_from(args),
         };
         match parse {
             Err(err) => {


### PR DESCRIPTION
Use shlex tokenization to parse dot commands arguments in all cases.
This allows using quoted strings which contain white spaces to be treated as a single argument, allowing for example paths with spaces, as reported in #7338 
Fixes #7338 