### PR TITLE
fix: `exec_round` should round half away from zero

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -793,9 +793,8 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let f: f64 = crate::numeric::str_to_f64(format!("{f:.precision$}"))
-            .expect("formatted float should always parse successfully")
-            .into();
+        let multiplier = 10f64.powi(precision as i32);
+        let f = (f * multiplier).round() / multiplier;
 
         Value::from_f64(f)
     }
@@ -2730,6 +2729,16 @@ mod tests {
         let input_val = Value::from_f64(100.123);
         let expected_val = Value::Null;
         assert_eq!(input_val.exec_round(Some(&Value::Null)), expected_val);
+
+        let input_val = Value::from_f64(2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.225);
+        let precision_val = Value::from_i64(2);
+        let expected_val = Value::from_f64(2.23);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
     }
 
     #[test]

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -793,10 +793,7 @@ impl Value {
             return Value::from_f64(((f + if f < 0.0 { -0.5 } else { 0.5 }) as i64) as f64);
         }
 
-        let multiplier = 10f64.powi(precision as i32);
-        let f = (f * multiplier).round() / multiplier;
-
-        Value::from_f64(f)
+        Value::from_f64(round_half_away_from_zero(f, precision))
     }
 
     fn _exec_trim(&self, pattern: Option<&Value>, trim_type: TrimType) -> Value {
@@ -1612,6 +1609,37 @@ fn compare_chars(p: char, t: char, no_case: bool) -> bool {
         p.eq_ignore_ascii_case(&t)
     } else {
         p == t
+    }
+}
+
+/// Rounds `f` to `precision` fractional digits, rounding halves away from zero
+/// to match SQLite's `ROUND()`. Uses `mul_add` to recover the error of the scaling multiply.
+///
+/// Values past ~15 significant digits may still differ from SQLite, but those are beyond f64's
+/// reliable precision regardless.
+fn round_half_away_from_zero(f: f64, precision: usize) -> f64 {
+    debug_assert!((1..=30).contains(&precision));
+
+    let sign_negative = f.is_sign_negative();
+    let abs_f = f.abs();
+    let scale = 10f64.powi(precision as i32);
+
+    // True product is `scaled + err`; `err` is the bits the multiply dropped.
+    let scaled = abs_f * scale;
+    let err = abs_f.mul_add(scale, -scaled);
+
+    let floor = scaled.floor();
+    let decision = (scaled - floor - 0.5) + err;
+
+    // `>= 0.0` rounds up both above the halfway point and at an exact tie,
+    // which goes away from zero (up, since `abs_f` is non-negative).
+    let rounded_scaled = if decision >= 0.0 { floor + 1.0 } else { floor };
+
+    let abs_result = rounded_scaled / scale;
+    if sign_negative {
+        -abs_result
+    } else {
+        abs_result
     }
 }
 
@@ -2738,6 +2766,81 @@ mod tests {
         let input_val = Value::from_f64(2.225);
         let precision_val = Value::from_i64(2);
         let expected_val = Value::from_f64(2.23);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.675);
+        let precision_val = Value::from_i64(2);
+        let expected_val = Value::from_f64(2.67);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(1.15);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(1.1);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.675);
+        let precision_val = Value::from_i64(2);
+        let expected_val = Value::from_f64(-2.67);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(0.5);
+        let precision_val = Value::from_i64(0);
+        let expected_val = Value::from_f64(1.0);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.5);
+        let precision_val = Value::from_i64(0);
+        let expected_val = Value::from_f64(3.0);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.5);
+        let precision_val = Value::from_i64(0);
+        let expected_val = Value::from_f64(-3.0);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(1.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(1.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-2.25);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(-2.3);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(0.999);
+        let precision_val = Value::from_i64(2);
+        let expected_val = Value::from_f64(1.0);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(9.99);
+        let precision_val = Value::from_i64(1);
+        let expected_val = Value::from_f64(10.0);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(0.125);
+        let precision_val = Value::from_i64(2);
+        let expected_val = Value::from_f64(0.13);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(1.005);
+        let precision_val = Value::from_i64(2);
+        let expected_val = Value::from_f64(1.0);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(-0.5);
+        let precision_val = Value::from_i64(0);
+        let expected_val = Value::from_f64(-1.0);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(2.675);
+        let precision_val = Value::build_text("2");
+        let expected_val = Value::from_f64(2.67);
+        assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
+
+        let input_val = Value::from_f64(0.5);
+        let precision_val = Value::build_text("0");
+        let expected_val = Value::from_f64(1.0);
         assert_eq!(input_val.exec_round(Some(&precision_val)), expected_val);
     }
 

--- a/testing/sqltests/tests/math/round.sqltest
+++ b/testing/sqltests/tests/math/round.sqltest
@@ -1,0 +1,169 @@
+@database :memory:
+
+test round-basic {
+    SELECT round(123.456);
+}
+expect {
+    123.0
+}
+
+test round-precision-2 {
+    SELECT round(123.456, 2);
+}
+expect {
+    123.46
+}
+
+test round-text-precision {
+    SELECT round(123.456, '1');
+}
+expect {
+    123.5
+}
+
+test round-text-input {
+    SELECT round('123.456', 2);
+}
+expect {
+    123.46
+}
+
+test round-int-input {
+    SELECT round(123, 1);
+}
+expect {
+    123.0
+}
+
+test round-no-precision {
+    SELECT round(100.123);
+}
+expect {
+    100.0
+}
+
+test round-null-precision {
+    SELECT round(100.123, NULL);
+}
+expect {
+    NULL
+}
+
+test round-half-away-from-zero-2-25 {
+    SELECT round(2.25, 1);
+}
+expect {
+    2.3
+}
+
+test round-half-away-from-zero-2-225 {
+    SELECT round(2.225, 2);
+}
+expect {
+    2.23
+}
+
+test round-float-repr-2-675 {
+    SELECT round(2.675, 2);
+}
+expect {
+    2.67
+}
+
+test round-float-repr-1-15 {
+    SELECT round(1.15, 1);
+}
+expect {
+    1.1
+}
+
+test round-float-repr-neg-2-675 {
+    SELECT round(-2.675, 2);
+}
+expect {
+    -2.67
+}
+
+test round-half-away-from-zero-0-5 {
+    SELECT round(0.5, 0);
+}
+expect {
+    1.0
+}
+
+test round-half-away-from-zero-2-5 {
+    SELECT round(2.5, 0);
+}
+expect {
+    3.0
+}
+
+test round-half-away-from-zero-neg-2-5 {
+    SELECT round(-2.5, 0);
+}
+expect {
+    -3.0
+}
+
+test round-half-away-from-zero-1-25 {
+    SELECT round(1.25, 1);
+}
+expect {
+    1.3
+}
+
+test round-half-away-from-zero-neg-2-25 {
+    SELECT round(-2.25, 1);
+}
+expect {
+    -2.3
+}
+
+test round-carry-0-999 {
+    SELECT round(0.999, 2);
+}
+expect {
+    1.0
+}
+
+test round-carry-9-99 {
+    SELECT round(9.99, 1);
+}
+expect {
+    10.0
+}
+
+test round-half-away-from-zero-0-125 {
+    SELECT round(0.125, 2);
+}
+expect {
+    0.13
+}
+
+test round-float-repr-1-005 {
+    SELECT round(1.005, 2);
+}
+expect {
+    1.0
+}
+
+test round-half-away-from-zero-neg-0-5 {
+    SELECT round(-0.5, 0);
+}
+expect {
+    -1.0
+}
+
+test round-text-precision-2 {
+    SELECT round(2.675, '2');
+}
+expect {
+    2.67
+}
+
+test round-text-precision-0 {
+    SELECT round(0.5, '0');
+}
+expect {
+    1.0
+}

--- a/testing/sqltests/tests/math/round.sqltest
+++ b/testing/sqltests/tests/math/round.sqltest
@@ -46,7 +46,6 @@ test round-null-precision {
     SELECT round(100.123, NULL);
 }
 expect {
-    NULL
 }
 
 test round-half-away-from-zero-2-25 {

--- a/testing/sqltests/tests/math/round.sqltest
+++ b/testing/sqltests/tests/math/round.sqltest
@@ -6,6 +6,9 @@ test round-basic {
 expect {
     123.0
 }
+expect @js {
+    123
+}
 
 test round-precision-2 {
     SELECT round(123.456, 2);
@@ -34,12 +37,18 @@ test round-int-input {
 expect {
     123.0
 }
+expect @js {
+    123
+}
 
 test round-no-precision {
     SELECT round(100.123);
 }
 expect {
     100.0
+}
+expect @js {
+    100
 }
 
 test round-null-precision {
@@ -89,6 +98,9 @@ test round-half-away-from-zero-0-5 {
 expect {
     1.0
 }
+expect @js {
+    1
+}
 
 test round-half-away-from-zero-2-5 {
     SELECT round(2.5, 0);
@@ -96,12 +108,18 @@ test round-half-away-from-zero-2-5 {
 expect {
     3.0
 }
+expect @js {
+    3
+}
 
 test round-half-away-from-zero-neg-2-5 {
     SELECT round(-2.5, 0);
 }
 expect {
     -3.0
+}
+expect @js {
+    -3
 }
 
 test round-half-away-from-zero-1-25 {
@@ -124,12 +142,18 @@ test round-carry-0-999 {
 expect {
     1.0
 }
+expect @js {
+    1
+}
 
 test round-carry-9-99 {
     SELECT round(9.99, 1);
 }
 expect {
     10.0
+}
+expect @js {
+    10
 }
 
 test round-half-away-from-zero-0-125 {
@@ -145,12 +169,18 @@ test round-float-repr-1-005 {
 expect {
     1.0
 }
+expect @js {
+    1
+}
 
 test round-half-away-from-zero-neg-0-5 {
     SELECT round(-0.5, 0);
 }
 expect {
     -1.0
+}
+expect @js {
+    -1
 }
 
 test round-text-precision-2 {
@@ -165,4 +195,7 @@ test round-text-precision-0 {
 }
 expect {
     1.0
+}
+expect @js {
+    1
 }


### PR DESCRIPTION

## Description

 ROUND(x, d) was using Rust's `format!("{:.N}", f)` to perform rounding, which applies round-half-to-even (banker's rounding). SQLite uses round-half-away-from-zero.
 
This resulted in inconsistent rounding results for values halfway between precision.
 
This fix replaces the string format roundtrip by scaling the input by 10^precision, and using `mul_add` to recover the rounding errors in scaling.

This also eliminates the per call heap allocation of Rust's `format!` approach.

## Motivation and context

Fixes #5748


## Description of AI Usage

Claude Code was used to verify correctness, explore non-naive rounding solutions, and locally establish baseline and post-fix benchmarks.
