### PR TITLE
Add support for encryption in WASM database bindings

### DIFF
--- a/bindings/javascript/packages/wasm/index-vite-dev-hack.ts
+++ b/bindings/javascript/packages/wasm/index-vite-dev-hack.ts
@@ -8,6 +8,7 @@ let napiModule = {
     OpfsFile: {} as any,
     Statement: {} as any,
     initThreadPool: {} as any,
+    EncryptionCipher: {} as any,
   }
 };
 
@@ -37,3 +38,4 @@ export const Opfs = napiModule.exports.Opfs
 export const OpfsFile = napiModule.exports.OpfsFile
 export const Statement = napiModule.exports.Statement
 export const initThreadPool = napiModule.exports.initThreadPool
+export const EncryptionCipher = napiModule.exports.EncryptionCipher

--- a/bindings/javascript/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/packages/wasm/promise-vite-dev-hack.ts
@@ -1,6 +1,22 @@
-import { DatabasePromise, DatabaseOpts, SqliteError, } from "@tursodatabase/database-common"
+import { DatabasePromise, DatabaseOpts, SqliteError, EncryptionCipher } from "@tursodatabase/database-common"
 import { registerFileAtWorker, unregisterFileAtWorker, ioNotifier } from "@tursodatabase/database-wasm-common";
-import { initThreadPool, MainWorker, Database as NativeDatabase } from "./index-vite-dev-hack.js";
+import { initThreadPool, MainWorker, Database as NativeDatabase, EncryptionCipher as NativeEncryptionCipher } from "./index-vite-dev-hack.js";
+
+function getCipherValue(cipher: EncryptionCipher): number {
+    if (!NativeEncryptionCipher) {
+        throw new Error('Encryption is not supported in this build');
+    }
+    const cipherMap: Record<EncryptionCipher, number> = {
+        'aes128gcm': NativeEncryptionCipher.Aes128Gcm,
+        'aes256gcm': NativeEncryptionCipher.Aes256Gcm,
+        'aegis256': NativeEncryptionCipher.Aegis256,
+        'aegis256x2': NativeEncryptionCipher.Aegis256x2,
+        'aegis128l': NativeEncryptionCipher.Aegis128l,
+        'aegis128x2': NativeEncryptionCipher.Aegis128x2,
+        'aegis128x4': NativeEncryptionCipher.Aegis128x4,
+    };
+    return cipherMap[cipher];
+}
 
 async function init(): Promise<Worker> {
     await initThreadPool();
@@ -13,8 +29,15 @@ async function init(): Promise<Worker> {
 class Database extends DatabasePromise {
     #worker: Worker | null;
     constructor(path: string, opts: DatabaseOpts = {}) {
+        const nativeOpts: any = { ...opts };
+        if (opts.encryption) {
+            nativeOpts.encryption = {
+                cipher: getCipherValue(opts.encryption.cipher),
+                hexkey: opts.encryption.hexkey,
+            };
+        }
         super(
-            new NativeDatabase(path, opts) as unknown as any,
+            new NativeDatabase(path, nativeOpts) as unknown as any,
             () => ioNotifier.waitForCompletion(),
         )
     }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -135,12 +135,12 @@ loom = { workspace = true }
 [target.'cfg(shuttle)'.dependencies]
 shuttle = { workspace = true }
 
-# Use pure-rust for Android and MacOS to avoid C cross-compilation issues.
+# Use pure-rust for Android, MacOS, and WASM to avoid C cross-compilation issues.
 # Other targets can opt in via the `pure-rust-crypto` feature.
-[target.'cfg(any(target_os = "android", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "macos", target_arch = "wasm32"))'.dependencies]
 aegis = { version = "0.9.8", features = ["pure-rust"] }
 
-[target.'cfg(not(any(target_os = "android", target_os = "macos")))'.dependencies]
+[target.'cfg(not(any(target_os = "android", target_os = "macos", target_arch = "wasm32")))'.dependencies]
 aegis = { version = "0.9.8" }
 
 [build-dependencies]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -5479,7 +5479,9 @@ impl Pager {
         // we will set the encryption context only if the encryption is opted-in.
         if !self.enable_encryption.load(Ordering::SeqCst) {
             return Err(LimboError::InvalidArgument(
-                "encryption is an opt in feature. enable it via passing `--experimental-encryption`"
+                "encryption is an opt-in feature. Enable it with the `--experimental-encryption` \
+                 CLI flag, or when using an SDK by passing the `encryption` option (or \
+                 `experimental: ['encryption']`) when opening the database."
                     .into(),
             ));
         }

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@
 
 - [`database-node`](./javascript/database-node/) — Node.js, local file database (no sync)
 - [`database-wasm-vite`](./javascript/database-wasm-vite/) — Browser (WASM), local database in the browser
+- [`database-wasm-encryption-vite`](./javascript/database-wasm-encryption-vite/) — Browser (WASM), local encrypted database in the browser
 - [`sync-node`](./javascript/sync-node/) — Node.js with bidirectional sync to [Turso Cloud](https://turso.tech/)
 - [`sync-wasm-vite`](./javascript/sync-wasm-vite/) — Browser (WASM) with bidirectional sync to [Turso Cloud](https://turso.tech/)
 - [`concurrent-writes`](./javascript/concurrent-writes/) — MVCC: 16 concurrent writers using `BEGIN CONCURRENT`

--- a/examples/javascript/database-wasm-encryption-vite/README.md
+++ b/examples/javascript/database-wasm-encryption-vite/README.md
@@ -1,0 +1,23 @@
+# database-wasm-encryption-vite
+
+Browser example for local encryption with [`@tursodatabase/database-wasm`](https://www.npmjs.com/package/@tursodatabase/database-wasm) and Vite.
+
+Pass `encryption` when calling `connect()`:
+
+```js
+const db = await connect("encrypted-guestbook.db", {
+  encryption: {
+    cipher: "aegis256",
+    hexkey: "<64-char hex key>",
+  },
+});
+```
+
+Build the WASM bindings first (see [`database-wasm-vite`](../database-wasm-vite/README.md)), then:
+
+```bash
+npm install
+npm run dev
+```
+
+COOP/COEP headers are required for SharedArrayBuffer — see [`database-wasm-vite`](../database-wasm-vite/README.md).

--- a/examples/javascript/database-wasm-encryption-vite/index.html
+++ b/examples/javascript/database-wasm-encryption-vite/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Encrypted Guestbook</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 600px;
+      margin: 2rem auto;
+    }
+
+    #status {
+      padding: 8px 12px;
+      border-radius: 6px;
+      background: #eef7ee;
+      color: #1b5e20;
+      margin-bottom: 1rem;
+    }
+
+    #comments {
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 0;
+      list-style: none;
+    }
+
+    #comments li {
+      padding: 8px;
+      border-top: 1px solid #eee;
+    }
+
+    #comments li:first-child {
+      border-top: none;
+    }
+
+    .time {
+      font-size: 0.8em;
+      color: gray;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Encrypted Guestbook</h1>
+  <p id="status">Opening encrypted database…</p>
+  <form id="form">
+    <input id="comment" placeholder="Write a comment..." style="width:70%; padding:6px;" />
+    <button type="submit">Add</button>
+  </form>
+  <ul id="comments"></ul>
+
+  <script type="module">
+    import { connect } from "@tursodatabase/database-wasm/vite";
+
+    const ENCRYPTION_KEY =
+      "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+    const status = document.getElementById("status");
+
+    let db = await connect("encrypted-guestbook.db", {
+      timeout: 1000,
+      encryption: {
+        cipher: "aegis256",
+        hexkey: ENCRYPTION_KEY,
+      },
+    });
+
+    status.textContent =
+      "Database opened with aegis256 encryption. Data is stored encrypted in OPFS.";
+
+    await db.exec(`
+      CREATE TABLE IF NOT EXISTS guestbook ( comment TEXT, created_at DEFAULT (unixepoch()) );
+      CREATE INDEX IF NOT EXISTS guestbook_idx ON guestbook (created_at);
+    `);
+    await refresh();
+
+    async function addComment() {
+      const insert = db.prepare(`INSERT INTO guestbook(comment) VALUES (?)`);
+
+      const input = document.getElementById("comment");
+      const text = input.value.trim();
+      input.value = "";
+
+      await insert.run([text]);
+      await refresh();
+    }
+    document.getElementById("form").addEventListener("submit", (e) => {
+      e.preventDefault();
+      addComment();
+    });
+
+    async function refresh() {
+      const select = db.prepare(`SELECT comment, created_at FROM guestbook ORDER BY created_at DESC LIMIT ?`);
+      const rows = await select.all([5]);
+
+      const ul = document.getElementById("comments");
+      ul.innerHTML = "";
+      rows.forEach((row) => {
+        const li = document.createElement("li");
+        li.innerHTML = `
+              <div>${row.comment}</div>
+              <div class="time">${new Date(row.created_at * 1000).toLocaleString()}</div>
+            `;
+        ul.appendChild(li);
+      });
+    }
+  </script>
+</body>
+
+</html>

--- a/examples/javascript/database-wasm-encryption-vite/package.json
+++ b/examples/javascript/database-wasm-encryption-vite/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "database-wasm-encryption-vite",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "node server.mjs"
+  },
+  "devDependencies": {
+    "vite": "^7.3.2"
+  },
+  "dependencies": {
+    "@tursodatabase/database-wasm": "../../../bindings/javascript/packages/wasm"
+  }
+}

--- a/examples/javascript/database-wasm-encryption-vite/vite.config.ts
+++ b/examples/javascript/database-wasm-encryption-vite/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    }
+  }
+})


### PR DESCRIPTION
# NOTICE:

<!--
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->

## Description

Fixes #5361 — improves Wasm encryption usability for browser SDK users.

**Changes:**

1. **Clearer opt-in error** (`core/storage/pager.rs`)  
   When encryption PRAGMAs are used without opting in at open time, the error now mentions both the CLI flag (`--experimental-encryption`) and the SDK path (`encryption` option or `experimental: ['encryption']` on `connect()`).

2. **Wasm cipher conversion** (`bindings/javascript/packages/wasm/promise-vite-dev-hack.ts`, `index-vite-dev-hack.ts`)  
   The Node bindings already convert string cipher names (e.g. `"aegis256"`) to the native enum before calling Rust. The Wasm Vite entry point did not, causing:
   `Failed to convert napi value String into rust type i32 on EncryptionOpts.cipher`.  
   This mirrors the existing `getCipherValue()` logic from `packages/native/promise.ts`.

3. **Wasm crypto build** (`core/Cargo.toml`)  
   Use pure-rust `aegis` on `wasm32` (same as Android/macOS) so encryption compiles and runs in browser builds without C cross-compilation issues.

4. **Example** (`examples/javascript/database-wasm-encryption-vite/`)  
   New Vite browser example showing the correct way to open an encrypted database:

   ```js
   await connect("encrypted-guestbook.db", {
     encryption: { cipher: "aegis256", hexkey: "..." },
   });
   ```

## Motivation and context

Reported in #5361 / Discord: a user got encryption working in the browser except when using PRAGMAs alone. The error pointed to `--experimental-encryption`, which does not apply in Wasm/JS.

Root causes:

- Misleading error message for SDK users
- Wasm bindings not converting `encryption.cipher` strings to the Rust enum (Node already did)
- Possible Wasm build issues with non–pure-rust `aegis`

**Note:** The cipher conversion is applied to the Vite dev entry point (`@tursodatabase/database-wasm/vite`), which is what the new example and `npm run dev` use. Other Wasm entry points (`promise-default`, `promise-bundle`, `promise-turbopack-hack`) could get the same treatment in a follow-up.

## Test plan

- [x] Build Wasm bindings in order: `database-common` → `database-wasm-common` → `database-wasm`
- [x] Run `examples/javascript/database-wasm-encryption-vite` with `npm run dev` — encrypted guestbook works with `cipher: "aegis256"`
- [x] Reproduce original issue: connect without encryption opts + `PRAGMA cipher`/`hexkey` → improved error message
- [x] Open encrypted DB with wrong key → fails as expected
- [ ] `cargo fmt` / clippy on changed Rust files

## Description of AI Usage

AI (Cursor) was used to explore the codebase, trace the issue from #5361 through the Rust pager, JS bindings, and Wasm build, and to implement the changes above. The author reproduced the bugs locally (import resolution, string→enum conversion, decryption on stale OPFS files) and validated the fix by building bindings and running the encryption example. All changes were reviewed before opening this PR.
