### PR TITLE
Fix Issue #7326: BETWEEN in WHERE clause uses the wrong operand's collation

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1553,9 +1553,9 @@ pub fn rewrite_between_exprs(expr: &mut Expr) -> Result<()> {
             let (lower, upper, combine_op) = if *not {
                 (
                     Expr::Binary(
-                        Box::new(start_expr),
-                        ast::Operator::Greater,
                         Box::new(lhs_expr.clone()),
+                        ast::Operator::Less,
+                        Box::new(start_expr),
                     ),
                     Expr::Binary(
                         Box::new(lhs_expr),
@@ -1567,9 +1567,9 @@ pub fn rewrite_between_exprs(expr: &mut Expr) -> Result<()> {
             } else {
                 (
                     Expr::Binary(
-                        Box::new(start_expr),
-                        ast::Operator::LessEquals,
                         Box::new(lhs_expr.clone()),
+                        ast::Operator::GreaterEquals,
+                        Box::new(start_expr),
                     ),
                     Expr::Binary(
                         Box::new(lhs_expr),

--- a/testing/sqltests/tests/collate.sqltest
+++ b/testing/sqltests/tests/collate.sqltest
@@ -552,6 +552,81 @@ expect {
     Date|0
 }
 
+# --- BETWEEN in WHERE:  should keep lhs as left operand for both comparisons to respect SQLite collation precedence ---
+@cross-check-integrity
+test collate_between_where_nocase_lhs_column_bound {
+    CREATE TABLE t(a COLLATE NOCASE, b);
+    INSERT INTO t VALUES ('ABC','abc');
+    SELECT a, b FROM t WHERE a BETWEEN b AND b;
+}
+expect {
+    ABC|abc
+}
+
+# --- BETWEEN in WHERE - BINARY lhs vs NOCASE bound: collation from lhs (BINARY), so 'ABC' is not in ['abc','abc'] ---
+@cross-check-integrity
+test collate_between_where_binary_lhs_nocase_bound {
+    CREATE TABLE t(a COLLATE BINARY, b COLLATE NOCASE);
+    INSERT INTO t VALUES ('ABC','abc');
+    SELECT count(*) FROM t WHERE a BETWEEN b AND b;
+    SELECT a BETWEEN b AND b FROM t;
+}
+expect {
+    0
+    0
+}
+
+# --- BETWEEN in WHERE - NOT BETWEEN lower-bound path: NOCASE lhs equals bound so NOT BETWEEN excludes the row ---
+@cross-check-integrity
+test collate_not_between_where_nocase_lhs {
+    CREATE TABLE t(a COLLATE NOCASE, b);
+    INSERT INTO t VALUES ('ABC','abc');
+    SELECT count(*) FROM t WHERE a NOT BETWEEN b AND b;
+    SELECT a NOT BETWEEN b AND b FROM t;
+}
+expect {
+    0
+    0
+}
+
+# --- BETWEEN in WHERE - NOCASE lhs with distinct start/end cols: 'Banana' matches, 'Apple' falls below 'banana' ---
+@cross-check-integrity
+test collate_between_where_nocase_lhs_range_columns {
+    CREATE TABLE t(a TEXT COLLATE NOCASE, lo TEXT, hi TEXT);
+    INSERT INTO t VALUES ('Banana', 'apple', 'cherry');
+    INSERT INTO t VALUES ('Apple',  'banana', 'cherry');
+    SELECT a FROM t WHERE a BETWEEN lo AND hi ORDER BY rowid;
+}
+expect {
+    Banana
+}
+
+# --- BETWEEN in WHERE - RTRIM lhs ignores trailing spaces in bound: 'abc' is within ['abc   ','abc   '] ---
+@cross-check-integrity
+test collate_between_where_rtrim_lhs_column_bound {
+    CREATE TABLE t(a COLLATE RTRIM, b);
+    INSERT INTO t VALUES ('abc', 'abc   ');
+    SELECT count(*) FROM t WHERE a BETWEEN b AND b;
+    SELECT a BETWEEN b AND b FROM t;
+}
+expect {
+    1
+    1
+}
+
+# --- BETWEEN in WHERE - Explicit COLLATE on lhs overrides column collation: BINARY col matches under ---
+@cross-check-integrity
+test collate_between_where_explicit_collate_lhs {
+    CREATE TABLE t(a COLLATE BINARY, b COLLATE BINARY);
+    INSERT INTO t VALUES ('ABC','abc');
+    SELECT count(*) FROM t WHERE a COLLATE NOCASE BETWEEN b AND b;
+    SELECT count(*) FROM t WHERE a BETWEEN b AND b;
+}
+expect {
+    1
+    0
+}
+
 # --- GROUP BY on NOCASE column + aggregate + scalar comparison ---
 # The GROUP BY should group case-insensitively, and the scalar comparison
 # in the SELECT must still use the column's NOCASE collation.

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
@@ -101,8 +101,8 @@ addr  opcode       p1  p2  p3  p4                                     p5  commen
   48    Gt         59  60  58  Binary                                  0  if r[59]>r[60] goto 58
   49    Column      1   5  64                                          0  r[64]=part.P_SIZE
   50    Gt         64  65  58  Binary                                  0  if r[64]>r[65] goto 58
-  51    Column      1   5  68                                          0  r[68]=part.P_SIZE
-  52    Gt         67  68  58  Binary                                  0  if r[67]>r[68] goto 58
+  51    Column      1   5  67                                          0  r[67]=part.P_SIZE
+  52    Lt         67  68  58  Binary                                  0  if r[67]<r[68] goto 58
   53    Column      0   5  70                                          0  r[70]=lineitem.L_EXTENDEDPRICE
   54    Column      0   6  73                                          0  r[73]=lineitem.L_DISCOUNT
   55    Subtract   72  73  71                                          0  r[71]=r[72]-r[73]
@@ -146,6 +146,6 @@ addr  opcode       p1  p2  p3  p4                                     p5  commen
   93  Integer      10  62   0                                          0  r[62]=10
   94  Add          61  62  60                                          0  r[60]=r[61]+r[62]
   95  Integer      15  65   0                                          0  r[65]=15
-  96  Integer       1  67   0                                          0  r[67]=1
+  96  Integer       1  68   0                                          0  r[68]=1
   97  Integer       1  72   0                                          0  r[72]=1
   98  Goto          0   1   0                                          0

--- a/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q6-forecasting-revenue.snap
+++ b/testing/sqltests/tests/snapshot_tests/tpch/snapshots/tpch__q6-forecasting-revenue.snap
@@ -31,8 +31,8 @@ addr  opcode       p1  p2  p3  p4                                     p5  commen
    5    Lt          4   5  18  Binary                                  0  if r[4]<r[5] goto 18
    6    Column      0  10   7                                          0  r[7]=lineitem.L_SHIPDATE
    7    Ge          7   8  18  Binary                                  0  if r[7]>=r[8] goto 18
-   8    Column      0   6  11                                          0  r[11]=lineitem.L_DISCOUNT
-   9    Gt         10  11  18  Binary                                  0  if r[10]>r[11] goto 18
+   8    Column      0   6  10                                          0  r[10]=lineitem.L_DISCOUNT
+   9    Lt         10  11  18  Binary                                  0  if r[10]<r[11] goto 18
   10    Column      0   6  15                                          0  r[15]=lineitem.L_DISCOUNT
   11    Gt         15  16  18  Binary                                  0  if r[15]>r[16] goto 18
   12    Column      0   4  20                                          0  r[20]=lineitem.L_QUANTITY
@@ -51,7 +51,7 @@ addr  opcode       p1  p2  p3  p4                                     p5  commen
   25  String8       0   8   0  1995-01-01                              0  r[8]='1995-01-01'
   26  Real          0  12   0  0.08                                    0  r[12]=0.08
   27  Real          0  13   0  0.01                                    0  r[13]=0.01
-  28  Subtract     12  13  10                                          0  r[10]=r[12]-r[13]
+  28  Subtract     12  13  11                                          0  r[11]=r[12]-r[13]
   29  Real          0  17   0  0.08                                    0  r[17]=0.08
   30  Real          0  18   0  0.01                                    0  r[18]=0.01
   31  Add          17  18  16                                          0  r[16]=r[17]+r[18]


### PR DESCRIPTION
## Summary

Fixes https://github.com/tursodatabase/turso/issues/7326 by correcting the operand order when rewriting BETWEEN predicates in a WHERE clause, ensuring collation is always derived from the left-hand-side operand.


## Issue

  A `BETWEEN` predicate in a `WHERE` clause used the collating sequence of the
  **range bound** instead of the **left-hand-side (LHS) expression**. The same
  predicate in a `SELECT` list produced the correct result.

Reproducer: 

  ```sql
  CREATE TABLE t(a COLLATE NOCASE, b);
  INSERT INTO t VALUES ('ABC', 'abc');

  SELECT a, b FROM t WHERE a BETWEEN b AND b;
  -- Turso (before fix):  (no rows)
  -- SQLite:              ABC|abc

  SELECT a BETWEEN b AND b FROM t;
  -- Turso:   1  ✓ (already correct)
  -- SQLite:  1  ✓
  ```

  ## Brief background
  SQLite has no native BETWEEN instruction. The engine rewrites it into two ordinary comparisons:

  **`lhs BETWEEN A AND B`** expands to:
  ```
  lhs >= A  AND  lhs <= B
  ```

  **`lhs NOT BETWEEN A AND B`** expands to:
  ```
  NOT (lhs >= A  AND  lhs <= B)
  ```
 By De Morgan's law, this is equivalent to:
  ```
  lhs < A  OR  lhs > B
  ```

  ## Collation rule

  SQLite (and Turso) resolve the comparison collation from the **left operand** first:

  > "If either operand is a column, then the collating function of that column is used with precedence to the left
  operand." — SQLite docs

  So in `lhs >= A`, collation comes from `lhs`. In `A <= lhs`, collation comes from `A`. Same math, different
  collation — different result.

  ## Root cause

  Two separate code paths rewrote BETWEEN into binary comparisons and disagreed on operand order for the **lower
  bound**:

  | Path | Lower bound written as | Collation taken from |
  |------|----------------------|---------------------|
  | `build_between_terms` in `core/translate/expr/metadata.rs` (SELECT list) | `lhs >= A` | `lhs` ✓ |
  | inline rewrite in `parse_where` in `core/translate/planner.rs` (WHERE clause) | `A <= lhs` | `A` ✗ |

  The upper bound (`lhs <= B`) was correct in both paths — `lhs` was already on the left there.

  ## Fix

  In `core/translate/planner.rs`, keep `lhs` as the **left operand of both comparisons**, mirroring
  `build_between_terms`:

  ```
  Before (buggy):      A <= lhs  AND  lhs <= B
  After  (fixed):   lhs >= A     AND  lhs <= B

  Before NOT (buggy):  A >  lhs  OR   lhs > B
  After  NOT (fixed):  lhs < A   OR   lhs > B
  ```

  ## Tests added (`testing/sqltests/tests/collate.sqltest`)

  The existing `collate_between_nocase` test used **literal** bounds (`'b'`, `'d'`) which have no column collation —
  so collation was found via the right operand regardless of order. The bug only surfaces when **the bound is also a
  column** with its own collation.

  New tests (all `@cross-check-integrity`, all fail before fix / pass after):

  | Test | What it covers |
  |------|---------------|
  | `collate_between_where_nocase_lhs_column_bound` | Exact issue reproducer: NOCASE lhs, BINARY bound |
  | `collate_between_where_binary_lhs_nocase_bound` | Reversed: BINARY lhs, NOCASE bound — bound must not win |
  | `collate_not_between_where_nocase_lhs` | NOT BETWEEN lower-bound operand order |
  | `collate_between_where_nocase_lhs_range_columns` | Distinct lo/hi bound columns, multi-row |
  | `collate_between_where_rtrim_lhs_column_bound` | RTRIM collation variety |
  | `collate_between_where_explicit_collate_lhs` | Explicit COLLATE on lhs overrides column collation |

## Evidence

1) Let's write some tests that will verify the collation rules are taken from the left operand for BETWEEN predicates in a WHERE clause: 

<img width="1853" height="965" alt="Screenshot From 2026-06-10 02-28-19" src="https://github.com/user-attachments/assets/08568e0a-973a-446d-94d5-aeb7e0f86a4d" />



2)  They all failed... Let's take a look at the bytecode: 

<img width="697" height="384" alt="Screenshot From 2026-06-10 01-20-07" src="https://github.com/user-attachments/assets/7eea1024-5e88-4374-ae46-307b32e5029d" />

As you can see, both comparisons should use NoCase (from a COLLATE NOCASE), but the lower-bound check uses Binary taken from column B — meaning the parser was rewriting a >= b as b <= a...


3) After we apply the fix, we run the tests again:

<img width="646" height="656" alt="Screenshot From 2026-06-10 01-27-30" src="https://github.com/user-attachments/assets/f4a94f0b-1cf8-46d6-9201-1ac8345642dd" />

Tests are good to go.


4) Nice, since all tests pass, lets check that the bytecode shows the collation rules are now taken ONLY from the LHS operand:

<img width="713" height="529" alt="Screenshot From 2026-06-10 01-37-00" src="https://github.com/user-attachments/assets/1a136c91-dc68-4991-b35e-dd5468ebc05e" />


We are now aligned with SQLite on this matter (within a WHERE clause).