### PR TITLE
Add custom comparator support to skip list collections

### DIFF
--- a/core/skiplist/alloc_helper.rs
+++ b/core/skiplist/alloc_helper.rs
@@ -1,0 +1,85 @@
+use core::{alloc::Layout, ptr::NonNull};
+
+// Based on unstable alloc::alloc::Global.
+//
+// Note: unlike alloc::alloc::Global that returns NonNull<[u8]>,
+// this returns NonNull<u8>.
+pub(crate) struct Global;
+#[allow(clippy::unused_self)]
+impl Global {
+    #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Option<NonNull<u8>> {
+        // Layout::dangling is unstable
+        #[inline]
+        #[must_use]
+        fn dangling(layout: Layout) -> NonNull<u8> {
+            // SAFETY: align is guaranteed to be non-zero
+            unsafe { NonNull::new_unchecked(without_provenance_mut::<u8>(layout.align())) }
+        }
+
+        match layout.size() {
+            0 => Some(dangling(layout)),
+            // SAFETY: `layout` is non-zero in size,
+            _size => unsafe {
+                #[allow(clippy::disallowed_methods)] // we are in alloc_helper
+                let raw_ptr = if zeroed {
+                    std::alloc::alloc_zeroed(layout)
+                } else {
+                    std::alloc::alloc(layout)
+                };
+                NonNull::new(raw_ptr)
+            },
+        }
+    }
+    #[allow(dead_code)]
+    #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    pub(crate) fn allocate(self, layout: Layout) -> Option<NonNull<u8>> {
+        self.alloc_impl(layout, false)
+    }
+    #[allow(dead_code)]
+    #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    pub(crate) fn allocate_zeroed(self, layout: Layout) -> Option<NonNull<u8>> {
+        self.alloc_impl(layout, true)
+    }
+    #[allow(dead_code)]
+    #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+    pub(crate) unsafe fn deallocate(self, ptr: NonNull<u8>, layout: Layout) {
+        if layout.size() != 0 {
+            // SAFETY:
+            // * We have checked that `layout` is non-zero in size.
+            // * The caller is obligated to provide a layout that "fits", and in this case,
+            //   "fit" always means a layout that is equal to the original, because our
+            //   `allocate()`, `grow()`, and `shrink()` implementations never returns a larger
+            //   allocation than requested.
+            // * Other conditions must be upheld by the caller, as per `Allocator::deallocate()`'s
+            //   safety documentation.
+            #[allow(clippy::disallowed_methods)] // we are in alloc_helper
+            unsafe {
+                std::alloc::dealloc(ptr.as_ptr(), layout)
+            }
+        }
+    }
+}
+
+#[inline(always)]
+#[must_use]
+const fn without_provenance_mut<T>(addr: usize) -> *mut T {
+    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a
+    // pointer without provenance. Note that this is *not* a stable guarantee about transmute
+    // semantics, it relies on sysroot crates having special status.
+    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that
+    // pointer).
+    #[cfg(miri)]
+    unsafe {
+        core::mem::transmute(addr)
+    }
+    // Using transmute doesn't work with CHERI: https://github.com/kent-weak-memory/rust/blob/0c0ca909de877f889629057e1ddf139527446d75/library/core/src/ptr/mod.rs#L607
+    #[cfg(not(miri))]
+    {
+        addr as *mut T
+    }
+}

--- a/core/skiplist/base.rs
+++ b/core/skiplist/base.rs
@@ -1,17 +1,24 @@
 //! A lock-free skip list. See [`SkipList`].
 
-use core::borrow::Borrow;
-use core::cmp;
-use core::fmt;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::{Bound, Deref, Index, RangeBounds};
-use core::ptr;
-use core::sync::atomic::{fence, AtomicUsize, Ordering};
-use std::alloc::{alloc, dealloc, handle_alloc_error, Layout};
+use core::{
+    alloc::Layout,
+    cmp, fmt,
+    marker::PhantomData,
+    mem,
+    ops::{Bound, Deref, RangeBounds},
+    ptr,
+    ptr::NonNull,
+    sync::atomic::{fence, AtomicUsize, Ordering},
+};
+use std::alloc::handle_alloc_error;
 
 use crossbeam_epoch::{self as epoch, Atomic, Collector, Guard, Shared};
 use crossbeam_utils::CachePadded;
+
+use super::{
+    alloc_helper::Global,
+    comparator::{BasicComparator, Comparator},
+};
 
 /// Number of bits needed to store height.
 const HEIGHT_BITS: usize = 5;
@@ -31,12 +38,48 @@ struct Tower<K, V> {
     pointers: [Atomic<Node<K, V>>; 0],
 }
 
-impl<K, V> Index<usize> for Tower<K, V> {
-    type Output = Atomic<Node<K, V>>;
-    fn index(&self, index: usize) -> &Atomic<Node<K, V>> {
-        // This implementation is actually unsafe since we don't check if the
-        // index is in-bounds. But this is fine since this is only used internally.
-        unsafe { &*(&self.pointers as *const Atomic<Node<K, V>>).add(index) }
+/// A "reference" to a Tower that preserves provenance for accessing the dynamically sized tower.
+///
+/// A regular `&'a Tower<K, V>` would not have permission to access any bytes under stacked borrows
+/// since Tower is a placeholder ZST.
+///
+/// Note, under tree borrows this isn't necessary.
+struct TowerRef<'a, K, V> {
+    ptr: NonNull<Tower<K, V>>,
+    _marker: PhantomData<&'a Tower<K, V>>,
+}
+
+impl<K, V> Clone for TowerRef<'_, K, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<K, V> Copy for TowerRef<'_, K, V> {}
+
+impl<'a, K, V> TowerRef<'a, K, V> {
+    /// Creates a TowerRef.
+    ///
+    /// # Safety
+    ///
+    /// Same as NonNull::as_ref, except the pointer must be valid for accessing the actual
+    /// size of the tower.
+    #[inline]
+    unsafe fn new(ptr: NonNull<Tower<K, V>>) -> Self {
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Gets the atomic node pointer at the specified level of the tower.
+    ///
+    /// # Safety
+    ///
+    /// Index must be in bounds.
+    #[inline]
+    unsafe fn get_level(self, index: usize) -> &'a Atomic<Node<K, V>> {
+        // SAFETY: Requirements passed to caller.
+        unsafe { &*(self.ptr.as_ptr() as *const Atomic<Node<K, V>>).add(index) }
     }
 }
 
@@ -58,12 +101,22 @@ impl<K, V> Head<K, V> {
             pointers: Default::default(),
         }
     }
-}
 
-impl<K, V> Deref for Head<K, V> {
-    type Target = Tower<K, V>;
-    fn deref(&self) -> &Tower<K, V> {
-        unsafe { &*(self as *const _ as *const Tower<K, V>) }
+    /// Gets `TowerRef`
+    #[inline]
+    fn as_tower(&self) -> TowerRef<'_, K, V> {
+        unsafe { TowerRef::new(NonNull::from(self).cast::<Tower<K, V>>()) }
+    }
+
+    /// Gets the atomic node pointer at the specified level.
+    ///
+    /// # Safety
+    ///
+    /// Index must be in bounds.
+    #[inline]
+    unsafe fn get_level(&self, index: usize) -> &Atomic<Node<K, V>> {
+        // SAFETY: Requirements passed to caller.
+        unsafe { self.pointers.get_unchecked(index) }
     }
 }
 
@@ -91,6 +144,29 @@ struct Node<K, V> {
     tower: Tower<K, V>,
 }
 
+/// A "reference" to a Node that preserves provenance for accessing the dynamically sized tower at
+/// the end of the node allocation.
+///
+/// Note, in a few situations below, we also rely on this for preserving write permissions.
+struct NodeRef<'a, K, V> {
+    ptr: NonNull<Node<K, V>>,
+    _marker: PhantomData<&'a Node<K, V>>,
+}
+
+impl<K, V> Clone for NodeRef<'_, K, V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<K, V> Copy for NodeRef<'_, K, V> {}
+
+// Local modification (candidate for upstreaming): `NodeRef` is semantically
+// `&'a Node<K, V>`, so mirror that reference's auto traits, which were lost
+// when the field became `NonNull` for provenance reasons. This restores
+// `Send`/`Sync` on entries and iterators, as in crossbeam-skiplist 0.1.3.
+unsafe impl<K, V> Send for NodeRef<'_, K, V> where Node<K, V>: Sync {}
+unsafe impl<K, V> Sync for NodeRef<'_, K, V> where Node<K, V>: Sync {}
+
 impl<K, V> Node<K, V> {
     /// Allocates a node.
     ///
@@ -100,13 +176,13 @@ impl<K, V> Node<K, V> {
     unsafe fn alloc(height: usize, ref_count: usize) -> *mut Self {
         let layout = Self::get_layout(height);
         unsafe {
-            let ptr = alloc(layout).cast::<Self>();
-            if ptr.is_null() {
-                handle_alloc_error(layout);
-            }
+            let ptr = match Global.allocate(layout) {
+                Some(ptr) => ptr.as_ptr().cast::<Self>(),
+                None => handle_alloc_error(layout),
+            };
 
             ptr::addr_of_mut!((*ptr).refs_and_height)
-                .write(AtomicUsize::new((height - 1) | ref_count << HEIGHT_BITS));
+                .write(AtomicUsize::new((height - 1) | (ref_count << HEIGHT_BITS)));
             ptr::addr_of_mut!((*ptr).tower.pointers)
                 .cast::<Atomic<Self>>()
                 .write_bytes(0, height);
@@ -121,7 +197,7 @@ impl<K, V> Node<K, V> {
         unsafe {
             let height = (*ptr).height();
             let layout = Self::get_layout(height);
-            dealloc(ptr.cast::<u8>(), layout);
+            Global.deallocate(NonNull::new_unchecked(ptr.cast::<u8>()), layout);
         }
     }
 
@@ -140,43 +216,6 @@ impl<K, V> Node<K, V> {
     #[inline]
     fn height(&self) -> usize {
         (self.refs_and_height.load(Ordering::Relaxed) & HEIGHT_MASK) + 1
-    }
-
-    /// Marks all pointers in the tower and returns `true` if the level 0 was not marked.
-    fn mark_tower(&self) -> bool {
-        let height = self.height();
-
-        for level in (0..height).rev() {
-            let tag = unsafe {
-                // We're loading the pointer only for the tag, so it's okay to use
-                // `epoch::unprotected()` in this situation.
-                // TODO(Amanieu): can we use release ordering here?
-                self.tower[level]
-                    .fetch_or(1, Ordering::SeqCst, epoch::unprotected())
-                    .tag()
-            };
-
-            // If the level 0 pointer was already marked, somebody else removed the node.
-            if level == 0 && tag == 1 {
-                return false;
-            }
-        }
-
-        // We marked the level 0 pointer, therefore we removed the node.
-        true
-    }
-
-    /// Returns `true` if the node is removed.
-    #[inline]
-    fn is_removed(&self) -> bool {
-        let tag = unsafe {
-            // We're loading the pointer only for the tag, so it's okay to use
-            // `epoch::unprotected()` in this situation.
-            self.tower[0]
-                .load(Ordering::Relaxed, epoch::unprotected())
-                .tag()
-        };
-        tag == 1
     }
 
     /// Attempts to increment the reference count of a node and returns `true` on success.
@@ -216,9 +255,46 @@ impl<K, V> Node<K, V> {
         }
     }
 
+    /// Drops the key and value of a node, then deallocates it.
+    #[cold]
+    unsafe fn finalize(ptr: *mut Self) {
+        unsafe {
+            // Call destructors: drop the key and the value.
+            ptr::drop_in_place(&mut (*ptr).key);
+            ptr::drop_in_place(&mut (*ptr).value);
+
+            // Finally, deallocate the memory occupied by the node.
+            Self::dealloc(ptr);
+        }
+    }
+}
+
+impl<'a, K, V> NodeRef<'a, K, V> {
+    /// Creates a NodeRef.
+    ///
+    /// # Safety
+    ///
+    /// Same as NonNull::as_ref, except the pointer must also be valid for accessing the actual
+    /// size of the tower at the end of the node.
+    #[inline]
+    unsafe fn new(ptr: NonNull<Node<K, V>>) -> Self {
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    /// # Safety
+    ///
+    /// See [`Shared::as_ref`].
+    #[inline]
+    unsafe fn from_shared(shared: Shared<'a, Node<K, V>>) -> Option<Self> {
+        NonNull::new(shared.as_raw() as *mut Node<K, V>).map(|ptr| unsafe { Self::new(ptr) })
+    }
+
     /// Decrements the reference count of a node, destroying it if the count becomes zero.
     #[inline]
-    unsafe fn decrement(&self, guard: &Guard) {
+    unsafe fn decrement(self, guard: &Guard) {
         if self
             .refs_and_height
             .fetch_sub(1 << HEIGHT_BITS, Ordering::Release)
@@ -226,14 +302,14 @@ impl<K, V> Node<K, V> {
             == 1
         {
             fence(Ordering::Acquire);
-            unsafe { guard.defer_unchecked(move || Self::finalize(self)) }
+            unsafe { guard.defer_unchecked(move || Node::finalize(self.ptr.as_ptr())) }
         }
     }
 
     /// Decrements the reference count of a node, pinning the thread and destroying the node
     /// if the count become zero.
     #[inline]
-    unsafe fn decrement_with_pin<F>(&self, parent: &SkipList<K, V>, pin: F)
+    unsafe fn decrement_with_pin<F, C>(self, parent: &SkipList<K, V, C>, pin: F)
     where
         F: FnOnce() -> Guard,
     {
@@ -246,23 +322,83 @@ impl<K, V> Node<K, V> {
             fence(Ordering::Acquire);
             let guard = &pin();
             parent.check_guard(guard);
-            unsafe { guard.defer_unchecked(move || Self::finalize(self)) }
+            unsafe { guard.defer_unchecked(move || Node::finalize(self.ptr.as_ptr())) }
         }
     }
 
-    /// Drops the key and value of a node, then deallocates it.
-    #[cold]
-    unsafe fn finalize(ptr: *const Self) {
-        let ptr = ptr as *mut Self;
+    /// Marks all pointers in the tower and returns `true` if the level 0 was not marked.
+    fn mark_tower(self) -> bool {
+        let height = self.height();
 
-        unsafe {
-            // Call destructors: drop the key and the value.
-            ptr::drop_in_place(&mut (*ptr).key);
-            ptr::drop_in_place(&mut (*ptr).value);
+        for level in (0..height).rev() {
+            let tag = unsafe {
+                // We're loading the pointer only for the tag, so it's okay to use
+                // `epoch::unprotected()` in this situation.
+                // TODO(Amanieu): can we use release ordering here?
+                self.get_level(level)
+                    .fetch_or(1, Ordering::SeqCst, epoch::unprotected())
+                    .tag()
+            };
 
-            // Finally, deallocate the memory occupied by the node.
-            Self::dealloc(ptr);
+            // If the level 0 pointer was already marked, somebody else removed the node.
+            if level == 0 && tag == 1 {
+                return false;
+            }
         }
+
+        // We marked the level 0 pointer, therefore we removed the node.
+        true
+    }
+
+    /// Returns `true` if the node is removed.
+    #[inline]
+    fn is_removed(self) -> bool {
+        let tag = unsafe {
+            // We're loading the pointer only for the tag, so it's okay to use
+            // `epoch::unprotected()` in this situation.
+            self.get_level(0)
+                .load(Ordering::Relaxed, epoch::unprotected())
+                .tag()
+        };
+        tag == 1
+    }
+
+    /// Creates a TowerRef to the atomic pointers at the end of this Node allocation.
+    #[inline]
+    fn as_tower(self) -> TowerRef<'a, K, V> {
+        // SAFETY: self.ptr has provenance to access the tower.
+        unsafe {
+            TowerRef::new(NonNull::new_unchecked(
+                ptr::addr_of!((*self.ptr.as_ptr()).tower) as *mut Tower<K, V>,
+            ))
+        }
+    }
+
+    /// Gets a plain reference to the node which can be used for anything that doesn't need to access
+    /// the tower.
+    #[inline]
+    fn as_ref(self) -> &'a Node<K, V> {
+        // SAFETY: Self::new requires the conditions for creating a Node reference.
+        unsafe { self.ptr.as_ref() }
+    }
+
+    /// Gets the atomic node pointer at the specified level of the tower.
+    ///
+    /// # Safety
+    ///
+    /// Index must be in bounds.
+    #[inline]
+    unsafe fn get_level(&self, index: usize) -> &Atomic<Node<K, V>> {
+        // SAFETY: Requirements passed to caller.
+        unsafe { self.as_tower().get_level(index) }
+    }
+}
+
+impl<K, V> Deref for NodeRef<'_, K, V> {
+    type Target = Node<K, V>;
+    #[inline]
+    fn deref(&self) -> &Node<K, V> {
+        self.as_ref()
     }
 }
 
@@ -279,6 +415,16 @@ where
     }
 }
 
+impl<K, V> fmt::Debug for NodeRef<'_, K, V>
+where
+    K: fmt::Debug,
+    V: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Node<K, V> as fmt::Debug>::fmt(self, f)
+    }
+}
+
 /// A search result.
 ///
 /// The result indicates whether the key was found, as well as what were the adjacent nodes to the
@@ -287,10 +433,10 @@ struct Position<'a, K, V> {
     /// Reference to a node with the given key, if found.
     ///
     /// If this is `Some` then it will point to the same node as `right[0]`.
-    found: Option<&'a Node<K, V>>,
+    found: Option<NodeRef<'a, K, V>>,
 
     /// Adjacent nodes with smaller keys (predecessors).
-    left: [&'a Tower<K, V>; MAX_HEIGHT],
+    left: [TowerRef<'a, K, V>; MAX_HEIGHT],
 
     /// Adjacent nodes with equal or greater keys (successors).
     right: [Shared<'a, Node<K, V>>; MAX_HEIGHT],
@@ -322,7 +468,7 @@ struct HotData {
 // As a further future optimization, if `!mem::needs_drop::<K>() && !mem::needs_drop::<V>()`
 // (neither key nor the value have destructors), there's no point in creating a new local
 // collector, so we should simply use the global one.
-pub struct SkipList<K, V> {
+pub struct SkipList<K, V, C = BasicComparator> {
     /// The head of the skip list (just a dummy node, not a real entry).
     head: Head<K, V>,
 
@@ -331,14 +477,24 @@ pub struct SkipList<K, V> {
 
     /// Hot data associated with the skip list, stored in a dedicated cache line.
     hot_data: CachePadded<HotData>,
+
+    /// The `Comparator` used to determine key ordering.
+    comparator: C,
 }
 
-unsafe impl<K: Send + Sync, V: Send + Sync> Send for SkipList<K, V> {}
-unsafe impl<K: Send + Sync, V: Send + Sync> Sync for SkipList<K, V> {}
+unsafe impl<K: Send + Sync, V: Send + Sync, C: Send + Sync> Send for SkipList<K, V, C> {}
+unsafe impl<K: Send + Sync, V: Send + Sync, C: Send + Sync> Sync for SkipList<K, V, C> {}
 
 impl<K, V> SkipList<K, V> {
     /// Returns a new, empty skip list.
     pub fn new(collector: Collector) -> Self {
+        Self::with_comparator(collector, Default::default())
+    }
+}
+
+impl<K, V, C> SkipList<K, V, C> {
+    /// Returns a new, empty skip list using the given comparator.
+    pub fn with_comparator(collector: Collector, comparator: C) -> Self {
         Self {
             head: Head::new(),
             collector,
@@ -347,6 +503,7 @@ impl<K, V> SkipList<K, V> {
                 len: AtomicUsize::new(0),
                 max_height: AtomicUsize::new(1),
             }),
+            comparator,
         }
     }
 
@@ -380,14 +537,14 @@ impl<K, V> SkipList<K, V> {
     }
 }
 
-impl<K, V> SkipList<K, V>
+impl<K, V, C> SkipList<K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
     /// Returns the entry with the smallest key.
-    pub fn front<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V>> {
+    pub fn front<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V, C>> {
         self.check_guard(guard);
-        let n = self.next_node(&self.head, Bound::Unbounded, guard)?;
+        let n = self.next_node(self.head.as_tower(), Bound::Unbounded, guard)?;
         Some(Entry {
             parent: self,
             node: n,
@@ -396,9 +553,9 @@ where
     }
 
     /// Returns the entry with the largest key.
-    pub fn back<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V>> {
+    pub fn back<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V, C>> {
         self.check_guard(guard);
-        let n = self.search_bound(Bound::Unbounded, true, guard)?;
+        let n = self.search_bound::<K>(Bound::Unbounded, true, guard)?;
         Some(Entry {
             parent: self,
             node: n,
@@ -409,23 +566,24 @@ where
     /// Returns `true` if the map contains a value for the specified key.
     pub fn contains_key<Q>(&self, key: &Q, guard: &Guard) -> bool
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         self.get(key, guard).is_some()
     }
 
     /// Returns an entry with the specified `key`.
-    pub fn get<'a: 'g, 'g, Q>(&'a self, key: &Q, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V>>
+    pub fn get<'a: 'g, 'g, Q>(&'a self, key: &Q, guard: &'g Guard) -> Option<Entry<'a, 'g, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         self.check_guard(guard);
         let n = self.search_bound(Bound::Included(key), false, guard)?;
-        if n.key.borrow() != key {
+        if !self.comparator.equivalent(&n.key, key) {
             return None;
         }
+
         Some(Entry {
             parent: self,
             node: n,
@@ -440,10 +598,10 @@ where
         &'a self,
         bound: Bound<&Q>,
         guard: &'g Guard,
-    ) -> Option<Entry<'a, 'g, K, V>>
+    ) -> Option<Entry<'a, 'g, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         self.check_guard(guard);
         let n = self.search_bound(bound, false, guard)?;
@@ -461,10 +619,10 @@ where
         &'a self,
         bound: Bound<&Q>,
         guard: &'g Guard,
-    ) -> Option<Entry<'a, 'g, K, V>>
+    ) -> Option<Entry<'a, 'g, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         self.check_guard(guard);
         let n = self.search_bound(bound, true, guard)?;
@@ -476,19 +634,18 @@ where
     }
 
     /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
-    pub fn get_or_insert(&self, key: K, value: V, guard: &Guard) -> RefEntry<'_, K, V> {
+    pub fn get_or_insert(&self, key: K, value: V, guard: &Guard) -> RefEntry<'_, K, V, C> {
         self.insert_internal(key, || value, |_| false, guard)
     }
 
     /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist,
     /// where value is calculated with a function.
     ///
-    ///
     /// <b>Note:</b> Another thread may write key value first, leading to the result of this closure
     /// discarded. If closure is modifying some other state (such as shared counters or shared
     /// objects), it may lead to <u>undesired behaviour</u> such as counters being changed without
     /// result of closure inserted
-    pub fn get_or_insert_with<F>(&self, key: K, value: F, guard: &Guard) -> RefEntry<'_, K, V>
+    pub fn get_or_insert_with<F>(&self, key: K, value: F, guard: &Guard) -> RefEntry<'_, K, V, C>
     where
         F: FnOnce() -> V,
     {
@@ -496,7 +653,7 @@ where
     }
 
     /// Returns an iterator over all entries in the skip list.
-    pub fn iter<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Iter<'a, 'g, K, V> {
+    pub fn iter<'a: 'g, 'g>(&'a self, guard: &'g Guard) -> Iter<'a, 'g, K, V, C> {
         self.check_guard(guard);
         Iter {
             parent: self,
@@ -507,7 +664,7 @@ where
     }
 
     /// Returns an iterator over all entries in the skip list.
-    pub fn ref_iter(&self) -> RefIter<'_, K, V> {
+    pub fn ref_iter(&self) -> RefIter<'_, K, V, C> {
         RefIter {
             parent: self,
             head: None,
@@ -520,11 +677,11 @@ where
         &'a self,
         range: R,
         guard: &'g Guard,
-    ) -> Range<'a, 'g, Q, R, K, V>
+    ) -> Range<'a, 'g, Q, R, K, V, C>
     where
-        K: Borrow<Q>,
+        C: Comparator<K, Q>,
         R: RangeBounds<Q>,
-        Q: Ord + ?Sized,
+        Q: ?Sized,
     {
         self.check_guard(guard);
         Range {
@@ -539,11 +696,11 @@ where
 
     /// Returns an iterator over a subset of entries in the skip list.
     #[allow(clippy::needless_lifetimes)]
-    pub fn ref_range<'a, Q, R>(&'a self, range: R) -> RefRange<'a, Q, R, K, V>
+    pub fn ref_range<'a, Q, R>(&'a self, range: R) -> RefRange<'a, Q, R, K, V, C>
     where
-        K: Borrow<Q>,
+        C: Comparator<K, Q>,
         R: RangeBounds<Q>,
-        Q: Ord + ?Sized,
+        Q: ?Sized,
     {
         RefRange {
             parent: self,
@@ -574,7 +731,9 @@ where
             // Note that we're loading the pointer only to check whether it is null, so it's okay
             // to use `epoch::unprotected()` in this situation.
             while height >= 4
-                && self.head[height - 2]
+                && self
+                    .head
+                    .get_level(height - 2)
                     .load(Ordering::Relaxed, epoch::unprotected())
                     .is_null()
             {
@@ -607,14 +766,14 @@ where
     unsafe fn help_unlink<'a>(
         &'a self,
         pred: &'a Atomic<Node<K, V>>,
-        curr: &'a Node<K, V>,
+        curr: NodeRef<'a, K, V>,
         succ: Shared<'a, Node<K, V>>,
         guard: &'a Guard,
     ) -> Option<Shared<'a, Node<K, V>>> {
         // If `succ` is marked, that means `curr` is removed. Let's try
         // unlinking it from the skip list at this level.
         match pred.compare_exchange(
-            Shared::from(curr as *const _),
+            Shared::from(curr.ptr.as_ptr() as *const Node<K, V>),
             succ.with_tag(0),
             Ordering::Release,
             Ordering::Relaxed,
@@ -634,13 +793,13 @@ where
     /// node is reached then a search is performed using the given key.
     fn next_node<'a>(
         &'a self,
-        pred: &'a Tower<K, V>,
+        pred: TowerRef<'a, K, V>,
         lower_bound: Bound<&K>,
         guard: &'a Guard,
-    ) -> Option<&'a Node<K, V>> {
+    ) -> Option<NodeRef<'a, K, V>> {
         unsafe {
             // Load the level 0 successor of the current node.
-            let mut curr = pred[0].load_consume(guard);
+            let mut curr = pred.get_level(0).load_consume(guard);
 
             // If `curr` is marked, that means `pred` is removed and we have to use
             // a key search.
@@ -648,11 +807,11 @@ where
                 return self.search_bound(lower_bound, false, guard);
             }
 
-            while let Some(c) = curr.as_ref() {
-                let succ = c.tower[0].load_consume(guard);
+            while let Some(c) = NodeRef::from_shared(curr) {
+                let succ = c.get_level(0).load_consume(guard);
 
                 if succ.tag() == 1 {
-                    if let Some(c) = self.help_unlink(&pred[0], c, succ, guard) {
+                    if let Some(c) = self.help_unlink(pred.get_level(0), c, succ, guard) {
                         // On success, continue searching through the current level.
                         curr = c;
                         continue;
@@ -683,10 +842,10 @@ where
         bound: Bound<&Q>,
         upper_bound: bool,
         guard: &'a Guard,
-    ) -> Option<&'a Node<K, V>>
+    ) -> Option<NodeRef<'a, K, V>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         unsafe {
             'search: loop {
@@ -695,7 +854,9 @@ where
 
                 // Fast loop to skip empty tower levels.
                 while level >= 1
-                    && self.head[level - 1]
+                    && self
+                        .head
+                        .get_level(level - 1)
                         .load(Ordering::Relaxed, guard)
                         .is_null()
                 {
@@ -706,13 +867,13 @@ where
                 let mut result = None;
 
                 // The predecessor node
-                let mut pred = &*self.head;
+                let mut pred = self.head.as_tower();
 
                 while level >= 1 {
                     level -= 1;
 
                     // Two adjacent nodes at the current level.
-                    let mut curr = pred[level].load_consume(guard);
+                    let mut curr = pred.get_level(level).load_consume(guard);
 
                     // If `curr` is marked, that means `pred` is removed and we have to restart the
                     // search.
@@ -722,11 +883,12 @@ where
 
                     // Iterate through the current level until we reach a node with a key greater
                     // than or equal to `key`.
-                    while let Some(c) = curr.as_ref() {
-                        let succ = c.tower[level].load_consume(guard);
+                    while let Some(c) = NodeRef::from_shared(curr) {
+                        let succ = c.get_level(level).load_consume(guard);
 
                         if succ.tag() == 1 {
-                            if let Some(c) = self.help_unlink(&pred[level], c, succ, guard) {
+                            if let Some(c) = self.help_unlink(pred.get_level(level), c, succ, guard)
+                            {
                                 // On success, continue searching through the current level.
                                 curr = c;
                                 continue;
@@ -744,17 +906,17 @@ where
                         // bound, we return the last node before the condition became true. For the
                         // lower bound, we return the first node after the condition became true.
                         if upper_bound {
-                            if !below_upper_bound(&bound, c.key.borrow()) {
+                            if !below_upper_bound(&self.comparator, &bound, &c.key) {
                                 break;
                             }
                             result = Some(c);
-                        } else if above_lower_bound(&bound, c.key.borrow()) {
+                        } else if above_lower_bound(&self.comparator, &bound, &c.key) {
                             result = Some(c);
                             break;
                         }
 
                         // Move one step forward.
-                        pred = &c.tower;
+                        pred = c.as_tower();
                         curr = succ;
                     }
                 }
@@ -767,15 +929,15 @@ where
     /// Searches for a key in the skip list and returns a list of all adjacent nodes.
     fn search_position<'a, Q>(&'a self, key: &Q, guard: &'a Guard) -> Position<'a, K, V>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         unsafe {
             'search: loop {
                 // The result of this search.
                 let mut result = Position {
                     found: None,
-                    left: [&*self.head; MAX_HEIGHT],
+                    left: [self.head.as_tower(); MAX_HEIGHT],
                     right: [Shared::null(); MAX_HEIGHT],
                 };
 
@@ -784,7 +946,9 @@ where
 
                 // Fast loop to skip empty tower levels.
                 while level >= 1
-                    && self.head[level - 1]
+                    && self
+                        .head
+                        .get_level(level - 1)
                         .load(Ordering::Relaxed, guard)
                         .is_null()
                 {
@@ -792,13 +956,13 @@ where
                 }
 
                 // The predecessor node
-                let mut pred = &*self.head;
+                let mut pred = self.head.as_tower();
 
                 while level >= 1 {
                     level -= 1;
 
                     // Two adjacent nodes at the current level.
-                    let mut curr = pred[level].load_consume(guard);
+                    let mut curr = pred.get_level(level).load_consume(guard);
 
                     // If `curr` is marked, that means `pred` is removed and we have to restart the
                     // search.
@@ -808,11 +972,12 @@ where
 
                     // Iterate through the current level until we reach a node with a key greater
                     // than or equal to `key`.
-                    while let Some(c) = curr.as_ref() {
-                        let succ = c.tower[level].load_consume(guard);
+                    while let Some(c) = NodeRef::from_shared(curr) {
+                        let succ = c.get_level(level).load_consume(guard);
 
                         if succ.tag() == 1 {
-                            if let Some(c) = self.help_unlink(&pred[level], c, succ, guard) {
+                            if let Some(c) = self.help_unlink(pred.get_level(level), c, succ, guard)
+                            {
                                 // On success, continue searching through the current level.
                                 curr = c;
                                 continue;
@@ -825,7 +990,7 @@ where
 
                         // If `curr` contains a key that is greater than or equal to `key`, we're
                         // done with this level.
-                        match c.key.borrow().cmp(key) {
+                        match self.comparator.compare(&c.key, key) {
                             cmp::Ordering::Greater => break,
                             cmp::Ordering::Equal => {
                                 result.found = Some(c);
@@ -835,7 +1000,7 @@ where
                         }
 
                         // Move one step forward.
-                        pred = &c.tower;
+                        pred = c.as_tower();
                         curr = succ;
                     }
 
@@ -858,8 +1023,9 @@ where
         value: F,
         replace: CompareF,
         guard: &Guard,
-    ) -> RefEntry<'_, K, V>
+    ) -> RefEntry<'_, K, V, C>
     where
+        C: Comparator<K>,
         F: FnOnce() -> V,
         CompareF: Fn(&V) -> bool,
     {
@@ -871,33 +1037,17 @@ where
             // the lifetime of the guard.
             let guard = &*(guard as *const _);
 
-            let mut search;
-            loop {
-                // First try searching for the key.
-                // Note that the `Ord` implementation for `K` may panic during the search.
-                search = self.search_position(&key, guard);
-
-                let r = match search.found {
-                    Some(r) => r,
-                    None => break,
-                };
+            // First try searching for the key.
+            // Note that the `Ord` implementation for `K` may panic during the search.
+            let mut search = self.search_position(&key, guard);
+            if let Some(r) = search.found {
                 let replace = replace(&r.value);
-                if replace {
-                    // If a node with the key was found and we should replace it, mark its tower
-                    // and then repeat the search.
-                    if r.mark_tower() {
-                        self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
-                    }
-                } else {
+                if !replace {
                     // If a node with the key was found and we're not going to replace it, let's
                     // try returning it as an entry.
                     if let Some(e) = RefEntry::try_acquire(self, r) {
                         return e;
                     }
-
-                    // If we couldn't increment the reference count, that means someone has just
-                    // now removed the node.
-                    break;
                 }
             }
 
@@ -915,7 +1065,10 @@ where
                 ptr::addr_of_mut!((*n).key).write(key);
                 ptr::addr_of_mut!((*n).value).write(value);
 
-                (Shared::<Node<K, V>>::from(n as *const _), &*n)
+                (
+                    Shared::<Node<K, V>>::from(n as *const _),
+                    NodeRef::new(NonNull::new_unchecked(n)),
+                )
             };
 
             // Optimistically increment `len`.
@@ -923,11 +1076,12 @@ where
 
             loop {
                 // Set the lowest successor of `n` to `search.right[0]`.
-                n.tower[0].store(search.right[0], Ordering::Relaxed);
+                n.get_level(0).store(search.right[0], Ordering::Relaxed);
 
                 // Try installing the new node into the skip list (at level 0).
                 // TODO(Amanieu): can we use release ordering here?
-                if search.left[0][0]
+                if search.left[0]
+                    .get_level(0)
                     .compare_exchange(
                         search.right[0],
                         node,
@@ -937,6 +1091,12 @@ where
                     )
                     .is_ok()
                 {
+                    // This node has been abandoned
+                    if let Some(r) = search.found {
+                        if r.mark_tower() {
+                            self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
+                        }
+                    }
                     break;
                 }
 
@@ -946,7 +1106,7 @@ where
                     struct ScopeGuard<K, V>(*const Node<K, V>);
                     impl<K, V> Drop for ScopeGuard<K, V> {
                         fn drop(&mut self) {
-                            unsafe { Node::finalize(self.0) }
+                            unsafe { Node::finalize(self.0 as *mut Node<K, V>) }
                         }
                     }
                     let sg = ScopeGuard(node.as_raw());
@@ -956,18 +1116,12 @@ where
 
                 if let Some(r) = search.found {
                     let replace = replace(&r.value);
-                    if replace {
-                        // If a node with the key was found and we should replace it, mark its
-                        // tower and then repeat the search.
-                        if r.mark_tower() {
-                            self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
-                        }
-                    } else {
+                    if !replace {
                         // If a node with the key was found and we're not going to replace it,
                         // let's try returning it as an entry.
                         if let Some(e) = RefEntry::try_acquire(self, r) {
                             // Destroy the new node.
-                            Node::finalize(node.as_raw());
+                            Node::finalize(node.as_raw() as *mut Node<K, V>);
                             self.hot_data.len.fetch_sub(1, Ordering::Relaxed);
 
                             return e;
@@ -994,7 +1148,7 @@ where
 
                     // Load the current value of the pointer in the tower at this level.
                     // TODO(Amanieu): can we use relaxed ordering here?
-                    let next = n.tower[level].load(Ordering::SeqCst, guard);
+                    let next = n.get_level(level).load(Ordering::SeqCst, guard);
 
                     // If the current pointer is marked, that means another thread is already
                     // removing the node we've just inserted. In that case, let's just stop
@@ -1021,7 +1175,10 @@ where
                     // the tower without breaking any invariants. Note that building higher levels
                     // is completely optional. Only the lowest level really matters, and all the
                     // higher levels are there just to make searching faster.
-                    if succ.as_ref().map(|s| &s.key) == Some(&n.key) {
+                    if succ
+                        .as_ref()
+                        .is_some_and(|s| self.comparator.equivalent(&s.key, &n.key))
+                    {
                         search = self.search_position(&n.key, guard);
                         continue;
                     }
@@ -1030,7 +1187,7 @@ where
                     // operation fails, that means another thread has marked the pointer and we
                     // should stop building the tower.
                     // TODO(Amanieu): can we use release ordering here?
-                    if n.tower[level]
+                    if n.get_level(level)
                         .compare_exchange(next, succ, Ordering::SeqCst, Ordering::SeqCst, guard)
                         .is_err()
                     {
@@ -1044,7 +1201,8 @@ where
 
                     // Try installing the new node at the current level.
                     // TODO(Amanieu): can we use release ordering here?
-                    if pred[level]
+                    if pred
+                        .get_level(level)
                         .compare_exchange(succ, node, Ordering::SeqCst, Ordering::SeqCst, guard)
                         .is_ok()
                     {
@@ -1073,7 +1231,7 @@ where
             // installation, we must repeat the search, which will unlink the new node at that
             // level.
             // TODO(Amanieu): can we use relaxed ordering here?
-            if n.tower[height - 1].load(Ordering::SeqCst, guard).tag() == 1 {
+            if n.get_level(height - 1).load(Ordering::SeqCst, guard).tag() == 1 {
                 self.search_bound(Bound::Included(&n.key), false, guard);
             }
 
@@ -1083,16 +1241,17 @@ where
     }
 }
 
-impl<K, V> SkipList<K, V>
+impl<K, V, C> SkipList<K, V, C>
 where
-    K: Ord + Send + 'static,
+    C: Comparator<K>,
+    K: Send + 'static,
     V: Send + 'static,
 {
     /// Inserts a `key`-`value` pair into the skip list and returns the new entry.
     ///
     /// If there is an existing entry with this key, it will be removed before inserting the new
     /// one.
-    pub fn insert(&self, key: K, value: V, guard: &Guard) -> RefEntry<'_, K, V> {
+    pub fn insert(&self, key: K, value: V, guard: &Guard) -> RefEntry<'_, K, V, C> {
         self.insert_internal(key, || value, |_| true, guard)
     }
 
@@ -1107,7 +1266,7 @@ where
         value: V,
         compare_fn: F,
         guard: &Guard,
-    ) -> RefEntry<'_, K, V>
+    ) -> RefEntry<'_, K, V, C>
     where
         F: Fn(&V) -> bool,
     {
@@ -1115,10 +1274,10 @@ where
     }
 
     /// Removes an entry with the specified `key` from the map and returns it.
-    pub fn remove<Q>(&self, key: &Q, guard: &Guard) -> Option<RefEntry<'_, K, V>>
+    pub fn remove<Q>(&self, key: &Q, guard: &Guard) -> Option<RefEntry<'_, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         self.check_guard(guard);
 
@@ -1151,13 +1310,14 @@ where
                     // the `left` and `right` lists.
                     for level in (0..n.height()).rev() {
                         // TODO(Amanieu): can we use relaxed ordering here?
-                        let succ = n.tower[level].load(Ordering::SeqCst, guard).with_tag(0);
+                        let succ = n.get_level(level).load(Ordering::SeqCst, guard).with_tag(0);
 
                         // Try linking the predecessor and successor at this level.
                         // TODO(Amanieu): can we use release ordering here?
-                        if search.left[level][level]
+                        if search.left[level]
+                            .get_level(level)
                             .compare_exchange(
-                                Shared::from(n as *const _),
+                                Shared::from(n.ptr.as_ptr() as *const Node<K, V>),
                                 succ,
                                 Ordering::SeqCst,
                                 Ordering::SeqCst,
@@ -1173,14 +1333,18 @@ where
                             break;
                         }
                     }
+                    return Some(entry);
+                } else {
+                    // The node has already been marked.
+                    n.decrement(guard);
+                    return None;
                 }
-                return Some(entry);
             }
         }
     }
 
     /// Removes an entry from the front of the skip list.
-    pub fn pop_front(&self, guard: &Guard) -> Option<RefEntry<'_, K, V>> {
+    pub fn pop_front(&self, guard: &Guard) -> Option<RefEntry<'_, K, V, C>> {
         self.check_guard(guard);
         loop {
             let e = self.front(guard)?;
@@ -1195,7 +1359,7 @@ where
     }
 
     /// Removes an entry from the back of the skip list.
-    pub fn pop_back(&self, guard: &Guard) -> Option<RefEntry<'_, K, V>> {
+    pub fn pop_back(&self, guard: &Guard) -> Option<RefEntry<'_, K, V, C>> {
         self.check_guard(guard);
         loop {
             let e = self.back(guard)?;
@@ -1224,7 +1388,7 @@ where
                 // By unlinking nodes in batches we make sure that the final search doesn't
                 // unlink all nodes at once, which could keep the current thread pinned for a
                 // long time.
-                let mut entry = self.lower_bound(Bound::Unbounded, guard);
+                let mut entry = self.lower_bound::<K>(Bound::Unbounded, guard);
 
                 for _ in 0..BATCH_SIZE {
                     // Stop if we have reached the end of the list.
@@ -1253,23 +1417,25 @@ where
     }
 }
 
-impl<K, V> Drop for SkipList<K, V> {
+impl<K, V, C> Drop for SkipList<K, V, C> {
     fn drop(&mut self) {
         unsafe {
-            let mut node = self.head[0]
-                .load(Ordering::Relaxed, epoch::unprotected())
-                .as_ref();
+            let mut node = NodeRef::from_shared(
+                self.head
+                    .get_level(0)
+                    .load(Ordering::Relaxed, epoch::unprotected()),
+            );
 
             // Iterate through the whole skip list and destroy every node.
             while let Some(n) = node {
                 // Unprotected loads are okay because this function is the only one currently using
                 // the skip list.
-                let next = n.tower[0]
-                    .load(Ordering::Relaxed, epoch::unprotected())
-                    .as_ref();
+                let next = NodeRef::from_shared(
+                    n.get_level(0).load(Ordering::Relaxed, epoch::unprotected()),
+                );
 
                 // Deallocate every node.
-                Node::finalize(n);
+                Node::finalize(n.ptr.as_ptr());
 
                 node = next;
             }
@@ -1277,9 +1443,9 @@ impl<K, V> Drop for SkipList<K, V> {
     }
 }
 
-impl<K, V> fmt::Debug for SkipList<K, V>
+impl<K, V, C> fmt::Debug for SkipList<K, V, C>
 where
-    K: Ord + fmt::Debug,
+    K: fmt::Debug,
     V: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1287,23 +1453,27 @@ where
     }
 }
 
-impl<K, V> IntoIterator for SkipList<K, V> {
+impl<K, V, C> IntoIterator for SkipList<K, V, C> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
-    fn into_iter(self) -> IntoIter<K, V> {
+    fn into_iter(self) -> Self::IntoIter {
         unsafe {
             // Load the front node.
             //
             // Unprotected loads are okay because this function is the only one currently using
             // the skip list.
-            let front = self.head[0]
+            let front = self
+                .head
+                .get_level(0)
                 .load(Ordering::Relaxed, epoch::unprotected())
                 .as_raw();
 
             // Clear the skip list by setting all pointers in head to null.
             for level in 0..MAX_HEIGHT {
-                self.head[level].store(Shared::null(), Ordering::Relaxed);
+                self.head
+                    .get_level(level)
+                    .store(Shared::null(), Ordering::Relaxed);
             }
 
             IntoIter {
@@ -1318,13 +1488,13 @@ impl<K, V> IntoIterator for SkipList<K, V> {
 /// The lifetimes of the key and value are the same as that of the `Guard`
 /// used when creating the `Entry` (`'g`). This lifetime is also constrained to
 /// not outlive the `SkipList`.
-pub struct Entry<'a: 'g, 'g, K, V> {
-    parent: &'a SkipList<K, V>,
-    node: &'g Node<K, V>,
+pub struct Entry<'a: 'g, 'g, K, V, C = BasicComparator> {
+    parent: &'a SkipList<K, V, C>,
+    node: NodeRef<'g, K, V>,
     guard: &'g Guard,
 }
 
-impl<'a: 'g, 'g, K: 'a, V: 'a> Entry<'a, 'g, K, V> {
+impl<'a: 'g, 'g, K: 'a, V: 'a, C> Entry<'a, 'g, K, V, C> {
     /// Returns `true` if the entry is removed from the skip list.
     pub fn is_removed(&self) -> bool {
         self.node.is_removed()
@@ -1332,16 +1502,16 @@ impl<'a: 'g, 'g, K: 'a, V: 'a> Entry<'a, 'g, K, V> {
 
     /// Returns a reference to the key.
     pub fn key(&self) -> &'g K {
-        &self.node.key
+        &self.node.as_ref().key
     }
 
     /// Returns a reference to the value.
     pub fn value(&self) -> &'g V {
-        &self.node.value
+        &self.node.as_ref().value
     }
 
     /// Returns a reference to the parent `SkipList`
-    pub fn skiplist(&self) -> &'a SkipList<K, V> {
+    pub fn skiplist(&self) -> &'a SkipList<K, V, C> {
         self.parent
     }
 
@@ -1350,14 +1520,15 @@ impl<'a: 'g, 'g, K: 'a, V: 'a> Entry<'a, 'g, K, V> {
     ///
     /// This method may return `None` if the reference count is already 0 and
     /// the node has been queued for deletion.
-    pub fn pin(&self) -> Option<RefEntry<'a, K, V>> {
+    pub fn pin(&self) -> Option<RefEntry<'a, K, V, C>> {
         unsafe { RefEntry::try_acquire(self.parent, self.node) }
     }
 }
 
-impl<K, V> Entry<'_, '_, K, V>
+impl<K, V, C> Entry<'_, '_, K, V, C>
 where
-    K: Ord + Send + 'static,
+    C: Comparator<K>,
+    K: Send + 'static,
     V: Send + 'static,
 {
     /// Removes the entry from the skip list.
@@ -1380,7 +1551,7 @@ where
     }
 }
 
-impl<K, V> Clone for Entry<'_, '_, K, V> {
+impl<K, V, C> Clone for Entry<'_, '_, K, V, C> {
     fn clone(&self) -> Self {
         Self {
             parent: self.parent,
@@ -1390,7 +1561,7 @@ impl<K, V> Clone for Entry<'_, '_, K, V> {
     }
 }
 
-impl<K, V> fmt::Debug for Entry<'_, '_, K, V>
+impl<K, V, C> fmt::Debug for Entry<'_, '_, K, V, C>
 where
     K: fmt::Debug,
     V: fmt::Debug,
@@ -1403,9 +1574,9 @@ where
     }
 }
 
-impl<'a: 'g, 'g, K, V> Entry<'a, 'g, K, V>
+impl<K, V, C> Entry<'_, '_, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
     /// Moves to the next entry in the skip list.
     pub fn move_next(&mut self) -> bool {
@@ -1419,9 +1590,9 @@ where
     }
 
     /// Returns the next entry in the skip list.
-    pub fn next(&self) -> Option<Entry<'a, 'g, K, V>> {
+    pub fn next(&self) -> Option<Self> {
         let n = self.parent.next_node(
-            &self.node.tower,
+            self.node.as_tower(),
             Bound::Excluded(&self.node.key),
             self.guard,
         )?;
@@ -1444,7 +1615,7 @@ where
     }
 
     /// Returns the previous entry in the skip list.
-    pub fn prev(&self) -> Option<Entry<'a, 'g, K, V>> {
+    pub fn prev(&self) -> Option<Self> {
         let n = self
             .parent
             .search_bound(Bound::Excluded(&self.node.key), true, self.guard)?;
@@ -1460,29 +1631,29 @@ where
 ///
 /// You *must* call `release` to free this type, otherwise the node will be
 /// leaked. This is because releasing the entry requires a `Guard`.
-pub struct RefEntry<'a, K, V> {
-    parent: &'a SkipList<K, V>,
-    node: &'a Node<K, V>,
+pub struct RefEntry<'a, K, V, C = BasicComparator> {
+    parent: &'a SkipList<K, V, C>,
+    node: NodeRef<'a, K, V>,
 }
 
-impl<'a, K: 'a, V: 'a> RefEntry<'a, K, V> {
+impl<'a, K: 'a, V: 'a, C: 'a> RefEntry<'a, K, V, C> {
     /// Returns `true` if the entry is removed from the skip list.
     pub fn is_removed(&self) -> bool {
         self.node.is_removed()
     }
 
     /// Returns a reference to the key.
-    pub fn key(&self) -> &K {
-        &self.node.key
+    pub fn key(&self) -> &'a K {
+        &self.node.as_ref().key
     }
 
     /// Returns a reference to the value.
-    pub fn value(&self) -> &V {
-        &self.node.value
+    pub fn value(&self) -> &'a V {
+        &self.node.as_ref().value
     }
 
     /// Returns a reference to the parent `SkipList`
-    pub fn skiplist(&self) -> &'a SkipList<K, V> {
+    pub fn skiplist(&self) -> &'a SkipList<K, V, C> {
         self.parent
     }
 
@@ -1503,17 +1674,14 @@ impl<'a, K: 'a, V: 'a> RefEntry<'a, K, V> {
 
     /// Tries to create a new `RefEntry` by incrementing the reference count of
     /// a node.
-    unsafe fn try_acquire(
-        parent: &'a SkipList<K, V>,
-        node: &Node<K, V>,
-    ) -> Option<RefEntry<'a, K, V>> {
+    unsafe fn try_acquire(parent: &'a SkipList<K, V, C>, node: NodeRef<'_, K, V>) -> Option<Self> {
         if unsafe { node.try_increment() } {
             Some(RefEntry {
                 parent,
 
                 // We re-bind the lifetime of the node here to that of the skip
                 // list since we now hold a reference to it.
-                node: unsafe { &*(node as *const _) },
+                node: unsafe { NodeRef::new(node.ptr) },
             })
         } else {
             None
@@ -1521,9 +1689,10 @@ impl<'a, K: 'a, V: 'a> RefEntry<'a, K, V> {
     }
 }
 
-impl<K, V> RefEntry<'_, K, V>
+impl<K, V, C> RefEntry<'_, K, V, C>
 where
-    K: Ord + Send + 'static,
+    C: Comparator<K>,
+    K: Send + 'static,
     V: Send + 'static,
 {
     /// Removes the entry from the skip list.
@@ -1548,11 +1717,11 @@ where
     }
 }
 
-impl<K, V> Clone for RefEntry<'_, K, V> {
+impl<K, V, C> Clone for RefEntry<'_, K, V, C> {
     fn clone(&self) -> Self {
         unsafe {
             // Incrementing will always succeed since we're already holding a reference to the node.
-            Node::try_increment(self.node);
+            Node::try_increment(&*self.node);
         }
         Self {
             parent: self.parent,
@@ -1561,7 +1730,7 @@ impl<K, V> Clone for RefEntry<'_, K, V> {
     }
 }
 
-impl<K, V> fmt::Debug for RefEntry<'_, K, V>
+impl<K, V, C> fmt::Debug for RefEntry<'_, K, V, C>
 where
     K: fmt::Debug,
     V: fmt::Debug,
@@ -1574,9 +1743,9 @@ where
     }
 }
 
-impl<'a, K, V> RefEntry<'a, K, V>
+impl<K, V, C> RefEntry<'_, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
     /// Moves to the next entry in the skip list.
     pub fn move_next(&mut self, guard: &Guard) -> bool {
@@ -1590,14 +1759,14 @@ where
     }
 
     /// Returns the next entry in the skip list.
-    pub fn next(&self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+    pub fn next(&self, guard: &Guard) -> Option<Self> {
         self.parent.check_guard(guard);
         unsafe {
             let mut n = self.node;
             loop {
                 n = self
                     .parent
-                    .next_node(&n.tower, Bound::Excluded(&n.key), guard)?;
+                    .next_node(n.as_tower(), Bound::Excluded(&n.key), guard)?;
                 if let Some(e) = RefEntry::try_acquire(self.parent, n) {
                     return Some(e);
                 }
@@ -1617,7 +1786,7 @@ where
     }
 
     /// Returns the previous entry in the skip list.
-    pub fn prev(&self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+    pub fn prev(&self, guard: &Guard) -> Option<Self> {
         self.parent.check_guard(guard);
         unsafe {
             let mut n = self.node;
@@ -1634,30 +1803,31 @@ where
 }
 
 /// An iterator over the entries of a `SkipList`.
-pub struct Iter<'a: 'g, 'g, K, V> {
-    parent: &'a SkipList<K, V>,
-    head: Option<&'g Node<K, V>>,
-    tail: Option<&'g Node<K, V>>,
+pub struct Iter<'a: 'g, 'g, K, V, C = BasicComparator> {
+    parent: &'a SkipList<K, V, C>,
+    head: Option<NodeRef<'g, K, V>>,
+    tail: Option<NodeRef<'g, K, V>>,
     guard: &'g Guard,
 }
 
-impl<'a: 'g, 'g, K: 'a, V: 'a> Iterator for Iter<'a, 'g, K, V>
+impl<'a: 'g, 'g, K: 'a, V: 'a, C> Iterator for Iter<'a, 'g, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
-    type Item = Entry<'a, 'g, K, V>;
+    type Item = Entry<'a, 'g, K, V, C>;
 
-    fn next(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.head = match self.head {
             Some(n) => self
                 .parent
-                .next_node(&n.tower, Bound::Excluded(&n.key), self.guard),
-            None => self
-                .parent
-                .next_node(&self.parent.head, Bound::Unbounded, self.guard),
+                .next_node(n.as_tower(), Bound::Excluded(&n.key), self.guard),
+            None => {
+                self.parent
+                    .next_node(self.parent.head.as_tower(), Bound::Unbounded, self.guard)
+            }
         };
         if let (Some(h), Some(t)) = (self.head, self.tail) {
-            if h.key >= t.key {
+            if self.parent.comparator.compare(&h.key, &t.key).is_ge() {
                 self.head = None;
                 self.tail = None;
             }
@@ -1670,19 +1840,21 @@ where
     }
 }
 
-impl<'a: 'g, 'g, K: 'a, V: 'a> DoubleEndedIterator for Iter<'a, 'g, K, V>
+impl<'a: 'g, 'g, K: 'a, V: 'a, C> DoubleEndedIterator for Iter<'a, 'g, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
-    fn next_back(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         self.tail = match self.tail {
             Some(n) => self
                 .parent
                 .search_bound(Bound::Excluded(&n.key), true, self.guard),
-            None => self.parent.search_bound(Bound::Unbounded, true, self.guard),
+            None => self
+                .parent
+                .search_bound::<K>(Bound::Unbounded, true, self.guard),
         };
         if let (Some(h), Some(t)) = (self.head, self.tail) {
-            if h.key >= t.key {
+            if self.parent.comparator.compare(&h.key, &t.key).is_ge() {
                 self.head = None;
                 self.tail = None;
             }
@@ -1695,27 +1867,27 @@ where
     }
 }
 
-impl<K, V> fmt::Debug for Iter<'_, '_, K, V>
+impl<K, V, C> fmt::Debug for Iter<'_, '_, K, V, C>
 where
     K: fmt::Debug,
     V: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Iter")
-            .field("head", &self.head.map(|n| (&n.key, &n.value)))
-            .field("tail", &self.tail.map(|n| (&n.key, &n.value)))
+            .field("head", &self.head.as_deref().map(|n| (&n.key, &n.value)))
+            .field("tail", &self.tail.as_deref().map(|n| (&n.key, &n.value)))
             .finish()
     }
 }
 
 /// An iterator over reference-counted entries of a `SkipList`.
-pub struct RefIter<'a, K, V> {
-    parent: &'a SkipList<K, V>,
-    head: Option<RefEntry<'a, K, V>>,
-    tail: Option<RefEntry<'a, K, V>>,
+pub struct RefIter<'a, K, V, C = BasicComparator> {
+    parent: &'a SkipList<K, V, C>,
+    head: Option<RefEntry<'a, K, V, C>>,
+    tail: Option<RefEntry<'a, K, V, C>>,
 }
 
-impl<K, V> fmt::Debug for RefIter<'_, K, V>
+impl<K, V, C> fmt::Debug for RefIter<'_, K, V, C>
 where
     K: fmt::Debug,
     V: fmt::Debug,
@@ -1734,12 +1906,12 @@ where
     }
 }
 
-impl<'a, K: 'a, V: 'a> RefIter<'a, K, V>
+impl<'a, K: 'a, V: 'a, C> RefIter<'a, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
     /// Advances the iterator and returns the next value.
-    pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+    pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V, C>> {
         self.parent.check_guard(guard);
         let next_head = match &self.head {
             Some(e) => e.next(guard),
@@ -1747,7 +1919,9 @@ where
         };
         match (&next_head, &self.tail) {
             // The next key is larger than the latest tail key we observed with this iterator.
-            (Some(ref next), Some(t)) if next.key() >= t.key() => {
+            (Some(ref next), Some(t))
+                if self.parent.comparator.compare(next.key(), t.key()).is_ge() =>
+            {
                 unsafe {
                     next.node.decrement(guard);
                 }
@@ -1766,7 +1940,7 @@ where
     }
 
     /// Removes and returns an element from the end of the iterator.
-    pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+    pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V, C>> {
         self.parent.check_guard(guard);
         let next_tail = match &self.tail {
             Some(e) => e.prev(guard),
@@ -1774,7 +1948,9 @@ where
         };
         match (&self.head, &next_tail) {
             // The prev key is smaller than the latest head key we observed with this iterator.
-            (Some(h), Some(next)) if h.key() >= next.key() => {
+            (Some(h), Some(next))
+                if self.parent.comparator.compare(h.key(), next.key()).is_ge() =>
+            {
                 unsafe {
                     next.node.decrement(guard);
                 }
@@ -1793,7 +1969,7 @@ where
     }
 }
 
-impl<'a, K: 'a, V: 'a> RefIter<'a, K, V> {
+impl<'a, K: 'a, V: 'a, C> RefIter<'a, K, V, C> {
     /// Decrements the reference count of `RefEntry` owned by the iterator.
     pub fn drop_impl(&mut self, guard: &Guard) {
         self.parent.check_guard(guard);
@@ -1807,46 +1983,54 @@ impl<'a, K: 'a, V: 'a> RefIter<'a, K, V> {
 }
 
 /// An iterator over a subset of entries of a `SkipList`.
-pub struct Range<'a: 'g, 'g, Q, R, K, V>
+pub struct Range<'a: 'g, 'g, Q, R, K, V, C = BasicComparator>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    parent: &'a SkipList<K, V>,
-    head: Option<&'g Node<K, V>>,
-    tail: Option<&'g Node<K, V>>,
+    parent: &'a SkipList<K, V, C>,
+    head: Option<NodeRef<'g, K, V>>,
+    tail: Option<NodeRef<'g, K, V>>,
     range: R,
     guard: &'g Guard,
     _marker: PhantomData<fn() -> Q>, // covariant over `Q`
 }
 
-impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> Iterator for Range<'a, 'g, Q, R, K, V>
+impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a, C> Iterator for Range<'a, 'g, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    type Item = Entry<'a, 'g, K, V>;
+    type Item = Entry<'a, 'g, K, V, C>;
 
-    fn next(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.head = match self.head {
             Some(n) => self
                 .parent
-                .next_node(&n.tower, Bound::Excluded(&n.key), self.guard),
+                .next_node(n.as_tower(), Bound::Excluded(&n.key), self.guard),
             None => self
                 .parent
                 .search_bound(self.range.start_bound(), false, self.guard),
         };
         if let Some(h) = self.head {
-            let bound = match self.tail {
-                Some(t) => Bound::Excluded(t.key.borrow()),
-                None => self.range.end_bound(),
+            match self.tail {
+                Some(t) => {
+                    let bound = Bound::Excluded(&t.as_ref().key);
+                    if !below_upper_bound(&self.parent.comparator, &bound, &h.key) {
+                        self.head = None;
+                        self.tail = None;
+                    }
+                }
+                None => {
+                    let bound = self.range.end_bound();
+                    if !below_upper_bound(&self.parent.comparator, &bound, &h.key) {
+                        self.head = None;
+                        self.tail = None;
+                    }
+                }
             };
-            if !below_upper_bound(&bound, h.key.borrow()) {
-                self.head = None;
-                self.tail = None;
-            }
         }
         self.head.map(|n| Entry {
             parent: self.parent,
@@ -1856,30 +2040,38 @@ where
     }
 }
 
-impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a> DoubleEndedIterator for Range<'a, 'g, Q, R, K, V>
+impl<'a: 'g, 'g, Q, R, K: 'a, V: 'a, C> DoubleEndedIterator for Range<'a, 'g, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    fn next_back(&mut self) -> Option<Entry<'a, 'g, K, V>> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         self.tail = match self.tail {
             Some(n) => self
                 .parent
-                .search_bound(Bound::Excluded(n.key.borrow()), true, self.guard),
+                .search_bound::<K>(Bound::Excluded(&n.key), true, self.guard),
             None => self
                 .parent
                 .search_bound(self.range.end_bound(), true, self.guard),
         };
         if let Some(t) = self.tail {
-            let bound = match self.head {
-                Some(h) => Bound::Excluded(h.key.borrow()),
-                None => self.range.start_bound(),
+            match self.head {
+                Some(h) => {
+                    let bound = Bound::Excluded(&h.as_ref().key);
+                    if !above_lower_bound(&self.parent.comparator, &bound, &t.key) {
+                        self.head = None;
+                        self.tail = None;
+                    }
+                }
+                None => {
+                    let bound = self.range.start_bound();
+                    if !above_lower_bound(&self.parent.comparator, &bound, &t.key) {
+                        self.head = None;
+                        self.tail = None;
+                    }
+                }
             };
-            if !above_lower_bound(&bound, t.key.borrow()) {
-                self.head = None;
-                self.tail = None;
-            }
         }
         self.tail.map(|n| Entry {
             parent: self.parent,
@@ -1889,12 +2081,13 @@ where
     }
 }
 
-impl<Q, R, K, V> fmt::Debug for Range<'_, '_, Q, R, K, V>
+impl<Q, R, K, V, C> fmt::Debug for Range<'_, '_, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q> + fmt::Debug,
+    C: Comparator<K> + Comparator<K, Q>,
+    K: fmt::Debug,
     V: fmt::Debug,
     R: RangeBounds<Q> + fmt::Debug,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Range")
@@ -1906,41 +2099,42 @@ where
 }
 
 /// An iterator over reference-counted subset of entries of a `SkipList`.
-pub struct RefRange<'a, Q, R, K, V>
+pub struct RefRange<'a, Q, R, K, V, C = BasicComparator>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    parent: &'a SkipList<K, V>,
-    pub(crate) head: Option<RefEntry<'a, K, V>>,
-    pub(crate) tail: Option<RefEntry<'a, K, V>>,
+    parent: &'a SkipList<K, V, C>,
+    pub(crate) head: Option<RefEntry<'a, K, V, C>>,
+    pub(crate) tail: Option<RefEntry<'a, K, V, C>>,
     pub(crate) range: R,
     _marker: PhantomData<fn() -> Q>, // covariant over `Q`
 }
 
-unsafe impl<Q, R, K, V> Send for RefRange<'_, Q, R, K, V>
+unsafe impl<Q, R, K, V, C> Send for RefRange<'_, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
 }
 
-unsafe impl<Q, R, K, V> Sync for RefRange<'_, Q, R, K, V>
+unsafe impl<Q, R, K, V, C> Sync for RefRange<'_, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
 }
 
-impl<Q, R, K, V> fmt::Debug for RefRange<'_, Q, R, K, V>
+impl<Q, R, K, V, C> fmt::Debug for RefRange<'_, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q> + fmt::Debug,
+    C: Comparator<K> + Comparator<K, Q>,
+    K: fmt::Debug,
     V: fmt::Debug,
     R: RangeBounds<Q> + fmt::Debug,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RefRange")
@@ -1951,14 +2145,14 @@ where
     }
 }
 
-impl<'a, Q, R, K: 'a, V: 'a> RefRange<'a, Q, R, K, V>
+impl<'a, Q, R, K: 'a, V: 'a, C> RefRange<'a, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
     /// Advances the iterator and returns the next value.
-    pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+    pub fn next(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V, C>> {
         self.parent.check_guard(guard);
         let next_head = match self.head {
             Some(ref e) => e.next(guard),
@@ -1966,18 +2160,39 @@ where
         };
 
         if let Some(ref h) = next_head {
-            let bound = match self.tail {
-                Some(ref t) => Bound::Excluded(t.key().borrow()),
-                None => self.range.end_bound(),
-            };
-            if below_upper_bound(&bound, h.key().borrow()) {
-                self.head = next_head.clone();
-                next_head
-            } else {
-                unsafe {
-                    h.node.decrement(guard);
+            match self.tail {
+                Some(ref t) => {
+                    let bound = Bound::Excluded(t.key());
+                    if below_upper_bound(&self.parent.comparator, &bound, h.key()) {
+                        if let Some(e) = mem::replace(&mut self.head, next_head.clone()) {
+                            unsafe {
+                                e.node.decrement(guard);
+                            }
+                        }
+                        next_head
+                    } else {
+                        unsafe {
+                            h.node.decrement(guard);
+                        }
+                        None
+                    }
                 }
-                None
+                None => {
+                    let bound = self.range.end_bound();
+                    if below_upper_bound(&self.parent.comparator, &bound, h.key()) {
+                        if let Some(e) = mem::replace(&mut self.head, next_head.clone()) {
+                            unsafe {
+                                e.node.decrement(guard);
+                            }
+                        }
+                        next_head
+                    } else {
+                        unsafe {
+                            h.node.decrement(guard);
+                        }
+                        None
+                    }
+                }
             }
         } else {
             None
@@ -1985,7 +2200,7 @@ where
     }
 
     /// Removes and returns an element from the end of the iterator.
-    pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V>> {
+    pub fn next_back(&mut self, guard: &Guard) -> Option<RefEntry<'a, K, V, C>> {
         self.parent.check_guard(guard);
         let next_tail = match self.tail {
             Some(ref e) => e.prev(guard),
@@ -1993,18 +2208,39 @@ where
         };
 
         if let Some(ref t) = next_tail {
-            let bound = match self.head {
-                Some(ref h) => Bound::Excluded(h.key().borrow()),
-                None => self.range.start_bound(),
-            };
-            if above_lower_bound(&bound, t.key().borrow()) {
-                self.tail = next_tail.clone();
-                next_tail
-            } else {
-                unsafe {
-                    t.node.decrement(guard);
+            match self.head {
+                Some(ref h) => {
+                    let bound = Bound::Excluded(h.key());
+                    if above_lower_bound(&self.parent.comparator, &bound, t.key()) {
+                        if let Some(e) = mem::replace(&mut self.tail, next_tail.clone()) {
+                            unsafe {
+                                e.node.decrement(guard);
+                            }
+                        }
+                        next_tail
+                    } else {
+                        unsafe {
+                            t.node.decrement(guard);
+                        }
+                        None
+                    }
                 }
-                None
+                None => {
+                    let bound = self.range.start_bound();
+                    if above_lower_bound(&self.parent.comparator, &bound, t.key()) {
+                        if let Some(e) = mem::replace(&mut self.tail, next_tail.clone()) {
+                            unsafe {
+                                e.node.decrement(guard);
+                            }
+                        }
+                        next_tail
+                    } else {
+                        unsafe {
+                            t.node.decrement(guard);
+                        }
+                        None
+                    }
+                }
             }
         } else {
             None
@@ -2034,15 +2270,18 @@ pub struct IntoIter<K, V> {
 impl<K, V> Drop for IntoIter<K, V> {
     fn drop(&mut self) {
         // Iterate through the whole chain and destroy every node.
-        while !self.node.is_null() {
+        while let Some(node) = NonNull::new(self.node) {
             unsafe {
+                let node = NodeRef::new(node);
                 // Unprotected loads are okay because this function is the only one currently using
                 // the skip list.
-                let next = (&(*self.node).tower)[0].load(Ordering::Relaxed, epoch::unprotected());
+                let next = node
+                    .get_level(0)
+                    .load(Ordering::Relaxed, epoch::unprotected());
 
                 // We can safely do this without deferring because references to
                 // keys & values that we give out never outlive the SkipList.
-                Node::finalize(self.node);
+                Node::finalize(node.ptr.as_ptr());
 
                 self.node = next.as_raw() as *mut Node<K, V>;
             }
@@ -2053,7 +2292,7 @@ impl<K, V> Drop for IntoIter<K, V> {
 impl<K, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
 
-    fn next(&mut self) -> Option<(K, V)> {
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             // Have we reached the end of the skip list?
             if self.node.is_null() {
@@ -2069,7 +2308,11 @@ impl<K, V> Iterator for IntoIter<K, V> {
                 //
                 // Unprotected loads are okay because this function is the only one currently using
                 // the skip list.
-                let next = (&(*self.node).tower)[0].load(Ordering::Relaxed, epoch::unprotected());
+                let next = {
+                    let node = NodeRef::new(NonNull::new_unchecked(self.node));
+                    node.get_level(0)
+                        .load(Ordering::Relaxed, epoch::unprotected())
+                };
 
                 // Deallocate the current node and move to the next one.
                 Node::dealloc(self.node);
@@ -2093,9 +2336,9 @@ impl<K, V> fmt::Debug for IntoIter<K, V> {
 
 /// Helper function to retry an operation until pinning succeeds or `None` is
 /// returned.
-pub(crate) fn try_pin_loop<'a: 'g, 'g, F, K, V>(mut f: F) -> Option<RefEntry<'a, K, V>>
+pub(crate) fn try_pin_loop<'a: 'g, 'g, F, K, V, C>(mut f: F) -> Option<RefEntry<'a, K, V, C>>
 where
-    F: FnMut() -> Option<Entry<'a, 'g, K, V>>,
+    F: FnMut() -> Option<Entry<'a, 'g, K, V, C>>,
 {
     loop {
         if let Some(e) = f()?.pin() {
@@ -2105,19 +2348,27 @@ where
 }
 
 /// Helper function to check if a value is above a lower bound
-fn above_lower_bound<T: Ord + ?Sized>(bound: &Bound<&T>, other: &T) -> bool {
+fn above_lower_bound<V, T, C>(comparator: &C, bound: &Bound<&T>, other: &V) -> bool
+where
+    T: ?Sized,
+    C: Comparator<V, T>,
+{
     match *bound {
         Bound::Unbounded => true,
-        Bound::Included(key) => other >= key,
-        Bound::Excluded(key) => other > key,
+        Bound::Included(key) => comparator.compare(other, key).is_ge(),
+        Bound::Excluded(key) => comparator.compare(other, key).is_gt(),
     }
 }
 
 /// Helper function to check if a value is below an upper bound
-fn below_upper_bound<T: Ord + ?Sized>(bound: &Bound<&T>, other: &T) -> bool {
+fn below_upper_bound<V, T, C>(comparator: &C, bound: &Bound<&T>, other: &V) -> bool
+where
+    T: ?Sized,
+    C: Comparator<V, T>,
+{
     match *bound {
         Bound::Unbounded => true,
-        Bound::Included(key) => other <= key,
-        Bound::Excluded(key) => other < key,
+        Bound::Included(key) => comparator.compare(other, key).is_le(),
+        Bound::Excluded(key) => comparator.compare(other, key).is_lt(),
     }
 }

--- a/core/skiplist/base_tests.rs
+++ b/core/skiplist/base_tests.rs
@@ -1,7 +1,9 @@
-#![allow(clippy::redundant_clone)]
+#![allow(clippy::redundant_clone, clippy::missing_spin_loop)]
 
-use std::ops::Bound;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    ops::Bound,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use crate::skiplist::{base, SkipList};
 use crossbeam_epoch as epoch;
@@ -899,4 +901,123 @@ fn drops() {
     handle.pin().flush();
     assert_eq!(KEYS.load(Ordering::SeqCst), 8);
     assert_eq!(VALUES.load(Ordering::SeqCst), 7);
+}
+
+#[test]
+fn comparable_get() {
+    use crate::skiplist::equivalent::{Comparable, Equivalent};
+
+    #[derive(PartialEq, Eq, PartialOrd, Ord)]
+    struct Foo {
+        a: u64,
+        b: u32,
+    }
+
+    #[derive(PartialEq, Eq)]
+    struct FooRef<'a> {
+        data: &'a [u8],
+    }
+
+    impl PartialOrd for FooRef<'_> {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Ord for FooRef<'_> {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            let a = u64::from_be_bytes(self.data[..8].try_into().unwrap());
+            let b = u32::from_be_bytes(self.data[8..].try_into().unwrap());
+            let other_a = u64::from_be_bytes(other.data[..8].try_into().unwrap());
+            let other_b = u32::from_be_bytes(other.data[8..].try_into().unwrap());
+            Foo { a, b }.cmp(&Foo {
+                a: other_a,
+                b: other_b,
+            })
+        }
+    }
+
+    impl<'a> Equivalent<FooRef<'a>> for Foo {
+        fn equivalent(&self, key: &FooRef<'a>) -> bool {
+            let a = u64::from_be_bytes(key.data[..8].try_into().unwrap());
+            let b = u32::from_be_bytes(key.data[8..].try_into().unwrap());
+            a == self.a && b == self.b
+        }
+    }
+
+    impl<'a> Comparable<FooRef<'a>> for Foo {
+        fn compare(&self, key: &FooRef<'a>) -> std::cmp::Ordering {
+            let a = u64::from_be_bytes(key.data[..8].try_into().unwrap());
+            let b = u32::from_be_bytes(key.data[8..].try_into().unwrap());
+            Self { a, b }.cmp(self)
+        }
+    }
+
+    let s = SkipList::new(epoch::default_collector().clone());
+    let foo = Foo { a: 1, b: 2 };
+
+    let g = &epoch::pin();
+    s.insert(foo, 12, g);
+
+    let buf = 1u64
+        .to_be_bytes()
+        .iter()
+        .chain(2u32.to_be_bytes().iter())
+        .copied()
+        .collect::<Vec<_>>();
+    let foo_ref = FooRef { data: &buf };
+
+    let ent = s.get(&foo_ref, g).unwrap();
+    assert_eq!(ent.key().a, 1);
+    assert_eq!(ent.key().b, 2);
+    assert_eq!(*ent.value(), 12);
+}
+
+// https://github.com/crossbeam-rs/crossbeam/pull/1143
+#[test]
+fn remove_race() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const NTHREADS: u32 = 16;
+    const KEY_RANGE: u32 = if cfg!(miri) { 100 } else { 100_000 };
+
+    let guard = &epoch::pin();
+    let s = SkipList::new(epoch::default_collector().clone());
+
+    for x in 0..KEY_RANGE {
+        s.insert(x, (), guard).release(guard);
+    }
+
+    let barrier1 = AtomicU32::new(NTHREADS);
+    let barrier2 = AtomicU32::new(NTHREADS);
+    let mut total_removed = AtomicU32::new(0);
+
+    std::thread::scope(|scope| {
+        for _ in 0..NTHREADS {
+            scope.spawn(|| {
+                let guard = &epoch::pin();
+                let mut removed_entries = Vec::with_capacity(KEY_RANGE as usize);
+
+                barrier1.fetch_sub(1, Ordering::Relaxed);
+                while barrier1.load(Ordering::Acquire) != 0 {}
+
+                for x in 0..KEY_RANGE {
+                    if let Some(entry) = s.remove(&x, guard) {
+                        removed_entries.push(entry);
+                    }
+                }
+
+                barrier2.fetch_sub(1, Ordering::Relaxed);
+                while barrier2.load(Ordering::Acquire) != 0 {}
+
+                total_removed.fetch_add(removed_entries.len() as u32, Ordering::Relaxed);
+
+                for entry in removed_entries.drain(..) {
+                    entry.release(guard);
+                }
+            });
+        }
+    });
+
+    assert_eq!(*total_removed.get_mut(), KEY_RANGE);
 }

--- a/core/skiplist/comparator.rs
+++ b/core/skiplist/comparator.rs
@@ -1,0 +1,96 @@
+//! Traits for key comparison in maps.
+
+use core::cmp::Ordering;
+
+use super::equivalent::{Comparable, Equivalent};
+
+/// Key equality trait.
+///
+/// This trait allows for very flexible comparison of objects. You may
+/// borrow/dereference `L` and `R` using `Borrow` or another trait. The trait
+/// takes a `self` parameter, which you can use to change how the operands are
+/// compared. For example, you can toggle string case-sensitivity on and off at
+/// runtime, or you can use `Box<dyn Equivalator<L, R>>` to allow the user of
+/// your code to supply a custom comparison function.
+///
+/// Implementations of `Equivalator` don't affect the inherent `Eq` or `Hash`
+/// implementations for a type. Currently there is no companion trait that
+/// allows for custom hashing the way `Equivalator` allows for custom
+/// comparison.
+///
+/// See also `Comparator`.
+///
+/// ## Example
+/// ```
+/// use turso_core::skiplist::comparator::Equivalator;
+///
+/// struct MyEquivalator {
+///     case_sensitive: bool,
+/// }
+///
+/// impl Equivalator<[u8], [u8]> for MyEquivalator {
+///     fn equivalent(&self, lhs: &[u8], rhs: &[u8]) -> bool {
+///         if self.case_sensitive {
+///             lhs == rhs
+///         } else {
+///             // Case-insensitive ASCII comparison on raw bytes
+///             if lhs.len() != rhs.len() { return false; }
+///             for (&c1, &c2) in lhs.iter().zip(rhs.iter()) {
+///                 let c1 = if c1 >= 0x61 && c1 <= 0x7a { c1 - 32 } else { c1 };
+///                 let c2 = if c2 >= 0x61 && c2 <= 0x7a { c2 - 32 } else { c2 };
+///                 if c1 != c2 { return false; }
+///             }
+///             true
+///         }
+///     }
+/// }
+/// ```
+pub trait Equivalator<L: ?Sized, R: ?Sized = L> {
+    /// Compare `lhs` to `rhs` for equality.
+    fn equivalent(&self, lhs: &L, rhs: &R) -> bool;
+}
+
+/// Key ordering trait.
+///
+/// This trait allows for very flexible comparison of objects. You may
+/// borrow/dereference `L` and `R` using `Borrow` or another trait. The trait
+/// takes a `self` parameter, which you can use to change how the operands are
+/// compared. For example, you can toggle string case-sensitivity on and off,
+/// or you can use `Box<dyn Comparator<L, R>>` to allow the user of your code
+/// to supply a custom comparison function.
+///
+/// The `Comparator` and `Equivalator` implementations for a comparator must
+/// agree on which inputs are equal.
+///
+/// See also `Equivalator`.
+pub trait Comparator<L: ?Sized, R: ?Sized = L>: Equivalator<L, R> {
+    /// Compare `lhs` to `rhs` and return their ordering.
+    fn compare(&self, lhs: &L, rhs: &R) -> Ordering;
+}
+
+/// This comparator uses the `Equivalent` and `Comparable` traits to perform
+/// comparisons, which themselves fall back on the standard library `Borrow`
+/// and `Ord` traits. When used in a map, this results in the same behavior as
+/// the standard `BTreeMap` interface.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BasicComparator;
+
+impl<K: ?Sized, Q: ?Sized> Equivalator<K, Q> for BasicComparator
+where
+    K: Equivalent<Q>,
+{
+    #[inline]
+    fn equivalent(&self, lhs: &K, rhs: &Q) -> bool {
+        <K as Equivalent<Q>>::equivalent(lhs, rhs)
+    }
+}
+
+impl<K: ?Sized, Q: ?Sized> Comparator<K, Q> for BasicComparator
+where
+    K: Comparable<Q>,
+{
+    #[inline]
+    fn compare(&self, lhs: &K, rhs: &Q) -> Ordering {
+        <K as Comparable<Q>>::compare(lhs, rhs)
+    }
+}

--- a/core/skiplist/equivalent.rs
+++ b/core/skiplist/equivalent.rs
@@ -1,0 +1,54 @@
+// These traits are based on `equivalent` crate, but `K` and `Q` are flipped to avoid type inference issues:
+// https://github.com/indexmap-rs/equivalent/issues/5
+
+//! Traits for key comparison in maps.
+
+use core::{borrow::Borrow, cmp::Ordering};
+
+/// Key equivalence trait.
+///
+/// This trait allows hash table lookup to be customized. It has one blanket
+/// implementation that uses the regular solution with `Borrow` and `Eq`, just
+/// like `HashMap` does, so that you can pass `&str` to lookup into a map with
+/// `String` keys and so on.
+///
+/// # Contract
+///
+/// The implementor **must** hash like `Q`, if it is hashable.
+pub trait Equivalent<Q: ?Sized> {
+    /// Compare self to `key` and return `true` if they are equal.
+    fn equivalent(&self, key: &Q) -> bool;
+}
+
+impl<K: ?Sized, Q: ?Sized> Equivalent<Q> for K
+where
+    K: Borrow<Q>,
+    Q: Eq,
+{
+    #[inline]
+    fn equivalent(&self, key: &Q) -> bool {
+        PartialEq::eq(self.borrow(), key)
+    }
+}
+
+/// Key ordering trait.
+///
+/// This trait allows ordered map lookup to be customized. It has one blanket
+/// implementation that uses the regular solution with `Borrow` and `Ord`, just
+/// like `BTreeMap` does, so that you can pass `&str` to lookup into a map with
+/// `String` keys and so on.
+pub trait Comparable<Q: ?Sized>: Equivalent<Q> {
+    /// Compare self to `key` and return their ordering.
+    fn compare(&self, key: &Q) -> Ordering;
+}
+
+impl<K: ?Sized, Q: ?Sized> Comparable<Q> for K
+where
+    K: Borrow<Q>,
+    Q: Ord,
+{
+    #[inline]
+    fn compare(&self, key: &Q) -> Ordering {
+        Ord::cmp(self.borrow(), key)
+    }
+}

--- a/core/skiplist/map.rs
+++ b/core/skiplist/map.rs
@@ -1,26 +1,36 @@
 //! An ordered map based on a lock-free skip list. See [`SkipMap`].
 
-use std::borrow::Borrow;
-use std::fmt;
-use std::mem::ManuallyDrop;
-use std::ops::{Bound, RangeBounds};
-use std::ptr;
+use core::{
+    fmt,
+    mem::ManuallyDrop,
+    ops::{Bound, RangeBounds},
+    ptr,
+};
 
-use super::base::{self, try_pin_loop};
 use crossbeam_epoch as epoch;
+
+use super::{
+    base::{self, try_pin_loop},
+    comparator::{BasicComparator, Comparator},
+};
 
 /// An ordered map based on a lock-free skip list.
 ///
 /// This is an alternative to [`BTreeMap`] which supports
 /// concurrent access across multiple threads.
 ///
+/// A custom comparator may be provided, causing all keys
+/// to be ordered by the comparison function used instead
+/// of the standard `Ord` impl. See [`Comparator`].
+///
 /// [`BTreeMap`]: std::collections::BTreeMap
-pub struct SkipMap<K, V> {
-    inner: base::SkipList<K, V>,
+/// [`Comparator`]: crate::skiplist::comparator::Comparator
+pub struct SkipMap<K, V, C = BasicComparator> {
+    inner: base::SkipList<K, V, C>,
 }
 
 impl<K, V> SkipMap<K, V> {
-    /// Returns a new, empty map.
+    /// Returns a new, empty map with the default comparator.
     ///
     /// # Example
     ///
@@ -32,6 +42,23 @@ impl<K, V> SkipMap<K, V> {
     pub fn new() -> Self {
         Self {
             inner: base::SkipList::new(epoch::default_collector().clone()),
+        }
+    }
+}
+
+impl<K, V, C> SkipMap<K, V, C> {
+    /// Returns a new, empty map with the given comparator.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::{SkipMap, comparator::BasicComparator};
+    ///
+    /// let map: SkipMap<i32, &str> = SkipMap::with_comparator(BasicComparator);
+    /// ```
+    pub fn with_comparator(comparator: C) -> Self {
+        Self {
+            inner: base::SkipList::with_comparator(epoch::default_collector().clone(), comparator),
         }
     }
 
@@ -75,9 +102,9 @@ impl<K, V> SkipMap<K, V> {
     }
 }
 
-impl<K, V> SkipMap<K, V>
+impl<K, V, C> SkipMap<K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
     /// Returns the entry with the smallest key.
     ///
@@ -94,7 +121,7 @@ where
     /// numbers.insert(6, "six");
     /// assert_eq!(*numbers.front().unwrap().value(), "five");
     /// ```
-    pub fn front(&self) -> Option<Entry<'_, K, V>> {
+    pub fn front(&self) -> Option<Entry<'_, K, V, C>> {
         let guard = &epoch::pin();
         try_pin_loop(|| self.inner.front(guard)).map(Entry::new)
     }
@@ -114,11 +141,97 @@ where
     /// numbers.insert(6, "six");
     /// assert_eq!(*numbers.back().unwrap().value(), "six");
     /// ```
-    pub fn back(&self) -> Option<Entry<'_, K, V>> {
+    pub fn back(&self) -> Option<Entry<'_, K, V, C>> {
         let guard = &epoch::pin();
         try_pin_loop(|| self.inner.back(guard)).map(Entry::new)
     }
 
+    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let ages = SkipMap::new();
+    /// let gates_age = ages.get_or_insert("Bill Gates", 64);
+    /// assert_eq!(*gates_age.value(), 64);
+    ///
+    /// ages.insert("Steve Jobs", 65);
+    /// let jobs_age = ages.get_or_insert("Steve Jobs", -1);
+    /// assert_eq!(*jobs_age.value(), 65);
+    /// ```
+    pub fn get_or_insert(&self, key: K, value: V) -> Entry<'_, K, V, C> {
+        let guard = &epoch::pin();
+        Entry::new(self.inner.get_or_insert(key, value, guard))
+    }
+
+    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist,
+    /// where value is calculated with a function.
+    ///
+    /// <b>Note:</b> Another thread may write key value first, leading to the result of this closure
+    /// discarded. If closure is modifying some other state (such as shared counters or shared
+    /// objects), it may lead to <u>undesired behaviour</u> such as counters being changed without
+    /// result of closure inserted
+    ///
+    /// This function returns an [`Entry`] which
+    /// can be used to access the key's associated value.
+    ///
+    /// # Example
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let ages = SkipMap::new();
+    /// let gates_age = ages.get_or_insert_with("Bill Gates", || 64);
+    /// assert_eq!(*gates_age.value(), 64);
+    ///
+    /// ages.insert("Steve Jobs", 65);
+    /// let jobs_age = ages.get_or_insert_with("Steve Jobs", || -1);
+    /// assert_eq!(*jobs_age.value(), 65);
+    /// ```
+    pub fn get_or_insert_with<F>(&self, key: K, value_fn: F) -> Entry<'_, K, V, C>
+    where
+        F: FnOnce() -> V,
+    {
+        let guard = &epoch::pin();
+        Entry::new(self.inner.get_or_insert_with(key, value_fn, guard))
+    }
+
+    /// Returns an iterator over all entries in the map,
+    /// sorted by key.
+    ///
+    /// This iterator returns [`Entry`]s which
+    /// can be used to access keys and their associated values.
+    ///
+    /// # Examples
+    /// ```
+    /// use turso_core::skiplist::SkipMap;
+    ///
+    /// let numbers = SkipMap::new();
+    /// numbers.insert(6, "six");
+    /// numbers.insert(7, "seven");
+    /// numbers.insert(12, "twelve");
+    ///
+    /// // Print then numbers from least to greatest
+    /// for entry in numbers.iter() {
+    ///     let number = entry.key();
+    ///     let number_str = entry.value();
+    ///     println!("{} is {}", number, number_str);
+    /// }
+    /// ```
+    pub fn iter(&self) -> Iter<'_, K, V, C> {
+        Iter {
+            inner: self.inner.ref_iter(),
+        }
+    }
+}
+
+impl<K, V, C> SkipMap<K, V, C>
+where
+    C: Comparator<K>,
+{
     /// Returns `true` if the map contains a value for the specified key.
     ///
     /// # Example
@@ -133,8 +246,8 @@ where
     /// ```
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         let guard = &epoch::pin();
         self.inner.contains_key(key, guard)
@@ -155,10 +268,10 @@ where
     /// numbers.insert("six", 6);
     /// assert_eq!(*numbers.get("six").unwrap().value(), 6);
     /// ```
-    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, K, V>>
+    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         let guard = &epoch::pin();
         try_pin_loop(|| self.inner.get(key, guard)).map(Entry::new)
@@ -190,10 +303,10 @@ where
     /// let greater_than_thirteen = numbers.lower_bound(Excluded(&13));
     /// assert!(greater_than_thirteen.is_none());
     /// ```
-    pub fn lower_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, K, V>>
+    pub fn lower_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         let guard = &epoch::pin();
         try_pin_loop(|| self.inner.lower_bound(bound, guard)).map(Entry::new)
@@ -222,96 +335,13 @@ where
     /// let less_than_six = numbers.upper_bound(Excluded(&6));
     /// assert!(less_than_six.is_none());
     /// ```
-    pub fn upper_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, K, V>>
+    pub fn upper_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         let guard = &epoch::pin();
         try_pin_loop(|| self.inner.upper_bound(bound, guard)).map(Entry::new)
-    }
-
-    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist.
-    ////
-    /// This function returns an [`Entry`] which
-    /// can be used to access the key's associated value.
-    ///
-    /// # Example
-    /// ```
-    /// use turso_core::skiplist::SkipMap;
-    ///
-    /// let ages = SkipMap::new();
-    /// let gates_age = ages.get_or_insert("Bill Gates", 64);
-    /// assert_eq!(*gates_age.value(), 64);
-    ///
-    /// ages.insert("Steve Jobs", 65);
-    /// let jobs_age = ages.get_or_insert("Steve Jobs", -1);
-    /// assert_eq!(*jobs_age.value(), 65);
-    /// ```
-    pub fn get_or_insert(&self, key: K, value: V) -> Entry<'_, K, V> {
-        let guard = &epoch::pin();
-        Entry::new(self.inner.get_or_insert(key, value, guard))
-    }
-
-    /// Finds an entry with the specified key, or inserts a new `key`-`value` pair if none exist,
-    /// where value is calculated with a function.
-    ///
-    ///
-    /// <b>Note:</b> Another thread may write key value first, leading to the result of this closure
-    /// discarded. If closure is modifying some other state (such as shared counters or shared
-    /// objects), it may lead to <u>undesired behaviour</u> such as counters being changed without
-    /// result of closure inserted
-    ////
-    /// This function returns an [`Entry`] which
-    /// can be used to access the key's associated value.
-    ///
-    ///
-    /// # Example
-    /// ```
-    /// use turso_core::skiplist::SkipMap;
-    ///
-    /// let ages = SkipMap::new();
-    /// let gates_age = ages.get_or_insert_with("Bill Gates", || 64);
-    /// assert_eq!(*gates_age.value(), 64);
-    ///
-    /// ages.insert("Steve Jobs", 65);
-    /// let jobs_age = ages.get_or_insert_with("Steve Jobs", || -1);
-    /// assert_eq!(*jobs_age.value(), 65);
-    /// ```
-    pub fn get_or_insert_with<F>(&self, key: K, value_fn: F) -> Entry<'_, K, V>
-    where
-        F: FnOnce() -> V,
-    {
-        let guard = &epoch::pin();
-        Entry::new(self.inner.get_or_insert_with(key, value_fn, guard))
-    }
-
-    /// Returns an iterator over all entries in the map,
-    /// sorted by key.
-    ///
-    /// This iterator returns [`Entry`]s which
-    /// can be used to access keys and their associated values.
-    ///
-    /// # Examples
-    /// ```
-    /// use turso_core::skiplist::SkipMap;
-    ///
-    /// let numbers = SkipMap::new();
-    /// numbers.insert(6, "six");
-    /// numbers.insert(7, "seven");
-    /// numbers.insert(12, "twelve");
-    ///
-    /// // Print then numbers from least to greatest
-    /// for entry in numbers.iter() {
-    ///     let number = entry.key();
-    ///     let number_str = entry.value();
-    ///     println!("{} is {}", number, number_str);
-    /// }
-    /// ```
-    pub fn iter(&self) -> Iter<'_, K, V> {
-        Iter {
-            inner: self.inner.ref_iter(),
-        }
     }
 
     /// Returns an iterator over a subset of entries in the map.
@@ -335,11 +365,11 @@ where
     ///     println!("{} is {}", number, number_str);
     /// }
     /// ```
-    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, K, V>
+    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, K, V, C>
     where
-        K: Borrow<Q>,
         R: RangeBounds<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         Range {
             inner: self.inner.ref_range(range),
@@ -347,9 +377,10 @@ where
     }
 }
 
-impl<K, V> SkipMap<K, V>
+impl<K, V, C> SkipMap<K, V, C>
 where
-    K: Ord + Send + 'static,
+    C: Comparator<K>,
+    K: Send + 'static,
     V: Send + 'static,
 {
     /// Inserts a `key`-`value` pair into the map and returns the new entry.
@@ -369,7 +400,7 @@ where
     ///
     /// assert_eq!(*map.get("key").unwrap().value(), "value");
     /// ```
-    pub fn insert(&self, key: K, value: V) -> Entry<'_, K, V> {
+    pub fn insert(&self, key: K, value: V) -> Entry<'_, K, V, C> {
         let guard = &epoch::pin();
         Entry::new(self.inner.insert(key, value, guard))
     }
@@ -396,7 +427,7 @@ where
     /// map.compare_insert("absent_key", 0, |_| false);
     /// assert_eq!(*map.get("absent_key").unwrap().value(), 0);
     /// ```
-    pub fn compare_insert<F>(&self, key: K, value: V, compare_fn: F) -> Entry<'_, K, V>
+    pub fn compare_insert<F>(&self, key: K, value: V, compare_fn: F) -> Entry<'_, K, V, C>
     where
         F: Fn(&V) -> bool,
     {
@@ -422,10 +453,10 @@ where
     /// map.insert("key", "value");
     /// assert_eq!(*map.remove("key").unwrap().value(), "value");
     /// ```
-    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, K, V>>
+    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, K, V, C>>
     where
-        K: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<K, Q>,
+        Q: ?Sized,
     {
         let guard = &epoch::pin();
         self.inner.remove(key, guard).map(Entry::new)
@@ -453,7 +484,7 @@ where
     /// // All entries have been removed now.
     /// assert!(numbers.is_empty());
     /// ```
-    pub fn pop_front(&self) -> Option<Entry<'_, K, V>> {
+    pub fn pop_front(&self) -> Option<Entry<'_, K, V, C>> {
         let guard = &epoch::pin();
         self.inner.pop_front(guard).map(Entry::new)
     }
@@ -480,7 +511,7 @@ where
     /// // All entries have been removed now.
     /// assert!(numbers.is_empty());
     /// ```
-    pub fn pop_back(&self) -> Option<Entry<'_, K, V>> {
+    pub fn pop_back(&self) -> Option<Entry<'_, K, V, C>> {
         let guard = &epoch::pin();
         self.inner.pop_back(guard).map(Entry::new)
     }
@@ -504,15 +535,18 @@ where
     }
 }
 
-impl<K, V> Default for SkipMap<K, V> {
+impl<K, V, C> Default for SkipMap<K, V, C>
+where
+    C: Default,
+{
     fn default() -> Self {
-        Self::new()
+        Self::with_comparator(Default::default())
     }
 }
 
-impl<K, V> fmt::Debug for SkipMap<K, V>
+impl<K, V, C> fmt::Debug for SkipMap<K, V, C>
 where
-    K: Ord + fmt::Debug,
+    K: fmt::Debug,
     V: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -520,38 +554,38 @@ where
     }
 }
 
-impl<K, V> IntoIterator for SkipMap<K, V> {
+impl<K, V, C> IntoIterator for SkipMap<K, V, C> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
-    fn into_iter(self) -> IntoIter<K, V> {
+    fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             inner: self.inner.into_iter(),
         }
     }
 }
 
-impl<'a, K, V> IntoIterator for &'a SkipMap<K, V>
+impl<'a, K, V, C> IntoIterator for &'a SkipMap<K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
-    type Item = Entry<'a, K, V>;
-    type IntoIter = Iter<'a, K, V>;
+    type Item = Entry<'a, K, V, C>;
+    type IntoIter = Iter<'a, K, V, C>;
 
-    fn into_iter(self) -> Iter<'a, K, V> {
+    fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<K, V> FromIterator<(K, V)> for SkipMap<K, V>
+impl<K, V, C> FromIterator<(K, V)> for SkipMap<K, V, C>
 where
-    K: Ord,
+    C: Comparator<K> + Default,
 {
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
     {
-        let s = Self::new();
+        let s = Self::default();
         for (k, v) in iter {
             s.get_or_insert(k, v);
         }
@@ -560,24 +594,24 @@ where
 }
 
 /// A reference-counted entry in a map.
-pub struct Entry<'a, K, V> {
-    inner: ManuallyDrop<base::RefEntry<'a, K, V>>,
+pub struct Entry<'a, K, V, C = BasicComparator> {
+    inner: ManuallyDrop<base::RefEntry<'a, K, V, C>>,
 }
 
-impl<'a, K, V> Entry<'a, K, V> {
-    fn new(inner: base::RefEntry<'a, K, V>) -> Self {
+impl<'a, K, V, C> Entry<'a, K, V, C> {
+    fn new(inner: base::RefEntry<'a, K, V, C>) -> Self {
         Self {
             inner: ManuallyDrop::new(inner),
         }
     }
 
     /// Returns a reference to the key.
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         self.inner.key()
     }
 
     /// Returns a reference to the value.
-    pub fn value(&self) -> &V {
+    pub fn value(&self) -> &'a V {
         self.inner.value()
     }
 
@@ -587,7 +621,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     }
 }
 
-impl<K, V> Drop for Entry<'_, K, V> {
+impl<K, V, C> Drop for Entry<'_, K, V, C> {
     fn drop(&mut self) {
         unsafe {
             ManuallyDrop::into_inner(ptr::read(&self.inner)).release_with_pin(epoch::pin);
@@ -595,9 +629,9 @@ impl<K, V> Drop for Entry<'_, K, V> {
     }
 }
 
-impl<'a, K, V> Entry<'a, K, V>
+impl<K, V, C> Entry<'_, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
     /// Moves to the next entry in the map.
     pub fn move_next(&mut self) -> bool {
@@ -612,21 +646,22 @@ where
     }
 
     /// Returns the next entry in the map.
-    pub fn next(&self) -> Option<Entry<'a, K, V>> {
+    pub fn next(&self) -> Option<Self> {
         let guard = &epoch::pin();
         self.inner.next(guard).map(Entry::new)
     }
 
     /// Returns the previous entry in the map.
-    pub fn prev(&self) -> Option<Entry<'a, K, V>> {
+    pub fn prev(&self) -> Option<Self> {
         let guard = &epoch::pin();
         self.inner.prev(guard).map(Entry::new)
     }
 }
 
-impl<K, V> Entry<'_, K, V>
+impl<K, V, C> Entry<'_, K, V, C>
 where
-    K: Ord + Send + 'static,
+    C: Comparator<K>,
+    K: Send + 'static,
     V: Send + 'static,
 {
     /// Removes the entry from the map.
@@ -638,7 +673,7 @@ where
     }
 }
 
-impl<K, V> Clone for Entry<'_, K, V> {
+impl<K, V, C> Clone for Entry<'_, K, V, C> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -646,7 +681,7 @@ impl<K, V> Clone for Entry<'_, K, V> {
     }
 }
 
-impl<K, V> fmt::Debug for Entry<'_, K, V>
+impl<K, V, C> fmt::Debug for Entry<'_, K, V, C>
 where
     K: fmt::Debug,
     V: fmt::Debug,
@@ -667,7 +702,7 @@ pub struct IntoIter<K, V> {
 impl<K, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
 
-    fn next(&mut self) -> Option<(K, V)> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
@@ -679,39 +714,39 @@ impl<K, V> fmt::Debug for IntoIter<K, V> {
 }
 
 /// An iterator over the entries of a `SkipMap`.
-pub struct Iter<'a, K, V> {
-    inner: base::RefIter<'a, K, V>,
+pub struct Iter<'a, K, V, C = BasicComparator> {
+    inner: base::RefIter<'a, K, V, C>,
 }
 
-impl<'a, K, V> Iterator for Iter<'a, K, V>
+impl<'a, K, V, C> Iterator for Iter<'a, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
-    type Item = Entry<'a, K, V>;
+    type Item = Entry<'a, K, V, C>;
 
-    fn next(&mut self) -> Option<Entry<'a, K, V>> {
+    fn next(&mut self) -> Option<Entry<'a, K, V, C>> {
         let guard = &epoch::pin();
         self.inner.next(guard).map(Entry::new)
     }
 }
 
-impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V>
+impl<'a, K, V, C> DoubleEndedIterator for Iter<'a, K, V, C>
 where
-    K: Ord,
+    C: Comparator<K>,
 {
-    fn next_back(&mut self) -> Option<Entry<'a, K, V>> {
+    fn next_back(&mut self) -> Option<Entry<'a, K, V, C>> {
         let guard = &epoch::pin();
         self.inner.next_back(guard).map(Entry::new)
     }
 }
 
-impl<K, V> fmt::Debug for Iter<'_, K, V> {
+impl<K, V, C> fmt::Debug for Iter<'_, K, V, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Iter { .. }")
     }
 }
 
-impl<K, V> Drop for Iter<'_, K, V> {
+impl<K, V, C> Drop for Iter<'_, K, V, C> {
     fn drop(&mut self) {
         let guard = &epoch::pin();
         self.inner.drop_impl(guard);
@@ -719,47 +754,48 @@ impl<K, V> Drop for Iter<'_, K, V> {
 }
 
 /// An iterator over a subset of entries of a `SkipMap`.
-pub struct Range<'a, Q, R, K, V>
+pub struct Range<'a, Q, R, K, V, C = BasicComparator>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    pub(crate) inner: base::RefRange<'a, Q, R, K, V>,
+    pub(crate) inner: base::RefRange<'a, Q, R, K, V, C>,
 }
 
-impl<'a, Q, R, K, V> Iterator for Range<'a, Q, R, K, V>
+impl<'a, Q, R, K, V, C> Iterator for Range<'a, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    type Item = Entry<'a, K, V>;
+    type Item = Entry<'a, K, V, C>;
 
-    fn next(&mut self) -> Option<Entry<'a, K, V>> {
+    fn next(&mut self) -> Option<Entry<'a, K, V, C>> {
         let guard = &epoch::pin();
         self.inner.next(guard).map(Entry::new)
     }
 }
 
-impl<'a, Q, R, K, V> DoubleEndedIterator for Range<'a, Q, R, K, V>
+impl<'a, Q, R, K, V, C> DoubleEndedIterator for Range<'a, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    fn next_back(&mut self) -> Option<Entry<'a, K, V>> {
+    fn next_back(&mut self) -> Option<Entry<'a, K, V, C>> {
         let guard = &epoch::pin();
         self.inner.next_back(guard).map(Entry::new)
     }
 }
 
-impl<Q, R, K, V> fmt::Debug for Range<'_, Q, R, K, V>
+impl<Q, R, K, V, C> fmt::Debug for Range<'_, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q> + fmt::Debug,
+    C: Comparator<K> + Comparator<K, Q>,
+    K: fmt::Debug,
     V: fmt::Debug,
     R: RangeBounds<Q> + fmt::Debug,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Range")
@@ -770,11 +806,11 @@ where
     }
 }
 
-impl<Q, R, K, V> Drop for Range<'_, Q, R, K, V>
+impl<Q, R, K, V, C> Drop for Range<'_, Q, R, K, V, C>
 where
-    K: Ord + Borrow<Q>,
+    C: Comparator<K> + Comparator<K, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
     fn drop(&mut self) {
         let guard = &epoch::pin();

--- a/core/skiplist/map_tests.rs
+++ b/core/skiplist/map_tests.rs
@@ -1,4 +1,9 @@
-use std::{iter, ops::Bound, sync::Barrier};
+use std::{
+    borrow::Borrow,
+    iter,
+    ops::Bound,
+    sync::{Arc, Barrier},
+};
 
 use crate::skiplist::SkipMap;
 use crossbeam_utils::thread;
@@ -919,4 +924,105 @@ fn clear() {
     s.clear();
     assert!(s.is_empty());
     assert_eq!(s.len(), 0);
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/1023
+#[test]
+fn concurrent_insert_get_same_key() {
+    let map: Arc<SkipMap<u32, ()>> = Arc::new(SkipMap::new());
+    let len = if cfg!(miri) { 100 } else { 10_000 };
+    let key = 0;
+    map.insert(0, ());
+
+    let getter = map.clone();
+    let handle = std::thread::spawn(move || {
+        for _ in 0..len {
+            map.insert(0, ());
+        }
+    });
+    for _ in 0..len {
+        assert!(getter.get(&key).is_some());
+    }
+    handle.join().unwrap()
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/1178
+#[test]
+fn issue_1178() {
+    let map = SkipMap::new();
+    let _ = map.insert(vec![1u8], vec![1u8]);
+    let _ = map.insert(vec![2], vec![2]);
+    let _ = map.insert(vec![3], vec![3]);
+
+    let kvs: Vec<(Vec<u8>, Vec<u8>)> = map
+        .range(vec![1]..vec![3])
+        .map(|e| (e.key().clone(), e.value().clone()))
+        .collect();
+
+    for (k, v) in kvs {
+        map.insert(k, v);
+    }
+}
+
+#[test]
+fn comparator() {
+    use std::cmp::Ordering;
+
+    use crate::skiplist::comparator::{Comparator, Equivalator};
+
+    #[derive(Debug)]
+    struct CaseComparator {
+        case_sensitive: bool,
+    }
+
+    impl<L: Borrow<str> + ?Sized, R: Borrow<str> + ?Sized> Equivalator<L, R> for CaseComparator {
+        fn equivalent(&self, lhs: &L, rhs: &R) -> bool {
+            if self.case_sensitive {
+                lhs.borrow() == rhs.borrow()
+            } else {
+                lhs.borrow()
+                    .chars()
+                    .flat_map(|c| c.to_lowercase())
+                    .eq(rhs.borrow().chars().flat_map(|c| c.to_lowercase()))
+            }
+        }
+    }
+
+    impl<L: Borrow<str> + ?Sized, R: Borrow<str> + ?Sized> Comparator<L, R> for CaseComparator {
+        fn compare(&self, lhs: &L, rhs: &R) -> Ordering {
+            if self.case_sensitive {
+                lhs.borrow().cmp(rhs.borrow())
+            } else {
+                lhs.borrow()
+                    .chars()
+                    .flat_map(|c| c.to_lowercase())
+                    .cmp(rhs.borrow().chars().flat_map(|c| c.to_lowercase()))
+            }
+        }
+    }
+
+    let s: SkipMap<String, u32, _> = SkipMap::with_comparator(CaseComparator {
+        case_sensitive: true,
+    });
+    s.insert("abc".to_owned(), 1);
+    s.insert("ABC".to_owned(), 2);
+    assert_eq!(s.len(), 2);
+    assert_eq!(*s.get("abc").unwrap().value(), 1);
+    assert_eq!(*s.get("ABC").unwrap().value(), 2);
+    assert!(!s.contains_key("aBc"));
+    s.remove("abc");
+    assert!(!s.contains_key("abc"));
+    assert!(s.contains_key("ABC"));
+
+    let s: SkipMap<String, u32, _> = SkipMap::with_comparator(CaseComparator {
+        case_sensitive: false,
+    });
+    s.insert("abc".to_owned(), 1);
+    s.insert("ABC".to_owned(), 2);
+    assert_eq!(s.len(), 1);
+    assert_eq!(*s.get("abc").unwrap().value(), 2);
+    assert_eq!(*s.get("ABC").unwrap().value(), 2);
+    assert_eq!(*s.get("aBc").unwrap().value(), 2);
+    assert_eq!(s.remove("AbC").unwrap().key(), "ABC");
+    assert!(s.is_empty());
 }

--- a/core/skiplist/mod.rs
+++ b/core/skiplist/mod.rs
@@ -112,7 +112,7 @@
 //!
 //! What happens here? If the map implementation frees the memory
 //! belonging to a value when it is
-//! removed, then a user-after-free occurs, resulting in memory corruption.
+//! removed, then a use-after-free occurs, resulting in memory corruption.
 //!
 //! To solve the above, this crate uses the _epoch-based memory reclamation_ mechanism
 //! implemented in [`crossbeam-epoch`]. Simplified, a value removed from the map
@@ -229,14 +229,18 @@
 //! ```
 //!
 //! # Provenance
-//! Vendored from the `crossbeam-skiplist` crate, version 0.1.3
+//! Vendored from the `crossbeam-skiplist` crate at crossbeam git master,
+//! commit `05f9478b333ead58c0bf8e5a37d9ef9bd3b5bf17`
 //! (<https://github.com/crossbeam-rs/crossbeam>), licensed under MIT OR
 //! Apache-2.0 (see `licenses/core/`). Local modifications are kept minimal;
 //! prefer upstreaming fixes.
 
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
+mod alloc_helper;
+
 pub mod base;
+
 #[doc(inline)]
 pub use base::SkipList;
 
@@ -245,6 +249,9 @@ pub mod set;
 
 #[doc(inline)]
 pub use self::{map::SkipMap, set::SkipSet};
+
+pub mod comparator;
+pub mod equivalent;
 
 #[cfg(test)]
 mod base_tests;

--- a/core/skiplist/set.rs
+++ b/core/skiplist/set.rs
@@ -1,24 +1,32 @@
 //! A set based on a lock-free skip list. See [`SkipSet`].
 
-use std::borrow::Borrow;
-use std::fmt;
-use std::ops::Deref;
-use std::ops::{Bound, RangeBounds};
+use core::{
+    fmt,
+    ops::{Bound, Deref, RangeBounds},
+};
 
-use super::map;
+use super::{
+    comparator::{BasicComparator, Comparator},
+    map,
+};
 
 /// A set based on a lock-free skip list.
 ///
 /// This is an alternative to [`BTreeSet`] which supports
 /// concurrent access across multiple threads.
 ///
+/// A custom comparator may be provided, causing all
+/// elements to be ordered by the comparison function used
+/// instead of the standard `Ord` impl. See [`Comparator`].
+///
 /// [`BTreeSet`]: std::collections::BTreeSet
-pub struct SkipSet<T> {
-    inner: map::SkipMap<T, ()>,
+/// [`Comparator`]: crate::skiplist::comparator::Comparator
+pub struct SkipSet<T, C = BasicComparator> {
+    inner: map::SkipMap<T, (), C>,
 }
 
 impl<T> SkipSet<T> {
-    /// Returns a new, empty set.
+    /// Returns a new, empty set with the default comparator.
     ///
     /// # Example
     ///
@@ -30,6 +38,23 @@ impl<T> SkipSet<T> {
     pub fn new() -> Self {
         Self {
             inner: map::SkipMap::new(),
+        }
+    }
+}
+
+impl<T, C> SkipSet<T, C> {
+    /// Returns a new, empty set with the given comparator.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use turso_core::skiplist::{SkipSet, comparator::BasicComparator};
+    ///
+    /// let set: SkipSet<i32> = SkipSet::with_comparator(BasicComparator);
+    /// ```
+    pub fn with_comparator(comparator: C) -> Self {
+        Self {
+            inner: map::SkipMap::with_comparator(comparator),
         }
     }
 
@@ -71,9 +96,9 @@ impl<T> SkipSet<T> {
     }
 }
 
-impl<T> SkipSet<T>
+impl<T, C> SkipSet<T, C>
 where
-    T: Ord,
+    C: Comparator<T>,
 {
     /// Returns the entry with the smallest key.
     ///
@@ -88,7 +113,7 @@ where
     /// set.insert(2);
     /// assert_eq!(*set.front().unwrap(), 1);
     /// ```
-    pub fn front(&self) -> Option<Entry<'_, T>> {
+    pub fn front(&self) -> Option<Entry<'_, T, C>> {
         self.inner.front().map(Entry::new)
     }
 
@@ -105,7 +130,7 @@ where
     /// set.insert(2);
     /// assert_eq!(*set.back().unwrap(), 2);
     /// ```
-    pub fn back(&self) -> Option<Entry<'_, T>> {
+    pub fn back(&self) -> Option<Entry<'_, T, C>> {
         self.inner.back().map(Entry::new)
     }
 
@@ -122,8 +147,8 @@ where
     /// ```
     pub fn contains<Q>(&self, key: &Q) -> bool
     where
-        T: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<T, Q>,
+        Q: ?Sized,
     {
         self.inner.contains_key(key)
     }
@@ -139,10 +164,10 @@ where
     /// assert_eq!(*set.get(&3).unwrap(), 3);
     /// assert!(set.get(&4).is_none());
     /// ```
-    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, T>>
+    pub fn get<Q>(&self, key: &Q) -> Option<Entry<'_, T, C>>
     where
-        T: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<T, Q>,
+        Q: ?Sized,
     {
         self.inner.get(key).map(Entry::new)
     }
@@ -171,10 +196,10 @@ where
     /// let greater_than_thirteen = set.lower_bound(Excluded(&13));
     /// assert!(greater_than_thirteen.is_none());
     /// ```
-    pub fn lower_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, T>>
+    pub fn lower_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, T, C>>
     where
-        T: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<T, Q>,
+        Q: ?Sized,
     {
         self.inner.lower_bound(bound).map(Entry::new)
     }
@@ -200,10 +225,10 @@ where
     /// let less_than_six = set.upper_bound(Excluded(&6));
     /// assert!(less_than_six.is_none());
     /// ```
-    pub fn upper_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, T>>
+    pub fn upper_bound<'a, Q>(&'a self, bound: Bound<&Q>) -> Option<Entry<'a, T, C>>
     where
-        T: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<T, Q>,
+        Q: ?Sized,
     {
         self.inner.upper_bound(bound).map(Entry::new)
     }
@@ -219,7 +244,7 @@ where
     /// let entry = set.get_or_insert(2);
     /// assert_eq!(*entry, 2);
     /// ```
-    pub fn get_or_insert(&self, key: T) -> Entry<'_, T> {
+    pub fn get_or_insert(&self, key: T) -> Entry<'_, T, C> {
         Entry::new(self.inner.get_or_insert(key, ()))
     }
 
@@ -241,7 +266,7 @@ where
     /// assert_eq!(*set_iter.next().unwrap(), 12);
     /// assert!(set_iter.next().is_none());
     /// ```
-    pub fn iter(&self) -> Iter<'_, T> {
+    pub fn iter(&self) -> Iter<'_, T, C> {
         Iter {
             inner: self.inner.iter(),
         }
@@ -264,11 +289,11 @@ where
     /// assert_eq!(*set_range.next().unwrap(), 7);
     /// assert!(set_range.next().is_none());
     /// ```
-    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, T>
+    pub fn range<Q, R>(&self, range: R) -> Range<'_, Q, R, T, C>
     where
-        T: Borrow<Q>,
         R: RangeBounds<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<T, Q>,
+        Q: ?Sized,
     {
         Range {
             inner: self.inner.range(range),
@@ -276,9 +301,10 @@ where
     }
 }
 
-impl<T> SkipSet<T>
+impl<T, C> SkipSet<T, C>
 where
-    T: Ord + Send + 'static,
+    C: Comparator<T>,
+    T: Send + 'static,
 {
     /// Inserts a `key`-`value` pair into the set and returns the new entry.
     ///
@@ -294,7 +320,7 @@ where
     /// set.insert(2);
     /// assert_eq!(*set.get(&2).unwrap(), 2);
     /// ```
-    pub fn insert(&self, key: T) -> Entry<'_, T> {
+    pub fn insert(&self, key: T) -> Entry<'_, T, C> {
         Entry::new(self.inner.insert(key, ()))
     }
 
@@ -313,10 +339,10 @@ where
     /// assert_eq!(*set.remove(&2).unwrap(), 2);
     /// assert!(set.remove(&2).is_none());
     /// ```
-    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, T>>
+    pub fn remove<Q>(&self, key: &Q) -> Option<Entry<'_, T, C>>
     where
-        T: Borrow<Q>,
-        Q: Ord + ?Sized,
+        C: Comparator<T, Q>,
+        Q: ?Sized,
     {
         self.inner.remove(key).map(Entry::new)
     }
@@ -342,7 +368,7 @@ where
     /// // All entries have been removed now.
     /// assert!(set.is_empty());
     /// ```
-    pub fn pop_front(&self) -> Option<Entry<'_, T>> {
+    pub fn pop_front(&self) -> Option<Entry<'_, T, C>> {
         self.inner.pop_front().map(Entry::new)
     }
 
@@ -367,7 +393,7 @@ where
     /// // All entries have been removed now.
     /// assert!(set.is_empty());
     /// ```
-    pub fn pop_back(&self) -> Option<Entry<'_, T>> {
+    pub fn pop_back(&self) -> Option<Entry<'_, T, C>> {
         self.inner.pop_back().map(Entry::new)
     }
 
@@ -390,53 +416,57 @@ where
     }
 }
 
-impl<T> Default for SkipSet<T> {
+impl<T, C> Default for SkipSet<T, C>
+where
+    C: Default,
+{
     fn default() -> Self {
-        Self::new()
+        Self::with_comparator(Default::default())
     }
 }
 
-impl<T> fmt::Debug for SkipSet<T>
+impl<T, C> fmt::Debug for SkipSet<T, C>
 where
-    T: Ord + fmt::Debug,
+    C: Comparator<T>,
+    T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("SkipSet { .. }")
     }
 }
 
-impl<T> IntoIterator for SkipSet<T> {
+impl<T, C> IntoIterator for SkipSet<T, C> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
-    fn into_iter(self) -> IntoIter<T> {
+    fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             inner: self.inner.into_iter(),
         }
     }
 }
 
-impl<'a, T> IntoIterator for &'a SkipSet<T>
+impl<'a, T, C> IntoIterator for &'a SkipSet<T, C>
 where
-    T: Ord,
+    C: Comparator<T>,
 {
-    type Item = Entry<'a, T>;
-    type IntoIter = Iter<'a, T>;
+    type Item = Entry<'a, T, C>;
+    type IntoIter = Iter<'a, T, C>;
 
-    fn into_iter(self) -> Iter<'a, T> {
+    fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<T> FromIterator<T> for SkipSet<T>
+impl<T, C> FromIterator<T> for SkipSet<T, C>
 where
-    T: Ord,
+    C: Comparator<T> + Default,
 {
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = T>,
     {
-        let s = Self::new();
+        let s = Self::default();
         for t in iter {
             s.get_or_insert(t);
         }
@@ -445,17 +475,17 @@ where
 }
 
 /// A reference-counted entry in a set.
-pub struct Entry<'a, T> {
-    inner: map::Entry<'a, T, ()>,
+pub struct Entry<'a, T, C = BasicComparator> {
+    inner: map::Entry<'a, T, (), C>,
 }
 
-impl<'a, T> Entry<'a, T> {
-    fn new(inner: map::Entry<'a, T, ()>) -> Self {
+impl<'a, T, C> Entry<'a, T, C> {
+    fn new(inner: map::Entry<'a, T, (), C>) -> Self {
         Self { inner }
     }
 
     /// Returns a reference to the value.
-    pub fn value(&self) -> &T {
+    pub fn value(&self) -> &'a T {
         self.inner.key()
     }
 
@@ -465,9 +495,9 @@ impl<'a, T> Entry<'a, T> {
     }
 }
 
-impl<'a, T> Entry<'a, T>
+impl<T, C> Entry<'_, T, C>
 where
-    T: Ord,
+    C: Comparator<T>,
 {
     /// Moves to the next entry in the set.
     pub fn move_next(&mut self) -> bool {
@@ -480,19 +510,20 @@ where
     }
 
     /// Returns the next entry in the set.
-    pub fn next(&self) -> Option<Entry<'a, T>> {
+    pub fn next(&self) -> Option<Self> {
         self.inner.next().map(Entry::new)
     }
 
     /// Returns the previous entry in the set.
-    pub fn prev(&self) -> Option<Entry<'a, T>> {
+    pub fn prev(&self) -> Option<Self> {
         self.inner.prev().map(Entry::new)
     }
 }
 
-impl<T> Entry<'_, T>
+impl<T, C> Entry<'_, T, C>
 where
-    T: Ord + Send + 'static,
+    C: Comparator<T>,
+    T: Send + 'static,
 {
     /// Removes the entry from the set.
     ///
@@ -502,7 +533,7 @@ where
     }
 }
 
-impl<T> Clone for Entry<'_, T> {
+impl<T, C> Clone for Entry<'_, T, C> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -510,7 +541,7 @@ impl<T> Clone for Entry<'_, T> {
     }
 }
 
-impl<T> fmt::Debug for Entry<'_, T>
+impl<T, C> fmt::Debug for Entry<'_, T, C>
 where
     T: fmt::Debug,
 {
@@ -521,7 +552,7 @@ where
     }
 }
 
-impl<T> Deref for Entry<'_, T> {
+impl<T, C> Deref for Entry<'_, T, C> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -537,7 +568,7 @@ pub struct IntoIter<T> {
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
-    fn next(&mut self) -> Option<T> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(k, ())| k)
     }
 }
@@ -549,75 +580,76 @@ impl<T> fmt::Debug for IntoIter<T> {
 }
 
 /// An iterator over the entries of a `SkipSet`.
-pub struct Iter<'a, T> {
-    inner: map::Iter<'a, T, ()>,
+pub struct Iter<'a, T, C = BasicComparator> {
+    inner: map::Iter<'a, T, (), C>,
 }
 
-impl<'a, T> Iterator for Iter<'a, T>
+impl<'a, T, C> Iterator for Iter<'a, T, C>
 where
-    T: Ord,
+    C: Comparator<T>,
 {
-    type Item = Entry<'a, T>;
+    type Item = Entry<'a, T, C>;
 
-    fn next(&mut self) -> Option<Entry<'a, T>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(Entry::new)
     }
 }
 
-impl<'a, T> DoubleEndedIterator for Iter<'a, T>
+impl<T, C> DoubleEndedIterator for Iter<'_, T, C>
 where
-    T: Ord,
+    C: Comparator<T>,
 {
-    fn next_back(&mut self) -> Option<Entry<'a, T>> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         self.inner.next_back().map(Entry::new)
     }
 }
 
-impl<T> fmt::Debug for Iter<'_, T> {
+impl<T, C> fmt::Debug for Iter<'_, T, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Iter { .. }")
     }
 }
 
 /// An iterator over a subset of entries of a `SkipSet`.
-pub struct Range<'a, Q, R, T>
+pub struct Range<'a, Q, R, T, C = BasicComparator>
 where
-    T: Ord + Borrow<Q>,
+    C: Comparator<T> + Comparator<T, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    inner: map::Range<'a, Q, R, T, ()>,
+    inner: map::Range<'a, Q, R, T, (), C>,
 }
 
-impl<'a, Q, R, T> Iterator for Range<'a, Q, R, T>
+impl<'a, Q, R, T, C> Iterator for Range<'a, Q, R, T, C>
 where
-    T: Ord + Borrow<Q>,
+    C: Comparator<T> + Comparator<T, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    type Item = Entry<'a, T>;
+    type Item = Entry<'a, T, C>;
 
-    fn next(&mut self) -> Option<Entry<'a, T>> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(Entry::new)
     }
 }
 
-impl<'a, Q, R, T> DoubleEndedIterator for Range<'a, Q, R, T>
+impl<Q, R, T, C> DoubleEndedIterator for Range<'_, Q, R, T, C>
 where
-    T: Ord + Borrow<Q>,
+    C: Comparator<T> + Comparator<T, Q>,
     R: RangeBounds<Q>,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
-    fn next_back(&mut self) -> Option<Entry<'a, T>> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         self.inner.next_back().map(Entry::new)
     }
 }
 
-impl<Q, R, T> fmt::Debug for Range<'_, Q, R, T>
+impl<Q, R, T, C> fmt::Debug for Range<'_, Q, R, T, C>
 where
-    T: Ord + Borrow<Q> + fmt::Debug,
+    C: Comparator<T> + Comparator<T, Q>,
+    T: fmt::Debug,
     R: RangeBounds<Q> + fmt::Debug,
-    Q: Ord + ?Sized,
+    Q: ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Range")

--- a/core/skiplist/set_tests.rs
+++ b/core/skiplist/set_tests.rs
@@ -1,6 +1,11 @@
+use std::{
+    iter,
+    ops::Bound,
+    sync::{Arc, Barrier},
+};
+
 use crate::skiplist::SkipSet;
 use crossbeam_utils::thread;
-use std::{iter, ops::Bound, sync::Barrier};
 
 #[test]
 fn smoke() {
@@ -691,4 +696,123 @@ fn clear() {
     s.clear();
     assert!(s.is_empty());
     assert_eq!(s.len(), 0);
+}
+
+// https://github.com/crossbeam-rs/crossbeam/issues/1023
+#[test]
+fn concurrent_insert_get_same_key() {
+    let set: Arc<SkipSet<u32>> = Arc::new(SkipSet::new());
+    let len = if cfg!(miri) { 100 } else { 10_000 };
+    let key = 0;
+    set.insert(0);
+
+    let getter = set.clone();
+    let handle = std::thread::spawn(move || {
+        for _ in 0..len {
+            set.insert(0);
+        }
+    });
+    for _ in 0..len {
+        assert!(getter.get(&key).is_some());
+    }
+    handle.join().unwrap()
+}
+
+#[test]
+fn comparator() {
+    use std::cmp::Ordering;
+
+    use crate::skiplist::comparator::{Comparator, Equivalator};
+
+    struct DynComparator {
+        #[allow(clippy::type_complexity)]
+        inner: Box<dyn Fn(&[u8], &[u8]) -> Ordering>,
+    }
+
+    impl<L: ?Sized, R: ?Sized> Equivalator<L, R> for DynComparator
+    where
+        L: std::borrow::Borrow<[u8]>,
+        R: std::borrow::Borrow<[u8]>,
+    {
+        fn equivalent(&self, lhs: &L, rhs: &R) -> bool {
+            (self.inner)(lhs.borrow(), rhs.borrow()).is_eq()
+        }
+    }
+
+    impl<L: ?Sized, R: ?Sized> Comparator<L, R> for DynComparator
+    where
+        L: std::borrow::Borrow<[u8]>,
+        R: std::borrow::Borrow<[u8]>,
+    {
+        fn compare(&self, lhs: &L, rhs: &R) -> Ordering {
+            (self.inner)(lhs.borrow(), rhs.borrow())
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct OrderedF32(f32);
+
+    impl PartialEq for OrderedF32 {
+        fn eq(&self, other: &Self) -> bool {
+            self.cmp(other).is_eq()
+        }
+    }
+
+    impl Eq for OrderedF32 {}
+
+    impl PartialOrd for OrderedF32 {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl Ord for OrderedF32 {
+        fn cmp(&self, other: &Self) -> Ordering {
+            match self.0.partial_cmp(&other.0) {
+                Some(o) => o,
+                None => Ordering::Equal,
+            }
+        }
+    }
+
+    fn encode(slice: &[f32]) -> Vec<u8> {
+        let mut bytes = vec![];
+        for &f in slice {
+            bytes.extend_from_slice(&f.to_le_bytes());
+        }
+        bytes
+    }
+
+    fn decode(slice: &[u8]) -> impl Iterator<Item = OrderedF32> + '_ {
+        slice
+            .chunks_exact(4)
+            .map(|b| OrderedF32(f32::from_le_bytes(b.try_into().unwrap())))
+    }
+
+    fn compare(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        decode(lhs).cmp(decode(rhs))
+    }
+
+    let s = SkipSet::with_comparator(DynComparator {
+        inner: Box::new(compare),
+    });
+    s.insert(encode(&[0f32]));
+    s.insert(encode(&[1f32]));
+    s.insert(encode(&[0f32, 1f32]));
+    s.insert(encode(&[-0f32]));
+
+    assert_eq!(s.len(), 3);
+    assert!(s.contains(&encode(&[0f32])));
+    assert!(s.contains(&encode(&[-0f32])));
+    assert!(s.contains(&encode(&[1f32])));
+    assert!(s.contains(&encode(&[0f32, 1f32])));
+
+    let elems: Vec<_> = s.iter().map(|x| &x.value()[..]).collect();
+    assert_eq!(
+        elems,
+        [&encode(&[-0f32]), &encode(&[0f32, 1f32]), &encode(&[1f32])],
+    );
+
+    s.remove(&encode(&[0f32]));
+    assert!(!s.contains(&encode(&[-0f32])));
 }


### PR DESCRIPTION
## Description

This PR adds support for custom comparators to the skip list-based collections (`SkipList`, `SkipMap`, `SkipSet`), enabling users to define custom key ordering logic instead of relying solely on the `Ord` trait.

### Key Changes

1. **New Comparator Traits** (`core/skiplist/comparator.rs`):
   - `Equivalator<L, R>`: Trait for custom equality comparison
   - `Comparator<L, R>`: Trait for custom ordering comparison
   - `BasicComparator`: Default implementation using standard `Ord`

2. **Equivalent Traits** (`core/skiplist/equivalent.rs`):
   - `Equivalent<Q>`: Blanket implementation for `Borrow`-based equality
   - `Comparable<Q>`: Blanket implementation for `Borrow`-based ordering
   - Enables heterogeneous lookups (e.g., `&str` in a `String`-keyed map)

3. **Allocation Helper** (`core/skiplist/alloc_helper.rs`):
   - Extracted allocation logic into a reusable `Global` allocator wrapper
   - Replaces direct calls to `std::alloc::{alloc, dealloc}`

4. **Provenance-Preserving References**:
   - `TowerRef<'a, K, V>`: Wrapper around `NonNull<Tower<K, V>>` to preserve pointer provenance for accessing dynamically-sized tower arrays
   - `NodeRef<'a, K, V>`: Wrapper around `NonNull<Node<K, V>>` for safe access to node data and towers
   - Both implement `Copy` and preserve `Send`/`Sync` bounds for compatibility with entries and iterators

5. **API Updates**:
   - `SkipList<K, V, C = BasicComparator>`: Added generic comparator parameter
   - `SkipMap<K, V, C = BasicComparator>`: Added generic comparator parameter
   - `SkipSet<T, C = BasicComparator>`: Added generic comparator parameter
   - New `with_comparator()` constructors for all three types
   - Removed `Borrow` bounds; now use `Comparator` trait bounds instead

6. **Test Coverage**:
   - Added `comparable_get()` test demonstrating heterogeneous lookups with custom comparators
   - Added `remove_race()` test for concurrent removal scenarios
   - Added `concurrent_insert_get_same_key()` tests for maps and sets
   - Added `comparator()` tests demonstrating custom comparator implementations

### Motivation

This change enables more flexible key comparison strategies while maintaining backward compatibility through default type parameters. Users can now:
- Implement case-insensitive string comparisons
- Use custom ordering for complex types
- Perform heterogeneous lookups without allocating new keys
- Maintain the same API surface for existing code

### Backward Compatibility

All changes are backward compatible:
- Default type parameter `C = BasicComparator` maintains existing behavior
- Existing code using `SkipList<K, V>` continues to work unchanged
- `new()` constructors still available and work as before

https://claude.ai/code/session_01KoHW3KLr8GVWdnTZFx8DMa