### PR TITLE
core/mvcc: Call checkpoint hooks during bootstrap recovery

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1174,9 +1174,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 self.durable_txid_max_new = durable_old.max(committed_max);
                 self.maybe_stage_mvcc_metadata_write()?;
 
-                self.mvstore
-                    .storage
-                    .on_checkpoint_start(self.durable_txid_max_new)?;
+                self.mvstore.storage.on_checkpoint_start()?;
 
                 if self.write_set.is_empty() && self.index_write_set.is_empty() {
                     // Nothing to checkpoint, skip pager txn and go straight to WAL checkpoint.
@@ -1920,17 +1918,13 @@ impl<Clock: LogicalClock> StateTransition for CheckpointStateMachine<Clock> {
         let res = self.step_inner(&());
         match res {
             Err(ref err) => {
-                self.mvstore
-                    .storage
-                    .on_checkpoint_end(self.durable_txid_max_new, Err(err.clone()))?;
+                self.mvstore.storage.on_checkpoint_end(Err(err.clone()))?;
                 tracing::debug!("Error in checkpoint state machine: {err}");
                 self.cleanup_after_external_io_error();
                 res
             }
             Ok(TransitionResult::Done(ref result)) => {
-                self.mvstore
-                    .storage
-                    .on_checkpoint_end(self.durable_txid_max_new, Ok(result))?;
+                self.mvstore.storage.on_checkpoint_end(Ok(result))?;
                 res
             }
             Ok(result) => Ok(result),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5864,60 +5864,83 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         };
         self.storage.set_header(header);
 
+        self.storage.on_checkpoint_start()?;
+
         // NOTE: this uses `CheckpointMode::Truncate` to drive WAL backfill only; we still
         // truncate the WAL explicitly below to preserve WAL-last ordering in recovery.
-        let mut checkpoint_result = pager.io.block(|| {
+        let mut checkpoint_result = match pager.io.block(|| {
             wal.checkpoint(
                 &pager,
                 CheckpointMode::Truncate {
                     upper_bound_inclusive: None,
                 },
             )
-        })?;
-        if !checkpoint_result.everything_backfilled() {
-            return Err(LimboError::Corrupt(
-                "Unable to fully backfill committed WAL frames during MVCC recovery".to_string(),
-            ));
-        }
+        }) {
+            Ok(result) => result,
+            Err(err) => {
+                self.storage.on_checkpoint_end(Err(err.clone()))?;
+                return Err(err);
+            }
+        };
 
-        if connection.get_sync_mode() != SyncMode::Off
-            && checkpoint_result.wal_checkpoint_backfilled > 0
-        {
-            let c = pager
-                .db_file
-                .sync(Completion::new_sync(|_| {}), pager.get_sync_type())?;
-            pager.io.wait_for_completion(c)?;
-        }
+        let recovery_result = (|| -> Result<()> {
+            if !checkpoint_result.everything_backfilled() {
+                return Err(LimboError::Corrupt(
+                    "Unable to fully backfill committed WAL frames during MVCC recovery"
+                        .to_string(),
+                ));
+            }
 
-        // Write a fresh log header (distinct from the checkpoint state machine which no
-        // longer rewrites the header). This is bootstrap-only: we need a valid header on
-        // disk before truncating WAL. CRC verify + retry guards against torn header writes.
-        let mut retried_crc = false;
-        loop {
-            let c = self.storage.update_header()?;
-            pager.io.wait_for_completion(c)?;
-
-            if connection.get_sync_mode() != SyncMode::Off {
-                let c = self.storage.sync(pager.get_sync_type())?;
+            if connection.get_sync_mode() != SyncMode::Off
+                && checkpoint_result.wal_checkpoint_backfilled > 0
+            {
+                let c = pager
+                    .db_file
+                    .sync(Completion::new_sync(|_| {}), pager.get_sync_type())?;
                 pager.io.wait_for_completion(c)?;
             }
 
-            if self.logical_log_header_crc_valid(&pager)? {
-                break;
+            // Write a fresh log header (distinct from the checkpoint state machine which no
+            // longer rewrites the header). This is bootstrap-only: we need a valid header on
+            // disk before truncating WAL. CRC verify + retry guards against torn header writes.
+            let mut retried_crc = false;
+            loop {
+                let c = self.storage.update_header()?;
+                pager.io.wait_for_completion(c)?;
+
+                if connection.get_sync_mode() != SyncMode::Off {
+                    let c = self.storage.sync(pager.get_sync_type())?;
+                    pager.io.wait_for_completion(c)?;
+                }
+
+                if self.logical_log_header_crc_valid(&pager)? {
+                    break;
+                }
+
+                if retried_crc {
+                    return Err(LimboError::Corrupt(
+                        "Logical log header CRC mismatch after retry".to_string(),
+                    ));
+                }
+                retried_crc = true;
             }
 
-            if retried_crc {
-                return Err(LimboError::Corrupt(
-                    "Logical log header CRC mismatch after retry".to_string(),
-                ));
+            pager
+                .io
+                .block(|| wal.truncate_wal(&mut checkpoint_result, pager.get_sync_type()))?;
+            Ok(())
+        })();
+
+        match recovery_result {
+            Ok(()) => {
+                self.storage.on_checkpoint_end(Ok(&checkpoint_result))?;
+                Ok(())
             }
-            retried_crc = true;
+            Err(err) => {
+                self.storage.on_checkpoint_end(Err(err.clone()))?;
+                Err(err)
+            }
         }
-
-        pager
-            .io
-            .block(|| wal.truncate_wal(&mut checkpoint_result, pager.get_sync_type()))?;
-        Ok(())
     }
 
     /// Replays committed logical-log frames into the in-memory MVCC store.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -13931,11 +13931,11 @@ fn busy_from_log_tx_strands_pager_commit_lock_then_blocks_subsequent_commit() {
         fn set_header(&self, h: LogHeader) {
             self.inner.set_header(h)
         }
-        fn on_checkpoint_start(&self, m: u64) -> Result<()> {
-            self.inner.on_checkpoint_start(m)
+        fn on_checkpoint_start(&self) -> Result<()> {
+            self.inner.on_checkpoint_start()
         }
-        fn on_checkpoint_end(&self, m: u64, r: Result<&CheckpointResult>) -> Result<()> {
-            self.inner.on_checkpoint_end(m, r)
+        fn on_checkpoint_end(&self, r: Result<&CheckpointResult>) -> Result<()> {
+            self.inner.on_checkpoint_end(r)
         }
         fn encryption_ctx(&self) -> Option<EncryptionContext> {
             self.inner.encryption_ctx()

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -89,19 +89,13 @@ pub trait DurableStorage: Send + Sync + Debug {
     fn set_header(&self, header: logical_log::LogHeader);
 
     /// Called when a checkpoint begins, before any rows are written to the B-tree.
-    /// `durable_txid_max` is the transaction watermark that will be durably persisted
-    /// once the checkpoint completes.
-    fn on_checkpoint_start(&self, _durable_txid_max: u64) -> Result<()> {
+    fn on_checkpoint_start(&self) -> Result<()> {
         Ok(())
     }
 
     /// Called after the checkpoint has fully completed: rows are flushed, WAL is
     /// truncated, and the logical log is reset.
-    fn on_checkpoint_end(
-        &self,
-        _durable_txid_max: u64,
-        _result: Result<&CheckpointResult>,
-    ) -> Result<()> {
+    fn on_checkpoint_end(&self, _result: Result<&CheckpointResult>) -> Result<()> {
         Ok(())
     }
 


### PR DESCRIPTION
## Description
Needed so that our checkpoint code calls the hooks that are defined in DurableStorage during bootstrap. Also removes the `durable_txid_max` as we dont use it for anything