### PR TITLE
Reject `ALTER TABLE ADD COLUM` when generated-columns flag is off

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1,5 +1,5 @@
 use crate::sync::Arc;
-use crate::{schema::BTreeTable, turso_assert_eq, turso_assert_ne};
+use crate::{bail_parse_error, schema::BTreeTable, turso_assert_eq, turso_assert_ne};
 use turso_parser::{
     ast::{self, TableInternalId},
     parser::Parser,
@@ -1219,6 +1219,11 @@ pub fn translate_alter_table(
                 return Err(LimboError::ParseError(
                     "cannot add a STORED column".to_string(),
                 ));
+            }
+            if is_generated && !connection.experimental_generated_columns_enabled() {
+                bail_parse_error!(
+                    "Generated columns require --experimental-generated-columns flag"
+                );
             }
             if is_generated {
                 for c in &col_def.constraints {

--- a/tests/integration/query_processing/test_alter_table_reopen.rs
+++ b/tests/integration/query_processing/test_alter_table_reopen.rs
@@ -180,3 +180,54 @@ fn test_alter_table_add_column_preserves_multiple_unique_constraints_reopen() {
         conn.close().unwrap();
     }
 }
+
+/// ALTER TABLE ADD COLUMN with a generated expression must be
+/// rejected when --experimental-generated-columns is disabled
+#[test]
+fn test_alter_add_generated_column_rejected_without_flag() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t(a)").unwrap();
+
+    let err = conn
+        .execute("ALTER TABLE t ADD COLUMN b AS (a)")
+        .expect_err("generated column must be rejected without the flag");
+    assert!(
+        err.to_string().contains("Generated columns require"),
+        "unexpected error: {err}"
+    );
+
+    let cols: Vec<(String,)> = conn.exec_rows("SELECT name FROM pragma_table_info('t')");
+    assert_eq!(cols, vec![("a".to_string(),)]);
+}
+
+/// ALTER TABLE ADD COLUMN with a generated expression must be
+/// accepted when --experimental-generated-columns is enabled
+#[test]
+fn test_alter_add_generated_column_succeeds_with_flag() {
+    let path = TempDir::new()
+        .unwrap()
+        .keep()
+        .join("alter_add_generated_column.db");
+    let opts = turso_core::DatabaseOpts::new().with_generated_columns(true);
+
+    {
+        let db = TempDatabase::new_with_existent_with_opts(&path, opts);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a)").unwrap();
+        conn.execute("INSERT INTO t VALUES (5)").unwrap();
+        conn.execute("ALTER TABLE t ADD COLUMN b AS (a)").unwrap();
+
+        let rows: Vec<(i64, i64)> = conn.exec_rows("SELECT a, b FROM t");
+        assert_eq!(rows, vec![(5, 5)]);
+        conn.close().unwrap();
+    }
+
+    {
+        let db = TempDatabase::new_with_existent_with_opts(&path, opts);
+        let conn = db.connect_limbo();
+        let rows: Vec<(i64, i64)> = conn.exec_rows("SELECT a, b FROM t");
+        assert_eq!(rows, vec![(5, 5)]);
+        conn.close().unwrap();
+    }
+}


### PR DESCRIPTION
Small fix for `ALTER TABLE ADD COLUMN` with a generated expression, and 2 tests to ensure positive and negative scenario passes
It skipped the `experimental_generated_columns_enabled()` check so the column got added even when the flag was off. The schema couldn't be parsed on reopen, and left the db inaccessible

Closes #7418