### PR TITLE
simulator: dont rollback simulator connection level transaction state for create table failure

### DIFF
--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -624,14 +624,16 @@ impl Property {
                 let table_name = create.table.name.clone();
 
                 let assertion = InteractionType::Assertion(Assertion::new("creating two tables with the name should result in a failure for the second query"
-                                    .to_string(), move |stack: &Vec<ResultSet>, env| {
+                                    .to_string(), move |stack: &Vec<ResultSet>, _env: &mut SimulatorEnv| {
                                 let last = stack.last().unwrap();
                                 match last {
                                     Ok(success) => Ok(Err(format!("expected table creation to fail but it succeeded: {success:?}"))),
                                     Err(e) => {
+                                        // A failed CREATE TABLE (table already exists) is a statement-level
+                                        // error in SQLite/Turso; it does NOT roll back an active transaction.
+                                        // The shadow model must mirror that and leave the connection's
+                                        // transaction state (and its uncommitted rows) untouched.
                                         if e.to_string().to_lowercase().contains(&format!("table {table_name} already exists")) {
-                                             // On error we rollback the transaction if there is any active here
-                                            env.rollback_conn(connection_index);
                                             Ok(Ok(()))
                                         } else {
                                             Ok(Err(format!("expected table already exists error, got: {e}")))


### PR DESCRIPTION
found by the following simulator seed failure:
```console
./target/debug/limbo_sim --maximum-tests 1000  \
--min-tick 10 --max-tick 50 --io-backend=memory \
--seed 11558114576248437680
```
which showed that the database had more rows than the simulator model. clanker tracked down the issue being that for a `CREATE TABLE` statement failing is a statement level error, and we don't need to model that the entire connection's TX state needs to be rolled back.

seed now passes locally 