### PR TITLE
mvcc: some memory use improvements

### DIFF
--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1743,7 +1743,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
                         let record = ImmutableRecord::from_values(&values, values.len())?;
-                        row_version.row.data = Some(record.get_payload().to_owned());
+                        row_version.row.data = Some(Arc::from(record.get_payload()));
                         row_version.clone()
                     };
                     self.created_btrees
@@ -1776,7 +1776,7 @@ impl<Clock: LogicalClock> CheckpointStateMachine<Clock> {
                         let mut values = record.get_values_owned()?;
                         values[3] = Value::from_i64(root_page as i64);
                         let record = ImmutableRecord::from_values(&values, values.len())?;
-                        row_version.row.data = Some(record.get_payload().to_owned());
+                        row_version.row.data = Some(Arc::from(record.get_payload()));
                         row_version.clone()
                     };
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -296,7 +296,7 @@ impl RowID {
 pub struct Row {
     pub id: RowID,
     /// Data is None for index rows because the key holds all the data.
-    pub data: Option<Vec<u8>>,
+    pub data: Option<Arc<[u8]>>,
     pub column_count: usize,
 }
 
@@ -304,7 +304,7 @@ impl Row {
     pub fn new_table_row(id: RowID, data: Vec<u8>, column_count: usize) -> Self {
         Self {
             id,
-            data: Some(data),
+            data: Some(Arc::from(data)),
             column_count,
         }
     }
@@ -323,7 +323,7 @@ impl Row {
 
     pub fn payload(&self) -> &[u8] {
         match self.id.row_id {
-            RowKey::Int(_) => self.data.as_ref().expect("table rows should have data"),
+            RowKey::Int(_) => self.data.as_deref().expect("table rows should have data"),
             RowKey::Record(ref sortable_key) => sortable_key.key.as_blob(),
         }
     }
@@ -4851,7 +4851,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
             RowKey::Record(record) => {
                 let index_rows = self.index_rows.get_or_insert_with(table_id, SkipMap::new);
                 let index_rows = index_rows.value();
-                let Some(versions) = index_rows.get(record) else {
+                let Some(versions) = index_rows.get(record.as_ref()) else {
                     // No MVCC version -> B-tree is valid
                     return true;
                 };
@@ -5686,7 +5686,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         let Some(index) = self.index_rows.get(&rowid.table_id) else {
             return false;
         };
-        let Some(entry) = index.value().get(record) else {
+        let Some(entry) = index.value().get(record.as_ref()) else {
             return false;
         };
         let versions = entry.value().read();


### PR DESCRIPTION
Two primary changes here (represented in clanker chart as items 4 and 6)

1. Box RowKey enum variant with SortableIndexKey, shrinking other variant by 24 bytes
2. Stop cloning Row data on each mvcc read, switch to refcount bump 

<img width="718" height="264" alt="image" src="https://github.com/user-attachments/assets/98e7cb1f-a824-4184-a3d0-e3513078bc20" />

