### PR TITLE
core/translate: Fix partial index predicate consumption

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -11,8 +11,9 @@ use crate::stats::AnalyzeStats;
 use crate::translate::collate::CollationSeq;
 use crate::translate::expr::{as_binary_components, walk_expr, WalkControl};
 use crate::translate::optimizer::constraints::{
-    convert_to_vtab_constraint, ordered_materialized_key_columns, BinaryExprSide, Constraint,
-    ConstraintOperator, RangeConstraintRef,
+    convert_to_vtab_constraint, ordered_materialized_key_columns, partial_index,
+    partial_index_predicate_terms, BinaryExprSide, Constraint, ConstraintOperator,
+    RangeConstraintRef,
 };
 use crate::translate::optimizer::cost::{rows_per_leaf_page_for_index, RowCountEstimate};
 use crate::translate::optimizer::cost_params::CostModelParams;
@@ -170,6 +171,7 @@ pub(super) struct ChosenBtreeCandidate {
     pub(super) iter_dir: IterationDirection,
     pub(super) index: Option<Arc<Index>>,
     pub(super) constraint_refs: Vec<RangeConstraintRef>,
+    pub(super) base_row_count: RowCountEstimate,
     pub(super) cost: Cost,
 }
 
@@ -234,6 +236,7 @@ pub(super) fn choose_best_btree_candidate(
         iter_dir: IterationDirection::Forwards,
         index: None,
         constraint_refs: vec![],
+        base_row_count,
         cost: best_cost,
     };
     let mut best_adjusted_output = f64::MAX;
@@ -449,6 +452,7 @@ pub(super) fn choose_best_btree_candidate(
                 iter_dir,
                 index: candidate.index.clone(),
                 constraint_refs: usable_constraint_refs.clone(),
+                base_row_count: candidate_base_row_count,
                 cost,
             };
         }
@@ -478,6 +482,21 @@ fn consumed_where_terms_from_constraint_refs(
         }
     }
     consumed
+}
+
+fn consume_partial_index_predicate_terms(
+    consumed: &mut SmallVec<[usize; 4]>,
+    index: &Index,
+    rhs_table: &JoinedTable,
+    where_clause: &[WhereTerm],
+) {
+    let predicate_terms = partial_index_predicate_terms(index, rhs_table, where_clause)
+        .expect("selected partial index predicate must be implied by query");
+    for term_idx in predicate_terms {
+        if !consumed.contains(&term_idx) {
+            consumed.push(term_idx);
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -745,8 +764,9 @@ fn find_best_access_method_for_btree(
     )?
     .expect("btree candidate selection must always consider the rowid candidate");
 
+    let access_base_row_count = best.base_row_count;
     let estimated_rows_per_outer_row = if best.constraint_refs.is_empty() {
-        *base_row_count
+        *access_base_row_count
     } else {
         let index_info = match best.index.as_ref() {
             Some(index) => IndexInfo {
@@ -775,18 +795,27 @@ fn find_best_access_method_for_btree(
             index_info,
             &rhs_constraints.constraints,
             &best.constraint_refs,
-            base_row_count,
+            access_base_row_count,
             Some(&analyze_ctx),
         )
     };
+    let mut consumed_where_terms = consumed_where_terms_from_constraint_refs(
+        &rhs_constraints.constraints,
+        &best.constraint_refs,
+    );
+    if let Some(index) = partial_index(best.index.as_ref()) {
+        consume_partial_index_predicate_terms(
+            &mut consumed_where_terms,
+            index,
+            rhs_table,
+            where_clause,
+        );
+    }
     let mut best_access_method = AccessMethod {
         cost: best.cost,
         estimated_rows_per_outer_row,
         residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
-        consumed_where_terms: consumed_where_terms_from_constraint_refs(
-            &rhs_constraints.constraints,
-            &best.constraint_refs,
-        ),
+        consumed_where_terms,
         params: AccessMethodParams::BTreeTable {
             iter_dir: best.iter_dir,
             index: best.index,
@@ -806,6 +835,17 @@ fn find_best_access_method_for_btree(
             params,
             best_access_method.cost,
         )? {
+            let mut in_seek_method = in_seek_method;
+            if let AccessMethodParams::InSeek { index, .. } = &in_seek_method.params {
+                if let Some(index) = partial_index(index.as_ref()) {
+                    consume_partial_index_predicate_terms(
+                        &mut in_seek_method.consumed_where_terms,
+                        index,
+                        rhs_table,
+                        where_clause,
+                    );
+                }
+            }
             best_access_method = in_seek_method;
         }
 

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -6,13 +6,17 @@ use crate::{
         expr::{as_binary_components, comparison_affinity, walk_expr_mut, WalkControl},
         expression_index::normalize_expr_for_index_matching,
         plan::{JoinOrderMember, JoinedTable, NonFromClauseSubquery, TableReferences, WhereTerm},
-        planner::{break_predicate_at_and_boundaries, table_mask_from_expr, TableMask, ROWID_STRS},
+        planner::{
+            break_predicate_at_and_boundaries, rewrite_between_exprs, table_mask_from_expr,
+            TableMask, ROWID_STRS,
+        },
     },
     util::exprs_are_equivalent,
     vdbe::affinity::Affinity,
     Result,
 };
 use crate::{turso_assert, turso_debug_assert};
+use smallvec::SmallVec;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintOp};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
@@ -866,7 +870,8 @@ pub fn constraints_from_where_clause(
                     if let Some(index_candidate) = cs.candidates.iter_mut().find_map(|candidate| {
                         if candidate.index.as_ref().is_some_and(|i| {
                             Arc::ptr_eq(index, i)
-                                && can_use_partial_index(index, table_reference, where_clause)
+                                && (index.where_clause.is_none()
+                                    || can_use_partial_index(index, table_reference, where_clause))
                         }) {
                             Some(candidate)
                         } else {
@@ -1191,14 +1196,26 @@ pub fn ordered_materialized_key_columns(constraints: &[&Constraint]) -> Vec<usiz
     ordered
 }
 
-fn can_use_partial_index(
+pub(super) fn partial_index_predicate_terms(
     index: &Index,
     table_reference: &JoinedTable,
     query_where_clause: &[WhereTerm],
-) -> bool {
-    let Some(index_where) = &index.where_clause else {
-        // Full index, always usable
-        return true;
+) -> Option<SmallVec<[usize; 4]>> {
+    let index_where = index
+        .where_clause
+        .as_ref()
+        .expect("partial_index_predicate_terms requires a partial index");
+    let can_use_query_term = |term: &WhereTerm| -> bool {
+        let Some(join_info) = &table_reference.join_info else {
+            return true;
+        };
+        if join_info.is_full_outer() {
+            return false;
+        }
+        if join_info.is_outer() {
+            return term.from_outer_join == Some(table_reference.internal_id);
+        }
+        true
     };
     // Bind the index WHERE expression's column references to this query's
     // table reference so it can be compared symmetrically against bound query
@@ -1206,15 +1223,39 @@ fn can_use_partial_index(
     // WHERE term for the partial index to be safe to use.
     let mut bound = (**index_where).clone();
     bind_partial_index_columns(&mut bound, table_reference);
+    rewrite_between_exprs(&mut bound).ok()?;
     let mut index_conjuncts: Vec<ast::Expr> = Vec::new();
     break_predicate_at_and_boundaries(&bound, &mut index_conjuncts);
-    index_conjuncts.iter().all(|ic| {
-        query_where_clause
-            .iter()
-            .any(|t| exprs_are_equivalent(ic, &t.expr))
-    })
+    let mut matched_terms = SmallVec::<[usize; 4]>::new();
+    for index_conjunct in index_conjuncts.iter() {
+        let (term_idx, _) = query_where_clause.iter().enumerate().find(|(_, term)| {
+            can_use_query_term(term) && exprs_are_equivalent(index_conjunct, &term.expr)
+        })?;
+        if !matched_terms.contains(&term_idx) {
+            matched_terms.push(term_idx);
+        }
+    }
+    Some(matched_terms)
     // TODO: recognize implication beyond syntactic equivalence (e.g. `x = 5` implies
     // `x IS NOT NULL`, `x > 10` implies `x > 5`).
+}
+
+pub(super) fn partial_index(index: Option<&Arc<Index>>) -> Option<&Index> {
+    let index = index?;
+    index.where_clause.as_ref()?;
+    Some(index.as_ref())
+}
+
+pub(super) fn can_use_partial_index(
+    index: &Index,
+    table_reference: &JoinedTable,
+    query_where_clause: &[WhereTerm],
+) -> bool {
+    assert!(
+        index.where_clause.is_some(),
+        "can_use_partial_index requires a partial index"
+    );
+    partial_index_predicate_terms(index, table_reference, query_where_clause).is_some()
 }
 
 /// Rewrite identifier nodes in a partial-index WHERE expression to bound
@@ -1592,6 +1633,8 @@ fn analyze_binary_term_index_info<'a>(
 pub(crate) fn summarize_binary_term_for_index(
     expr: &ast::Expr,
     table_id: TableInternalId,
+    table_reference: &JoinedTable,
+    query_where_clause: &[WhereTerm],
     indexes: Option<&VecDeque<Arc<Index>>>,
     rowid_alias_column: Option<usize>,
     table_references: &TableReferences,
@@ -1611,6 +1654,8 @@ pub(crate) fn summarize_binary_term_for_index(
         indexes,
         rowid_alias_column,
         is_rowid,
+        table_reference,
+        query_where_clause,
     );
     if constraint_refs.is_empty() {
         return None;
@@ -1646,6 +1691,7 @@ pub(crate) fn analyze_binary_term_for_index(
     where_term_idx: usize,
     table_id: TableInternalId,
     table_reference: &JoinedTable,
+    query_where_clause: &[WhereTerm],
     indexes: Option<&VecDeque<Arc<Index>>>,
     rowid_alias_column: Option<usize>,
     table_references: &TableReferences,
@@ -1670,6 +1716,8 @@ pub(crate) fn analyze_binary_term_for_index(
         indexes,
         rowid_alias_column,
         is_rowid,
+        table_reference,
+        query_where_clause,
     );
 
     // If no index can be used, this term is not indexable
@@ -1747,6 +1795,8 @@ fn find_best_index_for_constraint(
     indexes: Option<&VecDeque<Arc<Index>>>,
     rowid_alias_column: Option<usize>,
     is_rowid: bool,
+    table_reference: &JoinedTable,
+    query_where_clause: &[WhereTerm],
 ) -> (Option<Arc<Index>>, Vec<RangeConstraintRef>) {
     // Handle implicit rowid (no alias column, table_col_pos is None)
     if is_rowid && table_col_pos.is_none() {
@@ -1807,6 +1857,11 @@ fn find_best_index_for_constraint(
     // Find the best index that has this column as its first column
     if let Some(indexes) = indexes {
         for index in indexes.iter().filter(|idx| idx.index_method.is_none()) {
+            if index.where_clause.is_some()
+                && !can_use_partial_index(index.as_ref(), table_reference, query_where_clause)
+            {
+                continue;
+            }
             if let Some(idx_col_pos) = index.column_table_pos_to_index_pos(col_pos) {
                 // For multi-index OR, we prefer indexes where the constraint column
                 // is the first column (leftmost prefix)

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -52,7 +52,8 @@ use crate::{
 };
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert, turso_soft_unreachable};
 use constraints::{
-    constraints_from_where_clause, usable_constraints_for_join_order, Constraint,
+    can_use_partial_index, constraints_from_where_clause, partial_index,
+    partial_index_predicate_terms, usable_constraints_for_join_order, Constraint,
     ConstraintOperator, ConstraintRef,
 };
 use cost::Cost;
@@ -1755,6 +1756,8 @@ fn expr_has_null_masking_for_table(expr: &ast::Expr, table_id: ast::TableInterna
 fn enforce_indexed_by_hints(
     table_references: &TableReferences,
     available_indexes: &AvailableIndexes,
+    where_clause: &[WhereTerm],
+    simple_aggregate: Option<&SimpleAggregate>,
     constraints_per_table: &mut [TableConstraints],
 ) -> Result<()> {
     for (i, table_ref) in table_references.joined_tables().iter().enumerate() {
@@ -1776,6 +1779,21 @@ fn enforce_indexed_by_hints(
                 let Some(forced_index) = forced_index else {
                     crate::bail_parse_error!("no such index: {}", idx_name);
                 };
+                let forced_partial_index_unusable = forced_index.where_clause.is_some()
+                    && !can_use_partial_index(forced_index.as_ref(), table_ref, where_clause);
+                if forced_partial_index_unusable
+                    && matches!(simple_aggregate, Some(SimpleAggregate::Count))
+                {
+                    // SQLite's isSimpleCount() path emits OP_Count without
+                    // invoking sqlite3WhereBegin(), so a forced unusable
+                    // partial index is ignored here instead of causing
+                    // "no query solution".
+                    cs.candidates.retain(|c| c.index.is_none());
+                    continue;
+                }
+                if forced_partial_index_unusable {
+                    crate::bail_parse_error!("no query solution");
+                }
                 // Keep only the candidate for the forced index.
                 let forced_index = forced_index.clone();
                 cs.candidates.retain(|c| {
@@ -1924,13 +1942,6 @@ fn optimize_table_access(
         params,
     )?;
 
-    // Enforce INDEXED BY / NOT INDEXED hints on constraint candidates.
-    enforce_indexed_by_hints(
-        table_references,
-        available_indexes,
-        &mut constraints_per_table,
-    )?;
-
     let base_table_rows = table_references
         .joined_tables()
         .iter()
@@ -2002,12 +2013,18 @@ fn optimize_table_access(
             schema,
             params,
         )?;
-        enforce_indexed_by_hints(
-            table_references,
-            available_indexes,
-            &mut constraints_per_table,
-        )?;
     }
+
+    // Enforce INDEXED BY / NOT INDEXED after outer-join rewrites settle, because
+    // a null-rejecting WHERE term can turn a LEFT JOIN into an INNER JOIN and
+    // then safely prove a forced partial index.
+    enforce_indexed_by_hints(
+        table_references,
+        available_indexes,
+        where_clause,
+        simple_aggregate,
+        &mut constraints_per_table,
+    )?;
 
     let planning_context = JoinPlanningContext {
         maybe_order_target: maybe_order_target.as_ref(),
@@ -2214,6 +2231,18 @@ fn optimize_table_access(
                     let try_to_build_ephemeral_index = !is_leftmost_table && !uses_index;
 
                     if !try_to_build_ephemeral_index {
+                        if let Some(index) = partial_index(index.as_ref()) {
+                            let is_outer_join = table_references.joined_tables()[table_idx]
+                                .join_info
+                                .as_ref()
+                                .is_some_and(|join_info| join_info.is_outer());
+                            mark_partial_index_predicate_terms_consumed(
+                                index,
+                                &table_references.joined_tables()[table_idx],
+                                where_clause,
+                                is_outer_join,
+                            );
+                        }
                         table_references.joined_tables_mut()[table_idx].op =
                             Operation::Scan(Scan::BTreeTable {
                                 iter_dir: *iter_dir,
@@ -2330,11 +2359,19 @@ fn optimize_table_access(
                             )?,
                         });
                 } else {
-                    let is_outer_join = table_references.joined_tables_mut()[table_idx]
+                    let is_outer_join = table_references.joined_tables()[table_idx]
                         .join_info
                         .as_ref()
                         .is_some_and(|join_info| join_info.is_outer());
                     let defer_cross_table_constraints = hash_join_build_only_tables.get(table_idx);
+                    if let Some(index) = partial_index(index.as_ref()) {
+                        mark_partial_index_predicate_terms_consumed(
+                            index,
+                            &table_references.joined_tables()[table_idx],
+                            where_clause,
+                            is_outer_join,
+                        );
+                    }
                     mark_seek_constraints_consumed(
                         &constraints_per_table[table_idx].constraints,
                         constraint_refs,
@@ -2556,6 +2593,18 @@ fn optimize_table_access(
                         ));
                     }
                 };
+                let is_outer_join = table_references.joined_tables()[table_idx]
+                    .join_info
+                    .as_ref()
+                    .is_some_and(|join_info| join_info.is_outer());
+                if let Some(index) = partial_index(index.as_ref()) {
+                    mark_partial_index_predicate_terms_consumed(
+                        index,
+                        &table_references.joined_tables()[table_idx],
+                        where_clause,
+                        is_outer_join,
+                    );
+                }
                 where_clause[*where_term_idx].consumed = true;
                 table_references.joined_tables_mut()[table_idx].op =
                     Operation::Search(Search::InSeek {
@@ -2740,6 +2789,26 @@ fn mark_seek_constraints_consumed(
             }
             where_term.consumed = true;
         }
+    }
+}
+
+fn mark_partial_index_predicate_terms_consumed(
+    index: &Index,
+    table_reference: &JoinedTable,
+    where_clause: &mut [WhereTerm],
+    is_outer_join: bool,
+) {
+    let predicate_terms = partial_index_predicate_terms(index, table_reference, where_clause)
+        .expect("selected partial index predicate must be implied by query");
+    for term_idx in predicate_terms {
+        let where_term = &mut where_clause[term_idx];
+        if where_term.consumed {
+            continue;
+        }
+        if is_outer_join && where_term.from_outer_join != Some(table_reference.internal_id) {
+            continue;
+        }
+        where_term.consumed = true;
     }
 }
 

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -15,8 +15,9 @@ use crate::translate::optimizer::access_method::{
     BranchReadMode, ChosenInSeekCandidate, ResidualConstraintMode,
 };
 use crate::translate::optimizer::constraints::{
-    analyze_binary_term_for_index, constraints_from_where_clause, summarize_binary_term_for_index,
-    Constraint, RangeConstraintRef, TableConstraints,
+    analyze_binary_term_for_index, can_use_partial_index, constraints_from_where_clause,
+    partial_index_predicate_terms, summarize_binary_term_for_index, Constraint, RangeConstraintRef,
+    TableConstraints,
 };
 use crate::translate::optimizer::cost::{
     estimate_cost_for_scan_or_seek, estimate_rows_per_seek, rows_per_leaf_page_for_index,
@@ -446,6 +447,8 @@ struct MultiOrResidualPrePostFilters {
 fn partition_residual_multi_or_exprs(
     branch_terms: &[WhereTerm],
     access: &MultiIdxBranchAccess,
+    index: Option<&Index>,
+    rhs_table: &JoinedTable,
     lhs_mask: &TableMask,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
@@ -470,6 +473,18 @@ fn partition_residual_multi_or_exprs(
             }
         }
         MultiIdxBranchAccess::InSeek { constraint_idx, .. } => consumed[*constraint_idx] = true,
+    }
+    if let Some(index) = index {
+        if index.where_clause.is_some() {
+            let Some(predicate_terms) =
+                partial_index_predicate_terms(index, rhs_table, branch_terms)
+            else {
+                return Ok(None);
+            };
+            for idx in predicate_terms {
+                consumed[idx] = true;
+            }
+        }
     }
 
     let mut pre_filter_exprs = Vec::new();
@@ -789,6 +804,8 @@ fn analyze_and_terms_for_multi_index(
         let Some(summary) = summarize_binary_term_for_index(
             &term.expr,
             table_id,
+            table_reference,
+            where_clause,
             indexes,
             rowid_alias_column,
             table_references,
@@ -816,6 +833,13 @@ fn analyze_and_terms_for_multi_index(
     // that single lookup path over intersection.
     if let Some(indexes) = indexes {
         for index in indexes.iter().filter(|idx| idx.index_method.is_none()) {
+            // An unproven partial index cannot be the single-index alternative
+            // that suppresses intersection planning.
+            if index.where_clause.is_some()
+                && !can_use_partial_index(index, table_reference, where_clause)
+            {
+                continue;
+            }
             let mut columns_covered = 0;
             for (i, branch) in candidate_branches.iter().enumerate() {
                 let col_pos = branch.table_col_pos;
@@ -870,6 +894,7 @@ fn analyze_and_terms_for_multi_index(
                 branch.where_term_idx,
                 table_id,
                 table_reference,
+                where_clause,
                 indexes,
                 rowid_alias_column,
                 table_references,
@@ -990,6 +1015,8 @@ pub fn consider_multi_index_union(
                 let Some(partitioned_pre_post) = partition_residual_multi_or_exprs(
                     &synthetic_where_terms,
                     &chosen.access,
+                    chosen.index.as_deref(),
+                    rhs_table,
                     lhs_mask,
                     table_references,
                     subqueries,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1490,51 +1490,7 @@ pub fn parse_where(
                 resolver,
                 BindingBehavior::TryCanonicalColumnsFirst,
             )?;
-            let _ = walk_expr_mut(&mut expr.expr, &mut |e: &mut Expr| -> Result<WalkControl> {
-                if let Expr::Between {
-                    lhs,
-                    not,
-                    start,
-                    end,
-                } = e
-                {
-                    let lhs_expr = std::mem::take(lhs.as_mut());
-                    let start_expr = std::mem::take(start.as_mut());
-                    let end_expr = std::mem::take(end.as_mut());
-
-                    let (lower, upper, combine_op) = if *not {
-                        (
-                            Expr::Binary(
-                                Box::new(start_expr),
-                                ast::Operator::Greater,
-                                Box::new(lhs_expr.clone()),
-                            ),
-                            Expr::Binary(
-                                Box::new(lhs_expr),
-                                ast::Operator::Greater,
-                                Box::new(end_expr),
-                            ),
-                            ast::Operator::Or,
-                        )
-                    } else {
-                        (
-                            Expr::Binary(
-                                Box::new(start_expr),
-                                ast::Operator::LessEquals,
-                                Box::new(lhs_expr.clone()),
-                            ),
-                            Expr::Binary(
-                                Box::new(lhs_expr),
-                                ast::Operator::LessEquals,
-                                Box::new(end_expr),
-                            ),
-                            ast::Operator::And,
-                        )
-                    };
-                    *e = Expr::Binary(Box::new(lower), combine_op, Box::new(upper));
-                }
-                Ok(WalkControl::Continue)
-            });
+            rewrite_between_exprs(&mut expr.expr)?;
         }
         // BETWEEN in WHERE is rewritten to binary terms here so each side can be
         // considered independently by constraint extraction and range planning.
@@ -1566,6 +1522,55 @@ pub fn parse_where(
     } else {
         Ok(())
     }
+}
+
+pub fn rewrite_between_exprs(expr: &mut Expr) -> Result<()> {
+    walk_expr_mut(expr, &mut |e: &mut Expr| -> Result<WalkControl> {
+        if let Expr::Between {
+            lhs,
+            not,
+            start,
+            end,
+        } = e
+        {
+            let lhs_expr = std::mem::take(lhs.as_mut());
+            let start_expr = std::mem::take(start.as_mut());
+            let end_expr = std::mem::take(end.as_mut());
+
+            let (lower, upper, combine_op) = if *not {
+                (
+                    Expr::Binary(
+                        Box::new(start_expr),
+                        ast::Operator::Greater,
+                        Box::new(lhs_expr.clone()),
+                    ),
+                    Expr::Binary(
+                        Box::new(lhs_expr),
+                        ast::Operator::Greater,
+                        Box::new(end_expr),
+                    ),
+                    ast::Operator::Or,
+                )
+            } else {
+                (
+                    Expr::Binary(
+                        Box::new(start_expr),
+                        ast::Operator::LessEquals,
+                        Box::new(lhs_expr.clone()),
+                    ),
+                    Expr::Binary(
+                        Box::new(lhs_expr),
+                        ast::Operator::LessEquals,
+                        Box::new(end_expr),
+                    ),
+                    ast::Operator::And,
+                )
+            };
+            *e = Expr::Binary(Box::new(lower), combine_op, Box::new(upper));
+        }
+        Ok(WalkControl::Continue)
+    })?;
+    Ok(())
 }
 
 /**

--- a/testing/sqltests/tests/partial_idx.sqltest
+++ b/testing/sqltests/tests/partial_idx.sqltest
@@ -801,6 +801,35 @@ expect {
     hundred
 }
 
+setup partial_index_indexed_by_between_schema {
+    CREATE TABLE t_between_forced(id INTEGER PRIMARY KEY, a INTEGER, c TEXT, e INTEGER);
+    CREATE INDEX idx_between_forced ON t_between_forced(a, c, id) WHERE e BETWEEN -10 AND 10;
+    INSERT INTO t_between_forced VALUES
+        (1, 1, 'in', 0),
+        (2, 2, 'out', 20),
+        (3, 3, 'also_in', -10);
+}
+
+@setup partial_index_indexed_by_between_schema
+test partial-index-indexed-by-between-predicate-can-prove-index {
+    SELECT id, a, c
+    FROM t_between_forced INDEXED BY idx_between_forced
+    WHERE e BETWEEN -10 AND 10
+    ORDER BY a, c, id;
+}
+expect {
+    1|1|in
+    3|3|also_in
+}
+
+@setup partial_index_indexed_by_between_schema
+snapshot-eqp partial-index-indexed-by-between-predicate-can-prove-index-eqp {
+    SELECT id, a, c
+    FROM t_between_forced INDEXED BY idx_between_forced
+    WHERE e BETWEEN -10 AND 10
+    ORDER BY a, c, id;
+}
+
 # Multiple partial indexes with BETWEEN on same table
 @cross-check-integrity
 test partial-index-between-multiple {
@@ -1228,27 +1257,212 @@ expect {
 
 # Functional correctness: results match what you'd expect when the partial
 # index is consulted for a seek.
-@cross-check-integrity
-test partial-index-seek-correctness {
+setup partial_index_seek_schema {
     CREATE TABLE samples (id INTEGER PRIMARY KEY, library_id INTEGER, attack_score INTEGER, name TEXT);
     CREATE INDEX samples_pidx ON samples(name) WHERE library_id IS NULL AND attack_score IS NOT NULL;
     INSERT INTO samples VALUES (1, NULL, 5, 'a'), (2, NULL, NULL, 'a'),
                                 (3, 1,    7, 'a'), (4, NULL, 9, 'b');
+}
+
+@setup partial_index_seek_schema
+@cross-check-integrity
+test partial-index-seek-correctness {
     SELECT id FROM samples WHERE library_id IS NULL AND attack_score IS NOT NULL AND name = 'a';
 }
 expect {
     1
 }
 
-@cross-check-integrity
-test partial-index-full-scan-correctness {
+@setup partial_index_seek_schema
+snapshot-eqp partial-index-seek-correctness-eqp {
+    SELECT id FROM samples WHERE library_id IS NULL AND attack_score IS NOT NULL AND name = 'a';
+}
+
+setup partial_index_full_scan_schema {
     CREATE TABLE samples (id INTEGER PRIMARY KEY, library_id INTEGER, attack_score INTEGER);
     CREATE INDEX samples_user_processed_idx ON samples (id)
         WHERE library_id IS NULL AND attack_score IS NOT NULL;
     INSERT INTO samples VALUES (1, NULL, 5), (2, NULL, NULL),
                                 (3, 1,    7), (4, NULL, 9);
+}
+
+@setup partial_index_full_scan_schema
+@cross-check-integrity
+test partial-index-full-scan-correctness {
     SELECT COUNT(*) FROM samples WHERE library_id IS NULL AND attack_score IS NOT NULL;
 }
 expect {
     2
+}
+
+@setup partial_index_full_scan_schema
+snapshot-eqp partial-index-full-scan-correctness-eqp {
+    SELECT COUNT(*) FROM samples WHERE library_id IS NULL AND attack_score IS NOT NULL;
+}
+
+# A RHS ON-clause predicate may prove a LEFT JOIN partial index: rows outside
+# the predicate cannot match the left row anyway.
+setup partial_index_left_join_on_schema {
+    CREATE TABLE left_items(id INTEGER);
+    CREATE TABLE right_items(id INTEGER, marker INTEGER);
+    CREATE INDEX right_marker_null_idx ON right_items(id) WHERE marker IS NULL;
+    INSERT INTO left_items VALUES(1), (2);
+    INSERT INTO right_items VALUES(10, NULL), (11, 5);
+}
+
+@setup partial_index_left_join_on_schema
+test partial-index-left-join-on-predicate-can-prove-index {
+    SELECT left_items.id, right_items.id, right_items.marker
+    FROM left_items
+    LEFT JOIN right_items ON right_items.marker IS NULL
+    ORDER BY left_items.id, right_items.id;
+}
+expect {
+    1|10|
+    2|10|
+}
+
+@setup partial_index_left_join_on_schema
+snapshot-eqp partial-index-left-join-on-predicate-can-prove-index-eqp {
+    SELECT left_items.id, right_items.id, right_items.marker
+    FROM left_items
+    LEFT JOIN right_items ON right_items.marker IS NULL
+    ORDER BY left_items.id, right_items.id;
+}
+
+# The same RHS predicate in WHERE is post-join. It cannot prove a partial index
+# for the right side of a LEFT JOIN because omitted non-matching RHS rows would
+# incorrectly create NULL-extended rows.
+setup partial_index_left_join_where_schema {
+    CREATE TABLE left_items(id INTEGER);
+    CREATE TABLE right_items(id INTEGER, marker INTEGER);
+    CREATE INDEX right_marker_null_idx ON right_items(id) WHERE marker IS NULL;
+    INSERT INTO left_items VALUES(1);
+    INSERT INTO right_items VALUES(10, 5);
+}
+
+@setup partial_index_left_join_where_schema
+test partial-index-left-join-where-predicate-cannot-prove-index {
+    SELECT COUNT(*)
+    FROM left_items
+    LEFT JOIN right_items ON 1
+    WHERE right_items.marker IS NULL;
+}
+expect {
+    0
+}
+
+@setup partial_index_left_join_where_schema
+snapshot-eqp partial-index-left-join-where-predicate-cannot-prove-index-eqp {
+    SELECT COUNT(*)
+    FROM left_items
+    LEFT JOIN right_items ON 1
+    WHERE right_items.marker IS NULL;
+}
+
+test partial-index-indexed-by-left-join-where-predicate-rejected {
+    CREATE TABLE left_items(id INTEGER);
+    CREATE TABLE right_items(id INTEGER, marker INTEGER);
+    CREATE INDEX right_marker_null_idx ON right_items(id) WHERE marker IS NULL;
+    INSERT INTO left_items VALUES(1);
+    INSERT INTO right_items VALUES(10, 5);
+    SELECT COUNT(*)
+    FROM left_items
+    LEFT JOIN right_items INDEXED BY right_marker_null_idx ON 1
+    WHERE right_items.marker IS NULL;
+}
+expect error {
+    no query solution
+}
+
+setup partial_index_indexed_by_null_rejecting_schema {
+    CREATE TABLE left_items(id INTEGER);
+    CREATE TABLE right_items(id INTEGER, marker INTEGER);
+    CREATE INDEX right_marker_five_idx ON right_items(id) WHERE marker = 5;
+    INSERT INTO left_items VALUES(1);
+    INSERT INTO right_items VALUES(1, 5), (1, 6);
+}
+
+@setup partial_index_indexed_by_null_rejecting_schema
+test partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite {
+    SELECT COUNT(*)
+    FROM left_items
+    LEFT JOIN right_items INDEXED BY right_marker_five_idx ON left_items.id = right_items.id
+    WHERE right_items.marker = 5;
+}
+expect {
+    1
+}
+
+@setup partial_index_indexed_by_null_rejecting_schema
+snapshot-eqp partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite-eqp {
+    SELECT COUNT(*)
+    FROM left_items
+    LEFT JOIN right_items INDEXED BY right_marker_five_idx ON left_items.id = right_items.id
+    WHERE right_items.marker = 5;
+}
+
+test partial-index-indexed-by-without-predicate-rejected {
+    CREATE TABLE indexed_items(id INTEGER, marker INTEGER);
+    CREATE INDEX indexed_items_marker_null_idx ON indexed_items(id) WHERE marker IS NULL;
+    INSERT INTO indexed_items VALUES(1, NULL), (2, 5);
+    SELECT id FROM indexed_items INDEXED BY indexed_items_marker_null_idx ORDER BY id;
+}
+expect error {
+    no query solution
+}
+
+setup partial_index_indexed_by_count_schema {
+    CREATE TABLE indexed_items(id INTEGER, marker INTEGER);
+    CREATE INDEX indexed_items_marker_null_idx ON indexed_items(id) WHERE marker IS NULL;
+    INSERT INTO indexed_items VALUES(1, NULL), (2, 5);
+}
+
+@setup partial_index_indexed_by_count_schema
+test partial-index-indexed-by-count-star-without-predicate-counts-table {
+    SELECT COUNT(*) FROM indexed_items INDEXED BY indexed_items_marker_null_idx;
+}
+expect {
+    2
+}
+
+@setup partial_index_indexed_by_count_schema
+snapshot-eqp partial-index-indexed-by-count-star-without-predicate-counts-table-eqp {
+    SELECT COUNT(*) FROM indexed_items INDEXED BY indexed_items_marker_null_idx;
+}
+
+setup partial_index_multi_index_or_schema {
+    CREATE TABLE indexed_items(a INT, b INT, c INT);
+    CREATE INDEX indexed_items_a_partial_idx ON indexed_items(a) WHERE b = 1;
+    CREATE INDEX indexed_items_c_idx ON indexed_items(c);
+    INSERT INTO indexed_items VALUES (2, 0, 9), (2, 1, 8), (5, 0, 3);
+}
+
+@setup partial_index_multi_index_or_schema
+test partial-index-multi-index-or-can-use-proven-partial-index {
+    SELECT a, b, c FROM indexed_items WHERE (a = 2 AND b = 1) OR c = 3 ORDER BY b, c;
+}
+expect {
+    5|0|3
+    2|1|8
+}
+
+@setup partial_index_multi_index_or_schema
+snapshot-eqp partial-index-multi-index-or-can-use-proven-partial-index-eqp {
+    SELECT a, b, c FROM indexed_items WHERE (a = 2 AND b = 1) OR c = 3 ORDER BY b, c;
+}
+
+@setup partial_index_multi_index_or_schema
+test partial-index-multi-index-or-rejects-unproven-partial-index {
+    SELECT a, b, c FROM indexed_items WHERE a = 2 OR c = 3 ORDER BY b, c;
+}
+expect {
+    5|0|3
+    2|0|9
+    2|1|8
+}
+
+@setup partial_index_multi_index_or_schema
+snapshot-eqp partial-index-multi-index-or-rejects-unproven-partial-index-eqp {
+    SELECT a, b, c FROM indexed_items WHERE a = 2 OR c = 3 ORDER BY b, c;
 }

--- a/testing/sqltests/tests/snapshot_tests/aggregation/aggregation.sqltest
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/aggregation.sqltest
@@ -232,6 +232,26 @@ snapshot simple-count-star {
     SELECT count(*) FROM t1;
 }
 
+setup partial_index_count_table {
+    CREATE TABLE t2(
+        id INTEGER PRIMARY KEY,
+        marker,
+        key_col INTEGER NOT NULL,
+        aux_col INTEGER
+    );
+    CREATE UNIQUE INDEX t2_partial_key_idx
+        ON t2(key_col)
+        WHERE marker IS NULL;
+    CREATE INDEX t2_partial_aux_idx
+        ON t2(aux_col)
+        WHERE marker IS NULL;
+}
+
+@setup partial_index_count_table
+snapshot partial-index-count-star {
+    SELECT count(*) FROM t2 WHERE marker IS NULL;
+}
+
 @setup simple_table
 snapshot simple-count-no-args {
     SELECT count() FROM t1;

--- a/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
+++ b/testing/sqltests/tests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
@@ -1,0 +1,31 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(*) FROM t2 WHERE marker IS NULL;
+info:
+  statement_type: SELECT
+  tables:
+  - t2
+  setup_blocks:
+  - partial_index_count_table
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t2 USING INDEX t2_partial_aux_idx
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4            p5  comment
+   0  Init             0  12   0                 0  Start at 12
+   1  Null             0   2   0                 0  r[2]=NULL
+   2  OpenRead         0   2   0  k(4,B,B,B,B)   0  table=t2, root=2, iDb=0
+   3  OpenRead         1   4   0  k(2,B)         0  index=t2_partial_aux_idx, root=4, iDb=0
+   4  Rewind           1   8   0                 0  Rewind index t2_partial_aux_idx
+   5    DeferredSeek   1   0   0                 0
+   6    AggStep        0   3   2  count          0  accum=r[2] step(r[3])
+   7  Next             1   5   0                 0
+   8  AggFinal         0   2   0  count          0  accum=r[2]
+   9  Copy             2   1   0                 0  r[1]=r[2]
+  10  ResultRow        1   1   0                 0  output=r[1]
+  11  Halt             0   0   0                 0
+  12  Transaction      0   1   3                 0  iDb=0 tx_mode=Read
+  13  Integer          1   3   0                 0  r[3]=1
+  14  Goto             0   1   0                 0

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-full-scan-correctness-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-full-scan-correctness-eqp.snap
@@ -1,0 +1,13 @@
+---
+source: partial_idx.sqltest
+expression: SELECT COUNT(*) FROM samples WHERE library_id IS NULL AND attack_score IS NOT NULL;
+info:
+  statement_type: SELECT
+  tables:
+  - samples
+  setup_blocks:
+  - partial_index_full_scan_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN samples USING INDEX samples_user_processed_idx

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-indexed-by-between-predicate-can-prove-index-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-indexed-by-between-predicate-can-prove-index-eqp.snap
@@ -1,0 +1,17 @@
+---
+source: partial_idx.sqltest
+expression: |-
+  SELECT id, a, c
+      FROM t_between_forced INDEXED BY idx_between_forced
+      WHERE e BETWEEN -10 AND 10
+      ORDER BY a, c, id;
+info:
+  statement_type: SELECT
+  tables:
+  - t_between_forced
+  setup_blocks:
+  - partial_index_indexed_by_between_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t_between_forced USING INDEX idx_between_forced

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-indexed-by-count-star-without-predicate-counts-table-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-indexed-by-count-star-without-predicate-counts-table-eqp.snap
@@ -1,0 +1,13 @@
+---
+source: partial_idx.sqltest
+expression: SELECT COUNT(*) FROM indexed_items INDEXED BY indexed_items_marker_null_idx;
+info:
+  statement_type: SELECT
+  tables:
+  - indexed_items
+  setup_blocks:
+  - partial_index_indexed_by_count_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN indexed_items

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite-eqp.snap
@@ -1,0 +1,20 @@
+---
+source: partial_idx.sqltest
+expression: |-
+  SELECT COUNT(*)
+      FROM left_items
+      LEFT JOIN right_items INDEXED BY right_marker_five_idx ON left_items.id = right_items.id
+      WHERE right_items.marker = 5;
+info:
+  statement_type: SELECT
+  tables:
+  - left_items
+  - left_items.id
+  - right_items
+  setup_blocks:
+  - partial_index_indexed_by_null_rejecting_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN left_items
+`--SEARCH right_items USING INDEX right_marker_five_idx (id=?)

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-left-join-on-predicate-can-prove-index-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-left-join-on-predicate-can-prove-index-eqp.snap
@@ -1,0 +1,21 @@
+---
+source: partial_idx.sqltest
+expression: |-
+  SELECT left_items.id, right_items.id, right_items.marker
+      FROM left_items
+      LEFT JOIN right_items ON right_items.marker IS NULL
+      ORDER BY left_items.id, right_items.id;
+info:
+  statement_type: SELECT
+  tables:
+  - left_items
+  - right_items
+  - right_items.marker
+  setup_blocks:
+  - partial_index_left_join_on_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN left_items
+|--SCAN right_items USING INDEX right_marker_null_idx
+`--USE SORTER FOR ORDER BY

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-left-join-where-predicate-cannot-prove-index-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-left-join-where-predicate-cannot-prove-index-eqp.snap
@@ -1,0 +1,19 @@
+---
+source: partial_idx.sqltest
+expression: |-
+  SELECT COUNT(*)
+      FROM left_items
+      LEFT JOIN right_items ON 1
+      WHERE right_items.marker IS NULL;
+info:
+  statement_type: SELECT
+  tables:
+  - left_items
+  - right_items
+  setup_blocks:
+  - partial_index_left_join_where_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN left_items
+`--SCAN right_items

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-multi-index-or-can-use-proven-partial-index-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-multi-index-or-can-use-proven-partial-index-eqp.snap
@@ -1,0 +1,14 @@
+---
+source: partial_idx.sqltest
+expression: SELECT a, b, c FROM indexed_items WHERE (a = 2 AND b = 1) OR c = 3 ORDER BY b, c;
+info:
+  statement_type: SELECT
+  tables:
+  - indexed_items
+  setup_blocks:
+  - partial_index_multi_index_or_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--MULTI-INDEX OR indexed_items (indexed_items_a_partial_idx, indexed_items_c_idx)
+`--USE SORTER FOR ORDER BY

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-multi-index-or-rejects-unproven-partial-index-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-multi-index-or-rejects-unproven-partial-index-eqp.snap
@@ -1,0 +1,14 @@
+---
+source: partial_idx.sqltest
+expression: SELECT a, b, c FROM indexed_items WHERE a = 2 OR c = 3 ORDER BY b, c;
+info:
+  statement_type: SELECT
+  tables:
+  - indexed_items
+  setup_blocks:
+  - partial_index_multi_index_or_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN indexed_items
+`--USE SORTER FOR ORDER BY

--- a/testing/sqltests/tests/snapshots/partial_idx__partial-index-seek-correctness-eqp.snap
+++ b/testing/sqltests/tests/snapshots/partial_idx__partial-index-seek-correctness-eqp.snap
@@ -1,0 +1,13 @@
+---
+source: partial_idx.sqltest
+expression: SELECT id FROM samples WHERE library_id IS NULL AND attack_score IS NOT NULL AND name = 'a';
+info:
+  statement_type: SELECT
+  tables:
+  - samples
+  setup_blocks:
+  - partial_index_seek_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH samples USING INDEX samples_pidx (name=?)


### PR DESCRIPTION
Fixes the behavior described in #7410 - partial index WHERE terms were being redundantly evaluated for each row, even though every row in the index already satisfies the predicate by definition.

One stupid edge case to call out: in SQLite, `SELECT count(*) FROM tbl INDEXED BY some_tbl_partial_index` still returns the full count from the table (ignores the index) without erroring. Added a test for that as well