### PR TITLE
Add shared buffer views for serialization callbacks

### DIFF
--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -525,8 +525,83 @@ impl<'a> WriteBatch<'a> {
 
 pub type BufferData = Pin<Box<[u8]>>;
 
+#[derive(Clone)]
+pub enum SharedBufferData {
+    Full(Arc<Box<[u8]>>),
+    View(SharedBufferView),
+}
+
+#[derive(Clone)]
+pub struct SharedBufferView {
+    data: Arc<Box<[u8]>>,
+    start: usize,
+}
+
+impl SharedBufferView {
+    fn new(data: Arc<Box<[u8]>>, start: usize) -> Self {
+        assert!(
+            start <= data.len(),
+            "SharedBufferData::new_view: start ({start}) > data.len() ({})",
+            data.len()
+        );
+        Self { data, start }
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len() - self.start
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data.as_ref().as_ref()[self.start..]
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        unsafe { self.data.as_ref().as_ptr().add(self.start) }
+    }
+}
+
+impl SharedBufferData {
+    pub fn new(data: Arc<Box<[u8]>>) -> Self {
+        Self::Full(data)
+    }
+
+    pub fn new_view(data: Arc<Box<[u8]>>, start: usize) -> Self {
+        Self::View(SharedBufferView::new(data, start))
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Full(data) => data.len(),
+            Self::View(view) => view.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Full(data) => data.as_ref().as_ref(),
+            Self::View(view) => view.as_slice(),
+        }
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        match self {
+            Self::Full(data) => data.as_ref().as_ptr(),
+            Self::View(view) => view.as_ptr(),
+        }
+    }
+}
+
 pub enum Buffer {
     Heap(BufferData),
+    Shared(SharedBufferData),
     /// A heap buffer with a logical start offset: only `data[start..]` is
     /// exposed via [`Buffer::as_slice`] / [`Buffer::len`]. Used to skip a
     /// pre-allocated prefix without shifting bytes in memory before I/O.
@@ -542,6 +617,7 @@ impl Debug for Buffer {
         match self {
             Self::Pooled(p) => write!(f, "Pooled(len={})", p.logical_len()),
             Self::Heap(buf) => write!(f, "{buf:?}: {}", buf.len()),
+            Self::Shared(buf) => write!(f, "Shared(len={})", buf.len()),
             Self::HeapView { data, start } => {
                 write!(
                     f,
@@ -566,7 +642,7 @@ impl Drop for Buffer {
                     cache.return_buffer(buffer, underlying_len);
                 });
             }
-            Self::Pooled(_) => {}
+            Self::Pooled(_) | Self::Shared(_) => {}
         }
     }
 }
@@ -575,6 +651,14 @@ impl Buffer {
     pub fn new(data: Vec<u8>) -> Self {
         tracing::trace!("buffer::new({:?})", data);
         Self::Heap(Pin::new(data.into_boxed_slice()))
+    }
+
+    pub fn new_shared(data: Arc<Box<[u8]>>) -> Self {
+        Self::Shared(SharedBufferData::new(data))
+    }
+
+    pub fn new_shared_data(data: SharedBufferData) -> Self {
+        Self::Shared(data)
     }
 
     /// Wraps `data` so that only bytes `[start..]` are visible via
@@ -598,7 +682,7 @@ impl Buffer {
     /// io_uring. Only for use with `UringIO` backend.
     pub fn fixed_id(&self) -> Option<u32> {
         match self {
-            Self::Heap(..) | Self::HeapView { .. } => None,
+            Self::Heap(..) | Self::HeapView { .. } | Self::Shared(..) => None,
             Self::Pooled(buf) => buf.fixed_id(),
         }
     }
@@ -620,6 +704,7 @@ impl Buffer {
     pub fn len(&self) -> usize {
         match self {
             Self::Heap(buf) => buf.len(),
+            Self::Shared(buf) => buf.len(),
             Self::HeapView { data, start } => data.len() - *start,
             Self::Pooled(buf) => buf.logical_len(),
         }
@@ -635,6 +720,7 @@ impl Buffer {
                 // SAFETY: The buffer is guaranteed to be valid for the lifetime of the slice
                 unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) }
             }
+            Self::Shared(buf) => buf.as_slice(),
             Self::HeapView { data, start } => {
                 // SAFETY: `start` was bounds-checked at construction; the buffer
                 // is valid for the lifetime of the returned slice.
@@ -654,6 +740,7 @@ impl Buffer {
     pub fn as_ptr(&self) -> *const u8 {
         match self {
             Self::Heap(buf) => buf.as_ptr(),
+            Self::Shared(buf) => buf.as_ptr(),
             Self::HeapView { data, start } => unsafe { data.as_ptr().add(*start) },
             Self::Pooled(buf) => buf.as_ptr(),
         }
@@ -662,6 +749,7 @@ impl Buffer {
     pub fn as_mut_ptr(&self) -> *mut u8 {
         match self {
             Self::Heap(buf) => buf.as_ptr() as *mut u8,
+            Self::Shared(_) => panic!("Buffer::Shared is immutable"),
             Self::HeapView { data, start } => unsafe { (data.as_ptr() as *mut u8).add(*start) },
             Self::Pooled(buf) => buf.as_ptr() as *mut u8,
         }
@@ -681,6 +769,37 @@ impl Buffer {
 crate::thread::thread_local! {
     /// thread local cache to re-use temporary buffers to prevent churn when pool overflows
     pub static TEMP_BUFFER_CACHE: RefCell<TempBufferCache> = RefCell::new(TempBufferCache::new());
+}
+
+#[cfg(test)]
+mod buffer_tests {
+    use super::*;
+
+    #[test]
+    fn shared_buffer_exposes_arc_bytes() {
+        let data = Arc::new(vec![1, 2, 3, 4].into_boxed_slice());
+        let buffer = Buffer::new_shared(data.clone());
+
+        assert_eq!(buffer.len(), 4);
+        assert_eq!(buffer.as_slice(), &[1, 2, 3, 4]);
+        assert_eq!(buffer.as_ptr(), data.as_ref().as_ptr());
+        assert!(!buffer.is_heap());
+        assert!(!buffer.is_pooled());
+    }
+
+    #[test]
+    fn shared_buffer_view_exposes_tail_without_copying() {
+        let data = Arc::new(vec![0, 1, 2, 3, 4].into_boxed_slice());
+        let shared = SharedBufferData::new_view(data.clone(), 2);
+        let buffer = Buffer::new_shared_data(shared.clone());
+
+        assert_eq!(shared.len(), 3);
+        assert_eq!(shared.as_slice(), &[2, 3, 4]);
+        assert_eq!(shared.as_ptr(), unsafe { data.as_ref().as_ptr().add(2) });
+        assert_eq!(buffer.len(), 3);
+        assert_eq!(buffer.as_slice(), &[2, 3, 4]);
+        assert_eq!(buffer.as_ptr(), shared.as_ptr());
+    }
 }
 
 /// A cache for temporary or any additional `Buffer` allocations beyond

--- a/core/io/win_iocp.rs
+++ b/core/io/win_iocp.rs
@@ -63,10 +63,9 @@ use super::FileSyncType;
 use crate::io::completions::CompletionInner;
 use crate::io::{SharedWalLockKind, SharedWalMappedRegion};
 use windows_sys::Win32::Foundation::{
-    CloseHandle, GetLastError, LocalFree, ERROR_HANDLE_EOF, ERROR_IO_PENDING,
-    ERROR_LOCK_VIOLATION, ERROR_NOT_LOCKED,
-    ERROR_OPERATION_ABORTED, FALSE, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
-    TRUE, WAIT_TIMEOUT,
+    CloseHandle, GetLastError, LocalFree, ERROR_HANDLE_EOF, ERROR_IO_PENDING, ERROR_LOCK_VIOLATION,
+    ERROR_NOT_LOCKED, ERROR_OPERATION_ABORTED, FALSE, GENERIC_READ, GENERIC_WRITE, HANDLE,
+    INVALID_HANDLE_VALUE, TRUE, WAIT_TIMEOUT,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     CreateFileW, FileEndOfFileInfo, FlushFileBuffers, GetFileSizeEx, LockFileEx, ReadFile,
@@ -75,16 +74,16 @@ use windows_sys::Win32::Storage::FileSystem::{
     FILE_SHARE_READ, FILE_SHARE_WRITE, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
     OPEN_ALWAYS, OPEN_EXISTING,
 };
-use windows_sys::Win32::System::IO::{
-    CancelIoEx, CreateIoCompletionPort, GetOverlappedResult, GetQueuedCompletionStatus, OVERLAPPED,
-    OVERLAPPED_0, OVERLAPPED_0_0,
-};
 use windows_sys::Win32::System::Memory::{
     CreateFileMappingW, MapViewOfFile, UnmapViewOfFile, FILE_MAP_READ, FILE_MAP_WRITE,
     PAGE_READWRITE,
 };
 use windows_sys::Win32::System::SystemInformation::{GetSystemInfo, SYSTEM_INFO};
 use windows_sys::Win32::System::Threading::CreateEventW;
+use windows_sys::Win32::System::IO::{
+    CancelIoEx, CreateIoCompletionPort, GetOverlappedResult, GetQueuedCompletionStatus, OVERLAPPED,
+    OVERLAPPED_0, OVERLAPPED_0_0,
+};
 
 // Constants
 
@@ -235,9 +234,11 @@ impl SharedWalMappedRegion for WindowsSharedWalMapping {
 impl Drop for WindowsSharedWalMapping {
     fn drop(&mut self) {
         unsafe {
-            if UnmapViewOfFile(windows_sys::Win32::System::Memory::MEMORY_MAPPED_VIEW_ADDRESS {
-                Value: self.view_ptr.as_ptr().cast(),
-            }) == FALSE
+            if UnmapViewOfFile(
+                windows_sys::Win32::System::Memory::MEMORY_MAPPED_VIEW_ADDRESS {
+                    Value: self.view_ptr.as_ptr().cast(),
+                },
+            ) == FALSE
             {
                 tracing::error!(
                     "UnmapViewOfFile failed for shared WAL coordination region: {}",
@@ -741,12 +742,8 @@ impl WindowsFile {
 
             let mut bytes = 0;
             unsafe {
-                if GetOverlappedResult(
-                    self.file_handle,
-                    &raw mut overlapped,
-                    &raw mut bytes,
-                    TRUE,
-                ) == TRUE
+                if GetOverlappedResult(self.file_handle, &raw mut overlapped, &raw mut bytes, TRUE)
+                    == TRUE
                 {
                     return Ok(true);
                 }
@@ -791,12 +788,8 @@ impl WindowsFile {
 
             let mut bytes = 0;
             unsafe {
-                if GetOverlappedResult(
-                    self.file_handle,
-                    &raw mut overlapped,
-                    &raw mut bytes,
-                    TRUE,
-                ) == TRUE
+                if GetOverlappedResult(self.file_handle, &raw mut overlapped, &raw mut bytes, TRUE)
+                    == TRUE
                 {
                     return Ok(());
                 }
@@ -922,7 +915,7 @@ impl File for WindowsFile {
             get_unique_key_from_completion(&completion).addr()
         );
 
-        let buffer_ptr = buffer.as_mut_ptr();
+        let buffer_ptr = buffer.as_ptr();
         let buffer_len = buffer
             .len()
             .try_into()
@@ -1081,8 +1074,16 @@ impl File for WindowsFile {
             .checked_add(len)
             .ok_or_else(|| LimboError::InternalError("shared WAL map length overflow".into()))?;
 
-        let mapping_handle =
-            unsafe { CreateFileMappingW(self.file_handle, ptr::null(), PAGE_READWRITE, 0, 0, ptr::null()) };
+        let mapping_handle = unsafe {
+            CreateFileMappingW(
+                self.file_handle,
+                ptr::null(),
+                PAGE_READWRITE,
+                0,
+                0,
+                ptr::null(),
+            )
+        };
         if mapping_handle.is_null() {
             return Err(io_error(
                 io::Error::last_os_error(),
@@ -1105,7 +1106,10 @@ impl File for WindowsFile {
             unsafe {
                 CloseHandle(mapping_handle);
             }
-            return Err(io_error(io::Error::last_os_error(), "map shared WAL coordination file"));
+            return Err(io_error(
+                io::Error::last_os_error(),
+                "map shared WAL coordination file",
+            ));
         }
 
         let view_ptr = NonNull::new(mapped_ptr.Value.cast::<u8>())

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -145,8 +145,8 @@ pub use io::WindowsIOCP;
 pub use io::{
     clock::{Clock, MonotonicInstant, WallClockInstant},
     get_registered_io, list_registered_io, register_io, unregister_io, Buffer, Completion,
-    CompletionType, File, GroupCompletion, MemoryIO, OpenFlags, PlatformIO, SyscallIO,
-    WriteCompletion, IO,
+    CompletionType, File, GroupCompletion, MemoryIO, OpenFlags, PlatformIO, SharedBufferData,
+    SyscallIO, WriteCompletion, IO,
 };
 pub use numeric::{nonnan::NonNan, Numeric};
 pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -231,7 +231,7 @@
 //! Frame-level atomicity only: torn tails are discarded; partially written frames are not salvaged.
 #![allow(dead_code)]
 
-use crate::io::FileSyncType;
+use crate::io::{FileSyncType, SharedBufferData};
 use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::turso_assert;
@@ -255,9 +255,10 @@ use crate::File;
 /// Default to the size of 1000 SQLite WAL frames; disable by setting a negative value.
 pub const DEFAULT_LOG_CHECKPOINT_THRESHOLD: i64 = 4120 * 1000;
 
-/// Optional callback invoked after serialization with a zero-copy reference to
-/// the serialized frame bytes and the running CRC, before the disk write.
-pub type OnSerializationComplete<'a> = Option<&'a dyn Fn(&[u8], u32) -> crate::Result<()>>;
+/// Optional callback invoked after serialization with shared ownership of the
+/// serialized frame bytes and the running CRC, before the disk write.
+pub type OnSerializationComplete<'a> =
+    Option<&'a dyn Fn(SharedBufferData, u32) -> crate::Result<()>>;
 
 const LOG_MAGIC: u32 = 0x4C4D4C32; // "LML2" in LE
 const LOG_VERSION_V2: u8 = 2;
@@ -818,28 +819,29 @@ impl LogicalLog {
 
         // 5. Fill the LOG_HDR slot (first-write only). Non-first-write
         // commits leave it as zeros; those bytes never reach disk because
-        // we wrap the buffer with `new_with_start(..., LOG_HDR_SIZE)` below.
+        // the shared view exposes only `data[LOG_HDR_SIZE..]` below.
         if is_first_write {
             let header_bytes = self.header.as_ref().unwrap().encode();
             tx.buf[..LOG_HDR_SIZE].copy_from_slice(&header_bytes);
         }
 
-        // 6. Observer hook: gets a zero-copy reference into the on-disk bytes.
-        let on_disk_start = if is_first_write { 0 } else { LOG_HDR_SIZE };
+        // 6. Observer hook: gets shared ownership of a zero-copy view into the
+        // on-disk bytes.
+        let raw = Arc::new(tx.buf.into_boxed_slice());
+        let shared = if is_first_write {
+            SharedBufferData::new(raw)
+        } else {
+            SharedBufferData::new_view(raw, LOG_HDR_SIZE)
+        };
         if let Some(cb) = on_serialization_complete {
-            cb(&tx.buf[on_disk_start..], crc)?;
+            cb(shared.clone(), crc)?;
         }
 
         // 7. Hand off `tx.buf` to the I/O layer without copying. For
         // non-first-write commits, the Buffer wrapper exposes only
         // `data[LOG_HDR_SIZE..]` so the unused 56-byte prefix never reaches
-        // disk — a single pwrite, no shift.
-        let raw = tx.buf;
-        let buffer = if is_first_write {
-            Arc::new(Buffer::new(raw))
-        } else {
-            Arc::new(Buffer::new_with_start(raw, LOG_HDR_SIZE))
-        };
+        // disk: a single pwrite, no shift.
+        let buffer = Arc::new(Buffer::new_shared_data(shared));
         let buffer_len = buffer.len();
         let c = Completion::new_write(move |res: Result<i32, CompletionError>| {
             let Ok(bytes_written) = res else {
@@ -902,8 +904,8 @@ impl LogicalLog {
     /// Returns `(completion, bytes_written)`. The caller must call
     /// `advance_offset_after_success(bytes)` after confirming the commit succeeded.
     ///
-    /// If `on_serialization_complete` is provided, it is called with a zero-copy
-    /// reference to the framed bytes and the running CRC after framing but
+    /// If `on_serialization_complete` is provided, it is called with shared
+    /// ownership of the framed bytes and the running CRC after framing but
     /// before the disk write.
     pub fn log_tx_deferred_offset(
         &mut self,
@@ -3900,6 +3902,7 @@ pub(crate) enum IndexOpKind {
 mod tests {
     use crate::types::IOResult;
     use crate::util::IOExt as _;
+    use std::cell::RefCell;
     use std::collections::BTreeSet;
     use std::sync::Once;
 
@@ -3922,7 +3925,7 @@ mod tests {
             read_varint, read_varint_partial, varint_len, write_varint, DatabaseHeader,
         },
         types::{ImmutableRecord, ImmutableRecordRef, IndexInfo, Text},
-        Buffer, Completion, Value, ValueRef,
+        Buffer, Completion, SharedBufferData, Value, ValueRef,
     };
 
     use super::{
@@ -4032,6 +4035,20 @@ mod tests {
             }
         }
         ops
+    }
+
+    fn read_file_range_bytes(
+        file: &Arc<dyn crate::File>,
+        io: &Arc<dyn crate::IO>,
+        pos: u64,
+        len: usize,
+    ) -> Vec<u8> {
+        let buf = Arc::new(Buffer::new_temporary(len));
+        let c = file
+            .pread(pos, Completion::new_read(buf.clone(), |_| None))
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+        buf.as_slice().to_vec()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4991,6 +5008,89 @@ mod tests {
             ExpectedTableOp::Upsert { rowid, .. } => assert_eq!(*rowid, 3),
             other => panic!("unexpected op: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_on_serialization_complete_gets_shared_write_bytes() {
+        init_tracing();
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let file = io
+            .open_file(
+                "serialization-callback-shared.db-log",
+                OpenFlags::Create,
+                false,
+            )
+            .unwrap();
+        let mut log = LogicalLog::new(file.clone(), io.clone(), None);
+        let captured = RefCell::new(Vec::<(SharedBufferData, u32)>::new());
+        let callback = |bytes: SharedBufferData, crc: u32| {
+            captured.borrow_mut().push((bytes, crc));
+            Ok(())
+        };
+
+        let tx1 = crate::mvcc::database::LogRecord::for_test(
+            1,
+            &[crate::mvcc::database::RowVersion {
+                id: 1,
+                begin: crate::mvcc::database::PackedTs::pack(Some(
+                    crate::mvcc::database::TxTimestampOrID::Timestamp(1),
+                )),
+                end: crate::mvcc::database::PackedTs::pack(None),
+                row: generate_simple_string_row((-2).into(), 1, "first"),
+                btree_resident: false,
+            }],
+            None,
+        );
+        let (c, first_len) = log.log_tx_deferred_offset(tx1, Some(&callback)).unwrap();
+        io.wait_for_completion(c).unwrap();
+        log.advance_offset_after_success(first_len);
+
+        let tx2 = crate::mvcc::database::LogRecord::for_test(
+            2,
+            &[crate::mvcc::database::RowVersion {
+                id: 2,
+                begin: crate::mvcc::database::PackedTs::pack(Some(
+                    crate::mvcc::database::TxTimestampOrID::Timestamp(2),
+                )),
+                end: crate::mvcc::database::PackedTs::pack(None),
+                row: generate_simple_string_row((-2).into(), 2, "second"),
+                btree_resident: false,
+            }],
+            None,
+        );
+        let (c, second_len) = log.log_tx_deferred_offset(tx2, Some(&callback)).unwrap();
+        io.wait_for_completion(c).unwrap();
+        log.advance_offset_after_success(second_len);
+
+        let captured = captured.borrow();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[0].0.len(), first_len as usize);
+        assert_eq!(captured[1].0.len(), second_len as usize);
+        assert!(matches!(&captured[0].0, SharedBufferData::Full(_)));
+        assert!(matches!(&captured[1].0, SharedBufferData::View(_)));
+
+        let first_on_disk = read_file_range_bytes(&file, &io, 0, first_len as usize);
+        let second_on_disk = read_file_range_bytes(&file, &io, first_len, second_len as usize);
+        assert_eq!(captured[0].0.as_slice(), first_on_disk.as_slice());
+        assert_eq!(captured[1].0.as_slice(), second_on_disk.as_slice());
+        assert_eq!(
+            captured[0].1,
+            u32::from_le_bytes(
+                captured[0].0.as_slice()[captured[0].0.len() - TX_TRAILER_SIZE
+                    ..captured[0].0.len() - TX_TRAILER_SIZE + 4]
+                    .try_into()
+                    .unwrap()
+            )
+        );
+        assert_eq!(
+            captured[1].1,
+            u32::from_le_bytes(
+                captured[1].0.as_slice()[captured[1].0.len() - TX_TRAILER_SIZE
+                    ..captured[1].0.len() - TX_TRAILER_SIZE + 4]
+                    .try_into()
+                    .unwrap()
+            )
+        );
     }
 
     /// What this test checks: A payload bit flip in a fully present tail frame is ignored as invalid tail.

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -34,10 +34,10 @@ pub trait DurableStorage: Send + Sync + Debug {
 
     /// Write a transaction to the logical log without advancing the writer offset.
     ///
-    /// If `on_serialization_complete` is provided, it is called with a zero-copy
-    /// reference to the framed bytes and the running CRC after framing but
+    /// If `on_serialization_complete` is provided, it is called with shared
+    /// ownership of the framed bytes and the running CRC after framing but
     /// before the disk write. The callback runs while the internal write lock
-    /// is held, so it should be fast (e.g. memcpy to a side buffer).
+    /// is held, so it should be fast.
     fn log_tx(
         &self,
         m: LogRecord,

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -64,7 +64,9 @@ impl turso_core::mvcc::persistent_storage::DurableStorage for RecordingDurableSt
     fn log_tx(
         &self,
         m: turso_core::mvcc::database::LogRecord,
-        on_serialization_complete: Option<&dyn Fn(&[u8], u32) -> turso_core::Result<()>>,
+        on_serialization_complete: Option<
+            &dyn Fn(turso_core::SharedBufferData, u32) -> turso_core::Result<()>,
+        >,
     ) -> turso_core::Result<(turso_core::Completion, u64)> {
         self.used_log_tx
             .store(true, std::sync::atomic::Ordering::SeqCst);


### PR DESCRIPTION
## Description
I want to have the serialization callback to be zero copy for server use. I just copied the same kind of code for HeapBuffer for the SharedBufferData. Right now we dont have separate types for mutable and immutable buffers like `compio` has it, so we just panic for `as_mut_ptr` if some code incorrectly asks for a mutable pointer in some write operation.

## Motivation and context
Allow zero copy serialization callbacks


## Description of AI Usage
Codex just did what I told it to do