### PR TITLE
ci: run Whopper recovery-heavy profile on PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -345,6 +345,12 @@ jobs:
           - name: in-process-mvcc
             iterations: 25
             args: "--mode fast --reopen-probability 0.01 --enable-mvcc"
+          - name: recovery-heavy
+            iterations: 100
+            args: "--mode recovery-heavy --max-steps 10000"
+          - name: recovery-heavy-mvcc
+            iterations: 25
+            args: "--mode recovery-heavy --enable-mvcc --max-steps 10000"
           - name: multiprocess
             iterations: 10
             args: "--mode fast --multiprocess --connections-per-process 4 --processes 4"


### PR DESCRIPTION
## What

Wire the `recovery-heavy` Whopper mode into the `concurrent-simulator` job in `rust.yml` by adding two in-process matrix profiles:

| profile | iterations | args |
|---|---|---|
| `recovery-heavy` | 100 | `--mode recovery-heavy --max-steps 10000` |
| `recovery-heavy-mvcc` | 25 | `--mode recovery-heavy --enable-mvcc --max-steps 10000` |

This job runs on every `pull_request` and `push` to `main`, so the recovery-heavy mode now runs on PRs alongside the existing fast-mode profiles. The profiles are additive — no existing coverage is removed.

## Why

The `recovery-heavy` profile (`WhopperOpts::recovery_heavy()`) was added a while back but was never run in CI — the commit that introduced it touched only the simulator crate, not any workflow. It biases toward recovery paths: ungraceful connection close, frequent DB reopen (`reopen_probability: 0.1`), disabled MVCC auto-checkpoint, and a recovery-friendly schema bias. Those are exactly the paths we want exercised on every PR.

## Why `--max-steps 10000` instead of the default 100k

`recovery-heavy` reopens the database ~10% of steps, and each reopen replays recovery over the whole file, so per-run cost scales **superlinearly** with step count (the DB keeps growing). Measured in `--release` on a dev box:

| steps | recovery-heavy | recovery-heavy-mvcc |
|------:|---------------:|--------------------:|
| 10k | 3.9s | 16.2s |
| 20k | 14.8s | 46.9s |
| 50k | 78.4s | 369.2s |
| 100k | 361.0s | ~25 min (extrapolated) |

The default 100k would be unpredictable and far too heavy (especially MVCC) for a CI loop. Capping at 10k keeps each run bounded and predictable while still doing ~1k reopens/recovery cycles per iteration; running many iterations gives seed diversity. The 100 / 25 iteration split mirrors the existing `in-process` / `in-process-mvcc` cadence and lands at ~6.5 min of simulation per profile on the dev box — comfortably inside the job's 40-minute timeout even with CI slowdown. Both invocations were verified to exit 0.

## Scope / limitation

`recovery-heavy` is **in-process only**: `run_multiprocess()` only accepts `fast`/`chaos`/`ragnarök`, and `MultiprocessOpts` doesn't carry the recovery-heavy knobs (schema bias, reopen probability, ungraceful close). So the `multiprocess`/`multiprocess-kill` matrix entries, the Windows multiprocess smoke test, and the Elle consistency job (which takes no `--mode`) are intentionally left on fast mode. Running recovery-heavy under multiprocess would be a separate, larger change — happy to do it as a follow-up if wanted.

https://claude.ai/code/session_012ah3SL7s2Gsm44Dmkhjkum

---
_Generated by [Claude Code](https://claude.ai/code/session_012ah3SL7s2Gsm44Dmkhjkum)_