### PR TITLE
serverless/javascript: add option for custom request headers

### DIFF
--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -70,6 +70,21 @@ await conn.transaction(async () => {
 }).concurrent();
 ```
 
+### Custom Headers
+
+Requests can carry extra HTTP headers, e.g. for routing through a gateway:
+
+```javascript
+const conn = connect({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+  // Extra headers attached to every request. Applied after the standard
+  // headers, so they can override e.g. `Authorization`. The `Host` key has
+  // no effect — fetch forbids setting it.
+  requestHeaders: { "x-custom-header": "value" },
+});
+```
+
 ### libSQL Compatibility Layer
 
 For existing libSQL applications, use the compatibility layer:

--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -79,8 +79,8 @@ const conn = connect({
   url: process.env.TURSO_DATABASE_URL,
   authToken: process.env.TURSO_AUTH_TOKEN,
   // Extra headers attached to every request. Applied after the standard
-  // headers, so they can override e.g. `Authorization`. The `Host` key has
-  // no effect — fetch forbids setting it.
+  // headers, so they can override e.g. `Authorization`. Setting the `Host`
+  // key throws — fetch forbids it.
   requestHeaders: { "x-custom-header": "value" },
 });
 ```

--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { decodeValue, encodeValue } from '../dist/protocol.js';
 import { Session } from '../dist/session.js';
+import { DatabaseError } from '../dist/error.js';
 
 // Unit tests for serverless protocol encoding/decoding.
 // These test the serverless driver directly — no server needed.
@@ -197,14 +198,13 @@ test('Session.batch encodes named arguments for statement objects', async t => {
 
 // --- requestHeaders ---
 
-test('Session attaches requestHeaders, lets them override Authorization, and drops Host', async t => {
+test('Session attaches requestHeaders and lets them override Authorization', async t => {
   const session = new Session({
     url: 'http://fake-host',
     authToken: 'standard-token',
     requestHeaders: {
       'x-custom-header': 'custom-value',
       'Authorization': 'Bearer override-token',
-      'Host': 'evil-host',
     },
   });
   const capturedHeaders = [];
@@ -226,5 +226,33 @@ test('Session attaches requestHeaders, lets them override Authorization, and dro
   t.is(headers['x-custom-header'], 'custom-value');
   t.is(headers['Authorization'], 'Bearer override-token',
     'requestHeaders are applied after standard headers, so they override Authorization');
-  t.false('Host' in headers, 'Host is a forbidden fetch header and must be dropped');
+});
+
+test('Session construction rejects a Host requestHeader instead of silently dropping it', t => {
+  // Mixed case to prove the check is case-insensitive.
+  for (const hostKey of ['Host', 'host', 'hOsT']) {
+    const error = t.throws(
+      () => new Session({
+        url: 'http://fake-host',
+        requestHeaders: { [hostKey]: 'evil-host' },
+      }),
+      {
+        instanceOf: DatabaseError,
+        message: "overwriting the 'Host' header is not supported",
+      }
+    );
+    t.is(error.name, 'DatabaseError');
+  }
+});
+
+test('request building rejects a Host requestHeader added after construction', async t => {
+  // Defense in depth: even if a Host header sneaks past construction-time
+  // validation (the config object is mutable), the request must not be sent.
+  const session = new Session({ url: 'http://fake-host' });
+  session['config'].requestHeaders = { Host: 'evil-host' };
+
+  await t.throwsAsync(() => session.execute('SELECT 1'), {
+    instanceOf: DatabaseError,
+    message: "overwriting the 'Host' header is not supported",
+  });
 });

--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -194,3 +194,37 @@ test('Session.batch encodes named arguments for statement objects', async t => {
     { name: 'age', value: { type: 'integer', value: '30' } },
   ]);
 });
+
+// --- requestHeaders ---
+
+test('Session attaches requestHeaders, lets them override Authorization, and drops Host', async t => {
+  const session = new Session({
+    url: 'http://fake-host',
+    authToken: 'standard-token',
+    requestHeaders: {
+      'x-custom-header': 'custom-value',
+      'Authorization': 'Bearer override-token',
+      'Host': 'evil-host',
+    },
+  });
+  const capturedHeaders = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url, opts) => {
+    capturedHeaders.push(opts.headers);
+    return new Response(
+      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_begin', cols: [] })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 0 })}\n`,
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  await session.execute('SELECT 1');
+
+  const headers = capturedHeaders[0];
+  t.is(headers['x-custom-header'], 'custom-value');
+  t.is(headers['Authorization'], 'Bearer override-token',
+    'requestHeaders are applied after standard headers, so they override Authorization');
+  t.false('Host' in headers, 'Host is a forbidden fetch header and must be dropped');
+});

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -207,6 +207,55 @@ export interface CursorEntry {
 /** HTTP header key for the encryption key */
 export const ENCRYPTION_KEY_HEADER = 'x-turso-encryption-key';
 
+/**
+ * Per-request HTTP context: where to send the request and which headers to
+ * attach. Built by the Session from its config and current base URL.
+ */
+export interface HttpContext {
+  /** Base URL requests are sent to. */
+  url: string;
+  /** Authentication token, sent as `Authorization: Bearer <token>`. */
+  authToken?: string;
+  /** Encryption key for the remote database, sent as `x-turso-encryption-key`. */
+  remoteEncryptionKey?: string;
+  /**
+   * Extra HTTP headers attached to the request. Applied after the standard
+   * headers, so they can override e.g. `Authorization`. The `Host` key
+   * (case-insensitive) is ignored — fetch forbids setting it.
+   */
+  requestHeaders?: Record<string, string>;
+}
+
+function buildHeaders(ctx: HttpContext): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (ctx.authToken) {
+    headers['Authorization'] = `Bearer ${ctx.authToken}`;
+  }
+  if (ctx.remoteEncryptionKey) {
+    headers[ENCRYPTION_KEY_HEADER] = ctx.remoteEncryptionKey;
+  }
+  for (const [name, value] of Object.entries(ctx.requestHeaders ?? {})) {
+    // `Host` is a forbidden fetch header and would be silently dropped —
+    // skip it explicitly so the behavior is documented rather than accidental.
+    if (name.toLowerCase() === 'host') {
+      continue;
+    }
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function buildFetchOptions(ctx: HttpContext, body: string, signal?: AbortSignal): RequestInit {
+  return {
+    method: 'POST',
+    headers: buildHeaders(ctx),
+    body,
+    signal,
+  };
+}
+
 /** Per-query timeout options. Overrides defaultQueryTimeout for this call. */
 export interface QueryOptions {
   /** Per-query timeout in milliseconds. Overrides defaultQueryTimeout for this call. */
@@ -221,30 +270,13 @@ function wrapAbortError(error: unknown): never {
 }
 
 export async function executeCursor(
-  url: string,
-  authToken: string | undefined,
+  ctx: HttpContext,
   request: CursorRequest,
-  remoteEncryptionKey?: string,
   signal?: AbortSignal
 ): Promise<{ response: CursorResponse; entries: AsyncGenerator<CursorEntry> }> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  if (authToken) {
-    headers['Authorization'] = `Bearer ${authToken}`;
-  }
-  if (remoteEncryptionKey) {
-    headers[ENCRYPTION_KEY_HEADER] = remoteEncryptionKey;
-  }
-
   let response: Response;
   try {
-    response = await fetch(`${url}/v3/cursor`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(request),
-      signal,
-    });
+    response = await fetch(`${ctx.url}/v3/cursor`, buildFetchOptions(ctx, JSON.stringify(request), signal));
   } catch (error) {
     wrapAbortError(error);
   }
@@ -349,30 +381,13 @@ export async function executeCursor(
 }
 
 export async function executePipeline(
-  url: string,
-  authToken: string | undefined,
+  ctx: HttpContext,
   request: PipelineRequest,
-  remoteEncryptionKey?: string,
   signal?: AbortSignal
 ): Promise<PipelineResponse> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  if (authToken) {
-    headers['Authorization'] = `Bearer ${authToken}`;
-  }
-  if (remoteEncryptionKey) {
-    headers[ENCRYPTION_KEY_HEADER] = remoteEncryptionKey;
-  }
-
   let response: Response;
   try {
-    response = await fetch(`${url}/v3/pipeline`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(request),
-      signal,
-    });
+    response = await fetch(`${ctx.url}/v3/pipeline`, buildFetchOptions(ctx, JSON.stringify(request), signal));
   } catch (error) {
     wrapAbortError(error);
   }

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -220,8 +220,8 @@ export interface HttpContext {
   remoteEncryptionKey?: string;
   /**
    * Extra HTTP headers attached to the request. Applied after the standard
-   * headers, so they can override e.g. `Authorization`. The `Host` key
-   * (case-insensitive) is ignored — fetch forbids setting it.
+   * headers, so they can override e.g. `Authorization`. Passing the `Host`
+   * key (case-insensitive) throws — fetch forbids setting it.
    */
   requestHeaders?: Record<string, string>;
 }
@@ -238,9 +238,9 @@ function buildHeaders(ctx: HttpContext): Record<string, string> {
   }
   for (const [name, value] of Object.entries(ctx.requestHeaders ?? {})) {
     // `Host` is a forbidden fetch header and would be silently dropped —
-    // skip it explicitly so the behavior is documented rather than accidental.
+    // throw instead so the caller learns the override never takes effect.
     if (name.toLowerCase() === 'host') {
-      continue;
+      throw new DatabaseError("overwriting the 'Host' header is not supported");
     }
     headers[name] = value;
   }

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -14,6 +14,7 @@ import {
   type DescribeResult,
   type GetAutocommitRequest,
   type QueryOptions,
+  type HttpContext,
 } from './protocol.js';
 import { DatabaseError } from './error.js';
 import { encodeSqlArgs } from './args.js';
@@ -39,6 +40,13 @@ export interface SessionConfig {
   remoteEncryptionKey?: string;
   /** Default maximum query execution time in milliseconds before interruption. */
   defaultQueryTimeout?: number;
+  /**
+   * Extra HTTP headers attached to every request sent to the server.
+   * Applied after the standard headers, so they can override e.g.
+   * `Authorization`. Passing the `Host` key (case-insensitive) has no
+   * effect — fetch forbids setting it.
+   */
+  requestHeaders?: Record<string, string>;
 }
 
 function normalizeUrl(url: string): string {
@@ -66,6 +74,15 @@ export class Session {
   constructor(config: SessionConfig) {
     this.config = config;
     this.baseUrl = normalizeUrl(config.url);
+  }
+
+  private httpContext(): HttpContext {
+    return {
+      url: this.baseUrl,
+      authToken: this.config.authToken,
+      remoteEncryptionKey: this.config.remoteEncryptionKey,
+      requestHeaders: this.config.requestHeaders,
+    };
   }
 
   /**
@@ -126,7 +143,7 @@ export class Session {
 
     let response;
     try {
-      response = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
+      response = await executePipeline(this.httpContext(), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       this.autocommit = true;
@@ -194,7 +211,7 @@ export class Session {
 
     let result;
     try {
-      result = await executeCursor(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
+      result = await executeCursor(this.httpContext(), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       throw e;
@@ -376,7 +393,7 @@ export class Session {
 
     let batchResult;
     try {
-      batchResult = await executeCursor(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
+      batchResult = await executeCursor(this.httpContext(), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       throw e;
@@ -470,7 +487,7 @@ export class Session {
 
     let seqResponse;
     try {
-      seqResponse = await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey, this.createAbortSignal(queryOptions));
+      seqResponse = await executePipeline(this.httpContext(), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       this.autocommit = true;
@@ -509,7 +526,7 @@ export class Session {
           } as CloseRequest]
         };
 
-        await executePipeline(this.baseUrl, this.config.authToken, request, this.config.remoteEncryptionKey);
+        await executePipeline(this.httpContext(), request);
       } catch {
         // Ignore errors during close — the connection might already be closed
         // or the baton may be stale after a timeout.

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -43,8 +43,8 @@ export interface SessionConfig {
   /**
    * Extra HTTP headers attached to every request sent to the server.
    * Applied after the standard headers, so they can override e.g.
-   * `Authorization`. Passing the `Host` key (case-insensitive) has no
-   * effect — fetch forbids setting it.
+   * `Authorization`. Passing the `Host` key (case-insensitive) throws —
+   * fetch forbids setting it.
    */
   requestHeaders?: Record<string, string>;
 }
@@ -72,6 +72,13 @@ export class Session {
   private autocommit: boolean = true;
 
   constructor(config: SessionConfig) {
+    for (const name of Object.keys(config.requestHeaders ?? {})) {
+      // `Host` is a forbidden fetch header and would be silently dropped —
+      // reject it up front so the caller learns the override never takes effect.
+      if (name.toLowerCase() === 'host') {
+        throw new DatabaseError("overwriting the 'Host' header is not supported");
+      }
+    }
     this.config = config;
     this.baseUrl = normalizeUrl(config.url);
   }


### PR DESCRIPTION
Simple PR to allow user to set arbitrary request headers for serverless driver. For example:

```js
const conn = connect({
  url: process.env.TURSO_DATABASE_URL,
  authToken: process.env.TURSO_AUTH_TOKEN,
  requestHeaders: { "x-custom-header": "value" },
});
```
