### PR TITLE
core/mvcc: checkpoint must use the schema of the database it operates on

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1988,6 +1988,7 @@ impl Connection {
                 self.clone(),
                 true,
                 self.get_sync_mode(),
+                MAIN_DB_ID,
             );
             loop {
                 match ckpt_sm.step(&()) {
@@ -3162,6 +3163,28 @@ impl Connection {
                 let schema = self.cached_non_main_schema(database_id);
                 f(&schema)
             }
+        }
+    }
+
+    /// Clone the *shared* schema of `database_id` (main or attached), bypassing
+    /// the per-connection schema cache. Falls back to the main DB's shared
+    /// schema when `database_id` does not name an attached database — callers
+    /// in error paths get something usable instead of a panic.
+    ///
+    /// MVCC checkpoint specifically must call this rather than [`Self::with_schema`]:
+    /// it writes from the mv store to the pager, so the schema it uses must
+    /// match the pager being checkpointed and cannot be a stale per-connection
+    /// copy.
+    pub(crate) fn clone_shared_schema(&self, database_id: usize) -> Arc<Schema> {
+        if database_id == crate::MAIN_DB_ID {
+            self.db.clone_schema()
+        } else {
+            self.attached_databases
+                .read()
+                .index_to_data
+                .get(&database_id)
+                .map(|(db, _)| db.schema.lock().clone())
+                .unwrap_or_else(|| self.db.clone_schema())
         }
     }
 

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -601,12 +601,14 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
         connection: Arc<Connection>,
         update_transaction_state: bool,
         sync_mode: SyncMode,
+        database_id: usize,
     ) -> Self {
         let checkpoint_lock = mvstore.blocking_checkpoint_lock.clone();
-        // Prevent stale per-connection schema during checkpoint by using the shared DB schema.
-        // Unlike in WAL mode we actually write stuff from mv store to pager in checkpoint
-        // so this is important.
-        let schema = connection.db.clone_schema();
+        // Use the shared DB schema (not the per-connection cache, which may be
+        // stale) for the database whose pager we're checkpointing. Unlike WAL
+        // mode, MVCC checkpoint writes from the mv store back to the pager —
+        // so the schema must match the pager being checkpointed.
+        let schema = connection.clone_shared_schema(database_id);
         let index_id_to_index = schema
             .indexes
             .values()
@@ -2464,6 +2466,7 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
+            crate::MAIN_DB_ID,
         );
         checkpoint.durable_txid_max_old = std::num::NonZeroU64::new(10);
         checkpoint.durable_txid_max_new = 10;
@@ -2522,6 +2525,7 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
+            crate::MAIN_DB_ID,
         );
 
         // More than one chunk worth of committed rows so collection must preempt.
@@ -2560,6 +2564,7 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
+            crate::MAIN_DB_ID,
         );
 
         let index_id = MVTableId::from(-7);
@@ -2591,6 +2596,7 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
+            crate::MAIN_DB_ID,
         );
         checkpoint.lock_states.blocking_checkpoint_lock_held = true;
         checkpoint.durable_txid_max_new = 5;
@@ -2637,6 +2643,7 @@ mod tests {
             conn.clone(),
             true,
             conn.get_sync_mode(),
+            crate::MAIN_DB_ID,
         );
         checkpoint.lock_states.blocking_checkpoint_lock_held = true;
         checkpoint.durable_txid_max_new = 5;

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3067,6 +3067,7 @@ impl<Clock: LogicalClock> StateTransition for CommitStateMachine<Clock> {
                         self.connection.clone(),
                         false,
                         self.connection.get_sync_mode(),
+                        self.db_id,
                     ));
                     let state_machine = Mutex::new(state_machine);
                     self.state = CommitState::Checkpoint { state_machine };

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -616,6 +616,7 @@ fn advance_checkpoint_until_wal_has_commit_frame(
         conn.clone(),
         true,
         conn.get_sync_mode(),
+        crate::MAIN_DB_ID,
     );
 
     for _ in 0..10_000 {
@@ -1625,6 +1626,7 @@ fn test_checkpoint_truncates_wal_last() {
         conn.clone(),
         true,
         conn.get_sync_mode(),
+        crate::MAIN_DB_ID,
     );
 
     let mut saw_truncate_log_state_with_wal = false;
@@ -2355,6 +2357,7 @@ fn test_meta_checkpoint_case_10_metadata_upsert_is_atomic_with_pager_commit() {
             conn.clone(),
             true,
             conn.get_sync_mode(),
+            crate::MAIN_DB_ID,
         );
 
         for _ in 0..50_000 {
@@ -2727,6 +2730,7 @@ fn test_meta_checkpoint_case_11_auto_checkpoint_failure_after_commit_remains_rec
         conn.clone(),
         true,
         conn.get_sync_mode(),
+        crate::MAIN_DB_ID,
     );
     let mut reached_truncate = false;
     for _ in 0..50_000 {
@@ -2756,7 +2760,8 @@ fn test_meta_checkpoint_case_11_auto_checkpoint_failure_after_commit_remains_rec
     );
 
     let sync_mode = conn.get_sync_mode();
-    let checkpoint_sm2 = CheckpointStateMachine::new(pager, mvcc_store, conn, true, sync_mode);
+    let checkpoint_sm2 =
+        CheckpointStateMachine::new(pager, mvcc_store, conn, true, sync_mode, crate::MAIN_DB_ID);
     let (old_boundary, _) = checkpoint_sm2.checkpoint_bounds_for_test();
     assert!(
         old_boundary.unwrap_or_default() >= ts1,
@@ -2824,6 +2829,7 @@ fn test_checkpoint_resamples_boundary_before_starting() {
         delayed_conn.clone(),
         true,
         delayed_conn.get_sync_mode(),
+        crate::MAIN_DB_ID,
     );
     let (old_boundary, _) = delayed_checkpoint.checkpoint_bounds_for_test();
     assert_eq!(old_boundary, Some(first_boundary));
@@ -2836,6 +2842,7 @@ fn test_checkpoint_resamples_boundary_before_starting() {
         interrupted_conn.clone(),
         true,
         interrupted_conn.get_sync_mode(),
+        crate::MAIN_DB_ID,
     );
     let mut reached_wal_checkpoint = false;
     for _ in 0..50_000 {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -605,6 +605,7 @@ pub fn op_checkpoint(
             program.connection.clone(),
             true,
             program.connection.get_sync_mode(),
+            *database,
         );
         let CheckpointResult {
             wal_max_frame,
@@ -15692,6 +15693,7 @@ fn op_journal_mode_inner(
                                 program.connection.clone(),
                                 true,
                                 program.connection.get_sync_mode(),
+                                *db,
                             ))));
                     }
 

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -557,6 +557,56 @@ fn test_drop_cleans_up_mvcc_transactions(tmp_db: TempDatabase) -> anyhow::Result
     Ok(())
 }
 
+/// `PRAGMA aux.wal_checkpoint(TRUNCATE)` on an attached MVCC database must use
+/// the *attached* database's schema, not the main database's. Otherwise the
+/// `CheckpointStateMachine`'s `index_id_to_index` map is built from the wrong
+/// indexes and the WriteRow phase either misses index updates or trips on
+/// table-id lookups that don't exist in the wrong schema.
+///
+/// Regression: `CheckpointStateMachine::new` used to unconditionally call
+/// `connection.db.clone_schema()` (the main DB's schema), so an attached DB
+/// whose schema diverged from main — here, aux has an indexed table that main
+/// doesn't — would checkpoint with the wrong index set.
+#[turso_macros::test]
+fn test_mvcc_qualified_checkpoint_uses_attached_db_schema(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.pragma_update("journal_mode", "'mvcc'")?;
+
+    let aux_path = tmp_db.path.with_extension("aux_qualified_ckpt.db");
+    create_mvcc_db(&tmp_db.io, &aux_path)?;
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+
+    // Schema divergence: aux carries an indexed table that main does not. If
+    // checkpoint pulls the schema from main, this index is invisible and the
+    // checkpoint either skips updating it or panics on a missing table id.
+    conn.execute("CREATE TABLE aux.indexed_t(id INTEGER PRIMARY KEY, val INTEGER)")?;
+    conn.execute("CREATE INDEX aux.idx_indexed_t_val ON indexed_t(val)")?;
+
+    for i in 0..32 {
+        conn.execute(format!(
+            "INSERT INTO aux.indexed_t VALUES ({i}, {})",
+            i * 10
+        ))?;
+    }
+
+    // Should complete without panicking. The pre-fix panic was
+    // "checkpoint index struct missing before BTreeCreateIndex" — the
+    // CheckpointStateMachine built its index_id_to_index from the main DB's
+    // schema, which doesn't contain aux's index, so a WriteRow phase referencing
+    // aux's index tripped on the missing entry.
+    let rows = conn.pragma_query("aux.wal_checkpoint(TRUNCATE)")?;
+    assert_eq!(
+        rows.len(),
+        1,
+        "wal_checkpoint(TRUNCATE) should return exactly one row"
+    );
+
+    Ok(())
+}
+
 /// A single transaction that writes to both the main DB and an attached MVCC
 /// database must commit changes to both.  Note: WAL mode does not provide
 /// cross-file transactionality — each DB commits independently.


### PR DESCRIPTION
## Summary

- `PRAGMA aux.wal_checkpoint(TRUNCATE)` against an attached MVCC database panics with `checkpoint index struct missing before BTreeCreateIndex` whenever the attached DB's schema diverges from main's. Root cause: `CheckpointStateMachine::new` always pulled `connection.db.clone_schema()` (the main DB's), so `index_id_to_index` was built from the wrong indexes regardless of which pager the state machine was actually checkpointing.
- Fix threads `database_id: usize` through `CheckpointStateMachine::new`, and adds `Connection::clone_shared_schema(database_id)` so the lookup logic lives on Connection instead of leaking into the state machine.
- Adds `test_mvcc_qualified_checkpoint_uses_attached_db_schema`, which panics on `main` and passes with the fix.

## Test plan

- [x] `cargo test -p core_tester --test integration_tests -- test_mvcc_qualified_checkpoint_uses_attached_db_schema` — fails on `main` (panic at `checkpoint_state_machine.rs:1626`), passes here.
- [x] `cargo test -p core_tester --test integration_tests -- mvcc:: attach:: pragma::` — 65 / 65 pass.
- [x] `cargo test -p turso_core --lib mvcc::database` — 307 / 307 pass.
- [x] `cargo clippy --workspace --all-features --all-targets -- --deny=warnings` clean.
- [x] `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
