### PR TITLE
lock cargo-fuzz to 0.13.0 to prevent CI failure

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -139,6 +139,6 @@ jobs:
         prefix-key: "v1-rust-fuzz"
         cache-on-failure: true
     - name: Install cargo-fuzz
-      run: cargo install cargo-fuzz
+      run: cargo install cargo-fuzz@0.13.0
     - name: Run scalar_func fuzzer
       run: cargo +nightly fuzz run scalar_func -- -max_total_time=300


### PR DESCRIPTION
causes: https://github.com/tursodatabase/turso/actions/runs/27227979449/job/80400190373?pr=7423
