### PR TITLE
core, sdk-kit: ColumnTypeInfo for custom-type-aware column metadata

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -146,7 +146,7 @@ pub use io::{
     WriteCompletion, IO,
 };
 pub use numeric::{nonnan::NonNan, Numeric};
-pub use statement::{Statement, StatementStatusCounter};
+pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};
 pub use storage::{
     buffer_pool::BufferPool,
     database::{DatabaseStorage, IOContext},

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -74,6 +74,217 @@ impl StatementOrigin {
     }
 }
 
+/// Structured type information for a result column.
+///
+/// Returned by [`Statement::get_column_type_info`]. Surfaces the array depth
+/// and custom-type resolution that the SQLite-compat `get_column_decltype`
+/// API does not expose, and also carries the inferred-affinity result for
+/// computed expressions (`SELECT 1+1`, function calls in subqueries, etc.)
+/// — the consumer asks one question, the API decides which path applies.
+///
+/// For a direct table-column reference, `declared_name` is the literal
+/// string the user wrote in CREATE TABLE (`"INTEGER"`, `"cents"`,
+/// `"VARCHAR"`), `array_dimensions` is the bracket depth, and `base_type` /
+/// `kind` carry any CREATE TYPE / CREATE DOMAIN resolution.
+///
+/// For a literal (`SELECT 42`, `SELECT 'x'`, `SELECT 3.14`), `declared_name`
+/// is the primitive that matches the literal's parsed value type
+/// (`"INTEGER"`, `"TEXT"`, `"REAL"`). For a typed expression — CAST, rowid,
+/// or anything else SQLite's affinity rules can pin down — it's the
+/// inferred primitive. In both cases `array_dimensions` is `0`, `base_type`
+/// is `None`, and `kind` is [`ColumnTypeKind::Builtin`]. When neither path
+/// produces a usable primitive (binary arithmetic that SQLite refuses to
+/// propagate through, BLOB literals, NULL literals, function calls without
+/// declared return affinity), `get_column_type_info` returns `Ok(None)`
+/// rather than fabricating a name — callers can fall through to their own
+/// default.
+///
+/// New fields may be added over time; the struct is marked
+/// `#[non_exhaustive]` so consumers must use struct-update or accessor
+/// patterns rather than exhaustive matches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ColumnTypeInfo {
+    /// The declared type name as written in CREATE TABLE — e.g. `"INTEGER"`,
+    /// `"VARCHAR"`, or the name of a `CREATE TYPE` / `CREATE DOMAIN` such as
+    /// `"cents"`. This is the same string `get_column_decltype` returns.
+    pub declared_name: String,
+    /// Array dimensionality: `0` for scalar columns, `1` for `INTEGER[]`,
+    /// `2` for `TEXT[][]`, etc.
+    pub array_dimensions: u32,
+    /// For columns whose declared type resolves to a `CREATE TYPE` or
+    /// `CREATE DOMAIN` definition, this is the underlying primitive type name
+    /// (`"INTEGER"`, `"TEXT"`, `"REAL"`, `"BLOB"`, or `"NUMERIC"`). `None`
+    /// when the declared name is a built-in primitive directly.
+    ///
+    /// Use this to distinguish "the user wrote `INTEGER`" (base_type: `None`)
+    /// from "the user wrote `cents`, which happens to be INTEGER underneath"
+    /// (base_type: `Some("INTEGER")`).
+    pub base_type: Option<String>,
+    /// Classification of the declared type. Distinguishes `BUILTIN` (the
+    /// declared name is a primitive) from the four `CREATE TYPE`/`CREATE
+    /// DOMAIN` flavours.
+    ///
+    /// This matters for callers like wire-protocol layers that need to map
+    /// a column to its native type code: a column declared as a `STRUCT`
+    /// type stores a BLOB on disk (`base_type` is `Some("BLOB")`), but the
+    /// caller usually wants to expose it as a composite/JSON type rather
+    /// than raw bytes. The `kind` field carries that distinction directly
+    /// without forcing the caller to re-query the schema.
+    pub kind: ColumnTypeKind,
+}
+
+/// Classification of a result column's declared type.
+///
+/// Returned as part of [`ColumnTypeInfo`]. `#[non_exhaustive]` so that new
+/// kinds (e.g. for future enum or table-row types) can be added without a
+/// breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ColumnTypeKind {
+    /// A SQLite-style primitive type: `INTEGER`, `TEXT`, `REAL`, `BLOB`,
+    /// `NUMERIC`, `ANY`. The declared name is itself the primitive.
+    Builtin,
+    /// A user- or built-in custom type defined with
+    /// `CREATE TYPE name BASE primitive ENCODE ... DECODE ...`. Has an
+    /// underlying primitive (see `base_type`) and an encode/decode pipeline.
+    /// Built-in types like `uuid`, `boolean`, `numeric` register through
+    /// this path too.
+    Custom,
+    /// A domain defined with `CREATE DOMAIN name AS base [CHECK ...]`.
+    /// Shares an underlying primitive with its base type but adds CHECK
+    /// constraints; values are otherwise identical to the base.
+    Domain,
+    /// A composite type defined with `CREATE TYPE name AS STRUCT(...)`.
+    /// Values are stored as BLOBs containing the packed record; the
+    /// declared name carries the field schema.
+    Struct,
+    /// A tagged union defined with `CREATE TYPE name AS UNION(...)`.
+    /// Values are stored as BLOBs containing a tag and a payload; the
+    /// declared name carries the variant schema.
+    Union,
+}
+
+/// Recursively infer the result primitive of a non-table-column expression
+/// and return its uppercase name (`"INTEGER"`, `"REAL"`, `"TEXT"`,
+/// `"NUMERIC"`, `"BLOB"`) or `None` when no determination can be made.
+///
+/// Used by [`Statement::get_column_type_info`] to give wire-protocol layers
+/// a usable type for `SELECT 1+1`-style result columns. Goes beyond SQLite's
+/// `get_expr_affinity` (which deliberately stops at binary operators because
+/// SQLite's affinity model is about *column* coercion, not expression
+/// inference) by walking through arithmetic, bitwise, comparison, logical,
+/// and concat operators — letting `SELECT 42 + 1` report INT4 to a
+/// PostgreSQL client the way PG itself does.
+fn infer_expression_primitive(
+    expr: &turso_parser::ast::Expr,
+    referenced_tables: Option<&translate::plan::TableReferences>,
+) -> Option<&'static str> {
+    use turso_parser::ast::{Expr, Operator};
+
+    match expr {
+        // Bare literal: read the parsed concrete value type.
+        Expr::Literal(lit) => match translate::alter::literal_default_value(lit)
+            .ok()?
+            .value_type()
+        {
+            crate::types::ValueType::Integer => Some("INTEGER"),
+            crate::types::ValueType::Float => Some("REAL"),
+            crate::types::ValueType::Text => Some("TEXT"),
+            _ => None,
+        },
+        Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+            infer_expression_primitive(exprs.first().unwrap(), referenced_tables)
+        }
+        Expr::Collate(inner, _) => infer_expression_primitive(inner, referenced_tables),
+        Expr::Unary(_, inner) => {
+            // Unary +/-/NOT preserve the operand's primitive (NOT on INTEGER
+            // is still INTEGER in SQLite).
+            infer_expression_primitive(inner, referenced_tables)
+        }
+        Expr::Binary(left, op, right) => match op {
+            // Arithmetic: widen INTEGER × INTEGER to INTEGER, anything mixed
+            // with REAL becomes REAL, fall through to NUMERIC otherwise.
+            Operator::Add
+            | Operator::Subtract
+            | Operator::Multiply
+            | Operator::Divide
+            | Operator::Modulus => {
+                let l = infer_expression_primitive(left, referenced_tables);
+                let r = infer_expression_primitive(right, referenced_tables);
+                Some(combine_arithmetic_primitive(l, r))
+            }
+            // Bitwise: result is always INTEGER in both SQLite and PG.
+            Operator::BitwiseAnd
+            | Operator::BitwiseOr
+            | Operator::BitwiseNot
+            | Operator::LeftShift
+            | Operator::RightShift => Some("INTEGER"),
+            // Comparison and logical: SQLite returns 0/1 INTEGER; pgmicro
+            // maps INTEGER to BOOL at the wire layer for boolean columns,
+            // but the type the wire layer reports is still INTEGER here.
+            Operator::Equals
+            | Operator::NotEquals
+            | Operator::Less
+            | Operator::LessEquals
+            | Operator::Greater
+            | Operator::GreaterEquals
+            | Operator::Is
+            | Operator::IsNot
+            | Operator::And
+            | Operator::Or
+            | Operator::ArrayContains
+            | Operator::ArrayOverlap => Some("INTEGER"),
+            // Concat is always TEXT.
+            Operator::Concat => Some("TEXT"),
+            // JSON ops fall through to the affinity machinery — `->` returns
+            // JSON / blob, `->>` returns TEXT; the existing affinity rules
+            // give the correct answer.
+            Operator::ArrowRight | Operator::ArrowRightShift => affinity_to_primitive(
+                translate::expr::get_expr_affinity(expr, referenced_tables, None),
+            ),
+        },
+        Expr::RowId { .. } => Some("INTEGER"),
+        // CAST, column references, and anything else: defer to the affinity
+        // machinery, which handles these shapes correctly.
+        _ => affinity_to_primitive(translate::expr::get_expr_affinity(
+            expr,
+            referenced_tables,
+            None,
+        )),
+    }
+}
+
+/// Map [`crate::vdbe::affinity::Affinity`] to the uppercase primitive name
+/// `infer_expression_primitive` returns. `Blob` collapses to `None` because
+/// SQLite's "no determined affinity" sentinel isn't a usable wire type.
+fn affinity_to_primitive(affinity: crate::vdbe::affinity::Affinity) -> Option<&'static str> {
+    match affinity {
+        crate::vdbe::affinity::Affinity::Integer => Some("INTEGER"),
+        crate::vdbe::affinity::Affinity::Real => Some("REAL"),
+        crate::vdbe::affinity::Affinity::Text => Some("TEXT"),
+        crate::vdbe::affinity::Affinity::Numeric => Some("NUMERIC"),
+        crate::vdbe::affinity::Affinity::Blob => None,
+    }
+}
+
+/// Pick the widening primitive for an arithmetic binary op given each
+/// operand's inferred primitive. `INTEGER + INTEGER -> INTEGER`,
+/// `INTEGER + REAL -> REAL`, everything else collapses to `NUMERIC` (the
+/// safe wire default for a mixed-affinity numeric result).
+fn combine_arithmetic_primitive(
+    left: Option<&'static str>,
+    right: Option<&'static str>,
+) -> &'static str {
+    match (left, right) {
+        (Some("INTEGER"), Some("INTEGER")) => "INTEGER",
+        (Some("INTEGER"), Some("REAL"))
+        | (Some("REAL"), Some("INTEGER"))
+        | (Some("REAL"), Some("REAL")) => "REAL",
+        _ => "NUMERIC",
+    }
+}
+
 pub struct Statement {
     pub(crate) program: vdbe::Program,
     state: vdbe::ProgramState,
@@ -785,6 +996,118 @@ impl Statement {
             }
             _ => None,
         }
+    }
+
+    /// Returns rich type information for a result column.
+    ///
+    /// This is Turso's single entry point for "what is the type of this
+    /// column?" — covering both **direct table-column references** (where the
+    /// schema carries declared name, array depth, custom-type kind, and the
+    /// resolved primitive) and **computed expressions** (where the SQLite-
+    /// style affinity machinery infers a primitive type from the expression
+    /// shape). One call, one shape, regardless of which path applies.
+    ///
+    /// ### Return value
+    ///
+    /// - `Err(_)` when this connection does not have the experimental
+    ///   custom-types feature enabled. This API is the public surface of the
+    ///   custom-types system; callers must opt in by enabling
+    ///   `--experimental-custom-types` (or `DatabaseOpts::with_custom_types`)
+    ///   before they can rely on it.
+    /// - `Ok(None)` when the statement is in EXPLAIN mode, when `idx` is out
+    ///   of bounds, when the result column has no schema column behind it
+    ///   AND the affinity machinery returns `BLOB` (i.e. "no determined
+    ///   affinity"), or when a join/CTE reference can't be resolved.
+    /// - `Ok(Some(info))` otherwise. For a table-column reference, `info`
+    ///   carries the declared name verbatim; for an expression, `declared_name`
+    ///   is the inferred-affinity primitive (`"INTEGER"`, `"TEXT"`, `"REAL"`,
+    ///   or `"NUMERIC"`) and `kind` is `Builtin`.
+    ///
+    /// This is a Turso-specific API; it has no `sqlite3_*` counterpart. The
+    /// returned struct is `#[non_exhaustive]` so additional metadata can be
+    /// added over time without breaking callers.
+    pub fn get_column_type_info(&self, idx: usize) -> Result<Option<ColumnTypeInfo>> {
+        if !self.program.connection.experimental_custom_types_enabled() {
+            return Err(LimboError::ParseError(
+                "get_column_type_info requires --experimental-custom-types".to_string(),
+            ));
+        }
+        if self.query_mode != QueryMode::Normal {
+            return Ok(None);
+        }
+        let Some(column) = self.program.result_columns.get(idx) else {
+            return Ok(None);
+        };
+        // Direct table-column reference: pull declared name, array depth, and
+        // any registered CREATE TYPE / CREATE DOMAIN resolution out of the
+        // schema. Anything else falls through to the expression-affinity
+        // inference path below.
+        if let turso_parser::ast::Expr::Column {
+            table,
+            column: column_idx,
+            ..
+        } = &column.expr
+        {
+            let Some((_, table_ref)) = self
+                .program
+                .table_references
+                .find_table_by_internal_id(*table)
+            else {
+                return Ok(None);
+            };
+            let Some(table_column) = table_ref.get_column_at(*column_idx) else {
+                return Ok(None);
+            };
+            let declared_name = table_column.ty_str.clone();
+            let array_dimensions = table_column.array_dimensions();
+            let schema = self.program.connection.schema.read();
+            let resolved = schema
+                .resolve_type(&declared_name, table_ref.is_strict())
+                .ok()
+                .flatten();
+            // `kind` is computed from the leaf TypeDef in the resolution chain:
+            // STRUCT and UNION are tagged on `TypeDefKind`, DOMAIN is tagged
+            // separately on `TypeDef.is_domain`, and anything else registered
+            // through CREATE TYPE is a Custom. A column whose declared name
+            // does not appear in the type registry is a Builtin.
+            let (base_type, kind) = match resolved {
+                Some(resolved) => {
+                    let leaf = resolved.leaf();
+                    let kind = if leaf.is_struct() {
+                        ColumnTypeKind::Struct
+                    } else if leaf.is_union() {
+                        ColumnTypeKind::Union
+                    } else if leaf.is_domain {
+                        ColumnTypeKind::Domain
+                    } else {
+                        ColumnTypeKind::Custom
+                    };
+                    (Some(resolved.primitive.to_uppercase()), kind)
+                }
+                None => (None, ColumnTypeKind::Builtin),
+            };
+            drop(schema);
+            return Ok(Some(ColumnTypeInfo {
+                declared_name,
+                array_dimensions,
+                base_type,
+                kind,
+            }));
+        }
+        // Not a table column: infer the result primitive from the
+        // expression's shape (literal value type, operand types of a binary
+        // op, the CAST target, etc.).
+        let Some(name) =
+            infer_expression_primitive(&column.expr, Some(&self.program.table_references))
+        else {
+            return Ok(None);
+        };
+        Ok(Some(ColumnTypeInfo {
+            declared_name: name.to_string(),
+            array_dimensions: 0,
+            base_type: None,
+            kind: ColumnTypeKind::Builtin,
+        }))
     }
 
     /// Returns the type affinity name of a result column (e.g., "INTEGER", "TEXT", "REAL", "BLOB", "NUMERIC").

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -532,6 +532,42 @@ unsafe extern "C" {
         index: usize,
     ) -> *const ::std::os::raw::c_char;
 }
+pub const turso_column_kind_t_TURSO_COLUMN_KIND_NONE: turso_column_kind_t = -1;
+pub const turso_column_kind_t_TURSO_COLUMN_KIND_BUILTIN: turso_column_kind_t = 0;
+pub const turso_column_kind_t_TURSO_COLUMN_KIND_CUSTOM: turso_column_kind_t = 1;
+pub const turso_column_kind_t_TURSO_COLUMN_KIND_DOMAIN: turso_column_kind_t = 2;
+pub const turso_column_kind_t_TURSO_COLUMN_KIND_STRUCT: turso_column_kind_t = 3;
+pub const turso_column_kind_t_TURSO_COLUMN_KIND_UNION: turso_column_kind_t = 4;
+#[doc = " Classification of a result column's declared type.\n\n Returned by turso_statement_column_kind. Values match the\n ColumnTypeKind variants in the Rust API and are kept stable: new kinds\n are appended."]
+pub type turso_column_kind_t = ::std::os::raw::c_int;
+unsafe extern "C" {
+    #[doc = " Get the declared type name of the column at `index`.\n\n Returns the same string as turso_statement_column_decltype, but resolved\n through the richer type-info path so the result is consistent with the\n other turso_statement_column_* getters declared below.\n\n Returns NULL when no type info is available (statement finalized, index\n out of bounds, or the result column is not a direct table-column ref).\n C string allocated by Turso must be freed with turso_str_deinit."]
+    pub fn turso_statement_column_declared_name(
+        self_: *const turso_statement_t,
+        index: usize,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    #[doc = " Get the array depth of the column at `index`.\n\n Returns 0 for scalar table columns, n for n-dimensional array columns\n (e.g. INTEGER[][] -> 2), and 0 when no type info is available. To\n distinguish \"scalar column\" from \"no info\", check\n turso_statement_column_kind first: it returns TURSO_COLUMN_KIND_NONE in\n the latter case."]
+    pub fn turso_statement_column_array_dimensions(
+        self_: *const turso_statement_t,
+        index: usize,
+    ) -> u32;
+}
+unsafe extern "C" {
+    #[doc = " Get the underlying primitive type name for columns whose declared type\n is a CREATE TYPE or CREATE DOMAIN.\n\n Returns one of \"INTEGER\", \"TEXT\", \"REAL\", \"BLOB\", \"NUMERIC\". Returns NULL\n when the declared type is a built-in primitive directly, when no type\n info is available, or when the column is not a direct table-column\n reference. C string allocated by Turso must be freed with\n turso_str_deinit."]
+    pub fn turso_statement_column_base_type(
+        self_: *const turso_statement_t,
+        index: usize,
+    ) -> *const ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    #[doc = " Classify the column's declared type as builtin / custom / domain /\n struct / union (see turso_column_kind_t).\n\n Returns TURSO_COLUMN_KIND_NONE when no type information is available."]
+    pub fn turso_statement_column_kind(
+        self_: *const turso_statement_t,
+        index: usize,
+    ) -> turso_column_kind_t;
+}
 unsafe extern "C" {
     #[doc = " Get the row value at the the index for a current statement state\n SAFETY: returned pointers will be valid only until next invocation of statement operation (step, finalize, reset, etc)\n Caller must make sure that any non-owning memory is copied appropriated if it will be used for longer lifetime"]
     pub fn turso_statement_row_value_kind(

--- a/sdk-kit/src/capi.rs
+++ b/sdk-kit/src/capi.rs
@@ -592,6 +592,124 @@ pub extern "C" fn turso_statement_column_decltype(
     }
 }
 
+/// Sentinel value returned by `turso_statement_column_kind` when no type
+/// information is available (statement finalized, index out of bounds, or
+/// the result column is not a direct table-column reference).
+///
+/// Mirrors `c::TURSO_COLUMN_KIND_NONE`. The named-constant form is included
+/// so the value flows through the auto-generated bindings.
+const TURSO_COLUMN_KIND_NONE: i32 = -1;
+
+/// Maps a [`turso_core::ColumnTypeKind`] onto the C ABI int constants
+/// declared in `turso.h`. The constants are deliberately kept stable: new
+/// variants added to `ColumnTypeKind` upstream are surfaced here as
+/// `TURSO_COLUMN_KIND_NONE` until this mapping is updated, so a stale C
+/// caller sees "unknown kind" rather than a wrong-but-valid kind.
+fn column_type_kind_to_c(kind: turso_core::ColumnTypeKind) -> i32 {
+    match kind {
+        turso_core::ColumnTypeKind::Builtin => 0,
+        turso_core::ColumnTypeKind::Custom => 1,
+        turso_core::ColumnTypeKind::Domain => 2,
+        turso_core::ColumnTypeKind::Struct => 3,
+        turso_core::ColumnTypeKind::Union => 4,
+        // `ColumnTypeKind` is `#[non_exhaustive]`; treat unknown variants as
+        // "no info" rather than silently mapping them onto an existing kind.
+        _ => TURSO_COLUMN_KIND_NONE,
+    }
+}
+
+/// Get the declared type name of the column at `index` — same string as
+/// `turso_statement_column_decltype`, but resolved through the richer
+/// type-info path so the result is consistent with the other
+/// `_column_type_info_*` getters below.
+///
+/// Returns NULL when no type info is available (see [`TURSO_COLUMN_KIND_NONE`]).
+/// The returned C string must be freed with `turso_str_deinit`.
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_statement_column_declared_name(
+    statement: *const c::turso_statement_t,
+    index: usize,
+) -> *const std::ffi::c_char {
+    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
+        Ok(statement) => statement,
+        Err(_) => return std::ptr::null(),
+    };
+    match statement.column_type_info(index) {
+        Some(info) => str_to_c_string(&info.declared_name),
+        None => std::ptr::null(),
+    }
+}
+
+/// Get the array depth of the column at `index`. `0` for scalar table
+/// columns, `n` for n-dimensional array columns (e.g. `INTEGER[][]` → 2),
+/// and `0` when no type info is available — call
+/// `turso_statement_column_kind` first to distinguish "scalar column"
+/// (returns 0) from "no info" (kind == -1).
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_statement_column_array_dimensions(
+    statement: *const c::turso_statement_t,
+    index: usize,
+) -> u32 {
+    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
+        Ok(statement) => statement,
+        Err(_) => return 0,
+    };
+    statement
+        .column_type_info(index)
+        .map(|info| info.array_dimensions)
+        .unwrap_or(0)
+}
+
+/// Get the underlying primitive type name for columns declared with a
+/// `CREATE TYPE` or `CREATE DOMAIN`. Returns one of `"INTEGER"`, `"TEXT"`,
+/// `"REAL"`, `"BLOB"`, `"NUMERIC"`.
+///
+/// Returns NULL when the declared type is a built-in primitive directly,
+/// when no type info is available, or when the column is not a direct
+/// table-column reference. The returned C string must be freed with
+/// `turso_str_deinit`.
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_statement_column_base_type(
+    statement: *const c::turso_statement_t,
+    index: usize,
+) -> *const std::ffi::c_char {
+    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
+        Ok(statement) => statement,
+        Err(_) => return std::ptr::null(),
+    };
+    match statement
+        .column_type_info(index)
+        .and_then(|info| info.base_type)
+    {
+        Some(s) => str_to_c_string(&s),
+        None => std::ptr::null(),
+    }
+}
+
+/// Classify the column's declared type: `0 = Builtin`, `1 = Custom`,
+/// `2 = Domain`, `3 = Struct`, `4 = Union`. Returns `-1` (`TURSO_COLUMN_KIND_NONE`)
+/// when no type information is available — statement finalized, index out
+/// of bounds, or the column is not a direct table-column reference (e.g.
+/// `SELECT id + 1`).
+#[no_mangle]
+#[signature(c)]
+pub extern "C" fn turso_statement_column_kind(
+    statement: *const c::turso_statement_t,
+    index: usize,
+) -> i32 {
+    let statement = match unsafe { TursoStatement::ref_from_capi(statement) } {
+        Ok(statement) => statement,
+        Err(_) => return TURSO_COLUMN_KIND_NONE,
+    };
+    match statement.column_type_info(index) {
+        Some(info) => column_type_kind_to_c(info.kind),
+        None => TURSO_COLUMN_KIND_NONE,
+    }
+}
+
 /// Lock the statement handle and get a ValueRef for the given row index.
 /// Returns None if the statement is null, finalized, has no row, or index is out of bounds.
 /// The returned MutexGuard must be kept alive for the duration of ValueRef use.

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1345,6 +1345,24 @@ impl TursoStatement {
         }
         stmt.get_column_decltype(index)
     }
+
+    /// Returns rich type information for the column at `index`.
+    ///
+    /// Wraps [`turso_core::Statement::get_column_type_info`]. Returns `None`
+    /// when the statement has been finalized, when the index is out of
+    /// bounds, when the connection does not have the experimental custom-
+    /// types feature enabled (the underlying call errors and we surface that
+    /// as "no info"; the C ABI has no error channel), when the statement is
+    /// in EXPLAIN mode, or when the expression behind the column has no
+    /// determined affinity.
+    pub fn column_type_info(&self, index: usize) -> Option<turso_core::ColumnTypeInfo> {
+        let handle = self.handle.lock().unwrap();
+        let stmt = handle.as_ref()?;
+        if index >= stmt.num_columns() {
+            return None;
+        }
+        stmt.get_column_type_info(index).ok().flatten()
+    }
     /// finalize statement execution
     /// this method must be called in the end of statement execution (either successfull or not)
     pub fn finalize(&mut self, waker: Option<&Waker>) -> Result<TursoStatusCode, TursoError> {

--- a/sdk-kit/turso.h
+++ b/sdk-kit/turso.h
@@ -412,6 +412,62 @@ const char *turso_statement_column_name(const turso_statement_t *self, size_t in
  */
 const char *turso_statement_column_decltype(const turso_statement_t *self, size_t index);
 
+/** Classification of a result column's declared type.
+ *
+ * Returned by turso_statement_column_kind. Values match the
+ * ColumnTypeKind variants in the Rust API and are kept stable: new kinds
+ * are appended.
+ */
+typedef enum
+{
+    TURSO_COLUMN_KIND_NONE = -1,
+    TURSO_COLUMN_KIND_BUILTIN = 0,
+    TURSO_COLUMN_KIND_CUSTOM = 1,
+    TURSO_COLUMN_KIND_DOMAIN = 2,
+    TURSO_COLUMN_KIND_STRUCT = 3,
+    TURSO_COLUMN_KIND_UNION = 4,
+} turso_column_kind_t;
+
+/** Get the declared type name of the column at `index`.
+ *
+ * Returns the same string as turso_statement_column_decltype, but resolved
+ * through the richer type-info path so the result is consistent with the
+ * other turso_statement_column_* getters declared below.
+ *
+ * Returns NULL when no type info is available (statement finalized, index
+ * out of bounds, or the result column is not a direct table-column ref).
+ * C string allocated by Turso must be freed with turso_str_deinit.
+ */
+const char *turso_statement_column_declared_name(const turso_statement_t *self, size_t index);
+
+/** Get the array depth of the column at `index`.
+ *
+ * Returns 0 for scalar table columns, n for n-dimensional array columns
+ * (e.g. INTEGER[][] -> 2), and 0 when no type info is available. To
+ * distinguish "scalar column" from "no info", check
+ * turso_statement_column_kind first: it returns TURSO_COLUMN_KIND_NONE in
+ * the latter case.
+ */
+uint32_t turso_statement_column_array_dimensions(const turso_statement_t *self, size_t index);
+
+/** Get the underlying primitive type name for columns whose declared type
+ * is a CREATE TYPE or CREATE DOMAIN.
+ *
+ * Returns one of "INTEGER", "TEXT", "REAL", "BLOB", "NUMERIC". Returns NULL
+ * when the declared type is a built-in primitive directly, when no type
+ * info is available, or when the column is not a direct table-column
+ * reference. C string allocated by Turso must be freed with
+ * turso_str_deinit.
+ */
+const char *turso_statement_column_base_type(const turso_statement_t *self, size_t index);
+
+/** Classify the column's declared type as builtin / custom / domain /
+ * struct / union (see turso_column_kind_t).
+ *
+ * Returns TURSO_COLUMN_KIND_NONE when no type information is available.
+ */
+turso_column_kind_t turso_statement_column_kind(const turso_statement_t *self, size_t index);
+
 /** Get the row value at the the index for a current statement state
  * SAFETY: returned pointers will be valid only until next invocation of statement operation (step, finalize, reset, etc)
  * Caller must make sure that any non-owning memory is copied appropriated if it will be used for longer lifetime

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -15,6 +15,7 @@ mod query_processing;
 mod query_timeout;
 mod queued_io;
 mod reindex;
+mod statement_metadata;
 mod statement_reset;
 mod stmt_journal;
 mod stmt_readonly;

--- a/tests/integration/statement_metadata.rs
+++ b/tests/integration/statement_metadata.rs
@@ -1,0 +1,365 @@
+//! Tests for Turso-specific statement result-column metadata APIs.
+//!
+//! `Statement::get_column_type_info` is one entry point for "what is the type
+//! of this column?", covering both direct table-column references (declared
+//! name, array depth, custom-type kind, resolved primitive) and computed
+//! expressions (inferred affinity primitive). Gated behind the experimental
+//! custom-types feature.
+
+#[cfg(test)]
+mod tests {
+    use crate::common::TempDatabase;
+    use tempfile::TempDir;
+    use turso_core::{ColumnTypeInfo, ColumnTypeKind, Statement};
+
+    /// Helper: open a fresh DB with custom types + STRICT support enabled.
+    /// Array, struct, union and domain columns require STRICT mode and the
+    /// `custom_types` opt, and `get_column_type_info` itself requires the
+    /// same opt — every test that exercises the rich type-info path uses
+    /// this constructor.
+    fn fresh_db_with_custom_types(name: &str) -> TempDatabase {
+        let path = TempDir::new().unwrap().keep().join(name);
+        let opts = turso_core::DatabaseOpts::new().with_custom_types(true);
+        TempDatabase::new_with_existent_with_opts(&path, opts)
+    }
+
+    /// Unwrap `Result<Option<ColumnTypeInfo>>` down to `ColumnTypeInfo`,
+    /// panicking with a useful message at each layer. Used by the happy-path
+    /// tests where neither the experimental-feature error nor the "no info"
+    /// signal applies.
+    fn expect_info(stmt: &Statement, idx: usize) -> ColumnTypeInfo {
+        stmt.get_column_type_info(idx)
+            .unwrap_or_else(|e| panic!("get_column_type_info({idx}) errored: {e}"))
+            .unwrap_or_else(|| panic!("get_column_type_info({idx}) returned None"))
+    }
+
+    /// Built-in scalar columns: `array_dimensions == 0`, no `base_type`
+    /// (declared name is itself the primitive), `kind == Builtin`.
+    #[test]
+    fn type_info_for_builtin_scalar_columns() {
+        let db = fresh_db_with_custom_types("type_info_builtin_scalar.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, label TEXT) STRICT")
+            .unwrap();
+
+        let stmt = conn.prepare("SELECT id, label FROM t").unwrap();
+
+        let id_info = expect_info(&stmt, 0);
+        assert_eq!(id_info.declared_name, "INTEGER");
+        assert_eq!(id_info.array_dimensions, 0);
+        assert_eq!(id_info.base_type, None);
+        assert_eq!(id_info.kind, ColumnTypeKind::Builtin);
+
+        let label_info = expect_info(&stmt, 1);
+        assert_eq!(label_info.declared_name, "TEXT");
+        assert_eq!(label_info.array_dimensions, 0);
+        assert_eq!(label_info.base_type, None);
+        assert_eq!(label_info.kind, ColumnTypeKind::Builtin);
+    }
+
+    /// Array columns report `array_dimensions` matching the bracket depth in
+    /// CREATE TABLE. The declared name is still the element type (no
+    /// brackets), preserving compatibility with how `get_column_decltype`
+    /// already names the type.
+    #[test]
+    fn type_info_for_array_columns() {
+        let db = fresh_db_with_custom_types("type_info_arrays.db");
+        let conn = db.connect_limbo();
+        conn.execute(
+            "CREATE TABLE t(\
+                 arr_1d INTEGER[],\
+                 arr_2d TEXT[][]\
+             ) STRICT",
+        )
+        .unwrap();
+
+        let stmt = conn.prepare("SELECT arr_1d, arr_2d FROM t").unwrap();
+
+        let one_d = expect_info(&stmt, 0);
+        assert_eq!(one_d.declared_name, "INTEGER");
+        assert_eq!(one_d.array_dimensions, 1);
+        assert_eq!(one_d.base_type, None);
+        assert_eq!(one_d.kind, ColumnTypeKind::Builtin);
+
+        let two_d = expect_info(&stmt, 1);
+        assert_eq!(two_d.declared_name, "TEXT");
+        assert_eq!(two_d.array_dimensions, 2);
+        assert_eq!(two_d.base_type, None);
+        assert_eq!(two_d.kind, ColumnTypeKind::Builtin);
+    }
+
+    /// A column whose declared type is a `CREATE TYPE ... BASE ...` reports
+    /// the declared name verbatim, resolves `base_type` to the underlying
+    /// primitive, and reports `kind == Custom`.
+    #[test]
+    fn type_info_for_custom_type_columns() {
+        let db = fresh_db_with_custom_types("type_info_custom.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TYPE cents BASE integer ENCODE value * 100 DECODE value / 100")
+            .unwrap();
+        conn.execute("CREATE TABLE accounts(id INTEGER PRIMARY KEY, amount cents) STRICT")
+            .unwrap();
+
+        let stmt = conn.prepare("SELECT id, amount FROM accounts").unwrap();
+
+        let id_info = expect_info(&stmt, 0);
+        assert_eq!(id_info.declared_name, "INTEGER");
+        assert_eq!(id_info.base_type, None);
+        assert_eq!(id_info.kind, ColumnTypeKind::Builtin);
+
+        let amount_info = expect_info(&stmt, 1);
+        assert_eq!(amount_info.declared_name, "cents");
+        assert_eq!(amount_info.array_dimensions, 0);
+        assert_eq!(amount_info.base_type, Some("INTEGER".to_string()));
+        assert_eq!(amount_info.kind, ColumnTypeKind::Custom);
+    }
+
+    /// `CREATE DOMAIN` columns share the same underlying primitive as their
+    /// base type but report `kind == Domain` — letting consumers know there
+    /// are CHECK constraints attached even though the on-disk representation
+    /// is identical to the base.
+    #[test]
+    fn type_info_for_domain_columns() {
+        let db = fresh_db_with_custom_types("type_info_domain.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE DOMAIN positive_int AS integer CHECK (VALUE > 0)")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, score positive_int) STRICT")
+            .unwrap();
+
+        let stmt = conn.prepare("SELECT score FROM t").unwrap();
+        let score_info = expect_info(&stmt, 0);
+        assert_eq!(score_info.declared_name, "positive_int");
+        assert_eq!(score_info.base_type, Some("INTEGER".to_string()));
+        assert_eq!(score_info.kind, ColumnTypeKind::Domain);
+    }
+
+    /// `CREATE TYPE ... AS STRUCT(...)` columns are stored as BLOBs but
+    /// report `kind == Struct` so wire-protocol layers can map them to
+    /// composite / JSON types instead of raw BYTEA.
+    #[test]
+    fn type_info_for_struct_columns() {
+        let db = fresh_db_with_custom_types("type_info_struct.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TYPE point AS STRUCT(x INT, y INT)")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INT, pos point) STRICT")
+            .unwrap();
+
+        let stmt = conn.prepare("SELECT pos FROM t").unwrap();
+        let pos_info = expect_info(&stmt, 0);
+        assert_eq!(pos_info.declared_name, "point");
+        assert_eq!(pos_info.array_dimensions, 0);
+        // Structs flatten to BLOB on disk, but `kind` exposes the original
+        // shape so callers can tell apart a struct column from a plain BLOB.
+        assert_eq!(pos_info.base_type, Some("BLOB".to_string()));
+        assert_eq!(pos_info.kind, ColumnTypeKind::Struct);
+    }
+
+    /// `CREATE TYPE ... AS UNION(...)` columns are stored as BLOBs but
+    /// report `kind == Union`, distinguishing them from struct columns and
+    /// plain BLOBs.
+    #[test]
+    fn type_info_for_union_columns() {
+        let db = fresh_db_with_custom_types("type_info_union.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TYPE shape AS UNION(circle INT, square INT)")
+            .unwrap();
+        conn.execute("CREATE TABLE t(id INT, s shape) STRICT")
+            .unwrap();
+
+        let stmt = conn.prepare("SELECT s FROM t").unwrap();
+        let s_info = expect_info(&stmt, 0);
+        assert_eq!(s_info.declared_name, "shape");
+        assert_eq!(s_info.array_dimensions, 0);
+        assert_eq!(s_info.base_type, Some("BLOB".to_string()));
+        assert_eq!(s_info.kind, ColumnTypeKind::Union);
+    }
+
+    /// Computed expressions whose primitive type is statically inferable —
+    /// `CAST(... AS type)` casts and `ROWID`-typed references — report that
+    /// inferred primitive in `declared_name` with `kind == Builtin`, giving
+    /// wire-protocol layers a usable type without a schema column behind it.
+    #[test]
+    fn type_info_for_typed_expressions() {
+        let db = fresh_db_with_custom_types("type_info_typed_exprs.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY) STRICT")
+            .unwrap();
+
+        let stmt = conn
+            .prepare(
+                "SELECT \
+                     CAST(? AS INTEGER), \
+                     CAST(? AS TEXT), \
+                     CAST(? AS REAL), \
+                     rowid \
+                 FROM t",
+            )
+            .unwrap();
+
+        let cast_int = expect_info(&stmt, 0);
+        assert_eq!(cast_int.declared_name, "INTEGER");
+        assert_eq!(cast_int.kind, ColumnTypeKind::Builtin);
+        assert_eq!(cast_int.base_type, None);
+        assert_eq!(cast_int.array_dimensions, 0);
+
+        let cast_text = expect_info(&stmt, 1);
+        assert_eq!(cast_text.declared_name, "TEXT");
+        assert_eq!(cast_text.kind, ColumnTypeKind::Builtin);
+
+        let cast_real = expect_info(&stmt, 2);
+        assert_eq!(cast_real.declared_name, "REAL");
+        assert_eq!(cast_real.kind, ColumnTypeKind::Builtin);
+
+        let rowid_col = expect_info(&stmt, 3);
+        assert_eq!(rowid_col.declared_name, "INTEGER");
+        assert_eq!(rowid_col.kind, ColumnTypeKind::Builtin);
+    }
+
+    /// Bare literals carry a concrete primitive that the wire-protocol layer
+    /// must report (a PostgreSQL client running `SELECT 42` expects INT4,
+    /// not TEXT). The API deliberately departs from SQLite's "literals have
+    /// no affinity" rule here: SQLite's affinity machinery is about how
+    /// columns coerce values at runtime, but a literal already IS a typed
+    /// value — we can classify it directly from its parsed form.
+    #[test]
+    fn type_info_for_literal_expressions() {
+        let db = fresh_db_with_custom_types("type_info_literals.db");
+        let conn = db.connect_limbo();
+
+        let stmt = conn.prepare("SELECT 42, 'literal', 3.14").unwrap();
+
+        let int_lit = expect_info(&stmt, 0);
+        assert_eq!(int_lit.declared_name, "INTEGER");
+        assert_eq!(int_lit.kind, ColumnTypeKind::Builtin);
+        assert_eq!(int_lit.base_type, None);
+        assert_eq!(int_lit.array_dimensions, 0);
+
+        let text_lit = expect_info(&stmt, 1);
+        assert_eq!(text_lit.declared_name, "TEXT");
+        assert_eq!(text_lit.kind, ColumnTypeKind::Builtin);
+
+        let real_lit = expect_info(&stmt, 2);
+        assert_eq!(real_lit.declared_name, "REAL");
+        assert_eq!(real_lit.kind, ColumnTypeKind::Builtin);
+    }
+
+    /// Arithmetic over typed operands propagates: `42 + 1` reports INTEGER,
+    /// matching what PostgreSQL itself reports. Mixed-precision arithmetic
+    /// widens to REAL; mixing in a non-numeric column collapses to NUMERIC.
+    /// This goes beyond SQLite's column-affinity machinery (which deliberately
+    /// stops at binary operators) because wire-protocol clients need a usable
+    /// type per result column.
+    #[test]
+    fn type_info_propagates_through_arithmetic() {
+        let db = fresh_db_with_custom_types("type_info_arith.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY) STRICT")
+            .unwrap();
+
+        // Pure integer arithmetic → INTEGER (the PG-compatible answer).
+        let int_arith = conn
+            .prepare("SELECT 42 + 1, id - 1, 7 * 8, 10 % 3 FROM t")
+            .unwrap();
+        for idx in 0..4 {
+            let info = expect_info(&int_arith, idx);
+            assert_eq!(
+                info.declared_name, "INTEGER",
+                "column {idx} should be INTEGER, got {:?}",
+                info.declared_name
+            );
+            assert_eq!(info.kind, ColumnTypeKind::Builtin);
+        }
+
+        // Mixed INTEGER + REAL → REAL.
+        let mixed = conn.prepare("SELECT 42 + 1.5, 3.14 * id FROM t").unwrap();
+        assert_eq!(expect_info(&mixed, 0).declared_name, "REAL");
+        assert_eq!(expect_info(&mixed, 1).declared_name, "REAL");
+
+        // Bitwise ops always return INTEGER.
+        let bitwise = conn.prepare("SELECT 1 << 4, 0xFF & 0x0F, 1 | 2").unwrap();
+        for idx in 0..3 {
+            assert_eq!(expect_info(&bitwise, idx).declared_name, "INTEGER");
+        }
+
+        // Comparison and logical ops return INTEGER (SQLite's 0/1).
+        let bools = conn.prepare("SELECT 1 = 1, 2 < 3, 1 AND 0, NOT 1").unwrap();
+        for idx in 0..4 {
+            assert_eq!(expect_info(&bools, idx).declared_name, "INTEGER");
+        }
+
+        // Concat is always TEXT.
+        let concat = conn.prepare("SELECT 'hello' || ' world'").unwrap();
+        assert_eq!(expect_info(&concat, 0).declared_name, "TEXT");
+    }
+
+    /// Expressions whose primitive can't be determined statically — function
+    /// calls without a declared return affinity, BLOB literals, NULL literals
+    /// — yield `Ok(None)`. Callers fall through to their own default (TEXT
+    /// is the typical wire-protocol choice).
+    #[test]
+    fn type_info_none_for_indeterminate_expressions() {
+        let db = fresh_db_with_custom_types("type_info_indet.db");
+        let conn = db.connect_limbo();
+
+        // `randomblob(N)` returns a BLOB — no useful wire primitive to
+        // report. Use any function call with no declared return affinity.
+        let blob = conn.prepare("SELECT randomblob(8)").unwrap();
+        assert!(blob.get_column_type_info(0).unwrap().is_none());
+
+        // Blob literals carry a concrete value type but no useful primitive
+        // to expose in wire-protocol terms (clients consuming BYTEA already
+        // get an exact byte stream; there's nothing to "report").
+        let blob_lit = conn.prepare("SELECT x'AB'").unwrap();
+        assert!(blob_lit.get_column_type_info(0).unwrap().is_none());
+
+        // NULL literal: type is genuinely indeterminate at compile time.
+        let null_lit = conn.prepare("SELECT NULL").unwrap();
+        assert!(null_lit.get_column_type_info(0).unwrap().is_none());
+    }
+
+    /// `get_column_type_info` is the public surface of the custom-types
+    /// system, so it errors when the connection does not have the
+    /// `--experimental-custom-types` flag enabled. Callers that want plain
+    /// type metadata regardless of feature flags can use
+    /// `get_column_decltype` (mirrors SQLite's stable contract).
+    #[test]
+    fn type_info_errors_without_experimental_custom_types() {
+        let db = TempDatabase::new_empty(); // custom_types off by default
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(id INTEGER)").unwrap();
+
+        let stmt = conn.prepare("SELECT id FROM t").unwrap();
+        let err = stmt
+            .get_column_type_info(0)
+            .expect_err("expected experimental-feature error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("experimental-custom-types"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    /// Array depth survives `SELECT *` expansion — the planner preserves the
+    /// table-column refs even when the projection is implicit.
+    #[test]
+    fn type_info_survives_star_expansion() {
+        let db = fresh_db_with_custom_types("type_info_star.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a INTEGER[], b INTEGER) STRICT")
+            .unwrap();
+
+        let stmt = conn.prepare("SELECT * FROM t").unwrap();
+
+        let a_info = expect_info(&stmt, 0);
+        assert_eq!(a_info.declared_name, "INTEGER");
+        assert_eq!(a_info.array_dimensions, 1);
+        assert_eq!(a_info.kind, ColumnTypeKind::Builtin);
+
+        let b_info = expect_info(&stmt, 1);
+        assert_eq!(b_info.declared_name, "INTEGER");
+        assert_eq!(b_info.array_dimensions, 0);
+        assert_eq!(b_info.kind, ColumnTypeKind::Builtin);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Statement::get_column_type_info` — a Turso-specific column metadata API that returns declared name, array dimensions, base type, and kind (Builtin/Custom/Domain/Struct/Union) for schema-tagged columns, and inferred primitive types for computed expressions. Gated behind `--experimental-custom-types`; the existing `get_column_decltype` keeps its narrow SQLite-compat contract.
- Extends expression type inference past SQLite's `get_expr_affinity` boundary so wire-protocol layers get usable types for arithmetic (INTEGER × INTEGER → INTEGER, mixed → REAL), bitwise/comparison/logical → INTEGER, and `||` → TEXT. Verified empirically via pgmicro over the raw PG wire protocol.
- Exposes the same surface through the sdk-kit C ABI as four independent getters (`turso_statement_column_declared_name`, `_array_dimensions`, `_base_type`, `_kind`) with a `TURSO_COLUMN_KIND_NONE = -1` sentinel for "no type info" and unknown-variant defaulting so stale callers can't observe a wrong-but-valid kind.

## Test plan
- [ ] `cargo test -p turso_core statement_metadata` — covers builtin/array/custom/domain/struct/union columns, literal & typed expressions, arithmetic/bitwise/comparison/logical/concat propagation, indeterminate-expression `None` cases, the `--experimental-custom-types` error path, and `SELECT *` star expansion.
- [ ] `cargo clippy --workspace --all-features --all-targets -- --deny=warnings`
- [ ] Verify the C ABI surface from a Turso embedder (declared name, array dims, base type, kind).