### PR TITLE
core: vendor crossbeam-skiplist 0.1.3 as core/skiplist module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,16 +1311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-skiplist"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6653,7 +6643,8 @@ dependencies = [
  "codspeed-divan-compat",
  "crc32c",
  "criterion",
- "crossbeam-skiplist",
+ "crossbeam-epoch",
+ "crossbeam-utils",
  "either",
  "env_logger",
  "fallible-iterator",

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -41,6 +41,12 @@ This project depends on libm, distributed by the rust-lang project:
 * License: licenses/extensions/libm-mit-license.md (MIT License)
 * Homepage: https://github.com/rust-lang/libm
 
+This project includes a vendored copy of crossbeam-skiplist (in `core/skiplist`), distributed by the Crossbeam project developers:
+
+* License: licenses/core/crossbeam-skiplist-apache-license.md (Apache License v2.0)
+* License: licenses/core/crossbeam-skiplist-mit-license.md (MIT License)
+* Homepage: https://github.com/crossbeam-rs/crossbeam
+
 This project depends on pastey, distributed by the pastey authors:
 
 * License: licenses/core/pastey-apache-license.md (Apache License v2.0)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -90,7 +90,8 @@ turso_macros = { workspace = true }
 miette = { workspace = true }
 strum = { workspace = true }
 parking_lot = { workspace = true, features = ["arc_lock"] }
-crossbeam-skiplist = "0.1.3"
+crossbeam-epoch = "0.9.18"
+crossbeam-utils = "0.8.21"
 tracing = { workspace = true }
 ryu = "1.0.19"
 uncased = "0.9.10"

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -25,6 +25,7 @@ pub mod mvcc;
 #[cfg(any(feature = "fuzz", feature = "bench"))]
 pub mod numeric;
 pub mod schema;
+pub mod skiplist;
 pub mod state_machine;
 pub mod storage;
 pub mod types;

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,6 +1,6 @@
+use crate::skiplist::map::Entry;
+use crate::skiplist::SkipMap;
 use crate::turso_assert;
-use crossbeam_skiplist::map::Entry;
-use crossbeam_skiplist::SkipMap;
 
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
@@ -308,7 +308,7 @@ pub(crate) type MvccIterator<'l, T> =
 ///
 /// # Why a macro instead of a function?
 ///
-/// Rust's `crossbeam_skiplist::map::Entry<'a, K, V>` is *invariant* over `K`, meaning
+/// Rust's `crate::skiplist::map::Entry<'a, K, V>` is *invariant* over `K`, meaning
 /// the lifetime `'a` cannot be coerced through a function boundary. When we try to pass
 /// `Box<dyn Iterator<Item = Entry<'_, K, V>>>` to a function expecting a generic lifetime,
 /// the compiler cannot unify the lifetimes across the function call.

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4,6 +4,8 @@ use crate::mvcc::cursor::{static_iterator_hack, MvccIterator};
 use crate::mvcc::yield_hooks::{ProvidesYieldContext, YieldContext, YieldPointMarker};
 use crate::mvcc::yield_points::{inject_transition_failure, inject_transition_yield};
 use crate::schema::{Schema, Table};
+use crate::skiplist::map::Entry;
+use crate::skiplist::SkipMap;
 use crate::state_machine::StateMachine;
 use crate::state_machine::StateTransition;
 use crate::state_machine::TransitionResult;
@@ -41,8 +43,6 @@ use crate::{
     turso_assert, turso_assert_eq, turso_assert_less_than, turso_assert_reachable, Numeric,
 };
 use crate::{Connection, Pager, SyncMode};
-use crossbeam_skiplist::map::Entry;
-use crossbeam_skiplist::SkipMap;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 use std::collections::BTreeSet;
@@ -4886,7 +4886,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn find_next_visible_index_row<'a, I>(&self, tx: &Transaction, mut rows: I) -> Option<RowID>
     where
         I: Iterator<
-            Item = crossbeam_skiplist::map::Entry<
+            Item = crate::skiplist::map::Entry<
                 'a,
                 Arc<SortableIndexKey>,
                 Arc<RwLock<Vec<RowVersion>>>,

--- a/core/skiplist/base.rs
+++ b/core/skiplist/base.rs
@@ -1,0 +1,2123 @@
+//! A lock-free skip list. See [`SkipList`].
+
+use core::borrow::Borrow;
+use core::cmp;
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::{Bound, Deref, Index, RangeBounds};
+use core::ptr;
+use core::sync::atomic::{fence, AtomicUsize, Ordering};
+use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
+
+use crossbeam_epoch::{self as epoch, Atomic, Collector, Guard, Shared};
+use crossbeam_utils::CachePadded;
+
+/// Number of bits needed to store height.
+const HEIGHT_BITS: usize = 5;
+
+/// Maximum height of a skip list tower.
+const MAX_HEIGHT: usize = 1 << HEIGHT_BITS;
+
+/// The bits of `refs_and_height` that keep the height.
+const HEIGHT_MASK: usize = (1 << HEIGHT_BITS) - 1;
+
+/// The tower of atomic pointers.
+///
+/// The actual size of the tower will vary depending on the height that a node
+/// was allocated with.
+#[repr(C)]
+struct Tower<K, V> {
+    pointers: [Atomic<Node<K, V>>; 0],
+}
+
+impl<K, V> Index<usize> for Tower<K, V> {
+    type Output = Atomic<Node<K, V>>;
+    fn index(&self, index: usize) -> &Atomic<Node<K, V>> {
+        // This implementation is actually unsafe since we don't check if the
+        // index is in-bounds. But this is fine since this is only used internally.
+        unsafe { &*(&self.pointers as *const Atomic<Node<K, V>>).add(index) }
+    }
+}
+
+/// Tower at the head of a skip list.
+///
+/// This is located in the `SkipList` struct itself and holds a full height
+/// tower.
+#[repr(C)]
+struct Head<K, V> {
+    pointers: [Atomic<Node<K, V>>; MAX_HEIGHT],
+}
+
+impl<K, V> Head<K, V> {
+    /// Initializes a `Head`.
+    #[inline]
+    fn new() -> Self {
+        // Initializing arrays in rust is a pain...
+        Self {
+            pointers: Default::default(),
+        }
+    }
+}
+
+impl<K, V> Deref for Head<K, V> {
+    type Target = Tower<K, V>;
+    fn deref(&self) -> &Tower<K, V> {
+        unsafe { &*(self as *const _ as *const Tower<K, V>) }
+    }
+}
+
+/// A skip list node.
+///
+/// This struct is marked with `repr(C)` so that the specific order of fields is enforced.
+/// It is important that the tower is the last field since it is dynamically sized. The key,
+/// reference count, and height are kept close to the tower to improve cache locality during
+/// skip list traversal.
+#[repr(C)]
+struct Node<K, V> {
+    /// The value.
+    value: V,
+
+    /// The key.
+    key: K,
+
+    /// Keeps the reference count and the height of its tower.
+    ///
+    /// The reference count is equal to the number of `Entry`s pointing to this node, plus the
+    /// number of levels in which this node is installed.
+    refs_and_height: AtomicUsize,
+
+    /// The tower of atomic pointers.
+    tower: Tower<K, V>,
+}
+
+impl<K, V> Node<K, V> {
+    /// Allocates a node.
+    ///
+    /// The returned node will start with reference count of `ref_count` and the tower will be initialized
+    /// with null pointers. However, the key and the value will be left uninitialized, and that is
+    /// why this function is unsafe.
+    unsafe fn alloc(height: usize, ref_count: usize) -> *mut Self {
+        let layout = Self::get_layout(height);
+        unsafe {
+            let ptr = alloc(layout).cast::<Self>();
+            if ptr.is_null() {
+                handle_alloc_error(layout);
+            }
+
+            ptr::addr_of_mut!((*ptr).refs_and_height)
+                .write(AtomicUsize::new((height - 1) | ref_count << HEIGHT_BITS));
+            ptr::addr_of_mut!((*ptr).tower.pointers)
+                .cast::<Atomic<Self>>()
+                .write_bytes(0, height);
+            ptr
+        }
+    }
+
+    /// Deallocates a node.
+    ///
+    /// This function will not run any destructors.
+    unsafe fn dealloc(ptr: *mut Self) {
+        unsafe {
+            let height = (*ptr).height();
+            let layout = Self::get_layout(height);
+            dealloc(ptr.cast::<u8>(), layout);
+        }
+    }
+
+    /// Returns the layout of a node with the given `height`.
+    fn get_layout(height: usize) -> Layout {
+        assert!((1..=MAX_HEIGHT).contains(&height));
+
+        Layout::new::<Self>()
+            .extend(Layout::array::<Atomic<Self>>(height).unwrap())
+            .unwrap()
+            .0
+            .pad_to_align()
+    }
+
+    /// Returns the height of this node's tower.
+    #[inline]
+    fn height(&self) -> usize {
+        (self.refs_and_height.load(Ordering::Relaxed) & HEIGHT_MASK) + 1
+    }
+
+    /// Marks all pointers in the tower and returns `true` if the level 0 was not marked.
+    fn mark_tower(&self) -> bool {
+        let height = self.height();
+
+        for level in (0..height).rev() {
+            let tag = unsafe {
+                // We're loading the pointer only for the tag, so it's okay to use
+                // `epoch::unprotected()` in this situation.
+                // TODO(Amanieu): can we use release ordering here?
+                self.tower[level]
+                    .fetch_or(1, Ordering::SeqCst, epoch::unprotected())
+                    .tag()
+            };
+
+            // If the level 0 pointer was already marked, somebody else removed the node.
+            if level == 0 && tag == 1 {
+                return false;
+            }
+        }
+
+        // We marked the level 0 pointer, therefore we removed the node.
+        true
+    }
+
+    /// Returns `true` if the node is removed.
+    #[inline]
+    fn is_removed(&self) -> bool {
+        let tag = unsafe {
+            // We're loading the pointer only for the tag, so it's okay to use
+            // `epoch::unprotected()` in this situation.
+            self.tower[0]
+                .load(Ordering::Relaxed, epoch::unprotected())
+                .tag()
+        };
+        tag == 1
+    }
+
+    /// Attempts to increment the reference count of a node and returns `true` on success.
+    ///
+    /// The reference count can be incremented only if it is non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the reference count overflows.
+    #[inline]
+    unsafe fn try_increment(&self) -> bool {
+        let mut refs_and_height = self.refs_and_height.load(Ordering::Relaxed);
+
+        loop {
+            // If the reference count is zero, then the node has already been
+            // queued for deletion. Incrementing it again could lead to a
+            // double-free.
+            if refs_and_height & !HEIGHT_MASK == 0 {
+                return false;
+            }
+
+            // If all bits in the reference count are ones, we're about to overflow it.
+            let new_refs_and_height = refs_and_height
+                .checked_add(1 << HEIGHT_BITS)
+                .expect("SkipList reference count overflow");
+
+            // Try incrementing the count.
+            match self.refs_and_height.compare_exchange_weak(
+                refs_and_height,
+                new_refs_and_height,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(current) => refs_and_height = current,
+            }
+        }
+    }
+
+    /// Decrements the reference count of a node, destroying it if the count becomes zero.
+    #[inline]
+    unsafe fn decrement(&self, guard: &Guard) {
+        if self
+            .refs_and_height
+            .fetch_sub(1 << HEIGHT_BITS, Ordering::Release)
+            >> HEIGHT_BITS
+            == 1
+        {
+            fence(Ordering::Acquire);
+            unsafe { guard.defer_unchecked(move || Self::finalize(self)) }
+        }
+    }
+
+    /// Decrements the reference count of a node, pinning the thread and destroying the node
+    /// if the count become zero.
+    #[inline]
+    unsafe fn decrement_with_pin<F>(&self, parent: &SkipList<K, V>, pin: F)
+    where
+        F: FnOnce() -> Guard,
+    {
+        if self
+            .refs_and_height
+            .fetch_sub(1 << HEIGHT_BITS, Ordering::Release)
+            >> HEIGHT_BITS
+            == 1
+        {
+            fence(Ordering::Acquire);
+            let guard = &pin();
+            parent.check_guard(guard);
+            unsafe { guard.defer_unchecked(move || Self::finalize(self)) }
+        }
+    }
+
+    /// Drops the key and value of a node, then deallocates it.
+    #[cold]
+    unsafe fn finalize(ptr: *const Self) {
+        let ptr = ptr as *mut Self;
+
+        unsafe {
+            // Call destructors: drop the key and the value.
+            ptr::drop_in_place(&mut (*ptr).key);
+            ptr::drop_in_place(&mut (*ptr).value);
+
+            // Finally, deallocate the memory occupied by the node.
+            Self::dealloc(ptr);
+        }
+    }
+}
+
+impl<K, V> fmt::Debug for Node<K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Node")
+            .field(&self.key)
+            .field(&self.value)
+            .finish()
+    }
+}
+
+/// A search result.
+///
+/// The result indicates whether the key was found, as well as what were the adjacent nodes to the
+/// key on each level of the skip list.
+struct Position<'a, K, V> {
+    /// Reference to a node with the given key, if found.
+    ///
+    /// If this is `Some` then it will point to the same node as `right[0]`.
+    found: Option<&'a Node<K, V>>,
+
+    /// Adjacent nodes with smaller keys (predecessors).
+    left: [&'a Tower<K, V>; MAX_HEIGHT],
+
+    /// Adjacent nodes with equal or greater keys (successors).
+    right: [Shared<'a, Node<K, V>>; MAX_HEIGHT],
+}
+
+/// Frequently modified data associated with a skip list.
+struct HotData {
+    /// The seed for random height generation.
+    seed: AtomicUsize,
+
+    /// The number of entries in the skip list.
+    len: AtomicUsize,
+
+    /// Highest tower currently in use. This value is used as a hint for where
+    /// to start lookups and never decreases.
+    max_height: AtomicUsize,
+}
+
+/// A lock-free skip list.
+// TODO(stjepang): Embed a custom `epoch::Collector` inside `SkipList<K, V>`. Instead of adding
+// garbage to the default global collector, we should add it to a local collector tied to the
+// particular skip list instance.
+//
+// Since global collector might destroy garbage arbitrarily late in the future, some skip list
+// methods have `K: 'static` and `V: 'static` bounds. But a local collector embedded in the skip
+// list would destroy all remaining garbage when the skip list is dropped, so in that case we'd be
+// able to remove those bounds on types `K` and `V`.
+//
+// As a further future optimization, if `!mem::needs_drop::<K>() && !mem::needs_drop::<V>()`
+// (neither key nor the value have destructors), there's no point in creating a new local
+// collector, so we should simply use the global one.
+pub struct SkipList<K, V> {
+    /// The head of the skip list (just a dummy node, not a real entry).
+    head: Head<K, V>,
+
+    /// The `Collector` associated with this skip list.
+    collector: Collector,
+
+    /// Hot data associated with the skip list, stored in a dedicated cache line.
+    hot_data: CachePadded<HotData>,
+}
+
+unsafe impl<K: Send + Sync, V: Send + Sync> Send for SkipList<K, V> {}
+unsafe impl<K: Send + Sync, V: Send + Sync> Sync for SkipList<K, V> {}
+
+impl<K, V> SkipList<K, V> {
+    /// Returns a new, empty skip list.
+    pub fn new(collector: Collector) -> Self {
+        Self {
+            head: Head::new(),
+            collector,
+            hot_data: CachePadded::new(HotData {
+                seed: AtomicUsize::new(1),
+                len: AtomicUsize::new(0),
+                max_height: AtomicUsize::new(1),
+            }),
+        }
+    }
+
+    /// Returns `true` if the skip list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of entries in the skip list.
+    ///
+    /// If the skip list is being concurrently modified, consider the returned number just an
+    /// approximation without any guarantees.
+    pub fn len(&self) -> usize {
+        let len = self.hot_data.len.load(Ordering::Relaxed);
+
+        // Due to the relaxed memory ordering, the length counter may sometimes
+        // underflow and produce a very large value. We treat such values as 0.
+        if len > isize::MAX as usize {
+            0
+        } else {
+            len
+        }
+    }
+
+    /// Ensures that all `Guard`s used with the skip list come from the same
+    /// `Collector`.
+    fn check_guard(&self, guard: &Guard) {
+        if let Some(c) = guard.collector() {
+            assert!(c == &self.collector);
+        }
+    }
+}
+
+impl<K, V> SkipList<K, V>
+where
+    K: Ord,
+{
+    /// Returns the entry with the smallest key.
+    pub fn front<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V>> {
+        self.check_guard(guard);
+        let n = self.next_node(&self.head, Bound::Unbounded, guard)?;
+        Some(Entry {
+            parent: self,
+            node: n,
+            guard,
+        })
+    }
+
+    /// Returns the entry with the largest key.
+    pub fn back<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V>> {
+        self.check_guard(guard);
+        let n = self.search_bound(Bound::Unbounded, true, guard)?;
+        Some(Entry {
+            parent: self,
+            node: n,
+            guard,
+        })
+    }
+
+    /// Returns `true` if the map contains a value for the specified key.
+    pub fn contains_key<Q>(&self, key: &Q, guard: &Guard) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.get(key, guard).is_some()
+    }
+
+    /// Returns an entry with the specified `key`.
+    pub fn get<'a: 'g, 'g, Q>(&'a self, key: &Q, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.check_guard(guard);
+        let n = self.search_bound(Bound::Included(key), false, guard)?;
+        if n.key.borrow() != key {
+            return None;
+        }
+        Some(Entry {
+            parent: self,
+            node: n,
+            guard,
+        })
+    }
+
+    /// Returns an `Entry` pointing to the lowest element whose key is above
+    /// the given bound. If no such element is found then `None` is
+    /// returned.
+    pub fn lower_bound<'a: 'g, 'g, Q>(
+        &'a self,
+        bound: Bound<&Q>,
+        guard: &'g Guard,
+    ) -> Option<Entry<'a, 'g, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.check_guard(guard);
+        let n = self.search_bound(bound, false, guard)?;
+        Some(Entry {
+            parent: self,
+            node: n,
+            guard,
+        })
+    }
+
+    /// Returns an `Entry` pointing to the highest element whose key is below
+    /// the given bound. If no such element is found then `None` is
+    /// returned.
+    pub fn upper_bound<'a: 'g, 'g, Q>(
+        &'a self,
+        bound: Bound<&Q>,
+        guard: &'g Guard,
+    ) -> Option<Entry<'a, 'g, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.check_guard(guard);
+        let n = self.search_bound(bound, true, guard)?;
+        Some(Entry {
+            parent: self,
+            node: n,
+            guard,
+        })
+    }
+
+    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
+    pub fn get_or_insert(&self, key: K, value: V, guard: &Guard) -> RefEntry<'_, K, V> {
+        self.insert_internal(key, || value, |_| false, guard)
+    }
+
+    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist,
+    /// where value is calculated with a function.
+    ///
+    ///
+    /// <b>Note:</b> Another thread may write key value first, leading to the result of this closure
+    /// discarded. If closure is modifying some other state (such as shared counters or shared
+    /// objects), it may lead to <u>undesired behaviour</u> such as counters being changed without
+    /// result of closure inserted
+    pub fn get_or_insert_with<F>(&self, key: K, value: F, guard: &Guard) -> RefEntry<'_, K, V>
+    where
+        F: FnOnce() -> V,
+    {
+        self.insert_internal(key, value, |_| false, guard)
+    }
+
+    /// Returns an iterator over all entries in the skip list.
+    pub fn iter<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Iter<'a, 'g, K, V> {
+        self.check_guard(guard);
+        Iter {
+            parent: self,
+            head: None,
+            tail: None,
+            guard,
+        }
+    }
+
+    /// Returns an iterator over all entries in the skip list.
+    pub fn ref_iter(&self) -> RefIter<'_, K, V> {
+        RefIter {
+            parent: self,
+            head: None,
+            tail: None,
+        }
+    }
+
+    /// Returns an iterator over a subset of entries in the skip list.
+    pub fn range<'a: 'g, 'g, Q, R>(
+        &'a self,
+        range: R,
+        guard: &'g Guard,
+    ) -> Range<'a, 'g, Q, R, K, V>
+    where
+        K: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.check_guard(guard);
+        Range {
+            parent: self,
+            head: None,
+            tail: None,
+            range,
+            guard,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns an iterator over a subset of entries in the skip list.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn ref_range<'a, Q, R>(&'a self, range: R) -> RefRange<'a, Q, R, K, V>
+    where
+        K: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
+    {
+        RefRange {
+            parent: self,
+            range,
+            head: None,
+            tail: None,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Generates a random height and returns it.
+    fn random_height(&self) -> usize {
+        // Pseudorandom number generation from "Xorshift RNGs" by George Marsaglia.
+        //
+        // This particular set of operations generates 32-bit integers. See:
+        // https://en.wikipedia.org/wiki/Xorshift#Example_implementation
+        let mut num = self.hot_data.seed.load(Ordering::Relaxed);
+        num ^= num << 13;
+        num ^= num >> 17;
+        num ^= num << 5;
+        self.hot_data.seed.store(num, Ordering::Relaxed);
+
+        let mut height = cmp::min(MAX_HEIGHT, num.trailing_zeros() as usize + 1);
+        unsafe {
+            // Keep decreasing the height while it's much larger than all towers currently in the
+            // skip list.
+            //
+            // Note that we're loading the pointer only to check whether it is null, so it's okay
+            // to use `epoch::unprotected()` in this situation.
+            while height >= 4
+                && self.head[height - 2]
+                    .load(Ordering::Relaxed, epoch::unprotected())
+                    .is_null()
+            {
+                height -= 1;
+            }
+        }
+
+        // Track the max height to speed up lookups
+        let mut max_height = self.hot_data.max_height.load(Ordering::Relaxed);
+        while height > max_height {
+            match self.hot_data.max_height.compare_exchange_weak(
+                max_height,
+                height,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(h) => max_height = h,
+            }
+        }
+        height
+    }
+
+    /// If we encounter a deleted node while searching, help with the deletion
+    /// by attempting to unlink the node from the list.
+    ///
+    /// If the unlinking is successful then this function returns the next node
+    /// with which the search should continue on the current level.
+    #[cold]
+    unsafe fn help_unlink<'a>(
+        &'a self,
+        pred: &'a Atomic<Node<K, V>>,
+        curr: &'a Node<K, V>,
+        succ: Shared<'a, Node<K, V>>,
+        guard: &'a Guard,
+    ) -> Option<Shared<'a, Node<K, V>>> {
+        // If `succ` is marked, that means `curr` is removed. Let's try
+        // unlinking it from the skip list at this level.
+        match pred.compare_exchange(
+            Shared::from(curr as *const _),
+            succ.with_tag(0),
+            Ordering::Release,
+            Ordering::Relaxed,
+            guard,
+        ) {
+            Ok(_) => {
+                unsafe { curr.decrement(guard) }
+                Some(succ.with_tag(0))
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Returns the successor of a node.
+    ///
+    /// This will keep searching until a non-deleted node is found. If a deleted
+    /// node is reached then a search is performed using the given key.
+    fn next_node<'a>(
+        &'a self,
+        pred: &'a Tower<K, V>,
+        lower_bound: Bound<&K>,
+        guard: &'a Guard,
+    ) -> Option<&'a Node<K, V>> {
+        unsafe {
+            // Load the level 0 successor of the current node.
+            let mut curr = pred[0].load_consume(guard);
+
+            // If `curr` is marked, that means `pred` is removed and we have to use
+            // a key search.
+            if curr.tag() == 1 {
+                return self.search_bound(lower_bound, false, guard);
+            }
+
+            while let Some(c) = curr.as_ref() {
+                let succ = c.tower[0].load_consume(guard);
+
+                if succ.tag() == 1 {
+                    if let Some(c) = self.help_unlink(&pred[0], c, succ, guard) {
+                        // On success, continue searching through the current level.
+                        curr = c;
+                        continue;
+                    } else {
+                        // On failure, we cannot do anything reasonable to continue
+                        // searching from the current position. Restart the search.
+                        return self.search_bound(lower_bound, false, guard);
+                    }
+                }
+
+                return Some(c);
+            }
+
+            None
+        }
+    }
+
+    /// Searches for first/last node that is greater/less/equal to a key in the skip list.
+    ///
+    /// If `upper_bound == true`: the last node less than (or equal to) the key.
+    ///
+    /// If `upper_bound == false`: the first node greater than (or equal to) the key.
+    ///
+    /// This is unsafe because the returned nodes are bound to the lifetime of
+    /// the `SkipList`, not the `Guard`.
+    fn search_bound<'a, Q>(
+        &'a self,
+        bound: Bound<&Q>,
+        upper_bound: bool,
+        guard: &'a Guard,
+    ) -> Option<&'a Node<K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        unsafe {
+            'search: loop {
+                // The current level we're at.
+                let mut level = self.hot_data.max_height.load(Ordering::Relaxed);
+
+                // Fast loop to skip empty tower levels.
+                while level >= 1
+                    && self.head[level - 1]
+                        .load(Ordering::Relaxed, guard)
+                        .is_null()
+                {
+                    level -= 1;
+                }
+
+                // The current best node
+                let mut result = None;
+
+                // The predecessor node
+                let mut pred = &*self.head;
+
+                while level >= 1 {
+                    level -= 1;
+
+                    // Two adjacent nodes at the current level.
+                    let mut curr = pred[level].load_consume(guard);
+
+                    // If `curr` is marked, that means `pred` is removed and we have to restart the
+                    // search.
+                    if curr.tag() == 1 {
+                        continue 'search;
+                    }
+
+                    // Iterate through the current level until we reach a node with a key greater
+                    // than or equal to `key`.
+                    while let Some(c) = curr.as_ref() {
+                        let succ = c.tower[level].load_consume(guard);
+
+                        if succ.tag() == 1 {
+                            if let Some(c) = self.help_unlink(&pred[level], c, succ, guard) {
+                                // On success, continue searching through the current level.
+                                curr = c;
+                                continue;
+                            } else {
+                                // On failure, we cannot do anything reasonable to continue
+                                // searching from the current position. Restart the search.
+                                continue 'search;
+                            }
+                        }
+
+                        // If `curr` contains a key that is greater than (or equal) to `key`, we're
+                        // done with this level.
+                        //
+                        // The condition determines whether we should stop the search. For the upper
+                        // bound, we return the last node before the condition became true. For the
+                        // lower bound, we return the first node after the condition became true.
+                        if upper_bound {
+                            if !below_upper_bound(&bound, c.key.borrow()) {
+                                break;
+                            }
+                            result = Some(c);
+                        } else if above_lower_bound(&bound, c.key.borrow()) {
+                            result = Some(c);
+                            break;
+                        }
+
+                        // Move one step forward.
+                        pred = &c.tower;
+                        curr = succ;
+                    }
+                }
+
+                return result;
+            }
+        }
+    }
+
+    /// Searches for a key in the skip list and returns a list of all adjacent nodes.
+    fn search_position<'a, Q>(&'a self, key: &Q, guard: &'a Guard) -> Position<'a, K, V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        unsafe {
+            'search: loop {
+                // The result of this search.
+                let mut result = Position {
+                    found: None,
+                    left: [&*self.head; MAX_HEIGHT],
+                    right: [Shared::null(); MAX_HEIGHT],
+                };
+
+                // The current level we're at.
+                let mut level = self.hot_data.max_height.load(Ordering::Relaxed);
+
+                // Fast loop to skip empty tower levels.
+                while level >= 1
+                    && self.head[level - 1]
+                        .load(Ordering::Relaxed, guard)
+                        .is_null()
+                {
+                    level -= 1;
+                }
+
+                // The predecessor node
+                let mut pred = &*self.head;
+
+                while level >= 1 {
+                    level -= 1;
+
+                    // Two adjacent nodes at the current level.
+                    let mut curr = pred[level].load_consume(guard);
+
+                    // If `curr` is marked, that means `pred` is removed and we have to restart the
+                    // search.
+                    if curr.tag() == 1 {
+                        continue 'search;
+                    }
+
+                    // Iterate through the current level until we reach a node with a key greater
+                    // than or equal to `key`.
+                    while let Some(c) = curr.as_ref() {
+                        let succ = c.tower[level].load_consume(guard);
+
+                        if succ.tag() == 1 {
+                            if let Some(c) = self.help_unlink(&pred[level], c, succ, guard) {
+                                // On success, continue searching through the current level.
+                                curr = c;
+                                continue;
+                            } else {
+                                // On failure, we cannot do anything reasonable to continue
+                                // searching from the current position. Restart the search.
+                                continue 'search;
+                            }
+                        }
+
+                        // If `curr` contains a key that is greater than or equal to `key`, we're
+                        // done with this level.
+                        match c.key.borrow().cmp(key) {
+                            cmp::Ordering::Greater => break,
+                            cmp::Ordering::Equal => {
+                                result.found = Some(c);
+                                break;
+                            }
+                            cmp::Ordering::Less => {}
+                        }
+
+                        // Move one step forward.
+                        pred = &c.tower;
+                        curr = succ;
+                    }
+
+                    // Store the position at the current level into the result.
+                    result.left[level] = pred;
+                    result.right[level] = curr;
+                }
+
+                return result;
+            }
+        }
+    }
+
+    /// Inserts an entry with the specified `key` and `value`.
+    ///
+    /// If `replace` is `true`, then any existing entry with this key will first be removed.
+    fn insert_internal<F, CompareF>(
+        &self,
+        key: K,
+        value: F,
+        replace: CompareF,
+        guard: &Guard,
+    ) -> RefEntry<'_, K, V>
+    where
+        F: FnOnce() -> V,
+        CompareF: Fn(&V) -> bool,
+    {
+        self.check_guard(guard);
+
+        unsafe {
+            // Rebind the guard to the lifetime of self. This is a bit of a
+            // hack but it allows us to return references that are not bound to
+            // the lifetime of the guard.
+            let guard = &*(guard as *const _);
+
+            let mut search;
+            loop {
+                // First try searching for the key.
+                // Note that the `Ord` implementation for `K` may panic during the search.
+                search = self.search_position(&key, guard);
+
+                let r = match search.found {
+                    Some(r) => r,
+                    None => break,
+                };
+                let replace = replace(&r.value);
+                if replace {
+                    // If a node with the key was found and we should replace it, mark its tower
+                    // and then repeat the search.
+                    if r.mark_tower() {
+                        self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                    }
+                } else {
+                    // If a node with the key was found and we're not going to replace it, let's
+                    // try returning it as an entry.
+                    if let Some(e) = RefEntry::try_acquire(self, r) {
+                        return e;
+                    }
+
+                    // If we couldn't increment the reference count, that means someone has just
+                    // now removed the node.
+                    break;
+                }
+            }
+
+            // create value before creating node, so extra allocation doesn't happen if value() function panics
+            let value = value();
+            // Create a new node.
+            let height = self.random_height();
+            let (node, n) = {
+                // The reference count is initially two to account for:
+                // 1. The entry that will be returned.
+                // 2. The link at the level 0 of the tower.
+                let n = Node::<K, V>::alloc(height, 2);
+
+                // Write the key and the value into the node.
+                ptr::addr_of_mut!((*n).key).write(key);
+                ptr::addr_of_mut!((*n).value).write(value);
+
+                (Shared::<Node<K, V>>::from(n as *const _), &*n)
+            };
+
+            // Optimistically increment `len`.
+            self.hot_data.len.fetch_add(1, Ordering::Relaxed);
+
+            loop {
+                // Set the lowest successor of `n` to `search.right[0]`.
+                n.tower[0].store(search.right[0], Ordering::Relaxed);
+
+                // Try installing the new node into the skip list (at level 0).
+                // TODO(Amanieu): can we use release ordering here?
+                if search.left[0][0]
+                    .compare_exchange(
+                        search.right[0],
+                        node,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                        guard,
+                    )
+                    .is_ok()
+                {
+                    break;
+                }
+
+                // We failed. Let's search for the key and try again.
+                {
+                    // Create a guard that destroys the new node in case search panics.
+                    struct ScopeGuard<K, V>(*const Node<K, V>);
+                    impl<K, V> Drop for ScopeGuard<K, V> {
+                        fn drop(&mut self) {
+                            unsafe { Node::finalize(self.0) }
+                        }
+                    }
+                    let sg = ScopeGuard(node.as_raw());
+                    search = self.search_position(&n.key, guard);
+                    mem::forget(sg);
+                }
+
+                if let Some(r) = search.found {
+                    let replace = replace(&r.value);
+                    if replace {
+                        // If a node with the key was found and we should replace it, mark its
+                        // tower and then repeat the search.
+                        if r.mark_tower() {
+                            self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                        }
+                    } else {
+                        // If a node with the key was found and we're not going to replace it,
+                        // let's try returning it as an entry.
+                        if let Some(e) = RefEntry::try_acquire(self, r) {
+                            // Destroy the new node.
+                            Node::finalize(node.as_raw());
+                            self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+
+                            return e;
+                        }
+
+                        // If we couldn't increment the reference count, that means someone has
+                        // just now removed the node.
+                    }
+                }
+            }
+
+            // The new node was successfully installed. Let's create an entry associated with it.
+            let entry = RefEntry {
+                parent: self,
+                node: n,
+            };
+
+            // Build the rest of the tower above level 0.
+            'build: for level in 1..height {
+                loop {
+                    // Obtain the predecessor and successor at the current level.
+                    let pred = search.left[level];
+                    let succ = search.right[level];
+
+                    // Load the current value of the pointer in the tower at this level.
+                    // TODO(Amanieu): can we use relaxed ordering here?
+                    let next = n.tower[level].load(Ordering::SeqCst, guard);
+
+                    // If the current pointer is marked, that means another thread is already
+                    // removing the node we've just inserted. In that case, let's just stop
+                    // building the tower.
+                    if next.tag() == 1 {
+                        break 'build;
+                    }
+
+                    // When searching for `key` and traversing the skip list from the highest level
+                    // to the lowest, it is possible to observe a node with an equal key at higher
+                    // levels and then find it missing at the lower levels if it gets removed
+                    // during traversal. Even worse, it is possible to observe completely different
+                    // nodes with the exact same key at different levels.
+                    //
+                    // Linking the new node to a dead successor with an equal key could create
+                    // subtle corner cases that would require special care. It's much easier to
+                    // simply prohibit linking two nodes with equal keys.
+                    //
+                    // If the successor has the same key as the new node, that means it is marked
+                    // as removed and should be unlinked from the skip list. In that case, let's
+                    // repeat the search to make sure it gets unlinked and try again.
+                    //
+                    // If this comparison or the following search panics, we simply stop building
+                    // the tower without breaking any invariants. Note that building higher levels
+                    // is completely optional. Only the lowest level really matters, and all the
+                    // higher levels are there just to make searching faster.
+                    if succ.as_ref().map(|s| &s.key) == Some(&n.key) {
+                        search = self.search_position(&n.key, guard);
+                        continue;
+                    }
+
+                    // Change the pointer at the current level from `next` to `succ`. If this CAS
+                    // operation fails, that means another thread has marked the pointer and we
+                    // should stop building the tower.
+                    // TODO(Amanieu): can we use release ordering here?
+                    if n.tower[level]
+                        .compare_exchange(next, succ, Ordering::SeqCst, Ordering::SeqCst, guard)
+                        .is_err()
+                    {
+                        break 'build;
+                    }
+
+                    // Increment the reference count. The current value will always be at least 1
+                    // because we are holding `entry`.
+                    n.refs_and_height
+                        .fetch_add(1 << HEIGHT_BITS, Ordering::Relaxed);
+
+                    // Try installing the new node at the current level.
+                    // TODO(Amanieu): can we use release ordering here?
+                    if pred[level]
+                        .compare_exchange(succ, node, Ordering::SeqCst, Ordering::SeqCst, guard)
+                        .is_ok()
+                    {
+                        // Success! Continue on the next level.
+                        break;
+                    }
+
+                    // Installation failed. Decrement the reference count.
+                    n.refs_and_height
+                        .fetch_sub(1 << HEIGHT_BITS, Ordering::Relaxed);
+
+                    // We don't have the most up-to-date search results. Repeat the search.
+                    //
+                    // If this search panics, we simply stop building the tower without breaking
+                    // any invariants. Note that building higher levels is completely optional.
+                    // Only the lowest level really matters, and all the higher levels are there
+                    // just to make searching faster.
+                    search = self.search_position(&n.key, guard);
+                }
+            }
+
+            // If any pointer in the tower is marked, that means our node is in the process of
+            // removal or already removed. It is possible that another thread (either partially or
+            // completely) removed the new node while we were building the tower, and just after
+            // that we installed the new node at one of the higher levels. In order to undo that
+            // installation, we must repeat the search, which will unlink the new node at that
+            // level.
+            // TODO(Amanieu): can we use relaxed ordering here?
+            if n.tower[height - 1].load(Ordering::SeqCst, guard).tag() == 1 {
+                self.search_bound(Bound::Included(&n.key), false, guard);
+            }
+
+            // Finally, return the new entry.
+            entry
+        }
+    }
+}
+
+impl<K, V> SkipList<K, V>
+where
+    K: Ord + Send + 'static,
+    V: Send + 'static,
+{
+    /// Inserts a `key`-`value` pair into the skip list and returns the new entry.
+    ///
+    /// If there is an existing entry with this key, it will be removed before inserting the new
+    /// one.
+    pub fn insert(&self, key: K, value: V, guard: &Guard) -> RefEntry<'_, K, V> {
+        self.insert_internal(key, || value, |_| true, guard)
+    }
+
+    /// Inserts a `key`-`value` pair into the skip list and returns the new entry.
+    ///
+    /// If there is an existing entry with this key and compare(entry.value) returns true,
+    /// it will be removed before inserting the new one.
+    /// The closure will not be called if the key is not present.
+    pub fn compare_insert<F>(
+        &self,
+        key: K,
+        value: V,
+        compare_fn: F,
+        guard: &Guard,
+    ) -> RefEntry<'_, K, V>
+    where
+        F: Fn(&V) -> bool,
+    {
+        self.insert_internal(key, || value, compare_fn, guard)
+    }
+
+    /// Removes an entry with the specified `key` from the map and returns it.
+    pub fn remove<Q>(&self, key: &Q, guard: &Guard) -> Option<RefEntry<'_, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.check_guard(guard);
+
+        unsafe {
+            // Rebind the guard to the lifetime of self. This is a bit of a
+            // hack but it allows us to return references that are not bound to
+            // the lifetime of the guard.
+            let guard = &*(guard as *const _);
+
+            loop {
+                // Try searching for the key.
+                let search = self.search_position(key, guard);
+
+                let n = search.found?;
+
+                // First try incrementing the reference count because we have to return the node as
+                // an entry. If this fails, repeat the search.
+                let entry = match RefEntry::try_acquire(self, n) {
+                    Some(e) => e,
+                    None => continue,
+                };
+
+                // Try removing the node by marking its tower.
+                if n.mark_tower() {
+                    // Success! Decrement `len`.
+                    self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+
+                    // Unlink the node at each level of the skip list. We could do this by simply
+                    // repeating the search, but it's usually faster to unlink it manually using
+                    // the `left` and `right` lists.
+                    for level in (0..n.height()).rev() {
+                        // TODO(Amanieu): can we use relaxed ordering here?
+                        let succ = n.tower[level].load(Ordering::SeqCst, guard).with_tag(0);
+
+                        // Try linking the predecessor and successor at this level.
+                        // TODO(Amanieu): can we use release ordering here?
+                        if search.left[level][level]
+                            .compare_exchange(
+                                Shared::from(n as *const _),
+                                succ,
+                                Ordering::SeqCst,
+                                Ordering::SeqCst,
+                                guard,
+                            )
+                            .is_ok()
+                        {
+                            // Success! Decrement the reference count.
+                            n.decrement(guard);
+                        } else {
+                            // Failed! Just repeat the search to completely unlink the node.
+                            self.search_bound(Bound::Included(key), false, guard);
+                            break;
+                        }
+                    }
+                }
+                return Some(entry);
+            }
+        }
+    }
+
+    /// Removes an entry from the front of the skip list.
+    pub fn pop_front(&self, guard: &Guard) -> Option<RefEntry<'_, K, V>> {
+        self.check_guard(guard);
+        loop {
+            let e = self.front(guard)?;
+            if let Some(e) = e.pin() {
+                if e.remove(guard) {
+                    return Some(e);
+                } else {
+                    e.release(guard);
+                }
+            }
+        }
+    }
+
+    /// Removes an entry from the back of the skip list.
+    pub fn pop_back(&self, guard: &Guard) -> Option<RefEntry<'_, K, V>> {
+        self.check_guard(guard);
+        loop {
+            let e = self.back(guard)?;
+            if let Some(e) = e.pin() {
+                if e.remove(guard) {
+                    return Some(e);
+                } else {
+                    e.release(guard);
+                }
+            }
+        }
+    }
+
+    /// Iterates over the map and removes every entry.
+    pub fn clear(&self, guard: &mut Guard) {
+        self.check_guard(guard);
+
+        /// Number of steps after which we repin the current thread and unlink removed nodes.
+        const BATCH_SIZE: usize = 100;
+
+        loop {
+            {
+                // Search for the first entry in order to unlink all the preceding entries
+                // we have removed.
+                //
+                // By unlinking nodes in batches we make sure that the final search doesn't
+                // unlink all nodes at once, which could keep the current thread pinned for a
+                // long time.
+                let mut entry = self.lower_bound(Bound::Unbounded, guard);
+
+                for _ in 0..BATCH_SIZE {
+                    // Stop if we have reached the end of the list.
+                    let e = match entry {
+                        None => return,
+                        Some(e) => e,
+                    };
+
+                    // Before removing the current entry, first obtain the following one.
+                    let next = e.next();
+
+                    // Try removing the current entry.
+                    if e.node.mark_tower() {
+                        // Success! Decrement `len`.
+                        self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                    }
+
+                    entry = next;
+                }
+            }
+
+            // Repin the current thread because we don't want to keep it pinned in the same
+            // epoch for a too long time.
+            guard.repin();
+        }
+    }
+}
+
+impl<K, V> Drop for SkipList<K, V> {
+    fn drop(&mut self) {
+        unsafe {
+            let mut node = self.head[0]
+                .load(Ordering::Relaxed, epoch::unprotected())
+                .as_ref();
+
+            // Iterate through the whole skip list and destroy every node.
+            while let Some(n) = node {
+                // Unprotected loads are okay because this function is the only one currently using
+                // the skip list.
+                let next = n.tower[0]
+                    .load(Ordering::Relaxed, epoch::unprotected())
+                    .as_ref();
+
+                // Deallocate every node.
+                Node::finalize(n);
+
+                node = next;
+            }
+        }
+    }
+}
+
+impl<K, V> fmt::Debug for SkipList<K, V>
+where
+    K: Ord + fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("SkipList { .. }")
+    }
+}
+
+impl<K, V> IntoIterator for SkipList<K, V> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> IntoIter<K, V> {
+        unsafe {
+            // Load the front node.
+            //
+            // Unprotected loads are okay because this function is the only one currently using
+            // the skip list.
+            let front = self.head[0]
+                .load(Ordering::Relaxed, epoch::unprotected())
+                .as_raw();
+
+            // Clear the skip list by setting all pointers in head to null.
+            for level in 0..MAX_HEIGHT {
+                self.head[level].store(Shared::null(), Ordering::Relaxed);
+            }
+
+            IntoIter {
+                node: front as *mut Node<K, V>,
+            }
+        }
+    }
+}
+
+/// An entry in a skip list, protected by a `Guard`.
+///
+/// The lifetimes of the key and value are the same as that of the `Guard`
+/// used when creating the `Entry` (`'g`). This lifetime is also constrained to
+/// not outlive the `SkipList`.
+pub struct Entry<'a: 'g, 'g, K, V> {
+    parent: &'a SkipList<K, V>,
+    node: &'g Node<K, V>,
+    guard: &'g Guard,
+}
+
+impl<'a: 'g, 'g, K: 'a, V: 'a> Entry<'a, 'g, K, V> {
+    /// Returns `true` if the entry is removed from the skip list.
+    pub fn is_removed(&self) -> bool {
+        self.node.is_removed()
+    }
+
+    /// Returns a reference to the key.
+    pub fn key(&self) -> &'g K {
+        &self.node.key
+    }
+
+    /// Returns a reference to the value.
+    pub fn value(&self) -> &'g V {
+        &self.node.value
+    }
+
+    /// Returns a reference to the parent `SkipList`
+    pub fn skiplist(&self) -> &'a SkipList<K, V> {
+        self.parent
+    }
+
+    /// Attempts to pin the entry with a reference count, ensuring that it
+    /// remains accessible even after the `Guard` is dropped.
+    ///
+    /// This method may return `None` if the reference count is already 0 and
+    /// the node has been queued for deletion.
+    pub fn pin(&self) -> Option<RefEntry<'a, K, V>> {
+        unsafe { RefEntry::try_acquire(self.parent, self.node) }
+    }
+}
+
+impl<K, V> Entry<'_, '_, K, V>
+where
+    K: Ord + Send + 'static,
+    V: Send + 'static,
+{
+    /// Removes the entry from the skip list.
+    ///
+    /// Returns `true` if this call removed the entry and `false` if it was already removed.
+    pub fn remove(&self) -> bool {
+        // Try marking the tower.
+        if self.node.mark_tower() {
+            // Success - the entry is removed. Now decrement `len`.
+            self.parent.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+
+            // Search for the key to unlink the node from the skip list.
+            self.parent
+                .search_bound(Bound::Included(&self.node.key), false, self.guard);
+
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<K, V> Clone for Entry<'_, '_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            parent: self.parent,
+            node: self.node,
+            guard: self.guard,
+        }
+    }
+}
+
+impl<K, V> fmt::Debug for Entry<'_, '_, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Entry")
+            .field(self.key())
+            .field(self.value())
+            .finish()
+    }
+}
+
+impl<'a: 'g, 'g, K, V> Entry<'a, 'g, K, V>
+where
+    K: Ord,
+{
+    /// Moves to the next entry in the skip list.
+    pub fn move_next(&mut self) -> bool {
+        match self.next() {
+            None => false,
+            Some(n) => {
+                *self = n;
+                true
+            }
+        }
+    }
+
+    /// Returns the next entry in the skip list.
+    pub fn next(&self) -> Option<Entry<'a, 'g, K, V>> {
+        let n = self.parent.next_node(
+            &self.node.tower,
+            Bound::Excluded(&self.node.key),
+            self.guard,
+        )?;
+        Some(Entry {
+            parent: self.parent,
+            node: n,
+            guard: self.guard,
+        })
+    }
+
+    /// Moves to the previous entry in the skip list.
+    pub fn move_prev(&mut self) -> bool {
+        match self.prev() {
+            None => false,
+            Some(n) => {
+                *self = n;
+                true
+            }
+        }
+    }
+
+    /// Returns the previous entry in the skip list.
+    pub fn prev(&self) -> Option<Entry<'a, 'g, K, V>> {
+        let n = self
+            .parent
+            .search_bound(Bound::Excluded(&self.node.key), true, self.guard)?;
+        Some(Entry {
+            parent: self.parent,
+            node: n,
+            guard: self.guard,
+        })
+    }
+}
+
+/// A reference-counted entry in a skip list.
+///
+/// You *must* call `release` to free this type, otherwise the node will be
+/// leaked. This is because releasing the entry requires a `Guard`.
+pub struct RefEntry<'a, K, V> {
+    parent: &'a SkipList<K, V>,
+    node: &'a Node<K, V>,
+}
+
+impl<'a, K: 'a, V: 'a> RefEntry<'a, K, V> {
+    /// Returns `true` if the entry is removed from the skip list.
+    pub fn is_removed(&self) -> bool {
+        self.node.is_removed()
+    }
+
+    /// Returns a reference to the key.
+    pub fn key(&self) -> &K {
+        &self.node.key
+    }
+
+    /// Returns a reference to the value.
+    pub fn value(&self) -> &V {
+        &self.node.value
+    }
+
+    /// Returns a reference to the parent `SkipList`
+    pub fn skiplist(&self) -> &'a SkipList<K, V> {
+        self.parent
+    }
+
+    /// Releases the reference on the entry.
+    pub fn release(self, guard: &Guard) {
+        self.parent.check_guard(guard);
+        unsafe { self.node.decrement(guard) }
+    }
+
+    /// Releases the reference of the entry, pinning the thread only when
+    /// the reference count of the node becomes 0.
+    pub fn release_with_pin<F>(self, pin: F)
+    where
+        F: FnOnce() -> Guard,
+    {
+        unsafe { self.node.decrement_with_pin(self.parent, pin) }
+    }
+
+    /// Tries to create a new `RefEntry` by incrementing the reference count of
+    /// a node.
+    unsafe fn try_acquire(
+        parent: &'a SkipList<K, V>,
+        node: &Node<K, V>,
+    ) -> Option<RefEntry<'a, K, V>> {
+        if unsafe { node.try_increment() } {
+            Some(RefEntry {
+                parent,
+
+                // We re-bind the lifetime of the node here to that of the skip
+                // list since we now hold a reference to it.
+                node: unsafe { &*(node as *const _) },
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<K, V> RefEntry<'_, K, V>
+where
+    K: Ord + Send + 'static,
+    V: Send + 'static,
+{
+    /// Removes the entry from the skip list.
+    ///
+    /// Returns `true` if this call removed the entry and `false` if it was already removed.
+    pub fn remove(&self, guard: &Guard) -> bool {
+        self.parent.check_guard(guard);
+
+        // Try marking the tower.
+        if self.node.mark_tower() {
+            // Success - the entry is removed. Now decrement `len`.
+            self.parent.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+
+            // Search for the key to unlink the node from the skip list.
+            self.parent
+                .search_bound(Bound::Included(&self.node.key), false, guard);
+
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<K, V> Clone for RefEntry<'_, K, V> {
+    fn clone(&self) -> Self {
+        unsafe {
+            // Incrementing will always succeed since we're already holding a reference to the node.
+            Node::try_increment(self.node);
+        }
+        Self {
+            parent: self.parent,
+            node: self.node,
+        }
+    }
+}
+
+impl<K, V> fmt::Debug for RefEntry<'_, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RefEntry")
+            .field(self.key())
+            .field(self.value())
+            .finish()
+    }
+}
+
+impl<'a, K, V> RefEntry<'a, K, V>
+where
+    K: Ord,
+{
+    /// Moves to the next entry in the skip list.
+    pub fn move_next(&mut self, guard: &Guard) -> bool {
+        match self.next(guard) {
+            None => false,
+            Some(e) => {
+                mem::replace(self, e).release(guard);
+                true
+            }
+        }
+    }
+
+    /// Returns the next entry in the skip list.
+    pub fn next(&self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+        self.parent.check_guard(guard);
+        unsafe {
+            let mut n = self.node;
+            loop {
+                n = self
+                    .parent
+                    .next_node(&n.tower, Bound::Excluded(&n.key), guard)?;
+                if let Some(e) = RefEntry::try_acquire(self.parent, n) {
+                    return Some(e);
+                }
+            }
+        }
+    }
+
+    /// Moves to the previous entry in the skip list.
+    pub fn move_prev(&mut self, guard: &Guard) -> bool {
+        match self.prev(guard) {
+            None => false,
+            Some(e) => {
+                mem::replace(self, e).release(guard);
+                true
+            }
+        }
+    }
+
+    /// Returns the previous entry in the skip list.
+    pub fn prev(&self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+        self.parent.check_guard(guard);
+        unsafe {
+            let mut n = self.node;
+            loop {
+                n = self
+                    .parent
+                    .search_bound(Bound::Excluded(&n.key), true, guard)?;
+                if let Some(e) = RefEntry::try_acquire(self.parent, n) {
+                    return Some(e);
+                }
+            }
+        }
+    }
+}
+
+/// An iterator over the entries of a `SkipList`.
+pub struct Iter<'a: 'g, 'g, K, V> {
+    parent: &'a SkipList<K, V>,
+    head: Option<&'g Node<K, V>>,
+    tail: Option<&'g Node<K, V>>,
+    guard: &'g Guard,
+}
+
+impl<'a: 'g, 'g, K: 'a, V: 'a> Iterator for Iter<'a, 'g, K, V>
+where
+    K: Ord,
+{
+    type Item = Entry<'a, 'g, K, V>;
+
+    fn next(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+        self.head = match self.head {
+            Some(n) => self
+                .parent
+                .next_node(&n.tower, Bound::Excluded(&n.key), self.guard),
+            None => self
+                .parent
+                .next_node(&self.parent.head, Bound::Unbounded, self.guard),
+        };
+        if let (Some(h), Some(t)) = (self.head, self.tail) {
+            if h.key >= t.key {
+                self.head = None;
+                self.tail = None;
+            }
+        }
+        self.head.map(|n| Entry {
+            parent: self.parent,
+            node: n,
+            guard: self.guard,
+        })
+    }
+}
+
+impl<'a: 'g, 'g, K: 'a, V: 'a> DoubleEndedIterator for Iter<'a, 'g, K, V>
+where
+    K: Ord,
+{
+    fn next_back(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+        self.tail = match self.tail {
+            Some(n) => self
+                .parent
+                .search_bound(Bound::Excluded(&n.key), true, self.guard),
+            None => self.parent.search_bound(Bound::Unbounded, true, self.guard),
+        };
+        if let (Some(h), Some(t)) = (self.head, self.tail) {
+            if h.key >= t.key {
+                self.head = None;
+                self.tail = None;
+            }
+        }
+        self.tail.map(|n| Entry {
+            parent: self.parent,
+            node: n,
+            guard: self.guard,
+        })
+    }
+}
+
+impl<K, V> fmt::Debug for Iter<'_, '_, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Iter")
+            .field("head", &self.head.map(|n| (&n.key, &n.value)))
+            .field("tail", &self.tail.map(|n| (&n.key, &n.value)))
+            .finish()
+    }
+}
+
+/// An iterator over reference-counted entries of a `SkipList`.
+pub struct RefIter<'a, K, V> {
+    parent: &'a SkipList<K, V>,
+    head: Option<RefEntry<'a, K, V>>,
+    tail: Option<RefEntry<'a, K, V>>,
+}
+
+impl<K, V> fmt::Debug for RefIter<'_, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("RefIter");
+        match &self.head {
+            None => d.field("head", &None::<(&K, &V)>),
+            Some(e) => d.field("head", &(e.key(), e.value())),
+        };
+        match &self.tail {
+            None => d.field("tail", &None::<(&K, &V)>),
+            Some(e) => d.field("tail", &(e.key(), e.value())),
+        };
+        d.finish()
+    }
+}
+
+impl<'a, K: 'a, V: 'a> RefIter<'a, K, V>
+where
+    K: Ord,
+{
+    /// Advances the iterator and returns the next value.
+    pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+        self.parent.check_guard(guard);
+        let next_head = match &self.head {
+            Some(e) => e.next(guard),
+            None => try_pin_loop(|| self.parent.front(guard)),
+        };
+        match (&next_head, &self.tail) {
+            // The next key is larger than the latest tail key we observed with this iterator.
+            (Some(ref next), Some(t)) if next.key() >= t.key() => {
+                unsafe {
+                    next.node.decrement(guard);
+                }
+                None
+            }
+            (Some(_), _) => {
+                if let Some(e) = mem::replace(&mut self.head, next_head.clone()) {
+                    unsafe {
+                        e.node.decrement(guard);
+                    }
+                }
+                next_head
+            }
+            (None, _) => None,
+        }
+    }
+
+    /// Removes and returns an element from the end of the iterator.
+    pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+        self.parent.check_guard(guard);
+        let next_tail = match &self.tail {
+            Some(e) => e.prev(guard),
+            None => try_pin_loop(|| self.parent.back(guard)),
+        };
+        match (&self.head, &next_tail) {
+            // The prev key is smaller than the latest head key we observed with this iterator.
+            (Some(h), Some(next)) if h.key() >= next.key() => {
+                unsafe {
+                    next.node.decrement(guard);
+                }
+                None
+            }
+            (_, Some(_)) => {
+                if let Some(e) = mem::replace(&mut self.tail, next_tail.clone()) {
+                    unsafe {
+                        e.node.decrement(guard);
+                    }
+                }
+                next_tail
+            }
+            (_, None) => None,
+        }
+    }
+}
+
+impl<'a, K: 'a, V: 'a> RefIter<'a, K, V> {
+    /// Decrements the reference count of `RefEntry` owned by the iterator.
+    pub fn drop_impl(&mut self, guard: &Guard) {
+        self.parent.check_guard(guard);
+        if let Some(e) = self.head.take() {
+            unsafe { e.node.decrement(guard) };
+        }
+        if let Some(e) = self.tail.take() {
+            unsafe { e.node.decrement(guard) };
+        }
+    }
+}
+
+/// An iterator over a subset of entries of a `SkipList`.
+pub struct Range<'a: 'g, 'g, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    parent: &'a SkipList<K, V>,
+    head: Option<&'g Node<K, V>>,
+    tail: Option<&'g Node<K, V>>,
+    range: R,
+    guard: &'g Guard,
+    _marker: PhantomData<fn() -> Q>, // covariant over `Q`
+}
+
+impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> Iterator for Range<'a, 'g, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    type Item = Entry<'a, 'g, K, V>;
+
+    fn next(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+        self.head = match self.head {
+            Some(n) => self
+                .parent
+                .next_node(&n.tower, Bound::Excluded(&n.key), self.guard),
+            None => self
+                .parent
+                .search_bound(self.range.start_bound(), false, self.guard),
+        };
+        if let Some(h) = self.head {
+            let bound = match self.tail {
+                Some(t) => Bound::Excluded(t.key.borrow()),
+                None => self.range.end_bound(),
+            };
+            if !below_upper_bound(&bound, h.key.borrow()) {
+                self.head = None;
+                self.tail = None;
+            }
+        }
+        self.head.map(|n| Entry {
+            parent: self.parent,
+            node: n,
+            guard: self.guard,
+        })
+    }
+}
+
+impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> DoubleEndedIterator for Range<'a, 'g, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    fn next_back(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+        self.tail = match self.tail {
+            Some(n) => self
+                .parent
+                .search_bound(Bound::Excluded(n.key.borrow()), true, self.guard),
+            None => self
+                .parent
+                .search_bound(self.range.end_bound(), true, self.guard),
+        };
+        if let Some(t) = self.tail {
+            let bound = match self.head {
+                Some(h) => Bound::Excluded(h.key.borrow()),
+                None => self.range.start_bound(),
+            };
+            if !above_lower_bound(&bound, t.key.borrow()) {
+                self.head = None;
+                self.tail = None;
+            }
+        }
+        self.tail.map(|n| Entry {
+            parent: self.parent,
+            node: n,
+            guard: self.guard,
+        })
+    }
+}
+
+impl<Q, R, K, V> fmt::Debug for Range<'_, '_, Q, R, K, V>
+where
+    K: Ord + Borrow<Q> + fmt::Debug,
+    V: fmt::Debug,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Range")
+            .field("range", &self.range)
+            .field("head", &self.head)
+            .field("tail", &self.tail)
+            .finish()
+    }
+}
+
+/// An iterator over reference-counted subset of entries of a `SkipList`.
+pub struct RefRange<'a, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    parent: &'a SkipList<K, V>,
+    pub(crate) head: Option<RefEntry<'a, K, V>>,
+    pub(crate) tail: Option<RefEntry<'a, K, V>>,
+    pub(crate) range: R,
+    _marker: PhantomData<fn() -> Q>, // covariant over `Q`
+}
+
+unsafe impl<Q, R, K, V> Send for RefRange<'_, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+}
+
+unsafe impl<Q, R, K, V> Sync for RefRange<'_, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+}
+
+impl<Q, R, K, V> fmt::Debug for RefRange<'_, Q, R, K, V>
+where
+    K: Ord + Borrow<Q> + fmt::Debug,
+    V: fmt::Debug,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RefRange")
+            .field("range", &self.range)
+            .field("head", &self.head)
+            .field("tail", &self.tail)
+            .finish()
+    }
+}
+
+impl<'a, Q, R, K: 'a, V: 'a> RefRange<'a, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    /// Advances the iterator and returns the next value.
+    pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+        self.parent.check_guard(guard);
+        let next_head = match self.head {
+            Some(ref e) => e.next(guard),
+            None => try_pin_loop(|| self.parent.lower_bound(self.range.start_bound(), guard)),
+        };
+
+        if let Some(ref h) = next_head {
+            let bound = match self.tail {
+                Some(ref t) => Bound::Excluded(t.key().borrow()),
+                None => self.range.end_bound(),
+            };
+            if below_upper_bound(&bound, h.key().borrow()) {
+                self.head = next_head.clone();
+                next_head
+            } else {
+                unsafe {
+                    h.node.decrement(guard);
+                }
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Removes and returns an element from the end of the iterator.
+    pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+        self.parent.check_guard(guard);
+        let next_tail = match self.tail {
+            Some(ref e) => e.prev(guard),
+            None => try_pin_loop(|| self.parent.upper_bound(self.range.end_bound(), guard)),
+        };
+
+        if let Some(ref t) = next_tail {
+            let bound = match self.head {
+                Some(ref h) => Bound::Excluded(h.key().borrow()),
+                None => self.range.start_bound(),
+            };
+            if above_lower_bound(&bound, t.key().borrow()) {
+                self.tail = next_tail.clone();
+                next_tail
+            } else {
+                unsafe {
+                    t.node.decrement(guard);
+                }
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Decrements a reference count owned by this iterator.
+    pub fn drop_impl(&mut self, guard: &Guard) {
+        self.parent.check_guard(guard);
+        if let Some(e) = self.head.take() {
+            unsafe { e.node.decrement(guard) };
+        }
+        if let Some(e) = self.tail.take() {
+            unsafe { e.node.decrement(guard) };
+        }
+    }
+}
+
+/// An owning iterator over the entries of a `SkipList`.
+pub struct IntoIter<K, V> {
+    /// The current node.
+    ///
+    /// All preceding nods have already been destroyed.
+    node: *mut Node<K, V>,
+}
+
+impl<K, V> Drop for IntoIter<K, V> {
+    fn drop(&mut self) {
+        // Iterate through the whole chain and destroy every node.
+        while !self.node.is_null() {
+            unsafe {
+                // Unprotected loads are okay because this function is the only one currently using
+                // the skip list.
+                let next = (&(*self.node).tower)[0].load(Ordering::Relaxed, epoch::unprotected());
+
+                // We can safely do this without deferring because references to
+                // keys & values that we give out never outlive the SkipList.
+                Node::finalize(self.node);
+
+                self.node = next.as_raw() as *mut Node<K, V>;
+            }
+        }
+    }
+}
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<(K, V)> {
+        loop {
+            // Have we reached the end of the skip list?
+            if self.node.is_null() {
+                return None;
+            }
+
+            unsafe {
+                // Take the key and value out of the node.
+                let key = ptr::read(&(*self.node).key);
+                let value = ptr::read(&(*self.node).value);
+
+                // Get the next node in the skip list.
+                //
+                // Unprotected loads are okay because this function is the only one currently using
+                // the skip list.
+                let next = (&(*self.node).tower)[0].load(Ordering::Relaxed, epoch::unprotected());
+
+                // Deallocate the current node and move to the next one.
+                Node::dealloc(self.node);
+                self.node = next.as_raw() as *mut Node<K, V>;
+
+                // The current node may be marked. If it is, it's been removed from the skip list
+                // and we should just skip it.
+                if next.tag() == 0 {
+                    return Some((key, value));
+                }
+            }
+        }
+    }
+}
+
+impl<K, V> fmt::Debug for IntoIter<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("IntoIter { .. }")
+    }
+}
+
+/// Helper function to retry an operation until pinning succeeds or `None` is
+/// returned.
+pub(crate) fn try_pin_loop<'a: 'g, 'g, F, K, V>(mut f: F) -> Option<RefEntry<'a, K, V>>
+where
+    F: FnMut() -> Option<Entry<'a, 'g, K, V>>,
+{
+    loop {
+        if let Some(e) = f()?.pin() {
+            return Some(e);
+        }
+    }
+}
+
+/// Helper function to check if a value is above a lower bound
+fn above_lower_bound<T: Ord + ?Sized>(bound: &Bound<&T>, other: &T) -> bool {
+    match *bound {
+        Bound::Unbounded => true,
+        Bound::Included(key) => other >= key,
+        Bound::Excluded(key) => other > key,
+    }
+}
+
+/// Helper function to check if a value is below an upper bound
+fn below_upper_bound<T: Ord + ?Sized>(bound: &Bound<&T>, other: &T) -> bool {
+    match *bound {
+        Bound::Unbounded => true,
+        Bound::Included(key) => other <= key,
+        Bound::Excluded(key) => other < key,
+    }
+}

--- a/core/skiplist/base_tests.rs
+++ b/core/skiplist/base_tests.rs
@@ -1,0 +1,902 @@
+#![allow(clippy::redundant_clone)]
+
+use std::ops::Bound;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::skiplist::{base, SkipList};
+use crossbeam_epoch as epoch;
+
+fn ref_entry<'a, K, V>(e: impl Into<Option<base::RefEntry<'a, K, V>>>) -> Entry<'a, K, V> {
+    Entry(e.into())
+}
+struct Entry<'a, K, V>(Option<base::RefEntry<'a, K, V>>);
+impl<K, V> Entry<'_, K, V> {
+    fn value(&self) -> &V {
+        self.0.as_ref().unwrap().value()
+    }
+}
+impl<K, V> Drop for Entry<'_, K, V> {
+    fn drop(&mut self) {
+        if let Some(e) = self.0.take() {
+            e.release_with_pin(epoch::pin)
+        }
+    }
+}
+
+#[test]
+fn new() {
+    SkipList::<i32, i32>::new(epoch::default_collector().clone());
+    SkipList::<String, Box<i32>>::new(epoch::default_collector().clone());
+}
+
+#[test]
+fn is_empty() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    assert!(s.is_empty());
+
+    s.insert(1, 10, guard).release(guard);
+    assert!(!s.is_empty());
+    s.insert(2, 20, guard).release(guard);
+    s.insert(3, 30, guard).release(guard);
+    assert!(!s.is_empty());
+
+    s.remove(&2, guard).unwrap().release(guard);
+    assert!(!s.is_empty());
+
+    s.remove(&1, guard).unwrap().release(guard);
+    assert!(!s.is_empty());
+
+    s.remove(&3, guard).unwrap().release(guard);
+    assert!(s.is_empty());
+}
+
+#[test]
+fn insert() {
+    let guard = &epoch::pin();
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let not_present = [1, 3, 6, 9, 10];
+    let s = SkipList::new(epoch::default_collector().clone());
+
+    for &x in &insert {
+        s.insert(x, x * 10, guard).release(guard);
+        assert_eq!(*s.get(&x, guard).unwrap().value(), x * 10);
+    }
+
+    for &x in &not_present {
+        assert!(s.get(&x, guard).is_none());
+    }
+}
+
+#[test]
+fn remove() {
+    let guard = &epoch::pin();
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let not_present = [1, 3, 6, 9, 10];
+    let remove = [2, 12, 8];
+    let remaining = [0, 4, 5, 7, 11];
+
+    let s = SkipList::new(epoch::default_collector().clone());
+
+    for &x in &insert {
+        s.insert(x, x * 10, guard).release(guard);
+    }
+    for x in &not_present {
+        assert!(s.remove(x, guard).is_none());
+    }
+    for x in &remove {
+        s.remove(x, guard).unwrap().release(guard);
+    }
+
+    let mut v = vec![];
+    let mut e = s.front(guard).unwrap();
+    loop {
+        v.push(*e.key());
+        if !e.move_next() {
+            break;
+        }
+    }
+
+    assert_eq!(v, remaining);
+    for x in &insert {
+        ref_entry(s.remove(x, guard));
+    }
+    assert!(s.is_empty());
+}
+
+#[test]
+fn entry() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+
+    assert!(s.front(guard).is_none());
+    assert!(s.back(guard).is_none());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10, guard).release(guard);
+    }
+
+    let mut e = s.front(guard).unwrap();
+    assert_eq!(*e.key(), 2);
+    assert!(!e.move_prev());
+    assert!(e.move_next());
+    assert_eq!(*e.key(), 4);
+
+    e = s.back(guard).unwrap();
+    assert_eq!(*e.key(), 12);
+    assert!(!e.move_next());
+    assert!(e.move_prev());
+    assert_eq!(*e.key(), 11);
+}
+
+#[test]
+fn entry_remove() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10, guard).release(guard);
+    }
+
+    let mut e = s.get(&7, guard).unwrap();
+    assert!(!e.is_removed());
+    assert!(e.remove());
+    assert!(e.is_removed());
+
+    e.move_prev();
+    e.move_next();
+    assert_ne!(*e.key(), 7);
+
+    for e in s.iter(guard) {
+        assert!(!s.is_empty());
+        assert_ne!(s.len(), 0);
+        e.remove();
+    }
+    assert!(s.is_empty());
+    assert_eq!(s.len(), 0);
+}
+
+#[test]
+fn entry_reposition() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10, guard).release(guard);
+    }
+
+    let mut e = s.get(&7, guard).unwrap();
+    assert!(!e.is_removed());
+    assert!(e.remove());
+    assert!(e.is_removed());
+
+    s.insert(7, 700, guard).release(guard);
+    e.move_prev();
+    e.move_next();
+    assert_eq!(*e.key(), 7);
+}
+
+#[test]
+fn len() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    assert_eq!(s.len(), 0);
+
+    for (i, &x) in [4, 2, 12, 8, 7, 11, 5].iter().enumerate() {
+        s.insert(x, x * 10, guard).release(guard);
+        assert_eq!(s.len(), i + 1);
+    }
+
+    s.insert(5, 0, guard).release(guard);
+    assert_eq!(s.len(), 7);
+    s.insert(5, 0, guard).release(guard);
+    assert_eq!(s.len(), 7);
+
+    assert!(s.remove(&6, guard).is_none());
+    assert_eq!(s.len(), 7);
+    s.remove(&5, guard).unwrap().release(guard);
+    assert_eq!(s.len(), 6);
+    s.remove(&12, guard).unwrap().release(guard);
+    assert_eq!(s.len(), 5);
+}
+
+#[test]
+fn insert_and_remove() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    let keys = || s.iter(guard).map(|e| *e.key()).collect::<Vec<_>>();
+
+    s.insert(3, 0, guard).release(guard);
+    s.insert(5, 0, guard).release(guard);
+    s.insert(1, 0, guard).release(guard);
+    s.insert(4, 0, guard).release(guard);
+    s.insert(2, 0, guard).release(guard);
+    assert_eq!(keys(), [1, 2, 3, 4, 5]);
+
+    s.remove(&4, guard).unwrap().release(guard);
+    assert_eq!(keys(), [1, 2, 3, 5]);
+    s.remove(&3, guard).unwrap().release(guard);
+    assert_eq!(keys(), [1, 2, 5]);
+    s.remove(&1, guard).unwrap().release(guard);
+    assert_eq!(keys(), [2, 5]);
+
+    assert!(s.remove(&1, guard).is_none());
+    assert_eq!(keys(), [2, 5]);
+    assert!(s.remove(&3, guard).is_none());
+    assert_eq!(keys(), [2, 5]);
+
+    s.remove(&2, guard).unwrap().release(guard);
+    assert_eq!(keys(), [5]);
+    s.remove(&5, guard).unwrap().release(guard);
+    assert!(keys().is_empty());
+
+    s.insert(3, 0, guard).release(guard);
+    assert_eq!(keys(), [3]);
+    s.insert(1, 0, guard).release(guard);
+    assert_eq!(keys(), [1, 3]);
+    s.insert(3, 0, guard).release(guard);
+    assert_eq!(keys(), [1, 3]);
+    s.insert(5, 0, guard).release(guard);
+    assert_eq!(keys(), [1, 3, 5]);
+
+    s.remove(&3, guard).unwrap().release(guard);
+    assert_eq!(keys(), [1, 5]);
+    s.remove(&1, guard).unwrap().release(guard);
+    assert_eq!(keys(), [5]);
+    assert!(s.remove(&3, guard).is_none());
+    assert_eq!(keys(), [5]);
+    s.remove(&5, guard).unwrap().release(guard);
+    assert!(keys().is_empty());
+}
+
+#[test]
+fn get() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    s.insert(30, 3, guard).release(guard);
+    s.insert(50, 5, guard).release(guard);
+    s.insert(10, 1, guard).release(guard);
+    s.insert(40, 4, guard).release(guard);
+    s.insert(20, 2, guard).release(guard);
+
+    assert_eq!(*s.get(&10, guard).unwrap().value(), 1);
+    assert_eq!(*s.get(&20, guard).unwrap().value(), 2);
+    assert_eq!(*s.get(&30, guard).unwrap().value(), 3);
+    assert_eq!(*s.get(&40, guard).unwrap().value(), 4);
+    assert_eq!(*s.get(&50, guard).unwrap().value(), 5);
+
+    assert!(s.get(&7, guard).is_none());
+    assert!(s.get(&27, guard).is_none());
+    assert!(s.get(&31, guard).is_none());
+    assert!(s.get(&97, guard).is_none());
+}
+
+#[test]
+fn lower_bound() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    s.insert(30, 3, guard).release(guard);
+    s.insert(50, 5, guard).release(guard);
+    s.insert(10, 1, guard).release(guard);
+    s.insert(40, 4, guard).release(guard);
+    s.insert(20, 2, guard).release(guard);
+
+    assert_eq!(*s.lower_bound(Bound::Unbounded, guard).unwrap().value(), 1);
+
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&10), guard).unwrap().value(),
+        1
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&20), guard).unwrap().value(),
+        2
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&30), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&40), guard).unwrap().value(),
+        4
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&50), guard).unwrap().value(),
+        5
+    );
+
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&7), guard).unwrap().value(),
+        1
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&27), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Included(&31), guard).unwrap().value(),
+        4
+    );
+    assert!(s.lower_bound(Bound::Included(&97), guard).is_none());
+
+    assert_eq!(
+        *s.lower_bound(Bound::Excluded(&10), guard).unwrap().value(),
+        2
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Excluded(&20), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Excluded(&30), guard).unwrap().value(),
+        4
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Excluded(&40), guard).unwrap().value(),
+        5
+    );
+    assert!(s.lower_bound(Bound::Excluded(&50), guard).is_none());
+
+    assert_eq!(
+        *s.lower_bound(Bound::Excluded(&7), guard).unwrap().value(),
+        1
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Excluded(&27), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.lower_bound(Bound::Excluded(&31), guard).unwrap().value(),
+        4
+    );
+    assert!(s.lower_bound(Bound::Excluded(&97), guard).is_none());
+}
+
+#[test]
+fn upper_bound() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    s.insert(30, 3, guard).release(guard);
+    s.insert(50, 5, guard).release(guard);
+    s.insert(10, 1, guard).release(guard);
+    s.insert(40, 4, guard).release(guard);
+    s.insert(20, 2, guard).release(guard);
+
+    assert_eq!(*s.upper_bound(Bound::Unbounded, guard).unwrap().value(), 5);
+
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&10), guard).unwrap().value(),
+        1
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&20), guard).unwrap().value(),
+        2
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&30), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&40), guard).unwrap().value(),
+        4
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&50), guard).unwrap().value(),
+        5
+    );
+
+    assert!(s.upper_bound(Bound::Included(&7), guard).is_none());
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&27), guard).unwrap().value(),
+        2
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&31), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Included(&97), guard).unwrap().value(),
+        5
+    );
+
+    assert!(s.upper_bound(Bound::Excluded(&10), guard).is_none());
+    assert_eq!(
+        *s.upper_bound(Bound::Excluded(&20), guard).unwrap().value(),
+        1
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Excluded(&30), guard).unwrap().value(),
+        2
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Excluded(&40), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Excluded(&50), guard).unwrap().value(),
+        4
+    );
+
+    assert!(s.upper_bound(Bound::Excluded(&7), guard).is_none());
+    assert_eq!(
+        *s.upper_bound(Bound::Excluded(&27), guard).unwrap().value(),
+        2
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Excluded(&31), guard).unwrap().value(),
+        3
+    );
+    assert_eq!(
+        *s.upper_bound(Bound::Excluded(&97), guard).unwrap().value(),
+        5
+    );
+}
+
+#[test]
+fn get_or_insert() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    s.insert(3, 3, guard).release(guard);
+    s.insert(5, 5, guard).release(guard);
+    s.insert(1, 1, guard).release(guard);
+    s.insert(4, 4, guard).release(guard);
+    s.insert(2, 2, guard).release(guard);
+
+    assert_eq!(*s.get(&4, guard).unwrap().value(), 4);
+    assert_eq!(*ref_entry(s.insert(4, 40, guard)).value(), 40);
+    assert_eq!(*s.get(&4, guard).unwrap().value(), 40);
+
+    assert_eq!(*s.get_or_insert(4, 400, guard).value(), 40);
+    assert_eq!(*s.get(&4, guard).unwrap().value(), 40);
+    assert_eq!(*s.get_or_insert(6, 600, guard).value(), 600);
+}
+
+#[test]
+fn get_or_insert_with() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    s.insert(3, 3, guard).release(guard);
+    s.insert(5, 5, guard).release(guard);
+    s.insert(1, 1, guard).release(guard);
+    s.insert(4, 4, guard).release(guard);
+    s.insert(2, 2, guard).release(guard);
+
+    assert_eq!(*s.get(&4, guard).unwrap().value(), 4);
+    assert_eq!(*ref_entry(s.insert(4, 40, guard)).value(), 40);
+    assert_eq!(*s.get(&4, guard).unwrap().value(), 40);
+
+    assert_eq!(*s.get_or_insert_with(4, || 400, guard).value(), 40);
+    assert_eq!(*s.get(&4, guard).unwrap().value(), 40);
+    assert_eq!(*s.get_or_insert_with(6, || 600, guard).value(), 600);
+}
+
+#[test]
+fn get_or_insert_with_panic() {
+    use std::panic;
+
+    let s = SkipList::new(epoch::default_collector().clone());
+    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let guard = &epoch::pin();
+        s.get_or_insert_with(4, || panic!(), guard);
+    }));
+    assert!(res.is_err());
+    assert!(s.is_empty());
+    let guard = &epoch::pin();
+    assert_eq!(*s.get_or_insert_with(4, || 40, guard).value(), 40);
+    assert_eq!(s.len(), 1);
+}
+
+#[test]
+fn get_or_insert_with_parallel_run() {
+    use std::sync::{Arc, Mutex};
+
+    let s = Arc::new(SkipList::new(epoch::default_collector().clone()));
+    let s2 = s.clone();
+    let called = Arc::new(Mutex::new(false));
+    let called2 = called.clone();
+    let handle = std::thread::spawn(move || {
+        let guard = &epoch::pin();
+        assert_eq!(
+            *s2.get_or_insert_with(
+                7,
+                || {
+                    *called2.lock().unwrap() = true;
+
+                    // allow main thread to run before we return result
+                    std::thread::sleep(std::time::Duration::from_secs(4));
+                    70
+                },
+                guard,
+            )
+            .value(),
+            700
+        );
+    });
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let guard = &epoch::pin();
+
+    // main thread writes the value first
+    assert_eq!(*s.get_or_insert(7, 700, guard).value(), 700);
+    handle.join().unwrap();
+    assert!(*called.lock().unwrap());
+}
+
+#[test]
+fn get_next_prev() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    s.insert(3, 3, guard).release(guard);
+    s.insert(5, 5, guard).release(guard);
+    s.insert(1, 1, guard).release(guard);
+    s.insert(4, 4, guard).release(guard);
+    s.insert(2, 2, guard).release(guard);
+
+    let mut e = s.get(&3, guard).unwrap();
+    assert_eq!(*e.next().unwrap().value(), 4);
+    assert_eq!(*e.prev().unwrap().value(), 2);
+    assert_eq!(*e.value(), 3);
+
+    e.move_prev();
+    assert_eq!(*e.next().unwrap().value(), 3);
+    assert_eq!(*e.prev().unwrap().value(), 1);
+    assert_eq!(*e.value(), 2);
+
+    e.move_prev();
+    assert_eq!(*e.next().unwrap().value(), 2);
+    assert!(e.prev().is_none());
+    assert_eq!(*e.value(), 1);
+
+    e.move_next();
+    e.move_next();
+    e.move_next();
+    e.move_next();
+    assert!(e.next().is_none());
+    assert_eq!(*e.prev().unwrap().value(), 4);
+    assert_eq!(*e.value(), 5);
+}
+
+#[test]
+fn front_and_back() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    assert!(s.front(guard).is_none());
+    assert!(s.back(guard).is_none());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10, guard);
+    }
+
+    assert_eq!(*s.front(guard).unwrap().key(), 2);
+    assert_eq!(*s.back(guard).unwrap().key(), 12);
+}
+
+#[test]
+fn iter() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10, guard).release(guard);
+    }
+
+    assert_eq!(
+        s.iter(guard).map(|e| *e.key()).collect::<Vec<_>>(),
+        &[2, 4, 5, 7, 8, 11, 12]
+    );
+
+    let mut it = s.iter(guard);
+    s.remove(&2, guard).unwrap().release(guard);
+    assert_eq!(*it.next().unwrap().key(), 4);
+    s.remove(&7, guard).unwrap().release(guard);
+    assert_eq!(*it.next().unwrap().key(), 5);
+    s.remove(&5, guard).unwrap().release(guard);
+    assert_eq!(*it.next().unwrap().key(), 8);
+    s.remove(&12, guard).unwrap().release(guard);
+    assert_eq!(*it.next().unwrap().key(), 11);
+    assert!(it.next().is_none());
+}
+
+#[test]
+fn iter_range() {
+    use std::ops::Bound::*;
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    let v = (0..10).map(|x| x * 10).collect::<Vec<_>>();
+    for &x in v.iter() {
+        s.insert(x, x, guard).release(guard);
+    }
+
+    assert_eq!(
+        s.iter(guard).map(|x| *x.value()).collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.iter(guard).rev().map(|x| *x.value()).collect::<Vec<_>>(),
+        vec![90, 80, 70, 60, 50, 40, 30, 20, 10, 0]
+    );
+    assert_eq!(
+        s.range(.., guard).map(|x| *x.value()).collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+
+    assert_eq!(
+        s.range((Included(&0), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&0), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&25), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&70), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&70), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&100), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Unbounded), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Unbounded, Included(&90)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&90)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&25)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&25)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&70)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&70)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&-1)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&-1)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&25), Included(&80)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Included(&25), Excluded(&80)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Included(&80)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Excluded(&80)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70]
+    );
+
+    assert_eq!(
+        s.range((Included(&25), Included(&25)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Included(&25), Excluded(&25)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Included(&25)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Excluded(&25)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&50), Included(&50)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![50]
+    );
+    assert_eq!(
+        s.range((Included(&50), Excluded(&50)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&50), Included(&50)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&50), Excluded(&50)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&100), Included(&-2)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Included(&100), Excluded(&-2)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Included(&-2)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Excluded(&-2)), guard)
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+}
+
+#[test]
+fn into_iter() {
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10, guard).release(guard);
+    }
+
+    assert_eq!(
+        s.into_iter().collect::<Vec<_>>(),
+        &[
+            (2, 20),
+            (4, 40),
+            (5, 50),
+            (7, 70),
+            (8, 80),
+            (11, 110),
+            (12, 120),
+        ]
+    );
+}
+
+#[test]
+fn clear() {
+    let guard = &mut epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10, guard).release(guard);
+    }
+
+    assert!(!s.is_empty());
+    assert_ne!(s.len(), 0);
+    s.clear(guard);
+    assert!(s.is_empty());
+    assert_eq!(s.len(), 0);
+}
+
+#[test]
+fn drops() {
+    static KEYS: AtomicUsize = AtomicUsize::new(0);
+    static VALUES: AtomicUsize = AtomicUsize::new(0);
+
+    let collector = epoch::Collector::new();
+    let handle = collector.register();
+    {
+        let guard = &handle.pin();
+
+        #[derive(Eq, PartialEq, Ord, PartialOrd)]
+        struct Key(i32);
+
+        impl Drop for Key {
+            fn drop(&mut self) {
+                KEYS.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        struct Value;
+
+        impl Drop for Value {
+            fn drop(&mut self) {
+                VALUES.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let s = SkipList::new(collector.clone());
+        for &x in &[4, 2, 12, 8, 7, 11, 5] {
+            s.insert(Key(x), Value, guard).release(guard);
+        }
+        assert_eq!(KEYS.load(Ordering::SeqCst), 0);
+        assert_eq!(VALUES.load(Ordering::SeqCst), 0);
+
+        let key7 = Key(7);
+        s.remove(&key7, guard).unwrap().release(guard);
+        assert_eq!(KEYS.load(Ordering::SeqCst), 0);
+        assert_eq!(VALUES.load(Ordering::SeqCst), 0);
+
+        drop(s);
+    }
+
+    handle.pin().flush();
+    handle.pin().flush();
+    assert_eq!(KEYS.load(Ordering::SeqCst), 8);
+    assert_eq!(VALUES.load(Ordering::SeqCst), 7);
+}

--- a/core/skiplist/map.rs
+++ b/core/skiplist/map.rs
@@ -1,0 +1,783 @@
+//! An ordered map based on a lock-free skip list. See [`SkipMap`].
+
+use std::borrow::Borrow;
+use std::fmt;
+use std::mem::ManuallyDrop;
+use std::ops::{Bound, RangeBounds};
+use std::ptr;
+
+use super::base::{self, try_pin_loop};
+use crossbeam_epoch as epoch;
+
+/// An ordered map based on a lock-free skip list.
+///
+/// This is an alternative to [`BTreeMap`] which supports
+/// concurrent access across multiple threads.
+///
+/// [`BTreeMap`]: std::collections::BTreeMap
+pub struct SkipMap<K, V> {
+    inner: base::SkipList<K, V>,
+}
+
+impl<K, V> SkipMap<K, V> {
+    /// Returns a new, empty map.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let map: SkipMap<i32, &str> = SkipMap::new();
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            inner: base::SkipList::new(epoch::default_collector().clone()),
+        }
+    }
+
+    /// Returns `true` if the map is empty.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let map: SkipMap<&str, &str> = SkipMap::new();
+    /// assert!(map.is_empty());
+    ///
+    /// map.insert("key", "value");
+    /// assert!(!map.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the number of entries in the map.
+    ///
+    /// If the map is being concurrently modified, consider the returned number just an
+    /// approximation without any guarantees.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let map = SkipMap::new();
+    /// map.insert(0, 1);
+    /// assert_eq!(map.len(), 1);
+    ///
+    /// for x in 1..=5 {
+    ///     map.insert(x, x + 1);
+    /// }
+    ///
+    /// assert_eq!(map.len(), 6);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl<K, V> SkipMap<K, V>
+where
+    K: Ord,
+{
+    /// Returns the entry with the smallest key.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(5, "five");
+    /// assert_eq!(*numbers.front().unwrap().value(), "five");
+    /// numbers.insert(6, "six");
+    /// assert_eq!(*numbers.front().unwrap().value(), "five");
+    /// ```
+    pub fn front(&self) -> Option<Entry<'_, K, V>> {
+        let guard = &epoch::pin();
+        try_pin_loop(|| self.inner.front(guard)).map(Entry::new)
+    }
+
+    /// Returns the entry with the largest key.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(5, "five");
+    /// assert_eq!(*numbers.back().unwrap().value(), "five");
+    /// numbers.insert(6, "six");
+    /// assert_eq!(*numbers.back().unwrap().value(), "six");
+    /// ```
+    pub fn back(&self) -> Option<Entry<'_, K, V>> {
+        let guard = &epoch::pin();
+        try_pin_loop(|| self.inner.back(guard)).map(Entry::new)
+    }
+
+    /// Returns `true` if the map contains a value for the specified key.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let ages = SkipMap::new();
+    /// ages.insert("Bill Gates", 64);
+    ///
+    /// assert!(ages.contains_key(&"Bill Gates"));
+    /// assert!(!ages.contains_key(&"Steve Jobs"));
+    /// ```
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let guard = &epoch::pin();
+        self.inner.contains_key(key, guard)
+    }
+
+    /// Returns an entry with the specified `key`.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers: SkipMap<&str, i32> = SkipMap::new();
+    /// assert!(numbers.get("six").is_none());
+    ///
+    /// numbers.insert("six", 6);
+    /// assert_eq!(*numbers.get("six").unwrap().value(), 6);
+    /// ```
+    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let guard = &epoch::pin();
+        try_pin_loop(|| self.inner.get(key, guard)).map(Entry::new)
+    }
+
+    /// Returns an `Entry` pointing to the lowest element whose key is above
+    /// the given bound. If no such element is found then `None` is
+    /// returned.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    /// use std::ops::Bound::*;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(6, "six");
+    /// numbers.insert(7, "seven");
+    /// numbers.insert(12, "twelve");
+    ///
+    /// let greater_than_five = numbers.lower_bound(Excluded(&5)).unwrap();
+    /// assert_eq!(*greater_than_five.value(), "six");
+    ///
+    /// let greater_than_six = numbers.lower_bound(Excluded(&6)).unwrap();
+    /// assert_eq!(*greater_than_six.value(), "seven");
+    ///
+    /// let greater_than_thirteen = numbers.lower_bound(Excluded(&13));
+    /// assert!(greater_than_thirteen.is_none());
+    /// ```
+    pub fn lower_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let guard = &epoch::pin();
+        try_pin_loop(|| self.inner.lower_bound(bound, guard)).map(Entry::new)
+    }
+
+    /// Returns an `Entry` pointing to the highest element whose key is below
+    /// the given bound. If no such element is found then `None` is
+    /// returned.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    /// use std::ops::Bound::*;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(6, "six");
+    /// numbers.insert(7, "seven");
+    /// numbers.insert(12, "twelve");
+    ///
+    /// let less_than_eight = numbers.upper_bound(Excluded(&8)).unwrap();
+    /// assert_eq!(*less_than_eight.value(), "seven");
+    ///
+    /// let less_than_six = numbers.upper_bound(Excluded(&6));
+    /// assert!(less_than_six.is_none());
+    /// ```
+    pub fn upper_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let guard = &epoch::pin();
+        try_pin_loop(|| self.inner.upper_bound(bound, guard)).map(Entry::new)
+    }
+
+    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
+    ////
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let ages = SkipMap::new();
+    /// let gates_age = ages.get_or_insert("Bill Gates", 64);
+    /// assert_eq!(*gates_age.value(), 64);
+    ///
+    /// ages.insert("Steve Jobs", 65);
+    /// let jobs_age = ages.get_or_insert("Steve Jobs", -1);
+    /// assert_eq!(*jobs_age.value(), 65);
+    /// ```
+    pub fn get_or_insert(&self, key: K, value: V) -> Entry<'_, K, V> {
+        let guard = &epoch::pin();
+        Entry::new(self.inner.get_or_insert(key, value, guard))
+    }
+
+    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist,
+    /// where value is calculated with a function.
+    ///
+    ///
+    /// <b>Note:</b> Another thread may write key value first, leading to the result of this closure
+    /// discarded. If closure is modifying some other state (such as shared counters or shared
+    /// objects), it may lead to <u>undesired behaviour</u> such as counters being changed without
+    /// result of closure inserted
+    ////
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let ages = SkipMap::new();
+    /// let gates_age = ages.get_or_insert_with("Bill Gates", || 64);
+    /// assert_eq!(*gates_age.value(), 64);
+    ///
+    /// ages.insert("Steve Jobs", 65);
+    /// let jobs_age = ages.get_or_insert_with("Steve Jobs", || -1);
+    /// assert_eq!(*jobs_age.value(), 65);
+    /// ```
+    pub fn get_or_insert_with<F>(&self, key: K, value_fn: F) -> Entry<'_, K, V>
+    where
+        F: FnOnce() -> V,
+    {
+        let guard = &epoch::pin();
+        Entry::new(self.inner.get_or_insert_with(key, value_fn, guard))
+    }
+
+    /// Returns an iterator over all entries in the map,
+    /// sorted by key.
+    ///
+    /// This iterator returns [`Entry`]s which
+    /// can be used to access keys and their associated values.
+    ///
+    /// # Examples
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(6, "six");
+    /// numbers.insert(7, "seven");
+    /// numbers.insert(12, "twelve");
+    ///
+    /// // Print then numbers from least to greatest
+    /// for entry in numbers.iter() {
+    ///     let number = entry.key();
+    ///     let number_str = entry.value();
+    ///     println!("{} is {}", number, number_str);
+    /// }
+    /// ```
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter {
+            inner: self.inner.ref_iter(),
+        }
+    }
+
+    /// Returns an iterator over a subset of entries in the map.
+    ///
+    /// This iterator returns [`Entry`]s which
+    /// can be used to access keys and their associated values.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(6, "six");
+    /// numbers.insert(7, "seven");
+    /// numbers.insert(12, "twelve");
+    ///
+    /// // Print all numbers in the map between 5 and 8.
+    /// for entry in numbers.range(5..=8) {
+    ///     let number = entry.key();
+    ///     let number_str = entry.value();
+    ///     println!("{} is {}", number, number_str);
+    /// }
+    /// ```
+    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, K, V>
+    where
+        K: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
+    {
+        Range {
+            inner: self.inner.ref_range(range),
+        }
+    }
+}
+
+impl<K, V> SkipMap<K, V>
+where
+    K: Ord + Send + 'static,
+    V: Send + 'static,
+{
+    /// Inserts a `key`-`value` pair into the map and returns the new entry.
+    ///
+    /// If there is an existing entry with this key, it will be removed before inserting the new
+    /// one.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the inserted key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let map = SkipMap::new();
+    /// map.insert("key", "value");
+    ///
+    /// assert_eq!(*map.get("key").unwrap().value(), "value");
+    /// ```
+    pub fn insert(&self, key: K, value: V) -> Entry<'_, K, V> {
+        let guard = &epoch::pin();
+        Entry::new(self.inner.insert(key, value, guard))
+    }
+
+    /// Inserts a `key`-`value` pair into the skip list and returns the new entry.
+    ///
+    /// If there is an existing entry with this key and compare(entry.value) returns true,
+    /// it will be removed before inserting the new one.
+    /// The closure will not be called if the key is not present.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the inserted key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let map = SkipMap::new();
+    /// map.insert("key", 1);
+    /// map.compare_insert("key", 0, |x| x < &0);
+    /// assert_eq!(*map.get("key").unwrap().value(), 1);
+    /// map.compare_insert("key", 2, |x| x < &2);
+    /// assert_eq!(*map.get("key").unwrap().value(), 2);
+    /// map.compare_insert("absent_key", 0, |_| false);
+    /// assert_eq!(*map.get("absent_key").unwrap().value(), 0);
+    /// ```
+    pub fn compare_insert<F>(&self, key: K, value: V, compare_fn: F) -> Entry<'_, K, V>
+    where
+        F: Fn(&V) -> bool,
+    {
+        let guard = &epoch::pin();
+        Entry::new(self.inner.compare_insert(key, value, compare_fn, guard))
+    }
+
+    /// Removes an entry with the specified `key` from the map and returns it.
+    ///
+    /// The value will not actually be dropped until all references to it have gone
+    /// out of scope.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the removed key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let map: SkipMap<&str, &str> = SkipMap::new();
+    /// assert!(map.remove("invalid key").is_none());
+    ///
+    /// map.insert("key", "value");
+    /// assert_eq!(*map.remove("key").unwrap().value(), "value");
+    /// ```
+    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, K, V>>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let guard = &epoch::pin();
+        self.inner.remove(key, guard).map(Entry::new)
+    }
+
+    /// Removes the entry with the lowest key
+    /// from the map. Returns the removed entry.
+    ///
+    /// The value will not actually be dropped until all references to it have gone
+    /// out of scope.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(6, "six");
+    /// numbers.insert(7, "seven");
+    /// numbers.insert(12, "twelve");
+    ///
+    /// assert_eq!(*numbers.pop_front().unwrap().value(), "six");
+    /// assert_eq!(*numbers.pop_front().unwrap().value(), "seven");
+    /// assert_eq!(*numbers.pop_front().unwrap().value(), "twelve");
+    ///
+    /// // All entries have been removed now.
+    /// assert!(numbers.is_empty());
+    /// ```
+    pub fn pop_front(&self) -> Option<Entry<'_, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.pop_front(guard).map(Entry::new)
+    }
+
+    /// Removes the entry with the greatest key from the map.
+    /// Returns the removed entry.
+    ///
+    /// The value will not actually be dropped until all references to it have gone
+    /// out of scope.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(6, "six");
+    /// numbers.insert(7, "seven");
+    /// numbers.insert(12, "twelve");
+    ///
+    /// assert_eq!(*numbers.pop_back().unwrap().value(), "twelve");
+    /// assert_eq!(*numbers.pop_back().unwrap().value(), "seven");
+    /// assert_eq!(*numbers.pop_back().unwrap().value(), "six");
+    ///
+    /// // All entries have been removed now.
+    /// assert!(numbers.is_empty());
+    /// ```
+    pub fn pop_back(&self) -> Option<Entry<'_, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.pop_back(guard).map(Entry::new)
+    }
+
+    /// Removes all entries from the map.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let people = SkipMap::new();
+    /// people.insert("Bill", "Gates");
+    /// people.insert("Steve", "Jobs");
+    ///
+    /// people.clear();
+    /// assert!(people.is_empty());
+    /// ```
+    pub fn clear(&self) {
+        let guard = &mut epoch::pin();
+        self.inner.clear(guard);
+    }
+}
+
+impl<K, V> Default for SkipMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> fmt::Debug for SkipMap<K, V>
+where
+    K: Ord + fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("SkipMap { .. }")
+    }
+}
+
+impl<K, V> IntoIterator for SkipMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> IntoIter<K, V> {
+        IntoIter {
+            inner: self.inner.into_iter(),
+        }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a SkipMap<K, V>
+where
+    K: Ord,
+{
+    type Item = Entry<'a, K, V>;
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Iter<'a, K, V> {
+        self.iter()
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for SkipMap<K, V>
+where
+    K: Ord,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let s = Self::new();
+        for (k, v) in iter {
+            s.get_or_insert(k, v);
+        }
+        s
+    }
+}
+
+/// A reference-counted entry in a map.
+pub struct Entry<'a, K, V> {
+    inner: ManuallyDrop<base::RefEntry<'a, K, V>>,
+}
+
+impl<'a, K, V> Entry<'a, K, V> {
+    fn new(inner: base::RefEntry<'a, K, V>) -> Self {
+        Self {
+            inner: ManuallyDrop::new(inner),
+        }
+    }
+
+    /// Returns a reference to the key.
+    pub fn key(&self) -> &K {
+        self.inner.key()
+    }
+
+    /// Returns a reference to the value.
+    pub fn value(&self) -> &V {
+        self.inner.value()
+    }
+
+    /// Returns `true` if the entry is removed from the map.
+    pub fn is_removed(&self) -> bool {
+        self.inner.is_removed()
+    }
+}
+
+impl<K, V> Drop for Entry<'_, K, V> {
+    fn drop(&mut self) {
+        unsafe {
+            ManuallyDrop::into_inner(ptr::read(&self.inner)).release_with_pin(epoch::pin);
+        }
+    }
+}
+
+impl<'a, K, V> Entry<'a, K, V>
+where
+    K: Ord,
+{
+    /// Moves to the next entry in the map.
+    pub fn move_next(&mut self) -> bool {
+        let guard = &epoch::pin();
+        self.inner.move_next(guard)
+    }
+
+    /// Moves to the previous entry in the map.
+    pub fn move_prev(&mut self) -> bool {
+        let guard = &epoch::pin();
+        self.inner.move_prev(guard)
+    }
+
+    /// Returns the next entry in the map.
+    pub fn next(&self) -> Option<Entry<'a, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.next(guard).map(Entry::new)
+    }
+
+    /// Returns the previous entry in the map.
+    pub fn prev(&self) -> Option<Entry<'a, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.prev(guard).map(Entry::new)
+    }
+}
+
+impl<K, V> Entry<'_, K, V>
+where
+    K: Ord + Send + 'static,
+    V: Send + 'static,
+{
+    /// Removes the entry from the map.
+    ///
+    /// Returns `true` if this call removed the entry and `false` if it was already removed.
+    pub fn remove(&self) -> bool {
+        let guard = &epoch::pin();
+        self.inner.remove(guard)
+    }
+}
+
+impl<K, V> Clone for Entry<'_, K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<K, V> fmt::Debug for Entry<'_, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Entry")
+            .field(self.key())
+            .field(self.value())
+            .finish()
+    }
+}
+
+/// An owning iterator over the entries of a `SkipMap`.
+pub struct IntoIter<K, V> {
+    inner: base::IntoIter<K, V>,
+}
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<(K, V)> {
+        self.inner.next()
+    }
+}
+
+impl<K, V> fmt::Debug for IntoIter<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("IntoIter { .. }")
+    }
+}
+
+/// An iterator over the entries of a `SkipMap`.
+pub struct Iter<'a, K, V> {
+    inner: base::RefIter<'a, K, V>,
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V>
+where
+    K: Ord,
+{
+    type Item = Entry<'a, K, V>;
+
+    fn next(&mut self) -> Option<Entry<'a, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.next(guard).map(Entry::new)
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V>
+where
+    K: Ord,
+{
+    fn next_back(&mut self) -> Option<Entry<'a, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.next_back(guard).map(Entry::new)
+    }
+}
+
+impl<K, V> fmt::Debug for Iter<'_, K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("Iter { .. }")
+    }
+}
+
+impl<K, V> Drop for Iter<'_, K, V> {
+    fn drop(&mut self) {
+        let guard = &epoch::pin();
+        self.inner.drop_impl(guard);
+    }
+}
+
+/// An iterator over a subset of entries of a `SkipMap`.
+pub struct Range<'a, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    pub(crate) inner: base::RefRange<'a, Q, R, K, V>,
+}
+
+impl<'a, Q, R, K, V> Iterator for Range<'a, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    type Item = Entry<'a, K, V>;
+
+    fn next(&mut self) -> Option<Entry<'a, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.next(guard).map(Entry::new)
+    }
+}
+
+impl<'a, Q, R, K, V> DoubleEndedIterator for Range<'a, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    fn next_back(&mut self) -> Option<Entry<'a, K, V>> {
+        let guard = &epoch::pin();
+        self.inner.next_back(guard).map(Entry::new)
+    }
+}
+
+impl<Q, R, K, V> fmt::Debug for Range<'_, Q, R, K, V>
+where
+    K: Ord + Borrow<Q> + fmt::Debug,
+    V: fmt::Debug,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Range")
+            .field("range", &self.inner.range)
+            .field("head", &self.inner.head)
+            .field("tail", &self.inner.tail)
+            .finish()
+    }
+}
+
+impl<Q, R, K, V> Drop for Range<'_, Q, R, K, V>
+where
+    K: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    fn drop(&mut self) {
+        let guard = &epoch::pin();
+        self.inner.drop_impl(guard);
+    }
+}

--- a/core/skiplist/map_tests.rs
+++ b/core/skiplist/map_tests.rs
@@ -1,0 +1,922 @@
+use std::{iter, ops::Bound, sync::Barrier};
+
+use crate::skiplist::SkipMap;
+use crossbeam_utils::thread;
+
+#[test]
+fn smoke() {
+    let m = SkipMap::new();
+    m.insert(1, 10);
+    m.insert(5, 50);
+    m.insert(7, 70);
+}
+
+#[test]
+fn is_empty() {
+    let s = SkipMap::new();
+    assert!(s.is_empty());
+
+    s.insert(1, 10);
+    assert!(!s.is_empty());
+    s.insert(2, 20);
+    s.insert(3, 30);
+    assert!(!s.is_empty());
+
+    s.remove(&2);
+    assert!(!s.is_empty());
+
+    s.remove(&1);
+    assert!(!s.is_empty());
+
+    s.remove(&3);
+    assert!(s.is_empty());
+}
+
+#[test]
+fn insert() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let not_present = [1, 3, 6, 9, 10];
+    let s = SkipMap::new();
+
+    for &x in &insert {
+        s.insert(x, x * 10);
+        assert_eq!(*s.get(&x).unwrap().value(), x * 10);
+    }
+
+    for &x in &not_present {
+        assert!(s.get(&x).is_none());
+    }
+}
+
+#[test]
+fn compare_and_insert() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let not_present = [1, 3, 6, 9, 10];
+    let s = SkipMap::new();
+
+    for &x in &insert {
+        s.insert(x, x * 10);
+    }
+
+    for &x in &insert {
+        let value = x * 5;
+        let old_value = *s.get(&x).unwrap().value();
+        s.compare_insert(x, value, |x| x < &value);
+        assert_eq!(*s.get(&x).unwrap().value(), old_value);
+    }
+
+    for &x in &insert {
+        let value = x * 15;
+        s.compare_insert(x, value, |x| x < &value);
+        assert_eq!(*s.get(&x).unwrap().value(), value);
+    }
+
+    for &x in &not_present {
+        assert!(s.get(&x).is_none());
+    }
+}
+
+#[test]
+fn compare_insert_with_absent_key() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let s = SkipMap::new();
+
+    // The closure will not be called if the key is not present,
+    // so the key-value will be inserted into the map
+    for &x in &insert {
+        let value = x * 15;
+        s.compare_insert(x, value, |_| false);
+        assert_eq!(*s.get(&x).unwrap().value(), value);
+    }
+}
+
+#[test]
+fn remove() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let not_present = [1, 3, 6, 9, 10];
+    let remove = [2, 12, 8];
+    let remaining = [0, 4, 5, 7, 11];
+
+    let s = SkipMap::new();
+
+    for &x in &insert {
+        s.insert(x, x * 10);
+    }
+    for x in &not_present {
+        assert!(s.remove(x).is_none());
+    }
+    for x in &remove {
+        assert!(s.remove(x).is_some());
+    }
+
+    let mut v = vec![];
+    let mut e = s.front().unwrap();
+    loop {
+        v.push(*e.key());
+        if !e.move_next() {
+            break;
+        }
+    }
+
+    assert_eq!(v, remaining);
+    for x in &insert {
+        s.remove(x);
+    }
+    assert!(s.is_empty());
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/672
+#[test]
+fn concurrent_insert() {
+    for _ in 0..100 {
+        let set: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+        let barrier = Barrier::new(2);
+        thread::scope(|s| {
+            s.spawn(|_| {
+                barrier.wait();
+                set.insert(1, 1);
+            });
+            s.spawn(|_| {
+                barrier.wait();
+                set.insert(1, 1);
+            });
+        })
+        .unwrap();
+    }
+}
+
+#[test]
+fn concurrent_compare_and_insert() {
+    let set: SkipMap<i32, i32> = SkipMap::new();
+    let set = std::sync::Arc::new(set);
+    let len = 100;
+    let mut handlers = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        let set = set.clone();
+        let handler = std::thread::spawn(move || {
+            set.compare_insert(1, i, |j| j < &i);
+        });
+        handlers.push(handler);
+    }
+    for handler in handlers {
+        handler.join().unwrap();
+    }
+    assert_eq!(*set.get(&1).unwrap().value(), len - 1);
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/672
+#[test]
+fn concurrent_remove() {
+    for _ in 0..100 {
+        let set: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+        let barrier = Barrier::new(2);
+        thread::scope(|s| {
+            s.spawn(|_| {
+                barrier.wait();
+                set.remove(&1);
+            });
+            s.spawn(|_| {
+                barrier.wait();
+                set.remove(&1);
+            });
+        })
+        .unwrap();
+    }
+}
+
+#[test]
+fn next_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    let mut iter = map.iter();
+    let e = iter.next_back();
+    assert!(e.is_some());
+    let e = iter.next();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+#[test]
+fn next_back_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    map.insert(1, 1);
+    let mut iter = map.iter();
+    let e = iter.next();
+    assert!(e.is_some());
+    let e = iter.next_back();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+#[test]
+fn range_next_memory_leak() {
+    let map: SkipMap<i32, i32> = iter::once((1, 1)).collect();
+    let mut iter = map.range(0..);
+    let e = iter.next();
+    assert!(e.is_some());
+    let e = iter.next_back();
+    assert!(e.is_none());
+    map.remove(&1);
+}
+
+#[test]
+fn entry() {
+    let s = SkipMap::new();
+
+    assert!(s.front().is_none());
+    assert!(s.back().is_none());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10);
+    }
+
+    let mut e = s.front().unwrap();
+    assert_eq!(*e.key(), 2);
+    assert!(!e.move_prev());
+    assert!(e.move_next());
+    assert_eq!(*e.key(), 4);
+
+    e = s.back().unwrap();
+    assert_eq!(*e.key(), 12);
+    assert!(!e.move_next());
+    assert!(e.move_prev());
+    assert_eq!(*e.key(), 11);
+}
+
+#[test]
+fn ordered_iter() {
+    let s: SkipMap<i32, i32> = SkipMap::new();
+    s.insert(1, 1);
+
+    let mut iter = s.iter();
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(2, 2);
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(3, 3);
+    s.insert(4, 4);
+    s.insert(5, 5);
+    assert_eq!(*iter.next_back().unwrap().key(), 5);
+    assert_eq!(*iter.next().unwrap().key(), 3);
+    assert_eq!(*iter.next_back().unwrap().key(), 4);
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+}
+
+#[test]
+fn ordered_range() {
+    let s: SkipMap<i32, i32> = SkipMap::new();
+    s.insert(1, 1);
+
+    let mut iter = s.range(0..);
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(2, 2);
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    s.insert(3, 3);
+    s.insert(4, 4);
+    s.insert(5, 5);
+    assert_eq!(*iter.next_back().unwrap().key(), 5);
+    assert_eq!(*iter.next().unwrap().key(), 3);
+    assert_eq!(*iter.next_back().unwrap().key(), 4);
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+    assert!(iter.next().is_none());
+    assert!(iter.next_back().is_none());
+}
+#[test]
+fn entry_remove() {
+    let s = SkipMap::new();
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10);
+    }
+
+    let mut e = s.get(&7).unwrap();
+    assert!(!e.is_removed());
+    assert!(e.remove());
+    assert!(e.is_removed());
+
+    e.move_prev();
+    e.move_next();
+    assert_ne!(*e.key(), 7);
+
+    for e in s.iter() {
+        assert!(!s.is_empty());
+        assert_ne!(s.len(), 0);
+        e.remove();
+    }
+    assert!(s.is_empty());
+    assert_eq!(s.len(), 0);
+}
+
+#[test]
+fn entry_reposition() {
+    let s = SkipMap::new();
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10);
+    }
+
+    let mut e = s.get(&7).unwrap();
+    assert!(!e.is_removed());
+    assert!(e.remove());
+    assert!(e.is_removed());
+
+    s.insert(7, 700);
+    e.move_prev();
+    e.move_next();
+    assert_eq!(*e.key(), 7);
+}
+
+#[test]
+fn len() {
+    let s = SkipMap::new();
+    assert_eq!(s.len(), 0);
+
+    for (i, &x) in [4, 2, 12, 8, 7, 11, 5].iter().enumerate() {
+        s.insert(x, x * 10);
+        assert_eq!(s.len(), i + 1);
+    }
+
+    s.insert(5, 0);
+    assert_eq!(s.len(), 7);
+    s.insert(5, 0);
+    assert_eq!(s.len(), 7);
+
+    s.remove(&6);
+    assert_eq!(s.len(), 7);
+    s.remove(&5);
+    assert_eq!(s.len(), 6);
+    s.remove(&12);
+    assert_eq!(s.len(), 5);
+}
+
+#[test]
+fn insert_and_remove() {
+    let s = SkipMap::new();
+    let keys = || s.iter().map(|e| *e.key()).collect::<Vec<_>>();
+
+    s.insert(3, 0);
+    s.insert(5, 0);
+    s.insert(1, 0);
+    s.insert(4, 0);
+    s.insert(2, 0);
+    assert_eq!(keys(), [1, 2, 3, 4, 5]);
+
+    assert!(s.remove(&4).is_some());
+    assert_eq!(keys(), [1, 2, 3, 5]);
+    assert!(s.remove(&3).is_some());
+    assert_eq!(keys(), [1, 2, 5]);
+    assert!(s.remove(&1).is_some());
+    assert_eq!(keys(), [2, 5]);
+
+    assert!(s.remove(&1).is_none());
+    assert_eq!(keys(), [2, 5]);
+    assert!(s.remove(&3).is_none());
+    assert_eq!(keys(), [2, 5]);
+
+    assert!(s.remove(&2).is_some());
+    assert_eq!(keys(), [5]);
+    assert!(s.remove(&5).is_some());
+    assert!(keys().is_empty());
+
+    s.insert(3, 0);
+    assert_eq!(keys(), [3]);
+    s.insert(1, 0);
+    assert_eq!(keys(), [1, 3]);
+    s.insert(3, 0);
+    assert_eq!(keys(), [1, 3]);
+    s.insert(5, 0);
+    assert_eq!(keys(), [1, 3, 5]);
+
+    assert!(s.remove(&3).is_some());
+    assert_eq!(keys(), [1, 5]);
+    assert!(s.remove(&1).is_some());
+    assert_eq!(keys(), [5]);
+    assert!(s.remove(&3).is_none());
+    assert_eq!(keys(), [5]);
+    assert!(s.remove(&5).is_some());
+    assert!(keys().is_empty());
+}
+
+#[test]
+fn get() {
+    let s = SkipMap::new();
+    s.insert(30, 3);
+    s.insert(50, 5);
+    s.insert(10, 1);
+    s.insert(40, 4);
+    s.insert(20, 2);
+
+    assert_eq!(*s.get(&10).unwrap().value(), 1);
+    assert_eq!(*s.get(&20).unwrap().value(), 2);
+    assert_eq!(*s.get(&30).unwrap().value(), 3);
+    assert_eq!(*s.get(&40).unwrap().value(), 4);
+    assert_eq!(*s.get(&50).unwrap().value(), 5);
+
+    assert!(s.get(&7).is_none());
+    assert!(s.get(&27).is_none());
+    assert!(s.get(&31).is_none());
+    assert!(s.get(&97).is_none());
+}
+
+#[test]
+fn lower_bound() {
+    let s = SkipMap::new();
+    s.insert(30, 3);
+    s.insert(50, 5);
+    s.insert(10, 1);
+    s.insert(40, 4);
+    s.insert(20, 2);
+
+    assert_eq!(*s.lower_bound(Bound::Unbounded).unwrap().value(), 1);
+
+    assert_eq!(*s.lower_bound(Bound::Included(&10)).unwrap().value(), 1);
+    assert_eq!(*s.lower_bound(Bound::Included(&20)).unwrap().value(), 2);
+    assert_eq!(*s.lower_bound(Bound::Included(&30)).unwrap().value(), 3);
+    assert_eq!(*s.lower_bound(Bound::Included(&40)).unwrap().value(), 4);
+    assert_eq!(*s.lower_bound(Bound::Included(&50)).unwrap().value(), 5);
+
+    assert_eq!(*s.lower_bound(Bound::Included(&7)).unwrap().value(), 1);
+    assert_eq!(*s.lower_bound(Bound::Included(&27)).unwrap().value(), 3);
+    assert_eq!(*s.lower_bound(Bound::Included(&31)).unwrap().value(), 4);
+    assert!(s.lower_bound(Bound::Included(&97)).is_none());
+
+    assert_eq!(*s.lower_bound(Bound::Excluded(&10)).unwrap().value(), 2);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&20)).unwrap().value(), 3);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&30)).unwrap().value(), 4);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&40)).unwrap().value(), 5);
+    assert!(s.lower_bound(Bound::Excluded(&50)).is_none());
+
+    assert_eq!(*s.lower_bound(Bound::Excluded(&7)).unwrap().value(), 1);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&27)).unwrap().value(), 3);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&31)).unwrap().value(), 4);
+    assert!(s.lower_bound(Bound::Excluded(&97)).is_none());
+}
+
+#[test]
+fn upper_bound() {
+    let s = SkipMap::new();
+    s.insert(30, 3);
+    s.insert(50, 5);
+    s.insert(10, 1);
+    s.insert(40, 4);
+    s.insert(20, 2);
+
+    assert_eq!(*s.upper_bound(Bound::Unbounded).unwrap().value(), 5);
+
+    assert_eq!(*s.upper_bound(Bound::Included(&10)).unwrap().value(), 1);
+    assert_eq!(*s.upper_bound(Bound::Included(&20)).unwrap().value(), 2);
+    assert_eq!(*s.upper_bound(Bound::Included(&30)).unwrap().value(), 3);
+    assert_eq!(*s.upper_bound(Bound::Included(&40)).unwrap().value(), 4);
+    assert_eq!(*s.upper_bound(Bound::Included(&50)).unwrap().value(), 5);
+
+    assert!(s.upper_bound(Bound::Included(&7)).is_none());
+    assert_eq!(*s.upper_bound(Bound::Included(&27)).unwrap().value(), 2);
+    assert_eq!(*s.upper_bound(Bound::Included(&31)).unwrap().value(), 3);
+    assert_eq!(*s.upper_bound(Bound::Included(&97)).unwrap().value(), 5);
+
+    assert!(s.upper_bound(Bound::Excluded(&10)).is_none());
+    assert_eq!(*s.upper_bound(Bound::Excluded(&20)).unwrap().value(), 1);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&30)).unwrap().value(), 2);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&40)).unwrap().value(), 3);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&50)).unwrap().value(), 4);
+
+    assert!(s.upper_bound(Bound::Excluded(&7)).is_none());
+    assert_eq!(*s.upper_bound(Bound::Excluded(&27)).unwrap().value(), 2);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&31)).unwrap().value(), 3);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&97)).unwrap().value(), 5);
+}
+
+#[test]
+fn get_or_insert() {
+    let s = SkipMap::new();
+    s.insert(3, 3);
+    s.insert(5, 5);
+    s.insert(1, 1);
+    s.insert(4, 4);
+    s.insert(2, 2);
+
+    assert_eq!(*s.get(&4).unwrap().value(), 4);
+    assert_eq!(*s.insert(4, 40).value(), 40);
+    assert_eq!(*s.get(&4).unwrap().value(), 40);
+
+    assert_eq!(*s.get_or_insert(4, 400).value(), 40);
+    assert_eq!(*s.get(&4).unwrap().value(), 40);
+    assert_eq!(*s.get_or_insert(6, 600).value(), 600);
+}
+
+#[test]
+fn get_or_insert_with() {
+    let s = SkipMap::new();
+    s.insert(3, 3);
+    s.insert(5, 5);
+    s.insert(1, 1);
+    s.insert(4, 4);
+    s.insert(2, 2);
+
+    assert_eq!(*s.get(&4).unwrap().value(), 4);
+    assert_eq!(*s.insert(4, 40).value(), 40);
+    assert_eq!(*s.get(&4).unwrap().value(), 40);
+
+    assert_eq!(*s.get_or_insert_with(4, || 400).value(), 40);
+    assert_eq!(*s.get(&4).unwrap().value(), 40);
+    assert_eq!(*s.get_or_insert_with(6, || 600).value(), 600);
+}
+
+#[test]
+fn get_or_insert_with_panic() {
+    use std::panic;
+
+    let s = SkipMap::new();
+    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        s.get_or_insert_with(4, || panic!());
+    }));
+    assert!(res.is_err());
+    assert!(s.is_empty());
+    assert_eq!(*s.get_or_insert_with(4, || 40).value(), 40);
+    assert_eq!(s.len(), 1);
+}
+
+#[test]
+fn get_or_insert_with_parallel_run() {
+    use std::sync::{Arc, Mutex};
+
+    let s = Arc::new(SkipMap::new());
+    let s2 = s.clone();
+    let called = Arc::new(Mutex::new(false));
+    let called2 = called.clone();
+    let handle = std::thread::spawn(move || {
+        assert_eq!(
+            *s2.get_or_insert_with(7, || {
+                *called2.lock().unwrap() = true;
+
+                // allow main thread to run before we return result
+                std::thread::sleep(std::time::Duration::from_secs(4));
+                70
+            })
+            .value(),
+            700
+        );
+    });
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // main thread writes the value first
+    assert_eq!(*s.get_or_insert(7, 700).value(), 700);
+    handle.join().unwrap();
+    assert!(*called.lock().unwrap());
+}
+
+#[test]
+fn get_next_prev() {
+    let s = SkipMap::new();
+    s.insert(3, 3);
+    s.insert(5, 5);
+    s.insert(1, 1);
+    s.insert(4, 4);
+    s.insert(2, 2);
+
+    let mut e = s.get(&3).unwrap();
+    assert_eq!(*e.next().unwrap().value(), 4);
+    assert_eq!(*e.prev().unwrap().value(), 2);
+    assert_eq!(*e.value(), 3);
+
+    e.move_prev();
+    assert_eq!(*e.next().unwrap().value(), 3);
+    assert_eq!(*e.prev().unwrap().value(), 1);
+    assert_eq!(*e.value(), 2);
+
+    e.move_prev();
+    assert_eq!(*e.next().unwrap().value(), 2);
+    assert!(e.prev().is_none());
+    assert_eq!(*e.value(), 1);
+
+    e.move_next();
+    e.move_next();
+    e.move_next();
+    e.move_next();
+    assert!(e.next().is_none());
+    assert_eq!(*e.prev().unwrap().value(), 4);
+    assert_eq!(*e.value(), 5);
+}
+
+#[test]
+fn front_and_back() {
+    let s = SkipMap::new();
+    assert!(s.front().is_none());
+    assert!(s.back().is_none());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10);
+    }
+
+    assert_eq!(*s.front().unwrap().key(), 2);
+    assert_eq!(*s.back().unwrap().key(), 12);
+}
+
+#[test]
+fn iter() {
+    let s = SkipMap::new();
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10);
+    }
+
+    assert_eq!(
+        s.iter().map(|e| *e.key()).collect::<Vec<_>>(),
+        &[2, 4, 5, 7, 8, 11, 12]
+    );
+
+    let mut it = s.iter();
+    s.remove(&2);
+    assert_eq!(*it.next().unwrap().key(), 4);
+    s.remove(&7);
+    assert_eq!(*it.next().unwrap().key(), 5);
+    s.remove(&5);
+    assert_eq!(*it.next().unwrap().key(), 8);
+    s.remove(&12);
+    assert_eq!(*it.next().unwrap().key(), 11);
+    assert!(it.next().is_none());
+}
+
+#[test]
+fn iter_range() {
+    use std::ops::Bound::*;
+    let s = SkipMap::new();
+    let v = (0..10).map(|x| x * 10).collect::<Vec<_>>();
+    for &x in v.iter() {
+        s.insert(x, x);
+    }
+
+    assert_eq!(
+        s.iter().map(|x| *x.value()).collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.iter().rev().map(|x| *x.value()).collect::<Vec<_>>(),
+        vec![90, 80, 70, 60, 50, 40, 30, 20, 10, 0]
+    );
+    assert_eq!(
+        s.range(..).map(|x| *x.value()).collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+
+    assert_eq!(
+        s.range((Included(&0), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&0), Included(&60)))
+            .rev()
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![60, 50, 40, 30, 20, 10, 0]
+    );
+    assert_eq!(
+        s.range((Excluded(&0), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&25), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&70), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&70), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&100), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Unbounded))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Unbounded, Included(&90)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&90)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&25)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&25)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&70)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&70)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&-1)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&-1)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&25), Included(&80)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Included(&25), Excluded(&80)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Included(&80)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Excluded(&80)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70]
+    );
+
+    assert_eq!(
+        s.range((Included(&25), Included(&25)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Included(&25), Excluded(&25)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Included(&25)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Excluded(&25)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&50), Included(&50)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        vec![50]
+    );
+    assert_eq!(
+        s.range((Included(&50), Excluded(&50)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&50), Included(&50)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&50), Excluded(&50)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&100), Included(&-2)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Included(&100), Excluded(&-2)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Included(&-2)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Excluded(&-2)))
+            .map(|x| *x.value())
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/671
+#[test]
+fn iter_range2() {
+    let set: SkipMap<_, _> = [1, 3, 5].iter().map(|x| (*x, *x)).collect();
+    assert_eq!(set.range(2..4).count(), 1);
+    set.insert(3, 3);
+}
+
+#[test]
+fn into_iter() {
+    let s = SkipMap::new();
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10);
+    }
+
+    assert_eq!(
+        s.into_iter().collect::<Vec<_>>(),
+        &[
+            (2, 20),
+            (4, 40),
+            (5, 50),
+            (7, 70),
+            (8, 80),
+            (11, 110),
+            (12, 120),
+        ]
+    );
+}
+
+#[test]
+fn clear() {
+    let s = SkipMap::new();
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x, x * 10);
+    }
+
+    assert!(!s.is_empty());
+    assert_ne!(s.len(), 0);
+    s.clear();
+    assert!(s.is_empty());
+    assert_eq!(s.len(), 0);
+}

--- a/core/skiplist/mod.rs
+++ b/core/skiplist/mod.rs
@@ -1,0 +1,254 @@
+//! Concurrent maps and sets based on [skip lists].
+//!
+//! This crate provides the types [`SkipMap`] and [`SkipSet`].
+//! These data structures provide an interface similar to [`BTreeMap`] and [`BTreeSet`],
+//! respectively, except they support safe concurrent access across
+//! multiple threads.
+//!
+//! # Concurrent access
+//! [`SkipMap`] and [`SkipSet`] implement [`Send`] and [`Sync`],
+//! so they can be shared across threads with ease.
+//!
+//! Methods which mutate the map, such as [`insert`],
+//! take `&self` rather than `&mut self`. This allows
+//! them to be invoked concurrently.
+//!
+//! ```
+//! use turso_core::skiplist::SkipMap;
+//! use crossbeam_utils::thread::scope;
+//!
+//! let person_ages = SkipMap::new();
+//!
+//! scope(|s| {
+//!     // Insert entries into the map from multiple threads.
+//!     s.spawn(|_| {
+//!         person_ages.insert("Spike Garrett", 22);
+//!         person_ages.insert("Stan Hancock", 47);
+//!         person_ages.insert("Rea Bryan", 234);
+//!
+//!         assert_eq!(person_ages.get("Spike Garrett").unwrap().value(), &22);
+//!     });
+//!     s.spawn(|_| {
+//!         person_ages.insert("Bryon Conroy", 65);
+//!         person_ages.insert("Lauren Reilly", 2);
+//!     });
+//! }).unwrap();
+//!
+//! assert!(person_ages.contains_key("Spike Garrett"));
+//! person_ages.remove("Rea Bryan");
+//! assert!(!person_ages.contains_key("Rea Bryan"));
+//!
+//! ```
+//!
+//! Concurrent access to skip lists is lock-free and sound.
+//! Threads won't get blocked waiting for other threads to finish operating
+//! on the map.
+//!
+//! Be warned that, because of this lock-freedom, it's easy to introduce
+//! race conditions into your code. For example:
+//! ```no_run
+//! use turso_core::skiplist::SkipSet;
+//! use crossbeam_utils::thread::scope;
+//!
+//! let numbers = SkipSet::new();
+//! scope(|s| {
+//!     // Spawn a thread which will remove 5 from the set.
+//!     s.spawn(|_| {
+//!         numbers.remove(&5);
+//!     });
+//!
+//!     // While the thread above is running, insert a value into the set.
+//!     numbers.insert(5);
+//!
+//!     // This check can fail!
+//!     // The other thread may remove the value
+//!     // before we perform this check.
+//!     assert!(numbers.contains(&5));
+//! }).unwrap();
+//! ```
+//!
+//! In effect, a _single_ operation on the map, such as [`insert`],
+//! operates atomically: race conditions are impossible. However,
+//! concurrent calls to functions can become interleaved across
+//! threads, introducing non-determinism.
+//!
+//! To avoid this sort of race condition, never assume that a collection's
+//! state will remain the same across multiple lines of code. For instance,
+//! in the example above, the problem arises from the assumption that
+//! the map won't be mutated between the calls to `insert` and `contains`.
+//! In sequential code, this would be correct. But when multiple
+//! threads are introduced, more care is needed.
+//!
+//! Note that race conditions do not violate Rust's memory safety rules.
+//! A race between multiple threads can never cause memory errors or
+//! segfaults. A race condition is a _logic error_ in its entirety.
+//!
+//! # Mutable access to elements
+//! [`SkipMap`] and [`SkipSet`] provide no way to retrieve a mutable reference
+//! to a value. Since access methods can be called concurrently, providing
+//! e.g. a `get_mut` function could cause data races.
+//!
+//! A solution to the above is to have the implementation wrap
+//! each value in a lock. However, this has some repercussions:
+//! * The map would no longer be lock-free, inhibiting scalability
+//!   and allowing for deadlocks.
+//! * If a user of the map doesn't need mutable access, then they pay
+//!   the price of locks without actually needing them.
+//!
+//! Instead, the approach taken by this crate gives more control to the user.
+//! If mutable access is needed, then you can use interior mutability,
+//! such as [`RwLock`]: `SkipMap<Key, RwLock<Value>>`.
+//!
+//! # Garbage collection
+//! A problem faced by many concurrent data structures
+//! is choosing when to free unused memory. Care must be
+//! taken to prevent use-after-frees and double-frees, both
+//! of which cause undefined behavior.
+//!
+//! Consider the following sequence of events operating on a [`SkipMap`]:
+//! * Thread A calls [`get`] and holds a reference to a value in the map.
+//! * Thread B removes that key from the map.
+//! * Thread A now attempts to access the value.
+//!
+//! What happens here? If the map implementation frees the memory
+//! belonging to a value when it is
+//! removed, then a user-after-free occurs, resulting in memory corruption.
+//!
+//! To solve the above, this crate uses the _epoch-based memory reclamation_ mechanism
+//! implemented in [`crossbeam-epoch`]. Simplified, a value removed from the map
+//! is not freed until after all references to it have been dropped. This mechanism
+//! is similar to the garbage collection found in some languages, such as Java, except
+//! it operates solely on the values inside the map.
+//!
+//! This garbage collection scheme functions automatically; users don't have to worry about it.
+//! However, keep in mind that holding [`Entry`] handles to entries in the map will prevent
+//! that memory from being freed until at least after the handles are dropped.
+//!
+//! # Performance versus B-trees
+//! In general, when you need concurrent writes
+//! to an ordered collection, skip lists are a reasonable choice.
+//! However, they can be substantially slower than B-trees
+//! in some scenarios.
+//!
+//! The main benefit of a skip list over a `RwLock<BTreeMap>`
+//! is that it allows concurrent writes to progress without
+//! mutual exclusion. However, when the frequency
+//! of writes is low, this benefit isn't as useful.
+//! In these cases, a shared [`BTreeMap`] may be a faster option.
+//!
+//! These guidelines should be taken with a grain of salt—performance
+//! in practice varies depending on your use case.
+//! In the end, the best way to choose between [`BTreeMap`] and [`SkipMap`]
+//! is to benchmark them in your own application.
+//!
+//! # Alternatives
+//! This crate implements _ordered_ maps and sets, akin to [`BTreeMap`] and [`BTreeSet`].
+//! In many situations, however, a defined order on elements is not required. For these
+//! purposes, unordered maps will suffice. In addition, unordered maps
+//! often have better performance characteristics than their ordered alternatives.
+//!
+//! Crossbeam [does not currently provide a concurrent unordered map](https://github.com/crossbeam-rs/rfcs/issues/32).
+//! That said, here are some other crates which may suit you:
+//! * [`DashMap`](https://docs.rs/dashmap) implements a novel concurrent hash map
+//!   with good performance characteristics.
+//! * [`flurry`](https://docs.rs/flurry) is a Rust port of Java's `ConcurrentHashMap`.
+//!
+//! [`insert`]: SkipMap::insert
+//! [`get`]: SkipMap::get
+//! [`Entry`]: map::Entry
+//! [skip lists]: https://en.wikipedia.org/wiki/Skip_list
+//! [`crossbeam-epoch`]: https://docs.rs/crossbeam-epoch
+//! [`BTreeMap`]: std::collections::BTreeMap
+//! [`BTreeSet`]: std::collections::BTreeSet
+//! [`RwLock`]: std::sync::RwLock
+//!
+//! # Examples
+//! [`SkipMap`] basic usage:
+//! ```
+//! use turso_core::skiplist::SkipMap;
+//!
+//! // Note that the variable doesn't have to be mutable:
+//! // SkipMap methods take &self to support concurrent access.
+//! let movie_reviews = SkipMap::new();
+//!
+//! // Insert some key-value pairs.
+//! movie_reviews.insert("Office Space",       "Deals with real issues in the workplace.");
+//! movie_reviews.insert("Pulp Fiction",       "Masterpiece.");
+//! movie_reviews.insert("The Godfather",      "Very enjoyable.");
+//! movie_reviews.insert("The Blues Brothers", "Eye lyked it a lot.");
+//!
+//! // Get the value associated with a key.
+//! // get() returns an Entry, which gives
+//! // references to the key and value.
+//! let pulp_fiction = movie_reviews.get("Pulp Fiction").unwrap();
+//! assert_eq!(*pulp_fiction.key(), "Pulp Fiction");
+//! assert_eq!(*pulp_fiction.value(), "Masterpiece.");
+//!
+//! // Remove a key-value pair.
+//! movie_reviews.remove("The Blues Brothers");
+//! assert!(movie_reviews.get("The Blues Brothers").is_none());
+//!
+//! // Iterate over the reviews. Since SkipMap
+//! // is an ordered map, the iterator will yield
+//! // keys in lexicographical order.
+//! for entry in &movie_reviews {
+//!     let movie = entry.key();
+//!     let review = entry.value();
+//!     println!("{}: \"{}\"", movie, review);
+//! }
+//! ```
+//!
+//! [`SkipSet`] basic usage:
+//! ```
+//! use turso_core::skiplist::SkipSet;
+//!
+//! let books = SkipSet::new();
+//!
+//! // Add some books to the set.
+//! books.insert("A Dance With Dragons");
+//! books.insert("To Kill a Mockingbird");
+//! books.insert("The Odyssey");
+//! books.insert("The Great Gatsby");
+//!
+//! // Check for a specific one.
+//! if !books.contains("The Winds of Winter") {
+//!    println!("We have {} books, but The Winds of Winter ain't one.",
+//!             books.len());
+//! }
+//!
+//! // Remove a book from the set.
+//! books.remove("To Kill a Mockingbird");
+//! assert!(!books.contains("To Kill a Mockingbird"));
+//!
+//! // Iterate over the books in the set.
+//! // Values are returned in lexicographical order.
+//! for entry in &books {
+//!     let book = entry.value();
+//!     println!("{}", book);
+//! }
+//! ```
+//!
+//! # Provenance
+//! Vendored from the `crossbeam-skiplist` crate, version 0.1.3
+//! (<https://github.com/crossbeam-rs/crossbeam>), licensed under MIT OR
+//! Apache-2.0 (see `licenses/core/`). Local modifications are kept minimal;
+//! prefer upstreaming fixes.
+
+#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
+
+pub mod base;
+#[doc(inline)]
+pub use base::SkipList;
+
+pub mod map;
+pub mod set;
+
+#[doc(inline)]
+pub use self::{map::SkipMap, set::SkipSet};
+
+#[cfg(test)]
+mod base_tests;
+#[cfg(test)]
+mod map_tests;
+#[cfg(test)]
+mod set_tests;

--- a/core/skiplist/set.rs
+++ b/core/skiplist/set.rs
@@ -1,0 +1,629 @@
+//! A set based on a lock-free skip list. See [`SkipSet`].
+
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
+use std::ops::{Bound, RangeBounds};
+
+use super::map;
+
+/// A set based on a lock-free skip list.
+///
+/// This is an alternative to [`BTreeSet`] which supports
+/// concurrent access across multiple threads.
+///
+/// [`BTreeSet`]: std::collections::BTreeSet
+pub struct SkipSet<T> {
+    inner: map::SkipMap<T, ()>,
+}
+
+impl<T> SkipSet<T> {
+    /// Returns a new, empty set.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set: SkipSet<i32> = SkipSet::new();
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            inner: map::SkipMap::new(),
+        }
+    }
+
+    /// Returns `true` if the set is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// assert!(set.is_empty());
+    ///
+    /// set.insert(1);
+    /// assert!(!set.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the number of entries in the set.
+    ///
+    /// If the set is being concurrently modified, consider the returned number just an
+    /// approximation without any guarantees.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// assert_eq!(set.len(), 0);
+    ///
+    /// set.insert(1);
+    /// assert_eq!(set.len(), 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl<T> SkipSet<T>
+where
+    T: Ord,
+{
+    /// Returns the entry with the smallest key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(1);
+    /// assert_eq!(*set.front().unwrap(), 1);
+    /// set.insert(2);
+    /// assert_eq!(*set.front().unwrap(), 1);
+    /// ```
+    pub fn front(&self) -> Option<Entry<'_, T>> {
+        self.inner.front().map(Entry::new)
+    }
+
+    /// Returns the entry with the largest key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(1);
+    /// assert_eq!(*set.back().unwrap(), 1);
+    /// set.insert(2);
+    /// assert_eq!(*set.back().unwrap(), 2);
+    /// ```
+    pub fn back(&self) -> Option<Entry<'_, T>> {
+        self.inner.back().map(Entry::new)
+    }
+
+    /// Returns `true` if the set contains a value for the specified key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set: SkipSet<_> = (1..=3).collect();
+    /// assert!(set.contains(&1));
+    /// assert!(!set.contains(&4));
+    /// ```
+    pub fn contains<Q>(&self, key: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.inner.contains_key(key)
+    }
+
+    /// Returns an entry with the specified `key`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set: SkipSet<_> = (1..=3).collect();
+    /// assert_eq!(*set.get(&3).unwrap(), 3);
+    /// assert!(set.get(&4).is_none());
+    /// ```
+    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, T>>
+    where
+        T: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.inner.get(key).map(Entry::new)
+    }
+
+    /// Returns an `Entry` pointing to the lowest element whose key is above
+    /// the given bound. If no such element is found then `None` is
+    /// returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    /// use std::ops::Bound::*;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(6);
+    /// set.insert(7);
+    /// set.insert(12);
+    ///
+    /// let greater_than_five = set.lower_bound(Excluded(&5)).unwrap();
+    /// assert_eq!(*greater_than_five, 6);
+    ///
+    /// let greater_than_six = set.lower_bound(Excluded(&6)).unwrap();
+    /// assert_eq!(*greater_than_six, 7);
+    ///
+    /// let greater_than_thirteen = set.lower_bound(Excluded(&13));
+    /// assert!(greater_than_thirteen.is_none());
+    /// ```
+    pub fn lower_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, T>>
+    where
+        T: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.inner.lower_bound(bound).map(Entry::new)
+    }
+
+    /// Returns an `Entry` pointing to the highest element whose key is below
+    /// the given bound. If no such element is found then `None` is
+    /// returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    /// use std::ops::Bound::*;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(6);
+    /// set.insert(7);
+    /// set.insert(12);
+    ///
+    /// let less_than_eight = set.upper_bound(Excluded(&8)).unwrap();
+    /// assert_eq!(*less_than_eight, 7);
+    ///
+    /// let less_than_six = set.upper_bound(Excluded(&6));
+    /// assert!(less_than_six.is_none());
+    /// ```
+    pub fn upper_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, T>>
+    where
+        T: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.inner.upper_bound(bound).map(Entry::new)
+    }
+
+    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// let entry = set.get_or_insert(2);
+    /// assert_eq!(*entry, 2);
+    /// ```
+    pub fn get_or_insert(&self, key: T) -> Entry<'_, T> {
+        Entry::new(self.inner.get_or_insert(key, ()))
+    }
+
+    /// Returns an iterator over all entries in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(6);
+    /// set.insert(7);
+    /// set.insert(12);
+    ///
+    /// let mut set_iter = set.iter();
+    /// assert_eq!(*set_iter.next().unwrap(), 6);
+    /// assert_eq!(*set_iter.next().unwrap(), 7);
+    /// assert_eq!(*set_iter.next().unwrap(), 12);
+    /// assert!(set_iter.next().is_none());
+    /// ```
+    pub fn iter(&self) -> Iter<'_, T> {
+        Iter {
+            inner: self.inner.iter(),
+        }
+    }
+
+    /// Returns an iterator over a subset of entries in the set.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(6);
+    /// set.insert(7);
+    /// set.insert(12);
+    ///
+    /// let mut set_range = set.range(5..=8);
+    /// assert_eq!(*set_range.next().unwrap(), 6);
+    /// assert_eq!(*set_range.next().unwrap(), 7);
+    /// assert!(set_range.next().is_none());
+    /// ```
+    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, T>
+    where
+        T: Borrow<Q>,
+        R: RangeBounds<Q>,
+        Q: Ord + ?Sized,
+    {
+        Range {
+            inner: self.inner.range(range),
+        }
+    }
+}
+
+impl<T> SkipSet<T>
+where
+    T: Ord + Send + 'static,
+{
+    /// Inserts a `key`-`value` pair into the set and returns the new entry.
+    ///
+    /// If there is an existing entry with this key, it will be removed before inserting the new
+    /// one.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(2);
+    /// assert_eq!(*set.get(&2).unwrap(), 2);
+    /// ```
+    pub fn insert(&self, key: T) -> Entry<'_, T> {
+        Entry::new(self.inner.insert(key, ()))
+    }
+
+    /// Removes an entry with the specified key from the set and returns it.
+    ///
+    /// The value will not actually be dropped until all references to it have gone
+    /// out of scope.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(2);
+    /// assert_eq!(*set.remove(&2).unwrap(), 2);
+    /// assert!(set.remove(&2).is_none());
+    /// ```
+    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, T>>
+    where
+        T: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.inner.remove(key).map(Entry::new)
+    }
+
+    /// Removes an entry from the front of the set.
+    /// Returns the removed entry.
+    ///
+    /// The value will not actually be dropped until all references to it have gone
+    /// out of scope.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(1);
+    /// set.insert(2);
+    ///
+    /// assert_eq!(*set.pop_front().unwrap(), 1);
+    /// assert_eq!(*set.pop_front().unwrap(), 2);
+    ///
+    /// // All entries have been removed now.
+    /// assert!(set.is_empty());
+    /// ```
+    pub fn pop_front(&self) -> Option<Entry<'_, T>> {
+        self.inner.pop_front().map(Entry::new)
+    }
+
+    /// Removes an entry from the back of the set.
+    /// Returns the removed entry.
+    ///
+    /// The value will not actually be dropped until all references to it have gone
+    /// out of scope.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(1);
+    /// set.insert(2);
+    ///
+    /// assert_eq!(*set.pop_back().unwrap(), 2);
+    /// assert_eq!(*set.pop_back().unwrap(), 1);
+    ///
+    /// // All entries have been removed now.
+    /// assert!(set.is_empty());
+    /// ```
+    pub fn pop_back(&self) -> Option<Entry<'_, T>> {
+        self.inner.pop_back().map(Entry::new)
+    }
+
+    /// Iterates over the set and removes every entry.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::SkipSet;
+    ///
+    /// let set = SkipSet::new();
+    /// set.insert(1);
+    /// set.insert(2);
+    ///
+    /// set.clear();
+    /// assert!(set.is_empty());
+    /// ```
+    pub fn clear(&self) {
+        self.inner.clear();
+    }
+}
+
+impl<T> Default for SkipSet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> fmt::Debug for SkipSet<T>
+where
+    T: Ord + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("SkipSet { .. }")
+    }
+}
+
+impl<T> IntoIterator for SkipSet<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> IntoIter<T> {
+        IntoIter {
+            inner: self.inner.into_iter(),
+        }
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SkipSet<T>
+where
+    T: Ord,
+{
+    type Item = Entry<'a, T>;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
+    }
+}
+
+impl<T> FromIterator<T> for SkipSet<T>
+where
+    T: Ord,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let s = Self::new();
+        for t in iter {
+            s.get_or_insert(t);
+        }
+        s
+    }
+}
+
+/// A reference-counted entry in a set.
+pub struct Entry<'a, T> {
+    inner: map::Entry<'a, T, ()>,
+}
+
+impl<'a, T> Entry<'a, T> {
+    fn new(inner: map::Entry<'a, T, ()>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns a reference to the value.
+    pub fn value(&self) -> &T {
+        self.inner.key()
+    }
+
+    /// Returns `true` if the entry is removed from the set.
+    pub fn is_removed(&self) -> bool {
+        self.inner.is_removed()
+    }
+}
+
+impl<'a, T> Entry<'a, T>
+where
+    T: Ord,
+{
+    /// Moves to the next entry in the set.
+    pub fn move_next(&mut self) -> bool {
+        self.inner.move_next()
+    }
+
+    /// Moves to the previous entry in the set.
+    pub fn move_prev(&mut self) -> bool {
+        self.inner.move_prev()
+    }
+
+    /// Returns the next entry in the set.
+    pub fn next(&self) -> Option<Entry<'a, T>> {
+        self.inner.next().map(Entry::new)
+    }
+
+    /// Returns the previous entry in the set.
+    pub fn prev(&self) -> Option<Entry<'a, T>> {
+        self.inner.prev().map(Entry::new)
+    }
+}
+
+impl<T> Entry<'_, T>
+where
+    T: Ord + Send + 'static,
+{
+    /// Removes the entry from the set.
+    ///
+    /// Returns `true` if this call removed the entry and `false` if it was already removed.
+    pub fn remove(&self) -> bool {
+        self.inner.remove()
+    }
+}
+
+impl<T> Clone for Entry<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> fmt::Debug for Entry<'_, T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Entry")
+            .field("value", self.value())
+            .finish()
+    }
+}
+
+impl<T> Deref for Entry<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value()
+    }
+}
+
+/// An owning iterator over the entries of a `SkipSet`.
+pub struct IntoIter<T> {
+    inner: map::IntoIter<T, ()>,
+}
+
+impl<T> Iterator for IntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.inner.next().map(|(k, ())| k)
+    }
+}
+
+impl<T> fmt::Debug for IntoIter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("IntoIter { .. }")
+    }
+}
+
+/// An iterator over the entries of a `SkipSet`.
+pub struct Iter<'a, T> {
+    inner: map::Iter<'a, T, ()>,
+}
+
+impl<'a, T> Iterator for Iter<'a, T>
+where
+    T: Ord,
+{
+    type Item = Entry<'a, T>;
+
+    fn next(&mut self) -> Option<Entry<'a, T>> {
+        self.inner.next().map(Entry::new)
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Iter<'a, T>
+where
+    T: Ord,
+{
+    fn next_back(&mut self) -> Option<Entry<'a, T>> {
+        self.inner.next_back().map(Entry::new)
+    }
+}
+
+impl<T> fmt::Debug for Iter<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("Iter { .. }")
+    }
+}
+
+/// An iterator over a subset of entries of a `SkipSet`.
+pub struct Range<'a, Q, R, T>
+where
+    T: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    inner: map::Range<'a, Q, R, T, ()>,
+}
+
+impl<'a, Q, R, T> Iterator for Range<'a, Q, R, T>
+where
+    T: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    type Item = Entry<'a, T>;
+
+    fn next(&mut self) -> Option<Entry<'a, T>> {
+        self.inner.next().map(Entry::new)
+    }
+}
+
+impl<'a, Q, R, T> DoubleEndedIterator for Range<'a, Q, R, T>
+where
+    T: Ord + Borrow<Q>,
+    R: RangeBounds<Q>,
+    Q: Ord + ?Sized,
+{
+    fn next_back(&mut self) -> Option<Entry<'a, T>> {
+        self.inner.next_back().map(Entry::new)
+    }
+}
+
+impl<Q, R, T> fmt::Debug for Range<'_, Q, R, T>
+where
+    T: Ord + Borrow<Q> + fmt::Debug,
+    R: RangeBounds<Q> + fmt::Debug,
+    Q: Ord + ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Range")
+            .field("range", &self.inner.inner.range)
+            .field("head", &self.inner.inner.head.as_ref().map(|e| e.key()))
+            .field("tail", &self.inner.inner.tail.as_ref().map(|e| e.key()))
+            .finish()
+    }
+}

--- a/core/skiplist/set_tests.rs
+++ b/core/skiplist/set_tests.rs
@@ -1,0 +1,694 @@
+use crate::skiplist::SkipSet;
+use crossbeam_utils::thread;
+use std::{iter, ops::Bound, sync::Barrier};
+
+#[test]
+fn smoke() {
+    let m = SkipSet::new();
+    m.insert(1);
+    m.insert(5);
+    m.insert(7);
+}
+
+#[test]
+fn is_empty() {
+    let s = SkipSet::new();
+    assert!(s.is_empty());
+
+    s.insert(1);
+    assert!(!s.is_empty());
+    s.insert(2);
+    s.insert(3);
+    assert!(!s.is_empty());
+
+    s.remove(&2);
+    assert!(!s.is_empty());
+
+    s.remove(&1);
+    assert!(!s.is_empty());
+
+    s.remove(&3);
+    assert!(s.is_empty());
+}
+
+#[test]
+fn insert() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let not_present = [1, 3, 6, 9, 10];
+    let s = SkipSet::new();
+
+    for &x in &insert {
+        s.insert(x);
+        assert_eq!(*s.get(&x).unwrap(), x);
+    }
+
+    for &x in &not_present {
+        assert!(s.get(&x).is_none());
+    }
+}
+
+#[test]
+fn remove() {
+    let insert = [0, 4, 2, 12, 8, 7, 11, 5];
+    let not_present = [1, 3, 6, 9, 10];
+    let remove = [2, 12, 8];
+    let remaining = [0, 4, 5, 7, 11];
+
+    let s = SkipSet::new();
+
+    for &x in &insert {
+        s.insert(x);
+    }
+    for x in &not_present {
+        assert!(s.remove(x).is_none());
+    }
+    for x in &remove {
+        assert!(s.remove(x).is_some());
+    }
+
+    let mut v = vec![];
+    let mut e = s.front().unwrap();
+    loop {
+        v.push(*e);
+        if !e.move_next() {
+            break;
+        }
+    }
+
+    assert_eq!(v, remaining);
+    for x in &insert {
+        s.remove(x);
+    }
+    assert!(s.is_empty());
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/672
+#[test]
+fn concurrent_insert() {
+    for _ in 0..100 {
+        let set: SkipSet<i32> = iter::once(1).collect();
+        let barrier = Barrier::new(2);
+        thread::scope(|s| {
+            s.spawn(|_| {
+                barrier.wait();
+                set.insert(1);
+            });
+            s.spawn(|_| {
+                barrier.wait();
+                set.insert(1);
+            });
+        })
+        .unwrap();
+    }
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/672
+#[test]
+fn concurrent_remove() {
+    for _ in 0..100 {
+        let set: SkipSet<i32> = iter::once(1).collect();
+        let barrier = Barrier::new(2);
+        thread::scope(|s| {
+            s.spawn(|_| {
+                barrier.wait();
+                set.remove(&1);
+            });
+            s.spawn(|_| {
+                barrier.wait();
+                set.remove(&1);
+            });
+        })
+        .unwrap();
+    }
+}
+
+#[test]
+fn entry() {
+    let s = SkipSet::new();
+
+    assert!(s.front().is_none());
+    assert!(s.back().is_none());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x);
+    }
+
+    let mut e = s.front().unwrap();
+    assert_eq!(*e, 2);
+    assert!(!e.move_prev());
+    assert!(e.move_next());
+    assert_eq!(*e, 4);
+
+    e = s.back().unwrap();
+    assert_eq!(*e, 12);
+    assert!(!e.move_next());
+    assert!(e.move_prev());
+    assert_eq!(*e, 11);
+}
+
+#[test]
+fn entry_remove() {
+    let s = SkipSet::new();
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x);
+    }
+
+    let mut e = s.get(&7).unwrap();
+    assert!(!e.is_removed());
+    assert!(e.remove());
+    assert!(e.is_removed());
+
+    e.move_prev();
+    e.move_next();
+    assert_ne!(*e, 7);
+
+    for e in s.iter() {
+        assert!(!s.is_empty());
+        assert_ne!(s.len(), 0);
+        e.remove();
+    }
+    assert!(s.is_empty());
+    assert_eq!(s.len(), 0);
+}
+
+#[test]
+fn entry_reposition() {
+    let s = SkipSet::new();
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x);
+    }
+
+    let mut e = s.get(&7).unwrap();
+    assert!(!e.is_removed());
+    assert!(e.remove());
+    assert!(e.is_removed());
+
+    s.insert(7);
+    e.move_prev();
+    e.move_next();
+    assert_eq!(*e, 7);
+}
+
+#[test]
+fn len() {
+    let s = SkipSet::new();
+    assert_eq!(s.len(), 0);
+
+    for (i, &x) in [4, 2, 12, 8, 7, 11, 5].iter().enumerate() {
+        s.insert(x);
+        assert_eq!(s.len(), i + 1);
+    }
+
+    s.insert(5);
+    assert_eq!(s.len(), 7);
+    s.insert(5);
+    assert_eq!(s.len(), 7);
+
+    s.remove(&6);
+    assert_eq!(s.len(), 7);
+    s.remove(&5);
+    assert_eq!(s.len(), 6);
+    s.remove(&12);
+    assert_eq!(s.len(), 5);
+}
+
+#[test]
+fn insert_and_remove() {
+    let s = SkipSet::new();
+    let keys = || s.iter().map(|e| *e).collect::<Vec<_>>();
+
+    s.insert(3);
+    s.insert(5);
+    s.insert(1);
+    s.insert(4);
+    s.insert(2);
+    assert_eq!(keys(), [1, 2, 3, 4, 5]);
+
+    assert!(s.remove(&4).is_some());
+    assert_eq!(keys(), [1, 2, 3, 5]);
+    assert!(s.remove(&3).is_some());
+    assert_eq!(keys(), [1, 2, 5]);
+    assert!(s.remove(&1).is_some());
+    assert_eq!(keys(), [2, 5]);
+
+    assert!(s.remove(&1).is_none());
+    assert_eq!(keys(), [2, 5]);
+    assert!(s.remove(&3).is_none());
+    assert_eq!(keys(), [2, 5]);
+
+    assert!(s.remove(&2).is_some());
+    assert_eq!(keys(), [5]);
+    assert!(s.remove(&5).is_some());
+    assert!(keys().is_empty());
+
+    s.insert(3);
+    assert_eq!(keys(), [3]);
+    s.insert(1);
+    assert_eq!(keys(), [1, 3]);
+    s.insert(3);
+    assert_eq!(keys(), [1, 3]);
+    s.insert(5);
+    assert_eq!(keys(), [1, 3, 5]);
+
+    assert!(s.remove(&3).is_some());
+    assert_eq!(keys(), [1, 5]);
+    assert!(s.remove(&1).is_some());
+    assert_eq!(keys(), [5]);
+    assert!(s.remove(&3).is_none());
+    assert_eq!(keys(), [5]);
+    assert!(s.remove(&5).is_some());
+    assert!(keys().is_empty());
+}
+
+#[test]
+fn get() {
+    let s = SkipSet::new();
+    s.insert(30);
+    s.insert(50);
+    s.insert(10);
+    s.insert(40);
+    s.insert(20);
+
+    assert_eq!(*s.get(&10).unwrap(), 10);
+    assert_eq!(*s.get(&20).unwrap(), 20);
+    assert_eq!(*s.get(&30).unwrap(), 30);
+    assert_eq!(*s.get(&40).unwrap(), 40);
+    assert_eq!(*s.get(&50).unwrap(), 50);
+
+    assert!(s.get(&7).is_none());
+    assert!(s.get(&27).is_none());
+    assert!(s.get(&31).is_none());
+    assert!(s.get(&97).is_none());
+}
+
+#[test]
+fn lower_bound() {
+    let s = SkipSet::new();
+    s.insert(30);
+    s.insert(50);
+    s.insert(10);
+    s.insert(40);
+    s.insert(20);
+
+    assert_eq!(*s.lower_bound(Bound::Unbounded).unwrap(), 10);
+
+    assert_eq!(*s.lower_bound(Bound::Included(&10)).unwrap(), 10);
+    assert_eq!(*s.lower_bound(Bound::Included(&20)).unwrap(), 20);
+    assert_eq!(*s.lower_bound(Bound::Included(&30)).unwrap(), 30);
+    assert_eq!(*s.lower_bound(Bound::Included(&40)).unwrap(), 40);
+    assert_eq!(*s.lower_bound(Bound::Included(&50)).unwrap(), 50);
+
+    assert_eq!(*s.lower_bound(Bound::Included(&7)).unwrap(), 10);
+    assert_eq!(*s.lower_bound(Bound::Included(&27)).unwrap(), 30);
+    assert_eq!(*s.lower_bound(Bound::Included(&31)).unwrap(), 40);
+    assert!(s.lower_bound(Bound::Included(&97)).is_none());
+
+    assert_eq!(*s.lower_bound(Bound::Excluded(&10)).unwrap(), 20);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&20)).unwrap(), 30);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&30)).unwrap(), 40);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&40)).unwrap(), 50);
+    assert!(s.lower_bound(Bound::Excluded(&50)).is_none());
+
+    assert_eq!(*s.lower_bound(Bound::Excluded(&7)).unwrap(), 10);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&27)).unwrap(), 30);
+    assert_eq!(*s.lower_bound(Bound::Excluded(&31)).unwrap(), 40);
+    assert!(s.lower_bound(Bound::Excluded(&97)).is_none());
+}
+
+#[test]
+fn upper_bound() {
+    let s = SkipSet::new();
+    s.insert(30);
+    s.insert(50);
+    s.insert(10);
+    s.insert(40);
+    s.insert(20);
+
+    assert_eq!(*s.upper_bound(Bound::Unbounded).unwrap(), 50);
+
+    assert_eq!(*s.upper_bound(Bound::Included(&10)).unwrap(), 10);
+    assert_eq!(*s.upper_bound(Bound::Included(&20)).unwrap(), 20);
+    assert_eq!(*s.upper_bound(Bound::Included(&30)).unwrap(), 30);
+    assert_eq!(*s.upper_bound(Bound::Included(&40)).unwrap(), 40);
+    assert_eq!(*s.upper_bound(Bound::Included(&50)).unwrap(), 50);
+
+    assert!(s.upper_bound(Bound::Included(&7)).is_none());
+    assert_eq!(*s.upper_bound(Bound::Included(&27)).unwrap(), 20);
+    assert_eq!(*s.upper_bound(Bound::Included(&31)).unwrap(), 30);
+    assert_eq!(*s.upper_bound(Bound::Included(&97)).unwrap(), 50);
+
+    assert!(s.upper_bound(Bound::Excluded(&10)).is_none());
+    assert_eq!(*s.upper_bound(Bound::Excluded(&20)).unwrap(), 10);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&30)).unwrap(), 20);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&40)).unwrap(), 30);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&50)).unwrap(), 40);
+
+    assert!(s.upper_bound(Bound::Excluded(&7)).is_none());
+    assert_eq!(*s.upper_bound(Bound::Excluded(&27)).unwrap(), 20);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&31)).unwrap(), 30);
+    assert_eq!(*s.upper_bound(Bound::Excluded(&97)).unwrap(), 50);
+}
+
+#[test]
+fn get_or_insert() {
+    let s = SkipSet::new();
+    s.insert(3);
+    s.insert(5);
+    s.insert(1);
+    s.insert(4);
+    s.insert(2);
+
+    assert_eq!(*s.get(&4).unwrap(), 4);
+    assert_eq!(*s.insert(4), 4);
+    assert_eq!(*s.get(&4).unwrap(), 4);
+
+    assert_eq!(*s.get_or_insert(4), 4);
+    assert_eq!(*s.get(&4).unwrap(), 4);
+    assert_eq!(*s.get_or_insert(6), 6);
+}
+
+#[test]
+fn get_next_prev() {
+    let s = SkipSet::new();
+    s.insert(3);
+    s.insert(5);
+    s.insert(1);
+    s.insert(4);
+    s.insert(2);
+
+    let mut e = s.get(&3).unwrap();
+    assert_eq!(*e.next().unwrap(), 4);
+    assert_eq!(*e.prev().unwrap(), 2);
+    assert_eq!(*e, 3);
+
+    e.move_prev();
+    assert_eq!(*e.next().unwrap(), 3);
+    assert_eq!(*e.prev().unwrap(), 1);
+    assert_eq!(*e, 2);
+
+    e.move_prev();
+    assert_eq!(*e.next().unwrap(), 2);
+    assert!(e.prev().is_none());
+    assert_eq!(*e, 1);
+
+    e.move_next();
+    e.move_next();
+    e.move_next();
+    e.move_next();
+    assert!(e.next().is_none());
+    assert_eq!(*e.prev().unwrap(), 4);
+    assert_eq!(*e, 5);
+}
+
+#[test]
+fn front_and_back() {
+    let s = SkipSet::new();
+    assert!(s.front().is_none());
+    assert!(s.back().is_none());
+
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x);
+    }
+
+    assert_eq!(*s.front().unwrap(), 2);
+    assert_eq!(*s.back().unwrap(), 12);
+}
+
+#[test]
+fn iter() {
+    let s = SkipSet::new();
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x);
+    }
+
+    assert_eq!(
+        s.iter().map(|e| *e).collect::<Vec<_>>(),
+        &[2, 4, 5, 7, 8, 11, 12]
+    );
+
+    let mut it = s.iter();
+    s.remove(&2);
+    assert_eq!(*it.next().unwrap(), 4);
+    s.remove(&7);
+    assert_eq!(*it.next().unwrap(), 5);
+    s.remove(&5);
+    assert_eq!(*it.next().unwrap(), 8);
+    s.remove(&12);
+    assert_eq!(*it.next().unwrap(), 11);
+    assert!(it.next().is_none());
+}
+
+#[test]
+fn iter_range() {
+    use std::ops::Bound::*;
+    let s = SkipSet::new();
+    let v = (0..10).map(|x| x * 10).collect::<Vec<_>>();
+    for &x in v.iter() {
+        s.insert(x);
+    }
+
+    assert_eq!(
+        s.iter().map(|x| *x).collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.iter().rev().map(|x| *x).collect::<Vec<_>>(),
+        vec![90, 80, 70, 60, 50, 40, 30, 20, 10, 0]
+    );
+    assert_eq!(
+        s.range(..).map(|x| *x).collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+
+    assert_eq!(
+        s.range((Included(&0), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&0), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&25), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&70), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Excluded(&70), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![80, 90]
+    );
+    assert_eq!(
+        s.range((Included(&100), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Unbounded))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Unbounded, Included(&90)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&90)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&25)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&25)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&70)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60, 70]
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&70)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![0, 10, 20, 30, 40, 50, 60]
+    );
+    assert_eq!(
+        s.range((Unbounded, Included(&-1)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Unbounded, Excluded(&-1)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&25), Included(&80)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Included(&25), Excluded(&80)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Included(&80)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70, 80]
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Excluded(&80)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![30, 40, 50, 60, 70]
+    );
+
+    assert_eq!(
+        s.range((Included(&25), Included(&25)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Included(&25), Excluded(&25)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Included(&25)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&25), Excluded(&25)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&50), Included(&50)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        vec![50]
+    );
+    assert_eq!(
+        s.range((Included(&50), Excluded(&50)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&50), Included(&50)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&50), Excluded(&50)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+
+    assert_eq!(
+        s.range((Included(&100), Included(&-2)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Included(&100), Excluded(&-2)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Included(&-2)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+    assert_eq!(
+        s.range((Excluded(&100), Excluded(&-2)))
+            .map(|x| *x)
+            .collect::<Vec<_>>(),
+        Vec::<i32>::new()
+    );
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/671
+#[test]
+fn iter_range2() {
+    let set: SkipSet<_> = [1, 3, 5].iter().cloned().collect();
+    assert_eq!(set.range(2..4).count(), 1);
+    set.insert(3);
+}
+
+#[test]
+fn into_iter() {
+    let s = SkipSet::new();
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x);
+    }
+
+    assert_eq!(s.into_iter().collect::<Vec<_>>(), &[2, 4, 5, 7, 8, 11, 12]);
+}
+
+#[test]
+fn clear() {
+    let s = SkipSet::new();
+    for &x in &[4, 2, 12, 8, 7, 11, 5] {
+        s.insert(x);
+    }
+
+    assert!(!s.is_empty());
+    assert_ne!(s.len(), 0);
+    s.clear();
+    assert!(s.is_empty());
+    assert_eq!(s.len(), 0);
+}

--- a/licenses/core/crossbeam-skiplist-apache-license.md
+++ b/licenses/core/crossbeam-skiplist-apache-license.md
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/licenses/core/crossbeam-skiplist-mit-license.md
+++ b/licenses/core/crossbeam-skiplist-mit-license.md
@@ -1,0 +1,27 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 The Crossbeam Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Vendors the skiplist implementation from crossbeam-skiplist 0.1.3 (checksum-verified against the published crates.io tarball) directly into `turso_core` as `core/skiplist`, replacing the registry dependency. Used by `core/mvcc`. The upstream integration tests come along as unit test modules; `crossbeam-epoch`/`crossbeam-utils` become direct dependencies of core.

Local modifications from upstream, beyond path/import rewrites:
- fix `dangerous_implicit_autorefs` (deny-by-default on nightly; registry deps got `--cap-lints allow`, in-tree code does not)
- annotate empty-collection asserts in tests (serde_json provides `PartialEq<Value> for i32`, making inference ambiguous inside turso_core)
- `isize::max_value()` -> `isize::MAX`, doc list indentation (clippy)

License copies added to `licenses/core` and NOTICE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)