### PR TITLE
mvcc: add sequence_watermark function and track sequence allocations

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -213,6 +213,13 @@ enum ReparsePhase {
         stmt: Option<Box<Statement>>,
         /// Descriptor row `(start, inc, min, max, cycle)` captured from `stmt`.
         meta: Option<(i64, i64, i64, i64, bool)>,
+        /// Sequence reconstructed from `meta`, retained while the watermark
+        /// query yields IO.
+        seq: Option<crate::schema::Sequence>,
+        /// In-flight watermark `SELECT`, created after `seq` is known.
+        watermark_stmt: Option<Box<Statement>>,
+        /// Watermark row `(value, is_called)` captured from `watermark_stmt`.
+        watermark_row: Option<(i64, bool)>,
     },
     /// Loading custom type definitions from the internal types table.
     LoadTypes {
@@ -242,6 +249,13 @@ pub enum LoadSequenceDescriptorsState {
         stmt: Option<Box<Statement>>,
         /// Descriptor row `(start, inc, min, max, cycle)` captured from `stmt`.
         meta: Option<(i64, i64, i64, i64, bool)>,
+        /// Sequence reconstructed from `meta`, retained while the watermark
+        /// query yields IO.
+        seq: Option<crate::schema::Sequence>,
+        /// In-flight watermark `SELECT`, created after `seq` is known.
+        watermark_stmt: Option<Box<Statement>>,
+        /// Watermark row `(value, is_called)` captured from `watermark_stmt`.
+        watermark_row: Option<(i64, bool)>,
     },
 }
 
@@ -1267,6 +1281,9 @@ impl Connection {
                         idx: 0,
                         stmt: None,
                         meta: None,
+                        seq: None,
+                        watermark_stmt: None,
+                        watermark_row: None,
                     };
                 }
                 ReparsePhase::PopulateSequences {
@@ -1274,6 +1291,9 @@ impl Connection {
                     idx,
                     stmt,
                     meta,
+                    seq,
+                    watermark_stmt,
+                    watermark_row,
                 } => {
                     // Lazy init: graft the VACUUM-preserved descriptor map, or
                     // compute the worklist of backing tables to read from disk.
@@ -1312,22 +1332,49 @@ impl Connection {
                         if inner.fresh.sequences.contains_key(&normalized) {
                             *idx += 1;
                             *stmt = None;
+                            *meta = None;
+                            *seq = None;
+                            *watermark_stmt = None;
+                            *watermark_row = None;
                             continue;
                         }
-                        crate::return_if_io!(self.read_seq_descriptor_row_nonblock(
+                        if seq.is_none() {
+                            crate::return_if_io!(self.read_seq_descriptor_row_nonblock(
+                                &backing_table_name,
+                                &seq_name,
+                                stmt,
+                                meta,
+                            ));
+                            *seq = Some(Self::sequence_from_descriptor_meta(
+                                &seq_name,
+                                &backing_table_name,
+                                *meta,
+                            )?);
+                            *stmt = None;
+                            *meta = None;
+                        }
+                        let sequence = seq.as_ref().expect("sequence set above");
+                        crate::return_if_io!(self.read_sequence_watermark_row_nonblock(
                             &backing_table_name,
-                            &seq_name,
-                            stmt,
-                            meta,
+                            sequence,
+                            watermark_stmt,
+                            watermark_row,
                         ));
-                        let seq = Self::sequence_from_descriptor_meta(
-                            &seq_name,
+                        let watermark = Self::sequence_watermark_from_row(
                             &backing_table_name,
-                            *meta,
+                            sequence,
+                            *watermark_row,
                         )?;
-                        inner.fresh.sequences.insert(normalized, Arc::new(seq));
+                        if let Some(mv_store) = self.db.get_mv_store().as_ref() {
+                            mv_store.set_sequence_watermark(&normalized, watermark);
+                        }
+                        let sequence = seq.take().expect("sequence set above");
+                        inner.fresh.sequences.insert(normalized, Arc::new(sequence));
                         *idx += 1;
                         *stmt = None;
+                        *meta = None;
+                        *watermark_stmt = None;
+                        *watermark_row = None;
                     }
 
                     // Decide whether to load custom types next.
@@ -3404,6 +3451,9 @@ impl Connection {
                         idx: 0,
                         stmt: None,
                         meta: None,
+                        seq: None,
+                        watermark_stmt: None,
+                        watermark_row: None,
                     };
                 }
                 LoadSequenceDescriptorsState::Reading {
@@ -3411,6 +3461,9 @@ impl Connection {
                     idx,
                     stmt,
                     meta,
+                    seq,
+                    watermark_stmt,
+                    watermark_row,
                 } => loop {
                     let entry = {
                         if *idx >= pending.len() {
@@ -3425,21 +3478,53 @@ impl Connection {
                     if already_present {
                         *idx += 1;
                         *stmt = None;
+                        *meta = None;
+                        *seq = None;
+                        *watermark_stmt = None;
+                        *watermark_row = None;
                         continue;
                     }
-                    crate::return_if_io!(self.read_seq_descriptor_row_nonblock(
+                    if seq.is_none() {
+                        crate::return_if_io!(self.read_seq_descriptor_row_nonblock(
+                            &backing_table_name,
+                            &seq_name,
+                            stmt,
+                            meta,
+                        ));
+                        *seq = Some(Self::sequence_from_descriptor_meta(
+                            &seq_name,
+                            &backing_table_name,
+                            *meta,
+                        )?);
+                        *stmt = None;
+                        *meta = None;
+                    }
+                    let sequence = seq.as_ref().expect("sequence set above");
+                    crate::return_if_io!(self.read_sequence_watermark_row_nonblock(
                         &backing_table_name,
-                        &seq_name,
-                        stmt,
-                        meta,
+                        sequence,
+                        watermark_stmt,
+                        watermark_row,
                     ));
-                    let seq =
-                        Self::sequence_from_descriptor_meta(&seq_name, &backing_table_name, *meta)?;
+                    let watermark = Self::sequence_watermark_from_row(
+                        &backing_table_name,
+                        sequence,
+                        *watermark_row,
+                    )?;
+                    if let Some(mv_store) = self.db.get_mv_store().as_ref() {
+                        mv_store.set_sequence_watermark(&normalized, watermark);
+                    }
+                    let sequence = seq.take().expect("sequence set above");
                     self.with_database_schema_mut(MAIN_DB_ID, |schema| {
-                        schema.sequences.insert(normalized.clone(), Arc::new(seq));
+                        schema
+                            .sequences
+                            .insert(normalized.clone(), Arc::new(sequence));
                     });
                     *idx += 1;
                     *stmt = None;
+                    *meta = None;
+                    *watermark_stmt = None;
+                    *watermark_row = None;
                 },
             }
         }
@@ -3524,6 +3609,68 @@ impl Connection {
                  \"{seq_name}\" descriptor is invalid: {err}"
             ))
         })
+    }
+
+    /// Drive one backing-table watermark read to completion (re-entrant).
+    ///
+    /// The returned row is converted by [`Self::sequence_watermark_from_row`]
+    /// into the exclusive upper bound used by `sequence_watermark()`.
+    fn read_sequence_watermark_row_nonblock(
+        self: &Arc<Connection>,
+        backing_table_name: &str,
+        seq: &crate::schema::Sequence,
+        stmt: &mut Option<Box<Statement>>,
+        row: &mut Option<(i64, bool)>,
+    ) -> Result<crate::types::IOResult<()>> {
+        use crate::types::IOResult;
+        if stmt.is_none() {
+            let escaped = backing_table_name.replace('"', "\"\"");
+            let direction = if seq.increment_by >= 0 { "DESC" } else { "ASC" };
+            let sql = format!(
+                "SELECT value, is_called FROM \"{escaped}\" ORDER BY value {direction} LIMIT 1"
+            );
+            let prepared = self.prepare_internal(sql).map_err(|err| {
+                LimboError::Corrupt(format!(
+                    "internal sequence backing table \"{backing_table_name}\" for sequence \
+                     \"{}\": cannot prepare watermark SELECT: {err}",
+                    seq.name
+                ))
+            })?;
+            *stmt = Some(Box::new(prepared));
+            *row = None;
+        }
+        let s = stmt.as_mut().expect("stmt set above");
+        match s.run_with_row_callback_nonblock(|r| {
+            let value = r.get::<i64>(0)?;
+            let is_called = r.get::<i64>(1)? != 0;
+            *row = Some((value, is_called));
+            Ok(())
+        }) {
+            Ok(IOResult::IO(io)) => Ok(IOResult::IO(io)),
+            Ok(IOResult::Done(())) => Ok(IOResult::Done(())),
+            Err(err) => Err(LimboError::Corrupt(format!(
+                "internal sequence backing table \"{backing_table_name}\" for sequence \
+                 \"{}\": watermark row read failed: {err}",
+                seq.name
+            ))),
+        }
+    }
+
+    fn sequence_watermark_from_row(
+        backing_table_name: &str,
+        seq: &crate::schema::Sequence,
+        row: Option<(i64, bool)>,
+    ) -> Result<i64> {
+        let (value, is_called) = row.ok_or_else(|| {
+            LimboError::Corrupt(format!(
+                "internal sequence backing table \"{backing_table_name}\" for sequence \
+                 \"{}\" is empty; cannot derive sequence watermark",
+                seq.name
+            ))
+        })?;
+        Ok(crate::mvcc::database::first_unsafe_sequence_watermark(
+            seq, value, is_called,
+        ))
     }
 
     /// Sync AUTOINCREMENT backing-table watermarks from `sqlite_sequence`.
@@ -3667,6 +3814,14 @@ impl Connection {
                         }
                         SyncRowStep::Upsert { stmt } => {
                             crate::return_if_io!(stmt.run_with_row_callback_nonblock(|_| Ok(())));
+                            if let Some(mv_store) = self.db.get_mv_store().as_ref() {
+                                let watermark = rows[*idx].1;
+                                let first_unsafe = watermark.checked_add(1).unwrap_or(watermark);
+                                mv_store.set_sequence_watermark(
+                                    &autoincrement_sequence_name(&rows[*idx].0),
+                                    first_unsafe,
+                                );
+                            }
                             *idx += 1;
                             *sub = SyncRowStep::Start;
                         }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3614,7 +3614,7 @@ impl Connection {
     /// Drive one backing-table watermark read to completion (re-entrant).
     ///
     /// The returned row is converted by [`Self::sequence_watermark_from_row`]
-    /// into the exclusive upper bound used by `sequence_watermark()`.
+    /// into the exclusive upper bound used by `sequence_watermark_experimental()`.
     fn read_sequence_watermark_row_nonblock(
         self: &Arc<Connection>,
         backing_table_name: &str,

--- a/core/function.rs
+++ b/core/function.rs
@@ -784,6 +784,7 @@ pub enum ScalarFunc {
     StatGet,
     ConnTxnId,
     IsAutocommit,
+    SequenceWatermark,
     // Test type functions (for custom type system testing)
     TestUintEncode,
     TestUintDecode,
@@ -910,6 +911,7 @@ impl Deterministic for ScalarFunc {
             ScalarFunc::StatGet => false,  // internal ANALYZE function
             ScalarFunc::ConnTxnId => false, // depends on connection state
             ScalarFunc::IsAutocommit => false, // depends on connection state
+            ScalarFunc::SequenceWatermark => false, // depends on active MVCC transactions
             ScalarFunc::TestUintEncode
             | ScalarFunc::TestUintDecode
             | ScalarFunc::TestUintAdd
@@ -1049,6 +1051,7 @@ impl Display for ScalarFunc {
             Self::StatGet => "stat_get",
             Self::ConnTxnId => "conn_txn_id",
             Self::IsAutocommit => "is_autocommit",
+            Self::SequenceWatermark => "sequence_watermark",
             Self::TestUintEncode => "test_uint_encode",
             Self::TestUintDecode => "test_uint_decode",
             Self::TestUintAdd => "test_uint_add",
@@ -1152,7 +1155,8 @@ impl ScalarFunc {
             | Self::Upper
             | Self::ZeroBlob
             | Self::Likely
-            | Self::Unlikely => &[1],
+            | Self::Unlikely
+            | Self::SequenceWatermark => &[1],
             // 2-arg
             Self::Glob
             | Self::Instr
@@ -1711,6 +1715,7 @@ impl Func {
             "bin_record_json_object" => Ok(Some(Self::Scalar(ScalarFunc::BinRecordJsonObject))),
             "conn_txn_id" => Ok(Some(Self::Scalar(ScalarFunc::ConnTxnId))),
             "is_autocommit" => Ok(Some(Self::Scalar(ScalarFunc::IsAutocommit))),
+            "sequence_watermark" => Ok(Some(Self::Scalar(ScalarFunc::SequenceWatermark))),
             "acos" => Ok(Some(Self::Math(MathFunc::Acos))),
             "acosh" => Ok(Some(Self::Math(MathFunc::Acosh))),
             "asin" => Ok(Some(Self::Math(MathFunc::Asin))),

--- a/core/function.rs
+++ b/core/function.rs
@@ -1051,7 +1051,7 @@ impl Display for ScalarFunc {
             Self::StatGet => "stat_get",
             Self::ConnTxnId => "conn_txn_id",
             Self::IsAutocommit => "is_autocommit",
-            Self::SequenceWatermark => "sequence_watermark",
+            Self::SequenceWatermark => "sequence_watermark_experimental",
             Self::TestUintEncode => "test_uint_encode",
             Self::TestUintDecode => "test_uint_decode",
             Self::TestUintAdd => "test_uint_add",
@@ -1715,7 +1715,9 @@ impl Func {
             "bin_record_json_object" => Ok(Some(Self::Scalar(ScalarFunc::BinRecordJsonObject))),
             "conn_txn_id" => Ok(Some(Self::Scalar(ScalarFunc::ConnTxnId))),
             "is_autocommit" => Ok(Some(Self::Scalar(ScalarFunc::IsAutocommit))),
-            "sequence_watermark" => Ok(Some(Self::Scalar(ScalarFunc::SequenceWatermark))),
+            "sequence_watermark_experimental" => {
+                Ok(Some(Self::Scalar(ScalarFunc::SequenceWatermark)))
+            }
             "acos" => Ok(Some(Self::Math(MathFunc::Acos))),
             "acosh" => Ok(Some(Self::Math(MathFunc::Acosh))),
             "asin" => Ok(Some(Self::Math(MathFunc::Asin))),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4,7 +4,7 @@ use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
 #[cfg(any(test, injected_yields))]
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
 use crate::mvcc::yield_points::{inject_transition_failure, inject_transition_yield};
-use crate::schema::{Schema, Table};
+use crate::schema::{Schema, Sequence, Table};
 use crate::skiplist::map::Entry;
 use crate::skiplist::SkipMap;
 use crate::state_machine::StateMachine;
@@ -46,7 +46,7 @@ use crate::{
 use crate::{Connection, Pager, SyncMode};
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap as StdHashMap};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Bound;
@@ -81,6 +81,20 @@ pub mod tests;
 
 /// Sentinel value for `MvStore::exclusive_tx` indicating no exclusive transaction is active.
 const NO_EXCLUSIVE_TX: u64 = 0;
+
+/// Convert a sequence backing-table row into the exclusive upper bound used by
+/// sync scans. This is intentionally tailored to ascending non-CYCLE sequences,
+/// which is the shape used by AUTOINCREMENT CDC ids.
+pub(crate) fn first_unsafe_sequence_watermark(seq: &Sequence, value: i64, is_called: bool) -> i64 {
+    if !is_called {
+        return value;
+    }
+    if seq.increment_by > 0 && !seq.cycle {
+        value.checked_add(seq.increment_by).unwrap_or(value)
+    } else {
+        value
+    }
+}
 
 #[cfg(not(any(test, injected_yields)))]
 struct YieldContext;
@@ -3711,6 +3725,15 @@ pub struct MvStore<Clock: LogicalClock> {
     /// deadlock.
     last_global_header_ts: AtomicU64,
     table_id_to_last_rowid: RwLock<HashMap<MVTableId, Arc<RowidAllocator>>>,
+    /// Per-sequence first value not guaranteed safe to read past based only on
+    /// durable/current sequence state. Active allocations can lower this.
+    sequence_watermarks: Mutex<HashMap<String, i64>>,
+    /// Per-sequence minimum allocated value for each active transaction.
+    ///
+    /// This is in-memory and therefore only correct while all MVCC writers for a
+    /// database live in one process. Multi-process MVCC will need a shared
+    /// coordination mechanism before sync can rely on this watermark.
+    sequence_allocations: Mutex<HashMap<String, StdHashMap<TxID, i64>>>,
 }
 
 impl<Clock: LogicalClock> MvStore<Clock> {
@@ -3786,6 +3809,8 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             last_committed_tx_ts: AtomicU64::new(0),
             last_global_header_ts: AtomicU64::new(0),
             table_id_to_last_rowid: RwLock::new(HashMap::default()),
+            sequence_watermarks: Mutex::new(HashMap::default()),
+            sequence_allocations: Mutex::new(HashMap::default()),
         }
     }
 
@@ -5241,6 +5266,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     }
 
     pub fn remove_tx(&self, tx_id: TxID) {
+        self.remove_sequence_allocations(tx_id);
         if let Some(entry) = self.txs.get(&tx_id) {
             let tx = entry.value();
             if let TransactionState::Committed(commit_ts) = tx.state.load() {
@@ -5263,6 +5289,87 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         }
         self.txs.remove(&tx_id);
         self.blocking_checkpoint_lock.unlock();
+    }
+
+    pub fn register_sequence_allocation(
+        &self,
+        tx_id: TxID,
+        sequence_name: &str,
+        sequence_value: i64,
+    ) -> Result<()> {
+        let Some(tx) = self.txs.get(&tx_id) else {
+            return Err(LimboError::NoSuchTransactionID(tx_id.to_string()));
+        };
+        turso_assert!(
+            matches!(
+                tx.value().state.load(),
+                TransactionState::Active | TransactionState::Preparing(_)
+            ),
+            "sequence allocation must be registered while the transaction is active or preparing"
+        );
+
+        let sequence_name = crate::util::normalize_ident(sequence_name);
+        let mut allocations = self.sequence_allocations.lock();
+        let tx_allocations = allocations.entry(sequence_name).or_default();
+        tx_allocations
+            .entry(tx_id)
+            .and_modify(|value| *value = (*value).min(sequence_value))
+            .or_insert(sequence_value);
+        Ok(())
+    }
+
+    pub fn set_sequence_watermark(&self, sequence_name: &str, watermark: i64) {
+        let sequence_name = crate::util::normalize_ident(sequence_name);
+        self.sequence_watermarks
+            .lock()
+            .insert(sequence_name, watermark);
+    }
+
+    /// Returns the first sequence value that is not safe for cursor scans to pass.
+    ///
+    /// Readers can safely consume rows with sequence values less than this
+    /// watermark. The value is the minimum of the current sequence boundary and
+    /// any lower value already allocated by an active transaction.
+    pub fn sequence_watermark(&self, sequence_name: &str) -> Option<i64> {
+        let sequence_name = crate::util::normalize_ident(sequence_name);
+        let mut allocations = self.sequence_allocations.lock();
+        let mut remove_allocations = false;
+        let active_watermark = {
+            allocations
+                .get_mut(&sequence_name)
+                .and_then(|tx_allocations| {
+                    tx_allocations.retain(|tx_id, _| {
+                        self.txs.get(tx_id).is_some_and(|tx| {
+                            matches!(
+                                tx.value().state.load(),
+                                TransactionState::Active | TransactionState::Preparing(_)
+                            )
+                        })
+                    });
+                    let watermark = tx_allocations.values().copied().min();
+                    if tx_allocations.is_empty() {
+                        remove_allocations = true;
+                    }
+                    watermark
+                })
+        };
+        if remove_allocations {
+            allocations.remove(&sequence_name);
+        }
+        let current_watermark = self.sequence_watermarks.lock().get(&sequence_name).copied();
+        match (current_watermark, active_watermark) {
+            (Some(current), Some(active)) => Some(current.min(active)),
+            (Some(current), None) => Some(current),
+            (None, active) => active,
+        }
+    }
+
+    fn remove_sequence_allocations(&self, tx_id: TxID) {
+        let mut allocations = self.sequence_allocations.lock();
+        allocations.retain(|_, tx_allocations| {
+            tx_allocations.remove(&tx_id);
+            !tx_allocations.is_empty()
+        });
     }
 
     /// Atomically retire a committed tx: clear the connection's mv_tx_id cache

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4143,7 +4143,7 @@ fn test_sequence_watermark_function_returns_current_watermark_without_active_all
 
     conn.execute("CREATE SEQUENCE s").unwrap();
     mv_store.set_sequence_watermark("s", 42);
-    let rows = get_rows(&conn, "SELECT sequence_watermark('s')");
+    let rows = get_rows(&conn, "SELECT sequence_watermark_experimental('s')");
 
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0][0].as_int().unwrap(), 42);
@@ -4152,12 +4152,12 @@ fn test_sequence_watermark_function_returns_current_watermark_without_active_all
     mv_store
         .register_sequence_allocation(tx_id, "s", 10)
         .unwrap();
-    let rows = get_rows(&conn, "SELECT sequence_watermark('s')");
+    let rows = get_rows(&conn, "SELECT sequence_watermark_experimental('s')");
 
     assert_eq!(rows[0][0].as_int().unwrap(), 10);
 
     mv_store.rollback_tx(tx_id, pager, conn.as_ref(), crate::MAIN_DB_ID);
-    let rows = get_rows(&conn, "SELECT sequence_watermark('s')");
+    let rows = get_rows(&conn, "SELECT sequence_watermark_experimental('s')");
 
     assert_eq!(rows[0][0].as_int().unwrap(), 42);
 }
@@ -4168,12 +4168,12 @@ fn test_sequence_watermark_tracks_nextval_allocations() {
     let setup = db.connect();
     setup.execute("CREATE SEQUENCE s START WITH 1").unwrap();
 
-    let rows = get_rows(&setup, "SELECT sequence_watermark('s')");
+    let rows = get_rows(&setup, "SELECT sequence_watermark_experimental('s')");
     assert!(matches!(rows[0][0], Value::Null));
 
     let rows = get_rows(&setup, "SELECT nextval('s')");
     assert_eq!(rows[0][0].as_int().unwrap(), 1);
-    let rows = get_rows(&setup, "SELECT sequence_watermark('s')");
+    let rows = get_rows(&setup, "SELECT sequence_watermark_experimental('s')");
     assert_eq!(rows[0][0].as_int().unwrap(), 2);
 
     let writer = db.connect();
@@ -4182,12 +4182,204 @@ fn test_sequence_watermark_tracks_nextval_allocations() {
     assert_eq!(rows[0][0].as_int().unwrap(), 2);
 
     let observer = db.connect();
-    let rows = get_rows(&observer, "SELECT sequence_watermark('s')");
+    let rows = get_rows(&observer, "SELECT sequence_watermark_experimental('s')");
     assert_eq!(rows[0][0].as_int().unwrap(), 2);
 
     writer.execute("COMMIT").unwrap();
-    let rows = get_rows(&observer, "SELECT sequence_watermark('s')");
+    let rows = get_rows(&observer, "SELECT sequence_watermark_experimental('s')");
     assert_eq!(rows[0][0].as_int().unwrap(), 3);
+}
+
+/// What this test checks: a sync-style cursor that bounds its scan by
+/// `sequence_watermark_experimental()` (read *outside* a transaction, as the
+/// contract requires) never skips a committed row, even while many writers
+/// concurrently allocate sequence ids in overlapping `BEGIN CONCURRENT`
+/// transactions and commit/abort them at random.
+///
+/// Why this matters: this is the exact hazard the watermark exists to prevent.
+/// A writer can allocate a low sequence id, stay open, and commit *after*
+/// another transaction publishes a higher id. A cursor that only advances on
+/// `id > last_seen` would step over the lower id and lose it forever. The
+/// watermark is the first id that is *not* safe to pass, so a reader that
+/// claims "everything below the watermark is final" must be correct: every
+/// committed row whose id is below the highest watermark the reader ever
+/// passed must have been observed by the reader.
+///
+/// The reader collects ids it sees and tracks `last` = the highest
+/// `watermark - 1` it has advanced to. After the workload drains, we read the
+/// authoritative committed set and assert no committed id `<= last` is missing
+/// from what the reader collected — i.e. the watermark never let the reader
+/// advance past a row it had not yet seen.
+#[test]
+fn test_sequence_watermark_reader_never_skips_committed_rows_fuzz() {
+    use std::collections::BTreeSet;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    let db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let setup = db.connect();
+        setup
+            .execute("CREATE TABLE t (id INTEGER PRIMARY KEY, who INTEGER)")
+            .unwrap();
+        setup.execute("CREATE SEQUENCE s START WITH 1").unwrap();
+        setup.close().unwrap();
+    }
+
+    const N_WRITERS: u64 = 4;
+    const INSERTS_PER_WRITER: u64 = 25;
+    // Per-row commit retry budget: the only contention is the autonomous inner
+    // tx that advances the sequence backing table, which is transient, so a
+    // generous budget lets every row eventually commit without the test
+    // wedging.
+    const COMMIT_ATTEMPTS: u64 = 200;
+
+    let done = Arc::new(AtomicU64::new(0));
+
+    let mut writers = Vec::new();
+    for who in 0..N_WRITERS {
+        let db_arc = db.get_db();
+        let done = done.clone();
+        writers.push(std::thread::spawn(move || {
+            let conn = db_arc.connect().unwrap();
+            // Seed each writer differently so jitter (and thus the
+            // commit/abort interleaving) varies between threads but stays
+            // reproducible across runs.
+            let mut rng = ChaCha8Rng::seed_from_u64(0x5EED_0000 + who);
+            for _ in 0..INSERTS_PER_WRITER {
+                for _ in 0..COMMIT_ATTEMPTS {
+                    let txn = (|| -> crate::Result<bool> {
+                        conn.execute("BEGIN CONCURRENT")?;
+                        conn.execute(format!(
+                            "INSERT INTO t(id, who) VALUES (nextval('s'), {who})"
+                        ))?;
+                        // Widen the window in which the row is allocated but
+                        // uncommitted, so other writers publish higher ids
+                        // while this low id is still in flight — the precise
+                        // ordering the watermark must defend against. Roughly
+                        // 1-in-6 transactions abort instead of commit, leaving
+                        // sequence "holes" the reader must also tolerate.
+                        std::thread::sleep(Duration::from_micros(rng.random_range(0..200)));
+                        if rng.random_range(0..6) == 0 {
+                            conn.execute("ROLLBACK")?;
+                            Ok(false)
+                        } else {
+                            conn.execute("COMMIT")?;
+                            Ok(true)
+                        }
+                    })();
+                    match txn {
+                        Ok(_) => break,
+                        Err(_) => {
+                            // Transient conflict (e.g. Busy on the sequence
+                            // inner tx). Abandon this attempt's tx and retry.
+                            let _ = conn.execute("ROLLBACK");
+                            std::thread::sleep(Duration::from_micros(50));
+                        }
+                    }
+                }
+            }
+            conn.close().unwrap();
+            done.fetch_add(1, Ordering::SeqCst);
+        }));
+    }
+
+    let reader = db.connect();
+
+    // Read ids strictly below the watermark, advancing `last` to `watermark-1`.
+    // Returns false only when the watermark is not yet published (NULL), so the
+    // caller can tell a poll apart from a no-op.
+    let poll = |last: &mut i64, collected: &mut BTreeSet<i64>| -> bool {
+        let mut wm_stmt = match reader.prepare("SELECT sequence_watermark_experimental('s')") {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let mut watermark = None;
+        if wm_stmt
+            .run_with_row_callback(|row| {
+                watermark = row.get_values().next().and_then(|v| v.as_int());
+                Ok(())
+            })
+            .is_err()
+        {
+            return false;
+        }
+        let Some(watermark) = watermark else {
+            return false;
+        };
+        // The watermark is the first *unsafe* id, so it is an exclusive upper
+        // bound on what the reader may claim as final.
+        let query = format!("SELECT id FROM t WHERE id > {last} AND id < {watermark} ORDER BY id");
+        if let Ok(mut stmt) = reader.prepare(&query) {
+            let _ = stmt.run_with_row_callback(|row| {
+                if let Some(id) = row.get_values().next().and_then(|v| v.as_int()) {
+                    collected.insert(id);
+                }
+                Ok(())
+            });
+        }
+        let new_last = watermark - 1;
+        if new_last > *last {
+            *last = new_last;
+        }
+        true
+    };
+
+    let mut last: i64 = 0;
+    let mut collected: BTreeSet<i64> = BTreeSet::new();
+
+    // Poll concurrently with the writers.
+    while done.load(Ordering::SeqCst) < N_WRITERS {
+        poll(&mut last, &mut collected);
+        std::thread::sleep(Duration::from_micros(100));
+    }
+    for writer in writers {
+        writer.join().unwrap();
+    }
+
+    // Drain: with no active allocations left, the watermark is the sequence
+    // boundary, so `last` advances to cover every committed row. Loop until it
+    // stops moving (bounded, so a bug cannot hang the test).
+    for _ in 0..1000 {
+        let prev = last;
+        poll(&mut last, &mut collected);
+        if last == prev {
+            break;
+        }
+    }
+
+    // Authoritative committed set, read outside any transaction.
+    let mut committed: BTreeSet<i64> = BTreeSet::new();
+    {
+        let mut stmt = reader.prepare("SELECT id FROM t ORDER BY id").unwrap();
+        stmt.run_with_row_callback(|row| {
+            if let Some(id) = row.get_values().next().and_then(|v| v.as_int()) {
+                committed.insert(id);
+            }
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    // Sanity: the workload actually committed rows and the reader actually
+    // advanced — otherwise the invariant below is vacuous.
+    assert!(
+        !committed.is_empty(),
+        "no rows committed; workload did not exercise the watermark"
+    );
+    assert!(last > 0, "reader never advanced past any watermark");
+
+    // The invariant: every committed id the reader claimed as safe (id <= last)
+    // must have actually been observed. A skipped row is a watermark failure.
+    for id in &committed {
+        if *id <= last {
+            assert!(
+                collected.contains(id),
+                "watermark reader skipped committed id {id} (advanced last to {last}); \
+                 collected={collected:?}"
+            );
+        }
+    }
 }
 
 /// What this test checks: Cursor traversal and seek operations honor MVCC visibility and key ordering under updates/deletes.

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -4096,6 +4096,100 @@ pub(crate) fn commit_tx_no_conn(
     Ok(())
 }
 
+#[test]
+fn test_sequence_watermark_tracks_lowest_active_allocation() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    let mv_store = db.get_mvcc_store();
+    let pager = conn.pager.load().clone();
+
+    mv_store.set_sequence_watermark("turso_cdc_pk_autoincrement", 13);
+    let tx1 = mv_store.begin_tx(pager.clone()).unwrap();
+    let tx2 = mv_store.begin_tx(pager.clone()).unwrap();
+    mv_store
+        .register_sequence_allocation(tx1, "turso_cdc_pk_autoincrement", 10)
+        .unwrap();
+    mv_store
+        .register_sequence_allocation(tx2, "turso_cdc_pk_autoincrement", 12)
+        .unwrap();
+    mv_store
+        .register_sequence_allocation(tx1, "turso_cdc_pk_autoincrement", 11)
+        .unwrap();
+
+    assert_eq!(
+        mv_store.sequence_watermark("turso_cdc_pk_autoincrement"),
+        Some(10)
+    );
+
+    commit_tx(mv_store.clone(), &conn, tx1).unwrap();
+    assert_eq!(
+        mv_store.sequence_watermark("turso_cdc_pk_autoincrement"),
+        Some(12)
+    );
+
+    mv_store.rollback_tx(tx2, pager, conn.as_ref(), crate::MAIN_DB_ID);
+    assert_eq!(
+        mv_store.sequence_watermark("turso_cdc_pk_autoincrement"),
+        Some(13)
+    );
+}
+
+#[test]
+fn test_sequence_watermark_function_returns_current_watermark_without_active_allocations() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    let mv_store = db.get_mvcc_store();
+    let pager = conn.pager.load().clone();
+
+    conn.execute("CREATE SEQUENCE s").unwrap();
+    mv_store.set_sequence_watermark("s", 42);
+    let rows = get_rows(&conn, "SELECT sequence_watermark('s')");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0][0].as_int().unwrap(), 42);
+
+    let tx_id = mv_store.begin_tx(pager.clone()).unwrap();
+    mv_store
+        .register_sequence_allocation(tx_id, "s", 10)
+        .unwrap();
+    let rows = get_rows(&conn, "SELECT sequence_watermark('s')");
+
+    assert_eq!(rows[0][0].as_int().unwrap(), 10);
+
+    mv_store.rollback_tx(tx_id, pager, conn.as_ref(), crate::MAIN_DB_ID);
+    let rows = get_rows(&conn, "SELECT sequence_watermark('s')");
+
+    assert_eq!(rows[0][0].as_int().unwrap(), 42);
+}
+
+#[test]
+fn test_sequence_watermark_tracks_nextval_allocations() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let setup = db.connect();
+    setup.execute("CREATE SEQUENCE s START WITH 1").unwrap();
+
+    let rows = get_rows(&setup, "SELECT sequence_watermark('s')");
+    assert!(matches!(rows[0][0], Value::Null));
+
+    let rows = get_rows(&setup, "SELECT nextval('s')");
+    assert_eq!(rows[0][0].as_int().unwrap(), 1);
+    let rows = get_rows(&setup, "SELECT sequence_watermark('s')");
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+
+    let writer = db.connect();
+    writer.execute("BEGIN CONCURRENT").unwrap();
+    let rows = get_rows(&writer, "SELECT nextval('s')");
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+
+    let observer = db.connect();
+    let rows = get_rows(&observer, "SELECT sequence_watermark('s')");
+    assert_eq!(rows[0][0].as_int().unwrap(), 2);
+
+    writer.execute("COMMIT").unwrap();
+    let rows = get_rows(&observer, "SELECT sequence_watermark('s')");
+    assert_eq!(rows[0][0].as_int().unwrap(), 3);
+}
+
 /// What this test checks: Cursor traversal and seek operations honor MVCC visibility and key ordering under updates/deletes.
 /// Why this matters: Read-path correctness is critical: wrong cursor semantics directly surface as wrong query answers.
 #[test]

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -1235,7 +1235,8 @@ pub fn translate_expr(
                         | ScalarFunc::RandomBlob
                         | ScalarFunc::Sign
                         | ScalarFunc::Soundex
-                        | ScalarFunc::ZeroBlob => {
+                        | ScalarFunc::ZeroBlob
+                        | ScalarFunc::SequenceWatermark => {
                             let args = expect_arguments_exact!(args, 1, srf);
                             let start_reg = program.alloc_register();
                             translate_expr(

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -358,6 +358,18 @@ pub fn emit_disk_read_nextval(
         target_register,
     )?;
 
+    // Register the active allocation against the outer tx *before* the inner
+    // tx commits and makes this value observable to other connections. This
+    // closes the race where another allocator could advance the watermark past
+    // a value whose row the outer tx still holds uncommitted. See
+    // `op_sequence_register_allocation`.
+    program.emit_insn(Insn::SequenceRegisterAllocation {
+        db: database_id,
+        seq_name_reg,
+        value_reg: target_register,
+        saved_outer_reg,
+    });
+
     program.emit_insn(Insn::SequenceCommitInnerTx {
         db: database_id,
         path_kind_reg,

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -381,6 +381,12 @@ pub fn emit_disk_read_nextval(
     });
     program.preassign_label_to_next_insn(after_retry_label);
 
+    program.emit_insn(Insn::SequenceTrackAllocation {
+        db: database_id,
+        seq_name_reg,
+        value_reg: target_register,
+    });
+
     program.emit_insn(Insn::SetSequenceCurrval {
         seq_name_reg,
         value_reg: target_register,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8200,6 +8200,39 @@ pub fn op_function(
                 let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
                 state.registers[*dest].set_int(if auto_commit { 1 } else { 0 });
             }
+            ScalarFunc::SequenceWatermark => {
+                assert_eq!(arg_count, 1);
+                let sequence_name = match state.registers[*start_reg].get_value() {
+                    Value::Text(text) => text.as_str(),
+                    Value::Null => {
+                        state.registers[*dest].set_value(Value::Null);
+                        return Ok(InsnFunctionStepResult::Step);
+                    }
+                    _ => {
+                        return Err(LimboError::InternalError(
+                            "sequence_watermark() argument must be TEXT".to_string(),
+                        ));
+                    }
+                };
+                let (db_id, sequence_key) =
+                    if let Some((schema_name, sequence_name)) = sequence_name.split_once('.') {
+                        (
+                            program.connection.get_database_id_by_name(schema_name)?,
+                            crate::util::normalize_ident(sequence_name),
+                        )
+                    } else {
+                        (MAIN_DB_ID, crate::util::normalize_ident(sequence_name))
+                    };
+                program.connection.find_sequence(sequence_name)?;
+                let watermark = program
+                    .connection
+                    .mv_store_for_db(db_id)
+                    .and_then(|mv_store| mv_store.sequence_watermark(&sequence_key));
+                match watermark {
+                    Some(watermark) => state.registers[*dest].set_int(watermark),
+                    None => state.registers[*dest].set_value(Value::Null),
+                }
+            }
             ScalarFunc::TestUintEncode => {
                 check_arg_count!(arg_count, 1);
                 let val = &state.registers[*start_reg];
@@ -11716,6 +11749,72 @@ pub fn op_set_sequence_currval(
         })?;
 
     program.connection.set_sequence_currval(&seq_name, value);
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
+/// Publish sequence allocation metadata used by `sequence_watermark()`.
+///
+/// The translator emits this only after the sequence backing-table RMW has
+/// committed successfully. At that point `SequenceCommitInnerTx` has restored
+/// the connection's MVCC transaction to the outer tx, so any active allocation
+/// is attributed to the transaction whose row changes may become visible later.
+pub fn op_sequence_track_allocation(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(
+        SequenceTrackAllocation {
+            db,
+            seq_name_reg,
+            value_reg,
+        },
+        insn
+    );
+
+    let seq_name = match state.registers[*seq_name_reg].get_value() {
+        Value::Text(t) => t.as_str().to_string(),
+        _ => {
+            return Err(crate::LimboError::ParseError(
+                "SequenceTrackAllocation: seq_name_reg must be text".to_string(),
+            ));
+        }
+    };
+    let value = state.registers[*value_reg]
+        .get_value()
+        .as_int()
+        .ok_or_else(|| {
+            crate::LimboError::InternalError(
+                "SequenceTrackAllocation: value_reg must be integer".to_string(),
+            )
+        })?;
+
+    let bare_seq_name = seq_name
+        .rsplit_once('.')
+        .map(|(_, n)| n)
+        .unwrap_or(&seq_name);
+    let normalized_seq_name = crate::util::normalize_ident(bare_seq_name);
+
+    if let Some(mv_store) = program.connection.mv_store_for_db(*db) {
+        let seq = program
+            .connection
+            .with_schema(*db, |s| s.get_sequence(&normalized_seq_name).cloned())
+            .ok_or_else(|| {
+                crate::LimboError::ParseError(format!("sequence \"{seq_name}\" does not exist"))
+            })?;
+        let current_watermark =
+            crate::mvcc::database::first_unsafe_sequence_watermark(&seq, value, true);
+        mv_store.set_sequence_watermark(&normalized_seq_name, current_watermark);
+
+        if let Some((tx_id, _)) = program.connection.get_mv_tx_for_db(*db) {
+            if mv_store.is_tx_rollbackable(tx_id) {
+                mv_store.register_sequence_allocation(tx_id, &normalized_seq_name, value)?;
+            }
+        }
+    }
+
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8210,7 +8210,7 @@ pub fn op_function(
                     }
                     _ => {
                         return Err(LimboError::InternalError(
-                            "sequence_watermark() argument must be TEXT".to_string(),
+                            "sequence_watermark_experimental() argument must be TEXT".to_string(),
                         ));
                     }
                 };
@@ -11753,7 +11753,7 @@ pub fn op_set_sequence_currval(
     Ok(InsnFunctionStepResult::Step)
 }
 
-/// Publish sequence allocation metadata used by `sequence_watermark()`.
+/// Publish sequence allocation metadata used by `sequence_watermark_experimental()`.
 ///
 /// The translator emits this only after the sequence backing-table RMW has
 /// committed successfully. At that point `SequenceCommitInnerTx` has restored
@@ -11812,6 +11812,86 @@ pub fn op_sequence_track_allocation(
             if mv_store.is_tx_rollbackable(tx_id) {
                 mv_store.register_sequence_allocation(tx_id, &normalized_seq_name, value)?;
             }
+        }
+    }
+
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
+/// Register an in-flight sequence allocation against the *outer* transaction
+/// *before* the paired `SequenceCommitInnerTx` publishes the new boundary.
+///
+/// Without this, there is a window where one connection has committed the
+/// inner-tx RMW (so its allocated value is now readable by other connections
+/// and the next allocator can advance the stored watermark past it) but has not
+/// yet run `SequenceTrackAllocation` to register its allocation. A reader that
+/// computes `sequence_watermark_experimental()` in that window sees the
+/// advanced boundary without the lower active allocation, claims the value
+/// safe, and a forward-only cursor advances past a row the outer tx still holds
+/// uncommitted — skipping it once the outer tx commits.
+///
+/// Registering here, ahead of the commit that makes the value observable,
+/// guarantees the active allocation is in place before any other connection can
+/// advance the watermark past it. The post-commit `SequenceTrackAllocation`
+/// re-registers the same `(tx, value)` (an idempotent `min`) and additionally
+/// covers the skipped-inner-tx (exclusive outer / WAL) and autocommit paths,
+/// where the outer tx is not encoded in `saved_outer_reg`.
+pub fn op_sequence_register_allocation(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(
+        SequenceRegisterAllocation {
+            db,
+            seq_name_reg,
+            value_reg,
+            saved_outer_reg,
+        },
+        insn
+    );
+
+    // Only the wrapped inner-tx path encodes a saved outer mv_tx. An empty
+    // blob means there is no outer tx whose uncommitted row needs protecting
+    // (autocommit) or the inner tx was skipped (exclusive / WAL) — both are
+    // handled by the post-commit `SequenceTrackAllocation`.
+    let saved_outer = match state.registers[*saved_outer_reg].get_value() {
+        Value::Blob(bytes) => decode_saved_outer_mv_tx(bytes.as_slice()),
+        _ => None,
+    };
+    let Some((outer_tx_id, _)) = saved_outer else {
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    };
+
+    let seq_name = match state.registers[*seq_name_reg].get_value() {
+        Value::Text(t) => t.as_str().to_string(),
+        _ => {
+            return Err(crate::LimboError::ParseError(
+                "SequenceRegisterAllocation: seq_name_reg must be text".to_string(),
+            ));
+        }
+    };
+    let value = state.registers[*value_reg]
+        .get_value()
+        .as_int()
+        .ok_or_else(|| {
+            crate::LimboError::InternalError(
+                "SequenceRegisterAllocation: value_reg must be integer".to_string(),
+            )
+        })?;
+
+    let bare_seq_name = seq_name
+        .rsplit_once('.')
+        .map(|(_, n)| n)
+        .unwrap_or(&seq_name);
+    let normalized_seq_name = crate::util::normalize_ident(bare_seq_name);
+
+    if let Some(mv_store) = program.connection.mv_store_for_db(*db) {
+        if mv_store.is_tx_rollbackable(outer_tx_id) {
+            mv_store.register_sequence_allocation(outer_tx_id, &normalized_seq_name, value)?;
         }
     }
 

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1759,6 +1759,19 @@ pub fn insn_to_row(
                 0,
                 format!("currval(r[{seq_name_reg}]) = r[{value_reg}]"),
             ),
+            Insn::SequenceTrackAllocation {
+                db,
+                seq_name_reg,
+                value_reg,
+            } => (
+                "SequenceTrackAllocation",
+                *db as i64,
+                *seq_name_reg as i64,
+                *value_reg as i64,
+                Value::Null,
+                0,
+                format!("track sequence allocation r[{seq_name_reg}] = r[{value_reg}]"),
+            ),
             Insn::SequenceBeginInnerTx {
                 db,
                 path_kind_reg,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1772,6 +1772,23 @@ pub fn insn_to_row(
                 0,
                 format!("track sequence allocation r[{seq_name_reg}] = r[{value_reg}]"),
             ),
+            Insn::SequenceRegisterAllocation {
+                db,
+                seq_name_reg,
+                value_reg,
+                saved_outer_reg,
+            } => (
+                "SequenceRegisterAllocation",
+                *db as i64,
+                *seq_name_reg as i64,
+                *value_reg as i64,
+                Value::Null,
+                0,
+                format!(
+                    "register allocation r[{seq_name_reg}] = r[{value_reg}] \
+                     against outer mv_tx r[{saved_outer_reg}]"
+                ),
+            ),
             Insn::SequenceBeginInnerTx {
                 db,
                 path_kind_reg,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1455,6 +1455,13 @@ pub enum Insn {
         seq_name_reg: usize,
         value_reg: usize,
     },
+    /// Publish sequence allocation metadata for sync watermarks after a
+    /// successful sequence RMW commit.
+    SequenceTrackAllocation {
+        db: usize,
+        seq_name_reg: usize,
+        value_reg: usize,
+    },
     /// Add a custom type to the in-memory schema by parsing its CREATE TYPE SQL
     AddType {
         /// The database within which this type needs to be added
@@ -2089,6 +2096,7 @@ impl InsnVariants {
             InsnVariants::DropSequence => execute::op_drop_sequence,
             InsnVariants::SequenceComputeNext => execute::op_sequence_compute_next,
             InsnVariants::SetSequenceCurrval => execute::op_set_sequence_currval,
+            InsnVariants::SequenceTrackAllocation => execute::op_sequence_track_allocation,
             InsnVariants::SequenceBeginInnerTx => execute::op_sequence_begin_inner_tx,
             InsnVariants::SequenceCommitInnerTx => execute::op_sequence_commit_inner_tx,
             InsnVariants::AddType => execute::op_add_type,
@@ -2208,6 +2216,7 @@ impl Insn {
             | Self::DropSequence { .. }
             | Self::SequenceComputeNext { .. }
             | Self::SetSequenceCurrval { .. }
+            | Self::SequenceTrackAllocation { .. }
             | Self::SequenceBeginInnerTx { .. }
             | Self::SequenceCommitInnerTx { .. }
             | Self::AddType { .. }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1462,6 +1462,21 @@ pub enum Insn {
         seq_name_reg: usize,
         value_reg: usize,
     },
+    /// Register an in-flight sequence allocation against the *outer*
+    /// transaction *before* the inner-tx RMW commit publishes the new
+    /// boundary. Emitted ahead of `SequenceCommitInnerTx` so the active
+    /// allocation is visible to `sequence_watermark_experimental()` the
+    /// instant another connection can observe (and advance past) this
+    /// value. See `op_sequence_register_allocation` for the race this
+    /// closes.
+    SequenceRegisterAllocation {
+        db: usize,
+        seq_name_reg: usize,
+        value_reg: usize,
+        /// Register holding the encoded saved outer mv_tx (the blob written
+        /// by `SequenceBeginInnerTx`). Empty blob means "no outer tx".
+        saved_outer_reg: usize,
+    },
     /// Add a custom type to the in-memory schema by parsing its CREATE TYPE SQL
     AddType {
         /// The database within which this type needs to be added
@@ -2097,6 +2112,7 @@ impl InsnVariants {
             InsnVariants::SequenceComputeNext => execute::op_sequence_compute_next,
             InsnVariants::SetSequenceCurrval => execute::op_set_sequence_currval,
             InsnVariants::SequenceTrackAllocation => execute::op_sequence_track_allocation,
+            InsnVariants::SequenceRegisterAllocation => execute::op_sequence_register_allocation,
             InsnVariants::SequenceBeginInnerTx => execute::op_sequence_begin_inner_tx,
             InsnVariants::SequenceCommitInnerTx => execute::op_sequence_commit_inner_tx,
             InsnVariants::AddType => execute::op_add_type,
@@ -2217,6 +2233,7 @@ impl Insn {
             | Self::SequenceComputeNext { .. }
             | Self::SetSequenceCurrval { .. }
             | Self::SequenceTrackAllocation { .. }
+            | Self::SequenceRegisterAllocation { .. }
             | Self::SequenceBeginInnerTx { .. }
             | Self::SequenceCommitInnerTx { .. }
             | Self::AddType { .. }


### PR DESCRIPTION
This PR adds `sequence_watermark(name)` as a scalar function for MVCC sequence users.

The function returns the first sequence value that is not safe for cursor-based readers to pass. Sync can use it as an exclusive upper bound, for example:

```sql
SELECT * FROM turso_cdc
WHERE change_id > ?
  AND change_id < sequence_watermark('__turso_internal_autoincrement_turso_cdc');
```

MVCC allows concurrent transactions. A transaction can allocate an AUTOINCREMENT-backed CDC id, stay open, and commit after another transaction with a higher CDC id. A sync cursor that only reads `id > last_seen` can then advance past the lower uncommitted id and skip it when it appears later.

The watermark prevents sync from advancing into a range where active transactions may still publish sequence values.

- Added in-memory MVCC tracking for active sequence allocations.
- Tracks the current sequence boundary from the sequence backing table.
- Returns `min(current_sequence_boundary, active_transaction_allocation_low)`.
- Wires tracking into the PG-style sequence table path after successful
  autonomous sequence commit.
- Seeds sequence watermarks during MVCC bootstrap and WAL-to-MVCC
  AUTOINCREMENT sync.