### PR TITLE
core/mvcc: fix requires_seek on mvcc checkpoint insert

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3129,7 +3129,22 @@ impl StateTransition for WriteRowStateMachine {
                     record.start_serialization(row_data)?;
                     Some(record)
                 };
-                if self.requires_seek {
+                // `requires_seek == false` is a write_set-level *candidate* for the
+                // sequential-write optimization (this row's key is exactly previous
+                // row's key + 1, so the cursor — left on the previous row and advanced
+                // by WriteRowState::Next — is usually already at the insert position).
+                // It is only sound if the cursor is still PAST the start of its leaf:
+                // if the previous row was the last cell of its leaf, next() crossed
+                // into the following leaf (cell 0), and this row may belong on the
+                // other side of the parent divider. Dividers keep their key when the
+                // checkpoint deletes their row, so the divider can
+                // be >= this row's key, meaning the row MUST go into the left leaf
+                // even though the cursor is in the right one. Writing it at the
+                // cursor would keep the leaf locally sorted but break the interior
+                // ordering invariant, making the row invisible to point lookups
+                // ("Rowid N out of order" under sqlite3 integrity_check). Fall back
+                // to a real seek, which resolves the divider comparison correctly.
+                if self.requires_seek || !self.cursor.read().is_positioned_past_page_start() {
                     self.state = WriteRowState::Seek;
                 } else {
                     self.state = WriteRowState::Insert;

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -15298,3 +15298,48 @@ fn injected_yield_surfaces_as_step_result_yield() {
     let rows = get_rows(&conn, "SELECT id, v FROM t");
     assert_eq!(rows.len(), 1);
 }
+
+#[test]
+fn test_checkpoint_seek_skip_divider_reinsert_loses_row() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    // Same shape as the stress table hot_floor_424: tiny rows, rowid-alias PK.
+    conn.execute("CREATE TABLE t (v REAL NOT NULL, pk INTEGER PRIMARY KEY)")
+        .unwrap();
+    // Bulk-load in ONE transaction => one checkpoint pass bulk-inserts ascending and
+    // splits the btree, creating dividers (~every 250 rows at this record size).
+    conn.execute("BEGIN").unwrap();
+    for i in 0..1000 {
+        conn.execute(format!("INSERT INTO t VALUES ({}.5, {})", i % 7, i))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    for i in (0..1000).filter(|i| i % 5 == 3) {
+        conn.execute(format!("DELETE FROM t WHERE pk = {i}"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+
+    for g in 1..400i64 {
+        conn.execute(format!("DELETE FROM t WHERE pk = {g}"))
+            .unwrap();
+        conn.execute("BEGIN").unwrap();
+        conn.execute(format!("INSERT OR REPLACE INTO t VALUES (1.25, {})", g - 1))
+            .unwrap();
+        conn.execute(format!("INSERT INTO t VALUES (2.5, {g})"))
+            .unwrap();
+        conn.execute("COMMIT").unwrap();
+        let rows = get_rows(&conn, &format!("SELECT pk FROM t WHERE pk = {g}"));
+        assert_eq!(
+            rows.len(),
+            1,
+            "rowid {g} vanished from point lookup after re-insert \
+             (checkpoint seek-skip wrote it on the wrong side of the divider)"
+        );
+    }
+}

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3013,7 +3013,9 @@ impl BTreeCursor {
                         if matches!(page_type, PageType::IndexInterior) {
                             turso_assert!(parent_contents.overflow_cells.len() == 1, "index interior page must have no more than 1 overflow cell, as a result of InteriorNodeReplacement");
                         } else {
-                            turso_assert!(false, "page type must have no overflow cells", { "page_type": page_type });
+                            turso_assert!(false, "page type must have no overflow cells", {
+                                "page_type": page_type
+                            });
                         }
                         let overflow_cell = parent_contents.overflow_cells.first().unwrap();
                         let parent_page_cell_idx = self.stack.current_cell_index() as usize;
@@ -5301,6 +5303,20 @@ impl BTreeCursor {
 
     pub fn is_write_in_progress(&self) -> bool {
         matches!(self.state, CursorState::Write(_))
+    }
+
+    /// True iff the cursor sits on a valid record that is NOT the first cell of
+    /// its page. Used by the MVCC checkpoint's sequential-write optimization:
+    /// only at such a position is "insert the next adjacent rowid here, without
+    /// re-seeking" provably within the page's divider bounds (the previous,
+    /// strictly smaller rowid is in this same page, and so is a strictly larger
+    /// one). At cell 0 the cursor has just crossed a leaf boundary, and the
+    /// adjacent rowid may belong on the LEFT side of the parent divider — a
+    /// divider whose row was deleted keeps its key, so the divider can
+    /// be >= the rowid being inserted — in which case the caller must re-seek
+    /// from the root.
+    pub fn is_positioned_past_page_start(&self) -> bool {
+        self.has_record() && self.stack.current_cell_index() > 0
     }
 
     /// saveAllCursors pass for this cursor's insert/delete entry. Iteration


### PR DESCRIPTION

## Description

After https://github.com/tursodatabase/turso/pull/7289 was merged as an optimization it made it possible for a corruption to happen. Basically it could lead to state where `next` in Write state machine would leave cursor pointing to next page where:

```
             Divider
Page 1              Page 2
                         cursor points cell 0 here
                         rowid <= divider
```

## Description of AI Usage

CC was used for finding and fixing the bug
