### PR TITLE
Resolve cargo artifact dir via scripts/cargo-target-dir

### DIFF
--- a/perf/clickbench/benchmark.sh
+++ b/perf/clickbench/benchmark.sh
@@ -3,7 +3,7 @@
 # https://github.com/ClickHouse/ClickBench/tree/main/sqlite
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-RELEASE_BUILD_DIR="$REPO_ROOT/target/release"
+RELEASE_BUILD_DIR="$("$REPO_ROOT/scripts/cargo-target-dir")/release"
 CLICKBENCH_DIR="$REPO_ROOT/perf/clickbench"
 
 # Install sqlite3 locally if needed

--- a/perf/clickbench/run.sh
+++ b/perf/clickbench/run.sh
@@ -6,7 +6,7 @@
 TRIES=1
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-RELEASE_BUILD_DIR=$REPO_ROOT/target/release
+RELEASE_BUILD_DIR="$("$REPO_ROOT/scripts/cargo-target-dir")/release"
 CLICKBENCH_DIR=$REPO_ROOT/perf/clickbench
 
 # Install sqlite3 locally if needed

--- a/perf/connection/limbo/run-benchmark.sh
+++ b/perf/connection/limbo/run-benchmark.sh
@@ -3,6 +3,9 @@
 echo "Building benchmark..."
 cargo build --release
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+RELEASE_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/release"
+
 echo "Running connection benchmarks..."
 echo "database,iterations,p50,p90,p95,p99,p999,p9999,p99999" > results.csv
 
@@ -10,7 +13,7 @@ echo "database,iterations,p50,p90,p95,p99,p999,p9999,p99999" > results.csv
 for db in database_10.db database_1k.db database_5k.db database_10k.db
 do
   echo "Testing $db..."
-  ./target/release/limbo-connection-benchmark $db --iterations 1000 | tail -1 >> results.csv
+  "$RELEASE_DIR/limbo-connection-benchmark" $db --iterations 1000 | tail -1 >> results.csv
 done
 
 echo "Results written to results.csv"

--- a/perf/connection/rusqlite/run-benchmark.sh
+++ b/perf/connection/rusqlite/run-benchmark.sh
@@ -3,6 +3,9 @@
 echo "Building benchmark..."
 cargo build --release
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+RELEASE_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/release"
+
 echo "Running connection benchmarks..."
 echo "database,iterations,p50,p90,p95,p99,p999,p9999,p99999" > results.csv
 
@@ -10,7 +13,7 @@ echo "database,iterations,p50,p90,p95,p99,p999,p9999,p99999" > results.csv
 for db in database_10.db database_1k.db database_5k.db database_10k.db
 do
   echo "Testing $db..."
-  ./target/release/rusqlite-connection-benchmark $db --iterations 1000 | tail -1 >> results.csv
+  "$RELEASE_DIR/rusqlite-connection-benchmark" $db --iterations 1000 | tail -1 >> results.csv
 done
 
 echo "Results written to results.csv"

--- a/perf/latency/limbo/run-benchmark.sh
+++ b/perf/latency/limbo/run-benchmark.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+RELEASE_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/release"
+
 for i in $(seq 10 10 100)
 do
-  ./target/release/limbo-multitenancy $i >> results.csv
+  "$RELEASE_DIR/limbo-multitenancy" $i >> results.csv
 done

--- a/perf/latency/rusqlite/run-benchmark.sh
+++ b/perf/latency/rusqlite/run-benchmark.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+RELEASE_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/release"
+
 for i in $(seq 10 10 100)
 do
-  ./target/release/rusqlite-multitenancy $i >> results.csv
+  "$RELEASE_DIR/rusqlite-multitenancy" $i >> results.csv
 done

--- a/perf/throughput/rusqlite/scripts/bench.sh
+++ b/perf/throughput/rusqlite/scripts/bench.sh
@@ -2,11 +2,14 @@
 
 cargo build --release
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+RELEASE_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/release"
+
 echo "system,threads,batch_size,compute,throughput"
 
 for threads in 1 2 4 8; do
   for compute in 0 100 500 1000; do
       rm -f write_throughput_test.db*
-      ../../../target/release/write-throughput-sqlite --threads ${threads} --batch-size 100 --compute ${compute} -i 1000
+      "$RELEASE_DIR/write-throughput-sqlite" --threads ${threads} --batch-size 100 --compute ${compute} -i 1000
   done
 done

--- a/perf/throughput/turso/scripts/bench.sh
+++ b/perf/throughput/turso/scripts/bench.sh
@@ -2,11 +2,14 @@
 
 cargo build --release
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+RELEASE_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/release"
+
 echo "system,threads,batch_size,compute,throughput"
 
 for threads in 1 2 4 8; do
   for compute in 0 100 500 1000; do
       rm -f write_throughput_test.db*
-      ../../../target/release/write-throughput --threads ${threads} --batch-size 100 --compute ${compute} -i 1000 --mode concurrent
+      "$RELEASE_DIR/write-throughput" --threads ${threads} --batch-size 100 --compute ${compute} -i 1000 --mode concurrent
   done
 done

--- a/perf/tpc-h/benchmark.sh
+++ b/perf/tpc-h/benchmark.sh
@@ -2,7 +2,7 @@
 # TPC-H benchmark script
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-RELEASE_BUILD_DIR="$REPO_ROOT/target/release"
+RELEASE_BUILD_DIR="$("$REPO_ROOT/scripts/cargo-target-dir")/release"
 TPCH_DIR="$REPO_ROOT/perf/tpc-h"
 DB_FILE="$TPCH_DIR/TPC-H.db"
 

--- a/perf/tpc-h/compare.sh
+++ b/perf/tpc-h/compare.sh
@@ -8,7 +8,7 @@ if [ -z "$1" ]; then
     exit 1
 fi
 MAIN_BIN=$1
-CURR_BIN=${2:-./target/release/tursodb}
+CURR_BIN=${2:-$(./scripts/cargo-target-dir)/release/tursodb}
 DB=perf/tpc-h/TPC-H.db
 QUERY_GLOB=${TPCH_QUERY_GLOB:-*.sql}
 if [ ! -f "$DB" ]; then

--- a/perf/tpc-h/run.sh
+++ b/perf/tpc-h/run.sh
@@ -3,7 +3,7 @@
 
 export RUST_LOG=off
 REPO_ROOT=$(git rev-parse --show-toplevel)
-RELEASE_BUILD_DIR="$REPO_ROOT/target/release"
+RELEASE_BUILD_DIR="$("$REPO_ROOT/scripts/cargo-target-dir")/release"
 TPCH_DIR="$REPO_ROOT/perf/tpc-h"
 DB_FILE="$TPCH_DIR/TPC-H.db"
 QUERIES_DIR="$TPCH_DIR/queries"

--- a/scripts/cargo-target-dir
+++ b/scripts/cargo-target-dir
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Print the directory cargo uses for build artefacts."""
+
+import json
+import os
+import subprocess
+import sys
+
+# Resolve the workspace manifest from this script's location so the answer is
+# independent of the caller's working directory.
+repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+manifest = os.path.join(repo_root, "Cargo.toml")
+
+result = subprocess.run(
+    [
+        "cargo", "metadata", "--format-version", "1", "--no-deps", "--offline",
+        "--manifest-path", manifest,
+    ],
+    capture_output=True,
+    text=True,
+)
+if result.returncode != 0:
+    sys.exit(result.stderr.strip() or "cargo metadata failed")
+print(json.loads(result.stdout)["target_directory"])

--- a/scripts/limbo-sqlite3
+++ b/scripts/limbo-sqlite3
@@ -2,9 +2,9 @@
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Go to the project root (one level up from scripts/)
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-TURSODB="$PROJECT_ROOT/target/debug/tursodb"
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+TARGET_DIR="$("$SCRIPT_DIR/cargo-target-dir")"
+TURSODB="$TARGET_DIR/debug/tursodb"
 
 # Add experimental features for testing
 EXPERIMENTAL_FLAGS="--experimental-views --experimental-attach"

--- a/scripts/turso-mvcc-sqlite3
+++ b/scripts/turso-mvcc-sqlite3
@@ -2,9 +2,9 @@
 
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Go to the project root (one level up from scripts/)
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-TURSODB="$PROJECT_ROOT/target/debug/tursodb"
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+TARGET_DIR="$("$SCRIPT_DIR/cargo-target-dir")"
+TURSODB="$TARGET_DIR/debug/tursodb"
 
 # Add experimental features for testing
 # Note: MVCC is enabled via PRAGMA journal_mode = 'mvcc'

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -1,9 +1,25 @@
 #!/usr/bin/env python3
 import os
+import subprocess
+from pathlib import Path
 
 from cli_tests import console
 from cli_tests.test_turso_cli import TestTursoShell
 
+
+def _cargo_debug_dir() -> str:
+    """Return cargo's debug artefact directory (honours CARGO_TARGET_DIR)."""
+    root = Path(__file__).resolve().parents[2]
+    out = subprocess.run(
+        [str(root / "scripts" / "cargo-target-dir")],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return f"{out.stdout.strip()}/debug"
+
+
+DEBUG_DIR = _cargo_debug_dir()
 sqlite_exec = "./scripts/limbo-sqlite3"
 sqlite_flags = os.getenv("SQLITE_FLAGS", "-q").split(" ")
 
@@ -72,7 +88,7 @@ def null(res):
 
 def test_regexp():
     turso = TestTursoShell(test_data)
-    extension_path = "./target/debug/liblimbo_regexp"
+    extension_path = f"{DEBUG_DIR}/liblimbo_regexp"
     # regexp() is a built-in, verify it works before loading the extension
     turso.run_test_fn("SELECT regexp('a.c', 'abc');", true)
     turso.run_test_fn(f".load {extension_path}", null)
@@ -271,7 +287,7 @@ def validate_base64_decode(a):
 
 def test_crypto():
     turso = TestTursoShell()
-    extension_path = "./target/debug/liblimbo_crypto"
+    extension_path = f"{DEBUG_DIR}/liblimbo_crypto"
     # assert no function before extension loads
     turso.run_test_fn(
         "SELECT crypto_blake('a');",
@@ -409,8 +425,8 @@ def _test_series(limbo: TestTursoShell):
 
 
 def test_kv():
-    _test_kv(exec_name=None, ext_path="target/debug/libturso_ext_tests")
-    _test_kv(exec_name="sqlite3", ext_path="target/debug/liblimbo_sqlite_test_ext")
+    _test_kv(exec_name=None, ext_path=f"{DEBUG_DIR}/libturso_ext_tests")
+    _test_kv(exec_name="sqlite3", ext_path=f"{DEBUG_DIR}/liblimbo_sqlite_test_ext")
 
 
 def _test_kv(exec_name, ext_path):
@@ -526,7 +542,7 @@ def _test_kv(exec_name, ext_path):
 
 def test_ipaddr():
     turso = TestTursoShell()
-    ext_path = "./target/debug/liblimbo_ipaddr"
+    ext_path = f"{DEBUG_DIR}/liblimbo_ipaddr"
 
     turso.run_test_fn(
         "SELECT ipfamily('192.168.1.1');",
@@ -650,7 +666,7 @@ def validate_fuzzy_script(a):
 
 def test_fuzzy():
     turso = TestTursoShell()
-    ext_path = "./target/debug/liblimbo_fuzzy"
+    ext_path = f"{DEBUG_DIR}/liblimbo_fuzzy"
     turso.run_test_fn(
         "SELECT fuzzy_leven('awesome', 'aewsme');",
         lambda res: "error: no such function: " in res,
@@ -787,7 +803,7 @@ def test_fuzzy():
 
 def test_vfs():
     turso = TestTursoShell()
-    ext_path = "target/debug/libturso_ext_tests"
+    ext_path = f"{DEBUG_DIR}/libturso_ext_tests"
     turso.run_test_fn(".vfslist", lambda x: "testvfs" not in x, "testvfs not loaded")
     turso.execute_dot(f".load {ext_path}")
     turso.run_test_fn(".vfslist", lambda res: "testvfs" in res, "testvfs extension loaded")
@@ -844,7 +860,7 @@ def test_csv():
     # open new empty connection explicitly to test whether we can load an extension
     # with brand new connection/uninitialized database.
     turso = TestTursoShell(init_commands="")
-    test_module_list(turso, "target/debug/liblimbo_csv", "csv")
+    test_module_list(turso, f"{DEBUG_DIR}/liblimbo_csv", "csv")
 
     turso.run_test_fn(
         "CREATE VIRTUAL TABLE csv USING csv(filename=./testing/cli_tests/test_files/test.csv);",
@@ -923,7 +939,7 @@ def cleanup():
 
 
 def test_tablestats():
-    ext_path = "target/debug/libturso_ext_tests"
+    ext_path = f"{DEBUG_DIR}/libturso_ext_tests"
     turso = TestTursoShell(use_testing_db=True)
     test_module_list(turso, ext_path=ext_path, module_name="tablestats")
     turso.execute_dot("CREATE TABLE people(id INTEGER PRIMARY KEY, name TEXT);")

--- a/testing/cli_tests/sqlite_bench.py
+++ b/testing/cli_tests/sqlite_bench.py
@@ -14,8 +14,14 @@ from cli_tests.console import error, info, test
 from cli_tests.test_turso_cli import TestTursoShell
 from faker import Faker
 
-# for now, use debug for the debug assertions
-LIMBO_BIN = Path("./target/release/tursodb")
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+_TARGET_DIR = subprocess.run(
+    [str(Path(__file__).resolve().parents[2] / "scripts" / "cargo-target-dir")],
+    capture_output=True,
+    text=True,
+    check=True,
+).stdout.strip()
+LIMBO_BIN = Path(_TARGET_DIR) / "release" / "tursodb"
 DB_FILE = Path("testing/system/temp.db")
 
 SQLITE_BIN = "sqlite3"

--- a/testing/cli_tests/vfs_bench.py
+++ b/testing/cli_tests/vfs_bench.py
@@ -13,7 +13,14 @@ from typing import Dict
 from cli_tests.console import error, info, test
 from cli_tests.test_turso_cli import TestTursoShell
 
-LIMBO_BIN = Path("./target/release/tursodb")
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+_TARGET_DIR = subprocess.run(
+    [str(Path(__file__).resolve().parents[2] / "scripts" / "cargo-target-dir")],
+    capture_output=True,
+    text=True,
+    check=True,
+).stdout.strip()
+LIMBO_BIN = Path(_TARGET_DIR) / "release" / "tursodb"
 DB_FILE = Path("testing/system/temp.db")
 vfs_list = ["syscall"]
 if platform.system() == "Linux":

--- a/testing/concurrent-simulator/bin/explore
+++ b/testing/concurrent-simulator/bin/explore
@@ -30,7 +30,10 @@ fi
 
 cargo build $FEATURES -p turso_whopper
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+DEBUG_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/debug"
+
 echo "Running Whopper in an infinite loop in 'fast' mode..."
 while true; do
-    time RUST_BACKTRACE=full ./target/debug/turso_whopper --mode fast "${ARGS[@]}"
+    time RUST_BACKTRACE=full "$DEBUG_DIR/turso_whopper" --mode fast "${ARGS[@]}"
 done

--- a/testing/concurrent-simulator/bin/run
+++ b/testing/concurrent-simulator/bin/run
@@ -30,4 +30,7 @@ fi
 
 cargo build $FEATURES -p turso_whopper
 
-time RUST_BACKTRACE=full ./target/debug/turso_whopper "${ARGS[@]}"
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+DEBUG_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/debug"
+
+time RUST_BACKTRACE=full "$DEBUG_DIR/turso_whopper" "${ARGS[@]}"

--- a/testing/concurrent-simulator/bin/run-elle
+++ b/testing/concurrent-simulator/bin/run-elle
@@ -57,13 +57,16 @@ else
 fi
 cargo build -p turso_whopper
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+DEBUG_DIR="$("$(git rev-parse --show-toplevel)/scripts/cargo-target-dir")/debug"
+
 WHOPPER_ARGS=(--elle list-append --elle-output "$OUTPUT_FILE" --dump-db)
 if [[ "$ENABLE_MVCC" -eq 1 ]]; then
     WHOPPER_ARGS+=(--enable-mvcc)
 fi
 WHOPPER_ARGS+=("${ARGS[@]}")
 
-time RUST_BACKTRACE=full ./target/debug/turso_whopper "${WHOPPER_ARGS[@]}"
+time RUST_BACKTRACE=full "$DEBUG_DIR/turso_whopper" "${WHOPPER_ARGS[@]}"
 
 if [[ "$SKIP_ANALYSIS" -eq 1 ]]; then
     echo ""

--- a/testing/sqlright/collect_coverage.sh
+++ b/testing/sqlright/collect_coverage.sh
@@ -24,7 +24,8 @@ fi
 echo "=== Building coverage-instrumented tursodb ==="
 cd "$LIMBO_ROOT"
 RUSTFLAGS="-C instrument-coverage" cargo build --bin tursodb 2>&1 | tail -5
-COV_BINARY="$LIMBO_ROOT/target/debug/tursodb"
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+COV_BINARY="$("$LIMBO_ROOT/scripts/cargo-target-dir")/debug/tursodb"
 
 echo "=== Replaying corpus through coverage binary ==="
 rm -rf "$COV_PROFILE_DIR"

--- a/testing/sqlright/crash_reports/collect_crashes.py
+++ b/testing/sqlright/crash_reports/collect_crashes.py
@@ -8,6 +8,7 @@ Idempotent and incremental - safe to run multiple times.
 
 import argparse
 import logging
+import subprocess
 import sys
 from pathlib import Path
 
@@ -29,10 +30,28 @@ def setup_logging(verbose: bool = False):
     )
 
 
+def _cargo_target_dir() -> Path | None:
+    """Return cargo's target directory (honours CARGO_TARGET_DIR), or None."""
+    repo_root = Path(__file__).resolve().parents[3]
+    helper = repo_root / "scripts" / "cargo-target-dir"
+    if not helper.exists():
+        return None
+    try:
+        out = subprocess.run([str(helper)], capture_output=True, text=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return Path(out.stdout.strip())
+
+
 def find_tursodb() -> Path:
     """Find tursodb binary."""
     # Try common locations
-    locations = [
+    locations = []
+    target_dir = _cargo_target_dir()
+    if target_dir is not None:
+        locations.append(target_dir / "debug" / "tursodb")
+        locations.append(target_dir / "release" / "tursodb")
+    locations += [
         Path.home() / "work/limbo-main/target/debug/tursodb",
         Path.home() / "work/limbo-main/target/release/tursodb",
         Path("/usr/local/bin/tursodb"),

--- a/testing/system/tester.tcl
+++ b/testing/system/tester.tcl
@@ -5,13 +5,16 @@ set test_small_dbs [list "testing/system/testing_small.db" ]
 # Array storing loaded extensions
 array set extensions {}
 
+# Ask cargo where build artefacts live (honours CARGO_TARGET_DIR)
+set debug_dir "[exec ./scripts/cargo-target-dir]/debug"
+
 # Mapping of extension names to their respective library paths per database type
-set extension_map {
-    test_ext {
-        sqlite "./target/debug/liblimbo_sqlite_test_ext"
-        turso  "./target/debug/libturso_ext_tests"
-    }
-}
+set extension_map [list \
+    test_ext [list \
+        sqlite "$debug_dir/liblimbo_sqlite_test_ext" \
+        turso  "$debug_dir/libturso_ext_tests" \
+    ] \
+]
 
 proc load_extension {extension_name} {
     global extension_map


### PR DESCRIPTION
Scripts that hardcoded target/debug or target/release now ask the
scripts/cargo-target-dir helper for cargo's actual artifact directory,
so they keep working when CARGO_TARGET_DIR points elsewhere.
