### PR TITLE
core/mvcc: RowKey::Record set to Arc

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -790,10 +790,10 @@ impl<Clock: LogicalClock + 'static> MvccLazyCursor<Clock> {
                     }
                 };
                 Ok(maybe_record.map(|record| {
-                    RowKey::Record(SortableIndexKey {
+                    RowKey::Record(Arc::new(SortableIndexKey {
                         key: record.clone(),
                         metadata: index_info.clone(),
-                    })
+                    }))
                 }))
             }
         }
@@ -1460,28 +1460,43 @@ impl<Clock: LogicalClock + 'static> CursorTrait for MvccLazyCursor<Clock> {
                 let MvccCursorType::Index(index_info) = &self.mv_cursor_type else {
                     panic!("BTreeKey::IndexKey requires Index cursor type");
                 };
-                let sortable_key =
-                    SortableIndexKey::new_from_record((*record).clone(), index_info.clone());
+                let sortable_key = Arc::new(SortableIndexKey::new_from_record(
+                    (*record).clone(),
+                    index_info.clone(),
+                ));
                 RowID::new(self.table_id, RowKey::Record(sortable_key))
             }
         };
-        let record_buf = key
-            .get_record()
-            .ok_or_else(|| LimboError::InternalError("BTreeKey should have a record".to_string()))?
-            .get_payload()
-            .to_vec();
-        let num_columns = match key {
-            BTreeKey::IndexKey(record) => record.column_count(),
-            BTreeKey::TableRowId((_, record)) => record
-                .as_ref()
-                .ok_or_else(|| {
-                    LimboError::InternalError("TableRowId should have a record".to_string())
-                })?
-                .column_count(),
-        };
         let row = match &self.mv_cursor_type {
-            MvccCursorType::Table => Row::new_table_row(row_id, record_buf, num_columns),
-            MvccCursorType::Index(_) => Row::new_index_row(row_id, num_columns),
+            MvccCursorType::Table => {
+                let record_buf = key
+                    .get_record()
+                    .ok_or_else(|| {
+                        LimboError::InternalError("BTreeKey should have a record".to_string())
+                    })?
+                    .get_payload()
+                    .to_vec();
+                let BTreeKey::TableRowId((_, record)) = key else {
+                    return Err(LimboError::InternalError(
+                        "Table cursor requires a TableRowId key".to_string(),
+                    ));
+                };
+                let num_columns = record
+                    .as_ref()
+                    .ok_or_else(|| {
+                        LimboError::InternalError("TableRowId should have a record".to_string())
+                    })?
+                    .column_count();
+                Row::new_table_row(row_id, record_buf, num_columns)
+            }
+            MvccCursorType::Index(_) => {
+                let BTreeKey::IndexKey(record) = key else {
+                    return Err(LimboError::InternalError(
+                        "Index cursor requires an IndexKey".to_string(),
+                    ));
+                };
+                Row::new_index_row(row_id, record.column_count())
+            }
         };
 
         // Check if the cursor is currently positioned at a B-tree row that matches

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -2452,7 +2452,10 @@ mod tests {
         .unwrap();
         let sortable_key = SortableIndexKey::new_from_record(key_record, index_info);
         let key_arc = Arc::new(sortable_key.clone());
-        let row = Row::new_index_row(RowID::new(index_id, RowKey::Record(sortable_key)), 2);
+        let row = Row::new_index_row(
+            RowID::new(index_id, RowKey::Record(Arc::new(sortable_key))),
+            2,
+        );
         let row_version = RowVersion {
             id: version_id,
             begin: begin.map(TxTimestampOrID::Timestamp),

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -252,7 +252,7 @@ impl Ord for SortableIndexKey {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RowKey {
     Int(i64),
-    Record(SortableIndexKey),
+    Record(Arc<SortableIndexKey>),
 }
 
 impl RowKey {
@@ -4324,8 +4324,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                 // returns the canonical Arc (ours on miss, an existing one
                 // on hit), which we hand to savepoint tracking.
                 let (canonical_key, row_versions) =
-                    self.insert_index_version(index_id, Arc::new(sortable_key), row_version);
-                tx.insert_to_write_set(id, row_versions);
+                    self.insert_index_version(index_id, sortable_key, row_version);
+                tx.insert_to_write_set(
+                    RowID::new(id.table_id, RowKey::Record(canonical_key.clone())),
+                    row_versions,
+                );
                 tx.record_created_index_version((index_id, canonical_key), version_id);
             }
             None => {
@@ -4382,8 +4385,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     panic!("Index writes must be to a record");
                 };
                 let (canonical_key, row_versions) =
-                    self.insert_index_version(index_id, Arc::new(sortable_key), row_version);
-                tx.insert_to_write_set(id, row_versions);
+                    self.insert_index_version(index_id, sortable_key, row_version);
+                tx.insert_to_write_set(
+                    RowID::new(id.table_id, RowKey::Record(canonical_key.clone())),
+                    row_versions,
+                );
                 tx.record_created_index_version((index_id, canonical_key), version_id);
             }
             None => {
@@ -4431,8 +4437,11 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                     panic!("Index writes must be to a record");
                 };
                 let (canonical_key, row_versions) =
-                    self.insert_index_version(index_id, Arc::new(sortable_key), row_version);
-                tx.insert_to_write_set(id, row_versions);
+                    self.insert_index_version(index_id, sortable_key, row_version);
+                tx.insert_to_write_set(
+                    RowID::new(id.table_id, RowKey::Record(canonical_key.clone())),
+                    row_versions,
+                );
                 tx.record_created_index_version((index_id, canonical_key), version_id);
             }
             None => {
@@ -6108,13 +6117,12 @@ impl<Clock: LogicalClock> MvStore<Clock> {
     fn get_or_create_index_key_arc(
         &self,
         index_id: MVTableId,
-        key: SortableIndexKey,
+        key: Arc<SortableIndexKey>,
     ) -> Arc<SortableIndexKey> {
         let index = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
         let index = index.value();
-        // Check if key exists and get the Arc if so
-        let existing = index.get(&key).map(|entry| entry.key().clone());
-        existing.unwrap_or_else(|| Arc::new(key))
+        let existing = index.get(&*key).map(|entry| entry.key().clone());
+        existing.unwrap_or(key)
     }
 
     /// Inserts (or appends to) the version chain for an index entry and returns
@@ -6123,7 +6131,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         &self,
         index_id: MVTableId,
         key: Arc<SortableIndexKey>,
-        row_version: RowVersion,
+        mut row_version: RowVersion,
     ) -> (Arc<SortableIndexKey>, RowVersions) {
         let index = self.index_rows.get_or_insert_with(index_id, SkipMap::new);
         let index = index.value();
@@ -6132,6 +6140,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
         // passed in (on miss) or a pre-existing one (on hit). Return that
         // canonical Arc so savepoint tracking and the SkipMap stay in sync.
         let canonical_key = entry.key().clone();
+        row_version.row.id.row_id = RowKey::Record(canonical_key.clone());
         let row_versions = entry.value().clone();
         self.insert_version_raw(&mut row_versions.write(), row_version);
         (canonical_key, row_versions)
@@ -7205,11 +7214,7 @@ impl<Clock: LogicalClock> MvStore<Clock> {
                         let RowKey::Record(sortable_key) = rowid.row_id.clone() else {
                             panic!("Index writes must be to a record");
                         };
-                        self.insert_index_version(
-                            rowid.table_id,
-                            Arc::new(sortable_key),
-                            row_version,
-                        );
+                        self.insert_index_version(rowid.table_id, sortable_key, row_version);
                     }
                     StreamingResult::DeleteIndexRow {
                         row,

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6695,7 +6695,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     .unwrap();
     let row_key = SortableIndexKey::new_from_record(record, index_info);
     let row = Row::new_index_row(
-        RowID::new(MVTableId::new(-42), RowKey::Record(row_key)),
+        RowID::new(MVTableId::new(-42), RowKey::Record(Arc::new(row_key))),
         index.columns.len(),
     );
     let mut write_row_sm = db

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -3513,7 +3513,7 @@ impl StreamingLogicalLogReader {
                 let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Upsert)?;
-                let key = SortableIndexKey::new_from_record(key_record, index_info);
+                let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
                 let rowid = RowID::new(table_id, RowKey::Record(key));
                 let row = Row::new_index_row(rowid.clone(), column_count);
                 Ok(StreamingResult::UpsertIndexRow {
@@ -3532,7 +3532,7 @@ impl StreamingLogicalLogReader {
                 let key_record = crate::types::ImmutableRecord::from_bin_record(payload);
                 let column_count = key_record.column_count();
                 let index_info = get_index_info(table_id, IndexOpKind::Delete)?;
-                let key = SortableIndexKey::new_from_record(key_record, index_info);
+                let key = Arc::new(SortableIndexKey::new_from_record(key_record, index_info));
                 let rowid = RowID::new(table_id, RowKey::Record(key));
                 let row = Row::new_index_row(rowid.clone(), column_count);
                 Ok(StreamingResult::DeleteIndexRow {
@@ -4720,7 +4720,7 @@ mod tests {
             )
             .unwrap();
             let sortable_key = SortableIndexKey::new_from_record(key_record, index_info.clone());
-            let index_rowid = RowID::new(index_id, RowKey::Record(sortable_key));
+            let index_rowid = RowID::new(index_id, RowKey::Record(Arc::new(sortable_key)));
 
             // Use read_from_table_or_index to read the index row
             // This verifies that index rows were properly serialized and deserialized from the logical log
@@ -6124,7 +6124,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let row_id = RowID::new(table_id, RowKey::Record(sortable_key));
+        let row_id = RowID::new(table_id, RowKey::Record(Arc::new(sortable_key)));
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,
@@ -6177,7 +6177,7 @@ mod tests {
         is_delete: bool,
     ) -> crate::mvcc::database::RowVersion {
         let sortable_key = SortableIndexKey::new_from_bytes(payload_bytes, test_index_info());
-        let row_id = RowID::new(table_id, RowKey::Record(sortable_key));
+        let row_id = RowID::new(table_id, RowKey::Record(Arc::new(sortable_key)));
         let row = Row::new_index_row(row_id, 2);
         crate::mvcc::database::RowVersion {
             id: rowid as u64,


### PR DESCRIPTION
## Description

There were things that wasted a lot of memory a cpu cycles because we cloned to create a `RowKey::Record`. In theory we only ever need one copy of payloads and it should be on `index_rows` so everything else should be cloned with `Arc`
1. `row.clone()` into the new RowVersion
2. `row.id.clone()` into the transaction's write set 
3. `record_buf to_vec()` wasn't necessary on index path


## Description of AI Usage

Noticed we do this unnecessary clones so prompted claude to fix it.
