### PR TITLE
core: disallow multiple write stmts in single connection and poison tx if half-done write stmt is abandoned

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -157,7 +157,11 @@ Turso did not open a statement savepoint for it, the transaction becomes
 rollback-only. A later `COMMIT` rolls back the whole transaction and returns an
 error. `ROLLBACK` also clears that state. This prevents a half-finished statement
 from being committed after control returned to the application at an async I/O
-point.
+point. Two caveats until then: statements running later in the same transaction
+can observe the abandoned statement's partial changes (they are undone only when
+the transaction ends), and `ROLLBACK TO` a savepoint does not clear the
+rollback-only marker even if it restored every page the abandoned statement
+touched — only `ROLLBACK` recovers the connection.
 
 In experimental MVCC mode there is an additional known gap: all statements on a
 connection share one MVCC transaction, so a write statement that finishes while

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -152,6 +152,14 @@ writer without risking the second writer's state. Returning `SQLITE_BUSY` keeps
 the connection state simple: finish or reset the active writer first, then start
 the next write statement.
 
+These same-connection `SQLITE_BUSY` rejections are errors ("... - SQL
+statements in progress") that abort the rejected statement: it must be reset
+or re-executed, not merely stepped again, and the busy handler is never
+invoked for them. No amount of waiting can release the conflict, because only
+the application finishing or resetting its own statement can. This matches
+SQLite, which reports its statements-in-progress rejections as error-class
+`SQLITE_BUSY` and reserves the busy handler for lock contention.
+
 If a write statement inside `BEGIN` is reset or dropped before it finishes and
 Turso did not open a statement savepoint for it, the transaction becomes
 rollback-only. A later `COMMIT` rolls back the whole transaction and returns an

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -135,6 +135,30 @@ ongoing work to pass the full SQLite TCL test suite.
 | CREATE TRIGGER ... INSTEAD OF | ❌ No  | Triggers on views are not supported. Currently errors with misleading "no such table" message. |
 | CREATE VIEW IF NOT EXISTS | 🚧 Partial | Not idempotent — second create on an existing view errors instead of no-op. |
 
+#### Same-connection write statements
+
+SQLite allows more than one active write statement on the same connection. For
+example, an application can step one `INSERT ... RETURNING`, leave it open, and
+then start another write statement on the same connection.
+
+Turso currently returns `SQLITE_BUSY` for the second write statement. Reads may
+still run while a write statement is active.
+
+This is a deliberate compatibility gap. SQLite's built-in write opcodes do not
+return control to the application halfway through the mutation. Turso can suspend
+there for async I/O. If a second writer were allowed to start, dropping or
+resetting the first half-finished writer could not always clean up only that
+writer without risking the second writer's state. Returning `SQLITE_BUSY` keeps
+the connection state simple: finish or reset the active writer first, then start
+the next write statement.
+
+If a write statement inside `BEGIN` is reset or dropped before it finishes and
+Turso did not open a statement savepoint for it, the transaction becomes
+rollback-only. A later `COMMIT` rolls back the whole transaction and returns an
+error. `ROLLBACK` also clears that state. This prevents a half-finished statement
+from being committed after control returned to the application at an async I/O
+point.
+
 #### [PRAGMA](https://www.sqlite.org/pragma.html)
 
 

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -152,6 +152,13 @@ writer without risking the second writer's state. Returning `SQLITE_BUSY` keeps
 the connection state simple: finish or reset the active writer first, then start
 the next write statement.
 
+`SAVEPOINT`, `RELEASE`, and `ROLLBACK TO` also return `SQLITE_BUSY` while a
+write statement on the connection is active. SQLite rejects `SAVEPOINT` and
+`RELEASE` the same way ("SQL statements in progress"); for `ROLLBACK TO` it
+instead aborts the in-progress statements, which Turso does not support, so
+Turso rejects that too rather than let a suspended writer resume over pages the
+rollback just restored.
+
 These same-connection `SQLITE_BUSY` rejections are errors ("... - SQL
 statements in progress") that abort the rejected statement: it must be reset
 or re-executed, not merely stepped again, and the busy handler is never

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -159,6 +159,18 @@ error. `ROLLBACK` also clears that state. This prevents a half-finished statemen
 from being committed after control returned to the application at an async I/O
 point.
 
+In experimental MVCC mode there is an additional known gap: all statements on a
+connection share one MVCC transaction, so a write statement that finishes while
+a sibling statement is still active defers its commit until the last sibling
+finishes. SQLite instead commits at the writer's own completion and lets the
+remaining statements continue on a read-only transaction. Until Turso does the
+same, a write that reported success is not durable while sibling statements
+remain active, and it is silently rolled back if the transaction then ends
+abnormally — for example if the last sibling reader is reset or dropped
+mid-scan, or a later write statement on the same connection fails after
+changing rows. Finish or reset sibling statements promptly after writing to
+avoid this window.
+
 #### [PRAGMA](https://www.sqlite.org/pragma.html)
 
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -3055,6 +3055,9 @@ fn limbo_err_code(err: &LimboError) -> i32 {
         LimboError::TableLocked => SQLITE_LOCKED,
         LimboError::ReadOnly => SQLITE_READONLY,
         LimboError::Busy => SQLITE_BUSY,
+        // SQLite reports its "SQL statements in progress" rejections as
+        // error-class SQLITE_BUSY (vdbe.c, OP_AutoCommit / OP_Savepoint).
+        LimboError::StatementsInProgress(_) => SQLITE_BUSY,
         LimboError::SchemaUpdated | LimboError::SchemaConflict => SQLITE_SCHEMA,
         _ => SQLITE_ERROR,
     }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -352,6 +352,10 @@ pub struct Connection {
     /// Whether to automatically commit transaction
     pub(crate) auto_commit: AtomicBool,
     pub(super) transaction_state: AtomicTransactionState,
+    /// True when an unfinished write statement inside an explicit transaction
+    /// was reset or dropped and there was no statement savepoint to undo only
+    /// that statement. COMMIT must roll back the whole transaction.
+    pub(crate) poisoned_tx: AtomicBool,
     pub(super) last_insert_rowid: AtomicI64,
     pub(crate) changes: AtomicI64,
     pub(crate) total_changes: AtomicI64,
@@ -461,7 +465,10 @@ pub struct Connection {
     /// Whether pragma foreign_keys=ON for this connection
     pub(super) fk_pragma: AtomicBool,
     pub(crate) fk_deferred_violations: AtomicIsize,
-    /// Number of active write statements on this connection.
+    /// Number of active top-level write statements on this connection.
+    ///
+    /// This is currently only 0 or 1. We return Busy instead of allowing a
+    /// second same-connection writer to start.
     pub(crate) n_active_writes: AtomicI32,
     /// Number of active root statements currently executing on this connection.
     /// This is Turso's equivalent of SQLite's top-level active-VDBE count
@@ -2602,6 +2609,24 @@ impl Connection {
         self.auto_commit.load(Ordering::SeqCst)
     }
 
+    /// Mark the active explicit transaction poisoned so COMMIT rolls it back.
+    ///
+    /// This is used when a write statement under BEGIN is abandoned before it
+    /// reaches Halt/Done and that statement did not open a statement savepoint.
+    pub(crate) fn mark_tx_poisoned(&self) {
+        self.poisoned_tx.store(true, Ordering::SeqCst);
+    }
+
+    /// Return whether the active explicit transaction must roll back at COMMIT.
+    pub(crate) fn tx_is_poisoned(&self) -> bool {
+        self.poisoned_tx.load(Ordering::SeqCst)
+    }
+
+    /// Clear the poison marker after BEGIN, COMMIT, or ROLLBACK.
+    pub(crate) fn clear_tx_poison(&self) {
+        self.poisoned_tx.store(false, Ordering::SeqCst);
+    }
+
     pub fn set_load_extension_enabled(&self, enabled: bool) {
         self.enable_load_extension.store(enabled, Ordering::Release);
     }
@@ -4680,6 +4705,7 @@ impl Connection {
         }
         self.rollback_attached_wal_txns();
         self.set_tx_state(TransactionState::None);
+        self.clear_tx_poison();
     }
 
     /// Roll back transaction state for helpers that start a manual `BEGIN`
@@ -4710,6 +4736,7 @@ impl Connection {
         }
 
         self.rollback_temp_schema();
+        self.clear_tx_poison();
         self.set_cdc_transaction_id(-1);
         self.clear_named_savepoints();
         self.clear_deferred_foreign_key_violations();

--- a/core/error.rs
+++ b/core/error.rs
@@ -65,6 +65,16 @@ pub enum LimboError {
     ReadOnly,
     #[error("Database is busy")]
     Busy,
+    /// A transaction-control or savepoint operation, or a second concurrent
+    /// write statement, was rejected because another statement on the same
+    /// connection is still in progress. This carries SQLITE_BUSY semantics at
+    /// the API surface (SQLite reports these as SQLITE_BUSY, e.g. "cannot
+    /// commit transaction - SQL statements in progress"), but unlike `Busy`
+    /// it is not retryable in place and must never invoke the busy handler:
+    /// waiting cannot help, only the application finishing or resetting its
+    /// own statement can. The payload names the rejected operation.
+    #[error("{0} - SQL statements in progress")]
+    StatementsInProgress(&'static str),
     #[error("interrupt")]
     Interrupt,
     #[error("Database snapshot is stale. You must rollback and retry the whole transaction.")]

--- a/core/ext/vtab_xconnect.rs
+++ b/core/ext/vtab_xconnect.rs
@@ -61,7 +61,9 @@ pub unsafe extern "C" fn execute(
                         ResultCode::OK
                     }
                     Err(err) => match err {
-                        crate::LimboError::Busy => ResultCode::Busy,
+                        crate::LimboError::Busy | crate::LimboError::StatementsInProgress(_) => {
+                            ResultCode::Busy
+                        }
                         crate::LimboError::Interrupt => ResultCode::Interrupt,
                         _ => {
                             tracing::error!("execute: failed to execute query: {:?}", err);
@@ -171,7 +173,7 @@ pub unsafe extern "C" fn stmt_step(stmt: *mut Stmt) -> ResultCode {
             ResultCode::EOF
         }
         Err(LimboError::Interrupt) => ResultCode::Interrupt,
-        Err(LimboError::Busy) => ResultCode::Busy,
+        Err(LimboError::Busy) | Err(LimboError::StatementsInProgress(_)) => ResultCode::Busy,
         Err(_) => ResultCode::Error,
     }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2158,6 +2158,7 @@ impl Database {
             database_schemas: RwLock::new(HashMap::default()),
             auto_commit: AtomicBool::new(true),
             transaction_state: AtomicTransactionState::new(TransactionState::None),
+            poisoned_tx: AtomicBool::new(false),
             last_insert_rowid: AtomicI64::new(0),
             changes: AtomicI64::new(0),
             total_changes: AtomicI64::new(0),

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -20,6 +20,7 @@ use crate::{
     schema::Trigger,
     stats::refresh_analyze_stats,
     translate::{self, display::PlanContext, emitter::TransactionMode, plan::BitSet},
+    turso_assert,
     vdbe::{
         self,
         explain::{EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE},
@@ -587,6 +588,10 @@ impl Statement {
             // After ANALYZE completes, refresh in-memory stats so planners can use them.
             let sql = self.program.sql.trim_start().as_bytes();
             if sql.len() >= 7 && sql[..7].eq_ignore_ascii_case(b"ANALYZE") {
+                // The stats refresh runs a SELECT on this same connection. At
+                // this point ANALYZE is already Done, so it must not count as a
+                // sibling root statement for that internal SELECT.
+                self.release_active_root_if_counted();
                 refresh_analyze_stats(&self.program.connection);
             }
         } else {
@@ -1424,10 +1429,15 @@ impl Statement {
         // mid-execution), ensure n_active_writes is decremented before reset
         // clears the flag.
         if self.state.is_active_write {
-            self.program
+            let previous = self
+                .program
                 .connection
                 .n_active_writes
                 .fetch_sub(1, Ordering::SeqCst);
+            turso_assert!(
+                previous == 1,
+                "resetting a writer with {previous} active writer(s)"
+            );
             self.state.is_active_write = false;
         }
         if self.counted_as_active_root && !preserve_active_root_count {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3549,7 +3549,9 @@ pub fn op_transaction_inner(
                     && !state.is_active_write
                     && active_writers > 0
                 {
-                    return Err(LimboError::Busy);
+                    return Err(LimboError::StatementsInProgress(
+                        "cannot start a write statement",
+                    ));
                 }
 
                 // Fast path: if checkpoint root publication already replaced the
@@ -4131,7 +4133,11 @@ pub fn op_auto_commit(
         if matches!(tx_op, TxOp::Commit | TxOp::Rollback)
             && conn.n_active_writes.load(Ordering::SeqCst) > 0
         {
-            return Err(LimboError::Busy);
+            return Err(LimboError::StatementsInProgress(match tx_op {
+                TxOp::Commit => "cannot commit transaction",
+                TxOp::Rollback => "cannot rollback transaction",
+                TxOp::Begin => unreachable!("guard only matches Commit | Rollback"),
+            }));
         }
 
         match tx_op {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3126,6 +3126,25 @@ pub fn halt(
             // Another root statement may own the implicit autocommit
             // transaction. This statement can finish, but must not commit or
             // roll back connection-level state it did not start.
+            //
+            // FIXME: when this statement is a writer in MVCC mode, deferring
+            // its commit to the last sibling statement means the writer's
+            // caller observes success before the changes are durable. If the
+            // shared transaction then ends in a rollback — the last sibling
+            // reader is reset or dropped mid-scan, or a later joining writer
+            // errors or is abandoned after changing rows — the finished
+            // writer's changes are silently discarded
+            // (see test_mvcc_completed_writer_changes_lost_when_last_reader_abandoned).
+            // SQLite never has this window: it commits at the writer's own
+            // halt and downgrades the transaction to read-only for the
+            // remaining statements (btreeEndTransaction). The MVCC equivalent
+            // is to commit here, allocating a successor read-only
+            // transaction's begin timestamp inside the same
+            // `get_commit_timestamp` critical section as this commit's end
+            // timestamp, swapping `mv_tx` to that successor so remaining
+            // readers keep an identical snapshot. That also attributes commit
+            // errors (e.g. WriteWriteConflict) to the writer's own step
+            // instead of whichever sibling happens to finish last.
             if let Some(cdc_info) = state.pending_cdc_info.take() {
                 program.connection.set_capture_data_changes_info(cdc_info);
             }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2946,7 +2946,7 @@ pub fn halt(
 ) -> Result<InsnFunctionStepResult> {
     let mv_store = program.connection.mv_store();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
-    let owns_auto_txn = state.owns_auto_txn();
+    let can_autocommit_now = state.can_autocommit_now(&program.connection);
 
     // Check if we're resuming from a FAIL commit I/O wait.
     // If pending_fail_error is set, we were in the middle of committing partial changes
@@ -3023,7 +3023,7 @@ pub fn halt(
         // For FAIL mode with autocommit, commit partial changes before returning error.
         // This matches SQLite behavior where FAIL keeps changes made before the error.
         // Note: ON CONFLICT FAIL does NOT apply to FK violations, so we check for those first.
-        if program.resolve_type == ResolveType::Fail && owns_auto_txn {
+        if program.resolve_type == ResolveType::Fail && can_autocommit_now {
             // Check for immediate FK violations - FK errors don't respect ON CONFLICT
             if program.connection.foreign_keys_enabled()
                 && state.get_fk_immediate_violations_during_stmt() > 0
@@ -3055,9 +3055,9 @@ pub fn halt(
     }
 
     tracing::trace!(
-        "halt(auto_commit={}, owns_auto_txn={})",
+        "halt(auto_commit={}, can_autocommit_now={})",
         auto_commit,
-        owns_auto_txn
+        can_autocommit_now
     );
 
     // Check for immediate foreign key violations.
@@ -3077,7 +3077,7 @@ pub fn halt(
     if auto_commit {
         // In autocommit mode, a statement that leaves deferred violations must fail here,
         // and it also ends the transaction.
-        if owns_auto_txn && program.connection.foreign_keys_enabled() {
+        if can_autocommit_now && program.connection.foreign_keys_enabled() {
             let deferred_violations = program
                 .connection
                 .fk_deferred_violations
@@ -3099,7 +3099,7 @@ pub fn halt(
             }
         }
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
-        if owns_auto_txn {
+        if can_autocommit_now {
             vtab_commit_all(&program.connection)?;
             index_method_pre_commit_all(state, pager)?;
             // Sequence backing-table compaction and sqlite_sequence sync
@@ -3492,22 +3492,50 @@ pub fn op_transaction_inner(
     let pager = program.get_pager_from_database_index(db)?;
     // Get the MvStore for the specific database (main or attached).
     let mv_store = program.connection.mv_store_for_db(*db);
+    let is_main_db = *db == crate::MAIN_DB_ID;
+    let is_secondary_db = !is_main_db;
+    let write = matches!(
+        tx_mode,
+        TransactionMode::Write | TransactionMode::Concurrent
+    );
+    // BEGIN IMMEDIATE / EXCLUSIVE / CONCURRENT need write-capable transaction
+    // access, but they are not themselves write statements. Only statements in
+    // `write_databases` count for same-connection writer blocking and
+    // active-writer cleanup.
+    let statement_writes_db = program.write_databases.get(*db);
     loop {
         match *state.active_op_state.transaction() {
             OpTransactionState::Start => {
                 let conn = program.connection.clone();
-                let write = matches!(
-                    tx_mode,
-                    TransactionMode::Write | TransactionMode::Concurrent
-                );
                 let mut started_secondary_tx = false;
                 if write && conn.is_readonly(*db) {
                     return Err(LimboError::ReadOnly);
                 }
+                let active_writers = conn.n_active_writes.load(Ordering::SeqCst);
+                turso_assert!(
+                    active_writers <= 1,
+                    "n_active_writes must be 0 or 1, got {active_writers}"
+                );
+                // One connection may have many active readers, but only one
+                // top-level writer. A second writer on the same connection is
+                // rejected before it opens transaction or savepoint state.
+                //
+                // This is stricter than SQLite. SQLite can run overlapping
+                // write statements on one connection because sqlite3_step()
+                // does not return to the caller in the middle of built-in
+                // write opcodes. Turso can suspend there for async I/O, so a
+                // second writer would make reset/drop cleanup hard to get right.
+                if statement_writes_db
+                    && !conn.is_nested_stmt()
+                    && !state.is_active_write
+                    && active_writers > 0
+                {
+                    return Err(LimboError::Busy);
+                }
 
                 // Fast path: if checkpoint root publication already replaced the
                 // shared schema, force reprepare before opening any transaction state.
-                if *db == crate::MAIN_DB_ID
+                if is_main_db
                     && mv_store.is_some()
                     && conn.mvcc_schema_requires_reprepare_before_tx()
                 {
@@ -3532,7 +3560,6 @@ pub fn op_transaction_inner(
 
                 // 1. We try to upgrade current version
                 let current_state = conn.get_tx_state();
-                let is_secondary_db = *db != crate::MAIN_DB_ID;
                 let (new_transaction_state, updated) = if conn.is_nested_stmt() {
                     (current_state, false)
                 } else if is_secondary_db {
@@ -3867,7 +3894,7 @@ pub fn op_transaction_inner(
             OpTransactionState::BeginNamedSavepoints => {
                 match open_connection_named_savepoints_for_db(&program.connection, *db, &pager)? {
                     IOResult::Done(()) => {
-                        if *db != crate::MAIN_DB_ID
+                        if is_secondary_db
                             && mv_store.is_none()
                             && matches!(tx_mode, TransactionMode::Write)
                             && !pager.holds_write_lock()
@@ -3911,64 +3938,86 @@ pub fn op_transaction_inner(
             }
             OpTransactionState::BeginStatement => {
                 let needs_stmt_journal = program.needs_stmt_subtransactions.load(Ordering::Relaxed);
-                let in_explicit_txn = !program.connection.auto_commit.load(Ordering::SeqCst);
-                if *db == crate::MAIN_DB_ID && needs_stmt_journal {
-                    let write = matches!(tx_mode, TransactionMode::Write);
-                    let res = state.begin_statement(&program.connection, &pager, write)?;
-                    if let IOResult::IO(io) = res {
-                        return Ok(InsnFunctionStepResult::IO(io));
-                    }
-                } else if *db != crate::MAIN_DB_ID
-                    && matches!(tx_mode, TransactionMode::Write)
-                    && needs_stmt_journal
-                {
-                    if in_explicit_txn && !state.has_stmt_transaction {
-                        state.has_stmt_transaction = true;
-                        state.fk_deferred_violations_when_stmt_started.store(
-                            program
-                                .connection
-                                .fk_deferred_violations
-                                .load(Ordering::Acquire),
-                            Ordering::SeqCst,
-                        );
-                        state
-                            .fk_immediate_violations_during_stmt
-                            .store(0, Ordering::Release);
-                    }
-                    if !in_explicit_txn {
-                        // Autocommit statements rollback the whole transaction on error, so
-                        // non-main pagers do not need statement savepoints here.
-                    } else if let Some(mv_store) = program.connection.mv_store_for_db(*db) {
-                        // Attached MVCC DB: open an MvStore savepoint.
-                        if let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) {
-                            mv_store.begin_savepoint(tx_id);
+                let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
+                let in_explicit_txn = !auto_commit;
+                if needs_stmt_journal {
+                    if is_main_db {
+                        let res = state.begin_statement(
+                            &program.connection,
+                            &pager,
+                            statement_writes_db,
+                        )?;
+                        if let IOResult::IO(io) = res {
+                            return Ok(InsnFunctionStepResult::IO(io));
                         }
-                    } else {
-                        // Attached WAL DB: open a pager savepoint for statement rollback.
-                        let db_size =
-                            return_if_io!(pager.with_header(|header| header.database_size.get()));
-                        pager.open_subjournal()?;
-                        pager.try_use_subjournal()?;
-                        let result = pager.open_savepoint(db_size);
-                        if result.is_err() {
-                            pager.stop_use_subjournal();
+                    } else if statement_writes_db && in_explicit_txn {
+                        if !state.has_stmt_transaction {
+                            state.has_stmt_transaction = true;
+                            state.fk_deferred_violations_when_stmt_started.store(
+                                program
+                                    .connection
+                                    .fk_deferred_violations
+                                    .load(Ordering::Acquire),
+                                Ordering::SeqCst,
+                            );
+                            state
+                                .fk_immediate_violations_during_stmt
+                                .store(0, Ordering::Release);
                         }
-                        result?;
-                        state.attached_savepoint_pagers.push(pager.clone());
+                        if let Some(mv_store) = mv_store.as_ref() {
+                            // Attached MVCC DB: open an MvStore savepoint.
+                            if let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) {
+                                mv_store.begin_savepoint(tx_id);
+                            }
+                        } else {
+                            // Attached WAL DB: open a pager savepoint for statement rollback.
+                            let db_size = return_if_io!(
+                                pager.with_header(|header| header.database_size.get())
+                            );
+                            pager.open_subjournal()?;
+                            pager.try_use_subjournal()?;
+                            let result = pager.open_savepoint(db_size);
+                            if result.is_err() {
+                                pager.stop_use_subjournal();
+                            }
+                            result?;
+                            state.attached_savepoint_pagers.push(pager.clone());
+                        }
                     }
                 }
 
-                if *db == MAIN_DB_ID
-                    && matches!(tx_mode, TransactionMode::Write)
-                    && !program.connection.auto_commit.load(Ordering::SeqCst)
-                {
-                    program
-                        .connection
-                        .n_active_writes
-                        .fetch_add(1, Ordering::SeqCst);
-                    state.is_active_write = true;
-                    if state.has_stmt_transaction {
+                let is_top_level_statement = !program.connection.is_nested_stmt();
+                if statement_writes_db && is_top_level_statement {
+                    if !state.is_active_write {
+                        let previous = program
+                            .connection
+                            .n_active_writes
+                            .fetch_add(1, Ordering::SeqCst);
+                        turso_assert!(
+                            previous == 0,
+                            "starting a writer while {previous} writer(s) are already active"
+                        );
+                        state.is_active_write = true;
+                    }
+                    if is_main_db && in_explicit_txn && state.has_stmt_transaction {
                         state.auto_txn_cleanup = TxnCleanup::RollbackSavepoint;
+                    }
+                }
+                if is_top_level_statement
+                    && is_main_db
+                    && auto_commit
+                    && state.auto_txn_cleanup == TxnCleanup::None
+                {
+                    let active_root_statements = program
+                        .connection
+                        .n_active_root_statements
+                        .load(Ordering::SeqCst);
+                    if active_root_statements > 1 {
+                        // A sibling statement opened the implicit transaction
+                        // before this statement joined it. Mark this statement
+                        // so the last remaining sibling can close the
+                        // transaction.
+                        state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                     }
                 }
                 state.pc += 1;
@@ -4023,6 +4072,7 @@ pub fn op_auto_commit(
             res,
             Ok(InsnFunctionStepResult::Step | InsnFunctionStepResult::Done)
         ) {
+            conn.clear_tx_poison();
             conn.clear_named_savepoints();
         }
         return res;
@@ -4083,11 +4133,26 @@ pub fn op_auto_commit(
                 conn.set_cdc_transaction_id(-1);
             }
             TxOp::Commit => {
+                if conn.tx_is_poisoned() {
+                    // A write statement inside BEGIN was reset/dropped before
+                    // it reached Done, and there was no statement savepoint to
+                    // undo only that statement. Letting COMMIT proceed would
+                    // persist a partial statement, so COMMIT rolls back the
+                    // whole transaction and reports the abandoned write.
+                    conn.rollback_manual_txn_cleanup(pager, true);
+                    return Err(LimboError::TxError(
+                        "cannot commit - an unfinished write statement was abandoned".to_string(),
+                    ));
+                }
                 // Pre-check deferred FKs; leave tx open and do NOT clear violations
                 check_deferred_fk_on_commit(&conn)?;
                 conn.auto_commit.store(true, Ordering::SeqCst);
             }
             TxOp::Begin => {
+                turso_assert!(
+                    !conn.tx_is_poisoned(),
+                    "rollback-only marker leaked outside an explicit transaction"
+                );
                 conn.auto_commit.store(false, Ordering::SeqCst);
                 return Ok(InsnFunctionStepResult::Done);
             }
@@ -4150,6 +4215,7 @@ pub fn op_auto_commit(
 
     // Reset CDC transaction ID after successful COMMIT or ROLLBACK.
     conn.set_cdc_transaction_id(-1);
+    conn.clear_tx_poison();
     conn.clear_named_savepoints();
 
     Ok(res)
@@ -4254,6 +4320,10 @@ pub fn op_savepoint(
                     }
                     conn.push_named_savepoint(frame);
                     if starts_transaction {
+                        turso_assert!(
+                            !conn.tx_is_poisoned(),
+                            "rollback-only marker leaked outside an explicit transaction"
+                        );
                         conn.auto_commit.store(false, Ordering::SeqCst);
                     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4256,6 +4256,24 @@ pub fn op_savepoint(
     let conn = program.connection.clone();
     let mv_store = conn.mv_store();
 
+    // No savepoint operation may run while a write statement on this
+    // connection is suspended mid-execution. SQLite rejects SAVEPOINT and
+    // RELEASE with SQLITE_BUSY while write statements are in progress
+    // (vdbe.c, OP_Savepoint: "cannot open/release savepoint - SQL statements
+    // in progress"). SQLite does allow ROLLBACK TO there because it trips all
+    // open cursors so the affected statements abort instead of resuming;
+    // Turso has no cursor-tripping mechanism, and letting a suspended writer
+    // resume on top of pages restored by ROLLBACK TO would interleave two
+    // inconsistent page states. Rejecting all three keeps the rule simple:
+    // finish or reset the active writer first.
+    if !conn.is_nested_stmt() && conn.n_active_writes.load(Ordering::SeqCst) > 0 {
+        return Err(LimboError::StatementsInProgress(match *op {
+            SavepointOp::Begin => "cannot open savepoint",
+            SavepointOp::Release => "cannot release savepoint",
+            SavepointOp::RollbackTo => "cannot rollback savepoint",
+        }));
+    }
+
     match *op {
         SavepointOp::Begin => {
             conn.with_savepoint_schema_snapshot(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -32,6 +32,8 @@ pub mod insn;
 pub mod metrics;
 pub mod rowset;
 pub mod sorter;
+#[cfg(test)]
+mod statement_lifecycle_tests;
 pub mod vacuum;
 pub mod value;
 // for benchmarks
@@ -995,12 +997,41 @@ impl ProgramState {
         self.n_total_change.fetch_add(1, Ordering::SeqCst);
     }
 
-    /// Whether this statement owns the implicit autocommit transaction it is
-    /// about to finish, including re-entry while its commit is in progress.
+    /// Whether this statement may finish the implicit autocommit transaction
+    /// now, including re-entry while its commit is in progress.
     #[inline]
-    pub(crate) fn owns_auto_txn(&self) -> bool {
-        self.auto_txn_cleanup == TxnCleanup::RollbackTxn
-            || !matches!(self.commit_state, CommitState::Ready)
+    pub(crate) fn can_autocommit_now(&self, connection: &Connection) -> bool {
+        let is_already_committing = !matches!(self.commit_state, CommitState::Ready);
+        if is_already_committing {
+            return true;
+        }
+        if self.auto_txn_cleanup != TxnCleanup::RollbackTxn {
+            return false;
+        }
+        let active_writers = connection.n_active_writes.load(Ordering::SeqCst);
+        turso_assert!(
+            active_writers <= 1,
+            "n_active_writes must be 0 or 1, got {active_writers}"
+        );
+        if self.is_active_write {
+            turso_assert!(
+                active_writers == 1,
+                "active writer state without an active writer count"
+            );
+        }
+        if connection.mv_store().is_some() {
+            // MVCC keeps one tx id on the connection. A writer waits for
+            // sibling readers, and a reader waits for sibling readers/writers.
+            return connection.n_active_root_statements.load(Ordering::SeqCst) == 1
+                && (self.is_active_write || active_writers == 0);
+        }
+        if self.is_active_write {
+            // Pager/WAL writers can finish while sibling readers remain active.
+            // The readers keep their cursors and release them when they finish.
+            return true;
+        }
+        // Pager/WAL readers do not wait for sibling readers.
+        active_writers == 0
     }
 
     #[inline]
@@ -1126,7 +1157,11 @@ impl ProgramState {
         end_statement: EndStatement,
     ) -> Result<()> {
         if self.is_active_write {
-            connection.n_active_writes.fetch_sub(1, Ordering::SeqCst);
+            let previous = connection.n_active_writes.fetch_sub(1, Ordering::SeqCst);
+            turso_assert!(
+                previous == 1,
+                "ending a writer with {previous} active writer(s)"
+            );
             self.is_active_write = false;
         }
         // If begin_statement was never called, no savepoint/FK cleanup needed.
@@ -2481,7 +2516,41 @@ impl Program {
         }
         // Errors from nested statements are handled by the parent statement.
         if !self.connection.is_nested_stmt() && !self.is_trigger_subprogram() {
-            let owns_auto_txn = state.owns_auto_txn();
+            let unfinished_statement_reset_or_drop =
+                err.is_none() && state.execution_state.is_running();
+            let inside_explicit_transaction = !self.connection.get_auto_commit();
+            let unfinished_writer = state.is_active_write;
+            let can_rollback_just_this_statement =
+                state.auto_txn_cleanup == TxnCleanup::RollbackSavepoint;
+
+            let poison_tx = unfinished_statement_reset_or_drop
+                && inside_explicit_transaction
+                && unfinished_writer
+                && !can_rollback_just_this_statement;
+            if poison_tx {
+                // Example: BEGIN; UPDATE rows SET ... writes one row, then
+                // returns IO before reaching Done. If the caller drops that
+                // statement, we cannot pretend COMMIT is still safe: there is
+                // no statement savepoint to undo only the partial UPDATE.
+                self.connection.mark_tx_poisoned();
+            }
+
+            let can_autocommit_now = state.can_autocommit_now(&self.connection);
+            let is_mvcc = self.connection.mv_store().is_some();
+            let changed_shared_mvcc_auto_txn = !can_autocommit_now
+                && state.auto_txn_cleanup == TxnCleanup::RollbackTxn
+                && state.n_change.load(Ordering::SeqCst) > 0;
+            if changed_shared_mvcc_auto_txn {
+                turso_assert!(
+                    is_mvcc,
+                    "shared autocommit transaction needed full rollback outside MVCC"
+                );
+                // A writer changed rows in an MVCC autocommit transaction, but
+                // a sibling reader is still holding that transaction open. The
+                // writer had no statement savepoint, so the only safe cleanup
+                // is rolling back the whole MVCC transaction.
+            }
+            let must_rollback_tx_if_needed = can_autocommit_now || changed_shared_mvcc_auto_txn;
             if err.is_some() && !pager.is_checkpointing() {
                 // For ON CONFLICT FAIL, do NOT rollback the statement savepoint —
                 // changes made before the error should persist.
@@ -2529,7 +2598,7 @@ impl Program {
                 // FK errors always behave like ABORT: rollback statement,
                 // rollback transaction in autocommit mode.
                 Some(LimboError::ForeignKeyConstraint(_)) => {
-                    if owns_auto_txn {
+                    if must_rollback_tx_if_needed {
                         self.rollback_current_txn(pager);
                     }
                     self.connection.set_changes(0);
@@ -2565,7 +2634,7 @@ impl Program {
                                     "Failed to release statement savepoint during abort",
                                 );
                             }
-                            if owns_auto_txn {
+                            if can_autocommit_now {
                                 // Autocommit FAIL: commit partial changes.
                                 // This matches halt()'s FAIL+autocommit path.
                                 let mv_store = self.connection.mv_store();
@@ -2614,7 +2683,7 @@ impl Program {
                             }
                         }
                         _ => {
-                            if owns_auto_txn {
+                            if must_rollback_tx_if_needed {
                                 self.rollback_current_txn(pager);
                             }
                         }
@@ -2636,10 +2705,12 @@ impl Program {
                 }
                 _ => match state.auto_txn_cleanup {
                     TxnCleanup::RollbackTxn => {
-                        self.rollback_current_txn(pager);
+                        if must_rollback_tx_if_needed {
+                            self.rollback_current_txn(pager);
+                        }
                     }
                     TxnCleanup::RollbackSavepoint => {
-                        if owns_auto_txn {
+                        if can_autocommit_now {
                             self.rollback_current_txn(pager);
                         } else if err.is_none() && !pager.is_checkpointing() {
                             if let Err(end_stmt_err) = state.end_statement(
@@ -2656,7 +2727,9 @@ impl Program {
                         }
                     }
                     TxnCleanup::None => {
-                        if owns_auto_txn || (!self.connection.get_auto_commit() && err.is_some()) {
+                        if can_autocommit_now
+                            || (!self.connection.get_auto_commit() && err.is_some())
+                        {
                             self.rollback_current_txn(pager);
                         }
                     }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2579,6 +2579,12 @@ impl Program {
                 Some(LimboError::TableLocked) => {}
                 // Busy errors do not cause a rollback.
                 Some(LimboError::Busy) => {}
+                // Same-connection "SQL statements in progress" rejections do
+                // not cause a rollback either: the rejected operation was
+                // refused before it touched any transaction or savepoint
+                // state, and the in-progress statement it collided with must
+                // keep running unharmed.
+                Some(LimboError::StatementsInProgress(_)) => {}
                 // BusySnapshot errors do not cause a rollback either - user must rollback explicitly.
                 // BusySnapshot is distinct from Busy in that a busy_timeout or handler should not be
                 // used because it will not help - the snapshot is permanently stale and rollback is

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -1,0 +1,1075 @@
+use std::collections::HashSet;
+
+use crate::io::{MemoryIO, PlatformIO, IO};
+use crate::mvcc::cursor::CursorYieldPoint;
+use crate::mvcc::yield_hooks::YieldPointMarker;
+use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
+use crate::sync::{Arc, Mutex};
+use crate::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, Result, Value};
+
+#[derive(Debug)]
+struct FixedYieldInjector {
+    remaining: Mutex<HashSet<YieldPoint>>,
+}
+
+impl FixedYieldInjector {
+    fn new(points: impl IntoIterator<Item = YieldPoint>) -> Arc<Self> {
+        Arc::new(Self {
+            remaining: Mutex::new(points.into_iter().collect()),
+        })
+    }
+}
+
+impl YieldInjector for FixedYieldInjector {
+    fn should_yield(&self, _instance_id: u64, _selection_key: u64, point: YieldPoint) -> bool {
+        self.remaining.lock().remove(&point)
+    }
+}
+
+fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
+    let mut stmt = conn.prepare(query).unwrap();
+    let mut rows = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        let values = row.get_values().cloned().collect::<Vec<_>>();
+        rows.push(values);
+        Ok(())
+    })
+    .unwrap();
+    rows
+}
+
+fn open_mvcc_database_with_opts(path: &str, opts: DatabaseOpts) -> Arc<Database> {
+    let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file_with_flags(io, path, OpenFlags::default(), opts, None).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.close().unwrap();
+    db
+}
+
+struct SameConnectionMvcc {
+    conn: Arc<Connection>,
+    observer: Arc<Connection>,
+}
+
+struct SameConnectionWal {
+    conn: Arc<Connection>,
+    observer: Arc<Connection>,
+}
+
+impl SameConnectionWal {
+    fn new(path: &str) -> Self {
+        let io = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, path).unwrap();
+        let conn = db.connect().unwrap();
+        let observer = db.connect().unwrap();
+        Self { conn, observer }
+    }
+
+    fn setup_rows_table(&self) {
+        self.conn
+            .execute("CREATE TABLE rows(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+    }
+}
+
+impl SameConnectionMvcc {
+    fn new(path: &str) -> Self {
+        let io = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, path).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        let observer = db.connect().unwrap();
+        Self { conn, observer }
+    }
+
+    fn setup_rows_table(&self) {
+        self.conn
+            .execute("CREATE TABLE rows(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+    }
+
+    fn setup_rows_and_source_tables(&self) {
+        self.setup_rows_table();
+        self.conn
+            .execute("CREATE TABLE src(id INTEGER PRIMARY KEY, v TEXT)")
+            .unwrap();
+        self.conn
+            .execute("INSERT INTO src VALUES (2, 'src-two')")
+            .unwrap();
+        self.conn
+            .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+    }
+
+    fn observer_ids(&self) -> Vec<i64> {
+        ids_from_query(&self.observer, "SELECT id FROM rows ORDER BY id")
+    }
+
+    fn observer_count(&self) -> i64 {
+        scalar_i64(&self.observer, "SELECT COUNT(*) FROM rows")
+    }
+
+    fn observer_value_for_id(&self, id: i64) -> String {
+        scalar_text(
+            &self.observer,
+            &format!("SELECT v FROM rows WHERE id = {id}"),
+        )
+    }
+}
+
+fn scalar_i64(conn: &Arc<Connection>, sql: &str) -> i64 {
+    let rows = get_rows(conn, sql);
+    assert_eq!(rows.len(), 1, "expected one row for {sql}, got {rows:?}");
+    rows[0][0]
+        .as_int()
+        .unwrap_or_else(|| panic!("expected integer scalar for {sql}, got {:?}", rows[0][0]))
+}
+
+fn scalar_text(conn: &Arc<Connection>, sql: &str) -> String {
+    let rows = get_rows(conn, sql);
+    assert_eq!(rows.len(), 1, "expected one row for {sql}, got {rows:?}");
+    rows[0][0].to_string()
+}
+
+fn ids_from_query(conn: &Arc<Connection>, sql: &str) -> Vec<i64> {
+    get_rows(conn, sql)
+        .into_iter()
+        .map(|row| {
+            row[0]
+                .as_int()
+                .unwrap_or_else(|| panic!("expected integer id for {sql}, got {:?}", row[0]))
+        })
+        .collect()
+}
+
+fn prepare_insert_returning(conn: &Arc<Connection>, id: i64, value: &str) -> crate::Statement {
+    conn.prepare(format!(
+        "INSERT INTO rows VALUES ({id}, '{value}') RETURNING id"
+    ))
+    .unwrap()
+}
+
+fn step_returning_id(stmt: &mut crate::Statement) -> i64 {
+    match stmt.step().unwrap() {
+        crate::StepResult::Row => stmt.row().unwrap().get::<i64>(0).unwrap(),
+        other => panic!("expected RETURNING row, got {other:?}"),
+    }
+}
+
+fn expect_step_busy(stmt: &mut crate::Statement, context: &str) {
+    match stmt.step() {
+        Ok(crate::StepResult::Busy) | Err(LimboError::Busy) => {}
+        Ok(result) => panic!("expected Busy for {context}, got {result:?}"),
+        Err(err) => panic!("expected Busy for {context}, got {err:?}"),
+    }
+}
+
+fn expect_busy(result: Result<()>, context: &str) {
+    let err = result.expect_err(context);
+    assert!(
+        matches!(err, LimboError::Busy),
+        "expected Busy for {context}, got {err:?}"
+    );
+}
+
+fn expect_unfinished_write_commit_error(result: Result<()>) {
+    let err = result.expect_err("COMMIT should reject an abandoned unfinished write");
+    assert!(
+        matches!(&err, LimboError::TxError(message) if message.contains("unfinished write statement was abandoned")),
+        "expected unfinished-write TxError, got {err:?}"
+    );
+}
+
+fn expect_io_yield(stmt: &mut crate::Statement, context: &str) {
+    match stmt.step().unwrap() {
+        crate::StepResult::IO => {}
+        other => panic!("expected injected IO yield during {context}, got {other:?}"),
+    }
+}
+
+fn finish_without_rows(stmt: &mut crate::Statement) {
+    loop {
+        match stmt.step().unwrap() {
+            crate::StepResult::Done => return,
+            crate::StepResult::IO => stmt.get_pager().io.step().unwrap(),
+            crate::StepResult::Row => panic!("expected statement to finish without more rows"),
+            other => panic!("expected statement to finish, got {other:?}"),
+        }
+    }
+}
+
+fn drain_returning_ids(stmt: &mut crate::Statement) -> Vec<i64> {
+    let mut ids = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            crate::StepResult::Done => return ids,
+            crate::StepResult::IO => stmt.get_pager().io.step().unwrap(),
+            crate::StepResult::Row => ids.push(stmt.row().unwrap().get::<i64>(0).unwrap()),
+            other => panic!("expected RETURNING rows or Done, got {other:?}"),
+        }
+    }
+}
+
+fn prepare_yielding_insert_select(env: &SameConnectionMvcc) -> crate::Statement {
+    prepare_yielding_insert_select_sql(env, "INSERT INTO rows SELECT id, v FROM src")
+}
+
+fn prepare_yielding_insert_select_sql(env: &SameConnectionMvcc, sql: &str) -> crate::Statement {
+    prepare_yielding_statement(&env.conn, sql, CursorYieldPoint::NextStart, "INSERT SELECT")
+}
+
+/// Prepare a statement, force it to suspend at one cursor yield point, then
+/// disable injection so later steps exercise normal resume/cleanup behavior.
+fn prepare_yielding_statement(
+    conn: &Arc<Connection>,
+    sql: impl AsRef<str>,
+    yield_point: CursorYieldPoint,
+    context: &str,
+) -> crate::Statement {
+    conn.set_yield_injector(Some(FixedYieldInjector::new([yield_point.point()])));
+    let mut stmt = conn.prepare(sql).unwrap();
+    expect_io_yield(&mut stmt, context);
+    conn.set_yield_injector(None);
+    stmt
+}
+
+fn prepare_yielding_update_all_rows(conn: &Arc<Connection>, value: &str) -> crate::Statement {
+    prepare_yielding_statement(
+        conn,
+        format!("UPDATE rows SET v = '{value}'"),
+        CursorYieldPoint::NextStart,
+        "UPDATE all rows",
+    )
+}
+
+fn prepare_wal_update_yielding_on_table_read(
+    env: &SameConnectionWal,
+    value: &str,
+) -> crate::Statement {
+    let root_page = scalar_i64(
+        &env.conn,
+        "SELECT rootpage FROM sqlite_schema WHERE type = 'table' AND name = 'rows'",
+    );
+    env.conn.get_pager().arm_spill_yield_on_read(root_page, 0);
+    let mut stmt = env
+        .conn
+        .prepare(format!("UPDATE rows SET v = '{value}'"))
+        .unwrap();
+    expect_io_yield(&mut stmt, "WAL UPDATE table read");
+    stmt
+}
+
+#[test]
+fn test_returning_owner_drop_does_not_commit_interrupted_drop_table() {
+    let io = Arc::new(MemoryIO::new());
+    let path = ":memory:returning-owner-interrupted-drop-table";
+    let db = Database::open_file(io.clone(), path).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute(
+        "CREATE TABLE core(\
+            id INTEGER PRIMARY KEY, \
+            row_number INTEGER, \
+            deletion_timestamp INTEGER\
+        )",
+    )
+    .unwrap();
+    conn.execute("CREATE TABLE other(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    conn.execute(
+        "CREATE UNIQUE INDEX core_active_row_number_index \
+         ON core (row_number) WHERE deletion_timestamp IS NULL",
+    )
+    .unwrap();
+
+    let before = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'core' ORDER BY rowid",
+    );
+    assert_eq!(before.len(), 2);
+    assert_eq!(before[0][0].to_string(), "table");
+    assert_eq!(before[0][1].to_string(), "core");
+    assert_eq!(before[1][0].to_string(), "index");
+    assert_eq!(before[1][1].to_string(), "core_active_row_number_index");
+
+    let mut returning_owner = conn
+        .prepare("INSERT INTO other VALUES (1) RETURNING id")
+        .unwrap();
+    match returning_owner.step().unwrap() {
+        crate::StepResult::Row => {
+            let row = returning_owner.row().unwrap();
+            assert_eq!(row.get::<i64>(0).unwrap(), 1);
+        }
+        other => panic!("expected INSERT RETURNING to yield its row; got {other:?}"),
+    }
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        CursorYieldPoint::NextStart.point()
+    ])));
+    let mut drop_stmt = conn.prepare("DROP TABLE core").unwrap();
+    expect_step_busy(&mut drop_stmt, "DROP TABLE while RETURNING is active");
+    conn.set_yield_injector(None);
+
+    drop(returning_owner);
+    drop(drop_stmt);
+    drop(conn);
+    drop(db);
+
+    let db = Database::open_file(io, path).expect(
+        "reopen should not fail; dropping a RETURNING owner must not commit another statement's interrupted DROP",
+    );
+    let conn = db.connect().unwrap();
+    let after = get_rows(
+        &conn,
+        "SELECT type, name FROM sqlite_schema \
+         WHERE tbl_name = 'core' ORDER BY rowid",
+    );
+    assert_eq!(after.len(), 2, "schema must not be half-dropped: {after:?}");
+    assert_eq!(after[0][0].to_string(), "table");
+    assert_eq!(after[0][1].to_string(), "core");
+    assert_eq!(after[1][0].to_string(), "index");
+    assert_eq!(after[1][1].to_string(), "core_active_row_number_index");
+}
+
+#[test]
+fn test_drop_table_while_returning_active_is_table_locked() {
+    let env = SameConnectionMvcc::new(":memory:drop-table-returning-active-locked");
+    env.conn
+        .execute("CREATE TABLE core(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    env.conn
+        .execute("CREATE TABLE other(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut returning = env
+        .conn
+        .prepare("INSERT INTO other VALUES (1), (2) RETURNING id")
+        .unwrap();
+    assert_eq!(step_returning_id(&mut returning), 1);
+
+    let mut dropper = env.conn.prepare("DROP TABLE core").unwrap();
+    expect_step_busy(&mut dropper, "DROP TABLE while RETURNING is active");
+    drop(dropper);
+
+    assert_eq!(
+        scalar_i64(
+            &env.observer,
+            "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'core'"
+        ),
+        1,
+        "failed DROP must leave the table schema intact"
+    );
+    assert_eq!(
+        scalar_i64(&env.observer, "SELECT COUNT(*) FROM other"),
+        0,
+        "failed DROP must not commit the active RETURNING writer"
+    );
+
+    assert_eq!(step_returning_id(&mut returning), 2);
+    finish_without_rows(&mut returning);
+    assert_eq!(scalar_i64(&env.observer, "SELECT COUNT(*) FROM other"), 2);
+}
+
+#[test]
+fn test_second_returning_writer_is_busy_and_first_can_commit_after_second_drop() {
+    let env = SameConnectionMvcc::new(":memory:multi-returning-first-then-second");
+    env.setup_rows_table();
+
+    let mut first = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut first), 1);
+    let mut second = prepare_insert_returning(&env.conn, 2, "two");
+    expect_step_busy(&mut second, "second RETURNING writer");
+
+    assert_eq!(env.observer_ids(), Vec::<i64>::new());
+    drop(second);
+    drop(first);
+    assert_eq!(env.observer_ids(), vec![1]);
+}
+
+#[test]
+fn test_second_returning_writer_is_busy_and_first_can_commit_after_first_drop() {
+    let env = SameConnectionMvcc::new(":memory:multi-returning-second-then-first");
+    env.setup_rows_table();
+
+    let mut first = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut first), 1);
+    let mut second = prepare_insert_returning(&env.conn, 2, "two");
+    expect_step_busy(&mut second, "second RETURNING writer");
+
+    drop(second);
+    assert_eq!(env.observer_ids(), Vec::<i64>::new());
+    drop(first);
+    assert_eq!(env.observer_ids(), vec![1]);
+}
+
+#[test]
+fn test_busy_second_returning_writer_does_not_block_first_reset_commit() {
+    let env = SameConnectionMvcc::new(":memory:returning-reset-defers");
+    env.setup_rows_table();
+
+    let mut first = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut first), 1);
+    let mut second = prepare_insert_returning(&env.conn, 2, "two");
+    expect_step_busy(&mut second, "second RETURNING writer");
+
+    drop(second);
+    first.reset().unwrap();
+    assert_eq!(env.observer_ids(), vec![1]);
+}
+
+#[test]
+fn test_plain_insert_done_does_not_commit_while_returning_writer_active() {
+    let env = SameConnectionMvcc::new(":memory:plain-insert-waits-for-returning");
+    env.setup_rows_table();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    expect_busy(
+        env.conn.execute("INSERT INTO rows VALUES (2, 'plain-two')"),
+        "plain INSERT while RETURNING is active",
+    );
+
+    assert_eq!(
+        env.observer_ids(),
+        Vec::<i64>::new(),
+        "completed plain INSERT must not commit the shared tx while RETURNING is active"
+    );
+    drop(returning);
+    assert_eq!(env.observer_ids(), vec![1]);
+}
+
+#[test]
+fn test_same_connection_select_does_not_commit_active_returning_writer() {
+    let env = SameConnectionMvcc::new(":memory:select-does-not-commit-returning");
+    env.setup_rows_table();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+
+    assert_eq!(
+        scalar_i64(&env.conn, "SELECT COUNT(*) FROM rows"),
+        1,
+        "the owning connection sees its uncommitted write"
+    );
+    assert_eq!(
+        env.observer_count(),
+        0,
+        "a read statement must not finalize the active implicit write tx"
+    );
+    drop(returning);
+    assert_eq!(env.observer_ids(), vec![1]);
+}
+
+#[test]
+fn test_suspended_read_does_not_finish_joined_returning_writer() {
+    let env = SameConnectionMvcc::new(":memory:suspended-read-joined-writer");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'existing')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 10);
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+
+    drop(reader);
+    assert_eq!(
+        env.observer_ids(),
+        vec![10],
+        "dropping the read that opened the transaction must not finish the joined writer"
+    );
+    drop(returning);
+    assert_eq!(env.observer_ids(), vec![1, 10]);
+}
+
+#[test]
+fn test_completed_writer_waits_for_sibling_mvcc_reader_to_commit() {
+    let env = SameConnectionMvcc::new(":memory:completed-writer-waits-for-reader");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'existing')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 10);
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    finish_without_rows(&mut returning);
+    drop(returning);
+
+    assert_eq!(
+        env.observer_ids(),
+        vec![10],
+        "completed writer must not commit while the reader still holds the shared MVCC transaction"
+    );
+
+    finish_without_rows(&mut reader);
+    assert_eq!(
+        env.observer_ids(),
+        vec![1, 10],
+        "the last sibling statement should commit the completed writer's changes"
+    );
+}
+
+#[test]
+fn test_suspended_read_does_not_finish_sibling_read_transaction() {
+    let env = SameConnectionMvcc::new(":memory:suspended-read-sibling-read");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten'), (20, 'twenty')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut first = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut first), 10);
+    let mut second = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut second), 10);
+
+    drop(first);
+    assert_eq!(
+        step_returning_id(&mut second),
+        20,
+        "dropping one read must not close the transaction under a sibling read"
+    );
+    finish_without_rows(&mut second);
+    assert_eq!(env.conn.get_mv_tx(), None);
+    assert_eq!(
+        env.conn.get_tx_state(),
+        crate::connection::TransactionState::None
+    );
+}
+
+#[test]
+fn test_wal_returning_writer_can_commit_while_sibling_reader_is_active() {
+    let env = SameConnectionWal::new(":memory:wal-reader-active-writer-commit");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 10);
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    finish_without_rows(&mut returning);
+
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![1, 10],
+        "WAL mode follows SQLite's only-active-writer rule: the writer can commit while a reader is still active"
+    );
+    finish_without_rows(&mut reader);
+}
+
+#[test]
+fn test_wal_begin_immediate_does_not_count_as_active_writer() {
+    let env = SameConnectionWal::new(":memory:wal-begin-immediate-not-active-writer");
+    env.setup_rows_table();
+
+    let mut begin = env.conn.prepare("BEGIN IMMEDIATE").unwrap();
+    finish_without_rows(&mut begin);
+
+    let mut insert = env
+        .conn
+        .prepare("INSERT INTO rows VALUES (1, 'one')")
+        .unwrap();
+    finish_without_rows(&mut insert);
+    assert_eq!(
+        scalar_i64(&env.observer, "SELECT COUNT(*) FROM rows"),
+        0,
+        "BEGIN IMMEDIATE opens the transaction, but the INSERT is still uncommitted"
+    );
+
+    env.conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![1]
+    );
+}
+
+#[test]
+fn test_wal_dropping_reader_does_not_rollback_active_returning_writer() {
+    let env = SameConnectionWal::new(":memory:wal-drop-reader-active-writer");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 10);
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+
+    drop(reader);
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![10],
+        "dropping the reader must not commit the active writer"
+    );
+
+    finish_without_rows(&mut returning);
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![1, 10]
+    );
+}
+
+#[test]
+fn test_wal_dropping_one_reader_does_not_close_sibling_reader_transaction() {
+    let env = SameConnectionWal::new(":memory:wal-sibling-readers");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten'), (20, 'twenty')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut first = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut first), 10);
+    let mut second = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut second), 10);
+
+    drop(first);
+    assert_eq!(
+        step_returning_id(&mut second),
+        20,
+        "dropping one reader must not close the transaction under a sibling reader"
+    );
+    finish_without_rows(&mut second);
+}
+
+#[test]
+fn test_insert_select_is_busy_while_returning_writer_is_active() {
+    let env = SameConnectionMvcc::new(":memory:suspended-insert-select-resume");
+    env.setup_rows_and_source_tables();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    let mut insert_select = env
+        .conn
+        .prepare("INSERT INTO rows SELECT id, v FROM src")
+        .unwrap();
+    expect_step_busy(
+        &mut insert_select,
+        "INSERT SELECT while RETURNING is active",
+    );
+
+    drop(insert_select);
+    drop(returning);
+    assert_eq!(env.observer_ids(), vec![1]);
+}
+
+#[test]
+fn test_rejected_insert_select_does_not_roll_back_active_returning_writer() {
+    let env = SameConnectionMvcc::new(":memory:suspended-insert-select-abandon");
+    env.setup_rows_and_source_tables();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    let mut insert_select = env
+        .conn
+        .prepare("INSERT INTO rows SELECT id, v FROM src")
+        .unwrap();
+    expect_step_busy(
+        &mut insert_select,
+        "INSERT SELECT while RETURNING is active",
+    );
+
+    drop(insert_select);
+    drop(returning);
+    assert_eq!(
+        env.observer_ids(),
+        vec![1],
+        "rejected sibling writer must not roll back the active RETURNING writer"
+    );
+}
+
+#[test]
+fn test_first_writer_without_statement_savepoint_abandon_rolls_back_joined_writer() {
+    let env = SameConnectionMvcc::new(":memory:first-writer-without-savepoint-abandon");
+    env.setup_rows_and_source_tables();
+
+    let insert_select = prepare_yielding_insert_select(&env);
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    expect_step_busy(
+        &mut returning,
+        "RETURNING writer while INSERT SELECT is active",
+    );
+
+    drop(insert_select);
+    drop(returning);
+
+    assert_eq!(
+        env.observer_ids(),
+        Vec::<i64>::new(),
+        "abandoning a non-final writer without a local rollback boundary must roll back the shared tx"
+    );
+}
+
+#[test]
+fn test_first_writer_without_statement_savepoint_resume_last_commits_joined_writer() {
+    let env = SameConnectionMvcc::new(":memory:first-writer-without-savepoint-resume");
+    env.setup_rows_and_source_tables();
+
+    let mut insert_select = prepare_yielding_insert_select(&env);
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    expect_step_busy(
+        &mut returning,
+        "RETURNING writer while INSERT SELECT is active",
+    );
+
+    drop(returning);
+    finish_without_rows(&mut insert_select);
+
+    assert_eq!(env.observer_ids(), vec![2]);
+}
+
+#[test]
+fn test_first_writer_without_statement_savepoint_error_rolls_back_joined_writer() {
+    let env = SameConnectionMvcc::new(":memory:first-writer-without-savepoint-error");
+    env.setup_rows_table();
+    env.conn
+        .execute("CREATE TABLE src(id INTEGER, v TEXT)")
+        .unwrap();
+    env.conn
+        .execute("INSERT INTO rows VALUES (1, 'existing')")
+        .unwrap();
+    env.conn
+        .execute("INSERT INTO src VALUES (2, 'src-two'), (1, 'duplicate')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut insert_select =
+        prepare_yielding_insert_select_sql(&env, "INSERT INTO rows SELECT id, v FROM src");
+    let mut returning = prepare_insert_returning(&env.conn, 3, "joined");
+    expect_step_busy(
+        &mut returning,
+        "RETURNING writer while INSERT SELECT is active",
+    );
+
+    let err = insert_select
+        .step()
+        .expect_err("resumed INSERT SELECT should hit duplicate primary key");
+    assert!(
+        matches!(err, LimboError::Constraint(_)),
+        "expected duplicate-key constraint error, got {err:?}"
+    );
+    drop(insert_select);
+    drop(returning);
+
+    assert_eq!(
+        env.observer_ids(),
+        vec![1],
+        "an error from a writer without a local rollback boundary must roll back the whole shared tx"
+    );
+}
+
+#[test]
+fn test_attached_only_returning_writer_defers_shared_auto_txn_commit() {
+    let main_dir = tempfile::TempDir::new().unwrap();
+    let main_path = main_dir.path().join("main.db");
+    let db = open_mvcc_database_with_opts(
+        main_path.to_str().unwrap(),
+        DatabaseOpts::new().with_attach(true),
+    );
+    let aux_dir = tempfile::TempDir::new().unwrap();
+    let aux_path = aux_dir.path().join("aux.db");
+    let aux_path = aux_path.to_str().unwrap();
+
+    let conn = db.connect().unwrap();
+    conn.attach_database(aux_path, "aux").unwrap();
+    conn.execute("CREATE TABLE aux.rows(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+
+    let observer = db.connect().unwrap();
+    observer.attach_database(aux_path, "aux").unwrap();
+
+    let mut returning = conn
+        .prepare("INSERT INTO aux.rows VALUES (1, 'one'), (2, 'two') RETURNING id")
+        .unwrap();
+    assert_eq!(step_returning_id(&mut returning), 1);
+
+    expect_busy(
+        conn.execute("INSERT INTO aux.rows VALUES (3, 'plain')"),
+        "attached INSERT while attached RETURNING is active",
+    );
+    assert_eq!(
+        ids_from_query(&observer, "SELECT id FROM aux.rows ORDER BY id"),
+        Vec::<i64>::new(),
+        "rejected attached writer must not commit the active RETURNING writer"
+    );
+
+    assert_eq!(drain_returning_ids(&mut returning), vec![2]);
+    assert_eq!(
+        ids_from_query(&observer, "SELECT id FROM aux.rows ORDER BY id"),
+        vec![1, 2]
+    );
+}
+
+#[test]
+fn test_mvcc_explicit_tx_unfinished_writer_poisons_transaction() {
+    let env = SameConnectionMvcc::new(":memory:explicit-unfinished-writer-poison");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten'), (20, 'twenty')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    env.conn.execute("BEGIN").unwrap();
+
+    let older = prepare_yielding_update_all_rows(&env.conn, "older");
+    let mut newer = env
+        .conn
+        .prepare("UPDATE rows SET v = 'newer' RETURNING id")
+        .unwrap();
+    expect_step_busy(&mut newer, "second UPDATE writer in explicit transaction");
+
+    drop(newer);
+    drop(older);
+    expect_unfinished_write_commit_error(env.conn.execute("COMMIT"));
+
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![10, 20]
+    );
+    assert_eq!(env.observer_value_for_id(10), "ten");
+    assert_eq!(env.observer_value_for_id(20), "twenty");
+
+    env.conn
+        .execute("INSERT INTO rows VALUES (30, 'thirty')")
+        .unwrap();
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![10, 20, 30]
+    );
+}
+
+#[test]
+fn test_wal_explicit_tx_unfinished_writer_poisons_transaction() {
+    let env = SameConnectionWal::new(":memory:wal-explicit-unfinished-writer-poison");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten'), (20, 'twenty')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    env.conn.execute("BEGIN").unwrap();
+
+    let writer = prepare_wal_update_yielding_on_table_read(&env, "partial");
+    drop(writer);
+    expect_unfinished_write_commit_error(env.conn.execute("COMMIT"));
+
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![10, 20]
+    );
+    assert_eq!(
+        scalar_text(&env.observer, "SELECT v FROM rows WHERE id = 10"),
+        "ten"
+    );
+    assert_eq!(
+        scalar_text(&env.observer, "SELECT v FROM rows WHERE id = 20"),
+        "twenty"
+    );
+}
+
+#[test]
+fn test_explicit_tx_rollback_clears_unfinished_writer_poison() {
+    let env = SameConnectionMvcc::new(":memory:explicit-unfinished-writer-rollback-clear");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten'), (20, 'twenty')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    env.conn.execute("BEGIN").unwrap();
+
+    let writer = prepare_yielding_update_all_rows(&env.conn, "partial");
+    drop(writer);
+    env.conn.execute("ROLLBACK").unwrap();
+
+    env.conn
+        .execute("INSERT INTO rows VALUES (30, 'thirty')")
+        .unwrap();
+    assert_eq!(
+        ids_from_query(&env.observer, "SELECT id FROM rows ORDER BY id"),
+        vec![10, 20, 30]
+    );
+}
+
+#[test]
+fn test_unfinished_drop_abandon_first_rolls_back_only_drop() {
+    let env = SameConnectionMvcc::new(":memory:unfinished-drop-first");
+    env.conn
+        .execute("CREATE TABLE core(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    env.setup_rows_table();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    let mut dropper = env.conn.prepare("DROP TABLE core").unwrap();
+    expect_step_busy(&mut dropper, "DROP TABLE while RETURNING is active");
+
+    drop(dropper);
+    drop(returning);
+
+    assert_eq!(
+        env.observer_ids(),
+        vec![1],
+        "rejected DROP must not roll back the active RETURNING writer"
+    );
+    assert_eq!(
+        scalar_i64(
+            &env.observer,
+            "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'core'"
+        ),
+        1
+    );
+}
+
+#[test]
+fn test_update_is_busy_while_returning_writer_is_active() {
+    let env = SameConnectionMvcc::new(":memory:unfinished-update-abandon");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'original')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    let mut updater = env.conn.prepare("UPDATE rows SET v = 'updated'").unwrap();
+    expect_step_busy(&mut updater, "UPDATE while RETURNING is active");
+
+    drop(returning);
+    drop(updater);
+
+    assert_eq!(env.observer_ids(), vec![10]);
+    assert_eq!(env.observer_value_for_id(10), "original");
+}
+
+#[test]
+fn test_delete_is_busy_while_returning_writer_is_active() {
+    let env = SameConnectionMvcc::new(":memory:unfinished-delete-abandon");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'original')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    let mut deleter = env.conn.prepare("DELETE FROM rows WHERE id = 10").unwrap();
+    expect_step_busy(&mut deleter, "DELETE while RETURNING is active");
+
+    drop(returning);
+    drop(deleter);
+
+    assert_eq!(env.observer_ids(), vec![10]);
+    assert_eq!(env.observer_value_for_id(10), "original");
+}
+
+#[test]
+fn test_duplicate_insert_is_busy_while_returning_writer_is_active() {
+    let env = SameConnectionMvcc::new(":memory:constraint-error-rolls-back-failing");
+    env.setup_rows_table();
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+
+    expect_busy(
+        env.conn.execute("INSERT INTO rows VALUES (1, 'duplicate')"),
+        "duplicate INSERT while RETURNING is active",
+    );
+    drop(returning);
+
+    assert_eq!(
+        env.observer_ids(),
+        vec![1],
+        "rejected duplicate writer must not roll back the active RETURNING writer"
+    );
+}
+
+#[test]
+fn test_rejected_second_returning_and_drop_do_not_rollback_first_returning() {
+    let env = SameConnectionMvcc::new(":memory:two-returning-then-unfinished-drop");
+    env.conn
+        .execute("CREATE TABLE core(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    env.setup_rows_table();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut first = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut first), 1);
+    let mut second = prepare_insert_returning(&env.conn, 2, "two");
+    expect_step_busy(&mut second, "second RETURNING writer");
+    let mut dropper = env.conn.prepare("DROP TABLE core").unwrap();
+    expect_step_busy(&mut dropper, "DROP TABLE while RETURNING is active");
+
+    drop(second);
+    drop(dropper);
+    drop(first);
+
+    assert_eq!(env.observer_ids(), vec![1]);
+    assert_eq!(
+        scalar_i64(
+            &env.observer,
+            "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'core'"
+        ),
+        1
+    );
+}
+
+#[test]
+fn test_insert_is_busy_while_update_returning_writer_is_active() {
+    let env = SameConnectionMvcc::new(":memory:update-returning-plus-insert-returning");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'original')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut update = env
+        .conn
+        .prepare("UPDATE rows SET v = 'updated' WHERE id = 10 RETURNING id")
+        .unwrap();
+    assert_eq!(step_returning_id(&mut update), 10);
+    let mut insert = prepare_insert_returning(&env.conn, 1, "one");
+    expect_step_busy(&mut insert, "INSERT while UPDATE RETURNING is active");
+
+    drop(insert);
+    drop(update);
+    assert_eq!(env.observer_ids(), vec![10]);
+    assert_eq!(env.observer_value_for_id(10), "updated");
+}
+
+#[test]
+fn test_insert_is_busy_while_delete_returning_writer_is_active() {
+    let env = SameConnectionMvcc::new(":memory:delete-returning-plus-insert-returning");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'original')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut delete = env
+        .conn
+        .prepare("DELETE FROM rows WHERE id = 10 RETURNING id")
+        .unwrap();
+    assert_eq!(step_returning_id(&mut delete), 10);
+    let mut insert = prepare_insert_returning(&env.conn, 1, "one");
+    expect_step_busy(&mut insert, "INSERT while DELETE RETURNING is active");
+
+    drop(insert);
+    drop(delete);
+    assert_eq!(env.observer_ids(), Vec::<i64>::new());
+}

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -26,6 +26,16 @@ impl YieldInjector for FixedYieldInjector {
     }
 }
 
+fn drive_attach(conn: &Arc<Connection>, path: &str, alias: &str) {
+    let mut state = crate::connection::AttachDatabaseState::default();
+    loop {
+        match conn.attach_database(path, alias, &mut state).unwrap() {
+            crate::IOResult::Done(()) => return,
+            crate::IOResult::IO(io) => io.wait(conn.db.io.as_ref()).unwrap(),
+        }
+    }
+}
+
 fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     let mut stmt = conn.prepare(query).unwrap();
     let mut rows = Vec::new();
@@ -181,10 +191,17 @@ fn expect_unfinished_write_commit_error(result: Result<()>) {
     );
 }
 
-fn expect_io_yield(stmt: &mut crate::Statement, context: &str) {
-    match stmt.step().unwrap() {
-        crate::StepResult::IO => {}
-        other => panic!("expected injected IO yield during {context}, got {other:?}"),
+/// Step until the injected yield suspends the statement mid-execution,
+/// driving any genuine I/O encountered before the injection point. Injected
+/// yields surface as `StepResult::Yield` (explicit yields are not stored as
+/// pending I/O), so the statement stays parked at the same PC afterwards.
+fn expect_injected_yield(stmt: &mut crate::Statement, context: &str) {
+    loop {
+        match stmt.step().unwrap() {
+            crate::StepResult::Yield => return,
+            crate::StepResult::IO => stmt.get_pager().io.step().unwrap(),
+            other => panic!("expected injected yield during {context}, got {other:?}"),
+        }
     }
 }
 
@@ -229,7 +246,7 @@ fn prepare_yielding_statement(
 ) -> crate::Statement {
     conn.set_yield_injector(Some(FixedYieldInjector::new([yield_point.point()])));
     let mut stmt = conn.prepare(sql).unwrap();
-    expect_io_yield(&mut stmt, context);
+    expect_injected_yield(&mut stmt, context);
     conn.set_yield_injector(None);
     stmt
 }
@@ -256,7 +273,7 @@ fn prepare_wal_update_yielding_on_table_read(
         .conn
         .prepare(format!("UPDATE rows SET v = '{value}'"))
         .unwrap();
-    expect_io_yield(&mut stmt, "WAL UPDATE table read");
+    expect_injected_yield(&mut stmt, "WAL UPDATE table read");
     stmt
 }
 
@@ -788,12 +805,12 @@ fn test_attached_only_returning_writer_defers_shared_auto_txn_commit() {
     let aux_path = aux_path.to_str().unwrap();
 
     let conn = db.connect().unwrap();
-    conn.attach_database(aux_path, "aux").unwrap();
+    drive_attach(&conn, aux_path, "aux");
     conn.execute("CREATE TABLE aux.rows(id INTEGER PRIMARY KEY, v TEXT)")
         .unwrap();
 
     let observer = db.connect().unwrap();
-    observer.attach_database(aux_path, "aux").unwrap();
+    drive_attach(&observer, aux_path, "aux");
 
     let mut returning = conn
         .prepare("INSERT INTO aux.rows VALUES (1, 'one'), (2, 'two') RETURNING id")

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -1101,6 +1101,95 @@ fn test_insert_is_busy_while_delete_returning_writer_is_active() {
     assert_eq!(env.observer_ids(), Vec::<i64>::new());
 }
 
+/// SQLite rejects SAVEPOINT and RELEASE with SQLITE_BUSY while write
+/// statements are in progress (vdbe.c, OP_Savepoint), and aborts in-progress
+/// statements on ROLLBACK TO. Turso cannot abort a suspended statement, so all
+/// three savepoint operations are rejected while a writer is suspended; the
+/// writer can then resume and the savepoint stack stays usable.
+#[test]
+fn test_wal_savepoint_ops_are_busy_while_writer_suspended() {
+    let env = SameConnectionWal::new(":memory:wal-savepoint-busy-mid-writer");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten'), (20, 'twenty')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    env.conn.execute("BEGIN").unwrap();
+    env.conn.execute("SAVEPOINT s").unwrap();
+
+    let mut writer = prepare_wal_update_yielding_on_table_read(&env, "updated");
+    expect_busy(
+        env.conn.execute("SAVEPOINT t"),
+        "SAVEPOINT while a writer is suspended",
+    );
+    expect_busy(
+        env.conn.execute("ROLLBACK TO s"),
+        "ROLLBACK TO while a writer is suspended",
+    );
+    expect_busy(
+        env.conn.execute("RELEASE s"),
+        "RELEASE while a writer is suspended",
+    );
+
+    finish_without_rows(&mut writer);
+    env.conn.execute("RELEASE s").unwrap();
+    env.conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        scalar_text(&env.observer, "SELECT v FROM rows WHERE id = 10"),
+        "updated"
+    );
+    assert_eq!(
+        scalar_text(&env.observer, "SELECT v FROM rows WHERE id = 20"),
+        "updated"
+    );
+}
+
+#[test]
+fn test_wal_savepoint_is_busy_while_autocommit_writer_suspended() {
+    let env = SameConnectionWal::new(":memory:wal-savepoint-busy-autocommit-writer");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut writer = prepare_wal_update_yielding_on_table_read(&env, "updated");
+    expect_busy(
+        env.conn.execute("SAVEPOINT s"),
+        "SAVEPOINT while an autocommit writer is suspended",
+    );
+
+    finish_without_rows(&mut writer);
+    assert_eq!(
+        scalar_text(&env.observer, "SELECT v FROM rows WHERE id = 10"),
+        "updated"
+    );
+    env.conn.execute("SAVEPOINT s").unwrap();
+    env.conn.execute("RELEASE s").unwrap();
+}
+
+#[test]
+fn test_mvcc_savepoint_is_busy_while_writer_suspended() {
+    let env = SameConnectionMvcc::new(":memory:mvcc-savepoint-busy-mid-writer");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'ten')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    env.conn.execute("BEGIN").unwrap();
+
+    let mut writer = prepare_yielding_update_all_rows(&env.conn, "updated");
+    expect_busy(
+        env.conn.execute("SAVEPOINT s"),
+        "SAVEPOINT while an MVCC writer is suspended",
+    );
+
+    finish_without_rows(&mut writer);
+    env.conn.execute("COMMIT").unwrap();
+    assert_eq!(env.observer_value_for_id(10), "updated");
+}
+
 /// A same-connection rejection must bypass the busy handler: only the
 /// application finishing or resetting its own statement can resolve it, so
 /// retrying would burn the whole busy_timeout before failing anyway. The

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -1073,3 +1073,80 @@ fn test_insert_is_busy_while_delete_returning_writer_is_active() {
     drop(delete);
     assert_eq!(env.observer_ids(), Vec::<i64>::new());
 }
+
+// The two tests below pin known data-loss gaps in the MVCC deferred-commit
+// model; they document current behavior, not desired behavior. A writer that
+// finishes while a sibling statement holds the shared implicit MVCC
+// transaction open defers its commit to the last sibling, so any path that
+// ends that transaction in a rollback silently discards changes whose caller
+// already observed success. The durable fix is committing at the writer's own
+// halt; see the FIXME in `halt` (core/vdbe/execute.rs).
+
+#[test]
+fn test_mvcc_completed_writer_changes_lost_when_last_reader_abandoned() {
+    let env = SameConnectionMvcc::new(":memory:completed-writer-lost-reader-abandoned");
+    env.setup_rows_table();
+    env.conn
+        .execute("INSERT INTO rows VALUES (10, 'existing')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = env.conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 10);
+
+    let mut returning = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut returning), 1);
+    finish_without_rows(&mut returning);
+    drop(returning);
+
+    // The reader is abandoned mid-scan instead of finishing, so the shared
+    // transaction ends through the rollback path and the completed writer's
+    // row is lost. Compare test_completed_writer_waits_for_sibling_mvcc_reader_to_commit,
+    // where the reader finishes normally and the writer's row commits.
+    drop(reader);
+
+    assert_eq!(
+        env.observer_ids(),
+        vec![10],
+        "pins the deferred-commit gap: an abandoned last reader discards the completed writer's row"
+    );
+}
+
+#[test]
+fn test_mvcc_completed_writer_changes_lost_when_joining_writer_errors() {
+    let env = SameConnectionMvcc::new(":memory:completed-writer-lost-joining-writer-error");
+    env.setup_rows_table();
+    env.conn
+        .execute("CREATE TABLE src(id INTEGER, v TEXT)")
+        .unwrap();
+    env.conn
+        .execute("INSERT INTO src VALUES (2, 'two'), (1, 'duplicate')")
+        .unwrap();
+    env.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = env.conn.prepare("SELECT id FROM src ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 1);
+
+    env.conn
+        .execute("INSERT INTO rows VALUES (1, 'one')")
+        .unwrap();
+
+    // The joining writer changes a row (id 2) before hitting the duplicate,
+    // and has no local rollback boundary, so the whole shared transaction is
+    // rolled back — including the earlier INSERT that already reported success.
+    let err = env
+        .conn
+        .execute("INSERT INTO rows SELECT id, v FROM src")
+        .expect_err("second insert should hit duplicate primary key");
+    assert!(
+        matches!(err, LimboError::Constraint(_)),
+        "expected duplicate-key constraint error, got {err:?}"
+    );
+
+    drop(reader);
+    assert_eq!(
+        env.observer_ids(),
+        Vec::<i64>::new(),
+        "pins the deferred-commit gap: a failing joined writer discards the completed writer's row"
+    );
+}

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -167,19 +167,23 @@ fn step_returning_id(stmt: &mut crate::Statement) -> i64 {
     }
 }
 
+/// Same-connection conflicts surface as `Err(StatementsInProgress)` — a
+/// BUSY-class error that aborts the statement instead of the retryable
+/// `StepResult::Busy`, mirroring SQLite's "SQL statements in progress"
+/// rejections (error-class SQLITE_BUSY that never invokes the busy handler).
 fn expect_step_busy(stmt: &mut crate::Statement, context: &str) {
     match stmt.step() {
-        Ok(crate::StepResult::Busy) | Err(LimboError::Busy) => {}
-        Ok(result) => panic!("expected Busy for {context}, got {result:?}"),
-        Err(err) => panic!("expected Busy for {context}, got {err:?}"),
+        Err(LimboError::StatementsInProgress(_)) => {}
+        Ok(result) => panic!("expected StatementsInProgress for {context}, got {result:?}"),
+        Err(err) => panic!("expected StatementsInProgress for {context}, got {err:?}"),
     }
 }
 
 fn expect_busy(result: Result<()>, context: &str) {
     let err = result.expect_err(context);
     assert!(
-        matches!(err, LimboError::Busy),
-        "expected Busy for {context}, got {err:?}"
+        matches!(err, LimboError::StatementsInProgress(_)),
+        "expected StatementsInProgress for {context}, got {err:?}"
     );
 }
 
@@ -967,10 +971,13 @@ fn test_update_is_busy_while_returning_writer_is_active() {
     let mut updater = env.conn.prepare("UPDATE rows SET v = 'updated'").unwrap();
     expect_step_busy(&mut updater, "UPDATE while RETURNING is active");
 
+    // The rejection aborts the UPDATE at step time, releasing its root
+    // statement slot, so dropping the RETURNING writer commits its own
+    // insert instead of deferring to a rejected sibling that will never run.
     drop(returning);
     drop(updater);
 
-    assert_eq!(env.observer_ids(), vec![10]);
+    assert_eq!(env.observer_ids(), vec![1, 10]);
     assert_eq!(env.observer_value_for_id(10), "original");
 }
 
@@ -988,10 +995,13 @@ fn test_delete_is_busy_while_returning_writer_is_active() {
     let mut deleter = env.conn.prepare("DELETE FROM rows WHERE id = 10").unwrap();
     expect_step_busy(&mut deleter, "DELETE while RETURNING is active");
 
+    // The rejection aborts the DELETE at step time, releasing its root
+    // statement slot, so dropping the RETURNING writer commits its own
+    // insert instead of deferring to a rejected sibling that will never run.
     drop(returning);
     drop(deleter);
 
-    assert_eq!(env.observer_ids(), vec![10]);
+    assert_eq!(env.observer_ids(), vec![1, 10]);
     assert_eq!(env.observer_value_for_id(10), "original");
 }
 
@@ -1089,6 +1099,30 @@ fn test_insert_is_busy_while_delete_returning_writer_is_active() {
     drop(insert);
     drop(delete);
     assert_eq!(env.observer_ids(), Vec::<i64>::new());
+}
+
+/// A same-connection rejection must bypass the busy handler: only the
+/// application finishing or resetting its own statement can resolve it, so
+/// retrying would burn the whole busy_timeout before failing anyway. The
+/// rejection is an error (`StatementsInProgress`), not the retryable
+/// `StepResult::Busy`, so the armed 600s busy_timeout never engages — if the
+/// rejection ever regressed into the retryable path, the step below would
+/// surface as StepResult::IO and expect_step_busy would catch it.
+#[test]
+fn test_second_writer_busy_does_not_invoke_busy_handler() {
+    let env = SameConnectionMvcc::new(":memory:second-writer-skips-busy-handler");
+    env.setup_rows_table();
+    env.conn
+        .set_busy_timeout(std::time::Duration::from_secs(600));
+
+    let mut first = prepare_insert_returning(&env.conn, 1, "one");
+    assert_eq!(step_returning_id(&mut first), 1);
+    let mut second = prepare_insert_returning(&env.conn, 2, "two");
+    expect_step_busy(&mut second, "second writer with busy_timeout set");
+
+    drop(second);
+    drop(first);
+    assert_eq!(env.observer_ids(), vec![1]);
 }
 
 // The two tests below pin known data-loss gaps in the MVCC deferred-commit

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -510,6 +510,9 @@ impl From<LimboError> for TursoError {
             LimboError::DatabaseFull(e) => TursoError::DatabaseFull(e),
             LimboError::ReadOnly => TursoError::Readonly("database is readonly".to_string()),
             LimboError::Busy => TursoError::Busy("database is locked".to_string()),
+            // Same-connection rejections carry SQLITE_BUSY semantics, but the
+            // caller must finish/reset its own statement rather than wait.
+            err @ LimboError::StatementsInProgress(_) => TursoError::Busy(err.to_string()),
             LimboError::BusySnapshot => TursoError::BusySnapshot(
                 "database snapshot is stale, rollback and retry the transaction".to_string(),
             ),

--- a/tests/integration/abandoned_statement_pager.rs
+++ b/tests/integration/abandoned_statement_pager.rs
@@ -1,0 +1,346 @@
+#![cfg(feature = "io_memory_yield")]
+
+//! Regression tests for write statements abandoned (dropped) at an I/O
+//! boundary mid-mutation (#7682).
+//!
+//! An abandoned partial write must never reach disk. On this branch that is
+//! enforced at COMMIT: abandoning an unfinished write statement inside an
+//! explicit transaction marks the transaction rollback-only, so a later
+//! COMMIT rolls everything back and returns an error instead of persisting a
+//! half-applied statement. These tests iterate over every I/O boundary of the
+//! abandoned statement and assert that, whatever point it was abandoned at,
+//! the database ends up intact (original rows, integrity_check ok, table and
+//! index in agreement) and the connection stays usable afterwards.
+
+use std::sync::Arc;
+
+use turso_core::{Connection, Database, LimboError, MemoryYieldIO, StepResult, IO};
+
+fn open_conn(io: Arc<MemoryYieldIO>, path: &str) -> Arc<Connection> {
+    Database::open_file(io, path).unwrap().connect().unwrap()
+}
+
+fn integrity_check(conn: &Arc<Connection>) -> Vec<String> {
+    conn.prepare("PRAGMA integrity_check")
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()
+        .into_iter()
+        .map(|row| row[0].to_string())
+        .collect()
+}
+
+fn ids(conn: &Arc<Connection>, sql: &str) -> Vec<i64> {
+    conn.prepare(sql)
+        .unwrap()
+        .run_collect_rows()
+        .unwrap()
+        .into_iter()
+        .map(|row| row[0].as_int().unwrap())
+        .collect()
+}
+
+fn expect_unfinished_write_commit_error(result: turso_core::Result<()>, context: &str) {
+    let err = result.expect_err(context);
+    assert!(
+        matches!(&err, LimboError::TxError(message) if message.contains("unfinished write statement was abandoned")),
+        "{context}: expected unfinished-write TxError, got {err:?}"
+    );
+}
+
+/// Steps `sql` until the `target_io`-th `StepResult::IO`, completes that I/O,
+/// then drops the statement without stepping it again. Returns false if the
+/// statement finished before reaching `target_io` I/Os.
+fn abandon_statement_after_io_completion(
+    conn: &Arc<Connection>,
+    io: &Arc<MemoryYieldIO>,
+    sql: &str,
+    target_io: usize,
+) -> bool {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut io_count = 0;
+
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO => {
+                io_count += 1;
+                io.step().unwrap();
+                if io_count == target_io {
+                    drop(stmt);
+                    return true;
+                }
+            }
+            StepResult::Done => return false,
+            StepResult::Yield => {}
+            other => panic!("unexpected step result while abandoning statement: {other:?}"),
+        }
+    }
+}
+
+/// Steps `sql` until the `target_io`-th `StepResult::IO` and drops the
+/// statement while that I/O is still pending. Returns false if the statement
+/// finished before reaching `target_io` I/Os.
+fn abandon_statement_before_io_completion(
+    conn: &Arc<Connection>,
+    io: &Arc<MemoryYieldIO>,
+    sql: &str,
+    target_io: usize,
+) -> bool {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut io_count = 0;
+
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO => {
+                io_count += 1;
+                if io_count == target_io {
+                    drop(stmt);
+                    return true;
+                }
+                io.step().unwrap();
+            }
+            StepResult::Done => return false,
+            StepResult::Yield => {}
+            other => panic!("unexpected step result while abandoning statement: {other:?}"),
+        }
+    }
+}
+
+fn seed_indexed_overflow_rows(conn: &Arc<Connection>, payload: &str) {
+    conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x, b TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_x ON t(x)").unwrap();
+    for id in 1..=8 {
+        conn.execute(format!("INSERT INTO t VALUES({id}, {id}, '{payload}')"))
+            .unwrap();
+    }
+    conn.execute("DELETE FROM t WHERE id = 1").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
+/// Abandoning an INSERT with overflow pages mid-I/O must not poison the
+/// freelist. A user savepoint rollback restores the pre-statement page state,
+/// but the transaction stays rollback-only, so COMMIT is rejected and rolls
+/// everything back. Afterwards the connection must be fully usable and the
+/// freelist intact.
+#[test]
+fn test_abandoned_insert_savepoint_rollback_preserves_freelist() {
+    for target_io in 1..=512 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("abandoned-overflow-insert-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        {
+            let conn = open_conn(io.clone(), path);
+            conn.execute("PRAGMA page_size=512").unwrap();
+            conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+            conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB)")
+                .unwrap();
+            conn.execute(
+                "INSERT INTO t VALUES
+                 (1, zeroblob(50000)),
+                 (2, zeroblob(50000)),
+                 (3, zeroblob(50000)),
+                 (4, zeroblob(50000)),
+                 (5, zeroblob(50000))",
+            )
+            .unwrap();
+            conn.execute("DELETE FROM t WHERE id IN (2,3,4)").unwrap();
+        }
+
+        let conn = open_conn(io.clone(), path);
+        conn.execute("BEGIN").unwrap();
+        conn.execute("SAVEPOINT s").unwrap();
+
+        if !abandon_statement_before_io_completion(
+            &conn,
+            &io,
+            "INSERT INTO t VALUES (100, zeroblob(50000))",
+            target_io,
+        ) {
+            conn.execute("ROLLBACK").unwrap();
+            assert!(
+                target_io > 1,
+                "INSERT finished without any I/O; the abandonment sweep never ran"
+            );
+            break;
+        }
+
+        conn.execute("ROLLBACK TO s").unwrap();
+        conn.execute("RELEASE s").unwrap();
+
+        let rows = conn
+            .prepare("SELECT id, length(b) FROM t ORDER BY id")
+            .unwrap()
+            .run_collect_rows()
+            .unwrap()
+            .into_iter()
+            .map(|row| (row[0].as_int().unwrap(), row[1].as_int().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            rows,
+            vec![(1, 50000), (5, 50000)],
+            "target_io={target_io}: abandoned INSERT changed visible table rows"
+        );
+
+        conn.execute("INSERT INTO t VALUES (200, zeroblob(50000))")
+            .unwrap();
+        // The abandoned writer had no statement savepoint, so the transaction
+        // is rollback-only even after ROLLBACK TO s undid its pages.
+        expect_unfinished_write_commit_error(
+            conn.execute("COMMIT"),
+            &format!("target_io={target_io}: COMMIT after abandoned INSERT"),
+        );
+
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t ORDER BY id"),
+            vec![1, 5],
+            "target_io={target_io}: rejected COMMIT must roll back the whole transaction"
+        );
+
+        // The connection must be usable again and the freelist intact.
+        conn.execute("INSERT INTO t VALUES (200, zeroblob(50000))")
+            .unwrap();
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t ORDER BY id"),
+            vec![1, 5, 200],
+            "target_io={target_io}: post-rollback INSERT missing"
+        );
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io}: abandoned INSERT poisoned freelist state"
+        );
+    }
+}
+
+#[test]
+fn test_abandoned_delete_does_not_poison_next_delete() {
+    let payload = "x".repeat(20_000);
+
+    for target_io in 1..=128 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("abandoned-delete-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        {
+            let conn = open_conn(io.clone(), path);
+            seed_indexed_overflow_rows(&conn, &payload);
+        }
+
+        let conn = open_conn(io.clone(), path);
+        conn.execute("BEGIN").unwrap();
+
+        if !abandon_statement_after_io_completion(
+            &conn,
+            &io,
+            "DELETE FROM t WHERE id IN (2,3)",
+            target_io,
+        ) {
+            conn.execute("ROLLBACK").unwrap();
+            assert!(
+                target_io > 1,
+                "DELETE finished without any I/O; the abandonment sweep never ran"
+            );
+            break;
+        }
+
+        // The abandoned DELETE's partial effects stay in the uncommitted
+        // transaction; a later statement in the same transaction must still
+        // execute without corrupting anything.
+        conn.execute("DELETE FROM t WHERE id = 4").unwrap();
+        expect_unfinished_write_commit_error(
+            conn.execute("COMMIT"),
+            &format!("target_io={target_io}: COMMIT after abandoned DELETE"),
+        );
+
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t ORDER BY id"),
+            vec![2, 3, 4, 5, 6, 7, 8],
+            "target_io={target_io}: rejected COMMIT must roll back the abandoned DELETE"
+        );
+
+        conn.execute("DELETE FROM t WHERE id = 4").unwrap();
+
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io}: abandoned DELETE poisoned the next DELETE"
+        );
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t INDEXED BY t_x ORDER BY x"),
+            vec![2, 3, 5, 6, 7, 8],
+            "target_io={target_io}: indexed scan disagrees after next DELETE"
+        );
+    }
+}
+
+#[test]
+fn test_abandoned_insert_does_not_poison_next_insert() {
+    let payload = "x".repeat(20_000);
+
+    for target_io in 1..=128 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join(format!("abandoned-insert-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        {
+            let conn = open_conn(io.clone(), path);
+            seed_indexed_overflow_rows(&conn, &payload);
+        }
+
+        let conn = open_conn(io.clone(), path);
+        conn.execute("BEGIN").unwrap();
+
+        if !abandon_statement_after_io_completion(
+            &conn,
+            &io,
+            &format!("INSERT INTO t VALUES(9, 9, '{payload}')"),
+            target_io,
+        ) {
+            conn.execute("ROLLBACK").unwrap();
+            assert!(
+                target_io > 1,
+                "INSERT finished without any I/O; the abandonment sweep never ran"
+            );
+            break;
+        }
+
+        conn.execute(format!("INSERT INTO t VALUES(10, 10, '{payload}')"))
+            .unwrap();
+        expect_unfinished_write_commit_error(
+            conn.execute("COMMIT"),
+            &format!("target_io={target_io}: COMMIT after abandoned INSERT"),
+        );
+
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t ORDER BY id"),
+            vec![2, 3, 4, 5, 6, 7, 8],
+            "target_io={target_io}: rejected COMMIT must roll back the abandoned INSERT"
+        );
+
+        conn.execute(format!("INSERT INTO t VALUES(10, 10, '{payload}')"))
+            .unwrap();
+
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io}: abandoned INSERT poisoned the next INSERT"
+        );
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t INDEXED BY t_x ORDER BY x"),
+            vec![2, 3, 4, 5, 6, 7, 8, 10],
+            "target_io={target_io}: indexed scan disagrees after next INSERT"
+        );
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 mod abandoned_create_index;
+mod abandoned_statement_pager;
 mod assert_details;
 mod attach;
 mod common;

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -970,6 +970,13 @@ pub fn concurrent_writes_over_single_connection(limbo: TempDatabase) {
                     *stmt_opt = None;
                     oks += 1;
                 }
+                Err(LimboError::StatementsInProgress(_)) => {
+                    // Only one write statement may run at a time on a
+                    // connection; the rejection aborts this statement, so
+                    // reset it and retry on a later round once the active
+                    // writer has finished.
+                    stmt.reset().unwrap();
+                }
                 Err(err) => {
                     println!("err: {err:?}");
                     *stmt_opt = None;
@@ -982,8 +989,9 @@ pub fn concurrent_writes_over_single_connection(limbo: TempDatabase) {
     }
     println!("errors: {errors}, oks: {oks}");
 
-    // all statement will be executed successfully - because turso return Busy error for all except one running statement
-    // and later retry operation for the failed statements
+    // Every statement completes: blocked writers are rejected with
+    // StatementsInProgress and succeed when retried after the active
+    // writer finishes.
     assert_eq!((oks, errors), (COUNT, 0));
 }
 
@@ -1071,20 +1079,22 @@ pub fn concurrent_commit_and_insert_over_single_connection(limbo: TempDatabase) 
     loop {
         match stmt1.step().unwrap() {
             StepResult::Row => {
+                // COMMIT while a write statement is in progress is an
+                // error-class BUSY rejection, mirroring SQLite's "cannot
+                // commit transaction - SQL statements in progress". The
+                // transaction stays open and unharmed.
                 let mut stmt2 = conn1.prepare("COMMIT").unwrap();
-                let mut busy = false;
-                loop {
+                let err = loop {
                     match stmt2.step() {
-                        Ok(StepResult::Done) => break,
                         Ok(StepResult::IO) => stmt2._io().step().unwrap(),
-                        Ok(StepResult::Busy) => {
-                            busy = true;
-                            break;
-                        }
+                        Err(err) => break err,
                         r => panic!("unexpected step result: {r:?}"),
                     }
-                }
-                assert!(busy);
+                };
+                assert!(
+                    matches!(err, LimboError::StatementsInProgress(_)),
+                    "expected StatementsInProgress, got {err:?}"
+                );
             }
             StepResult::Done => break,
             StepResult::IO => stmt1._io().step().unwrap(),
@@ -1111,20 +1121,22 @@ pub fn concurrent_rollback_and_insert_over_single_connection(limbo: TempDatabase
     loop {
         match stmt1.step().unwrap() {
             StepResult::Row => {
+                // ROLLBACK while a write statement is in progress is an
+                // error-class BUSY rejection: Turso cannot abort the
+                // suspended writer the way SQLite does, so the rollback is
+                // refused and the transaction stays open.
                 let mut stmt2 = conn1.prepare("ROLLBACK").unwrap();
-                let mut busy = false;
-                loop {
+                let err = loop {
                     match stmt2.step() {
-                        Ok(StepResult::Done) => break,
                         Ok(StepResult::IO) => stmt2._io().step().unwrap(),
-                        Ok(StepResult::Busy) => {
-                            busy = true;
-                            break;
-                        }
+                        Err(err) => break err,
                         r => panic!("unexpected step result: {r:?}"),
                     }
-                }
-                assert!(busy);
+                };
+                assert!(
+                    matches!(err, LimboError::StatementsInProgress(_)),
+                    "expected StatementsInProgress, got {err:?}"
+                );
             }
             StepResult::Done => break,
             StepResult::IO => stmt1._io().step().unwrap(),


### PR DESCRIPTION
Took Claude Fable for a test drive just for writing this PR description, and it actually turned out pretty good. AGI confirmed.

---

## What this PR does

Two things, in two commits:

1. **A connection can now run only one write statement at a time.** Starting a second write statement while another is mid-flight returns `SQLITE_BUSY`. Additionally, if a half-finished write statement inside a `BEGIN ... COMMIT` transaction is abandoned, the transaction refuses to commit.
2. **Documents a known durability edge case in MVCC**, with tests that document the current behavior so any eventual fix changes them deliberately rather than accidentally.

## Background: why Turso has a problem SQLite doesn't

In SQLite, `sqlite3_step()` never returns control to the application in the middle of modifying the database. A write statement either runs to completion or stops at a clean boundary, like returning a row.

Turso supports asynchronous I/O, so a statement *can* pause in the middle of a write — say, halfway through an `UPDATE` that touches many rows — while waiting for the disk. That's normally fine: the application steps the statement again and it resumes where it left off.

The trouble starts when the application doesn't resume it. If the half-done statement is reset or dropped, or another write statement starts in the meantime, the transaction now contains changes from a statement that never finished, and we have to decide what's safe to commit and what must be undone.

## Commit 1: one writer at a time, and poisoned transactions

**One writer at a time.** If a second write statement could start while the first is suspended mid-write, then resetting or dropping either one would require undoing only *that* statement's changes. Our undo mechanisms (statement savepoints) can't cleanly undo that statement's changes due to being a LIFO stack. Rather than risk committing or rolling back the wrong thing, the second write statement now gets `SQLITE_BUSY`: finish or reset the active one first. Reads can still run alongside a write.

This is a deliberate divergence from SQLite, which allows overlapping write statements — it can, because it never pauses mid-mutation. Documented in COMPAT.md.

**Poisoning.** If a write statement inside an interactive tx is reset or dropped before finishing, and no statement savepoint exists that could undo just that statement, the transaction is marked rollback-only ("poisoned"). A later `COMMIT` rolls everything back and returns an error instead of committing a half-applied statement. `ROLLBACK` clears the marker as usual.

## Commit 2: the MVCC durability gap (documented, not yet fixed)

In MVCC, all concurrent statements on one connection share a single MVCC transaction. A write statement that finishes while a sibling statement (say, an open `SELECT` being stepped row by row) is still active cannot commit yet, because committing would end the transaction the `SELECT` is still reading from. So the commit is deferred until the last statement finishes.

The gap: between "your `INSERT` returned success" and "the last sibling statement finished", the data is not durable. Worse, if the shared transaction ends in a rollback — the open `SELECT` is dropped mid-scan, or a later write statement fails after changing rows — the `INSERT` that already reported success is silently rolled back.

SQLite never has this window: it commits when the writer itself finishes and lets the remaining statements carry on under a read-only transaction. The proper fix is the MVCC equivalent — commit at the writer's completion and move remaining readers onto a fresh read-only transaction that sees exactly the same data. A FIXME at the deferral site in `core/vdbe/execute.rs` spells this out. Until that lands, this commit documents the gap in COMPAT.md and pins both loss scenarios with tests.
