### PR TITLE
partial index query plan

### DIFF
--- a/testing/sqltests/tests/snapshot_tests/aggregation/aggregation.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/aggregation.sqltest
@@ -232,6 +232,29 @@ snapshot simple-count-star {
     SELECT count(*) FROM t1;
 }
 
+setup partial_index_count_table {
+    CREATE TABLE t2(
+        id INTEGER PRIMARY KEY,
+        marker,
+        key_col INTEGER NOT NULL,
+        aux_col INTEGER
+    );
+    CREATE UNIQUE INDEX t2_partial_key_idx
+        ON t2(key_col)
+        WHERE marker IS NULL;
+    CREATE INDEX t2_partial_aux_idx
+        ON t2(aux_col)
+        WHERE marker IS NULL;
+}
+
+@setup partial_index_count_table
+# This should count from the partial index without rechecking the predicate:
+# SQLite may still emit a lazy DeferredSeek, but it does not read t2.marker
+# from the table or emit a NotNull filter because the index predicate proves it.
+snapshot partial-index-count-star {
+    SELECT count(*) FROM t2 WHERE marker IS NULL;
+}
+
 @setup simple_table
 snapshot simple-count-no-args {
     SELECT count() FROM t1;

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
@@ -1,0 +1,33 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM t2 WHERE marker IS NULL;
+info:
+  statement_type: SELECT
+  tables:
+  - t2
+  setup_blocks:
+  - partial_index_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t2 USING INDEX t2_partial_aux_idx
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4            p5  comment
+   0  Init             0  14   0                 0  Start at 14
+   1  Null             0   2   0                 0  r[2]=NULL
+   2  OpenRead         0   2   0  k(4,B,B,B,B)   0  table=t2, root=2, iDb=0
+   3  OpenRead         1   4   0  k(2,B)         0  index=t2_partial_aux_idx, root=4, iDb=0
+   4  Rewind           1  10   0                 0  Rewind index t2_partial_aux_idx
+   5    DeferredSeek   1   0   0                 0
+   6    Column         0   1   3                 0  r[3]=t2.marker
+   7    NotNull        3   9   0                 0  r[3]!=NULL -> goto 9
+   8    AggStep        0   4   2  count          0  accum=r[2] step(r[4])
+   9  Next             1   5   0                 0
+  10  AggFinal         0   2   0  count          0  accum=r[2]
+  11  Copy             2   1   0                 0  r[1]=r[2]
+  12  ResultRow        1   1   0                 0  output=r[1]
+  13  Halt             0   0   0                 0
+  14  Transaction      0   1   3                 0  iDb=0 tx_mode=Read
+  15  Integer          1   4   0                 0  r[4]=1
+  16  Goto             0   1   0                 0


### PR DESCRIPTION
TODO
## Description
## Partial-index `count(*)` rechecks predicate instead of counting index entries

This query should be able to count directly from the partial index:

```sql
SELECT count(*) FROM t2 WHERE marker IS NULL;
```

Schema:

```sql
CREATE TABLE t2(
    id INTEGER PRIMARY KEY,
    marker,
    key_col INTEGER NOT NULL,
    aux_col INTEGER
);

CREATE UNIQUE INDEX t2_partial_key_idx
    ON t2(key_col)
    WHERE marker IS NULL;

CREATE INDEX t2_partial_aux_idx
    ON t2(aux_col)
    WHERE marker IS NULL;
```

The partial index predicate proves that every entry in the index already satisfies
`marker IS NULL`, so the bytecode should not need to read `marker` from the table
or emit a `NotNull` recheck.

## SQLite output

Checked against the repo-pinned SQLite binary: `.sqlite3/sqlite3`.

```text
QUERY PLAN
`--SCAN t2 USING INDEX t2_partial_aux_idx
```

```text
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     12    0                    0   Start at 12
1     Null           0     1     1                    0   r[1..1]=NULL
2     OpenRead       0     2     0     2              0   root=2 iDb=0; t2
3     OpenRead       1     4     0     k(2,,)         0   root=4 iDb=0; t2_partial_aux_idx
4     Rewind         1     8     2     0              0
5       DeferredSeek   1     0     0                    0   Move 0 to 1.rowid if needed
6       AggStep        0     0     1     count(0)       0   accum=r[1] step(r[0])
7     Next           1     5     0                    1
8     AggFinal       1     0     0     count(0)       0   accum=r[1] N=0
9     Copy           1     2     0                    0   r[2]=r[1]
10    ResultRow      2     1     0                    0   output=r[2]
11    Halt           0     0     0                    0
12    Transaction    0     0     3     0              1   usesStmtJournal=0
13    Goto           0     1     0                    0
```

SQLite may still emit a lazy `DeferredSeek`, but it does not actually read
`t2.marker` from the table and does not recheck `marker IS NULL`.

## Turso output

Current Turso snapshot:

```text
QUERY PLAN
`--SCAN t2 USING INDEX t2_partial_aux_idx
```

```text
addr  opcode          p1  p2  p3  p4            p5  comment
   0  Init             0  14   0                 0  Start at 14
   1  Null             0   2   0                 0  r[2]=NULL
   2  OpenRead         0   2   0  k(4,B,B,B,B)   0  table=t2, root=2, iDb=0
   3  OpenRead         1   4   0  k(2,B)         0  index=t2_partial_aux_idx, root=4, iDb=0
   4  Rewind           1  10   0                 0  Rewind index t2_partial_aux_idx
   5    DeferredSeek   1   0   0                 0
   6    Column         0   1   3                 0  r[3]=t2.marker
   7    NotNull        3   9   0                 0  r[3]!=NULL -> goto 9
   8    AggStep        0   4   2  count          0  accum=r[2] step(r[4])
   9  Next             1   5   0                 0
  10  AggFinal         0   2   0  count          0  accum=r[2]
  11  Copy             2   1   0                 0  r[1]=r[2]
  12  ResultRow        1   1   0                 0  output=r[1]
  13  Halt             0   0   0                 0
  14  Transaction      0   1   3                 0  iDb=0 tx_mode=Read
  15  Integer          1   4   0                 0  r[4]=1
  16  Goto             0   1   0                 0
```

The problematic part is:

```text
Column   0   1   3        r[3]=t2.marker
NotNull  3   9   0        r[3]!=NULL -> goto 9
```

That means Turso is doing a table lookup and rechecking the partial-index
predicate for every index entry, even though the selected partial index already
guarantees `marker IS NULL`.

## Expected behavior

Turso should match SQLite's behavior here: scan the partial index and aggregate
`count(*)` without reading `marker` from the table or emitting the `NotNull`
predicate recheck.


## Motivation and context


## Description of AI Usage
