### PR TITLE
Fix 5152 delete planner between rewrite

### DIFF
--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -447,8 +447,10 @@ pub fn constraints_from_where_clause(
                 }
             }
 
-            // Try to extract as binary expression first
-            if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {
+            let mut add_constraints_for_binary = |lhs: &ast::Expr,
+                                                  operator: ConstraintOperator,
+                                                  rhs: &ast::Expr|
+             -> Result<()> {
                 // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
                 match lhs {
                     ast::Expr::Column { table, column, .. } => {
@@ -632,6 +634,12 @@ pub fn constraints_from_where_clause(
                     }
                     _ => {}
                 };
+                Ok(())
+            };
+
+            // Try to extract as binary expression first
+            if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {
+                add_constraints_for_binary(lhs, operator, rhs)?;
             }
 
             // IN expressions are handled separately from binary expressions above because:

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -114,51 +114,121 @@ impl Constraint {
 
         let (idx, side) = self.where_clause_pos;
         let where_term = &where_clause[idx];
-        let Ok(Some((lhs, op, rhs))) = as_binary_components(&where_term.expr) else {
-            panic!("Expected a valid binary expression");
-        };
-        let mut affinity = Affinity::Blob;
-        if op.as_ast_operator().is_some_and(|op| op.is_comparison()) && self.table_col_pos.is_some()
-        {
-            affinity = comparison_affinity(lhs, rhs, referenced_tables, None);
-        }
+        if let Ok(Some((lhs, op, rhs))) = as_binary_components(&where_term.expr) {
+            let mut affinity = Affinity::Blob;
+            if op.as_ast_operator().is_some_and(|op| op.is_comparison())
+                && self.table_col_pos.is_some()
+            {
+                affinity = comparison_affinity(lhs, rhs, referenced_tables, None);
+            }
 
-        if side == BinaryExprSide::Lhs {
-            if affinity.expr_needs_no_affinity_change(lhs) {
-                affinity = Affinity::Blob;
+            if side == BinaryExprSide::Lhs {
+                if affinity.expr_needs_no_affinity_change(lhs) {
+                    affinity = Affinity::Blob;
+                }
+                (
+                    self.operator.as_ast_operator().expect(
+                        "expected an ast operator because as_binary_components returned Some",
+                    ),
+                    lhs.clone(),
+                    affinity,
+                )
+            } else {
+                if affinity.expr_needs_no_affinity_change(rhs) {
+                    affinity = Affinity::Blob;
+                }
+                (
+                    self.operator.as_ast_operator().expect(
+                        "expected an ast operator because as_binary_components returned Some",
+                    ),
+                    rhs.clone(),
+                    affinity,
+                )
             }
-            (
-                self.operator
+        } else if let ast::Expr::Between { lhs, .. } = &where_term.expr {
+            let Some(op) = self.operator.as_ast_operator() else {
+                panic!("Expected comparison operator for BETWEEN constraint");
+            };
+            let original_op = if side == BinaryExprSide::Lhs {
+                opposite_cmp_op(self.operator)
                     .as_ast_operator()
-                    .expect("expected an ast operator because as_binary_components returned Some"),
-                lhs.clone(),
-                affinity,
-            )
+                    .expect("Expected comparison operator for BETWEEN constraint")
+            } else {
+                op
+            };
+            let bound_expr = between_bound_expr(&where_term.expr, original_op)
+                .expect("Expected BETWEEN constraint bound");
+            let mut affinity = Affinity::Blob;
+            if op.is_comparison() && self.table_col_pos.is_some() {
+                affinity = comparison_affinity(lhs, bound_expr, referenced_tables, None);
+            }
+            if side == BinaryExprSide::Lhs {
+                if affinity.expr_needs_no_affinity_change(lhs) {
+                    affinity = Affinity::Blob;
+                }
+                (op, lhs.as_ref().clone(), affinity)
+            } else {
+                if affinity.expr_needs_no_affinity_change(bound_expr) {
+                    affinity = Affinity::Blob;
+                }
+                (op, bound_expr.clone(), affinity)
+            }
         } else {
-            if affinity.expr_needs_no_affinity_change(rhs) {
-                affinity = Affinity::Blob;
-            }
-            (
-                self.operator
-                    .as_ast_operator()
-                    .expect("expected an ast operator because as_binary_components returned Some"),
-                rhs.clone(),
-                affinity,
-            )
+            panic!("Expected binary or BETWEEN constraint expression");
         }
     }
 
     pub fn get_constraining_expr_ref<'a>(&self, where_clause: &'a [WhereTerm]) -> &'a ast::Expr {
         let (idx, side) = self.where_clause_pos;
         let where_term = &where_clause[idx];
-        let Ok(Some((lhs, _, rhs))) = as_binary_components(&where_term.expr) else {
-            panic!("Expected a valid binary expression");
-        };
-        if side == BinaryExprSide::Lhs {
-            lhs
+        if let Ok(Some((lhs, _, rhs))) = as_binary_components(&where_term.expr) {
+            if side == BinaryExprSide::Lhs {
+                lhs
+            } else {
+                rhs
+            }
+        } else if let Some(op) = self.operator.as_ast_operator() {
+            between_bound_for_constraint(&where_term.expr, op, side)
+                .expect("Expected binary or BETWEEN constraint expression")
         } else {
-            rhs
+            panic!("Expected binary or BETWEEN constraint expression");
         }
+    }
+}
+
+fn between_bound_for_constraint(
+    expr: &ast::Expr,
+    operator: ast::Operator,
+    side: BinaryExprSide,
+) -> Option<&ast::Expr> {
+    let ast::Expr::Between {
+        lhs, start, end, ..
+    } = expr
+    else {
+        return None;
+    };
+    if side == BinaryExprSide::Lhs {
+        return Some(lhs.as_ref());
+    }
+    between_bound_expr_inner(operator, start, end)
+}
+
+fn between_bound_expr(expr: &ast::Expr, operator: ast::Operator) -> Option<&ast::Expr> {
+    let ast::Expr::Between { start, end, .. } = expr else {
+        return None;
+    };
+    between_bound_expr_inner(operator, start, end)
+}
+
+fn between_bound_expr_inner<'a>(
+    operator: ast::Operator,
+    start: &'a ast::Expr,
+    end: &'a ast::Expr,
+) -> Option<&'a ast::Expr> {
+    match operator {
+        ast::Operator::Greater | ast::Operator::GreaterEquals => Some(start),
+        ast::Operator::Less | ast::Operator::LessEquals => Some(end),
+        _ => None,
     }
 }
 
@@ -447,11 +517,13 @@ pub fn constraints_from_where_clause(
                 }
             }
 
+            // Try to extract as binary expression first
             let mut add_constraints_for_binary = |lhs: &ast::Expr,
                                                   operator: ConstraintOperator,
                                                   rhs: &ast::Expr|
              -> Result<()> {
                 // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
+
                 match lhs {
                     ast::Expr::Column { table, column, .. } => {
                         if *table == table_reference.internal_id {
@@ -636,6 +708,19 @@ pub fn constraints_from_where_clause(
                 };
                 Ok(())
             };
+
+            if let ast::Expr::Between {
+                lhs,
+                not,
+                start,
+                end,
+            } = &term.expr
+            {
+                if !*not {
+                    add_constraints_for_binary(lhs, ast::Operator::GreaterEquals.into(), start)?;
+                    add_constraints_for_binary(lhs, ast::Operator::LessEquals.into(), end)?;
+                }
+            }
 
             // Try to extract as binary expression first
             if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -2720,6 +2720,25 @@ fn mark_seek_constraints_consumed(
     is_outer_join: bool,
     defer_cross_table: bool,
 ) {
+    // BETWEEN contributes two range constraints that map back to one WhereTerm.
+    // Count how many constraints from each term are actually used so we only
+    // consume a BETWEEN term once both bounds are consumed; otherwise its
+    // residual predicate must still evaluate at runtime to enforce the
+    // unconsumed bound.
+    let mut used_constraints_per_term: HashMap<usize, usize> = HashMap::default();
+    for cref in constraint_refs.iter() {
+        for pos in [
+            cref.eq.as_ref().map(|e| e.constraint_pos),
+            cref.lower_bound,
+            cref.upper_bound,
+        ] {
+            let Some(pos) = pos else { continue };
+            let constraint = &constraints[pos];
+            *used_constraints_per_term
+                .entry(constraint.where_clause_pos.0)
+                .or_insert(0) += 1;
+        }
+    }
     for cref in constraint_refs.iter() {
         for pos in [
             cref.eq.as_ref().map(|e| e.constraint_pos),
@@ -2737,6 +2756,15 @@ fn mark_seek_constraints_consumed(
             }
             if defer_cross_table && !constraint.lhs_mask.is_empty() {
                 continue;
+            }
+            if matches!(where_term.expr, ast::Expr::Between { .. }) {
+                let used = used_constraints_per_term
+                    .get(&constraint.where_clause_pos.0)
+                    .copied()
+                    .unwrap_or(0);
+                if used < 2 {
+                    continue;
+                }
             }
             where_term.consumed = true;
         }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -2,7 +2,7 @@ use crate::sync::Arc;
 use crate::{turso_assert, turso_assert_greater_than_or_equal};
 
 use super::{
-    expr::{walk_expr, walk_expr_mut},
+    expr::walk_expr,
     plan::{
         Aggregate, ColumnMask, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
         JoinOrderMember, JoinType as PlanJoinType, JoinedTable, Operation, OuterQueryReference,
@@ -1490,77 +1490,6 @@ pub fn parse_where(
                 resolver,
                 BindingBehavior::TryCanonicalColumnsFirst,
             )?;
-            let _ = walk_expr_mut(&mut expr.expr, &mut |e: &mut Expr| -> Result<WalkControl> {
-                if let Expr::Between {
-                    lhs,
-                    not,
-                    start,
-                    end,
-                } = e
-                {
-                    let lhs_expr = std::mem::take(lhs.as_mut());
-                    let start_expr = std::mem::take(start.as_mut());
-                    let end_expr = std::mem::take(end.as_mut());
-
-                    let (lower, upper, combine_op) = if *not {
-                        (
-                            Expr::Binary(
-                                Box::new(start_expr),
-                                ast::Operator::Greater,
-                                Box::new(lhs_expr.clone()),
-                            ),
-                            Expr::Binary(
-                                Box::new(lhs_expr),
-                                ast::Operator::Greater,
-                                Box::new(end_expr),
-                            ),
-                            ast::Operator::Or,
-                        )
-                    } else {
-                        (
-                            Expr::Binary(
-                                Box::new(start_expr),
-                                ast::Operator::LessEquals,
-                                Box::new(lhs_expr.clone()),
-                            ),
-                            Expr::Binary(
-                                Box::new(lhs_expr),
-                                ast::Operator::LessEquals,
-                                Box::new(end_expr),
-                            ),
-                            ast::Operator::And,
-                        )
-                    };
-                    *e = Expr::Binary(Box::new(lower), combine_op, Box::new(upper));
-                }
-                Ok(WalkControl::Continue)
-            });
-        }
-        // BETWEEN in WHERE is rewritten to binary terms here so each side can be
-        // considered independently by constraint extraction and range planning.
-        // Re-break any ANDs that were created so they become separate WhereTerms for
-        // constraint extraction.
-        let mut i = start_idx;
-        while i < out_where_clause.len() {
-            if matches!(
-                &out_where_clause[i].expr,
-                Expr::Binary(_, ast::Operator::And, _)
-            ) {
-                let term = out_where_clause.remove(i);
-                let mut new_terms: Vec<WhereTerm> = Vec::new();
-                break_predicate_at_and_boundaries(&term.expr, &mut new_terms);
-                // Preserve from_outer_join from the original term
-                for new_term in new_terms.iter_mut() {
-                    new_term.from_outer_join = term.from_outer_join;
-                }
-                let count = new_terms.len();
-                for (j, new_term) in new_terms.into_iter().enumerate() {
-                    out_where_clause.insert(i + j, new_term);
-                }
-                i += count;
-            } else {
-                i += 1;
-            }
         }
         Ok(())
     } else {

--- a/testing/sqltests/tests/not_between.sqltest
+++ b/testing/sqltests/tests/not_between.sqltest
@@ -82,3 +82,15 @@ test not-between-subquery-bound-orderby-offset {
 expect {
     0
 }
+
+@cross-check-integrity
+test between-scalar-subquery-lhs-issue-5152 {
+    CREATE TABLE t(id INTEGER PRIMARY KEY);
+    INSERT INTO t VALUES(1), (2), (3);
+    SELECT id FROM t WHERE (SELECT max(id) FROM t) BETWEEN 1 AND 3;
+}
+expect {
+    1
+    2
+    3
+}

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-delete.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-delete.snap
@@ -1,0 +1,66 @@
+---
+source: subqueries.sqltest
+expression: |-
+  DELETE FROM products
+      WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+info:
+  statement_type: DELETE
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4              p5  comment
+   0    Init           0  42   0                   0  Start at 42
+   1    OpenWrite      0   2   0                   0  root=2; iDb=0
+   2    OpenWrite      1   8   0                   0  root=8; iDb=0
+   3    Null           0   1   0                   0  r[1]=NULL
+   4    Once          21   0   0                   0  goto 21
+   5    BeginSubrtn    3   0   0                   0  r[3]=NULL
+   6    Null           0   2   0                   0  r[2]=NULL
+   7    Null           0   5   0                   0  r[5]=NULL
+   8    Integer        1   6   0                   0  r[6]=1; LIMIT counter
+   9    IfNot          6  17   0                   0  if !r[6] goto 17
+  10    OpenRead       2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  11    Last           2  17   0                   0
+  12      RowId        2   7   0                   0  r[7]=products.rowid
+  13      CollSeq      0   0   0  Binary           0  collation=Binary
+  14      AggStep      0   7   5  max              0  accum=r[5] step(r[7])
+  15      Goto         0  17   0                   0
+  16    Prev           2  12   0                   0
+  17    AggFinal       0   5   0  max              0  accum=r[5]
+  18    Copy           5   4   0                   0  r[4]=r[5]
+  19    Copy           4   2   0                   0  r[2]=r[4]
+  20  Return           3   0   1                   0
+  21  OpenRead         0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  22  Copy             2  11   0                   0  r[11]=r[2]
+  23  Gt              10  11  30                   0  if r[10]>r[11] goto 30
+  24  Copy             2  13   0                   0  r[13]=r[2]
+  25  Gt              13  14  30                   0  if r[13]>r[14] goto 30
+  26  Rewind           0  30   0                   0  Rewind table products
+  27    RowId          0   8   0                   0  r[8]=products.rowid
+  28    RowSetAdd      1   8   0                   0
+  29  Next             0  27   0                   0
+  30  Close            0   0   0                   0
+  31  OpenWrite        0   2   0                   0  root=2; iDb=0
+  32  OpenWrite        3   8   0                   0  root=8; iDb=0
+  33    RowSetRead     1  41  15                   0
+  34    NotExists      0  40  15                   0
+  35    NotExists      0  40  15                   0
+  36    Column         0   2  16                   0  r[16]=products.category_id
+  37    RowId          0  17   0                   0  r[17]=products.rowid
+  38    IdxDelete      1  16   2                   1
+  39    Delete         0   0   0  products         0
+  40  Goto             0  33   0                   0
+  41  Halt             0   0   0                   0
+  42  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
+  43  Integer          1  10   0                   0  r[10]=1
+  44  Integer        100  14   0                   0  r[14]=100
+  45  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-delete.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-delete.snap
@@ -18,7 +18,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4              p5  comment
-   0    Init           0  42   0                   0  Start at 42
+   0    Init           0  49   0                   0  Start at 49
    1    OpenWrite      0   2   0                   0  root=2; iDb=0
    2    OpenWrite      1   8   0                   0  root=8; iDb=0
    3    Null           0   1   0                   0  r[1]=NULL
@@ -40,27 +40,34 @@ addr  opcode          p1  p2  p3  p4              p5  comment
   19    Copy           4   2   0                   0  r[2]=r[4]
   20  Return           3   0   1                   0
   21  OpenRead         0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  22  Copy             2  11   0                   0  r[11]=r[2]
-  23  Gt              10  11  30                   0  if r[10]>r[11] goto 30
-  24  Copy             2  13   0                   0  r[13]=r[2]
-  25  Gt              13  14  30                   0  if r[13]>r[14] goto 30
-  26  Rewind           0  30   0                   0  Rewind table products
-  27    RowId          0   8   0                   0  r[8]=products.rowid
-  28    RowSetAdd      1   8   0                   0
-  29  Next             0  27   0                   0
-  30  Close            0   0   0                   0
-  31  OpenWrite        0   2   0                   0  root=2; iDb=0
-  32  OpenWrite        3   8   0                   0  root=8; iDb=0
-  33    RowSetRead     1  41  15                   0
-  34    NotExists      0  40  15                   0
-  35    NotExists      0  40  15                   0
-  36    Column         0   2  16                   0  r[16]=products.category_id
-  37    RowId          0  17   0                   0  r[17]=products.rowid
-  38    IdxDelete      1  16   2                   1
-  39    Delete         0   0   0  products         0
-  40  Goto             0  33   0                   0
-  41  Halt             0   0   0                   0
-  42  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
-  43  Integer          1  10   0                   0  r[10]=1
-  44  Integer        100  14   0                   0  r[14]=100
-  45  Goto             0   1   0                   0
+  22  Copy             2  10   0                   0  r[10]=r[2]
+  23  Copy            10  12   0                   0  r[12]=r[10]
+  24  Integer          1  11   0                   0  r[11]=1
+  25  Ge              12  13  27                   0  if r[12]>=r[13] goto 27
+  26  ZeroOrNull      12  11  13                   0  ((r[12]=NULL)|(r[13]=NULL)) ? r[11]=NULL : r[11]=0
+  27  Copy            10  15   0                   0  r[15]=r[10]
+  28  Integer          1  14   0                   0  r[14]=1
+  29  Le              15  16  31                   0  if r[15]<=r[16] goto 31
+  30  ZeroOrNull      15  14  16                   0  ((r[15]=NULL)|(r[16]=NULL)) ? r[14]=NULL : r[14]=0
+  31  And             14  11   9                   0  r[9]=(r[11] && r[14])
+  32  IfNot            9  37   1                   0  if !r[9] goto 37
+  33  Rewind           0  37   0                   0  Rewind table products
+  34    RowId          0   8   0                   0  r[8]=products.rowid
+  35    RowSetAdd      1   8   0                   0
+  36  Next             0  34   0                   0
+  37  Close            0   0   0                   0
+  38  OpenWrite        0   2   0                   0  root=2; iDb=0
+  39  OpenWrite        3   8   0                   0  root=8; iDb=0
+  40    RowSetRead     1  48  17                   0
+  41    NotExists      0  47  17                   0
+  42    NotExists      0  47  17                   0
+  43    Column         0   2  18                   0  r[18]=products.category_id
+  44    RowId          0  19   0                   0  r[19]=products.rowid
+  45    IdxDelete      1  18   2                   1
+  46    Delete         0   0   0  products         0
+  47  Goto             0  40   0                   0
+  48  Halt             0   0   0                   0
+  49  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
+  50  Integer          1  13   0                   0  r[13]=1
+  51  Integer        100  16   0                   0  r[16]=100
+  52  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-not.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-not.snap
@@ -19,7 +19,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4              p5  comment
-   0    Init          0  28   0                   0  Start at 28
+   0    Init          0  35   0                   0  Start at 35
    1    Once         18   0   0                   0  goto 18
    2    BeginSubrtn   2   0   0                   0  r[2]=NULL
    3    Null          0   1   0                   0  r[1]=NULL
@@ -38,16 +38,23 @@ addr  opcode         p1  p2  p3  p4              p5  comment
   16    Copy          3   1   0                   0  r[1]=r[3]
   17  Return          2   0   1                   0
   18  OpenRead        1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  19  Copy            1  10   0                   0  r[10]=r[1]
-  20  Gt              9  10  23                   0  if r[9]>r[10] goto 23
-  21  Copy            1  12   0                   0  r[12]=r[1]
-  22  Le             12  13  27                   0  if r[12]<=r[13] goto 27
-  23  Rewind          1  27   0                   0  Rewind table products
-  24    RowId         1   7   0                   0  r[7]=products.rowid
-  25    ResultRow     7   1   0                   0  output=r[7]
-  26  Next            1  24   0                   0
-  27  Halt            0   0   0                   0
-  28  Transaction     0   1  11                   0  iDb=0 tx_mode=Read
-  29  Integer        10   9   0                   0  r[9]=10
-  30  Integer        20  13   0                   0  r[13]=20
-  31  Goto            0   1   0                   0
+  19  Copy            1   9   0                   0  r[9]=r[1]
+  20  Copy            9  11   0                   0  r[11]=r[9]
+  21  Integer         1  10   0                   0  r[10]=1
+  22  Lt             11  12  24                   0  if r[11]<r[12] goto 24
+  23  ZeroOrNull     11  10  12                   0  ((r[11]=NULL)|(r[12]=NULL)) ? r[10]=NULL : r[10]=0
+  24  Copy            9  14   0                   0  r[14]=r[9]
+  25  Integer         1  13   0                   0  r[13]=1
+  26  Gt             14  15  28                   0  if r[14]>r[15] goto 28
+  27  ZeroOrNull     14  13  15                   0  ((r[14]=NULL)|(r[15]=NULL)) ? r[13]=NULL : r[13]=0
+  28  Or             13  10   8                   0  r[8]=(r[10] || r[13])
+  29  IfNot           8  34   1                   0  if !r[8] goto 34
+  30  Rewind          1  34   0                   0  Rewind table products
+  31    RowId         1   7   0                   0  r[7]=products.rowid
+  32    ResultRow     7   1   0                   0  output=r[7]
+  33  Next            1  31   0                   0
+  34  Halt            0   0   0                   0
+  35  Transaction     0   1  11                   0  iDb=0 tx_mode=Read
+  36  Integer        10  12   0                   0  r[12]=10
+  37  Integer        20  15   0                   0  r[15]=20
+  38  Goto            0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-not.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-not.snap
@@ -1,0 +1,53 @@
+---
+source: subqueries.sqltest
+expression: |-
+  SELECT id
+      FROM products
+      WHERE (SELECT max(id) FROM products) NOT BETWEEN 10 AND 20;
+info:
+  statement_type: SELECT
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode         p1  p2  p3  p4              p5  comment
+   0    Init          0  28   0                   0  Start at 28
+   1    Once         18   0   0                   0  goto 18
+   2    BeginSubrtn   2   0   0                   0  r[2]=NULL
+   3    Null          0   1   0                   0  r[1]=NULL
+   4    Null          0   4   0                   0  r[4]=NULL
+   5    Integer       1   5   0                   0  r[5]=1; LIMIT counter
+   6    IfNot         5  14   0                   0  if !r[5] goto 14
+   7    OpenRead      0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   8    Last          0  14   0                   0
+   9      RowId       0   6   0                   0  r[6]=products.rowid
+  10      CollSeq     0   0   0  Binary           0  collation=Binary
+  11      AggStep     0   6   4  max              0  accum=r[4] step(r[6])
+  12      Goto        0  14   0                   0
+  13    Prev          0   9   0                   0
+  14    AggFinal      0   4   0  max              0  accum=r[4]
+  15    Copy          4   3   0                   0  r[3]=r[4]
+  16    Copy          3   1   0                   0  r[1]=r[3]
+  17  Return          2   0   1                   0
+  18  OpenRead        1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  19  Copy            1  10   0                   0  r[10]=r[1]
+  20  Gt              9  10  23                   0  if r[9]>r[10] goto 23
+  21  Copy            1  12   0                   0  r[12]=r[1]
+  22  Le             12  13  27                   0  if r[12]<=r[13] goto 27
+  23  Rewind          1  27   0                   0  Rewind table products
+  24    RowId         1   7   0                   0  r[7]=products.rowid
+  25    ResultRow     7   1   0                   0  output=r[7]
+  26  Next            1  24   0                   0
+  27  Halt            0   0   0                   0
+  28  Transaction     0   1  11                   0  iDb=0 tx_mode=Read
+  29  Integer        10   9   0                   0  r[9]=10
+  30  Integer        20  13   0                   0  r[13]=20
+  31  Goto            0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
@@ -1,0 +1,63 @@
+---
+source: subqueries.sqltest
+expression: |-
+  UPDATE products
+      SET stock = stock + 1
+      WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+info:
+  statement_type: UPDATE
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4              p5  comment
+   0    Init           0  37   0                   0  Start at 37
+   1    Once          18   0   0                   0  goto 18
+   2    BeginSubrtn    2   0   0                   0  r[2]=NULL
+   3    Null           0   1   0                   0  r[1]=NULL
+   4    Null           0   4   0                   0  r[4]=NULL
+   5    Integer        1   5   0                   0  r[5]=1; LIMIT counter
+   6    IfNot          5  14   0                   0  if !r[5] goto 14
+   7    OpenRead       0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   8    Last           0  14   0                   0
+   9      RowId        0   6   0                   0  r[6]=products.rowid
+  10      CollSeq      0   0   0  Binary           0  collation=Binary
+  11      AggStep      0   6   4  max              0  accum=r[4] step(r[6])
+  12      Goto         0  14   0                   0
+  13    Prev           0   9   0                   0
+  14    AggFinal       0   4   0  max              0  accum=r[4]
+  15    Copy           4   3   0                   0  r[3]=r[4]
+  16    Copy           3   1   0                   0  r[1]=r[3]
+  17  Return           2   0   1                   0
+  18  OpenWrite        1   2   0                   0  root=2; iDb=0
+  19  Copy             1   9   0                   0  r[9]=r[1]
+  20  Gt               8   9  36                   0  if r[8]>r[9] goto 36
+  21  Copy             1  11   0                   0  r[11]=r[1]
+  22  Gt              11  12  36                   0  if r[11]>r[12] goto 36
+  23  Rewind           1  36   0                   0  Rewind table products
+  24    RowId          1  13   0                   0  r[13]=products.rowid
+  25    IsNull        13  36   0                   0  if (r[13]==NULL) goto 36
+  26    Null           0  14   0                   0  r[14]=NULL
+  27    Column         1   1  15                   0  r[15]=products.name
+  28    Column         1   2  16                   0  r[16]=products.category_id
+  29    Column         1   3  17                   0  r[17]=products.price
+  30    Column         1   4  19  0                0  r[19]=products.stock
+  31    Add           19  20  18                   0  r[18]=r[19]+r[20]
+  32    Affinity      14   5   0                   0  r[14..19] = D, B, D, E, D
+  33    MakeRecord    14   5  21                   0  r[21]=mkrec(r[14..18])
+  34    Insert         1  21  13  products         8  intkey=r[13] data=r[21]
+  35  Next             1  24   0                   0
+  36  Halt             0   0   0                   0
+  37  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
+  38  Integer          1   8   0                   0  r[8]=1
+  39  Integer        100  12   0                   0  r[12]=100
+  40  Integer          1  20   0                   0  r[20]=1
+  41  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs-update.snap
@@ -18,46 +18,62 @@ QUERY PLAN
 `--SCAN products
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4              p5  comment
-   0    Init           0  37   0                   0  Start at 37
-   1    Once          18   0   0                   0  goto 18
-   2    BeginSubrtn    2   0   0                   0  r[2]=NULL
-   3    Null           0   1   0                   0  r[1]=NULL
-   4    Null           0   4   0                   0  r[4]=NULL
-   5    Integer        1   5   0                   0  r[5]=1; LIMIT counter
-   6    IfNot          5  14   0                   0  if !r[5] goto 14
-   7    OpenRead       0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   8    Last           0  14   0                   0
-   9      RowId        0   6   0                   0  r[6]=products.rowid
-  10      CollSeq      0   0   0  Binary           0  collation=Binary
-  11      AggStep      0   6   4  max              0  accum=r[4] step(r[6])
-  12      Goto         0  14   0                   0
-  13    Prev           0   9   0                   0
-  14    AggFinal       0   4   0  max              0  accum=r[4]
-  15    Copy           4   3   0                   0  r[3]=r[4]
-  16    Copy           3   1   0                   0  r[1]=r[3]
-  17  Return           2   0   1                   0
-  18  OpenWrite        1   2   0                   0  root=2; iDb=0
-  19  Copy             1   9   0                   0  r[9]=r[1]
-  20  Gt               8   9  36                   0  if r[8]>r[9] goto 36
-  21  Copy             1  11   0                   0  r[11]=r[1]
-  22  Gt              11  12  36                   0  if r[11]>r[12] goto 36
-  23  Rewind           1  36   0                   0  Rewind table products
-  24    RowId          1  13   0                   0  r[13]=products.rowid
-  25    IsNull        13  36   0                   0  if (r[13]==NULL) goto 36
-  26    Null           0  14   0                   0  r[14]=NULL
-  27    Column         1   1  15                   0  r[15]=products.name
-  28    Column         1   2  16                   0  r[16]=products.category_id
-  29    Column         1   3  17                   0  r[17]=products.price
-  30    Column         1   4  19  0                0  r[19]=products.stock
-  31    Add           19  20  18                   0  r[18]=r[19]+r[20]
-  32    Affinity      14   5   0                   0  r[14..19] = D, B, D, E, D
-  33    MakeRecord    14   5  21                   0  r[21]=mkrec(r[14..18])
-  34    Insert         1  21  13  products         8  intkey=r[13] data=r[21]
-  35  Next             1  24   0                   0
-  36  Halt             0   0   0                   0
-  37  Transaction      0   2  11                   0  iDb=0 tx_mode=Write
-  38  Integer          1   8   0                   0  r[8]=1
-  39  Integer        100  12   0                   0  r[12]=100
-  40  Integer          1  20   0                   0  r[20]=1
-  41  Goto             0   1   0                   0
+addr  opcode            p1  p2  p3  p4                 p5  comment
+   0    Init             0  53   0                      0  Start at 53
+   1    OpenEphemeral    0   1   0                      0  cursor=0 is_table=true
+   2    Once            19   0   0                      0  goto 19
+   3    BeginSubrtn      2   0   0                      0  r[2]=NULL
+   4    Null             0   1   0                      0  r[1]=NULL
+   5    Null             0   4   0                      0  r[4]=NULL
+   6    Integer          1   5   0                      0  r[5]=1; LIMIT counter
+   7    IfNot            5  15   0                      0  if !r[5] goto 15
+   8    OpenRead         1   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+   9    Last             1  15   0                      0
+  10      RowId          1   6   0                      0  r[6]=products.rowid
+  11      CollSeq        0   0   0  Binary              0  collation=Binary
+  12      AggStep        0   6   4  max                 0  accum=r[4] step(r[6])
+  13      Goto           0  15   0                      0
+  14    Prev             1  10   0                      0
+  15    AggFinal         0   4   0  max                 0  accum=r[4]
+  16    Copy             4   3   0                      0  r[3]=r[4]
+  17    Copy             3   1   0                      0  r[1]=r[3]
+  18  Return             2   0   1                      0
+  19  OpenRead           2   2   0  k(5,B,B,B,B,B)      0  table=products, root=2, iDb=0
+  20  Copy               1   9   0                      0  r[9]=r[1]
+  21  Copy               9  11   0                      0  r[11]=r[9]
+  22  Integer            1  10   0                      0  r[10]=1
+  23  Ge                11  12  25                      0  if r[11]>=r[12] goto 25
+  24  ZeroOrNull        11  10  12                      0  ((r[11]=NULL)|(r[12]=NULL)) ? r[10]=NULL : r[10]=0
+  25  Copy               9  14   0                      0  r[14]=r[9]
+  26  Integer            1  13   0                      0  r[13]=1
+  27  Le                14  15  29                      0  if r[14]<=r[15] goto 29
+  28  ZeroOrNull        14  13  15                      0  ((r[14]=NULL)|(r[15]=NULL)) ? r[13]=NULL : r[13]=0
+  29  And               13  10   8                      0  r[8]=(r[10] && r[13])
+  30  IfNot              8  36   1                      0  if !r[8] goto 36
+  31  Rewind             2  36   0                      0  Rewind table products
+  32    RowId            2   7   0                      0  r[7]=products.rowid
+  33    MakeRecord       7   1  16                      0  r[16]=mkrec(r[7..7]); for ephemeral_scratch
+  34    Insert           0  16   7  ephemeral_scratch   6  intkey=r[7] data=r[16]
+  35  Next               2  32   0                      0
+  36  OpenWrite          2   2   0                      0  root=2; iDb=0
+  37  Rewind             0  52   0                      0  Rewind table ephemeral(ephemeral_scratch)
+  38    RowId            0  17   0                      0  r[17]=ephemeral(ephemeral_scratch).rowid
+  39    NotExists        2  51  17                      0
+  40    Null             0  18   0                      0  r[18]=NULL
+  41    Column           2   1  19                      0  r[19]=products.name
+  42    Column           2   2  20                      0  r[20]=products.category_id
+  43    Column           2   3  21                      0  r[21]=products.price
+  44    Column           2   4  23  0                   0  r[23]=products.stock
+  45    Add             23  24  22                      0  r[22]=r[23]+r[24]
+  46    Affinity        18   5   0                      0  r[18..23] = D, B, D, E, D
+  47    MakeRecord      18   5  25                      0  r[25]=mkrec(r[18..22])
+  48    NotExists        2  51  17                      0
+  49    Delete           2   0   0  products            0
+  50    Insert           2  25  17  products           11  intkey=r[17] data=r[25]
+  51  Next               0  38   0                      0
+  52  Halt               0   0   0                      0
+  53  Transaction        0   2  11                      0  iDb=0 tx_mode=Write
+  54  Integer            1  12   0                      0  r[12]=1
+  55  Integer          100  15   0                      0  r[15]=100
+  56  Integer            1  24   0                      0  r[24]=1
+  57  Goto               0   1   0                      0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs.snap
@@ -19,7 +19,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4              p5  comment
-   0    Init           0  28   0                   0  Start at 28
+   0    Init           0  35   0                   0  Start at 35
    1    Once          18   0   0                   0  goto 18
    2    BeginSubrtn    2   0   0                   0  r[2]=NULL
    3    Null           0   1   0                   0  r[1]=NULL
@@ -38,16 +38,23 @@ addr  opcode          p1  p2  p3  p4              p5  comment
   16    Copy           3   1   0                   0  r[1]=r[3]
   17  Return           2   0   1                   0
   18  OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  19  Copy             1  10   0                   0  r[10]=r[1]
-  20  Gt               9  10  27                   0  if r[9]>r[10] goto 27
-  21  Copy             1  12   0                   0  r[12]=r[1]
-  22  Gt              12  13  27                   0  if r[12]>r[13] goto 27
-  23  Rewind           1  27   0                   0  Rewind table products
-  24    RowId          1   7   0                   0  r[7]=products.rowid
-  25    ResultRow      7   1   0                   0  output=r[7]
-  26  Next             1  24   0                   0
-  27  Halt             0   0   0                   0
-  28  Transaction      0   1  11                   0  iDb=0 tx_mode=Read
-  29  Integer          1   9   0                   0  r[9]=1
-  30  Integer        100  13   0                   0  r[13]=100
-  31  Goto             0   1   0                   0
+  19  Copy             1   9   0                   0  r[9]=r[1]
+  20  Copy             9  11   0                   0  r[11]=r[9]
+  21  Integer          1  10   0                   0  r[10]=1
+  22  Ge              11  12  24                   0  if r[11]>=r[12] goto 24
+  23  ZeroOrNull      11  10  12                   0  ((r[11]=NULL)|(r[12]=NULL)) ? r[10]=NULL : r[10]=0
+  24  Copy             9  14   0                   0  r[14]=r[9]
+  25  Integer          1  13   0                   0  r[13]=1
+  26  Le              14  15  28                   0  if r[14]<=r[15] goto 28
+  27  ZeroOrNull      14  13  15                   0  ((r[14]=NULL)|(r[15]=NULL)) ? r[13]=NULL : r[13]=0
+  28  And             13  10   8                   0  r[8]=(r[10] && r[13])
+  29  IfNot            8  34   1                   0  if !r[8] goto 34
+  30  Rewind           1  34   0                   0  Rewind table products
+  31    RowId          1   7   0                   0  r[7]=products.rowid
+  32    ResultRow      7   1   0                   0  output=r[7]
+  33  Next             1  31   0                   0
+  34  Halt             0   0   0                   0
+  35  Transaction      0   1  11                   0  iDb=0 tx_mode=Read
+  36  Integer          1  12   0                   0  r[12]=1
+  37  Integer        100  15   0                   0  r[15]=100
+  38  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs.snap
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/snapshots/subqueries__between-subquery-lhs.snap
@@ -1,0 +1,53 @@
+---
+source: subqueries.sqltest
+expression: |-
+  SELECT id
+      FROM products
+      WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+info:
+  statement_type: SELECT
+  tables:
+  - products
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCALAR SUBQUERY 1
+|  `--SCAN products
+`--SCAN products
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4              p5  comment
+   0    Init           0  28   0                   0  Start at 28
+   1    Once          18   0   0                   0  goto 18
+   2    BeginSubrtn    2   0   0                   0  r[2]=NULL
+   3    Null           0   1   0                   0  r[1]=NULL
+   4    Null           0   4   0                   0  r[4]=NULL
+   5    Integer        1   5   0                   0  r[5]=1; LIMIT counter
+   6    IfNot          5  14   0                   0  if !r[5] goto 14
+   7    OpenRead       0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   8    Last           0  14   0                   0
+   9      RowId        0   6   0                   0  r[6]=products.rowid
+  10      CollSeq      0   0   0  Binary           0  collation=Binary
+  11      AggStep      0   6   4  max              0  accum=r[4] step(r[6])
+  12      Goto         0  14   0                   0
+  13    Prev           0   9   0                   0
+  14    AggFinal       0   4   0  max              0  accum=r[4]
+  15    Copy           4   3   0                   0  r[3]=r[4]
+  16    Copy           3   1   0                   0  r[1]=r[3]
+  17  Return           2   0   1                   0
+  18  OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  19  Copy             1  10   0                   0  r[10]=r[1]
+  20  Gt               9  10  27                   0  if r[9]>r[10] goto 27
+  21  Copy             1  12   0                   0  r[12]=r[1]
+  22  Gt              12  13  27                   0  if r[12]>r[13] goto 27
+  23  Rewind           1  27   0                   0  Rewind table products
+  24    RowId          1   7   0                   0  r[7]=products.rowid
+  25    ResultRow      7   1   0                   0  output=r[7]
+  26  Next             1  24   0                   0
+  27  Halt             0   0   0                   0
+  28  Transaction      0   1  11                   0  iDb=0 tx_mode=Read
+  29  Integer          1   9   0                   0  r[9]=1
+  30  Integer        100  13   0                   0  r[13]=100
+  31  Goto             0   1   0                   0

--- a/testing/sqltests/tests/snapshot_tests/subqueries/subqueries.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/subqueries/subqueries.sqltest
@@ -86,6 +86,37 @@ snapshot scalar-subquery-simple-count {
     SELECT (SELECT count(*) FROM orders) AS order_count;
 }
 
+# Ensures BETWEEN expr is emitted once. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs {
+    SELECT id
+    FROM products
+    WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+}
+
+# Ensures BETWEEN expr is emitted once in UPDATE. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs-update {
+    UPDATE products
+    SET stock = stock + 1
+    WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+}
+
+# Ensures BETWEEN expr is emitted once in DELETE. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs-delete {
+    DELETE FROM products
+    WHERE (SELECT max(id) FROM products) BETWEEN 1 AND 100;
+}
+
+# Ensures NOT BETWEEN expr is emitted once. Issue #5152.
+@setup schema
+snapshot between-subquery-lhs-not {
+    SELECT id
+    FROM products
+    WHERE (SELECT max(id) FROM products) NOT BETWEEN 10 AND 20;
+}
+
 # =============================================================================
 # EXISTS SUBQUERIES
 # =============================================================================

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
@@ -49,103 +49,130 @@ QUERY PLAN
 `--SEARCH part USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode       p1  p2  p3  p4                                     p5  comment
-   0  Init          0  63   0                                          0  Start at 63
-   1  Null          0   2   0                                          0  r[2]=NULL
-   2  OpenRead      0  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   3  OpenRead      1   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-   4  Rewind        0  59   0                                          0  Rewind table lineitem
-   5    Column      0  14   3                                          0  r[3]=lineitem.L_SHIPMODE
-   6    Eq          3   4   8  Binary                                  0  if r[3]==r[4] goto 8
-   7    Ne          3   5  58  Binary                                  0  if r[3]!=r[5] goto 58
-   8    Column      0  13   7                                          0  r[7]=lineitem.L_SHIPINSTRUCT
-   9    Ne          7   8  58  Binary                                  0  if r[7]!=r[8] goto 58
-  10    Column      0   1   9                                          0  r[9]=lineitem.L_PARTKEY
-  11    SeekRowid   1   9  58                                          0  if (r[9]!=cursor 1 for table part.rowid) goto 58
-  12    Column      1   3  11                                          0  r[11]=part.P_BRAND
-  13    Ne         11  12  25  Binary                                  0  if r[11]!=r[12] goto 25
-  14    Column      1   6  13                                          0  r[13]=part.P_CONTAINER
-  15    Eq         13  14  19  Binary                                  0  if r[13]==r[14] goto 19
-  16    Eq         13  15  19  Binary                                  0  if r[13]==r[15] goto 19
-  17    Eq         13  16  19  Binary                                  0  if r[13]==r[16] goto 19
-  18    Ne         13  17  25  Binary                                  0  if r[13]!=r[17] goto 25
-  19    Column      0   4  19                                          0  r[19]=lineitem.L_QUANTITY
-  20    Lt         19  20  25  Binary                                  0  if r[19]<r[20] goto 25
-  21    Column      0   4  22                                          0  r[22]=lineitem.L_QUANTITY
-  22    Gt         22  23  25  Binary                                  0  if r[22]>r[23] goto 25
-  23    Column      1   5  27                                          0  r[27]=part.P_SIZE
-  24    Le         27  28  51  Binary                                  0  if r[27]<=r[28] goto 51
-  25    Column      1   3  30                                          0  r[30]=part.P_BRAND
-  26    Ne         30  31  38  Binary                                  0  if r[30]!=r[31] goto 38
-  27    Column      1   6  32                                          0  r[32]=part.P_CONTAINER
-  28    Eq         32  33  32  Binary                                  0  if r[32]==r[33] goto 32
-  29    Eq         32  34  32  Binary                                  0  if r[32]==r[34] goto 32
-  30    Eq         32  35  32  Binary                                  0  if r[32]==r[35] goto 32
-  31    Ne         32  36  38  Binary                                  0  if r[32]!=r[36] goto 38
-  32    Column      0   4  38                                          0  r[38]=lineitem.L_QUANTITY
-  33    Lt         38  39  38  Binary                                  0  if r[38]<r[39] goto 38
-  34    Column      0   4  41                                          0  r[41]=lineitem.L_QUANTITY
-  35    Gt         41  42  38  Binary                                  0  if r[41]>r[42] goto 38
-  36    Column      1   5  45                                          0  r[45]=part.P_SIZE
-  37    Le         45  46  51  Binary                                  0  if r[45]<=r[46] goto 51
-  38    Column      1   3  48                                          0  r[48]=part.P_BRAND
-  39    Ne         48  49  58  Binary                                  0  if r[48]!=r[49] goto 58
-  40    Column      1   6  50                                          0  r[50]=part.P_CONTAINER
-  41    Eq         50  51  45  Binary                                  0  if r[50]==r[51] goto 45
-  42    Eq         50  52  45  Binary                                  0  if r[50]==r[52] goto 45
-  43    Eq         50  53  45  Binary                                  0  if r[50]==r[53] goto 45
-  44    Ne         50  54  58  Binary                                  0  if r[50]!=r[54] goto 58
-  45    Column      0   4  56                                          0  r[56]=lineitem.L_QUANTITY
-  46    Lt         56  57  58  Binary                                  0  if r[56]<r[57] goto 58
-  47    Column      0   4  59                                          0  r[59]=lineitem.L_QUANTITY
-  48    Gt         59  60  58  Binary                                  0  if r[59]>r[60] goto 58
-  49    Column      1   5  64                                          0  r[64]=part.P_SIZE
-  50    Gt         64  65  58  Binary                                  0  if r[64]>r[65] goto 58
-  51    Column      1   5  68                                          0  r[68]=part.P_SIZE
-  52    Gt         67  68  58  Binary                                  0  if r[67]>r[68] goto 58
-  53    Column      0   5  70                                          0  r[70]=lineitem.L_EXTENDEDPRICE
-  54    Column      0   6  73                                          0  r[73]=lineitem.L_DISCOUNT
-  55    Subtract   72  73  71                                          0  r[71]=r[72]-r[73]
-  56    Multiply   70  71  69                                          0  r[69]=r[70]*r[71]
-  57    AggStep     0  69   2  sum                                     0  accum=r[2] step(r[69])
-  58  Next          0   5   0                                          0
-  59  AggFinal      0   2   0  sum                                     0  accum=r[2]
-  60  Copy          2   1   0                                          0  r[1]=r[2]
-  61  ResultRow     1   1   0                                          0  output=r[1]
-  62  Halt          0   0   0                                          0
-  63  Transaction   0   1   8                                          0  iDb=0 tx_mode=Read
-  64  String8       0   4   0  AIR                                     0  r[4]='AIR'
-  65  String8       0   5   0  AIR REG                                 0  r[5]='AIR REG'
-  66  String8       0   8   0  DELIVER IN PERSON                       0  r[8]='DELIVER IN PERSON'
-  67  String8       0  12   0  Brand#22                                0  r[12]='Brand#22'
-  68  String8       0  14   0  SM CASE                                 0  r[14]='SM CASE'
-  69  String8       0  15   0  SM BOX                                  0  r[15]='SM BOX'
-  70  String8       0  16   0  SM PACK                                 0  r[16]='SM PACK'
-  71  String8       0  17   0  SM PKG                                  0  r[17]='SM PKG'
-  72  Integer       8  20   0                                          0  r[20]=8
-  73  Integer       8  24   0                                          0  r[24]=8
-  74  Integer      10  25   0                                          0  r[25]=10
-  75  Add          24  25  23                                          0  r[23]=r[24]+r[25]
-  76  Integer       5  28   0                                          0  r[28]=5
-  77  String8       0  31   0  Brand#23                                0  r[31]='Brand#23'
-  78  String8       0  33   0  MED BAG                                 0  r[33]='MED BAG'
-  79  String8       0  34   0  MED BOX                                 0  r[34]='MED BOX'
-  80  String8       0  35   0  MED PKG                                 0  r[35]='MED PKG'
-  81  String8       0  36   0  MED PACK                                0  r[36]='MED PACK'
-  82  Integer      10  39   0                                          0  r[39]=10
-  83  Integer      10  43   0                                          0  r[43]=10
-  84  Add          43  43  42                                          0  r[42]=r[43]+r[43]
-  85  Integer      10  46   0                                          0  r[46]=10
-  86  String8       0  49   0  Brand#12                                0  r[49]='Brand#12'
-  87  String8       0  51   0  LG CASE                                 0  r[51]='LG CASE'
-  88  String8       0  52   0  LG BOX                                  0  r[52]='LG BOX'
-  89  String8       0  53   0  LG PACK                                 0  r[53]='LG PACK'
-  90  String8       0  54   0  LG PKG                                  0  r[54]='LG PKG'
-  91  Integer      24  57   0                                          0  r[57]=24
-  92  Integer      24  61   0                                          0  r[61]=24
-  93  Integer      10  62   0                                          0  r[62]=10
-  94  Add          61  62  60                                          0  r[60]=r[61]+r[62]
-  95  Integer      15  65   0                                          0  r[65]=15
-  96  Integer       1  67   0                                          0  r[67]=1
-  97  Integer       1  72   0                                          0  r[72]=1
-  98  Goto          0   1   0                                          0
+addr  opcode        p1  p2  p3  p4                                     p5  comment
+   0  Init           0  88   0                                          0  Start at 88
+   1  Null           0   2   0                                          0  r[2]=NULL
+   2  OpenRead       0  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   3  OpenRead       1   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
+   4  Rewind         0  84   0                                          0  Rewind table lineitem
+   5    Column       0  14   3                                          0  r[3]=lineitem.L_SHIPMODE
+   6    Eq           3   4   8  Binary                                  0  if r[3]==r[4] goto 8
+   7    Ne           3   5  83  Binary                                  0  if r[3]!=r[5] goto 83
+   8    Column       0  13   7                                          0  r[7]=lineitem.L_SHIPINSTRUCT
+   9    Ne           7   8  83  Binary                                  0  if r[7]!=r[8] goto 83
+  10    Column       0   1   9                                          0  r[9]=lineitem.L_PARTKEY
+  11    SeekRowid    1   9  83                                          0  if (r[9]!=cursor 1 for table part.rowid) goto 83
+  12    Column       1   3  11                                          0  r[11]=part.P_BRAND
+  13    Ne          11  12  34  Binary                                  0  if r[11]!=r[12] goto 34
+  14    Column       1   6  13                                          0  r[13]=part.P_CONTAINER
+  15    Eq          13  14  19  Binary                                  0  if r[13]==r[14] goto 19
+  16    Eq          13  15  19  Binary                                  0  if r[13]==r[15] goto 19
+  17    Eq          13  16  19  Binary                                  0  if r[13]==r[16] goto 19
+  18    Ne          13  17  34  Binary                                  0  if r[13]!=r[17] goto 34
+  19    Column       0   4  19                                          0  r[19]=lineitem.L_QUANTITY
+  20    Lt          19  20  34  Binary                                  0  if r[19]<r[20] goto 34
+  21    Column       0   4  22                                          0  r[22]=lineitem.L_QUANTITY
+  22    Gt          22  23  34  Binary                                  0  if r[22]>r[23] goto 34
+  23    Column       1   5  27                                          0  r[27]=part.P_SIZE
+  24    Copy        27  29   0                                          0  r[29]=r[27]
+  25    Integer      1  28   0                                          0  r[28]=1
+  26    Ge          29  30  28  Binary                                  0  if r[29]>=r[30] goto 28
+  27    ZeroOrNull  29  28  30                                          0  ((r[29]=NULL)|(r[30]=NULL)) ? r[28]=NULL : r[28]=0
+  28    Copy        27  32   0                                          0  r[32]=r[27]
+  29    Integer      1  31   0                                          0  r[31]=1
+  30    Le          32  33  32  Binary                                  0  if r[32]<=r[33] goto 32
+  31    ZeroOrNull  32  31  33                                          0  ((r[32]=NULL)|(r[33]=NULL)) ? r[31]=NULL : r[31]=0
+  32    And         31  28  26                                          0  r[26]=(r[28] && r[31])
+  33    If          26  78   0                                          0  if r[26] goto 78
+  34    Column       1   3  35                                          0  r[35]=part.P_BRAND
+  35    Ne          35  36  56  Binary                                  0  if r[35]!=r[36] goto 56
+  36    Column       1   6  37                                          0  r[37]=part.P_CONTAINER
+  37    Eq          37  38  41  Binary                                  0  if r[37]==r[38] goto 41
+  38    Eq          37  39  41  Binary                                  0  if r[37]==r[39] goto 41
+  39    Eq          37  40  41  Binary                                  0  if r[37]==r[40] goto 41
+  40    Ne          37  41  56  Binary                                  0  if r[37]!=r[41] goto 56
+  41    Column       0   4  43                                          0  r[43]=lineitem.L_QUANTITY
+  42    Lt          43  44  56  Binary                                  0  if r[43]<r[44] goto 56
+  43    Column       0   4  46                                          0  r[46]=lineitem.L_QUANTITY
+  44    Gt          46  47  56  Binary                                  0  if r[46]>r[47] goto 56
+  45    Column       1   5  50                                          0  r[50]=part.P_SIZE
+  46    Copy        50  52   0                                          0  r[52]=r[50]
+  47    Integer      1  51   0                                          0  r[51]=1
+  48    Ge          52  53  50  Binary                                  0  if r[52]>=r[53] goto 50
+  49    ZeroOrNull  52  51  53                                          0  ((r[52]=NULL)|(r[53]=NULL)) ? r[51]=NULL : r[51]=0
+  50    Copy        50  55   0                                          0  r[55]=r[50]
+  51    Integer      1  54   0                                          0  r[54]=1
+  52    Le          55  56  54  Binary                                  0  if r[55]<=r[56] goto 54
+  53    ZeroOrNull  55  54  56                                          0  ((r[55]=NULL)|(r[56]=NULL)) ? r[54]=NULL : r[54]=0
+  54    And         54  51  49                                          0  r[49]=(r[51] && r[54])
+  55    If          49  78   0                                          0  if r[49] goto 78
+  56    Column       1   3  58                                          0  r[58]=part.P_BRAND
+  57    Ne          58  59  83  Binary                                  0  if r[58]!=r[59] goto 83
+  58    Column       1   6  60                                          0  r[60]=part.P_CONTAINER
+  59    Eq          60  61  63  Binary                                  0  if r[60]==r[61] goto 63
+  60    Eq          60  62  63  Binary                                  0  if r[60]==r[62] goto 63
+  61    Eq          60  63  63  Binary                                  0  if r[60]==r[63] goto 63
+  62    Ne          60  64  83  Binary                                  0  if r[60]!=r[64] goto 83
+  63    Column       0   4  66                                          0  r[66]=lineitem.L_QUANTITY
+  64    Lt          66  67  83  Binary                                  0  if r[66]<r[67] goto 83
+  65    Column       0   4  69                                          0  r[69]=lineitem.L_QUANTITY
+  66    Gt          69  70  83  Binary                                  0  if r[69]>r[70] goto 83
+  67    Column       1   5  74                                          0  r[74]=part.P_SIZE
+  68    Copy        74  76   0                                          0  r[76]=r[74]
+  69    Integer      1  75   0                                          0  r[75]=1
+  70    Ge          76  77  72  Binary                                  0  if r[76]>=r[77] goto 72
+  71    ZeroOrNull  76  75  77                                          0  ((r[76]=NULL)|(r[77]=NULL)) ? r[75]=NULL : r[75]=0
+  72    Copy        74  79   0                                          0  r[79]=r[74]
+  73    Integer      1  78   0                                          0  r[78]=1
+  74    Le          79  80  76  Binary                                  0  if r[79]<=r[80] goto 76
+  75    ZeroOrNull  79  78  80                                          0  ((r[79]=NULL)|(r[80]=NULL)) ? r[78]=NULL : r[78]=0
+  76    And         78  75  73                                          0  r[73]=(r[75] && r[78])
+  77    IfNot       73  83   1                                          0  if !r[73] goto 83
+  78    Column       0   5  82                                          0  r[82]=lineitem.L_EXTENDEDPRICE
+  79    Column       0   6  85                                          0  r[85]=lineitem.L_DISCOUNT
+  80    Subtract    84  85  83                                          0  r[83]=r[84]-r[85]
+  81    Multiply    82  83  81                                          0  r[81]=r[82]*r[83]
+  82    AggStep      0  81   2  sum                                     0  accum=r[2] step(r[81])
+  83  Next           0   5   0                                          0
+  84  AggFinal       0   2   0  sum                                     0  accum=r[2]
+  85  Copy           2   1   0                                          0  r[1]=r[2]
+  86  ResultRow      1   1   0                                          0  output=r[1]
+  87  Halt           0   0   0                                          0
+  88  Transaction    0   1   8                                          0  iDb=0 tx_mode=Read
+  89  String8        0   4   0  AIR                                     0  r[4]='AIR'
+  90  String8        0   5   0  AIR REG                                 0  r[5]='AIR REG'
+  91  String8        0   8   0  DELIVER IN PERSON                       0  r[8]='DELIVER IN PERSON'
+  92  String8        0  12   0  Brand#22                                0  r[12]='Brand#22'
+  93  String8        0  14   0  SM CASE                                 0  r[14]='SM CASE'
+  94  String8        0  15   0  SM BOX                                  0  r[15]='SM BOX'
+  95  String8        0  16   0  SM PACK                                 0  r[16]='SM PACK'
+  96  String8        0  17   0  SM PKG                                  0  r[17]='SM PKG'
+  97  Integer        8  20   0                                          0  r[20]=8
+  98  Integer        8  24   0                                          0  r[24]=8
+  99  Integer       10  25   0                                          0  r[25]=10
+ 100  Add           24  25  23                                          0  r[23]=r[24]+r[25]
+ 101  Integer        1  30   0                                          0  r[30]=1
+ 102  Integer        5  33   0                                          0  r[33]=5
+ 103  String8        0  36   0  Brand#23                                0  r[36]='Brand#23'
+ 104  String8        0  38   0  MED BAG                                 0  r[38]='MED BAG'
+ 105  String8        0  39   0  MED BOX                                 0  r[39]='MED BOX'
+ 106  String8        0  40   0  MED PKG                                 0  r[40]='MED PKG'
+ 107  String8        0  41   0  MED PACK                                0  r[41]='MED PACK'
+ 108  Integer       10  44   0                                          0  r[44]=10
+ 109  Integer       10  48   0                                          0  r[48]=10
+ 110  Add           48  48  47                                          0  r[47]=r[48]+r[48]
+ 111  Integer        1  53   0                                          0  r[53]=1
+ 112  Integer       10  56   0                                          0  r[56]=10
+ 113  String8        0  59   0  Brand#12                                0  r[59]='Brand#12'
+ 114  String8        0  61   0  LG CASE                                 0  r[61]='LG CASE'
+ 115  String8        0  62   0  LG BOX                                  0  r[62]='LG BOX'
+ 116  String8        0  63   0  LG PACK                                 0  r[63]='LG PACK'
+ 117  String8        0  64   0  LG PKG                                  0  r[64]='LG PKG'
+ 118  Integer       24  67   0                                          0  r[67]=24
+ 119  Integer       24  71   0                                          0  r[71]=24
+ 120  Integer       10  72   0                                          0  r[72]=10
+ 121  Add           71  72  70                                          0  r[70]=r[71]+r[72]
+ 122  Integer        1  77   0                                          0  r[77]=1
+ 123  Integer       15  80   0                                          0  r[80]=15
+ 124  Integer        1  84   0                                          0  r[84]=1
+ 125  Goto           0   1   0                                          0

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q6-forecasting-revenue.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q6-forecasting-revenue.snap
@@ -22,38 +22,45 @@ QUERY PLAN
 `--SCAN lineitem
 
 BYTECODE
-addr  opcode       p1  p2  p3  p4                                     p5  comment
-   0  Init          0  23   0                                          0  Start at 23
-   1  Null          0   2   0                                          0  r[2]=NULL
-   2  OpenRead      0  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   3  Rewind        0  19   0                                          0  Rewind table lineitem
-   4    Column      0  10   4                                          0  r[4]=lineitem.L_SHIPDATE
-   5    Lt          4   5  18  Binary                                  0  if r[4]<r[5] goto 18
-   6    Column      0  10   7                                          0  r[7]=lineitem.L_SHIPDATE
-   7    Ge          7   8  18  Binary                                  0  if r[7]>=r[8] goto 18
-   8    Column      0   6  11                                          0  r[11]=lineitem.L_DISCOUNT
-   9    Gt         10  11  18  Binary                                  0  if r[10]>r[11] goto 18
-  10    Column      0   6  15                                          0  r[15]=lineitem.L_DISCOUNT
-  11    Gt         15  16  18  Binary                                  0  if r[15]>r[16] goto 18
-  12    Column      0   4  20                                          0  r[20]=lineitem.L_QUANTITY
-  13    Ge         20  21  18  Binary                                  0  if r[20]>=r[21] goto 18
-  14    Column      0   5  23                                          0  r[23]=lineitem.L_EXTENDEDPRICE
-  15    Column      0   6  24                                          0  r[24]=lineitem.L_DISCOUNT
-  16    Multiply   23  24  22                                          0  r[22]=r[23]*r[24]
-  17    AggStep     0  22   2  sum                                     0  accum=r[2] step(r[22])
-  18  Next          0   4   0                                          0
-  19  AggFinal      0   2   0  sum                                     0  accum=r[2]
-  20  Copy          2   1   0                                          0  r[1]=r[2]
-  21  ResultRow     1   1   0                                          0  output=r[1]
-  22  Halt          0   0   0                                          0
-  23  Transaction   0   1   8                                          0  iDb=0 tx_mode=Read
-  24  String8       0   5   0  1994-01-01                              0  r[5]='1994-01-01'
-  25  String8       0   8   0  1995-01-01                              0  r[8]='1995-01-01'
-  26  Real          0  12   0  0.08                                    0  r[12]=0.08
-  27  Real          0  13   0  0.01                                    0  r[13]=0.01
-  28  Subtract     12  13  10                                          0  r[10]=r[12]-r[13]
-  29  Real          0  17   0  0.08                                    0  r[17]=0.08
-  30  Real          0  18   0  0.01                                    0  r[18]=0.01
-  31  Add          17  18  16                                          0  r[16]=r[17]+r[18]
-  32  Integer      24  21   0                                          0  r[21]=24
-  33  Goto          0   1   0                                          0
+addr  opcode        p1  p2  p3  p4                                     p5  comment
+   0  Init           0  30   0                                          0  Start at 30
+   1  Null           0   2   0                                          0  r[2]=NULL
+   2  OpenRead       0  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   3  Rewind         0  26   0                                          0  Rewind table lineitem
+   4    Column       0  10   4                                          0  r[4]=lineitem.L_SHIPDATE
+   5    Lt           4   5  25  Binary                                  0  if r[4]<r[5] goto 25
+   6    Column       0  10   7                                          0  r[7]=lineitem.L_SHIPDATE
+   7    Ge           7   8  25  Binary                                  0  if r[7]>=r[8] goto 25
+   8    Column       0   6  10                                          0  r[10]=lineitem.L_DISCOUNT
+   9    Copy        10  12   0                                          0  r[12]=r[10]
+  10    Integer      1  11   0                                          0  r[11]=1
+  11    Ge          12  13  13  Binary                                  0  if r[12]>=r[13] goto 13
+  12    ZeroOrNull  12  11  13                                          0  ((r[12]=NULL)|(r[13]=NULL)) ? r[11]=NULL : r[11]=0
+  13    Copy        10  17   0                                          0  r[17]=r[10]
+  14    Integer      1  16   0                                          0  r[16]=1
+  15    Le          17  18  17  Binary                                  0  if r[17]<=r[18] goto 17
+  16    ZeroOrNull  17  16  18                                          0  ((r[17]=NULL)|(r[18]=NULL)) ? r[16]=NULL : r[16]=0
+  17    And         16  11   9                                          0  r[9]=(r[11] && r[16])
+  18    IfNot        9  25   1                                          0  if !r[9] goto 25
+  19    Column       0   4  22                                          0  r[22]=lineitem.L_QUANTITY
+  20    Ge          22  23  25  Binary                                  0  if r[22]>=r[23] goto 25
+  21    Column       0   5  25                                          0  r[25]=lineitem.L_EXTENDEDPRICE
+  22    Column       0   6  26                                          0  r[26]=lineitem.L_DISCOUNT
+  23    Multiply    25  26  24                                          0  r[24]=r[25]*r[26]
+  24    AggStep      0  24   2  sum                                     0  accum=r[2] step(r[24])
+  25  Next           0   4   0                                          0
+  26  AggFinal       0   2   0  sum                                     0  accum=r[2]
+  27  Copy           2   1   0                                          0  r[1]=r[2]
+  28  ResultRow      1   1   0                                          0  output=r[1]
+  29  Halt           0   0   0                                          0
+  30  Transaction    0   1   8                                          0  iDb=0 tx_mode=Read
+  31  String8        0   5   0  1994-01-01                              0  r[5]='1994-01-01'
+  32  String8        0   8   0  1995-01-01                              0  r[8]='1995-01-01'
+  33  Real           0  14   0  0.08                                    0  r[14]=0.08
+  34  Real           0  15   0  0.01                                    0  r[15]=0.01
+  35  Subtract      14  15  13                                          0  r[13]=r[14]-r[15]
+  36  Real           0  19   0  0.08                                    0  r[19]=0.08
+  37  Real           0  20   0  0.01                                    0  r[20]=0.01
+  38  Add           19  20  18                                          0  r[18]=r[19]+r[20]
+  39  Integer       24  23   0                                          0  r[23]=24
+  40  Goto           0   1   0                                          0


### PR DESCRIPTION
## Description
BETWEEN used to be rewritten into two binary expressions in the planner, which duplicated the left side. If the left side was a subquery, it got planned and scanned twice.
This change removes the rewrite. BETWEEN goes to the optimizer as-is. The optimizer extracts the range constraints directly from the BETWEEN node and tracks consumption so the runtime check still fires if only one bound ends up in the seek.

## Motivation and context

Closes #5152

This solutions was prompted by this [comment](https://github.com/tursodatabase/turso/pull/7299#discussion_r3339616000) on my previous PR attempt. This is my third attempt at a solution. The first involved skipping the rewrite when the LHS contains an unplanned subquery. The second attempt was changing the timing of the BETWEEN rewrite to after the subquery was planned. Both previous attempts are band-aids for the problem. Removing the rewrite addresses the root cause.

I also looked at this previously closed [PR](https://github.com/tursodatabase/turso/pull/5411) 

## Description of AI Usage

Claude was used for codebase exploration, evaluating fix approaches, and tracing WhereTerm consumption.