### PR TITLE
core: lazy reload analyze stats with mvcc

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -429,6 +429,13 @@ pub struct Connection {
     /// MUST be incremented whenever any setting that affects PrepareContext changes,
     /// and this is not currently centralized; each setter bumps the generation individually.
     pub(crate) prepare_context_generation: AtomicU64,
+    /// `prepare_context_generation` value at which ANALYZE stats were last
+    /// (re)checked. Under MVCC the user tables — including `sqlite_stat1` —
+    /// only arrive in this connection's schema when it adopts the shared
+    /// schema, after the connect()-time stats refresh has already run and
+    /// loaded nothing. Comparing against the generation lets prepare lazily
+    /// load stats exactly once per adopted schema instead of on every call.
+    pub(crate) analyze_stats_attempt_generation: AtomicU64,
     /// Per-connection last-returned value for each sequence (for currval()).
     pub(crate) sequence_currvals: RwLock<HashMap<String, i64>>,
 }
@@ -825,6 +832,7 @@ impl Connection {
         input: &str,
     ) -> Result<(Program, Arc<Pager>, QueryMode)> {
         self.maybe_update_schema();
+        crate::stats::maybe_lazy_load_analyze_stats(self);
 
         let syms = self.syms.read();
         let pager = self.pager.load().clone();
@@ -967,6 +975,7 @@ impl Connection {
         }
         let result = (|| {
             self.maybe_update_schema();
+            crate::stats::maybe_lazy_load_analyze_stats(self);
             let syms = self.syms.read();
             let pager = self.pager.load().clone();
             let mode = QueryMode::Normal;

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -436,6 +436,12 @@ pub struct Connection {
     /// loaded nothing. Comparing against the generation lets prepare lazily
     /// load stats exactly once per adopted schema instead of on every call.
     pub(crate) analyze_stats_attempt_generation: AtomicU64,
+    /// Last [`SharedAnalyzeStats`](crate::stats::SharedAnalyzeStats) epoch this
+    /// connection planned against. When the shared stats are refreshed (by this
+    /// or another connection) the epoch moves ahead of this value, and the next
+    /// statement compilation bumps `prepare_context_generation` so cached
+    /// statements recompile with the new statistics.
+    pub(crate) analyze_stats_seen_epoch: AtomicU64,
     /// Per-connection last-returned value for each sequence (for currval()).
     pub(crate) sequence_currvals: RwLock<HashMap<String, i64>>,
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2032,6 +2032,8 @@ impl Database {
             named_savepoints: RwLock::new(Vec::new()),
             schema_reparse_in_progress: AtomicBool::new(false),
             prepare_context_generation: AtomicU64::new(0),
+            // u64::MAX != any real generation, so the first prepare re-checks.
+            analyze_stats_attempt_generation: AtomicU64::new(u64::MAX),
             sequence_currvals: RwLock::new(HashMap::default()),
         });
         self.n_connections

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2034,6 +2034,9 @@ impl Database {
             prepare_context_generation: AtomicU64::new(0),
             // u64::MAX != any real generation, so the first prepare re-checks.
             analyze_stats_attempt_generation: AtomicU64::new(u64::MAX),
+            // 0 matches a freshly-default stats cell; the first prepare after a
+            // refresh sees the bumped epoch and recompiles.
+            analyze_stats_seen_epoch: AtomicU64::new(0),
             sequence_currvals: RwLock::new(HashMap::default()),
         });
         self.n_connections

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1186,7 +1186,8 @@ fn test_analyze_stats_lazily_loaded_after_mvcc_reopen() {
     conn.prepare("SELECT * FROM t WHERE a = 1 AND b = 'const'")
         .unwrap();
     let schema = conn.schema.read().clone();
-    let table_stats = schema.analyze_stats.table_stats("t");
+    let analyze_stats = schema.analyze_stats.snapshot();
+    let table_stats = analyze_stats.table_stats("t");
     assert!(
         table_stats.is_some_and(|stats| !stats.index_stats.is_empty()),
         "ANALYZE stats must be loaded after reopening an MVCC database"

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -1159,6 +1159,41 @@ fn test_recovery_clock_monotonicity() {
 /// What this test checks: Recovery stops cleanly at a torn/incomplete tail and keeps all previously validated frames.
 /// Why this matters: Crashes can leave partial writes at EOF; we need durable-prefix recovery, not all-or-nothing failure.
 #[test]
+fn test_analyze_stats_lazily_loaded_after_mvcc_reopen() {
+    let mut db = MvccTestDbNoConn::new_with_random_db();
+    {
+        let conn = db.connect();
+        conn.execute("CREATE TABLE t (a INTEGER, b TEXT, c TEXT, PRIMARY KEY (a, b))")
+            .unwrap();
+        conn.execute("CREATE INDEX t_b_c_idx ON t (b, c)").unwrap();
+        // Every row shares the same (b, c), so without stats the optimizer
+        // cannot tell that the secondary index prefix is non-selective.
+        for i in 0..100 {
+            conn.execute(format!("INSERT INTO t VALUES ({i}, 'const', 'const')"))
+                .unwrap();
+        }
+        conn.execute("ANALYZE").unwrap();
+        conn.close().unwrap();
+    }
+
+    db.restart();
+    let conn = db.connect();
+    // Under MVCC the user tables (and sqlite_stat1) reach the connection's
+    // schema only when statement compilation adopts the recovered shared
+    // schema — after the connect()-time stats refresh has already run and
+    // loaded nothing. Compiling a statement must lazily load the stats so
+    // the optimizer does not plan with empty statistics.
+    conn.prepare("SELECT * FROM t WHERE a = 1 AND b = 'const'")
+        .unwrap();
+    let schema = conn.schema.read().clone();
+    let table_stats = schema.analyze_stats.table_stats("t");
+    assert!(
+        table_stats.is_some_and(|stats| !stats.index_stats.is_empty()),
+        "ANALYZE stats must be loaded after reopening an MVCC database"
+    );
+}
+
+#[test]
 fn test_recover_logical_log_short_file_ignored() {
     let db = MvccTestDbNoConn::new_with_random_db();
     let conn = db.connect();

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -6,7 +6,7 @@ use crate::incremental::view::IncrementalView;
 use crate::incremental::{compiler::DBSP_CIRCUIT_VERSION, operator::create_dbsp_state_index};
 use crate::index_method::{IndexMethodAttachment, IndexMethodConfiguration};
 use crate::return_if_io;
-use crate::stats::AnalyzeStats;
+use crate::stats::SharedAnalyzeStats;
 use crate::sync::RwLock;
 use crate::translate::emitter::Resolver;
 use crate::translate::expr::{
@@ -783,8 +783,10 @@ pub struct Schema {
     pub indexes: HashMap<String, VecDeque<Arc<Index>>>,
     pub has_indexes: HashSet<String>,
     pub schema_version: u32,
-    /// Statistics collected via ANALYZE for regular B-tree tables and indexes.
-    pub analyze_stats: AnalyzeStats,
+    /// Statistics collected via ANALYZE, behind a shared interior-mutable cell
+    /// so they can be refreshed without deep-cloning the schema and are observed
+    /// by every connection sharing this schema lineage. See [`SharedAnalyzeStats`].
+    pub analyze_stats: Arc<SharedAnalyzeStats>,
 
     /// Mapping from table names to the materialized views that depend on them
     pub table_to_materialized_views: HashMap<String, Vec<String>>,
@@ -927,7 +929,7 @@ impl Schema {
             indexes,
             has_indexes,
             schema_version: 0,
-            analyze_stats: AnalyzeStats::default(),
+            analyze_stats: Arc::new(SharedAnalyzeStats::default()),
             table_to_materialized_views,
             incompatible_views,
             dropped_root_pages: HashSet::default(),

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -1,4 +1,6 @@
+use crate::sync::atomic::{AtomicU64, Ordering};
 use crate::sync::Arc;
+use arc_swap::ArcSwap;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::schema::Schema;
@@ -56,9 +58,6 @@ pub struct AnalyzeStats {
 }
 
 impl AnalyzeStats {
-    pub fn needs_refresh(&self) -> bool {
-        self.tables.is_empty()
-    }
     /// Get the statistics for a table, if present.
     pub fn table_stats(&self, table_name: &str) -> Option<&TableStat> {
         let table_name = normalize_ident(table_name);
@@ -87,6 +86,68 @@ impl AnalyzeStats {
     }
 }
 
+/// Atomically swappable ANALYZE statistics shared across every clone of a schema.
+///
+/// `epoch` advances on every change. A connection records the epoch it last
+/// planned against and bumps its `prepare_context_generation` when the epoch
+/// moves, forcing cached statements with stale or empty stats to recompile.
+#[derive(Debug)]
+pub struct SharedAnalyzeStats {
+    stats: ArcSwap<AnalyzeStats>,
+    epoch: AtomicU64,
+}
+
+impl Default for SharedAnalyzeStats {
+    fn default() -> Self {
+        Self {
+            stats: ArcSwap::from_pointee(AnalyzeStats::default()),
+            epoch: AtomicU64::new(0),
+        }
+    }
+}
+
+impl SharedAnalyzeStats {
+    /// Load a cheap, point-in-time snapshot of the current statistics. Hold the
+    /// returned `Arc` for the duration of a planning pass so the view is stable.
+    pub fn snapshot(&self) -> Arc<AnalyzeStats> {
+        self.stats.load_full()
+    }
+
+    /// Current change epoch. See the struct docs for how it drives replanning.
+    pub fn epoch(&self) -> u64 {
+        self.epoch.load(Ordering::Acquire)
+    }
+
+    /// Whether no statistics have been loaded yet.
+    pub fn is_empty(&self) -> bool {
+        self.stats.load().tables.is_empty()
+    }
+
+    /// Replace the statistics wholesale and advance the epoch.
+    pub fn store(&self, stats: AnalyzeStats) {
+        self.stats.store(Arc::new(stats));
+        self.epoch.fetch_add(1, Ordering::Release);
+    }
+
+    /// Drop all statistics for a table (e.g. on DROP TABLE). Copy-on-write: the
+    /// statistics map is small relative to the schema, and DDL is rare.
+    pub fn remove_table(&self, table_name: &str) {
+        let mut next = (**self.stats.load()).clone();
+        let before = next.tables.len();
+        next.remove_table(table_name);
+        if next.tables.len() != before {
+            self.store(next);
+        }
+    }
+
+    /// Drop statistics for a single index (e.g. on DROP INDEX).
+    pub fn remove_index(&self, table_name: &str, index_name: &str) {
+        let mut next = (**self.stats.load()).clone();
+        next.remove_index(table_name, index_name);
+        self.store(next);
+    }
+}
+
 /// Read sqlite_stat1 contents into an AnalyzeStats map without mutating schema.
 ///
 /// Only regular B-tree tables and indexes are considered. Virtual and ephemeral
@@ -103,9 +164,39 @@ pub fn gather_sqlite_stat1(
     Ok(stats)
 }
 
+/// Called at the start of statement compilation. Does two things:
+///
+/// 1. Detects when the shared ANALYZE stats have been refreshed (by any
+///    connection) since this connection last planned, and bumps the prepare
+///    context generation so cached statements recompile against the new stats.
+/// 2. Lazily loads stats from `sqlite_stat1` into the shared cell when they are
+///    missing — needed under MVCC, where the user tables (including
+///    `sqlite_stat1`) only reach this connection's schema after the
+///    connect()-time refresh has already run and loaded nothing.
+///
+/// Both steps mutate the stats via the [`SharedAnalyzeStats`] cell, so neither
+/// deep-clones the (potentially huge) schema.
 pub fn maybe_lazy_load_analyze_stats(conn: &Arc<Connection>) {
-    use crate::sync::atomic::Ordering;
+    // Nested sub-programs (e.g. trigger bodies, the internal stats query below)
+    // must never touch the prepare context; the parent compilation owns it.
+    if conn.is_nested_stmt() || !conn.is_db_initialized() {
+        return;
+    }
 
+    // Adopt any stats refresh published by ourselves or another
+    // connection. `swap` records the epoch we are now planning against.
+    let cell_epoch = conn.schema.read().analyze_stats.epoch();
+    if conn
+        .analyze_stats_seen_epoch
+        .swap(cell_epoch, Ordering::AcqRel)
+        != cell_epoch
+    {
+        conn.bump_prepare_context_generation();
+    }
+
+    // Load stats from sqlite_stat1 if we have not already tried for this
+    // generation. Guarding on the generation also stops the internal
+    // STATS_QUERY prepare below from re-entering this load.
     let generation = conn.prepare_context_generation();
     if conn
         .analyze_stats_attempt_generation
@@ -115,9 +206,7 @@ pub fn maybe_lazy_load_analyze_stats(conn: &Arc<Connection>) {
         return;
     }
     // Transient states: skip without marking so a later prepare retries.
-    if !conn.is_db_initialized()
-        || conn.is_nested_stmt()
-        || conn.schema_reparse_in_progress()
+    if conn.schema_reparse_in_progress()
         || conn.is_mvcc_bootstrap_connection()
         || !matches!(conn.get_tx_state(), TransactionState::None)
         || conn.get_mv_tx().is_some()
@@ -125,7 +214,7 @@ pub fn maybe_lazy_load_analyze_stats(conn: &Arc<Connection>) {
         return;
     }
     let schema = conn.schema.read().clone();
-    if !schema.analyze_stats.needs_refresh() || schema.get_btree_table(STATS_TABLE).is_none() {
+    if !schema.analyze_stats.is_empty() || schema.get_btree_table(STATS_TABLE).is_none() {
         // Nothing to load for this schema; don't re-check until it changes.
         conn.analyze_stats_attempt_generation
             .store(generation, Ordering::Release);
@@ -141,30 +230,13 @@ pub fn maybe_lazy_load_analyze_stats(conn: &Arc<Connection>) {
     if stats.tables.is_empty() {
         return;
     }
-    let mut with_stats = (*schema).clone();
-    with_stats.analyze_stats = stats;
-    let with_stats = Arc::new(with_stats);
-    // Publish into the shared schema so other connections adopt the stats
-    // instead of clobbering them; skip if the shared schema moved on.
-    let mut installed = false;
-    {
-        let mut shared = conn.db.schema.lock();
-        if Arc::ptr_eq(&shared, &schema) {
-            *shared = with_stats.clone();
-            installed = true;
-        }
-    }
-    {
-        let mut local = conn.schema.write();
-        if Arc::ptr_eq(&local, &schema) {
-            *local = with_stats;
-            installed = true;
-        }
-    }
-    if installed {
-        // Cached statements were planned without stats; force reprepare.
-        conn.bump_prepare_context_generation();
-    }
+    // Publish into the shared cell. Every connection holding any clone of this
+    // schema lineage observes the stats; the epoch bump (and our own generation
+    // bump) forces statements planned without stats to recompile.
+    schema.analyze_stats.store(stats);
+    conn.analyze_stats_seen_epoch
+        .store(schema.analyze_stats.epoch(), Ordering::Release);
+    conn.bump_prepare_context_generation();
 }
 
 /// Best-effort refresh analyze_stats on the connection's schema.
@@ -184,9 +256,7 @@ pub fn refresh_analyze_stats(conn: &Arc<Connection>) {
 
     let mv_tx = conn.get_mv_tx();
     if let Ok(stats) = gather_sqlite_stat1(conn, &schema_snapshot, mv_tx) {
-        conn.with_schema_mut(|schema| {
-            schema.analyze_stats = stats;
-        });
+        schema_snapshot.analyze_stats.store(stats);
     }
 }
 
@@ -243,9 +313,11 @@ pub fn refresh_analyze_stats_nonblock(
                     Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
                     Ok(IOResult::Done(())) => {
                         let stats = std::mem::take(stats);
-                        conn.with_schema_mut(|schema| {
-                            schema.analyze_stats = stats;
-                        });
+                        // Store into the shared cell captured at Start. During
+                        // schema reparse this snapshot shares its stats cell with
+                        // the schema about to be installed; otherwise the lazy
+                        // loader will reload on the next prepare.
+                        schema_snapshot.analyze_stats.store(stats);
                         *st = RefreshAnalyzeStatsState::Start;
                         return Ok(IOResult::Done(()));
                     }

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -103,6 +103,70 @@ pub fn gather_sqlite_stat1(
     Ok(stats)
 }
 
+pub fn maybe_lazy_load_analyze_stats(conn: &Arc<Connection>) {
+    use crate::sync::atomic::Ordering;
+
+    let generation = conn.prepare_context_generation();
+    if conn
+        .analyze_stats_attempt_generation
+        .load(Ordering::Acquire)
+        == generation
+    {
+        return;
+    }
+    // Transient states: skip without marking so a later prepare retries.
+    if !conn.is_db_initialized()
+        || conn.is_nested_stmt()
+        || conn.schema_reparse_in_progress()
+        || conn.is_mvcc_bootstrap_connection()
+        || !matches!(conn.get_tx_state(), TransactionState::None)
+        || conn.get_mv_tx().is_some()
+    {
+        return;
+    }
+    let schema = conn.schema.read().clone();
+    if !schema.analyze_stats.needs_refresh() || schema.get_btree_table(STATS_TABLE).is_none() {
+        // Nothing to load for this schema; don't re-check until it changes.
+        conn.analyze_stats_attempt_generation
+            .store(generation, Ordering::Release);
+        return;
+    }
+    // Mark before running the internal query so this prepare's nested
+    // statement cannot re-enter, and errors don't retry on every prepare.
+    conn.analyze_stats_attempt_generation
+        .store(generation, Ordering::Release);
+    let Ok(stats) = gather_sqlite_stat1(conn, &schema, None) else {
+        return;
+    };
+    if stats.tables.is_empty() {
+        return;
+    }
+    let mut with_stats = (*schema).clone();
+    with_stats.analyze_stats = stats;
+    let with_stats = Arc::new(with_stats);
+    // Publish into the shared schema so other connections adopt the stats
+    // instead of clobbering them; skip if the shared schema moved on.
+    let mut installed = false;
+    {
+        let mut shared = conn.db.schema.lock();
+        if Arc::ptr_eq(&shared, &schema) {
+            *shared = with_stats.clone();
+            installed = true;
+        }
+    }
+    {
+        let mut local = conn.schema.write();
+        if Arc::ptr_eq(&local, &schema) {
+            *local = with_stats;
+            installed = true;
+        }
+    }
+    if installed {
+        // Cached statements were planned without stats; force reprepare.
+        conn.bump_prepare_context_generation();
+    }
+}
+
 /// Best-effort refresh analyze_stats on the connection's schema.
 pub fn refresh_analyze_stats(conn: &Arc<Connection>) {
     if !conn.is_db_initialized() || conn.is_nested_stmt() {

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -259,7 +259,8 @@ fn estimate_selectivity(
     is_rowid: bool,
 ) -> f64 {
     // Get ANALYZE stats for this table if available
-    let table_stats = schema.analyze_stats.table_stats(table_name);
+    let analyze_stats = schema.analyze_stats.snapshot();
+    let table_stats = analyze_stats.table_stats(table_name);
     let row_count = table_stats.and_then(|s| s.row_count).unwrap_or(0);
 
     match op {
@@ -349,9 +350,8 @@ fn selectivity_index_for_column<'a>(
     available_indexes: &'a AvailableIndexes,
     column_pos: usize,
 ) -> Option<&'a Index> {
-    let table_stats = schema
-        .analyze_stats
-        .table_stats(table_reference.table.get_name());
+    let analyze_stats = schema.analyze_stats.snapshot();
+    let table_stats = analyze_stats.table_stats(table_reference.table.get_name());
     available_indexes
         .btree_indexes_for_column(table_reference.internal_id, column_pos)
         .find(|index| {
@@ -654,9 +654,8 @@ pub fn constraints_from_where_clause(
                         subqueries,
                     )?)?;
                 }
-                let table_stats = schema
-                    .analyze_stats
-                    .table_stats(table_reference.table.get_name());
+                let analyze_stats = schema.analyze_stats.snapshot();
+                let table_stats = analyze_stats.table_stats(table_reference.table.get_name());
                 let row_count = table_stats
                     .and_then(|s| s.row_count)
                     .unwrap_or(params.rows_per_table_fallback as u64)
@@ -719,9 +718,9 @@ pub fn constraints_from_where_clause(
                 // Only use as constraint if NOT correlated
                 if !subquery.correlated {
                     let estimated_values = params.in_subquery_rows;
-                    let table_stats = schema
-                        .analyze_stats
-                        .table_stats(table_reference.table.get_name());
+                    let analyze_stats = schema.analyze_stats.snapshot();
+                    let table_stats =
+                        analyze_stats.table_stats(table_reference.table.get_name());
                     let row_count = table_stats
                         .and_then(|s| s.row_count)
                         .unwrap_or(params.rows_per_table_fallback as u64)

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -719,8 +719,7 @@ pub fn constraints_from_where_clause(
                 if !subquery.correlated {
                     let estimated_values = params.in_subquery_rows;
                     let analyze_stats = schema.analyze_stats.snapshot();
-                    let table_stats =
-                        analyze_stats.table_stats(table_reference.table.get_name());
+                    let table_stats = analyze_stats.table_stats(table_reference.table.get_name());
                     let row_count = table_stats
                         .and_then(|s| s.row_count)
                         .unwrap_or(params.rows_per_table_fallback as u64)

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1582,7 +1582,8 @@ fn base_row_estimate(
 ) -> RowCountEstimate {
     match &table.table {
         Table::BTree(btree) => {
-            if let Some(stats) = schema.analyze_stats.table_stats(&btree.name) {
+            let analyze_stats = schema.analyze_stats.snapshot();
+            if let Some(stats) = analyze_stats.table_stats(&btree.name) {
                 if let Some(rows) = stats.row_count.or_else(|| {
                     stats
                         .index_stats
@@ -2030,6 +2031,7 @@ fn optimize_table_access(
         maybe_order_target: maybe_order_target.as_ref(),
     };
 
+    let analyze_stats = schema.analyze_stats.snapshot();
     let Some(best_join_order_result) = compute_best_join_order_with_context(
         table_references.joined_tables(),
         initial_input_cardinality,
@@ -2041,7 +2043,7 @@ fn optimize_table_access(
         subqueries,
         &index_method_candidates,
         params,
-        &schema.analyze_stats,
+        &analyze_stats,
         available_indexes,
         table_references,
         schema,


### PR DESCRIPTION
From clanker: Under MVCC, the ANALYZE-stats loader ran before the schema it needed existed and never ran again, so the optimizer planned every query with zero statistics — and one cost-model tie later, a point-delete became a 10,000-row scan that dominated both the latency floor and the contention abort storm.

I have 0 idea about how analyze works currently but this indeed fixed problems with analyze and mvcc