### PR TITLE
core/mvcc: fix unbounded memory growth from checkpoint starvation (+ skiplist range leak)

### DIFF
--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -7,7 +7,10 @@ description: How to benchmark and analyze memory usage in Turso using the memory
 
 The `perf/memory` crate benchmarks memory usage of SQL workloads under WAL and MVCC journal modes. It uses `dhat` as the global allocator to track every heap allocation, and `memory-stats` for process-level RSS snapshots.
 
-It also contains a `stack-report` helper binary for stack-usage investigations.
+It also contains a `stack-report` helper binary for stack-usage investigations,
+and an `mvcc-starvation-probe` binary for measuring MVCC memory behavior under
+barrier-free concurrent load (heap + logical-log size over time, auto-checkpoint
+failure visibility).
 That binary runs a SQL payload with the `stacker` feature enabled and captures
 `turso_stack` tracing events in-process, aggregating structured tracing fields
 instead of parsing stderr log text.
@@ -77,6 +80,29 @@ The runner currently uses a fixed in-memory database and enables generated
 columns, custom types, and materialized views internally. There are no stack
 report CLI flags for selecting the database path or toggling those experimental
 features.
+
+## Running the MVCC Starvation Probe
+
+`mvcc-starvation-probe` runs N tasks in continuous BEGIN CONCURRENT / INSERT
+2KB blobs / COMMIT loops (no round barriers, unlike the main benchmark's run
+phase) until a shared row budget is exhausted, sampling dhat heap and
+`.db-log` size every 500ms. Auto-checkpoint failures appear on stderr as
+"MVCC auto-checkpoint failed" tracing lines (INFO level).
+
+```bash
+cargo run --release -p memory-benchmark --bin mvcc-starvation-probe -- <connections> <total-rows>
+# e.g. compare:
+cargo run --release -p memory-benchmark --bin mvcc-starvation-probe -- 1 30000 2>/dev/null
+cargo run --release -p memory-benchmark --bin mvcc-starvation-probe -- 4 30000 2>err.log
+grep -c 'auto-checkpoint failed' err.log
+```
+
+Healthy output shows a sawtooth: heap and log rise to the auto-checkpoint
+threshold (~4.1 MB log) and drop at each successful checkpoint. Monotonic
+growth with a large failure count means checkpoints are being starved by
+concurrent transactions. The main `memory-benchmark` run phase cannot show
+starvation because it awaits all connection tasks between batches, giving
+every round-final commit a contention-free checkpoint window.
 
 ## Running Benchmarks
 

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1447,8 +1447,17 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                 tracing::debug!("Acquiring blocking checkpoint lock");
                 let locked = self.checkpoint_lock.write();
                 if !locked {
+                    // Arm the drain gate: begin_tx refuses new transactions
+                    // until the active ones (whose read guards just beat us)
+                    // finish, so a subsequent checkpoint attempt can win.
+                    self.mvstore
+                        .checkpoint_pending
+                        .store(true, Ordering::Release);
                     return Err(crate::LimboError::Busy);
                 }
+                self.mvstore
+                    .checkpoint_pending
+                    .store(false, Ordering::Release);
                 self.lock_states.blocking_checkpoint_lock_held = true;
 
                 // Checkpoint state machines can be created before they are run.

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3631,6 +3631,15 @@ pub struct MvStore<Clock: LogicalClock> {
     /// - Immediately TRUNCATE checkpoint the WAL into the database file.
     /// - Release the blocking_checkpoint_lock.
     blocking_checkpoint_lock: Arc<TursoRwLock>,
+    /// Set when a checkpoint failed to acquire `blocking_checkpoint_lock`
+    /// because transactions were active. While set (and readers remain),
+    /// `begin_tx`/`begin_exclusive_tx` return Busy so in-flight transactions
+    /// drain and the next commit-tail auto-checkpoint can acquire the lock.
+    /// Cleared when a checkpoint acquires the lock. Without this gate,
+    /// sustained concurrent traffic starves checkpoints indefinitely: every
+    /// attempt finds another active transaction holding a read guard, so the
+    /// logical log and the in-memory version chains grow without bound.
+    pub(crate) checkpoint_pending: AtomicBool,
     /// The highest transaction ID that has been made durable in the WAL.
     /// Used to skip checkpointing transactions from mv store to WAL that have already been processed.
     durable_txid_max: AtomicU64,
@@ -3721,6 +3730,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             commit_coordinator: Arc::new(CommitCoordinator::new()),
             global_header: Arc::new(RwLock::new(None)),
             blocking_checkpoint_lock: Arc::new(TursoRwLock::new()),
+            checkpoint_pending: AtomicBool::new(false),
             durable_txid_max: AtomicU64::new(0),
             last_committed_schema_change_ts: AtomicU64::new(0),
             last_committed_tx_ts: AtomicU64::new(0),
@@ -5030,6 +5040,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // Existing transactions already hold one blocking-checkpoint read guard
         // from begin_tx(). When upgrading read->write, do not acquire another one.
         let acquires_checkpoint_guard = maybe_existing_tx_id.is_none();
+        if acquires_checkpoint_guard && self.checkpoint_gate_busy() {
+            // A checkpoint lost the lock race to active transactions; refuse
+            // new transactions until the existing ones drain so it can run.
+            return Err(LimboError::Busy);
+        }
         if acquires_checkpoint_guard && !self.blocking_checkpoint_lock.read() {
             // If there is a stop-the-world checkpoint in progress, we cannot begin any transaction at all.
             return Err(LimboError::Busy);
@@ -5141,12 +5156,28 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         Ok(tx_id)
     }
 
+    /// Returns `true` while new transactions must be refused so that active
+    /// ones drain and a pending checkpoint can acquire the blocking lock.
+    /// The gate disengages once no read guards remain: at that point the next
+    /// commit-tail checkpoint attempt (which runs after the committing
+    /// transaction releases its own guard) acquires the lock and clears
+    /// `checkpoint_pending`, so the gate cannot wedge an idle database.
+    fn checkpoint_gate_busy(&self) -> bool {
+        self.checkpoint_pending.load(Ordering::Acquire)
+            && self.blocking_checkpoint_lock.has_active_readers()
+    }
+
     /// Begins a new transaction in the database.
     ///
     /// This function starts a new transaction in the database and returns a `TxID` value
     /// that you can use to perform operations within the transaction. All changes made within the
     /// transaction are isolated from other transactions until you commit the transaction.
     pub fn begin_tx(&self, pager: Arc<Pager>) -> Result<TxID> {
+        if self.checkpoint_gate_busy() {
+            // A checkpoint lost the lock race to active transactions; refuse
+            // new transactions until the existing ones drain so it can run.
+            return Err(LimboError::Busy);
+        }
         if !self.blocking_checkpoint_lock.read() {
             // If there is a stop-the-world checkpoint in progress, we cannot begin any transaction at all.
             return Err(LimboError::Busy);

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -15162,3 +15162,99 @@ fn test_create_index_exclusive_acquire_rechecks_timestamp_after_cas() {
     assert_eq!(integrity.len(), 1);
     assert_eq!(integrity[0][0].to_string(), "ok");
 }
+
+/// What this test checks: When an auto-checkpoint loses the blocking-lock race
+/// to an active transaction, the drain gate arms: new transactions get Busy
+/// until the active ones finish, after which the next commit-tail checkpoint
+/// acquires the lock, truncates the log, and disarms the gate.
+/// Why this matters: Without the gate, sustained concurrent traffic starves
+/// checkpoints indefinitely — every attempt finds another active transaction
+/// holding a read guard — so the logical log and the in-memory version chains
+/// grow without bound.
+#[test]
+fn test_checkpoint_starvation_drain_gate() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let mv_store = db.get_mvcc_store();
+    let writer = db.connect();
+    writer.execute("CREATE TABLE t(x)").unwrap();
+
+    // Force should_checkpoint() at every commit tail.
+    mv_store.set_checkpoint_threshold(0);
+
+    // Hold a transaction open so the auto-checkpoint cannot take the lock.
+    let holder = db.connect();
+    holder.execute("BEGIN CONCURRENT").unwrap();
+    holder.execute("INSERT INTO t VALUES (0)").unwrap();
+
+    // This commit's auto-checkpoint attempt fails (holder is active) and must
+    // arm the drain gate.
+    writer.execute("INSERT INTO t VALUES (1)").unwrap();
+    assert!(
+        mv_store.checkpoint_pending.load(Ordering::Acquire),
+        "failed auto-checkpoint should arm the drain gate"
+    );
+
+    // While the gate is armed and a reader is active, new transactions are
+    // refused so the system drains.
+    let late = db.connect();
+    let err = late.execute("BEGIN CONCURRENT").unwrap_err();
+    assert!(
+        matches!(err, LimboError::Busy),
+        "begin while draining should be Busy, got {err:?}"
+    );
+
+    // The holder finishing drains the last read guard; its commit-tail
+    // checkpoint acquires the lock, checkpoints, and disarms the gate.
+    holder.execute("COMMIT").unwrap();
+    assert!(
+        !mv_store.checkpoint_pending.load(Ordering::Acquire),
+        "successful checkpoint should disarm the drain gate"
+    );
+    assert!(
+        !mv_store.has_uncheckpointed_log().unwrap(),
+        "log should be truncated by the drained checkpoint"
+    );
+
+    // New transactions proceed normally again.
+    late.execute("BEGIN CONCURRENT").unwrap();
+    late.execute("INSERT INTO t VALUES (2)").unwrap();
+    late.execute("COMMIT").unwrap();
+    assert_eq!(get_rows(&late, "SELECT count(*) FROM t").len(), 1);
+}
+
+/// What this test checks: The drain gate cannot wedge the database if the
+/// last active transaction rolls back (rollback runs no checkpoint): with no
+/// readers left the gate stops refusing transactions, and the next commit
+/// checkpoints and disarms it.
+/// Why this matters: A gate keyed only on the pending flag would deadlock
+/// here — no transaction could ever run again to perform the checkpoint.
+#[test]
+fn test_checkpoint_drain_gate_rollback_does_not_wedge() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let mv_store = db.get_mvcc_store();
+    let writer = db.connect();
+    writer.execute("CREATE TABLE t(x)").unwrap();
+    mv_store.set_checkpoint_threshold(0);
+
+    let holder = db.connect();
+    holder.execute("BEGIN CONCURRENT").unwrap();
+    holder.execute("INSERT INTO t VALUES (0)").unwrap();
+    writer.execute("INSERT INTO t VALUES (1)").unwrap();
+    assert!(mv_store.checkpoint_pending.load(Ordering::Acquire));
+
+    // Rollback releases the read guard without attempting a checkpoint.
+    holder.execute("ROLLBACK").unwrap();
+    assert!(
+        mv_store.checkpoint_pending.load(Ordering::Acquire),
+        "rollback alone does not checkpoint, gate stays armed"
+    );
+
+    // No readers remain, so the gate must let new transactions through; the
+    // commit tail then checkpoints and disarms the gate.
+    writer.execute("INSERT INTO t VALUES (2)").unwrap();
+    assert!(
+        !mv_store.checkpoint_pending.load(Ordering::Acquire),
+        "commit after drain should checkpoint and disarm the gate"
+    );
+    assert!(!mv_store.has_uncheckpointed_log().unwrap());
+}

--- a/core/skiplist/base.rs
+++ b/core/skiplist/base.rs
@@ -1971,7 +1971,14 @@ where
                 None => self.range.end_bound(),
             };
             if below_upper_bound(&bound, h.key().borrow()) {
-                self.head = next_head.clone();
+                // Release the reference owned by the old head before
+                // replacing it, otherwise its node is leaked (RefEntry has
+                // no Drop; see RefIter::next for the same pattern).
+                if let Some(e) = mem::replace(&mut self.head, next_head.clone()) {
+                    unsafe {
+                        e.node.decrement(guard);
+                    }
+                }
                 next_head
             } else {
                 unsafe {
@@ -1998,7 +2005,14 @@ where
                 None => self.range.start_bound(),
             };
             if above_lower_bound(&bound, t.key().borrow()) {
-                self.tail = next_tail.clone();
+                // Release the reference owned by the old tail before
+                // replacing it, otherwise its node is leaked (RefEntry has
+                // no Drop; see RefIter::next_back for the same pattern).
+                if let Some(e) = mem::replace(&mut self.tail, next_tail.clone()) {
+                    unsafe {
+                        e.node.decrement(guard);
+                    }
+                }
                 next_tail
             } else {
                 unsafe {

--- a/core/skiplist/base_tests.rs
+++ b/core/skiplist/base_tests.rs
@@ -900,3 +900,68 @@ fn drops() {
     assert_eq!(KEYS.load(Ordering::SeqCst), 8);
     assert_eq!(VALUES.load(Ordering::SeqCst), 7);
 }
+
+// Regression test: `RefRange::next`/`next_back` used to overwrite `head`/
+// `tail` without releasing the old reference (`RefEntry` has no `Drop`),
+// leaking one node reference per yielded entry. Nodes removed afterwards
+// could then never be finalized, so their keys and values leaked.
+#[test]
+fn drops_after_range_iteration() {
+    static KEYS: AtomicUsize = AtomicUsize::new(0);
+    static VALUES: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Eq, PartialEq, Ord, PartialOrd)]
+    struct Key(i32);
+
+    impl Drop for Key {
+        fn drop(&mut self) {
+            KEYS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct Value;
+
+    impl Drop for Value {
+        fn drop(&mut self) {
+            VALUES.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    const N: i32 = 16;
+    let collector = epoch::Collector::new();
+    let handle = collector.register();
+    {
+        let guard = &handle.pin();
+
+        let s = SkipList::new(collector.clone());
+        for x in 0..N {
+            s.insert(Key(x), Value, guard).release(guard);
+        }
+
+        // Drain a full range forwards, then another one backwards.
+        let mut range = s.ref_range::<Key, _>(..);
+        while let Some(e) = range.next(guard) {
+            e.release(guard);
+        }
+        range.drop_impl(guard);
+
+        let mut range = s.ref_range::<Key, _>(..);
+        while let Some(e) = range.next_back(guard) {
+            e.release(guard);
+        }
+        range.drop_impl(guard);
+
+        // Remove every entry. With balanced reference counts, every node is
+        // queued for destruction here.
+        for x in 0..N {
+            s.remove(&Key(x), guard).unwrap().release(guard);
+        }
+        drop(s);
+    }
+
+    handle.pin().flush();
+    handle.pin().flush();
+    // N node keys + N probe keys passed to remove().
+    assert_eq!(KEYS.load(Ordering::SeqCst), 2 * N as usize);
+    assert_eq!(VALUES.load(Ordering::SeqCst), N as usize);
+}

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -338,6 +338,12 @@ impl TursoRwLock {
         false
     }
 
+    /// Returns `true` if any shared read locks are currently held.
+    #[inline]
+    pub fn has_active_readers(&self) -> bool {
+        Self::has_readers(self.0.load(Ordering::Acquire))
+    }
+
     /// Try to take an exclusive lock. Succeeds if no readers and no writer.
     #[inline]
     pub fn write(&self) -> bool {

--- a/perf/memory/Cargo.toml
+++ b/perf/memory/Cargo.toml
@@ -12,6 +12,10 @@ path = "src/main.rs"
 name = "stack-report"
 path = "src/stack_report.rs"
 
+[[bin]]
+name = "mvcc-starvation-probe"
+path = "src/mvcc_starvation_probe.rs"
+
 [features]
 stacker = ["turso/stacker"]
 

--- a/perf/memory/src/mvcc_starvation_probe.rs
+++ b/perf/memory/src/mvcc_starvation_probe.rs
@@ -1,0 +1,137 @@
+//! Barrier-free MVCC checkpoint starvation probe.
+//!
+//! N tasks run continuous BEGIN CONCURRENT / INSERT 2KB blobs / COMMIT loops
+//! against one database until a shared row budget is exhausted — no round
+//! barriers, so with N > 1 some transaction is almost always active. A sampler
+//! prints heap (dhat) and logical-log size over time. Auto-checkpoint failures
+//! are visible on stderr via `tracing` at INFO ("MVCC auto-checkpoint failed").
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::{Duration, Instant};
+
+use turso::Value;
+use turso::params::Params;
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+const BATCH: i64 = 20;
+
+fn heap_bytes() -> u64 {
+    dhat::HeapStats::get().curr_bytes as u64
+}
+
+fn main() {
+    let _profiler = dhat::Profiler::new_heap();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args: Vec<String> = std::env::args().collect();
+    let n_conns: usize = args.get(1).map(|s| s.parse().unwrap()).unwrap_or(4);
+    let total_rows: i64 = args.get(2).map(|s| s.parse().unwrap()).unwrap_or(30_000);
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(n_conns.max(2))
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(run(n_conns, total_rows));
+    drop(rt);
+    println!("FINAL after runtime drop: heap={}", heap_bytes());
+}
+
+async fn run(n_conns: usize, total_rows: i64) {
+    let db_path = "/tmp/mvcc_starvation_probe.db";
+    for suffix in ["", "-wal", "-log"] {
+        let _ = std::fs::remove_file(format!("{db_path}{suffix}"));
+    }
+
+    let db = turso::Builder::new_local(db_path).build().await.unwrap();
+    let setup = db.connect().unwrap();
+    setup.busy_timeout(Duration::from_secs(30)).unwrap();
+    setup.pragma_update("journal_mode", "'mvcc'").await.unwrap();
+    setup
+        .execute("CREATE TABLE bench(id INTEGER PRIMARY KEY, data BLOB)", ())
+        .await
+        .unwrap();
+
+    let next_id = Arc::new(AtomicI64::new(0));
+    let start = Instant::now();
+    let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    // Sampler: heap + log size every 500 ms.
+    let sampler = {
+        let done = done.clone();
+        let next_id = next_id.clone();
+        tokio::spawn(async move {
+            let log_path = format!("{db_path}-log");
+            while !done.load(Ordering::Relaxed) {
+                let log = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
+                println!(
+                    "t={:>6}ms rows={:>6} heap={:>11} log={:>11}",
+                    start.elapsed().as_millis(),
+                    next_id.load(Ordering::Relaxed).min(total_rows),
+                    heap_bytes(),
+                    log
+                );
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+    };
+
+    let mut workers = Vec::new();
+    for _ in 0..n_conns {
+        let conn = db.connect().unwrap();
+        conn.busy_timeout(Duration::from_secs(30)).unwrap();
+        let next_id = next_id.clone();
+        workers.push(tokio::spawn(async move {
+            let blob = vec![0u8; 2048];
+            loop {
+                let base = next_id.fetch_add(BATCH, Ordering::Relaxed);
+                if base >= total_rows {
+                    break;
+                }
+                loop {
+                    match conn.execute("BEGIN CONCURRENT", ()).await {
+                        Ok(_) => break,
+                        Err(_) => tokio::time::sleep(Duration::from_millis(1)).await,
+                    }
+                }
+                for i in 0..BATCH {
+                    conn.execute(
+                        "INSERT INTO bench(id, data) VALUES (?, ?)",
+                        Params::Positional(vec![
+                            Value::Integer(base + i),
+                            Value::Blob(blob.clone()),
+                        ]),
+                    )
+                    .await
+                    .unwrap();
+                }
+                conn.execute("COMMIT", ()).await.unwrap();
+            }
+        }));
+    }
+    for w in workers {
+        w.await.unwrap();
+    }
+    done.store(true, Ordering::Relaxed);
+    sampler.await.unwrap();
+
+    let log = std::fs::metadata(format!("{db_path}-log"))
+        .map(|m| m.len())
+        .unwrap_or(0);
+    let db_size = std::fs::metadata(db_path).map(|m| m.len()).unwrap_or(0);
+    println!(
+        "DONE   conns={n_conns} rows={total_rows} elapsed={}ms heap={} log={} db={}",
+        start.elapsed().as_millis(),
+        heap_bytes(),
+        log,
+        db_size
+    );
+    drop(setup);
+    drop(db);
+    println!("FINAL after db drop: heap={}", heap_bytes());
+}


### PR DESCRIPTION
Investigation of suspected MVCC memory leaks found two independent causes. This PR fixes both; the first commit is equivalent to the skiplist fix in #7450 and can be dropped on rebase if that lands first.

## Commit 1: vendored skiplist `RefRange` node reference leak

`RefRange::next()`/`next_back()` overwrite `head`/`tail` without releasing the old `RefEntry` (which has no `Drop`), leaking one node reference per entry yielded by every `SkipMap::range()` scan. Any node removed after being range-scanned can never be finalized — and the MVCC cursor (and the checkpoint itself) scans `MvStore.rows` via `range()`, so every checkpointed row-version chain leaked permanently, surviving even `MvStore` drop.

Inherited from upstream crossbeam-skiplist 0.1.3 (issue crossbeam-rs/crossbeam#1178, fixed unreleased on their main by crossbeam-rs/crossbeam#1217). dhat data, mixed workload (200 it × 100 ops, 4 connections, final checkpoint): heap live at process exit drops from **32.5 MB in 150,305 blocks → 1.5 MB** with the fix. Includes a deterministic drop-counting regression test (upstream's own test only fails under sanitizers).

See #7450 for the fuller re-vendor that also picks this up — whichever lands first, the other rebases.

## Commit 2: checkpoint starvation under concurrent load (the bigger issue)

MVCC auto-checkpoint runs at the commit tail and takes `blocking_checkpoint_lock` with a **try-lock**; every `begin_tx` holds a read guard for the transaction's lifetime. If the try fails, the attempt is skipped (`info!` log only). Under sustained multi-connection load some transaction is virtually always active, so **every attempt fails and checkpoints starve indefinitely**: versions are never GC'd, the logical log is never truncated.

Measured with the new barrier-free `mvcc-starvation-probe` (4 connections, continuous 20-row commits of 2 KB blobs, 60k rows; release build, dhat):

| | 1 conn | 4 conns before | 4 conns after |
|---|---|---|---|
| auto-checkpoint failures | 0 | **2,900 of 2,900** | 87, each then drained+succeeded |
| logical log | ~4 MB sawtooth | **monotonic → 124 MB** | sawtooth capped at threshold |
| live heap during load | 8–20 MB sawtooth | monotonic, **~800 MB** catch-up spike | **18–23 MB sawtooth** |
| wall time | — | 37.2 s | **28.3 s (−24%)** |

Before the fix, memory only recovered because the workload *ended* (one giant catch-up checkpoint). This matches the field observation that the growth appears only with `connections > 1`. The round-barriered `memory-benchmark` run phase can't reproduce it — it awaits all connection tasks between batches, handing every round-final commit a contention-free checkpoint window — hence the new probe (documented in the memory-benchmark skill).

**Fix:** when a checkpoint loses the lock race, arm `checkpoint_pending`. While armed and read guards remain, `begin_tx`/`begin_exclusive_tx` return `Busy` — the same error clients already handle for the existing stop-the-world checkpoint window — so in-flight transactions drain and the next commit-tail attempt acquires the lock and disarms the flag. The gate disengages whenever no readers remain, so a rollback ending the last active transaction (rollbacks attempt no checkpoint) cannot wedge the database: the next transaction is admitted and its commit tail checkpoints.

Relates to #4455 (blocking-checkpoint design).

## Testing

- New regression tests: skiplist drop-counting range test; gate arming / Busy-while-draining / disarm + log truncation; rollback-drain edge. All fail without their fixes.
- `turso_core` lib suite green (379 mvcc + 86 skiplist tests; only pre-existing, environment-specific `test_wal_readlock0_optimization_behavior` failure, which fails identically on pristine main here).
- `cargo clippy --all-features --all-targets -- --deny=warnings` clean; `cargo fmt` applied.

https://claude.ai/code/session_016EF4WtS6JuVw9spsN1Wtjr

---
_Generated by [Claude Code](https://claude.ai/code/session_016EF4WtS6JuVw9spsN1Wtjr)_