### PR TITLE
core/mvcc: Shrink version chains and remove empty slots at checkpoint

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2244,7 +2244,16 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
 
             CheckpointState::Finalize => {
                 tracing::debug!("Releasing blocking checkpoint lock");
-                self.mvstore.drop_unused_row_versions();
+                // The blocking checkpoint lock is still held here, so the
+                // slot-removing GC variant is safe: no concurrent writer can
+                // race the empty-slot removal. This bounds the skip-map entry
+                // counts — the lazy (non-removing) GC otherwise leaves empty
+                // chain slots behind forever for rows never written again.
+                assert!(
+                    self.lock_states.blocking_checkpoint_lock_held,
+                    "finalize GC requires the blocking checkpoint lock"
+                );
+                self.mvstore.drop_unused_row_versions_and_slots();
                 self.checkpoint_lock.unlock();
                 self.finalize(&())?;
                 Ok(TransitionResult::Done(

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -5865,12 +5865,34 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// Covers both table rows (`self.rows`) and index rows (`self.index_rows`).
     /// Returns the number of removed versions.
     pub fn drop_unused_row_versions(&self) -> usize {
+        self.drop_unused_row_versions_inner(false)
+    }
+
+    /// Like [`Self::drop_unused_row_versions`], but additionally removes chain
+    /// slots that end up empty from the skip maps, bounding their entry counts.
+    ///
+    /// The caller must hold the blocking checkpoint lock (or otherwise guarantee
+    /// no concurrent writers): slot removal happens after the chain write lock
+    /// is dropped, so without that guarantee it races a concurrent
+    /// `get_or_insert_with` on the same key — see the TOCTOU note in
+    /// `gc_table_row_versions`.
+    pub fn drop_unused_row_versions_and_slots(&self) -> usize {
+        self.drop_unused_row_versions_inner(true)
+    }
+
+    fn drop_unused_row_versions_inner(&self, remove_empty_slots: bool) -> usize {
         let lwm = self.compute_lwm();
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
         let mut referenced_tx_ids = HashSet::default();
 
-        let dropped = self.gc_table_row_versions(lwm, ckpt_max, &mut referenced_tx_ids)
-            + self.gc_index_row_versions(lwm, ckpt_max, &mut referenced_tx_ids);
+        let dropped =
+            self.gc_table_row_versions(lwm, ckpt_max, &mut referenced_tx_ids, remove_empty_slots)
+                + self.gc_index_row_versions(
+                    lwm,
+                    ckpt_max,
+                    &mut referenced_tx_ids,
+                    remove_empty_slots,
+                );
         let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids);
 
         tracing::trace!(
@@ -5887,18 +5909,27 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         lwm: u64,
         ckpt_max: u64,
         referenced_tx_ids: &mut HashSet<TxID>,
+        remove_empty_slots: bool,
     ) -> usize {
         let mut dropped = 0;
 
         for entry in self.rows.iter() {
-            let mut versions = entry.value().write();
-            dropped += Self::gc_version_chain(&mut versions, lwm, ckpt_max);
-            Self::collect_referenced_txids(&versions, referenced_tx_ids);
-            // Empty entries are left in the SkipMap (lazy removal). This avoids
-            // a TOCTOU race where a concurrent writer inserts a version between
-            // the emptiness check and SkipMap::remove(). Empty entries are reused
-            // by get_or_insert_with on subsequent inserts and cleaned up by
+            let is_now_empty = {
+                let mut versions = entry.value().write();
+                dropped += Self::gc_version_chain(&mut versions, lwm, ckpt_max);
+                Self::collect_referenced_txids(&versions, referenced_tx_ids);
+                versions.is_empty()
+            };
+            // Unless the caller holds the blocking checkpoint lock
+            // (`remove_empty_slots`), empty entries are left in the SkipMap
+            // (lazy removal). This avoids a TOCTOU race where a concurrent
+            // writer inserts a version between the emptiness check and
+            // SkipMap::remove(). Empty entries are reused by
+            // get_or_insert_with on subsequent inserts and cleaned up by
             // checkpoint-time GC which runs under the blocking lock.
+            if remove_empty_slots && is_now_empty {
+                entry.remove();
+            }
         }
         dropped
     }
@@ -5908,6 +5939,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         lwm: u64,
         ckpt_max: u64,
         referenced_tx_ids: &mut HashSet<TxID>,
+        remove_empty_slots: bool,
     ) -> usize {
         let mut dropped = 0;
 
@@ -5915,11 +5947,18 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             let inner_map = outer_entry.value();
 
             for inner_entry in inner_map.iter() {
-                let mut versions = inner_entry.value().write();
-                dropped += Self::gc_version_chain(&mut versions, lwm, ckpt_max);
-                Self::collect_referenced_txids(&versions, referenced_tx_ids);
+                let is_now_empty = {
+                    let mut versions = inner_entry.value().write();
+                    dropped += Self::gc_version_chain(&mut versions, lwm, ckpt_max);
+                    Self::collect_referenced_txids(&versions, referenced_tx_ids);
+                    versions.is_empty()
+                };
+                // Same TOCTOU rationale as table rows. The outer per-index map
+                // is kept even when emptied — it is bounded by index count.
+                if remove_empty_slots && is_now_empty {
+                    inner_entry.remove();
+                }
             }
-            // Empty entries left in place — same TOCTOU rationale as table rows.
         }
         dropped
     }
@@ -6006,7 +6045,26 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             }
         }
 
+        Self::shrink_version_chain_allocation(versions);
+
         before - versions.len()
+    }
+
+    /// Chains with capacity at or below this are never shrunk — the
+    /// allocation is too small to be worth a realloc.
+    const CHAIN_SHRINK_MIN_CAPACITY: usize = 16;
+
+    /// Release excess version-chain capacity after GC trimmed the chain.
+    /// `retain`/`clear` keep the Vec's allocation, so a one-off burst of
+    /// versions (e.g. a hot row between checkpoints) would otherwise pin its
+    /// peak allocation forever. Capacity drops to a quarter of its current
+    /// value — deliberately not to fit — when the survivors occupy less than
+    /// a quarter of it, so steady-state chains keep slack for new versions.
+    fn shrink_version_chain_allocation(versions: &mut Vec<RowVersion>) {
+        let capacity = versions.capacity();
+        if capacity > Self::CHAIN_SHRINK_MIN_CAPACITY && versions.len() < capacity / 4 {
+            versions.shrink_to(capacity / 4);
+        }
     }
 
     // Extracts the begin timestamp from a transaction
@@ -6168,7 +6226,9 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     /// write to the same key.
     pub fn purge_row_versions_during_checkpoint(&self, rowid: RowID) {
         if let Some(entry) = self.rows.get(&rowid) {
-            entry.value().write().clear();
+            let mut versions = entry.value().write();
+            versions.clear();
+            Self::shrink_version_chain_allocation(&mut versions);
         }
     }
 

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -349,16 +349,22 @@ fn mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets() {
     db.conn.execute("DELETE FROM t WHERE id = 2").unwrap();
     db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 
-    // Normal MVCC checkpoint GC removes versions but can leave empty map
-    // buckets behind; VACUUM reset must not preserve those stale keys.
-    let checkpointed_row_ids = db
+    // Checkpoint-time GC removes the buckets it empties (it runs under the
+    // blocking lock), so recreate the condition VACUUM reset must handle:
+    // lazy background GC empties chains but leaves the buckets in the maps.
+    db.conn.execute("BEGIN").unwrap();
+    db.conn.execute("INSERT INTO t VALUES (4, 'd')").unwrap();
+    db.conn.execute("ROLLBACK").unwrap();
+    db.mvcc_store.drop_unused_row_versions();
+
+    let empty_row_ids = db
         .mvcc_store
         .rows
         .iter()
         .filter(|entry| entry.value().read().is_empty())
         .map(|entry| entry.key().clone())
         .collect::<Vec<_>>();
-    let checkpointed_index_ids = db
+    let empty_index_ids = db
         .mvcc_store
         .index_rows
         .iter()
@@ -371,12 +377,12 @@ fn mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets() {
         .map(|entry| *entry.key())
         .collect::<Vec<_>>();
     assert!(
-        !checkpointed_row_ids.is_empty(),
-        "checkpoint GC should leave empty table row buckets before VACUUM reset"
+        !empty_row_ids.is_empty(),
+        "lazy GC should leave empty table row buckets before VACUUM reset"
     );
     assert!(
-        !checkpointed_index_ids.is_empty(),
-        "checkpoint GC should leave empty index buckets before VACUUM reset"
+        !empty_index_ids.is_empty(),
+        "lazy GC should leave empty index buckets before VACUUM reset"
     );
 
     db.conn.demote_to_mvcc_connection();
@@ -389,16 +395,16 @@ fn mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets() {
         .reset_after_vacuum(DatabaseHeader::default(), schema.as_ref());
     db.mvcc_store.release_vacuum_gate();
 
-    for row_id in checkpointed_row_ids {
+    for row_id in empty_row_ids {
         assert!(
             db.mvcc_store.rows.get(&row_id).is_none(),
-            "checkpointed empty table row buckets must be cleared across VACUUM reset"
+            "empty table row buckets must be cleared across VACUUM reset"
         );
     }
-    for index_id in checkpointed_index_ids {
+    for index_id in empty_index_ids {
         assert!(
             db.mvcc_store.index_rows.get(&index_id).is_none(),
-            "checkpointed empty index buckets must be cleared across VACUUM reset"
+            "empty index buckets must be cleared across VACUUM reset"
         );
     }
 }
@@ -7543,6 +7549,95 @@ fn test_gc_integration_rollback_creates_aborted_garbage() {
     assert!(
         entry.unwrap().value().read().is_empty(),
         "but versions should be empty"
+    );
+}
+
+/// GC trims chains with retain()/clear(), which keeps the Vec's allocation.
+/// After a burst of versions is collected, the chain's capacity must be
+/// released down to a quarter of its previous value (deliberately not to fit)
+/// so a hot row doesn't pin its peak allocation forever.
+#[test]
+fn test_gc_shrinks_version_chain_capacity() {
+    let make_version = |begin, end| RowVersion {
+        id: 0,
+        begin,
+        end,
+        row: generate_simple_string_row((-2).into(), 1, "shrink"),
+        btree_resident: false,
+    };
+
+    // One committed current version that survives GC (b=1 > ckpt_max=0, so
+    // rule 3 doesn't fire), plus a burst of aborted garbage (always removed).
+    let mut versions: Vec<RowVersion> = Vec::new();
+    versions.push(make_version(Some(TxTimestampOrID::Timestamp(1)), None));
+    for _ in 0..1023 {
+        versions.push(make_version(None, None));
+    }
+    let capacity_before = versions.capacity();
+    assert!(capacity_before >= 1024);
+
+    let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 0, 0);
+    assert_eq!(dropped, 1023);
+    assert_eq!(versions.len(), 1);
+    assert!(
+        versions.capacity() <= capacity_before / 4,
+        "chain capacity should shrink to a quarter of {capacity_before}, got {}",
+        versions.capacity()
+    );
+
+    // A chain emptied entirely also releases its allocation.
+    let mut versions: Vec<RowVersion> = (0..1024).map(|_| make_version(None, None)).collect();
+    let capacity_before = versions.capacity();
+    let dropped = MvStore::<MvccClock>::gc_version_chain(&mut versions, 0, 0);
+    assert_eq!(dropped, 1024);
+    assert!(versions.is_empty());
+    assert!(
+        versions.capacity() <= capacity_before / 4,
+        "empty chain capacity should shrink to a quarter of {capacity_before}, got {}",
+        versions.capacity()
+    );
+
+    // Small chains are not worth a realloc: capacity at or below the minimum
+    // threshold is left untouched even when fully emptied.
+    let mut small: Vec<RowVersion> = Vec::with_capacity(16);
+    small.push(make_version(None, None));
+    let capacity_before = small.capacity();
+    MvStore::<MvccClock>::gc_version_chain(&mut small, 0, 0);
+    assert!(small.is_empty());
+    assert_eq!(small.capacity(), capacity_before);
+}
+
+/// `drop_unused_row_versions_and_slots` (used at checkpoint Finalize while the
+/// blocking checkpoint lock is held) must remove chain slots that GC emptied,
+/// unlike the lazy background variant which leaves them in the SkipMap.
+#[test]
+fn test_gc_with_slot_removal_drops_empty_skipmap_entries() {
+    let db = MvccTestDb::new();
+
+    let tx1 = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    let row = generate_simple_string_row((-2).into(), 1, "will_rollback");
+    db.mvcc_store.insert(tx1, row).unwrap();
+    db.mvcc_store.rollback_tx(
+        tx1,
+        db.conn.pager.load().clone(),
+        &db.conn,
+        crate::MAIN_DB_ID,
+    );
+
+    // Rollback leaves aborted garbage behind in the chain.
+    let row_id = RowID::new((-2).into(), RowKey::Int(1));
+    assert!(db.mvcc_store.rows.get(&row_id).is_some());
+
+    // The slot-removing GC variant collects the garbage AND drops the slot.
+    // No concurrent writers exist in this test, satisfying the caller contract.
+    let dropped = db.mvcc_store.drop_unused_row_versions_and_slots();
+    assert_eq!(dropped, 1);
+    assert!(
+        db.mvcc_store.rows.get(&row_id).is_none(),
+        "empty chain slot should be removed from the SkipMap"
     );
 }
 


### PR DESCRIPTION
## Description

This PR improves MVCC garbage collection efficiency by:

1. **Shrinking version chain allocations after GC**: When `retain()`/`clear()` trim version chains, the underlying Vec keeps its full allocation. This change releases excess capacity down to a quarter of the previous value when survivors occupy less than a quarter of it. This prevents hot rows from pinning peak allocations forever between checkpoints.

2. **Removing empty chain slots at checkpoint**: Introduces `drop_unused_row_versions_and_slots()` which removes empty chain slots from skip maps during checkpoint finalization (when the blocking lock is held). The lazy background GC variant (`drop_unused_row_versions()`) continues to leave empty slots for reuse, avoiding TOCTOU races with concurrent writers. The checkpoint variant bounds skip-map entry counts for rows never written again.

3. **Updating test expectations**: Modifies `mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets` to properly test the lazy GC behavior by creating empty chains through background GC rather than checkpoint GC, and updates variable names and assertions to reflect the actual GC mechanism being tested.

## Motivation and context

MVCC garbage collection can leave behind:
- Excess Vec capacity in version chains after trimming (memory waste)
- Empty chain slots in skip maps that are never reused (unbounded map growth)

The checkpoint finalization phase runs under the blocking lock, making it safe to aggressively clean up empty slots. This complements the lazy background GC which must be conservative to avoid races.

## Changes

**core/mvcc/database/mod.rs**:
- Split `drop_unused_row_versions()` into a public lazy variant and internal `drop_unused_row_versions_inner()`
- Added `drop_unused_row_versions_and_slots()` for checkpoint-time GC with slot removal
- Updated `gc_table_row_versions()` and `gc_index_row_versions()` to conditionally remove empty slots
- Added `shrink_version_chain_allocation()` to release excess Vec capacity (min threshold: 16 elements)
- Updated `purge_row_versions_during_checkpoint()` to also shrink allocation

**core/mvcc/database/checkpoint_state_machine.rs**:
- Changed checkpoint Finalize to call `drop_unused_row_versions_and_slots()` instead of the lazy variant
- Added assertion and comment documenting the blocking lock requirement

**core/mvcc/database/tests.rs**:
- Updated `mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets` to test lazy GC behavior
- Added `test_gc_shrinks_version_chain_capacity` covering capacity shrinking logic
- Added `test_gc_with_slot_removal_drops_empty_skipmap_entries` covering slot removal at checkpoint

## Test Plan

All changes are covered by new and updated unit tests:
- `test_gc_shrinks_version_chain_capacity`: Validates capacity shrinking for both partially-emptied and fully-emptied chains, and verifies small chains are not reallocated
- `test_gc_with_slot_removal_drops_empty_skipmap_entries`: Validates that checkpoint-time GC removes empty slots
- Updated `mvcc_reset_after_vacuum_clears_checkpointed_empty_version_buckets`: Validates VACUUM reset clears empty buckets left by lazy GC

Existing MVCC tests continue to pass, validating backward compatibility of the lazy GC path.

https://claude.ai/code/session_01L1DY6C89phiYBsA5pbJGUo