### PR TITLE
 fix: handle rowid-alias columns in composite FK key probes

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1749,15 +1749,33 @@ pub(crate) fn emit_columns_and_dependencies(
     resolver: &Resolver,
 ) -> Result<DmlColumnContext> {
     let targets: Vec<usize> = target_columns.into_iter().collect();
+    let target_mask: ColumnMask = targets.iter().copied().try_collect()?;
+    let non_rowid_targets: Vec<usize> = targets
+        .iter()
+        .copied()
+        .filter(|&idx| !table.columns()[idx].is_rowid_alias())
+        .collect();
+    let mut non_rowid_target_positions = vec![None; table.columns().len()];
+    for (pos, idx) in non_rowid_targets.iter().copied().enumerate() {
+        non_rowid_target_positions[idx] = Some(pos);
+    }
     let dependencies = table.dependencies_of_columns(targets.iter().copied())?;
 
-    let target_base = program.alloc_registers(targets.len());
+    let target_base = if non_rowid_targets.is_empty() {
+        0
+    } else {
+        program.alloc_registers(non_rowid_targets.len())
+    };
     let extra_base = {
         let mut dependencies_not_in_targets: ColumnMask = dependencies.clone();
-        let target_mask = targets.iter().copied().try_collect()?;
-        dependencies_not_in_targets.union_with(&target_mask)?;
+        dependencies_not_in_targets -= &target_mask;
 
-        let extra_count = dependencies_not_in_targets.count();
+        let extra_count = table
+            .columns()
+            .iter()
+            .enumerate()
+            .filter(|(idx, col)| dependencies_not_in_targets.get(*idx) && !col.is_rowid_alias())
+            .count();
 
         if extra_count > 0 {
             program.alloc_registers(extra_count)
@@ -1768,14 +1786,14 @@ pub(crate) fn emit_columns_and_dependencies(
 
     let mut extra_idx = 0;
     let pairs = table.columns().iter().enumerate().map(|(idx, col)| {
-        let reg = if col.is_rowid_alias() {
-            rowid_reg
-        } else if let Some(pos) = targets.iter().position(|&t| t == idx) {
+        let reg = if let Some(pos) = non_rowid_target_positions[idx] {
             let reg = target_base + pos;
             if !col.is_virtual_generated() {
                 program.emit_column_or_rowid(cursor_id, idx, reg);
             }
             reg
+        } else if col.is_rowid_alias() {
+            rowid_reg
         } else if dependencies.get(idx) {
             let reg = extra_base + extra_idx;
             program.emit_column_or_rowid(cursor_id, idx, reg);

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1733,18 +1733,13 @@ pub(crate) fn init_limit(
     Ok(())
 }
 
-/// Emits  `target_columns`, plus the stored columns needed by `target_columns`, into compact
-/// registers. This takes into account stored columns, and any stored columns required
-/// by virtual columns in `target_columns`.
+/// Emits `target_columns`, plus the stored columns needed by `target_columns`, into a
+/// DML row context. This takes into account stored columns, and any stored columns
+/// required by virtual columns in `target_columns`.
 ///
-/// Target columns are guaranteed to be in a contiguous block, in the given order, at the start of
-/// registers. The following postcondition holds:
-///
-/// ```text
-/// dml_ctx.to_column_reg(target_columns[i]) == dml_ctx.to_column_reg(target_columns[0]) + i
-/// ```
-///
-/// This way, target_columns[0] can be used as a base for opcodes that require unpacked records.
+/// Non-rowid target columns are allocated in target order. Rowid-alias columns resolve
+/// to `rowid_reg`, so callers that need an unpacked contiguous key or record must
+/// materialize one from `DmlColumnContext::to_column_reg`.
 pub(crate) fn emit_columns_and_dependencies(
     program: &mut ProgramBuilder,
     table: &BTreeTable,
@@ -1792,9 +1787,14 @@ pub(crate) fn emit_columns_and_dependencies(
         (col, reg)
     });
     let dml_ctx = DmlColumnContext::from_column_reg_mapping(pairs);
-    debug_assert!(targets
-        .windows(2)
-        .all(|w| { dml_ctx.to_column_reg(w[1]) == dml_ctx.to_column_reg(w[0]) + 1 }));
+    if targets
+        .iter()
+        .all(|&idx| !table.columns()[idx].is_rowid_alias())
+    {
+        debug_assert!(targets
+            .windows(2)
+            .all(|w| { dml_ctx.to_column_reg(w[1]) == dml_ctx.to_column_reg(w[0]) + 1 }));
+    }
 
     let table_arc = Arc::new(table.clone());
     gencol::compute_virtual_columns(

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -316,6 +316,34 @@ fn copy_with_affinity(
     dst
 }
 
+/// Build an unpacked key for opcodes that require adjacent registers; rowid aliases
+/// may resolve outside the compact column block.
+#[inline]
+fn copy_context_columns_with_affinity(
+    program: &mut ProgramBuilder,
+    dml_ctx: &DmlColumnContext,
+    column_positions: &[usize],
+    idx: &Index,
+    aff_from_tbl: &BTreeTable,
+) -> usize {
+    let dst = program.alloc_registers(column_positions.len());
+    for (i, pos) in column_positions.iter().enumerate() {
+        program.emit_insn(Insn::Copy {
+            src_reg: dml_ctx.to_column_reg(*pos),
+            dst_reg: dst + i,
+            extra_amount: 0,
+        });
+    }
+    if let Some(count) = NonZeroUsize::new(column_positions.len()) {
+        program.emit_insn(Insn::Affinity {
+            start_reg: dst,
+            count,
+            affinities: build_index_affinity_string(idx, aff_from_tbl),
+        });
+    }
+    dst
+}
+
 /// Issue an index probe using `Found`/`NotFound` and route to `on_found`/`on_not_found`.
 pub fn index_probe<F, G>(
     program: &mut ProgramBuilder,
@@ -1117,10 +1145,13 @@ pub fn emit_fk_child_update_counters(
                         .expect("parent unique index required");
                     let icur = open_read_index(program, idx, database_id);
 
-                    // this is safe because emit_columns_and_dependencies
-                    // guarantees target columns are contiguous.
-                    let old_start = dml_ctx.to_column_reg(fk_col_positions[0]);
-                    let probe = copy_with_affinity(program, old_start, ncols, idx, &parent_tbl);
+                    let probe = copy_context_columns_with_affinity(
+                        program,
+                        &dml_ctx,
+                        &fk_col_positions,
+                        idx,
+                        &parent_tbl,
+                    );
                     // Found: nothing; Not found: guarded decrement
                     index_probe(
                         program,

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -1584,6 +1584,27 @@ expect {
     10|7|7
 }
 
+# Composite child FK whose first component is an INTEGER PRIMARY KEY rowid alias.
+# The OLD child key probe must materialize each component, not assume adjacent registers.
+@cross-check-integrity
+test fk-deferred-child-update-rowid-alias-composite-old-probe {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(a INT, b INT, UNIQUE(a,b));
+    CREATE TABLE child(
+        id INTEGER PRIMARY KEY,
+        x INT,
+        FOREIGN KEY(id,x) REFERENCES parent(a,b) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES(1,2),(1,3);
+    INSERT INTO child VALUES(1,2);
+    BEGIN;
+    INSERT INTO child VALUES(9,9);
+    UPDATE child SET x=3 WHERE id=1;
+    COMMIT;
+}
+expect error {
+}
+
 # TX: NULL in child FK -> never a violation
 @cross-check-integrity
 test fk-deferred-null-fk-never-violates {

--- a/testing/sqltests/tests/foreign_keys.sqltest
+++ b/testing/sqltests/tests/foreign_keys.sqltest
@@ -1605,6 +1605,27 @@ test fk-deferred-child-update-rowid-alias-composite-old-probe {
 expect error {
 }
 
+# Composite child FK whose second component is an INTEGER PRIMARY KEY rowid alias.
+# This covers the non-leading alias case for OLD child key materialization.
+@cross-check-integrity
+test fk-deferred-child-update-rowid-alias-composite-old-probe-second-component {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(a INT, b INT, UNIQUE(a,b));
+    CREATE TABLE child(
+        x INT,
+        id INTEGER PRIMARY KEY,
+        FOREIGN KEY(x,id) REFERENCES parent(a,b) DEFERRABLE INITIALLY DEFERRED
+    );
+    INSERT INTO parent VALUES(2,1),(3,1);
+    INSERT INTO child(x,id) VALUES(2,1);
+    BEGIN;
+    INSERT INTO child(x,id) VALUES(9,9);
+    UPDATE child SET x=3 WHERE id=1;
+    COMMIT;
+}
+expect error {
+}
+
 # TX: NULL in child FK -> never a violation
 @cross-check-integrity
 test fk-deferred-null-fk-never-violates {


### PR DESCRIPTION
  Extracted (cherry-picked) from https://github.com/tursodatabase/turso/pull/7262
  
  The FK bytecode path assumed composite key values were in contiguous registers.
  That is usually true for normal columns, but not for `INTEGER PRIMARY KEY`
  columns. In SQLite, an `INTEGER PRIMARY KEY` is a rowid alias, so Turso reads it
  from the rowid register instead of the normal column layout.

  For example, with `FOREIGN KEY(x, id)`, where `id` is an `INTEGER PRIMARY KEY`,
  the values may be laid out as:

  ```text
  OLD x  -> normal column register
  OLD id -> rowid register
  ```

  Those registers are not guaranteed to be adjacent. The old code copied a
  contiguous range and (could) read the wrong register for the `id`.

  Fix is to build the FK probe key by resolving each FK column's actual register,
  then copying those values into a fresh contiguous probe block before probing the
  parent index.