### PR TITLE
Fix auto-index virtual generated column reads

### DIFF
--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -493,30 +493,47 @@ pub(super) fn emit_autoindex(
         pc_if_empty: label_ephemeral_build_loop_start,
     });
     program.preassign_label_to_next_insn(label_ephemeral_build_loop_start);
-    // Emit all columns from source table that are needed in the ephemeral index.
+    let contains_virtual_column = table_columns.is_some_and(|columns| {
+        index.columns.iter().any(|col| {
+            columns
+                .get(col.pos_in_table)
+                .is_some_and(crate::schema::Column::is_virtual_generated)
+        })
+    });
+
     // Also reserve a register for the rowid if the source table has rowids.
     let num_regs_to_reserve = index.columns.len() + table_has_rowid as usize;
     let ephemeral_cols_start_reg = program.alloc_registers(num_regs_to_reserve);
-    for (i, col) in index.columns.iter().enumerate() {
-        let reg = ephemeral_cols_start_reg + i;
-        if let Some(columns) = table_columns {
-            if let Some(column_def) = columns.get(col.pos_in_table) {
-                if column_def.is_virtual_generated() {
-                    crate::translate::expr::emit_table_column(
-                        program,
-                        table_cursor_id,
-                        table_ref_id,
-                        table_references,
-                        column_def,
-                        col.pos_in_table,
-                        reg,
-                        resolver,
-                    )?;
-                    continue;
-                }
-            }
-        }
-        program.emit_column_or_rowid(table_cursor_id, col.pos_in_table, reg);
+    if contains_virtual_column {
+        // A virtual generated column is computed by running the expression
+        // stored in the schema. If that expression mentions another column from
+        // the same table, normal SELECT code may try to fetch that other column
+        // from the index chosen for the query. While this automatic index is
+        // being filled, that index is empty/in-progress, so those reads must
+        // come from the source table row instead.
+        program.with_cursor_override(table_ref_id, table_cursor_id, |program| {
+            emit_autoindex_columns(
+                program,
+                index,
+                table_cursor_id,
+                table_columns,
+                table_ref_id,
+                table_references,
+                resolver,
+                ephemeral_cols_start_reg,
+            )
+        })?;
+    } else {
+        emit_autoindex_columns(
+            program,
+            index,
+            table_cursor_id,
+            table_columns,
+            table_ref_id,
+            table_references,
+            resolver,
+            ephemeral_cols_start_reg,
+        )?;
     }
     if table_has_rowid {
         program.emit_insn(Insn::RowId {
@@ -557,4 +574,44 @@ pub(super) fn emit_autoindex(
     });
     program.preassign_label_to_next_insn(label_ephemeral_build_end);
     Ok(AutoIndexResult { use_bloom_filter })
+}
+
+/// Fill registers with the values that will become one automatic-index entry.
+///
+/// Ordinary columns are copied directly from the current table row. Virtual
+/// generated columns are recomputed here because their values are not stored in
+/// the table row; their expression may read other columns from that same row.
+#[expect(clippy::too_many_arguments)]
+fn emit_autoindex_columns(
+    program: &mut ProgramBuilder,
+    index: &Index,
+    table_cursor_id: CursorID,
+    table_columns: Option<&[crate::schema::Column]>,
+    table_ref_id: turso_parser::ast::TableInternalId,
+    table_references: &TableReferences,
+    resolver: &Resolver<'_>,
+    ephemeral_cols_start_reg: usize,
+) -> Result<()> {
+    for (i, col) in index.columns.iter().enumerate() {
+        let reg = ephemeral_cols_start_reg + i;
+        if let Some(columns) = table_columns {
+            if let Some(column_def) = columns.get(col.pos_in_table) {
+                if column_def.is_virtual_generated() {
+                    crate::translate::expr::emit_table_column(
+                        program,
+                        table_cursor_id,
+                        table_ref_id,
+                        table_references,
+                        column_def,
+                        col.pos_in_table,
+                        reg,
+                        resolver,
+                    )?;
+                    continue;
+                }
+            }
+        }
+        program.emit_column_or_rowid(table_cursor_id, col.pos_in_table, reg);
+    }
+    Ok(())
 }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1491,6 +1491,36 @@ impl ProgramBuilder {
         self.cursor_overrides.insert(table_ref_id.into(), cursor_id);
     }
 
+    /// Run `f` while reads for this table use `cursor_id`.
+    ///
+    /// The caller must already control where `cursor_id` is positioned. The
+    /// main use is automatic-index construction for virtual generated columns:
+    /// the ephemeral index entry is still being assembled, so generated-column
+    /// expressions cannot read their same-table dependencies from that index.
+    /// They must read from the source table cursor that the auto-index loop has
+    /// positioned with `Rewind` and `Next`.
+    ///
+    /// A register-backed generated-column context could avoid this override,
+    /// but it would also have to model dependencies between generated columns.
+    /// Keeping this scoped lets us reuse the normal expression emitter while
+    /// restoring the previous cursor choice after `f` returns.
+    pub fn with_cursor_override<T>(
+        &mut self,
+        table_ref_id: TableInternalId,
+        cursor_id: CursorID,
+        f: impl FnOnce(&mut Self) -> Result<T>,
+    ) -> Result<T> {
+        let table_id = table_ref_id.into();
+        let previous = self.cursor_overrides.insert(table_id, cursor_id);
+        let result = f(self);
+        if let Some(previous) = previous {
+            self.cursor_overrides.insert(table_id, previous);
+        } else {
+            self.cursor_overrides.remove(&table_id);
+        }
+        result
+    }
+
     /// Clear the cursor override for a table.
     pub fn clear_cursor_override(&mut self, table_ref_id: TableInternalId) {
         self.cursor_overrides.remove(&table_ref_id.into());

--- a/testing/sqltests/tests/gencol.sqltest
+++ b/testing/sqltests/tests/gencol.sqltest
@@ -4977,3 +4977,74 @@ test update-or-virtual-deferred-seek-no-panic-explicit-index {
 expect error {
     UNIQUE constraint failed
 }
+
+setup gencol_autoindex_virtual_column_setup {
+    CREATE TABLE rhs_items(base TEXT, v TEXT AS (base) VIRTUAL);
+    CREATE TABLE lhs_items(marker TEXT);
+    INSERT INTO rhs_items(base) VALUES ('gorgeous_sugar'), ('diplomatic_thwaite');
+    INSERT INTO lhs_items(marker) VALUES ('dynamic_hine');
+}
+
+@setup gencol_autoindex_virtual_column_setup
+test gencol-autoindex-virtual-column-uses-source-table-cursor {
+    SELECT DISTINCT lhs_items.marker, rhs_items.base
+    FROM lhs_items
+    INNER JOIN rhs_items ON lhs_items.marker = 'dynamic_hine'
+    WHERE rhs_items.v < 'gorgeovHrOTvcD'
+    ORDER BY 2;
+}
+expect {
+    dynamic_hine|diplomatic_thwaite
+    dynamic_hine|gorgeous_sugar
+}
+
+@setup gencol_autoindex_virtual_column_setup
+snapshot-eqp gencol-autoindex-virtual-column-uses-source-table-cursor-eqp {
+    SELECT DISTINCT lhs_items.marker, rhs_items.base
+    FROM lhs_items
+    INNER JOIN rhs_items ON lhs_items.marker = 'dynamic_hine'
+    WHERE rhs_items.v < 'gorgeovHrOTvcD'
+    ORDER BY 2;
+}
+
+@setup gencol_autoindex_virtual_column_setup
+test gencol-autoindex-base-column-control {
+    SELECT DISTINCT lhs_items.marker, rhs_items.base
+    FROM lhs_items
+    INNER JOIN rhs_items ON lhs_items.marker = 'dynamic_hine'
+    WHERE rhs_items.base < 'gorgeovHrOTvcD'
+    ORDER BY 2;
+}
+expect {
+    dynamic_hine|diplomatic_thwaite
+    dynamic_hine|gorgeous_sugar
+}
+
+setup gencol_autoindex_chained_virtual_column_setup {
+    CREATE TABLE rhs_items(base TEXT, v1 TEXT AS (base) VIRTUAL, v2 TEXT AS (v1 || '') VIRTUAL);
+    CREATE TABLE lhs_items(marker TEXT);
+    INSERT INTO rhs_items(base) VALUES ('gorgeous_sugar'), ('diplomatic_thwaite');
+    INSERT INTO lhs_items(marker) VALUES ('dynamic_hine');
+}
+
+@setup gencol_autoindex_chained_virtual_column_setup
+test gencol-autoindex-chained-virtual-column-uses-source-table-cursor {
+    SELECT DISTINCT lhs_items.marker, rhs_items.base
+    FROM lhs_items
+    INNER JOIN rhs_items ON lhs_items.marker = 'dynamic_hine'
+    WHERE rhs_items.v2 < 'gorgeovHrOTvcD'
+    ORDER BY 2;
+}
+expect {
+    dynamic_hine|diplomatic_thwaite
+    dynamic_hine|gorgeous_sugar
+}
+
+@setup gencol_autoindex_chained_virtual_column_setup
+snapshot-eqp gencol-autoindex-chained-virtual-column-uses-source-table-cursor-eqp {
+    SELECT DISTINCT lhs_items.marker, rhs_items.base
+    FROM lhs_items
+    INNER JOIN rhs_items ON lhs_items.marker = 'dynamic_hine'
+    WHERE rhs_items.v2 < 'gorgeovHrOTvcD'
+    ORDER BY 2;
+}

--- a/testing/sqltests/tests/snapshots/gencol__gencol-autoindex-chained-virtual-column-uses-source-table-cursor-eqp.snap
+++ b/testing/sqltests/tests/snapshots/gencol__gencol-autoindex-chained-virtual-column-uses-source-table-cursor-eqp.snap
@@ -1,0 +1,23 @@
+---
+source: gencol.sqltest
+expression: |-
+  SELECT DISTINCT lhs_items.marker, rhs_items.base
+      FROM lhs_items
+      INNER JOIN rhs_items ON lhs_items.marker = 'dynamic_hine'
+      WHERE rhs_items.v2 < 'gorgeovHrOTvcD'
+      ORDER BY 2;
+info:
+  statement_type: SELECT
+  tables:
+  - lhs_items
+  - lhs_items.marker
+  - rhs_items
+  setup_blocks:
+  - gencol_autoindex_chained_virtual_column_setup
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN lhs_items
+|--SEARCH rhs_items USING INDEX ephemeral_rhs_items_t2 (v2<?)
+|--USE HASH TABLE FOR DISTINCT
+`--USE SORTER FOR ORDER BY

--- a/testing/sqltests/tests/snapshots/gencol__gencol-autoindex-virtual-column-uses-source-table-cursor-eqp.snap
+++ b/testing/sqltests/tests/snapshots/gencol__gencol-autoindex-virtual-column-uses-source-table-cursor-eqp.snap
@@ -1,0 +1,23 @@
+---
+source: gencol.sqltest
+expression: |-
+  SELECT DISTINCT lhs_items.marker, rhs_items.base
+      FROM lhs_items
+      INNER JOIN rhs_items ON lhs_items.marker = 'dynamic_hine'
+      WHERE rhs_items.v < 'gorgeovHrOTvcD'
+      ORDER BY 2;
+info:
+  statement_type: SELECT
+  tables:
+  - lhs_items
+  - lhs_items.marker
+  - rhs_items
+  setup_blocks:
+  - gencol_autoindex_virtual_column_setup
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN lhs_items
+|--SEARCH rhs_items USING INDEX ephemeral_rhs_items_t2 (v<?)
+|--USE HASH TABLE FOR DISTINCT
+`--USE SORTER FOR ORDER BY


### PR DESCRIPTION
Fixes a bug when a query uses an automatic index on a virtual generated column.

Example:

```
CREATE TABLE rhs (
  name TEXT,
  v TEXT AS (name) VIRTUAL
);

SELECT rhs.name
FROM lhs
JOIN rhs ON ...
WHERE rhs.v < 'm';
```

To build the automatic index, we have to compute rhs.v for each rhs row. Since `v` is defined as `name`, that means reading `rhs.name`.

The bug was that this inner `rhs.name` tried to read from the automatic index that was still being built, so there was no finished index row to read from.

This change makes that generated-column calculation read from the current table row instead using the existing cursor override mechanism

Extracted from #7432 since it was encountered there