### PR TITLE
core: demote instrumentation spans from INFO to DEBUG/TRACE

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -886,7 +886,7 @@ impl Connection {
         self.prepare_with_origin(sql, StatementOrigin::InternalHelper)
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::TRACE)]
     pub fn _prepare(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<Statement> {
         self.prepare_with_origin(sql, StatementOrigin::Root)
     }
@@ -1439,7 +1439,7 @@ impl Connection {
         }
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::TRACE)]
     pub fn prepare_execute_batch(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<()> {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
@@ -1463,7 +1463,7 @@ impl Connection {
         Ok(())
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::TRACE)]
     pub fn query(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<Option<Statement>> {
         if self.is_closed() {
             return Err(LimboError::InternalError("Connection closed".to_string()));
@@ -1482,7 +1482,7 @@ impl Connection {
         }
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::TRACE)]
     pub(crate) fn run_cmd(
         self: &Arc<Connection>,
         cmd: Cmd,
@@ -1502,7 +1502,7 @@ impl Connection {
 
     /// Execute will run a query from start to finish taking ownership of I/O because it will run pending I/Os if it didn't finish.
     /// TODO: make this api async
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::TRACE)]
     #[turso_macros::trace_stack]
     pub fn execute(self: &Arc<Connection>, sql: impl AsRef<str>) -> Result<()> {
         if self.is_closed() {
@@ -1524,7 +1524,7 @@ impl Connection {
         Ok(())
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::TRACE)]
     pub fn consume_stmt(
         self: &Arc<Connection>,
         sql: impl AsRef<str>,

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -497,7 +497,7 @@ impl File for UnixFile {
             .len())
     }
 
-    #[instrument(err, skip_all, level = Level::INFO)]
+    #[instrument(err, skip_all, level = Level::TRACE)]
     fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
         let result = self.file.set_len(len);
         match result {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1930,14 +1930,14 @@ impl Database {
         }
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::DEBUG)]
     pub fn connect(self: &Arc<Database>) -> Result<Arc<Connection>> {
         self._connect(false, None, None)
     }
 
     /// Connect with an encryption key.
     /// Use this when opening an encrypted database where the key is known at connect time.
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::DEBUG)]
     pub fn connect_with_encryption(
         self: &Arc<Database>,
         encryption_key: Option<EncryptionKey>,
@@ -1945,7 +1945,7 @@ impl Database {
         self._connect(false, None, encryption_key)
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::DEBUG)]
     fn _connect(
         self: &Arc<Database>,
         is_mvcc_bootstrap_connection: bool,

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -272,7 +272,7 @@ impl DatabaseStorage for DatabaseFile {
         self.file.size()
     }
 
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::DEBUG)]
     fn truncate(&self, len: usize, c: Completion) -> Result<Completion> {
         let c = self.file.truncate(len as u64, c)?;
         Ok(c)

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3367,7 +3367,7 @@ impl Pager {
 
     /// Flush all dirty pages to disk (async/re-entrant).
     /// Unlike commit_dirty_pages, this function does not commit, checkpoint nor sync the WAL/Database.
-    #[instrument(skip_all, level = Level::INFO)]
+    #[instrument(skip_all, level = Level::DEBUG)]
     pub fn cacheflush(&self) -> Result<IOResult<Vec<Completion>>> {
         let wal = self
             .wal

--- a/core/util.rs
+++ b/core/util.rs
@@ -196,7 +196,7 @@ impl ParseSchemaRowsState {
 /// `state`, feeding each row to `handle_schema_row`, and yields IO instead of
 /// pumping it. Re-invoke after each yielded completion; accumulators persist in
 /// `state`. On completion, populates indices and materialized views.
-#[instrument(skip_all, level = Level::INFO)]
+#[instrument(skip_all, level = Level::DEBUG)]
 pub fn parse_schema_rows(
     state: &mut ParseSchemaRowsState,
     schema: &mut Schema,


### PR DESCRIPTION
Several functions were instrumented at INFO level, which spams the logs of any application that consumes turso_core with a logger configured at the default INFO level: every connect, prepare, and execute shows up as a span in the application's log output.

A library should emit nothing at INFO unless an operator needs to see it. Demote connection lifecycle spans (connect, schema parsing, truncate, cacheflush) to DEBUG and per-statement and I/O hot paths (prepare, query, execute, truncate) to TRACE, matching the levels used by sibling functions in the same files.

This also restores the intent of the tracing_release feature: release_max_level_info compiles sub-INFO spans to no-ops in release builds, so these spans no longer add overhead to benchmarks.