### PR TITLE
core/io: Kill IO::sleep() and IO::yield_now()

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -9,6 +9,7 @@ use crate::sync::{
     },
     Arc, RwLock,
 };
+use crate::types::IOResult;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
@@ -1057,7 +1058,12 @@ impl Connection {
             })?
         } else {
             // first, quickly read schema_version from the root page in order to check if schema changed
-            pager.begin_read_tx()?;
+            //
+            // This is a synchronous entry point that cannot yield, so persistent
+            // lock contention surfaces as Busy and the caller decides how to back off.
+            if let IOResult::IO(_) = pager.begin_read_tx()? {
+                return Err(LimboError::Busy);
+            }
             let on_disk_schema_version = pager
                 .io
                 .block(|| pager.with_header(|header| header.schema_cookie));
@@ -1094,7 +1100,9 @@ impl Connection {
         //
         // from now on we must be very careful with errors propagation
         // in order to not accidentally keep read transaction opened
-        pager.begin_read_tx()?;
+        if let IOResult::IO(_) = pager.begin_read_tx()? {
+            return Err(LimboError::Busy);
+        }
         self.set_tx_state(TransactionState::Read);
 
         let reparse_result = self.reparse_schema();
@@ -1934,7 +1942,11 @@ impl Connection {
     #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
     pub fn wal_insert_begin(&self) -> Result<()> {
         let pager = self.pager.load();
-        pager.begin_read_tx()?;
+        // Synchronous raw-WAL entry point: persistent lock contention surfaces
+        // as Busy and the caller decides how to back off.
+        if let IOResult::IO(_) = pager.begin_read_tx()? {
+            return Err(LimboError::Busy);
+        }
         // Sync-engine drives WAL maintenance explicitly: any auto-restart of
         // the WAL header here would invalidate the watermarks the caller has
         // already published (see `wal_changed_pages_after`), so opt out of

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -437,18 +437,6 @@ pub trait IO: Clock + Send + Sync {
         ))
     }
 
-    /// Yield the current thread to the scheduler.
-    /// Used for backoff in contended lock acquisition.
-    fn yield_now(&self) {
-        crate::thread::yield_now();
-    }
-
-    /// Sleep for the specified duration.
-    /// Used for progressive backoff in contended lock acquisition.
-    fn sleep(&self, duration: std::time::Duration) {
-        crate::thread::sleep(duration);
-    }
-
     /// Return the file identity for the given path.
     /// Default uses OS-level metadata; non-filesystem backends override
     /// with synthetic hash-based identity.

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -426,6 +426,8 @@ enum InitState {
     Start,
     /// Driving `init_pager` (its only IO is the DB-header read).
     InitPager(DbHeaderReadState),
+    /// Pager built; opening the read transaction (may yield on contention).
+    BeginReadTx { pager: Box<Pager> },
     /// Pager built and read-tx open; reading page 1 for the autovacuum mode.
     ReadPage1 { pager: Box<Pager> },
 }
@@ -1529,29 +1531,22 @@ impl Database {
                         pager.set_encryption_context(cipher_mode, key)?;
                     }
 
+                    *st = InitState::BeginReadTx {
+                        pager: Box::new(pager),
+                    };
+                }
+                InitState::BeginReadTx { pager } => {
                     // Start a read transaction before reading page 1 to prevent a concurrent
                     // checkpoint from truncating the WAL underneath bootstrap. Under heavy
                     // same-process connection churn, the shared WAL bootstrap path can
-                    // briefly contend on short-lived in-process locks, so treat Busy here as
-                    // a transient and retry rather than failing `connect()`.
-                    let mut read_tx_attempts = 0u32;
-                    loop {
-                        match pager.begin_read_tx() {
-                            Ok(()) => break,
-                            Err(LimboError::Busy) => {
-                                read_tx_attempts += 1;
-                                if read_tx_attempts > 1 {
-                                    return Err(LimboError::Busy);
-                                }
-                                pager.io.yield_now();
-                            }
-                            Err(err) => return Err(err),
-                        }
-                    }
+                    // briefly contend on short-lived in-process locks; begin_read_tx yields
+                    // on contention and we re-enter here until it resolves.
+                    return_if_io!(pager.begin_read_tx());
 
-                    *st = InitState::ReadPage1 {
-                        pager: Box::new(pager),
+                    let InitState::BeginReadTx { pager } = std::mem::take(st) else {
+                        unreachable!("state is BeginReadTx");
                     };
+                    *st = InitState::ReadPage1 { pager };
                 }
                 InitState::ReadPage1 { pager } => {
                     // Read page 1 within the read transaction to determine the

--- a/core/multiprocess_tests.rs
+++ b/core/multiprocess_tests.rs
@@ -849,7 +849,7 @@ fn multiprocess_shm_hold_read_tx_child_process() {
     let conn = db.connect().unwrap();
     let pager = conn.pager.load();
     let wal = pager.wal.as_ref().unwrap();
-    wal.begin_read_tx().unwrap();
+    while let crate::types::IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
     std::fs::write(&ready_file, b"ready").unwrap();
     wait_for_file(&release_file);
     wal.end_read_tx();

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1507,7 +1507,10 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                     .as_ref()
                     .is_some_and(|wal| wal.holds_read_lock());
                 if !read_tx_active {
-                    self.pager.begin_read_tx()?;
+                    match self.pager.begin_read_tx()? {
+                        IOResult::Done(()) => {}
+                        IOResult::IO(io) => return Ok(TransitionResult::Io(io)),
+                    }
                     self.lock_states.pager_read_tx = true;
                 }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6410,7 +6410,7 @@ fn test_mvcc_conn_drop_releases_read_tx() {
     conn.execute("CREATE TABLE t(x)").unwrap();
 
     let pager = conn.pager.load();
-    pager.begin_read_tx().unwrap();
+    while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
     let wal = pager.wal.as_ref().expect("wal should be enabled").clone();
     assert!(wal.holds_read_lock());
 
@@ -6907,7 +6907,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         on_conflict: None,
     };
 
-    pager.begin_read_tx().unwrap();
+    while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
     run_pager_until_done(
         || pager.begin_write_tx(crate::storage::wal::WalAutoActions::all_enabled()),
         pager.as_ref(),
@@ -6945,7 +6945,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     }
     run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
 
-    pager.begin_read_tx().unwrap();
+    while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
     let mut interior_key = None;
     for key in 1..=600 {
         let record =
@@ -6996,7 +6996,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     }
     run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
 
-    pager.begin_read_tx().unwrap();
+    while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
     let count_after = run_pager_until_done(|| cursor.write().count(), pager.as_ref()).unwrap();
     assert_eq!(
         count_after, count_before,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1528,8 +1528,8 @@ impl Schema {
                         ));
                     }
 
+                    return_if_io!(pager.begin_read_tx());
                     state.cursor = Some(BTreeCursor::new_table(Arc::clone(pager), 1, 10));
-                    pager.begin_read_tx()?;
                     state.read_tx_active = true;
 
                     state.accumulators = Some(MakeFromBtreeAccumulators {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9342,7 +9342,7 @@ mod tests {
         // FIXME: handle page cache is full
 
         // force allocate page1 with a transaction
-        pager.begin_read_tx().unwrap();
+        while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
         run_until_done(
             || pager.begin_write_tx(WalAutoActions::all_enabled()),
             &pager,
@@ -9623,7 +9623,7 @@ mod tests {
             tracing::info!("seed: {seed}");
             for insert_id in 0..inserts {
                 let do_validate = do_validate_btree || (insert_id % VALIDATE_INTERVAL == 0);
-                pager.begin_read_tx().unwrap();
+                while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
                 run_until_done(
                     || pager.begin_write_tx(WalAutoActions::all_enabled()),
                     &pager,
@@ -9672,7 +9672,7 @@ mod tests {
                 )
                 .unwrap();
                 pager.io.block(|| pager.commit_tx(&conn, true)).unwrap();
-                pager.begin_read_tx().unwrap();
+                while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
                 // FIXME: add sorted vector instead, should be okay for small amounts of keys for now :P, too lazy to fix right now
                 let _c = cursor.move_to_root().unwrap();
                 let mut valid = true;
@@ -9702,7 +9702,7 @@ mod tests {
                 }
                 pager.end_read_tx();
             }
-            pager.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
             tracing::info!(
                 "=========== btree ===========\n{}\n\n",
                 format_btree(pager.clone(), root_page, 0)
@@ -9774,7 +9774,7 @@ mod tests {
             let mut keys = SortedVec::new();
             tracing::info!("seed: {seed}");
             for i in 0..inserts {
-                pager.begin_read_tx().unwrap();
+                while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
                 pager
                     .io
                     .block(|| pager.begin_write_tx(WalAutoActions::all_enabled()))
@@ -9824,7 +9824,7 @@ mod tests {
             }
 
             // Check that all keys can be found by seeking
-            pager.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
             let _c = cursor.move_to_root().unwrap();
             for (i, key) in keys.iter().enumerate() {
                 tracing::info!("seeking key {}/{}: {:?}", i + 1, keys.len(), key);
@@ -9954,7 +9954,7 @@ mod tests {
             tracing::info!("seed: {seed}");
             for i in 0..operations {
                 let print_progress = i % 100 == 0;
-                pager.begin_read_tx().unwrap();
+                while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
 
                 pager
                     .io
@@ -10070,7 +10070,7 @@ mod tests {
         seed: u64,
     ) {
         // Check that all expected keys can be found by seeking
-        pager.begin_read_tx().unwrap();
+        while let IOResult::IO(_) = pager.begin_read_tx().unwrap() {}
         let _c = cursor.move_to_root().unwrap();
         for (i, key) in expected_keys.iter().enumerate() {
             tracing::info!(

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -2861,18 +2861,18 @@ impl Pager {
 
     #[inline(always)]
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn begin_read_tx(&self) -> Result<()> {
+    pub fn begin_read_tx(&self) -> Result<IOResult<()>> {
         let Some(wal) = self.wal.as_ref() else {
-            return Ok(());
+            return Ok(IOResult::Done(()));
         };
-        let changed = wal.begin_read_tx()?;
+        let changed = return_if_io!(wal.begin_read_tx());
         if changed {
             // Someone else changed the database -> assume our page cache is invalid (this is default SQLite behavior, we can probably do better with more granular invalidation)
             self.clear_page_cache(false);
             // Invalidate cached schema cookie to force re-read on next access
             self.set_schema_cookie(None);
         }
-        Ok(())
+        Ok(IOResult::Done(()))
     }
 
     /// MVCC-only: refresh connection-private WAL change counters without starting a read tx and invalidate cache if needed.

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -598,7 +598,8 @@ trait WalCoordination: Debug + Send + Sync {
 pub trait Wal: Debug + Send + Sync {
     /// Begin a read transaction.
     /// Returns whether the database state has changed since the last read transaction.
-    fn begin_read_tx(&self) -> Result<bool>;
+    /// Yields on transient lock contention; callers must re-enter until `Done`.
+    fn begin_read_tx(&self) -> Result<IOResult<bool>>;
     /// MVCC helper: check if WAL state changed without starting a read tx.
     fn mvcc_refresh_if_db_changed(&self) -> bool;
 
@@ -2545,6 +2546,10 @@ pub struct WalFile {
     /// This is the index to the read_lock in WalFileShared that we are holding. This lock contains
     /// the max frame for this connection.
     max_frame_read_lock_index: AtomicUsize,
+    /// Number of consecutive `begin_read_tx` attempts that hit transient lock
+    /// contention. Persists across the yields `begin_read_tx` returns so that
+    /// sustained contention is bounded and surfaces as Busy.
+    begin_read_tx_attempts: AtomicU32,
     /// Max frame allowed to lookup range=(minframe..max_frame)
     max_frame: AtomicU64,
     /// Start of range to look for frames range=(minframe..max_frame)
@@ -3083,38 +3088,35 @@ impl WalFile {
 }
 
 impl Wal for WalFile {
-    fn begin_read_tx(&self) -> Result<bool> {
-        // Implement progressive backoff because transient lock contention
-        // should resolve quickly, but under heavy contention busy-spinning wastes
-        // CPU. SQLite uses quadratic backoff after 5 retries, with total delay
-        // up to ~10 seconds before giving up, so we just mirror SQLite's implementation
-        // here.
-        let mut cnt = 0u32;
+    fn begin_read_tx(&self) -> Result<IOResult<bool>> {
+        // Transient lock contention (SQLite's WAL_RETRY) usually resolves
+        // quickly, so retry a few times immediately. If contention persists,
+        // yield back to the caller instead of blocking: this runs on the
+        // non-blocking step() path, so backoff policy belongs to the upper
+        // layers. The attempt counter persists across yields so sustained
+        // contention eventually surfaces as Busy, mirroring SQLite's bounded
+        // retries.
         loop {
-            tracing::trace!("begin_read_tx: cnt={cnt}");
-            match self.try_begin_read_tx() {
-                TryBeginReadResult::Ok(changed) => return Ok(changed),
+            let result = self.try_begin_read_tx();
+            if !matches!(result, TryBeginReadResult::Retry) {
+                self.begin_read_tx_attempts.store(0, Ordering::Relaxed);
+            }
+            match result {
+                TryBeginReadResult::Ok(changed) => return Ok(IOResult::Done(changed)),
                 TryBeginReadResult::Err(err) => return Err(err),
                 TryBeginReadResult::Busy => return Err(LimboError::Busy),
                 TryBeginReadResult::Retry => {
-                    cnt += 1;
-                    if cnt > 100 {
+                    let attempts = self.begin_read_tx_attempts.fetch_add(1, Ordering::Relaxed) + 1;
+                    tracing::trace!("begin_read_tx: attempts={attempts}");
+                    if attempts > 100 {
+                        self.begin_read_tx_attempts.store(0, Ordering::Relaxed);
                         return Err(LimboError::Busy);
                     }
-                    // Progressive backoff: first 5 retries are immediate, then we
-                    // start yielding/sleeping with increasing delays.
-                    if cnt > 5 {
-                        if cnt < 10 {
-                            // Retries 6-9: yield to scheduler (minimal delay)
-                            self.io.yield_now();
-                        } else {
-                            // Retries 10+: quadratic backoff in microseconds
-                            // Formula matches SQLite: (cnt-9)^2 * 39 microseconds
-                            let delay_us = ((cnt - 9) * (cnt - 9) * 39) as u64;
-                            self.io.sleep(std::time::Duration::from_micros(delay_us));
-                        }
+                    // The first few retries are immediate; after that, yield
+                    // back to the caller between attempts.
+                    if attempts > 5 {
+                        io_yield_one!(Completion::new_yield());
                     }
-                    continue;
                 }
             }
         }
@@ -4393,6 +4395,7 @@ impl WalFile {
             min_frame: AtomicU64::new(0),
             transaction_count: AtomicU64::new(0),
             max_frame_read_lock_index: AtomicUsize::new(NO_LOCK_HELD),
+            begin_read_tx_attempts: AtomicU32::new(0),
             last_checksum: RwLock::new(last_checksum),
             checkpoint_guard: RwLock::new(None),
             io_ctx: RwLock::new(IOContext::default()),
@@ -7169,7 +7172,7 @@ pub mod test {
             buffer_pool,
         );
 
-        wal.begin_read_tx().unwrap();
+        while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
         reopened_authority.mark_frame_index_overflowed_for_tests();
 
         assert!(
@@ -7182,8 +7185,14 @@ pub mod test {
         );
 
         wal.end_read_tx();
+        let result = loop {
+            match wal.begin_read_tx() {
+                Ok(IOResult::IO(_)) => continue,
+                other => break other,
+            }
+        };
         assert!(
-            matches!(wal.begin_read_tx(), Err(LimboError::Busy)),
+            matches!(result, Err(LimboError::Busy)),
             "new readers must also refuse an uncovered overflowed frame index without blocking"
         );
     }
@@ -8747,7 +8756,7 @@ pub mod test {
         let readmark = {
             let pager = conn2.pager.load();
             let wal2 = pager.wal.as_ref().unwrap();
-            wal2.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal2.begin_read_tx().unwrap() {}
             wal2.get_max_frame()
         };
 
@@ -8816,14 +8825,11 @@ pub mod test {
         let conn2 = db.connect().unwrap();
 
         // Start a read transaction
-        conn2
-            .pager
-            .load()
-            .wal
-            .as_ref()
-            .unwrap()
-            .begin_read_tx()
-            .unwrap();
+        {
+            let pager = conn2.pager.load();
+            let wal = pager.wal.as_ref().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
+        }
 
         // checkpoint should succeed here because the wal is fully checkpointed (empty)
         // so the reader is using readmark0 to read directly from the db file.
@@ -8854,7 +8860,7 @@ pub mod test {
                 .unwrap();
         }
         // now that we have some frames to checkpoint, try again
-        conn2.pager.load().begin_read_tx().unwrap();
+        while let IOResult::IO(_) = conn2.pager.load().begin_read_tx().unwrap() {}
         let p = conn1.pager.load();
         let w = p.wal.as_ref().unwrap();
         loop {
@@ -8931,7 +8937,7 @@ pub mod test {
         let r1_max_frame = {
             let pager = conn_r1.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
             wal.get_max_frame()
         };
         bulk_inserts(&conn_writer, 5, 10);
@@ -8940,7 +8946,7 @@ pub mod test {
         let r2_max_frame = {
             let pager = conn_r2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
             wal.get_max_frame()
         };
 
@@ -9019,7 +9025,7 @@ pub mod test {
         {
             let pager = conn2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            let _ = wal.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
             wal.begin_write_tx(WalAutoActions::all_enabled()).unwrap();
         }
 
@@ -9316,7 +9322,7 @@ pub mod test {
         {
             let pager = conn2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
         }
         // Make changes using conn1
         bulk_inserts(&conn1, 5, 5);
@@ -9334,7 +9340,7 @@ pub mod test {
             let pager = conn2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
             wal.end_read_tx();
-            wal.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
         }
         // Now write transaction should work
         let result = {
@@ -9370,7 +9376,7 @@ pub mod test {
         {
             let pager = conn2.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
         }
         // should use slot 0, as everything is backfilled
         assert!(check_read_lock_slot(&conn2, 0));
@@ -9464,7 +9470,7 @@ pub mod test {
         {
             let pager = reader.pager.load();
             let wal = pager.wal.as_ref().unwrap();
-            wal.begin_read_tx().unwrap();
+            while let IOResult::IO(_) = wal.begin_read_tx().unwrap() {}
         }
         let r_snapshot = {
             let pager = reader.pager.load();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3562,7 +3562,7 @@ pub fn op_transaction_inner(
                         // for them. We need it here to pin a consistent WAL snapshot
                         // for the attached pager's B-tree page reads.
                         if !pager.holds_read_lock() {
-                            pager.begin_read_tx()?;
+                            return_if_io!(pager.begin_read_tx());
                         }
                         pager.mvcc_refresh_if_db_changed();
 
@@ -3623,7 +3623,7 @@ pub fn op_transaction_inner(
                                 !conn.is_nested_stmt(),
                                 "nested stmt should not begin a new read transaction"
                             );
-                            pager.begin_read_tx()?;
+                            return_if_io!(pager.begin_read_tx());
                             if conn.get_auto_commit() {
                                 state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                             }
@@ -3739,7 +3739,7 @@ pub fn op_transaction_inner(
                                 OpTransactionState::CheckSchemaCookie;
                             continue;
                         }
-                        pager.begin_read_tx()?;
+                        return_if_io!(pager.begin_read_tx());
                         started_secondary_tx = true;
                         if matches!(tx_mode, TransactionMode::Write) {
                             // Transition to AttachedBeginWriteTx to handle begin_write_tx
@@ -3759,7 +3759,7 @@ pub fn op_transaction_inner(
                             !conn.is_nested_stmt(),
                             "nested stmt should not begin a new read transaction"
                         );
-                        pager.begin_read_tx()?;
+                        return_if_io!(pager.begin_read_tx());
                         // https://github.com/tursodatabase/turso/issues/7106 : If auto-commit is turned off,
                         // then we shouldn't be setting the auto_txn_cleanup, this will cause errors in case the client explicitly calls commit post a drop of the statement struct
                         if conn.get_auto_commit() {
@@ -4165,7 +4165,7 @@ pub fn op_savepoint(
                         );
                     } else {
                         if !pager.holds_read_lock() {
-                            pager.begin_read_tx()?;
+                            return_if_io!(pager.begin_read_tx());
                         }
                         if matches!(conn.get_tx_state(), TransactionState::None) {
                             conn.set_tx_state(TransactionState::Read);
@@ -13302,9 +13302,10 @@ pub fn op_open_ephemeral(
         }
         OpOpenEphemeralState::StartingTxn { pager, temp_file } => {
             tracing::trace!("StartingTxn");
-            pager
-                .begin_read_tx() // we have to begin a read tx before beginning a write
-                .expect("Failed to start read transaction");
+            // we have to begin a read tx before beginning a write
+            if !pager.holds_read_lock() {
+                return_if_io!(pager.begin_read_tx());
+            }
             return_if_io!(pager.begin_write_tx(WalAutoActions::all_enabled()));
             *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::CreateBtree {
                 pager: pager.clone(),
@@ -16707,7 +16708,7 @@ mod tests {
         conn.execute("BEGIN").unwrap();
         let attached_db_id = conn.get_database_id_by_name("att").unwrap();
         let attached_pager = conn.get_pager_from_database_index(&attached_db_id).unwrap();
-        attached_pager.begin_read_tx().unwrap();
+        while let IOResult::IO(_) = attached_pager.begin_read_tx().unwrap() {}
 
         assert!(
             !conn.pager.load().holds_read_lock(),

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -3,6 +3,7 @@ use std::sync::{atomic::Ordering, Arc};
 
 use crate::error::LimboError;
 use crate::io::{Buffer, Completion, CompletionGroup, WriteBatch as IOWriteBatch};
+use crate::return_if_io;
 use crate::schema::{BTreeTable, Schema, TypeDef};
 use crate::storage::pager::{AutoVacuumMode, Page, PageRef, Pager};
 use crate::storage::sqlite3_ondisk::{
@@ -1585,10 +1586,10 @@ fn install_mvcc_state_after_vacuum_commit(
 fn capture_target_metadata(
     temp_db: &VacuumTempDb,
     source_sequences: FxHashMap<String, Arc<crate::schema::Sequence>>,
-) -> Result<VacuumCommittedImageMeta> {
+) -> Result<IOResult<VacuumCommittedImageMeta>> {
     let temp_conn = &temp_db.conn;
     let temp_pager = temp_conn.get_pager();
-    temp_pager.begin_read_tx()?;
+    return_if_io!(temp_pager.begin_read_tx());
     temp_conn.set_tx_state(crate::connection::TransactionState::Read);
 
     let capture_result = (|| {
@@ -1607,7 +1608,7 @@ fn capture_target_metadata(
 
     temp_pager.end_read_tx();
     temp_conn.set_tx_state(crate::connection::TransactionState::None);
-    capture_result
+    capture_result.map(IOResult::Done)
 }
 
 /// Install the already-captured replacement schema/header after the source WAL
@@ -1642,8 +1643,8 @@ fn install_committed_vacuum_image(
 fn reload_physical_schema_for_mvcc_vacuum(
     connection: &Arc<Connection>,
     source_pager: &Pager,
-) -> Result<()> {
-    source_pager.begin_read_tx()?;
+) -> Result<IOResult<()>> {
+    return_if_io!(source_pager.begin_read_tx());
     connection.set_tx_state(crate::connection::TransactionState::Read);
 
     // Preserve the current sequences map and graft it onto the reparsed
@@ -1661,7 +1662,7 @@ fn reload_physical_schema_for_mvcc_vacuum(
     source_pager.end_read_tx();
     connection.set_tx_state(crate::connection::TransactionState::None);
 
-    reparse_result
+    reparse_result.map(IOResult::Done)
 }
 
 /// Step the in-place VACUUM state machine once. Returns `IO` to yield or
@@ -1743,7 +1744,12 @@ fn vacuum_in_place_step(
                     // After demotion this connection stops reading schema-cookie state from the
                     // MV store and starts reading directly from the pager-backed DB image.
                     // Let's be conservative, and reparse schema
-                    reload_physical_schema_for_mvcc_vacuum(connection, &source_pager)?;
+                    // Yielding here drops `guard`, whose Drop fully undoes the
+                    // demotion and releases the gate; re-entry re-acquires.
+                    return_if_io!(reload_physical_schema_for_mvcc_vacuum(
+                        connection,
+                        &source_pager
+                    ));
                     Some(guard)
                 } else {
                     None
@@ -1863,7 +1869,10 @@ fn vacuum_in_place_step(
                     .as_ref()
                     .expect("VACUUM CaptureTargetMetadata phase requires temp db");
                 let source_sequences = connection.schema.read().sequences.clone();
-                *committed_image = Some(capture_target_metadata(temp_db_ref, source_sequences)?);
+                *committed_image = Some(return_if_io!(capture_target_metadata(
+                    temp_db_ref,
+                    source_sequences
+                )));
                 *phase = VacuumInPlacePhase::BeginTempReadTx;
                 continue;
             }
@@ -1880,7 +1889,7 @@ fn vacuum_in_place_step(
                     !temp_pager.holds_read_lock(),
                     "VACUUM temp COMMIT should release the temp WAL read lock"
                 );
-                temp_pager.begin_read_tx()?;
+                return_if_io!(temp_pager.begin_read_tx());
 
                 // one invariant is that temp db should have disabled checkpoints and all raeds
                 // must happen over WAL only. In that case, the db file should be same as the page
@@ -2848,7 +2857,10 @@ mod tests {
         }
         temp.conn.execute("COMMIT")?;
 
-        let committed = capture_target_metadata(&temp, FxHashMap::default())?;
+        let committed = match capture_target_metadata(&temp, FxHashMap::default())? {
+            crate::IOResult::Done(committed) => committed,
+            crate::IOResult::IO(_) => panic!("temp capture should not need async I/O"),
+        };
 
         assert_eq!(committed.header.schema_cookie.get(), 42);
         assert_eq!(committed.header.read_version, mvcc_version);

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1124,6 +1124,11 @@ fn step_inner(
     async_io: bool,
     waker: Option<&Waker>,
 ) -> Result<TursoStatusCode, TursoError> {
+    // Consecutive lock-contention yields seen in this sync loop. turso_core no
+    // longer sleeps internally on contention (it killed IO::sleep/yield_now and
+    // surfaces a Yield instead, leaving backoff policy to the embedder), so we
+    // reproduce its old progressive backoff here, mirroring SQLite's WAL_RETRY.
+    let mut contention_yields = 0u32;
     loop {
         let result = if let Some(waker) = waker {
             stmt.step_with_waker(waker)
@@ -1135,11 +1140,35 @@ fn step_inner(
             StepResult::Row => Ok(TursoStatusCode::Row),
             StepResult::Busy => Err(TursoError::Busy("database is locked".to_string())),
             StepResult::Interrupt => Err(TursoError::Interrupt("interrupted".to_string())),
-            StepResult::IO | StepResult::Yield => {
+            StepResult::IO => {
                 if async_io {
                     Ok(TursoStatusCode::Io)
                 } else {
+                    contention_yields = 0;
                     stmt._io().step()?;
+                    continue;
+                }
+            }
+            StepResult::Yield => {
+                if async_io {
+                    // Event-loop embedders re-poll on Io and own their own
+                    // pacing between polls, so just hand control back.
+                    Ok(TursoStatusCode::Io)
+                } else {
+                    // A Yield means another connection holds a contended lock;
+                    // there is no pending I/O to drive, so stepping I/O would
+                    // busy-spin. Back off progressively instead. turso_core has
+                    // already burned its immediate retries before yielding, so
+                    // the first few yields just relinquish the scheduler and the
+                    // rest sleep with the same quadratic curve core used to.
+                    contention_yields += 1;
+                    if contention_yields <= 4 {
+                        std::thread::yield_now();
+                    } else {
+                        let steps = (contention_yields - 4) as u64;
+                        let delay_us = steps * steps * 39;
+                        std::thread::sleep(Duration::from_micros(delay_us));
+                    }
                     continue;
                 }
             }

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -126,10 +126,6 @@ impl Clock for SimulatorIO {
 }
 
 impl IO for SimulatorIO {
-    fn sleep(&self, duration: std::time::Duration) {
-        self.time
-            .fetch_add(duration.as_micros() as u64, Ordering::SeqCst);
-    }
     fn open_file(&self, path: &str, _flags: OpenFlags, _create_new: bool) -> Result<Arc<dyn File>> {
         let lookup_key = canonical_key(path);
         {

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -48,9 +48,6 @@ impl Clock for TestIo {
 }
 
 impl IO for TestIo {
-    // we don't sleep in test io in order to make tests faster
-    fn sleep(&self, _duration: std::time::Duration) {}
-
     fn open_file(
         &self,
         path: &str,
@@ -93,9 +90,6 @@ impl IO for TestIo {
     }
     fn wait_for_completion(&self, c: turso_core::Completion) -> turso_core::Result<()> {
         self.io.wait_for_completion(c)
-    }
-    fn yield_now(&self) {
-        self.io.yield_now();
     }
 }
 


### PR DESCRIPTION
Sleeping and yielding are fundamentally incompatible with a non-blocking step() function. Therefore, remove them from the IO API.